### PR TITLE
feat: add getter for api addresses

### DIFF
--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2808,41 +2808,41 @@ func (c *MockStateGetUnitNamesForNetNodeCall) DoAndReturn(f func(context.Context
 	return c
 }
 
-// GetUnitNetNodes mocks base method.
-func (m *MockState) GetUnitNetNodes(ctx context.Context, uuid unit.UUID) ([]string, error) {
+// GetUnitNetNodesByName mocks base method.
+func (m *MockState) GetUnitNetNodesByName(ctx context.Context, name unit.Name) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitNetNodes", ctx, uuid)
+	ret := m.ctrl.Call(m, "GetUnitNetNodesByName", ctx, name)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetUnitNetNodes indicates an expected call of GetUnitNetNodes.
-func (mr *MockStateMockRecorder) GetUnitNetNodes(ctx, uuid any) *MockStateGetUnitNetNodesCall {
+// GetUnitNetNodesByName indicates an expected call of GetUnitNetNodesByName.
+func (mr *MockStateMockRecorder) GetUnitNetNodesByName(ctx, name any) *MockStateGetUnitNetNodesByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNetNodes", reflect.TypeOf((*MockState)(nil).GetUnitNetNodes), ctx, uuid)
-	return &MockStateGetUnitNetNodesCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNetNodesByName", reflect.TypeOf((*MockState)(nil).GetUnitNetNodesByName), ctx, name)
+	return &MockStateGetUnitNetNodesByNameCall{Call: call}
 }
 
-// MockStateGetUnitNetNodesCall wrap *gomock.Call
-type MockStateGetUnitNetNodesCall struct {
+// MockStateGetUnitNetNodesByNameCall wrap *gomock.Call
+type MockStateGetUnitNetNodesByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitNetNodesCall) Return(arg0 []string, arg1 error) *MockStateGetUnitNetNodesCall {
+func (c *MockStateGetUnitNetNodesByNameCall) Return(arg0 []string, arg1 error) *MockStateGetUnitNetNodesByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitNetNodesCall) Do(f func(context.Context, unit.UUID) ([]string, error)) *MockStateGetUnitNetNodesCall {
+func (c *MockStateGetUnitNetNodesByNameCall) Do(f func(context.Context, unit.Name) ([]string, error)) *MockStateGetUnitNetNodesByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitNetNodesCall) DoAndReturn(f func(context.Context, unit.UUID) ([]string, error)) *MockStateGetUnitNetNodesCall {
+func (c *MockStateGetUnitNetNodesByNameCall) DoAndReturn(f func(context.Context, unit.Name) ([]string, error)) *MockStateGetUnitNetNodesByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -9,7 +9,6 @@ import (
 	stdtesting "testing"
 	"time"
 
-	"github.com/juju/collections/transform"
 	"github.com/juju/tc"
 	"github.com/kr/pretty"
 	"go.uber.org/mock/gomock"
@@ -26,7 +25,6 @@ import (
 	"github.com/juju/juju/domain/application"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
-	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/status"
 	"github.com/juju/juju/internal/errors"
 )
@@ -1101,32 +1099,4 @@ func (s *unitServiceSuite) TestGetUnitSubordinatesError(c *tc.C) {
 
 	_, err := s.service.GetUnitSubordinates(c.Context(), unitName)
 	c.Assert(err, tc.ErrorIs, boom)
-}
-
-func (s *serviceSuite) TestGetUnitNetNodesNotFound(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	unitName := coreunit.Name("foo/0")
-
-	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), coreunit.Name("foo/0")).Return("", applicationerrors.UnitNotFound)
-
-	_, err := s.service.GetUnitNetNodes(context.Background(), unitName)
-	c.Assert(err, tc.ErrorMatches, "unit not found")
-}
-
-func (s *serviceSuite) TestGetUnitNetNodes(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	unitName := coreunit.Name("foo/0")
-
-	netNodeUUIDs := []string{"node-uuid-1", "node-uuid-2"}
-
-	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), coreunit.Name("foo/0")).Return("foo-uuid", nil)
-	s.state.EXPECT().GetUnitNetNodes(gomock.Any(), coreunit.UUID("foo-uuid")).Return(netNodeUUIDs, nil)
-
-	netNodes, err := s.service.GetUnitNetNodes(context.Background(), unitName)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(netNodes, tc.DeepEquals, transform.Slice(netNodeUUIDs, func(s string) domainnetwork.NetNodeUUID {
-		return domainnetwork.NetNodeUUID(s)
-	}))
 }

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -1515,7 +1515,7 @@ func (s *unitStateSuite) TestGetUnitAddresses(c *tc.C) {
 }
 
 func (s *unitStateSuite) TestGetUnitNetNodesNotFound(c *tc.C) {
-	_, err := s.state.GetUnitNetNodes(c.Context(), "unknown-unit-uuid")
+	_, err := s.state.GetUnitNetNodesByName(c.Context(), "unknown-unit")
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
@@ -1523,13 +1523,11 @@ func (s *unitStateSuite) TestGetUnitNetNodesK8s(c *tc.C) {
 	appID := s.createIAASApplication(c, "foo", life.Alive, application.InsertUnitArg{
 		UnitName: "foo/0",
 	})
-	unitUUID, err := s.state.GetUnitUUIDByName(c.Context(), "foo/0")
-	c.Assert(err, tc.ErrorIsNil)
 
 	unitNetNodeUUID := "unit-node-uuid"
 	serviceNetNodeUUID := "service-node-uuid"
 
-	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		insertNetNode0 := `INSERT INTO net_node (uuid) VALUES (?)`
 		_, err := tx.ExecContext(ctx, insertNetNode0, unitNetNodeUUID)
 		if err != nil {
@@ -1554,7 +1552,7 @@ func (s *unitStateSuite) TestGetUnitNetNodesK8s(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	netNodeUUID, err := s.state.GetUnitNetNodes(c.Context(), unitUUID)
+	netNodeUUID, err := s.state.GetUnitNetNodesByName(c.Context(), "foo/0")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(netNodeUUID, tc.SameContents, []string{serviceNetNodeUUID, unitNetNodeUUID})
 }
@@ -1563,10 +1561,8 @@ func (s *unitStateSuite) TestGetUnitNetNodesMachine(c *tc.C) {
 	_ = s.createIAASApplication(c, "foo", life.Alive, application.InsertUnitArg{
 		UnitName: "foo/0",
 	})
-	unitUUID, err := s.state.GetUnitUUIDByName(c.Context(), "foo/0")
-	c.Assert(err, tc.ErrorIsNil)
 
-	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		insertNetNode0 := `INSERT INTO net_node (uuid) VALUES (?)`
 		_, err := tx.ExecContext(ctx, insertNetNode0, "machine-net-node-uuid")
 		if err != nil {
@@ -1581,7 +1577,7 @@ func (s *unitStateSuite) TestGetUnitNetNodesMachine(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	netNodeUUID, err := s.state.GetUnitNetNodes(c.Context(), unitUUID)
+	netNodeUUID, err := s.state.GetUnitNetNodesByName(c.Context(), "foo/0")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(netNodeUUID, tc.SameContents, []string{"machine-net-node-uuid"})
 }

--- a/domain/controllernode/errors/errors.go
+++ b/domain/controllernode/errors/errors.go
@@ -17,4 +17,8 @@ const (
 	// EmptyControllerIDs describes an error that occurs when no controller IDs
 	// are found.
 	EmptyControllerIDs = errors.ConstError("no controller IDs found")
+
+	// EmptyAPIAddresses describes an error that occurs when no API addresses
+	// are found.
+	EmptyAPIAddresses = errors.ConstError("no API addresses found")
 )

--- a/domain/controllernode/service/package_mock_test.go
+++ b/domain/controllernode/service/package_mock_test.go
@@ -79,6 +79,84 @@ func (c *MockStateCurateNodesCall) DoAndReturn(f func(context.Context, []string,
 	return c
 }
 
+// GetAPIAddresses mocks base method.
+func (m *MockState) GetAPIAddresses(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAPIAddresses", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAPIAddresses indicates an expected call of GetAPIAddresses.
+func (mr *MockStateMockRecorder) GetAPIAddresses(arg0, arg1 any) *MockStateGetAPIAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIAddresses", reflect.TypeOf((*MockState)(nil).GetAPIAddresses), arg0, arg1)
+	return &MockStateGetAPIAddressesCall{Call: call}
+}
+
+// MockStateGetAPIAddressesCall wrap *gomock.Call
+type MockStateGetAPIAddressesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetAPIAddressesCall) Return(arg0 []string, arg1 error) *MockStateGetAPIAddressesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetAPIAddressesCall) Do(f func(context.Context, string) ([]string, error)) *MockStateGetAPIAddressesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetAPIAddressesCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockStateGetAPIAddressesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetAPIAddressesForAgents mocks base method.
+func (m *MockState) GetAPIAddressesForAgents(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAPIAddressesForAgents", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAPIAddressesForAgents indicates an expected call of GetAPIAddressesForAgents.
+func (mr *MockStateMockRecorder) GetAPIAddressesForAgents(arg0, arg1 any) *MockStateGetAPIAddressesForAgentsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIAddressesForAgents", reflect.TypeOf((*MockState)(nil).GetAPIAddressesForAgents), arg0, arg1)
+	return &MockStateGetAPIAddressesForAgentsCall{Call: call}
+}
+
+// MockStateGetAPIAddressesForAgentsCall wrap *gomock.Call
+type MockStateGetAPIAddressesForAgentsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetAPIAddressesForAgentsCall) Return(arg0 []string, arg1 error) *MockStateGetAPIAddressesForAgentsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetAPIAddressesForAgentsCall) Do(f func(context.Context, string) ([]string, error)) *MockStateGetAPIAddressesForAgentsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockStateGetAPIAddressesForAgentsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetControllerIDs mocks base method.
 func (m *MockState) GetControllerIDs(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -62,6 +62,14 @@ type State interface {
 	// GetControllerIDs returns the list of controller IDs from the controller node
 	// records.
 	GetControllerIDs(ctx context.Context) ([]string, error)
+
+	// GetAPIAddresses returns the list of API addresses for the provided controller
+	// node.
+	GetAPIAddresses(ctx context.Context, ctrlID string) ([]string, error)
+
+	// GetAPIAddressesForAgents returns the list of API addresses for the provided
+	// controller node that are available for agents.
+	GetAPIAddressesForAgents(ctx context.Context, ctrlID string) ([]string, error)
 }
 
 // WatcherFactory instances return watchers for a given namespace and UUID.
@@ -247,4 +255,22 @@ func (s *Service) GetControllerIDs(ctx context.Context) ([]string, error) {
 		return nil, errors.Capture(err)
 	}
 	return res, nil
+}
+
+// GetAPIAddresses returns the list of API addresses for the provided controller
+// node.
+func (s *Service) GetAPIAddresses(ctx context.Context, nodeID string) ([]string, error) {
+	if nodeID == "" {
+		return nil, errors.Errorf("node ID %q is %w, cannot be empty", nodeID, coreerrors.NotValid)
+	}
+	return s.st.GetAPIAddresses(ctx, nodeID)
+}
+
+// GetAPIAddressesForAgents returns the list of API addresses for the provided
+// controller node that are available for agents.
+func (s *Service) GetAPIAddressesForAgents(ctx context.Context, nodeID string) ([]string, error) {
+	if nodeID == "" {
+		return nil, errors.Errorf("node ID %q is %w, cannot be empty", nodeID, coreerrors.NotValid)
+	}
+	return s.st.GetAPIAddressesForAgents(ctx, nodeID)
 }

--- a/domain/controllernode/state/types.go
+++ b/domain/controllernode/state/types.go
@@ -39,11 +39,14 @@ type controllerNodeAgentVersion struct {
 }
 
 // controllerAPIAddress is the database representation of a controller api
-// address.
+// address with the controller id and whether it is for agents or clients.
 type controllerAPIAddress struct {
+	// ControllerID is the controller node id.
 	ControllerID string `db:"controller_id"`
-	Address      string `db:"address"`
-	IsAgent      bool   `db:"is_agent"`
+	// Address is the address of the controller node.
+	Address string `db:"address"`
+	// IsAgent is whether the address is for agents as well as for clients.
+	IsAgent bool `db:"is_agent"`
 }
 
 // countResult is the database representation of a count result.
@@ -54,4 +57,11 @@ type countResult struct {
 // controllerID is the database representation of a controller node id.
 type controllerID struct {
 	ID string `db:"controller_id"`
+}
+
+// controllerAPIAddressStr is the database representation of a controller api
+// address alone.
+type controllerAPIAddressStr struct {
+	// Address is the address of the controller node.
+	Address string `db:"address"`
 }

--- a/domain/schema/model/sql/0021-network.sql
+++ b/domain/schema/model/sql/0021-network.sql
@@ -240,6 +240,9 @@ ON ip_address (device_uuid);
 CREATE INDEX idx_ip_address_subnet_uuid
 ON ip_address (subnet_uuid);
 
+CREATE INDEX idx_ip_address_net_node_uuid
+ON ip_address (net_node_uuid);
+
 CREATE TABLE provider_ip_address (
     provider_id TEXT NOT NULL PRIMARY KEY,
     address_uuid TEXT NOT NULL,

--- a/internal/worker/apiaddresssetter/package_mocks_test.go
+++ b/internal/worker/apiaddresssetter/package_mocks_test.go
@@ -17,7 +17,6 @@ import (
 	network "github.com/juju/juju/core/network"
 	unit "github.com/juju/juju/core/unit"
 	watcher "github.com/juju/juju/core/watcher"
-	network0 "github.com/juju/juju/domain/network"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -145,45 +144,6 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetUnitNetNodes mocks base method.
-func (m *MockApplicationService) GetUnitNetNodes(arg0 context.Context, arg1 unit.Name) ([]network0.NetNodeUUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitNetNodes", arg0, arg1)
-	ret0, _ := ret[0].([]network0.NetNodeUUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUnitNetNodes indicates an expected call of GetUnitNetNodes.
-func (mr *MockApplicationServiceMockRecorder) GetUnitNetNodes(arg0, arg1 any) *MockApplicationServiceGetUnitNetNodesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNetNodes", reflect.TypeOf((*MockApplicationService)(nil).GetUnitNetNodes), arg0, arg1)
-	return &MockApplicationServiceGetUnitNetNodesCall{Call: call}
-}
-
-// MockApplicationServiceGetUnitNetNodesCall wrap *gomock.Call
-type MockApplicationServiceGetUnitNetNodesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetUnitNetNodesCall) Return(arg0 []network0.NetNodeUUID, arg1 error) *MockApplicationServiceGetUnitNetNodesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetUnitNetNodesCall) Do(f func(context.Context, unit.Name) ([]network0.NetNodeUUID, error)) *MockApplicationServiceGetUnitNetNodesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetUnitNetNodesCall) DoAndReturn(f func(context.Context, unit.Name) ([]network0.NetNodeUUID, error)) *MockApplicationServiceGetUnitNetNodesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetUnitPublicAddresses mocks base method.
 func (m *MockApplicationService) GetUnitPublicAddresses(arg0 context.Context, arg1 unit.Name) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
@@ -223,46 +183,41 @@ func (c *MockApplicationServiceGetUnitPublicAddressesCall) DoAndReturn(f func(co
 	return c
 }
 
-// WatchNetNodeAddress mocks base method.
-func (m *MockApplicationService) WatchNetNodeAddress(arg0 context.Context, arg1 ...network0.NetNodeUUID) (watcher.Watcher[struct{}], error) {
+// WatchUnitAddresses mocks base method.
+func (m *MockApplicationService) WatchUnitAddresses(arg0 context.Context, arg1 unit.Name) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0}
-	for _, a := range arg1 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "WatchNetNodeAddress", varargs...)
+	ret := m.ctrl.Call(m, "WatchUnitAddresses", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchNetNodeAddress indicates an expected call of WatchNetNodeAddress.
-func (mr *MockApplicationServiceMockRecorder) WatchNetNodeAddress(arg0 any, arg1 ...any) *MockApplicationServiceWatchNetNodeAddressCall {
+// WatchUnitAddresses indicates an expected call of WatchUnitAddresses.
+func (mr *MockApplicationServiceMockRecorder) WatchUnitAddresses(arg0, arg1 any) *MockApplicationServiceWatchUnitAddressesCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNetNodeAddress", reflect.TypeOf((*MockApplicationService)(nil).WatchNetNodeAddress), varargs...)
-	return &MockApplicationServiceWatchNetNodeAddressCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnitAddresses", reflect.TypeOf((*MockApplicationService)(nil).WatchUnitAddresses), arg0, arg1)
+	return &MockApplicationServiceWatchUnitAddressesCall{Call: call}
 }
 
-// MockApplicationServiceWatchNetNodeAddressCall wrap *gomock.Call
-type MockApplicationServiceWatchNetNodeAddressCall struct {
+// MockApplicationServiceWatchUnitAddressesCall wrap *gomock.Call
+type MockApplicationServiceWatchUnitAddressesCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceWatchNetNodeAddressCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockApplicationServiceWatchNetNodeAddressCall {
+func (c *MockApplicationServiceWatchUnitAddressesCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockApplicationServiceWatchUnitAddressesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceWatchNetNodeAddressCall) Do(f func(context.Context, ...network0.NetNodeUUID) (watcher.Watcher[struct{}], error)) *MockApplicationServiceWatchNetNodeAddressCall {
+func (c *MockApplicationServiceWatchUnitAddressesCall) Do(f func(context.Context, unit.Name) (watcher.Watcher[struct{}], error)) *MockApplicationServiceWatchUnitAddressesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceWatchNetNodeAddressCall) DoAndReturn(f func(context.Context, ...network0.NetNodeUUID) (watcher.Watcher[struct{}], error)) *MockApplicationServiceWatchNetNodeAddressCall {
+func (c *MockApplicationServiceWatchUnitAddressesCall) DoAndReturn(f func(context.Context, unit.Name) (watcher.Watcher[struct{}], error)) *MockApplicationServiceWatchUnitAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/apiaddresssetter/worker_test.go
+++ b/internal/worker/apiaddresssetter/worker_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
-	domainnetwork "github.com/juju/juju/domain/network"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -111,13 +110,7 @@ func (s *workerSuite) TestNewControllerNode(c *tc.C) {
 
 	// Starts the controller tracker for the new node.
 	s.controllerNodeService.EXPECT().GetControllerIDs(gomock.Any()).Return([]string{"1"}, nil)
-
-	netNodeUUID, err := domainnetwork.NewNetNodeUUID()
-	c.Assert(err, tc.ErrorIsNil)
-	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return(
-		[]domainnetwork.NetNodeUUID{netNodeUUID}, nil)
-
-	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), netNodeUUID).Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
+	s.applicationService.EXPECT().WatchUnitAddresses(gomock.Any(), unit.Name("controller/1")).Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
 	// Updates the API addresses for the new node.
 	addrs := network.SpaceAddresses{
 		{
@@ -189,12 +182,7 @@ func (s *workerSuite) TestConfigChange(c *tc.C) {
 
 	// Starts the controller tracker for the new node.
 	s.controllerNodeService.EXPECT().GetControllerIDs(gomock.Any()).Return([]string{"1"}, nil)
-
-	netNodeUUID, err := domainnetwork.NewNetNodeUUID()
-	c.Assert(err, tc.ErrorIsNil)
-	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return(
-		[]domainnetwork.NetNodeUUID{netNodeUUID}, nil)
-	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), netNodeUUID).Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
+	s.applicationService.EXPECT().WatchUnitAddresses(gomock.Any(), unit.Name("controller/1")).Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
 
 	// Updates the API addresses for the new node.
 	addrs := network.SpaceAddresses{
@@ -295,15 +283,10 @@ func (s *workerSuite) TestNodeAddressChange(c *tc.C) {
 
 	// Starts the controller tracker for the new node.
 	s.controllerNodeService.EXPECT().GetControllerIDs(gomock.Any()).Return([]string{"1"}, nil)
-	netNodeUUID, err := domainnetwork.NewNetNodeUUID()
-	c.Assert(err, tc.ErrorIsNil)
-
-	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return(
-		[]domainnetwork.NetNodeUUID{netNodeUUID}, nil)
 	addrCh := make(chan struct{})
 
 	netNodeAddressWatcher := watchertest.NewMockNotifyWatcher(addrCh)
-	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), netNodeUUID).Return(netNodeAddressWatcher, nil)
+	s.applicationService.EXPECT().WatchUnitAddresses(gomock.Any(), unit.Name("controller/1")).Return(netNodeAddressWatcher, nil)
 
 	// Updates the API addresses for the new node.
 	addrs := network.SpaceAddresses{


### PR DESCRIPTION
This patch adds the service and state layer methods to retrieve controller node API addresses.

Also, a new index has been added to ip_address on net_node_uuid, the net nodes watcher in the app domain has been renamed to WatchUnitAddresses to avoid exposing the net node concept when we only care about the unit addresses.

As a side quest as well, the controller node API address insertion has been improved so we only update the addresses if there is indeed a change in them.

__Note: The two side quests on this PR originated in the following comments in a previous PR:__
- https://github.com/juju/juju/pull/19748#discussion_r2091137795: for the deltas in the API addresses.
- https://github.com/juju/juju/pull/19748#discussion_r2091159212: for the change in the net node addresses watcher.

## QA steps
Unit tests pass.

