### PR TITLE
3.6 detailed health errors

### DIFF
--- a/internal/worker/caasprober/controller.go
+++ b/internal/worker/caasprober/controller.go
@@ -113,10 +113,6 @@ func ProbeHandler(name probe.ProbeType, probes *CAASProbes) http.Handler {
 		}
 
 		detail := &bytes.Buffer{}
-		if shouldDetailResponse {
-			// Start the detailed response on a clean line
-			detail.WriteString("\n")
-		}
 		good, n, err := aggProbe.ProbeWithResultCallback(
 			probe.ProbeResultCallback(func(probeKey string, val bool, err error) {
 				if !shouldDetailResponse {
@@ -177,12 +173,15 @@ func ProbeHandler(name probe.ProbeType, probes *CAASProbes) http.Handler {
 			http.Error(res, fmt.Sprintf("%s: probe %s",
 				http.StatusText(http.StatusTeapot), name),
 				http.StatusTeapot)
+			if shouldDetailResponse {
+				_, _ = io.Copy(res, detail)
+			}
 			return
 		}
 
 		res.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		res.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(res, "%s: probe %s", http.StatusText(http.StatusOK), name)
+		_, _ = fmt.Fprintf(res, "%s: probe %s\n", http.StatusText(http.StatusOK), name)
 		if shouldDetailResponse {
 			_, _ = io.Copy(res, detail)
 		}

--- a/internal/worker/caasprober/controller.go
+++ b/internal/worker/caasprober/controller.go
@@ -113,6 +113,10 @@ func ProbeHandler(name probe.ProbeType, probes *CAASProbes) http.Handler {
 		}
 
 		detail := &bytes.Buffer{}
+		if shouldDetailResponse {
+			// Start the detailed response on a clean line
+			detail.WriteString("\n")
+		}
 		good, n, err := aggProbe.ProbeWithResultCallback(
 			probe.ProbeResultCallback(func(probeKey string, val bool, err error) {
 				if !shouldDetailResponse {
@@ -126,33 +130,39 @@ func ProbeHandler(name probe.ProbeType, probes *CAASProbes) http.Handler {
 
 				if val {
 					// Print + on probe success
-					fmt.Fprintf(detail, "+ ")
+					detail.WriteString("+ ")
 				} else {
 					// Print - on probe failure
-					fmt.Fprintf(detail, "- ")
+					detail.WriteString("- ")
 				}
 
 				// Print the probe name
-				fmt.Fprint(detail, probeKey)
+				detail.WriteString(probeKey)
 
 				// Print the error if one exists
 				if err != nil {
-					fmt.Fprintf(detail, ": %s", err)
+					_, _ = fmt.Fprintf(detail, ": %s", err)
 				}
 
 				// Finish the current line
-				fmt.Fprintf(detail, "\n")
+				detail.WriteString("\n")
 			}),
 		)
 		if errors.Is(err, errors.NotImplemented) {
 			http.Error(res, fmt.Sprintf("%s: probe %s",
 				http.StatusText(http.StatusNotImplemented), name),
 				http.StatusNotImplemented)
+			if shouldDetailResponse {
+				_, _ = io.Copy(res, detail)
+			}
 			return
 		} else if err != nil {
 			http.Error(res, fmt.Sprintf("%s: probe %s",
 				http.StatusText(http.StatusInternalServerError), name),
 				http.StatusInternalServerError)
+			if shouldDetailResponse {
+				_, _ = io.Copy(res, detail)
+			}
 			return
 		}
 
@@ -172,7 +182,7 @@ func ProbeHandler(name probe.ProbeType, probes *CAASProbes) http.Handler {
 
 		res.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		res.WriteHeader(http.StatusOK)
-		fmt.Fprintf(res, "%s: probe %s", http.StatusText(http.StatusOK), name)
+		_, _ = fmt.Fprintf(res, "%s: probe %s", http.StatusText(http.StatusOK), name)
 		if shouldDetailResponse {
 			_, _ = io.Copy(res, detail)
 		}

--- a/internal/worker/caasprober/controller_test.go
+++ b/internal/worker/caasprober/controller_test.go
@@ -4,6 +4,7 @@
 package caasprober_test
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -155,6 +156,7 @@ func (s *ControllerSuite) TestControllerNotImplemented(c *gc.C) {
 
 func (s *ControllerSuite) TestControllerProbeError(c *gc.C) {
 	waitGroup := sync.WaitGroup{}
+	// We should trigger the handler 3 times, one for each probe type
 	waitGroup.Add(3)
 
 	mux := dummyMux{
@@ -163,6 +165,10 @@ func (s *ControllerSuite) TestControllerProbeError(c *gc.C) {
 			recorder := httptest.NewRecorder()
 			h.ServeHTTP(recorder, req)
 			c.Check(recorder.Result().StatusCode, gc.Equals, http.StatusInternalServerError)
+			body := &bytes.Buffer{}
+			_, err := recorder.Body.WriteTo(body)
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(body.String(), gc.Equals, "test error\n")
 			waitGroup.Done()
 			return nil
 		},

--- a/observability/probe/prober.go
+++ b/observability/probe/prober.go
@@ -67,7 +67,7 @@ var (
 	// indicates to its caller that it's not implemented. The resulting error
 	// should hold true with errors.IsNotImplemented(err)
 	NotImplemented Prober = ProberFn(func() (bool, error) {
-		return false, errors.NotImplementedf("probe not implemented")
+		return false, errors.NotImplementedf("probe")
 	})
 
 	// Success is a convenience wrapper probe that always evaluates to success.

--- a/observability/probe/prober.go
+++ b/observability/probe/prober.go
@@ -46,10 +46,10 @@ const (
 	// ProbeLiveness represents a liveness probe
 	ProbeLiveness = ProbeType("liveness")
 
-	// ProbeLiveness represents a readiness probe
+	// ProbeReadiness represents a readiness probe
 	ProbeReadiness = ProbeType("readiness")
 
-	// ProbeLiveness represents a startup probe
+	// ProbeStartup represents a startup probe
 	ProbeStartup = ProbeType("startup")
 )
 
@@ -64,7 +64,7 @@ var (
 	})
 
 	// NotImplemented is a convenience wrapper for supplying a probe that
-	// indiciates to it's caller that it's not implemented. Resulting error
+	// indicates to its caller that it's not implemented. The resulting error
 	// should hold true with errors.IsNotImplemented(err)
 	NotImplemented Prober = ProberFn(func() (bool, error) {
 		return false, errors.NotImplementedf("probe not implemented")

--- a/observability/probe/prober_test.go
+++ b/observability/probe/prober_test.go
@@ -20,6 +20,9 @@ func TestProbeNotImplemented(t *testing.T) {
 	if !errors.IsNotImplemented(err) {
 		t.Errorf("expected probe.NotImplemented to return an error that satisfies errors.IsNotImplemented")
 	}
+	if err.Error() != "probe not implemented" {
+		t.Errorf(`expected probe.NotImplemented to string to "probe not implemented" got: %q`, err.Error())
+	}
 }
 
 func TestProbeSuccess(t *testing.T) {


### PR DESCRIPTION
While investigating an issue in PS6-3.6 we realized that we put in code so that when hitting a health endpoint you can ask for details, and find out what probes it is running, and what errors they are returning.

However, we made the mistake that those details are only included in the health check when the health check returns StatusOk, which isn't particularly helpful when debugging failures.

This updates all the code paths to make sure they return errors (we might consider changing the flow, given the awkwardness around trapping all the paths).

This also uncovered that we were using a `NotImplemented("foo not implemented")` which when turned into a string becomes "foo not implemented not implemented", so I fixed that one.

This also adds a `make ck8s-operator-update` to mirror the microk8s one. I'm not positive that I'm doing it all correctly, but it was successful on my machine to import and bootstrap.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ sudo apt install podman
$ export JUJU_BUILD_NUMBER=12345
$ make go-install
$ make ck8s-operater-update
$ juju bootstrap k8s k8s-test
$ juju add-model health-test
$ juju deploy juju-qa-test
$ juju ssh --container charm juju-qa-test bash
# cat /var/lib/pebble/default/layers/001-container-agent.yaml
# curl http://localhost:65301/readiness?detailed=true
OK: probe readiness
+ uniter
```

Without this patch the final curl would give:
```
# curl http://localhost:65301/readiness?detailed=true
OK: probe readiness+ uniter
```

Of more interest would be if something was failing, but I don't know how to introduce a failure to manually see that Juju reports the actual failures correctly. (However, this is covered by the unit tests.)

## Documentation changes

No explicit documentation changes. This improves debugging when introspecting why a readiness or liveliness check is failing.

## Links

None.

