### PR TITLE
docs: fix broken label references

### DIFF
--- a/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for.md
@@ -53,7 +53,7 @@ See also:
     wait-for unit
 
 ## Subcommands
-- [application](#wait-for-application)
-- [machine](#wait-for-machine)
-- [model](#wait-for-model)
-- [unit](#wait-for-unit)
+- [application](#command-juju-wait-for_application)
+- [machine](#command-juju-wait-for_machine)
+- [model](#command-juju-wait-for_model)
+- [unit](#command-juju-wait-for_unit)

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for_application.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for_application.md
@@ -1,6 +1,6 @@
 (command-juju-wait-for_application)=
 # `juju wait-for_application`
-> See also: [wait-for model](#wait-for model), [wait-for machine](#wait-for machine), [wait-for unit](#wait-for unit)
+> See also: [wait-for model](#command-juju-wait-for_model), [wait-for machine](#command-juju-wait-for_machine), [wait-for unit](#command-juju-wait-for_unit)
 
 ## Summary
 Wait for an application to reach a specified state.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for_machine.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for_machine.md
@@ -1,6 +1,6 @@
 (command-juju-wait-for_machine)=
 # `juju wait-for_machine`
-> See also: [wait-for model](#wait-for model), [wait-for application](#wait-for application), [wait-for unit](#wait-for unit)
+> See also: [wait-for model](#command-juju-wait-for_model), [wait-for application](#command-juju-wait-for_application), [wait-for unit](#command-juju-wait-for_unit)
 
 ## Summary
 Wait for a machine to reach a specified state.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for_model.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for_model.md
@@ -1,6 +1,6 @@
 (command-juju-wait-for_model)=
 # `juju wait-for_model`
-> See also: [wait-for application](#wait-for application), [wait-for machine](#wait-for machine), [wait-for unit](#wait-for unit)
+> See also: [wait-for application](#command-juju-wait-for_application), [wait-for machine](#command-juju-wait-for_machine), [wait-for unit](#command-juju-wait-for_unit)
 
 ## Summary
 Wait for a model to reach a specified state.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for_unit.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for_unit.md
@@ -1,6 +1,6 @@
 (command-juju-wait-for_unit)=
 # `juju wait-for_unit`
-> See also: [wait-for model](#wait-for model), [wait-for application](#wait-for application), [wait-for machine](#wait-for machine)
+> See also: [wait-for model](#command-juju-wait-for_model), [wait-for application](#command-juju-wait-for_application), [wait-for machine](#command-juju-wait-for_machine)
 
 ## Summary
 Wait for a unit to reach a specified state.


### PR DESCRIPTION
## Checklist

- [~] Code style: imports ordered, good names, simple structure, etc
- [~] Comments saying why design decisions were made
- [~] Go unit tests, with comments saying what you're testing
- [~] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [~] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Documentation changes

This PR addresses label reference errors like these:
```bash
/home/ubuntu/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for.md:56: WARNING: 'myst' cross-reference target not found: 'wait-for-application'
/home/ubuntu/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for.md:57: WARNING: 'myst' cross-reference target not found: 'wait-for-machine'
/home/ubuntu/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for.md:58: WARNING: 'myst' cross-reference target not found: 'wait-for-model'
/home/ubuntu/docs/reference/juju-cli/list-of-juju-cli-commands/wait-for.md:59: WARNING: 'myst' cross-reference target not found: 'wait-for-unit'
```

## Links

**Issue:** Fixes #19562
