### PR TITLE
ci: fix internal pkg filter + new make target to audit test pkgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,16 +431,7 @@ run-tests: musl-install-if-missing dqlite-install-if-missing
 	$(eval ARCH = $(shell go env GOARCH))
 	$(eval BUILD_ARCH = $(subst ppc64el,ppc64le,${ARCH}))
 	$(eval TMP := $(shell mktemp -d $${TMPDIR:-/tmp}/jj-XXX))
-# How this line selects packages to test:
-# 1. List all the project packages with json output.
-# 2. Filter out packages without test files and select their package import path.
-# 3. Sort the list for comm.
-# 4. If there is a list of packages in TEST_PACKAGE_LIST, use it as a filter.
-# 5. Filter out vendored packages.
-# 6. Filter out packages in the generate directory.
-# 7. Filter out packages in the mocks directory.
-# 8. Filter out all mocks.
-	$(eval TEST_PACKAGES := $(shell go list -json $(PROJECT)/... | jq -s -r '[.[] | if (.TestGoFiles | length) + (.XTestGoFiles | length) > 0 then .ImportPath else null end]|del(..|nulls).[]' | sort | ([ -f "$(TEST_PACKAGE_LIST)" ] && comm -12 "$(TEST_PACKAGE_LIST)" - || cat) | grep -v $(PROJECT)$$ | grep -v $(PROJECT)/vendor/ | grep -v $(PROJECT)/generate/ | grep -v $(PROJECT)/mocks/ | grep -v $(PROJECT)/internal/ | grep -v mocks))
+	$(eval TEST_PACKAGES := $(shell make -s test-packages))
 	@echo 'go test -mod=$(JUJU_GOMOD_MODE) -tags=$(FINAL_BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES -check.v $(TEST_EXTRA_ARGS)'
 	@TMPDIR=$(TMP) \
 		PATH="${MUSL_BIN_PATH}:${PATH}" \
@@ -452,6 +443,20 @@ run-tests: musl-install-if-missing dqlite-install-if-missing
 		CGO_ENABLED=1 \
 		go test -v -mod=$(JUJU_GOMOD_MODE) -tags=$(FINAL_BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -ldflags ${CGO_LINK_FLAGS} -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES) -check.v $(TEST_EXTRA_ARGS)
 	@rm -r $(TMP)
+
+.PHONY: test-packages
+test-packages:
+## test-packages: List all the packages that should be tested
+# How this line selects packages to test:
+# 1. List all the project packages with json output.
+# 2. Filter out packages without test files and select their package import path.
+# 3. Sort the list for comm.
+# 4. If there is a list of packages in TEST_PACKAGE_LIST, use it as a filter.
+# 5. Filter out vendored packages.
+# 6. Filter out packages in the generate directory.
+# 7. Filter out packages in the mocks directory.
+# 8. Filter out all mocks.
+	@go list -json $(PROJECT)/... | jq -s -r '[.[] | if (.TestGoFiles | length) + (.XTestGoFiles | length) > 0 then .ImportPath else null end]|del(..|nulls).[]' | sort | ([ -f "$(TEST_PACKAGE_LIST)" ] && comm -12 "$(TEST_PACKAGE_LIST)" - || cat) | grep -v $(PROJECT)$$ | grep -v $(PROJECT)/vendor/ | grep -v $(PROJECT)/generate/ | grep -v $(PROJECT)/mocks/ | grep -v mocks
 
 run-go-tests: musl-install-if-missing dqlite-install-if-missing
 ## run-go-tests: Run the unit tests


### PR DESCRIPTION
A filter of internal packages from testing was mistakenly added in #19533.

To prevent future incidents of filtering out important packages, this
change moves the test package listing/filtering into a separate make
target, `test-packages`, which is now invoked from the `run-tests` target.

## QA steps

Check the excluded packages are sane.
`$ diff -u0 <(go list github.com/juju/juju/... | sort) <(make test-packages)`
```diff
--- /proc/self/fd/11	2025-04-30 20:48:47.392186956 +1000
+++ /proc/self/fd/12	2025-04-30 20:48:47.393186985 +1000
@@ -1 +0,0 @@
-github.com/juju/juju
@@ -5 +3,0 @@
-github.com/juju/juju/agent/constants
@@ -9,2 +6,0 @@
-github.com/juju/juju/api/agent/caasadmission
-github.com/juju/juju/api/agent/caasagent
@@ -16 +11,0 @@
-github.com/juju/juju/api/agent/fanconfigurer
@@ -19 +13,0 @@
-github.com/juju/juju/api/agent/instancemutater/mocks
@@ -22 +15,0 @@
-github.com/juju/juju/api/agent/lifeflag
@@ -31 +23,0 @@
-github.com/juju/juju/api/agent/provisioner/mocks
@@ -36 +27,0 @@
-github.com/juju/juju/api/agent/secretsdrain/mocks
@@ -44,3 +34,0 @@
-github.com/juju/juju/api/base
-github.com/juju/juju/api/base/mocks
-github.com/juju/juju/api/base/testing
@@ -67 +54,0 @@
-github.com/juju/juju/api/client/modelupgrader/mocks
@@ -83 +69,0 @@
-github.com/juju/juju/api/common/secretbackends/mocks
@@ -85,2 +70,0 @@
-github.com/juju/juju/api/common/secretsdrain/mocks
-github.com/juju/juju/api/common/stream
@@ -97 +80,0 @@
-github.com/juju/juju/api/controller/charmdownloader
@@ -108 +90,0 @@
-github.com/juju/juju/api/controller/lifeflag
@@ -124 +105,0 @@
-github.com/juju/juju/api/controller/usersecretsdrain/mocks
@@ -126 +106,0 @@
-github.com/juju/juju/api/http/mocks
@@ -133,2 +112,0 @@
-github.com/juju/juju/apiserver/authentication/macaroon
-github.com/juju/juju/apiserver/bakeryutil
@@ -136 +113,0 @@
-github.com/juju/juju/apiserver/common/apihttp
@@ -138 +114,0 @@
-github.com/juju/juju/apiserver/common/charms/mocks
@@ -141 +116,0 @@
-github.com/juju/juju/apiserver/common/credentialcommon/mocks
@@ -143 +117,0 @@
-github.com/juju/juju/apiserver/common/crossmodel/mocks
@@ -146 +119,0 @@
-github.com/juju/juju/apiserver/common/mocks
@@ -148 +120,0 @@
-github.com/juju/juju/apiserver/common/networkingcommon/mocks
@@ -150 +121,0 @@
-github.com/juju/juju/apiserver/common/secrets/mocks
@@ -152 +122,0 @@
-github.com/juju/juju/apiserver/common/testing
@@ -156,3 +125,0 @@
-github.com/juju/juju/apiserver/facade/facadetest
-github.com/juju/juju/apiserver/facade/mocks
-github.com/juju/juju/apiserver/facades
@@ -160 +126,0 @@
-github.com/juju/juju/apiserver/facades/agent/caasadmission
@@ -170 +135,0 @@
-github.com/juju/juju/apiserver/facades/agent/instancemutater/mocks
@@ -173 +137,0 @@
-github.com/juju/juju/apiserver/facades/agent/lifeflag
@@ -178,2 +141,0 @@
-github.com/juju/juju/apiserver/facades/agent/meterstatus/mocks
-github.com/juju/juju/apiserver/facades/agent/meterstatus/testing
@@ -182 +143,0 @@
-github.com/juju/juju/apiserver/facades/agent/metricsender/testing
@@ -187 +147,0 @@
-github.com/juju/juju/apiserver/facades/agent/provisioner/mocks
@@ -193 +152,0 @@
-github.com/juju/juju/apiserver/facades/agent/secretsdrain/mocks
@@ -195 +153,0 @@
-github.com/juju/juju/apiserver/facades/agent/secretsmanager/mocks
@@ -201 +158,0 @@
-github.com/juju/juju/apiserver/facades/agent/uniter/mocks
@@ -205 +161,0 @@
-github.com/juju/juju/apiserver/facades/agent/upgradesteps/mocks
@@ -209 +164,0 @@
-github.com/juju/juju/apiserver/facades/client/application/mocks
@@ -215,2 +169,0 @@
-github.com/juju/juju/apiserver/facades/client/charms/interfaces
-github.com/juju/juju/apiserver/facades/client/charms/mocks
@@ -218 +170,0 @@
-github.com/juju/juju/apiserver/facades/client/charms/services/mocks
@@ -220,2 +171,0 @@
-github.com/juju/juju/apiserver/facades/client/client/mocks
-github.com/juju/juju/apiserver/facades/client/client/testing
@@ -223 +172,0 @@
-github.com/juju/juju/apiserver/facades/client/cloud/mocks
@@ -225 +173,0 @@
-github.com/juju/juju/apiserver/facades/client/controller/mocks
@@ -230,2 +177,0 @@
-github.com/juju/juju/apiserver/facades/client/keymanager/mocks
-github.com/juju/juju/apiserver/facades/client/keymanager/testing
@@ -233 +178,0 @@
-github.com/juju/juju/apiserver/facades/client/machinemanager/mocks
@@ -236 +180,0 @@
-github.com/juju/juju/apiserver/facades/client/modelconfig/mocks
@@ -238 +181,0 @@
-github.com/juju/juju/apiserver/facades/client/modelgeneration/mocks
@@ -240 +182,0 @@
-github.com/juju/juju/apiserver/facades/client/modelmanager/mocks
@@ -242 +183,0 @@
-github.com/juju/juju/apiserver/facades/client/modelupgrader/mocks
@@ -245 +185,0 @@
-github.com/juju/juju/apiserver/facades/client/resources/mocks
@@ -247 +186,0 @@
-github.com/juju/juju/apiserver/facades/client/secretbackends/mocks
@@ -249 +187,0 @@
-github.com/juju/juju/apiserver/facades/client/secrets/mocks
@@ -252 +189,0 @@
-github.com/juju/juju/apiserver/facades/client/sshclient/mocks
@@ -255 +191,0 @@
-github.com/juju/juju/apiserver/facades/client/subnets/mocks
@@ -263 +198,0 @@
-github.com/juju/juju/apiserver/facades/controller/caasmodelconfigmanager/mocks
@@ -269 +203,0 @@
-github.com/juju/juju/apiserver/facades/controller/charmdownloader/mocks
@@ -271 +204,0 @@
-github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater/mocks
@@ -276 +208,0 @@
-github.com/juju/juju/apiserver/facades/controller/crossmodelsecrets/mocks
@@ -280 +211,0 @@
-github.com/juju/juju/apiserver/facades/controller/firewaller/mocks
@@ -288 +218,0 @@
-github.com/juju/juju/apiserver/facades/controller/migrationmaster/mocks
@@ -291 +220,0 @@
-github.com/juju/juju/apiserver/facades/controller/remoterelations/mocks
@@ -293 +221,0 @@
-github.com/juju/juju/apiserver/facades/controller/secretbackendmanager/mocks
@@ -301,2 +228,0 @@
-github.com/juju/juju/apiserver/facades/controller/usersecretsdrain/mocks
-github.com/juju/juju/apiserver/facades/controller/usersecrets/mocks
@@ -306,2 +231,0 @@
-github.com/juju/juju/apiserver/logsink/mocks
-github.com/juju/juju/apiserver/mocks
@@ -309 +232,0 @@
-github.com/juju/juju/apiserver/observer/fakeobserver
@@ -311 +233,0 @@
-github.com/juju/juju/apiserver/observer/metricobserver/mocks
@@ -314,4 +235,0 @@
-github.com/juju/juju/apiserver/testserver
-github.com/juju/juju/apiserver/websocket
-github.com/juju/juju/apiserver/websocket/websockettest
-github.com/juju/juju/api/testing
@@ -320 +237,0 @@
-github.com/juju/juju/caas/kubernetes
@@ -326 +242,0 @@
-github.com/juju/juju/caas/kubernetes/provider/constants
@@ -328,3 +243,0 @@
-github.com/juju/juju/caas/kubernetes/provider/exec/mocks
-github.com/juju/juju/caas/kubernetes/provider/mocks
-github.com/juju/juju/caas/kubernetes/provider/pebble
@@ -333 +245,0 @@
-github.com/juju/juju/caas/kubernetes/provider/resources/mocks
@@ -336 +247,0 @@
-github.com/juju/juju/caas/kubernetes/provider/specs/mocks
@@ -338 +248,0 @@
-github.com/juju/juju/caas/kubernetes/provider/testing
@@ -340,3 +249,0 @@
-github.com/juju/juju/caas/kubernetes/provider/watcher
-github.com/juju/juju/caas/kubernetes/provider/watcher/test
-github.com/juju/juju/caas/mocks
@@ -350 +256,0 @@
-github.com/juju/juju/cloudconfig/cloudinit/cloudinittest
@@ -358,2 +263,0 @@
-github.com/juju/juju/cmd/cmdtest
-github.com/juju/juju/cmd/constants
@@ -361 +264,0 @@
-github.com/juju/juju/cmd/containeragent/config
@@ -363 +265,0 @@
-github.com/juju/juju/cmd/containeragent/initialize/mocks
@@ -365,2 +266,0 @@
-github.com/juju/juju/cmd/containeragent/utils
-github.com/juju/juju/cmd/containeragent/utils/mocks
@@ -368 +267,0 @@
-github.com/juju/juju/cmd/juju
@@ -374 +272,0 @@
-github.com/juju/juju/cmd/juju/application/bundle/mocks
@@ -376,2 +273,0 @@
-github.com/juju/juju/cmd/juju/application/deployer/mocks
-github.com/juju/juju/cmd/juju/application/mocks
@@ -380 +275,0 @@
-github.com/juju/juju/cmd/juju/application/store/mocks
@@ -382 +276,0 @@
-github.com/juju/juju/cmd/juju/application/utils/mocks
@@ -385 +278,0 @@
-github.com/juju/juju/cmd/jujuc
@@ -387 +279,0 @@
-github.com/juju/juju/cmd/juju/caas/mocks
@@ -389 +280,0 @@
-github.com/juju/juju/cmd/juju/charmhub/mocks
@@ -391 +281,0 @@
-github.com/juju/juju/cmd/juju/cloud/mocks
@@ -393 +282,0 @@
-github.com/juju/juju/cmd/juju/commands/mocks
@@ -398 +286,0 @@
-github.com/juju/juju/cmd/jujud
@@ -401 +288,0 @@
-github.com/juju/juju/cmd/jujud/agent/agenttest
@@ -403 +289,0 @@
-github.com/juju/juju/cmd/jujud/agent/config
@@ -405 +290,0 @@
-github.com/juju/juju/cmd/jujud/agent/engine/enginetest
@@ -408 +292,0 @@
-github.com/juju/juju/cmd/jujud/agent/mocks
@@ -412 +295,0 @@
-github.com/juju/juju/cmd/jujud/dumplogs
@@ -415 +297,0 @@
-github.com/juju/juju/cmd/jujud/reboot/mocks
@@ -421 +302,0 @@
-github.com/juju/juju/cmd/juju/machine/mocks
@@ -424 +304,0 @@
-github.com/juju/juju/cmd/juju/model/mocks
@@ -428 +307,0 @@
-github.com/juju/juju/cmd/juju/secretbackends/mocks
@@ -430 +308,0 @@
-github.com/juju/juju/cmd/juju/secrets/mocks
@@ -433 +310,0 @@
-github.com/juju/juju/cmd/juju/space/mocks
@@ -435 +311,0 @@
-github.com/juju/juju/cmd/juju/ssh/mocks
@@ -442 +317,0 @@
-github.com/juju/juju/cmd/juju/waitfor/api/mocks
@@ -445 +319,0 @@
-github.com/juju/juju/cmd/modelcmd/mocks
@@ -448 +321,0 @@
-github.com/juju/juju/cmd/output/progress/mocks
@@ -450,2 +322,0 @@
-github.com/juju/juju/cmd/service
-github.com/juju/juju/common/sender
@@ -454 +324,0 @@
-github.com/juju/juju/container/broker/mocks
@@ -459 +328,0 @@
-github.com/juju/juju/container/kvm/testing
@@ -461 +329,0 @@
-github.com/juju/juju/container/lxd/mocks
@@ -463 +330,0 @@
-github.com/juju/juju/container/testing
@@ -465 +331,0 @@
-github.com/juju/juju/controller/authentication
@@ -467,2 +332,0 @@
-github.com/juju/juju/core
-github.com/juju/juju/core/actions
@@ -477,2 +340,0 @@
-github.com/juju/juju/core/cache/cachetest
-github.com/juju/juju/core/changestream
@@ -481,2 +342,0 @@
-github.com/juju/juju/core/charm/downloader/mocks
-github.com/juju/juju/core/charm/metrics
@@ -484 +343,0 @@
-github.com/juju/juju/core/charm/repository/mocks
@@ -488,2 +346,0 @@
-github.com/juju/juju/core/context
-github.com/juju/juju/core/controller
@@ -491 +347,0 @@
-github.com/juju/juju/core/database
@@ -494 +349,0 @@
-github.com/juju/juju/core/globalclock
@@ -496,3 +350,0 @@
-github.com/juju/juju/core/leadership
-github.com/juju/juju/core/leadership/mocks
-github.com/juju/juju/core/lease
@@ -501 +352,0 @@
-github.com/juju/juju/core/logger/mocks
@@ -503,2 +353,0 @@
-github.com/juju/juju/core/lxdprofile/mocks
-github.com/juju/juju/core/macaroon
@@ -513 +361,0 @@
-github.com/juju/juju/core/paths
@@ -519 +366,0 @@
-github.com/juju/juju/core/relation
@@ -521 +367,0 @@
-github.com/juju/juju/core/resources/testing
@@ -528 +373,0 @@
-github.com/juju/juju/core/watcher/watchertest
@@ -531,5 +375,0 @@
-github.com/juju/juju/database/app
-github.com/juju/juju/database/client
-github.com/juju/juju/database/dqlite
-github.com/juju/juju/database/driver
-github.com/juju/juju/database/pragma
@@ -537 +376,0 @@
-github.com/juju/juju/database/testing
@@ -543,2 +381,0 @@
-github.com/juju/juju/docker/registry/internal/mocks
-github.com/juju/juju/docker/registry/mocks
@@ -551 +387,0 @@
-github.com/juju/juju/environs/context/mocks
@@ -555 +390,0 @@
-github.com/juju/juju/environs/imagemetadata/testing
@@ -557 +391,0 @@
-github.com/juju/juju/environs/instances/instancetest
@@ -561,2 +394,0 @@
-github.com/juju/juju/environs/mocks
-github.com/juju/juju/environs/models
@@ -564 +395,0 @@
-github.com/juju/juju/environs/simplestreams/testing
@@ -571,3 +401,0 @@
-github.com/juju/juju/environs/tools/testing
-github.com/juju/juju/environs/utils
-github.com/juju/juju/feature
@@ -575,6 +402,0 @@
-github.com/juju/juju/generate
-github.com/juju/juju/generate/certgen
-github.com/juju/juju/generate/filetoconst
-github.com/juju/juju/generate/schemagen
-github.com/juju/juju/generate/schemagen/gen
-github.com/juju/juju/internal/debug/coveruploader
@@ -598 +419,0 @@
-github.com/juju/juju/internal/worker/caasapplicationprovisioner/mocks
@@ -603 +423,0 @@
-github.com/juju/juju/internal/worker/caasfirewallersidecar/mocks
@@ -605 +424,0 @@
-github.com/juju/juju/internal/worker/caasmodelconfigmanager/mocks
@@ -608 +426,0 @@
-github.com/juju/juju/internal/worker/caasoperator/mocks
@@ -614 +431,0 @@
-github.com/juju/juju/internal/worker/caasrbacmapper/test
@@ -617 +433,0 @@
-github.com/juju/juju/internal/worker/caasunitsmanager/mocks
@@ -626 +441,0 @@
-github.com/juju/juju/internal/worker/charmdownloader/mocks
@@ -630 +444,0 @@
-github.com/juju/juju/internal/worker/common/charmrunner
@@ -633 +446,0 @@
-github.com/juju/juju/internal/worker/containerbroker/mocks
@@ -653 +465,0 @@
-github.com/juju/juju/internal/worker/instancemutater/mocks
@@ -655 +466,0 @@
-github.com/juju/juju/internal/worker/instancepoller/mocks
@@ -657 +467,0 @@
-github.com/juju/juju/internal/worker/introspection/pprof
@@ -669 +478,0 @@
-github.com/juju/juju/internal/worker/logsender/logsendertest
@@ -671 +479,0 @@
-github.com/juju/juju/internal/worker/machineactions/mocks
@@ -675 +482,0 @@
-github.com/juju/juju/internal/worker/meterstatus/mocks
@@ -683 +489,0 @@
-github.com/juju/juju/internal/worker/mocks
@@ -687 +492,0 @@
-github.com/juju/juju/internal/worker/multiwatcher/testbacking
@@ -692 +496,0 @@
-github.com/juju/juju/internal/worker/provisioner/mocks
@@ -695 +498,0 @@
-github.com/juju/juju/internal/worker/pruner/mocks
@@ -701 +503,0 @@
-github.com/juju/juju/internal/worker/s3caller
@@ -703 +504,0 @@
-github.com/juju/juju/internal/worker/secretbackendrotate/mocks
@@ -705 +505,0 @@
-github.com/juju/juju/internal/worker/secretexpire/mocks
@@ -707 +506,0 @@
-github.com/juju/juju/internal/worker/secretrotate/mocks
@@ -709 +507,0 @@
-github.com/juju/juju/internal/worker/secretsdrainworker/mocks
@@ -711 +508,0 @@
-github.com/juju/juju/internal/worker/secretspruner/mocks
@@ -715 +511,0 @@
-github.com/juju/juju/internal/worker/sshtunneler
@@ -719 +514,0 @@
-github.com/juju/juju/internal/worker/stateconverter/mocks
@@ -731 +525,0 @@
-github.com/juju/juju/internal/worker/uniter/charm/mocks
@@ -736,2 +529,0 @@
-github.com/juju/juju/internal/worker/uniter/operation/mocks
-github.com/juju/juju/internal/worker/uniter/reboot
@@ -739 +530,0 @@
-github.com/juju/juju/internal/worker/uniter/relation/mocks
@@ -745 +535,0 @@
-github.com/juju/juju/internal/worker/uniter/runner/context/mocks
@@ -750,4 +539,0 @@
-github.com/juju/juju/internal/worker/uniter/runner/jujuc/jujuctesting
-github.com/juju/juju/internal/worker/uniter/runner/jujuc/mocks
-github.com/juju/juju/internal/worker/uniter/runner/mocks
-github.com/juju/juju/internal/worker/uniter/runner/testing
@@ -755 +540,0 @@
-github.com/juju/juju/internal/worker/uniter/secrets/mocks
@@ -760 +544,0 @@
-github.com/juju/juju/internal/worker/upgradedatabase/mocks
@@ -763 +546,0 @@
-github.com/juju/juju/internal/worker/upgradeseries/mocks
@@ -767,3 +549,0 @@
-github.com/juju/juju/jujuclient/jujuclienttesting
-github.com/juju/juju/juju/keys
-github.com/juju/juju/juju/names
@@ -772 +551,0 @@
-github.com/juju/juju/juju/testing
@@ -778 +556,0 @@
-github.com/juju/juju/mongo/mongotest
@@ -786 +563,0 @@
-github.com/juju/juju/network/ssh/testing
@@ -789 +565,0 @@
-github.com/juju/juju/packaging/dependency
@@ -793 +568,0 @@
-github.com/juju/juju/pki/test
@@ -795 +569,0 @@
-github.com/juju/juju/provider/all
@@ -797 +570,0 @@
-github.com/juju/juju/provider/azure/internal/armtemplates
@@ -800 +572,0 @@
-github.com/juju/juju/provider/azure/internal/azuretesting
@@ -804 +575,0 @@
-github.com/juju/juju/provider/azure/internal/tracing
@@ -806 +576,0 @@
-github.com/juju/juju/provider/common/mocks
@@ -809 +578,0 @@
-github.com/juju/juju/provider/ec2/internal/testing
@@ -811 +579,0 @@
-github.com/juju/juju/provider/equinix/mocks
@@ -815 +582,0 @@
-github.com/juju/juju/provider/lxd/lxdnames
@@ -820 +586,0 @@
-github.com/juju/juju/provider/oci/testing
@@ -823 +588,0 @@
-github.com/juju/juju/provider/vsphere/internal/ovatest
@@ -825,2 +589,0 @@
-github.com/juju/juju/provider/vsphere/mocks
-github.com/juju/juju/proxy
@@ -828,4 +590,0 @@
-github.com/juju/juju/proxy/factory
-github.com/juju/juju/proxy/testing
-github.com/juju/juju/pubsub/agent
-github.com/juju/juju/pubsub/apiserver
@@ -833,4 +591,0 @@
-github.com/juju/juju/pubsub/common
-github.com/juju/juju/pubsub/controller
-github.com/juju/juju/pubsub/forwarder
-github.com/juju/juju/pubsub/lease
@@ -838 +592,0 @@
-github.com/juju/juju/resource/mocks
@@ -842,16 +595,0 @@
-github.com/juju/juju/scripts/charmhub
-github.com/juju/juju/scripts/dqlite/cmd
-github.com/juju/juju/scripts/facadecheck
-github.com/juju/juju/scripts/generate-password
-github.com/juju/juju/scripts/import-inspector
-github.com/juju/juju/scripts/juju-blobstore-cleanup
-github.com/juju/juju/scripts/juju-force-upgrade
-github.com/juju/juju/scripts/juju-inspect
-github.com/juju/juju/scripts/juju-inspect/rules
-github.com/juju/juju/scripts/juju-leasediff
-github.com/juju/juju/scripts/juju-list-blobstore
-github.com/juju/juju/scripts/leadershipclaimer
-github.com/juju/juju/scripts/md-gen/controller-config
-github.com/juju/juju/scripts/md-gen/hook-commands
-github.com/juju/juju/scripts/md-gen/version-notice
-github.com/juju/juju/scripts/mgo-run-txn
@@ -859,2 +596,0 @@
-github.com/juju/juju/scripts/ssh-keycheck
-github.com/juju/juju/scripts/try-merge
@@ -862 +597,0 @@
-github.com/juju/juju/secrets/mocks
@@ -865 +599,0 @@
-github.com/juju/juju/secrets/provider/juju
@@ -867 +600,0 @@
-github.com/juju/juju/secrets/provider/kubernetes/mocks
@@ -869 +601,0 @@
-github.com/juju/juju/secrets/provider/vault/mocks
@@ -872,3 +603,0 @@
-github.com/juju/juju/service/mocks
-github.com/juju/juju/service/pebble/identity
-github.com/juju/juju/service/pebble/plan
@@ -877 +605,0 @@
-github.com/juju/juju/service/systemd/testing
@@ -880 +607,0 @@
-github.com/juju/juju/state/backups/testing
@@ -884,2 +610,0 @@
-github.com/juju/juju/state/errors
-github.com/juju/juju/state/mgo
@@ -887 +611,0 @@
-github.com/juju/juju/state/mocks
@@ -890 +613,0 @@
-github.com/juju/juju/state/testing
@@ -892 +614,0 @@
-github.com/juju/juju/state/watcher/watchertest
@@ -895,4 +616,0 @@
-github.com/juju/juju/storage/plans
-github.com/juju/juju/storage/plans/common
-github.com/juju/juju/storage/plans/iscsi
-github.com/juju/juju/storage/plans/local
@@ -901,4 +618,0 @@
-github.com/juju/juju/storage/provider/dummy
-github.com/juju/juju/testcharms
-github.com/juju/juju/testcharms/charm-hub/charms/juju-qa-test-resources/resource
-github.com/juju/juju/testcharms/repo
@@ -909 +622,0 @@
-github.com/juju/juju/upgrades/mocks
@@ -911 +623,0 @@
-github.com/juju/juju/upgrades/upgradevalidation/mocks
@@ -917 +628,0 @@
-github.com/juju/juju/version/helper
```

## Links

https://github.com/juju/juju/pull/19646#discussion_r2068391176
