### PR TITLE
fix: fix broken enable-ha on azure

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -921,7 +921,7 @@ func (env *azureEnviron) createVirtualMachine(
 		if env.cloud.Credential.AuthType() == cloud.ManagedIdentityAuthType {
 			// Add a new controller after bootstrap (enable-ha).
 			managedIdentity = env.cloud.Credential.Attributes()[credManagedIdentity]
-		} else if instanceConfig.Bootstrap.BootstrapMachineConstraints.HasInstanceRole() {
+		} else if instanceConfig.Bootstrap != nil && instanceConfig.Bootstrap.BootstrapMachineConstraints.HasInstanceRole() {
 			// Bootstrap.
 			managedIdentity = *instanceConfig.Bootstrap.BootstrapMachineConstraints.InstanceRole
 		}

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -37,6 +37,7 @@ import (
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -388,6 +389,7 @@ func (s *environSuite) initResourceGroupSenders(resourceGroupName string) azuret
 
 type startInstanceSenderParams struct {
 	bootstrap               bool
+	controller              bool
 	subnets                 []*armnetwork.Subnet
 	diskEncryptionSetName   string
 	vaultName               string
@@ -454,7 +456,7 @@ func (s *environSuite) startInstanceSenders(c *gc.C, args startInstanceSenderPar
 		}
 		if len(args.subnets) == 0 {
 			subnetName := "juju-internal-subnet"
-			if args.bootstrap {
+			if args.bootstrap || args.controller {
 				subnetName = "juju-controller-subnet"
 			}
 			args.subnets = []*armnetwork.Subnet{{
@@ -844,6 +846,21 @@ func (s *environSuite) TestStartInstanceInvalidCredential(c *gc.C) {
 	_, err = env.StartInstance(s.callCtx, makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04")))
 	c.Assert(err, gc.NotNil)
 	c.Assert(s.invalidatedCredential, jc.IsTrue)
+}
+
+func (s *environSuite) TestStartControllerInstance(c *gc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap:  false,
+		controller: true,
+	})
+
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.InstanceConfig.Jobs = []model.MachineJob{model.JobManageModel}
+	params.InstanceConfig.ControllerConfig["api-port"] = 17070
+	_, err := env.StartInstance(s.callCtx, params)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environSuite) TestStartInstanceCentOS(c *gc.C) {


### PR DESCRIPTION
`juju enable-ha` on Azure is broken because of a bad credential check which results in a nil pointer.
This PR fixes that and adds a unit test.

## QA steps

```
juju bootstrap azure
juju enable-ha
juju show-controller
```

## Links

**Issue:** Fixes #19367
