### PR TITLE
refactor: use the correct correctial watcher in the provider tracker

### DIFF
--- a/domain/model/service/providerservice.go
+++ b/domain/model/service/providerservice.go
@@ -6,26 +6,45 @@ package service
 import (
 	"context"
 
+	corecloud "github.com/juju/juju/core/cloud"
+	"github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/watcher"
 )
 
-// ProviderState is the model state required by the provide service. This is
-// the model database state, not the controller state.
-type ProviderState interface {
+// ProviderModelState is the model state required by the provide service.
+type ProviderModelState interface {
 	// GetModel returns a the model info.
 	GetModel(context.Context) (coremodel.ModelInfo, error)
+}
+
+// ProviderControllerState is the controller state required by the provider service.
+type ProviderControllerState interface {
+	// GetModelCloudAndCredential returns the cloud and credential UUID for the model.
+	// The following errors can be expected:
+	// - [modelerrors.NotFound] if the model is not found.
+	GetModelCloudAndCredential(
+		ctx context.Context,
+		modelUUID coremodel.UUID,
+	) (corecloud.UUID, credential.UUID, error)
 }
 
 // ProviderService defines a service for interacting with the underlying model
 // state, as opposed to the controller state.
 type ProviderService struct {
-	st ProviderState
+	controllerSt   ProviderControllerState
+	modelSt        ProviderModelState
+	watcherFactory WatcherFactory
 }
 
-// NewProviderService returns a new Service for interacting with a models state.
-func NewProviderService(st ProviderState) *ProviderService {
+// NewProviderService returns a new Service for interacting with a model's state.
+func NewProviderService(
+	controllerSt ProviderControllerState, modelSt ProviderModelState, watcherFactory WatcherFactory,
+) *ProviderService {
 	return &ProviderService{
-		st: st,
+		controllerSt:   controllerSt,
+		modelSt:        modelSt,
+		watcherFactory: watcherFactory,
 	}
 }
 
@@ -34,5 +53,16 @@ func NewProviderService(st ProviderState) *ProviderService {
 // The following error types can be expected to be returned:
 // - [modelerrors.NotFound]: When the model is not found for a given uuid.
 func (s *ProviderService) Model(ctx context.Context) (coremodel.ModelInfo, error) {
-	return s.st.GetModel(ctx)
+	return s.modelSt.GetModel(ctx)
+}
+
+// WatchModelCloudCredential returns a new NotifyWatcher watching for changes that
+// result in the cloud spec for a model changing. The changes watched for are:
+// - updates to model cloud.
+// - updates to model credential.
+// - changes to the credential set on a model.
+// The following errors can be expected:
+// - [modelerrors.NotFound] when the model is not found.
+func (s *ProviderService) WatchModelCloudCredential(ctx context.Context, modelUUID coremodel.UUID) (watcher.NotifyWatcher, error) {
+	return watchModelCloudCredential(ctx, s.controllerSt, s.watcherFactory, modelUUID)
 }

--- a/domain/model/service/providerservice_test.go
+++ b/domain/model/service/providerservice_test.go
@@ -5,18 +5,34 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	corecloud "github.com/juju/juju/core/cloud"
+	cloudtesting "github.com/juju/juju/core/cloud/testing"
+	"github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
+	"github.com/juju/juju/core/watcher/watchertest"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/internal/uuid"
 )
 
 type dummyProviderState struct {
-	model *coremodel.ModelInfo
+	model          *coremodel.ModelInfo
+	cloudUUID      corecloud.UUID
+	credentialUUID credential.UUID
+}
+
+func (d *dummyProviderState) GetModelCloudAndCredential(ctx context.Context, modelUUID coremodel.UUID) (corecloud.UUID, credential.UUID, error) {
+	if d.model == nil {
+		return "", "", modelerrors.NotFound
+	}
+	return d.cloudUUID, d.credentialUUID, nil
 }
 
 func (d *dummyProviderState) GetModel(ctx context.Context) (coremodel.ModelInfo, error) {
@@ -30,16 +46,30 @@ type providerServiceSuite struct {
 	testing.IsolationSuite
 
 	state *dummyProviderState
+
+	mockControllerState *MockState
+	mockWatcherFactory  *MockWatcherFactory
 }
 
 var _ = gc.Suite(&providerServiceSuite{})
 
+func (s *providerServiceSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.mockControllerState = NewMockState(ctrl)
+	s.mockWatcherFactory = NewMockWatcherFactory(ctrl)
+
+	return ctrl
+}
+
 func (s *providerServiceSuite) SetUpTest(c *gc.C) {
-	s.state = &dummyProviderState{}
+	s.state = &dummyProviderState{
+		cloudUUID:      cloudtesting.GenCloudUUID(c),
+		credentialUUID: credential.UUID(uuid.MustNewUUID().String()),
+	}
 }
 
 func (s *providerServiceSuite) TestModel(c *gc.C) {
-	svc := NewProviderService(s.state)
+	svc := NewProviderService(s.state, s.state, nil)
 
 	id := modeltesting.GenModelUUID(c)
 	model := coremodel.ModelInfo{
@@ -55,4 +85,39 @@ func (s *providerServiceSuite) TestModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(got, gc.Equals, model)
+}
+
+func (s *providerServiceSuite) TestWatchModelCloudCredential(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := modeltesting.GenModelUUID(c)
+	cloudUUID := cloudtesting.GenCloudUUID(c)
+	credentialUUID := credential.UUID(uuid.MustNewUUID().String())
+	s.mockControllerState.EXPECT().GetModelCloudAndCredential(gomock.Any(), modelUUID).Return(cloudUUID, credentialUUID, nil)
+
+	ch := make(chan struct{}, 1)
+	watcher := watchertest.NewMockNotifyWatcher(ch)
+	s.mockWatcherFactory.EXPECT().NewNotifyMapperWatcher(
+		gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(watcher, nil)
+
+	svc := NewProviderService(
+		s.mockControllerState,
+		&dummyProviderState{},
+		s.mockWatcherFactory,
+	)
+	w, err := svc.WatchModelCloudCredential(context.Background(), modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case ch <- struct{}{}:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("failed to send changes to channel")
+	}
+
+	select {
+	case <-w.Changes():
+	case <-time.After(testing.LongWait):
+		c.Fatalf("failed to receive changes from watcher")
+	}
 }

--- a/domain/services/provider.go
+++ b/domain/services/provider.go
@@ -42,10 +42,14 @@ func NewProviderServices(
 // Model returns the provider model service.
 func (s *ProviderServices) Model() *modelservice.ProviderService {
 	return modelservice.NewProviderService(
+		modelstate.NewState(
+			changestream.NewTxnRunnerFactory(s.controllerDB),
+		),
 		modelstate.NewModelState(
 			changestream.NewTxnRunnerFactory(s.modelDB),
 			s.logger.Child("modelinfo"),
 		),
+		s.controllerWatcherFactory("model"),
 	)
 }
 

--- a/internal/worker/modelworkermanager/providerservice.go
+++ b/internal/worker/modelworkermanager/providerservice.go
@@ -17,14 +17,15 @@ import (
 type ProviderModelService interface {
 	// Model returns information for the current model
 	Model(ctx context.Context) (coremodel.ModelInfo, error)
+	// WatchModelCloudCredential returns a new NotifyWatcher watching for changes that
+	// result in the cloud spec for a model changing.
+	WatchModelCloudCredential(ctx context.Context, modelUUID coremodel.UUID) (watcher.NotifyWatcher, error)
 }
 
 // ProviderCloudService represents the cloud service provided by the provider.
 type ProviderCloudService interface {
 	// Cloud returns the named cloud.
 	Cloud(ctx context.Context, name string) (*cloud.Cloud, error)
-	// WatchCloud returns a watcher that observes changes to the specified cloud.
-	WatchCloud(ctx context.Context, name string) (watcher.NotifyWatcher, error)
 }
 
 // ProviderConfigService represents the config service provided by the provider.
@@ -41,9 +42,6 @@ type ProviderConfigService interface {
 type ProviderCredentialService interface {
 	// CloudCredential returns the cloud credential for the given tag.
 	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
-	// WatchCredential returns a watcher that observes changes to the specified
-	// credential.
-	WatchCredential(ctx context.Context, key credential.Key) (watcher.NotifyWatcher, error)
 	// InvalidateCredential marks the cloud credential for the given key as invalid.
 	InvalidateCredential(ctx context.Context, key credential.Key, reason string) error
 }

--- a/internal/worker/providertracker/providerservice.go
+++ b/internal/worker/providertracker/providerservice.go
@@ -36,14 +36,15 @@ type DomainServices interface {
 type ModelService interface {
 	// Model returns information for the current model.
 	Model(ctx context.Context) (model.ModelInfo, error)
+	// WatchModelCloudCredential returns a new NotifyWatcher watching for changes that
+	// result in the cloud spec for a model changing.
+	WatchModelCloudCredential(ctx context.Context, modelUUID model.UUID) (watcher.NotifyWatcher, error)
 }
 
 // CloudService represents the cloud service provided by the provider.
 type CloudService interface {
 	// Cloud returns the named cloud.
 	Cloud(ctx context.Context, name string) (*cloud.Cloud, error)
-	// WatchCloud returns a watcher that observes changes to the specified cloud.
-	WatchCloud(ctx context.Context, name string) (watcher.NotifyWatcher, error)
 }
 
 // ConfigService represents the config service provided by the provider.
@@ -60,9 +61,6 @@ type ConfigService interface {
 type CredentialService interface {
 	// CloudCredential returns the cloud credential for the given tag.
 	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
-	// WatchCredential returns a watcher that observes changes to the specified
-	// credential.
-	WatchCredential(ctx context.Context, key credential.Key) (watcher.NotifyWatcher, error)
 	// InvalidateCredential marks the cloud credential for the given key as invalid.
 	InvalidateCredential(ctx context.Context, key credential.Key, reason string) error
 }

--- a/internal/worker/providertracker/providertracker_mock_test.go
+++ b/internal/worker/providertracker/providertracker_mock_test.go
@@ -319,6 +319,45 @@ func (c *MockModelServiceModelCall) DoAndReturn(f func(context.Context) (model.M
 	return c
 }
 
+// WatchModelCloudCredential mocks base method.
+func (m *MockModelService) WatchModelCloudCredential(arg0 context.Context, arg1 model.UUID) (watcher.Watcher[struct{}], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchModelCloudCredential", arg0, arg1)
+	ret0, _ := ret[0].(watcher.Watcher[struct{}])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchModelCloudCredential indicates an expected call of WatchModelCloudCredential.
+func (mr *MockModelServiceMockRecorder) WatchModelCloudCredential(arg0, arg1 any) *MockModelServiceWatchModelCloudCredentialCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchModelCloudCredential", reflect.TypeOf((*MockModelService)(nil).WatchModelCloudCredential), arg0, arg1)
+	return &MockModelServiceWatchModelCloudCredentialCall{Call: call}
+}
+
+// MockModelServiceWatchModelCloudCredentialCall wrap *gomock.Call
+type MockModelServiceWatchModelCloudCredentialCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelServiceWatchModelCloudCredentialCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockModelServiceWatchModelCloudCredentialCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelServiceWatchModelCloudCredentialCall) Do(f func(context.Context, model.UUID) (watcher.Watcher[struct{}], error)) *MockModelServiceWatchModelCloudCredentialCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelServiceWatchModelCloudCredentialCall) DoAndReturn(f func(context.Context, model.UUID) (watcher.Watcher[struct{}], error)) *MockModelServiceWatchModelCloudCredentialCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockCloudService is a mock of CloudService interface.
 type MockCloudService struct {
 	ctrl     *gomock.Controller
@@ -377,45 +416,6 @@ func (c *MockCloudServiceCloudCall) Do(f func(context.Context, string) (*cloud.C
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCloudServiceCloudCall) DoAndReturn(f func(context.Context, string) (*cloud.Cloud, error)) *MockCloudServiceCloudCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// WatchCloud mocks base method.
-func (m *MockCloudService) WatchCloud(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchCloud", arg0, arg1)
-	ret0, _ := ret[0].(watcher.Watcher[struct{}])
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchCloud indicates an expected call of WatchCloud.
-func (mr *MockCloudServiceMockRecorder) WatchCloud(arg0, arg1 any) *MockCloudServiceWatchCloudCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCloud", reflect.TypeOf((*MockCloudService)(nil).WatchCloud), arg0, arg1)
-	return &MockCloudServiceWatchCloudCall{Call: call}
-}
-
-// MockCloudServiceWatchCloudCall wrap *gomock.Call
-type MockCloudServiceWatchCloudCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockCloudServiceWatchCloudCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockCloudServiceWatchCloudCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockCloudServiceWatchCloudCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockCloudServiceWatchCloudCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCloudServiceWatchCloudCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockCloudServiceWatchCloudCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -617,45 +617,6 @@ func (c *MockCredentialServiceInvalidateCredentialCall) Do(f func(context.Contex
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCredentialServiceInvalidateCredentialCall) DoAndReturn(f func(context.Context, credential.Key, string) error) *MockCredentialServiceInvalidateCredentialCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// WatchCredential mocks base method.
-func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 credential.Key) (watcher.Watcher[struct{}], error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchCredential", arg0, arg1)
-	ret0, _ := ret[0].(watcher.Watcher[struct{}])
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchCredential indicates an expected call of WatchCredential.
-func (mr *MockCredentialServiceMockRecorder) WatchCredential(arg0, arg1 any) *MockCredentialServiceWatchCredentialCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCredential", reflect.TypeOf((*MockCredentialService)(nil).WatchCredential), arg0, arg1)
-	return &MockCredentialServiceWatchCredentialCall{Call: call}
-}
-
-// MockCredentialServiceWatchCredentialCall wrap *gomock.Call
-type MockCredentialServiceWatchCredentialCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockCredentialServiceWatchCredentialCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockCredentialServiceWatchCredentialCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockCredentialServiceWatchCredentialCall) Do(f func(context.Context, credential.Key) (watcher.Watcher[struct{}], error)) *MockCredentialServiceWatchCredentialCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCredentialServiceWatchCredentialCall) DoAndReturn(f func(context.Context, credential.Key) (watcher.Watcher[struct{}], error)) *MockCredentialServiceWatchCredentialCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
The WatchModelCloudCredential watcher triggers on all the needed events to tell the provider tracker that the cloud spec has change. As a single watcher, the provider tracker no longer needs to use separate watchers to do the job.

This WatchModelCloudCredential watcher operates off controller state. The provider tracker uses a service that currently serves up model info off model state. The model info relies on mutable data in the read only model table, so there will need to be a refactoring of all of this, possibly resulting in the model provider service only needing one state passed to it. But all of that is beyond the scope of this PR, which is just to fix the watcher issue.

## QA steps

update a models' credential to an invalid value and back again and ensure provisioning of resource is not affected

## Links

**Jira card:** [JUJU-7917](https://warthogs.atlassian.net/browse/JUJU-7917)
