### PR TITLE
feat(application): wire up Public and Private unit address functions

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -175,6 +175,19 @@ type ApplicationService interface {
 	// If the unit does not exist an error satisfying [applicationerrors.UnitNotFound]
 	// will be returned.
 	WatchUnitAddressesHash(ctx context.Context, unitName coreunit.Name) (watcher.StringsWatcher, error)
+
+	// GetUnitPublicAddress returns the public address for the specified unit.
+	//
+	// The following errors may be returned:
+	// - [uniterrors.UnitNotFound] if the unit does not exist
+	// - [network.NoAddressError] if the unit has no public address associated
+	GetUnitPublicAddress(ctx context.Context, unitName coreunit.Name) (network.SpaceAddress, error)
+
+	// GetUnitPrivateAddress returns the private address for the specified unit.
+	//
+	// The following errors may be returned:
+	// - [uniterrors.UnitNotFound] if the unit does not exist
+	GetUnitPrivateAddress(ctx context.Context, unitName coreunit.Name) (network.SpaceAddress, error)
 }
 
 type ResolveService interface {

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -19,6 +19,7 @@ import (
 	life "github.com/juju/juju/core/life"
 	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
+	network "github.com/juju/juju/core/network"
 	relation "github.com/juju/juju/core/relation"
 	status "github.com/juju/juju/core/status"
 	unit "github.com/juju/juju/core/unit"
@@ -633,6 +634,84 @@ func (c *MockApplicationServiceGetUnitPrincipalCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetUnitPrincipalCall) DoAndReturn(f func(context.Context, unit.Name) (unit.Name, bool, error)) *MockApplicationServiceGetUnitPrincipalCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitPrivateAddress mocks base method.
+func (m *MockApplicationService) GetUnitPrivateAddress(arg0 context.Context, arg1 unit.Name) (network.SpaceAddress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitPrivateAddress", arg0, arg1)
+	ret0, _ := ret[0].(network.SpaceAddress)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitPrivateAddress indicates an expected call of GetUnitPrivateAddress.
+func (mr *MockApplicationServiceMockRecorder) GetUnitPrivateAddress(arg0, arg1 any) *MockApplicationServiceGetUnitPrivateAddressCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitPrivateAddress", reflect.TypeOf((*MockApplicationService)(nil).GetUnitPrivateAddress), arg0, arg1)
+	return &MockApplicationServiceGetUnitPrivateAddressCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitPrivateAddressCall wrap *gomock.Call
+type MockApplicationServiceGetUnitPrivateAddressCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitPrivateAddressCall) Return(arg0 network.SpaceAddress, arg1 error) *MockApplicationServiceGetUnitPrivateAddressCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitPrivateAddressCall) Do(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockApplicationServiceGetUnitPrivateAddressCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitPrivateAddressCall) DoAndReturn(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockApplicationServiceGetUnitPrivateAddressCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitPublicAddress mocks base method.
+func (m *MockApplicationService) GetUnitPublicAddress(arg0 context.Context, arg1 unit.Name) (network.SpaceAddress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitPublicAddress", arg0, arg1)
+	ret0, _ := ret[0].(network.SpaceAddress)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitPublicAddress indicates an expected call of GetUnitPublicAddress.
+func (mr *MockApplicationServiceMockRecorder) GetUnitPublicAddress(arg0, arg1 any) *MockApplicationServiceGetUnitPublicAddressCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitPublicAddress", reflect.TypeOf((*MockApplicationService)(nil).GetUnitPublicAddress), arg0, arg1)
+	return &MockApplicationServiceGetUnitPublicAddressCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitPublicAddressCall wrap *gomock.Call
+type MockApplicationServiceGetUnitPublicAddressCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitPublicAddressCall) Return(arg0 network.SpaceAddress, arg1 error) *MockApplicationServiceGetUnitPublicAddressCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitPublicAddressCall) Do(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockApplicationServiceGetUnitPublicAddressCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitPublicAddressCall) DoAndReturn(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockApplicationServiceGetUnitPublicAddressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter_legacy_test.go
+++ b/apiserver/facades/agent/uniter/uniter_legacy_test.go
@@ -224,12 +224,6 @@ func (s *uniterLegacySuite) TestWatchUnitNoPermission(c *gc.C) {
 	}})
 }
 
-func (s *uniterLegacySuite) TestPublicAddress(c *gc.C) {
-}
-
-func (s *uniterLegacySuite) TestPrivateAddress(c *gc.C) {
-}
-
 func (s *uniterLegacySuite) TestResolvedAPIV6(c *gc.C) {
 }
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -25,6 +25,7 @@ import (
 	coremachine "github.com/juju/juju/core/machine"
 	coremachinetesting "github.com/juju/juju/core/machine/testing"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
 	corerelation "github.com/juju/juju/core/relation"
 	relationtesting "github.com/juju/juju/core/relation/testing"
 	"github.com/juju/juju/core/status"
@@ -465,6 +466,46 @@ func (s *uniterSuite) TestWatchConfiSettingsHash(c *gc.C) {
 	})
 }
 
+func (s *uniterSuite) TestPublicAddress(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "unit-wordpress-0"},
+		{Tag: "unit-foo-42"},
+	}}
+	s.badTag = names.NewUnitTag("mysql/0")
+	s.applicationService.EXPECT().GetUnitPublicAddress(gomock.Any(), coreunit.Name("wordpress/0")).Return(network.SpaceAddress{
+		SpaceID: network.AlphaSpaceId,
+		Origin:  network.OriginMachine,
+		MachineAddress: network.MachineAddress{
+			Value:      "10.0.0.1",
+			ConfigType: network.ConfigStatic,
+			Type:       network.IPv4Address,
+			Scope:      network.ScopeMachineLocal,
+		},
+	}, nil)
+	expectErr := &params.Error{
+		Code:    params.CodeNoAddressSet,
+		Message: `"unit-foo-42" has no public address set`,
+	}
+	s.applicationService.EXPECT().GetUnitPublicAddress(gomock.Any(), coreunit.Name("foo/42")).Return(network.SpaceAddress{}, network.NoAddressError(""))
+
+	// Act:
+	result, err := s.uniter.PublicAddress(context.Background(), args)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Error: apiservertesting.ErrUnauthorized},
+			{Result: "10.0.0.1"},
+			{Error: expectErr},
+		},
+	})
+}
+
 func (s *uniterSuite) TestWatchTrustConfiSettingsHash(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -498,6 +539,46 @@ func (s *uniterSuite) TestWatchTrustConfiSettingsHash(c *gc.C) {
 			},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.NotFoundError(`unit "postgresql/0"`)},
+		},
+	})
+}
+
+func (s *uniterSuite) TestPrivateAddress(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: "unit-mysql-0"},
+		{Tag: "unit-wordpress-0"},
+		{Tag: "unit-foo-42"},
+	}}
+	s.badTag = names.NewUnitTag("mysql/0")
+	s.applicationService.EXPECT().GetUnitPrivateAddress(gomock.Any(), coreunit.Name("wordpress/0")).Return(network.SpaceAddress{
+		SpaceID: network.AlphaSpaceId,
+		Origin:  network.OriginMachine,
+		MachineAddress: network.MachineAddress{
+			Value:      "10.0.0.1",
+			ConfigType: network.ConfigStatic,
+			Type:       network.IPv4Address,
+			Scope:      network.ScopeMachineLocal,
+		},
+	}, nil)
+	expectErr := &params.Error{
+		Code:    params.CodeNoAddressSet,
+		Message: `"unit-foo-42" has no private address set`,
+	}
+	s.applicationService.EXPECT().GetUnitPrivateAddress(gomock.Any(), coreunit.Name("foo/42")).Return(network.SpaceAddress{}, network.NoAddressError(""))
+
+	// Act:
+	result, err := s.uniter.PrivateAddress(context.Background(), args)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{
+			{Error: apiservertesting.ErrUnauthorized},
+			{Result: "10.0.0.1"},
+			{Error: expectErr},
 		},
 	})
 }
@@ -537,6 +618,67 @@ func (s *uniterSuite) TestWatchUnitAddressesHash(c *gc.C) {
 			{Error: apiservertesting.NotFoundError(`unit "postgresql/0"`)},
 		},
 	})
+}
+
+func (s *uniterSuite) TestNetworkInfo(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	args := params.NetworkInfoParams{
+		Unit:      "unit-mysql-0",
+		Endpoints: []string{"endpoint1"},
+	}
+	s.applicationService.EXPECT().GetUnitPublicAddress(gomock.Any(), coreunit.Name("mysql/0")).Return(network.SpaceAddress{
+		MachineAddress: network.MachineAddress{
+			Value: "10.0.0.1",
+		},
+	}, nil)
+
+	// Act:
+	result, err := s.uniter.NetworkInfo(context.Background(), args)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.NetworkInfoResults{
+		Results: map[string]params.NetworkInfoResult{
+			"endpoint1": {IngressAddresses: []string{"10.0.0.1"}},
+		},
+	})
+}
+
+func (s *uniterSuite) TestNetworkInfoError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	args := params.NetworkInfoParams{
+		Unit:      "unit-mysql-0",
+		Endpoints: []string{"endpoint1"},
+	}
+	boom := internalerrors.New("boom")
+	s.applicationService.EXPECT().GetUnitPublicAddress(gomock.Any(), coreunit.Name("mysql/0")).Return(network.SpaceAddress{}, boom)
+
+	// Act:
+	_, err := s.uniter.NetworkInfo(context.Background(), args)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIs, boom)
+}
+
+func (s *uniterSuite) TestNetworkInfoUnauthorized(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	args := params.NetworkInfoParams{
+		Unit:      "unit-mysql-0",
+		Endpoints: []string{"endpoint1"},
+	}
+	s.badTag = names.NewUnitTag("mysql/0")
+
+	// Act:
+	_, err := s.uniter.NetworkInfo(context.Background(), args)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIs, apiservererrors.ErrPerm)
 }
 
 func (s *uniterSuite) expectGetUnitPrincipal(c *gc.C, unitName, principalName coreunit.Name, ok bool, err error) {
@@ -1281,14 +1423,13 @@ func (s *uniterRelationSuite) TestSetRelationStatusRelationNotFound(c *gc.C) {
 }
 
 func (s *uniterRelationSuite) TestEnterScopeErrUnauthorized(c *gc.C) {
-	c.Skip("Until unit PublicAddress() is implemented in its domain")
-	// arrange
+	// Arrange
 	defer s.setupMocks(c).Finish()
 	relTag := names.NewRelationTag("mysql:database wordpress:mysql")
 	failRelTag := names.NewRelationTag("postgresql:database wordpress:mysql")
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, failRelTag.Id()), "", relationerrors.RelationNotFound)
 
-	// act
+	// Act
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		// relation tag not parsable
 		{Relation: "relation-42", Unit: "unit-wordpress-0"},
@@ -1299,7 +1440,7 @@ func (s *uniterRelationSuite) TestEnterScopeErrUnauthorized(c *gc.C) {
 	}}
 	result, err := s.uniter.EnterScope(context.Background(), args)
 
-	// assert
+	// Assert
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1311,22 +1452,22 @@ func (s *uniterRelationSuite) TestEnterScopeErrUnauthorized(c *gc.C) {
 }
 
 func (s *uniterRelationSuite) TestEnterScope(c *gc.C) {
-	c.Skip("Until unit PublicAddress() is implemented in its domain")
-	// arrange
+	// Arrange
 	defer s.setupMocks(c).Finish()
 	relTag := names.NewRelationTag("mysql:database wordpress:mysql")
 	relUUID := relationtesting.GenRelationUUID(c)
+	s.expectGetUnitPublicAddress(coreunit.Name(s.wordpressUnitTag.Id()), "x.x.x.x", nil)
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
 	settings := map[string]string{"ingress-address": "x.x.x.x"}
 	s.expectEnterScope(relUUID, coreunit.Name(s.wordpressUnitTag.Id()), settings, nil)
 
-	// act
+	// Act
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		{Relation: relTag.String(), Unit: s.wordpressUnitTag.String()},
 	}}
 	result, err := s.uniter.EnterScope(context.Background(), args)
 
-	// assert
+	// Assert
 	c.Assert(err, jc.ErrorIsNil)
 	emptyErrorResults := params.ErrorResults{Results: []params.ErrorResult{{}}}
 	c.Assert(result, gc.DeepEquals, emptyErrorResults)
@@ -1336,26 +1477,81 @@ func (s *uniterRelationSuite) TestEnterScope(c *gc.C) {
 // returns PotentialRelationUnitNotValid the facade method still returns no
 // error.
 func (s *uniterRelationSuite) TestEnterScopeReturnsPotentialRelationUnitNotValid(c *gc.C) {
-	c.Skip("Until unit PublicAddress() is implemented in its domain")
-	// arrange
+	// Arrange
 	defer s.setupMocks(c).Finish()
 	relTag := names.NewRelationTag("mysql:database wordpress:mysql")
 	relUUID := relationtesting.GenRelationUUID(c)
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
+	s.expectGetUnitPublicAddress(coreunit.Name(s.wordpressUnitTag.Id()), "x.x.x.x", nil)
 	settings := map[string]string{"ingress-address": "x.x.x.x"}
 	s.expectEnterScope(relUUID, coreunit.Name(s.wordpressUnitTag.Id()), settings,
 		relationerrors.PotentialRelationUnitNotValid)
 
-	// act
+	// Act
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		{Relation: relTag.String(), Unit: s.wordpressUnitTag.String()},
 	}}
 	result, err := s.uniter.EnterScope(context.Background(), args)
 
-	// assert
+	// Assert
 	c.Assert(err, jc.ErrorIsNil)
 	emptyErrorResults := params.ErrorResults{Results: []params.ErrorResult{{}}}
 	c.Assert(result, gc.DeepEquals, emptyErrorResults)
+
+}
+
+func (s *uniterRelationSuite) TestEnterScopeCannotEnterScope(c *gc.C) {
+	// Arrange
+	defer s.setupMocks(c).Finish()
+
+	relTag := names.NewRelationTag("mysql:database wordpress:mysql")
+	relUUID := relationtesting.GenRelationUUID(c)
+	settings := map[string]string{"ingress-address": "x.x.x.x"}
+
+	s.expectGetUnitPublicAddress(coreunit.Name(s.wordpressUnitTag.Id()), "x.x.x.x", nil)
+	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
+	s.expectEnterScope(relUUID, coreunit.Name(s.wordpressUnitTag.Id()), settings, relationerrors.CannotEnterScopeNotAlive)
+
+	// Act
+	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
+		{Relation: relTag.String(), Unit: s.wordpressUnitTag.String()},
+	}}
+	result, err := s.uniter.EnterScope(context.Background(), args)
+
+	// Assert
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: &params.Error{Message: `cannot enter scope, unit or relation not alive`, Code: params.CodeCannotEnterScope}},
+		},
+	})
+}
+
+func (s *uniterRelationSuite) TestEnterScopeCannotEnterScopeYet(c *gc.C) {
+	// Arrange
+	defer s.setupMocks(c).Finish()
+
+	relTag := names.NewRelationTag("mysql:database wordpress:mysql")
+	relUUID := relationtesting.GenRelationUUID(c)
+	settings := map[string]string{"ingress-address": "x.x.x.x"}
+
+	s.expectGetUnitPublicAddress(coreunit.Name(s.wordpressUnitTag.Id()), "x.x.x.x", nil)
+	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
+	s.expectEnterScope(relUUID, coreunit.Name(s.wordpressUnitTag.Id()), settings, relationerrors.CannotEnterScopeSubordinateNotAlive)
+
+	// Act
+	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
+		{Relation: relTag.String(), Unit: s.wordpressUnitTag.String()},
+	}}
+	result, err := s.uniter.EnterScope(context.Background(), args)
+
+	// Assert
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: &params.Error{Message: `cannot enter scope, subordinate unit exists but is not alive`, Code: params.CodeCannotEnterScopeYet}},
+		},
+	})
 }
 
 // TestLeaveScopeFails tests for unauthorized errors, unit tag
@@ -1708,6 +1904,14 @@ func (s *uniterRelationSuite) expectWatchLifeSuspendedStatus(unitUUID coreunit.U
 
 func (s *uniterRelationSuite) expectWatcherRegistry(watchID string, watch *watchertest.MockStringsWatcher, err error) {
 	s.watcherRegistry.EXPECT().Register(watch).Return(watchID, err).AnyTimes()
+}
+
+func (s *uniterRelationSuite) expectGetUnitPublicAddress(unitName coreunit.Name, addr string, err error) {
+	s.applicationService.EXPECT().GetUnitPublicAddress(gomock.Any(), unitName).Return(network.SpaceAddress{
+		MachineAddress: network.MachineAddress{
+			Value: addr,
+		},
+	}, err)
 }
 
 func (s *uniterRelationSuite) expectWatchRelatedUnitsChange(


### PR DESCRIPTION
Replace unit.PublicAddress and unit.PrivateAddress in the uniter with
their domain equivilents. Add tests for the wired up functions. This
includes fully testing EnterScope.

Note that the NetworkInfo facade method is not at all complete. It
currently only gets the public address of the unit. Other information is
not yet available. A full wire up will be done as part of the Link Layer
Devices epic.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
The main use of these facades is in the `unit-get` hook tool. This is currently disabled as actions are moved over to domain.

If they were not, this would be the QA
```
juju bootstrap lxd test
juju add-model m
juju deploy ubuntu
juju exec --unit ubuntu/0 "unit-get"
```

However, we can test enter scope right now:
```
juju deploy juju-qa-dummy-source
juju deploy juju-qa-dummy-sink  
juju relate dummy-source dummy-sink
# Check that the relation has been joined once everything has settled.
juju status --relation
Model  Controller    Cloud/Region  Version      Timestamp
m      test-address  lxd/default   4.0-beta6.1  10:28:09+01:00

App           Version  Status   Scale  Charm                 Channel        Rev  Exposed  Message
dummy-sink             waiting      1  juju-qa-dummy-sink    latest/stable    7  no       Waiting for token
dummy-source           blocked      1  juju-qa-dummy-source  latest/stable    6  no       Set the token
ubuntu        24.04    active       1  ubuntu                latest/stable   25  no       

Unit             Workload  Agent  Machine  Public address  Ports  Message
dummy-sink/0*    waiting   idle                                   Waiting for token
dummy-source/0*  blocked   idle                                   Set the token
ubuntu/0*        active    idle                                   

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.101.18.40   juju-5b7829-0  ubuntu@24.04      Running
1        started  10.101.18.62   juju-5b7829-1  ubuntu@20.04      Running
2        started  10.101.18.147  juju-5b7829-2  ubuntu@20.04      Running

Integration provider  Requirer           Interface    Type     Message
dummy-sink:source     dummy-source:sink  dummy-token  regular  
```

## Links

**Jira card:** [JUJU-7819](https://warthogs.atlassian.net/browse/JUJU-7819)


[JUJU-7819]: https://warthogs.atlassian.net/browse/JUJU-7819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ