### PR TITLE
feat: add state method to retrieve only unit addresses

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -75,12 +75,18 @@ type ApplicationState interface {
 	// exist.
 	UpsertCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error
 
-	// GetUnitAddresses returns the addresses of the specified unit.
+	// GetUnitAndK8sServiceAddresses returns the addresses of the specified unit.
 	// The addresses are taken by unioning the net node UUIDs of the cloud service
 	// (if any) and the net node UUIDs of the unit, where each net node has an
 	// associated address.
 	// This apprach allows us to get the addresses regardless of the substrate
 	// (k8s or machines).
+	//
+	// The following errors may be returned:
+	// - [uniterrors.UnitNotFound] if the unit does not exist
+	GetUnitAndK8sServiceAddresses(ctx context.Context, uuid coreunit.UUID) (network.SpaceAddresses, error)
+
+	// GetUnitAddresses returns the addresses of the specified unit.
 	//
 	// The following errors may be returned:
 	// - [uniterrors.UnitNotFound] if the unit does not exist

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2535,6 +2535,45 @@ func (c *MockStateGetUnitAddressesCall) DoAndReturn(f func(context.Context, unit
 	return c
 }
 
+// GetUnitAndK8sServiceAddresses mocks base method.
+func (m *MockState) GetUnitAndK8sServiceAddresses(ctx context.Context, uuid unit.UUID) (network.SpaceAddresses, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitAndK8sServiceAddresses", ctx, uuid)
+	ret0, _ := ret[0].(network.SpaceAddresses)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitAndK8sServiceAddresses indicates an expected call of GetUnitAndK8sServiceAddresses.
+func (mr *MockStateMockRecorder) GetUnitAndK8sServiceAddresses(ctx, uuid any) *MockStateGetUnitAndK8sServiceAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitAndK8sServiceAddresses", reflect.TypeOf((*MockState)(nil).GetUnitAndK8sServiceAddresses), ctx, uuid)
+	return &MockStateGetUnitAndK8sServiceAddressesCall{Call: call}
+}
+
+// MockStateGetUnitAndK8sServiceAddressesCall wrap *gomock.Call
+type MockStateGetUnitAndK8sServiceAddressesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitAndK8sServiceAddressesCall) Return(arg0 network.SpaceAddresses, arg1 error) *MockStateGetUnitAndK8sServiceAddressesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitAndK8sServiceAddressesCall) Do(f func(context.Context, unit.UUID) (network.SpaceAddresses, error)) *MockStateGetUnitAndK8sServiceAddressesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitAndK8sServiceAddressesCall) DoAndReturn(f func(context.Context, unit.UUID) (network.SpaceAddresses, error)) *MockStateGetUnitAndK8sServiceAddressesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetUnitLife mocks base method.
 func (m *MockState) GetUnitLife(arg0 context.Context, arg1 unit.Name) (life.Life, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -648,7 +648,7 @@ func (s *Service) GetUnitPublicAddresses(ctx context.Context, unitName coreunit.
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	addrs, err := s.st.GetUnitAddresses(ctx, unitUUID)
+	addrs, err := s.st.GetUnitAndK8sServiceAddresses(ctx, unitUUID)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -598,7 +598,7 @@ func (s *unitServiceSuite) TestGetPublicAddressWithCloudServiceError(c *tc.C) {
 	unitName := coreunit.Name("foo/0")
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(coreunit.UUID("foo"), nil)
-	s.state.EXPECT().GetUnitAddresses(gomock.Any(), coreunit.UUID("foo")).Return(nil, errors.New("boom"))
+	s.state.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), coreunit.UUID("foo")).Return(nil, errors.New("boom"))
 
 	_, err := s.service.GetUnitPublicAddress(c.Context(), unitName)
 	c.Assert(err, tc.ErrorMatches, "boom")
@@ -649,7 +649,7 @@ func (s *unitServiceSuite) TestGetPublicAddressNonMatchingAddresses(c *tc.C) {
 	}
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), coreunit.Name("foo/0")).Return(coreunit.UUID("foo-uuid"), nil)
-	s.state.EXPECT().GetUnitAddresses(gomock.Any(), coreunit.UUID("foo-uuid")).Return(nonMatchingScopeAddrs, nil)
+	s.state.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), coreunit.UUID("foo-uuid")).Return(nonMatchingScopeAddrs, nil)
 
 	_, err := s.service.GetUnitPublicAddress(c.Context(), unitName)
 	c.Assert(err, tc.ErrorMatches, "no public address.*")
@@ -691,7 +691,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddress(c *tc.C) {
 	}
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(coreunit.UUID("foo"), nil)
-	s.state.EXPECT().GetUnitAddresses(gomock.Any(), coreunit.UUID("foo")).Return(matchingScopeAddrs, nil)
+	s.state.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), coreunit.UUID("foo")).Return(matchingScopeAddrs, nil)
 
 	addr, err := s.service.GetUnitPublicAddress(c.Context(), unitName)
 	c.Assert(err, tc.ErrorIsNil)
@@ -739,7 +739,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressSameOrigin(c *tc.C
 	}
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(coreunit.UUID("foo"), nil)
-	s.state.EXPECT().GetUnitAddresses(gomock.Any(), coreunit.UUID("foo")).Return(matchingScopeAddrs, nil)
+	s.state.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), coreunit.UUID("foo")).Return(matchingScopeAddrs, nil)
 
 	addr, err := s.service.GetUnitPublicAddress(c.Context(), unitName)
 	c.Assert(err, tc.ErrorIsNil)
@@ -787,7 +787,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressOneProviderOnly(c 
 	}
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(coreunit.UUID("foo"), nil)
-	s.state.EXPECT().GetUnitAddresses(gomock.Any(), coreunit.UUID("foo")).Return(matchingScopeAddrs, nil)
+	s.state.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), coreunit.UUID("foo")).Return(matchingScopeAddrs, nil)
 
 	addr, err := s.service.GetUnitPublicAddress(c.Context(), unitName)
 	c.Assert(err, tc.ErrorIsNil)
@@ -835,7 +835,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressOneProviderOtherUn
 	}
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(coreunit.UUID("foo"), nil)
-	s.state.EXPECT().GetUnitAddresses(gomock.Any(), coreunit.UUID("foo")).Return(matchingScopeAddrs, nil)
+	s.state.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), coreunit.UUID("foo")).Return(matchingScopeAddrs, nil)
 
 	addr, err := s.service.GetUnitPublicAddress(c.Context(), unitName)
 	c.Assert(err, tc.ErrorIsNil)
@@ -889,7 +889,7 @@ func (s *unitServiceSuite) TestGetPublicAddresses(c *tc.C) {
 	}
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(coreunit.UUID("foo"), nil)
-	s.state.EXPECT().GetUnitAddresses(gomock.Any(), coreunit.UUID("foo")).Return(unitAddresses, nil)
+	s.state.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), coreunit.UUID("foo")).Return(unitAddresses, nil)
 
 	addrs, err := s.service.GetUnitPublicAddresses(context.Background(), unitName)
 	c.Assert(err, tc.ErrorIsNil)
@@ -942,7 +942,7 @@ func (s *unitServiceSuite) TestGetPublicAddressesCloudLocal(c *tc.C) {
 	}
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(coreunit.UUID("foo"), nil)
-	s.state.EXPECT().GetUnitAddresses(gomock.Any(), coreunit.UUID("foo")).Return(unitAddresses, nil)
+	s.state.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), coreunit.UUID("foo")).Return(unitAddresses, nil)
 
 	addrs, err := s.service.GetUnitPublicAddresses(context.Background(), unitName)
 	c.Assert(err, tc.ErrorIsNil)


### PR DESCRIPTION
Previously, we only had a state method that retrieved the unit *and* k8s_service addresses together, this is unioned so it can work independently from CAAS/IAAS.
This patch adds a new state method to retrieve the unit addresses, which is now wired to the GetUnitPrivetAddress on the service layer.



## QA steps

Nothing wired, unit tests should pass.


