### PR TITLE
fix: jwt ssh access check

### DIFF
--- a/internal/worker/sshserver/authorization.go
+++ b/internal/worker/sshserver/authorization.go
@@ -50,6 +50,10 @@ func (a *authorizer) authorize(ctx ssh.Context, destination virtualhostname.Info
 
 func (a *authorizer) checkSSHAccessViaJWT(token jwt.Token, destination virtualhostname.Info) bool {
 	modelTag := names.NewModelTag(destination.ModelUUID())
-
-	return token.PrivateClaims()[modelTag.String()] == permission.AdminAccess
+	accessClaims, ok := token.PrivateClaims()["access"].(map[string]interface{})
+	if !ok || len(accessClaims) == 0 {
+		return false
+	}
+	modelAccess, _ := accessClaims[modelTag.String()].(string)
+	return modelAccess == string(permission.AdminAccess)
 }

--- a/internal/worker/sshserver/authorization_test.go
+++ b/internal/worker/sshserver/authorization_test.go
@@ -71,7 +71,9 @@ func (s *authorizationSuite) TestAuthorizerViaJWT(c *gc.C) {
 
 	token, err := jwt.NewBuilder().
 		Subject("alice").
-		Claim(modelTag.String(), permission.AdminAccess).
+		Claim("access", map[string]any{
+			modelTag.String(): string(permission.AdminAccess),
+		}).
 		Build()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -87,7 +89,6 @@ func (s *authorizationSuite) TestAuthorizerViaJWT(c *gc.C) {
 	c.Check(authorizer.authorize(s.ctx, destination), jc.IsTrue)
 	// Test that alice does not have access to arbitrary destinations.
 	c.Check(authorizer.authorize(s.ctx, virtualhostname.Info{}), jc.IsFalse)
-
 }
 
 func (s *authorizationSuite) TestMissingContextValues(c *gc.C) {

--- a/internal/worker/sshserver/server_test.go
+++ b/internal/worker/sshserver/server_test.go
@@ -349,7 +349,9 @@ func (s *sshServerSuite) TestPasswordHandler(c *gc.C) {
 	// that authenticated at JIMM.
 	token, err := jwt.NewBuilder().
 		Claim("ssh_public_key", base64.StdEncoding.EncodeToString(s.userSigner.PublicKey().Marshal())).
-		Claim(destinationModel.String(), permission.AdminAccess).
+		Claim("access", map[string]any{
+			destinationModel.String(): string(permission.AdminAccess),
+		}).
 		Subject("an-external-user@canonical"). // This user is not the same user in the initial connection (normally JIMM).
 		Build()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This PR adds a fix for how we check for access claims in the JWT token passed to the SSH server's password handler.

To follow [the convention](https://github.com/juju/juju/blob/3.6/apiserver/authentication/jwt/jwt.go#L199) set by the existing tokens JIMM sends for Juju RPC login, the access claims are specified as a map inside a claim titled "access" on the JWT.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
