### PR TITLE
chore: allow controller to restart without jimm reachable

### DIFF
--- a/apiserver/common/crossmodel/bakery.go
+++ b/apiserver/common/crossmodel/bakery.go
@@ -123,7 +123,7 @@ func (o *JaaSOfferBakery) RefreshDischargeURL(accessEndpoint string) (string, er
 		return accessEndpoint, nil
 	}
 	o.currrentAccessEndpoint = accessEndpoint
-	return accessEndpoint, errors.Trace(o.refreshBakery(accessEndpoint))
+	return accessEndpoint, errors.Trace(o.setupBakery(accessEndpoint))
 }
 
 // cleanDischargeURL expects an address to JIMM's login-token-refresh-url,
@@ -147,29 +147,24 @@ func (o *JaaSOfferBakery) cleanDischargeURL(addr string) (string, error) {
 	return refreshURL.String(), nil
 }
 
-func (o *JaaSOfferBakery) refreshBakery(accessEndpoint string) (err error) {
-	thirdPartyInfo, err := httpbakery.ThirdPartyInfoForLocation(
-		context.TODO(), &http.Client{Transport: DefaultTransport}, accessEndpoint,
-	)
-	logger.Tracef("got third party info %#v from %q", thirdPartyInfo, accessEndpoint)
-	if err != nil {
-		return errors.Trace(err)
-	}
+func (o *JaaSOfferBakery) setupBakery(accessEndpoint string) (err error) {
 	key, err := o.bakeryConfig.GetExternalUsersThirdPartyKey()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	pkCache := bakery.NewThirdPartyStore()
-	pkCache.AddInfo(accessEndpoint, thirdPartyInfo)
-	locator := httpbakery.NewThirdPartyLocator(nil, pkCache)
+	externalKeyLocator := &externalPublicKeyLocator{
+		ThirdPartyStore: pkCache,
+		accessEndpoint:  accessEndpoint,
+	}
 
 	o.bakery = &bakeryutil.ExpirableStorageBakery{
 		Bakery: bakery.New(
 			bakery.BakeryParams{
 				Checker:       o.checker,
 				RootKeyStore:  o.store,
-				Locator:       locator,
+				Locator:       externalKeyLocator,
 				Key:           key,
 				OpsAuthorizer: CrossModelAuthorizer{},
 				Location:      o.location,
@@ -178,9 +173,33 @@ func (o *JaaSOfferBakery) refreshBakery(accessEndpoint string) (err error) {
 		Location: o.location,
 		Key:      key,
 		Store:    o.store,
-		Locator:  locator,
+		Locator:  externalKeyLocator,
 	}
 	return nil
+}
+
+type externalPublicKeyLocator struct {
+	*bakery.ThirdPartyStore
+	accessEndpoint string
+}
+
+// ThirdPartyInfo implements bakery.PublicKeyLocator.
+// It first checks the local store for the public key, and if not found,
+// it fetches the public key from the access endpoint and caches it.
+func (f *externalPublicKeyLocator) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
+	var info bakery.ThirdPartyInfo
+	info, err := f.ThirdPartyStore.ThirdPartyInfo(ctx, f.accessEndpoint)
+	if err == nil {
+		return info, nil
+	}
+	client := &http.Client{Transport: DefaultTransport}
+	info, err = httpbakery.ThirdPartyInfoForLocation(ctx, client, f.accessEndpoint)
+	logger.Tracef("got third party info %#v from %q", info, f.accessEndpoint)
+	if err != nil {
+		return info, errors.Trace(err)
+	}
+	f.ThirdPartyStore.AddInfo(f.accessEndpoint, info)
+	return info, nil
 }
 
 var (

--- a/internal/jwtparser/jwt.go
+++ b/internal/jwtparser/jwt.go
@@ -73,10 +73,6 @@ func (j *Parser) SetJWKSCache(ctx context.Context, refreshURL string) error {
 	if err != nil {
 		return fmt.Errorf("registering jwk cache with url %q: %w", refreshURL, err)
 	}
-	_, err = j.cache.Refresh(ctx, refreshURL)
-	if err != nil {
-		return fmt.Errorf("refreshing jwk cache at %q: %w", refreshURL, err)
-	}
 	j.refreshURL = refreshURL
 	return nil
 }

--- a/internal/jwtparser/jwt_test.go
+++ b/internal/jwtparser/jwt_test.go
@@ -50,13 +50,13 @@ func (s *jwtParserSuite) TestCacheRegistration(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *jwtParserSuite) TestCacheRegistrationFailureWithBadURL(c *gc.C) {
+func (s *jwtParserSuite) TestCacheRegistrationSucceedsWithBadURL(c *gc.C) {
 	ctx, done := context.WithCancel(context.Background())
 	defer done()
 	authenticator := NewParserWithHTTPClient(ctx, s.client)
 	err := authenticator.SetJWKSCache(context.Background(), "noexisturl")
-	// We want to make sure that we get an error for a bad url.
-	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(authenticator.refreshURL, gc.Equals, "noexisturl")
 }
 
 func (s *jwtParserSuite) TestParseJWT(c *gc.C) {


### PR DESCRIPTION
This PR resolves an oustanding issue that a Juju controller connected to JAAS will fail to start if JAAS is not available. Originally attempted in https://github.com/juju/juju/pull/17566, the outstanding issue there was a request to validate the JAAS url at least once on startup, then allow the controller to restart even if JAAS is not reachable.
 
For more context, JAAS provides 2 public keys, one for signing JWTs and another used when minting macaroons with 3rd party caveats. If JAAS is not reachable, the Juju controller should remain operational. This was prohibited by the fact that we were fetching the public keys on startup in a blocking manner. This change ensures the keys are only fetched on-demand and cached to keep things operational when JAAS is down.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

I took a lot of time to prove to myself that this all works using the following:
1. Validate that bootstrap fails when the login-token-refresh-url is not reachable by running `juju bootstrap lxd expect-failure --config login-token-refresh-url=http://fake-domain.localhost/.well-known/jwks.json --debug`
  ```
  2025-05-19 15:02:46 INFO juju.cmd.jujud bootstrap.go:541 started mongo
  ERROR failed to fetch jwks: failed to fetch "http://fake-domain.localhost/.well-known/jwks.json": Get "http://fake-domain.localhost/.well-known/jwks.json": dial tcp [::1]:80: connect: connection refused
  2025-05-19 15:02:46 DEBUG cmd supercommand.go:571 error stack: 
  failed to fetch "http://fake-domain.localhost/.well-known/jwks.json": Get "http://fake-domain.localhost/.well-known/jwks.json": dial tcp [::1]:80: connect: connection refused
  github.com/juju/juju/agent/agentbootstrap.InitializeState:113: failed to fetch jwks
  github.com/juju/juju/cmd/jujud/agent/agentconf.(*agentConf).ChangeConfig:103: 
  github.com/juju/juju/cmd/jujud/agent.(*BootstrapCommand).Run:362: 
  2025-05-19 15:02:46 DEBUG juju.cmd.jujud main.go:287 jujud complete, code 0, err <nil>
  17:02:46 ERROR juju.cmd.juju.commands bootstrap.go:1032 failed to bootstrap model: subprocess encountered error code 1
  ```
2. I have created the following gist that emulates a JIMM controller, returning a JSON public key and macaroon discharge/public key endpoints. The gist is [here](https://gist.github.com/kian99/d63d3d6e9c8ea697f61f8fce451b4313) with instructions to run it. This will create an HTTP server that discharges macaroons without any permission checks.
3. To create a Juju controller in LXD that communicates with a mock-jimm run the following.
  ```
  CLOUDINIT_FILE="cloudinit-tweak.temp.yaml"
  CONTROLLER_NAME="macaroons-test-lxd"
  CLOUDINIT_TEMPLATE=$'cloudinit-userdata: |
    preruncmd:
      - echo "%s    fake-jimm.domain" >> /etc/hosts'
  printf "$CLOUDINIT_TEMPLATE" "$(lxc network get lxdbr0 ipv4.address | cut -f1 -d/)" > "${CLOUDINIT_FILE}"
  juju bootstrap lxd "${CONTROLLER_NAME}" --config "${CLOUDINIT_FILE}" --config login-token-refresh-url=http://fake-jimm.domain:9091/.well-known/jwks.json --debug
  ``` 
4. `juju add-model source`
5. `juju offer source`
6. `juju add-model sink`
7. `juju consume admin/source.dummy-source`
8. `juju relate dummy-sink dummy-source`
9. `juju switch source`
10. `juju config dummy-source token=foo`
11. `juju switch sink`
12. Observe that the sink app has the token from source.
13. `juju remove-relation dummy-sink dummy-source`
14. Stop the fake-jimm server.
15. Restart the Juju controller i.e. `lxd restart <container-name>`
16. Juju will no longer have the public key of JIMM stored.
17. `juju relate dummy-sink dummy-source`
18. `juju debug-log`
19. Observe that the relation is failing to be created, `juju debug-log` should show the following
  ```
  controller-0: 16:48:30 ERROR juju.worker.remoterelations cmr exited "dummy-source": watching status for offer: cannot create macaroon: cannot add caveat checkers.Caveat{Condition:"is-consumer user-admin 6b28966f-7801-49d4-88df-8cf2537eb394", Namespace:"", Location:"http://test-jimm.domain:9091/macaroons"}: cannot find public key for location "http://test-jimm.domain:9091/macaroons": Get "http://test-jimm.domain:9091/macaroons/discharge/info": dial tcp 10.16.149.1:9091: connect: connection refused
  ```
20. Start the fake-jimm server
21. Observe the relation begins to work again.
