### PR TITLE
chore: add ssh proxy integration test

### DIFF
--- a/tests/includes/ssh.sh
+++ b/tests/includes/ssh.sh
@@ -1,0 +1,33 @@
+# This file contains functions to facilitate SSH connections through a jump host.
+# The commands are useful for testing Juju's SSH proxy using both ssh and scp.
+
+ssh_flags=(
+	-o StrictHostKeyChecking=no
+	-o UserKnownHostsFile=/dev/null
+)
+
+# Note the use of ProxyCommand below instead of the simpler -J flag.
+# This is needed because -J issues an ssh process which doesn't
+# inherit the arguements from the parent process. We want both ssh
+# connections to ignore the host key check to ensure the test runs non-interactively.
+
+make_proxy_command() {
+	local jump_host=$1
+	local ssh_port=17022
+
+	echo "ssh ${ssh_flags[*]} -p $ssh_port $jump_host -W %h:%p"
+}
+
+ssh_wrapper_with_proxy() {
+    local jump_host=$1
+    shift # Remove jump_host from arguments
+
+    ssh "${ssh_flags[@]}" -o ProxyCommand="$(make_proxy_command "$jump_host")" "$@"
+}
+
+scp_wrapper_with_proxy() {
+	local jump_host=$1
+	shift # Remove jump_host from arguments
+
+	scp "${ssh_flags[@]}" -o ProxyCommand="$(make_proxy_command "$jump_host")" "$@"
+}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -74,6 +74,8 @@ TEST_NAMES="agents \
             sidecar \
             smoke \
             spaces_ec2 \
+            ssh_iaas \
+            ssh_k8s \
             static_analysis \
             storage \
             unit \

--- a/tests/suites/ssh_iaas/ssh.sh
+++ b/tests/suites/ssh_iaas/ssh.sh
@@ -1,0 +1,73 @@
+run_ssh() {
+	echo
+
+	model_name='model-ssh'
+	juju --show-log add-model "$model_name"
+	model_uuid=$(juju show-model $model_name --format json | jq -r ".[\"${model_name}\"][\"model-uuid\"]")
+
+	app_name="ubuntu"
+	juju deploy $app_name
+	wait_for $app_name "$(active_idle_condition $app_name 0 0)"
+
+	controller_name=$(juju controllers --format json | jq -r '."current-controller"')
+	controller_address=$(juju show-controller --format json | jq -r ".[\"${controller_name}\"][\"details\"][\"api-endpoints\"][0]" | cut -d ':' -f 1)
+
+	machine_hostname=0.$model_uuid.juju.local
+	unit_hostname=0.$app_name.$model_uuid.juju.local
+
+	check_ssh_using_openssh "$controller_address" "$machine_hostname"
+	check_ssh_using_openssh "$controller_address" "$unit_hostname"
+
+	check_scp_using_openssh "$controller_address" "$machine_hostname"
+	check_scp_using_openssh "$controller_address" "$unit_hostname"
+
+	# TODO: Add tests for the Juju CLI below
+
+	destroy_model "${model_name}"
+}
+
+check_ssh_using_openssh() {
+	controller_address=${1}
+	virtual_hostname=${2}
+	test_file="test-ssh.txt"
+
+	# Check that we can write a file on the remote host then read it back.
+	ssh_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname" "echo hello > $test_file"
+	output=$(ssh_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname" "cat $test_file")
+	check_contains "$output" hello
+}
+
+check_scp_using_openssh() {
+	controller_address=${1}
+	virtual_hostname=${2}
+	scp_file="test-scp.txt"
+
+	# Check that we can copy a file to the remote host then copy it back.
+	echo hello > $scp_file
+	scp_no_hostkey_check -J admin@"$controller_address":17022 test-scp.txt ubuntu@"$virtual_hostname":$scp_file
+	scp_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname":$scp_file $scp_file
+	check_contains "$(cat $scp_file)" hello
+}
+
+ssh_no_hostkey_check() {
+	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
+}
+
+scp_no_hostkey_check() {
+	scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
+}
+
+test_ssh() {
+	if [ "$(skip 'test_ssh')" ]; then
+		echo "==> TEST SKIPPED: test_ssh"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_ssh"
+	)
+}

--- a/tests/suites/ssh_iaas/ssh.sh
+++ b/tests/suites/ssh_iaas/ssh.sh
@@ -33,8 +33,9 @@ check_ssh_using_openssh() {
 
 	# Check that we can write a file on the remote host then read it back.
 	jump_host=admin@"$controller_address"
-	ssh_no_hostkey_check "$jump_host" ubuntu@"$virtual_hostname" "echo hello > $test_file"
-	output=$(ssh_no_hostkey_check "$jump_host" ubuntu@"$virtual_hostname" "cat $test_file")
+
+	ssh_wrapper_with_proxy "$jump_host" ubuntu@"$virtual_hostname" "echo hello > $test_file"
+	output=$(ssh_wrapper_with_proxy "$jump_host" ubuntu@"$virtual_hostname" "cat $test_file")
 	check_contains "$output" hello
 }
 
@@ -46,35 +47,11 @@ check_scp_using_openssh() {
 	# Check that we can copy a file to the remote host then copy it back.
 	echo hello > $scp_file
 	jump_host=admin@"$controller_address"
-	scp_no_hostkey_check "$jump_host" test-scp.txt ubuntu@"$virtual_hostname":$scp_file
-	scp_no_hostkey_check "$jump_host" ubuntu@"$virtual_hostname":$scp_file $scp_file
+
+	scp_wrapper_with_proxy "$jump_host" test-scp.txt ubuntu@"$virtual_hostname":$scp_file
+	scp_wrapper_with_proxy "$jump_host" ubuntu@"$virtual_hostname":$scp_file $scp_file
 	check_contains "$(cat $scp_file)" hello
 }
-
-ssh_no_hostkey_check() {
-	jump_host=${1}
-	ssh_port=17022
-
-	# Note the use of ProxyCommand instead of the simpler -J flag.
-	# Needed because -J issues another ssh process which doesn't
-	# inherit the arguements from the parent process. We need both ssh
-	# processes to ignore the host key check to ensure the process is not interactive.
-	proxy_command="ssh ${ssh_flags[*]} -p $ssh_port $jump_host -W %h:%p"
-	ssh "${ssh_flags[@]}" -o ProxyCommand="$proxy_command" "${@:2}"
-}
-
-scp_no_hostkey_check() {
-	jump_host=${1}
-	ssh_port=17022
-
-	proxy_command="ssh ${ssh_flags[*]} -p $ssh_port $jump_host -W %h:%p"
-	scp "${ssh_flags[@]}" -o ProxyCommand="$proxy_command" "${@:2}"
-}
-
-ssh_flags=(
-	-o StrictHostKeyChecking=no
-	-o UserKnownHostsFile=/dev/null
-)
 
 test_ssh() {
 	if [ "$(skip 'test_ssh')" ]; then

--- a/tests/suites/ssh_iaas/ssh.sh
+++ b/tests/suites/ssh_iaas/ssh.sh
@@ -32,8 +32,9 @@ check_ssh_using_openssh() {
 	test_file="test-ssh.txt"
 
 	# Check that we can write a file on the remote host then read it back.
-	ssh_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname" "echo hello > $test_file"
-	output=$(ssh_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname" "cat $test_file")
+	jump_host=admin@"$controller_address"
+	ssh_no_hostkey_check "$jump_host" ubuntu@"$virtual_hostname" "echo hello > $test_file"
+	output=$(ssh_no_hostkey_check "$jump_host" ubuntu@"$virtual_hostname" "cat $test_file")
 	check_contains "$output" hello
 }
 
@@ -44,18 +45,36 @@ check_scp_using_openssh() {
 
 	# Check that we can copy a file to the remote host then copy it back.
 	echo hello > $scp_file
-	scp_no_hostkey_check -J admin@"$controller_address":17022 test-scp.txt ubuntu@"$virtual_hostname":$scp_file
-	scp_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname":$scp_file $scp_file
+	jump_host=admin@"$controller_address"
+	scp_no_hostkey_check "$jump_host" test-scp.txt ubuntu@"$virtual_hostname":$scp_file
+	scp_no_hostkey_check "$jump_host" ubuntu@"$virtual_hostname":$scp_file $scp_file
 	check_contains "$(cat $scp_file)" hello
 }
 
 ssh_no_hostkey_check() {
-	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
+	jump_host=${1}
+	ssh_port=17022
+
+	# Note the use of ProxyCommand instead of the simpler -J flag.
+	# Needed because -J issues another ssh process which doesn't
+	# inherit the arguements from the parent process. We need both ssh
+	# processes to ignore the host key check to ensure the process is not interactive.
+	proxy_command="ssh ${ssh_flags[*]} -p $ssh_port $jump_host -W %h:%p"
+	ssh "${ssh_flags[@]}" -o ProxyCommand="$proxy_command" "${@:2}"
 }
 
 scp_no_hostkey_check() {
-	scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
+	jump_host=${1}
+	ssh_port=17022
+
+	proxy_command="ssh ${ssh_flags[*]} -p $ssh_port $jump_host -W %h:%p"
+	scp "${ssh_flags[@]}" -o ProxyCommand="$proxy_command" "${@:2}"
 }
+
+ssh_flags=(
+	-o StrictHostKeyChecking=no
+	-o UserKnownHostsFile=/dev/null
+)
 
 test_ssh() {
 	if [ "$(skip 'test_ssh')" ]; then

--- a/tests/suites/ssh_iaas/task.sh
+++ b/tests/suites/ssh_iaas/task.sh
@@ -1,0 +1,25 @@
+test_ssh_iaas() {
+	if [ "$(skip 'test_ssh')" ]; then
+		echo "==> TEST SKIPPED: ssh tests"
+		return
+	fi
+
+	set_verbosity
+
+	if [ "${BOOTSTRAP_PROVIDER:-}" == "k8s" ]; then
+		echo "==> TEST SKIPPED: iaas ssh tests, not valid using a k8s provider"
+		return
+	fi
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-ssh-iaas.log"
+
+	JUJU_DEV_FEATURE_FLAGS=ssh-jump bootstrap "test-ssh-iaas" "${file}"
+
+	# Add tests here
+	test_ssh
+
+	destroy_controller "test-ssh-iaas"
+}

--- a/tests/suites/ssh_k8s/ssh.sh
+++ b/tests/suites/ssh_k8s/ssh.sh
@@ -28,13 +28,11 @@ check_ssh_using_openssh() {
 	test_file="test-ssh.txt"
 
 	# Check that we can write a file on the remote host then read it back.
-	ssh_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname" "echo hello > $test_file"
-	output=$(ssh_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname" "cat $test_file")
+	jump_host=admin@"$controller_address"
+	
+	ssh_wrapper_with_proxy "$jump_host" ubuntu@"$virtual_hostname" "echo hello > $test_file"
+	output=$(ssh_wrapper_with_proxy "$jump_host" ubuntu@"$virtual_hostname" "cat $test_file")
 	check_contains "$output" hello
-}
-
-ssh_no_hostkey_check() {
-	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
 }
 
 test_ssh() {

--- a/tests/suites/ssh_k8s/ssh.sh
+++ b/tests/suites/ssh_k8s/ssh.sh
@@ -1,0 +1,53 @@
+run_ssh() {
+	echo
+
+	model_name='test-ssh'
+	juju --show-log add-model "$model_name"
+	model_uuid=$(juju show-model $model_name --format json | jq -r ".[\"${model_name}\"][\"model-uuid\"]")
+
+	app_name="hello-kubecon"
+	juju deploy $app_name
+	wait_for $app_name "$(active_idle_condition $app_name 0 0)"
+
+	controller_name=$(juju controllers --format json | jq -r '."current-controller"')
+	controller_address=$(juju show-controller --format json | jq -r ".[\"${controller_name}\"][\"details\"][\"api-endpoints\"][0]" | cut -d ':' -f 1)
+
+	container_name="charm"
+	container_hostname=$container_name.0.$app_name.$model_uuid.juju.local
+
+	check_ssh_using_openssh "$controller_address" "$container_hostname"
+
+	# TODO: Add tests for the Juju CLI below
+
+	destroy_model "${model_name}"
+}
+
+check_ssh_using_openssh() {
+	controller_address=${1}
+	virtual_hostname=${2}
+	test_file="test-ssh.txt"
+
+	# Check that we can write a file on the remote host then read it back.
+	ssh_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname" "echo hello > $test_file"
+	output=$(ssh_no_hostkey_check -J admin@"$controller_address":17022 ubuntu@"$virtual_hostname" "cat $test_file")
+	check_contains "$output" hello
+}
+
+ssh_no_hostkey_check() {
+	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
+}
+
+test_ssh() {
+	if [ "$(skip 'test_ssh')" ]; then
+		echo "==> TEST SKIPPED: test_ssh"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_ssh"
+	)
+}

--- a/tests/suites/ssh_k8s/task.sh
+++ b/tests/suites/ssh_k8s/task.sh
@@ -1,0 +1,25 @@
+test_ssh_k8s() {
+	if [ "$(skip 'test_ssh')" ]; then
+		echo "==> TEST SKIPPED: ssh tests"
+		return
+	fi
+
+	set_verbosity
+
+	if [ "${BOOTSTRAP_PROVIDER:-}" != "k8s" ]; then
+		echo "==> TEST SKIPPED: caas ssh tests, not a k8s provider"
+		return
+	fi
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-ssh-k8s.log"
+
+	JUJU_DEV_FEATURE_FLAGS=ssh-jump bootstrap "test-ssh-k8s" "${file}"
+
+	# Add tests here
+	test_ssh
+
+	destroy_controller "test-ssh-k8s"
+}


### PR DESCRIPTION
This PR introduces some initial integration tests for the SSH proxy feature. It creates 2 separate integration test suites, one for controllers on K8s clouds and another for controllers on machine clouds.

It tests that SSH commands can be proxied through the Juju controller to a target machine/unit/container using the OpenSSH client. Further tests for the Juju CLI are expected in a follow-up PR. It verifies non-interactive sessions by echoing content to a file and then uses `cat` to read the file content, on both K8s and machine models. 
It also verifies `scp` functionality works (only on machine models).

The tests do not currently cover interactive sessions.

Some common functionality between the two test suites has been introduced in the `tests/includes` directory so that it can be shared.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Testing on LXD:
1. `make install`
2. `cd tests/`
3. `./main.sh -V ssh_iaas`

Testing on Microk8s:
1. `make install`
2. `make microk8s-operator-update`
3. `cd tests/`
4. `BOOTSTRAP_PROVIDER=k8s ./main.sh -V ssh_k8s`

## Links

**Jira card:** [JUJU-7892](https://warthogs.atlassian.net/browse/JUJU-7892)
