### PR TITLE
docs: 3.6 set up kroki

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -4,3 +4,5 @@ sphinx-tabs
 sphinxext-rediraffe
 sphinx-new-tab-link
 sphinxcontrib.lightbox2
+sphinxcontrib.kroki
+setuptools

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,6 +224,7 @@ extensions = [
     # new_tab_link_show_external_link_icon must also be set to True
     'sphinx_new_tab_link',
     'sphinxcontrib.lightbox2',
+    'sphinxcontrib.kroki',
     ]
 
 


### PR DESCRIPTION
In our docs, diagrams are currently .png files. The source, when available, is not stored in the repo.

This PR sets up a Sphinx extension that makes it possible to generate diagrams straight from source.

https://github.com/sphinx-contrib/kroki 
https://kroki.io/

# QA

Open a doc file and add this small excerpt:


```{kroki}
:type: mermaid

graph TD
  A[ Anyone ] -->|Can help | B( Go to github.com/yuzutech/kroki )
  B --> C{ How to contribute? }
  C --> D[ Reporting bugs ]
  C --> E[ Sharing ideas ]
  C --> F[ Advocating ]
```

You should see 

![image](https://github.com/user-attachments/assets/180c8e0e-357d-45b5-8bf2-cb8d80fa14a0)

The source can also be saved to its own separate file and included via the `include` directive. For example:

```{include} mydiagram.txt
```