### PR TITLE
chore: merge 3.6 to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,8 @@ discovered that way. To preview the docs as they will be rendered on RTD, in
 errors, try `make clean`, then `make run` again. For other checks, see `make
 [Tab]` and select the command for the desired check.
 
+> Note: If you are building locally on an Ubuntu Cloud VM or a container, you may experience issues accessing the page from a browser. To resolve this, add the export variable to your shell `export SPHINX_HOST=0.0.0.0`
+
 </details>
 
 ----------------

--- a/docs/Makefile.sp
+++ b/docs/Makefile.sp
@@ -19,6 +19,8 @@ ALLFILES        =  *.rst **/*.rst
 METRICSDIR      = $(SOURCEDIR)/.sphinx/metrics
 REQPDFPACKS     = latexmk fonts-freefont-otf texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-lang-cjk texlive-xetex plantuml xindy tex-gyre dvipng
 CONFIRM_SUDO    ?= N
+SPHINX_HOST     ?= 127.0.0.1
+SPHINX_PORT     ?= 8000
 
 .PHONY: sp-full-help sp-spellcheck-install sp-pa11y-install sp-install sp-run sp-html \
         sp-epub sp-serve sp-clean sp-clean-doc sp-spelling sp-spellcheck sp-linkcheck \
@@ -68,7 +70,7 @@ sp-pa11y-install:
 sp-install: $(VENVDIR)
 
 sp-run: sp-install
-	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 sp-html: sp-install

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,7 +301,7 @@ intersphinx_mapping = {
     # 'juju': ('https://canonical-juju.readthedocs-hosted.com/en/latest/', None),
     'tfjuju': ('https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/', None),
     'pyjuju': ('https://pythonlibjuju.readthedocs.io/en/latest/', None),
-    'jaas': ('https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/', None),
+    'jaas': ('https://canonical-jaas-documentation.readthedocs-hosted.com/latest/', None),
     'charmcraft': ('https://canonical-charmcraft.readthedocs-hosted.com/en/latest/', None),
     'ops': ('https://ops.readthedocs.io/en/latest/', None),
 }

--- a/internal/worker/sshserver/server_test.go
+++ b/internal/worker/sshserver/server_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"time"
 
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
@@ -171,7 +172,6 @@ func (s *sshServerSuite) TestSSHServer(c *gc.C) {
 }
 
 func (s *sshServerSuite) TestSSHServerMaxConnections(c *gc.C) {
-	c.Skip("this test is flaky, skipping until it is fixed")
 	// Firstly, start the server on an in-memory listener
 	listener := bufconn.Listen(1024)
 	worker, err := NewServerWorker(ServerWorkerConfig{
@@ -185,6 +185,28 @@ func (s *sshServerSuite) TestSSHServerMaxConnections(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, worker)
+
+	srv := worker.(*ServerWorker)
+
+	// Check server side that the connection count matches the expected value
+	// otherwise we face a race condition in tests where the server hasn't yet
+	// decreased the connection count.
+	checkConnCount := func(c *gc.C, expected int32) {
+		done := time.After(200 * time.Millisecond)
+		for {
+			connCount := srv.concurrentConnections.Load()
+			if connCount == expected {
+				return
+			}
+			select {
+			case <-time.After(10 * time.Millisecond):
+			case <-done:
+				c.Error("timeout waiting for expected connection count")
+				return
+			}
+		}
+	}
+
 	// the reason we repeat this test 2 times is to make sure that closing the connections on
 	// the first iteration completely resets the counter on the ssh server side.
 	for i := range 2 {
@@ -197,25 +219,27 @@ func (s *sshServerSuite) TestSSHServerMaxConnections(c *gc.C) {
 				gossh.PublicKeys(s.userSigner),
 			},
 		}
+		checkConnCount(c, 0)
 		for range maxConcurrentConnections {
 			client := inMemoryDial(c, listener, config)
-			_, err := client.Dial("tcp", fmt.Sprintf("%s:0", testVirtualHostname))
-			c.Assert(err, jc.ErrorIsNil)
 			clients = append(clients, client)
 		}
+		checkConnCount(c, maxConcurrentConnections)
 		jumpServerConn, err := listener.Dial()
 		c.Assert(err, jc.ErrorIsNil)
 
 		_, _, _, err = gossh.NewClientConn(jumpServerConn, "", config)
-		c.Assert(err, gc.ErrorMatches, ".*handshake failed: EOF.*")
+		c.Assert(err, gc.ErrorMatches, ".*handshake failed:.*")
 
 		// close the connections
 		for _, client := range clients {
 			client.Close()
 		}
+		checkConnCount(c, 0)
 		// check the next connection is accepted
 		client := inMemoryDial(c, listener, config)
 		client.Close()
+		checkConnCount(c, 0)
 	}
 }
 


### PR DESCRIPTION
Merges branch `3.6` to `main`.

Brings the following changes:
- 9bd727507a Merge pull request #19649 from hpidcock/fix-package-filter
  - 1 conflict, used the new make target from `3.6` but kept usage of the `TEST_BUILD_TAGS` over `FINAL_BUILD_TAGS`.
- 468a0581a7 Merge pull request #19640 from network-charles/patch-2
  - No conflicts
- 60dad4eb11 Merge pull request #19648 from network-charles/patch-3
  - No conflicts
- e44c0f4c0d Merge pull request #19594 from kian99/maxconnections-flaky-test
  - Resolved some conflicts due to disparity in the sshserver worker between `3.6` and `main`.