### PR TITLE
chore: bump names/v6 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/juju/lumberjack/v2 v2.0.2
 	github.com/juju/mgo/v3 v3.0.4
 	github.com/juju/mutex/v2 v2.0.0
-	github.com/juju/names/v6 v6.0.0-20250318090139-ec8d71d906f5
+	github.com/juju/names/v6 v6.0.0-20250512075813-b50ca77a4137
 	github.com/juju/naturalsort v1.0.0
 	github.com/juju/os/v2 v2.2.5
 	github.com/juju/persistent-cookiejar v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -424,8 +424,8 @@ github.com/juju/mutex/v2 v2.0.0-20220128011612-57176ebdcfa3/go.mod h1:TTCG9BJD9r
 github.com/juju/mutex/v2 v2.0.0-20220203023141-11eeddb42c6c/go.mod h1:jwCfBs/smYDaeZLqeaCi8CB8M+tOes4yf827HoOEoqk=
 github.com/juju/mutex/v2 v2.0.0 h1:rVmJdOaXGWF8rjcFHBNd4x57/1tks5CgXHx55O55SB0=
 github.com/juju/mutex/v2 v2.0.0/go.mod h1:jwCfBs/smYDaeZLqeaCi8CB8M+tOes4yf827HoOEoqk=
-github.com/juju/names/v6 v6.0.0-20250318090139-ec8d71d906f5 h1:1eVFjYvtBVLGdisz+jbjfks5AC1oeyM0Ef1Q1IrZBGE=
-github.com/juju/names/v6 v6.0.0-20250318090139-ec8d71d906f5/go.mod h1:msqFCjHhF+wL7NR5aEDRlpxCybna0+5E9kbRSb2fiz4=
+github.com/juju/names/v6 v6.0.0-20250512075813-b50ca77a4137 h1:y78AjQajOIz8xxLXENqZ/QlLNKrp4HL2VHeT+iXTDPM=
+github.com/juju/names/v6 v6.0.0-20250512075813-b50ca77a4137/go.mod h1:msqFCjHhF+wL7NR5aEDRlpxCybna0+5E9kbRSb2fiz4=
 github.com/juju/naturalsort v1.0.0 h1:kGmUUy3h8mJ5/SJYaqKOBR3f3owEd5R52Lh+Tjg/dNM=
 github.com/juju/naturalsort v1.0.0/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os/v2 v2.2.5 h1:Ayw9aC7axKtGgzy3dFRKx84FxasfISMege0iYDsH6io=


### PR DESCRIPTION
Bump names/v6 version to include the latest patch https://github.com/juju/names/pull/120.


## QA steps

The 4.0 client should work with 3.6 client when moving spaces.

1) Install Juju 3.6 snap (if needed): 
```
sudo snap install juju_36 --channel 3.6/stable
```
2) Actual QA:
```
$ juju_36 bootstrap lxd c
$ juju_36 add-model m
$ juju_36 add-space beta
# Now move spaces using the current client:
$ juju move-to-space beta 10.254.213.0/24
```
The last command should work and not panic.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
