### PR TITLE
feat: model owner information into read only view

### DIFF
--- a/core/model/modelinfo.go
+++ b/core/model/modelinfo.go
@@ -20,6 +20,13 @@ type ModelInfo struct {
 	// Name is the name of the model.
 	Name string
 
+	// OwnerName is the owner of the model.
+	OwnerName user.Name
+
+	// Owner is the owner uuid of the model. Prefer this value over
+	// [ModelInfo.Owner] when referencing users in the controller.
+	Owner user.UUID
+
 	// Type is the type of the model.
 	Type ModelType
 
@@ -33,9 +40,17 @@ type ModelInfo struct {
 	CloudRegion string
 
 	// CredentialOwner is the owner of the model.
+	//
+	// Deprecated: (tlm) This value should not be used in place of the model's
+	// owner. This value is also likely to change over the life of a model and
+	// shouldn't be considered up to date. This field will be removed soon.
 	CredentialOwner user.Name
 
 	// Credential name is the name of the credential to use for the model.
+	//
+	// Deprecated: (tlm) This value should not be used as it isn't considered
+	// static over the life of the model and may change. Do not rely on this
+	// value as it may not be correct.
 	CredentialName string
 
 	// IsControllerModel is a boolean value that indicates if the model is the

--- a/domain/agentprovisioner/state/state_test.go
+++ b/domain/agentprovisioner/state/state_test.go
@@ -12,6 +12,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/semversion"
+	usertesting "github.com/juju/juju/core/user/testing"
 	"github.com/juju/juju/domain/model"
 	modelstate "github.com/juju/juju/domain/model/state"
 	"github.com/juju/juju/domain/modelagent"
@@ -108,6 +109,8 @@ func (s *suite) TestModelID(c *gc.C) {
 	// Create model info.
 	modelID := modeltesting.GenModelUUID(c)
 	modelSt := modelstate.NewModelState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	userUUID := usertesting.GenUserUUID(c)
+	userName := usertesting.GenNewName(c, "tlm")
 	err := modelSt.Create(context.Background(), model.ModelDetailArgs{
 		UUID:           modelID,
 		AgentVersion:   semversion.Number{Major: 4, Minor: 21, Patch: 67},
@@ -117,6 +120,8 @@ func (s *suite) TestModelID(c *gc.C) {
 		Type:           coremodel.IAAS,
 		Cloud:          "aws",
 		CloudType:      "ec2",
+		OwnerName:      userName,
+		Owner:          userUUID,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/keyupdater/state/state_test.go
+++ b/domain/keyupdater/state/state_test.go
@@ -98,7 +98,8 @@ func (s *stateSuite) TestCheckMachineDoesNotExist(c *gc.C) {
 
 func (s *stateSuite) TestGetModelId(c *gc.C) {
 	mst := modelstate.NewModelState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	modelUUID := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
 		UUID:            modelUUID,
@@ -106,6 +107,8 @@ func (s *stateSuite) TestGetModelId(c *gc.C) {
 		AgentStream:     modelagent.AgentStreamReleased,
 		ControllerUUID:  uuid.MustNewUUID(),
 		Name:            "my-awesome-model",
+		OwnerName:       ownerName,
+		Owner:           ownerUUID,
 		Type:            coremodel.IAAS,
 		Cloud:           "aws",
 		CloudType:       "ec2",

--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -181,6 +181,8 @@ func CreateLocalModelRecordWithAgentStream(
 			UUID:              m.UUID,
 			ControllerUUID:    controllerUUID,
 			Name:              m.Name,
+			OwnerName:         m.OwnerName,
+			Owner:             m.Owner,
 			Type:              m.ModelType,
 			Cloud:             m.Cloud,
 			CloudRegion:       m.CloudRegion,

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -276,6 +276,8 @@ func (s *ModelService) CreateModelWithAgentVersionStream(
 		UUID:            m.UUID,
 		ControllerUUID:  m.ControllerUUID,
 		Name:            m.Name,
+		OwnerName:       m.OwnerName,
+		Owner:           m.Owner,
 		Type:            m.Type,
 		Cloud:           m.Cloud,
 		CloudType:       m.CloudType,

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -20,6 +20,7 @@ import (
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/semversion"
 	corestatus "github.com/juju/juju/core/status"
+	usertesting "github.com/juju/juju/core/user/testing"
 	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/domain/constraints"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
@@ -666,10 +667,14 @@ func (s *providerModelServiceSuite) TestCreateModel(c *gc.C) {
 
 	controllerUUID := uuid.MustNewUUID()
 	modelUUID := modeltesting.GenModelUUID(c)
+	ownerUUID := usertesting.GenUserUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
 	s.mockControllerState.EXPECT().GetModelSeedInformation(gomock.Any(), gomock.Any()).Return(coremodel.ModelInfo{
 		UUID:           modelUUID,
 		ControllerUUID: controllerUUID,
 		Name:           "my-awesome-model",
+		OwnerName:      ownerName,
+		Owner:          ownerUUID,
 		Cloud:          "aws",
 		CloudType:      "ec2",
 		CloudRegion:    "myregion",
@@ -679,6 +684,8 @@ func (s *providerModelServiceSuite) TestCreateModel(c *gc.C) {
 		UUID:           modelUUID,
 		ControllerUUID: controllerUUID,
 		Name:           "my-awesome-model",
+		OwnerName:      ownerName,
+		Owner:          ownerUUID,
 		Type:           coremodel.IAAS,
 		Cloud:          "aws",
 		CloudType:      "ec2",
@@ -710,9 +717,13 @@ func (s *providerModelServiceSuite) TestCreateModelFailedErrorAlreadyExists(c *g
 
 	controllerUUID := uuid.MustNewUUID()
 	modelUUID := modeltesting.GenModelUUID(c)
+	ownerUUID := usertesting.GenUserUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
 	s.mockControllerState.EXPECT().GetModelSeedInformation(gomock.Any(), gomock.Any()).Return(coremodel.ModelInfo{
 		UUID:           modelUUID,
 		Name:           "my-awesome-model",
+		OwnerName:      ownerName,
+		Owner:          ownerUUID,
 		ControllerUUID: controllerUUID,
 		Cloud:          "aws",
 		CloudType:      "ec2",
@@ -723,6 +734,8 @@ func (s *providerModelServiceSuite) TestCreateModelFailedErrorAlreadyExists(c *g
 		UUID:           modelUUID,
 		ControllerUUID: controllerUUID,
 		Name:           "my-awesome-model",
+		OwnerName:      ownerName,
+		Owner:          ownerUUID,
 		Type:           coremodel.IAAS,
 		Cloud:          "aws",
 		CloudType:      "ec2",

--- a/domain/model/state/controllerstate_test.go
+++ b/domain/model/state/controllerstate_test.go
@@ -369,6 +369,8 @@ func (m *stateSuite) TestGetModelSeedInformationNotActivated(c *gc.C) {
 		CredentialName:  "foobar",
 		Name:            "my-amazing-model",
 		Type:            coremodel.IAAS,
+		OwnerName:       m.userName,
+		Owner:           m.userUUID,
 	})
 }
 
@@ -396,6 +398,8 @@ func (m *stateSuite) TestGetModelSeedInformationActivated(c *gc.C) {
 		CredentialName:  "foobar",
 		Name:            "my-test-model",
 		Type:            coremodel.IAAS,
+		OwnerName:       m.userName,
+		Owner:           m.userUUID,
 	})
 }
 

--- a/domain/model/state/modelstate.go
+++ b/domain/model/state/modelstate.go
@@ -922,6 +922,8 @@ func InsertModelInfo(
 		UUID:           args.UUID.String(),
 		ControllerUUID: args.ControllerUUID.String(),
 		Name:           args.Name,
+		OwnerName:      args.OwnerName.String(),
+		OwnerUUID:      args.Owner.String(),
 		Type:           args.Type.String(),
 		Cloud:          args.Cloud,
 		CloudType:      args.CloudType,

--- a/domain/model/state/modelstate_test.go
+++ b/domain/model/state/modelstate_test.go
@@ -46,13 +46,17 @@ func (s *modelSuite) createTestModel(c *gc.C) coremodel.UUID {
 	runner := s.TxnRunnerFactory()
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
+		UUID:            uuid,
 		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",
+		OwnerName:       ownerName,
+		Owner:           ownerUUID,
 		Type:            coremodel.IAAS,
 		Cloud:           "aws",
 		CloudType:       "ec2",
@@ -62,20 +66,24 @@ func (s *modelSuite) createTestModel(c *gc.C) coremodel.UUID {
 	}
 	err := state.Create(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
-	return id
+	return uuid
 }
 
 func (s *modelSuite) TestCreateAndReadModel(c *gc.C) {
 	runner := s.TxnRunnerFactory()
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
+		UUID:            uuid,
 		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",
+		OwnerName:       ownerName,
+		Owner:           ownerUUID,
 		Type:            coremodel.IAAS,
 		Cloud:           "aws",
 		CloudType:       "ec2",
@@ -90,7 +98,7 @@ func (s *modelSuite) TestCreateAndReadModel(c *gc.C) {
 	model, err := state.GetModel(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(model, jc.DeepEquals, coremodel.ModelInfo{
-		UUID:            id,
+		UUID:            uuid,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",
@@ -107,13 +115,17 @@ func (s *modelSuite) TestDeleteModel(c *gc.C) {
 	runner := s.TxnRunnerFactory()
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
+		UUID:            uuid,
 		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",
+		OwnerName:       ownerName,
+		Owner:           ownerUUID,
 		Type:            coremodel.IAAS,
 		Cloud:           "aws",
 		CloudType:       "ec2",
@@ -124,10 +136,10 @@ func (s *modelSuite) TestDeleteModel(c *gc.C) {
 	err := state.Create(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = state.Delete(context.Background(), id)
+	err = state.Delete(context.Background(), uuid)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = state.Delete(context.Background(), id)
+	err = state.Delete(context.Background(), uuid)
 	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)
 
 	// Check that it was written correctly.
@@ -141,13 +153,17 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithSameUUID(c *gc.C) {
 
 	// Ensure that we can't create the same model twice.
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:           id,
+		UUID:           uuid,
 		AgentStream:    modelagent.AgentStreamReleased,
 		AgentVersion:   jujuversion.Current,
 		ControllerUUID: s.controllerUUID,
 		Name:           "my-awesome-model",
+		OwnerName:      ownerName,
+		Owner:          ownerUUID,
 		Type:           coremodel.IAAS,
 		Cloud:          "aws",
 		CloudType:      "ec2",
@@ -165,11 +181,15 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithDifferentUUID(c *gc.C) {
 
 	// Ensure that you can only ever insert one model.
 
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	err := state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:         modeltesting.GenModelUUID(c),
 		AgentStream:  modelagent.AgentStreamReleased,
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
+		OwnerName:    ownerName,
+		Owner:        ownerUUID,
 		Type:         coremodel.IAAS,
 		Cloud:        "aws",
 		CloudType:    "ec2",
@@ -182,6 +202,8 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithDifferentUUID(c *gc.C) {
 		AgentStream:  modelagent.AgentStreamReleased,
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
+		OwnerName:    ownerName,
+		Owner:        ownerUUID,
 		Type:         coremodel.IAAS,
 		Cloud:        "aws",
 		CloudType:    "ec2",
@@ -196,13 +218,17 @@ func (s *modelSuite) TestCreateModelAndUpdate(c *gc.C) {
 
 	// Ensure that you can't update it.
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	err := state.Create(context.Background(), model.ModelDetailArgs{
-		UUID:           id,
+		UUID:           uuid,
 		AgentStream:    modelagent.AgentStreamReleased,
 		AgentVersion:   jujuversion.Current,
 		ControllerUUID: s.controllerUUID,
 		Name:           "my-awesome-model",
+		OwnerName:      ownerName,
+		Owner:          ownerUUID,
 		Type:           coremodel.IAAS,
 		Cloud:          "aws",
 		CloudType:      "ec2",
@@ -211,7 +237,7 @@ func (s *modelSuite) TestCreateModelAndUpdate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	db := s.DB()
-	_, err = db.ExecContext(context.Background(), "UPDATE model SET name = 'new-name' WHERE uuid = $1", id)
+	_, err = db.ExecContext(context.Background(), "UPDATE model SET name = 'new-name' WHERE uuid = $1", uuid)
 	c.Assert(err, gc.ErrorMatches, `model table is immutable, only insertions are allowed`)
 }
 
@@ -226,12 +252,16 @@ func (s *modelSuite) CreateModelWithEmptyCloudRegion(c *gc.C) {
 	runner := s.TxnRunnerFactory()
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	err := state.Create(context.Background(), model.ModelDetailArgs{
-		UUID:         id,
+		UUID:         uuid,
 		AgentStream:  modelagent.AgentStreamReleased,
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
+		OwnerName:    ownerName,
+		Owner:        ownerUUID,
 		Type:         coremodel.IAAS,
 		Cloud:        "aws",
 		CloudType:    "ec2",
@@ -253,12 +283,16 @@ func (s *modelSuite) TestCreateModelAndDelete(c *gc.C) {
 
 	// Ensure that you can't update it.
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	err := state.Create(context.Background(), model.ModelDetailArgs{
-		UUID:         id,
+		UUID:         uuid,
 		AgentStream:  modelagent.AgentStreamReleased,
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
+		OwnerName:    ownerName,
+		Owner:        ownerUUID,
 		Type:         coremodel.IAAS,
 		Cloud:        "aws",
 		CloudType:    "ec2",
@@ -267,7 +301,7 @@ func (s *modelSuite) TestCreateModelAndDelete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	db := s.DB()
-	_, err = db.ExecContext(context.Background(), "DELETE FROM model WHERE uuid = $1", id)
+	_, err = db.ExecContext(context.Background(), "DELETE FROM model WHERE uuid = $1", uuid)
 	c.Assert(err, gc.ErrorMatches, `model table is immutable, only insertions are allowed`)
 }
 
@@ -564,14 +598,18 @@ func (s *modelSuite) TestGetModelCloudType(c *gc.C) {
 	runner := s.TxnRunnerFactory()
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
-		UUID:            id,
+		UUID:            uuid,
 		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "mymodel",
+		OwnerName:       ownerName,
+		Owner:           ownerUUID,
 		Type:            coremodel.IAAS,
 		Cloud:           "aws",
 		CloudType:       cloudType,
@@ -600,6 +638,8 @@ func (s *modelSuite) TestGetModelCloudRegionAndCredential(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
 		UUID:            uuid,
@@ -607,6 +647,8 @@ func (s *modelSuite) TestGetModelCloudRegionAndCredential(c *gc.C) {
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "mymodel",
+		OwnerName:       ownerName,
+		Owner:           ownerUUID,
 		Type:            coremodel.IAAS,
 		Cloud:           "aws",
 		CloudType:       cloudType,
@@ -644,6 +686,8 @@ func (s *modelSuite) TestIsControllerModelTrue(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
 		UUID:              uuid,
@@ -651,6 +695,8 @@ func (s *modelSuite) TestIsControllerModelTrue(c *gc.C) {
 		AgentVersion:      jujuversion.Current,
 		ControllerUUID:    s.controllerUUID,
 		Name:              "mycontrollermodel",
+		OwnerName:         ownerName,
+		Owner:             ownerUUID,
 		Type:              coremodel.IAAS,
 		Cloud:             "aws",
 		CloudType:         cloudType,
@@ -672,6 +718,8 @@ func (s *modelSuite) TestIsControllerModelFalse(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
 		UUID:              uuid,
@@ -679,6 +727,8 @@ func (s *modelSuite) TestIsControllerModelFalse(c *gc.C) {
 		AgentVersion:      jujuversion.Current,
 		ControllerUUID:    s.controllerUUID,
 		Name:              "mycontrollermodel",
+		OwnerName:         ownerName,
+		Owner:             ownerUUID,
 		Type:              coremodel.IAAS,
 		Cloud:             "aws",
 		CloudType:         cloudType,
@@ -722,6 +772,8 @@ func (s *modelSuite) TestGetControllerUUID(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
 		UUID:              uuid,
@@ -730,6 +782,8 @@ func (s *modelSuite) TestGetControllerUUID(c *gc.C) {
 		ControllerUUID:    s.controllerUUID,
 		Name:              "mycontrollermodel",
 		Type:              coremodel.CAAS,
+		OwnerName:         ownerName,
+		Owner:             ownerUUID,
 		Cloud:             "aws",
 		CloudType:         cloudType,
 		CloudRegion:       "myregion",

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -300,16 +300,16 @@ func (info *dbModelUserInfo) toModelUserInfo() (coremodel.ModelUserInfo, error) 
 }
 
 type dbReadOnlyModel struct {
-	UUID              string `db:"uuid"`
-	ControllerUUID    string `db:"controller_uuid"`
-	Name              string `db:"name"`
-	Type              string `db:"type"`
-	Cloud             string `db:"cloud"`
-	CloudType         string `db:"cloud_type"`
-	CloudRegion       string `db:"cloud_region"`
-	CredentialOwner   string `db:"credential_owner"`
-	CredentialName    string `db:"credential_name"`
-	IsControllerModel bool   `db:"is_controller_model"`
+	UUID              string         `db:"uuid"`
+	ControllerUUID    string         `db:"controller_uuid"`
+	Name              string         `db:"name"`
+	Type              string         `db:"type"`
+	Cloud             string         `db:"cloud"`
+	CloudType         string         `db:"cloud_type"`
+	CloudRegion       sql.NullString `db:"cloud_region"`
+	CredentialOwner   string         `db:"credential_owner"`
+	CredentialName    string         `db:"credential_name"`
+	IsControllerModel bool           `db:"is_controller_model"`
 }
 
 type dbModelMetrics struct {
@@ -320,6 +320,10 @@ type dbModelMetrics struct {
 
 type dbCloudType struct {
 	Type string `db:"type"`
+}
+
+type dbModelCloudType struct {
+	Type string `db:"cloud_type"`
 }
 
 type dbName struct {

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -53,7 +53,7 @@ type dbModel struct {
 	CredentialCloudName sql.NullString `db:"cloud_credential_cloud_name"`
 
 	// CredentialOwnerName is the owner of the model cloud credential.
-	CredentialOwnerName string `db:"cloud_credential_owner_name"`
+	CredentialOwnerName sql.NullString `db:"cloud_credential_owner_name"`
 
 	// OwnerUUID is the uuid of the user that owns this model in the Juju controller.
 	OwnerUUID string `db:"owner_uuid"`
@@ -71,8 +71,8 @@ func (m *dbModel) toCoreModel() (coremodel.Model, error) {
 		return coremodel.Model{}, errors.Capture(err)
 	}
 	var credOwnerName user.Name
-	if m.CredentialOwnerName != "" {
-		credOwnerName, err = user.NewName(m.CredentialOwnerName)
+	if m.CredentialOwnerName.Valid {
+		credOwnerName, err = user.NewName(m.CredentialOwnerName.String)
 		if err != nil {
 			return coremodel.Model{}, errors.Capture(err)
 		}
@@ -309,7 +309,7 @@ type dbReadOnlyModel struct {
 	Cloud             string         `db:"cloud"`
 	CloudType         string         `db:"cloud_type"`
 	CloudRegion       sql.NullString `db:"cloud_region"`
-	CredentialOwner   string         `db:"credential_owner"`
+	CredentialOwner   sql.NullString `db:"credential_owner"`
 	CredentialName    string         `db:"credential_name"`
 	IsControllerModel bool           `db:"is_controller_model"`
 }

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -303,6 +303,8 @@ type dbReadOnlyModel struct {
 	UUID              string         `db:"uuid"`
 	ControllerUUID    string         `db:"controller_uuid"`
 	Name              string         `db:"name"`
+	OwnerName         string         `db:"owner_name"`
+	OwnerUUID         string         `db:"owner_uuid"`
 	Type              string         `db:"type"`
 	Cloud             string         `db:"cloud"`
 	CloudType         string         `db:"cloud_type"`

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -84,6 +84,14 @@ type ModelDetailArgs struct {
 	// Must not be empty for a valid struct.
 	Name string
 
+	// OwnerName is the owner of the model.
+	OwnerName user.Name
+
+	// Owner is the uuid of the user that owns this model in the Juju
+	// controller. Prefer this value over [ModelDetailArgs.OwnerName] when
+	// referencing the owner in the controller.
+	Owner user.UUID
+
 	// Type is the type of the model.
 	// Type must satisfy IsValid() for a valid struct.
 	Type coremodel.ModelType

--- a/domain/modelmigration/state/state_test.go
+++ b/domain/modelmigration/state/state_test.go
@@ -39,13 +39,17 @@ func (s *migrationSuite) SetUpTest(c *gc.C) {
 	runner := s.TxnRunnerFactory()
 	state := modelstate.NewModelState(runner, loggertesting.WrapCheckLog(c))
 
-	id := modeltesting.GenModelUUID(c)
+	uuid := modeltesting.GenModelUUID(c)
+	ownerName := usertesting.GenNewName(c, "tlm")
+	ownerUUID := usertesting.GenUserUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
+		UUID:            uuid,
 		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",
+		OwnerName:       ownerName,
+		Owner:           ownerUUID,
 		Type:            coremodel.IAAS,
 		Cloud:           "aws",
 		CloudType:       "ec2",

--- a/domain/schema/model/sql/0004-read-only-model.sql
+++ b/domain/schema/model/sql/0004-read-only-model.sql
@@ -4,11 +4,13 @@
 --
 -- The model table primarily is used to drive the provider tracker. The model
 -- table should *not* be changed in a patch/build release. The only time to make
--- changes to this table is during a major/minor release. 
+-- changes to this table is during a major/minor release.
 CREATE TABLE model (
     uuid TEXT NOT NULL PRIMARY KEY,
     controller_uuid TEXT NOT NULL,
     name TEXT NOT NULL,
+    owner_name TEXT NOT NULL,
+    owner_uuid TEXT NOT NULL,
     type TEXT NOT NULL,
     cloud TEXT NOT NULL,
     cloud_type TEXT NOT NULL,


### PR DESCRIPTION
This PR is setting up some needed information for JUJU-7840 around correctly accessing the owner information of a model from the model database. An attempt was made to wire this information up previously but we inadvertently did the credential owner which is a value that could inflict some pain down the road. It is possible for credential owner to not be the same owner as the model, for the model to have no credential set and also for the credential to change over the life of the model.

This PR does not deal with the cleanup task of removing the references at this stage as there is a few to deal with. Instead this PR starts the process of correctly seeding this information into the model information so correct decisions on model owner can start being made today before the big fix up occurs.

Also in this PR I did a drive by for cloud region and credential owner to set these values to NULL in the database when they are not set on the model. Previously we were setting these values to the zero value of a string which made them look like they were set. The correct representation is NULL and this is how we store them in the controller database.

This work is done as list model support needs owner information to complete the summary information.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

I am happy with unit tests for this change. The changes are mechanical and not yet being exposed outwards.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-7840
