### PR TITLE
fix: deletion of user secrets on k8s models

### DIFF
--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -745,7 +745,8 @@ func newCachedBackendGetter(adminConfigGetter BackendAdminConfigGetter) (*cached
 
 // removeSecretFromExternal removes the specified secret from its respective secret backends.
 // Can be called for specific revisions, or omit revisions to remove all revisions of the secret.
-func removeSecretFromExternal(removeState SecretsRemoveState, adminConfigGetter BackendAdminConfigGetter, authTag names.Tag, uri *coresecrets.URI, revisions ...int) error {
+func removeUserSecretFromExternal(removeState SecretsRemoveState,
+	adminConfigGetter BackendAdminConfigGetter, modelUUID string, uri *coresecrets.URI, revisions ...int) error {
 	var (
 		revs []*coresecrets.SecretRevisionMetadata
 		err  error
@@ -851,12 +852,15 @@ func removeSecretFromExternal(removeState SecretsRemoveState, adminConfigGetter 
 		if err != nil {
 			return errors.Annotate(err, "getting secrets provider during provider cleanup")
 		}
+		if backendCfg.ModelUUID != modelUUID {
+			return errors.Errorf("inconsistent secret backend model UUID: %s", backendCfg.ModelUUID)
+		}
 		p, err := GetProvider(backendCfg.BackendType)
 		if err != nil {
 			return errors.Annotate(err, "getting secrets provider during provider cleanup")
 		}
 
-		modelTag := names.NewModelTag(backendCfg.ModelUUID)
+		modelTag := names.NewModelTag(modelUUID)
 		if err := p.CleanupSecrets(backendCfg, modelTag, secretRevisions); err != nil {
 			return errors.Annotate(err, "cleaning up secrets in provider")
 		}
@@ -869,7 +873,7 @@ func removeSecretFromExternal(removeState SecretsRemoveState, adminConfigGetter 
 // The secrets are removed from the state and backend, and the caller must have model admin access.
 func RemoveUserSecrets(
 	removeState SecretsRemoveState, adminConfigGetter BackendAdminConfigGetter,
-	authTag names.Tag, args params.DeleteSecretArgs,
+	args params.DeleteSecretArgs,
 	modelUUID string,
 	canDelete func(*coresecrets.URI) error,
 ) (params.ErrorResults, error) {
@@ -888,7 +892,7 @@ func RemoveUserSecrets(
 			continue
 		}
 		// We remove the secret from the backend first.
-		if err := removeSecretFromExternal(removeState, adminConfigGetter, authTag, uri, arg.Revisions...); err != nil {
+		if err := removeUserSecretFromExternal(removeState, adminConfigGetter, modelUUID, uri, arg.Revisions...); err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -918,7 +918,6 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminFromJujuBackend(c *gc.C) {
 
 	// Data needed for mocks
 	uri := coresecrets.NewURI()
-	userTag := names.NewUserTag("foo")
 	// Secret that lives only in the Juju database, not a backend
 	revisionMetadata := &coresecrets.SecretRevisionMetadata{
 		Revision: 5,
@@ -936,7 +935,6 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminFromJujuBackend(c *gc.C) {
 
 	results, err := secrets.RemoveUserSecrets(
 		removeState, adminConfigGetter,
-		userTag,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI:       (*uri).String(),
@@ -1001,7 +999,6 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminWithRevisions(c *gc.C) {
 
 	results, err := secrets.RemoveUserSecrets(
 		removeState, adminConfigGetter,
-		names.NewUserTag("foo"),
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI:       expectURI.String(),
@@ -1070,7 +1067,6 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdmin(c *gc.C) {
 
 	results, err := secrets.RemoveUserSecrets(
 		removeState, adminConfigGetter,
-		names.NewUserTag("foo"),
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI: expectURI.String(),
@@ -1098,7 +1094,6 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminDuringBackendMigration(c *g
 
 	// Data needed for mocks
 	uri := coresecrets.NewURI()
-	userTag := names.NewUserTag("foo")
 	revisionMetadataBeforeMigration := []*coresecrets.SecretRevisionMetadata{
 		{
 			Revision: 5,
@@ -1190,7 +1185,6 @@ func (s *secretsSuite) TestRemoveSecretsForModelAdminDuringBackendMigration(c *g
 
 	results, err := secrets.RemoveUserSecrets(
 		removeState, adminConfigGetter,
-		userTag,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI: (*uri).String(),
@@ -1216,7 +1210,6 @@ func (s *secretsSuite) TestRemoveSecretNotFoundForModelAdmin(c *gc.C) {
 
 	// Data needed for mocks
 	uri := coresecrets.NewURI()
-	userTag := names.NewUserTag("foo")
 
 	// Secret with two revisions with arbitrary revision numbers/IDs
 	var revisionMetadata []*coresecrets.SecretRevisionMetadata
@@ -1231,7 +1224,9 @@ func (s *secretsSuite) TestRemoveSecretNotFoundForModelAdmin(c *gc.C) {
 		revisionIDs.Add(revisionID)
 	}
 
-	backendCfg := &provider.ModelBackendConfig{}
+	backendCfg := &provider.ModelBackendConfig{
+		ModelUUID: coretesting.ModelTag.Id(),
+	}
 	backend := mocks.NewMockSecretsBackend(ctrl)
 	// backend.DeleteContent returns NotFound to any revisions to simulate a backend that has no secret revision data.
 	// backend.DeleteContent should be called exactly once for each secret revision, and return NotFound for each to
@@ -1270,7 +1265,6 @@ func (s *secretsSuite) TestRemoveSecretNotFoundForModelAdmin(c *gc.C) {
 
 	results, err := secrets.RemoveUserSecrets(
 		removeState, adminConfigGetter,
-		userTag,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI: (*uri).String(),

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -519,7 +519,7 @@ func (s *SecretsAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.ErrorRe
 	// TODO(secrets): JUJU-4719.
 	return commonsecrets.RemoveUserSecrets(
 		s.secretsState, s.adminBackendConfigGetter,
-		s.authTag, args, s.modelUUID,
+		args, s.modelUUID,
 		func(uri *coresecrets.URI) error {
 			if err := s.checkCanWrite(); err != nil {
 				return errors.Trace(err)

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -505,7 +505,7 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, uri *coresecrets.URI, isInte
 		s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-1").Return(nil)
 		s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-2").Return(nil)
 		s.provider.EXPECT().CleanupSecrets(
-			cfg, names.NewUserTag("foo"),
+			cfg, coretesting.ModelTag,
 			provider.SecretRevisions{uri.ID: set.NewStrings("rev-1", "rev-2")},
 		).Return(nil)
 
@@ -647,7 +647,7 @@ func (s *SecretsSuite) TestRemoveSecrets(c *gc.C) {
 	s.provider.EXPECT().NewBackend(cfg).Return(s.backend, nil)
 	s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
 	s.provider.EXPECT().CleanupSecrets(
-		cfg, names.NewUserTag("foo"),
+		cfg, coretesting.ModelTag,
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
 
@@ -747,7 +747,7 @@ func (s *SecretsSuite) TestRemoveSecretRevision(c *gc.C) {
 	s.provider.EXPECT().NewBackend(cfg).Return(s.backend, nil)
 	s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
 	s.provider.EXPECT().CleanupSecrets(
-		cfg, names.NewUserTag("foo"),
+		cfg, coretesting.ModelTag,
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
 

--- a/apiserver/facades/controller/usersecrets/secrets.go
+++ b/apiserver/facades/controller/usersecrets/secrets.go
@@ -52,7 +52,7 @@ func (s *UserSecretsManager) WatchRevisionsToPrune() (params.StringsWatchResult,
 func (s *UserSecretsManager) DeleteRevisions(args params.DeleteSecretArgs) (params.ErrorResults, error) {
 	return commonsecrets.RemoveUserSecrets(
 		s.secretsState, s.backendConfigGetter,
-		s.authTag, args, s.modelUUID,
+		args, s.modelUUID,
 		func(uri *coresecrets.URI) error {
 			md, err := s.secretsState.GetSecret(uri)
 			if err != nil {

--- a/apiserver/facades/controller/usersecrets/secrets_test.go
+++ b/apiserver/facades/controller/usersecrets/secrets_test.go
@@ -127,7 +127,7 @@ func (s *userSecretsSuite) TestDeleteRevisionsAutoPruneEnabled(c *gc.C) {
 	s.provider.EXPECT().NewBackend(cfg).Return(s.backend, nil)
 	s.backend.EXPECT().DeleteContent(gomock.Any(), "rev-666").Return(nil)
 	s.provider.EXPECT().CleanupSecrets(
-		cfg, names.NewUserTag("foo"),
+		cfg, coretesting.ModelTag,
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
 


### PR DESCRIPTION
When deleting secrets on a k8s model, a service account is used to enable the operation to proceed.
The tag of the entity which owns the secret is used to create the service account. When running the Cleanup operation for user secrets, the user tag of the authenticated user was being passed in instead of the model tag.

## QA steps

```
$ juju add-secret mine foo=bar
secret:d0jg427mp25c79d8c5b0
$ juju secrets
ID                    Name  Owner    Rotation  Revision  Last updated
d0jg427mp25c79d8c5b0  mine  <model>  never            1  2 seconds ago  
$ kubectl -n controller-test get secrets
NAME                            TYPE                                  DATA   AGE
controller-application-config   Opaque                                1      7m38s
controller-proxy                kubernetes.io/service-account-token   3      7m41s
controller-secret               Opaque                                2      7m40s
d0jg427mp25c79d8c5b0-1          Opaque                                1      20s
model-exec                      kubernetes.io/service-account-token   3      6m48s
$ juju remove-secret d0jg427mp25c79d8c5b0
$ kubectl -n controller-test get secrets
NAME                            TYPE                                  DATA   AGE
controller-application-config   Opaque                                1      7m52s
controller-proxy                kubernetes.io/service-account-token   3      7m55s
controller-secret               Opaque                                2      7m54s
model-exec                      kubernetes.io/service-account-token   3      7m2s
```

## Links

**Issue:** Fixes #19784.
