### PR TITLE
feat(machine): use `machine.UUID` instead of `string`

### DIFF
--- a/apiserver/common/instanceidgetter.go
+++ b/apiserver/common/instanceidgetter.go
@@ -20,9 +20,9 @@ import (
 // service.
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, mUUID machine.UUID) (instance.Id, error)
 }
 
 // InstanceIdGetter implements a common InstanceId method for use by

--- a/apiserver/common/instanceidgetter_test.go
+++ b/apiserver/common/instanceidgetter_test.go
@@ -44,11 +44,11 @@ func (s *instanceIdGetterSuite) TestInstanceId(c *gc.C) {
 		}, nil
 	}
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("x/0")).Return("uuid-0", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid-0").Return("foo", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid-0")).Return("foo", nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("x/2")).Return("uuid-2", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid-2").Return("", errors.New("x2 error"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid-2")).Return("", errors.New("x2 error"))
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("x/3")).Return("uuid-3", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid-3").Return("", errors.New("x3 error"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid-3")).Return("", errors.New("x3 error"))
 	ig := common.NewInstanceIdGetter(s.machineService, getCanRead)
 	entities := params.Entities{Entities: []params.Entity{
 		{Tag: "unit-x-0"}, {Tag: "unit-x-1"}, {Tag: "unit-x-2"}, {Tag: "unit-x-3"}, {Tag: "unit-x-4"},

--- a/apiserver/common/machinereboot.go
+++ b/apiserver/common/machinereboot.go
@@ -18,20 +18,20 @@ import (
 // MachineRebootService is an interface that defines methods for managing machine reboots.
 type MachineRebootService interface {
 	// RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
-	RequireMachineReboot(ctx context.Context, uuid string) error
+	RequireMachineReboot(ctx context.Context, uuid machine.UUID) error
 
 	// ClearMachineReboot removes the reboot flag of the machine referenced by its UUID if a reboot has previously been required.
-	ClearMachineReboot(ctx context.Context, uuid string) error
+	ClearMachineReboot(ctx context.Context, uuid machine.UUID) error
 
 	// IsMachineRebootRequired checks if the machine referenced by its UUID requires a reboot.
-	IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error)
+	IsMachineRebootRequired(ctx context.Context, uuid machine.UUID) (bool, error)
 
 	// ShouldRebootOrShutdown determines whether a machine should reboot or shutdown
-	ShouldRebootOrShutdown(ctx context.Context, uuid string) (machine.RebootAction, error)
+	ShouldRebootOrShutdown(ctx context.Context, uuid machine.UUID) (machine.RebootAction, error)
 
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	// It returns an errors.MachineNotFound if the machine does not exist.
-	GetMachineUUID(ctx context.Context, machineName machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, machineName machine.Name) (machine.UUID, error)
 }
 
 // RebootRequester implements the RequestReboot API method

--- a/apiserver/common/machinereboot_test.go
+++ b/apiserver/common/machinereboot_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	cmachine "github.com/juju/juju/core/machine"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
 )
@@ -94,13 +94,13 @@ func (s *MachineRebootTestSuite) TestRebootRequested(c *gc.C) {
 	expect := s.mockRebootService.EXPECT()
 
 	gomock.InOrder(
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/nouuid/0")).Return("", errors.New("machine not found")),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/nouuid/0")).Return("", errors.New("machine not found")),
 
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/requestfailed/0")).Return("requestfailed-uuid", nil),
-		expect.RequireMachineReboot(gomock.Any(), "requestfailed-uuid").Return(errors.New("request failed")),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/requestfailed/0")).Return("requestfailed-uuid", nil),
+		expect.RequireMachineReboot(gomock.Any(), coremachine.UUID("requestfailed-uuid")).Return(errors.New("request failed")),
 
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/autorized/0")).Return("authorized-uuid", nil),
-		expect.RequireMachineReboot(gomock.Any(), "authorized-uuid").Return(nil /* no error */),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/autorized/0")).Return("authorized-uuid", nil),
+		expect.RequireMachineReboot(gomock.Any(), coremachine.UUID("authorized-uuid")).Return(nil /* no error */),
 	)
 
 	// Act
@@ -181,19 +181,19 @@ func (s *MachineRebootTestSuite) TestRebootActionGet(c *gc.C) {
 	expect := s.mockRebootService.EXPECT()
 
 	gomock.InOrder(
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/nouuid/0")).Return("", errors.New("machine not found")),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/nouuid/0")).Return("", errors.New("machine not found")),
 
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/getfailed/0")).Return("getfailed-uuid", nil),
-		expect.ShouldRebootOrShutdown(gomock.Any(), "getfailed-uuid").Return("", errors.New("request failed")),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/getfailed/0")).Return("getfailed-uuid", nil),
+		expect.ShouldRebootOrShutdown(gomock.Any(), coremachine.UUID("getfailed-uuid")).Return("", errors.New("request failed")),
 
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/autorizedreboot/0")).Return("autorizedreboot-uuid", nil),
-		expect.ShouldRebootOrShutdown(gomock.Any(), "autorizedreboot-uuid").Return(cmachine.ShouldReboot, nil /* no error */),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/autorizedreboot/0")).Return("autorizedreboot-uuid", nil),
+		expect.ShouldRebootOrShutdown(gomock.Any(), coremachine.UUID("autorizedreboot-uuid")).Return(coremachine.ShouldReboot, nil /* no error */),
 
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/autorizedshutdown/0")).Return("autorizedshutdown-uuid", nil),
-		expect.ShouldRebootOrShutdown(gomock.Any(), "autorizedshutdown-uuid").Return(cmachine.ShouldShutdown, nil /* no error */),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/autorizedshutdown/0")).Return("autorizedshutdown-uuid", nil),
+		expect.ShouldRebootOrShutdown(gomock.Any(), coremachine.UUID("autorizedshutdown-uuid")).Return(coremachine.ShouldShutdown, nil /* no error */),
 
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/autorizeddonothing/0")).Return("autorizeddonothing-uuid", nil),
-		expect.ShouldRebootOrShutdown(gomock.Any(), "autorizeddonothing-uuid").Return(cmachine.ShouldDoNothing, nil /* no error */),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/autorizeddonothing/0")).Return("autorizeddonothing-uuid", nil),
+		expect.ShouldRebootOrShutdown(gomock.Any(), coremachine.UUID("autorizeddonothing-uuid")).Return(coremachine.ShouldDoNothing, nil /* no error */),
 	)
 
 	// Act
@@ -274,13 +274,13 @@ func (s *MachineRebootTestSuite) TestRebootCleared(c *gc.C) {
 
 	expect := s.mockRebootService.EXPECT()
 	gomock.InOrder(
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/nouuid/0")).Return("", errors.New("machine not found")),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/nouuid/0")).Return("", errors.New("machine not found")),
 
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/requestfailed/0")).Return("requestfailed-uuid", nil),
-		expect.ClearMachineReboot(gomock.Any(), "requestfailed-uuid").Return(errors.New("request failed")),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/requestfailed/0")).Return("requestfailed-uuid", nil),
+		expect.ClearMachineReboot(gomock.Any(), coremachine.UUID("requestfailed-uuid")).Return(errors.New("request failed")),
 
-		expect.GetMachineUUID(gomock.Any(), cmachine.Name("42/autorized/0")).Return("authorized-uuid", nil),
-		expect.ClearMachineReboot(gomock.Any(), "authorized-uuid").Return(nil /* no error */),
+		expect.GetMachineUUID(gomock.Any(), coremachine.Name("42/autorized/0")).Return("authorized-uuid", nil),
+		expect.ClearMachineReboot(gomock.Any(), coremachine.UUID("authorized-uuid")).Return(nil /* no error */),
 	)
 
 	// Act

--- a/apiserver/common/machinewatcher.go
+++ b/apiserver/common/machinewatcher.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/internal"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
 )
@@ -23,7 +24,7 @@ type WatchableMachineService interface {
 	// WatchMachineReboot returns a NotifyWatcher that is subscribed to
 	// the changes in the machine_requires_reboot table in the model.
 	// It raises an event whenever the machine uuid or its parent is added to the reboot table.
-	WatchMachineReboot(ctx context.Context, uuid string) (watcher.NotifyWatcher, error)
+	WatchMachineReboot(ctx context.Context, uuid coremachine.UUID) (watcher.NotifyWatcher, error)
 }
 
 // MachineWatcher is a struct that represents a watcher for various events produced by a specific
@@ -40,7 +41,7 @@ type MachineWatcher struct {
 // a string representation of the machine UUID and an error. It allows to smuggle machine
 // identification to the watcher, because retrieving the machine UUID implies a machine service calls
 // which requires a context.
-type GetMachineUUID func(context.Context) (string, error)
+type GetMachineUUID func(context.Context) (coremachine.UUID, error)
 
 // NewMachineRebootWatcher creates a new MachineWatcher instance with the given dependencies.
 // It takes a WatchableMachineService, a facade.WatcherRegistry, and a GetMachineUUID function as input.

--- a/apiserver/common/machinewatcher_test.go
+++ b/apiserver/common/machinewatcher_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/common/mocks"
 	"github.com/juju/juju/apiserver/facade"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/watcher/registry"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
@@ -44,7 +45,7 @@ func (s *MachineWatcherSuite) TestWatchForRebootEventCannotGetUUID(c *gc.C) {
 	// Arrange
 	defer s.setup(c).Finish()
 	errMachineNotFound := errors.New("machine not found")
-	getMachineUUID := func(ctx context.Context) (string, error) {
+	getMachineUUID := func(ctx context.Context) (machine.UUID, error) {
 		return "", errMachineNotFound
 	}
 	rebootWatcher := common.NewMachineRebootWatcher(s.mockWatchRebootService, s.watcherRegistry, getMachineUUID)
@@ -60,12 +61,12 @@ func (s *MachineWatcherSuite) TestWatchForRebootEventCannotGetUUID(c *gc.C) {
 func (s *MachineWatcherSuite) TestWatchForRebootEventErrorStartWatcher(c *gc.C) {
 	// Arrange
 	defer s.setup(c).Finish()
-	getMachineUUID := func(ctx context.Context) (string, error) {
+	getMachineUUID := func(ctx context.Context) (machine.UUID, error) {
 		return "machine-uuid", nil
 	}
 	rebootWatcher := common.NewMachineRebootWatcher(s.mockWatchRebootService, s.watcherRegistry, getMachineUUID)
 	errStartWatcher := errors.New("start watcher failed")
-	s.mockWatchRebootService.EXPECT().WatchMachineReboot(gomock.Any(), "machine-uuid").Return(nil, errStartWatcher)
+	s.mockWatchRebootService.EXPECT().WatchMachineReboot(gomock.Any(), machine.UUID("machine-uuid")).Return(nil, errStartWatcher)
 
 	// Act
 	_, err := rebootWatcher.WatchForRebootEvent(context.Background())
@@ -78,11 +79,11 @@ func (s *MachineWatcherSuite) TestWatchForRebootEventErrorStartWatcher(c *gc.C) 
 func (s *MachineWatcherSuite) TestWatchForRebootEvent(c *gc.C) {
 	// Arrange
 	defer s.setup(c).Finish()
-	getMachineUUID := func(ctx context.Context) (string, error) {
+	getMachineUUID := func(ctx context.Context) (machine.UUID, error) {
 		return "machine-uuid", nil
 	}
 	rebootWatcher := common.NewMachineRebootWatcher(s.mockWatchRebootService, s.watcherRegistry, getMachineUUID)
-	s.mockWatchRebootService.EXPECT().WatchMachineReboot(gomock.Any(), "machine-uuid").Return(apiservertesting.NewFakeNotifyWatcher(), nil)
+	s.mockWatchRebootService.EXPECT().WatchMachineReboot(gomock.Any(), machine.UUID("machine-uuid")).Return(apiservertesting.NewFakeNotifyWatcher(), nil)
 
 	// Act
 	result, err := rebootWatcher.WatchForRebootEvent(context.Background())

--- a/apiserver/common/mocks/common_mock.go
+++ b/apiserver/common/mocks/common_mock.go
@@ -912,7 +912,7 @@ func (m *MockMachineRebootService) EXPECT() *MockMachineRebootServiceMockRecorde
 }
 
 // ClearMachineReboot mocks base method.
-func (m *MockMachineRebootService) ClearMachineReboot(arg0 context.Context, arg1 string) error {
+func (m *MockMachineRebootService) ClearMachineReboot(arg0 context.Context, arg1 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearMachineReboot", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -938,22 +938,22 @@ func (c *MockMachineRebootServiceClearMachineRebootCall) Return(arg0 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineRebootServiceClearMachineRebootCall) Do(f func(context.Context, string) error) *MockMachineRebootServiceClearMachineRebootCall {
+func (c *MockMachineRebootServiceClearMachineRebootCall) Do(f func(context.Context, machine.UUID) error) *MockMachineRebootServiceClearMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineRebootServiceClearMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockMachineRebootServiceClearMachineRebootCall {
+func (c *MockMachineRebootServiceClearMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockMachineRebootServiceClearMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineRebootService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineRebootService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -971,25 +971,25 @@ type MockMachineRebootServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineRebootServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineRebootServiceGetMachineUUIDCall {
+func (c *MockMachineRebootServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineRebootServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineRebootServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineRebootServiceGetMachineUUIDCall {
+func (c *MockMachineRebootServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineRebootServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineRebootServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineRebootServiceGetMachineUUIDCall {
+func (c *MockMachineRebootServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineRebootServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // IsMachineRebootRequired mocks base method.
-func (m *MockMachineRebootService) IsMachineRebootRequired(arg0 context.Context, arg1 string) (bool, error) {
+func (m *MockMachineRebootService) IsMachineRebootRequired(arg0 context.Context, arg1 machine.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMachineRebootRequired", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -1016,19 +1016,19 @@ func (c *MockMachineRebootServiceIsMachineRebootRequiredCall) Return(arg0 bool, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineRebootServiceIsMachineRebootRequiredCall) Do(f func(context.Context, string) (bool, error)) *MockMachineRebootServiceIsMachineRebootRequiredCall {
+func (c *MockMachineRebootServiceIsMachineRebootRequiredCall) Do(f func(context.Context, machine.UUID) (bool, error)) *MockMachineRebootServiceIsMachineRebootRequiredCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineRebootServiceIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockMachineRebootServiceIsMachineRebootRequiredCall {
+func (c *MockMachineRebootServiceIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, machine.UUID) (bool, error)) *MockMachineRebootServiceIsMachineRebootRequiredCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RequireMachineReboot mocks base method.
-func (m *MockMachineRebootService) RequireMachineReboot(arg0 context.Context, arg1 string) error {
+func (m *MockMachineRebootService) RequireMachineReboot(arg0 context.Context, arg1 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequireMachineReboot", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1054,19 +1054,19 @@ func (c *MockMachineRebootServiceRequireMachineRebootCall) Return(arg0 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineRebootServiceRequireMachineRebootCall) Do(f func(context.Context, string) error) *MockMachineRebootServiceRequireMachineRebootCall {
+func (c *MockMachineRebootServiceRequireMachineRebootCall) Do(f func(context.Context, machine.UUID) error) *MockMachineRebootServiceRequireMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineRebootServiceRequireMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockMachineRebootServiceRequireMachineRebootCall {
+func (c *MockMachineRebootServiceRequireMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockMachineRebootServiceRequireMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ShouldRebootOrShutdown mocks base method.
-func (m *MockMachineRebootService) ShouldRebootOrShutdown(arg0 context.Context, arg1 string) (machine.RebootAction, error) {
+func (m *MockMachineRebootService) ShouldRebootOrShutdown(arg0 context.Context, arg1 machine.UUID) (machine.RebootAction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldRebootOrShutdown", arg0, arg1)
 	ret0, _ := ret[0].(machine.RebootAction)
@@ -1093,13 +1093,13 @@ func (c *MockMachineRebootServiceShouldRebootOrShutdownCall) Return(arg0 machine
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineRebootServiceShouldRebootOrShutdownCall) Do(f func(context.Context, string) (machine.RebootAction, error)) *MockMachineRebootServiceShouldRebootOrShutdownCall {
+func (c *MockMachineRebootServiceShouldRebootOrShutdownCall) Do(f func(context.Context, machine.UUID) (machine.RebootAction, error)) *MockMachineRebootServiceShouldRebootOrShutdownCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineRebootServiceShouldRebootOrShutdownCall) DoAndReturn(f func(context.Context, string) (machine.RebootAction, error)) *MockMachineRebootServiceShouldRebootOrShutdownCall {
+func (c *MockMachineRebootServiceShouldRebootOrShutdownCall) DoAndReturn(f func(context.Context, machine.UUID) (machine.RebootAction, error)) *MockMachineRebootServiceShouldRebootOrShutdownCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1189,7 +1189,7 @@ func (m *MockWatchableMachineService) EXPECT() *MockWatchableMachineServiceMockR
 }
 
 // WatchMachineReboot mocks base method.
-func (m *MockWatchableMachineService) WatchMachineReboot(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
+func (m *MockWatchableMachineService) WatchMachineReboot(arg0 context.Context, arg1 machine.UUID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchMachineReboot", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
@@ -1216,13 +1216,13 @@ func (c *MockWatchableMachineServiceWatchMachineRebootCall) Return(arg0 watcher.
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockWatchableMachineServiceWatchMachineRebootCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockWatchableMachineServiceWatchMachineRebootCall {
+func (c *MockWatchableMachineServiceWatchMachineRebootCall) Do(f func(context.Context, machine.UUID) (watcher.Watcher[struct{}], error)) *MockWatchableMachineServiceWatchMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockWatchableMachineServiceWatchMachineRebootCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockWatchableMachineServiceWatchMachineRebootCall {
+func (c *MockWatchableMachineServiceWatchMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) (watcher.Watcher[struct{}], error)) *MockWatchableMachineServiceWatchMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1351,10 +1351,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1372,25 +1372,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceID mocks base method.
-func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 string) (instance.Id, error) {
+func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 machine.UUID) (instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -1417,13 +1417,13 @@ func (c *MockMachineServiceInstanceIDCall) Return(arg0 instance.Id, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/common/model/machine_test.go
+++ b/apiserver/common/model/machine_test.go
@@ -58,11 +58,11 @@ func (s *machineSuite) TestMachineHardwareInfo(c *gc.C) {
 		},
 	}
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), "uuid-1").Return("123", "one-two-three", nil)
+	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "one-two-three", nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("uuid-2", nil)
-	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), "uuid-2").Return("456", "four-five-six", nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "uuid-1").Return(hw, nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "uuid-2").Return(&instance.HardwareCharacteristics{}, nil)
+	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("uuid-2")).Return("456", "four-five-six", nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(hw, nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("uuid-2")).Return(&instance.HardwareCharacteristics{}, nil)
 	info, err := model.ModelMachineInfo(context.Background(), &st, s.machineService)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, []params.ModelMachineInfo{
@@ -104,8 +104,8 @@ func (s *machineSuite) TestMachineMachineNotFound(c *gc.C) {
 		},
 	}
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), "uuid-1").Return("123", "one-two-three", nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "uuid-1").Return(hw, machineerrors.MachineNotFound)
+	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "one-two-three", nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(hw, machineerrors.MachineNotFound)
 	_, err := model.ModelMachineInfo(context.Background(), &st, s.machineService)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
@@ -165,11 +165,11 @@ func (s *machineSuite) TestMachineInstanceInfo(c *gc.C) {
 		},
 	}
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), "uuid-1").Return("123", "", nil)
+	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "", nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("uuid-2", nil)
-	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), "uuid-2").Return("456", "four-five-six", nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "uuid-1").Return(&instance.HardwareCharacteristics{}, nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "uuid-2").Return(&instance.HardwareCharacteristics{}, nil)
+	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("uuid-2")).Return("456", "four-five-six", nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(&instance.HardwareCharacteristics{}, nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("uuid-2")).Return(&instance.HardwareCharacteristics{}, nil)
 	info, err := model.ModelMachineInfo(context.Background(), &st, s.machineService)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, []params.ModelMachineInfo{
@@ -212,8 +212,8 @@ func (s *machineSuite) TestMachineInstanceInfoWithEmptyDisplayName(c *gc.C) {
 		},
 	}
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), "uuid-1").Return("123", "", nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "uuid-1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "", nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(&instance.HardwareCharacteristics{}, nil)
 	info, err := model.ModelMachineInfo(context.Background(), &st, s.machineService)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, []params.ModelMachineInfo{
@@ -249,8 +249,8 @@ func (s *machineSuite) TestMachineInstanceInfoWithSetDisplayName(c *gc.C) {
 		},
 	}
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), "uuid-1").Return("123", "snowflake", nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "uuid-1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "snowflake", nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(&instance.HardwareCharacteristics{}, nil)
 	info, err := model.ModelMachineInfo(context.Background(), &st, s.machineService)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, []params.ModelMachineInfo{
@@ -294,8 +294,8 @@ func (s *machineSuite) TestMachineInstanceInfoWithHAPrimary(c *gc.C) {
 		},
 	}
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), "uuid-1").Return("123", "snowflake", nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "uuid-1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.machineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "snowflake", nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(&instance.HardwareCharacteristics{}, nil)
 	info, err := model.ModelMachineInfo(context.Background(), &st, s.machineService)
 	c.Assert(err, jc.ErrorIsNil)
 	_true := true

--- a/apiserver/common/model/modelmanagerinterface.go
+++ b/apiserver/common/model/modelmanagerinterface.go
@@ -99,13 +99,13 @@ type Model interface {
 // service.
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// InstanceIDAndName returns the cloud specific instance ID and display name for
 	// this machine.
-	InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error)
+	InstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 }
 
 var _ ModelManagerBackend = (*modelManagerStateShim)(nil)

--- a/apiserver/common/model/service_mock_test.go
+++ b/apiserver/common/model/service_mock_test.go
@@ -44,10 +44,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -65,25 +65,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -110,19 +110,19 @@ func (c *MockMachineServiceHardwareCharacteristicsCall) Return(arg0 *instance.Ha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceIDAndName mocks base method.
-func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 string) (instance.Id, string, error) {
+func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 machine.UUID) (instance.Id, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceIDAndName", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -150,13 +150,13 @@ func (c *MockMachineServiceInstanceIDAndNameCall) Return(arg0 instance.Id, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -70,20 +70,20 @@ type ApplicationService interface {
 // MachineRebootService is an interface that defines methods for managing machine reboots.
 type MachineRebootService interface {
 	// RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
-	RequireMachineReboot(ctx context.Context, uuid string) error
+	RequireMachineReboot(ctx context.Context, uuid machine.UUID) error
 
 	// ClearMachineReboot removes the reboot flag of the machine referenced by its UUID if a reboot has previously been required.
-	ClearMachineReboot(ctx context.Context, uuid string) error
+	ClearMachineReboot(ctx context.Context, uuid machine.UUID) error
 
 	// IsMachineRebootRequired checks if the machine referenced by its UUID requires a reboot.
-	IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error)
+	IsMachineRebootRequired(ctx context.Context, uuid machine.UUID) (bool, error)
 
 	// ShouldRebootOrShutdown determines whether a machine should reboot or shutdown
-	ShouldRebootOrShutdown(ctx context.Context, uuid string) (machine.RebootAction, error)
+	ShouldRebootOrShutdown(ctx context.Context, uuid machine.UUID) (machine.RebootAction, error)
 
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	// It returns an errors.MachineNotFound if the machine does not exist.
-	GetMachineUUID(ctx context.Context, machineName machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, machineName machine.Name) (machine.UUID, error)
 }
 
 // ExternalControllerService defines the methods that the controller

--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -43,22 +43,22 @@ type InstanceMutaterV2 interface {
 // service.
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name coremachine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name coremachine.Name) (coremachine.UUID, error)
 
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, machineUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, machineUUID coremachine.UUID) (instance.Id, error)
 
 	// AppliedLXDProfileNames returns the names of the LXD profiles on the machine.
-	AppliedLXDProfileNames(ctx context.Context, machineUUID string) ([]string, error)
+	AppliedLXDProfileNames(ctx context.Context, machineUUID coremachine.UUID) ([]string, error)
 
 	// SetAppliedLXDProfileNames sets the list of LXD profile names to the
 	// lxd_profile table for the given machine. This method will overwrite the list
 	// of profiles for the given machine without any checks.
-	SetAppliedLXDProfileNames(ctx context.Context, machineUUID string, profileNames []string) error
+	SetAppliedLXDProfileNames(ctx context.Context, machineUUID coremachine.UUID, profileNames []string) error
 
 	// WatchLXDProfiles returns a NotifyWatcher that is subscribed to the changes in
 	// the machine_cloud_instance table in the model, for the given machine UUID.
-	WatchLXDProfiles(ctx context.Context, machineUUID string) (watcher.NotifyWatcher, error)
+	WatchLXDProfiles(ctx context.Context, machineUUID coremachine.UUID) (watcher.NotifyWatcher, error)
 }
 
 // ApplicationService is an interface for the application domain service.

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -267,8 +267,8 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfo(c *gc
 
 	s.machine.EXPECT().Id().Return("0")
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil)
-	s.machineService.EXPECT().AppliedLXDProfileNames(gomock.Any(), "uuid0").Return([]string{"charm-app-0"}, nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid0").Return("0", nil)
+	s.machineService.EXPECT().AppliedLXDProfileNames(gomock.Any(), machine.UUID("uuid0")).Return([]string{"charm-app-0"}, nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid0")).Return("0", nil)
 
 	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		Name: "foo",
@@ -316,8 +316,8 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithNo
 
 	s.machine.EXPECT().Id().Return("0")
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil)
-	s.machineService.EXPECT().AppliedLXDProfileNames(gomock.Any(), "uuid0").Return([]string{"charm-app-0"}, nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid0").Return("0", nil)
+	s.machineService.EXPECT().AppliedLXDProfileNames(gomock.Any(), machine.UUID("uuid0")).Return([]string{"charm-app-0"}, nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid0")).Return("0", nil)
 
 	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		Name: "foo",
@@ -378,7 +378,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithMa
 	facade := s.facadeAPIForScenario(c)
 	s.machine.EXPECT().Id().Return("0")
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid0").Return("", machineerrors.NotProvisioned)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid0")).Return("", machineerrors.NotProvisioned)
 
 	results, err := facade.CharmProfilingInfo(context.Background(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
@@ -491,7 +491,7 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfiles(c *gc.C) 
 	facade := s.facadeAPIForScenario(c)
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil)
-	s.machineService.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), "uuid0", profiles).Return(nil)
+	s.machineService.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), machine.UUID("uuid0"), profiles).Return(nil)
 
 	results, err := facade.SetCharmProfiles(context.Background(), params.SetProfileArgs{
 		Args: []params.SetProfileArg{
@@ -516,8 +516,8 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfilesWithError(
 	facade := s.facadeAPIForScenario(c)
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil).Times(2)
-	s.machineService.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), "uuid0", profiles).Return(nil)
-	s.machineService.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), "uuid0", profiles).Return(errors.New("Failure"))
+	s.machineService.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), machine.UUID("uuid0"), profiles).Return(nil)
+	s.machineService.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), machine.UUID("uuid0"), profiles).Return(errors.New("Failure"))
 
 	results, err := facade.SetCharmProfiles(context.Background(), params.SetProfileArgs{
 		Args: []params.SetProfileArg{

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
@@ -378,7 +378,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherMachineProvisioned(
 	s.setupScenarioWithProfile(c)
 	s.machine0.EXPECT().Id().Return("0")
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid0").Return("0", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid0")).Return("0", nil)
 	defer workertest.CleanKill(c, s.assertStartLxdProfileWatcher(c))
 
 	s.instanceChanges <- struct{}{}
@@ -407,7 +407,7 @@ func (s *lxdProfileWatcherSuite) setupWatchers(c *gc.C) {
 	s.state.EXPECT().WatchUnits().Return(s.unitsWatcher)
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil)
-	s.machineService.EXPECT().WatchLXDProfiles(gomock.Any(), "uuid0").Return(s.instanceWatcher, nil)
+	s.machineService.EXPECT().WatchLXDProfiles(gomock.Any(), machine.UUID("uuid0")).Return(s.instanceWatcher, nil)
 
 	s.applicationService.EXPECT().WatchCharms().Return(s.charmsWatcher, nil)
 

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -1090,7 +1090,7 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // AppliedLXDProfileNames mocks base method.
-func (m *MockMachineService) AppliedLXDProfileNames(arg0 context.Context, arg1 string) ([]string, error) {
+func (m *MockMachineService) AppliedLXDProfileNames(arg0 context.Context, arg1 machine.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppliedLXDProfileNames", arg0, arg1)
 	ret0, _ := ret[0].([]string)
@@ -1117,22 +1117,22 @@ func (c *MockMachineServiceAppliedLXDProfileNamesCall) Return(arg0 []string, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceAppliedLXDProfileNamesCall) Do(f func(context.Context, string) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
+func (c *MockMachineServiceAppliedLXDProfileNamesCall) Do(f func(context.Context, machine.UUID) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
+func (c *MockMachineServiceAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, machine.UUID) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1150,25 +1150,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceID mocks base method.
-func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 string) (instance.Id, error) {
+func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 machine.UUID) (instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -1195,19 +1195,19 @@ func (c *MockMachineServiceInstanceIDCall) Return(arg0 instance.Id, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetAppliedLXDProfileNames mocks base method.
-func (m *MockMachineService) SetAppliedLXDProfileNames(arg0 context.Context, arg1 string, arg2 []string) error {
+func (m *MockMachineService) SetAppliedLXDProfileNames(arg0 context.Context, arg1 machine.UUID, arg2 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAppliedLXDProfileNames", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1233,19 +1233,19 @@ func (c *MockMachineServiceSetAppliedLXDProfileNamesCall) Return(arg0 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceSetAppliedLXDProfileNamesCall) Do(f func(context.Context, string, []string) error) *MockMachineServiceSetAppliedLXDProfileNamesCall {
+func (c *MockMachineServiceSetAppliedLXDProfileNamesCall) Do(f func(context.Context, machine.UUID, []string) error) *MockMachineServiceSetAppliedLXDProfileNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceSetAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, string, []string) error) *MockMachineServiceSetAppliedLXDProfileNamesCall {
+func (c *MockMachineServiceSetAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, machine.UUID, []string) error) *MockMachineServiceSetAppliedLXDProfileNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchLXDProfiles mocks base method.
-func (m *MockMachineService) WatchLXDProfiles(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
+func (m *MockMachineService) WatchLXDProfiles(arg0 context.Context, arg1 machine.UUID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchLXDProfiles", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
@@ -1272,13 +1272,13 @@ func (c *MockMachineServiceWatchLXDProfilesCall) Return(arg0 watcher.Watcher[str
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceWatchLXDProfilesCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
+func (c *MockMachineServiceWatchLXDProfilesCall) Do(f func(context.Context, machine.UUID) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceWatchLXDProfilesCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
+func (c *MockMachineServiceWatchLXDProfilesCall) DoAndReturn(f func(context.Context, machine.UUID) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -66,18 +66,18 @@ type MachineService interface {
 	SetKeepInstance(ctx context.Context, machineName coremachine.Name, keep bool) error
 	// SetMachineCloudInstance sets an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
-	SetMachineCloudInstance(ctx context.Context, machineUUID string, instanceID instance.Id, displayName string, hardwareCharacteristics *instance.HardwareCharacteristics) error
+	SetMachineCloudInstance(ctx context.Context, machineUUID coremachine.UUID, instanceID instance.Id, displayName string, hardwareCharacteristics *instance.HardwareCharacteristics) error
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name coremachine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name coremachine.Name) (coremachine.UUID, error)
 	// SetAppliedLXDProfileNames sets the list of LXD profile names to the
 	// lxd_profile table for the given machine. This method will overwrite the list
 	// of profiles for the given machine without any checks.
-	SetAppliedLXDProfileNames(ctx context.Context, mUUID string, profileNames []string) error
+	SetAppliedLXDProfileNames(ctx context.Context, mUUID coremachine.UUID, profileNames []string) error
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID coremachine.UUID) (*instance.HardwareCharacteristics, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, mUUID coremachine.UUID) (instance.Id, error)
 }
 
 // StoragePoolGetter instances get a storage pool by name.

--- a/apiserver/facades/agent/reboot/reboot.go
+++ b/apiserver/facades/agent/reboot/reboot.go
@@ -61,7 +61,7 @@ func NewRebootAPI(
 		return nil, errors.Errorf("%q should be a %s", tag, names.MachineTagKind)
 	}
 
-	uuid := func(ctx context.Context) (string, error) {
+	uuid := func(ctx context.Context) (machine.UUID, error) {
 		uuid, err := machineService.GetMachineUUID(ctx, machine.Name(tag.Id()))
 		if err != nil {
 			return "", errors.Annotatef(err, "find machine uuid for machine %q", tag.Id())

--- a/apiserver/facades/agent/reboot/reboot_test.go
+++ b/apiserver/facades/agent/reboot/reboot_test.go
@@ -34,7 +34,7 @@ import (
 
 // testMachine is an helper struct to keep machine information during tests
 type testMachine struct {
-	uuid      string
+	uuid      coremachine.UUID
 	tag       names.Tag
 	rebootAPI *reboot.RebootAPI
 	args      params.Entities
@@ -75,7 +75,7 @@ func (s *rebootSuite) createMachineWithParent(c *gc.C, tag names.MachineTag, par
 	return s.setupMachine(c, tag, err, uuid)
 }
 
-func (s *rebootSuite) setupMachine(c *gc.C, tag names.MachineTag, err error, uuid string) *testMachine {
+func (s *rebootSuite) setupMachine(c *gc.C, tag names.MachineTag, err error, uuid coremachine.UUID) *testMachine {
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming we logged in as a machine agent.
 	authorizer := apiservertesting.FakeAuthorizer{

--- a/apiserver/facades/agent/storageprovisioner/service.go
+++ b/apiserver/facades/agent/storageprovisioner/service.go
@@ -36,15 +36,15 @@ type MachineService interface {
 	// gets updated.
 	EnsureDeadMachine(ctx context.Context, machineName machine.Name) error
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, mUUID machine.UUID) (instance.Id, error)
 	// InstanceIDAndName returns the cloud specific instance ID and display name for
 	// this machine.
-	InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error)
+	InstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 }
 
 // BlockDeviceService instances can fetch and watch block devices on a machine.

--- a/apiserver/facades/agent/unitassigner/unitassigner.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner.go
@@ -34,7 +34,7 @@ type assignerState interface {
 // MachineService is the interface that is used to interact with the machine
 // domain.
 type MachineService interface {
-	CreateMachine(context.Context, machine.Name) (string, error)
+	CreateMachine(context.Context, machine.Name) (machine.UUID, error)
 }
 
 // NetworkService is the interface that is used to interact with the

--- a/apiserver/facades/agent/unitassigner/unitassigner_test.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner_test.go
@@ -116,7 +116,7 @@ type fakeMachineService struct {
 	machineNames []machine.Name
 }
 
-func (f *fakeMachineService) CreateMachine(_ context.Context, machineName machine.Name) (string, error) {
+func (f *fakeMachineService) CreateMachine(_ context.Context, machineName machine.Name) (machine.UUID, error) {
 	f.machineNames = append(f.machineNames, machineName)
 	return "", nil
 }

--- a/apiserver/facades/agent/uniter/legacy_service_mock_test.go
+++ b/apiserver/facades/agent/uniter/legacy_service_mock_test.go
@@ -348,7 +348,7 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // AppliedLXDProfileNames mocks base method.
-func (m *MockMachineService) AppliedLXDProfileNames(arg0 context.Context, arg1 string) ([]string, error) {
+func (m *MockMachineService) AppliedLXDProfileNames(arg0 context.Context, arg1 machine.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppliedLXDProfileNames", arg0, arg1)
 	ret0, _ := ret[0].([]string)
@@ -375,19 +375,19 @@ func (c *MockMachineServiceAppliedLXDProfileNamesCall) Return(arg0 []string, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceAppliedLXDProfileNamesCall) Do(f func(context.Context, string) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
+func (c *MockMachineServiceAppliedLXDProfileNamesCall) Do(f func(context.Context, machine.UUID) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
+func (c *MockMachineServiceAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, machine.UUID) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // AvailabilityZone mocks base method.
-func (m *MockMachineService) AvailabilityZone(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockMachineService) AvailabilityZone(arg0 context.Context, arg1 machine.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZone", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -414,19 +414,19 @@ func (c *MockMachineServiceAvailabilityZoneCall) Return(arg0 string, arg1 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceAvailabilityZoneCall) Do(f func(context.Context, string) (string, error)) *MockMachineServiceAvailabilityZoneCall {
+func (c *MockMachineServiceAvailabilityZoneCall) Do(f func(context.Context, machine.UUID) (string, error)) *MockMachineServiceAvailabilityZoneCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceAvailabilityZoneCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockMachineServiceAvailabilityZoneCall {
+func (c *MockMachineServiceAvailabilityZoneCall) DoAndReturn(f func(context.Context, machine.UUID) (string, error)) *MockMachineServiceAvailabilityZoneCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ClearMachineReboot mocks base method.
-func (m *MockMachineService) ClearMachineReboot(arg0 context.Context, arg1 string) error {
+func (m *MockMachineService) ClearMachineReboot(arg0 context.Context, arg1 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearMachineReboot", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -452,22 +452,22 @@ func (c *MockMachineServiceClearMachineRebootCall) Return(arg0 error) *MockMachi
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceClearMachineRebootCall) Do(f func(context.Context, string) error) *MockMachineServiceClearMachineRebootCall {
+func (c *MockMachineServiceClearMachineRebootCall) Do(f func(context.Context, machine.UUID) error) *MockMachineServiceClearMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceClearMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockMachineServiceClearMachineRebootCall {
+func (c *MockMachineServiceClearMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockMachineServiceClearMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -485,25 +485,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // IsMachineRebootRequired mocks base method.
-func (m *MockMachineService) IsMachineRebootRequired(arg0 context.Context, arg1 string) (bool, error) {
+func (m *MockMachineService) IsMachineRebootRequired(arg0 context.Context, arg1 machine.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMachineRebootRequired", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -530,19 +530,19 @@ func (c *MockMachineServiceIsMachineRebootRequiredCall) Return(arg0 bool, arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceIsMachineRebootRequiredCall) Do(f func(context.Context, string) (bool, error)) *MockMachineServiceIsMachineRebootRequiredCall {
+func (c *MockMachineServiceIsMachineRebootRequiredCall) Do(f func(context.Context, machine.UUID) (bool, error)) *MockMachineServiceIsMachineRebootRequiredCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockMachineServiceIsMachineRebootRequiredCall {
+func (c *MockMachineServiceIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, machine.UUID) (bool, error)) *MockMachineServiceIsMachineRebootRequiredCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RequireMachineReboot mocks base method.
-func (m *MockMachineService) RequireMachineReboot(arg0 context.Context, arg1 string) error {
+func (m *MockMachineService) RequireMachineReboot(arg0 context.Context, arg1 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequireMachineReboot", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -568,19 +568,19 @@ func (c *MockMachineServiceRequireMachineRebootCall) Return(arg0 error) *MockMac
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceRequireMachineRebootCall) Do(f func(context.Context, string) error) *MockMachineServiceRequireMachineRebootCall {
+func (c *MockMachineServiceRequireMachineRebootCall) Do(f func(context.Context, machine.UUID) error) *MockMachineServiceRequireMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceRequireMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockMachineServiceRequireMachineRebootCall {
+func (c *MockMachineServiceRequireMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockMachineServiceRequireMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ShouldRebootOrShutdown mocks base method.
-func (m *MockMachineService) ShouldRebootOrShutdown(arg0 context.Context, arg1 string) (machine.RebootAction, error) {
+func (m *MockMachineService) ShouldRebootOrShutdown(arg0 context.Context, arg1 machine.UUID) (machine.RebootAction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldRebootOrShutdown", arg0, arg1)
 	ret0, _ := ret[0].(machine.RebootAction)
@@ -607,19 +607,19 @@ func (c *MockMachineServiceShouldRebootOrShutdownCall) Return(arg0 machine.Reboo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceShouldRebootOrShutdownCall) Do(f func(context.Context, string) (machine.RebootAction, error)) *MockMachineServiceShouldRebootOrShutdownCall {
+func (c *MockMachineServiceShouldRebootOrShutdownCall) Do(f func(context.Context, machine.UUID) (machine.RebootAction, error)) *MockMachineServiceShouldRebootOrShutdownCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceShouldRebootOrShutdownCall) DoAndReturn(f func(context.Context, string) (machine.RebootAction, error)) *MockMachineServiceShouldRebootOrShutdownCall {
+func (c *MockMachineServiceShouldRebootOrShutdownCall) DoAndReturn(f func(context.Context, machine.UUID) (machine.RebootAction, error)) *MockMachineServiceShouldRebootOrShutdownCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchLXDProfiles mocks base method.
-func (m *MockMachineService) WatchLXDProfiles(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
+func (m *MockMachineService) WatchLXDProfiles(arg0 context.Context, arg1 machine.UUID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchLXDProfiles", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
@@ -646,13 +646,13 @@ func (c *MockMachineServiceWatchLXDProfilesCall) Return(arg0 watcher.Watcher[str
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceWatchLXDProfilesCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
+func (c *MockMachineServiceWatchLXDProfilesCall) Do(f func(context.Context, machine.UUID) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceWatchLXDProfilesCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
+func (c *MockMachineServiceWatchLXDProfilesCall) DoAndReturn(f func(context.Context, machine.UUID) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/lxdprofile.go
@@ -145,7 +145,7 @@ func (u *LXDProfileAPI) WatchInstanceData(ctx context.Context, args params.Entit
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		watcherId, err := u.watchOneInstanceData(ctx, machineUUID.String())
+		watcherId, err := u.watchOneInstanceData(ctx, machineUUID)
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
@@ -158,7 +158,7 @@ func (u *LXDProfileAPI) WatchInstanceData(ctx context.Context, args params.Entit
 	return result, nil
 }
 
-func (u *LXDProfileAPI) watchOneInstanceData(ctx context.Context, machineUUID string) (string, error) {
+func (u *LXDProfileAPI) watchOneInstanceData(ctx context.Context, machineUUID coremachine.UUID) (string, error) {
 	watcher, err := u.machineService.WatchLXDProfiles(ctx, machineUUID)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -214,7 +214,7 @@ func (u *LXDProfileAPI) LXDProfileName(ctx context.Context, args params.Entities
 }
 
 func (u *LXDProfileAPI) getOneLXDProfileName(ctx context.Context, appName string, machineUUID coremachine.UUID) (string, error) {
-	profileNames, err := u.machineService.AppliedLXDProfileNames(ctx, machineUUID.String())
+	profileNames, err := u.machineService.AppliedLXDProfileNames(ctx, machineUUID)
 	if err != nil {
 		u.logger.Errorf(ctx, "unable to retrieve LXD profiles for machine %q: %v", machineUUID, err)
 		return "", err

--- a/apiserver/facades/agent/uniter/lxdprofile_test.go
+++ b/apiserver/facades/agent/uniter/lxdprofile_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/uniter"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/instance"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher/registry"
@@ -55,7 +56,7 @@ func (s *lxdProfileSuite) TestWatchInstanceData(c *gc.C) {
 		changes: make(chan struct{}, 1),
 	}
 	watcher.changes <- struct{}{}
-	s.machineService.EXPECT().WatchLXDProfiles(gomock.Any(), "uuid0").Return(watcher, nil)
+	s.machineService.EXPECT().WatchLXDProfiles(gomock.Any(), coremachine.UUID("uuid0")).Return(watcher, nil)
 	s.applicationService.EXPECT().GetUnitMachineUUID(gomock.Any(), coreunit.Name(s.unitTag1.Id())).Return("uuid0", nil)
 
 	args := params.Entities{
@@ -82,7 +83,7 @@ func (s *lxdProfileSuite) TestLXDProfileName(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.applicationService.EXPECT().GetUnitMachineUUID(gomock.Any(), coreunit.Name("mysql/1")).Return("uuid0", nil)
-	s.machineService.EXPECT().AppliedLXDProfileNames(gomock.Any(), "uuid0").
+	s.machineService.EXPECT().AppliedLXDProfileNames(gomock.Any(), coremachine.UUID("uuid0")).
 		Return([]string{"juju-model-mysql-1"}, nil)
 
 	args := params.Entities{

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -264,31 +264,31 @@ type NetworkService interface {
 // service.
 type MachineService interface {
 	// RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
-	RequireMachineReboot(ctx context.Context, uuid string) error
+	RequireMachineReboot(ctx context.Context, uuid coremachine.UUID) error
 
 	// ClearMachineReboot removes the reboot flag of the machine referenced by its UUID if a reboot has previously been required.
-	ClearMachineReboot(ctx context.Context, uuid string) error
+	ClearMachineReboot(ctx context.Context, uuid coremachine.UUID) error
 
 	// IsMachineRebootRequired checks if the machine referenced by its UUID requires a reboot.
-	IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error)
+	IsMachineRebootRequired(ctx context.Context, uuid coremachine.UUID) (bool, error)
 
 	// ShouldRebootOrShutdown determines whether a machine should reboot or shutdown
-	ShouldRebootOrShutdown(ctx context.Context, uuid string) (coremachine.RebootAction, error)
+	ShouldRebootOrShutdown(ctx context.Context, uuid coremachine.UUID) (coremachine.RebootAction, error)
 
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	// It returns an errors.MachineNotFound if the machine does not exist.
-	GetMachineUUID(ctx context.Context, machineName coremachine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, machineName coremachine.Name) (coremachine.UUID, error)
 
 	// AppliedLXDProfileNames returns the names of the LXD profiles on the machine.
-	AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]string, error)
+	AppliedLXDProfileNames(ctx context.Context, mUUID coremachine.UUID) ([]string, error)
 
 	// WatchMachineCloudInstances returns a StringsWatcher that is subscribed to
 	// the changes in the machine_cloud_instance table in the model.
-	WatchLXDProfiles(ctx context.Context, machineUUID string) (watcher.NotifyWatcher, error)
+	WatchLXDProfiles(ctx context.Context, machineUUID coremachine.UUID) (watcher.NotifyWatcher, error)
 
 	// AvailabilityZone returns the hardware characteristics of the
 	// specified machine.
-	AvailabilityZone(ctx context.Context, machineUUID string) (string, error)
+	AvailabilityZone(ctx context.Context, machineUUID coremachine.UUID) (string, error)
 }
 
 // RelationService defines the methods that the facade assumes from the

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -2032,7 +2032,7 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // AppliedLXDProfileNames mocks base method.
-func (m *MockMachineService) AppliedLXDProfileNames(arg0 context.Context, arg1 string) ([]string, error) {
+func (m *MockMachineService) AppliedLXDProfileNames(arg0 context.Context, arg1 machine.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppliedLXDProfileNames", arg0, arg1)
 	ret0, _ := ret[0].([]string)
@@ -2059,19 +2059,19 @@ func (c *MockMachineServiceAppliedLXDProfileNamesCall) Return(arg0 []string, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceAppliedLXDProfileNamesCall) Do(f func(context.Context, string) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
+func (c *MockMachineServiceAppliedLXDProfileNamesCall) Do(f func(context.Context, machine.UUID) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
+func (c *MockMachineServiceAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, machine.UUID) ([]string, error)) *MockMachineServiceAppliedLXDProfileNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // AvailabilityZone mocks base method.
-func (m *MockMachineService) AvailabilityZone(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockMachineService) AvailabilityZone(arg0 context.Context, arg1 machine.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZone", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -2098,19 +2098,19 @@ func (c *MockMachineServiceAvailabilityZoneCall) Return(arg0 string, arg1 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceAvailabilityZoneCall) Do(f func(context.Context, string) (string, error)) *MockMachineServiceAvailabilityZoneCall {
+func (c *MockMachineServiceAvailabilityZoneCall) Do(f func(context.Context, machine.UUID) (string, error)) *MockMachineServiceAvailabilityZoneCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceAvailabilityZoneCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockMachineServiceAvailabilityZoneCall {
+func (c *MockMachineServiceAvailabilityZoneCall) DoAndReturn(f func(context.Context, machine.UUID) (string, error)) *MockMachineServiceAvailabilityZoneCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ClearMachineReboot mocks base method.
-func (m *MockMachineService) ClearMachineReboot(arg0 context.Context, arg1 string) error {
+func (m *MockMachineService) ClearMachineReboot(arg0 context.Context, arg1 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearMachineReboot", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -2136,22 +2136,22 @@ func (c *MockMachineServiceClearMachineRebootCall) Return(arg0 error) *MockMachi
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceClearMachineRebootCall) Do(f func(context.Context, string) error) *MockMachineServiceClearMachineRebootCall {
+func (c *MockMachineServiceClearMachineRebootCall) Do(f func(context.Context, machine.UUID) error) *MockMachineServiceClearMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceClearMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockMachineServiceClearMachineRebootCall {
+func (c *MockMachineServiceClearMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockMachineServiceClearMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2169,25 +2169,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // IsMachineRebootRequired mocks base method.
-func (m *MockMachineService) IsMachineRebootRequired(arg0 context.Context, arg1 string) (bool, error) {
+func (m *MockMachineService) IsMachineRebootRequired(arg0 context.Context, arg1 machine.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMachineRebootRequired", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -2214,19 +2214,19 @@ func (c *MockMachineServiceIsMachineRebootRequiredCall) Return(arg0 bool, arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceIsMachineRebootRequiredCall) Do(f func(context.Context, string) (bool, error)) *MockMachineServiceIsMachineRebootRequiredCall {
+func (c *MockMachineServiceIsMachineRebootRequiredCall) Do(f func(context.Context, machine.UUID) (bool, error)) *MockMachineServiceIsMachineRebootRequiredCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockMachineServiceIsMachineRebootRequiredCall {
+func (c *MockMachineServiceIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, machine.UUID) (bool, error)) *MockMachineServiceIsMachineRebootRequiredCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RequireMachineReboot mocks base method.
-func (m *MockMachineService) RequireMachineReboot(arg0 context.Context, arg1 string) error {
+func (m *MockMachineService) RequireMachineReboot(arg0 context.Context, arg1 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequireMachineReboot", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -2252,19 +2252,19 @@ func (c *MockMachineServiceRequireMachineRebootCall) Return(arg0 error) *MockMac
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceRequireMachineRebootCall) Do(f func(context.Context, string) error) *MockMachineServiceRequireMachineRebootCall {
+func (c *MockMachineServiceRequireMachineRebootCall) Do(f func(context.Context, machine.UUID) error) *MockMachineServiceRequireMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceRequireMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockMachineServiceRequireMachineRebootCall {
+func (c *MockMachineServiceRequireMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockMachineServiceRequireMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ShouldRebootOrShutdown mocks base method.
-func (m *MockMachineService) ShouldRebootOrShutdown(arg0 context.Context, arg1 string) (machine.RebootAction, error) {
+func (m *MockMachineService) ShouldRebootOrShutdown(arg0 context.Context, arg1 machine.UUID) (machine.RebootAction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldRebootOrShutdown", arg0, arg1)
 	ret0, _ := ret[0].(machine.RebootAction)
@@ -2291,19 +2291,19 @@ func (c *MockMachineServiceShouldRebootOrShutdownCall) Return(arg0 machine.Reboo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceShouldRebootOrShutdownCall) Do(f func(context.Context, string) (machine.RebootAction, error)) *MockMachineServiceShouldRebootOrShutdownCall {
+func (c *MockMachineServiceShouldRebootOrShutdownCall) Do(f func(context.Context, machine.UUID) (machine.RebootAction, error)) *MockMachineServiceShouldRebootOrShutdownCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceShouldRebootOrShutdownCall) DoAndReturn(f func(context.Context, string) (machine.RebootAction, error)) *MockMachineServiceShouldRebootOrShutdownCall {
+func (c *MockMachineServiceShouldRebootOrShutdownCall) DoAndReturn(f func(context.Context, machine.UUID) (machine.RebootAction, error)) *MockMachineServiceShouldRebootOrShutdownCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchLXDProfiles mocks base method.
-func (m *MockMachineService) WatchLXDProfiles(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
+func (m *MockMachineService) WatchLXDProfiles(arg0 context.Context, arg1 machine.UUID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchLXDProfiles", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
@@ -2330,13 +2330,13 @@ func (c *MockMachineServiceWatchLXDProfilesCall) Return(arg0 watcher.Watcher[str
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceWatchLXDProfilesCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
+func (c *MockMachineServiceWatchLXDProfilesCall) Do(f func(context.Context, machine.UUID) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceWatchLXDProfilesCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
+func (c *MockMachineServiceWatchLXDProfilesCall) DoAndReturn(f func(context.Context, machine.UUID) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -198,7 +198,7 @@ func (u *UniterAPI) getOneMachineOpenedPortRanges(ctx context.Context, canAccess
 	if err != nil {
 		return nil, internalerrors.Errorf("getting machine UUID for %q: %w", tag, err)
 	}
-	machineOpenedPortRanges, err := u.portService.GetMachineOpenedPorts(ctx, machineUUID)
+	machineOpenedPortRanges, err := u.portService.GetMachineOpenedPorts(ctx, machineUUID.String())
 	if err != nil {
 		return nil, internalerrors.Errorf("getting opened ports for machine %q: %w", tag, err)
 	}
@@ -407,7 +407,7 @@ func (u *UniterAPI) AvailabilityZone(ctx context.Context, args params.Entities) 
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		az, err := u.machineService.AvailabilityZone(ctx, machineUUID.String())
+		az, err := u.machineService.AvailabilityZone(ctx, machineUUID)
 		if errors.Is(err, machineerrors.AvailabilityZoneNotFound) {
 			results.Results[i].Error = apiservererrors.ServerError(errors.NotProvisioned)
 			continue

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -441,7 +441,7 @@ func (s *uniterSuite) expectGetUnitMachineName(unitName coreunit.Name, machineNa
 }
 
 func (s *uniterSuite) expectedGetAvailabilityZone(machineUUID coremachine.UUID, az string, err error) {
-	s.machineService.EXPECT().AvailabilityZone(gomock.Any(), machineUUID.String()).Return(az, err)
+	s.machineService.EXPECT().AvailabilityZone(gomock.Any(), machineUUID).Return(az, err)
 }
 
 func (s *uniterSuite) setupMocks(c *gc.C) *gomock.Controller {

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -105,12 +105,12 @@ type NetworkService interface {
 // service.
 type MachineService interface {
 	// CreateMachine creates the specified machine.
-	CreateMachine(context.Context, machine.Name) (string, error)
+	CreateMachine(context.Context, machine.Name) (machine.UUID, error)
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 }
 
 // ApplicationService instances save an application to dqlite state.

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -604,10 +604,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -625,28 +625,28 @@ type MockMachineServiceCreateMachineCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceCreateMachineCall) Return(arg0 string, arg1 error) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -664,25 +664,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -709,13 +709,13 @@ func (c *MockMachineServiceHardwareCharacteristicsCall) Return(arg0 *instance.Ha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -602,20 +602,20 @@ func (s *charmsMockSuite) expectMachineConstraints(cons constraints.Value) {
 func (s *charmsMockSuite) expectHardwareCharacteristics() {
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), coremachine.Name("winnie-poo")).Return("deadbeef", nil)
 	arch := arch.DefaultArchitecture
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef").Return(&instance.HardwareCharacteristics{
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(&instance.HardwareCharacteristics{
 		Arch: &arch,
 	}, nil)
 }
 
 func (s *charmsMockSuite) expectEmptyHardwareCharacteristics() {
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), coremachine.Name("winnie-poo")).Return("deadbeef", nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef").Return(&instance.HardwareCharacteristics{}, nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(&instance.HardwareCharacteristics{}, nil)
 }
 
 func (s *charmsMockSuite) expectHardwareCharacteristics2() {
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), coremachine.Name("piglet")).Return("deadbeef", nil)
 	arch := "arm64"
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef").Return(&instance.HardwareCharacteristics{
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(&instance.HardwareCharacteristics{
 		Arch: &arch,
 	}, nil)
 }

--- a/apiserver/facades/client/charms/service.go
+++ b/apiserver/facades/client/charms/service.go
@@ -54,8 +54,8 @@ type ApplicationService interface {
 // service.
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 }

--- a/apiserver/facades/client/charms/service_mock_test.go
+++ b/apiserver/facades/client/charms/service_mock_test.go
@@ -294,10 +294,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -315,25 +315,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -360,13 +360,13 @@ func (c *MockMachineServiceHardwareCharacteristicsCall) Return(arg0 *instance.Ha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -69,17 +69,17 @@ type BlockDeviceService interface {
 // service.
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, machineUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, machineUUID machine.UUID) (instance.Id, error)
 	// InstanceIDAndName returns the cloud specific instance ID and display name
 	// for this machine.
-	InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error)
+	InstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 	// AppliedLXDProfiles returns the names of the LXD profiles on the machine.
-	AppliedLXDProfileNames(ctx context.Context, machineUUID string) ([]string, error)
+	AppliedLXDProfileNames(ctx context.Context, machineUUID machine.UUID) ([]string, error)
 }
 
 // ModelInfoService provides access to information about the model.

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -44,7 +44,7 @@ type NodeService interface {
 
 // MachineService instances save a machine to dqlite state.
 type MachineService interface {
-	CreateMachine(context.Context, machine.Name) (string, error)
+	CreateMachine(context.Context, machine.Name) (machine.UUID, error)
 }
 
 // ApplicationService instances add units to an application in dqlite state.

--- a/apiserver/facades/client/machinemanager/instanceconfig_test.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig_test.go
@@ -76,7 +76,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 	machine0.EXPECT().Tag().Return(names.NewMachineTag("0")).AnyTimes()
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), coremachine.Name("0")).Return("deadbeef", nil)
 	hc := instance.MustParseHardware("mem=4G arch=amd64")
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef").Return(&hc, nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(&hc, nil)
 	machine0.EXPECT().SetPassword(gomock.Any()).Return(nil)
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -91,7 +91,7 @@ type Authorizer interface {
 // MachineService is the interface that is used to interact with the machines.
 type MachineService interface {
 	// CreateMachine creates a machine with the given name.
-	CreateMachine(context.Context, coremachine.Name) (string, error)
+	CreateMachine(context.Context, coremachine.Name) (coremachine.UUID, error)
 	// DeleteMachine deletes a machine with the given name.
 	DeleteMachine(context.Context, coremachine.Name) error
 	// GetBootstrapEnviron returns the bootstrap environ.
@@ -108,10 +108,10 @@ type MachineService interface {
 	// It returns a NotFound if the given machine doesn't exist.
 	SetKeepInstance(ctx context.Context, machineName coremachine.Name, keep bool) error
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name coremachine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name coremachine.Name) (coremachine.UUID, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID coremachine.UUID) (*instance.HardwareCharacteristics, error)
 }
 
 // ApplicationService is the interface that is used to interact with

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -806,7 +806,7 @@ func (s *ProvisioningMachineManagerSuite) expectProvisioningMachine(ctrl *gomock
 	machine.EXPECT().Base().Return(state.Base{OS: "ubuntu", Channel: "20.04/stable"}).AnyTimes()
 	machine.EXPECT().Tag().Return(names.NewMachineTag("0")).AnyTimes()
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), coremachine.Name("0")).Return("deadbeef", nil)
-	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef").Return(&instance.HardwareCharacteristics{Arch: arch}, nil)
+	s.machineService.EXPECT().HardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(&instance.HardwareCharacteristics{Arch: arch}, nil)
 	if arch != nil {
 		machine.EXPECT().SetPassword(gomock.Any()).Return(nil)
 	}

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -1600,10 +1600,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1621,19 +1621,19 @@ type MockMachineServiceCreateMachineCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceCreateMachineCall) Return(arg0 string, arg1 error) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1755,10 +1755,10 @@ func (c *MockMachineServiceGetInstanceTypesFetcherCall) DoAndReturn(f func(conte
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1776,25 +1776,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -1821,13 +1821,13 @@ func (c *MockMachineServiceHardwareCharacteristicsCall) Return(arg0 *instance.Ha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -1680,10 +1680,10 @@ func (c *MockMachineServiceEnsureDeadMachineCall) DoAndReturn(f func(context.Con
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1701,25 +1701,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -1746,19 +1746,19 @@ func (c *MockMachineServiceHardwareCharacteristicsCall) Return(arg0 *instance.Ha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceID mocks base method.
-func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 string) (instance.Id, error) {
+func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 machine.UUID) (instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -1785,19 +1785,19 @@ func (c *MockMachineServiceInstanceIDCall) Return(arg0 instance.Id, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceIDAndName mocks base method.
-func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 string) (instance.Id, string, error) {
+func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 machine.UUID) (instance.Id, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceIDAndName", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -1825,13 +1825,13 @@ func (c *MockMachineServiceInstanceIDAndNameCall) Return(arg0 instance.Id, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -455,9 +455,9 @@ func (s *modelInfoSuite) TestModelInfoWriteAccess(c *gc.C) {
 	)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
@@ -625,9 +625,9 @@ func (s *modelInfoSuite) TestRunningMigration(c *gc.C) {
 	}
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	results, err := api.ModelInfo(context.Background(), params.Entities{
 		Entities: []params.Entity{{coretesting.ModelTag.String()}},
@@ -654,9 +654,9 @@ func (s *modelInfoSuite) TestFailedMigration(c *gc.C) {
 	}
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	results, err := api.ModelInfo(context.Background(), params.Entities{
 		Entities: []params.Entity{{coretesting.ModelTag.String()}},
@@ -677,9 +677,9 @@ func (s *modelInfoSuite) TestNoMigration(c *gc.C) {
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(coretesting.ModelTag.Id())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	results, err := api.ModelInfo(context.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: coretesting.ModelTag.String()}},
@@ -695,9 +695,9 @@ func (s *modelInfoSuite) TestAliveModelGetsAllInfo(c *gc.C) {
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	s.assertSuccess(c, api, s.st.model.cfg.UUID(), state.Alive, life.Alive)
 }
@@ -755,9 +755,9 @@ func (s *modelInfoSuite) TestDeadModelGetsAllInfo(c *gc.C) {
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	s.assertSuccess(c, api, s.st.model.cfg.UUID(), state.Dead, life.Dead)
 }
@@ -770,9 +770,9 @@ func (s *modelInfoSuite) TestDeadModelWithGetModelInfoFailure(c *gc.C) {
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	modelDomainServices := mocks.NewMockModelDomainServices(ctrl)
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any(), gomock.Any()).Return(modelDomainServices, nil).AnyTimes()
@@ -797,9 +797,9 @@ func (s *modelInfoSuite) TestDeadModelWithGetModelTargetAgentVersionFailure(c *g
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	modelDomainServices := mocks.NewMockModelDomainServices(ctrl)
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any(), gomock.Any()).Return(modelDomainServices, nil).AnyTimes()
@@ -823,9 +823,9 @@ func (s *modelInfoSuite) TestDeadModelWithStatusFailure(c *gc.C) {
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelStatusError,
@@ -841,9 +841,9 @@ func (s *modelInfoSuite) TestDeadModelWithUsersFailure(c *gc.C) {
 	s.mockSecretBackendService.EXPECT().BackendSummaryInfoForModel(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(nil, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelUsersError,
@@ -861,9 +861,9 @@ func (s *modelInfoSuite) TestDyingModelWithGetModelInfoFailure(c *gc.C) {
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	modelDomainServices := mocks.NewMockModelDomainServices(ctrl)
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any(), gomock.Any()).Return(modelDomainServices, nil).AnyTimes()
@@ -888,9 +888,9 @@ func (s *modelInfoSuite) TestDyingModelWithGetModelTargetAgentVersionFailure(c *
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	modelDomainServices := mocks.NewMockModelDomainServices(ctrl)
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any(), gomock.Any()).Return(modelDomainServices, nil).AnyTimes()
@@ -914,9 +914,9 @@ func (s *modelInfoSuite) TestDyingModelWithStatusFailure(c *gc.C) {
 	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(s.modelUserInfo, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelStatusError,
@@ -932,9 +932,9 @@ func (s *modelInfoSuite) TestDyingModelWithUsersFailure(c *gc.C) {
 	s.mockSecretBackendService.EXPECT().BackendSummaryInfoForModel(gomock.Any(), coremodel.UUID(s.st.model.cfg.UUID())).Return(nil, nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelUsersError,
@@ -952,9 +952,9 @@ func (s *modelInfoSuite) TestImportingModelGetsAllInfo(c *gc.C) {
 	s.st.migrationStatus = state.MigrationModeImporting
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	s.assertSuccess(c, api, s.st.model.cfg.UUID(), state.Alive, life.Alive)
 }
@@ -968,9 +968,9 @@ func (s *modelInfoSuite) TestImportingModelWithGetModelInfoFailure(c *gc.C) {
 	s.st.migrationStatus = state.MigrationModeImporting
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	modelDomainServices := mocks.NewMockModelDomainServices(ctrl)
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any(), gomock.Any()).Return(modelDomainServices, nil).AnyTimes()
@@ -996,9 +996,9 @@ func (s *modelInfoSuite) TestImportingModelWithGetModelTargetAgentVersionFailure
 	s.st.migrationStatus = state.MigrationModeImporting
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	modelDomainServices := mocks.NewMockModelDomainServices(ctrl)
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any(), gomock.Any()).Return(modelDomainServices, nil).AnyTimes()
@@ -1028,9 +1028,9 @@ func (s *modelInfoSuite) TestImportingModelWithStatusFailure(c *gc.C) {
 	}
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 	s.assertSuccessWithMissingData(c, api, testData)
 }
 
@@ -1041,9 +1041,9 @@ func (s *modelInfoSuite) TestImportingModelWithUsersFailure(c *gc.C) {
 	s.st.migrationStatus = state.MigrationModeImporting
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("deadbeef1", nil)
 	s.mockMachineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("deadbeef2", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef1").Return("inst-deadbeef1", "", nil)
-	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), "deadbeef2").Return("inst-deadbeef2", "", nil)
-	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), "deadbeef1").Return(&instance.HardwareCharacteristics{}, nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef1")).Return("inst-deadbeef1", "", nil)
+	s.mockMachineService.EXPECT().InstanceIDAndName(gomock.Any(), machine.UUID("deadbeef2")).Return("inst-deadbeef2", "", nil)
+	s.mockMachineService.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("deadbeef1")).Return(&instance.HardwareCharacteristics{}, nil)
 
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelUsersError,

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -237,15 +237,15 @@ type MachineService interface {
 	// gets updated.
 	EnsureDeadMachine(ctx context.Context, machineName machine.Name) error
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, mUUID machine.UUID) (instance.Id, error)
 	// InstanceIDAndName returns the cloud specific instance ID and display name for
 	// this machine.
-	InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error)
+	InstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 }
 
 // SecretBackendService is an interface for interacting with secret backend service.

--- a/apiserver/facades/controller/firewaller/interface.go
+++ b/apiserver/facades/controller/firewaller/interface.go
@@ -50,15 +50,15 @@ type MachineService interface {
 	// gets updated.
 	EnsureDeadMachine(ctx context.Context, machineName machine.Name) error
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, mUUID machine.UUID) (instance.Id, error)
 	// InstanceIDAndName returns the cloud specific instance ID and display name for
 	// this machine.
-	InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error)
+	InstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 }
 
 // ApplicationService provides access to the application service.

--- a/apiserver/facades/controller/firewaller/service_mock_test.go
+++ b/apiserver/facades/controller/firewaller/service_mock_test.go
@@ -492,10 +492,10 @@ func (c *MockMachineServiceEnsureDeadMachineCall) DoAndReturn(f func(context.Con
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -513,25 +513,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -558,19 +558,19 @@ func (c *MockMachineServiceHardwareCharacteristicsCall) Return(arg0 *instance.Ha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceID mocks base method.
-func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 string) (instance.Id, error) {
+func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 machine.UUID) (instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -597,19 +597,19 @@ func (c *MockMachineServiceInstanceIDCall) Return(arg0 instance.Id, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceIDAndName mocks base method.
-func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 string) (instance.Id, string, error) {
+func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 machine.UUID) (instance.Id, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceIDAndName", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -637,13 +637,13 @@ func (c *MockMachineServiceInstanceIDAndNameCall) Return(arg0 instance.Id, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -323,9 +323,9 @@ func (s *InstancePollerSuite) TestInstanceIdSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid-1").Return("i-foo", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid-1")).Return("i-foo", nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("uuid-2", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid-2").Return("", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid-2")).Return("", nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("42")).Return("", machineerrors.MachineNotFound)
 
 	result, err := s.api.InstanceId(context.Background(), s.mixedEntities)
@@ -352,9 +352,9 @@ func (s *InstancePollerSuite) TestInstanceIdFailure(c *gc.C) {
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("", errors.New("pow!"))
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("uuid-2", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid-2").Return("i-2", errors.New("FAIL"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid-2")).Return("i-2", errors.New("FAIL"))
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("3")).Return("uuid-3", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "uuid-3").Return("", machineerrors.NotProvisioned)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("uuid-3")).Return("", machineerrors.NotProvisioned)
 	result, err := s.api.InstanceId(context.Background(), s.machineEntities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StringResults{

--- a/apiserver/facades/controller/instancepoller/service.go
+++ b/apiserver/facades/controller/instancepoller/service.go
@@ -34,13 +34,13 @@ type MachineService interface {
 	// gets updated.
 	EnsureDeadMachine(ctx context.Context, machineName machine.Name) error
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, mUUID machine.UUID) (instance.Id, error)
 	// InstanceIDAndName returns the cloud specific instance ID and display name for
 	// this machine.
-	InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error)
+	InstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 }

--- a/apiserver/facades/controller/instancepoller/service_mock_test.go
+++ b/apiserver/facades/controller/instancepoller/service_mock_test.go
@@ -206,10 +206,10 @@ func (c *MockMachineServiceEnsureDeadMachineCall) DoAndReturn(f func(context.Con
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -227,25 +227,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -272,19 +272,19 @@ func (c *MockMachineServiceHardwareCharacteristicsCall) Return(arg0 *instance.Ha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
+func (c *MockMachineServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceID mocks base method.
-func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 string) (instance.Id, error) {
+func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 machine.UUID) (instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -311,19 +311,19 @@ func (c *MockMachineServiceInstanceIDCall) Return(arg0 instance.Id, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, string) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceIDAndName mocks base method.
-func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 string) (instance.Id, string, error) {
+func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 machine.UUID) (instance.Id, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceIDAndName", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -351,13 +351,13 @@ func (c *MockMachineServiceInstanceIDAndNameCall) Return(arg0 instance.Id, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/credential/service/modelcredential.go
+++ b/domain/credential/service/modelcredential.go
@@ -26,9 +26,9 @@ import (
 // the Machine service.
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (string, error)
+	InstanceID(ctx context.Context, mUUID machine.UUID) (string, error)
 }
 
 // MachineState provides access to all machines.

--- a/domain/credential/service/modelcredential_test.go
+++ b/domain/credential/service/modelcredential_test.go
@@ -73,7 +73,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesSuccess(c *gc.C) {
 
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 
 	results, err := checkMachineInstances(context.Background(), s.machineState, s.machineService, s.provider, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -86,9 +86,9 @@ func (s *CheckMachinesSuite) TestCheckMachinesInstancesMissing(c *gc.C) {
 	machine1 := createTestMachine("2", "birds")
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(machine1.Id())).Return("deadbeef-1", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef-1").Return("birds", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef-1")).Return("birds", nil)
 
 	results, err := checkMachineInstances(context.Background(), s.machineState, s.machineService, s.provider, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -102,7 +102,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesExtraInstances(c *gc.C) {
 
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 
 	instance2 := &mockInstance{id: "analyse"}
 	s.provider.allInstancesFunc = func(ctx context.Context) ([]instances.Instance, error) {
@@ -119,7 +119,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesExtraInstancesWhenMigrating(c *gc.
 
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 
 	instance2 := &mockInstance{id: "analyse"}
 	s.provider.allInstancesFunc = func(ctx context.Context) ([]instances.Instance, error) {
@@ -147,7 +147,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingInstances(c *gc.C) {
 
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("", errors.New("kaboom"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("", errors.New("kaboom"))
 
 	s.provider.allInstancesFunc = func(ctx context.Context) ([]instances.Instance, error) {
 		return nil, errors.New("kaboom")
@@ -165,7 +165,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesContainers(c *gc.C) {
 	machine1.container = true
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 
 	results, err := checkMachineInstances(context.Background(), s.machineState, s.machineService, s.provider, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -179,7 +179,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesManual(c *gc.C) {
 	machine1.manualFunc = func() (bool, error) { return true, nil }
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 
 	results, err := checkMachineInstances(context.Background(), s.machineState, s.machineService, s.provider, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -193,7 +193,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesHandlesManualFailure(c *gc.C) {
 	machine1.manualFunc = func() (bool, error) { return false, errors.New("manual retrieval failure") }
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 
 	results, err := checkMachineInstances(context.Background(), s.machineState, s.machineService, s.provider, false)
 	c.Assert(err, gc.ErrorMatches, "manual retrieval failure")
@@ -207,9 +207,9 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceId(c *g
 	machine1.instanceIdFunc = func() (instance.Id, error) { return "", errors.New("retrieval failure") }
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(machine1.Id())).Return("deadbeef-1", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef-1").Return("", errors.New("retrieval failure"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef-1")).Return("", errors.New("retrieval failure"))
 
 	results, err := checkMachineInstances(context.Background(), s.machineState, s.machineService, s.provider, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -225,9 +225,9 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 	s.machine.instanceIdFunc = machine1.instanceIdFunc
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("", errors.New("retrieval failure"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("", errors.New("retrieval failure"))
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(machine1.Id())).Return("deadbeef-1", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef-1").Return("", errors.New("retrieval failure"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef-1")).Return("", errors.New("retrieval failure"))
 
 	results, err := checkMachineInstances(context.Background(), s.machineState, s.machineService, s.provider, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -244,9 +244,9 @@ func (s *CheckMachinesSuite) TestCheckMachinesErrorGettingMachineInstanceIdNonFa
 	s.machine.instanceIdFunc = machine1.instanceIdFunc
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("", errors.New("retrieval failure"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("", errors.New("retrieval failure"))
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(machine1.Id())).Return("deadbeef-1", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef-1").Return("", errors.New("retrieval failure"))
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef-1")).Return("", errors.New("retrieval failure"))
 
 	results, err := checkMachineInstances(context.Background(), s.machineState, s.machineService, s.provider, true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -265,9 +265,9 @@ func (s *CheckMachinesSuite) TestCheckMachinesNotProvisionedError(c *gc.C) {
 	machine1.instanceIdFunc = func() (instance.Id, error) { return "", errors.Errorf("machine 2 %w", coreerrors.NotProvisioned) }
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef")).Return("wind-up", nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(machine1.Id())).Return("deadbeef-1", nil)
-	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef-1").Return("", machineerrors.NotProvisioned)
+	s.machineService.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef-1")).Return("", machineerrors.NotProvisioned)
 
 	// We should ignore the unprovisioned machine - we wouldn't expect
 	// the cloud to know about it.

--- a/domain/credential/service/state_mock_test.go
+++ b/domain/credential/service/state_mock_test.go
@@ -446,10 +446,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -467,25 +467,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceID mocks base method.
-func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockMachineService) InstanceID(arg0 context.Context, arg1 machine.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -512,13 +512,13 @@ func (c *MockMachineServiceInstanceIDCall) Return(arg0 string, arg1 error) *Mock
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, string) (string, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) Do(f func(context.Context, machine.UUID) (string, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockMachineServiceInstanceIDCall {
+func (c *MockMachineServiceInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (string, error)) *MockMachineServiceInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/modelmigration/export.go
+++ b/domain/machine/modelmigration/export.go
@@ -34,14 +34,14 @@ type ExportService interface {
 	AllMachineNames(ctx context.Context) ([]coremachine.Name, error)
 	// InstanceID returns the cloud specific instance id for this machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
-	InstanceID(ctx context.Context, machineUUID string) (instance.Id, error)
+	InstanceID(ctx context.Context, machineUUID coremachine.UUID) (instance.Id, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	HardwareCharacteristics(ctx context.Context, machineUUID coremachine.UUID) (*instance.HardwareCharacteristics, error)
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	// It returns a [github.com/juju/juju/domain/machine/errors.MachineNotFound]
 	// if the machine does not exist.
-	GetMachineUUID(ctx context.Context, name coremachine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name coremachine.Name) (coremachine.UUID, error)
 }
 
 // exportOperation describes a way to execute a migration for

--- a/domain/machine/modelmigration/export_test.go
+++ b/domain/machine/modelmigration/export_test.go
@@ -49,7 +49,7 @@ func (s *exportSuite) TestFailGetInstanceIDForExport(c *gc.C) {
 		Id: string(machineNames[0]),
 	})
 
-	machineUUIDs := []string{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
+	machineUUIDs := []coremachine.UUID{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
 	s.service.EXPECT().GetMachineUUID(gomock.Any(), machineNames[0]).
 		Return(machineUUIDs[0], nil)
 	s.service.EXPECT().InstanceID(gomock.Any(), machineUUIDs[0]).
@@ -69,7 +69,7 @@ func (s *exportSuite) TestFailGetHardwareCharacteristicsForExport(c *gc.C) {
 		Id: string(machineNames[0]),
 	})
 
-	machineUUIDs := []string{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
+	machineUUIDs := []coremachine.UUID{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
 	s.service.EXPECT().GetMachineUUID(gomock.Any(), machineNames[0]).
 		Return(machineUUIDs[0], nil)
 	s.service.EXPECT().InstanceID(gomock.Any(), machineUUIDs[0]).
@@ -91,7 +91,7 @@ func (s *exportSuite) TestExport(c *gc.C) {
 		Id: string(machineNames[0]),
 	})
 
-	machineUUIDs := []string{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
+	machineUUIDs := []coremachine.UUID{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
 	s.service.EXPECT().InstanceID(gomock.Any(), machineUUIDs[0]).
 		Return("inst-0", nil)
 	s.service.EXPECT().GetMachineUUID(gomock.Any(), machineNames[0]).

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -44,10 +44,10 @@ type importOperation struct {
 // another controller model to this controller.
 type ImportService interface {
 	// CreateMachine creates the specified machine.
-	CreateMachine(ctx context.Context, machineName machine.Name) (string, error)
+	CreateMachine(ctx context.Context, machineName machine.Name) (machine.UUID, error)
 	// SetMachineCloudInstance sets an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
-	SetMachineCloudInstance(ctx context.Context, machineUUID string, instanceID instance.Id, displayName string, hardwareCharacteristics *instance.HardwareCharacteristics) error
+	SetMachineCloudInstance(ctx context.Context, machineUUID machine.UUID, instanceID instance.Id, displayName string, hardwareCharacteristics *instance.HardwareCharacteristics) error
 }
 
 // Name returns the name of this operation.

--- a/domain/machine/modelmigration/import_test.go
+++ b/domain/machine/modelmigration/import_test.go
@@ -127,7 +127,7 @@ func (s *importSuite) TestFailImportMachineWithCloudInstance(c *gc.C) {
 	}
 	machine0.SetInstance(cloudInstanceArgs)
 
-	expectedMachineUUID := "deadbeef-1bad-500d-9000-4b1d0d06f00d"
+	expectedMachineUUID := machine.UUID("deadbeef-1bad-500d-9000-4b1d0d06f00d")
 	s.service.EXPECT().CreateMachine(gomock.Any(), machine.Name("0")).
 		Return(expectedMachineUUID, nil)
 	expectedHardwareCharacteristics := &instance.HardwareCharacteristics{
@@ -176,7 +176,7 @@ func (s *importSuite) TestImportMachineWithCloudInstance(c *gc.C) {
 	}
 	machine0.SetInstance(cloudInstanceArgs)
 
-	expectedMachineUUID := "deadbeef-1bad-500d-9000-4b1d0d06f00d"
+	expectedMachineUUID := machine.UUID("deadbeef-1bad-500d-9000-4b1d0d06f00d")
 	s.service.EXPECT().CreateMachine(gomock.Any(), machine.Name("0")).
 		Return(expectedMachineUUID, nil)
 	expectedHardwareCharacteristics := &instance.HardwareCharacteristics{

--- a/domain/machine/modelmigration/migrations_mock_test.go
+++ b/domain/machine/modelmigration/migrations_mock_test.go
@@ -102,10 +102,10 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -123,25 +123,25 @@ type MockImportServiceCreateMachineCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockImportServiceCreateMachineCall) Return(arg0 string, arg1 error) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 error) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, machine.Name) (string, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetMachineCloudInstance mocks base method.
-func (m *MockImportService) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 string, arg4 *instance.HardwareCharacteristics) error {
+func (m *MockImportService) SetMachineCloudInstance(arg0 context.Context, arg1 machine.UUID, arg2 instance.Id, arg3 string, arg4 *instance.HardwareCharacteristics) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMachineCloudInstance", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -167,13 +167,13 @@ func (c *MockImportServiceSetMachineCloudInstanceCall) Return(arg0 error) *MockI
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceSetMachineCloudInstanceCall) Do(f func(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error) *MockImportServiceSetMachineCloudInstanceCall {
+func (c *MockImportServiceSetMachineCloudInstanceCall) Do(f func(context.Context, machine.UUID, instance.Id, string, *instance.HardwareCharacteristics) error) *MockImportServiceSetMachineCloudInstanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error) *MockImportServiceSetMachineCloudInstanceCall {
+func (c *MockImportServiceSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, machine.UUID, instance.Id, string, *instance.HardwareCharacteristics) error) *MockImportServiceSetMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -241,10 +241,10 @@ func (c *MockExportServiceAllMachineNamesCall) DoAndReturn(f func(context.Contex
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockExportService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockExportService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -262,25 +262,25 @@ type MockExportServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockExportServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockExportServiceGetMachineUUIDCall {
+func (c *MockExportServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockExportServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockExportServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockExportServiceGetMachineUUIDCall {
+func (c *MockExportServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockExportServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockExportServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockExportServiceGetMachineUUIDCall {
+func (c *MockExportServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockExportServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockExportService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockExportService) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -307,19 +307,19 @@ func (c *MockExportServiceHardwareCharacteristicsCall) Return(arg0 *instance.Har
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockExportServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockExportServiceHardwareCharacteristicsCall {
+func (c *MockExportServiceHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockExportServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockExportServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockExportServiceHardwareCharacteristicsCall {
+func (c *MockExportServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockExportServiceHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceID mocks base method.
-func (m *MockExportService) InstanceID(arg0 context.Context, arg1 string) (instance.Id, error) {
+func (m *MockExportService) InstanceID(arg0 context.Context, arg1 machine.UUID) (instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -346,13 +346,13 @@ func (c *MockExportServiceInstanceIDCall) Return(arg0 instance.Id, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockExportServiceInstanceIDCall) Do(f func(context.Context, string) (instance.Id, error)) *MockExportServiceInstanceIDCall {
+func (c *MockExportServiceInstanceIDCall) Do(f func(context.Context, machine.UUID) (instance.Id, error)) *MockExportServiceInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockExportServiceInstanceIDCall) DoAndReturn(f func(context.Context, string) (instance.Id, error)) *MockExportServiceInstanceIDCall {
+func (c *MockExportServiceInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, error)) *MockExportServiceInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/machine_cloud_instance.go
+++ b/domain/machine/service/machine_cloud_instance.go
@@ -7,13 +7,14 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/internal/errors"
 )
 
 // InstanceID returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a
 // [github.com/juju/juju/domain/machine/errors.NotProvisioned]
-func (s *Service) InstanceID(ctx context.Context, machineUUID string) (instance.Id, error) {
+func (s *Service) InstanceID(ctx context.Context, machineUUID machine.UUID) (instance.Id, error) {
 	instanceId, err := s.st.InstanceID(ctx, machineUUID)
 	if err != nil {
 		return "", errors.Errorf("retrieving cloud instance id for machine %q: %w", machineUUID, err)
@@ -25,7 +26,7 @@ func (s *Service) InstanceID(ctx context.Context, machineUUID string) (instance.
 // this machine.
 // If the machine is not provisioned, it returns a
 // [github.com/juju/juju/domain/machine/errors.NotProvisioned]
-func (s *Service) InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error) {
+func (s *Service) InstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error) {
 	instanceID, instanceName, err := s.st.InstanceIDAndName(ctx, machineUUID)
 	if err != nil {
 		return "", "", errors.Errorf("retrieving cloud instance name for machine %q: %w", machineUUID, err)
@@ -34,7 +35,7 @@ func (s *Service) InstanceIDAndName(ctx context.Context, machineUUID string) (in
 }
 
 // AvailabilityZone returns the availability zone for the specified machine.
-func (s *Service) AvailabilityZone(ctx context.Context, machineUUID string) (string, error) {
+func (s *Service) AvailabilityZone(ctx context.Context, machineUUID machine.UUID) (string, error) {
 	az, err := s.st.AvailabilityZone(ctx, machineUUID)
 	if err != nil {
 		return az, errors.Errorf("retrieving availability zone for machine %q: %w", machineUUID, err)
@@ -44,7 +45,7 @@ func (s *Service) AvailabilityZone(ctx context.Context, machineUUID string) (str
 
 // HardwareCharacteristics returns the hardware characteristics of the
 // of the specified machine.
-func (s *Service) HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error) {
+func (s *Service) HardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error) {
 	hc, err := s.st.HardwareCharacteristics(ctx, machineUUID)
 	if err != nil {
 		return hc, errors.Errorf("retrieving hardware characteristics for machine %q: %w", machineUUID, err)
@@ -56,7 +57,7 @@ func (s *Service) HardwareCharacteristics(ctx context.Context, machineUUID strin
 // along with the instance tags and the link to a lxd profile if any.
 func (s *Service) SetMachineCloudInstance(
 	ctx context.Context,
-	machineUUID string,
+	machineUUID machine.UUID,
 	instanceID instance.Id,
 	displayName string,
 	hardwareCharacteristics *instance.HardwareCharacteristics,
@@ -71,7 +72,7 @@ func (s *Service) SetMachineCloudInstance(
 // DeleteMachineCloudInstance removes an entry in the machine cloud instance
 // table along with the instance tags and the link to a lxd profile if any, as
 // well as any associated status data.
-func (s *Service) DeleteMachineCloudInstance(ctx context.Context, machineUUID string) error {
+func (s *Service) DeleteMachineCloudInstance(ctx context.Context, machineUUID machine.UUID) error {
 	err := s.st.DeleteMachineCloudInstance(ctx, machineUUID)
 	if err != nil {
 		return errors.Errorf("deleting machine cloud instance for machine %q: %w", machineUUID, err)

--- a/domain/machine/service/machine_cloud_instance_test.go
+++ b/domain/machine/service/machine_cloud_instance_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -23,7 +24,7 @@ func (s *serviceSuite) TestRetrieveHardwareCharacteristics(c *gc.C) {
 		CpuCores: uintptr(4),
 		CpuPower: uintptr(75),
 	}
-	s.state.EXPECT().HardwareCharacteristics(gomock.Any(), "42").
+	s.state.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("42")).
 		Return(expected, nil)
 
 	hc, err := NewService(s.state).HardwareCharacteristics(context.Background(), "42")
@@ -34,7 +35,7 @@ func (s *serviceSuite) TestRetrieveHardwareCharacteristics(c *gc.C) {
 func (s *serviceSuite) TestRetrieveHardwareCharacteristicsFails(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().HardwareCharacteristics(gomock.Any(), "42").
+	s.state.EXPECT().HardwareCharacteristics(gomock.Any(), machine.UUID("42")).
 		Return(nil, errors.New("boom"))
 
 	hc, err := NewService(s.state).HardwareCharacteristics(context.Background(), "42")
@@ -45,7 +46,7 @@ func (s *serviceSuite) TestRetrieveHardwareCharacteristicsFails(c *gc.C) {
 func (s *serviceSuite) TestRetrieveAvailabilityZone(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AvailabilityZone(gomock.Any(), "42").
+	s.state.EXPECT().AvailabilityZone(gomock.Any(), machine.UUID("42")).
 		Return("foo", nil)
 
 	hc, err := NewService(s.state).AvailabilityZone(context.Background(), "42")
@@ -64,7 +65,7 @@ func (s *serviceSuite) TestSetMachineCloudInstance(c *gc.C) {
 	}
 	s.state.EXPECT().SetMachineCloudInstance(
 		gomock.Any(),
-		"42",
+		machine.UUID("42"),
 		instance.Id("instance-42"),
 		"42",
 		hc,
@@ -85,7 +86,7 @@ func (s *serviceSuite) TestSetMachineCloudInstanceFails(c *gc.C) {
 	}
 	s.state.EXPECT().SetMachineCloudInstance(
 		gomock.Any(),
-		"42",
+		machine.UUID("42"),
 		instance.Id("instance-42"),
 		"42",
 		hc,
@@ -98,7 +99,7 @@ func (s *serviceSuite) TestSetMachineCloudInstanceFails(c *gc.C) {
 func (s *serviceSuite) TestDeleteMachineCloudInstance(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().DeleteMachineCloudInstance(gomock.Any(), "42").Return(nil)
+	s.state.EXPECT().DeleteMachineCloudInstance(gomock.Any(), machine.UUID("42")).Return(nil)
 
 	err := NewService(s.state).DeleteMachineCloudInstance(context.Background(), "42")
 	c.Assert(err, jc.ErrorIsNil)
@@ -107,7 +108,7 @@ func (s *serviceSuite) TestDeleteMachineCloudInstance(c *gc.C) {
 func (s *serviceSuite) TestDeleteMachineCloudInstanceFails(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().DeleteMachineCloudInstance(gomock.Any(), "42").Return(errors.New("boom"))
+	s.state.EXPECT().DeleteMachineCloudInstance(gomock.Any(), machine.UUID("42")).Return(errors.New("boom"))
 
 	err := NewService(s.state).DeleteMachineCloudInstance(context.Background(), "42")
 	c.Assert(err, gc.ErrorMatches, "deleting machine cloud instance for machine \"42\": boom")

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -89,7 +89,7 @@ func (c *MockStateAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]ma
 }
 
 // AppliedLXDProfileNames mocks base method.
-func (m *MockState) AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]string, error) {
+func (m *MockState) AppliedLXDProfileNames(ctx context.Context, mUUID machine.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppliedLXDProfileNames", ctx, mUUID)
 	ret0, _ := ret[0].([]string)
@@ -116,19 +116,19 @@ func (c *MockStateAppliedLXDProfileNamesCall) Return(arg0 []string, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAppliedLXDProfileNamesCall) Do(f func(context.Context, string) ([]string, error)) *MockStateAppliedLXDProfileNamesCall {
+func (c *MockStateAppliedLXDProfileNamesCall) Do(f func(context.Context, machine.UUID) ([]string, error)) *MockStateAppliedLXDProfileNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockStateAppliedLXDProfileNamesCall {
+func (c *MockStateAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, machine.UUID) ([]string, error)) *MockStateAppliedLXDProfileNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // AvailabilityZone mocks base method.
-func (m *MockState) AvailabilityZone(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockState) AvailabilityZone(arg0 context.Context, arg1 machine.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZone", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -155,19 +155,19 @@ func (c *MockStateAvailabilityZoneCall) Return(arg0 string, arg1 error) *MockSta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAvailabilityZoneCall) Do(f func(context.Context, string) (string, error)) *MockStateAvailabilityZoneCall {
+func (c *MockStateAvailabilityZoneCall) Do(f func(context.Context, machine.UUID) (string, error)) *MockStateAvailabilityZoneCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAvailabilityZoneCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateAvailabilityZoneCall {
+func (c *MockStateAvailabilityZoneCall) DoAndReturn(f func(context.Context, machine.UUID) (string, error)) *MockStateAvailabilityZoneCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ClearMachineReboot mocks base method.
-func (m *MockState) ClearMachineReboot(ctx context.Context, uuid string) error {
+func (m *MockState) ClearMachineReboot(ctx context.Context, uuid machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearMachineReboot", ctx, uuid)
 	ret0, _ := ret[0].(error)
@@ -193,19 +193,19 @@ func (c *MockStateClearMachineRebootCall) Return(arg0 error) *MockStateClearMach
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateClearMachineRebootCall) Do(f func(context.Context, string) error) *MockStateClearMachineRebootCall {
+func (c *MockStateClearMachineRebootCall) Do(f func(context.Context, machine.UUID) error) *MockStateClearMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateClearMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockStateClearMachineRebootCall {
+func (c *MockStateClearMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockStateClearMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateMachine mocks base method.
-func (m *MockState) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2, arg3 string) error {
+func (m *MockState) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2 string, arg3 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -231,19 +231,19 @@ func (c *MockStateCreateMachineCall) Return(arg0 error) *MockStateCreateMachineC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateCreateMachineCall) Do(f func(context.Context, machine.Name, string, string) error) *MockStateCreateMachineCall {
+func (c *MockStateCreateMachineCall) Do(f func(context.Context, machine.Name, string, machine.UUID) error) *MockStateCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, string, string) error) *MockStateCreateMachineCall {
+func (c *MockStateCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, string, machine.UUID) error) *MockStateCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateMachineWithParent mocks base method.
-func (m *MockState) CreateMachineWithParent(arg0 context.Context, arg1, arg2 machine.Name, arg3, arg4 string) error {
+func (m *MockState) CreateMachineWithParent(arg0 context.Context, arg1, arg2 machine.Name, arg3 string, arg4 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachineWithParent", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -269,13 +269,13 @@ func (c *MockStateCreateMachineWithParentCall) Return(arg0 error) *MockStateCrea
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateCreateMachineWithParentCall) Do(f func(context.Context, machine.Name, machine.Name, string, string) error) *MockStateCreateMachineWithParentCall {
+func (c *MockStateCreateMachineWithParentCall) Do(f func(context.Context, machine.Name, machine.Name, string, machine.UUID) error) *MockStateCreateMachineWithParentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateMachineWithParentCall) DoAndReturn(f func(context.Context, machine.Name, machine.Name, string, string) error) *MockStateCreateMachineWithParentCall {
+func (c *MockStateCreateMachineWithParentCall) DoAndReturn(f func(context.Context, machine.Name, machine.Name, string, machine.UUID) error) *MockStateCreateMachineWithParentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -319,7 +319,7 @@ func (c *MockStateDeleteMachineCall) DoAndReturn(f func(context.Context, machine
 }
 
 // DeleteMachineCloudInstance mocks base method.
-func (m *MockState) DeleteMachineCloudInstance(arg0 context.Context, arg1 string) error {
+func (m *MockState) DeleteMachineCloudInstance(arg0 context.Context, arg1 machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMachineCloudInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -345,22 +345,22 @@ func (c *MockStateDeleteMachineCloudInstanceCall) Return(arg0 error) *MockStateD
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateDeleteMachineCloudInstanceCall) Do(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
+func (c *MockStateDeleteMachineCloudInstanceCall) Do(f func(context.Context, machine.UUID) error) *MockStateDeleteMachineCloudInstanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
+func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockStateDeleteMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetAllMachineRemovals mocks base method.
-func (m *MockState) GetAllMachineRemovals(arg0 context.Context) ([]string, error) {
+func (m *MockState) GetAllMachineRemovals(arg0 context.Context) ([]machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllMachineRemovals", arg0)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -378,19 +378,19 @@ type MockStateGetAllMachineRemovalsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetAllMachineRemovalsCall) Return(arg0 []string, arg1 error) *MockStateGetAllMachineRemovalsCall {
+func (c *MockStateGetAllMachineRemovalsCall) Return(arg0 []machine.UUID, arg1 error) *MockStateGetAllMachineRemovalsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetAllMachineRemovalsCall) Do(f func(context.Context) ([]string, error)) *MockStateGetAllMachineRemovalsCall {
+func (c *MockStateGetAllMachineRemovalsCall) Do(f func(context.Context) ([]machine.UUID, error)) *MockStateGetAllMachineRemovalsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetAllMachineRemovalsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockStateGetAllMachineRemovalsCall {
+func (c *MockStateGetAllMachineRemovalsCall) DoAndReturn(f func(context.Context) ([]machine.UUID, error)) *MockStateGetAllMachineRemovalsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -474,10 +474,10 @@ func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, machin
 }
 
 // GetMachineParentUUID mocks base method.
-func (m *MockState) GetMachineParentUUID(ctx context.Context, machineUUID string) (string, error) {
+func (m *MockState) GetMachineParentUUID(ctx context.Context, machineUUID machine.UUID) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineParentUUID", ctx, machineUUID)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -495,19 +495,19 @@ type MockStateGetMachineParentUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetMachineParentUUIDCall) Return(arg0 string, arg1 error) *MockStateGetMachineParentUUIDCall {
+func (c *MockStateGetMachineParentUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockStateGetMachineParentUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachineParentUUIDCall) Do(f func(context.Context, string) (string, error)) *MockStateGetMachineParentUUIDCall {
+func (c *MockStateGetMachineParentUUIDCall) Do(f func(context.Context, machine.UUID) (machine.UUID, error)) *MockStateGetMachineParentUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachineParentUUIDCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateGetMachineParentUUIDCall {
+func (c *MockStateGetMachineParentUUIDCall) DoAndReturn(f func(context.Context, machine.UUID) (machine.UUID, error)) *MockStateGetMachineParentUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -552,10 +552,10 @@ func (c *MockStateGetMachineStatusCall) DoAndReturn(f func(context.Context, mach
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockState) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockState) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -573,25 +573,25 @@ type MockStateGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockStateGetMachineUUIDCall {
+func (c *MockStateGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockStateGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockStateGetMachineUUIDCall {
+func (c *MockStateGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockStateGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateGetMachineUUIDCall {
+func (c *MockStateGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockStateGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HardwareCharacteristics mocks base method.
-func (m *MockState) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockState) HardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
 	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
@@ -618,13 +618,13 @@ func (c *MockStateHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
+func (c *MockStateHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
+func (c *MockStateHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -708,7 +708,7 @@ func (c *MockStateInitialWatchStatementCall) DoAndReturn(f func() (string, strin
 }
 
 // InstanceID mocks base method.
-func (m *MockState) InstanceID(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockState) InstanceID(arg0 context.Context, arg1 machine.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -735,19 +735,19 @@ func (c *MockStateInstanceIDCall) Return(arg0 string, arg1 error) *MockStateInst
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInstanceIDCall) Do(f func(context.Context, string) (string, error)) *MockStateInstanceIDCall {
+func (c *MockStateInstanceIDCall) Do(f func(context.Context, machine.UUID) (string, error)) *MockStateInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInstanceIDCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateInstanceIDCall {
+func (c *MockStateInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (string, error)) *MockStateInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceIDAndName mocks base method.
-func (m *MockState) InstanceIDAndName(ctx context.Context, mUUID string) (string, string, error) {
+func (m *MockState) InstanceIDAndName(ctx context.Context, mUUID machine.UUID) (string, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceIDAndName", ctx, mUUID)
 	ret0, _ := ret[0].(string)
@@ -775,13 +775,13 @@ func (c *MockStateInstanceIDAndNameCall) Return(arg0, arg1 string, arg2 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInstanceIDAndNameCall) Do(f func(context.Context, string) (string, string, error)) *MockStateInstanceIDAndNameCall {
+func (c *MockStateInstanceIDAndNameCall) Do(f func(context.Context, machine.UUID) (string, string, error)) *MockStateInstanceIDAndNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInstanceIDAndNameCall) DoAndReturn(f func(context.Context, string) (string, string, error)) *MockStateInstanceIDAndNameCall {
+func (c *MockStateInstanceIDAndNameCall) DoAndReturn(f func(context.Context, machine.UUID) (string, string, error)) *MockStateInstanceIDAndNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -826,7 +826,7 @@ func (c *MockStateIsMachineControllerCall) DoAndReturn(f func(context.Context, m
 }
 
 // IsMachineRebootRequired mocks base method.
-func (m *MockState) IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error) {
+func (m *MockState) IsMachineRebootRequired(ctx context.Context, uuid machine.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMachineRebootRequired", ctx, uuid)
 	ret0, _ := ret[0].(bool)
@@ -853,13 +853,13 @@ func (c *MockStateIsMachineRebootRequiredCall) Return(arg0 bool, arg1 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateIsMachineRebootRequiredCall) Do(f func(context.Context, string) (bool, error)) *MockStateIsMachineRebootRequiredCall {
+func (c *MockStateIsMachineRebootRequiredCall) Do(f func(context.Context, machine.UUID) (bool, error)) *MockStateIsMachineRebootRequiredCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockStateIsMachineRebootRequiredCall {
+func (c *MockStateIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, machine.UUID) (bool, error)) *MockStateIsMachineRebootRequiredCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1017,7 +1017,7 @@ func (c *MockStateNamespaceForWatchMachineRebootCall) DoAndReturn(f func() strin
 }
 
 // RequireMachineReboot mocks base method.
-func (m *MockState) RequireMachineReboot(ctx context.Context, uuid string) error {
+func (m *MockState) RequireMachineReboot(ctx context.Context, uuid machine.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequireMachineReboot", ctx, uuid)
 	ret0, _ := ret[0].(error)
@@ -1043,19 +1043,19 @@ func (c *MockStateRequireMachineRebootCall) Return(arg0 error) *MockStateRequire
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateRequireMachineRebootCall) Do(f func(context.Context, string) error) *MockStateRequireMachineRebootCall {
+func (c *MockStateRequireMachineRebootCall) Do(f func(context.Context, machine.UUID) error) *MockStateRequireMachineRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateRequireMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockStateRequireMachineRebootCall {
+func (c *MockStateRequireMachineRebootCall) DoAndReturn(f func(context.Context, machine.UUID) error) *MockStateRequireMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetAppliedLXDProfileNames mocks base method.
-func (m *MockState) SetAppliedLXDProfileNames(ctx context.Context, mUUID string, profileNames []string) error {
+func (m *MockState) SetAppliedLXDProfileNames(ctx context.Context, mUUID machine.UUID, profileNames []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAppliedLXDProfileNames", ctx, mUUID, profileNames)
 	ret0, _ := ret[0].(error)
@@ -1081,13 +1081,13 @@ func (c *MockStateSetAppliedLXDProfileNamesCall) Return(arg0 error) *MockStateSe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetAppliedLXDProfileNamesCall) Do(f func(context.Context, string, []string) error) *MockStateSetAppliedLXDProfileNamesCall {
+func (c *MockStateSetAppliedLXDProfileNamesCall) Do(f func(context.Context, machine.UUID, []string) error) *MockStateSetAppliedLXDProfileNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, string, []string) error) *MockStateSetAppliedLXDProfileNamesCall {
+func (c *MockStateSetAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, machine.UUID, []string) error) *MockStateSetAppliedLXDProfileNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1169,7 +1169,7 @@ func (c *MockStateSetKeepInstanceCall) DoAndReturn(f func(context.Context, machi
 }
 
 // SetMachineCloudInstance mocks base method.
-func (m *MockState) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 string, arg4 *instance.HardwareCharacteristics) error {
+func (m *MockState) SetMachineCloudInstance(arg0 context.Context, arg1 machine.UUID, arg2 instance.Id, arg3 string, arg4 *instance.HardwareCharacteristics) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMachineCloudInstance", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -1195,13 +1195,13 @@ func (c *MockStateSetMachineCloudInstanceCall) Return(arg0 error) *MockStateSetM
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetMachineCloudInstanceCall) Do(f func(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
+func (c *MockStateSetMachineCloudInstanceCall) Do(f func(context.Context, machine.UUID, instance.Id, string, *instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
+func (c *MockStateSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, machine.UUID, instance.Id, string, *instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1283,7 +1283,7 @@ func (c *MockStateSetMachineStatusCall) DoAndReturn(f func(context.Context, mach
 }
 
 // SetRunningAgentBinaryVersion mocks base method.
-func (m *MockState) SetRunningAgentBinaryVersion(arg0 context.Context, arg1 string, arg2 agentbinary.Version) error {
+func (m *MockState) SetRunningAgentBinaryVersion(arg0 context.Context, arg1 machine.UUID, arg2 agentbinary.Version) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRunningAgentBinaryVersion", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1309,13 +1309,13 @@ func (c *MockStateSetRunningAgentBinaryVersionCall) Return(arg0 error) *MockStat
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetRunningAgentBinaryVersionCall) Do(f func(context.Context, string, agentbinary.Version) error) *MockStateSetRunningAgentBinaryVersionCall {
+func (c *MockStateSetRunningAgentBinaryVersionCall) Do(f func(context.Context, machine.UUID, agentbinary.Version) error) *MockStateSetRunningAgentBinaryVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetRunningAgentBinaryVersionCall) DoAndReturn(f func(context.Context, string, agentbinary.Version) error) *MockStateSetRunningAgentBinaryVersionCall {
+func (c *MockStateSetRunningAgentBinaryVersionCall) DoAndReturn(f func(context.Context, machine.UUID, agentbinary.Version) error) *MockStateSetRunningAgentBinaryVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1360,7 +1360,7 @@ func (c *MockStateShouldKeepInstanceCall) DoAndReturn(f func(context.Context, ma
 }
 
 // ShouldRebootOrShutdown mocks base method.
-func (m *MockState) ShouldRebootOrShutdown(ctx context.Context, uuid string) (machine.RebootAction, error) {
+func (m *MockState) ShouldRebootOrShutdown(ctx context.Context, uuid machine.UUID) (machine.RebootAction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldRebootOrShutdown", ctx, uuid)
 	ret0, _ := ret[0].(machine.RebootAction)
@@ -1387,13 +1387,13 @@ func (c *MockStateShouldRebootOrShutdownCall) Return(arg0 machine.RebootAction, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateShouldRebootOrShutdownCall) Do(f func(context.Context, string) (machine.RebootAction, error)) *MockStateShouldRebootOrShutdownCall {
+func (c *MockStateShouldRebootOrShutdownCall) Do(f func(context.Context, machine.UUID) (machine.RebootAction, error)) *MockStateShouldRebootOrShutdownCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateShouldRebootOrShutdownCall) DoAndReturn(f func(context.Context, string) (machine.RebootAction, error)) *MockStateShouldRebootOrShutdownCall {
+func (c *MockStateShouldRebootOrShutdownCall) DoAndReturn(f func(context.Context, machine.UUID) (machine.RebootAction, error)) *MockStateShouldRebootOrShutdownCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -13,7 +13,7 @@ import (
 
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/instance"
-	cmachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/domain/life"
 	domainmachine "github.com/juju/juju/domain/machine"
@@ -38,7 +38,7 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 func (s *serviceSuite) TestCreateMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.Name("666"), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().CreateMachine(gomock.Any(), machine.Name("666"), gomock.Any(), gomock.Any()).Return(nil)
 
 	_, err := NewService(s.state).CreateMachine(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
@@ -50,7 +50,7 @@ func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.Name("666"), gomock.Any(), gomock.Any()).Return(rErr)
+	s.state.EXPECT().CreateMachine(gomock.Any(), machine.Name("666"), gomock.Any(), gomock.Any()).Return(rErr)
 
 	_, err := NewService(s.state).CreateMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -64,9 +64,9 @@ func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 func (s *serviceSuite) TestCreateMachineAlreadyExists(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.Name("666"), gomock.Any(), gomock.Any()).Return(machineerrors.MachineAlreadyExists)
+	s.state.EXPECT().CreateMachine(gomock.Any(), machine.Name("666"), gomock.Any(), gomock.Any()).Return(machineerrors.MachineAlreadyExists)
 
-	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.Name("666"))
+	_, err := NewService(s.state).CreateMachine(context.Background(), machine.Name("666"))
 	c.Check(err, jc.ErrorIs, machineerrors.MachineAlreadyExists)
 }
 
@@ -75,9 +75,9 @@ func (s *serviceSuite) TestCreateMachineAlreadyExists(c *gc.C) {
 func (s *serviceSuite) TestCreateMachineWithParentSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), machine.Name("666"), machine.Name("parent"), gomock.Any(), gomock.Any()).Return(nil)
 
-	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
+	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), machine.Name("666"), machine.Name("parent"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -87,9 +87,9 @@ func (s *serviceSuite) TestCreateMachineWithParentError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(rErr)
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), machine.Name("666"), machine.Name("parent"), gomock.Any(), gomock.Any()).Return(rErr)
 
-	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
+	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), machine.Name("666"), machine.Name("parent"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `creating machine "666" with parent "parent": boom`)
 }
@@ -101,9 +101,9 @@ func (s *serviceSuite) TestCreateMachineWithParentError(c *gc.C) {
 func (s *serviceSuite) TestCreateMachineWithParentParentNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(coreerrors.NotFound)
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), machine.Name("666"), machine.Name("parent"), gomock.Any(), gomock.Any()).Return(coreerrors.NotFound)
 
-	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
+	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), machine.Name("666"), machine.Name("parent"))
 	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
@@ -114,9 +114,9 @@ func (s *serviceSuite) TestCreateMachineWithParentParentNotFound(c *gc.C) {
 func (s *serviceSuite) TestCreateMachineWithParentMachineAlreadyExists(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(machineerrors.MachineAlreadyExists)
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), machine.Name("666"), machine.Name("parent"), gomock.Any(), gomock.Any()).Return(machineerrors.MachineAlreadyExists)
 
-	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
+	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), machine.Name("666"), machine.Name("parent"))
 	c.Check(err, jc.ErrorIs, machineerrors.MachineAlreadyExists)
 }
 
@@ -124,7 +124,7 @@ func (s *serviceSuite) TestCreateMachineWithParentMachineAlreadyExists(c *gc.C) 
 func (s *serviceSuite) TestDeleteMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.Name("666")).Return(nil)
+	s.state.EXPECT().DeleteMachine(gomock.Any(), machine.Name("666")).Return(nil)
 
 	err := NewService(s.state).DeleteMachine(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
@@ -136,7 +136,7 @@ func (s *serviceSuite) TestDeleteMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.Name("666")).Return(rErr)
+	s.state.EXPECT().DeleteMachine(gomock.Any(), machine.Name("666")).Return(rErr)
 
 	err := NewService(s.state).DeleteMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -148,7 +148,7 @@ func (s *serviceSuite) TestGetLifeSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	alive := life.Alive
-	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(&alive, nil)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), machine.Name("666")).Return(&alive, nil)
 
 	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
@@ -161,7 +161,7 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(nil, rErr)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), machine.Name("666")).Return(nil, rErr)
 
 	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Check(l, gc.IsNil)
@@ -175,7 +175,7 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(nil, coreerrors.NotFound)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), machine.Name("666")).Return(nil, coreerrors.NotFound)
 
 	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Check(l, gc.IsNil)
@@ -187,7 +187,7 @@ func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 func (s *serviceSuite) TestSetMachineLifeSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life.Alive).Return(nil)
+	s.state.EXPECT().SetMachineLife(gomock.Any(), machine.Name("666"), life.Alive).Return(nil)
 
 	err := NewService(s.state).SetMachineLife(context.Background(), "666", life.Alive)
 	c.Check(err, jc.ErrorIsNil)
@@ -199,7 +199,7 @@ func (s *serviceSuite) TestSetMachineLifeError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life.Alive).Return(rErr)
+	s.state.EXPECT().SetMachineLife(gomock.Any(), machine.Name("666"), life.Alive).Return(rErr)
 
 	err := NewService(s.state).SetMachineLife(context.Background(), "666", life.Alive)
 	c.Check(err, jc.ErrorIs, rErr)
@@ -212,7 +212,7 @@ func (s *serviceSuite) TestSetMachineLifeError(c *gc.C) {
 func (s *serviceSuite) TestSetMachineLifeMachineDontExist(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("nonexistent"), life.Alive).Return(coreerrors.NotFound)
+	s.state.EXPECT().SetMachineLife(gomock.Any(), machine.Name("nonexistent"), life.Alive).Return(coreerrors.NotFound)
 
 	err := NewService(s.state).SetMachineLife(context.Background(), "nonexistent", life.Alive)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
@@ -223,7 +223,7 @@ func (s *serviceSuite) TestSetMachineLifeMachineDontExist(c *gc.C) {
 func (s *serviceSuite) TestEnsureDeadMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life.Dead).Return(nil)
+	s.state.EXPECT().SetMachineLife(gomock.Any(), machine.Name("666"), life.Dead).Return(nil)
 
 	err := NewService(s.state).EnsureDeadMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
@@ -235,7 +235,7 @@ func (s *serviceSuite) TestEnsureDeadMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life.Dead).Return(rErr)
+	s.state.EXPECT().SetMachineLife(gomock.Any(), machine.Name("666"), life.Dead).Return(rErr)
 
 	err := NewService(s.state).EnsureDeadMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -244,11 +244,11 @@ func (s *serviceSuite) TestEnsureDeadMachineError(c *gc.C) {
 func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AllMachineNames(gomock.Any()).Return([]cmachine.Name{"666"}, nil)
+	s.state.EXPECT().AllMachineNames(gomock.Any()).Return([]machine.Name{"666"}, nil)
 
 	machines, err := NewService(s.state).AllMachineNames(context.Background())
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(machines, gc.DeepEquals, []cmachine.Name{"666"})
+	c.Assert(machines, gc.DeepEquals, []machine.Name{"666"})
 }
 
 // TestListAllMachinesError asserts that an error coming from the state layer is
@@ -267,7 +267,7 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 func (s *serviceSuite) TestInstanceIdSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceID(gomock.Any(), "deadbeef-0bad-400d-8000-4b1d0d06f00d").Return("123", nil)
+	s.state.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef-0bad-400d-8000-4b1d0d06f00d")).Return("123", nil)
 
 	instanceId, err := NewService(s.state).InstanceID(context.Background(), "deadbeef-0bad-400d-8000-4b1d0d06f00d")
 	c.Check(err, jc.ErrorIsNil)
@@ -280,7 +280,7 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().InstanceID(gomock.Any(), "deadbeef-0bad-400d-8000-4b1d0d06f00d").Return("", rErr)
+	s.state.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef-0bad-400d-8000-4b1d0d06f00d")).Return("", rErr)
 
 	instanceId, err := NewService(s.state).InstanceID(context.Background(), "deadbeef-0bad-400d-8000-4b1d0d06f00d")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -294,7 +294,7 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 func (s *serviceSuite) TestInstanceIdNotProvisionedError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceID(gomock.Any(), "deadbeef-0bad-400d-8000-4b1d0d06f00d").Return("", machineerrors.NotProvisioned)
+	s.state.EXPECT().InstanceID(gomock.Any(), machine.UUID("deadbeef-0bad-400d-8000-4b1d0d06f00d")).Return("", machineerrors.NotProvisioned)
 
 	instanceId, err := NewService(s.state).InstanceID(context.Background(), "deadbeef-0bad-400d-8000-4b1d0d06f00d")
 	c.Check(err, jc.ErrorIs, machineerrors.NotProvisioned)
@@ -306,7 +306,7 @@ func (s *serviceSuite) TestGetMachineStatusSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	expectedStatus := status.StatusInfo{Status: status.Started}
-	s.state.EXPECT().GetMachineStatus(gomock.Any(), cmachine.Name("666")).Return(domainmachine.StatusInfo[domainmachine.MachineStatusType]{
+	s.state.EXPECT().GetMachineStatus(gomock.Any(), machine.Name("666")).Return(domainmachine.StatusInfo[domainmachine.MachineStatusType]{
 		Status: domainmachine.MachineStatusStarted,
 	}, nil)
 
@@ -321,7 +321,7 @@ func (s *serviceSuite) TestGetMachineStatusError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().GetMachineStatus(gomock.Any(), cmachine.Name("666")).Return(domainmachine.StatusInfo[domainmachine.MachineStatusType]{}, rErr)
+	s.state.EXPECT().GetMachineStatus(gomock.Any(), machine.Name("666")).Return(domainmachine.StatusInfo[domainmachine.MachineStatusType]{}, rErr)
 
 	machineStatus, err := NewService(s.state).GetMachineStatus(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -333,7 +333,7 @@ func (s *serviceSuite) TestSetMachineStatusSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	newStatus := status.StatusInfo{Status: status.Started}
-	s.state.EXPECT().SetMachineStatus(gomock.Any(), cmachine.Name("666"), domainmachine.StatusInfo[domainmachine.MachineStatusType]{
+	s.state.EXPECT().SetMachineStatus(gomock.Any(), machine.Name("666"), domainmachine.StatusInfo[domainmachine.MachineStatusType]{
 		Status: domainmachine.MachineStatusStarted,
 	}).Return(nil)
 
@@ -348,7 +348,7 @@ func (s *serviceSuite) TestSetMachineStatusError(c *gc.C) {
 
 	newStatus := status.StatusInfo{Status: status.Started}
 	rErr := errors.New("boom")
-	s.state.EXPECT().SetMachineStatus(gomock.Any(), cmachine.Name("666"), domainmachine.StatusInfo[domainmachine.MachineStatusType]{
+	s.state.EXPECT().SetMachineStatus(gomock.Any(), machine.Name("666"), domainmachine.StatusInfo[domainmachine.MachineStatusType]{
 		Status: domainmachine.MachineStatusStarted,
 	}).Return(rErr)
 
@@ -368,7 +368,7 @@ func (s *serviceSuite) TestGetInstanceStatusSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	expectedStatus := status.StatusInfo{Status: status.Running}
-	s.state.EXPECT().GetInstanceStatus(gomock.Any(), cmachine.Name("666")).Return(domainmachine.StatusInfo[domainmachine.InstanceStatusType]{
+	s.state.EXPECT().GetInstanceStatus(gomock.Any(), machine.Name("666")).Return(domainmachine.StatusInfo[domainmachine.InstanceStatusType]{
 		Status: domainmachine.InstanceStatusRunning,
 	}, nil)
 
@@ -383,7 +383,7 @@ func (s *serviceSuite) TestGetInstanceStatusError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().GetInstanceStatus(gomock.Any(), cmachine.Name("666")).Return(domainmachine.StatusInfo[domainmachine.InstanceStatusType]{}, rErr)
+	s.state.EXPECT().GetInstanceStatus(gomock.Any(), machine.Name("666")).Return(domainmachine.StatusInfo[domainmachine.InstanceStatusType]{}, rErr)
 
 	instanceStatus, err := NewService(s.state).GetInstanceStatus(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -396,7 +396,7 @@ func (s *serviceSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	newStatus := status.StatusInfo{Status: status.Running}
-	s.state.EXPECT().SetInstanceStatus(gomock.Any(), cmachine.Name("666"), domainmachine.StatusInfo[domainmachine.InstanceStatusType]{
+	s.state.EXPECT().SetInstanceStatus(gomock.Any(), machine.Name("666"), domainmachine.StatusInfo[domainmachine.InstanceStatusType]{
 		Status: domainmachine.InstanceStatusRunning,
 	}).Return(nil)
 
@@ -411,7 +411,7 @@ func (s *serviceSuite) TestSetInstanceStatusError(c *gc.C) {
 
 	rErr := errors.New("boom")
 	newStatus := status.StatusInfo{Status: status.Running}
-	s.state.EXPECT().SetInstanceStatus(gomock.Any(), cmachine.Name("666"), domainmachine.StatusInfo[domainmachine.InstanceStatusType]{
+	s.state.EXPECT().SetInstanceStatus(gomock.Any(), machine.Name("666"), domainmachine.StatusInfo[domainmachine.InstanceStatusType]{
 		Status: domainmachine.InstanceStatusRunning,
 	}).Return(rErr)
 
@@ -430,9 +430,9 @@ func (s *serviceSuite) TestSetInstanceStatusInvalid(c *gc.C) {
 func (s *serviceSuite) TestIsControllerSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().IsMachineController(gomock.Any(), cmachine.Name("666")).Return(true, nil)
+	s.state.EXPECT().IsMachineController(gomock.Any(), machine.Name("666")).Return(true, nil)
 
-	isController, err := NewService(s.state).IsMachineController(context.Background(), cmachine.Name("666"))
+	isController, err := NewService(s.state).IsMachineController(context.Background(), machine.Name("666"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(isController, jc.IsTrue)
 }
@@ -443,9 +443,9 @@ func (s *serviceSuite) TestIsControllerError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().IsMachineController(gomock.Any(), cmachine.Name("666")).Return(false, rErr)
+	s.state.EXPECT().IsMachineController(gomock.Any(), machine.Name("666")).Return(false, rErr)
 
-	isController, err := NewService(s.state).IsMachineController(context.Background(), cmachine.Name("666"))
+	isController, err := NewService(s.state).IsMachineController(context.Background(), machine.Name("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(isController, jc.IsFalse)
 }
@@ -456,9 +456,9 @@ func (s *serviceSuite) TestIsControllerError(c *gc.C) {
 func (s *serviceSuite) TestIsControllerNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().IsMachineController(gomock.Any(), cmachine.Name("666")).Return(false, coreerrors.NotFound)
+	s.state.EXPECT().IsMachineController(gomock.Any(), machine.Name("666")).Return(false, coreerrors.NotFound)
 
-	isController, err := NewService(s.state).IsMachineController(context.Background(), cmachine.Name("666"))
+	isController, err := NewService(s.state).IsMachineController(context.Background(), machine.Name("666"))
 	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Check(isController, jc.IsFalse)
 }
@@ -466,7 +466,7 @@ func (s *serviceSuite) TestIsControllerNotFound(c *gc.C) {
 func (s *serviceSuite) TestRequireMachineRebootSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().RequireMachineReboot(gomock.Any(), "u-u-i-d").Return(nil)
+	s.state.EXPECT().RequireMachineReboot(gomock.Any(), machine.UUID("u-u-i-d")).Return(nil)
 
 	err := NewService(s.state).RequireMachineReboot(context.Background(), "u-u-i-d")
 	c.Assert(err, jc.ErrorIsNil)
@@ -478,7 +478,7 @@ func (s *serviceSuite) TestRequireMachineRebootError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().RequireMachineReboot(gomock.Any(), "u-u-i-d").Return(rErr)
+	s.state.EXPECT().RequireMachineReboot(gomock.Any(), machine.UUID("u-u-i-d")).Return(rErr)
 
 	err := NewService(s.state).RequireMachineReboot(context.Background(), "u-u-i-d")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -488,7 +488,7 @@ func (s *serviceSuite) TestRequireMachineRebootError(c *gc.C) {
 func (s *serviceSuite) TestClearMachineRebootSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().ClearMachineReboot(gomock.Any(), "u-u-i-d").Return(nil)
+	s.state.EXPECT().ClearMachineReboot(gomock.Any(), machine.UUID("u-u-i-d")).Return(nil)
 
 	err := NewService(s.state).ClearMachineReboot(context.Background(), "u-u-i-d")
 	c.Assert(err, jc.ErrorIsNil)
@@ -500,7 +500,7 @@ func (s *serviceSuite) TestClearMachineRebootError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().ClearMachineReboot(gomock.Any(), "u-u-i-d").Return(rErr)
+	s.state.EXPECT().ClearMachineReboot(gomock.Any(), machine.UUID("u-u-i-d")).Return(rErr)
 
 	err := NewService(s.state).ClearMachineReboot(context.Background(), "u-u-i-d")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -510,7 +510,7 @@ func (s *serviceSuite) TestClearMachineRebootError(c *gc.C) {
 func (s *serviceSuite) TestIsMachineRebootSuccessMachineNeedReboot(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().IsMachineRebootRequired(gomock.Any(), "u-u-i-d").Return(true, nil)
+	s.state.EXPECT().IsMachineRebootRequired(gomock.Any(), machine.UUID("u-u-i-d")).Return(true, nil)
 
 	needReboot, err := NewService(s.state).IsMachineRebootRequired(context.Background(), "u-u-i-d")
 	c.Assert(err, jc.ErrorIsNil)
@@ -520,7 +520,7 @@ func (s *serviceSuite) TestIsMachineRebootSuccessMachineNeedReboot(c *gc.C) {
 func (s *serviceSuite) TestIsMachineRebootSuccessMachineDontNeedReboot(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().IsMachineRebootRequired(gomock.Any(), "u-u-i-d").Return(false, nil)
+	s.state.EXPECT().IsMachineRebootRequired(gomock.Any(), machine.UUID("u-u-i-d")).Return(false, nil)
 
 	needReboot, err := NewService(s.state).IsMachineRebootRequired(context.Background(), "u-u-i-d")
 	c.Assert(err, jc.ErrorIsNil)
@@ -533,7 +533,7 @@ func (s *serviceSuite) TestIsMachineRebootError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().IsMachineRebootRequired(gomock.Any(), "u-u-i-d").Return(false, rErr)
+	s.state.EXPECT().IsMachineRebootRequired(gomock.Any(), machine.UUID("u-u-i-d")).Return(false, rErr)
 
 	_, err := NewService(s.state).IsMachineRebootRequired(context.Background(), "u-u-i-d")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -545,11 +545,11 @@ func (s *serviceSuite) TestIsMachineRebootError(c *gc.C) {
 func (s *serviceSuite) TestGetMachineParentUUIDSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), "666").Return("123", nil)
+	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), machine.UUID("666")).Return("123", nil)
 
-	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), "666")
+	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), machine.UUID("666"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(parentUUID, gc.Equals, "123")
+	c.Assert(parentUUID, gc.Equals, machine.UUID("123"))
 }
 
 // TestGetMachineParentUUIDError asserts that an error coming from the state
@@ -558,11 +558,11 @@ func (s *serviceSuite) TestGetMachineParentUUIDError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), "666").Return("", rErr)
+	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), machine.UUID("666")).Return("", rErr)
 
-	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), "666")
+	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), machine.UUID("666"))
 	c.Check(err, jc.ErrorIs, rErr)
-	c.Check(parentUUID, gc.Equals, "")
+	c.Check(parentUUID, gc.Equals, machine.UUID(""))
 }
 
 // TestGetMachineParentUUIDNotFound asserts that the state layer returns a
@@ -571,11 +571,11 @@ func (s *serviceSuite) TestGetMachineParentUUIDError(c *gc.C) {
 func (s *serviceSuite) TestGetMachineParentUUIDNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), "666").Return("", coreerrors.NotFound)
+	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), machine.UUID("666")).Return("", coreerrors.NotFound)
 
-	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), "666")
+	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), machine.UUID("666"))
 	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
-	c.Check(parentUUID, gc.Equals, "")
+	c.Check(parentUUID, gc.Equals, machine.UUID(""))
 }
 
 // TestGetMachineParentUUIDMachineHasNoParent asserts that the state layer
@@ -585,11 +585,11 @@ func (s *serviceSuite) TestGetMachineParentUUIDNotFound(c *gc.C) {
 func (s *serviceSuite) TestGetMachineParentUUIDMachineHasNoParent(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), "666").Return("", machineerrors.MachineHasNoParent)
+	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), machine.UUID("666")).Return("", machineerrors.MachineHasNoParent)
 
 	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, machineerrors.MachineHasNoParent)
-	c.Check(parentUUID, gc.Equals, "")
+	c.Check(parentUUID, gc.Equals, machine.UUID(""))
 }
 
 // TestMachineShouldRebootOrShutdownDoNothing asserts that the reboot action is preserved from the state
@@ -597,11 +597,11 @@ func (s *serviceSuite) TestGetMachineParentUUIDMachineHasNoParent(c *gc.C) {
 func (s *serviceSuite) TestMachineShouldRebootOrShutdownDoNothing(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().ShouldRebootOrShutdown(gomock.Any(), "u-u-i-d").Return(cmachine.ShouldDoNothing, nil)
+	s.state.EXPECT().ShouldRebootOrShutdown(gomock.Any(), machine.UUID("u-u-i-d")).Return(machine.ShouldDoNothing, nil)
 
 	needReboot, err := NewService(s.state).ShouldRebootOrShutdown(context.Background(), "u-u-i-d")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(needReboot, gc.Equals, cmachine.ShouldDoNothing)
+	c.Assert(needReboot, gc.Equals, machine.ShouldDoNothing)
 }
 
 // TestMachineShouldRebootOrShutdownReboot asserts that the reboot action is
@@ -609,11 +609,11 @@ func (s *serviceSuite) TestMachineShouldRebootOrShutdownDoNothing(c *gc.C) {
 func (s *serviceSuite) TestMachineShouldRebootOrShutdownReboot(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().ShouldRebootOrShutdown(gomock.Any(), "u-u-i-d").Return(cmachine.ShouldReboot, nil)
+	s.state.EXPECT().ShouldRebootOrShutdown(gomock.Any(), machine.UUID("u-u-i-d")).Return(machine.ShouldReboot, nil)
 
 	needReboot, err := NewService(s.state).ShouldRebootOrShutdown(context.Background(), "u-u-i-d")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(needReboot, gc.Equals, cmachine.ShouldReboot)
+	c.Assert(needReboot, gc.Equals, machine.ShouldReboot)
 }
 
 // TestMachineShouldRebootOrShutdownShutdown asserts that the reboot action is
@@ -621,11 +621,11 @@ func (s *serviceSuite) TestMachineShouldRebootOrShutdownReboot(c *gc.C) {
 func (s *serviceSuite) TestMachineShouldRebootOrShutdownShutdown(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().ShouldRebootOrShutdown(gomock.Any(), "u-u-i-d").Return(cmachine.ShouldShutdown, nil)
+	s.state.EXPECT().ShouldRebootOrShutdown(gomock.Any(), machine.UUID("u-u-i-d")).Return(machine.ShouldShutdown, nil)
 
 	needReboot, err := NewService(s.state).ShouldRebootOrShutdown(context.Background(), "u-u-i-d")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(needReboot, gc.Equals, cmachine.ShouldShutdown)
+	c.Assert(needReboot, gc.Equals, machine.ShouldShutdown)
 }
 
 // TestMachineShouldRebootOrShutdownError asserts that if the state layer
@@ -635,7 +635,7 @@ func (s *serviceSuite) TestMachineShouldRebootOrShutdownError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().ShouldRebootOrShutdown(gomock.Any(), "u-u-i-d").Return(cmachine.ShouldDoNothing, rErr)
+	s.state.EXPECT().ShouldRebootOrShutdown(gomock.Any(), machine.UUID("u-u-i-d")).Return(machine.ShouldDoNothing, rErr)
 
 	_, err := NewService(s.state).ShouldRebootOrShutdown(context.Background(), "u-u-i-d")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -647,9 +647,9 @@ func (s *serviceSuite) TestMachineShouldRebootOrShutdownError(c *gc.C) {
 func (s *serviceSuite) TestMarkMachineForRemovalSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().MarkMachineForRemoval(gomock.Any(), cmachine.Name("666")).Return(nil)
+	s.state.EXPECT().MarkMachineForRemoval(gomock.Any(), machine.Name("666")).Return(nil)
 
-	err := NewService(s.state).MarkMachineForRemoval(context.Background(), cmachine.Name("666"))
+	err := NewService(s.state).MarkMachineForRemoval(context.Background(), machine.Name("666"))
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -659,9 +659,9 @@ func (s *serviceSuite) TestMarkMachineForRemovalSuccess(c *gc.C) {
 func (s *serviceSuite) TestMarkMachineForRemovalMachineNotFoundError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().MarkMachineForRemoval(gomock.Any(), cmachine.Name("666")).Return(machineerrors.MachineNotFound)
+	s.state.EXPECT().MarkMachineForRemoval(gomock.Any(), machine.Name("666")).Return(machineerrors.MachineNotFound)
 
-	err := NewService(s.state).MarkMachineForRemoval(context.Background(), cmachine.Name("666"))
+	err := NewService(s.state).MarkMachineForRemoval(context.Background(), machine.Name("666"))
 	c.Check(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
@@ -671,9 +671,9 @@ func (s *serviceSuite) TestMarkMachineForRemovalError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().MarkMachineForRemoval(gomock.Any(), cmachine.Name("666")).Return(rErr)
+	s.state.EXPECT().MarkMachineForRemoval(gomock.Any(), machine.Name("666")).Return(rErr)
 
-	err := NewService(s.state).MarkMachineForRemoval(context.Background(), cmachine.Name("666"))
+	err := NewService(s.state).MarkMachineForRemoval(context.Background(), machine.Name("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 }
 
@@ -682,11 +682,11 @@ func (s *serviceSuite) TestMarkMachineForRemovalError(c *gc.C) {
 func (s *serviceSuite) TestGetAllMachineRemovalsSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetAllMachineRemovals(gomock.Any()).Return([]string{"666"}, nil)
+	s.state.EXPECT().GetAllMachineRemovals(gomock.Any()).Return([]machine.UUID{"666"}, nil)
 
 	machineRemovals, err := NewService(s.state).GetAllMachineRemovals(context.Background())
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(machineRemovals, gc.DeepEquals, []string{"666"})
+	c.Assert(machineRemovals, gc.DeepEquals, []machine.UUID{"666"})
 }
 
 // TestGetAllMachineRemovalsError asserts that an error coming from the state
@@ -707,11 +707,11 @@ func (s *serviceSuite) TestGetAllMachineRemovalsError(c *gc.C) {
 func (s *serviceSuite) TestGetMachineUUIDSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineUUID(gomock.Any(), cmachine.Name("666")).Return("123", nil)
+	s.state.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("666")).Return("123", nil)
 
 	uuid, err := NewService(s.state).GetMachineUUID(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(uuid, gc.Equals, "123")
+	c.Assert(uuid, gc.Equals, machine.UUID("123"))
 }
 
 // TestGetMachineUUIDNotFound asserts that the state layer returns a
@@ -720,17 +720,17 @@ func (s *serviceSuite) TestGetMachineUUIDSuccess(c *gc.C) {
 func (s *serviceSuite) TestGetMachineUUIDNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineUUID(gomock.Any(), cmachine.Name("666")).Return("", coreerrors.NotFound)
+	s.state.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("666")).Return("", coreerrors.NotFound)
 
 	uuid, err := NewService(s.state).GetMachineUUID(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
-	c.Check(uuid, gc.Equals, "")
+	c.Check(uuid, gc.Equals, machine.UUID(""))
 }
 
 func (s *serviceSuite) TestLXDProfilesSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AppliedLXDProfileNames(gomock.Any(), "666").Return([]string{"profile1", "profile2"}, nil)
+	s.state.EXPECT().AppliedLXDProfileNames(gomock.Any(), machine.UUID("666")).Return([]string{"profile1", "profile2"}, nil)
 
 	profiles, err := NewService(s.state).AppliedLXDProfileNames(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
@@ -741,7 +741,7 @@ func (s *serviceSuite) TestLXDProfilesError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().AppliedLXDProfileNames(gomock.Any(), "666").Return(nil, rErr)
+	s.state.EXPECT().AppliedLXDProfileNames(gomock.Any(), machine.UUID("666")).Return(nil, rErr)
 
 	_, err := NewService(s.state).AppliedLXDProfileNames(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
@@ -750,9 +750,9 @@ func (s *serviceSuite) TestLXDProfilesError(c *gc.C) {
 func (s *serviceSuite) TestSetLXDProfilesSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), "666", []string{"profile1", "profile2"}).Return(nil)
+	s.state.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), machine.UUID("666"), []string{"profile1", "profile2"}).Return(nil)
 
-	err := NewService(s.state).SetAppliedLXDProfileNames(context.Background(), "666", []string{"profile1", "profile2"})
+	err := NewService(s.state).SetAppliedLXDProfileNames(context.Background(), machine.UUID("666"), []string{"profile1", "profile2"})
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -760,7 +760,7 @@ func (s *serviceSuite) TestSetLXDProfilesError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), "666", []string{"profile1", "profile2"}).Return(rErr)
+	s.state.EXPECT().SetAppliedLXDProfileNames(gomock.Any(), machine.UUID("666"), []string{"profile1", "profile2"}).Return(rErr)
 
 	err := NewService(s.state).SetAppliedLXDProfileNames(context.Background(), "666", []string{"profile1", "profile2"})
 	c.Check(err, jc.ErrorIs, rErr)

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -24,7 +24,7 @@ import (
 // data retrieved from the machine cloud instance table.
 func (st *State) HardwareCharacteristics(
 	ctx context.Context,
-	machineUUID string,
+	machineUUID machine.UUID,
 ) (*instance.HardwareCharacteristics, error) {
 	db, err := st.DB()
 	if err != nil {
@@ -63,7 +63,7 @@ WHERE     v.machine_uuid = $instanceDataResult.machine_uuid`
 // [machineerrors.AvailabilityZoneNotFound].
 func (st *State) AvailabilityZone(
 	ctx context.Context,
-	machineUUID string,
+	machineUUID machine.UUID,
 ) (string, error) {
 	db, err := st.DB()
 	if err != nil {
@@ -105,7 +105,7 @@ WHERE     v.machine_uuid = $instanceDataResult.machine_uuid`
 // along with the instance tags and the link to a lxd profile if any.
 func (st *State) SetMachineCloudInstance(
 	ctx context.Context,
-	machineUUID string,
+	machineUUID machine.UUID,
 	instanceID instance.Id,
 	displayName string,
 	hardwareCharacteristics *instance.HardwareCharacteristics,
@@ -193,7 +193,7 @@ WHERE  availability_zone.name = $availabilityZoneName.name
 // well as any associated status data.
 func (st *State) DeleteMachineCloudInstance(
 	ctx context.Context,
-	mUUID string,
+	mUUID machine.UUID,
 ) error {
 	db, err := st.DB()
 	if err != nil {
@@ -253,7 +253,7 @@ WHERE machine_uuid=$machineUUID.uuid
 // InstanceID returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a
 // [machineerrors.NotProvisionedError].
-func (st *State) InstanceID(ctx context.Context, mUUID string) (string, error) {
+func (st *State) InstanceID(ctx context.Context, mUUID machine.UUID) (string, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", errors.Capture(err)
@@ -293,7 +293,7 @@ WHERE  machine_uuid = $machineUUID.uuid;`
 // this machine.
 // If the machine is not provisioned, it returns a
 // [machineerrors.NotProvisionedError].
-func (st *State) InstanceIDAndName(ctx context.Context, mUUID string) (string, string, error) {
+func (st *State) InstanceIDAndName(ctx context.Context, mUUID machine.UUID) (string, string, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", "", errors.Capture(err)

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -592,7 +592,7 @@ func (s *stateSuite) TestGetMachineParentUUIDSuccess(c *gc.C) {
 	// Get the parent UUID of the machine.
 	parentUUID, err := s.state.GetMachineParentUUID(context.Background(), "456")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(parentUUID, gc.Equals, "123")
+	c.Assert(parentUUID, gc.Equals, machine.UUID("123"))
 }
 
 // TestGetMachineParentUUIDNotFound asserts that a NotFound error is returned
@@ -644,7 +644,7 @@ func (s *stateSuite) TestMarkMachineForRemovalSuccessIdempotent(c *gc.C) {
 	machines, err := s.state.GetAllMachineRemovals(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 1)
-	c.Assert(machines[0], gc.Equals, "123")
+	c.Assert(machines[0], gc.Equals, machine.UUID("123"))
 }
 
 // TestMarkMachineForRemovalNotFound asserts that a NotFound error is returned
@@ -668,7 +668,7 @@ func (s *stateSuite) TestGetAllMachineRemovalsSuccess(c *gc.C) {
 	machines, err := s.state.GetAllMachineRemovals(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 1)
-	c.Assert(machines[0], gc.Equals, "123")
+	c.Assert(machines[0], gc.Equals, machine.UUID("123"))
 }
 
 // TestGetAllMachineRemovalsEmpty asserts that GetAllMachineRemovals returns an
@@ -700,8 +700,8 @@ func (s *stateSuite) TestGetSomeMachineRemovals(c *gc.C) {
 	machines, err := s.state.GetAllMachineRemovals(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 2)
-	c.Assert(machines[0], gc.Equals, "123")
-	c.Assert(machines[1], gc.Equals, "125")
+	c.Assert(machines[0], gc.Equals, machine.UUID("123"))
+	c.Assert(machines[1], gc.Equals, machine.UUID("125"))
 }
 
 // TestGetMachineUUIDNotFound asserts that a NotFound error is returned
@@ -718,7 +718,7 @@ func (s *stateSuite) TestGetMachineUUID(c *gc.C) {
 
 	name, err := s.state.GetMachineUUID(context.Background(), "rage")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(name, gc.Equals, "123")
+	c.Assert(name, gc.Equals, machine.UUID("123"))
 }
 
 func (s *stateSuite) TestKeepInstance(c *gc.C) {

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -17,42 +17,42 @@ import (
 // instanceData represents the struct to be inserted into the instance_data
 // table.
 type instanceData struct {
-	MachineUUID          string  `db:"machine_uuid"`
-	InstanceID           string  `db:"instance_id"`
-	DisplayName          string  `db:"display_name"`
-	Arch                 *string `db:"arch"`
-	Mem                  *uint64 `db:"mem"`
-	RootDisk             *uint64 `db:"root_disk"`
-	RootDiskSource       *string `db:"root_disk_source"`
-	CPUCores             *uint64 `db:"cpu_cores"`
-	CPUPower             *uint64 `db:"cpu_power"`
-	AvailabilityZoneUUID *string `db:"availability_zone_uuid"`
-	VirtType             *string `db:"virt_type"`
+	MachineUUID          machine.UUID `db:"machine_uuid"`
+	InstanceID           string       `db:"instance_id"`
+	DisplayName          string       `db:"display_name"`
+	Arch                 *string      `db:"arch"`
+	Mem                  *uint64      `db:"mem"`
+	RootDisk             *uint64      `db:"root_disk"`
+	RootDiskSource       *string      `db:"root_disk_source"`
+	CPUCores             *uint64      `db:"cpu_cores"`
+	CPUPower             *uint64      `db:"cpu_power"`
+	AvailabilityZoneUUID *string      `db:"availability_zone_uuid"`
+	VirtType             *string      `db:"virt_type"`
 }
 
 // instanceDataResult represents the struct used to retrieve rows when joining
 // the machine_cloud_instance table with the availability_zone table.
 type instanceDataResult struct {
-	MachineUUID      string  `db:"machine_uuid"`
-	InstanceID       string  `db:"instance_id"`
-	Arch             *string `db:"arch"`
-	Mem              *uint64 `db:"mem"`
-	RootDisk         *uint64 `db:"root_disk"`
-	RootDiskSource   *string `db:"root_disk_source"`
-	CPUCores         *uint64 `db:"cpu_cores"`
-	CPUPower         *uint64 `db:"cpu_power"`
-	AvailabilityZone *string `db:"availability_zone_name"`
-	VirtType         *string `db:"virt_type"`
+	MachineUUID      machine.UUID `db:"machine_uuid"`
+	InstanceID       string       `db:"instance_id"`
+	Arch             *string      `db:"arch"`
+	Mem              *uint64      `db:"mem"`
+	RootDisk         *uint64      `db:"root_disk"`
+	RootDiskSource   *string      `db:"root_disk_source"`
+	CPUCores         *uint64      `db:"cpu_cores"`
+	CPUPower         *uint64      `db:"cpu_power"`
+	AvailabilityZone *string      `db:"availability_zone_name"`
+	VirtType         *string      `db:"virt_type"`
 }
 
 // instanceTag represents the struct to be inserted into the instance_tag
 // table.
 type instanceTag struct {
-	MachineUUID string `db:"machine_uuid"`
-	Tag         string `db:"tag"`
+	MachineUUID machine.UUID `db:"machine_uuid"`
+	Tag         string       `db:"tag"`
 }
 
-func tagsFromHardwareCharacteristics(machineUUID string, hc *instance.HardwareCharacteristics) []instanceTag {
+func tagsFromHardwareCharacteristics(machineUUID machine.UUID, hc *instance.HardwareCharacteristics) []instanceTag {
 	if hc == nil || hc.Tags == nil {
 		return nil
 	}
@@ -82,8 +82,8 @@ func (d *instanceDataResult) toHardwareCharacteristics() *instance.HardwareChara
 // machineLife represents the struct to be used for the life_id column within
 // the sqlair statements in the machine domain.
 type machineLife struct {
-	UUID   string    `db:"uuid"`
-	LifeID life.Life `db:"life_id"`
+	UUID   machine.UUID `db:"uuid"`
+	LifeID life.Life    `db:"life_id"`
 }
 
 // instanceID represents the struct to be used for the instance_id column within
@@ -110,11 +110,11 @@ type machineStatus struct {
 // setMachineStatus represents the struct to be used for the columns of the
 // machine_status table within the sqlair statements in the machine domain.
 type setMachineStatus struct {
-	MachineUUID string     `db:"machine_uuid"`
-	StatusID    int        `db:"status_id"`
-	Message     string     `db:"message"`
-	Data        []byte     `db:"data"`
-	Updated     *time.Time `db:"updated_at"`
+	MachineUUID machine.UUID `db:"machine_uuid"`
+	StatusID    int          `db:"status_id"`
+	Message     string       `db:"message"`
+	Data        []byte       `db:"data"`
+	Updated     *time.Time   `db:"updated_at"`
 }
 
 // availabilityZoneName represents the struct to be used for the name column
@@ -133,13 +133,13 @@ type machineName struct {
 // machineMarkForRemoval represents the struct to be used for the columns of the
 // machine_removals table within the sqlair statements in the machine domain.
 type machineMarkForRemoval struct {
-	UUID string `db:"machine_uuid"`
+	UUID machine.UUID `db:"machine_uuid"`
 }
 
 // machineUUID represents the struct to be used for the machine_uuid column
 // within the sqlair statements in the machine domain.
 type machineUUID struct {
-	UUID string `db:"uuid"`
+	UUID machine.UUID `db:"uuid"`
 }
 
 // machineIsController represents the struct to be used for the is_controller column within the sqlair statements in the machine domain.
@@ -156,13 +156,13 @@ type keepInstance struct {
 // machineParent represents the struct to be used for the columns of the
 // machine_parent table within the sqlair statements in the machine domain.
 type machineParent struct {
-	MachineUUID string `db:"machine_uuid"`
-	ParentUUID  string `db:"parent_uuid"`
+	MachineUUID machine.UUID `db:"machine_uuid"`
+	ParentUUID  machine.UUID `db:"parent_uuid"`
 }
 
 // uuidSliceTransform is a function that is used to transform a slice of
 // machineUUID into a slice of string.
-func (s machineMarkForRemoval) uuidSliceTransform() string {
+func (s machineMarkForRemoval) uuidSliceTransform() machine.UUID {
 	return s.UUID
 }
 
@@ -250,7 +250,7 @@ func encodeCloudInstanceStatus(s domainmachine.InstanceStatusType) (int, error) 
 // of the createMachine state method in the machine domain.
 type createMachineArgs struct {
 	name        machine.Name
-	machineUUID string
+	machineUUID machine.UUID
 	netNodeUUID string
 	parentName  machine.Name
 }
@@ -258,7 +258,7 @@ type createMachineArgs struct {
 // lxdProfile represents the struct to be used for the sqlair statements on the
 // lxd_profile table.
 type lxdProfile struct {
-	MachineUUID string `db:"machine_uuid"`
-	Name        string `db:"name"`
-	Index       int    `db:"array_index"`
+	MachineUUID machine.UUID `db:"machine_uuid"`
+	Name        string       `db:"name"`
+	Index       int          `db:"array_index"`
 }

--- a/domain/modelagent/state/modelstate_test.go
+++ b/domain/modelagent/state/modelstate_test.go
@@ -23,6 +23,7 @@ import (
 	corearch "github.com/juju/juju/core/arch"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/machine"
+	coremachinetesting "github.com/juju/juju/core/machine/testing"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
 	coreunit "github.com/juju/juju/core/unit"
@@ -63,9 +64,8 @@ func (s *modelStateSuite) createMachineWithName(c *gc.C, name machine.Name) stri
 		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
-	uuid, err := uuid.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	err = machineSt.CreateMachine(context.Background(), name, uuid.String(), uuid.String())
+	uuid := coremachinetesting.GenUUID(c)
+	err := machineSt.CreateMachine(context.Background(), name, uuid.String(), uuid)
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := NewState(s.TxnRunnerFactory())
@@ -502,15 +502,13 @@ func (s *modelStateSuite) TestSetMachineRunningAgentBinaryVersionMachineNotFound
 }
 
 func (s *modelStateSuite) TestMachineSetRunningAgentBinaryVersionMachineDead(c *gc.C) {
-	machineUUID, err := uuid.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-
+	machineUUID := coremachinetesting.GenUUID(c)
 	machineSt := machinestate.NewState(
 		s.TxnRunnerFactory(),
 		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
-	err = machineSt.CreateMachine(context.Background(), "666", "", machineUUID.String())
+	err := machineSt.CreateMachine(context.Background(), "666", "", machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machineSt.SetMachineLife(context.Background(), "666", life.Dead)

--- a/domain/port/state/state_test.go
+++ b/domain/port/state/state_test.go
@@ -65,9 +65,9 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineSt := machinestate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-	err = machineSt.CreateMachine(context.Background(), "0", netNodeUUIDs[0], machineUUIDs[0])
+	err = machineSt.CreateMachine(context.Background(), "0", netNodeUUIDs[0], machine.UUID(machineUUIDs[0]))
 	c.Assert(err, jc.ErrorIsNil)
-	err = machineSt.CreateMachine(context.Background(), "1", netNodeUUIDs[1], machineUUIDs[1])
+	err = machineSt.CreateMachine(context.Background(), "1", netNodeUUIDs[1], machine.UUID(machineUUIDs[1]))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.appUUID = s.createApplicationWithRelations(c, appNames[0], "ep0", "ep1", "ep2")

--- a/domain/port/state/updateunitports_test.go
+++ b/domain/port/state/updateunitports_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/machine"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
@@ -48,9 +49,9 @@ func (s *updateUnitPortsSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	machineSt := machinestate.NewState(s.TxnRunnerFactory(), clock.WallClock, logger.GetLogger("juju.test.machine"))
-	err = machineSt.CreateMachine(context.Background(), "0", netNodeUUIDs[0], machineUUIDs[0])
+	err = machineSt.CreateMachine(context.Background(), "0", netNodeUUIDs[0], machine.UUID(machineUUIDs[0]))
 	c.Assert(err, jc.ErrorIsNil)
-	err = machineSt.CreateMachine(context.Background(), "1", netNodeUUIDs[1], machineUUIDs[1])
+	err = machineSt.CreateMachine(context.Background(), "1", netNodeUUIDs[1], machine.UUID(machineUUIDs[1]))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.appUUID = s.createApplicationWithRelations(c, appNames[0], "ep0", "ep1", "ep2")

--- a/domain/port/state/watcher_test.go
+++ b/domain/port/state/watcher_test.go
@@ -46,9 +46,9 @@ func (s *watcherSuite) SetUpTest(c *gc.C) {
 
 	machineSt := machinestate.NewState(s.TxnRunnerFactory(), clock.WallClock, logger.GetLogger("juju.test.machine"))
 
-	err = machineSt.CreateMachine(context.Background(), "0", netNodeUUIDs[0], machineUUIDs[0])
+	err = machineSt.CreateMachine(context.Background(), "0", netNodeUUIDs[0], machine.UUID(machineUUIDs[0]))
 	c.Assert(err, jc.ErrorIsNil)
-	err = machineSt.CreateMachine(context.Background(), "1", netNodeUUIDs[1], machineUUIDs[1])
+	err = machineSt.CreateMachine(context.Background(), "1", netNodeUUIDs[1], machine.UUID(machineUUIDs[1]))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.appUUIDs[0] = s.createApplicationWithRelations(c, appNames[0], "ep0", "ep1", "ep2")

--- a/domain/port/watcher_test.go
+++ b/domain/port/watcher_test.go
@@ -55,7 +55,7 @@ var (
 )
 
 var (
-	machineUUIDs = []string{"machine-0-uuid", "machine-1-uuid"}
+	machineUUIDs = []machine.UUID{"machine-0-uuid", "machine-1-uuid"}
 	netNodeUUIDs = []string{"net-node-0-uuid", "net-node-1-uuid"}
 	appNames     = []string{"app-zero", "app-one"}
 )

--- a/internal/worker/bootstrap/bootstrap_mock_test.go
+++ b/internal/worker/bootstrap/bootstrap_mock_test.go
@@ -1401,10 +1401,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1422,25 +1422,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceIDAndName mocks base method.
-func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 string) (instance.Id, string, error) {
+func (m *MockMachineService) InstanceIDAndName(arg0 context.Context, arg1 machine.UUID) (instance.Id, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceIDAndName", arg0, arg1)
 	ret0, _ := ret[0].(instance.Id)
@@ -1468,19 +1468,19 @@ func (c *MockMachineServiceInstanceIDAndNameCall) Return(arg0 instance.Id, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) Do(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, string) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
+func (c *MockMachineServiceInstanceIDAndNameCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceInstanceIDAndNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetMachineCloudInstance mocks base method.
-func (m *MockMachineService) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 string, arg4 *instance.HardwareCharacteristics) error {
+func (m *MockMachineService) SetMachineCloudInstance(arg0 context.Context, arg1 machine.UUID, arg2 instance.Id, arg3 string, arg4 *instance.HardwareCharacteristics) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMachineCloudInstance", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -1506,13 +1506,13 @@ func (c *MockMachineServiceSetMachineCloudInstanceCall) Return(arg0 error) *Mock
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceSetMachineCloudInstanceCall) Do(f func(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error) *MockMachineServiceSetMachineCloudInstanceCall {
+func (c *MockMachineServiceSetMachineCloudInstanceCall) Do(f func(context.Context, machine.UUID, instance.Id, string, *instance.HardwareCharacteristics) error) *MockMachineServiceSetMachineCloudInstanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error) *MockMachineServiceSetMachineCloudInstanceCall {
+func (c *MockMachineServiceSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, machine.UUID, instance.Id, string, *instance.HardwareCharacteristics) error) *MockMachineServiceSetMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/bootstrap/service.go
+++ b/internal/worker/bootstrap/service.go
@@ -105,19 +105,19 @@ type ModelConfigService interface {
 // the machine cloud instance data.
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// SetMachineCloudInstance sets an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
 	SetMachineCloudInstance(
 		ctx context.Context,
-		machineUUID string,
+		machineUUID machine.UUID,
 		instanceID instance.Id,
 		displayName string,
 		hardwareCharacteristics *instance.HardwareCharacteristics,
 	) error
 	// InstanceIDAndName returns the cloud specific instance ID and display name for
 	// this machine.
-	InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error)
+	InstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
 }
 
 // ModelService provides a means for interacting with the underlying models of

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -409,7 +409,7 @@ func (s *workerSuite) expectStateServingInfo() {
 
 func (s *workerSuite) expectSetMachineCloudInstance() {
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(agent.BootstrapControllerId)).Return("deadbeef", nil)
-	s.machineService.EXPECT().SetMachineCloudInstance(gomock.Any(), "deadbeef", instance.Id("i-deadbeef"), "", nil)
+	s.machineService.EXPECT().SetMachineCloudInstance(gomock.Any(), machine.UUID("deadbeef"), instance.Id("i-deadbeef"), "", nil)
 }
 
 func (s *workerSuite) expectReloadSpaces() {

--- a/internal/worker/computeprovisioner/computeprovisioner_test.go
+++ b/internal/worker/computeprovisioner/computeprovisioner_test.go
@@ -363,7 +363,7 @@ func (s *ProvisionerSuite) TestMachineStartedAndStopped(c *gc.C) {
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("666")).Return("machine-666-uuid", nil)
 	s.machineService.EXPECT().SetMachineCloudInstance(
 		gomock.Any(),
-		"machine-666-uuid",
+		machine.UUID("machine-666-uuid"),
 		instance.Id("inst-666"),
 		"",
 		nil,

--- a/internal/worker/computeprovisioner/manifold.go
+++ b/internal/worker/computeprovisioner/manifold.go
@@ -26,9 +26,9 @@ import (
 type MachineService interface {
 	// SetMachineCloudInstance sets an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
-	SetMachineCloudInstance(ctx context.Context, machineUUID string, instanceID instance.Id, displayName string, hardwareCharacteristics *instance.HardwareCharacteristics) error
+	SetMachineCloudInstance(ctx context.Context, machineUUID coremachine.UUID, instanceID instance.Id, displayName string, hardwareCharacteristics *instance.HardwareCharacteristics) error
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name coremachine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name coremachine.Name) (coremachine.UUID, error)
 }
 
 // GetMachineFunc is a helper function that gets a service from the manifold.

--- a/internal/worker/computeprovisioner/provisioner_mock_test.go
+++ b/internal/worker/computeprovisioner/provisioner_mock_test.go
@@ -528,10 +528,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -549,25 +549,25 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetMachineCloudInstance mocks base method.
-func (m *MockMachineService) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 string, arg4 *instance.HardwareCharacteristics) error {
+func (m *MockMachineService) SetMachineCloudInstance(arg0 context.Context, arg1 machine.UUID, arg2 instance.Id, arg3 string, arg4 *instance.HardwareCharacteristics) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMachineCloudInstance", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -593,13 +593,13 @@ func (c *MockMachineServiceSetMachineCloudInstanceCall) Return(arg0 error) *Mock
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceSetMachineCloudInstanceCall) Do(f func(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error) *MockMachineServiceSetMachineCloudInstanceCall {
+func (c *MockMachineServiceSetMachineCloudInstanceCall) Do(f func(context.Context, machine.UUID, instance.Id, string, *instance.HardwareCharacteristics) error) *MockMachineServiceSetMachineCloudInstanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error) *MockMachineServiceSetMachineCloudInstanceCall {
+func (c *MockMachineServiceSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, machine.UUID, instance.Id, string, *instance.HardwareCharacteristics) error) *MockMachineServiceSetMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/firewaller/firewaller.go
+++ b/internal/worker/firewaller/firewaller.go
@@ -777,7 +777,7 @@ func (fw *Firewaller) openedPortsChanged(ctx context.Context, machineTag names.M
 		return err
 	}
 
-	openedPortRangesByEndpoint, err := fw.portService.GetMachineOpenedPorts(ctx, machineUUID)
+	openedPortRangesByEndpoint, err := fw.portService.GetMachineOpenedPorts(ctx, machineUUID.String())
 	if err != nil {
 		return err
 	}

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machine"
+	coremachinetesting "github.com/juju/juju/core/machine/testing"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/core/relation"
@@ -38,7 +39,6 @@ import (
 	"github.com/juju/juju/environs/instances"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	coretesting "github.com/juju/juju/internal/testing"
-	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/internal/worker/firewaller"
 	"github.com/juju/juju/internal/worker/firewaller/mocks"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -324,9 +324,9 @@ func (s *firewallerBaseSuite) addUnit(c *gc.C, ctrl *gomock.Controller, app *moc
 	u.EXPECT().Application().Return(app, nil).AnyTimes()
 	u.EXPECT().AssignedMachine(gomock.Any()).Return(m.Tag(), nil).AnyTimes()
 
-	machineUUID := uuid.MustNewUUID().String()
+	machineUUID := coremachinetesting.GenUUID(c)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(m.Tag().Id())).Return(machineUUID, nil).AnyTimes()
-	s.portService.EXPECT().GetMachineOpenedPorts(gomock.Any(), machineUUID).DoAndReturn(
+	s.portService.EXPECT().GetMachineOpenedPorts(gomock.Any(), machineUUID.String()).DoAndReturn(
 		func(ctx context.Context, machineUUID string) (map[coreunit.Name]network.GroupedPortRanges, error) {
 			s.mu.Lock()
 			defer s.mu.Unlock()
@@ -2274,6 +2274,7 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	})
 	s.assertEnvironPorts(c, nil)
 }
+
 func (s *GlobalModeSuite) TestExposeToIPV6CIDRsOnIPV4OnlyProvider(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/internal/worker/firewaller/interface.go
+++ b/internal/worker/firewaller/interface.go
@@ -85,7 +85,7 @@ type PortService interface {
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	// It returns a MachineNotFound if the machine does not exist.
-	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
+	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 }
 
 // ApplicationService provides methods to query applications.

--- a/internal/worker/firewaller/mocks/domain_mocks.go
+++ b/internal/worker/firewaller/mocks/domain_mocks.go
@@ -45,10 +45,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // GetMachineUUID mocks base method.
-func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -66,19 +66,19 @@ type MockMachineServiceGetMachineUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Return(arg0 machine.UUID, arg1 error) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceGetMachineUUIDCall {
+func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
[Simon asked me](https://github.com/juju/juju/pull/19655#discussion_r2069088600) to change a machineUUID argument from `string` to `machine.UUID` and I may have gotten a bit carried away. I started though, so I'll finish. 

This PR changes all machine UUID arguments in the machine service from the type string to `machine.UUID`, along with all their usages.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA Steps

Unit tests + smoke.