### PR TITLE
fix: test with repository charms rather than directories and run shfmt

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -147,12 +147,12 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 	# check the export.
 	echo "Compare export-bundle with telegraf_bundle"
 
-# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
-    got=$(juju export-bundle 2>&1 1>/dev/null)
-    if [[ "$got" != *"not implemented"* ]]; then
-        echo "ERROR: export-bundle should return 'not implemented'."
-        exit 1
-    fi
+	# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
+	got=$(juju export-bundle 2>&1 1>/dev/null)
+	if [[ $got != *"not implemented"* ]]; then
+		echo "ERROR: export-bundle should return 'not implemented'."
+		exit 1
+	fi
 
 	destroy_model "test-export-bundles-deploy-with-fixed-revisions"
 }
@@ -224,12 +224,12 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	# everything is done deploying
 	echo "Compare export-bundle with telegraf_bundle_with_revisions"
 
-# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
-    got=$(juju export-bundle 2>&1 1>/dev/null)
-    if [[ "$got" != *"not implemented"* ]]; then
-        echo "ERROR: export-bundle should return 'not implemented'."
-        exit 1
-    fi
+	# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
+	got=$(juju export-bundle 2>&1 1>/dev/null)
+	if [[ $got != *"not implemented"* ]]; then
+		echo "ERROR: export-bundle should return 'not implemented'."
+		exit 1
+	fi
 
 	destroy_model "test-export-bundles-deploy-with-float-revisions"
 }

--- a/tests/suites/deploy/export_overlay.sh
+++ b/tests/suites/deploy/export_overlay.sh
@@ -8,20 +8,20 @@ run_cmr_bundles_export_overlay() {
 	juju add-user bar
 	juju deploy ./tests/suites/deploy/bundles/bundle-with-overlays/easyrsa.yaml
 
-# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
-    got=$(juju export-bundle 2>&1 1>/dev/null)
-    if [[ "$got" != *"not implemented"* ]]; then
-        echo "ERROR: export-bundle should return 'not implemented'."
-        exit 1
-    fi
+	# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
+	got=$(juju export-bundle 2>&1 1>/dev/null)
+	if [[ $got != *"not implemented"* ]]; then
+		echo "ERROR: export-bundle should return 'not implemented'."
+		exit 1
+	fi
 
 	juju deploy ./tests/suites/deploy/bundles/bundle-with-overlays/easyrsa-etcd.yaml --overlay overlay.yaml
-# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
-    got=$(juju export-bundle 2>&1 1>/dev/null)
-    if [[ "$got" != *"not implemented"* ]]; then
-        echo "ERROR: export-bundle should return 'not implemented'."
-        exit 1
-    fi
+	# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
+	got=$(juju export-bundle 2>&1 1>/dev/null)
+	if [[ $got != *"not implemented"* ]]; then
+		echo "ERROR: export-bundle should return 'not implemented'."
+		exit 1
+	fi
 
 	destroy_model "cmr-bundles-test-export-overlay"
 	destroy_model "test1"

--- a/tests/suites/firewall/expose_app.sh
+++ b/tests/suites/firewall/expose_app.sh
@@ -69,12 +69,12 @@ assert_export_bundle_output_includes_exposed_endpoints() {
 
 	echo "==> Checking that export-bundle output contains the exposed endpoint settings"
 
-# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
-    got=$(juju export-bundle 2>&1 1>/dev/null)
-    if [[ "$got" != *"not implemented"* ]]; then
-        echo "ERROR: export-bundle should return 'not implemented'."
-        exit 1
-    fi
+	# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
+	got=$(juju export-bundle 2>&1 1>/dev/null)
+	if [[ $got != *"not implemented"* ]]; then
+		echo "ERROR: export-bundle should return 'not implemented'."
+		exit 1
+	fi
 }
 
 test_expose_app_ec2() {

--- a/tests/suites/model/destroy.sh
+++ b/tests/suites/model/destroy.sh
@@ -20,15 +20,15 @@ run_model_destroy() {
 	echo "Ensure current model is 'model-new'"
 	juju models --format json | jq -r '."current-model"' | check 'model-new'
 
-  echo "Destroy model 'model-new'"
+	echo "Destroy model 'model-new'"
 	juju destroy-model --no-prompt 'model-new'
 
-  echo "Ensure model 'model-new' is destroyed"
+	echo "Ensure model 'model-new' is destroyed"
 	is_destroyed=$(juju models --format json | jq -r '.models[] | select(."short-name" == "model-new")')
 	if [[ -z ${is_destroyed} ]]; then is_destroyed=true; fi
 	check_contains "${is_destroyed}" true
 
-  echo "Switch to model 'model-destroy'"
+	echo "Switch to model 'model-destroy'"
 	juju switch model-destroy
 
 	echo "Ensure current model is 'model-destroy'"

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -8,14 +8,12 @@ run_relation_data_exchange() {
 	ensure "${model_name}" "${file}"
 
 	echo "Deploy 2 dummy-sink instances and one dummy-source instance"
-	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-sink) -n 2
-	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-source)
+
+	juju deploy juju-qa-dummy-sink -n 2
+	juju deploy juju-qa-dummy-source --config token=becomegreen
 
 	echo "Establish relation"
 	juju relate dummy-sink dummy-source
-	juju config dummy-source token=becomegreen
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 0)"
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 1)"

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -11,14 +11,12 @@ run_relation_list_app() {
 	ensure "${model_name}" "${file}"
 
 	echo "Deploy 2 departer instances"
-	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-sink)
-	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-source)
+
+	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-source --config token=becomegreen
 
 	echo "Establish relation"
 	juju relate dummy-sink dummy-source
-	juju config dummy-source token=becomegreen
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 0)"
 	wait_for "dummy-source" "$(idle_condition "dummy-source" 1 0)"

--- a/tests/suites/relations/relation_model_get.sh
+++ b/tests/suites/relations/relation_model_get.sh
@@ -9,12 +9,11 @@ run_relation_model_get() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy ./testcharms/charms/dummy-sink
-	juju deploy ./testcharms/charms/dummy-source
+	juju deploy juju-qa-dummy-sink
+	juju deploy juju-qa-dummy-source --config token=becomegreen
 
 	echo "Establish relation"
 	juju integrate dummy-sink dummy-source
-	juju config dummy-source token=becomegreen
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 0)"
 	wait_for "dummy-source" "$(idle_condition "dummy-source" 1 0)"
@@ -32,7 +31,7 @@ run_relation_model_get() {
 	another_model_name="test-relation-model-get-another"
 	juju add-model "${another_model_name}"
 
-	juju deploy ./testcharms/charms/dummy-sink
+	juju deploy juju-qa-dummy-sink
 	juju integrate dummy-sink "${model_name}.dummy-source"
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 0)"

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -35,17 +35,17 @@ run_domain_imports() {
 }
 
 run_juju_errors_imports() {
-    pkgs=("domain")
+	pkgs=("domain")
 
-    for pkg in "${pkgs[@]}"; do
-        dirs=$(find ${pkg} -mindepth 1 -maxdepth 10 -type d | sort -u)
-        for dir in $dirs; do
-            echo "Checking $dir"
-            imports=$(go list -json -e -test "./${dir}" 2>/dev/null | jq -r ".Imports // [] | .[]")
-            disallowed="github.com/juju/errors"
-            python3 tests/suites/static_analysis/lint_go.py -d "${disallowed}" -g "${imports}" || (echo "Error: pkg $dir contains juju/errors imports" && exit 1)
-        done
-    done
+	for pkg in "${pkgs[@]}"; do
+		dirs=$(find ${pkg} -mindepth 1 -maxdepth 10 -type d | sort -u)
+		for dir in $dirs; do
+			echo "Checking $dir"
+			imports=$(go list -json -e -test "./${dir}" 2>/dev/null | jq -r ".Imports // [] | .[]")
+			disallowed="github.com/juju/errors"
+			python3 tests/suites/static_analysis/lint_go.py -d "${disallowed}" -g "${imports}" || (echo "Error: pkg $dir contains juju/errors imports" && exit 1)
+		done
+	done
 }
 
 run_go() {

--- a/tests/suites/static_analysis/schema.sh
+++ b/tests/suites/static_analysis/schema.sh
@@ -20,12 +20,12 @@ run_schema() {
 
 	if [ "${CUR_SHA}" != "${NEW_SHA}" ]; then
 		(echo >&2 "\\nError: client facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
-		(>&2 diff "${TMP_ORIG}/schema.json" "${TMP}/schema.json")
+		(diff >&2 "${TMP_ORIG}/schema.json" "${TMP}/schema.json")
 		exit 1
 	fi
 	if [ "${CUR_AGENT_SHA}" != "${NEW_AGENT_SHA}" ]; then
 		(echo >&2 "\\nError: agent facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
-		(>&2 diff "${TMP_ORIG}/agent-schema.json" "${TMP}/agent-schema.json")
+		(diff >&2 "${TMP_ORIG}/agent-schema.json" "${TMP}/agent-schema.json")
 		exit 1
 	fi
 }


### PR DESCRIPTION
Deploy from directory is no longer supported. One test was still attempting to do this. Use the repository version of the charm instead.

Two tests were using the process to build a charm from directory, when the charms were available from the repository. Use the repository version instead.

Updated to deploy the `juju-qa-dummy-source` charm with the token as config. Currently in main, due to ongoing work to move off mongo, the change doesn't always appear. This will be resolved in the future, until, lets have the tests running further.

This will fix the tests entirely, however they won't fail on a know unsupported deployment.

Drive by: fix some formatting in the tests suites file, not sure why the static analysis GitHub actions did not catch these. 