### PR TITLE
refactor: model description create signatures

### DIFF
--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -29,7 +29,6 @@ import (
 	service "github.com/juju/juju/domain/modeldefaults/service"
 	service0 "github.com/juju/juju/domain/secretbackend/service"
 	config "github.com/juju/juju/environs/config"
-	uuid "github.com/juju/juju/internal/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -1053,17 +1052,17 @@ func (m *MockModelInfoService) EXPECT() *MockModelInfoServiceMockRecorder {
 }
 
 // CreateModel mocks base method.
-func (m *MockModelInfoService) CreateModel(arg0 context.Context, arg1 uuid.UUID) error {
+func (m *MockModelInfoService) CreateModel(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateModel", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateModel", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateModel indicates an expected call of CreateModel.
-func (mr *MockModelInfoServiceMockRecorder) CreateModel(arg0, arg1 any) *MockModelInfoServiceCreateModelCall {
+func (mr *MockModelInfoServiceMockRecorder) CreateModel(arg0 any) *MockModelInfoServiceCreateModelCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModel", reflect.TypeOf((*MockModelInfoService)(nil).CreateModel), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModel", reflect.TypeOf((*MockModelInfoService)(nil).CreateModel), arg0)
 	return &MockModelInfoServiceCreateModelCall{Call: call}
 }
 
@@ -1079,13 +1078,13 @@ func (c *MockModelInfoServiceCreateModelCall) Return(arg0 error) *MockModelInfoS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelInfoServiceCreateModelCall) Do(f func(context.Context, uuid.UUID) error) *MockModelInfoServiceCreateModelCall {
+func (c *MockModelInfoServiceCreateModelCall) Do(f func(context.Context) error) *MockModelInfoServiceCreateModelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelInfoServiceCreateModelCall) DoAndReturn(f func(context.Context, uuid.UUID) error) *MockModelInfoServiceCreateModelCall {
+func (c *MockModelInfoServiceCreateModelCall) DoAndReturn(f func(context.Context) error) *MockModelInfoServiceCreateModelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -279,16 +279,16 @@ func (m *ModelManagerAPI) createModelNew(
 		return modelID, errors.Annotatef(err, "failed to set model config for model %q", modelID)
 	}
 
+	// Create the model information in the model database.
+	if err := modelInfoService.CreateModel(ctx); err != nil {
+		return modelID, errors.Annotatef(err, "failed to create model info for model %q", modelID)
+	}
+
 	// TODO (stickupkid): Once tlm has fixed the CreateModel method to read
 	// from the model database to create the model, move the activator call
 	// to the end of the method.
 	if err := activator(ctx); err != nil {
 		return modelID, errors.Annotatef(err, "failed to finalise model %q", modelID)
-	}
-
-	// Create the model information in the model database.
-	if err := modelInfoService.CreateModel(ctx, m.controllerUUID); err != nil {
-		return modelID, errors.Annotatef(err, "failed to create model info for model %q", modelID)
 	}
 
 	// Reload the substrate spaces for the newly created model.

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -382,7 +382,7 @@ func (s *modelManagerSuite) expectCreateModelOnModelDB(
 	modelDomainServices.EXPECT().Machine().Return(machineService)
 
 	// Expect calls to functions of the model services.
-	modelInfoService.EXPECT().CreateModel(gomock.Any(), s.controllerUUID)
+	modelInfoService.EXPECT().CreateModel(gomock.Any()).Return(nil)
 	modelInfoService.EXPECT().GetStatus(gomock.Any()).Return(domainmodel.StatusInfo{
 		Status: status.Available,
 		Since:  time.Now(),
@@ -1063,7 +1063,7 @@ func (s *modelManagerStateSuite) expectCreateModelStateSuite(
 	modelAgentService.EXPECT().GetModelTargetAgentVersion(gomock.Any()).Return(jujuversion.Current, nil)
 	modelConfigService.EXPECT().SetModelConfig(gomock.Any(), gomock.Any())
 	modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).AnyTimes()
-	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), s.controllerUUID)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any()).Return(nil)
 	s.modelInfoService.EXPECT().GetStatus(gomock.Any()).Return(domainmodel.StatusInfo{
 		Status: status.Active,
 		Since:  time.Now(),

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -29,7 +29,6 @@ import (
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/services"
-	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/state"
 )
 
@@ -156,7 +155,7 @@ type ModelDefaultsService interface {
 type ModelInfoService interface {
 	// CreateModel is responsible for adding the details of the model
 	// that is being created.
-	CreateModel(context.Context, uuid.UUID) error
+	CreateModel(context.Context) error
 
 	// DeleteModel is responsible for deleting a model.
 	DeleteModel(context.Context) error

--- a/domain/model/modelmigration/migrations_mock_test.go
+++ b/domain/model/modelmigration/migrations_mock_test.go
@@ -20,7 +20,6 @@ import (
 	semversion "github.com/juju/juju/core/semversion"
 	user "github.com/juju/juju/core/user"
 	model0 "github.com/juju/juju/domain/model"
-	uuid "github.com/juju/juju/internal/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -315,40 +314,40 @@ func (m *MockModelDetailService) EXPECT() *MockModelDetailServiceMockRecorder {
 	return m.recorder
 }
 
-// CreateModelForVersion mocks base method.
-func (m *MockModelDetailService) CreateModelForVersion(arg0 context.Context, arg1 uuid.UUID, arg2 semversion.Number, arg3 agentbinary.AgentStream) error {
+// CreateModelWithAgentVersionStream mocks base method.
+func (m *MockModelDetailService) CreateModelWithAgentVersionStream(arg0 context.Context, arg1 semversion.Number, arg2 agentbinary.AgentStream) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateModelForVersion", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CreateModelWithAgentVersionStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreateModelForVersion indicates an expected call of CreateModelForVersion.
-func (mr *MockModelDetailServiceMockRecorder) CreateModelForVersion(arg0, arg1, arg2, arg3 any) *MockModelDetailServiceCreateModelForVersionCall {
+// CreateModelWithAgentVersionStream indicates an expected call of CreateModelWithAgentVersionStream.
+func (mr *MockModelDetailServiceMockRecorder) CreateModelWithAgentVersionStream(arg0, arg1, arg2 any) *MockModelDetailServiceCreateModelWithAgentVersionStreamCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModelForVersion", reflect.TypeOf((*MockModelDetailService)(nil).CreateModelForVersion), arg0, arg1, arg2, arg3)
-	return &MockModelDetailServiceCreateModelForVersionCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModelWithAgentVersionStream", reflect.TypeOf((*MockModelDetailService)(nil).CreateModelWithAgentVersionStream), arg0, arg1, arg2)
+	return &MockModelDetailServiceCreateModelWithAgentVersionStreamCall{Call: call}
 }
 
-// MockModelDetailServiceCreateModelForVersionCall wrap *gomock.Call
-type MockModelDetailServiceCreateModelForVersionCall struct {
+// MockModelDetailServiceCreateModelWithAgentVersionStreamCall wrap *gomock.Call
+type MockModelDetailServiceCreateModelWithAgentVersionStreamCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelDetailServiceCreateModelForVersionCall) Return(arg0 error) *MockModelDetailServiceCreateModelForVersionCall {
+func (c *MockModelDetailServiceCreateModelWithAgentVersionStreamCall) Return(arg0 error) *MockModelDetailServiceCreateModelWithAgentVersionStreamCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelDetailServiceCreateModelForVersionCall) Do(f func(context.Context, uuid.UUID, semversion.Number, agentbinary.AgentStream) error) *MockModelDetailServiceCreateModelForVersionCall {
+func (c *MockModelDetailServiceCreateModelWithAgentVersionStreamCall) Do(f func(context.Context, semversion.Number, agentbinary.AgentStream) error) *MockModelDetailServiceCreateModelWithAgentVersionStreamCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDetailServiceCreateModelForVersionCall) DoAndReturn(f func(context.Context, uuid.UUID, semversion.Number, agentbinary.AgentStream) error) *MockModelDetailServiceCreateModelForVersionCall {
+func (c *MockModelDetailServiceCreateModelWithAgentVersionStreamCall) DoAndReturn(f func(context.Context, semversion.Number, agentbinary.AgentStream) error) *MockModelDetailServiceCreateModelWithAgentVersionStreamCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/model/modelmigration/package_test.go
+++ b/domain/model/modelmigration/package_test.go
@@ -9,7 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-//go:generate go run go.uber.org/mock/mockgen -typed -package modelmigration -destination migrations_mock_test.go github.com/juju/juju/domain/model/modelmigration ExportService,ControllerConfigService,ModelImportService,ModelDetailService,UserService
+//go:generate go run go.uber.org/mock/mockgen -typed -package modelmigration -destination migrations_mock_test.go github.com/juju/juju/domain/model/modelmigration ExportService,ModelImportService,ModelDetailService,UserService
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)

--- a/domain/model/service/logsinkservice.go
+++ b/domain/model/service/logsinkservice.go
@@ -12,8 +12,15 @@ import (
 // LogSinkState is the model state required by the provide service. This is
 // the model database state, not the controller state.
 type LogSinkState interface {
-	// GetModelInfo returns a the model info.
-	GetModelInfo(context.Context, coremodel.UUID) (coremodel.ModelInfo, error)
+	// GetModelSeedInformation returns information related to a model for the
+	// purposes of seeding this information into other parts of a Juju controller.
+	// This method is similar to [State.GetModel] but it allows for the returning of
+	// information on models that are not activated yet.
+	//
+	// The following error types can be expected:
+	// - [modelerrors.NotFound]: When the model is not found for the given uuid
+	// regardless of the activated status.
+	GetModelSeedInformation(context.Context, coremodel.UUID) (coremodel.ModelInfo, error)
 }
 
 // LogSinkService defines a service for interacting with the underlying model
@@ -32,7 +39,7 @@ func NewLogSinkService(st LogSinkState) *LogSinkService {
 // Model returns model info for the current service.
 //
 // The following error types can be expected to be returned:
-// - [modelerrors.NotFound]: When the model is not found for a given uuid.
+// - [modelerrors.NotFound]: When the model is not found for the given uuid.
 func (s *LogSinkService) Model(ctx context.Context, modelUUID coremodel.UUID) (coremodel.ModelInfo, error) {
-	return s.st.GetModelInfo(ctx, modelUUID)
+	return s.st.GetModelSeedInformation(ctx, modelUUID)
 }

--- a/domain/model/service/logsinkservice_test.go
+++ b/domain/model/service/logsinkservice_test.go
@@ -19,7 +19,7 @@ type dummyLogSinkState struct {
 	model *coremodel.ModelInfo
 }
 
-func (d *dummyLogSinkState) GetModelInfo(ctx context.Context, modelUUID coremodel.UUID) (coremodel.ModelInfo, error) {
+func (d *dummyLogSinkState) GetModelSeedInformation(ctx context.Context, modelUUID coremodel.UUID) (coremodel.ModelInfo, error) {
 	if d.model != nil && d.model.UUID == modelUUID {
 		return *d.model, nil
 	}

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -34,6 +34,14 @@ type ModelState interface {
 	// Delete deletes a model.
 	Delete(context.Context, coremodel.UUID) error
 
+	// GetControllerUUID returns the controller uuid for the model.
+	// It is expected that CreateModel has been called before reading this value
+	// from the database.
+	// The following error types can be expected:
+	// - [modelerrors.NotFound] when no model has been created in the state
+	// layer.
+	GetControllerUUID(context.Context) (uuid.UUID, error)
+
 	// GetModel returns the read only model information set in the database.
 	GetModel(context.Context) (coremodel.ModelInfo, error)
 
@@ -70,8 +78,15 @@ type ModelState interface {
 // ControllerState is the controller state required by this service. This is the
 // controller database, not the model state.
 type ControllerState interface {
-	// GetModel returns the model with the given UUID.
-	GetModel(context.Context, coremodel.UUID) (coremodel.Model, error)
+	// GetModelSeedInformation returns information related to a model for the
+	// purposes of seeding this information into other parts of a Juju controller.
+	// This method is similar to [State.GetModel] but it allows for the returning of
+	// information on models that are not activated yet.
+	//
+	// The following error types can be expected:
+	// - [modelerrors.NotFound]: When the model is not found for the given uuid
+	// regardless of the activated status.
+	GetModelSeedInformation(context.Context, coremodel.UUID) (coremodel.ModelInfo, error)
 
 	// GetModelState returns the model state for the given model.
 	// It returns [modelerrors.NotFound] if the model does not exist for the given UUID.
@@ -182,18 +197,49 @@ func (s *ModelService) GetModelMetrics(ctx context.Context) (coremodel.ModelMetr
 	return s.modelSt.GetModelMetrics(ctx)
 }
 
-// CreateModelForVersion is responsible for creating a new model within the
-// model database, using the input agent version.
+// CreateModel is responsible for creating a new model within the model
+// database.
 //
 // The following error types can be expected to be returned:
-// - [modelerrors.AlreadyExists]: When the model uuid is already in use.
-func (s *ModelService) CreateModelForVersion(
+// - [modelerrors.AlreadyExists] when the model uuid is already in use.
+func (s *ModelService) CreateModel(
 	ctx context.Context,
-	controllerUUID uuid.UUID,
+) error {
+	defaultAgentVersion, defaultAgentStream := agentVersionSelector()
+	return s.CreateModelWithAgentVersionStream(
+		ctx, defaultAgentVersion, defaultAgentStream,
+	)
+}
+
+// CreateModelWithAgentVersion is responsible for creating a new model within
+// the model database using the specified agent version.
+//
+// The following error types can be expected to be returned:
+// - [modelerrors.AlreadyExists] when the model uuid is already in use.
+// - [modelerrors.AgentVersionNotSupported] when the agent version is not
+// supported.
+func (s *ModelService) CreateModelWithAgentVersion(
+	ctx context.Context,
+	agentVersion semversion.Number,
+) error {
+	_, defaultAgentStream := agentVersionSelector()
+	return s.CreateModelWithAgentVersionStream(ctx, agentVersion, defaultAgentStream)
+}
+
+// CreateModelForVersion is responsible for creating a new model within the
+// model database, using the input agent version and agent stream.
+//
+// The following error types can be expected to be returned:
+// - [modelerrors.AlreadyExists] when the model uuid is already in use.
+// - [coreerrors.NotValid] when the agent stream is not valid.
+// - [modelerrors.AgentVersionNotSupported] when the agent version is not
+// supported.
+func (s *ModelService) CreateModelWithAgentVersionStream(
+	ctx context.Context,
 	agentVersion semversion.Number,
 	agentStream agentbinary.AgentStream,
 ) error {
-	m, err := s.controllerSt.GetModel(ctx, s.modelUUID)
+	m, err := s.controllerSt.GetModelSeedInformation(ctx, s.modelUUID)
 	if err != nil {
 		return err
 	}
@@ -212,14 +258,14 @@ func (s *ModelService) CreateModelForVersion(
 
 	args := model.ModelDetailArgs{
 		UUID:            m.UUID,
-		ControllerUUID:  controllerUUID,
+		ControllerUUID:  m.ControllerUUID,
 		Name:            m.Name,
-		Type:            m.ModelType,
+		Type:            m.Type,
 		Cloud:           m.Cloud,
 		CloudType:       m.CloudType,
 		CloudRegion:     m.CloudRegion,
-		CredentialOwner: m.Credential.Owner,
-		CredentialName:  m.Credential.Name,
+		CredentialOwner: m.CredentialOwner,
+		CredentialName:  m.CredentialName,
 
 		AgentStream: argAgentStream,
 		// TODO (manadart 2024-01-13): Note that this comes from the arg.
@@ -348,24 +394,69 @@ func (s *ProviderModelService) CloudAPIVersion(ctx context.Context) (string, err
 }
 
 // CreateModel is responsible for creating a new model within the model
-// database, using the default agent version.
+// database. Upon creating the model any information required in the model's
+// provider will be initialised.
 //
 // The following error types can be expected to be returned:
-// - [modelerrors.AlreadyExists]: When the model uuid is already in use.
+// - [modelerrors.AlreadyExists] when the model uuid is already in use.
 func (s *ProviderModelService) CreateModel(
 	ctx context.Context,
-	controllerUUID uuid.UUID,
 ) error {
-	defaultAgentVersion, defaultAgentStream := agentVersionSelector()
-	if err := s.CreateModelForVersion(
-		ctx,
-		controllerUUID,
-		defaultAgentVersion,
-		defaultAgentStream,
+	if err := s.ModelService.CreateModel(ctx); err != nil {
+		return errors.Capture(err)
+	}
+
+	return s.createModelProviderResources(ctx)
+}
+
+// CreateModelWithAgentVersion is responsible for creating a new model within
+// the model database using the specified agent version. Upon creating the model
+// any information required in the model's provider will be initialised.
+//
+// The following error types can be expected to be returned:
+// - [modelerrors.AlreadyExists] when the model uuid is already in use.
+// - [modelerrors.AgentVersionNotSupported] when the agent version is not
+// supported.
+func (s *ProviderModelService) CreateModelWithAgentVersion(
+	ctx context.Context,
+	agentVersion semversion.Number,
+) error {
+	if err := s.ModelService.CreateModelWithAgentVersion(ctx, agentVersion); err != nil {
+		return errors.Capture(err)
+	}
+
+	return s.createModelProviderResources(ctx)
+}
+
+// CreateModelWithAgentVersionStream is responsible for creating a new model
+// within the model database using the specified agent version and agent stream.
+// Upon creating the model any information required in the model's provider
+// will be initialised.
+//
+// The following error types can be expected to be returned:
+// - [modelerrors.AlreadyExists] when the model uuid is already in use.
+// - [modelerrors.AgentVersionNotSupported] when the agent version is not
+// supported.
+// - [coreerrors.NotValid] when the agent stream is not valid.
+func (s *ProviderModelService) CreateModelWithAgentVersionStream(
+	ctx context.Context,
+	agentVersion semversion.Number,
+	agentStream agentbinary.AgentStream,
+) error {
+	if err := s.ModelService.CreateModelWithAgentVersionStream(
+		ctx, agentVersion, agentStream,
 	); err != nil {
 		return errors.Capture(err)
 	}
 
+	return s.createModelProviderResources(ctx)
+}
+
+// createModelProviderResources is responsible for creating the model resources
+// in the underlying provider after the model has been created.
+func (s *ProviderModelService) createModelProviderResources(
+	ctx context.Context,
+) error {
 	env, err := s.providerGetter(ctx)
 	if errors.Is(err, coreerrors.NotSupported) {
 		// Exit early if the provider does not support creating model resources for the new model.
@@ -376,12 +467,29 @@ func (s *ProviderModelService) CreateModel(
 	}
 
 	if err := env.ValidateProviderForNewModel(ctx); err != nil {
-		return errors.Errorf("creating model %q: %w", s.modelUUID, err)
+		return errors.Errorf("validating provider for model %q: %w", s.modelUUID, err)
 	}
+
+	controllerUUID, err := s.modelSt.GetControllerUUID(ctx)
+	if err != nil {
+		return errors.Errorf(
+			"getting controller uuid for model %q to initialise provider: %w",
+			s.modelUUID, err,
+		)
+	}
+	// TODO (tlm): This is incredibly dangerous and needs to be stopped. We
+	// should not create provider resources on behalf of a model that have the
+	// controller uuid. The reason for this is that the model may get migrated
+	// to a different controller. We have never had a process that updates this
+	// incorrect information.
+	//
+	// If we ever started using it to track down resources we could potentiall
+	// do the wrong thing or overwrite another controllers resources.
 	if err := env.CreateModelResources(ctx, environs.CreateParams{ControllerUUID: controllerUUID.String()}); err != nil {
 		// TODO: we should cleanup the model related data created above from database.
-		return errors.Errorf("creating model resources for %q: %w", s.modelUUID, err)
+		return errors.Errorf("creating model provider resources for %q: %w", s.modelUUID, err)
 	}
+
 	return nil
 }
 

--- a/domain/model/service/package_mock_test.go
+++ b/domain/model/service/package_mock_test.go
@@ -24,6 +24,7 @@ import (
 	life "github.com/juju/juju/domain/life"
 	model0 "github.com/juju/juju/domain/model"
 	environs "github.com/juju/juju/environs"
+	uuid "github.com/juju/juju/internal/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -50,41 +51,41 @@ func (m *MockControllerState) EXPECT() *MockControllerStateMockRecorder {
 	return m.recorder
 }
 
-// GetModel mocks base method.
-func (m *MockControllerState) GetModel(arg0 context.Context, arg1 model.UUID) (model.Model, error) {
+// GetModelSeedInformation mocks base method.
+func (m *MockControllerState) GetModelSeedInformation(arg0 context.Context, arg1 model.UUID) (model.ModelInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModel", arg0, arg1)
-	ret0, _ := ret[0].(model.Model)
+	ret := m.ctrl.Call(m, "GetModelSeedInformation", arg0, arg1)
+	ret0, _ := ret[0].(model.ModelInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetModel indicates an expected call of GetModel.
-func (mr *MockControllerStateMockRecorder) GetModel(arg0, arg1 any) *MockControllerStateGetModelCall {
+// GetModelSeedInformation indicates an expected call of GetModelSeedInformation.
+func (mr *MockControllerStateMockRecorder) GetModelSeedInformation(arg0, arg1 any) *MockControllerStateGetModelSeedInformationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModel", reflect.TypeOf((*MockControllerState)(nil).GetModel), arg0, arg1)
-	return &MockControllerStateGetModelCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModelSeedInformation", reflect.TypeOf((*MockControllerState)(nil).GetModelSeedInformation), arg0, arg1)
+	return &MockControllerStateGetModelSeedInformationCall{Call: call}
 }
 
-// MockControllerStateGetModelCall wrap *gomock.Call
-type MockControllerStateGetModelCall struct {
+// MockControllerStateGetModelSeedInformationCall wrap *gomock.Call
+type MockControllerStateGetModelSeedInformationCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerStateGetModelCall) Return(arg0 model.Model, arg1 error) *MockControllerStateGetModelCall {
+func (c *MockControllerStateGetModelSeedInformationCall) Return(arg0 model.ModelInfo, arg1 error) *MockControllerStateGetModelSeedInformationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerStateGetModelCall) Do(f func(context.Context, model.UUID) (model.Model, error)) *MockControllerStateGetModelCall {
+func (c *MockControllerStateGetModelSeedInformationCall) Do(f func(context.Context, model.UUID) (model.ModelInfo, error)) *MockControllerStateGetModelSeedInformationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerStateGetModelCall) DoAndReturn(f func(context.Context, model.UUID) (model.Model, error)) *MockControllerStateGetModelCall {
+func (c *MockControllerStateGetModelSeedInformationCall) DoAndReturn(f func(context.Context, model.UUID) (model.ModelInfo, error)) *MockControllerStateGetModelSeedInformationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -345,6 +346,45 @@ func (c *MockModelStateDeleteCall) Do(f func(context.Context, model.UUID) error)
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelStateDeleteCall) DoAndReturn(f func(context.Context, model.UUID) error) *MockModelStateDeleteCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetControllerUUID mocks base method.
+func (m *MockModelState) GetControllerUUID(arg0 context.Context) (uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControllerUUID", arg0)
+	ret0, _ := ret[0].(uuid.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetControllerUUID indicates an expected call of GetControllerUUID.
+func (mr *MockModelStateMockRecorder) GetControllerUUID(arg0 any) *MockModelStateGetControllerUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControllerUUID", reflect.TypeOf((*MockModelState)(nil).GetControllerUUID), arg0)
+	return &MockModelStateGetControllerUUIDCall{Call: call}
+}
+
+// MockModelStateGetControllerUUIDCall wrap *gomock.Call
+type MockModelStateGetControllerUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetControllerUUIDCall) Return(arg0 uuid.UUID, arg1 error) *MockModelStateGetControllerUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetControllerUUIDCall) Do(f func(context.Context) (uuid.UUID, error)) *MockModelStateGetControllerUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetControllerUUIDCall) DoAndReturn(f func(context.Context) (uuid.UUID, error)) *MockModelStateGetControllerUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/semversion"
 	coreuser "github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
@@ -425,17 +424,7 @@ func (s *Service) ImportModel(
 		)
 	}
 
-	// If we are importing a model we need to know the agent version in use to
-	// make sure we have tools to support the model and it will work with this
-	// controller.
-	if args.AgentVersion == semversion.Zero {
-		return nil, errors.Errorf(
-			"cannot import model with id %q, agent version cannot be zero: %w",
-			args.ID, modelerrors.AgentVersionNotSupported,
-		)
-	}
-
-	return s.createModel(ctx, args.ID, args.GlobalModelCreationArgs)
+	return s.createModel(ctx, args.UUID, args.GlobalModelCreationArgs)
 }
 
 // ControllerModel returns the model used for housing the Juju controller.

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -745,7 +745,7 @@ func (s *serviceSuite) TestImportModelWithMissingAgentVersion(c *gc.C) {
 			Owner:       s.userUUID,
 			Name:        "my-awesome-model",
 		},
-		ID: modelID,
+		UUID: modelID,
 	})
 	c.Assert(err, jc.ErrorIs, modelerrors.AgentVersionNotSupported)
 
@@ -778,8 +778,7 @@ func (s *serviceSuite) TestImportModel(c *gc.C) {
 			Owner:       s.userUUID,
 			Name:        "my-awesome-model",
 		},
-		ID:           modelID,
-		AgentVersion: jujuversion.Current,
+		UUID: modelID,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(activator(context.Background()), jc.ErrorIsNil)

--- a/domain/model/state/controllerstate.go
+++ b/domain/model/state/controllerstate.go
@@ -418,14 +418,24 @@ FROM   controller
 	return model, nil
 }
 
-// GetModelInfo returns the model associated with the provided uuid. This will
-// return a model, even if it's not activated, so it can be used to determine
-// the model's status. If the model does not exist then an error satisfying
-// [modelerrors.NotFound] will be returned.
-func (s *State) GetModelInfo(
+// GetModelSeedInformation returns information related to a model for the
+// purposes of seeding this information into other parts of a Juju controller.
+// This method is similar to [State.GetModel] but it allows for the returning of
+// information on models that are not activated yet.
+//
+// This is needed to seed the static read only information of a model into the
+// model's database or build a service on behalf of the model that should run
+// regardless if the model is activated like logging.
+//
+// The following error types can be expected:
+// - [modelerrors.NotFound]: When the model is not found for the given uuid
+// regardless of the activated status.
+func (s *State) GetModelSeedInformation(
 	ctx context.Context,
 	modelUUID coremodel.UUID,
 ) (coremodel.ModelInfo, error) {
+	// WARNING (tlm): You are potentially working with half initialized model
+	// information in this function be careful!
 	db, err := s.DB()
 	if err != nil {
 		return coremodel.ModelInfo{}, errors.Capture(err)

--- a/domain/model/state/controllerstate_test.go
+++ b/domain/model/state/controllerstate_test.go
@@ -324,7 +324,10 @@ func (m *stateSuite) TestGetModel(c *gc.C) {
 	})
 }
 
-func (m *stateSuite) TestGetModelInfoNotActivated(c *gc.C) {
+// TestGetModelSeedInformationNotActivated tests that
+// [State.GetModelSeedInformation] return information about a model that is not
+// yet activated.
+func (m *stateSuite) TestGetModelSeedInformationNotActivated(c *gc.C) {
 	runner := m.TxnRunnerFactory()
 
 	modelUUID := modeltesting.GenModelUUID(c)
@@ -354,7 +357,7 @@ func (m *stateSuite) TestGetModelInfoNotActivated(c *gc.C) {
 	userName, err := user.NewName("test-user")
 	c.Assert(err, jc.ErrorIsNil)
 
-	modelInfo, err := modelSt.GetModelInfo(context.Background(), modelUUID)
+	modelInfo, err := modelSt.GetModelSeedInformation(context.Background(), modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(modelInfo, gc.Equals, coremodel.ModelInfo{
 		UUID:            modelUUID,
@@ -369,7 +372,9 @@ func (m *stateSuite) TestGetModelInfoNotActivated(c *gc.C) {
 	})
 }
 
-func (m *stateSuite) TestGetModelInfoActivated(c *gc.C) {
+// TestGetModelInfoActivated tests that [State.GetModelSeedInformation] returns
+// information about a model when it is activated.
+func (m *stateSuite) TestGetModelSeedInformationActivated(c *gc.C) {
 	runner := m.TxnRunnerFactory()
 
 	userName, err := user.NewName("test-user")
@@ -379,7 +384,7 @@ func (m *stateSuite) TestGetModelInfoActivated(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelSt := NewState(runner)
-	modelInfo, err := modelSt.GetModelInfo(context.Background(), m.uuid)
+	modelInfo, err := modelSt.GetModelSeedInformation(context.Background(), m.uuid)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(modelInfo, gc.Equals, coremodel.ModelInfo{
 		UUID:            m.uuid,
@@ -394,11 +399,15 @@ func (m *stateSuite) TestGetModelInfoActivated(c *gc.C) {
 	})
 }
 
-func (m *stateSuite) TestGetModelInfoNotFound(c *gc.C) {
+// TestGetModelSeedInformationNotFound tests that when asking for seed
+// information on a model that does not exist not just non activated we get an
+// error satisfying [modelerrors.NotFound] back.
+func (m *stateSuite) TestGetModelSeedInformationNotFound(c *gc.C) {
 	runner := m.TxnRunnerFactory()
 
+	modelUUID := modeltesting.GenModelUUID(c)
 	modelSt := NewState(runner)
-	_, err := modelSt.GetModelInfo(context.Background(), "foo")
+	_, err := modelSt.GetModelSeedInformation(context.Background(), modelUUID)
 	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)
 }
 

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -143,6 +143,11 @@ type dbUUID struct {
 	UUID string `db:"uuid"`
 }
 
+// dbControllerUUID represents the controller uuid value on a model record.
+type dbControllerUUID struct {
+	UUID string `db:"controller_uuid"`
+}
+
 // dbModelUUIDRef represents the model uuid in tables that have a foreign key on
 // the model uuid.
 type dbModelUUIDRef struct {

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -128,11 +128,8 @@ type ModelImportArgs struct {
 	// importing the new model into Juju.
 	GlobalModelCreationArgs
 
-	// ID represents the unique id of the model to import.
-	ID coremodel.UUID
-
-	// AgentVersion is the target version for agents running in this model.
-	AgentVersion semversion.Number
+	// UUID represents the unique uuid of the model to import.
+	UUID coremodel.UUID
 }
 
 // Validate is responsible for checking all of the fields of [ModelImportArgs]
@@ -143,7 +140,7 @@ func (m ModelImportArgs) Validate() error {
 		return errors.Errorf("GlobalModelCreationArgs %w", err)
 	}
 
-	if err := m.ID.Validate(); err != nil {
+	if err := m.UUID.Validate(); err != nil {
 		return errors.Errorf("validating model import args id: %w", err)
 	}
 

--- a/domain/model/types_test.go
+++ b/domain/model/types_test.go
@@ -154,7 +154,7 @@ func (*typesSuite) TestModelImportArgsValidation(c *gc.C) {
 					Name:  "my-awesome-model",
 					Owner: userUUID,
 				},
-				ID: modeltesting.GenModelUUID(c),
+				UUID: modeltesting.GenModelUUID(c),
 			},
 		},
 		{
@@ -171,7 +171,7 @@ func (*typesSuite) TestModelImportArgsValidation(c *gc.C) {
 					Name:  "my-awesome-model",
 					Owner: userUUID,
 				},
-				ID: "not valid",
+				UUID: "not valid",
 			},
 			ErrTest: coreerrors.NotValid,
 		},


### PR DESCRIPTION
This PR exists to address a TODO comment left by @SimonRichardson in the model manager facade where by the model description record in the model database currently needs to be created after we call activate on the model. In the ideal world this happens before Activate. See https://github.com/juju/juju/blob/c0eb2ff1c9a3b23f447db43a1d1e4c8537c00fe1/apiserver/facades/client/modelmanager/modelmanager.go#L282 for the TODO and the problem.

The reason this problem existed was the information that we  used for seeding the model database was gated behind the active flag which introduces a chicken and egg scenario. Simon had already done the work to introduce the correct state layer function for pulling the information on non activated model. This was introduced to build up the model log service. I have slightly modified the state layer from this with a rename to use the word "seed" information. This better describes the purpose of the function and also high lights to any developers working on the function the dangers they need to be aware of.

While here I have also created 3 new function signatures for creating the read only model record depending on what the model manager facade will need to do. The variants deal with the fact that the user may or may not have set either an agent version for the new model and also an agent stream for the model. These are support cases we have for the Juju client today. This change  addresses a need in PR #19675 where the information for the new model around agent version needs to be extracted and set along with the new model.

The last change in this PR is fixing up the import arguments that we had for model migration. These arguments still incorrectly had an agent version member that can't be set on the controller database anymore. The structure also referred to the model uuid as "id" which is a pattern we have moved away from.

When this PR lands it will be integrated into the model manager facade.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

### Case 1
Bootstrap a new controller and add a new model and confirm that no errors happen with this process.

### Case 2
Migrate a model between two controllers and confirm the process succeeds. We are looking for errors around model import stage in controller logs on the target controller.

## Documentation changes

N/A

## Links

**Jira card:** [JUJU-7842](https://warthogs.atlassian.net/browse/JUJU-7842)
