### PR TITLE
chore: flaky ssh server tests

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -793,7 +793,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:                 loggo.GetLogger("juju.worker.sshserver"),
 			NewServerWrapperWorker: sshserver.NewServerWrapperWorker,
 			NewServerWorker:        sshserver.NewServerWorker,
-			NewSSHServerListener:   sshserver.NewSSHServerListener,
 		})),
 
 		// The jwtParser worker runs on the controller machine.

--- a/internal/worker/sshserver/listener.go
+++ b/internal/worker/sshserver/listener.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import (
+	"net"
+	"sync"
+)
+
+// syncListener is required to prevent a race condition that can
+// occur when closing the SSH server quickly after starting it.
+// There is a pending fix upstream https://github.com/gliderlabs/ssh/pull/248
+// that will fix this issue, at which point we can delete this file,
+// but until then this is a workaround.
+//
+// The SSH server tracks the listeners in use but if the server's close() method
+// executes before we reach a safe point in the Serve() method then the server's
+// map of listeners will be empty. A safe point to indicate the server is ready
+// is once we've entered the listener's Accept() method. Accept() will return with
+// error if the underlying listener is already closed.
+type syncListener struct {
+	net.Listener
+	// closeAllowed indicates when the server has reached
+	// a safe point that it can be killed.
+	closeAllowed chan struct{}
+	once         *sync.Once
+}
+
+// newSyncSSHServerListener returns a listener and a read-only
+// channel that indicates when the server can be safely closed.
+func newSyncSSHServerListener(l net.Listener) (<-chan struct{}, net.Listener) {
+	closeAllowed := make(chan struct{})
+	return closeAllowed, syncListener{
+		Listener:     l,
+		closeAllowed: closeAllowed,
+		once:         &sync.Once{},
+	}
+}
+
+// Accept first closes the closeAllowed channel, signalling that
+// any routines waiting to close the SSH server may proceed.
+// It then runs the listener's Accept() method.
+func (l syncListener) Accept() (net.Conn, error) {
+	l.once.Do(func() {
+		close(l.closeAllowed)
+	})
+	return l.Listener.Accept()
+}
+
+// Close first closes the closeAllowed channel, signalling that
+// any routines waiting to close the SSH server may proceed, this is
+// done to handle cases where the server was configured incorrectly
+// and never reaches a point where it calls Accept().
+// It then runs the listener's Close() method.
+func (l syncListener) Close() error {
+	l.once.Do(func() {
+		close(l.closeAllowed)
+	})
+	return l.Listener.Close()
+}

--- a/internal/worker/sshserver/listener_test.go
+++ b/internal/worker/sshserver/listener_test.go
@@ -4,65 +4,12 @@
 package sshserver
 
 import (
-	"context"
-	"net"
-	"sync"
 	"time"
 
 	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 )
-
-// testingSSHServerListener is required to prevent a race condition that can
-// occur in tests.
-//
-// The SSH server tracks the listeners in use but if the server's close() method
-// executes before we reach a safe point in the Serve() method then the server's
-// map of listeners will be empty. A safe point to indicate the server is ready
-// is right before we start accepting connections. Accept() will return with
-// error if the underlying listener is already closed.
-type testingSSHServerListener struct {
-	net.Listener
-	// closeAllowed indicates when the server has reached
-	// a safe point that it can be killed.
-	closeAllowed chan struct{}
-	once         *sync.Once
-
-	timeout time.Duration
-}
-
-// newTestingSSHServerListener returns a listener.
-func newTestingSSHServerListener(l net.Listener, timeout time.Duration) net.Listener {
-	return testingSSHServerListener{
-		Listener:     l,
-		closeAllowed: make(chan struct{}),
-		once:         &sync.Once{},
-		timeout:      timeout,
-	}
-}
-
-// Accept runs the listeners accept, but firstly closes the closeAllowed channel,
-// signalling that any routines waiting to close the listener may proceed.
-func (l testingSSHServerListener) Accept() (net.Conn, error) {
-	l.once.Do(func() {
-		close(l.closeAllowed)
-	})
-	return l.Listener.Accept()
-}
-
-func (l testingSSHServerListener) Close() error {
-	ctx, cancel := context.WithTimeout(context.Background(), l.timeout)
-	defer cancel()
-
-	select {
-	case <-l.closeAllowed:
-		return l.Listener.Close()
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
 
 type listenerSuite struct {
 	testing.IsolationSuite
@@ -72,43 +19,62 @@ type listenerSuite struct {
 
 var _ = gc.Suite(&listenerSuite{})
 
-func (s *listenerSuite) TestAcceptOnceListener(c *gc.C) {
+func (s *listenerSuite) TestSyncListenerAfterAccept(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.listener.EXPECT().Accept().Return(nil, nil)
-	s.listener.EXPECT().Close()
 
-	acceptOnceListener := newTestingSSHServerListener(s.listener, time.Second)
+	closeAllowed, syncListener := newSyncSSHServerListener(s.listener)
+
+	select {
+	case <-closeAllowed:
+		c.Error("closeAllowed channel should not be closed yet")
+	case <-time.After(testing.ShortWait):
+	}
 
 	done := make(chan struct{})
-
 	go func() {
 		defer close(done)
 
-		// Accept runs and sends down the channel, it is blocked then until
-		// Close continues.
-		acceptOnceListener.Accept()
+		// Accept runs and signals the server can now be closed.
+		_, _ = syncListener.Accept()
 	}()
 
-	err := acceptOnceListener.Close()
-	c.Assert(err, jc.ErrorIsNil)
-
+	<-done
 	select {
-	case <-done:
-	case <-time.After(testing.LongWait):
+	case <-closeAllowed:
+	case <-time.After(testing.ShortWait):
 		c.Fail()
 	}
 }
 
-func (s *listenerSuite) TestAcceptOnceListenerDoesNotStop(c *gc.C) {
+func (s *listenerSuite) TestSyncListenerAfterClose(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// No calls to the mock listener should have been made.
+	s.listener.EXPECT().Close().Return(nil)
 
-	acceptOnceListener := newTestingSSHServerListener(s.listener, time.Millisecond*50)
+	closeAllowed, syncListener := newSyncSSHServerListener(s.listener)
 
-	err := acceptOnceListener.Close()
-	c.Assert(err, jc.ErrorIs, context.DeadlineExceeded)
+	select {
+	case <-closeAllowed:
+		c.Error("closeAllowed channel should not be closed yet")
+	case <-time.After(testing.ShortWait):
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		// Close runs and signals the server can now be closed.
+		_ = syncListener.Close()
+	}()
+
+	<-done
+	select {
+	case <-closeAllowed:
+	case <-time.After(testing.ShortWait):
+		c.Fail()
+	}
 }
 
 func (s *listenerSuite) setupMocks(c *gc.C) *gomock.Controller {

--- a/internal/worker/sshserver/manifold.go
+++ b/internal/worker/sshserver/manifold.go
@@ -49,10 +49,6 @@ type ManifoldConfig struct {
 	// to run the server and other worker dependencies.
 	NewServerWorker func(ServerWorkerConfig) (worker.Worker, error)
 
-	// NewSSHServerListener is the function that creates a listener, based on
-	// an existing listener for the server worker.
-	NewSSHServerListener func(net.Listener, time.Duration) net.Listener
-
 	// Logger is the logger to use for the worker.
 	Logger Logger
 }
@@ -70,9 +66,6 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.APICallerName == "" {
 		return errors.NotValidf("empty APICallerName")
-	}
-	if config.NewSSHServerListener == nil {
-		return errors.NotValidf("nil NewSSHServerListener")
 	}
 	return nil
 }
@@ -112,11 +105,10 @@ func (config ManifoldConfig) startWrapperWorker(context dependency.Context) (wor
 	}
 
 	w, err := config.NewServerWrapperWorker(ServerWrapperWorkerConfig{
-		NewServerWorker:      config.NewServerWorker,
-		Logger:               config.Logger,
-		FacadeClient:         client,
-		NewSSHServerListener: config.NewSSHServerListener,
-		SessionHandler:       &stubSessionHandler{},
+		NewServerWorker: config.NewServerWorker,
+		Logger:          config.Logger,
+		FacadeClient:    client,
+		SessionHandler:  &stubSessionHandler{},
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/sshserver/manifold_test.go
+++ b/internal/worker/sshserver/manifold_test.go
@@ -40,7 +40,6 @@ func newManifoldConfig(l loggo.Logger, modifier func(cfg *ManifoldConfig)) *Mani
 		NewServerWorker:        func(ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
 		Logger:                 l,
 		APICallerName:          "api-caller",
-		NewSSHServerListener:   newTestingSSHServerListener,
 	}
 
 	modifier(cfg)
@@ -87,11 +86,6 @@ func (s *manifoldSuite) TestConfigValidate(c *gc.C) {
 	})
 	c.Check(errors.Is(cfg.Validate(), errors.NotValid), jc.IsTrue)
 
-	// Empty NewSSHServerListener.
-	cfg = newManifoldConfig(l, func(cfg *ManifoldConfig) {
-		cfg.NewSSHServerListener = nil
-	})
-	c.Check(errors.Is(cfg.Validate(), errors.NotValid), jc.IsTrue)
 }
 
 func (s *manifoldSuite) TestManifoldStart(c *gc.C) {
@@ -101,9 +95,8 @@ func (s *manifoldSuite) TestManifoldStart(c *gc.C) {
 		NewServerWrapperWorker: func(ServerWrapperWorkerConfig) (worker.Worker, error) {
 			return workertest.NewDeadWorker(nil), nil
 		},
-		NewServerWorker:      func(ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
-		Logger:               loggo.GetLogger("test"),
-		NewSSHServerListener: newTestingSSHServerListener,
+		NewServerWorker: func(ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
+		Logger:          loggo.GetLogger("test"),
 	})
 
 	// Check the inputs are as expected
@@ -130,7 +123,7 @@ func (a mockAPICaller) BestFacadeVersion(facade string) int {
 	return 0
 }
 
-func (s *manifoldSuite) TestManifolUninstall(c *gc.C) {
+func (s *manifoldSuite) TestManifoldUninstall(c *gc.C) {
 	// Unset feature flag
 	os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
@@ -140,9 +133,8 @@ func (s *manifoldSuite) TestManifolUninstall(c *gc.C) {
 		NewServerWrapperWorker: func(ServerWrapperWorkerConfig) (worker.Worker, error) {
 			return workertest.NewDeadWorker(nil), nil
 		},
-		NewServerWorker:      func(ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
-		Logger:               loggo.GetLogger("test"),
-		NewSSHServerListener: newTestingSSHServerListener,
+		NewServerWorker: func(ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
+		Logger:          loggo.GetLogger("test"),
 	})
 	// Start the worker
 	_, err := manifold.Start(

--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -49,10 +49,6 @@ type ServerWorkerConfig struct {
 	// we accept for our ssh server.
 	MaxConcurrentConnections int
 
-	// NewSSHServerListener is a function that returns a listener and a
-	// closeAllowed channel.
-	NewSSHServerListener func(net.Listener, time.Duration) net.Listener
-
 	// FacadeClient holds the SSH server's facade client.
 	FacadeClient FacadeClient
 
@@ -70,9 +66,6 @@ func (c ServerWorkerConfig) Validate() error {
 	}
 	if c.JumpHostKey == "" {
 		return errors.NotValidf("empty JumpHostKey")
-	}
-	if c.NewSSHServerListener == nil {
-		return errors.NotValidf("missing NewSSHServerListener")
 	}
 	if c.FacadeClient == nil {
 		return errors.NotValidf("missing FacadeClient")
@@ -121,7 +114,9 @@ func NewServerWorker(config ServerWorkerConfig) (worker.Worker, error) {
 		s.config.Listener = listener
 	}
 
-	listener := config.NewSSHServerListener(s.config.Listener, time.Second*10)
+	// Delete the below once https://github.com/gliderlabs/ssh/pull/248
+	// lands and we upgrade to the latest gliderlabs/ssh.
+	closeAllowed, listener := newSyncSSHServerListener(s.config.Listener)
 
 	// Start server.
 	s.tomb.Go(func() error {
@@ -137,11 +132,10 @@ func NewServerWorker(config ServerWorkerConfig) (worker.Worker, error) {
 		// Keep the listener and the server alive until the tomb is killed.
 		<-s.tomb.Dying()
 
-		// Close the listener, this prevents a race in the test.
-		if err := listener.Close(); err != nil {
-			s.config.Logger.Errorf("failed to close listener: %v", err)
-		}
-
+		// Wait on the closeAllowed to indicate when we can stop the SSH server.
+		// This ensures we don't face a race condition, closing the server
+		// too quickly after it was started, see listener.go for more details.
+		<-closeAllowed
 		if err := s.Server.Close(); err != nil {
 			// There's really not a lot we can do if the shutdown fails,
 			// either due to a timeout or another reason. So we simply log it.

--- a/internal/worker/sshserver/server_test.go
+++ b/internal/worker/sshserver/server_test.go
@@ -86,9 +86,8 @@ func newServerWorkerConfig(
 	modifier func(*ServerWorkerConfig),
 ) *ServerWorkerConfig {
 	cfg := &ServerWorkerConfig{
-		Logger:               l,
-		JumpHostKey:          j,
-		NewSSHServerListener: newTestingSSHServerListener,
+		Logger:      l,
+		JumpHostKey: j,
 	}
 
 	modifier(cfg)
@@ -114,12 +113,6 @@ func (s *sshServerSuite) TestValidate(c *gc.C) {
 	})
 	c.Assert(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 
-	// Test no NewSSHServerListener.
-	cfg = newServerWorkerConfig(l, "NewSSHServerListener", func(cfg *ServerWorkerConfig) {
-		cfg.NewSSHServerListener = nil
-	})
-	c.Assert(cfg.Validate(), jc.ErrorIs, errors.NotValid)
-
 	// Test no FacadeClient.
 	cfg = newServerWorkerConfig(l, "NewSSHServerListener", func(cfg *ServerWorkerConfig) {
 		cfg.FacadeClient = nil
@@ -140,7 +133,6 @@ func (s *sshServerSuite) TestSSHServerNoAuth(c *gc.C) {
 		Listener:                 listener,
 		MaxConcurrentConnections: maxConcurrentConnections,
 		JumpHostKey:              jujutesting.SSHServerHostKey,
-		NewSSHServerListener:     newTestingSSHServerListener,
 		FacadeClient:             s.facadeClient,
 		disableAuth:              true,
 		SessionHandler:           s.sessionHandler,
@@ -222,7 +214,6 @@ func (s *sshServerSuite) TestSSHPublicKeyHandler(c *gc.C) {
 		Listener:                 listener,
 		JumpHostKey:              jujutesting.SSHServerHostKey,
 		FacadeClient:             s.facadeClient,
-		NewSSHServerListener:     newTestingSSHServerListener,
 		MaxConcurrentConnections: maxConcurrentConnections,
 		SessionHandler:           s.sessionHandler,
 	})
@@ -295,7 +286,6 @@ func (s *sshServerSuite) TestHostKeyForTarget(c *gc.C) {
 		Listener:                 listener,
 		JumpHostKey:              jujutesting.SSHServerHostKey,
 		MaxConcurrentConnections: maxConcurrentConnections,
-		NewSSHServerListener:     newTestingSSHServerListener,
 		FacadeClient:             s.facadeClient,
 		disableAuth:              true,
 		SessionHandler:           s.sessionHandler,
@@ -351,7 +341,6 @@ func (s *sshServerSuite) TestSSHServerMaxConnections(c *gc.C) {
 		Listener:                 listener,
 		MaxConcurrentConnections: maxConcurrentConnections,
 		JumpHostKey:              jujutesting.SSHServerHostKey,
-		NewSSHServerListener:     newTestingSSHServerListener,
 		FacadeClient:             s.facadeClient,
 		disableAuth:              true,
 		SessionHandler:           s.sessionHandler,
@@ -423,7 +412,6 @@ func (s *sshServerSuite) TestSSHWorkerReport(c *gc.C) {
 		Listener:                 listener,
 		MaxConcurrentConnections: maxConcurrentConnections,
 		JumpHostKey:              jujutesting.SSHServerHostKey,
-		NewSSHServerListener:     newTestingSSHServerListener,
 		FacadeClient:             s.facadeClient,
 		disableAuth:              true,
 		SessionHandler:           s.sessionHandler,

--- a/internal/worker/sshserver/worker.go
+++ b/internal/worker/sshserver/worker.go
@@ -4,9 +4,7 @@
 package sshserver
 
 import (
-	"net"
 	"sync"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
@@ -15,11 +13,10 @@ import (
 
 // ServerWrapperWorkerConfig holds the configuration required by the server wrapper worker.
 type ServerWrapperWorkerConfig struct {
-	NewServerWorker      func(ServerWorkerConfig) (worker.Worker, error)
-	Logger               Logger
-	FacadeClient         FacadeClient
-	NewSSHServerListener func(net.Listener, time.Duration) net.Listener
-	SessionHandler       SessionHandler
+	NewServerWorker func(ServerWorkerConfig) (worker.Worker, error)
+	Logger          Logger
+	FacadeClient    FacadeClient
+	SessionHandler  SessionHandler
 }
 
 // Validate validates the workers configuration is as expected.
@@ -32,9 +29,6 @@ func (c ServerWrapperWorkerConfig) Validate() error {
 	}
 	if c.FacadeClient == nil {
 		return errors.NotValidf("FacadeClient is required")
-	}
-	if c.NewSSHServerListener == nil {
-		return errors.NotValidf("NewSSHServerListener is required")
 	}
 	if c.SessionHandler == nil {
 		return errors.NotValidf("SessionHandler is required")
@@ -144,7 +138,6 @@ func (ssw *serverWrapperWorker) loop() error {
 		JumpHostKey:              jumpHostKey,
 		Port:                     port,
 		MaxConcurrentConnections: maxConns,
-		NewSSHServerListener:     ssw.config.NewSSHServerListener,
 		FacadeClient:             ssw.config.FacadeClient,
 		SessionHandler:           ssw.config.SessionHandler,
 	})

--- a/internal/worker/sshserver/worker_test.go
+++ b/internal/worker/sshserver/worker_test.go
@@ -31,11 +31,10 @@ func newServerWrapperWorkerConfig(
 	modifier func(*ServerWrapperWorkerConfig),
 ) *ServerWrapperWorkerConfig {
 	cfg := &ServerWrapperWorkerConfig{
-		NewServerWorker:      func(ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
-		Logger:               l,
-		FacadeClient:         client,
-		NewSSHServerListener: newTestingSSHServerListener,
-		SessionHandler:       &MockSessionHandler{},
+		NewServerWorker: func(ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
+		Logger:          l,
+		FacadeClient:    client,
+		SessionHandler:  &MockSessionHandler{},
 	}
 
 	modifier(cfg)
@@ -84,16 +83,6 @@ func (s *workerSuite) TestValidate(c *gc.C) {
 	)
 	c.Assert(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 
-	// Test no NewSSHServerListener.
-	cfg = newServerWrapperWorkerConfig(
-		l,
-		mockFacadeClient,
-		func(cfg *ServerWrapperWorkerConfig) {
-			cfg.NewSSHServerListener = nil
-		},
-	)
-	c.Assert(cfg.Validate(), jc.ErrorIs, errors.NotValid)
-
 	// Test no SessionHandler.
 	cfg = newServerWrapperWorkerConfig(
 		l,
@@ -135,8 +124,7 @@ func (s *workerSuite) TestSSHServerWrapperWorkerCanBeKilled(c *gc.C) {
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			return serverWorker, nil
 		},
-		NewSSHServerListener: newTestingSSHServerListener,
-		SessionHandler:       &stubSessionHandler{},
+		SessionHandler: &stubSessionHandler{},
 	}
 	w, err := NewServerWrapperWorker(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -218,8 +206,7 @@ func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorker(c *gc.C) {
 			c.Check(swc.Port, gc.Equals, 22)
 			return serverWorker, nil
 		},
-		NewSSHServerListener: newTestingSSHServerListener,
-		SessionHandler:       &stubSessionHandler{},
+		SessionHandler: &stubSessionHandler{},
 	}
 	w, err := NewServerWrapperWorker(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -272,8 +259,7 @@ func (s *workerSuite) TestSSHServerWrapperWorkerErrorsOnMissingHostKey(c *gc.C) 
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			return serverWorker, nil
 		},
-		NewSSHServerListener: newTestingSSHServerListener,
-		SessionHandler:       &stubSessionHandler{},
+		SessionHandler: &stubSessionHandler{},
 	}
 	w1, err := NewServerWrapperWorker(cfg)
 	c.Assert(err, gc.IsNil)
@@ -291,8 +277,7 @@ func (s *workerSuite) TestSSHServerWrapperWorkerErrorsOnMissingHostKey(c *gc.C) 
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			return serverWorker, nil
 		},
-		NewSSHServerListener: newTestingSSHServerListener,
-		SessionHandler:       &stubSessionHandler{},
+		SessionHandler: &stubSessionHandler{},
 	}
 	w2, err := NewServerWrapperWorker(cfg)
 	c.Assert(err, gc.IsNil)
@@ -332,8 +317,7 @@ func (s *workerSuite) TestWrapperWorkerReport(c *gc.C) {
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			return &reportWorker{serverWorker}, nil
 		},
-		NewSSHServerListener: newTestingSSHServerListener,
-		SessionHandler:       &stubSessionHandler{},
+		SessionHandler: &stubSessionHandler{},
 	}
 	w, err := NewServerWrapperWorker(cfg)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This PR fixes flakiness in the sshserver tests caused by quickly closing the server after/during/before it has started. The correct fix is to update the library code which has been proposed upstream, but in the interim, this effectively does the same thing.

The origins of the flaky tests are best described in the upstream PR. A tldr; is that the current approach of closing the listener before we close the server can cause the server to return early before its "shutdown" flag has been set, returning with a non-nil error.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. `go test ./internal/worker/sshserver -c -race`
2. `stress ./sshserver.test`
```
1m35s: 332 runs so far, 0 failures, 16 active
```