### PR TITLE
fix: charm-user path in docs

### DIFF
--- a/docs/howto/manage-your-deployment/harden-your-deployment.md
+++ b/docs/howto/manage-your-deployment/harden-your-deployment.md
@@ -73,7 +73,7 @@ When you deploy (an) application(s) from a charm or a bundle, choose the charm /
 
 - Choose charms whose `charmcraft.yaml > containers > uid` and `gid` are not 0 (do not require root access). If not possible, make sure to audit those charms.
 
-- *Starting with Juju 3.6:* Choose charms whose `charmcraft.yaml > containers > charm-user` field set to `non-root`. If not possible, make sure to audit those charms.
+- *Starting with Juju 3.6:* Choose charms whose `charmcraft.yaml > charm-user` field set to `non-root`. If not possible, make sure to audit those charms.
 
 - Choose charms that support secrets (see more:  {ref}`secret`).
 


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Documentation changes

The path in the docs was wrong, the charm-user the path is `charmcraft.yaml > charm-user`, e.g.:
```
...
charm-user: non-root

...
```
