### PR TITLE
fix: slice access without guard causes panic

### DIFF
--- a/cmd/juju/crossmodel/showformatter.go
+++ b/cmd/juju/crossmodel/showformatter.go
@@ -107,18 +107,31 @@ func breakLines(text string) []string {
 	numLines := len(text)/columnWidth + 1
 	lines := make([]string, numLines)
 
-	index := 0
+	var index int
 	for _, aWord := range words {
+		if index >= len(lines) {
+			break
+		}
+
 		if len(lines[index]) == 0 {
 			lines[index] = aWord
 			continue
 		}
+
 		tp := fmt.Sprintf("%v %v", lines[index], aWord)
 		if len(tp) > columnWidth {
 			index++
+			if index >= len(lines) {
+				// There is an overflow because of the last word being too long
+				// and we need it to wrap to the next line. So, grow the line
+				// by one to accommodate the last word.
+				lines = append(lines, "")
+			}
+
 			lines[index] = aWord
 			continue
 		}
+
 		lines[index] = tp
 	}
 

--- a/cmd/juju/crossmodel/showformatter_test.go
+++ b/cmd/juju/crossmodel/showformatter_test.go
@@ -67,6 +67,20 @@ func (s *funcSuite) TestBreakLinesManyWordsManyLines(c *gc.C) {
 		})
 }
 
+func (s *funcSuite) TestBreakLinesManyWordsManyLinesOverflow(c *gc.C) {
+	// This causes a panic, because the last word is too long and it doesn't fit
+	// in the last line. So, we need to grow the lines by one to accommodate
+	// the last word.
+	aWord := "aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord panicme"
+	c.Assert(breakLines(aWord), gc.DeepEquals,
+		[]string{
+			"aWord aWord aWord aWord aWord aWord aWord",
+			"aWord aWord aWord aWord aWord aWord aWord",
+			"aWord aWord aWord aWord aWord aWord aWord",
+			"panicme",
+		})
+}
+
 func (s *funcSuite) TestBreakOneWord(c *gc.C) {
 	aWord := "aWord"
 	c.Assert(breakOneWord(aWord), gc.DeepEquals, []string{aWord})


### PR DESCRIPTION
The showformatter command attempts to be clever and word wrap a long line to a fix column width. Except that the calculation for the number of lines just isn't correct, and it requires it to overflow on to the next line. Except that the number of lines is calculated upfront. The solution (**hack**) is to add one more line for when this happens, so it can place the last word.

The real solution is to write a better algorithm to work out the correct spacing for words with the space being removed from the text. Yet, this isn't used that often, and isn't in a hot path, so I'm fine with shoving an additional line in at the end to solve the problem.


## Links

**Issue:** Fixes #19809.


