### PR TITLE
fix: data race in state pool

### DIFF
--- a/state/pool.go
+++ b/state/pool.go
@@ -6,6 +6,7 @@ package state
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -428,9 +429,13 @@ func (p *StatePool) Close() error {
 	// workers. These need to be stopped before we start closing connections
 	// as those workers use the pool.
 	p.closing = true
+
+	// Clone the pool so we can release the lock while stopping
+	// the workers.
+	pool := maps.Clone(p.pool)
 	p.mu.Unlock()
 
-	for uuid, item := range p.pool {
+	for uuid, item := range pool {
 		if err := item.state.stopWorkers(); err != nil {
 			logger.Infof("state workers for model %s did not stop: %v", uuid, err)
 		}
@@ -443,14 +448,14 @@ func (p *StatePool) Close() error {
 	// Hopefully by now any workers running that may have released objects
 	// to the pool should be fine.
 	p.mu.Lock()
-	pool := p.pool
 	p.pool = nil
+	p.mu.Unlock()
+
 	var lastErr error
 	// We release the lock as we are closing the state objects to allow
 	// other goroutines that may be attempting to Get a model from the pool
 	// to continue. The Get method will fail with a closed pool.
 	// We do this just in case the workers didn't stop above when we were trying.
-	p.mu.Unlock()
 	for _, item := range pool {
 		if item.refCount() != 0 || item.remove {
 			logger.Warningf(
@@ -465,12 +470,14 @@ func (p *StatePool) Close() error {
 			lastErr = err
 		}
 	}
+
 	p.mu.Lock()
 	if p.watcherRunner != nil {
 		_ = worker.Stop(p.watcherRunner)
 		p.txnWatcherSession.Close()
 	}
 	p.mu.Unlock()
+
 	// As with above and the other watchers, unlock while releasing the state
 	// session.
 	if err := p.systemState.Close(); err != nil {


### PR DESCRIPTION
If the state pool is closing and we're attempting to iterate over the pool, whilst it's still being written to, causes undefined behaviour (data race guarantees by the goruntime).

The solution is simple, create a shallow clone of the pool whilst holding the lock and loop over that.

This is not a behavioral change, just the fact that we're not iterating over the pool whilst it's still being written to.

>[!NOTE]
>The real fix is to ensure that no one can get a pooled state once it's closing. That might cause a serious amount of bugs as a fallout. Essentially swapping these two if statements around (see below). It might be something worth considering in the future, but I'm not 100% sure it's worth it right now.

https://github.com/juju/juju/blob/a93170f7ea42bb3e0774bc315ed5a6328631d8a3/state/pool.go#L260-L273

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model m1
$ juju destroy-model m1
$ juju add-model m2
$ juju deploy ubuntu
$ juju destroy-model m2
```