### PR TITLE
docs: fix unicode character error u200b

### DIFF
--- a/docs/reference/charm/charm-development-best-practices.md
+++ b/docs/reference/charm/charm-development-best-practices.md
@@ -304,7 +304,7 @@ Further, the use of nested functions is discouraged, instead, use either private
 f-strings are the preferred way of including variables in a string. For example:
 
 ```python
-​​foo = "substring"
+foo = "substring"
 
 # .format is not preferred
 


### PR DESCRIPTION
## Checklist

- [~] Code style: imports ordered, good names, simple structure, etc
- [~] Comments saying why design decisions were made
- [~] Go unit tests, with comments saying what you're testing
- [~] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [~] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Documentation changes

This PR addresses this unicode character error:

```bash
/home/ubuntu/docs/reference/charm/charm-development-best-practices.md:306: WARNING: Lexing literal_block
'\u200b\u200bfoo = "substring"\n\n# .format is not preferred\n\nbar = "string {}".format(foo)\n\n# string concatenation is
not preferred\n\nbar = "string " + foo\n\n# f-strings are preferred\n\nbar = f"string {foo}"\n' as "python" resulted in an
error at token: '\u200b'. Retrying in relaxed mode.
```

It's not noticeable here, but when you view the [live docs](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/#string-formatting), a red error line is displayed.