### PR TITLE
feat(state): add link-layer merging logic

### DIFF
--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -367,33 +367,6 @@ func netInterfaceToDML(
 	return devDML, dnsSearchDMLs, dnsAddressDMLs, errors.Capture(err)
 }
 
-// decodeDeviceType returns a network interface type for an identifier congruent
-// with the database lookup.
-// The caller should have retrieved the identifier from the database directly
-// but we guard against bad input anyway.
-func decodeDeviceType(kindID int64) (corenetwork.LinkLayerDeviceType, error) {
-	switch kindID {
-	case 0:
-		return corenetwork.UnknownDevice, nil
-	case 1:
-		return corenetwork.LoopbackDevice, nil
-	case 2:
-		return corenetwork.EthernetDevice, nil
-	case 3:
-		return corenetwork.VLAN8021QDevice, nil
-	case 4:
-		return corenetwork.BondDevice, nil
-	case 5:
-		return corenetwork.BridgeDevice, nil
-	case 6:
-		return corenetwork.VXLANDevice, nil
-	default:
-		return corenetwork.UnknownDevice,
-			errors.Errorf("unsupported device type id: %q",
-				kindID)
-	}
-}
-
 // encodeDeviceType returns an identifier congruent with the database lookup for
 // a network interface type. The caller of this method should already have
 // called IsValidLinkLayerDeviceType for the input in the service layer,


### PR DESCRIPTION
This patch introduces link layer merging logic, to update provider id into linker layer devices and relinquish to the machine addresses that aren't seen by the provider anymore.

It reproduces features in from :+1: 
https://github.com/juju/juju/blob/main/apiserver/facades/controller/instancepoller/merge.go

> [!NOTE]
> I don't update the subnet_provider id neither the provider_netword id for addresses, even if it is done in mongo. 
> It will be done in a followup PR, this one is already huge.
> Followup PRs:
> * [ ] #19841
> * [ ] #19851 

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

There are not used yet. Following PR will use it in double-write situation and provides proper QA.

However unit tests should pas.

## Links

**Jira card:** JUJU-7721
