### PR TITLE
chore: flakey sshsession worker tests

### DIFF
--- a/internal/worker/sshsession/worker.go
+++ b/internal/worker/sshsession/worker.go
@@ -198,10 +198,12 @@ func (w *sshSessionWorker) pipeConnectionToSSHD(ctx context.Context, ctrlAddress
 	if err != nil {
 		return errors.Trace(err)
 	}
+	defer controllerConn.Close()
 	sshdConn, err := w.connectionGetter.GetSSHDConnection()
 	if err != nil {
 		return errors.Trace(err)
 	}
+	defer sshdConn.Close()
 
 	// We close the connections when the context is done
 	// or, if the connections finish first, we signal the
@@ -223,7 +225,7 @@ func (w *sshSessionWorker) pipeConnectionToSSHD(ctx context.Context, ctrlAddress
 
 	go func() {
 		defer wg.Done()
-		// sshd -> conn
+		// conn -> sshd
 		defer controllerConn.Close()
 		defer sshdConn.Close()
 		_, _ = io.Copy(sshdConn, controllerConn)
@@ -232,7 +234,7 @@ func (w *sshSessionWorker) pipeConnectionToSSHD(ctx context.Context, ctrlAddress
 
 	go func() {
 		defer wg.Done()
-		// conn -> sshd
+		// sshd -> conn
 		defer controllerConn.Close()
 		defer sshdConn.Close()
 		_, _ = io.Copy(controllerConn, sshdConn)


### PR DESCRIPTION
This PR fixes some flaky tests in the `sshsession` worker. The PR is split into 2 commits to address 2 separate issues.

1. The first commit addresses flaky tests because of missing calls to `RemoveEphemeralKey` and `ControllerSSHPort` .Calls to the `RemoveEphemeralKey` key method are not always consistent because the function is deferred until after the client's connection is closed and the test has no way of synchronising with that event, so we allow the mock to be called AnyTimes().
Other flaky behaviour emerges due to not checking if the worker is alive so mock calls to `ControllerSSHPort()` are not satisfied until we check the worker is alive.
2. Fixes flakiness in the `TestSSHSessionWorkerMultipleConnections` test. The test was not correctly using mocks. The test creates 2 pairs of connections, one between the worker and the controller and another between the worker and sshd. Under certain conditions it could happen that the "wires get crossed" and the first pair of connections are associated with the second.
Now we synchronise these operations to ensure the test is always consistent.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
1. `go test ./internal/worker/sshsession -c -race`
2. `stress ./sshsession.test`
```
5s: 48 runs so far, 0 failures, 16 active
10s: 112 runs so far, 0 failures, 16 active
15s: 176 runs so far, 0 failures, 16 active
20s: 231 runs so far, 0 failures, 16 active
25s: 292 runs so far, 0 failures, 16 active
30s: 356 runs so far, 0 failures, 16 active
35s: 420 runs so far, 0 failures, 16 active
40s: 471 runs so far, 0 failures, 16 active
45s: 535 runs so far, 0 failures, 16 active
50s: 599 runs so far, 0 failures, 16 active
55s: 663 runs so far, 0 failures, 16 active
```