### PR TITLE
feat: remove context todo from internal packages

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -355,7 +355,7 @@ func (b *AgentBootstrap) Initialize(ctx context.Context) (_ *state.Controller, r
 	b.agentConfig.SetStateServingInfo(servingInfo)
 
 	// Filter out any LXC or LXD bridge addresses from the machine addresses.
-	filteredBootstrapMachineAddresses := network.FilterBridgeAddresses(b.bootstrapMachineAddresses)
+	filteredBootstrapMachineAddresses := network.FilterBridgeAddresses(ctx, b.bootstrapMachineAddresses)
 
 	st, err := ctrl.SystemState()
 	if err != nil {

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -354,7 +354,7 @@ func (c *downloadCommand) refresh(
 
 	var refreshConfig charmhub.RefreshConfig
 	if c.revision == -1 {
-		refreshConfig, err = charmhub.InstallOneFromChannel(c.charmOrBundle, normChannel.String(), charmhub.RefreshBase{
+		refreshConfig, err = charmhub.InstallOneFromChannel(ctx, c.charmOrBundle, normChannel.String(), charmhub.RefreshBase{
 			Architecture: normBase.Architecture,
 			Name:         normBase.OS,
 			Channel:      normBase.Channel,
@@ -363,7 +363,7 @@ func (c *downloadCommand) refresh(
 			return nil, nil, errors.Trace(err)
 		}
 	} else {
-		refreshConfig, err = charmhub.InstallOneFromRevision(c.charmOrBundle, c.revision)
+		refreshConfig, err = charmhub.InstallOneFromRevision(ctx, c.charmOrBundle, c.revision)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/internal/bootstrap/agentbinary.go
+++ b/internal/bootstrap/agentbinary.go
@@ -90,7 +90,7 @@ func PopulateAgentBinary(
 		SHA256:  agentTools.SHA256,
 	}
 
-	logger.Debugf(context.TODO(), "Adding agent binary: %v", agentTools.Version)
+	logger.Debugf(ctx, "Adding agent binary: %v", agentTools.Version)
 
 	if err := storage.Add(ctx, bytes.NewReader(data), metadata); err != nil {
 		return nil, errors.Trace(err)
@@ -113,12 +113,12 @@ func PopulateAgentBinary(
 	return func() {
 		// Ensure that we remove the agent binary from disk.
 		if err := os.Remove(binaryPath); err != nil {
-			logger.Warningf(context.TODO(), "failed to remove agent binary: %v", err)
+			logger.Warningf(ctx, "failed to remove agent binary: %v", err)
 		}
 		// Remove the sha that validates the agent binary file.
 		shaFilePath := filepath.Join(rootPath, fmt.Sprintf("juju%s.sha256", current.String()))
 		if err := os.Remove(shaFilePath); err != nil {
-			logger.Warningf(context.TODO(), "failed to remove agent binary sha: %v", err)
+			logger.Warningf(ctx, "failed to remove agent binary sha: %v", err)
 		}
 	}, nil
 }

--- a/internal/changestream/eventmultiplexer/eventmultiplexer.go
+++ b/internal/changestream/eventmultiplexer/eventmultiplexer.go
@@ -145,6 +145,9 @@ func (e *EventMultiplexer) Wait() error {
 // Report returns a map of the current state of the event queue. This is
 // used by the engine report.
 func (e *EventMultiplexer) Report() map[string]any {
+	ctx, cancel := e.scopedContext()
+	defer cancel()
+
 	r := reportRequest{
 		data: make(map[string]any),
 		done: make(chan struct{}),
@@ -159,7 +162,7 @@ func (e *EventMultiplexer) Report() map[string]any {
 	// This can happen if we're in the middle of a dispatch and the term
 	// channel is blocked.
 	case <-e.clock.After(time.Second):
-		e.logger.Errorf(context.TODO(), "report request timed out")
+		e.logger.Errorf(ctx, "report request timed out")
 		return nil
 	case e.reportsCh <- r:
 	}
@@ -188,6 +191,9 @@ func (e *EventMultiplexer) unsubscribe(subscriptionID uint64) {
 }
 
 func (e *EventMultiplexer) loop() error {
+	ctx, cancel := e.scopedContext()
+	defer cancel()
+
 	defer func() {
 		for _, sub := range e.subscriptions {
 			sub.close()
@@ -204,7 +210,7 @@ func (e *EventMultiplexer) loop() error {
 
 		// If the underlying stream is dying, then we should also exit.
 		case <-e.stream.Dying():
-			e.logger.Debugf(context.TODO(), "change stream is dying, waiting for catacomb to die")
+			e.logger.Debugf(ctx, "change stream is dying, waiting for catacomb to die")
 
 			<-e.catacomb.Dying()
 			return e.catacomb.ErrDying()
@@ -214,13 +220,13 @@ func (e *EventMultiplexer) loop() error {
 			// again using the change stream worker infrastructure. In this case
 			// just ignore and close out.
 			if !ok {
-				e.logger.Infof(context.TODO(), "change stream term channel is closed")
+				e.logger.Infof(ctx, "change stream term channel is closed")
 				return nil
 			}
 
 			changeSet := make(map[*subscription]ChangeSet)
 			for _, change := range term.Changes() {
-				subs := e.gatherSubscriptions(change)
+				subs := e.gatherSubscriptions(ctx, change)
 				if len(subs) == 0 {
 					continue
 				}
@@ -242,7 +248,7 @@ func (e *EventMultiplexer) loop() error {
 			// There isn't anything we can do in this case.
 			err := e.dispatchSet(changeSet)
 			if err != nil {
-				e.logger.Errorf(context.TODO(), "dispatching set: %v", err)
+				e.logger.Errorf(ctx, "dispatching set: %v", err)
 				e.dispatchErrorCount++
 			}
 			e.metrics.DispatchDurationObserve(e.clock.Now().Sub(begin).Seconds(), err != nil)
@@ -339,7 +345,7 @@ func (e *EventMultiplexer) loop() error {
 			// to bring down the entire multiplexer. Instead, just log it out
 			// and continue.
 			if err := sub.close(); err != nil {
-				e.logger.Infof(context.TODO(), "error closing subscription: %v", err)
+				e.logger.Infof(ctx, "error closing subscription: %v", err)
 			}
 
 		case r := <-e.reportsCh:
@@ -361,7 +367,7 @@ type reporter interface {
 	Report() map[string]interface{}
 }
 
-func (e *EventMultiplexer) gatherSubscriptions(ch changestream.ChangeEvent) []*subscription {
+func (e *EventMultiplexer) gatherSubscriptions(ctx context.Context, ch changestream.ChangeEvent) []*subscription {
 	subs := make(map[uint64]*subscription)
 
 	for id := range e.subscriptionsAll {
@@ -380,13 +386,13 @@ func (e *EventMultiplexer) gatherSubscriptions(ch changestream.ChangeEvent) []*s
 
 		if !subOpt.filter(ch) {
 			if traceEnabled {
-				e.logger.Tracef(context.TODO(), "filtering out change: %v", ch)
+				e.logger.Tracef(ctx, "filtering out change: %v", ch)
 			}
 			continue
 		}
 
 		if traceEnabled {
-			e.logger.Tracef(context.TODO(), "dispatching change: %v", ch)
+			e.logger.Tracef(ctx, "dispatching change: %v", ch)
 		}
 
 		subs[subOpt.subscriptionID] = e.subscriptions[subOpt.subscriptionID]
@@ -420,4 +426,8 @@ func (e *EventMultiplexer) dispatchSet(changeSet map[*subscription]ChangeSet) er
 	}
 
 	return grp.Wait()
+}
+
+func (e *EventMultiplexer) scopedContext() (context.Context, context.CancelFunc) {
+	return context.WithCancel(e.catacomb.Context(context.Background()))
 }

--- a/internal/changestream/stream/stream.go
+++ b/internal/changestream/stream/stream.go
@@ -336,7 +336,7 @@ func (s *Stream) loop() error {
 				case <-s.tomb.Dying():
 					return tomb.ErrDying
 				case <-s.clock.After(backOffStrategy(0, attempt)):
-					if err := s.reportIdleState(attempt); err != nil {
+					if err := s.reportIdleState(ctx, attempt); err != nil {
 						return errors.Trace(err)
 					}
 					continue
@@ -695,7 +695,7 @@ func (s *Stream) processWatermark(fn func(*termView) error) error {
 }
 
 // reportIdleState reports the idle state to the internal states channel.
-func (s *Stream) reportIdleState(attempt int) error {
+func (s *Stream) reportIdleState(ctx context.Context, attempt int) error {
 	// If there are no internal states, then we don't need to report the idle
 	// state. This is only used for testing.
 	if s.internalStates == nil {
@@ -708,7 +708,7 @@ func (s *Stream) reportIdleState(attempt int) error {
 	}
 
 	if bound := s.upperBound(); bound > 0 && maxChangeLogID > 0 && bound == maxChangeLogID {
-		s.logger.Tracef(context.TODO(), "no changes, backing off after %d attempt", attempt)
+		s.logger.Tracef(ctx, "no changes, backing off after %d attempt", attempt)
 
 		// Report the idle state to the internal states channel.
 		select {

--- a/internal/charm/charmdownloader/downloader.go
+++ b/internal/charm/charmdownloader/downloader.go
@@ -64,7 +64,7 @@ func NewCharmDownloader(client DownloadClient, logger logger.Logger) *CharmDownl
 // Returns [ErrInvalidHash] if the hash of the downloaded charm does not match
 // the expected hash.
 func (d *CharmDownloader) Download(ctx context.Context, url *url.URL, hash string) (_ *DownloadResult, err error) {
-	d.logger.Debugf(context.TODO(), "downloading charm: %s", url)
+	d.logger.Debugf(ctx, "downloading charm: %s", url)
 
 	tmpFile, err := os.CreateTemp("", "charm-")
 	if err != nil {
@@ -87,7 +87,7 @@ func (d *CharmDownloader) Download(ctx context.Context, url *url.URL, hash strin
 		// manually.
 		removeErr := os.Remove(tmpFile.Name())
 		if removeErr != nil {
-			d.logger.Warningf(context.TODO(), "failed to remove temporary file %q: %v", tmpFile.Name(), removeErr)
+			d.logger.Warningf(ctx, "failed to remove temporary file %q: %v", tmpFile.Name(), removeErr)
 		}
 	}()
 
@@ -102,7 +102,7 @@ func (d *CharmDownloader) Download(ctx context.Context, url *url.URL, hash strin
 		return nil, errors.Errorf("%w: %q, got %q", ErrInvalidDigestHash, hash, digest.SHA256)
 	}
 
-	d.logger.Debugf(context.TODO(), "downloaded charm: %q", url)
+	d.logger.Debugf(ctx, "downloaded charm: %q", url)
 
 	return &DownloadResult{
 		SHA256: digest.SHA256,

--- a/internal/charm/repository/charmhub_test.go
+++ b/internal/charm/repository/charmhub_test.go
@@ -120,9 +120,10 @@ func (s *charmHubRepositorySuite) TestResolveForUpgrade(c *gc.C) {
 		Channel: &channel,
 	}
 
-	cfg, err := charmhub.RefreshOne("instance-key", "charmCHARMcharmCHARMcharmCHARM01", 16, "latest/stable", charmhub.RefreshBase{
-		Architecture: arch.DefaultArchitecture,
-	})
+	cfg, err := charmhub.RefreshOne(context.Background(),
+		"instance-key", "charmCHARMcharmCHARMcharmCHARM01", 16, "latest/stable", charmhub.RefreshBase{
+			Architecture: arch.DefaultArchitecture,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectCharmRefresh(c, cfg, hash)
 
@@ -723,9 +724,10 @@ func (s *charmHubRepositorySuite) TestResourceInfo(c *gc.C) {
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannel(c *gc.C, hash string) {
-	cfg, err := charmhub.InstallOneFromChannel("wordpress", "latest/stable", charmhub.RefreshBase{
-		Architecture: arch.DefaultArchitecture,
-	})
+	cfg, err := charmhub.InstallOneFromChannel(context.Background(),
+		"wordpress", "latest/stable", charmhub.RefreshBase{
+			Architecture: arch.DefaultArchitecture,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectCharmRefresh(c, cfg, hash)
 }
@@ -771,9 +773,10 @@ options:
 }
 
 func (s *charmHubRepositorySuite) expectBundleRefresh(c *gc.C) {
-	cfg, err := charmhub.InstallOneFromChannel("core-kubernetes", "latest/stable", charmhub.RefreshBase{
-		Architecture: arch.DefaultArchitecture,
-	})
+	cfg, err := charmhub.InstallOneFromChannel(context.Background(),
+		"core-kubernetes", "latest/stable", charmhub.RefreshBase{
+			Architecture: arch.DefaultArchitecture,
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	s.client.EXPECT().Refresh(gomock.Any(), RefreshConfigMatcher{c: c, Config: cfg}).DoAndReturn(func(ctx context.Context, cfg charmhub.RefreshConfig) ([]transport.RefreshResponse, error) {
 		id := charmhub.ExtractConfigInstanceKey(cfg)
@@ -840,7 +843,7 @@ func (s *charmHubRepositorySuite) expectedRefreshRevisionNotFoundError() {
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannelFullBase(c *gc.C) {
-	cfg, err := charmhub.InstallOneFromChannel("wordpress", "latest/stable", charmhub.RefreshBase{
+	cfg, err := charmhub.InstallOneFromChannel(context.Background(), "wordpress", "latest/stable", charmhub.RefreshBase{
 		Architecture: arch.DefaultArchitecture, Name: "ubuntu", Channel: "20.04",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -848,7 +851,7 @@ func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannelFullBas
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneByRevisionResources(c *gc.C, hash string) {
-	cfg, err := charmhub.InstallOneFromRevision("wordpress", 16)
+	cfg, err := charmhub.InstallOneFromRevision(context.Background(), "wordpress", 16)
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectCharmRefresh(c, cfg, hash)
 }
@@ -964,13 +967,13 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 		Channel:  &channel,
 	}
 
-	cfg, err := refreshConfig(name, origin)
+	cfg, err := refreshConfig(context.Background(), name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := channel.String()
 	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
 
-	build, err := cfg.Build()
+	build, err := cfg.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(build, gc.DeepEquals, transport.RefreshRequest{
 		Actions: []transport.RefreshRequestAction{{
@@ -998,13 +1001,13 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 		Channel:  &channel,
 	}
 
-	cfg, err := refreshConfig(name, origin)
+	cfg, err := refreshConfig(context.Background(), name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := channel.String()
 	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
 
-	build, err := cfg.Build()
+	build, err := cfg.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(build, gc.DeepEquals, transport.RefreshRequest{
 		Actions: []transport.RefreshRequestAction{{
@@ -1032,12 +1035,12 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 		Revision: &revision,
 	}
 
-	cfg, err := refreshConfig(name, origin)
+	cfg, err := refreshConfig(context.Background(), name, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
 
-	build, err := cfg.Build()
+	build, err := cfg.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(build, gc.DeepEquals, transport.RefreshRequest{
 		Actions: []transport.RefreshRequestAction{{
@@ -1065,12 +1068,12 @@ func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 		InstanceKey: "instance-key",
 	}
 
-	cfg, err := refreshConfig("wordpress", origin)
+	cfg, err := refreshConfig(context.Background(), "wordpress", origin)
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
 
-	build, err := cfg.Build()
+	build, err := cfg.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(build, gc.DeepEquals, transport.RefreshRequest{
 		Actions: []transport.RefreshRequestAction{{
@@ -1188,7 +1191,7 @@ func (*selectNextBaseSuite) TestSelectNextBaseWithCentosBase(c *gc.C) {
 func (*selectNextBaseSuite) TestSelectNextBasesFromReleasesNoReleasesError(c *gc.C) {
 	channel := corecharm.MustParseChannel("stable/foo")
 	repo := new(CharmHubRepository)
-	err := repo.handleRevisionNotFound([]transport.Release{}, corecharm.Origin{
+	err := repo.handleRevisionNotFound(context.Background(), []transport.Release{}, corecharm.Origin{
 		Channel: &channel,
 	})
 	c.Assert(err, gc.ErrorMatches, `no releases available`)
@@ -1197,7 +1200,7 @@ func (*selectNextBaseSuite) TestSelectNextBasesFromReleasesNoReleasesError(c *gc
 func (*selectNextBaseSuite) TestSelectNextBasesFromReleasesAmbiguousMatchError(c *gc.C) {
 	channel := corecharm.MustParseChannel("stable/foo")
 	repo := new(CharmHubRepository)
-	err := repo.handleRevisionNotFound([]transport.Release{
+	err := repo.handleRevisionNotFound(context.Background(), []transport.Release{
 		{},
 	}, corecharm.Origin{
 		Channel: &channel,
@@ -1211,7 +1214,7 @@ func (s *selectNextBaseSuite) TestSelectNextBasesFromReleasesSuggestionError(c *
 	}
 
 	channel := corecharm.MustParseChannel("stable")
-	err := repo.handleRevisionNotFound([]transport.Release{{
+	err := repo.handleRevisionNotFound(context.Background(), []transport.Release{{
 		Base: transport.Base{
 			Name:         "os",
 			Channel:      "series",
@@ -1228,7 +1231,7 @@ func (s *selectNextBaseSuite) TestSelectNextBasesFromReleasesSuggestion(c *gc.C)
 	repo := &CharmHubRepository{
 		logger: loggertesting.WrapCheckLog(c),
 	}
-	err := repo.handleRevisionNotFound([]transport.Release{{
+	err := repo.handleRevisionNotFound(context.Background(), []transport.Release{{
 		Base: transport.Base{
 			Name:         "ubuntu",
 			Channel:      "20.04",
@@ -1256,7 +1259,7 @@ func (s *composeSuggestionsSuite) TestNoReleases(c *gc.C) {
 	repo := &CharmHubRepository{
 		logger: loggertesting.WrapCheckLog(c),
 	}
-	suggestions := repo.composeSuggestions([]transport.Release{}, corecharm.Origin{})
+	suggestions := repo.composeSuggestions(context.Background(), []transport.Release{}, corecharm.Origin{})
 	c.Assert(suggestions, gc.DeepEquals, []string(nil))
 }
 
@@ -1264,7 +1267,7 @@ func (s *composeSuggestionsSuite) TestNoMatchingArch(c *gc.C) {
 	repo := &CharmHubRepository{
 		logger: loggertesting.WrapCheckLog(c),
 	}
-	suggestions := repo.composeSuggestions([]transport.Release{{
+	suggestions := repo.composeSuggestions(context.Background(), []transport.Release{{
 		Base: transport.Base{
 			Name:         "os",
 			Channel:      "series",
@@ -1279,7 +1282,7 @@ func (s *composeSuggestionsSuite) TestSuggestion(c *gc.C) {
 	repo := &CharmHubRepository{
 		logger: loggertesting.WrapCheckLog(c),
 	}
-	suggestions := repo.composeSuggestions([]transport.Release{{
+	suggestions := repo.composeSuggestions(context.Background(), []transport.Release{{
 		Base: transport.Base{
 			Name:         "ubuntu",
 			Channel:      "20.04",
@@ -1300,7 +1303,7 @@ func (s *composeSuggestionsSuite) TestSuggestionWithRisk(c *gc.C) {
 	repo := &CharmHubRepository{
 		logger: loggertesting.WrapCheckLog(c),
 	}
-	suggestions := repo.composeSuggestions([]transport.Release{{
+	suggestions := repo.composeSuggestions(context.Background(), []transport.Release{{
 		Base: transport.Base{
 			Name:         "ubuntu",
 			Channel:      "20.04/stable",
@@ -1321,7 +1324,7 @@ func (s *composeSuggestionsSuite) TestMultipleSuggestion(c *gc.C) {
 	repo := &CharmHubRepository{
 		logger: loggertesting.WrapCheckLog(c),
 	}
-	suggestions := repo.composeSuggestions([]transport.Release{{
+	suggestions := repo.composeSuggestions(context.Background(), []transport.Release{{
 		Base: transport.Base{
 			Name:         "ubuntu",
 			Channel:      "20.04",
@@ -1364,7 +1367,7 @@ func (s *composeSuggestionsSuite) TestCentosSuggestion(c *gc.C) {
 	repo := &CharmHubRepository{
 		logger: loggertesting.WrapCheckLog(c),
 	}
-	suggestions := repo.composeSuggestions([]transport.Release{{
+	suggestions := repo.composeSuggestions(context.Background(), []transport.Release{{
 		Base: transport.Base{
 			Name:         "centos",
 			Channel:      "7",
@@ -1395,10 +1398,10 @@ func (m RefreshConfigMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
-	cb, err := m.Config.Build()
+	cb, err := m.Config.Build(context.Background())
 	m.c.Assert(err, jc.ErrorIsNil)
 
-	rcb, err := rc.Build()
+	rcb, err := rc.Build(context.Background())
 	m.c.Assert(err, jc.ErrorIsNil)
 	m.c.Assert(len(cb.Actions), gc.Equals, len(rcb.Actions))
 
@@ -1423,7 +1426,7 @@ func (m charmhubConfigMatcher) Matches(x interface{}) bool {
 	if !ok {
 		return false
 	}
-	h, err := config.Build()
+	h, err := config.Build(context.Background())
 	if err != nil {
 		return false
 	}

--- a/internal/charmhub/client.go
+++ b/internal/charmhub/client.go
@@ -131,8 +131,6 @@ func NewClient(config Config) (*Client, error) {
 		return nil, errors.Annotate(err, "constructing resources path")
 	}
 
-	logger.Tracef(context.TODO(), "NewClient to %q", url)
-
 	apiRequester := newAPIRequester(httpClient, logger)
 	apiRequestLogger := newAPIRequesterLogger(apiRequester, logger)
 	restClient := newHTTPRESTClient(apiRequestLogger)

--- a/internal/charmhub/download.go
+++ b/internal/charmhub/download.go
@@ -189,7 +189,7 @@ func (c *DownloadClient) downloadFromURL(ctx context.Context, resourceURL *url.U
 		return nil, errors.Annotatef(err, "cannot make new request")
 	}
 
-	c.logger.Tracef(context.TODO(), "download from URL %s", resourceURL.String())
+	c.logger.Tracef(ctx, "download from URL %s", resourceURL.String())
 
 	resp, err = c.httpClient.Do(req)
 	if err != nil {
@@ -201,7 +201,7 @@ func (c *DownloadClient) downloadFromURL(ctx context.Context, resourceURL *url.U
 		return resp, nil
 	}
 
-	c.logger.Errorf(context.TODO(), "download failed from %s: response code: %s", resourceURL.String(), resp.Status)
+	c.logger.Errorf(ctx, "download failed from %s: response code: %s", resourceURL.String(), resp.Status)
 
 	// Ensure we drain the response body so this connection can be reused. As
 	// there is no error message, we have no ability other than to check the

--- a/internal/charmhub/errors.go
+++ b/internal/charmhub/errors.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Handle some of the basic error messages.
-func handleBasicAPIErrors(list transport.APIErrors, logger corelogger.Logger) error {
+func handleBasicAPIErrors(ctx context.Context, list transport.APIErrors, logger corelogger.Logger) error {
 	if len(list) == 0 {
 		return nil
 	}
@@ -25,7 +25,7 @@ func handleBasicAPIErrors(list transport.APIErrors, logger corelogger.Logger) er
 		// We do this because the original error message can be huge and
 		// verbose, like a java stack trace!
 		if masked {
-			logger.Errorf(context.TODO(), "charmhub API error %s:%s", list[0].Code, list[0].Message)
+			logger.Errorf(ctx, "charmhub API error %s:%s", list[0].Code, list[0].Message)
 		}
 	}()
 

--- a/internal/charmhub/errors_test.go
+++ b/internal/charmhub/errors_test.go
@@ -4,6 +4,8 @@
 package charmhub
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,18 +20,18 @@ var _ = gc.Suite(&ErrorsSuite{})
 
 func (s *ErrorsSuite) TestHandleBasicAPIErrors(c *gc.C) {
 	var list transport.APIErrors
-	err := handleBasicAPIErrors(list, s.logger)
+	err := handleBasicAPIErrors(context.Background(), list, s.logger)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ErrorsSuite) TestHandleBasicAPIErrorsNotFound(c *gc.C) {
 	list := transport.APIErrors{{Code: transport.ErrorCodeNotFound, Message: "foo"}}
-	err := handleBasicAPIErrors(list, s.logger)
+	err := handleBasicAPIErrors(context.Background(), list, s.logger)
 	c.Assert(err, gc.ErrorMatches, `charm or bundle not found`)
 }
 
 func (s *ErrorsSuite) TestHandleBasicAPIErrorsOther(c *gc.C) {
 	list := transport.APIErrors{{Code: "other", Message: "foo"}}
-	err := handleBasicAPIErrors(list, s.logger)
+	err := handleBasicAPIErrors(context.Background(), list, s.logger)
 	c.Assert(err, gc.ErrorMatches, `foo`)
 }

--- a/internal/charmhub/find.go
+++ b/internal/charmhub/find.go
@@ -124,7 +124,7 @@ func (c *findClient) find(ctx context.Context, query string, options ...FindOpti
 		option(opts)
 	}
 
-	c.logger.Tracef(context.TODO(), "Find(%s)", query)
+	c.logger.Tracef(ctx, "Find(%s)", query)
 	path, err := c.path.Query("q", query)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -150,7 +150,7 @@ func (c *findClient) find(ctx context.Context, query string, options ...FindOpti
 	if restResp.StatusCode == http.StatusNotFound {
 		return nil, errors.NotFoundf(query)
 	}
-	if err := handleBasicAPIErrors(resp.ErrorList, c.logger); err != nil {
+	if err := handleBasicAPIErrors(ctx, resp.ErrorList, c.logger); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/internal/charmhub/http.go
+++ b/internal/charmhub/http.go
@@ -162,7 +162,7 @@ func (t *apiRequester) Do(req *http.Request) (*http.Response, error) {
 			return !errors.Is(err, io.EOF)
 		},
 		NotifyFunc: func(lastError error, attempt int) {
-			t.logger.Errorf(context.TODO(), "Charmhub API error (attempt %d): %v", attempt, lastError)
+			t.logger.Errorf(req.Context(), "Charmhub API error (attempt %d): %v", attempt, lastError)
 		},
 		Attempts: 2,
 		Delay:    t.retryDelay,
@@ -232,9 +232,9 @@ func newAPIRequesterLogger(httpClient HTTPClient, logger corelogger.Logger) *api
 func (t *apiRequestLogger) Do(req *http.Request) (*http.Response, error) {
 	if t.logger.IsLevelEnabled(corelogger.TRACE) {
 		if data, err := httputil.DumpRequest(req, true); err == nil {
-			t.logger.Tracef(context.TODO(), "%s request %s", req.Method, data)
+			t.logger.Tracef(req.Context(), "%s request %s", req.Method, data)
 		} else {
-			t.logger.Tracef(context.TODO(), "%s request DumpRequest error %s", req.Method, err.Error())
+			t.logger.Tracef(req.Context(), "%s request DumpRequest error %s", req.Method, err.Error())
 		}
 	}
 
@@ -245,9 +245,9 @@ func (t *apiRequestLogger) Do(req *http.Request) (*http.Response, error) {
 
 	if t.logger.IsLevelEnabled(corelogger.TRACE) {
 		if data, err := httputil.DumpResponse(resp, true); err == nil {
-			t.logger.Tracef(context.TODO(), "%s response %s", req.Method, data)
+			t.logger.Tracef(req.Context(), "%s response %s", req.Method, data)
 		} else {
-			t.logger.Tracef(context.TODO(), "%s response DumpResponse error %s", req.Method, err.Error())
+			t.logger.Tracef(req.Context(), "%s response DumpResponse error %s", req.Method, err.Error())
 		}
 	}
 

--- a/internal/charmhub/info.go
+++ b/internal/charmhub/info.go
@@ -78,7 +78,7 @@ func (c *infoClient) info(ctx context.Context, name string, options ...InfoOptio
 
 	isTraceEnabled := c.logger.IsLevelEnabled(corelogger.TRACE)
 	if isTraceEnabled {
-		c.logger.Tracef(context.TODO(), "Info(%s)", name)
+		c.logger.Tracef(ctx, "Info(%s)", name)
 	}
 
 	var resp transport.InfoResponse
@@ -106,7 +106,7 @@ func (c *infoClient) info(ctx context.Context, name string, options ...InfoOptio
 	if restResp.StatusCode == http.StatusNotFound {
 		return resp, errors.NotFoundf(name)
 	}
-	if err := handleBasicAPIErrors(resp.ErrorList, c.logger); err != nil {
+	if err := handleBasicAPIErrors(ctx, resp.ErrorList, c.logger); err != nil {
 		return resp, errors.Trace(err)
 	}
 
@@ -117,7 +117,7 @@ func (c *infoClient) info(ctx context.Context, name string, options ...InfoOptio
 	}
 
 	if isTraceEnabled {
-		c.logger.Tracef(context.TODO(), "Info() unmarshalled: %+v", resp)
+		c.logger.Tracef(ctx, "Info() unmarshalled: %+v", resp)
 	}
 	return resp, nil
 }

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -100,9 +100,9 @@ func newRefreshClient(path path.Path, client RESTClient, logger corelogger.Logge
 // Refresh is used to refresh installed charms to a more suitable revision.
 func (c *refreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]transport.RefreshResponse, error) {
 	if c.logger.IsLevelEnabled(corelogger.TRACE) {
-		c.logger.Tracef(context.TODO(), "Refresh(%s)", pretty.Sprint(config))
+		c.logger.Tracef(ctx, "Refresh(%s)", pretty.Sprint(config))
 	}
-	req, err := config.Build()
+	req, err := config.Build(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -113,9 +113,9 @@ func (c *refreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 // at the same time.  Used as part of the charm revision updater facade.
 func (c *refreshClient) RefreshWithRequestMetrics(ctx context.Context, config RefreshConfig, metrics Metrics) ([]transport.RefreshResponse, error) {
 	if c.logger.IsLevelEnabled(corelogger.TRACE) {
-		c.logger.Tracef(context.TODO(), "RefreshWithRequestMetrics(%s, %+v)", pretty.Sprint(config), metrics)
+		c.logger.Tracef(ctx, "RefreshWithRequestMetrics(%s, %+v)", pretty.Sprint(config), metrics)
 	}
-	req, err := config.Build()
+	req, err := config.Build(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -130,7 +130,7 @@ func (c *refreshClient) RefreshWithRequestMetrics(ctx context.Context, config Re
 // RefreshWithMetricsOnly is to provide metrics without context or actions. Used
 // as part of the charm revision updater facade.
 func (c *refreshClient) RefreshWithMetricsOnly(ctx context.Context, metrics Metrics) error {
-	c.logger.Tracef(context.TODO(), "RefreshWithMetricsOnly(%+v)", metrics)
+	c.logger.Tracef(ctx, "RefreshWithMetricsOnly(%+v)", metrics)
 	m, err := contextMetrics(metrics)
 	if err != nil {
 		return errors.Trace(err)
@@ -183,9 +183,9 @@ func (c *refreshClient) refresh(ctx context.Context, ensure func(responses []tra
 		return nil, errors.Trace(err)
 	}
 	if restResp.StatusCode == http.StatusNotFound {
-		return nil, logAndReturnError(errors.NotFoundf("refresh"))
+		return nil, logAndReturnError(ctx, errors.NotFoundf("refresh"))
 	}
-	if err := handleBasicAPIErrors(resp.ErrorList, c.logger); err != nil {
+	if err := handleBasicAPIErrors(ctx, resp.ErrorList, c.logger); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// Ensure that all the results contain the correct instance keys.
@@ -209,15 +209,15 @@ func (c *refreshClient) refresh(ctx context.Context, ensure func(responses []tra
 	}
 
 	if c.logger.IsLevelEnabled(corelogger.TRACE) {
-		c.logger.Tracef(context.TODO(), "Refresh() unmarshalled: %s", pretty.Sprint(results))
+		c.logger.Tracef(ctx, "Refresh() unmarshalled: %s", pretty.Sprint(results))
 	}
 	return results, nil
 }
 
 // RefreshOne creates a request config for requesting only one charm.
-func RefreshOne(key, id string, revision int, channel string, base RefreshBase) (RefreshConfig, error) {
+func RefreshOne(ctx context.Context, key, id string, revision int, channel string, base RefreshBase) (RefreshConfig, error) {
 	if id == "" {
-		return nil, logAndReturnError(errors.NotValidf("empty id"))
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty id"))
 	}
 	if key == "" {
 		// This is for compatibility reasons.  With older clients, the
@@ -225,12 +225,12 @@ func RefreshOne(key, id string, revision int, channel string, base RefreshBase) 
 		// the client.  Since a key is required, ensure we have one.
 		uuid, err := uuid.NewUUID()
 		if err != nil {
-			return nil, logAndReturnError(err)
+			return nil, logAndReturnError(ctx, err)
 		}
 		key = uuid.String()
 	}
 	if err := validateBase(base); err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	return refreshOne{
 		instanceKey: key,
@@ -254,13 +254,13 @@ func CreateInstanceKey(app names.ApplicationTag, model names.ModelTag) string {
 
 // InstallOneFromRevision creates a request config using the revision and not
 // the channel for requesting only one charm.
-func InstallOneFromRevision(name string, revision int) (RefreshConfig, error) {
+func InstallOneFromRevision(ctx context.Context, name string, revision int) (RefreshConfig, error) {
 	if name == "" {
-		return nil, logAndReturnError(errors.NotValidf("empty name"))
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
 	}
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	return executeOneByRevision{
 		action:      installAction,
@@ -307,16 +307,16 @@ func AddConfigMetrics(config RefreshConfig, metrics map[charmmetrics.MetricValue
 
 // InstallOneFromChannel creates a request config using the channel and not the
 // revision for requesting only one charm.
-func InstallOneFromChannel(name string, channel string, base RefreshBase) (RefreshConfig, error) {
+func InstallOneFromChannel(ctx context.Context, name string, channel string, base RefreshBase) (RefreshConfig, error) {
 	if name == "" {
-		return nil, logAndReturnError(errors.NotValidf("empty name"))
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
 	}
 	if err := validateBase(base); err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	return executeOne{
 		action:      installAction,
@@ -330,13 +330,13 @@ func InstallOneFromChannel(name string, channel string, base RefreshBase) (Refre
 
 // DownloadOneFromRevision creates a request config using the revision and not
 // the channel for requesting only one charm.
-func DownloadOneFromRevision(id string, revision int) (RefreshConfig, error) {
+func DownloadOneFromRevision(ctx context.Context, id string, revision int) (RefreshConfig, error) {
 	if id == "" {
-		return nil, logAndReturnError(errors.NotValidf("empty id"))
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty id"))
 	}
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	return executeOneByRevision{
 		action:      downloadAction,
@@ -349,13 +349,13 @@ func DownloadOneFromRevision(id string, revision int) (RefreshConfig, error) {
 
 // DownloadOneFromRevisionByName creates a request config using the revision and not
 // the channel for requesting only one charm.
-func DownloadOneFromRevisionByName(name string, revision int) (RefreshConfig, error) {
+func DownloadOneFromRevisionByName(ctx context.Context, name string, revision int) (RefreshConfig, error) {
 	if name == "" {
-		return nil, logAndReturnError(errors.NotValidf("empty name"))
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
 	}
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	return executeOneByRevision{
 		action:      downloadAction,
@@ -368,16 +368,16 @@ func DownloadOneFromRevisionByName(name string, revision int) (RefreshConfig, er
 
 // DownloadOneFromChannel creates a request config using the channel and not the
 // revision for requesting only one charm.
-func DownloadOneFromChannel(id string, channel string, base RefreshBase) (RefreshConfig, error) {
+func DownloadOneFromChannel(ctx context.Context, id string, channel string, base RefreshBase) (RefreshConfig, error) {
 	if id == "" {
-		return nil, logAndReturnError(errors.NotValidf("empty id"))
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty id"))
 	}
 	if err := validateBase(base); err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	return executeOne{
 		action:      downloadAction,
@@ -391,16 +391,16 @@ func DownloadOneFromChannel(id string, channel string, base RefreshBase) (Refres
 
 // DownloadOneFromChannelByName creates a request config using the channel and not the
 // revision for requesting only one charm.
-func DownloadOneFromChannelByName(name string, channel string, base RefreshBase) (RefreshConfig, error) {
+func DownloadOneFromChannelByName(ctx context.Context, name string, channel string, base RefreshBase) (RefreshConfig, error) {
 	if name == "" {
-		return nil, logAndReturnError(errors.NotValidf("empty name"))
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
 	}
 	if err := validateBase(base); err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return nil, logAndReturnError(err)
+		return nil, logAndReturnError(ctx, err)
 	}
 	return executeOne{
 		action:      downloadAction,
@@ -414,9 +414,9 @@ func DownloadOneFromChannelByName(name string, channel string, base RefreshBase)
 
 // constructRefreshBase creates a refresh request base that allows for
 // partial base queries.
-func constructRefreshBase(base RefreshBase) (transport.Base, error) {
+func constructRefreshBase(ctx context.Context, base RefreshBase) (transport.Base, error) {
 	if base.Architecture == "" {
-		return transport.Base{}, logAndReturnError(errors.NotValidf("refresh arch"))
+		return transport.Base{}, logAndReturnError(ctx, errors.NotValidf("refresh arch"))
 	}
 
 	name := base.Name
@@ -439,7 +439,7 @@ func constructRefreshBase(base RefreshBase) (transport.Base, error) {
 		var err error
 		channel, err = sanitiseChannel(base.Channel)
 		if err != nil {
-			return transport.Base{}, logAndReturnError(errors.Trace(err))
+			return transport.Base{}, logAndReturnError(ctx, errors.Trace(err))
 		}
 	}
 
@@ -504,9 +504,9 @@ func ExtractConfigInstanceKey(cfg RefreshConfig) string {
 // getting lost across the wire, so leave as is for now.
 var logger = internallogger.GetLogger("juju.charmhub", corelogger.CHARMHUB)
 
-func logAndReturnError(err error) error {
+func logAndReturnError(ctx context.Context, err error) error {
 	err = errors.Trace(err)
-	logger.Errorf(context.TODO(), err.Error())
+	logger.Errorf(ctx, err.Error())
 	return err
 }
 

--- a/internal/charmhub/refresh_test.go
+++ b/internal/charmhub/refresh_test.go
@@ -65,7 +65,7 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 		Fields: expRefreshFields,
 	}
 
-	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne(context.Background(), "instance-key", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -120,7 +120,7 @@ func (s *RefreshSuite) TestRefeshConfigValidate(c *gc.C) {
 }
 
 func (s *RefreshSuite) testRefeshConfigValidate(c *gc.C, rp RefreshBase) error {
-	_, err := DownloadOneFromChannel("meshuggah", "latest/stable", rp)
+	_, err := DownloadOneFromChannel(context.Background(), "meshuggah", "latest/stable", rp)
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 	return err
 }
@@ -171,14 +171,14 @@ func (s *RefreshSuite) TestRefreshMetadata(c *gc.C) {
 	restClient := newHTTPRESTClient(httpClient)
 	client := newRefreshClient(baseURLPath, restClient, s.logger)
 
-	config1, err := RefreshOne("instance-key-foo", "foo", 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne(context.Background(), "instance-key-foo", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	config2, err := RefreshOne("instance-key-bar", "bar", 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne(context.Background(), "instance-key-bar", "bar", 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: "amd64",
@@ -221,14 +221,14 @@ func (s *RefreshSuite) TestRefreshMetadataRandomOrder(c *gc.C) {
 	restClient := newHTTPRESTClient(httpClient)
 	client := newRefreshClient(baseURLPath, restClient, s.logger)
 
-	config1, err := RefreshOne("instance-key-foo", "foo", 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne(context.Background(), "instance-key-foo", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	config2, err := RefreshOne("instance-key-bar", "bar", 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne(context.Background(), "instance-key-bar", "bar", 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: "amd64",
@@ -327,14 +327,14 @@ func (s *RefreshSuite) TestRefreshWithRequestMetrics(c *gc.C) {
 		},
 	}
 
-	config1, err := RefreshOne("instance-key-foo", id, 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne(context.Background(), "instance-key-foo", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	config2, err := RefreshOne("instance-key-bar", id, 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne(context.Background(), "instance-key-bar", id, 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: "amd64",
@@ -382,7 +382,7 @@ func (s *RefreshSuite) TestRefreshFailure(c *gc.C) {
 	baseURLPath := path.MakePath(baseURL)
 	name := "meshuggah"
 
-	config, err := RefreshOne("instance-key", name, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne(context.Background(), "instance-key", name, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -437,14 +437,14 @@ var _ = gc.Suite(&RefreshConfigSuite{})
 
 func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 	id := "foo"
-	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne(context.Background(), "instance-key", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
@@ -469,14 +469,14 @@ func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 
 func (s *RefreshConfigSuite) TestRefreshOneWithBaseChannelRiskBuild(c *gc.C) {
 	id := "foo"
-	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne(context.Background(), "instance-key", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04/stable",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
@@ -502,7 +502,7 @@ func (s *RefreshConfigSuite) TestRefreshOneWithBaseChannelRiskBuild(c *gc.C) {
 
 func (s *RefreshConfigSuite) TestRefreshOneBuildInstanceKeyCompatibility(c *gc.C) {
 	id := "foo"
-	config, err := RefreshOne("", id, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne(context.Background(), "", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -515,7 +515,7 @@ func (s *RefreshConfigSuite) TestRefreshOneBuildInstanceKeyCompatibility(c *gc.C
 
 func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
 	id := "foo"
-	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne(context.Background(), "instance-key", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -528,7 +528,7 @@ func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
@@ -556,7 +556,7 @@ func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestRefreshOneFail(c *gc.C) {
-	_, err := RefreshOne("instance-key", "", 1, "latest/stable", RefreshBase{
+	_, err := RefreshOne(context.Background(), "instance-key", "", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -565,7 +565,7 @@ func (s *RefreshConfigSuite) TestRefreshOneFail(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestRefreshOneEnsure(c *gc.C) {
-	config, err := RefreshOne("instance-key", "foo", 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne(context.Background(), "instance-key", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -582,12 +582,12 @@ func (s *RefreshConfigSuite) TestInstallOneFromRevisionBuild(c *gc.C) {
 	revision := 1
 
 	name := "foo"
-	config, err := InstallOneFromRevision(name, revision)
+	config, err := InstallOneFromRevision(context.Background(), name, revision)
 	c.Assert(err, jc.ErrorIsNil)
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -602,7 +602,7 @@ func (s *RefreshConfigSuite) TestInstallOneFromRevisionBuild(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestInstallOneFromRevisionFail(c *gc.C) {
-	_, err := InstallOneFromRevision("", 1)
+	_, err := InstallOneFromRevision(context.Background(), "", 1)
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
@@ -611,14 +611,14 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevisionResources(c *gc.C) {
 	revision := 1
 
 	name := "foo"
-	config, err := InstallOneFromRevision(name, revision)
+	config, err := InstallOneFromRevision(context.Background(), name, revision)
 	c.Assert(err, jc.ErrorIsNil)
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 	config, ok := AddResource(config, "testme", 3)
 	c.Assert(ok, jc.IsTrue)
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -636,7 +636,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevisionResources(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestAddResourceFail(c *gc.C) {
-	config, err := RefreshOne("instance-key", "testingID", 7, "latest/edge", RefreshBase{
+	config, err := RefreshOne(context.Background(), "instance-key", "testingID", 7, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -650,7 +650,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 	channel := "latest/stable"
 
 	name := "foo"
-	config, err := InstallOneFromChannel(name, channel, RefreshBase{
+	config, err := InstallOneFromChannel(context.Background(), name, channel, RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -659,7 +659,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -679,7 +679,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestInstallOneChannelFail(c *gc.C) {
-	_, err := InstallOneFromChannel("", "stable", RefreshBase{
+	_, err := InstallOneFromChannel(context.Background(), "", "stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -691,14 +691,14 @@ func (s *RefreshConfigSuite) TestInstallOneWithPartialPlatform(c *gc.C) {
 	channel := "latest/stable"
 
 	name := "foo"
-	config, err := InstallOneFromChannel(name, channel, RefreshBase{
+	config, err := InstallOneFromChannel(context.Background(), name, channel, RefreshBase{
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -721,17 +721,17 @@ func (s *RefreshConfigSuite) TestInstallOneWithMissingArch(c *gc.C) {
 	channel := "latest/stable"
 
 	name := "foo"
-	config, err := InstallOneFromChannel(name, channel, RefreshBase{})
+	config, err := InstallOneFromChannel(context.Background(), name, channel, RefreshBase{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	_, err = config.Build()
+	_, err = config.Build(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
 func (s *RefreshConfigSuite) TestInstallOneFromChannelEnsure(c *gc.C) {
-	config, err := InstallOneFromChannel("foo", "latest/stable", RefreshBase{
+	config, err := InstallOneFromChannel(context.Background(), "foo", "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -747,7 +747,7 @@ func (s *RefreshConfigSuite) TestInstallOneFromChannelEnsure(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestInstallOneFromChannelFail(c *gc.C) {
-	_, err := InstallOneFromChannel("foo", "latest/stable", RefreshBase{
+	_, err := InstallOneFromChannel(context.Background(), "foo", "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -758,12 +758,12 @@ func (s *RefreshConfigSuite) TestInstallOneFromChannelFail(c *gc.C) {
 func (s *RefreshConfigSuite) TestDownloadOneFromRevisionBuild(c *gc.C) {
 	rev := 4
 	id := "foo"
-	config, err := DownloadOneFromRevision(id, rev)
+	config, err := DownloadOneFromRevision(context.Background(), id, rev)
 	c.Assert(err, jc.ErrorIsNil)
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -778,19 +778,19 @@ func (s *RefreshConfigSuite) TestDownloadOneFromRevisionBuild(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromRevisionFail(c *gc.C) {
-	_, err := DownloadOneFromRevision("", 7)
+	_, err := DownloadOneFromRevision(context.Background(), "", 7)
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromRevisionByNameBuild(c *gc.C) {
 	rev := 4
 	name := "foo"
-	config, err := DownloadOneFromRevisionByName(name, rev)
+	config, err := DownloadOneFromRevisionByName(context.Background(), name, rev)
 	c.Assert(err, jc.ErrorIsNil)
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -805,14 +805,14 @@ func (s *RefreshConfigSuite) TestDownloadOneFromRevisionByNameBuild(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromRevisionByNameFail(c *gc.C) {
-	_, err := DownloadOneFromRevisionByName("", 7)
+	_, err := DownloadOneFromRevisionByName(context.Background(), "", 7)
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
 	channel := "latest/stable"
 	id := "foo"
-	config, err := DownloadOneFromChannel(id, channel, RefreshBase{
+	config, err := DownloadOneFromChannel(context.Background(), id, channel, RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -821,7 +821,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -841,7 +841,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelFail(c *gc.C) {
-	_, err := DownloadOneFromChannel("", "latest/stable", RefreshBase{
+	_, err := DownloadOneFromChannel(context.Background(), "", "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -852,7 +852,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelFail(c *gc.C) {
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelByNameBuild(c *gc.C) {
 	channel := "latest/stable"
 	name := "foo"
-	config, err := DownloadOneFromChannelByName(name, channel, RefreshBase{
+	config, err := DownloadOneFromChannelByName(context.Background(), name, channel, RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -861,7 +861,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelByNameBuild(c *gc.C) {
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -881,7 +881,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelByNameBuild(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelByNameFail(c *gc.C) {
-	_, err := DownloadOneFromChannel("", "latest/stable", RefreshBase{
+	_, err := DownloadOneFromChannel(context.Background(), "", "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -892,7 +892,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelByNameFail(c *gc.C) {
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuildK8s(c *gc.C) {
 	channel := "latest/stable"
 	id := "foo"
-	config, err := DownloadOneFromChannel(id, channel, RefreshBase{
+	config, err := DownloadOneFromChannel(context.Background(), id, channel, RefreshBase{
 		Name:         "kubernetes",
 		Channel:      "kubernetes",
 		Architecture: arch.DefaultArchitecture,
@@ -901,7 +901,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuildK8s(c *gc.C) {
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{},
@@ -921,7 +921,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuildK8s(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelEnsure(c *gc.C) {
-	config, err := DownloadOneFromChannel("foo", "latest/stable", RefreshBase{
+	config, err := DownloadOneFromChannel(context.Background(), "foo", "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -938,12 +938,12 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelEnsure(c *gc.C) {
 
 func (s *RefreshConfigSuite) TestRefreshManyBuildContextNotNil(c *gc.C) {
 	id1 := "foo"
-	config1, err := DownloadOneFromRevision(id1, 1)
+	config1, err := DownloadOneFromRevision(context.Background(), id1, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	config1 = DefineInstanceKey(c, config1, "foo-bar")
 
 	id2 := "bar"
-	config2, err := DownloadOneFromChannel(id2, "latest/edge", RefreshBase{
+	config2, err := DownloadOneFromChannel(context.Background(), id2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: arch.DefaultArchitecture,
@@ -952,14 +952,14 @@ func (s *RefreshConfigSuite) TestRefreshManyBuildContextNotNil(c *gc.C) {
 	config2 = DefineInstanceKey(c, config2, "foo-baz")
 	config := RefreshMany(config1, config2)
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req.Context, gc.NotNil)
 }
 
 func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 	id1 := "foo"
-	config1, err := RefreshOne("instance-key", id1, 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne(context.Background(), "instance-key", id1, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -967,7 +967,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	id2 := "bar"
-	config2, err := RefreshOne("instance-key2", id2, 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne(context.Background(), "instance-key2", id2, 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: arch.DefaultArchitecture,
@@ -977,7 +977,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 	channel := "1/stable"
 
 	name3 := "baz"
-	config3, err := InstallOneFromChannel(name3, "1/stable", RefreshBase{
+	config3, err := InstallOneFromChannel(context.Background(), name3, "1/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "19.04",
 		Architecture: arch.DefaultArchitecture,
@@ -988,14 +988,14 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 
 	name4 := "forty-two"
 	rev4 := 42
-	config4, err := InstallOneFromRevision(name4, rev4)
+	config4, err := InstallOneFromRevision(context.Background(), name4, rev4)
 	c.Assert(err, jc.ErrorIsNil)
 
 	config4 = DefineInstanceKey(c, config4, "foo-two")
 
 	config := RefreshMany(config1, config2, config3, config4)
 
-	req, err := config.Build()
+	req, err := config.Build(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
@@ -1048,14 +1048,14 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestRefreshManyEnsure(c *gc.C) {
-	config1, err := RefreshOne("instance-key", "foo", 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne(context.Background(), "instance-key", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	config2, err := RefreshOne("instance-key2", "bar", 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne(context.Background(), "instance-key2", "bar", 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: arch.DefaultArchitecture,

--- a/internal/charmhub/refreshconfig.go
+++ b/internal/charmhub/refreshconfig.go
@@ -4,6 +4,7 @@
 package charmhub
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -16,7 +17,7 @@ import (
 // RefreshConfig defines a type for building refresh requests.
 type RefreshConfig interface {
 	// Build a refresh request for sending to the API.
-	Build() (transport.RefreshRequest, error)
+	Build(ctx context.Context) (transport.RefreshRequest, error)
 
 	// Ensure that the request back contains the information we requested.
 	Ensure([]transport.RefreshResponse) error
@@ -49,8 +50,8 @@ func (c refreshOne) String() string {
 }
 
 // Build a refresh request that can be past to the API.
-func (c refreshOne) Build() (transport.RefreshRequest, error) {
-	base, err := constructRefreshBase(c.Base)
+func (c refreshOne) Build(ctx context.Context) (transport.RefreshRequest, error) {
+	base, err := constructRefreshBase(ctx, c.Base)
 	if err != nil {
 		return transport.RefreshRequest{}, errors.Trace(err)
 	}
@@ -105,8 +106,8 @@ func (c executeOne) InstanceKey() string {
 }
 
 // Build a refresh request that can be past to the API.
-func (c executeOne) Build() (transport.RefreshRequest, error) {
-	base, err := constructRefreshBase(c.Base)
+func (c executeOne) Build(ctx context.Context) (transport.RefreshRequest, error) {
+	base, err := constructRefreshBase(ctx, c.Base)
 	if err != nil {
 		return transport.RefreshRequest{}, errors.Trace(err)
 	}
@@ -185,7 +186,7 @@ func (c executeOneByRevision) InstanceKey() string {
 }
 
 // Build a refresh request for sending to the API.
-func (c executeOneByRevision) Build() (transport.RefreshRequest, error) {
+func (c executeOneByRevision) Build(ctx context.Context) (transport.RefreshRequest, error) {
 	var name, id *string
 	if c.Name != "" {
 		name = &c.Name
@@ -251,7 +252,7 @@ func RefreshMany(configs ...RefreshConfig) RefreshConfig {
 }
 
 // Build a refresh request that can be past to the API.
-func (c refreshMany) Build() (transport.RefreshRequest, error) {
+func (c refreshMany) Build(ctx context.Context) (transport.RefreshRequest, error) {
 	if len(c.Configs) == 0 {
 		return transport.RefreshRequest{}, errors.NotFoundf("configs")
 	}
@@ -262,7 +263,7 @@ func (c refreshMany) Build() (transport.RefreshRequest, error) {
 		Context: []transport.RefreshRequestContext{},
 	}
 	for _, config := range c.Configs {
-		req, err := config.Build()
+		req, err := config.Build(ctx)
 		if err != nil {
 			return transport.RefreshRequest{}, errors.Trace(err)
 		}

--- a/internal/charmhub/resources.go
+++ b/internal/charmhub/resources.go
@@ -47,7 +47,7 @@ func (c *resourcesClient) ListResourceRevisions(ctx context.Context, charm, reso
 
 	isTraceEnabled := c.logger.IsLevelEnabled(corelogger.TRACE)
 	if isTraceEnabled {
-		c.logger.Tracef(context.TODO(), "ListResourceRevisions(%s, %s)", charm, resource)
+		c.logger.Tracef(ctx, "ListResourceRevisions(%s, %s)", charm, resource)
 	}
 
 	var resp transport.ResourcesResponse
@@ -64,7 +64,7 @@ func (c *resourcesClient) ListResourceRevisions(ctx context.Context, charm, reso
 	}
 
 	if isTraceEnabled {
-		c.logger.Tracef(context.TODO(), "ListResourceRevisions(%s, %s) unmarshalled: %s", charm, resource, pretty.Sprint(resp.Revisions))
+		c.logger.Tracef(ctx, "ListResourceRevisions(%s, %s) unmarshalled: %s", charm, resource, pretty.Sprint(resp.Revisions))
 	}
 	return resp.Revisions, nil
 }

--- a/internal/cmd/aliasfile.go
+++ b/internal/cmd/aliasfile.go
@@ -5,7 +5,7 @@ package cmd
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -13,15 +13,15 @@ import (
 // the content to a map of names to the command line arguments
 // they relate to.  The function will always return a valid map, even
 // if it is empty.
-func ParseAliasFile(aliasFilename string) map[string][]string {
+func ParseAliasFile(ctx context.Context, aliasFilename string) map[string][]string {
 	result := map[string][]string{}
 	if aliasFilename == "" {
 		return result
 	}
 
-	content, err := ioutil.ReadFile(aliasFilename)
+	content, err := os.ReadFile(aliasFilename)
 	if err != nil {
-		logger.Tracef(context.TODO(), "unable to read alias file %q: %s", aliasFilename, err)
+		logger.Tracef(ctx, "unable to read alias file %q: %s", aliasFilename, err)
 		return result
 	}
 
@@ -34,20 +34,20 @@ func ParseAliasFile(aliasFilename string) map[string][]string {
 		}
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
-			logger.Warningf(context.TODO(), "line %d bad in alias file: %s", i+1, line)
+			logger.Warningf(ctx, "line %d bad in alias file: %s", i+1, line)
 			continue
 		}
 		name, value := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 		if name == "" {
-			logger.Warningf(context.TODO(), "line %d missing alias name in alias file: %s", i+1, line)
+			logger.Warningf(ctx, "line %d missing alias name in alias file: %s", i+1, line)
 			continue
 		}
 		if value == "" {
-			logger.Warningf(context.TODO(), "line %d missing alias value in alias file: %s", i+1, line)
+			logger.Warningf(ctx, "line %d missing alias value in alias file: %s", i+1, line)
 			continue
 		}
 
-		logger.Tracef(context.TODO(), "setting alias %q=%q", name, value)
+		logger.Tracef(ctx, "setting alias %q=%q", name, value)
 		result[name] = strings.Fields(value)
 	}
 	return result

--- a/internal/cmd/aliasfile_test.go
+++ b/internal/cmd/aliasfile_test.go
@@ -4,8 +4,9 @@
 package cmd_test
 
 import (
+	"context"
 	_ "fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/testing"
@@ -23,7 +24,7 @@ var _ = gc.Suite(&ParseAliasFileSuite{})
 func (*ParseAliasFileSuite) TestMissing(c *gc.C) {
 	dir := c.MkDir()
 	filename := filepath.Join(dir, "missing")
-	aliases := cmd.ParseAliasFile(filename)
+	aliases := cmd.ParseAliasFile(context.Background(), filename)
 	c.Assert(aliases, gc.NotNil)
 	c.Assert(aliases, gc.HasLen, 0)
 }
@@ -47,9 +48,9 @@ no equals sign
 key = 
 = value
 `
-	err := ioutil.WriteFile(filename, []byte(content), 0644)
+	err := os.WriteFile(filename, []byte(content), 0644)
 	c.Assert(err, gc.IsNil)
-	aliases := cmd.ParseAliasFile(filename)
+	aliases := cmd.ParseAliasFile(context.Background(), filename)
 	c.Assert(aliases, gc.DeepEquals, map[string][]string{
 		"foo":    {"trailing-space"},
 		"repeat": {"second"},

--- a/internal/cmd/args_test.go
+++ b/internal/cmd/args_test.go
@@ -5,7 +5,7 @@ package cmd_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/juju/gnuflag"
 	"github.com/juju/testing"
@@ -44,7 +44,7 @@ func (*ArgsSuite) TestFlagsUsage(c *gc.C) {
 	}} {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
 		f := gnuflag.NewFlagSet("test", gnuflag.ContinueOnError)
-		f.SetOutput(ioutil.Discard)
+		f.SetOutput(io.Discard)
 		var value []string
 		f.Var(cmd.NewStringsValue(test.defaultValue, &value), "value", "help")
 		err := f.Parse(false, test.args)
@@ -164,7 +164,7 @@ func (*ArgsSuite) TestAppendStringsUsage(c *gc.C) {
 	}} {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
 		f := gnuflag.NewFlagSet("test", gnuflag.ContinueOnError)
-		f.SetOutput(ioutil.Discard)
+		f.SetOutput(io.Discard)
 		var value []string
 		f.Var(cmd.NewAppendStringsValue(&value), "value", "help")
 		err := f.Parse(false, test.args)

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -137,7 +137,7 @@ func (ctx *Context) Infof(format string, params ...interface{}) {
 		//level (since `Infof` calls `Logf` internally). This is done so
 		//that this function can produce more accurate source location
 		//debug information.
-		logger.Logf(context.TODO(), corelogger.INFO, corelogger.Labels{}, format, params...)
+		logger.Logf(ctx, corelogger.INFO, corelogger.Labels{}, format, params...)
 	} else {
 		ctx.write(format, params...)
 	}
@@ -152,7 +152,7 @@ func (ctx *Context) Warningf(format string, params ...interface{}) {
 	// `logger.Warningf` to avoid introducing an additional call stack level
 	// (since `Warningf` calls Logf internally). This is done so that this
 	// function can produce more accurate source location debug information.
-	logger.Logf(context.TODO(), corelogger.WARNING, corelogger.Labels{}, format, params...)
+	logger.Logf(ctx, corelogger.WARNING, corelogger.Labels{}, format, params...)
 }
 
 // Verbosef will write the formatted string to Stderr if the verbose is true,
@@ -166,7 +166,7 @@ func (ctx *Context) Verbosef(format string, params ...interface{}) {
 		// level (since `Infof` calls `Logf` internally). This is done so
 		// that this function can produce more accurate source location
 		// debug information.
-		logger.Logf(context.TODO(), corelogger.INFO, corelogger.Labels{}, format, params...)
+		logger.Logf(ctx, corelogger.INFO, corelogger.Labels{}, format, params...)
 	}
 }
 
@@ -181,7 +181,7 @@ func (ctx *Context) Errorf(format string, params ...interface{}) {
 	// level (since `Errorf` calls `Logf` internally). This is done so
 	// that this function can produce more accurate source location
 	// debug information.
-	logger.Logf(context.TODO(), corelogger.ERROR, corelogger.Labels{}, format, params...)
+	logger.Logf(ctx, corelogger.ERROR, corelogger.Labels{}, format, params...)
 }
 
 // WriteError will output the formatted text to the writer with

--- a/internal/cmd/cmdtesting/prompt.go
+++ b/internal/cmd/cmdtesting/prompt.go
@@ -119,7 +119,7 @@ func (p *SeqPrompter) prompt(text string) (string, error) {
 		return "", errors.Errorf("unexpected prompt %q; expected %q", text, p.ios[0].prompt)
 	}
 	reply := p.ios[0].reply
-	logger.Infof(context.TODO(), "prompt %q -> %q", text, reply)
+	logger.Infof(context.Background(), "prompt %q -> %q", text, reply)
 	p.ios = p.ios[1:]
 	return reply, nil
 }

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -181,11 +181,11 @@ func (c *helpCommand) Init(args []string) error {
 	return nil
 }
 
-func (c *helpCommand) getCommandHelp(super *SuperCommand, command Command, alias string) []byte {
+func (c *helpCommand) getCommandHelp(ctx context.Context, super *SuperCommand, command Command, alias string) []byte {
 	info := command.Info()
 
 	if command != super {
-		logger.Tracef(context.TODO(), "command not super")
+		logger.Tracef(ctx, "command not super")
 		// If the alias is to a subcommand of another super command
 		// the alias string holds the "super sub" name.
 		if alias == "" {
@@ -195,7 +195,7 @@ func (c *helpCommand) getCommandHelp(super *SuperCommand, command Command, alias
 		}
 	}
 	if super.usagePrefix != "" {
-		logger.Tracef(context.TODO(), "adding super prefix")
+		logger.Tracef(ctx, "adding super prefix")
 		info.Name = fmt.Sprintf("%s %s", super.usagePrefix, info.Name)
 	}
 
@@ -240,7 +240,7 @@ func (c *helpCommand) Run(ctx *Context) error {
 
 	// If the topic is a registered subcommand, then run the help command with it
 	if c.target != nil {
-		_, err := ctx.Stdout.Write(c.getCommandHelp(c.targetSuper, c.target.command, c.target.alias))
+		_, err := ctx.Stdout.Write(c.getCommandHelp(ctx, c.targetSuper, c.target.command, c.target.alias))
 		if err != nil {
 			return err
 		}
@@ -253,7 +253,7 @@ func (c *helpCommand) Run(ctx *Context) error {
 		// current action, but we want the info to be printed
 		// as if there was nothing selected.
 		c.super.action.command = nil
-		_, err := ctx.Stdout.Write(c.getCommandHelp(c.super, c.super, ""))
+		_, err := ctx.Stdout.Write(c.getCommandHelp(ctx, c.super, c.super, ""))
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/logging_test.go
+++ b/internal/cmd/logging_test.go
@@ -4,7 +4,6 @@
 package cmd_test
 
 import (
-	"context"
 	"io/ioutil"
 	"path/filepath"
 
@@ -92,7 +91,7 @@ func (s *LogSuite) TestStderr(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	err := l.Start(ctx)
 	c.Assert(err, gc.IsNil)
-	logger.Infof(context.TODO(), "hello")
+	logger.Infof(ctx, "hello")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `^.* INFO .* hello\n`)
 }
 
@@ -101,7 +100,7 @@ func (s *LogSuite) TestRelPathLog(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	err := l.Start(ctx)
 	c.Assert(err, gc.IsNil)
-	logger.Infof(context.TODO(), "hello")
+	logger.Infof(ctx, "hello")
 	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "foo.log"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(content), gc.Matches, `^.* INFO .* hello\n`)
@@ -115,7 +114,7 @@ func (s *LogSuite) TestAbsPathLog(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	err := l.Start(ctx)
 	c.Assert(err, gc.IsNil)
-	logger.Infof(context.TODO(), "hello")
+	logger.Infof(ctx, "hello")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	content, err := ioutil.ReadFile(path)
 	c.Assert(err, gc.IsNil)
@@ -127,7 +126,7 @@ func (s *LogSuite) TestLoggingToFileAndStderr(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	err := l.Start(ctx)
 	c.Assert(err, gc.IsNil)
-	logger.Infof(context.TODO(), "hello")
+	logger.Infof(ctx, "hello")
 	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "foo.log"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(content), gc.Matches, `^.* INFO .* hello\n`)
@@ -141,9 +140,9 @@ func (s *LogSuite) TestErrorAndWarningLoggingToStderr(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	err := l.Start(ctx)
 	c.Assert(err, gc.IsNil)
-	logger.Warningf(context.TODO(), "a warning")
-	logger.Errorf(context.TODO(), "an error")
-	logger.Infof(context.TODO(), "an info")
+	logger.Warningf(ctx, "a warning")
+	logger.Errorf(ctx, "an error")
+	logger.Infof(ctx, "an info")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `^.*WARNING a warning\n.*ERROR an error\n.*`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }

--- a/internal/cmd/supercommand.go
+++ b/internal/cmd/supercommand.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	stderr "errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"sort"
 	"strings"
@@ -259,7 +260,7 @@ func (c *SuperCommand) init() {
 		}
 	}
 
-	c.userAliases = ParseAliasFile(c.userAliasesFilename)
+	c.userAliases = ParseAliasFile(context.TODO(), c.userAliasesFilename)
 }
 
 // AddHelpTopic adds a new help topic with the description being the short
@@ -421,7 +422,7 @@ func (c *SuperCommand) SetCommonFlags(f *gnuflag.FlagSet) {
 	// plugins to provide a sensible line of text for 'juju help plugins'.
 	f.BoolVar(&c.showDescription, "description", false, "Show short description of plugin, if any")
 	c.commonflags = gnuflag.NewFlagSetWithFlagKnownAs(c.Info().Name, gnuflag.ContinueOnError, FlagAlias(c, "flag"))
-	c.commonflags.SetOutput(ioutil.Discard)
+	c.commonflags.SetOutput(io.Discard)
 	f.VisitAll(func(flag *gnuflag.Flag) {
 		c.commonflags.Var(flag.Value, flag.Name, flag.Usage)
 	})
@@ -567,19 +568,19 @@ func (c *SuperCommand) Run(ctx *Context) error {
 			// format, we should let the user know. In doing so, we dump the
 			// original error and return the handle error so that effective
 			// debugging is possible.
-			logger.Debugf(context.TODO(), "error stack: \n%v", errors.ErrorStack(err))
+			logger.Debugf(ctx, "error stack: \n%v", errors.ErrorStack(err))
 			return handleErr
 		}
 
 		WriteError(ctx.Stderr, err)
-		logger.Debugf(context.TODO(), "error stack: \n%v", errors.ErrorStack(err))
+		logger.Debugf(ctx, "error stack: \n%v", errors.ErrorStack(err))
 
 		// Err has been logged above, we can make the err silent so it does not log again in cmd/main
 		if !utils.IsRcPassthroughError(err) {
 			err = ErrSilent
 		}
 	} else {
-		logger.Infof(context.TODO(), "command finished")
+		logger.Infof(ctx, "command finished")
 	}
 	return err
 }

--- a/internal/container/broker/lxd-broker.go
+++ b/internal/container/broker/lxd-broker.go
@@ -61,7 +61,7 @@ func (broker *lxdBroker) StartInstance(ctx context.Context, args environs.StartI
 
 	config, err := broker.api.ContainerConfig(ctx)
 	if err != nil {
-		lxdLogger.Errorf(context.TODO(), "failed to get container config: %v", err)
+		lxdLogger.Errorf(ctx, "failed to get container config: %v", err)
 		return nil, err
 	}
 
@@ -74,7 +74,7 @@ func (broker *lxdBroker) StartInstance(ctx context.Context, args environs.StartI
 		return nil, errors.Trace(err)
 	}
 
-	interfaces, err := finishNetworkConfig(preparedInfo)
+	interfaces, err := finishNetworkConfig(ctx, preparedInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -118,7 +118,7 @@ func (broker *lxdBroker) StartInstance(ctx context.Context, args environs.StartI
 		cloudInitUserData,
 		append([]string{"default"}, pNames...),
 	); err != nil {
-		lxdLogger.Errorf(context.TODO(), "failed to populate machine config: %v", err)
+		lxdLogger.Errorf(ctx, "failed to populate machine config: %v", err)
 		return nil, err
 	}
 
@@ -139,9 +139,9 @@ func (broker *lxdBroker) StartInstance(ctx context.Context, args environs.StartI
 func (broker *lxdBroker) StopInstances(ctx context.Context, ids ...instance.Id) error {
 	// TODO: potentially parallelise.
 	for _, id := range ids {
-		lxdLogger.Infof(context.TODO(), "stopping lxd container for instance: %s", id)
+		lxdLogger.Infof(ctx, "stopping lxd container for instance: %s", id)
 		if err := broker.manager.DestroyContainer(id); err != nil {
-			lxdLogger.Errorf(context.TODO(), "container did not stop: %v", err)
+			lxdLogger.Errorf(ctx, "container did not stop: %v", err)
 			return err
 		}
 		releaseContainerAddresses(ctx, broker.api, id, broker.manager.Namespace(), lxdLogger)

--- a/internal/container/lxd/cluster.go
+++ b/internal/container/lxd/cluster.go
@@ -12,7 +12,7 @@ func (s *Server) ClusterSupported() bool {
 // UseTargetServer returns a new Server based on the input target node name.
 // It is intended for use when operations must target specific nodes in a
 // cluster.
-func (s *Server) UseTargetServer(name string) (*Server, error) {
-	logger.Debugf(context.TODO(), "creating LXD server for cluster node %q", name)
+func (s *Server) UseTargetServer(ctx context.Context, name string) (*Server, error) {
+	logger.Debugf(ctx, "creating LXD server for cluster node %q", name)
 	return NewServer(s.UseTarget(name))
 }

--- a/internal/container/lxd/cluster_test.go
+++ b/internal/container/lxd/cluster_test.go
@@ -4,6 +4,7 @@
 package lxd_test
 
 import (
+	"context"
 	"errors"
 
 	jc "github.com/juju/testing/checkers"
@@ -32,7 +33,7 @@ func (s *imageSuite) TestUseTargetGoodNode(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(c1Svr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = jujuSvr.UseTargetServer("cluster-2")
+	_, err = jujuSvr.UseTargetServer(context.Background(), "cluster-2")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -49,6 +50,6 @@ func (s *imageSuite) TestUseTargetBadNode(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(c1Svr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = jujuSvr.UseTargetServer("cluster-2")
+	_, err = jujuSvr.UseTargetServer(context.Background(), "cluster-2")
 	c.Assert(err, gc.ErrorMatches, "not a cluster member")
 }

--- a/internal/container/lxd/container.go
+++ b/internal/container/lxd/container.go
@@ -87,7 +87,6 @@ func (c *ContainerSpec) ApplyConstraints(serverVersion string, cons constraints.
 	}
 
 	if cons.HasVirtType() {
-
 		virtType, err := instance.ParseVirtType(*cons.VirtType)
 		if err != nil {
 			logger.Errorf(context.TODO(), "failed to parse virt-type constraint %q, ignoring err: %v", *cons.VirtType, err)

--- a/internal/container/lxd/image.go
+++ b/internal/container/lxd/image.go
@@ -186,7 +186,7 @@ func (s *Server) CopyRemoteImage(
 	ctx context.Context, sourced SourcedImage, aliases []string,
 	callback environs.StatusCallbackFunc,
 ) error {
-	logger.Debugf(context.TODO(), "Copying image from remote server")
+	logger.Debugf(ctx, "Copying image from remote server")
 
 	newAliases := make([]api.ImageAlias, len(aliases))
 	for i, a := range aliases {

--- a/internal/container/lxd/manager.go
+++ b/internal/container/lxd/manager.go
@@ -244,7 +244,7 @@ func (m *containerManager) getContainerSpec(
 		return ContainerSpec{}, errors.Trace(err)
 	}
 
-	logger.Debugf(context.TODO(), "configuring container %q with network devices: %v", name, nics)
+	logger.Debugf(ctx, "configuring container %q with network devices: %v", name, nics)
 
 	// If the default LXD bridge was supplied in network config,
 	// but without a CIDR, attempt to ensure it is configured for IPv4.
@@ -256,10 +256,10 @@ func (m *containerManager) getContainerSpec(
 				return ContainerSpec{}, errors.Annotate(err, "ensuring default bridge IPv4 config")
 			}
 			if mod {
-				logger.Infof(context.TODO(), `added "auto" IPv4 configuration to default LXD bridge`)
+				logger.Infof(ctx, `added "auto" IPv4 configuration to default LXD bridge`)
 			}
 		} else {
-			logger.Warningf(context.TODO(), "no CIDR was detected for the following networks: %v", unknown)
+			logger.Warningf(ctx, "no CIDR was detected for the following networks: %v", unknown)
 		}
 	}
 

--- a/internal/database/bootstrap.go
+++ b/internal/database/bootstrap.go
@@ -100,7 +100,7 @@ func BootstrapDqlite(
 	}
 	defer func() {
 		if err := dqlite.Close(); err != nil {
-			logger.Errorf(context.TODO(), "closing Dqlite: %v", err)
+			logger.Errorf(ctx, "closing Dqlite: %v", err)
 		}
 	}()
 

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -44,6 +44,6 @@ func (m *DBMigration) Apply(ctx context.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	m.logger.Debugf(context.TODO(), "Applied %d schema changes", changeSet.Post)
+	m.logger.Debugf(ctx, "Applied %d schema changes", changeSet.Post)
 	return nil
 }

--- a/internal/downloader/download_test.go
+++ b/internal/downloader/download_test.go
@@ -4,6 +4,7 @@
 package downloader_test
 
 import (
+	"context"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -55,6 +56,7 @@ func (s *DownloadSuite) testDownload(c *gc.C, hostnameVerification bool) {
 	tmp := c.MkDir()
 	jujutesting.Server.Response(200, nil, []byte("archive"))
 	d := downloader.StartDownload(
+		context.Background(),
 		downloader.Request{
 			URL:       s.URL(c, "/archive.tgz"),
 			TargetDir: tmp,
@@ -81,6 +83,7 @@ func (s *DownloadSuite) TestDownloadError(c *gc.C) {
 	jujutesting.Server.Response(404, nil, nil)
 	tmp := c.MkDir()
 	d := downloader.StartDownload(
+		context.Background(),
 		downloader.Request{
 			URL:       s.URL(c, "/archive.tgz"),
 			TargetDir: tmp,
@@ -98,6 +101,7 @@ func (s *DownloadSuite) TestVerifyValid(c *gc.C) {
 	tmp := c.MkDir()
 	jujutesting.Server.Response(200, nil, []byte("archive"))
 	dl := downloader.StartDownload(
+		context.Background(),
 		downloader.Request{
 			URL:       s.URL(c, "/archive.tgz"),
 			TargetDir: tmp,
@@ -120,6 +124,7 @@ func (s *DownloadSuite) TestVerifyInvalid(c *gc.C) {
 	jujutesting.Server.Response(200, nil, []byte("archive"))
 	invalid := errors.NotValidf("oops")
 	dl := downloader.StartDownload(
+		context.Background(),
 		downloader.Request{
 			URL:       s.URL(c, "/archive.tgz"),
 			TargetDir: tmp,
@@ -140,13 +145,15 @@ func (s *DownloadSuite) TestVerifyInvalid(c *gc.C) {
 func (s *DownloadSuite) TestAbort(c *gc.C) {
 	tmp := c.MkDir()
 	jujutesting.Server.Response(200, nil, []byte("archive"))
-	abort := make(chan struct{})
-	close(abort)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
 	dl := downloader.StartDownload(
+		ctx,
 		downloader.Request{
 			URL:       s.URL(c, "/archive.tgz"),
 			TargetDir: tmp,
-			Abort:     abort,
 		},
 		downloader.NewHTTPBlobOpener(true),
 	)

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -4,6 +4,7 @@
 package downloader
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -37,18 +38,18 @@ func New(args NewArgs) *Downloader {
 }
 
 // Start starts a new download and returns it.
-func (dlr Downloader) Start(req Request) *Download {
-	return StartDownload(req, dlr.OpenBlob)
+func (dlr Downloader) Start(ctx context.Context, req Request) *Download {
+	return StartDownload(ctx, req, dlr.OpenBlob)
 }
 
 // Download starts a new download, waits for it to complete, and
 // returns the local name of the file. The download can be aborted by
 // closing the Abort channel in the Request provided.
-func (dlr Downloader) Download(req Request) (string, error) {
+func (dlr Downloader) Download(ctx context.Context, req Request) (string, error) {
 	if err := os.MkdirAll(req.TargetDir, 0755); err != nil {
 		return "", errors.Trace(err)
 	}
-	dl := dlr.Start(req)
+	dl := dlr.Start(ctx, req)
 	filename, err := dl.Wait()
 	return filename, errors.Trace(err)
 }

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -4,6 +4,7 @@
 package downloader_test
 
 import (
+	"context"
 	"net/url"
 	"path/filepath"
 
@@ -56,7 +57,7 @@ func (s *DownloaderSuite) testStart(c *gc.C, hostnameVerification bool) {
 	dlr := downloader.New(downloader.NewArgs{
 		HostnameVerification: hostnameVerification,
 	})
-	dl := dlr.Start(downloader.Request{
+	dl := dlr.Start(context.Background(), downloader.Request{
 		URL:       s.URL(c, "/archive.tgz"),
 		TargetDir: tmp,
 	})
@@ -79,7 +80,7 @@ func (s *DownloaderSuite) TestDownload(c *gc.C) {
 	tmp := c.MkDir()
 	jujutesting.Server.Response(200, nil, []byte("archive"))
 	dlr := downloader.New(downloader.NewArgs{})
-	filename, err := dlr.Download(downloader.Request{
+	filename, err := dlr.Download(context.Background(), downloader.Request{
 		URL:       s.URL(c, "/archive.tgz"),
 		TargetDir: tmp,
 	})
@@ -93,7 +94,7 @@ func (s *DownloaderSuite) TestDownloadHandles409Responses(c *gc.C) {
 	tmp := c.MkDir()
 	jujutesting.Server.Response(409, nil, []byte("archive"))
 	dlr := downloader.New(downloader.NewArgs{})
-	_, err := dlr.Download(downloader.Request{
+	_, err := dlr.Download(context.Background(), downloader.Request{
 		URL:       s.URL(c, "/archive.tgz"),
 		TargetDir: tmp,
 	})

--- a/internal/downloader/utils.go
+++ b/internal/downloader/utils.go
@@ -27,7 +27,7 @@ func NewHTTPBlobOpener(hostnameVerification bool) func(Request) (io.ReadCloser, 
 			jujuhttp.WithLogger(logger.Child("http", corelogger.HTTP)),
 		)
 
-		resp, err := client.Get(context.TODO(), req.URL.String())
+		resp, err := client.Get(context.Background(), req.URL.String())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -280,7 +280,7 @@ func (c *Client) Get(ctx context.Context, path string) (resp *http.Response, err
 		// No need to fail, but let user know we're
 		// not tracing the client GET.
 		err = errors.Annotatef(err, "setup of http client tracing failed")
-		c.logger.Tracef(context.TODO(), "%s", err)
+		c.logger.Tracef(ctx, "%s", err)
 	}
 	return c.Do(req)
 }
@@ -297,28 +297,28 @@ func (c *Client) traceRequest(req *http.Request, url string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	c.logger.Tracef(context.TODO(), "request for %q: %q", url, dump)
+	c.logger.Tracef(req.Context(), "request for %q: %q", url, dump)
 	trace := &httptrace.ClientTrace{
 		DNSStart: func(info httptrace.DNSStartInfo) {
-			c.logger.Tracef(context.TODO(), "%s DNS Start: %q", url, info.Host)
+			c.logger.Tracef(req.Context(), "%s DNS Start: %q", url, info.Host)
 		},
 		DNSDone: func(dnsInfo httptrace.DNSDoneInfo) {
-			c.logger.Tracef(context.TODO(), "%s DNS Info: %+v\n", url, dnsInfo)
+			c.logger.Tracef(req.Context(), "%s DNS Info: %+v\n", url, dnsInfo)
 		},
 		ConnectDone: func(network, addr string, err error) {
-			c.logger.Tracef(context.TODO(), "%s Connection Done: network %q, addr %q, err %q", url, network, addr, err)
+			c.logger.Tracef(req.Context(), "%s Connection Done: network %q, addr %q, err %q", url, network, addr, err)
 		},
 		GetConn: func(hostPort string) {
-			c.logger.Tracef(context.TODO(), "%s Get Conn: %q", url, hostPort)
+			c.logger.Tracef(req.Context(), "%s Get Conn: %q", url, hostPort)
 		},
 		GotConn: func(connInfo httptrace.GotConnInfo) {
-			c.logger.Tracef(context.TODO(), "%s Got Conn: %+v", url, connInfo)
+			c.logger.Tracef(req.Context(), "%s Got Conn: %+v", url, connInfo)
 		},
 		TLSHandshakeStart: func() {
-			c.logger.Tracef(context.TODO(), "%s TLS Handshake Start", url)
+			c.logger.Tracef(req.Context(), "%s TLS Handshake Start", url)
 		},
 		TLSHandshakeDone: func(st tls.ConnectionState, err error) {
-			c.logger.Tracef(context.TODO(), "%s TLS Handshake Done: complete %t, verified chains %d, server name %q",
+			c.logger.Tracef(req.Context(), "%s TLS Handshake Done: complete %t, verified chains %d, server name %q",
 				url,
 				st.HandshakeComplete,
 				len(st.VerifiedChains),

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -43,13 +43,13 @@ func (s *httpSuite) SetUpTest(c *gc.C) {
 
 func (s *httpSuite) TestInsecureClientAllowAccess(c *gc.C) {
 	client := NewClient(WithSkipHostnameVerification(true))
-	_, err := client.Get(context.TODO(), s.server.URL)
+	_, err := client.Get(context.Background(), s.server.URL)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *httpSuite) TestSecureClientAllowAccess(c *gc.C) {
 	client := NewClient()
-	_, err := client.Get(context.TODO(), s.server.URL)
+	_, err := client.Get(context.Background(), s.server.URL)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -93,11 +93,11 @@ func (s *httpSuite) TestRequestRecorder(c *gc.C) {
 	recorder.EXPECT().RecordError("PUT", invalidTargetURL, gomock.Any())
 
 	client := NewClient(WithRequestRecorder(recorder))
-	res, err := client.Get(context.TODO(), validTarget)
+	res, err := client.Get(context.Background(), validTarget)
 	c.Assert(err, jc.ErrorIsNil)
 	defer res.Body.Close()
 
-	req, err := http.NewRequestWithContext(context.TODO(), "PUT", invalidTarget, nil)
+	req, err := http.NewRequestWithContext(context.Background(), "PUT", invalidTarget, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = client.Do(req)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
@@ -137,7 +137,7 @@ func (s *httpSuite) TestRetry(c *gc.C) {
 			MaxDelay: time.Minute,
 		}),
 	)
-	res, err := client.Get(context.TODO(), validTarget)
+	res, err := client.Get(context.Background(), validTarget)
 	c.Assert(err, jc.ErrorIsNil)
 	defer res.Body.Close()
 }
@@ -170,7 +170,7 @@ func (s *httpSuite) TestRetryExceeded(c *gc.C) {
 			MaxDelay: time.Minute,
 		}),
 	)
-	_, err = client.Get(context.TODO(), validTarget)
+	_, err = client.Get(context.Background(), validTarget)
 	c.Assert(err, gc.ErrorMatches, `.*attempt count exceeded: retryable error`)
 }
 
@@ -199,13 +199,13 @@ func (s *httpTLSServerSuite) TearDownTest(c *gc.C) {
 
 func (s *httpTLSServerSuite) TestValidatingClientGetter(c *gc.C) {
 	client := NewClient()
-	_, err := client.Get(context.TODO(), s.server.URL)
+	_, err := client.Get(context.Background(), s.server.URL)
 	c.Assert(err, gc.ErrorMatches, "(.|\n)*x509: certificate signed by unknown authority")
 }
 
 func (s *httpTLSServerSuite) TestNonValidatingClientGetter(c *gc.C) {
 	client := NewClient(WithSkipHostnameVerification(true))
-	resp, err := client.Get(context.TODO(), s.server.URL)
+	resp, err := client.Get(context.Background(), s.server.URL)
 	c.Assert(err, gc.IsNil)
 	_ = resp.Body.Close()
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
@@ -231,7 +231,7 @@ func (s *httpTLSServerSuite) testGetHTTPClientWithCerts(c *gc.C, skip bool) {
 		WithCACertificates(caPEM.String()),
 		WithSkipHostnameVerification(skip),
 	)
-	resp, err := client.Get(context.TODO(), s.server.URL)
+	resp, err := client.Get(context.Background(), s.server.URL)
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp.Body.Close(), gc.IsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -107,7 +107,7 @@ func getProxy(req *http.Request) (*url.URL, error) {
 	// And caused changes in proxy settings via model-config not to
 	// be used.
 	cfg := httpproxy.FromEnvironment()
-	midLogger.Tracef(context.TODO(), "proxy config http(%s), https(%s), no-proxy(%s)",
+	midLogger.Tracef(req.Context(), "proxy config http(%s), https(%s), no-proxy(%s)",
 		cfg.HTTPProxy, cfg.HTTPSProxy, cfg.NoProxy)
 	return cfg.ProxyFunc()(req.URL)
 }

--- a/internal/http/middleware_test.go
+++ b/internal/http/middleware_test.go
@@ -50,7 +50,7 @@ func (s *DialContextMiddlewareSuite) TestInsecureClientNoAccess(c *gc.C) {
 		),
 		WithSkipHostnameVerification(true),
 	)
-	_, err := client.Get(context.TODO(), "http://0.1.2.3:1234")
+	_, err := client.Get(context.Background(), "http://0.1.2.3:1234")
 	c.Assert(err, gc.ErrorMatches, `.*access to address "0.1.2.3:1234" not allowed`)
 }
 
@@ -60,7 +60,7 @@ func (s *DialContextMiddlewareSuite) TestSecureClientNoAccess(c *gc.C) {
 			DialContextMiddleware(NewLocalDialBreaker(false)),
 		),
 	)
-	_, err := client.Get(context.TODO(), "http://0.1.2.3:1234")
+	_, err := client.Get(context.Background(), "http://0.1.2.3:1234")
 	c.Assert(err, gc.ErrorMatches, `.*access to address "0.1.2.3:1234" not allowed`)
 }
 

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -384,7 +384,7 @@ func uploadCharms(ctx context.Context, config UploadBinariesConfig, logger corel
 	naturalsort.Sort(config.Charms)
 
 	for _, charmURL := range config.Charms {
-		logger.Debugf(context.TODO(), "sending charm %s to target", charmURL)
+		logger.Debugf(ctx, "sending charm %s to target", charmURL)
 		curl, err := charm.ParseURL(charmURL)
 		if err != nil {
 			return errors.Annotate(err, "bad charm URL")
@@ -461,7 +461,7 @@ func uploadResources(ctx context.Context, config UploadBinariesConfig, logger co
 }
 
 func uploadAppResource(ctx context.Context, config UploadBinariesConfig, rev resource.Resource, logger corelogger.Logger) error {
-	logger.Debugf(context.TODO(), "opening application resource for %s: %s", rev.ApplicationName, rev.Name)
+	logger.Debugf(ctx, "opening application resource for %s: %s", rev.ApplicationName, rev.Name)
 	reader, err := config.ResourceDownloader.OpenResource(ctx, rev.ApplicationName, rev.Name)
 	if err != nil {
 		return errors.Annotate(err, "cannot open resource")

--- a/internal/network/bridge.go
+++ b/internal/network/bridge.go
@@ -43,17 +43,19 @@ func (b *netplanBridger) Bridge(devices []DeviceToBridge) error {
 	if err != nil {
 		return errors.Errorf("bridge activation error: %s", err)
 	}
+
+	ctx := context.TODO()
 	if result != nil {
-		logger.Infof(context.TODO(), "bridger result=%v", result.Code)
+		logger.Infof(ctx, "bridger result=%v", result.Code)
 		if result.Code != 0 {
-			logger.Errorf(context.TODO(), "bridger stdout\n%s\n", result.Stdout)
-			logger.Errorf(context.TODO(), "bridger stderr\n%s\n", result.Stderr)
+			logger.Errorf(ctx, "bridger stdout\n%s\n", result.Stdout)
+			logger.Errorf(ctx, "bridger stderr\n%s\n", result.Stderr)
 			return errors.Errorf("bridger failed: %s", result.Stderr)
 		}
-		logger.Tracef(context.TODO(), "bridger stdout\n%s\n", result.Stdout)
-		logger.Tracef(context.TODO(), "bridger stderr\n%s\n", result.Stderr)
+		logger.Tracef(ctx, "bridger stdout\n%s\n", result.Stdout)
+		logger.Tracef(ctx, "bridger stderr\n%s\n", result.Stderr)
 	} else {
-		logger.Infof(context.TODO(), "bridger returned nothing")
+		logger.Infof(ctx, "bridger returned nothing")
 	}
 
 	return nil

--- a/internal/network/containerizer/bridgepolicy_test.go
+++ b/internal/network/containerizer/bridgepolicy_test.go
@@ -4,6 +4,7 @@
 package containerizer
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/juju/collections/set"
@@ -21,7 +22,6 @@ import (
 type bridgePolicySuite struct {
 	baseSuite
 
-	netBondReconfigureDelay   int
 	containerNetworkingMethod containermanager.NetworkingMethod
 
 	spaces corenetwork.SpaceInfos
@@ -33,7 +33,6 @@ var _ = gc.Suite(&bridgePolicySuite{})
 func (s *bridgePolicySuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
 
-	s.netBondReconfigureDelay = 13
 	s.containerNetworkingMethod = "local"
 	s.spaces = nil
 }
@@ -94,7 +93,6 @@ func (s *bridgePolicySuite) policy() *BridgePolicy {
 	return &BridgePolicy{
 		allSpaces:                 s.spaces,
 		allSubnets:                s.baseSuite.allSubnets,
-		netBondReconfigureDelay:   s.netBondReconfigureDelay,
 		containerNetworkingMethod: s.containerNetworkingMethod,
 	}
 }
@@ -105,7 +103,7 @@ func (s *bridgePolicySuite) TestDetermineContainerSpacesConstraints(c *gc.C) {
 	exp := s.guest.EXPECT()
 	exp.Constraints().Return(constraints.MustParse("spaces=foo,bar,^baz"), nil)
 
-	obtained, err := s.policy().determineContainerSpaces(s.machine, s.guest)
+	obtained, err := s.policy().determineContainerSpaces(context.Background(), s.machine, s.guest)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := corenetwork.SpaceInfos{
 		*s.spaces.GetByName("foo"),
@@ -120,7 +118,7 @@ func (s *bridgePolicySuite) TestDetermineContainerNoSpacesConstraints(c *gc.C) {
 	exp := s.guest.EXPECT()
 	exp.Constraints().Return(constraints.MustParse(""), nil)
 
-	obtained, err := s.policy().determineContainerSpaces(s.machine, s.guest)
+	obtained, err := s.policy().determineContainerSpaces(context.Background(), s.machine, s.guest)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := corenetwork.SpaceInfos{
 		*s.spaces.GetByName(corenetwork.AlphaSpaceName),

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -4,6 +4,7 @@
 package network_test
 
 import (
+	"context"
 	"net"
 
 	"github.com/juju/collections/set"
@@ -141,7 +142,7 @@ func (s *NetworkSuite) TestFilterBridgeAddresses(c *gc.C) {
 		"localhost",
 		"252.16.134.1",
 	}).AsProviderAddresses()
-	c.Assert(network.FilterBridgeAddresses(inputAddresses), jc.DeepEquals, filteredAddresses)
+	c.Assert(network.FilterBridgeAddresses(context.Background(), inputAddresses), jc.DeepEquals, filteredAddresses)
 }
 
 func checkQuoteSpaceSet(c *gc.C, expected string, spaces ...string) {

--- a/internal/pki/tls/sni.go
+++ b/internal/pki/tls/sni.go
@@ -25,7 +25,7 @@ func AuthoritySNITLSGetter(authority pki.Authority, logger logger.Logger) func(*
 		// empty server name here we assume the the connection is being made
 		// with an ip address as the host.
 		if hello.ServerName == "" {
-			logger.Debugf(context.TODO(), "tls client hello server name is empty. Attempting to provide ip address certificate")
+			logger.Debugf(context.Background(), "tls client hello server name is empty. Attempting to provide ip address certificate")
 			leaf, err := authority.LeafForGroup(pki.ControllerIPLeafGroup)
 			if err == nil {
 				cert = leaf.TLSCertificate()
@@ -43,7 +43,7 @@ func AuthoritySNITLSGetter(authority pki.Authority, logger logger.Logger) func(*
 		}
 
 		if cert == nil {
-			logger.Debugf(context.TODO(), "no matching certificate found for server name %s, using default certificate", hello.ServerName)
+			logger.Debugf(context.Background(), "no matching certificate found for server name %s, using default certificate", hello.ServerName)
 			leaf, err := authority.LeafForGroup(pki.DefaultLeafGroup)
 			if err != nil {
 				return nil, fmt.Errorf("getting default certificate: %w", err)

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -352,7 +352,7 @@ func (env *environ) getTargetServer(
 	if p.nodeName == "" {
 		return env.server(), nil
 	}
-	return env.server().UseTargetServer(p.nodeName)
+	return env.server().UseTargetServer(ctx, p.nodeName)
 }
 
 type lxdPlacement struct {

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -269,7 +269,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 		sExp.HostArch().Return(arch.AMD64),
 		sExp.IsClustered().Return(true),
 		sExp.GetClusterMembers().Return(members, nil),
-		sExp.UseTargetServer("node01").Return(jujuTarget, nil),
+		sExp.UseTargetServer(gomock.Any(), "node01").Return(jujuTarget, nil),
 		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		sExp.HostArch().Return(arch.AMD64),
 	)

--- a/internal/provider/lxd/package_mock_test.go
+++ b/internal/provider/lxd/package_mock_test.go
@@ -1896,18 +1896,18 @@ func (c *MockServerUseProjectCall) DoAndReturn(f func(string)) *MockServerUsePro
 }
 
 // UseTargetServer mocks base method.
-func (m *MockServer) UseTargetServer(arg0 string) (*lxd0.Server, error) {
+func (m *MockServer) UseTargetServer(arg0 context.Context, arg1 string) (*lxd0.Server, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UseTargetServer", arg0)
+	ret := m.ctrl.Call(m, "UseTargetServer", arg0, arg1)
 	ret0, _ := ret[0].(*lxd0.Server)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UseTargetServer indicates an expected call of UseTargetServer.
-func (mr *MockServerMockRecorder) UseTargetServer(arg0 any) *MockServerUseTargetServerCall {
+func (mr *MockServerMockRecorder) UseTargetServer(arg0, arg1 any) *MockServerUseTargetServerCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseTargetServer", reflect.TypeOf((*MockServer)(nil).UseTargetServer), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseTargetServer", reflect.TypeOf((*MockServer)(nil).UseTargetServer), arg0, arg1)
 	return &MockServerUseTargetServerCall{Call: call}
 }
 
@@ -1923,13 +1923,13 @@ func (c *MockServerUseTargetServerCall) Return(arg0 *lxd0.Server, arg1 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServerUseTargetServerCall) Do(f func(string) (*lxd0.Server, error)) *MockServerUseTargetServerCall {
+func (c *MockServerUseTargetServerCall) Do(f func(context.Context, string) (*lxd0.Server, error)) *MockServerUseTargetServerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServerUseTargetServerCall) DoAndReturn(f func(string) (*lxd0.Server, error)) *MockServerUseTargetServerCall {
+func (c *MockServerUseTargetServerCall) DoAndReturn(f func(context.Context, string) (*lxd0.Server, error)) *MockServerUseTargetServerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/provider/lxd/server.go
+++ b/internal/provider/lxd/server.go
@@ -78,7 +78,7 @@ type Server interface {
 	EnableHTTPSListener() error
 	GetNICsFromProfile(profName string) (map[string]map[string]string, error)
 	IsClustered() bool
-	UseTargetServer(name string) (*lxd.Server, error)
+	UseTargetServer(ctx context.Context, name string) (*lxd.Server, error)
 	GetClusterMembers() (members []lxdapi.ClusterMember, err error)
 	Name() string
 	HasExtension(extension string) (exists bool)

--- a/internal/provider/lxd/testing_test.go
+++ b/internal/provider/lxd/testing_test.go
@@ -719,7 +719,7 @@ func (*StubClient) GetInstanceState(string) (*api.InstanceState, string, error) 
 // TODO (manadart 2018-07-20): This exists to satisfy the testing stub
 // interface. It is temporary, pending replacement with mocks and
 // should not be called in tests.
-func (conn *StubClient) UseTargetServer(name string) (*lxd.Server, error) {
+func (conn *StubClient) UseTargetServer(ctx context.Context, name string) (*lxd.Server, error) {
 	conn.AddCall("UseTargetServer", name)
 	return nil, conn.NextErr()
 }

--- a/internal/provisionertask/provisioner_task.go
+++ b/internal/provisionertask/provisioner_task.go
@@ -241,13 +241,13 @@ func (task *provisionerTask) loop() (taskErr error) {
 	ctx, cancel := task.scopedContext()
 	defer cancel()
 
-	task.logger.Infof(context.TODO(), "entering provisioner task loop; using provisioner pool with %d workers", task.wp.Size())
+	task.logger.Infof(ctx, "entering provisioner task loop; using provisioner pool with %d workers", task.wp.Size())
 	defer func() {
 		wpErr := task.wp.Close()
 		if taskErr == nil {
 			taskErr = wpErr
 		}
-		task.logger.Infof(context.TODO(), "exiting provisioner task loop; err: %v", taskErr)
+		task.logger.Infof(ctx, "exiting provisioner task loop; err: %v", taskErr)
 	}()
 
 	// Don't allow the harvesting mode to change until we have read at
@@ -282,7 +282,7 @@ func (task *provisionerTask) loop() (taskErr error) {
 
 			// Stop the current pool (checking for any pending
 			// errors) and create a new one.
-			task.logger.Infof(context.TODO(), "resizing provision worker pool size to %d", numWorkers)
+			task.logger.Infof(ctx, "resizing provision worker pool size to %d", numWorkers)
 			if err := task.wp.Close(); err != nil {
 				return err
 			}
@@ -292,11 +292,11 @@ func (task *provisionerTask) loop() (taskErr error) {
 			if harvestMode == task.harvestMode {
 				break
 			}
-			task.logger.Infof(context.TODO(), "harvesting mode changed to %s", harvestMode)
+			task.logger.Infof(ctx, "harvesting mode changed to %s", harvestMode)
 			task.harvestMode = harvestMode
 			task.notifyEventProcessedCallback(eventTypeHarvestModeChanged)
 			if harvestMode.HarvestUnknown() {
-				task.logger.Infof(context.TODO(), "harvesting unknown machines")
+				task.logger.Infof(ctx, "harvesting unknown machines")
 				if err := task.processMachines(ctx, nil); err != nil {
 					return errors.Annotate(err, "processing machines after safe mode disabled")
 				}
@@ -346,24 +346,24 @@ func (task *provisionerTask) processMachinesWithTransientErrors(ctx context.Cont
 	if err != nil || len(results) == 0 {
 		return nil
 	}
-	task.logger.Tracef(context.TODO(), "processMachinesWithTransientErrors(%v)", results)
+	task.logger.Tracef(ctx, "processMachinesWithTransientErrors(%v)", results)
 	var pending []apiprovisioner.MachineProvisioner
 	for _, result := range results {
 		if result.Status.Error != nil {
-			task.logger.Errorf(context.TODO(), "cannot retry provisioning of machine %q: %v", result.Machine.Id(), result.Status.Error)
+			task.logger.Errorf(ctx, "cannot retry provisioning of machine %q: %v", result.Machine.Id(), result.Status.Error)
 			continue
 		}
 		machine := result.Machine
 		if err := machine.SetStatus(ctx, status.Pending, "", nil); err != nil {
-			task.logger.Errorf(context.TODO(), "cannot reset status of machine %q: %v", machine.Id(), err)
+			task.logger.Errorf(ctx, "cannot reset status of machine %q: %v", machine.Id(), err)
 			continue
 		}
 		if err := machine.SetInstanceStatus(ctx, status.Provisioning, "", nil); err != nil {
-			task.logger.Errorf(context.TODO(), "cannot reset instance status of machine %q: %v", machine.Id(), err)
+			task.logger.Errorf(ctx, "cannot reset instance status of machine %q: %v", machine.Id(), err)
 			continue
 		}
 		if err := machine.SetModificationStatus(ctx, status.Idle, "", nil); err != nil {
-			task.logger.Errorf(context.TODO(), "cannot reset modification status of machine %q: %v", machine.Id(), err)
+			task.logger.Errorf(ctx, "cannot reset modification status of machine %q: %v", machine.Id(), err)
 			continue
 		}
 		task.machinesMutex.Lock()
@@ -375,7 +375,7 @@ func (task *provisionerTask) processMachinesWithTransientErrors(ctx context.Cont
 }
 
 func (task *provisionerTask) processMachines(ctx context.Context, ids []string) error {
-	task.logger.Debugf(context.TODO(), "processing machines %v", ids)
+	task.logger.Debugf(ctx, "processing machines %v", ids)
 
 	// Populate the tasks maps of current instances and machines.
 	if err := task.populateMachineMaps(ctx, ids); err != nil {
@@ -445,7 +445,7 @@ func (task *provisionerTask) populateMachineMaps(ctx context.Context, ids []stri
 		case result.Err == nil:
 			task.machines[result.Machine.Id()] = result.Machine
 		case params.IsCodeNotFoundOrCodeUnauthorized(result.Err):
-			task.logger.Debugf(context.TODO(), "machine %q not found in state", ids[i])
+			task.logger.Debugf(ctx, "machine %q not found in state", ids[i])
 			delete(task.machines, ids[i])
 		default:
 			return errors.Annotatef(result.Err, "getting machine %v", ids[i])
@@ -469,16 +469,16 @@ func (task *provisionerTask) pendingOrDead(
 		// Ignore machines that have been either queued for deferred
 		// stopping or are currently stopping.
 		if _, found := task.machinesStopDeferred[id]; found {
-			task.logger.Tracef(context.TODO(), "pendingOrDead: ignoring machine %q; machine has deferred stop flag set", id)
+			task.logger.Tracef(ctx, "pendingOrDead: ignoring machine %q; machine has deferred stop flag set", id)
 			continue // ignore: will be stopped once started
 		} else if _, found := task.machinesStopping[id]; found {
-			task.logger.Tracef(context.TODO(), "pendingOrDead: ignoring machine %q; machine is currently being stopped", id)
+			task.logger.Tracef(ctx, "pendingOrDead: ignoring machine %q; machine is currently being stopped", id)
 			continue // ignore: currently being stopped.
 		}
 
 		machine, found := task.machines[id]
 		if !found {
-			task.logger.Infof(context.TODO(), "machine %q not found", id)
+			task.logger.Infof(ctx, "machine %q not found", id)
 			continue
 		}
 		var classification MachineClassification
@@ -494,7 +494,7 @@ func (task *provisionerTask) pendingOrDead(
 		}
 	}
 
-	task.logger.Debugf(context.TODO(), "pending: %v, dead: %v", pending, dead)
+	task.logger.Debugf(ctx, "pending: %v, dead: %v", pending, dead)
 	return pending, dead, nil
 }
 
@@ -528,7 +528,7 @@ func classifyMachine(ctx context.Context, logger logger.Logger, machine Classifi
 		} else if !params.IsCodeNotProvisioned(err) {
 			return None, errors.Annotatef(err, "loading dying machine id:%s, details:%v", machine.Id(), machine)
 		}
-		logger.Infof(context.TODO(), "killing dying, unprovisioned machine %q", machine)
+		logger.Infof(ctx, "killing dying, unprovisioned machine %q", machine)
 		if err := machine.EnsureDead(ctx); err != nil {
 			return None, errors.Annotatef(err, "ensuring machine dead id:%s, details:%v", machine.Id(), machine)
 		}
@@ -543,25 +543,25 @@ func classifyMachine(ctx context.Context, logger logger.Logger, machine Classifi
 		}
 		machineStatus, _, err := machine.Status(ctx)
 		if err != nil {
-			logger.Infof(context.TODO(), "cannot get machine id:%s, details:%v, err:%v", machine.Id(), machine, err)
+			logger.Infof(ctx, "cannot get machine id:%s, details:%v, err:%v", machine.Id(), machine, err)
 			return None, nil
 		}
 		if machineStatus == status.Pending {
-			logger.Infof(context.TODO(), "found machine pending provisioning id:%s, details:%v", machine.Id(), machine)
+			logger.Infof(ctx, "found machine pending provisioning id:%s, details:%v", machine.Id(), machine)
 			return Pending, nil
 		}
 		instanceStatus, _, err := machine.InstanceStatus(ctx)
 		if err != nil {
-			logger.Infof(context.TODO(), "cannot read instance status id:%s, details:%v, err:%v", machine.Id(), machine, err)
+			logger.Infof(ctx, "cannot read instance status id:%s, details:%v, err:%v", machine.Id(), machine, err)
 			return None, nil
 		}
 		if instanceStatus == status.Provisioning {
-			logger.Infof(context.TODO(), "found machine provisioning id:%s, details:%v", machine.Id(), machine)
+			logger.Infof(ctx, "found machine provisioning id:%s, details:%v", machine.Id(), machine)
 			return Pending, nil
 		}
 		return None, nil
 	}
-	logger.Infof(context.TODO(), "machine %s already started as instance %q", machine.Id(), instId)
+	logger.Infof(ctx, "machine %s already started as instance %q", machine.Id(), instId)
 
 	return None, nil
 }
@@ -645,7 +645,7 @@ func (task *provisionerTask) queueRemovalOfDeadMachines(
 	}
 
 	if !task.harvestMode.HarvestUnknown() && len(unknown) != 0 {
-		task.logger.Infof(context.TODO(),
+		task.logger.Infof(ctx,
 			"%s is set to %s; unknown instances not stopped %v",
 			config.ProvisionerHarvestModeKey,
 			task.harvestMode.String(),
@@ -655,7 +655,7 @@ func (task *provisionerTask) queueRemovalOfDeadMachines(
 	}
 
 	if (task.harvestMode.HarvestNone() || !task.harvestMode.HarvestDestroyed()) && len(stopping) != 0 {
-		task.logger.Infof(context.TODO(),
+		task.logger.Infof(ctx,
 			`%s is set to "%s"; will not harvest %s`,
 			config.ProvisionerHarvestModeKey,
 			task.harvestMode.String(),
@@ -672,10 +672,10 @@ func (task *provisionerTask) queueRemovalOfDeadMachines(
 		Type: "stop-instances",
 		Process: func() error {
 			if len(stopping) > 0 {
-				task.logger.Infof(context.TODO(), "stopping known instances %v", instanceIds(stopping))
+				task.logger.Infof(ctx, "stopping known instances %v", instanceIds(stopping))
 			}
 			if len(unknown) > 0 {
-				task.logger.Infof(context.TODO(), "stopping unknown instances %v", instanceIds(unknown))
+				task.logger.Infof(ctx, "stopping unknown instances %v", instanceIds(unknown))
 			}
 
 			// It is important that we stop unknown instances before starting
@@ -688,9 +688,9 @@ func (task *provisionerTask) queueRemovalOfDeadMachines(
 
 			// Remove any dead machines from state.
 			for _, machine := range dead {
-				task.logger.Infof(context.TODO(), "removing dead machine %q", machine.Id())
+				task.logger.Infof(ctx, "removing dead machine %q", machine.Id())
 				if err := machine.MarkForRemoval(ctx); err != nil {
-					task.logger.Errorf(context.TODO(), "failed to remove dead machine %q", machine.Id())
+					task.logger.Errorf(ctx, "failed to remove dead machine %q", machine.Id())
 				}
 				task.removeMachineFromAZMap(machine)
 				machID := machine.Id()
@@ -772,7 +772,7 @@ func (task *provisionerTask) instancesForDeadMachines(ctx context.Context, dead 
 		if err == nil {
 			keep, _ := machine.KeepInstance(ctx)
 			if keep {
-				task.logger.Debugf(context.TODO(), "machine %v is dead but keep-instance is true", instId)
+				task.logger.Debugf(ctx, "machine %v is dead but keep-instance is true", instId)
 				continue
 			}
 
@@ -1059,7 +1059,7 @@ func (task *provisionerTask) updateAvailabilityZoneMachines(ctx context.Context)
 	for i, azm := range task.availabilityZoneMachines {
 		zones[i] = azm.ZoneName
 	}
-	task.logger.Infof(context.TODO(), "provisioning in zones: %v", zones)
+	task.logger.Infof(ctx, "provisioning in zones: %v", zones)
 
 	return nil
 }
@@ -1138,7 +1138,7 @@ func (task *provisionerTask) checkProviderAvailabilityZones(
 		// If the zone isn't available, but we think we have machines there,
 		// play it safe and retain the entry.
 		if len(azm.MachineIds) > 0 {
-			task.logger.Warningf(context.TODO(), "machines %v are in zone %q, which is not available, or not known by the cloud",
+			task.logger.Warningf(ctx, "machines %v are in zone %q, which is not available, or not known by the cloud",
 				azm.MachineIds.Values(), azm.ZoneName)
 			newAZMs = append(newAZMs, azm)
 		}
@@ -1191,6 +1191,7 @@ func (task *provisionerTask) populateDistributionGroupZoneMap(machineIds []strin
 // Machines are not placed in a zone they are excluded from.
 // If availability zones are implemented and one isn't found, return NotFound error.
 func (task *provisionerTask) machineAvailabilityZoneDistribution(
+	ctx context.Context,
 	machineId string, distGroupMachineIds []string, cons constraints.Value,
 ) (string, error) {
 	task.machinesMutex.Lock()
@@ -1234,13 +1235,13 @@ done:
 			index := rand.Intn(len(zmList))
 			zoneMachines := zmList[index]
 			if !zoneMachines.MatchesConstraints(cons) {
-				task.logger.Debugf(context.TODO(), "machine %s does not match az %s: constraints do not match",
+				task.logger.Debugf(ctx, "machine %s does not match az %s: constraints do not match",
 					machineId, zoneMachines.ZoneName)
 			} else if zoneMachines.FailedMachineIds.Contains(machineId) {
-				task.logger.Debugf(context.TODO(), "machine %s does not match az %s: excluded in failed machine ids",
+				task.logger.Debugf(ctx, "machine %s does not match az %s: excluded in failed machine ids",
 					machineId, zoneMachines.ZoneName)
 			} else if zoneMachines.ExcludedMachineIds.Contains(machineId) {
-				task.logger.Debugf(context.TODO(), "machine %s does not match az %s: excluded machine id",
+				task.logger.Debugf(ctx, "machine %s does not match az %s: excluded machine id",
 					machineId, zoneMachines.ZoneName)
 			} else {
 				// Success, we're out of here.
@@ -1297,7 +1298,7 @@ func (task *provisionerTask) queueStartMachines(ctx context.Context, machines []
 	if err != nil {
 		return errors.Trace(err)
 	}
-	task.logger.Debugf(context.TODO(), "obtained provisioning info: %#v", pInfoResults)
+	task.logger.Debugf(ctx, "obtained provisioning info: %#v", pInfoResults)
 	pInfoMap := make(map[string]params.ProvisioningInfoResult, len(pInfoResults.Results))
 	for i, tag := range machineTags {
 		pInfoMap[tag.Id()] = pInfoResults.Results[i]
@@ -1345,7 +1346,7 @@ func (task *provisionerTask) queueStartMachines(ctx context.Context, machines []
 				task.machinesMutex.Unlock()
 
 				if stopDeferred {
-					task.logger.Debugf(context.TODO(), "triggering deferred stop of machine %q", machID)
+					task.logger.Debugf(ctx, "triggering deferred stop of machine %q", machID)
 					return task.queueRemovalOfDeadMachines(ctx, []apiprovisioner.MachineProvisioner{
 						machine,
 					})
@@ -1370,7 +1371,7 @@ func (task *provisionerTask) queueStartMachines(ctx context.Context, machines []
 }
 
 func (task *provisionerTask) setErrorStatus(ctx context.Context, msg string, machine apiprovisioner.MachineProvisioner, err error) error {
-	task.logger.Errorf(context.TODO(), msg, machine, err)
+	task.logger.Errorf(ctx, msg, machine, err)
 	errForStatus := errors.Cause(err)
 	if err2 := machine.SetInstanceStatus(ctx, status.ProvisioningError, errForStatus.Error(), nil); err2 != nil {
 		// Something is wrong with this machine, better report it back.
@@ -1397,13 +1398,13 @@ func (task *provisionerTask) doStartMachine(
 		defer task.machinesMutex.RUnlock()
 		machID := machine.Id()
 		if task.machinesStopDeferred[machID] {
-			task.logger.Tracef(context.TODO(), "doStartMachine: ignoring doStartMachine error (%v) for machine %q; machine has been marked dead while it was being started and has the deferred stop flag set", startErr, machID)
+			task.logger.Tracef(ctx, "doStartMachine: ignoring doStartMachine error (%v) for machine %q; machine has been marked dead while it was being started and has the deferred stop flag set", startErr, machID)
 			startErr = nil
 		}
 	}()
 
 	if err := machine.SetInstanceStatus(ctx, status.Provisioning, "starting", nil); err != nil {
-		task.logger.Errorf(context.TODO(), "%v", err)
+		task.logger.Errorf(ctx, "%v", err)
 	}
 
 	v, err := machine.ModelAgentVersion(ctx)
@@ -1435,12 +1436,13 @@ func (task *provisionerTask) doStartMachine(
 	// Is(err, environs.ErrAvailabilityZoneIndependent)
 	for attemptsLeft := task.retryStartInstanceStrategy.RetryCount; attemptsLeft >= 0; {
 		if startInstanceParams.AvailabilityZone, err = task.machineAvailabilityZoneDistribution(
+			ctx,
 			machine.Id(), distributionGroupMachineIds, startInstanceParams.Constraints,
 		); err != nil {
 			return task.setErrorStatus(ctx, "cannot start instance for machine %q: %v", machine, err)
 		}
 		if startInstanceParams.AvailabilityZone != "" {
-			task.logger.Infof(context.TODO(), "trying machine %s StartInstance in availability zone %s",
+			task.logger.Infof(ctx, "trying machine %s StartInstance in availability zone %s",
 				machine, startInstanceParams.AvailabilityZone)
 		}
 
@@ -1455,10 +1457,10 @@ func (task *provisionerTask) doStartMachine(
 			return task.setErrorStatus(ctx, "cannot start instance for machine %q: %v", machine, err)
 		} else {
 			if startInstanceParams.AvailabilityZone != "" {
-				task.logger.Warningf(context.TODO(), "machine %s failed to start in availability zone %s: %v",
+				task.logger.Warningf(ctx, "machine %s failed to start in availability zone %s: %v",
 					machine, startInstanceParams.AvailabilityZone, err)
 			} else {
-				task.logger.Warningf(context.TODO(), "machine %s failed to start: %v", machine, err)
+				task.logger.Warningf(ctx, "machine %s failed to start: %v", machine, err)
 			}
 		}
 
@@ -1471,7 +1473,7 @@ func (task *provisionerTask) doStartMachine(
 				startInstanceParams.AvailabilityZone, startInstanceParams.Constraints)
 			if err2 != nil {
 				if err = task.setErrorStatus(ctx, "cannot start instance: %v", machine, err2); err != nil {
-					task.logger.Errorf(context.TODO(), "setting error status: %s", err)
+					task.logger.Errorf(ctx, "setting error status: %s", err)
 				}
 				return err2
 			}
@@ -1481,7 +1483,7 @@ func (task *provisionerTask) doStartMachine(
 					machine, startInstanceParams.AvailabilityZone,
 					task.retryStartInstanceStrategy.RetryDelay, err,
 				)
-				task.logger.Debugf(context.TODO(), "%s", retryMsg)
+				task.logger.Debugf(ctx, "%s", retryMsg)
 				// There's still more zones to try, so don't decrement "attemptsLeft" yet.
 				retrying = false
 			} else {
@@ -1496,12 +1498,12 @@ func (task *provisionerTask) doStartMachine(
 				"failed to start machine %s (%s), retrying in %v (%d more attempts)",
 				machine, err.Error(), task.retryStartInstanceStrategy.RetryDelay, attemptsLeft,
 			)
-			task.logger.Warningf(context.TODO(), "%s", retryMsg)
+			task.logger.Warningf(ctx, "%s", retryMsg)
 			attemptsLeft--
 		}
 
 		if err3 := machine.SetInstanceStatus(ctx, status.Provisioning, retryMsg, nil); err3 != nil {
-			task.logger.Warningf(context.TODO(), "failed to set instance status: %v", err3)
+			task.logger.Warningf(ctx, "failed to set instance status: %v", err3)
 		}
 
 		select {
@@ -1521,6 +1523,7 @@ func (task *provisionerTask) doStartMachine(
 	// Gather the charm LXD profile names, including the lxd profile names from
 	// the container brokers.
 	charmLXDProfiles, err := task.gatherCharmLXDProfiles(
+		ctx,
 		instanceID.String(), machine.Tag().Id(), startInstanceParams.CharmLXDProfiles)
 	if err != nil {
 		return errors.Trace(err)
@@ -1539,14 +1542,14 @@ func (task *provisionerTask) doStartMachine(
 	); err != nil {
 		// We need to stop the instance right away here, set error status and go on.
 		if err2 := task.setErrorStatus(ctx, "cannot register instance for machine %v: %v", machine, err); err2 != nil {
-			task.logger.Errorf(context.TODO(), "%v", errors.Annotate(err2, "setting machine status"))
+			task.logger.Errorf(ctx, "%v", errors.Annotate(err2, "setting machine status"))
 		}
 		if err2 := task.broker.StopInstances(ctx, instanceID); err2 != nil {
-			task.logger.Errorf(context.TODO(), "%v", errors.Annotate(err2, "after failing to set instance info"))
+			task.logger.Errorf(ctx, "%v", errors.Annotate(err2, "after failing to set instance info"))
 		}
 		return errors.Annotate(err, "setting instance info")
 	}
-	task.logger.Infof(context.TODO(),
+	task.logger.Infof(ctx,
 		"started machine %s as instance %s with hardware %q, network config %+v, "+
 			"volumes %v, volume attachments %v, subnets to zones %v, lxd profiles %v",
 		machine,
@@ -1638,6 +1641,7 @@ func (task *provisionerTask) populateExcludedMachines(ctx context.Context, machi
 // gatherCharmLXDProfiles consumes the charms LXD Profiles from the different
 // sources. This includes getting the information from the broker.
 func (task *provisionerTask) gatherCharmLXDProfiles(
+	ctx context.Context,
 	instanceID, machineTag string, machineProfiles []string,
 ) ([]string, error) {
 	if !names.IsContainerMachine(machineTag) {
@@ -1646,7 +1650,7 @@ func (task *provisionerTask) gatherCharmLXDProfiles(
 
 	manager, ok := task.broker.(container.LXDProfileNameRetriever)
 	if !ok {
-		task.logger.Tracef(context.TODO(), "failed to gather profile names, broker didn't conform to LXDProfileNameRetriever")
+		task.logger.Tracef(ctx, "failed to gather profile names, broker didn't conform to LXDProfileNameRetriever")
 		return machineProfiles, nil
 	}
 

--- a/internal/resource/charmhub/charmhub.go
+++ b/internal/resource/charmhub/charmhub.go
@@ -72,14 +72,14 @@ type CharmHubClient struct {
 // GetResource returns data about the resource including an io.ReadCloser
 // to download the resource.  The caller is responsible for closing it.
 func (ch *CharmHubClient) GetResource(ctx context.Context, req ResourceRequest) (ResourceData, error) {
-	ch.logger.Tracef(context.TODO(), "GetResource(%s)", pretty.Sprint(req))
+	ch.logger.Tracef(ctx, "GetResource(%s)", pretty.Sprint(req))
 
 	res, resourceURL, err := ch.getResourceDetails(ctx, req)
 	if err != nil {
 		return ResourceData{}, errors.Capture(err)
 	}
 
-	ch.logger.Tracef(context.TODO(), "Read resource %q from %q", res.Name, resourceURL)
+	ch.logger.Tracef(ctx, "Read resource %q from %q", res.Name, resourceURL)
 
 	readCloser, err := ch.downloader.Download(ctx, resourceURL, res.Fingerprint.String(), res.Size)
 	if err != nil {
@@ -107,7 +107,7 @@ func (ch *CharmHubClient) getResourceDetails(ctx context.Context, req ResourceRe
 	// during deploy when a resolving resources for add pending resources.
 	// This also closes a timing window where a charm and resource
 	// is updated in the channel in between deploy and resource use.
-	cfg, err := charmhub.DownloadOneFromRevision(origin.ID, *origin.Revision)
+	cfg, err := charmhub.DownloadOneFromRevision(ctx, origin.ID, *origin.Revision)
 	if err != nil {
 		return charmresource.Resource{}, nil, errors.Capture(err)
 	}

--- a/internal/resource/charmhub/retryclient.go
+++ b/internal/resource/charmhub/retryclient.go
@@ -79,9 +79,9 @@ func (client ResourceRetryClient) GetResource(ctx context.Context, req ResourceR
 	var lastErr error
 	args.NotifyFunc = func(err error, i int) {
 		// Remember the error we're hiding and then retry!
-		client.logger.Warningf(context.TODO(), "attempt %d/%d to download resource %q from charm store [%scharm (%v), resource revision (%v)] failed with error (will retry): %v",
+		client.logger.Warningf(ctx, "attempt %d/%d to download resource %q from charm store [%scharm (%v), resource revision (%v)] failed with error (will retry): %v",
 			i, client.RetryArgs.Attempts, req.Name, channelStr, req.CharmID.URL, req.Revision, err)
-		client.logger.Tracef(context.TODO(), "resource get error stack: %v", errors.ErrorStack(err))
+		client.logger.Tracef(ctx, "resource get error stack: %v", errors.ErrorStack(err))
 		lastErr = err
 	}
 

--- a/internal/resource/downloader/downloader.go
+++ b/internal/resource/downloader/downloader.go
@@ -83,11 +83,11 @@ func (d *ResourceDownloader) Download(
 		// manually.
 		removeErr := os.Remove(tmpFile.Name())
 		if removeErr != nil {
-			d.logger.Warningf(context.TODO(), "failed to remove temporary file %q: %v", tmpFile.Name(), removeErr)
+			d.logger.Warningf(ctx, "failed to remove temporary file %q: %v", tmpFile.Name(), removeErr)
 		}
 	}()
 
-	d.logger.Debugf(context.TODO(), "downloading resource: %s", url)
+	d.logger.Debugf(ctx, "downloading resource: %s", url)
 
 	// Force the sha256 and sha384 digest to be calculated on download.
 	digest, err := d.client.Download(ctx, url, tmpFile.Name())
@@ -95,7 +95,7 @@ func (d *ResourceDownloader) Download(
 		return nil, errors.Capture(err)
 	}
 
-	d.logger.Debugf(context.TODO(), "downloaded resource: %s", url)
+	d.logger.Debugf(ctx, "downloaded resource: %s", url)
 
 	if digest.SHA384 != sha384 {
 		return nil, errors.Errorf(
@@ -142,7 +142,7 @@ func (f *tmpFileReader) Close() (err error) {
 		if err == nil {
 			err = removeErr
 		} else if removeErr != nil {
-			f.logger.Warningf(context.TODO(), "failed to remove temporary file %q: %v", f.Name(), removeErr)
+			f.logger.Warningf(context.Background(), "failed to remove temporary file %q: %v", f.Name(), removeErr)
 		}
 	}()
 

--- a/internal/resource/limiter.go
+++ b/internal/resource/limiter.go
@@ -58,7 +58,7 @@ func (r *resourceDownloadLimiter) Acquire(ctx context.Context, appName string) e
 		if err := r.globalLock.Acquire(ctx, 1); err != nil {
 			return err
 		}
-		resourceLogger.Debugf(context.TODO(), "acquire global resource download lock for %q, took %dms", appName, time.Now().Sub(start)/time.Millisecond)
+		resourceLogger.Debugf(ctx, "acquire global resource download lock for %q, took %dms", appName, time.Now().Sub(start)/time.Millisecond)
 	}
 	if r.applicationLimit <= 0 {
 		return nil
@@ -79,7 +79,7 @@ func (r *resourceDownloadLimiter) Acquire(ctx context.Context, appName string) e
 	if err := lock.Acquire(ctx); err != nil {
 		return err
 	}
-	resourceLogger.Debugf(context.TODO(), "acquire app resource download lock for %q, took %dms", appName, time.Now().Sub(start)/time.Millisecond)
+	resourceLogger.Debugf(ctx, "acquire app resource download lock for %q, took %dms", appName, time.Now().Sub(start)/time.Millisecond)
 	return nil
 }
 

--- a/internal/storage/plans/iscsi/iscsi.go
+++ b/internal/storage/plans/iscsi/iscsi.go
@@ -151,8 +151,8 @@ func newiSCSIInfo(info map[string]string) (*iscsiConnectionInfo, error) {
 	if err != nil {
 		return nil, errors.Errorf("invalid port: %v", port)
 	}
-	user, _ = info["chap-user"]
-	secret, _ = info["chap-secret"]
+	user = info["chap-user"]
+	secret = info["chap-secret"]
 	plan := &iscsiConnectionInfo{
 		iqn:        iqn,
 		address:    address,

--- a/internal/storage/provider/managedfs.go
+++ b/internal/storage/provider/managedfs.go
@@ -160,11 +160,11 @@ func (s *managedFilesystemSource) attachFilesystem(arg storage.FilesystemAttachm
 		return nil, errors.Trace(err)
 	}
 	return &storage.FilesystemAttachment{
-		arg.Filesystem,
-		arg.Machine,
-		storage.FilesystemAttachmentInfo{
-			arg.Path,
-			arg.ReadOnly,
+		Filesystem: arg.Filesystem,
+		Machine:    arg.Machine,
+		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
+			Path:     arg.Path,
+			ReadOnly: arg.ReadOnly,
 		},
 	}, nil
 }

--- a/internal/storage/provider/rootfs.go
+++ b/internal/storage/provider/rootfs.go
@@ -232,9 +232,9 @@ func (s *rootfsFilesystemSource) attachFilesystem(arg storage.FilesystemAttachme
 		return nil, err
 	}
 	return &storage.FilesystemAttachment{
-		arg.Filesystem,
-		arg.Machine,
-		storage.FilesystemAttachmentInfo{
+		Filesystem: arg.Filesystem,
+		Machine:    arg.Machine,
+		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
 			Path: mountPoint,
 		},
 	}, nil

--- a/internal/testing/base.go
+++ b/internal/testing/base.go
@@ -134,7 +134,7 @@ func (s *JujuOSEnvSuite) SetFeatureFlags(flag ...string) {
 	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, flags); err != nil {
 		panic(err)
 	}
-	logger.Debugf(context.TODO(), "setting feature flags: %s", flags)
+	logger.Debugf(context.Background(), "setting feature flags: %s", flags)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 

--- a/internal/upgradesteps/worker.go
+++ b/internal/upgradesteps/worker.go
@@ -144,7 +144,7 @@ func (w *BaseWorker) reportUpgradeFailure(ctx context.Context, err error, willRe
 	if !willRetry {
 		retryText = "giving up"
 	}
-	w.Logger.Errorf(context.TODO(), "upgrade from %v to %v for %q failed (%s): %v",
+	w.Logger.Errorf(ctx, "upgrade from %v to %v for %q failed (%s): %v",
 		w.FromVersion, w.ToVersion, w.Tag, retryText, err)
 	_ = w.StatusSetter.SetStatus(
 		ctx,

--- a/internal/worker/apiaddressupdater/apiaddressupdater.go
+++ b/internal/worker/apiaddressupdater/apiaddressupdater.go
@@ -135,7 +135,7 @@ func (c *APIAddressUpdater) getAddresses(ctx context.Context) ([]corenetwork.Pro
 	hpsToSet := make([]corenetwork.ProviderHostPorts, 0)
 	for _, hostPorts := range addresses {
 		// Strip ports, filter, then add ports again.
-		filtered := network.FilterBridgeAddresses(hostPorts.Addresses())
+		filtered := network.FilterBridgeAddresses(ctx, hostPorts.Addresses())
 		hps := make(corenetwork.ProviderHostPorts, 0, len(filtered))
 		for _, hostPort := range hostPorts {
 			for _, addr := range filtered {

--- a/internal/worker/charmrevisioner/worker.go
+++ b/internal/worker/charmrevisioner/worker.go
@@ -457,7 +457,7 @@ func (w *revisionUpdateWorker) request(ctx context.Context, client CharmhubClien
 			Name:         id.osType,
 			Channel:      id.osChannel,
 		}
-		cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, base)
+		cfg, err := charmhub.RefreshOne(ctx, id.instanceKey, id.id, id.revision, id.channel, base)
 		if err != nil {
 			return nil, internalerrors.Capture(err)
 		}

--- a/internal/worker/charmrevisioner/worker_test.go
+++ b/internal/worker/charmrevisioner/worker_test.go
@@ -350,7 +350,7 @@ func (s *WorkerSuite) TestFetchInfo(c *gc.C) {
 		},
 	}}
 
-	cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
+	cfg, err := charmhub.RefreshOne(context.Background(), id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
 		Architecture: id.arch,
 		Name:         id.osType,
 		Channel:      id.osChannel,
@@ -446,7 +446,7 @@ func (s *WorkerSuite) TestFetchInfoInvalidResponseLength(c *gc.C) {
 
 	apps := []appInfo{}
 
-	cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
+	cfg, err := charmhub.RefreshOne(context.Background(), id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
 		Architecture: id.arch,
 		Name:         id.osType,
 		Channel:      id.osChannel,
@@ -514,7 +514,7 @@ func (s *WorkerSuite) TestRequest(c *gc.C) {
 	}}
 	id := ids[0]
 
-	cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
+	cfg, err := charmhub.RefreshOne(context.Background(), id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
 		Architecture: id.arch,
 		Name:         id.osType,
 		Channel:      id.osChannel,
@@ -595,7 +595,7 @@ func (s *WorkerSuite) TestRequestWithResources(c *gc.C) {
 	}}
 	id := ids[0]
 
-	cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
+	cfg, err := charmhub.RefreshOne(context.Background(), id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
 		Architecture: id.arch,
 		Name:         id.osType,
 		Channel:      id.osChannel,

--- a/internal/worker/machiner/machiner.go
+++ b/internal/worker/machiner/machiner.go
@@ -160,7 +160,7 @@ func setMachineAddresses(ctx context.Context, tag names.MachineTag, m Machine) e
 		return nil
 	}
 	// Filter out any LXC or LXD bridge addresses.
-	hostAddresses = network.FilterBridgeAddresses(hostAddresses)
+	hostAddresses = network.FilterBridgeAddresses(ctx, hostAddresses)
 	logger.Infof(ctx, "setting addresses for %q to %v", tag, hostAddresses)
 
 	// TODO (manadart 2019-08-27): This needs refactoring.

--- a/internal/worker/uniter/charm/bundles_test.go
+++ b/internal/worker/uniter/charm/bundles_test.go
@@ -100,23 +100,23 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 	}
 
 	// Try to get the charm when the content doesn't match.
-	_, err = d.Read(context.Background(), &fakeBundleInfo{apiCharm, "", "..."}, nil)
+	_, err = d.Read(context.Background(), &fakeBundleInfo{BundleInfo: apiCharm, curl: "", sha256: "..."})
 	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "ch:quantal/wordpress-1" from API server: `)+`expected sha256 "...", got ".*"`)
 	checkDownloadsEmpty()
 
 	// Try to get a charm whose bundle doesn't exist.
-	_, err = d.Read(context.Background(), &fakeBundleInfo{apiCharm, "ch:quantal/spam-1", ""}, nil)
+	_, err = d.Read(context.Background(), &fakeBundleInfo{BundleInfo: apiCharm, curl: "ch:quantal/spam-1", sha256: ""})
 	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "ch:quantal/spam-1" from API server: `)+`.* not found`)
 	checkDownloadsEmpty()
 
 	// Get a charm whose bundle exists and whose content matches.
-	ch, err := d.Read(context.Background(), apiCharm, nil)
+	ch, err := d.Read(context.Background(), apiCharm)
 	c.Assert(err, jc.ErrorIsNil)
 	assertCharm(c, ch, sch)
 	checkDownloadsEmpty()
 
 	// Get the same charm again, without preparing a response from the server.
-	ch, err = d.Read(context.Background(), apiCharm, nil)
+	ch, err = d.Read(context.Background(), apiCharm)
 	c.Assert(err, jc.ErrorIsNil)
 	assertCharm(c, ch, sch)
 	checkDownloadsEmpty()
@@ -124,10 +124,11 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 	// Check the abort chan is honoured.
 	err = os.RemoveAll(bunsDir)
 	c.Assert(err, jc.ErrorIsNil)
-	abort := make(chan struct{})
-	close(abort)
 
-	ch, err = d.Read(context.Background(), apiCharm, abort)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch, err = d.Read(ctx, apiCharm)
 	c.Check(ch, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "ch:quantal/wordpress-1" from API server: download aborted`))
 	checkDownloadsEmpty()

--- a/internal/worker/uniter/charm/charm.go
+++ b/internal/worker/uniter/charm/charm.go
@@ -41,22 +41,20 @@ type BundleInfo interface {
 
 // BundleReader provides a mechanism for getting a Bundle from a BundleInfo.
 type BundleReader interface {
-
 	// Read returns the bundle identified by the supplied info. The abort chan
 	// can be used to notify an implementation that it need not complete the
 	// operation, and can immediately error out if it is convenient to do so.
-	Read(ctx context.Context, bi BundleInfo, abort <-chan struct{}) (Bundle, error)
+	Read(ctx context.Context, bi BundleInfo) (Bundle, error)
 }
 
 // Deployer is responsible for installing and upgrading charms.
 type Deployer interface {
-
 	// Stage must be called to prime the Deployer to install or upgrade the
 	// bundle identified by the supplied info. The abort chan can be used to
 	// notify an implementation that it need not complete the operation, and
 	// can immediately error out if it convenient to do so. It must always
 	// be safe to restage the same bundle, or to stage a new bundle.
-	Stage(ctx context.Context, info BundleInfo, abort <-chan struct{}) error
+	Stage(ctx context.Context, info BundleInfo) error
 
 	// Deploy will install or upgrade the most recently staged bundle.
 	// Behaviour is undefined if Stage has not been called. Failures that

--- a/internal/worker/uniter/charm/charm_test.go
+++ b/internal/worker/uniter/charm/charm_test.go
@@ -37,7 +37,7 @@ func (br *bundleReader) EnableWaitForAbort() (stopWaiting chan struct{}) {
 }
 
 // Read implements the BundleReader interface.
-func (br *bundleReader) Read(ctx context.Context, info charm.BundleInfo, abort <-chan struct{}) (charm.Bundle, error) {
+func (br *bundleReader) Read(ctx context.Context, info charm.BundleInfo) (charm.Bundle, error) {
 	bundle, ok := br.bundles[info.URL()]
 	if !ok {
 		return nil, fmt.Errorf("no such charm!")
@@ -46,7 +46,7 @@ func (br *bundleReader) Read(ctx context.Context, info charm.BundleInfo, abort <
 		// EnableWaitForAbort is a one-time wait; make sure we clear it.
 		defer func() { br.stopWaiting = nil }()
 		select {
-		case <-abort:
+		case <-ctx.Done():
 			return nil, fmt.Errorf("charm read aborted")
 		case <-br.stopWaiting:
 			// We can stop waiting for the abort chan and return the bundle.

--- a/internal/worker/uniter/charm/manifest_deployer_test.go
+++ b/internal/worker/uniter/charm/manifest_deployer_test.go
@@ -56,7 +56,7 @@ func (s *ManifestDeployerSuite) addCharm(c *gc.C, revision int, content ...ft.En
 
 func (s *ManifestDeployerSuite) deployCharm(c *gc.C, revision int, content ...ft.Entry) charm.BundleInfo {
 	info := s.addCharm(c, revision, content...)
-	err := s.deployer.Stage(context.Background(), info, nil)
+	err := s.deployer.Stage(context.Background(), info)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.deployer.Deploy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -73,24 +73,26 @@ func (s *ManifestDeployerSuite) assertCharm(c *gc.C, revision int, content ...ft
 
 func (s *ManifestDeployerSuite) TestAbortStageWhenClosed(c *gc.C) {
 	info := s.addMockCharm(1, mockBundle{})
-	abort := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	errors := make(chan error)
 	s.bundles.EnableWaitForAbort()
 	go func() {
-		errors <- s.deployer.Stage(context.Background(), info, abort)
+		errors <- s.deployer.Stage(ctx, info)
 	}()
-	close(abort)
+	cancel()
 	err := <-errors
 	c.Assert(err, gc.ErrorMatches, "charm read aborted")
 }
 
 func (s *ManifestDeployerSuite) TestDontAbortStageWhenNotClosed(c *gc.C) {
 	info := s.addMockCharm(1, mockBundle{})
-	abort := make(chan struct{})
 	errors := make(chan error)
 	stopWaiting := s.bundles.EnableWaitForAbort()
 	go func() {
-		errors <- s.deployer.Stage(context.Background(), info, abort)
+		errors <- s.deployer.Stage(context.Background(), info)
 	}()
 	close(stopWaiting)
 	err := <-errors
@@ -192,7 +194,7 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictResolveRetrySameCharm(c *gc.C
 		},
 	}
 	info := s.addMockCharm(2, mockCharm)
-	err := s.deployer.Stage(context.Background(), info, nil)
+	err := s.deployer.Stage(context.Background(), info)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ...and see it fail to expand. We're not too bothered about the actual
@@ -235,7 +237,7 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictRevertRetryDifferentCharm(c *
 		},
 	}
 	badInfo := s.addMockCharm(2, badCharm)
-	err := s.deployer.Stage(context.Background(), badInfo, nil)
+	err := s.deployer.Stage(context.Background(), badInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.deployer.Deploy()
 	c.Assert(err, gc.Equals, charm.ErrConflict)
@@ -266,7 +268,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.bundleInfo.EXPECT().URL().Return("ch:focal/dummy-1").AnyTimes()
-	s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")).AnyTimes()
+	s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")).AnyTimes()
 
 	go func() {
 		// We retry 10 times in total so we need to advance the clock 9
@@ -277,7 +279,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 		}
 	}()
 
-	_, err := s.rbr.Read(context.Background(), s.bundleInfo, nil)
+	_, err := s.rbr.Read(context.Background(), s.bundleInfo)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -286,8 +288,8 @@ func (s *RetryingBundleReaderSuite) TestReadBundleEventuallySucceeds(c *gc.C) {
 
 	s.bundleInfo.EXPECT().URL().Return("ch:focal/dummy-1").AnyTimes()
 	gomock.InOrder(
-		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")),
-		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).Return(s.bundle, nil),
+		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")),
+		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(s.bundle, nil),
 	)
 
 	go func() {
@@ -296,7 +298,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleEventuallySucceeds(c *gc.C) {
 		c.Assert(s.clock.WaitAdvance(10*time.Second, time.Second, 1), jc.ErrorIsNil)
 	}()
 
-	got, err := s.rbr.Read(context.Background(), s.bundleInfo, nil)
+	got, err := s.rbr.Read(context.Background(), s.bundleInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got, gc.Equals, s.bundle)
 }

--- a/internal/worker/uniter/charm/mocks/mocks.go
+++ b/internal/worker/uniter/charm/mocks/mocks.go
@@ -42,18 +42,18 @@ func (m *MockBundleReader) EXPECT() *MockBundleReaderMockRecorder {
 }
 
 // Read mocks base method.
-func (m *MockBundleReader) Read(arg0 context.Context, arg1 charm.BundleInfo, arg2 <-chan struct{}) (charm.Bundle, error) {
+func (m *MockBundleReader) Read(arg0 context.Context, arg1 charm.BundleInfo) (charm.Bundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Read", arg0, arg1)
 	ret0, _ := ret[0].(charm.Bundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockBundleReaderMockRecorder) Read(arg0, arg1, arg2 any) *MockBundleReaderReadCall {
+func (mr *MockBundleReaderMockRecorder) Read(arg0, arg1 any) *MockBundleReaderReadCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockBundleReader)(nil).Read), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockBundleReader)(nil).Read), arg0, arg1)
 	return &MockBundleReaderReadCall{Call: call}
 }
 
@@ -69,13 +69,13 @@ func (c *MockBundleReaderReadCall) Return(arg0 charm.Bundle, arg1 error) *MockBu
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBundleReaderReadCall) Do(f func(context.Context, charm.BundleInfo, <-chan struct{}) (charm.Bundle, error)) *MockBundleReaderReadCall {
+func (c *MockBundleReaderReadCall) Do(f func(context.Context, charm.BundleInfo) (charm.Bundle, error)) *MockBundleReaderReadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBundleReaderReadCall) DoAndReturn(f func(context.Context, charm.BundleInfo, <-chan struct{}) (charm.Bundle, error)) *MockBundleReaderReadCall {
+func (c *MockBundleReaderReadCall) DoAndReturn(f func(context.Context, charm.BundleInfo) (charm.Bundle, error)) *MockBundleReaderReadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/mockdeployer_test.go
+++ b/internal/worker/uniter/mockdeployer_test.go
@@ -23,10 +23,10 @@ type mockDeployer struct {
 	err      error
 }
 
-func (m *mockDeployer) Stage(ctx context.Context, info charm.BundleInfo, abort <-chan struct{}) error {
+func (m *mockDeployer) Stage(ctx context.Context, info charm.BundleInfo) error {
 	m.staged = info.URL()
 	var err error
-	m.bundle, err = m.bundles.Read(ctx, info, abort)
+	m.bundle, err = m.bundles.Read(ctx, info)
 	return err
 }
 

--- a/internal/worker/uniter/operation/deploy.go
+++ b/internal/worker/uniter/operation/deploy.go
@@ -26,7 +26,6 @@ type deploy struct {
 
 	callbacks Callbacks
 	deployer  charm.Deployer
-	abort     <-chan struct{}
 }
 
 // String is part of the Operation interface.
@@ -56,7 +55,7 @@ func (d *deploy) Prepare(ctx context.Context, state State) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := d.deployer.Stage(ctx, info, d.abort); err != nil {
+	if err := d.deployer.Stage(ctx, info); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// note: yes, this *should* be in Prepare, not Execute. Before we can safely

--- a/internal/worker/uniter/operation/deploy_test.go
+++ b/internal/worker/uniter/operation/deploy_test.go
@@ -124,11 +124,9 @@ func (s *DeploySuite) testPrepareStageError(c *gc.C, newDeploy newDeploy) {
 		MockNotifyResolved: &MockNoArgs{},
 		MockStage:          &MockStage{err: errors.New("squish")},
 	}
-	var abort <-chan struct{} = make(chan struct{})
 	factory := operation.NewFactory(operation.FactoryParams{
 		Deployer:  deployer,
 		Callbacks: callbacks,
-		Abort:     abort,
 		Logger:    loggertesting.WrapCheckLog(c),
 	})
 	op, err := newDeploy(factory, "ch:quantal/hive-23")
@@ -138,7 +136,6 @@ func (s *DeploySuite) testPrepareStageError(c *gc.C, newDeploy newDeploy) {
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "squish")
 	c.Check(*deployer.MockStage.gotInfo, gc.Equals, callbacks.MockGetArchiveInfo.info)
-	c.Check(*deployer.MockStage.gotAbort, gc.Equals, abort)
 }
 
 func (s *DeploySuite) TestPrepareStageError_Install(c *gc.C) {

--- a/internal/worker/uniter/operation/factory.go
+++ b/internal/worker/uniter/operation/factory.go
@@ -23,7 +23,6 @@ type FactoryParams struct {
 	RunnerFactory  runner.Factory
 	Callbacks      Callbacks
 	ActionGetter   ActionGetter
-	Abort          <-chan struct{}
 	MetricSpoolDir string
 	Logger         logger.Logger
 }
@@ -57,7 +56,6 @@ func (f *factory) newDeploy(kind Kind, charmURL string, revert, resolved bool) (
 		resolved:  resolved,
 		callbacks: f.config.Callbacks,
 		deployer:  f.config.Deployer,
-		abort:     f.config.Abort,
 	}
 	return op, nil
 }

--- a/internal/worker/uniter/operation/util_test.go
+++ b/internal/worker/uniter/operation/util_test.go
@@ -68,14 +68,12 @@ type MockBundleInfo struct {
 }
 
 type MockStage struct {
-	gotInfo  *charm.BundleInfo
-	gotAbort *<-chan struct{}
-	err      error
+	gotInfo *charm.BundleInfo
+	err     error
 }
 
-func (mock *MockStage) Call(info charm.BundleInfo, abort <-chan struct{}) error {
+func (mock *MockStage) Call(info charm.BundleInfo) error {
 	mock.gotInfo = &info
-	mock.gotAbort = &abort
 	return mock.err
 }
 
@@ -97,8 +95,8 @@ type MockDeployer struct {
 	MockNotifyResolved *MockNoArgs
 }
 
-func (d *MockDeployer) Stage(ctx context.Context, info charm.BundleInfo, abort <-chan struct{}) error {
-	return d.MockStage.Call(info, abort)
+func (d *MockDeployer) Stage(ctx context.Context, info charm.BundleInfo) error {
+	return d.MockStage.Call(info)
 }
 
 func (d *MockDeployer) Deploy() error {

--- a/internal/worker/uniter/resolver_test.go
+++ b/internal/worker/uniter/resolver_test.go
@@ -727,7 +727,7 @@ func (m *fakeRW) SetState(context.Context, params.SetUnitStateArg) error {
 type fakeDeployer struct {
 }
 
-func (m *fakeDeployer) Stage(_ context.Context, _ unitercharm.BundleInfo, _ <-chan struct{}) error {
+func (m *fakeDeployer) Stage(_ context.Context, _ unitercharm.BundleInfo) error {
 	return nil
 }
 

--- a/internal/worker/uniter/uniter.go
+++ b/internal/worker/uniter/uniter.go
@@ -845,7 +845,6 @@ func (u *Uniter) init(ctx stdcontext.Context, unitTag names.UnitTag) (err error)
 		RunnerFactory:  runnerFactory,
 		Callbacks:      &operationCallbacks{u},
 		ActionGetter:   u.client,
-		Abort:          u.catacomb.Dying(),
 		MetricSpoolDir: u.paths.GetMetricsSpoolDir(),
 		Logger:         u.logger.Child("operation"),
 	})


### PR DESCRIPTION
The context.TODO was used as a placeholder whilst we migrated some of the methods over to context.Context. This removes most but not all of them. More work will be required to remove the last of them, but that'll be a lot of work for very little gain.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
