### PR TITLE
docs: fix broken cross-references 1

### DIFF
--- a/docs/contributor/howto/create-a-unit-test-suite.md
+++ b/docs/contributor/howto/create-a-unit-test-suite.md
@@ -1,6 +1,6 @@
 (create-a-unit-test-suite)=
 # Create a unit test suite
-> See also: [Unit test suite](/doc/dev/reference/testing/unit-testing/unit-test-suite.md)
+> See also: [Unit test suite](#unit-test-suite)
 
 To create a new unit test suite, you can do something like:
 

--- a/docs/contributor/howto/write-an-integration-test.md
+++ b/docs/contributor/howto/write-an-integration-test.md
@@ -3,7 +3,7 @@
 
 This document demonstrates how to write an integration test for `juju`.
 
-First, navigate to https://github.com/juju/juju/tree/develop/tests/suites.
+First, navigate to the [suites](https://github.com/juju/juju/tree/main/tests/suites) folder.
 
 In this directory, create a subdirectory named after the integration test suite you want to use. Let's call ours
 `example_integration_test_suite`.
@@ -86,11 +86,11 @@ test_example() {
 }
 ```
 
-When you are done with your test file, navigate to [test folder](/tests), open the `main.sh`
+When you are done with your test file, navigate to the [tests folder](https://github.com/juju/juju/tree/main/tests), open the `main.sh`
 file (which is the entrypoint to your integration testing overall) and add your test suite name to the
 [`TEST_NAMES` variable](https://github.com/juju/juju/blob/main/tests/main.sh#L42).
 
-Finally, run your integration test, following the instructions in the [test folder](/tests) .
+Finally, run your integration test, following the instructions in the [tests folder](https://github.com/juju/juju/tree/main/tests).
 Essentially, what you need to do is as below:
 
 ```bash

--- a/docs/contributor/reference/agent.md
+++ b/docs/contributor/reference/agent.md
@@ -3,13 +3,15 @@
 > See first: {ref}`User docs | Agent <agent>`
 
 In Juju, an **agent** is any process that runs a dependency engine ([
-`dependency.NewEngine`](dependency-package#newengine)) to start and manage {ref}`workers <worker-cont>` for a particular domain
+`dependency.NewEngine`](#newengine)) to start and manage {ref}`workers <worker-cont>` for a particular domain
 entity in a particular deployment environment.
 
 ## List of agents
 
+
+
 While Juju agents can be counted based on the number of files in the codebase that invoke `dependency.NewEngine`, the
-type of process that they represent depends on the specific [`jujud`](/cmd/jujud/doc.go) / [
+type of process that they represent depends on the specific [`jujud`](https://github.com/juju/juju/blob/main/cmd/jujud/doc.go) / [
 `containeragent`](binary-containeragent.md)
 agent-creating command that they invoke, and the workers that they bring up depend on the specific manifold
 declaration (files conventionally called `*manifolds.go` that invoke [
@@ -25,7 +27,7 @@ the list of agents arising from the various splits defined in those files as the
 <!-- TODO: There is a lot of relative link to possible outdated version of code. Maybe we should review it to make it more
 relative to the code (and maybe move it into some doc.go or go documentation anyway -->
 
-- [cmd/jujud/agent/machine.go](/cmd/jujud/agent/machine.go) <br>
+- [cmd/jujud/agent/machine.go](https://github.com/juju/juju/blob/main/cmd/jujud/agent/machine.go) <br>
   Uses [`jujud/main.go` >
   `NewMachineAgentCmd`](https://github.com/juju/juju/blob/7a9eb97bee51d965f8e07f684b1f8929ab18d1f4/cmd/jujud/main.go#L275)
   with [cmd/jujud/agent/machine/manifolds.go](https://github.com/juju/juju/blob/7a9eb97bee51d965f8e07f684b1f8929ab18d1f4/cmd/jujud/agent/machine/manifolds.go#L980)

--- a/docs/contributor/reference/testing/unit-testing/unit-test-suite.md
+++ b/docs/contributor/reference/testing/unit-testing/unit-test-suite.md
@@ -1,6 +1,6 @@
 (unit-test-suite)=
 # Unit test suite
-> See also: [How to create a unit test suite](/doc/dev/how-to/create-unit-test-suite.md)
+> See also: [How to create a unit test suite](#create-a-unit-test-suite)
 
 A **unit test suite** is a collection of unit tests. Each suite has a distinct set-up and tear-down logic. Unit test
 suites are often composed of [util suites](util-suite.md).


### PR DESCRIPTION
## Checklist

- [~] Code style: imports ordered, good names, simple structure, etc
- [~] Comments saying why design decisions were made
- [~] Go unit tests, with comments saying what you're testing
- [~] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [~] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Documentation changes

This PR addresses these cross-reference errors:
```bash
/home/ubuntu/docs/contributor/howto/create-a-unit-test-suite.md:3: WARNING: 'myst' cross-reference target not found: '/doc/dev/reference/testing/unit-testing/unit-test-suite.md'
/home/ubuntu/docs/contributor/howto/write-an-integration-test.md:89: WARNING: 'myst' cross-reference target not found: '/tests'
/home/ubuntu/docs/contributor/howto/write-an-integration-test.md:93: WARNING: 'myst' cross-reference target not found: '/tests'
/home/ubuntu/docs/contributor/reference/agent.md:5: WARNING: 'myst' cross-reference target not found: 'dependency-package#newengine'
/home/ubuntu/docs/contributor/reference/agent.md:11: WARNING: 'myst' cross-reference target not found: '/cmd/jujud/doc.go'
/home/ubuntu/docs/contributor/reference/agent.md:11: WARNING: local id not found in doc 'contributor/reference/dependency-package': 'manifolds'
/home/ubuntu/docs/contributor/reference/agent.md:28: WARNING: 'myst' cross-reference target not found: '/cmd/jujud/agent/machine.go'
```
