### PR TITLE
refactor(relation): remove the nested select in getRelationRelatedUnit query

### DIFF
--- a/domain/relation/state/related_unit_watcher.go
+++ b/domain/relation/state/related_unit_watcher.go
@@ -183,13 +183,14 @@ SELECT
     re.uuid AS &relationEndpoint.uuid,
     ae.application_uuid AS &relationEndpoint.application_uuid
 FROM relation_endpoint AS re
-JOIN application_endpoint AS ae 
-  ON  re.endpoint_uuid = ae.uuid
-  AND re.relation_uuid = $getRelationUnit.relation_uuid
-JOIN application AS a ON ae.application_uuid = a.uuid
-WHERE ae.application_uuid NOT IN (SELECT application_uuid
-                                 FROM unit
-                                 WHERE name =  $getRelationUnit.name)
+JOIN application_endpoint AS ae ON  re.endpoint_uuid = ae.uuid
+LEFT JOIN unit AS u 
+  ON ae.application_uuid = u.application_uuid 
+  AND u.name = $getRelationUnit.name
+-- All units except the current one will have a NULL uuid due to the 
+-- left join on unit table, filtered by the current unit name.
+WHERE u.uuid IS NULL
+AND re.relation_uuid = $getRelationUnit.relation_uuid
 `, relationEndpoint{}, getRelationUnit{})
 	if err != nil {
 		return relationEndpoint{}, errors.Capture(err)

--- a/domain/relation/state/related_unit_watcher_test.go
+++ b/domain/relation/state/related_unit_watcher_test.go
@@ -55,8 +55,9 @@ func (s *relatedUnitWatcherSuite) TestGetRelatedEndpointUUIDForUnit(c *gc.C) {
 	s.addRelationEndpoint(c, otherRelationUUID, app2ReqUUID)
 	s.addRelationEndpoint(c, otherRelationUUID, app1ProvUUID)
 
-	// We create a unit, and a relation in which we are interested
+	// We create a units on both side, and a relation in which we are interested
 	s.addUnit(c, "app1/0", appUUID1, charmUUID)
+	s.addUnit(c, "app2/0", appUUID2, charmUUID)
 	relationUUID := s.addRelation(c)
 	s.addRelationEndpoint(c, relationUUID, app1ReqUUID)
 	expectedEndpoint := s.addRelationEndpoint(c, relationUUID, app2ProvUUID)


### PR DESCRIPTION
This patches improves the query to get related unit for a relation by removing the nested select. `EXPLAIN` query reduce the number of instructions from 48 to 37.

- `domain/relation/state/related_unit_watcher.go`: Remove the nested SELECT in favor of a LEFT JOIN, add a comment to explain the logic.
- `domain/relation/state/related_unit_watcher_test.go`: Added additional unit in arrange, since without it, removing the clause on unit.Name on the left join doesn't make the test fail, which was incorrect.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unit test should pass.

- deploy two charm with a relation, and check the relation still react correctly in uniter.