### PR TITLE
docs: fix broken cross-references 2

### DIFF
--- a/docs/contributor/howto/write-an-integration-test.md
+++ b/docs/contributor/howto/write-an-integration-test.md
@@ -1,3 +1,4 @@
+(write-an-integration-test)=
 # Write an integration test
 > See also: {ref}`integration-testing`
 

--- a/docs/contributor/reference/architectural-overview.md
+++ b/docs/contributor/reference/architectural-overview.md
@@ -122,9 +122,9 @@ The mongodb databases run on machines we refer to as *controllers*, and are only
 accessed by agents running on those machines; it's important to keep it locked down
 (and, honestly, to lock it down further and better than we currently have).
 
-There's some documentation on how to work with [the state package](hacking-state.md);
-and plenty more on the [state entities](lifecycles.md) and the details of their
-[creation](entity-creation.md) and [destruction](death-and-destruction.md) from various
+There's some documentation on how to work with the state package;
+and plenty more on the [state entities](#entity-lifecycle) and the details of their
+[creation](#entity-creation) and [destruction](#entity-death-and-destruction) from various
 perspectives; but there's not a lot more to say in this context.
 
 It *is* important to understand that the transaction-log watching is not an ideal

--- a/docs/contributor/reference/entity-lifecycle.md
+++ b/docs/contributor/reference/entity-lifecycle.md
@@ -1,3 +1,4 @@
+(entity-lifecycle)=
 # Entity lifecycle
 
 In Juju, certain fundamental state entities have "lifecycles". These entities
@@ -74,6 +75,7 @@ container-scoped relation and find that no suitable subordinate already exists.
     principal unit's participation in an Alive relation (implying an Alive
     subordinate application).
 
+(entity-death-and-destruction)=
 ## Entity death and destruction
 
 This section describes in detail the operations associated with the destruction

--- a/docs/contributor/reference/testing/integration-testing/index.md
+++ b/docs/contributor/reference/testing/integration-testing/index.md
@@ -8,7 +8,7 @@
 *
 ```
 
-> See also: [How to write a integration test](/doc/dev/how-to/write-an-integration-test.md)
+> See also: {ref}`write-an-integration-test`
 
 Integration testing `juju` currently relies on a series of custom-made `bash` scripts. All these scripts live
 in [test folder](/tests). This directory includes two subdirectories, one containing


### PR DESCRIPTION
## Checklist

- [~] Code style: imports ordered, good names, simple structure, etc
- [~] Comments saying why design decisions were made
- [~] Go unit tests, with comments saying what you're testing
- [~] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [~] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Documentation changes

This PR addresses these cross-reference errors:
```bash
/home/ubuntu/docs/contributor/reference/architectural-overview.md:125: WARNING: 'myst' cross-reference target not found: 'hacking-state.md'
/home/ubuntu/docs/contributor/reference/architectural-overview.md:125: WARNING: 'myst' cross-reference target not found: 'lifecycles.md'
/home/ubuntu/docs/contributor/reference/architectural-overview.md:125: WARNING: 'myst' cross-reference target not found: 'entity-creation.md'
/home/ubuntu/docs/contributor/reference/architectural-overview.md:125: WARNING: 'myst' cross-reference target not found: 'death-and-destruction.md'
/home/ubuntu/docs/contributor/reference/testing/integration-testing/index.md:11: WARNING: 'myst' cross-reference target not found: '/doc/dev/how-to/write-an-integration-test.md'
```
