### PR TITLE
feat(application): wire up three watchers in the uniter facade

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -163,6 +163,18 @@ type ApplicationService interface {
 
 	// GetUnitWorkloadVersion returns the workload version for the given unit.
 	GetUnitWorkloadVersion(ctx context.Context, unitName coreunit.Name) (string, error)
+
+	// WatchApplicationConfigHash watches for changes to the specified application's
+	// config hash.
+	WatchApplicationConfigHash(ctx context.Context, name string) (watcher.StringsWatcher, error)
+
+	// WatchUnitAddressesHash watches for changes to the specified unit's
+	// addresses hash, as well as changes to the endpoint bindings for the spaces
+	// the addresses belong to.
+	//
+	// If the unit does not exist an error satisfying [applicationerrors.UnitNotFound]
+	// will be returned.
+	WatchUnitAddressesHash(ctx context.Context, unitName coreunit.Name) (watcher.StringsWatcher, error)
 }
 
 type ResolveService interface {

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -831,6 +831,84 @@ func (c *MockApplicationServiceWatchApplicationCall) DoAndReturn(f func(context.
 	return c
 }
 
+// WatchApplicationConfigHash mocks base method.
+func (m *MockApplicationService) WatchApplicationConfigHash(arg0 context.Context, arg1 string) (watcher.Watcher[[]string], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchApplicationConfigHash", arg0, arg1)
+	ret0, _ := ret[0].(watcher.Watcher[[]string])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchApplicationConfigHash indicates an expected call of WatchApplicationConfigHash.
+func (mr *MockApplicationServiceMockRecorder) WatchApplicationConfigHash(arg0, arg1 any) *MockApplicationServiceWatchApplicationConfigHashCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationConfigHash", reflect.TypeOf((*MockApplicationService)(nil).WatchApplicationConfigHash), arg0, arg1)
+	return &MockApplicationServiceWatchApplicationConfigHashCall{Call: call}
+}
+
+// MockApplicationServiceWatchApplicationConfigHashCall wrap *gomock.Call
+type MockApplicationServiceWatchApplicationConfigHashCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceWatchApplicationConfigHashCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockApplicationServiceWatchApplicationConfigHashCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceWatchApplicationConfigHashCall) Do(f func(context.Context, string) (watcher.Watcher[[]string], error)) *MockApplicationServiceWatchApplicationConfigHashCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceWatchApplicationConfigHashCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[[]string], error)) *MockApplicationServiceWatchApplicationConfigHashCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// WatchUnitAddressesHash mocks base method.
+func (m *MockApplicationService) WatchUnitAddressesHash(arg0 context.Context, arg1 unit.Name) (watcher.Watcher[[]string], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchUnitAddressesHash", arg0, arg1)
+	ret0, _ := ret[0].(watcher.Watcher[[]string])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchUnitAddressesHash indicates an expected call of WatchUnitAddressesHash.
+func (mr *MockApplicationServiceMockRecorder) WatchUnitAddressesHash(arg0, arg1 any) *MockApplicationServiceWatchUnitAddressesHashCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnitAddressesHash", reflect.TypeOf((*MockApplicationService)(nil).WatchUnitAddressesHash), arg0, arg1)
+	return &MockApplicationServiceWatchUnitAddressesHashCall{Call: call}
+}
+
+// MockApplicationServiceWatchUnitAddressesHashCall wrap *gomock.Call
+type MockApplicationServiceWatchUnitAddressesHashCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceWatchUnitAddressesHashCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockApplicationServiceWatchUnitAddressesHashCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceWatchUnitAddressesHashCall) Do(f func(context.Context, unit.Name) (watcher.Watcher[[]string], error)) *MockApplicationServiceWatchUnitAddressesHashCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceWatchUnitAddressesHashCall) DoAndReturn(f func(context.Context, unit.Name) (watcher.Watcher[[]string], error)) *MockApplicationServiceWatchUnitAddressesHashCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // WatchUnitForLegacyUniter mocks base method.
 func (m *MockApplicationService) WatchUnitForLegacyUniter(arg0 context.Context, arg1 unit.Name) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Wire up the watcher: WatchConfigSettingsHash, WatchTrustConfigSettingsHash and WatchUnitAddressesHash

In this wiring up, both the WatchConfigSettingsHash and WatchTrustConfigSettingsHash are actually watching the same thing. This is because trust is a field on the application_settings table, and the watcher watchs only at the granulairty of some change within either the settings or config table. This means the uniter will get over-notified for changes to the trust table. But this should be ok. For this reason, it may be the case that we can get rid of the trust config watcher entirely, but I will leave this to be determined in the future.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
**Test the config watchers**
Bootstrap, deploy and change the config
```

juju  bootstrap lxd test-watcher
juju add-model m --config logging-config="<root>=DEBUG;<unit>=DEBUG"
juju deploy juju-qa-dummy-source
juju config dummy-source token="yeet"
```
Check that the uniter tries to fetch the new token in the debug log when it is changed. 
```
unit-dummy-source-0: 15:41:16 CRITICAL juju.worker.uniter.remotestate got trust config change for dummy-source/0: ok=true, hashes=[7d57afc180d3b43cfca151174e7ed82bb034556a96b2be721bc9280ed10b4eba]
unit-dummy-source-0: 15:41:16 CRITICAL juju.worker.uniter.remotestate got config change for dummy-source/0: ok=true, hashes=[7d57afc180d3b43cfca151174e7ed82bb034556a96b2be721bc9280ed10b4eba]
```
**Test the address watcher**
Add new space
```
juju add-space beta 10.101.18.0/24
```
Bind it in the DB, as `juju bind` is not yet wired up.
```
juju ssh -m controller 0 sudo /var/lib/juju/tools/machine-0/jujud db-repl --machine-id 0
repl (controller)> .switch model-m
repl (model-m)> SELECT * FROM application_endpoint
uuid                                    application_uuid                        space_uuid      charm_relation_uuid
298ae2c3-3a49-4d46-8a8a-540cce80cb11    fcb975bd-6259-4aff-8062-894fe660351b    <nil>           be9d4e97-62c5-4215-8d22-a33f16ff532b
e9596582-5854-41bf-85d0-0b283fddfe2c    fcb975bd-6259-4aff-8062-894fe660351b    <nil>           425187f2-b073-4ae0-8338-6973cb66f612
repl (model-m)> SELECT * FROM space
uuid                                    name
656b4a82-e28c-53d6-a014-f0dd53417eb6    alpha
0196a607-ddc7-7e85-b17f-d3f897715966    beta
repl (model-m)> UPDATE application_endpoint SET space_uuid="0196a607-ddc7-7e85-b17f-d3f897715966" WHERE uuid="e9596582-5854-41bf-85d0-0b283fddfe2c"
```
In the uniter, look for
```
unit-dummy-source-0: 15:43:03 CRITICAL juju.worker.uniter.remotestate got address change for dummy-source/0: ok=true, hashes=[b8991601e923d607a3a20aee9be556cfef38d160582a8715f2cf1ee0911bc7f0]
```

## Links

**Jira card:**[JUJU-7901](https://warthogs.atlassian.net/browse/JUJU-7901)

[JUJU-7901]: https://warthogs.atlassian.net/browse/JUJU-7901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ