### PR TITLE
chore: update import path for distribution/reference package

### DIFF
--- a/caas/kubernetes/provider/utils/dockerconfig.go
+++ b/caas/kubernetes/provider/utils/dockerconfig.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/juju/errors"
 )
 

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/juju/charm/v12"
 	"github.com/juju/errors"
 	"github.com/juju/version/v2"

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/juju/ansiterm"
 	"github.com/juju/charm/v12"
 	"github.com/juju/charm/v12/hooks"

--- a/core/resources/dockerresource.go
+++ b/core/resources/dockerresource.go
@@ -9,7 +9,7 @@ import (
 	_ "crypto/sha512"
 	"encoding/json"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 

--- a/docker/auth.go
+++ b/docker/auth.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 )

--- a/docker/registry/internal/base_client.go
+++ b/docker/registry/internal/base_client.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/canonical/pebble v1.19.1
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/distribution/reference v0.6.0
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gliderlabs/ssh v0.3.8
@@ -173,7 +174,6 @@ require (
 	github.com/creack/pty v1.1.15 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fatih/color v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
-github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
-github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=


### PR DESCRIPTION
This pull request updates the project to replace the deprecated package `github.com/docker/distribution/reference` with its new location, `github.com/distribution/reference`. 

The change ensures compatibility with modern dependency ecosystems and prevents version conflicts for downstream users.

### Motivation
  - **Deprecation Notice**: The package `github.com/docker/distribution/reference` has been officially deprecated and moved to `github.com/distribution/reference`. Continuing to use the old import path risks relying on an unmaintained codebase.
  - **Backward Compatibility Issue**: The latest version of `github.com/distribution/reference` (v0.6.0) introduces breaking changes and is not backward compatible with earlier versions. Projects depending on both this package and others using different versions of `github.com/distribution/reference` may encounter unresolvable conflicts due to Go’s Minimal Version Selection (MVS).

## QA steps

N/A

## Documentation changes

N/A

## Links

**Issue:** Fixes #19454 & #19455.

