### PR TITLE
fix: use pebble v1.19.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20241209155119-76da976c6ee7
-	github.com/canonical/pebble v1.19.0
+	github.com/canonical/pebble v1.19.1
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVy
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20241209155119-76da976c6ee7 h1:D+lFLV2E9um9NcknxFVBzboPSXpxJDEXspBbHMs4KxQ=
 github.com/canonical/lxd v0.0.0-20241209155119-76da976c6ee7/go.mod h1:RJwBW5w8gxwp7W4+tZJDDKp3uA5vB1W9f4qveoWA59U=
-github.com/canonical/pebble v1.19.0 h1:eY6MwsR93pDqS2XwvGsxZGg4hcaAtS3ZkHh/t5oSbmw=
-github.com/canonical/pebble v1.19.0/go.mod h1:fPtK3xrfuiRQBKSzfm3iBfdmIxlD/nup8yS1FVS8ZKQ=
+github.com/canonical/pebble v1.19.1 h1:9QzX58/KU03w7WtJevNi1Bnq+LQPHhgGqn76I3Fhvq0=
+github.com/canonical/pebble v1.19.1/go.mod h1:fPtK3xrfuiRQBKSzfm3iBfdmIxlD/nup8yS1FVS8ZKQ=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=


### PR DESCRIPTION
This brings in pebble v1.19.1 which includes a fix for how Notices and Changes are pruned. In v1.19.0 changes might be pruned, but the associated notice would then refer to a missing change. We increase the number of changes kept to 1000 (up from 500), and then ensure that notices are kept consistent with changes.


## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
$ sudo snap install k8s
$ sudo k8s bootstrap
$ sudo k8s config | juju add-k8s ck8s --client
$ make ck8s-operator-update
$ juju bootstrap ck8s src36
$ juju add-model test1
$ juju deploy grafana-k8s
$ juju ssh grafana-k8s/0 bash
$$ export PEBBLE_SOCKET=/charm/containers/grafana/pebble.socket
$$ for i in `seq 1500`; do /charm/bin/pebble notify foo.com/i$i foo=$i; done
# This should create > 1000 pebble notices
$$ /charm/bin/pebble notices
# pebble runs the pruning every 10 minutes by default
$$ /charm/bin/pebble logs
```
## Documentation changes

None

## Links

**Issue:** Fixes #19672
