### PR TITLE
chore: expose ssh public host key in controller config

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -278,6 +278,9 @@ const (
 	// SSHMaxConcurrentConnections is the maximum number of concurrent SSH
 	// connections to the controller.
 	SSHMaxConcurrentConnections = "ssh-max-concurrent-connections"
+
+	// SSHPublicHostKey is the public host key for the controller's SSH server.
+	SSHPublicHostKey = "ssh-host-key"
 )
 
 // Attribute Defaults
@@ -471,6 +474,7 @@ var (
 		JujudControllerSnapSource,
 		SSHMaxConcurrentConnections,
 		SSHServerPort,
+		SSHPublicHostKey,
 	}
 
 	// For backwards compatibility, we must include "anything", "juju-apiserver"
@@ -1039,6 +1043,11 @@ func (c Config) SSHServerPort() int {
 // SSH connections that the controller will allow.
 func (c Config) SSHMaxConcurrentConnections() int {
 	return c.intOrDefault(SSHMaxConcurrentConnections, DefaultSSHMaxConcurrentConnections)
+}
+
+// SSHHostKey returns the public host key for the SSH server.
+func (c Config) SSHHostKey() string {
+	return c.asString(SSHPublicHostKey)
 }
 
 // Validate ensures that config is a valid configuration.

--- a/docs/reference/configuration/list-of-controller-configuration-keys.md
+++ b/docs/reference/configuration/list-of-controller-configuration-keys.md
@@ -641,6 +641,14 @@ controller policy turned on.
 **Can be changed after bootstrap:** no
 
 
+(controller-config-ssh-host-key)=
+## `ssh-host-key`
+
+`ssh-host-key` is the public host key for the controller's SSH server.
+
+**Can be changed after bootstrap:** no
+
+
 (controller-config-ssh-max-concurrent-connections)=
 ## `ssh-max-concurrent-connections`
 

--- a/scripts/md-gen/controller-config/main.go
+++ b/scripts/md-gen/controller-config/main.go
@@ -293,6 +293,7 @@ func fillFromConfigType(data map[string]*keyInfo) {
 
 		rename := map[string]string{
 			"NUMACtlPreference": "SetNUMAControlPolicyKey",
+			"SSHHostKey":        "SSHPublicHostKey",
 		}
 		if rn, ok := rename[name]; ok {
 			name = rn

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -74,6 +74,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.JujudControllerSnapSource,
 		controller.SSHMaxConcurrentConnections,
 		controller.SSHServerPort,
+		controller.SSHPublicHostKey,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)


### PR DESCRIPTION
This PR exposes the public key part of the SSH server's host-key in Juju controller config. This is necessary so that client's can fetch the host-key by checking the controller config and importantly, it allows JIMM to implement the same functionality to act as a Juju controller/SSH jump server.

Currently the public host-key is only available using the `sshclient` facade which is a "model-level" facade. In order for JIMM to expose its host key, it would need to implement the same mechanism that a Juju controller uses to expose it. Since JIMM has not yet needed to handle model-level calls, it seems prudent to continue that trend and provide a "controller-level" way of retrieving this value.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
1. `make install`
2. `controller_name=test-ssh-config`
3. `JUJU_DEV_FEATURE_FLAGS=ssh-jump juju bootstrap localhost $controller_name --build-agent`
4. `juju controller-config` <- observe `ssh-host-key` is present.
5. `juju add-model foo`
6. `juju deploy ubuntu`
7. `model_name=foo`
9. `controller_address=$(juju show-controller --format json | jq -r ".[\"${controller_name}\"][\"details\"][\"api-endpoints\"][0]" | cut -d ':' -f 1)`
10. `model_uuid=$(juju show-model $model_name --format json | jq -r ".[\"${model_name}\"][\"model-uuid\"]")`
11. `echo "[$controller_address]:17022 $(juju controller-config ssh-host-key)" >> ~/.ssh/known_hosts`
12. `ssh -J admin@$controller_address:17022 ubuntu@0.$model_uuid.juju.local`

You should see only 1 prompt for the host-key of the final target, something like the below
```
$ ssh -J admin@$controller_address:17022 ubuntu@0.$model_uuid.juju.local
The authenticity of host '0.efcd5f05-27fa-4986-8e2a-fbc92d2788f4.juju.local (<no hostip for proxy command>)' can't be established.
ED25519 key fingerprint is SHA256:1cwMtsQMLOxPVIN+bQ832jSXJ4PT3NHxqIMJUXBsOz8.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])?
```

## Links

**Jira card:** [JUJU-7573](https://warthogs.atlassian.net/browse/JUJU-7573)
