### PR TITLE
fix: api addresses filtering by management space

### DIFF
--- a/domain/controllernode/watcher_test.go
+++ b/domain/controllernode/watcher_test.go
@@ -75,5 +75,6 @@ func (s *watcherSuite) setupService(c *tc.C, factory domain.WatchableDBFactory) 
 	return service.NewWatchableService(
 		state.NewState(modelDB),
 		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
+		loggertesting.WrapCheckLog(c),
 	)
 }

--- a/domain/services/controller.go
+++ b/domain/services/controller.go
@@ -91,6 +91,7 @@ func (s *ControllerServices) ControllerNode() *controllernodeservice.WatchableSe
 	return controllernodeservice.NewWatchableService(
 		controllernodestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		s.controllerWatcherFactory("controllernode"),
+		s.logger.Child("controllernode"),
 	)
 }
 

--- a/internal/worker/apiaddresssetter/package_mocks_test.go
+++ b/internal/worker/apiaddresssetter/package_mocks_test.go
@@ -329,7 +329,7 @@ func (c *MockControllerNodeServiceGetControllerIDsCall) DoAndReturn(f func(conte
 }
 
 // SetAPIAddresses mocks base method.
-func (m *MockControllerNodeService) SetAPIAddresses(arg0 context.Context, arg1 string, arg2 network.SpaceHostPorts, arg3 network.SpaceInfo) error {
+func (m *MockControllerNodeService) SetAPIAddresses(arg0 context.Context, arg1 string, arg2 network.SpaceHostPorts, arg3 *network.SpaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAPIAddresses", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -355,13 +355,13 @@ func (c *MockControllerNodeServiceSetAPIAddressesCall) Return(arg0 error) *MockC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerNodeServiceSetAPIAddressesCall) Do(f func(context.Context, string, network.SpaceHostPorts, network.SpaceInfo) error) *MockControllerNodeServiceSetAPIAddressesCall {
+func (c *MockControllerNodeServiceSetAPIAddressesCall) Do(f func(context.Context, string, network.SpaceHostPorts, *network.SpaceInfo) error) *MockControllerNodeServiceSetAPIAddressesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerNodeServiceSetAPIAddressesCall) DoAndReturn(f func(context.Context, string, network.SpaceHostPorts, network.SpaceInfo) error) *MockControllerNodeServiceSetAPIAddressesCall {
+func (c *MockControllerNodeServiceSetAPIAddressesCall) DoAndReturn(f func(context.Context, string, network.SpaceHostPorts, *network.SpaceInfo) error) *MockControllerNodeServiceSetAPIAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/apiaddresssetter/worker.go
+++ b/internal/worker/apiaddresssetter/worker.go
@@ -47,7 +47,7 @@ type ControllerNodeService interface {
 	//
 	// The following errors can be expected:
 	// - [controllernodeerrors.NotFound] if the controller node does not exist.
-	SetAPIAddresses(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, mgmtSpace network.SpaceInfo) error
+	SetAPIAddresses(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, mgmtSpace *network.SpaceInfo) error
 }
 
 // ApplicationService is an interface for the application domain service.
@@ -361,7 +361,7 @@ func (w *apiAddressSetterWorker) updateAPIAddresses(ctx context.Context) error {
 			continue
 		}
 
-		if err := w.config.ControllerNodeService.SetAPIAddresses(ctx, controllerID, hostPorts, *mgmtSpace); err != nil {
+		if err := w.config.ControllerNodeService.SetAPIAddresses(ctx, controllerID, hostPorts, mgmtSpace); err != nil {
 			return errors.Capture(err)
 		}
 	}

--- a/internal/worker/apiaddresssetter/worker_test.go
+++ b/internal/worker/apiaddresssetter/worker_test.go
@@ -119,15 +119,15 @@ func (s *workerSuite) TestNewControllerNode(c *tc.C) {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controller.Config{
 		controller.JujuManagementSpace: "space0",
 	}, nil)
-	sp := network.SpaceInfo{
+	sp := &network.SpaceInfo{
 		ID: "space0",
 	}
 	s.applicationService.EXPECT().GetUnitPublicAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil)
-	s.networkService.EXPECT().SpaceByName(gomock.Any(), "space0").Return(&sp, nil)
+	s.networkService.EXPECT().SpaceByName(gomock.Any(), "space0").Return(sp, nil)
 	// Synchronization point to ensure the worker processes the event.
 	sync := make(chan struct{})
 	hostPorts := network.SpaceAddressesWithPort(addrs, 17070)
-	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", hostPorts, sp).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp network.SpaceInfo) error {
+	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", hostPorts, sp).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp *network.SpaceInfo) error {
 		close(sync)
 		return nil
 	})
@@ -193,15 +193,15 @@ func (s *workerSuite) TestConfigChange(c *tc.C) {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controller.Config{
 		controller.JujuManagementSpace: "space0",
 	}, nil)
-	sp0 := network.SpaceInfo{
+	sp0 := &network.SpaceInfo{
 		ID: "space0",
 	}
 	s.applicationService.EXPECT().GetUnitPublicAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil)
-	s.networkService.EXPECT().SpaceByName(gomock.Any(), "space0").Return(&sp0, nil)
+	s.networkService.EXPECT().SpaceByName(gomock.Any(), "space0").Return(sp0, nil)
 	// Synchronization point to ensure the worker processes the event.
 	sync := make(chan struct{})
 	hostPorts := network.SpaceAddressesWithPort(addrs, 17070)
-	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", hostPorts, sp0).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp network.SpaceInfo) error {
+	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", hostPorts, sp0).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp *network.SpaceInfo) error {
 		close(sync)
 		return nil
 	})
@@ -209,14 +209,14 @@ func (s *workerSuite) TestConfigChange(c *tc.C) {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controller.Config{
 		controller.JujuManagementSpace: "space1",
 	}, nil)
-	sp1 := network.SpaceInfo{
+	sp1 := &network.SpaceInfo{
 		ID: "space1",
 	}
 	s.applicationService.EXPECT().GetUnitPublicAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil)
-	s.networkService.EXPECT().SpaceByName(gomock.Any(), "space1").Return(&sp1, nil)
+	s.networkService.EXPECT().SpaceByName(gomock.Any(), "space1").Return(sp1, nil)
 	// Synchronization point to ensure the worker processes the config event.
 	cfgSync := make(chan struct{})
-	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", hostPorts, sp1).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp network.SpaceInfo) error {
+	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", hostPorts, sp1).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp *network.SpaceInfo) error {
 		close(cfgSync)
 		return nil
 	})
@@ -297,15 +297,15 @@ func (s *workerSuite) TestNodeAddressChange(c *tc.C) {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controller.Config{
 		controller.JujuManagementSpace: "space0",
 	}, nil).MaxTimes(2)
-	sp0 := network.SpaceInfo{
+	sp0 := &network.SpaceInfo{
 		ID: "space0",
 	}
 	s.applicationService.EXPECT().GetUnitPublicAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil)
-	s.networkService.EXPECT().SpaceByName(gomock.Any(), "space0").Return(&sp0, nil).MaxTimes(2)
+	s.networkService.EXPECT().SpaceByName(gomock.Any(), "space0").Return(sp0, nil).MaxTimes(2)
 	// Synchronization point to ensure the worker processes the event.
 	sync := make(chan struct{})
 	hostPorts := network.SpaceAddressesWithPort(addrs, 17070)
-	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", hostPorts, sp0).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp network.SpaceInfo) error {
+	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", hostPorts, sp0).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp *network.SpaceInfo) error {
 		close(sync)
 		return nil
 	})
@@ -322,7 +322,7 @@ func (s *workerSuite) TestNodeAddressChange(c *tc.C) {
 	// Synchronization point to ensure the worker processes the config event.
 	addrSync := make(chan struct{})
 	newHP := network.SpaceAddressesWithPort(newAddrs, 17070)
-	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", newHP, sp0).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp network.SpaceInfo) error {
+	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), "1", newHP, sp0).DoAndReturn(func(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, sp *network.SpaceInfo) error {
 		close(addrSync)
 		return nil
 	})

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -1015,6 +1015,9 @@ func (w *dbWorker) ensureNamespace(ctx context.Context, namespace string) error 
 // running in this case. Do not place a call to this method where that may
 // *not* be the case.
 func (w *dbWorker) nodeService() *service.Service {
-	return service.NewService(state.NewState(
-		database.NewTxnRunnerFactoryForNamespace(w.workerFromCache, database.ControllerNS)))
+	return service.NewService(
+		state.NewState(
+			database.NewTxnRunnerFactoryForNamespace(w.workerFromCache, database.ControllerNS)),
+		w.cfg.Logger.Child("controllernode"),
+	)
 }


### PR DESCRIPTION
While working in the bootstrap wiring of k8s addresses, I realized that the logic for inserting API addresses in the controller node domain was wrong/incomplete.

In the original implementation (currently still present in the bootstrap worker for the legacy state), we always kept the addresses for the agents if the management space is nil and if all the addresses were filtered down, this way we ensure that agents can always reach the API server. See https://github.com/juju/juju/blob/main/internal/worker/bootstrap/worker.go#L438-L443.

This commit addresses these issues by updating the service layer method `SetAPIAddresses` in the controller node domain, also changing the signature to receive a pointer to space info (thus the changes in the call sites.

Some tests were added to ensure this behavior.


## QA steps

The `apiaddresssetter` worker is not wired yet, so for the moment unit tests should pass. 
