### PR TITLE
docs: only run function calls for auto-generated docs in conf.py when it's executed directly not when conf.py is imported

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -497,6 +497,7 @@ def generate_hook_command_docs():
 
     print("generated hook command list")
 
-generate_cli_docs()
-generate_controller_config_docs()
-generate_hook_command_docs()
+if __name__ == "__main__":
+    generate_cli_docs()
+    generate_controller_config_docs()
+    generate_hook_command_docs()


### PR DESCRIPTION
## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [~] Go unit tests, with comments saying what you're testing
- [~] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [~] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Documentation changes

When I run `make run`, Sphinx imports and executes the `conf.py` file. This auto-generates changes not made by me because their function calls are executed. But that shouldn't be the case structure-wise. The function calls should only be executed when conf.py runs directly, not when it's imported.

In my previously submitted PRs, I had to always comment the function call lines before I did a `make run`. This fix resolves it. The function still runs, but it only runs when it's executed directly by Sphinx, not when the file is imported.

## Links

https://realpython.com/if-name-main-python/
