### PR TITLE
fix: ensure log locations are correct

### DIFF
--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -148,6 +148,9 @@ type Logger interface {
 
 	// GetChildByName returns a child logger with the given name.
 	GetChildByName(name string) Logger
+
+	// Helper marks the caller as a helper function.
+	Helper()
 }
 
 // LoggerContext is an interface that provides a method to get loggers.

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/juju/gomaasapi/v2 v2.2.0
 	github.com/juju/idmclient/v2 v2.0.1
 	github.com/juju/jsonschema v1.0.0
-	github.com/juju/loggo/v2 v2.1.1-0.20240509163806-ebdeb290b961
+	github.com/juju/loggo/v2 v2.2.0
 	github.com/juju/lumberjack/v2 v2.0.2
 	github.com/juju/mgo/v3 v3.0.4
 	github.com/juju/mutex/v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/juju/replicaset/v3 v3.0.1
 	github.com/juju/retry v1.0.1
 	github.com/juju/schema v1.2.0
-	github.com/juju/tc v0.0.0-20250514125847-7dcebc1fd940
+	github.com/juju/tc v0.0.0-20250516102601-801bd4886c4f
 	github.com/juju/testing v1.2.0
 	github.com/juju/txn/v3 v3.0.2
 	github.com/juju/utils/v4 v4.0.3
@@ -314,3 +314,5 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
 replace go.uber.org/mock => go.uber.org/mock v0.4.0
 
 replace gopkg.in/check.v1 => github.com/hpidcock/gc-compat-tc v0.0.0-20250508070538-894dc8262d3d
+
+replace github.com/juju/loggo/v2 => github.com/juju/loggo/v2 v2.0.0-20250522055930-3a3c6d932936

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVE
 github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
 github.com/juju/loggo v1.0.0 h1:Y6ZMQOGR9Aj3BGkiWx7HBbIx6zNwNkxhVNOHU2i1bl0=
 github.com/juju/loggo v1.0.0/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
-github.com/juju/loggo/v2 v2.1.1-0.20240509163806-ebdeb290b961 h1:D7BGXKOIGURoRSyfDh2MrY1/Eg6jE4vb46R/JoaqnMI=
-github.com/juju/loggo/v2 v2.1.1-0.20240509163806-ebdeb290b961/go.mod h1:647d6WvXBLj5lvka2qBvccr7vMIvF2KFkEH+0ZuFOUM=
+github.com/juju/loggo/v2 v2.0.0-20250522055930-3a3c6d932936 h1:LTFhAT5c6tyiUgt6oig45vAhLohME9lgntRtRr+cmvQ=
+github.com/juju/loggo/v2 v2.0.0-20250522055930-3a3c6d932936/go.mod h1:647d6WvXBLj5lvka2qBvccr7vMIvF2KFkEH+0ZuFOUM=
 github.com/juju/lru v1.0.0 h1:FP8mBNF3jBnKwGO5PtsR+8iIegx8DREfhRhpcGpYcn4=
 github.com/juju/lru v1.0.0/go.mod h1:YauKGp6PAhOQyGuTOkiFdXVP1jR3vLkp/FI71GcpYcQ=
 github.com/juju/lumberjack/v2 v2.0.2 h1:FlxrR62Vb7FfN7jwpSBqqereyq5bBQUF0LqOhZ2VGeI=
@@ -456,8 +456,8 @@ github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0
 github.com/juju/schema v1.2.0 h1:+XywM0pYzuhGebQiK1aR4Bj7Q7nLV5MihcOgq6dLLxs=
 github.com/juju/schema v1.2.0/go.mod h1:VdljuJLc45loM79LYm4yKKmPJwK1bPKRekvMVlfywU0=
 github.com/juju/tc v0.0.0-20250507150813-1d13c1fc4d6c/go.mod h1:YdExdo5XpLqX+BT6eCcS8HCqbZO09fP3mwoiJXv35Vg=
-github.com/juju/tc v0.0.0-20250514125847-7dcebc1fd940 h1:Ptn+rxuEPah0DvC5vLVsmjqv6kZgC5RQmR5Ut9k4uXY=
-github.com/juju/tc v0.0.0-20250514125847-7dcebc1fd940/go.mod h1:YdExdo5XpLqX+BT6eCcS8HCqbZO09fP3mwoiJXv35Vg=
+github.com/juju/tc v0.0.0-20250516102601-801bd4886c4f h1:c+9a1wosNDcybuksf+SDWzuHtzaKcLS7yCU6xPN6Wwk=
+github.com/juju/tc v0.0.0-20250516102601-801bd4886c4f/go.mod h1:YdExdo5XpLqX+BT6eCcS8HCqbZO09fP3mwoiJXv35Vg=
 github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180517134105-72703b1e95eb/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -132,6 +132,7 @@ func (ctx *Context) write(format string, params ...interface{}) {
 // quiet is true the message is logged.
 func (ctx *Context) Infof(format string, params ...interface{}) {
 	if ctx.quiet {
+		logger.Helper()
 		//Here we use the Loggo.logger method `Logf` as opposed to
 		//`logger.Infof` to avoid introducing an additional call stack
 		//level (since `Infof` calls `Logf` internally). This is done so
@@ -148,6 +149,7 @@ func (ctx *Context) Infof(format string, params ...interface{}) {
 // command to fail (e.g. an error message used as a deprecation warning that
 // will be upgraded to a real error message at some point in the future.)
 func (ctx *Context) Warningf(format string, params ...interface{}) {
+	logger.Helper()
 	// Here we use the Loggo.logger method `Logf` as opposed to
 	// `logger.Warningf` to avoid introducing an additional call stack level
 	// (since `Warningf` calls Logf internally). This is done so that this
@@ -161,6 +163,7 @@ func (ctx *Context) Verbosef(format string, params ...interface{}) {
 	if ctx.verbose {
 		ctx.write(format, params...)
 	} else {
+		logger.Helper()
 		// Here we use the Loggo.logger method `Logf` as opposed to
 		// `logger.Infof` to avoid introducing an additional call stack
 		// level (since `Infof` calls `Logf` internally). This is done so
@@ -176,6 +179,7 @@ func (ctx *Context) Verbosef(format string, params ...interface{}) {
 // not always sufficient. For instance, if the client has performed multiple
 // actions
 func (ctx *Context) Errorf(format string, params ...interface{}) {
+	logger.Helper()
 	// Here we use the Loggo.logger method `Logf` as opposed to
 	// `logger.Errorf` to avoid introducing an additional call stack
 	// level (since `Errorf` calls `Logf` internally). This is done so

--- a/internal/dependency/logger.go
+++ b/internal/dependency/logger.go
@@ -23,20 +23,24 @@ func WrapLogger(logger logger.Logger) *WrappedLogger {
 
 // Error logs a message at the error level.
 func (c *WrappedLogger) Errorf(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Errorf(context.Background(), msg, args...)
 }
 
 // Info logs a message at the info level.
 func (c *WrappedLogger) Infof(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Infof(context.Background(), msg, args...)
 }
 
 // Debug logs a message at the debug level.
 func (c *WrappedLogger) Debugf(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Debugf(context.Background(), msg, args...)
 }
 
 // Trace logs a message at the trace level.
 func (c *WrappedLogger) Tracef(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Tracef(context.Background(), msg, args...)
 }

--- a/internal/logger/loggo.go
+++ b/internal/logger/loggo.go
@@ -24,6 +24,8 @@ func WrapLoggo(logger loggo.Logger) logger.Logger {
 
 // Criticalf logs a message at the critical level.
 func (c loggoLogger) Criticalf(ctx context.Context, msg string, args ...any) {
+	c.logger.Helper()
+
 	labels, ok := c.labelsFromContext(ctx)
 	if !ok {
 		c.logger.Criticalf(msg, args...)
@@ -35,6 +37,8 @@ func (c loggoLogger) Criticalf(ctx context.Context, msg string, args ...any) {
 
 // Errorf logs a message at the error level.
 func (c loggoLogger) Errorf(ctx context.Context, msg string, args ...any) {
+	c.logger.Helper()
+
 	labels, ok := c.labelsFromContext(ctx)
 	if !ok {
 		c.logger.Errorf(msg, args...)
@@ -46,6 +50,8 @@ func (c loggoLogger) Errorf(ctx context.Context, msg string, args ...any) {
 
 // Warningf logs a message at the warning level.
 func (c loggoLogger) Warningf(ctx context.Context, msg string, args ...any) {
+	c.logger.Helper()
+
 	labels, ok := c.labelsFromContext(ctx)
 	if !ok {
 		c.logger.Warningf(msg, args...)
@@ -57,6 +63,8 @@ func (c loggoLogger) Warningf(ctx context.Context, msg string, args ...any) {
 
 // Infof logs a message at the info level.
 func (c loggoLogger) Infof(ctx context.Context, msg string, args ...any) {
+	c.logger.Helper()
+
 	labels, ok := c.labelsFromContext(ctx)
 	if !ok {
 		c.logger.Infof(msg, args...)
@@ -68,6 +76,8 @@ func (c loggoLogger) Infof(ctx context.Context, msg string, args ...any) {
 
 // Debugf logs a message at the debug level.
 func (c loggoLogger) Debugf(ctx context.Context, msg string, args ...any) {
+	c.logger.Helper()
+
 	labels, ok := c.labelsFromContext(ctx)
 	if !ok {
 		c.logger.Debugf(msg, args...)
@@ -79,6 +89,8 @@ func (c loggoLogger) Debugf(ctx context.Context, msg string, args ...any) {
 
 // Tracef logs a message at the trace level.
 func (c loggoLogger) Tracef(ctx context.Context, msg string, args ...any) {
+	c.logger.Helper()
+
 	labels, ok := c.labelsFromContext(ctx)
 	if !ok {
 		c.logger.Tracef(msg, args...)
@@ -92,6 +104,8 @@ func (c loggoLogger) Tracef(ctx context.Context, msg string, args ...any) {
 // merged with the labels from the context, if any. The provided arguments
 // are assembled together into a string with fmt.Sprintf.
 func (c loggoLogger) Logf(ctx context.Context, level logger.Level, labels logger.Labels, msg string, args ...any) {
+	c.logger.Helper()
+
 	ctxLabels, ok := c.labelsFromContext(ctx)
 	if !ok {
 		ctxLabels = labels
@@ -107,6 +121,12 @@ func (c loggoLogger) Logf(ctx context.Context, level logger.Level, labels logger
 // IsLevelEnabled returns true if the given level is enabled for the logger.
 func (c loggoLogger) IsLevelEnabled(level logger.Level) bool {
 	return c.logger.IsLevelEnabled(loggo.Level(level))
+}
+
+// Helper marks the caller as a helper function and will skip it when capturing
+// the callsite location.
+func (c loggoLogger) Helper() {
+	loggo.Helper(2)
 }
 
 // Child returns a new logger with the given name.

--- a/internal/logger/noop.go
+++ b/internal/logger/noop.go
@@ -53,6 +53,11 @@ func (c noopLogger) IsLevelEnabled(level logger.Level) bool {
 	return false
 }
 
+// Helper marks the caller as a helper function and will skip it when capturing
+// the callsite location.
+func (c noopLogger) Helper() {
+}
+
 // Child returns a new logger with the given name.
 func (c noopLogger) Child(name string, tags ...string) logger.Logger {
 	return c

--- a/internal/logger/testing/record.go
+++ b/internal/logger/testing/record.go
@@ -16,3 +16,6 @@ func (r RecordLog) Logf(msg string, args ...any) {
 func (r RecordLog) Context() context.Context {
 	return context.Background()
 }
+
+func (r RecordLog) Helper() {
+}

--- a/internal/provider/openstack/client.go
+++ b/internal/provider/openstack/client.go
@@ -277,6 +277,7 @@ func wrapLogger(logger corelogger.Logger) *wrappedLogger {
 
 // Debug logs a message at the debug level.
 func (c *wrappedLogger) Debugf(msg string, args ...any) {
+	c.logger.Helper()
 	// We should either fix the goose logger to use a context, or we should
 	// instantiate a new client for each request rather than caching it for
 	// the lifetime of the provider.

--- a/internal/pubsub/logger.go
+++ b/internal/pubsub/logger.go
@@ -23,15 +23,18 @@ func WrapLogger(logger logger.Logger) *WrappedLogger {
 
 // Error logs a message at the error level.
 func (c *WrappedLogger) Errorf(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Errorf(context.Background(), msg, args...)
 }
 
 // Debug logs a message at the debug level.
 func (c *WrappedLogger) Debugf(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Debugf(context.Background(), msg, args...)
 }
 
 // Trace logs a message at the info level.
 func (c *WrappedLogger) Tracef(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Tracef(context.Background(), msg, args...)
 }

--- a/internal/statushistory/logger_mock_test.go
+++ b/internal/statushistory/logger_mock_test.go
@@ -244,6 +244,42 @@ func (c *MockLoggerGetChildByNameCall) DoAndReturn(f func(string) logger.Logger)
 	return c
 }
 
+// Helper mocks base method.
+func (m *MockLogger) Helper() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Helper")
+}
+
+// Helper indicates an expected call of Helper.
+func (mr *MockLoggerMockRecorder) Helper() *MockLoggerHelperCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Helper", reflect.TypeOf((*MockLogger)(nil).Helper))
+	return &MockLoggerHelperCall{Call: call}
+}
+
+// MockLoggerHelperCall wrap *gomock.Call
+type MockLoggerHelperCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockLoggerHelperCall) Return() *MockLoggerHelperCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockLoggerHelperCall) Do(f func()) *MockLoggerHelperCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockLoggerHelperCall) DoAndReturn(f func()) *MockLoggerHelperCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Infof mocks base method.
 func (m *MockLogger) Infof(arg0 context.Context, arg1 string, arg2 ...any) {
 	m.ctrl.T.Helper()

--- a/internal/statushistory/logger_test.go
+++ b/internal/statushistory/logger_test.go
@@ -54,6 +54,7 @@ func (s *loggerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.logger = NewMockLogger(ctrl)
+	s.logger.EXPECT().Helper().AnyTimes()
 
 	return ctrl
 }

--- a/internal/testhelpers/log.go
+++ b/internal/testhelpers/log.go
@@ -12,15 +12,6 @@ import (
 	"github.com/juju/tc"
 )
 
-var logLocation = false
-
-func init() {
-	switch os.Getenv("TEST_LOGGING_LOCATION") {
-	case "true", "1", "yes":
-		logLocation = true
-	}
-}
-
 // LoggingSuite redirects the juju logger to the test logger
 // when embedded in a gocheck suite type.
 type LoggingSuite struct {
@@ -45,11 +36,8 @@ func (w *gocheckWriter) Write(entry loggo.Entry) {
 	w.s.mut.RLock()
 	defer w.s.mut.RUnlock()
 	filename := filepath.Base(entry.Filename)
-	if logLocation {
-		w.c.Logf("%s %s %s:%d %s", entry.Level, entry.Module, filename, entry.Line, entry.Message)
-	} else {
-		w.c.Logf("%s %s %s", entry.Level, entry.Module, entry.Message)
-	}
+	w.c.Logf("%s:%d: %s %s %s", filename, entry.Line,
+		entry.Level, entry.Module, entry.Message)
 }
 
 func (s *LoggingSuite) SetUpSuite(c *tc.C) {

--- a/internal/worker/logger.go
+++ b/internal/worker/logger.go
@@ -23,15 +23,18 @@ func WrapLogger(logger logger.Logger) *WrappedLogger {
 
 // Error logs a message at the error level.
 func (c *WrappedLogger) Errorf(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Errorf(context.Background(), msg, args...)
 }
 
 // Info logs a message at the info level.
 func (c *WrappedLogger) Infof(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Infof(context.Background(), msg, args...)
 }
 
 // Debug logs a message at the debug level.
 func (c *WrappedLogger) Debugf(msg string, args ...any) {
+	c.logger.Helper()
 	c.logger.Debugf(context.Background(), msg, args...)
 }

--- a/internal/worker/logsink/logger_mock_test.go
+++ b/internal/worker/logsink/logger_mock_test.go
@@ -245,6 +245,42 @@ func (c *MockLoggerGetChildByNameCall) DoAndReturn(f func(string) logger.Logger)
 	return c
 }
 
+// Helper mocks base method.
+func (m *MockLogger) Helper() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Helper")
+}
+
+// Helper indicates an expected call of Helper.
+func (mr *MockLoggerMockRecorder) Helper() *MockLoggerHelperCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Helper", reflect.TypeOf((*MockLogger)(nil).Helper))
+	return &MockLoggerHelperCall{Call: call}
+}
+
+// MockLoggerHelperCall wrap *gomock.Call
+type MockLoggerHelperCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockLoggerHelperCall) Return() *MockLoggerHelperCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockLoggerHelperCall) Do(f func()) *MockLoggerHelperCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockLoggerHelperCall) DoAndReturn(f func()) *MockLoggerHelperCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Infof mocks base method.
 func (m *MockLogger) Infof(arg0 context.Context, arg1 string, arg2 ...any) {
 	m.ctrl.T.Helper()

--- a/internal/worker/querylogger/logger_mock_test.go
+++ b/internal/worker/querylogger/logger_mock_test.go
@@ -244,6 +244,42 @@ func (c *MockLoggerGetChildByNameCall) DoAndReturn(f func(string) logger.Logger)
 	return c
 }
 
+// Helper mocks base method.
+func (m *MockLogger) Helper() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Helper")
+}
+
+// Helper indicates an expected call of Helper.
+func (mr *MockLoggerMockRecorder) Helper() *MockLoggerHelperCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Helper", reflect.TypeOf((*MockLogger)(nil).Helper))
+	return &MockLoggerHelperCall{Call: call}
+}
+
+// MockLoggerHelperCall wrap *gomock.Call
+type MockLoggerHelperCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockLoggerHelperCall) Return() *MockLoggerHelperCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockLoggerHelperCall) Do(f func()) *MockLoggerHelperCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockLoggerHelperCall) DoAndReturn(f func()) *MockLoggerHelperCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Infof mocks base method.
 func (m *MockLogger) Infof(arg0 context.Context, arg1 string, arg2 ...any) {
 	m.ctrl.T.Helper()

--- a/internal/worker/querylogger/package_test.go
+++ b/internal/worker/querylogger/package_test.go
@@ -33,6 +33,7 @@ func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.clock = NewMockClock(ctrl)
 	s.timer = NewMockTimer(ctrl)
 	s.logger = NewMockLogger(ctrl)
+	s.logger.EXPECT().Helper().AnyTimes()
 
 	return ctrl
 }


### PR DESCRIPTION
Updates `github.com/juju/loggo/v2` to include Helper method on the logger. 
This aligns with the Helper method on testing.TB, which allows calls to log
methods to skip log shim functions when selecting from the call stack which
call-site will be used as the location for the log.

Depends on https://github.com/juju/loggo/pull/53.