### PR TITLE
chore: change snappass charm on alertmanager-k8s

### DIFF
--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -7,25 +7,25 @@ run_secrets() {
 	# k8s secrets are stored in an external backend.
 	# These checks ensure the secrets are deleted when the units and app are deleted.
 	echo "deploy an app and create an app owned secret and a unit owned secret"
-	juju --show-log deploy snappass-test
-	wait_for "snappass-test" "$(active_idle_condition "snappass-test" 0 0)"
-	wait_for "active" '.applications["snappass-test"] | ."application-status".current'
-	full_uri1=$(juju exec --unit snappass-test/0 -- secret-add foo=bar)
+	juju --show-log deploy alertmanager-k8s
+	wait_for "alertmanager-k8s" "$(active_idle_condition "alertmanager-k8s" 0 0)"
+	wait_for "active" '.applications["alertmanager-k8s"] | ."application-status".current'
+	full_uri1=$(juju exec --unit alertmanager-k8s/0 -- secret-add foo=bar)
 	short_uri1=${full_uri1##*/}
-	full_uri2=$(juju exec --unit snappass-test/0 -- secret-add --owner unit foo=bar2)
+	full_uri2=$(juju exec --unit alertmanager-k8s/0 -- secret-add --owner unit foo=bar2)
 	short_uri2=${full_uri2##*/}
 	check_contains "$(microk8s kubectl -n "$model_name" get secrets -o json | jq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")')" "${short_uri1}-1"
 	check_contains "$(microk8s kubectl -n "$model_name" get secrets -o json | jq -r '.items[].metadata.name | select(. == "'"${short_uri2}"'-1")')" "${short_uri2}-1"
 
 	echo "add another unit and create a unit owned secret"
-	juju --show-log scale-application snappass-test 2
-	wait_for "snappass-test" "$(active_idle_condition "snappass-test" 0 1)"
-	full_uri3=$(juju exec --unit snappass-test/1 -- secret-add --owner unit foo=bar3)
+	juju --show-log scale-application alertmanager-k8s 2
+	wait_for "alertmanager-k8s" "$(active_idle_condition "alertmanager-k8s" 0 1)"
+	full_uri3=$(juju exec --unit alertmanager-k8s/1 -- secret-add --owner unit foo=bar3)
 	short_uri3=${full_uri3##*/}
 	check_contains "$(microk8s kubectl -n "$model_name" get secrets -o json | jq -r '.items[].metadata.name | select(. == "'"${short_uri3}"'-1")')" "${short_uri3}-1"
 
 	echo "remove a unit and check only its secret is removed"
-	juju --show-log scale-application snappass-test 1
+	juju --show-log scale-application alertmanager-k8s 1
 	check_contains "$(microk8s kubectl -n "$model_name" get secrets -o json | jq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")')" "${short_uri1}-1"
 	check_contains "$(microk8s kubectl -n "$model_name" get secrets -o json | jq -r '.items[].metadata.name | select(. == "'"${short_uri2}"'-1")')" "${short_uri2}-1"
 	attempt=0
@@ -39,7 +39,7 @@ run_secrets() {
 	done
 
 	echo "remove the last unit and check only the app owned secret remains"
-	juju --show-log scale-application snappass-test 0
+	juju --show-log scale-application alertmanager-k8s 0
 	check_contains "$(microk8s kubectl -n "$model_name" get secrets -o json | jq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")')" "${short_uri1}-1"
 	attempt=0
 	until [[ -z $(microk8s kubectl -n "$model_name" get secrets -o json | jq -r '.items[].metadata.name | select(. == "'"${short_uri2}"'-1")') ]]; do
@@ -52,7 +52,7 @@ run_secrets() {
 	done
 
 	echo "remove the app and the app owned secret should be deleted too"
-	juju --show-log remove-application snappass-test
+	juju --show-log remove-application alertmanager-k8s
 	attempt=0
 	until [[ -z $(microk8s kubectl -n "$model_name" get secrets -o json | jq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")') ]]; do
 		if [[ ${attempt} -ge 30 ]]; then
@@ -63,8 +63,8 @@ run_secrets() {
 		attempt=$((attempt + 1))
 	done
 
-	juju --show-log deploy snappass-test hello
-	# TODO(anvial): remove the revision flag once we update snappass-test charm
+	juju --show-log deploy alertmanager-k8s hello
+	# TODO(anvial): remove the revision flag once we update alertmanager-k8s charm
 	#  (https://discourse.charmhub.io/t/old-ingress-relation-removal/12944)
 	#  or we choose an alternative pair of charms to integrate.
 	juju --show-log deploy nginx-ingress-integrator nginx --channel=latest/stable --revision=83
@@ -164,7 +164,7 @@ run_user_secrets() {
 	juju --show-log add-model "$model_name" --config secret-backend=auto
 	model_uuid=$(juju show-model $model_name --format json | jq -r ".[\"${model_name}\"][\"model-uuid\"]")
 
-	juju --show-log deploy snappass-test
+	juju --show-log deploy alertmanager-k8s
 
 	# create user secrets.
 	secret_uri=$(juju --show-log add-secret mysecret owned-by="$model_name-1" --info "this is a user secret")
@@ -176,10 +176,10 @@ run_user_secrets() {
 	juju --show-log update-secret "$secret_uri" --info info owned-by="$model_name-2"
 	check_contains "$(juju --show-log show-secret "$secret_uri" --revisions | yq ".${secret_short_uri}.description")" 'info'
 
-	# grant secret to snappass-test app, and now the application can access the revision 2.
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
-	juju --show-log grant-secret "$secret_uri" snappass-test
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
+	# grant secret to alertmanager-k8s app, and now the application can access the revision 2.
+	check_contains "$(juju exec --unit alertmanager-k8s/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	juju --show-log grant-secret "$secret_uri" alertmanager-k8s
+	check_contains "$(juju exec --unit alertmanager-k8s/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
 
 	# create a new revision 3.
 	juju --show-log update-secret "$secret_uri" owned-by="$model_name-3"
@@ -197,23 +197,23 @@ run_user_secrets() {
 	juju --show-log update-secret "$secret_uri" --auto-prune=true
 
 	# revision 1 should be pruned.
-	# revision 2 is still been used by snappass-test app, so it should not be pruned.
+	# revision 2 is still been used by alertmanager-k8s app, so it should not be pruned.
 	# revision 3 is the latest revision, so it should not be pruned.
 	check_num_secret_revisions "$secret_uri" "$secret_short_uri" 2
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 2 | yq .${secret_short_uri}.content)" "owned-by: $model_name-2"
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri --peek)" "owned-by: $model_name-3"
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri --refresh)" "owned-by: $model_name-3"
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-3"
+	check_contains "$(juju exec --unit alertmanager-k8s/0 -- secret-get $secret_short_uri --peek)" "owned-by: $model_name-3"
+	check_contains "$(juju exec --unit alertmanager-k8s/0 -- secret-get $secret_short_uri --refresh)" "owned-by: $model_name-3"
+	check_contains "$(juju exec --unit alertmanager-k8s/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-3"
 
 	# revision 2 should be pruned.
 	# revision 3 is the latest revision, so it should not be pruned.
 	check_num_secret_revisions "$secret_uri" "$secret_short_uri" 1
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
-	juju --show-log revoke-secret $secret_uri snappass-test
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	juju --show-log revoke-secret $secret_uri alertmanager-k8s
+	check_contains "$(juju exec --unit alertmanager-k8s/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
 
 	juju --show-log remove-secret $secret_uri
 	check_contains "$(juju --show-log secrets --format yaml | yq length)" '0'
@@ -227,7 +227,7 @@ run_secret_drain() {
 	vault_backend_name='myvault'
 	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
 
-	juju --show-log deploy snappass-test hello
+	juju --show-log deploy alertmanager-k8s hello
 	wait_for "active" '.applications["hello"] | ."application-status".current'
 	wait_for "hello" "$(idle_condition "hello" 0)"
 
@@ -293,7 +293,7 @@ run_user_secret_drain() {
 	vault_backend_name='myvault'
 	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
 
-	juju --show-log deploy snappass-test hello
+	juju --show-log deploy alertmanager-k8s hello
 	wait_for "active" '.applications["hello"] | ."application-status".current'
 	wait_for "hello" "$(idle_condition "hello" 0)"
 


### PR DESCRIPTION
Updated the snappass charm configuration for alertmanager-k8s. To fix issues with the current tests, because prev charm is not working anymore.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
make install
cd tests
./main.sh -v -c microk8s secrets_k8s test_secrets
```
