### PR TITLE
feat(application): cut over UnsetApplicationConfig

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2007,13 +2007,26 @@ func (api *APIBase) UnsetApplicationsConfig(ctx context.Context, args params.App
 	}
 	result.Results = make([]params.ErrorResult, len(args.Args))
 	for i, arg := range args.Args {
-		err := api.unsetApplicationConfig(arg)
+		err := api.unsetApplicationConfig(ctx, arg)
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil
 }
 
-func (api *APIBase) unsetApplicationConfig(arg params.ApplicationUnset) error {
+func (api *APIBase) unsetApplicationConfig(ctx context.Context, arg params.ApplicationUnset) error {
+	appID, err := api.applicationService.GetApplicationIDByName(ctx, arg.ApplicationName)
+	if errors.Is(err, applicationerrors.ApplicationNotFound) {
+		return errors.NotFoundf("application %s", arg.ApplicationName)
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	err = api.applicationService.UnsetApplicationConfigKeys(ctx, appID, arg.Options)
+	if errors.Is(err, applicationerrors.ApplicationNotFound) {
+		return errors.NotFoundf("application %s", arg.ApplicationName)
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+
 	app, err := api.backend.Application(arg.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -226,7 +226,7 @@ type ApplicationService interface {
 
 	// GetApplicationAndCharmConfig returns the application and charm config for the
 	// specified application ID.
-	GetApplicationAndCharmConfig(ctx context.Context, appID coreapplication.ID) (applicationservice.ApplicationConfig, error)
+	GetApplicationAndCharmConfig(context.Context, coreapplication.ID) (applicationservice.ApplicationConfig, error)
 
 	// SetApplicationConstraints sets the application constraints for the
 	// specified application ID.
@@ -236,7 +236,13 @@ type ApplicationService interface {
 	// error is returned.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	SetApplicationConstraints(ctx context.Context, appID coreapplication.ID, cons constraints.Value) error
+	SetApplicationConstraints(context.Context, coreapplication.ID, constraints.Value) error
+
+	// UnsetApplicationConfigKeys removes the specified keys from the application
+	// config. If the key does not exist, it is ignored.
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	UnsetApplicationConfigKeys(context.Context, coreapplication.ID, []string) error
 
 	// UpdateApplicationConfig updates the application config with the specified
 	// values. If the key does not exist, it is created. If the key already exists,

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -1998,6 +1998,44 @@ func (c *MockApplicationServiceSetApplicationScaleCall) DoAndReturn(f func(conte
 	return c
 }
 
+// UnsetApplicationConfigKeys mocks base method.
+func (m *MockApplicationService) UnsetApplicationConfigKeys(arg0 context.Context, arg1 application.ID, arg2 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnsetApplicationConfigKeys", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnsetApplicationConfigKeys indicates an expected call of UnsetApplicationConfigKeys.
+func (mr *MockApplicationServiceMockRecorder) UnsetApplicationConfigKeys(arg0, arg1, arg2 any) *MockApplicationServiceUnsetApplicationConfigKeysCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsetApplicationConfigKeys", reflect.TypeOf((*MockApplicationService)(nil).UnsetApplicationConfigKeys), arg0, arg1, arg2)
+	return &MockApplicationServiceUnsetApplicationConfigKeysCall{Call: call}
+}
+
+// MockApplicationServiceUnsetApplicationConfigKeysCall wrap *gomock.Call
+type MockApplicationServiceUnsetApplicationConfigKeysCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceUnsetApplicationConfigKeysCall) Return(arg0 error) *MockApplicationServiceUnsetApplicationConfigKeysCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceUnsetApplicationConfigKeysCall) Do(f func(context.Context, application.ID, []string) error) *MockApplicationServiceUnsetApplicationConfigKeysCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceUnsetApplicationConfigKeysCall) DoAndReturn(f func(context.Context, application.ID, []string) error) *MockApplicationServiceUnsetApplicationConfigKeysCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UnsetExposeSettings mocks base method.
 func (m *MockApplicationService) UnsetExposeSettings(arg0 context.Context, arg1 string, arg2 set.Strings) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The UnsetApplicationConfig facade method was not wired up to call the DQLite UnsetApplicationConfig method. This commit fixes that

Unfortunately, we still use mongo application config in a number of places, so we still need to dual write

## QA steps

```
$ juju bootstrap lxd lxd
$ juju deploy juju-qa-test
$ juju config juju-qa-test thing
🎁
$ juju config juju-qa-test thing=thong
$ juju config juju-qa-test thing
thong
$ juju config juju-qa-test --reset thing
$ juju config juju-qa-test thing
🎁
```