### PR TITLE
feat: wireup storage client facade

### DIFF
--- a/apiserver/facades/client/storage/domain_mock_test.go
+++ b/apiserver/facades/client/storage/domain_mock_test.go
@@ -14,10 +14,11 @@ import (
 	reflect "reflect"
 
 	machine "github.com/juju/juju/core/machine"
+	storage "github.com/juju/juju/core/storage"
 	unit "github.com/juju/juju/core/unit"
-	storage "github.com/juju/juju/domain/storage"
+	storage0 "github.com/juju/juju/domain/storage"
 	service "github.com/juju/juju/domain/storage/service"
-	storage0 "github.com/juju/juju/internal/storage"
+	storage1 "github.com/juju/juju/internal/storage"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -45,7 +46,7 @@ func (m *MockStorageService) EXPECT() *MockStorageServiceMockRecorder {
 }
 
 // CreateStoragePool mocks base method.
-func (m *MockStorageService) CreateStoragePool(arg0 context.Context, arg1 string, arg2 storage0.ProviderType, arg3 service.PoolAttrs) error {
+func (m *MockStorageService) CreateStoragePool(arg0 context.Context, arg1 string, arg2 storage1.ProviderType, arg3 service.PoolAttrs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStoragePool", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -71,13 +72,13 @@ func (c *MockStorageServiceCreateStoragePoolCall) Return(arg0 error) *MockStorag
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceCreateStoragePoolCall) Do(f func(context.Context, string, storage0.ProviderType, service.PoolAttrs) error) *MockStorageServiceCreateStoragePoolCall {
+func (c *MockStorageServiceCreateStoragePoolCall) Do(f func(context.Context, string, storage1.ProviderType, service.PoolAttrs) error) *MockStorageServiceCreateStoragePoolCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceCreateStoragePoolCall) DoAndReturn(f func(context.Context, string, storage0.ProviderType, service.PoolAttrs) error) *MockStorageServiceCreateStoragePoolCall {
+func (c *MockStorageServiceCreateStoragePoolCall) DoAndReturn(f func(context.Context, string, storage1.ProviderType, service.PoolAttrs) error) *MockStorageServiceCreateStoragePoolCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -120,50 +121,50 @@ func (c *MockStorageServiceDeleteStoragePoolCall) DoAndReturn(f func(context.Con
 	return c
 }
 
-// GetStoragePoolByName mocks base method.
-func (m *MockStorageService) GetStoragePoolByName(arg0 context.Context, arg1 string) (*storage0.Config, error) {
+// ImportFilesystem mocks base method.
+func (m *MockStorageService) ImportFilesystem(arg0 context.Context, arg1 service.ImportStorageParams) (storage.ID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStoragePoolByName", arg0, arg1)
-	ret0, _ := ret[0].(*storage0.Config)
+	ret := m.ctrl.Call(m, "ImportFilesystem", arg0, arg1)
+	ret0, _ := ret[0].(storage.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetStoragePoolByName indicates an expected call of GetStoragePoolByName.
-func (mr *MockStorageServiceMockRecorder) GetStoragePoolByName(arg0, arg1 any) *MockStorageServiceGetStoragePoolByNameCall {
+// ImportFilesystem indicates an expected call of ImportFilesystem.
+func (mr *MockStorageServiceMockRecorder) ImportFilesystem(arg0, arg1 any) *MockStorageServiceImportFilesystemCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolByName", reflect.TypeOf((*MockStorageService)(nil).GetStoragePoolByName), arg0, arg1)
-	return &MockStorageServiceGetStoragePoolByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportFilesystem", reflect.TypeOf((*MockStorageService)(nil).ImportFilesystem), arg0, arg1)
+	return &MockStorageServiceImportFilesystemCall{Call: call}
 }
 
-// MockStorageServiceGetStoragePoolByNameCall wrap *gomock.Call
-type MockStorageServiceGetStoragePoolByNameCall struct {
+// MockStorageServiceImportFilesystemCall wrap *gomock.Call
+type MockStorageServiceImportFilesystemCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStorageServiceGetStoragePoolByNameCall) Return(arg0 *storage0.Config, arg1 error) *MockStorageServiceGetStoragePoolByNameCall {
+func (c *MockStorageServiceImportFilesystemCall) Return(arg0 storage.ID, arg1 error) *MockStorageServiceImportFilesystemCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceGetStoragePoolByNameCall) Do(f func(context.Context, string) (*storage0.Config, error)) *MockStorageServiceGetStoragePoolByNameCall {
+func (c *MockStorageServiceImportFilesystemCall) Do(f func(context.Context, service.ImportStorageParams) (storage.ID, error)) *MockStorageServiceImportFilesystemCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceGetStoragePoolByNameCall) DoAndReturn(f func(context.Context, string) (*storage0.Config, error)) *MockStorageServiceGetStoragePoolByNameCall {
+func (c *MockStorageServiceImportFilesystemCall) DoAndReturn(f func(context.Context, service.ImportStorageParams) (storage.ID, error)) *MockStorageServiceImportFilesystemCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListStoragePools mocks base method.
-func (m *MockStorageService) ListStoragePools(arg0 context.Context, arg1 storage.Names, arg2 storage.Providers) ([]*storage0.Config, error) {
+func (m *MockStorageService) ListStoragePools(arg0 context.Context, arg1 storage0.Names, arg2 storage0.Providers) ([]*storage1.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStoragePools", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*storage0.Config)
+	ret0, _ := ret[0].([]*storage1.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -181,25 +182,25 @@ type MockStorageServiceListStoragePoolsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStorageServiceListStoragePoolsCall) Return(arg0 []*storage0.Config, arg1 error) *MockStorageServiceListStoragePoolsCall {
+func (c *MockStorageServiceListStoragePoolsCall) Return(arg0 []*storage1.Config, arg1 error) *MockStorageServiceListStoragePoolsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceListStoragePoolsCall) Do(f func(context.Context, storage.Names, storage.Providers) ([]*storage0.Config, error)) *MockStorageServiceListStoragePoolsCall {
+func (c *MockStorageServiceListStoragePoolsCall) Do(f func(context.Context, storage0.Names, storage0.Providers) ([]*storage1.Config, error)) *MockStorageServiceListStoragePoolsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceListStoragePoolsCall) DoAndReturn(f func(context.Context, storage.Names, storage.Providers) ([]*storage0.Config, error)) *MockStorageServiceListStoragePoolsCall {
+func (c *MockStorageServiceListStoragePoolsCall) DoAndReturn(f func(context.Context, storage0.Names, storage0.Providers) ([]*storage1.Config, error)) *MockStorageServiceListStoragePoolsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReplaceStoragePool mocks base method.
-func (m *MockStorageService) ReplaceStoragePool(arg0 context.Context, arg1 string, arg2 storage0.ProviderType, arg3 service.PoolAttrs) error {
+func (m *MockStorageService) ReplaceStoragePool(arg0 context.Context, arg1 string, arg2 storage1.ProviderType, arg3 service.PoolAttrs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceStoragePool", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -225,13 +226,13 @@ func (c *MockStorageServiceReplaceStoragePoolCall) Return(arg0 error) *MockStora
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceReplaceStoragePoolCall) Do(f func(context.Context, string, storage0.ProviderType, service.PoolAttrs) error) *MockStorageServiceReplaceStoragePoolCall {
+func (c *MockStorageServiceReplaceStoragePoolCall) Do(f func(context.Context, string, storage1.ProviderType, service.PoolAttrs) error) *MockStorageServiceReplaceStoragePoolCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceReplaceStoragePoolCall) DoAndReturn(f func(context.Context, string, storage0.ProviderType, service.PoolAttrs) error) *MockStorageServiceReplaceStoragePoolCall {
+func (c *MockStorageServiceReplaceStoragePoolCall) DoAndReturn(f func(context.Context, string, storage1.ProviderType, service.PoolAttrs) error) *MockStorageServiceReplaceStoragePoolCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -257,6 +258,159 @@ func NewMockApplicationService(ctrl *gomock.Controller) *MockApplicationService 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
+}
+
+// AddStorageForUnit mocks base method.
+func (m *MockApplicationService) AddStorageForUnit(arg0 context.Context, arg1 storage.Name, arg2 unit.Name, arg3 storage1.Directive) ([]storage.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddStorageForUnit", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]storage.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddStorageForUnit indicates an expected call of AddStorageForUnit.
+func (mr *MockApplicationServiceMockRecorder) AddStorageForUnit(arg0, arg1, arg2, arg3 any) *MockApplicationServiceAddStorageForUnitCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddStorageForUnit", reflect.TypeOf((*MockApplicationService)(nil).AddStorageForUnit), arg0, arg1, arg2, arg3)
+	return &MockApplicationServiceAddStorageForUnitCall{Call: call}
+}
+
+// MockApplicationServiceAddStorageForUnitCall wrap *gomock.Call
+type MockApplicationServiceAddStorageForUnitCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceAddStorageForUnitCall) Return(arg0 []storage.ID, arg1 error) *MockApplicationServiceAddStorageForUnitCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceAddStorageForUnitCall) Do(f func(context.Context, storage.Name, unit.Name, storage1.Directive) ([]storage.ID, error)) *MockApplicationServiceAddStorageForUnitCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceAddStorageForUnitCall) DoAndReturn(f func(context.Context, storage.Name, unit.Name, storage1.Directive) ([]storage.ID, error)) *MockApplicationServiceAddStorageForUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// AttachStorage mocks base method.
+func (m *MockApplicationService) AttachStorage(arg0 context.Context, arg1 storage.ID, arg2 unit.Name) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachStorage", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AttachStorage indicates an expected call of AttachStorage.
+func (mr *MockApplicationServiceMockRecorder) AttachStorage(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorage", reflect.TypeOf((*MockApplicationService)(nil).AttachStorage), arg0, arg1, arg2)
+	return &MockApplicationServiceAttachStorageCall{Call: call}
+}
+
+// MockApplicationServiceAttachStorageCall wrap *gomock.Call
+type MockApplicationServiceAttachStorageCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceAttachStorageCall) Return(arg0 error) *MockApplicationServiceAttachStorageCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceAttachStorageCall) Do(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceAttachStorageCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceAttachStorageCall) DoAndReturn(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceAttachStorageCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DetachStorage mocks base method.
+func (m *MockApplicationService) DetachStorage(arg0 context.Context, arg1 storage.ID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachStorage", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachStorage indicates an expected call of DetachStorage.
+func (mr *MockApplicationServiceMockRecorder) DetachStorage(arg0, arg1 any) *MockApplicationServiceDetachStorageCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachStorage", reflect.TypeOf((*MockApplicationService)(nil).DetachStorage), arg0, arg1)
+	return &MockApplicationServiceDetachStorageCall{Call: call}
+}
+
+// MockApplicationServiceDetachStorageCall wrap *gomock.Call
+type MockApplicationServiceDetachStorageCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceDetachStorageCall) Return(arg0 error) *MockApplicationServiceDetachStorageCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceDetachStorageCall) Do(f func(context.Context, storage.ID) error) *MockApplicationServiceDetachStorageCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceDetachStorageCall) DoAndReturn(f func(context.Context, storage.ID) error) *MockApplicationServiceDetachStorageCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DetachStorageForUnit mocks base method.
+func (m *MockApplicationService) DetachStorageForUnit(arg0 context.Context, arg1 storage.ID, arg2 unit.Name) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachStorageForUnit", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachStorageForUnit indicates an expected call of DetachStorageForUnit.
+func (mr *MockApplicationServiceMockRecorder) DetachStorageForUnit(arg0, arg1, arg2 any) *MockApplicationServiceDetachStorageForUnitCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachStorageForUnit", reflect.TypeOf((*MockApplicationService)(nil).DetachStorageForUnit), arg0, arg1, arg2)
+	return &MockApplicationServiceDetachStorageForUnitCall{Call: call}
+}
+
+// MockApplicationServiceDetachStorageForUnitCall wrap *gomock.Call
+type MockApplicationServiceDetachStorageForUnitCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceDetachStorageForUnitCall) Return(arg0 error) *MockApplicationServiceDetachStorageForUnitCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceDetachStorageForUnitCall) Do(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceDetachStorageForUnitCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceDetachStorageForUnitCall) DoAndReturn(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceDetachStorageForUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetUnitMachineName mocks base method.

--- a/apiserver/facades/client/storage/domain_mock_test.go
+++ b/apiserver/facades/client/storage/domain_mock_test.go
@@ -121,41 +121,41 @@ func (c *MockStorageServiceDeleteStoragePoolCall) DoAndReturn(f func(context.Con
 	return c
 }
 
-// ImportFilesystem mocks base method.
-func (m *MockStorageService) ImportFilesystem(arg0 context.Context, arg1 service.ImportStorageParams) (storage.ID, error) {
+// ImportProviderStorage mocks base method.
+func (m *MockStorageService) ImportProviderStorage(arg0 context.Context, arg1 service.ImportStorageParams) (storage.ID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ImportFilesystem", arg0, arg1)
+	ret := m.ctrl.Call(m, "ImportProviderStorage", arg0, arg1)
 	ret0, _ := ret[0].(storage.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ImportFilesystem indicates an expected call of ImportFilesystem.
-func (mr *MockStorageServiceMockRecorder) ImportFilesystem(arg0, arg1 any) *MockStorageServiceImportFilesystemCall {
+// ImportProviderStorage indicates an expected call of ImportProviderStorage.
+func (mr *MockStorageServiceMockRecorder) ImportProviderStorage(arg0, arg1 any) *MockStorageServiceImportProviderStorageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportFilesystem", reflect.TypeOf((*MockStorageService)(nil).ImportFilesystem), arg0, arg1)
-	return &MockStorageServiceImportFilesystemCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportProviderStorage", reflect.TypeOf((*MockStorageService)(nil).ImportProviderStorage), arg0, arg1)
+	return &MockStorageServiceImportProviderStorageCall{Call: call}
 }
 
-// MockStorageServiceImportFilesystemCall wrap *gomock.Call
-type MockStorageServiceImportFilesystemCall struct {
+// MockStorageServiceImportProviderStorageCall wrap *gomock.Call
+type MockStorageServiceImportProviderStorageCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStorageServiceImportFilesystemCall) Return(arg0 storage.ID, arg1 error) *MockStorageServiceImportFilesystemCall {
+func (c *MockStorageServiceImportProviderStorageCall) Return(arg0 storage.ID, arg1 error) *MockStorageServiceImportProviderStorageCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceImportFilesystemCall) Do(f func(context.Context, service.ImportStorageParams) (storage.ID, error)) *MockStorageServiceImportFilesystemCall {
+func (c *MockStorageServiceImportProviderStorageCall) Do(f func(context.Context, service.ImportStorageParams) (storage.ID, error)) *MockStorageServiceImportProviderStorageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceImportFilesystemCall) DoAndReturn(f func(context.Context, service.ImportStorageParams) (storage.ID, error)) *MockStorageServiceImportFilesystemCall {
+func (c *MockStorageServiceImportProviderStorageCall) DoAndReturn(f func(context.Context, service.ImportStorageParams) (storage.ID, error)) *MockStorageServiceImportProviderStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -299,78 +299,40 @@ func (c *MockApplicationServiceAddStorageForUnitCall) DoAndReturn(f func(context
 	return c
 }
 
-// AttachStorage mocks base method.
-func (m *MockApplicationService) AttachStorage(arg0 context.Context, arg1 storage.ID, arg2 unit.Name) error {
+// AttachStorageToUnit mocks base method.
+func (m *MockApplicationService) AttachStorageToUnit(arg0 context.Context, arg1 storage.ID, arg2 unit.Name) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachStorage", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AttachStorageToUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AttachStorage indicates an expected call of AttachStorage.
-func (mr *MockApplicationServiceMockRecorder) AttachStorage(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageCall {
+// AttachStorageToUnit indicates an expected call of AttachStorageToUnit.
+func (mr *MockApplicationServiceMockRecorder) AttachStorageToUnit(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageToUnitCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorage", reflect.TypeOf((*MockApplicationService)(nil).AttachStorage), arg0, arg1, arg2)
-	return &MockApplicationServiceAttachStorageCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToUnit", reflect.TypeOf((*MockApplicationService)(nil).AttachStorageToUnit), arg0, arg1, arg2)
+	return &MockApplicationServiceAttachStorageToUnitCall{Call: call}
 }
 
-// MockApplicationServiceAttachStorageCall wrap *gomock.Call
-type MockApplicationServiceAttachStorageCall struct {
+// MockApplicationServiceAttachStorageToUnitCall wrap *gomock.Call
+type MockApplicationServiceAttachStorageToUnitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceAttachStorageCall) Return(arg0 error) *MockApplicationServiceAttachStorageCall {
+func (c *MockApplicationServiceAttachStorageToUnitCall) Return(arg0 error) *MockApplicationServiceAttachStorageToUnitCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceAttachStorageCall) Do(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceAttachStorageCall {
+func (c *MockApplicationServiceAttachStorageToUnitCall) Do(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceAttachStorageToUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceAttachStorageCall) DoAndReturn(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceAttachStorageCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// DetachStorage mocks base method.
-func (m *MockApplicationService) DetachStorage(arg0 context.Context, arg1 storage.ID) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DetachStorage", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DetachStorage indicates an expected call of DetachStorage.
-func (mr *MockApplicationServiceMockRecorder) DetachStorage(arg0, arg1 any) *MockApplicationServiceDetachStorageCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachStorage", reflect.TypeOf((*MockApplicationService)(nil).DetachStorage), arg0, arg1)
-	return &MockApplicationServiceDetachStorageCall{Call: call}
-}
-
-// MockApplicationServiceDetachStorageCall wrap *gomock.Call
-type MockApplicationServiceDetachStorageCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceDetachStorageCall) Return(arg0 error) *MockApplicationServiceDetachStorageCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceDetachStorageCall) Do(f func(context.Context, storage.ID) error) *MockApplicationServiceDetachStorageCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceDetachStorageCall) DoAndReturn(f func(context.Context, storage.ID) error) *MockApplicationServiceDetachStorageCall {
+func (c *MockApplicationServiceAttachStorageToUnitCall) DoAndReturn(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceAttachStorageToUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -409,6 +371,44 @@ func (c *MockApplicationServiceDetachStorageForUnitCall) Do(f func(context.Conte
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceDetachStorageForUnitCall) DoAndReturn(f func(context.Context, storage.ID, unit.Name) error) *MockApplicationServiceDetachStorageForUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DetachStorageFromUnit mocks base method.
+func (m *MockApplicationService) DetachStorageFromUnit(arg0 context.Context, arg1 storage.ID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachStorageFromUnit", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachStorageFromUnit indicates an expected call of DetachStorageFromUnit.
+func (mr *MockApplicationServiceMockRecorder) DetachStorageFromUnit(arg0, arg1 any) *MockApplicationServiceDetachStorageFromUnitCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachStorageFromUnit", reflect.TypeOf((*MockApplicationService)(nil).DetachStorageFromUnit), arg0, arg1)
+	return &MockApplicationServiceDetachStorageFromUnitCall{Call: call}
+}
+
+// MockApplicationServiceDetachStorageFromUnitCall wrap *gomock.Call
+type MockApplicationServiceDetachStorageFromUnitCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceDetachStorageFromUnitCall) Return(arg0 error) *MockApplicationServiceDetachStorageFromUnitCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceDetachStorageFromUnitCall) Do(f func(context.Context, storage.ID) error) *MockApplicationServiceDetachStorageFromUnitCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceDetachStorageFromUnitCall) DoAndReturn(f func(context.Context, storage.ID) error) *MockApplicationServiceDetachStorageFromUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -46,7 +46,6 @@ type mockStorageAccessor struct {
 	machineFilesystemAttachments        func(machine names.MachineTag) ([]state.FilesystemAttachment, error)
 	filesystemAttachments               func(filesystem names.FilesystemTag) ([]state.FilesystemAttachment, error)
 	allFilesystems                      func() ([]state.Filesystem, error)
-	addStorageForUnit                   func(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)
 	destroyStorageInstance              func(names.StorageTag, bool, bool) error
 	releaseStorageInstance              func(names.StorageTag, bool, bool) error
 	attachStorage                       func(names.StorageTag, names.UnitTag) error
@@ -129,10 +128,6 @@ func (st *mockStorageAccessor) MachineFilesystemAttachments(machine names.Machin
 
 func (st *mockStorageAccessor) Filesystem(tag names.FilesystemTag) (state.Filesystem, error) {
 	return st.filesystem(tag)
-}
-
-func (st *mockStorageAccessor) AddStorageForUnit(u names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error) {
-	return st.addStorageForUnit(u, name, cons)
 }
 
 func (st *mockStorageAccessor) AttachStorage(storage names.StorageTag, unit names.UnitTag) error {

--- a/apiserver/facades/client/storage/register.go
+++ b/apiserver/facades/client/storage/register.go
@@ -47,7 +47,6 @@ func newStorageAPI(stdCtx context.Context, ctx facade.ModelContext) (*StorageAPI
 		domainServices.BlockDevice(),
 		storageService,
 		domainServices.Application(),
-		storageService.GetStorageRegistry,
 		authorizer,
 		domainServices.BlockCommand()), nil
 }

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -39,17 +39,6 @@ type storageInterface interface {
 	// identified unit.
 	UnitStorageAttachments(names.UnitTag) ([]state.StorageAttachment, error)
 
-	// AddStorageForUnit is required for storage add functionality.
-	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) ([]names.StorageTag, error)
-
-	// AttachStorage attaches the storage instance with the
-	// specified tag to the unit with the specified tag.
-	AttachStorage(names.StorageTag, names.UnitTag) error
-
-	// DetachStorage detaches the storage instance with the
-	// specified tag from the unit with the specified tag.
-	DetachStorage(names.StorageTag, names.UnitTag, bool, time.Duration) error
-
 	// DestroyStorageInstance destroys the storage instance with the specified tag.
 	DestroyStorageInstance(names.StorageTag, bool, bool, time.Duration) error
 
@@ -73,9 +62,6 @@ type storageVolume interface {
 
 	// Volume is required for volume functionality.
 	Volume(tag names.VolumeTag) (state.Volume, error)
-
-	// AddExistingFilesystem imports an existing filesystem into the model.
-	AddExistingFilesystem(f state.FilesystemInfo, v *state.VolumeInfo, storageName string) (names.StorageTag, error)
 }
 
 type storageFile interface {
@@ -92,9 +78,6 @@ type storageFile interface {
 
 	// Filesystem is required for filesystem functionality.
 	Filesystem(tag names.FilesystemTag) (state.Filesystem, error)
-
-	// AddExistingFilesystem imports an existing filesystem into the model.
-	AddExistingFilesystem(f state.FilesystemInfo, v *state.VolumeInfo, storageName string) (names.StorageTag, error)
 }
 
 var getStorageAccessor = func(

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -332,7 +332,7 @@ func (s *storageSuite) TestDetach(c *tc.C) {
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), blockcommand.ChangeBlock).Return("", blockcommanderrors.NotFound)
 
 	s.applicationService.EXPECT().DetachStorageForUnit(gomock.Any(), corestorage.ID("data/0"), coreunit.Name("mysql/0"))
-	s.applicationService.EXPECT().DetachStorage(gomock.Any(), corestorage.ID("data/0"))
+	s.applicationService.EXPECT().DetachStorageFromUnit(gomock.Any(), corestorage.ID("data/0"))
 
 	results, err := s.api.DetachStorage(
 		c.Context(),
@@ -386,7 +386,7 @@ func (s *storageSuite) TestDetachNoAttachmentsStorageNotFound(c *tc.C) {
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), blockcommand.ChangeBlock).Return("", blockcommanderrors.NotFound)
 
-	s.applicationService.EXPECT().DetachStorage(gomock.Any(), corestorage.ID("foo/42")).Return(storageerrors.StorageNotFound)
+	s.applicationService.EXPECT().DetachStorageFromUnit(gomock.Any(), corestorage.ID("foo/42")).Return(storageerrors.StorageNotFound)
 
 	results, err := s.api.DetachStorage(
 		c.Context(),
@@ -409,7 +409,7 @@ func (s *storageSuite) TestAttach(c *tc.C) {
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), blockcommand.ChangeBlock).Return("", blockcommanderrors.NotFound)
 
-	s.applicationService.EXPECT().AttachStorage(gomock.Any(), corestorage.ID("data/0"), coreunit.Name("mysql/0"))
+	s.applicationService.EXPECT().AttachStorageToUnit(gomock.Any(), corestorage.ID("data/0"), coreunit.Name("mysql/0"))
 
 	results, err := s.api.Attach(c.Context(),
 		params.StorageAttachmentIds{Ids: []params.StorageAttachmentId{
@@ -431,7 +431,7 @@ func (s *storageSuite) TestImportFilesystem(c *tc.C) {
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), blockcommand.ChangeBlock).Return("", blockcommanderrors.NotFound)
 
-	s.storageService.EXPECT().ImportFilesystem(gomock.Any(), service.ImportStorageParams{
+	s.storageService.EXPECT().ImportProviderStorage(gomock.Any(), service.ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "radiance",
 		ProviderId:  "foo",
@@ -457,7 +457,7 @@ func (s *storageSuite) TestImportFilesystemVolumeBacked(c *tc.C) {
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), blockcommand.ChangeBlock).Return("", blockcommanderrors.NotFound)
 
-	s.storageService.EXPECT().ImportFilesystem(gomock.Any(), service.ImportStorageParams{
+	s.storageService.EXPECT().ImportProviderStorage(gomock.Any(), service.ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "radiance",
 		ProviderId:  "foo",
@@ -482,7 +482,7 @@ func (s *storageSuite) TestImportFilesystemNotSupported(c *tc.C) {
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), blockcommand.ChangeBlock).Return("", blockcommanderrors.NotFound)
 
-	s.storageService.EXPECT().ImportFilesystem(gomock.Any(), service.ImportStorageParams{
+	s.storageService.EXPECT().ImportProviderStorage(gomock.Any(), service.ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "radiance",
 		ProviderId:  "foo",

--- a/apiserver/facades/client/storage/storageadd_test.go
+++ b/apiserver/facades/client/storage/storageadd_test.go
@@ -126,13 +126,13 @@ func (s *storageAddSuite) TestStorageAddUnitResultOrder(c *tc.C) {
 	}
 	msg := "storage name missing"
 	s.applicationService.EXPECT().AddStorageForUnit(
-		gomock.Any(), corestorage.Name("data"), coreunit.Name(s.unitTag.Id()), storage.Directive{}).DoAndReturn(
+		gomock.Any(), gomock.Any(), coreunit.Name(s.unitTag.Id()), storage.Directive{}).DoAndReturn(
 		func(_ context.Context, name corestorage.Name, unit coreunit.Name, directive storage.Directive) ([]corestorage.ID, error) {
 			if name == "" {
 				return nil, errors.New(msg)
 			}
 			return nil, nil
-		})
+		}).Times(2)
 	failures, err := s.api.AddToUnit(c.Context(), params.StoragesAddParams{
 		Storages: []params.StorageAddParams{
 			wrong0,

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -65,7 +65,7 @@ type StorageState interface {
 	DetachStorage(ctx context.Context, storageUUID corestorage.UUID) error
 }
 
-// AttachStorage attached the specified storage to the specified unit.
+// AttachStorageToUnit attached the specified storage to the specified unit.
 // If the attachment already exists, the result is a no op.
 // The following error types can be expected:
 // - [github.com/juju/juju/core/unit.InvalidUnitName]: when the unit name is not valid.
@@ -79,7 +79,7 @@ type StorageState interface {
 // - [github.com/juju/juju/domain/application/errors.StorageNameNotSupported]: when storage name is not defined in charm metadata.
 // - [github.com/juju/juju/domain/application/errors.InvalidStorageCount]: when the allowed attachment count would be violated.
 // - [github.com/juju/juju/domain/application/errors.InvalidStorageMountPoint]: when the filesystem being attached to the unit's machine has a mount point path conflict.
-func (s *Service) AttachStorage(ctx context.Context, storageID corestorage.ID, unitName coreunit.Name) error {
+func (s *Service) AttachStorageToUnit(ctx context.Context, storageID corestorage.ID, unitName coreunit.Name) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 	if err := unitName.Validate(); err != nil {
@@ -160,12 +160,12 @@ func (s *Service) DetachStorageForUnit(ctx context.Context, storageID corestorag
 	return s.st.DetachStorageForUnit(ctx, storageUUID, unitUUID)
 }
 
-// DetachStorage detaches the specified storage from whatever node it is attached to.
+// DetachStorageFromUnit detaches the specified storage from whatever node it is attached to.
 // The following error types can be expected:
 // - [github.com/juju/juju/core/storage.InvalidStorageID]: when the storage ID is not valid.
 // - [github.com/juju/juju/domain/storage/errors.StorageNotFound] when the storage doesn't exist.
 // - [github.com/juju/juju/domain/application/errors.StorageNotDetachable]: when the type of storage is not detachable.
-func (s *Service) DetachStorage(ctx context.Context, storageID corestorage.ID) error {
+func (s *Service) DetachStorageFromUnit(ctx context.Context, storageID corestorage.ID) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 	if err := storageID.Validate(); err != nil {

--- a/domain/application/service/storage_test.go
+++ b/domain/application/service/storage_test.go
@@ -60,7 +60,7 @@ func (s *storageSuite) TestAttachStorage(c *tc.C) {
 	s.mockState.EXPECT().GetStorageUUIDByID(gomock.Any(), corestorage.ID("pgdata/0")).Return(storageUUID, nil)
 	s.mockState.EXPECT().AttachStorage(gomock.Any(), storageUUID, unitUUID)
 
-	err := s.service.AttachStorage(c.Context(), "pgdata/0", "postgresql/666")
+	err := s.service.AttachStorageToUnit(c.Context(), "pgdata/0", "postgresql/666")
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -73,16 +73,16 @@ func (s *storageSuite) TestAttachStorageAlreadyAttached(c *tc.C) {
 	s.mockState.EXPECT().GetStorageUUIDByID(gomock.Any(), corestorage.ID("pgdata/0")).Return(storageUUID, nil)
 	s.mockState.EXPECT().AttachStorage(gomock.Any(), storageUUID, unitUUID).Return(errors.StorageAlreadyAttached)
 
-	err := s.service.AttachStorage(c.Context(), "pgdata/0", "postgresql/666")
+	err := s.service.AttachStorageToUnit(c.Context(), "pgdata/0", "postgresql/666")
 	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *storageSuite) TestAttachStorageValidate(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := s.service.AttachStorage(c.Context(), "pgdata/0", "666")
+	err := s.service.AttachStorageToUnit(c.Context(), "pgdata/0", "666")
 	c.Assert(err, tc.ErrorIs, unit.InvalidUnitName)
-	err = s.service.AttachStorage(c.Context(), "0", "postgresql/666")
+	err = s.service.AttachStorageToUnit(c.Context(), "0", "postgresql/666")
 	c.Assert(err, tc.ErrorIs, corestorage.InvalidStorageID)
 }
 
@@ -137,13 +137,13 @@ func (s *storageSuite) TestDetachStorage(c *tc.C) {
 	s.mockState.EXPECT().GetStorageUUIDByID(gomock.Any(), corestorage.ID("pgdata/0")).Return(storageUUID, nil)
 	s.mockState.EXPECT().DetachStorage(gomock.Any(), storageUUID)
 
-	err := s.service.DetachStorage(c.Context(), "pgdata/0")
+	err := s.service.DetachStorageFromUnit(c.Context(), "pgdata/0")
 	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *storageSuite) TestDetachStorageValidate(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := s.service.DetachStorage(c.Context(), "0")
+	err := s.service.DetachStorageFromUnit(c.Context(), "0")
 	c.Assert(err, tc.ErrorIs, corestorage.InvalidStorageID)
 }

--- a/domain/storage/errors/errors.go
+++ b/domain/storage/errors/errors.go
@@ -32,6 +32,10 @@ const (
 	// on does not exist.
 	StorageNotFound = errors.ConstError("storage not found")
 
+	// StorageAttachmentNotFound describes an error that occurs when the storage attachment
+	// being operated on does not exist.
+	StorageAttachmentNotFound = errors.ConstError("storage attachment not found")
+
 	// FilesystemNotFound describes an error that occurs when the filesystem being operated
 	// on does not exist.
 	FilesystemNotFound = errors.ConstError("filesystem not found")

--- a/domain/storage/service/storage.go
+++ b/domain/storage/service/storage.go
@@ -36,12 +36,12 @@ type StorageService struct {
 	registryGetter corestorage.ModelStorageRegistryGetter
 }
 
-// ImportFilesystem associates a filesystem (either native or volume backed) hosted by a cloud provider
+// ImportProviderStorage associates storage hosted by a cloud provider
 // with a new storage instance (and storage pool) in a model.
 // The following error types can be expected:
 // - [coreerrors.NotSupported]: when the importing the kind of storage is not supported by the provider.
 // - [storageerrors.InvalidPoolNameError]: when the supplied pool name is invalid.
-func (s *StorageService) ImportFilesystem(ctx context.Context, arg ImportStorageParams) (corestorage.ID, error) {
+func (s *StorageService) ImportProviderStorage(ctx context.Context, arg ImportStorageParams) (corestorage.ID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/storage/service/storage_test.go
+++ b/domain/storage/service/storage_test.go
@@ -75,7 +75,7 @@ func (s *storageSuite) service(c *tc.C) *Service {
 func (s *storageSuite) TestImportFilesystemValidate(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	_, err := s.service(c).ImportFilesystem(c.Context(), ImportStorageParams{
+	_, err := s.service(c).ImportProviderStorage(c.Context(), ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "elastic",
 		ProviderId:  "provider-id",
@@ -83,7 +83,7 @@ func (s *storageSuite) TestImportFilesystemValidate(c *tc.C) {
 	})
 	c.Check(err, tc.ErrorIs, corestorage.InvalidStorageName)
 
-	_, err = s.service(c).ImportFilesystem(c.Context(), ImportStorageParams{
+	_, err = s.service(c).ImportProviderStorage(c.Context(), ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "0",
 		ProviderId:  "provider-id",
@@ -91,7 +91,7 @@ func (s *storageSuite) TestImportFilesystemValidate(c *tc.C) {
 	})
 	c.Check(err, tc.ErrorIs, storageerrors.InvalidPoolNameError)
 
-	_, err = s.service(c).ImportFilesystem(c.Context(), ImportStorageParams{
+	_, err = s.service(c).ImportProviderStorage(c.Context(), ImportStorageParams{
 		Kind:        storage.StorageKindBlock,
 		Pool:        "elastic",
 		ProviderId:  "provider-id",
@@ -134,7 +134,7 @@ func (s *storageSuite) TestImportFilesystem(c *tc.C) {
 		Pool: "elastic",
 	}).Return("pgdata/0", nil)
 
-	result, err := s.service(c).ImportFilesystem(c.Context(), ImportStorageParams{
+	result, err := s.service(c).ImportProviderStorage(c.Context(), ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "elastic",
 		ProviderId:  "provider-id",
@@ -181,7 +181,7 @@ func (s *storageSuite) TestImportFilesystemUsingStoragePool(c *tc.C) {
 		Pool: "fast-elastic",
 	}).Return("pgdata/0", nil)
 
-	result, err := s.service(c).ImportFilesystem(c.Context(), ImportStorageParams{
+	result, err := s.service(c).ImportProviderStorage(c.Context(), ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "fast-elastic",
 		ProviderId:  "provider-id",
@@ -204,7 +204,7 @@ func (s *storageSuite) TestImportFilesystemNotSupported(c *tc.C) {
 		ModelUUID:      modeltesting.GenModelUUID(c).String(),
 		ControllerUUID: uuid.MustNewUUID().String(),
 	}, nil)
-	_, err = s.service(c).ImportFilesystem(c.Context(), ImportStorageParams{
+	_, err = s.service(c).ImportProviderStorage(c.Context(), ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "elastic",
 		ProviderId:  "provider-id",
@@ -256,7 +256,7 @@ func (s *storageSuite) TestImportFilesystemVolumeBacked(c *tc.C) {
 		},
 	}).Return("pgdata/0", nil)
 
-	result, err := s.service(c).ImportFilesystem(c.Context(), ImportStorageParams{
+	result, err := s.service(c).ImportProviderStorage(c.Context(), ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "ebs",
 		ProviderId:  "provider-id",
@@ -279,7 +279,7 @@ func (s *storageSuite) TestImportFilesystemVolumeBackedNotSupported(c *tc.C) {
 		ModelUUID:      modeltesting.GenModelUUID(c).String(),
 		ControllerUUID: uuid.MustNewUUID().String(),
 	}, nil)
-	_, err = s.service(c).ImportFilesystem(c.Context(), ImportStorageParams{
+	_, err = s.service(c).ImportProviderStorage(c.Context(), ImportStorageParams{
 		Kind:        storage.StorageKindFilesystem,
 		Pool:        "ebs",
 		ProviderId:  "provider-id",


### PR DESCRIPTION
The client storage facade apis for adding, attaching, detaching storage are wired through to the domain service calls instead of state. The domain service calls instead of state are:
- AttachStorage
- DetachStorageForUnit
- DetachStorage
- AddStorageForUnit

Basically these commands cover the recording in the model of storage intent when deploying or attaching storage.

A number of facade tests are dropped because the functionality is now beneath the service layer.
We also no longer need to pass the storage registry into the facade.

## QA steps

```
juju bootstrap
juju deploy postgresql --storage=pgdata,10M.rootfs
```

```
repl (model-controller)> select * from application_storage_directive;
application_uuid                        charm_uuid                              storage_name    storage_pool_uuid       storage_type    size_mib        count
927bf8af-8c0a-4d8b-8058-2fd5c7f5c2e1    6d54ba86-6850-4413-8809-52ab45e98824    pgdata          <nil>                   rootfs          10              1

repl (model-controller)> select * from storage_instance;
uuid                                    charm_uuid                              storage_name    storage_id      life_id storage_pool_uuid       storage_type    requested_size_mib
a5c8e5f7-63a9-49cf-8b16-73a288ba0ed0    6d54ba86-6850-4413-8809-52ab45e98824    pgdata          pgdata/0        0       <nil>                   rootfs          10
```

## Links

**Jira card:** [JUJU-7474](https://warthogs.atlassian.net/browse/JUJU-7474)


[JUJU-7474]: https://warthogs.atlassian.net/browse/JUJU-7474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ