### PR TITLE
chore: virtual hostnames extra check

### DIFF
--- a/core/virtualhostname/virtualhostname.go
+++ b/core/virtualhostname/virtualhostname.go
@@ -209,6 +209,9 @@ func Parse(hostname string) (Info, error) {
 	if err != nil {
 		return Info{}, errors.Annotatef(err, "failed to parse unit/machine number")
 	}
+	if result["containername"] != "" && result["appname"] == "" {
+		return Info{}, errors.Errorf("container name specified without an application name")
+	}
 
 	res := Info{}
 	appName := result["appname"]

--- a/core/virtualhostname/virtualhostname_test.go
+++ b/core/virtualhostname/virtualhostname_test.go
@@ -86,6 +86,11 @@ func (s *HostnameSuite) TestParseHostname(c *gc.C) {
 			hostname:    "1a.8419cd78-4993-4c3a-928e-c646226beeee.juju.local",
 			expectedErr: `could not parse hostname`,
 		},
+		{
+			desc:        "Container specified without application name",
+			hostname:    "hello-kubecon.0.976cbcdc-c49a-4e02-8f29-da260038e517.juju.local",
+			expectedErr: `container name specified without an application name`,
+		},
 	}
 	for i, tC := range testCases {
 		c.Logf("test %d: %s", i, tC.desc)


### PR DESCRIPTION
This PR adds additional validation to the `virtualhostname`'s `Parse` method which would accept an invalid hostname of the form `hello-kubecon.0.<model-uuid>.juju.local` which at first glance might look valid but doesn't fit our existing types for machines/units/containers. 

The reason it was accepted is because we parse the virtual hostname using a single regex, and there are some sections of the regex that are optional which can result in an invalid combination of fields. A possible improvement that would keep all validation in regex might be to use 3 separate regex expressions for each type of hostname we accept -  since the hostname format is not ambiguous between each target type, this could possibly work.

To avoid a larger rewrite and to over-complicating the regex, I've added validation with an if statement.

## Checklist
- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
