### PR TITLE
add `LinkLayerDeviceUUID` and `NetNodeUUID` types

### DIFF
--- a/core/application/id.go
+++ b/core/application/id.go
@@ -12,7 +12,7 @@ import (
 // ID represents a application unique identifier.
 type ID string
 
-// NewID is a convince function for generating a new application uuid.
+// NewID is a convenience function for generating a new application uuid.
 func NewID() (ID, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {

--- a/core/charm/id.go
+++ b/core/charm/id.go
@@ -12,7 +12,7 @@ import (
 // ID represents a charm unique identifier.
 type ID string
 
-// NewID is a convince function for generating a new charm uuid.
+// NewID is a convenience function for generating a new charm uuid.
 func NewID() (ID, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {

--- a/core/machine/id.go
+++ b/core/machine/id.go
@@ -12,7 +12,7 @@ import (
 // UUID represents a machine unique identifier.
 type UUID string
 
-// NewUUID is a convince function for generating a new machine uuid.
+// NewUUID is a convenience function for generating a new machine uuid.
 func NewUUID() (UUID, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -98,7 +98,7 @@ type Model struct {
 // UUID represents a model unique identifier.
 type UUID string
 
-// NewUUID is a convince function for generating a new model uuid.
+// NewUUID is a convenience function for generating a new model uuid.
 func NewUUID() (UUID, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {

--- a/core/network/linklayer.go
+++ b/core/network/linklayer.go
@@ -6,6 +6,10 @@ package network
 import (
 	"runtime"
 	"strings"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/uuid"
 )
 
 // LinkLayerDeviceType defines the type of a link-layer network device.
@@ -85,4 +89,43 @@ var whitespaceReplacer = strings.NewReplacer(
 func stringLengthBetween(value string, minLength, maxLength uint) bool {
 	length := uint(len(value))
 	return length >= minLength && length <= maxLength
+}
+
+// LinkLayerDeviceUUID represents a relation unique identifier.
+type LinkLayerDeviceUUID string
+
+// NewLinkLayerDeviceUUID is a convince function for generating a new
+// link layer device uuid.
+func NewLinkLayerDeviceUUID() (LinkLayerDeviceUUID, error) {
+	id, err := uuid.NewUUID()
+	if err != nil {
+		return LinkLayerDeviceUUID(""), err
+	}
+	return LinkLayerDeviceUUID(id.String()), nil
+}
+
+// ParseUUID returns a new UUID from the given string. If the string is not a
+// valid uuid an error satisfying [errors.NotValid] will be returned.
+func ParseLinkLayerDeviceUUID(value string) (LinkLayerDeviceUUID, error) {
+	if !uuid.IsValidUUIDString(value) {
+		return "", errors.Errorf("parsing relation uuid %q: %w", value, coreerrors.NotValid)
+	}
+	return LinkLayerDeviceUUID(value), nil
+}
+
+// String implements the stringer interface for UUID.
+func (u LinkLayerDeviceUUID) String() string {
+	return string(u)
+}
+
+// Validate ensures the consistency of the UUID. If the uuid is invalid an error
+// satisfying [errors.NotValid] will be returned.
+func (u LinkLayerDeviceUUID) Validate() error {
+	if u == "" {
+		return errors.Errorf("relation uuid cannot be empty").Add(coreerrors.NotValid)
+	}
+	if !uuid.IsValidUUIDString(string(u)) {
+		return errors.Errorf("relation uuid %q: %w", u, coreerrors.NotValid)
+	}
+	return nil
 }

--- a/core/network/linklayer.go
+++ b/core/network/linklayer.go
@@ -94,7 +94,7 @@ func stringLengthBetween(value string, minLength, maxLength uint) bool {
 // LinkLayerDeviceUUID represents a relation unique identifier.
 type LinkLayerDeviceUUID string
 
-// NewLinkLayerDeviceUUID is a convince function for generating a new
+// NewLinkLayerDeviceUUID is a convenience function for generating a new
 // link layer device uuid.
 func NewLinkLayerDeviceUUID() (LinkLayerDeviceUUID, error) {
 	id, err := uuid.NewUUID()

--- a/core/network/linklayer_test.go
+++ b/core/network/linklayer_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/juju/tc"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/internal/testhelpers"
+	"github.com/juju/juju/internal/uuid"
 )
 
 type linkLayerSuite struct {
@@ -140,5 +142,43 @@ func (s *linkLayerSuite) TestStringLengthBetweenWhenWithinLimit(c *tc.C) {
 		input := strings.Repeat("x", i)
 		result := stringLengthBetween(input, minLength, maxLength)
 		c.Check(result, tc.IsTrue)
+	}
+}
+
+type linkLayerDeviceUUIDSuite struct {
+}
+
+var _ = tc.Suite(&linkLayerDeviceUUIDSuite{})
+
+func (*linkLayerDeviceUUIDSuite) TestUUIDValidate(c *tc.C) {
+	// Test that the uuid.Validate method succeeds and
+	// fails as expected.
+	tests := []struct {
+		uuid string
+		err  error
+	}{
+		{
+			uuid: "",
+			err:  coreerrors.NotValid,
+		},
+		{
+			uuid: "invalid",
+			err:  coreerrors.NotValid,
+		},
+		{
+			uuid: uuid.MustNewUUID().String(),
+		},
+	}
+
+	for i, test := range tests {
+		c.Logf("test %d: %q", i, test.uuid)
+		err := LinkLayerDeviceUUID(test.uuid).Validate()
+
+		if test.err == nil {
+			c.Check(err, tc.IsNil)
+			continue
+		}
+
+		c.Check(err, tc.ErrorIs, test.err)
 	}
 }

--- a/core/network/netnode.go
+++ b/core/network/netnode.go
@@ -1,0 +1,46 @@
+package network
+
+import (
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// NetNodeUUID represents a net node unique identifier.
+type NetNodeUUID string
+
+// NewNetNodeUUID is a convince function for generating a new
+// net node uuid.
+func NewNetNodeUUID() (NetNodeUUID, error) {
+	id, err := uuid.NewUUID()
+	if err != nil {
+		return NetNodeUUID(""), err
+	}
+	return NetNodeUUID(id.String()), nil
+}
+
+// ParseNetNodeUUID returns a new UUID from the given string. If the string is not a
+// valid uuid an error satisfying [errors.NotValid] will be returned.
+func ParseNetNodeUUID(value string) (NetNodeUUID, error) {
+	if !uuid.IsValidUUIDString(value) {
+		return "", errors.Errorf("parsing relation uuid %q: %w", value, coreerrors.NotValid)
+	}
+	return NetNodeUUID(value), nil
+}
+
+// String implements the stringer interface for UUID.
+func (u NetNodeUUID) String() string {
+	return string(u)
+}
+
+// Validate ensures the consistency of the UUID. If the uuid is invalid an error
+// satisfying [errors.NotValid] will be returned.
+func (u NetNodeUUID) Validate() error {
+	if u == "" {
+		return errors.Errorf("relation uuid cannot be empty").Add(coreerrors.NotValid)
+	}
+	if !uuid.IsValidUUIDString(string(u)) {
+		return errors.Errorf("relation uuid %q: %w", u, coreerrors.NotValid)
+	}
+	return nil
+}

--- a/core/network/netnode.go
+++ b/core/network/netnode.go
@@ -9,7 +9,7 @@ import (
 // NetNodeUUID represents a net node unique identifier.
 type NetNodeUUID string
 
-// NewNetNodeUUID is a convince function for generating a new
+// NewNetNodeUUID is a convenience function for generating a new
 // net node uuid.
 func NewNetNodeUUID() (NetNodeUUID, error) {
 	id, err := uuid.NewUUID()

--- a/core/network/netnode_test.go
+++ b/core/network/netnode_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"github.com/juju/tc"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+type netNodeUUIDSuite struct {
+}
+
+var _ = tc.Suite(&netNodeUUIDSuite{})
+
+func (*netNodeUUIDSuite) TestUUIDValidate(c *tc.C) {
+	// Test that the uuid.Validate method succeeds and
+	// fails as expected.
+	tests := []struct {
+		uuid string
+		err  error
+	}{
+		{
+			uuid: "",
+			err:  coreerrors.NotValid,
+		},
+		{
+			uuid: "invalid",
+			err:  coreerrors.NotValid,
+		},
+		{
+			uuid: uuid.MustNewUUID().String(),
+		},
+	}
+
+	for i, test := range tests {
+		c.Logf("test %d: %q", i, test.uuid)
+		err := NetNodeUUID(test.uuid).Validate()
+
+		if test.err == nil {
+			c.Check(err, tc.IsNil)
+			continue
+		}
+
+		c.Check(err, tc.ErrorIs, test.err)
+	}
+}

--- a/core/network/testing/testing.go
+++ b/core/network/testing/testing.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/network"
+)
+
+// GenLinkLayerDeviceUUID can be used in testing for generating a link layer
+// device uuid that is checked for subsequent errors using the test suits go
+// check instance.
+func GenLinkLayerDeviceUUID(c *tc.C) network.LinkLayerDeviceUUID {
+	uuid, err := network.NewLinkLayerDeviceUUID()
+	c.Assert(err, tc.ErrorIsNil)
+	return uuid
+}

--- a/core/network/testing/testing.go
+++ b/core/network/testing/testing.go
@@ -10,10 +10,18 @@ import (
 )
 
 // GenLinkLayerDeviceUUID can be used in testing for generating a link layer
-// device uuid that is checked for subsequent errors using the test suits go
-// check instance.
+// device uuid that is checked for subsequent errors using the test suites
+// tc instance.
 func GenLinkLayerDeviceUUID(c *tc.C) network.LinkLayerDeviceUUID {
 	uuid, err := network.NewLinkLayerDeviceUUID()
+	c.Assert(err, tc.ErrorIsNil)
+	return uuid
+}
+
+// GenNetNodeUUID can be used in testing for generating a net node uuid
+// that is checked for subsequent errors using the test suites tc instance.
+func GenNetNodeUUID(c *tc.C) network.NetNodeUUID {
+	uuid, err := network.NewNetNodeUUID()
 	c.Assert(err, tc.ErrorIsNil)
 	return uuid
 }

--- a/core/objectstore/uuid.go
+++ b/core/objectstore/uuid.go
@@ -12,7 +12,7 @@ import (
 // UUID represents a object store unique identifier.
 type UUID string
 
-// NewUUID is a convince function for generating a new object store uuid.
+// NewUUID is a convenience function for generating a new object store uuid.
 func NewUUID() (UUID, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {

--- a/core/relation/uuid.go
+++ b/core/relation/uuid.go
@@ -12,7 +12,7 @@ import (
 // UUID represents a relation unique identifier.
 type UUID string
 
-// NewUUID is a convince function for generating a new relation uuid.
+// NewUUID is a convenience function for generating a new relation uuid.
 func NewUUID() (UUID, error) {
 	id, err := uuid.NewUUID()
 	if err != nil {
@@ -50,7 +50,7 @@ func (u UUID) Validate() error {
 // UnitUUID represents a relation unit unique identifier.
 type UnitUUID string
 
-// NewUnitUUID is a convince function for generating a new relation unit uuid.
+// NewUnitUUID is a convenience function for generating a new relation unit uuid.
 func NewUnitUUID() (UnitUUID, error) {
 	id, err := uuid.NewUUID()
 	if err != nil {

--- a/core/resource/uuid.go
+++ b/core/resource/uuid.go
@@ -12,7 +12,7 @@ import (
 // UUID represents a resource unique identifier.
 type UUID string
 
-// NewUUID is a convince function for generating a new resource uuid.
+// NewUUID is a convenience function for generating a new resource uuid.
 func NewUUID() (UUID, error) {
 	id, err := uuid.NewUUID()
 	if err != nil {

--- a/core/resources/containermetadataresource/uuid.go
+++ b/core/resources/containermetadataresource/uuid.go
@@ -12,7 +12,7 @@ import (
 // UUID represents a container metadata resource unique identifier.
 type UUID string
 
-// NewUUID is a convince function for generating a new container metadata resource uuid.
+// NewUUID is a convenience function for generating a new container metadata resource uuid.
 func NewUUID() (UUID, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {

--- a/core/unit/id.go
+++ b/core/unit/id.go
@@ -12,7 +12,7 @@ import (
 // UUID represents a unit unique identifier.
 type UUID string
 
-// NewUUID is a convince function for generating a new unit uuid.
+// NewUUID is a convenience function for generating a new unit uuid.
 func NewUUID() (UUID, error) {
 	id, err := uuid.NewUUID()
 	if err != nil {

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -266,11 +266,11 @@ type ApplicationState interface {
 	// InitialWatchStatementUnitAddressesHash returns the initial namespace query
 	// for the unit addresses hash watcher as well as the tables to be watched
 	// (ip_address and application_endpoint)
-	InitialWatchStatementUnitAddressesHash(appUUID coreapplication.ID, netNodeUUID string) (string, string, eventsource.NamespaceQuery)
+	InitialWatchStatementUnitAddressesHash(appUUID coreapplication.ID, netNodeUUID network.NetNodeUUID) (string, string, eventsource.NamespaceQuery)
 
 	// GetAddressesHash returns the sha256 hash of the application unit and cloud
 	// service (if any) addresses along with the associated endpoint bindings.
-	GetAddressesHash(ctx context.Context, appUUID coreapplication.ID, netNodeUUID string) (string, error)
+	GetAddressesHash(ctx context.Context, appUUID coreapplication.ID, netNodeUUID network.NetNodeUUID) (string, error)
 
 	// GetNetNodeUUIDByUnitName returns the net node UUID for the named unit or the
 	// cloud service associated with the unit's application. This method is meant
@@ -279,7 +279,7 @@ type ApplicationState interface {
 	//
 	// If the unit does not exist an error satisfying
 	// [applicationerrors.UnitNotFound] will be returned.
-	GetNetNodeUUIDByUnitName(ctx context.Context, name coreunit.Name) (string, error)
+	GetNetNodeUUIDByUnitName(ctx context.Context, name coreunit.Name) (network.NetNodeUUID, error)
 
 	// GetApplicationConstraints returns the application constraints for the
 	// specified application ID.

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -535,7 +535,7 @@ func (c *MockStateEndpointsExistCall) DoAndReturn(f func(context.Context, applic
 }
 
 // GetAddressesHash mocks base method.
-func (m *MockState) GetAddressesHash(ctx context.Context, appUUID application.ID, netNodeUUID string) (string, error) {
+func (m *MockState) GetAddressesHash(ctx context.Context, appUUID application.ID, netNodeUUID network.NetNodeUUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAddressesHash", ctx, appUUID, netNodeUUID)
 	ret0, _ := ret[0].(string)
@@ -562,13 +562,13 @@ func (c *MockStateGetAddressesHashCall) Return(arg0 string, arg1 error) *MockSta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetAddressesHashCall) Do(f func(context.Context, application.ID, string) (string, error)) *MockStateGetAddressesHashCall {
+func (c *MockStateGetAddressesHashCall) Do(f func(context.Context, application.ID, network.NetNodeUUID) (string, error)) *MockStateGetAddressesHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetAddressesHashCall) DoAndReturn(f func(context.Context, application.ID, string) (string, error)) *MockStateGetAddressesHashCall {
+func (c *MockStateGetAddressesHashCall) DoAndReturn(f func(context.Context, application.ID, network.NetNodeUUID) (string, error)) *MockStateGetAddressesHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2224,10 +2224,10 @@ func (c *MockStateGetLatestPendingCharmhubCharmCall) DoAndReturn(f func(context.
 }
 
 // GetMachineNetNodeUUIDFromName mocks base method.
-func (m *MockState) GetMachineNetNodeUUIDFromName(arg0 context.Context, arg1 machine.Name) (string, error) {
+func (m *MockState) GetMachineNetNodeUUIDFromName(arg0 context.Context, arg1 machine.Name) (network.NetNodeUUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineNetNodeUUIDFromName", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(network.NetNodeUUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2245,19 +2245,19 @@ type MockStateGetMachineNetNodeUUIDFromNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetMachineNetNodeUUIDFromNameCall) Return(arg0 string, arg1 error) *MockStateGetMachineNetNodeUUIDFromNameCall {
+func (c *MockStateGetMachineNetNodeUUIDFromNameCall) Return(arg0 network.NetNodeUUID, arg1 error) *MockStateGetMachineNetNodeUUIDFromNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachineNetNodeUUIDFromNameCall) Do(f func(context.Context, machine.Name) (string, error)) *MockStateGetMachineNetNodeUUIDFromNameCall {
+func (c *MockStateGetMachineNetNodeUUIDFromNameCall) Do(f func(context.Context, machine.Name) (network.NetNodeUUID, error)) *MockStateGetMachineNetNodeUUIDFromNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachineNetNodeUUIDFromNameCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateGetMachineNetNodeUUIDFromNameCall {
+func (c *MockStateGetMachineNetNodeUUIDFromNameCall) DoAndReturn(f func(context.Context, machine.Name) (network.NetNodeUUID, error)) *MockStateGetMachineNetNodeUUIDFromNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2341,10 +2341,10 @@ func (c *MockStateGetModelTypeCall) DoAndReturn(f func(context.Context) (model.M
 }
 
 // GetNetNodeUUIDByUnitName mocks base method.
-func (m *MockState) GetNetNodeUUIDByUnitName(ctx context.Context, name unit.Name) (string, error) {
+func (m *MockState) GetNetNodeUUIDByUnitName(ctx context.Context, name unit.Name) (network.NetNodeUUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetNodeUUIDByUnitName", ctx, name)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(network.NetNodeUUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2362,19 +2362,19 @@ type MockStateGetNetNodeUUIDByUnitNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetNetNodeUUIDByUnitNameCall) Return(arg0 string, arg1 error) *MockStateGetNetNodeUUIDByUnitNameCall {
+func (c *MockStateGetNetNodeUUIDByUnitNameCall) Return(arg0 network.NetNodeUUID, arg1 error) *MockStateGetNetNodeUUIDByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetNetNodeUUIDByUnitNameCall) Do(f func(context.Context, unit.Name) (string, error)) *MockStateGetNetNodeUUIDByUnitNameCall {
+func (c *MockStateGetNetNodeUUIDByUnitNameCall) Do(f func(context.Context, unit.Name) (network.NetNodeUUID, error)) *MockStateGetNetNodeUUIDByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetNetNodeUUIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (string, error)) *MockStateGetNetNodeUUIDByUnitNameCall {
+func (c *MockStateGetNetNodeUUIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (network.NetNodeUUID, error)) *MockStateGetNetNodeUUIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2731,7 +2731,7 @@ func (c *MockStateGetUnitNamesForApplicationCall) DoAndReturn(f func(context.Con
 }
 
 // GetUnitNamesForNetNode mocks base method.
-func (m *MockState) GetUnitNamesForNetNode(arg0 context.Context, arg1 string) ([]unit.Name, error) {
+func (m *MockState) GetUnitNamesForNetNode(arg0 context.Context, arg1 network.NetNodeUUID) ([]unit.Name, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitNamesForNetNode", arg0, arg1)
 	ret0, _ := ret[0].([]unit.Name)
@@ -2758,22 +2758,22 @@ func (c *MockStateGetUnitNamesForNetNodeCall) Return(arg0 []unit.Name, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitNamesForNetNodeCall) Do(f func(context.Context, string) ([]unit.Name, error)) *MockStateGetUnitNamesForNetNodeCall {
+func (c *MockStateGetUnitNamesForNetNodeCall) Do(f func(context.Context, network.NetNodeUUID) ([]unit.Name, error)) *MockStateGetUnitNamesForNetNodeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitNamesForNetNodeCall) DoAndReturn(f func(context.Context, string) ([]unit.Name, error)) *MockStateGetUnitNamesForNetNodeCall {
+func (c *MockStateGetUnitNamesForNetNodeCall) DoAndReturn(f func(context.Context, network.NetNodeUUID) ([]unit.Name, error)) *MockStateGetUnitNamesForNetNodeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetUnitNetNodes mocks base method.
-func (m *MockState) GetUnitNetNodes(ctx context.Context, uuid unit.UUID) ([]string, error) {
+func (m *MockState) GetUnitNetNodes(ctx context.Context, uuid unit.UUID) ([]network.NetNodeUUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitNetNodes", ctx, uuid)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]network.NetNodeUUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2791,19 +2791,19 @@ type MockStateGetUnitNetNodesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitNetNodesCall) Return(arg0 []string, arg1 error) *MockStateGetUnitNetNodesCall {
+func (c *MockStateGetUnitNetNodesCall) Return(arg0 []network.NetNodeUUID, arg1 error) *MockStateGetUnitNetNodesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitNetNodesCall) Do(f func(context.Context, unit.UUID) ([]string, error)) *MockStateGetUnitNetNodesCall {
+func (c *MockStateGetUnitNetNodesCall) Do(f func(context.Context, unit.UUID) ([]network.NetNodeUUID, error)) *MockStateGetUnitNetNodesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitNetNodesCall) DoAndReturn(f func(context.Context, unit.UUID) ([]string, error)) *MockStateGetUnitNetNodesCall {
+func (c *MockStateGetUnitNetNodesCall) DoAndReturn(f func(context.Context, unit.UUID) ([]network.NetNodeUUID, error)) *MockStateGetUnitNetNodesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -3083,7 +3083,7 @@ func (c *MockStateInitialWatchStatementApplicationsWithPendingCharmsCall) DoAndR
 }
 
 // InitialWatchStatementUnitAddressesHash mocks base method.
-func (m *MockState) InitialWatchStatementUnitAddressesHash(appUUID application.ID, netNodeUUID string) (string, string, eventsource.NamespaceQuery) {
+func (m *MockState) InitialWatchStatementUnitAddressesHash(appUUID application.ID, netNodeUUID network.NetNodeUUID) (string, string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitialWatchStatementUnitAddressesHash", appUUID, netNodeUUID)
 	ret0, _ := ret[0].(string)
@@ -3111,13 +3111,13 @@ func (c *MockStateInitialWatchStatementUnitAddressesHashCall) Return(arg0, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInitialWatchStatementUnitAddressesHashCall) Do(f func(application.ID, string) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementUnitAddressesHashCall {
+func (c *MockStateInitialWatchStatementUnitAddressesHashCall) Do(f func(application.ID, network.NetNodeUUID) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementUnitAddressesHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInitialWatchStatementUnitAddressesHashCall) DoAndReturn(f func(application.ID, string) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementUnitAddressesHashCall {
+func (c *MockStateInitialWatchStatementUnitAddressesHashCall) DoAndReturn(f func(application.ID, network.NetNodeUUID) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementUnitAddressesHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/core/semversion"
@@ -593,13 +594,15 @@ func (s *WatchableService) WatchApplicationExposed(ctx context.Context, name str
 // addresses.
 // This notifies on any changes to the net nodes addresses. It is up to the
 // caller to determine if the addresses they're interested in has changed.
-func (s *WatchableService) WatchNetNodeAddress(ctx context.Context, netNodeUUIDs ...string) (watcher.NotifyWatcher, error) {
-
+func (s *WatchableService) WatchNetNodeAddress(ctx context.Context, netNodeUUIDs ...network.NetNodeUUID) (watcher.NotifyWatcher, error) {
+	uuids := transform.Slice(netNodeUUIDs, func(in network.NetNodeUUID) string {
+		return in.String()
+	})
 	return s.watcherFactory.NewNotifyWatcher(
 		eventsource.PredicateFilter(
 			s.st.NamespaceForWatchNetNodeAddress(),
 			changestream.All,
-			eventsource.ContainsPredicate(netNodeUUIDs),
+			eventsource.ContainsPredicate(uuids),
 		),
 	)
 }

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -138,7 +138,7 @@ type UnitState interface {
 	GetUnitNamesForApplication(context.Context, coreapplication.ID) ([]coreunit.Name, error)
 
 	// GetUnitNamesForNetNode returns a slice of the unit names for the given net node
-	GetUnitNamesForNetNode(context.Context, string) ([]coreunit.Name, error)
+	GetUnitNamesForNetNode(context.Context, network.NetNodeUUID) ([]coreunit.Name, error)
 
 	// AddSubordinateUnit adds a new unit to the subordinate application. On
 	// IAAS, the new unit will be colocated on machine with the principal unit.
@@ -148,7 +148,7 @@ type UnitState interface {
 	// GetMachineNetNodeUUIDFromName returns the net node UUID for the named
 	// machine. The following errors may be returned: -
 	// [applicationerrors.MachineNotFound] if the machine does not exist
-	GetMachineNetNodeUUIDFromName(context.Context, machine.Name) (string, error)
+	GetMachineNetNodeUUIDFromName(context.Context, machine.Name) (network.NetNodeUUID, error)
 
 	// SetUnitWorkloadVersion sets the workload version for the given unit.
 	SetUnitWorkloadVersion(ctx context.Context, unitName coreunit.Name, version string) error
@@ -167,7 +167,7 @@ type UnitState interface {
 	//
 	// The following errors may be returned:
 	// - [uniterrors.UnitNotFound] if the unit does not exist
-	GetUnitNetNodes(ctx context.Context, uuid coreunit.UUID) ([]string, error)
+	GetUnitNetNodes(ctx context.Context, uuid coreunit.UUID) ([]network.NetNodeUUID, error)
 }
 
 func (s *Service) makeUnitArgs(modelType coremodel.ModelType, units []AddUnitArg, constraints constraints.Constraints) ([]application.AddUnitArg, error) {
@@ -716,7 +716,7 @@ func (s *Service) GetUnitSubordinates(ctx context.Context, unitName coreunit.Nam
 //
 // The following errors may be returned:
 // - [uniterrors.UnitNotFound] if the unit does not exist
-func (s *Service) GetUnitNetNodes(ctx context.Context, unitName coreunit.Name) ([]string, error) {
+func (s *Service) GetUnitNetNodes(ctx context.Context, unitName coreunit.Name) ([]network.NetNodeUUID, error) {
 	unitUUID, err := s.st.GetUnitUUIDByName(ctx, unitName)
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network/testing"
 	corestatus "github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
 	unittesting "github.com/juju/juju/core/unit/testing"
@@ -27,7 +28,6 @@ import (
 	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/status"
 	"github.com/juju/juju/internal/errors"
-	"github.com/juju/juju/internal/uuid"
 )
 
 type unitServiceSuite struct {
@@ -342,7 +342,7 @@ func (s *unitServiceSuite) TestGetUnitNamesOnMachineNotFound(c *tc.C) {
 func (s *unitServiceSuite) TestGetUnitNamesOnMachine(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	netNodeUUID := uuid.MustNewUUID().String()
+	netNodeUUID := testing.GenNetNodeUUID(c)
 	s.state.EXPECT().GetMachineNetNodeUUIDFromName(gomock.Any(), machine.Name("0")).Return(netNodeUUID, nil)
 	s.state.EXPECT().GetUnitNamesForNetNode(gomock.Any(), netNodeUUID).Return([]coreunit.Name{"foo/666", "bar/667"}, nil)
 
@@ -1119,7 +1119,7 @@ func (s *serviceSuite) TestGetUnitNetNodes(c *tc.C) {
 
 	unitName := coreunit.Name("foo/0")
 
-	netNodeUUIDs := []string{"foo-uuid", "bar-uuid"}
+	netNodeUUIDs := []network.NetNodeUUID{testing.GenNetNodeUUID(c), testing.GenNetNodeUUID(c)}
 
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), coreunit.Name("foo/0")).Return(coreunit.UUID("foo-uuid"), nil)
 	s.state.EXPECT().GetUnitNetNodes(gomock.Any(), coreunit.UUID("foo-uuid")).Return(netNodeUUIDs, nil)

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -22,6 +22,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/network"
+	networktesting "github.com/juju/juju/core/network/testing"
 	coreresource "github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/resource/testing"
 	"github.com/juju/juju/core/semversion"
@@ -3654,7 +3655,7 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudService(c *tc.C) {
 	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.NewSpaceAddresses("10.0.0.1"))
 	c.Assert(err, tc.ErrorIsNil)
 
-	var netNodeUUID string
+	var netNodeUUID network.NetNodeUUID
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT net_node_uuid FROM k8s_service WHERE application_uuid=?", appID).Scan(&netNodeUUID)
 		if err != nil {
@@ -3677,7 +3678,7 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudServiceWithEndpointBind
 	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.NewSpaceAddresses("10.0.0.1"))
 	c.Assert(err, tc.ErrorIsNil)
 
-	var netNodeUUID string
+	var netNodeUUID network.NetNodeUUID
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT net_node_uuid FROM k8s_service WHERE application_uuid=?", appID).Scan(&netNodeUUID)
 		if err != nil {
@@ -3792,17 +3793,18 @@ func (s *applicationStateSuite) TestGetNetNodeFromUnit(c *tc.C) {
 	_ = s.createApplication(c, "foo", life.Alive, application.InsertUnitArg{
 		UnitName: "foo/0",
 	})
+	expectedNetNodeUUID := networktesting.GenNetNodeUUID(c)
 
 	// Insert the unit net node to make sure the k8s service one is
 	// returned.
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		insertNetNode := `INSERT INTO net_node (uuid) VALUES (?)`
-		_, err := tx.ExecContext(ctx, insertNetNode, "net-node-uuid")
+		_, err := tx.ExecContext(ctx, insertNetNode, expectedNetNodeUUID)
 		if err != nil {
 			return err
 		}
 		updateUnit := `UPDATE unit SET net_node_uuid = ? WHERE name = ?`
-		_, err = tx.ExecContext(ctx, updateUnit, "net-node-uuid", "foo/0")
+		_, err = tx.ExecContext(ctx, updateUnit, expectedNetNodeUUID, "foo/0")
 		if err != nil {
 			return err
 		}
@@ -3813,7 +3815,7 @@ func (s *applicationStateSuite) TestGetNetNodeFromUnit(c *tc.C) {
 	// Check the unit net node is returned.
 	netNode, err := s.state.GetNetNodeUUIDByUnitName(c.Context(), "foo/0")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(netNode, tc.Equals, "net-node-uuid")
+	c.Check(netNode, tc.Equals, expectedNetNodeUUID)
 }
 
 func (s *applicationStateSuite) TestGetNetNodeUnitNotFound(c *tc.C) {

--- a/domain/application/state/machine_placement.go
+++ b/domain/application/state/machine_placement.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/sqlair"
 
 	"github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/network"
 	domainapplication "github.com/juju/juju/domain/application"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/deployment"
@@ -17,19 +18,18 @@ import (
 	"github.com/juju/juju/domain/sequence"
 	sequencestate "github.com/juju/juju/domain/sequence/state"
 	"github.com/juju/juju/internal/errors"
-	"github.com/juju/juju/internal/uuid"
 )
 
 // GetMachineNetNodeUUIDFromName returns the net node UUID for the named machine.
 // The following errors may be returned:
 // - [applicationerrors.MachineNotFound] if the machine does not exist
-func (st *State) GetMachineNetNodeUUIDFromName(ctx context.Context, name machine.Name) (string, error) {
+func (st *State) GetMachineNetNodeUUIDFromName(ctx context.Context, name machine.Name) (network.NetNodeUUID, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	var netNodeUUID string
+	var netNodeUUID network.NetNodeUUID
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		netNodeUUID, err = st.getMachineNetNodeUUIDFromName(ctx, tx, name)
@@ -47,7 +47,7 @@ func (st *State) GetMachineNetNodeUUIDFromName(ctx context.Context, name machine
 
 // placeMachine places the net node and machines if required, depending
 // on the placement.
-func (st *State) placeMachine(ctx context.Context, tx *sqlair.TX, directive deployment.Placement) (string, error) {
+func (st *State) placeMachine(ctx context.Context, tx *sqlair.TX, directive deployment.Placement) (network.NetNodeUUID, error) {
 	switch directive.Type {
 	case deployment.PlacementTypeUnset:
 		// The placement is unset, so we need to create a machine for the
@@ -158,7 +158,7 @@ WHERE name = $machineNameWithMachineUUID.name
 	return machine.UUID, nil
 }
 
-func (st *State) getMachineNetNodeUUIDFromName(ctx context.Context, tx *sqlair.TX, name machine.Name) (string, error) {
+func (st *State) getMachineNetNodeUUIDFromName(ctx context.Context, tx *sqlair.TX, name machine.Name) (network.NetNodeUUID, error) {
 	machine := machineNameWithNetNode{Name: name}
 	query := `
 SELECT &machineNameWithNetNode.net_node_uuid
@@ -179,13 +179,13 @@ WHERE name = $machineNameWithNetNode.name
 	return machine.NetNodeUUID, nil
 }
 
-func (st *State) insertNetNode(ctx context.Context, tx *sqlair.TX) (string, error) {
-	uuid, err := uuid.NewUUID()
+func (st *State) insertNetNode(ctx context.Context, tx *sqlair.TX) (network.NetNodeUUID, error) {
+	uuid, err := network.NewNetNodeUUID()
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	netNodeUUID := netNodeUUID{NetNodeUUID: uuid.String()}
+	netNodeUUID := netNodeUUID{NetNodeUUID: uuid}
 
 	createNode := `INSERT INTO net_node (uuid) VALUES ($netNodeUUID.*)`
 	createNodeStmt, err := st.Prepare(createNode, netNodeUUID)
@@ -200,7 +200,7 @@ func (st *State) insertNetNode(ctx context.Context, tx *sqlair.TX) (string, erro
 	return netNodeUUID.NetNodeUUID, nil
 }
 
-func (st *State) insertMachineAndNetNode(ctx context.Context, tx *sqlair.TX, machineName machine.Name) (machine.UUID, string, error) {
+func (st *State) insertMachineAndNetNode(ctx context.Context, tx *sqlair.TX, machineName machine.Name) (machine.UUID, network.NetNodeUUID, error) {
 	netNodeUUID, err := st.insertNetNode(ctx, tx)
 	if err != nil {
 		return "", "", errors.Capture(err)
@@ -259,7 +259,7 @@ func (st *State) insertChildMachineForContainerPlacement(
 	parentUUID machine.UUID,
 	parentName machine.Name,
 	scope string,
-) (string, error) {
+) (network.NetNodeUUID, error) {
 	machineName, err := st.nextContainerSequence(ctx, tx, scope, parentName)
 	if err != nil {
 		return "", errors.Capture(err)

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -13,6 +13,7 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
 	corestorage "github.com/juju/juju/core/storage"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"
@@ -283,7 +284,7 @@ func (st *State) attachUnitStorage(
 	ctx context.Context, tx *sqlair.TX,
 	poolKinds map[string]storage.StorageKind,
 	unitUUID coreunit.UUID,
-	netNodeUUID string,
+	netNodeUUID network.NetNodeUUID,
 	args []attachStorageArgs,
 ) error {
 
@@ -644,7 +645,7 @@ func ensureCharmStorageCountChange(charmStorage charmStorage, current, n uint64)
 }
 
 func (st *State) attachStorage(
-	ctx context.Context, tx *sqlair.TX, inst storageInstance, unitUUID coreunit.UUID, netNodeUUID string,
+	ctx context.Context, tx *sqlair.TX, inst storageInstance, unitUUID coreunit.UUID, netNodeUUID network.NetNodeUUID,
 	charmStorage charmStorage,
 ) error {
 	su := storageUnit{StorageUUID: inst.StorageUUID, UnitUUID: unitUUID}
@@ -885,7 +886,7 @@ INSERT INTO storage_attachment (*) VALUES ($storageAttachment.*)
 }
 
 func (st *State) attachFilesystemToNode(
-	ctx context.Context, tx *sqlair.TX, netNodeUUID string, args filesystemAttachmentParams,
+	ctx context.Context, tx *sqlair.TX, netNodeUUID network.NetNodeUUID, args filesystemAttachmentParams,
 ) error {
 	uuid, err := corestorage.NewFilesystemAttachmentUUID()
 	if err != nil {
@@ -914,7 +915,7 @@ INSERT INTO storage_filesystem_attachment (*) VALUES ($filesystemAttachment.*)
 }
 
 func (st *State) attachVolumeToNode(
-	ctx context.Context, tx *sqlair.TX, netNodeUUID string, args volumeAttachmentParams,
+	ctx context.Context, tx *sqlair.TX, netNodeUUID network.NetNodeUUID, args volumeAttachmentParams,
 ) error {
 	uuid, err := corestorage.NewVolumeAttachmentUUID()
 	if err != nil {
@@ -942,7 +943,7 @@ INSERT INTO storage_volume_attachment (*) VALUES ($volumeAttachment.*)
 }
 
 func (st *State) createFilesystem(
-	ctx context.Context, tx *sqlair.TX, storageUUID corestorage.UUID, netNodeUUID string,
+	ctx context.Context, tx *sqlair.TX, storageUUID corestorage.UUID, netNodeUUID network.NetNodeUUID,
 ) (corestorage.FilesystemUUID, error) {
 	filesystemId, err := sequencestate.NextValue(ctx, st, tx, filesystemNamespace)
 	if err != nil {
@@ -992,7 +993,7 @@ INSERT INTO storage_instance_filesystem (*) VALUES ($storageInstanceFilesystem.*
 }
 
 func (st *State) createVolume(
-	ctx context.Context, tx *sqlair.TX, storageUUID corestorage.UUID, netNodeUUID string,
+	ctx context.Context, tx *sqlair.TX, storageUUID corestorage.UUID, netNodeUUID network.NetNodeUUID,
 ) (corestorage.VolumeUUID, error) {
 	volumeId, err := sequencestate.NextValue(ctx, st, tx, volumeNamespace)
 	if err != nil {

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -102,14 +102,14 @@ type unitName struct {
 }
 
 type unitDetails struct {
-	UnitUUID                coreunit.UUID      `db:"uuid"`
-	CharmUUID               corecharm.ID       `db:"charm_uuid"`
-	NetNodeID               string             `db:"net_node_uuid"`
-	Name                    coreunit.Name      `db:"name"`
-	ApplicationID           coreapplication.ID `db:"application_uuid"`
-	LifeID                  life.Life          `db:"life_id"`
-	PasswordHash            sql.NullString     `db:"password_hash"`
-	PasswordHashAlgorithmID sql.NullInt16      `db:"password_hash_algorithm_id"`
+	UnitUUID                coreunit.UUID       `db:"uuid"`
+	CharmUUID               corecharm.ID        `db:"charm_uuid"`
+	NetNodeID               network.NetNodeUUID `db:"net_node_uuid"`
+	Name                    coreunit.Name       `db:"name"`
+	ApplicationID           coreapplication.ID  `db:"application_uuid"`
+	LifeID                  life.Life           `db:"life_id"`
+	PasswordHash            sql.NullString      `db:"password_hash"`
+	PasswordHashAlgorithmID sql.NullInt16       `db:"password_hash_algorithm_id"`
 }
 
 type unitAttributes struct {
@@ -129,10 +129,10 @@ type unitPassword struct {
 type unitUUIDs []coreunit.UUID
 
 type minimalUnit struct {
-	UUID      coreunit.UUID `db:"uuid"`
-	NetNodeID string        `db:"net_node_uuid"`
-	Name      coreunit.Name `db:"name"`
-	LifeID    life.Life     `db:"life_id"`
+	UUID      coreunit.UUID       `db:"uuid"`
+	NetNodeID network.NetNodeUUID `db:"net_node_uuid"`
+	Name      coreunit.Name       `db:"name"`
+	LifeID    life.Life           `db:"life_id"`
 }
 
 type unitCount struct {
@@ -155,18 +155,18 @@ type cloudContainer struct {
 }
 
 type cloudService struct {
-	UUID            string             `db:"uuid"`
-	ApplicationUUID coreapplication.ID `db:"application_uuid"`
-	NetNodeUUID     string             `db:"net_node_uuid"`
-	ProviderID      string             `db:"provider_id"`
+	UUID            string              `db:"uuid"`
+	ApplicationUUID coreapplication.ID  `db:"application_uuid"`
+	NetNodeUUID     network.NetNodeUUID `db:"net_node_uuid"`
+	ProviderID      string              `db:"provider_id"`
 }
 
 type cloudServiceDevice struct {
-	UUID              string `db:"uuid"`
-	Name              string `db:"name"`
-	NetNodeID         string `db:"net_node_uuid"`
-	DeviceTypeID      int    `db:"device_type_id"`
-	VirtualPortTypeID int    `db:"virtual_port_type_id"`
+	UUID              string              `db:"uuid"`
+	Name              string              `db:"name"`
+	NetNodeID         network.NetNodeUUID `db:"net_node_uuid"`
+	DeviceTypeID      int                 `db:"device_type_id"`
+	VirtualPortTypeID int                 `db:"virtual_port_type_id"`
 }
 
 type applicationCharmUUID struct {
@@ -174,11 +174,11 @@ type applicationCharmUUID struct {
 }
 
 type cloudContainerDevice struct {
-	UUID              string `db:"uuid"`
-	Name              string `db:"name"`
-	NetNodeID         string `db:"net_node_uuid"`
-	DeviceTypeID      int    `db:"device_type_id"`
-	VirtualPortTypeID int    `db:"virtual_port_type_id"`
+	UUID              string              `db:"uuid"`
+	Name              string              `db:"name"`
+	NetNodeID         network.NetNodeUUID `db:"net_node_uuid"`
+	DeviceTypeID      int                 `db:"device_type_id"`
+	VirtualPortTypeID int                 `db:"virtual_port_type_id"`
 }
 
 type cloudContainerPort struct {
@@ -187,14 +187,14 @@ type cloudContainerPort struct {
 }
 
 type ipAddress struct {
-	AddressUUID  string `db:"uuid"`
-	Value        string `db:"address_value"`
-	NetNodeUUID  string `db:"net_node_uuid"`
-	ConfigTypeID int    `db:"config_type_id"`
-	TypeID       int    `db:"type_id"`
-	OriginID     int    `db:"origin_id"`
-	ScopeID      int    `db:"scope_id"`
-	DeviceID     string `db:"device_uuid"`
+	AddressUUID  string              `db:"uuid"`
+	Value        string              `db:"address_value"`
+	NetNodeUUID  network.NetNodeUUID `db:"net_node_uuid"`
+	ConfigTypeID int                 `db:"config_type_id"`
+	TypeID       int                 `db:"type_id"`
+	OriginID     int                 `db:"origin_id"`
+	ScopeID      int                 `db:"scope_id"`
+	DeviceID     string              `db:"device_uuid"`
 }
 
 type spaceAddress struct {
@@ -945,7 +945,7 @@ type storageInstanceVolume struct {
 
 type filesystemAttachment struct {
 	UUID                 corestorage.FilesystemAttachmentUUID `db:"uuid"`
-	NetNodeUUID          string                               `db:"net_node_uuid"`
+	NetNodeUUID          network.NetNodeUUID                  `db:"net_node_uuid"`
 	FilesystemUUID       corestorage.FilesystemUUID           `db:"storage_filesystem_uuid"`
 	LifeID               life.Life                            `db:"life_id"`
 	MountPoint           string                               `db:"mount_point"`
@@ -955,7 +955,7 @@ type filesystemAttachment struct {
 
 type volumeAttachment struct {
 	UUID                 corestorage.VolumeAttachmentUUID `db:"uuid"`
-	NetNodeUUID          string                           `db:"net_node_uuid"`
+	NetNodeUUID          network.NetNodeUUID              `db:"net_node_uuid"`
 	VolumeUUID           corestorage.VolumeUUID           `db:"storage_volume_uuid"`
 	LifeID               life.Life                        `db:"life_id"`
 	ReadOnly             bool                             `db:"read_only"`
@@ -1188,15 +1188,15 @@ type setDeviceConstraintAttribute struct {
 }
 
 type createMachine struct {
-	MachineUUID machine.UUID `db:"uuid"`
-	NetNodeUUID string       `db:"net_node_uuid"`
-	Name        machine.Name `db:"name"`
-	LifeID      life.Life    `db:"life_id"`
+	MachineUUID machine.UUID        `db:"uuid"`
+	NetNodeUUID network.NetNodeUUID `db:"net_node_uuid"`
+	Name        machine.Name        `db:"name"`
+	LifeID      life.Life           `db:"life_id"`
 }
 
 type machineNameWithNetNode struct {
-	Name        machine.Name `db:"name"`
-	NetNodeUUID string       `db:"net_node_uuid"`
+	Name        machine.Name        `db:"name"`
+	NetNodeUUID network.NetNodeUUID `db:"net_node_uuid"`
 }
 
 type machineNameWithMachineUUID struct {
@@ -1205,11 +1205,11 @@ type machineNameWithMachineUUID struct {
 }
 
 type netNodeUUID struct {
-	NetNodeUUID string `db:"uuid"`
+	NetNodeUUID network.NetNodeUUID `db:"uuid"`
 }
 
 type unitNetNodeUUID struct {
-	NetNodeUUID string `db:"net_node_uuid"`
+	NetNodeUUID network.NetNodeUUID `db:"net_node_uuid"`
 }
 
 type machinePlacement struct {

--- a/internal/worker/apiaddresssetter/package_mocks_test.go
+++ b/internal/worker/apiaddresssetter/package_mocks_test.go
@@ -145,10 +145,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetUnitNetNodes mocks base method.
-func (m *MockApplicationService) GetUnitNetNodes(arg0 context.Context, arg1 unit.Name) ([]string, error) {
+func (m *MockApplicationService) GetUnitNetNodes(arg0 context.Context, arg1 unit.Name) ([]network.NetNodeUUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitNetNodes", arg0, arg1)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]network.NetNodeUUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -166,19 +166,19 @@ type MockApplicationServiceGetUnitNetNodesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetUnitNetNodesCall) Return(arg0 []string, arg1 error) *MockApplicationServiceGetUnitNetNodesCall {
+func (c *MockApplicationServiceGetUnitNetNodesCall) Return(arg0 []network.NetNodeUUID, arg1 error) *MockApplicationServiceGetUnitNetNodesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetUnitNetNodesCall) Do(f func(context.Context, unit.Name) ([]string, error)) *MockApplicationServiceGetUnitNetNodesCall {
+func (c *MockApplicationServiceGetUnitNetNodesCall) Do(f func(context.Context, unit.Name) ([]network.NetNodeUUID, error)) *MockApplicationServiceGetUnitNetNodesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetUnitNetNodesCall) DoAndReturn(f func(context.Context, unit.Name) ([]string, error)) *MockApplicationServiceGetUnitNetNodesCall {
+func (c *MockApplicationServiceGetUnitNetNodesCall) DoAndReturn(f func(context.Context, unit.Name) ([]network.NetNodeUUID, error)) *MockApplicationServiceGetUnitNetNodesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -223,7 +223,7 @@ func (c *MockApplicationServiceGetUnitPublicAddressesCall) DoAndReturn(f func(co
 }
 
 // WatchNetNodeAddress mocks base method.
-func (m *MockApplicationService) WatchNetNodeAddress(arg0 context.Context, arg1 ...string) (watcher.Watcher[struct{}], error) {
+func (m *MockApplicationService) WatchNetNodeAddress(arg0 context.Context, arg1 ...network.NetNodeUUID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0}
 	for _, a := range arg1 {
@@ -255,13 +255,13 @@ func (c *MockApplicationServiceWatchNetNodeAddressCall) Return(arg0 watcher.Watc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceWatchNetNodeAddressCall) Do(f func(context.Context, ...string) (watcher.Watcher[struct{}], error)) *MockApplicationServiceWatchNetNodeAddressCall {
+func (c *MockApplicationServiceWatchNetNodeAddressCall) Do(f func(context.Context, ...network.NetNodeUUID) (watcher.Watcher[struct{}], error)) *MockApplicationServiceWatchNetNodeAddressCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceWatchNetNodeAddressCall) DoAndReturn(f func(context.Context, ...string) (watcher.Watcher[struct{}], error)) *MockApplicationServiceWatchNetNodeAddressCall {
+func (c *MockApplicationServiceWatchNetNodeAddressCall) DoAndReturn(f func(context.Context, ...network.NetNodeUUID) (watcher.Watcher[struct{}], error)) *MockApplicationServiceWatchNetNodeAddressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/apiaddresssetter/worker.go
+++ b/internal/worker/apiaddresssetter/worker.go
@@ -56,7 +56,7 @@ type ApplicationService interface {
 	// addresses.
 	// This notifies on any changes to the net nodes addresses. It is up to the
 	// caller to determine if the addresses they're interested in has changed.
-	WatchNetNodeAddress(ctx context.Context, netNodeUUIDs ...string) (watcher.NotifyWatcher, error)
+	WatchNetNodeAddress(ctx context.Context, netNodeUUIDs ...network.NetNodeUUID) (watcher.NotifyWatcher, error)
 
 	// GetUnitNetNodes returns the net node UUIDs associated with the specified
 	// unit. The net nodes are selected in the same way as in GetUnitAddresses, i.e.
@@ -65,7 +65,7 @@ type ApplicationService interface {
 	//
 	// The following errors may be returned:
 	// - [uniterrors.UnitNotFound] if the unit does not exist
-	GetUnitNetNodes(ctx context.Context, unitName unit.Name) ([]string, error)
+	GetUnitNetNodes(ctx context.Context, unitName unit.Name) ([]network.NetNodeUUID, error)
 
 	// GetUnitPublicAddresses returns all public addresses for the specified unit.
 	//

--- a/internal/worker/apiaddresssetter/worker_test.go
+++ b/internal/worker/apiaddresssetter/worker_test.go
@@ -14,6 +14,7 @@ import (
 
 	controller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
+	networktesting "github.com/juju/juju/core/network/testing"
 	"github.com/juju/juju/core/unit"
 	watcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -105,8 +106,9 @@ func (s *workerSuite) TestNewControllerNode(c *tc.C) {
 
 	// Starts the controller tracker for the new node.
 	s.controllerNodeService.EXPECT().GetControllerIDs(gomock.Any()).Return([]string{"1"}, nil)
-	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return([]string{"net-node-0"}, nil)
-	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), "net-node-0").Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
+	netNodeUUID := networktesting.GenNetNodeUUID(c)
+	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return([]network.NetNodeUUID{netNodeUUID}, nil)
+	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), netNodeUUID).Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
 	// Updates the API addresses for the new node.
 	addrs := network.SpaceAddresses{
 		{
@@ -178,8 +180,9 @@ func (s *workerSuite) TestConfigChange(c *tc.C) {
 
 	// Starts the controller tracker for the new node.
 	s.controllerNodeService.EXPECT().GetControllerIDs(gomock.Any()).Return([]string{"1"}, nil)
-	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return([]string{"net-node-0"}, nil)
-	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), "net-node-0").Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
+	netNodeUUID := networktesting.GenNetNodeUUID(c)
+	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return([]network.NetNodeUUID{netNodeUUID}, nil)
+	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), netNodeUUID).Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
 
 	// Updates the API addresses for the new node.
 	addrs := network.SpaceAddresses{
@@ -280,10 +283,11 @@ func (s *workerSuite) TestNodeAddressChange(c *tc.C) {
 
 	// Starts the controller tracker for the new node.
 	s.controllerNodeService.EXPECT().GetControllerIDs(gomock.Any()).Return([]string{"1"}, nil)
-	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return([]string{"net-node-0"}, nil)
+	netNodeUUID := networktesting.GenNetNodeUUID(c)
+	s.applicationService.EXPECT().GetUnitNetNodes(gomock.Any(), unit.Name("controller/1")).Return([]network.NetNodeUUID{netNodeUUID}, nil)
 	addrCh := make(chan struct{})
 	netNodeAddressWatcher := watchertest.NewMockNotifyWatcher(addrCh)
-	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), "net-node-0").Return(netNodeAddressWatcher, nil)
+	s.applicationService.EXPECT().WatchNetNodeAddress(gomock.Any(), netNodeUUID).Return(netNodeAddressWatcher, nil)
 
 	// Updates the API addresses for the new node.
 	addrs := network.SpaceAddresses{


### PR DESCRIPTION
Two setup steps for the LinkLayerDevice epic, adding `LinkLayerDeviceUUID` and `NetNodeUUID` types. Updated the application service to use the new `NetNodeUUID` type.

Side quest to replace an incorrect work.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

No changes in current unit test results.
