### PR TITLE
feat: introduce strong types for cloud types

### DIFF
--- a/caas/kubernetes/provider/constants/constants_test.go
+++ b/caas/kubernetes/provider/constants/constants_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package constants
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestCAASProviderTypeEqualsCoreCloudValue tests that the unique provider type
+// value that a Kubernetes CAAS provider is registered with is equal to that of
+// [corecloud.CloudTypeKubernetes].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestCAASProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, CAASProviderType, tc.Equals, corecloud.CloudTypeKubernetes.String())
+}

--- a/core/cloud/cloudtype.go
+++ b/core/cloud/cloudtype.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+// CloudType represents a unique identifier for a Juju cloud provider.
+type CloudType string
+
+const (
+	// CloudTypeAzure represents the Azure cloud provider.
+	CloudTypeAzure CloudType = "azure"
+
+	// CloudTypeAWS represents the AWS/EC2 cloud provider.
+	CloudTypeEC2 CloudType = "ec2"
+
+	// CloudTypeGCE represents the Google Compute Engine (GCE) cloud provider.
+	CloudTypeGCE CloudType = "gce"
+
+	// CloudTypeKubernetes represents the Kubernetes CAAS cloud provider.
+	CloudTypeKubernetes CloudType = "kubernetes"
+
+	// CloudTypeLXD represents the LXD cloud provider.
+	CloudTypeLXD CloudType = "lxd"
+
+	// CloudTypeManual represents the Manual cloud provider.
+	CloudTypeManual CloudType = "manual"
+
+	// CloudTypeMAAS represents the MAAS cloud provider.
+	CloudTypeMAAS CloudType = "maas"
+
+	// CloudTypeOCI represents the Oracle Cloud Infastructure (OCI) cloud
+	// provider.
+	CloudTypeOCI CloudType = "oci"
+
+	// CloudTypeOpenStack represents the OpenStack cloud provider.
+	CloudTypeOpenStack CloudType = "openstack"
+
+	// CloudTypeVSphere represents the vSphere cloud provider.
+	CloudTypevSphere CloudType = "vsphere"
+)
+
+// String returns the string representation of [CloudType]. This function
+// fulfills the [fmt.Stringer] interface.
+func (c CloudType) String() string {
+	return string(c)
+}

--- a/domain/cloud/cloudtype.go
+++ b/domain/cloud/cloudtype.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+// CloudType represents the provider type of a cloud.
+type CloudType int
+
+const (
+	// CloudTypeKubernetes represents the Kubernetes CAAS provider.
+	CloudTypeKubernetes CloudType = iota
+
+	// CloudTypeLXD represents the LXD cloud provider.
+	CloudTypeLXD
+
+	// CloudTypeMAAS represents the MAAS cloud provider.
+	CloudTypeMAAS
+
+	// CloudTypeManual represents the Manual cloud provider.
+	CloudTypeManual
+
+	// CloudTypeAzure represents the Azure cloud provider.
+	CloudTypeAzure
+
+	// CloudTypeEC2 represents the AWS/EC2 cloud provider.
+	CloudTypeEC2
+
+	// CloudTypeGCE represents the Google Compute Engine (GCE) cloud provider.
+	CloudTypeGCE
+
+	// CloudTypeOCI represents the Oracle Cloud Infrastructure (OCI) cloud
+	// provider.
+	CloudTypeOCI
+
+	// CloudTypeOpenStack represents the OpenStack cloud provider.
+	CloudTypeOpenStack
+
+	// CloudTypevSphere represents the vSphere cloud provider.
+	CloudTypevSphere
+)

--- a/domain/cloud/cloudtype_test.go
+++ b/domain/cloud/cloudtype_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+// cloudTypeSuite is a test suite for making sure that the cloud type enums
+// defined in both this package and in [corecloud.CloudType] are in sync with
+// the database.
+type cloudTypeSuite struct {
+	schematesting.ControllerSuite
+}
+
+// TestCloudTypeSuite runs the tests located in [cloudTypeSuite].
+func TestCloudTypeSuite(t *testing.T) {
+	tc.Run(t, &cloudTypeSuite{})
+}
+
+// TestCloudTypeDBValues tests that the values in the cloud_type table against
+// the established [CloudType] enums in this package to make sure there is no
+// skew between the database and this package.
+func (s *cloudTypeSuite) TestCloudTypeDBValues(c *tc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, type FROM cloud_type")
+	c.Assert(err, tc.ErrorIsNil)
+	defer rows.Close()
+
+	dbValues := make(map[CloudType]string)
+	for rows.Next() {
+		var (
+			id       int
+			typeName string
+		)
+		err := rows.Scan(&id, &typeName)
+		c.Assert(err, tc.ErrorIsNil)
+		dbValues[CloudType(id)] = typeName
+	}
+
+	c.Check(dbValues, tc.DeepEquals, map[CloudType]string{
+		CloudTypeKubernetes: "kubernetes",
+		CloudTypeLXD:        "lxd",
+		CloudTypeMAAS:       "maas",
+		CloudTypeManual:     "manual",
+		CloudTypeAzure:      "azure",
+		CloudTypeEC2:        "ec2",
+		CloudTypeGCE:        "gce",
+		CloudTypeOCI:        "oci",
+		CloudTypeOpenStack:  "openstack",
+		CloudTypevSphere:    "vsphere",
+	})
+}
+
+// TestCloudTypeDBValuesAgainstCoreCloudTypes tests that the database type
+// strings in the cloud_type table match the constants defined in
+// [corecloud.CloudType]. If this tests fails it means the database has a
+// disconnect with the core cloud types and this needs to be corrected to be
+// able to establish providers correctly in the controller.
+func (s *cloudTypeSuite) TestCloudTypeDBValuesAgainstCoreCloudTypes(c *tc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT type FROM cloud_type")
+	c.Assert(err, tc.ErrorIsNil)
+	defer rows.Close()
+
+	var dbValues []corecloud.CloudType
+	for rows.Next() {
+		var typeName string
+		err := rows.Scan(&typeName)
+		c.Assert(err, tc.ErrorIsNil)
+		dbValues = append(dbValues, corecloud.CloudType(typeName))
+	}
+
+	c.Check(dbValues, tc.SameContents, []corecloud.CloudType{
+		corecloud.CloudTypeAzure,
+		corecloud.CloudTypeEC2,
+		corecloud.CloudTypeGCE,
+		corecloud.CloudTypeKubernetes,
+		corecloud.CloudTypeLXD,
+		corecloud.CloudTypeManual,
+		corecloud.CloudTypeMAAS,
+		corecloud.CloudTypeOCI,
+		corecloud.CloudTypeOpenStack,
+		corecloud.CloudTypevSphere,
+	})
+}

--- a/internal/provider/azure/init.go
+++ b/internal/provider/azure/init.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	// ProviderType defines the Azure provider.
-	ProviderType = "azure"
+	// providerType is the unique identifier that the azure provider gets
+	// registered with.
+	providerType = "azure"
 )
 
 // NewProvider instantiates and returns the Azure EnvironProvider using the
@@ -48,7 +49,7 @@ func init() {
 		panic(err)
 	}
 
-	environs.RegisterProvider(ProviderType, environProvider)
+	environs.RegisterProvider(providerType, environProvider)
 
 	// TODO(axw) register an image metadata data source that queries
 	// the Azure image registry, and introduce a way to disable the

--- a/internal/provider/azure/providertype_test.go
+++ b/internal/provider/azure/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestAzureProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the azure provider gets registered with is equal to that of
+// [corecloud.CloudTypeAzure].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestAzureProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypeAzure.String())
+}

--- a/internal/provider/ec2/init.go
+++ b/internal/provider/ec2/init.go
@@ -6,6 +6,8 @@ package ec2
 import "github.com/juju/juju/environs"
 
 const (
+	// providerType is the unique identifier that the ec2 provider gets
+	// registered with.
 	providerType = "ec2"
 )
 

--- a/internal/provider/ec2/providertype_test.go
+++ b/internal/provider/ec2/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestEC2ProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the ec2 provider gets registered with is equal to that of
+// [corecloud.CloudTypeEC2].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestEC2ProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypeEC2.String())
+}

--- a/internal/provider/gce/init.go
+++ b/internal/provider/gce/init.go
@@ -6,6 +6,8 @@ package gce
 import "github.com/juju/juju/environs"
 
 const (
+	// providerType is the unique identifier that the gce provider gets
+	// registered with.
 	providerType = "gce"
 )
 

--- a/internal/provider/gce/providertype_test.go
+++ b/internal/provider/gce/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gce
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestGCEProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the gce provider gets registered with is equal to that of
+// [corecloud.CloudTypeGCE].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestGCEProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypeGCE.String())
+}

--- a/internal/provider/lxd/init.go
+++ b/internal/provider/lxd/init.go
@@ -8,6 +8,12 @@ import (
 	"github.com/juju/juju/internal/provider/lxd/lxdnames"
 )
 
+const (
+	// providerType is the unique identifier that the lxd provider gets
+	// registered with.
+	providerType = lxdnames.ProviderType
+)
+
 func init() {
-	environs.RegisterProvider(lxdnames.ProviderType, NewProvider())
+	environs.RegisterProvider(providerType, NewProvider())
 }

--- a/internal/provider/lxd/providertype_test.go
+++ b/internal/provider/lxd/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestLXDProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the lxd provider gets registered with is equal to that of
+// [corecloud.CloudTypeLXD].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestLXDProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypeLXD.String())
+}

--- a/internal/provider/maas/init.go
+++ b/internal/provider/maas/init.go
@@ -8,6 +8,8 @@ import (
 )
 
 const (
+	// providerType is the unique identifier that the maas provider gets
+	// registered with.
 	providerType = "maas"
 )
 

--- a/internal/provider/maas/providertype_test.go
+++ b/internal/provider/maas/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestMAASProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the maas provider gets registered with is equal to that of
+// [corecloud.CloudTypeMAAS].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestMAASProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypeMAAS.String())
+}

--- a/internal/provider/manual/init.go
+++ b/internal/provider/manual/init.go
@@ -6,6 +6,8 @@ package manual
 import "github.com/juju/juju/environs"
 
 const (
+	// providerType is the unique identifier that the manual provider gets
+	// registered with.
 	providerType = "manual"
 )
 

--- a/internal/provider/manual/providertype_test.go
+++ b/internal/provider/manual/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package manual
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestManualProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the manual provider gets registered with is equal to that of
+// [corecloud.CloudTypeManual].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestManualProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypeManual.String())
+}

--- a/internal/provider/oci/init.go
+++ b/internal/provider/oci/init.go
@@ -6,6 +6,8 @@ package oci
 import "github.com/juju/juju/environs"
 
 const (
+	// providerType is the unique identifier that the oci provider gets
+	// registered with.
 	providerType = "oci"
 )
 

--- a/internal/provider/oci/providertype_test.go
+++ b/internal/provider/oci/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package oci
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestOCIProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the oci provider gets registered with is equal to that of
+// [corecloud.CloudTypeOCI].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestOCIProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypeOCI.String())
+}

--- a/internal/provider/openstack/init.go
+++ b/internal/provider/openstack/init.go
@@ -9,6 +9,8 @@ import (
 )
 
 const (
+	// providerType is the unique identifier that the openstack provider gets
+	// registered with.
 	providerType = "openstack"
 
 	// Default root disk size when root-disk-source is volume.

--- a/internal/provider/openstack/providertype_test.go
+++ b/internal/provider/openstack/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package openstack
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TesOpenStackProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the openstack provider gets registered with is equal to that
+// of [corecloud.CloudTypeOpenStack].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestOpenStackProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypeOpenStack.String())
+}

--- a/internal/provider/vsphere/init.go
+++ b/internal/provider/vsphere/init.go
@@ -12,6 +12,8 @@ import (
 )
 
 const (
+	// providerType is the unique identifier that the vsphere provider gets
+	// registered with.
 	providerType = "vsphere"
 )
 

--- a/internal/provider/vsphere/providertype_test.go
+++ b/internal/provider/vsphere/providertype_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphere
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	corecloud "github.com/juju/juju/core/cloud"
+)
+
+// TestVSphereProviderTypeEqualsCoreCloudValue checks that the unique provider
+// type value that the vsphere provider gets registered with is equal to that of
+// [corecloud.CloudTypevSphere].
+//
+// This is important test to make sure that enum values are kept in sync across
+// Juju.
+func TestVSphereProviderTypeEqualsCoreCloudValue(t *testing.T) {
+	tc.Assert(t, providerType, tc.Equals, corecloud.CloudTypevSphere.String())
+}


### PR DESCRIPTION
This commit introduces strong types for representing the type of a cloud. Currently when talking about a cloud's type inside that of a domain we use the string values and have no way to refer to a cloud type by a stronger primitive.

In this commit the cloud domain now has a CloudType value that is based off of the integer index in the DDL. The core/cloud package now also includes a set of CloudType enums that are based off of the string representation of the cloud type.

Tests have been added to the cloud domain to check first that the integer enums in the domain are aligned with the values that exist within the controller DDL. Another test in the cloud domain also checks that the core cloud type string values align with the type string representation of a cloud type in the controller DDL.

On top of this tests have been added to each provider to make sure that the provider type value each provider uses to register itself in the environ registry is the same as the value defined in core/cloud. This now means all the way from the the DDL to the provider we have unit tests to detect skew and drift of values.

The tests for the provider were done from the providers aspect of the problem. If the test was to be conducted from any other part of the code base it would bring the provider package in as a dependency. This would introduce the problem where we are unable to compile out certain providers and their dependencies from the controller.

The work here is done in advance to support a new ModelManager domain that is being developed. The ModelManager domain needs to be able to look at the cloud type of a model and calculate a corresponding type for the model. By now having this logic rely on the integer cloud type enums it means less lookup and matching needs to be performed within the database.

This pattern also makes the cloud domain and cloud type more inline with the idiomatic approach Juju is going in with DQlite where we prefer unique identifiers over that of strings.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
-  [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests validate this unused feature for the moment. Future model manager PR's will start making use of this.

## Documentation changes

N/A

## Links
