### PR TITLE
feat: add storage status types to status domain

### DIFF
--- a/core/storage/uuid.go
+++ b/core/storage/uuid.go
@@ -31,6 +31,11 @@ func NewFilesystemUUID() (FilesystemUUID, error) {
 	return FilesystemUUID(id.String()), nil
 }
 
+// String implements the stringer interface.
+func (u FilesystemUUID) String() string {
+	return string(u)
+}
+
 // VolumeUUID represents a volume unique identifier.
 type VolumeUUID string
 
@@ -41,6 +46,11 @@ func NewVolumeUUID() (VolumeUUID, error) {
 		return "", err
 	}
 	return VolumeUUID(id.String()), nil
+}
+
+// String implements the stringer interface.
+func (u VolumeUUID) String() string {
+	return string(u)
 }
 
 // FilesystemAttachmentUUID represents a filesystem attachment unique identifier.
@@ -55,6 +65,11 @@ func NewFilesystemAttachmentUUID() (FilesystemAttachmentUUID, error) {
 	return FilesystemAttachmentUUID(id.String()), nil
 }
 
+// String implements the stringer interface.
+func (u FilesystemAttachmentUUID) String() string {
+	return string(u)
+}
+
 // VolumeAttachmentUUID represents a volume attachment unique identifier.
 type VolumeAttachmentUUID string
 
@@ -65,4 +80,9 @@ func NewVolumeAttachmentUUID() (VolumeAttachmentUUID, error) {
 		return "", err
 	}
 	return VolumeAttachmentUUID(id.String()), nil
+}
+
+// String implements the stringer interface.
+func (u VolumeAttachmentUUID) String() string {
+	return string(u)
 }

--- a/domain/application/state/storage_test.go
+++ b/domain/application/state/storage_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 	stdtesting "testing"
+	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/tc"
@@ -23,6 +24,7 @@ import (
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/status"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/internal/errors"
@@ -508,18 +510,24 @@ type storageInstanceFilesystemArg struct {
 	// Filesystem.
 	FilesystemLifeID life.Life
 	FilesystemID     string
+	// Status
+	Status status.StorageFilesystemStatusType
 }
 
 func (s *baseStorageSuite) assertFilesystems(c *tc.C, charmUUID corecharm.ID, expected []storageInstanceFilesystemArg) {
+	now := time.Now()
+
 	var results []storageInstanceFilesystemArg
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		var row storageInstanceFilesystemArg
 		rows, err := tx.QueryContext(ctx, `
 SELECT
     sf.life_id AS filesystem_life_id, sf.filesystem_id,
+    sfs.status_id, sfs.updated_at,
     si.storage_id, si.storage_name, si.storage_pool, si.requested_size_mib
 FROM storage_filesystem sf
 JOIN storage_instance_filesystem sif ON sif.storage_filesystem_uuid = sf.uuid
+JOIN storage_filesystem_status sfs ON sf.uuid = sfs.filesystem_uuid
 JOIN v_storage_instance si ON si.uuid = sif.storage_instance_uuid
 WHERE si.charm_uuid = ?`,
 			charmUUID)
@@ -528,10 +536,16 @@ WHERE si.charm_uuid = ?`,
 		}
 		defer func() { _ = rows.Close() }()
 		for rows.Next() {
-			err = rows.Scan(&row.FilesystemLifeID, &row.FilesystemID, &row.StorageID,
-				&row.StorageName, &row.StoragePoolOrType, &row.SizeMIB)
+			var since time.Time
+			err = rows.Scan(&row.FilesystemLifeID, &row.FilesystemID,
+				&row.Status, &since,
+				&row.StorageID, &row.StorageName, &row.StoragePoolOrType,
+				&row.SizeMIB)
 			if err != nil {
 				return err
+			}
+			if since.IsZero() || since.After(now) {
+				return errors.Errorf("invalid status 'since' value: %s", since)
 			}
 			results = append(results, row)
 		}
@@ -552,18 +566,24 @@ type storageInstanceVolumeArg struct {
 	// Volume.
 	VolumeLifeID life.Life
 	VolumeID     string
+	// Status
+	Status status.StorageVolumeStatusType
 }
 
 func (s *baseStorageSuite) assertVolumes(c *tc.C, charmUUID corecharm.ID, expected []storageInstanceVolumeArg) {
+	now := time.Now()
+
 	var results []storageInstanceVolumeArg
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		var row storageInstanceVolumeArg
 		rows, err := tx.QueryContext(ctx, `
 SELECT
     sv.life_id AS volume_life_id, sv.volume_id,
+    svs.status_id, svs.updated_at,
     si.storage_id, si.storage_name, si.storage_pool, si.requested_size_mib
 FROM storage_volume sv
 JOIN storage_instance_volume siv ON siv.storage_volume_uuid = sv.uuid
+JOIN storage_volume_status svs ON sv.uuid = svs.volume_uuid
 JOIN v_storage_instance si ON si.uuid = siv.storage_instance_uuid
 WHERE si.charm_uuid = ?`,
 			charmUUID)
@@ -572,10 +592,16 @@ WHERE si.charm_uuid = ?`,
 		}
 		defer func() { _ = rows.Close() }()
 		for rows.Next() {
-			err = rows.Scan(&row.VolumeLifeID, &row.VolumeID, &row.StorageID,
+			var since time.Time
+			err = rows.Scan(&row.VolumeLifeID, &row.VolumeID,
+				&row.Status, &since,
+				&row.StorageID,
 				&row.StorageName, &row.StoragePool, &row.SizeMIB)
 			if err != nil {
 				return err
+			}
+			if since.IsZero() || since.After(now) {
+				return errors.Errorf("invalid status 'since' value: %s", since)
 			}
 			results = append(results, row)
 		}
@@ -876,6 +902,7 @@ WHERE charm_uuid = ?`, charmUUID)
 		SizeMIB:           20,
 		FilesystemLifeID:  life.Alive,
 		FilesystemID:      "0",
+		Status:            status.StorageFilesystemStatusTypePending,
 	}, {
 		StorageID:         "cache/3",
 		StorageName:       "cache",
@@ -884,6 +911,7 @@ WHERE charm_uuid = ?`, charmUUID)
 		SizeMIB:           30,
 		FilesystemLifeID:  life.Alive,
 		FilesystemID:      "1",
+		Status:            status.StorageFilesystemStatusTypePending,
 	}})
 	storageUUID, ok := storageUUIDByID["logs/2"]
 	c.Assert(ok, tc.IsTrue)
@@ -910,6 +938,7 @@ WHERE charm_uuid = ?`, charmUUID)
 		SizeMIB:      10,
 		VolumeLifeID: life.Alive,
 		VolumeID:     "0",
+		Status:       status.StorageVolumeStatusTypePending,
 	}, {
 		StorageID:    "database/1",
 		StorageName:  "database",
@@ -918,6 +947,7 @@ WHERE charm_uuid = ?`, charmUUID)
 		SizeMIB:      10,
 		VolumeLifeID: life.Alive,
 		VolumeID:     "1",
+		Status:       status.StorageVolumeStatusTypePending,
 	}, {
 		StorageID:    "cache/3",
 		StorageName:  "cache",
@@ -926,6 +956,7 @@ WHERE charm_uuid = ?`, charmUUID)
 		SizeMIB:      30,
 		VolumeLifeID: life.Alive,
 		VolumeID:     "2",
+		Status:       status.StorageVolumeStatusTypePending,
 	}})
 	storageUUID, ok = storageUUIDByID["database/0"]
 	c.Assert(ok, tc.IsTrue)

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -927,6 +927,13 @@ type filesystem struct {
 	SizeMIB      uint64                     `db:"size_mib"`
 }
 
+type filesystemStatus struct {
+	FilesystemUUID string     `db:"filesystem_uuid"`
+	StatusID       int        `db:"status_id"`
+	Message        string     `db:"message"`
+	UpdatedAt      *time.Time `db:"updated_at"`
+}
+
 type storageInstanceFilesystem struct {
 	StorageUUID    corestorage.UUID           `db:"storage_instance_uuid"`
 	FilesystemUUID corestorage.FilesystemUUID `db:"storage_filesystem_uuid"`
@@ -942,6 +949,13 @@ type volume struct {
 	HardwareIDID string                 `db:"hardware_id"`
 	WWN          string                 `db:"wwn"`
 	Persistent   bool                   `db:"persistent"`
+}
+
+type volumeStatus struct {
+	VolumeUUID string     `db:"volume_uuid"`
+	StatusID   int        `db:"status_id"`
+	Message    string     `db:"message"`
+	UpdatedAt  *time.Time `db:"updated_at"`
 }
 
 type storageInstanceVolume struct {

--- a/domain/status/status.go
+++ b/domain/status/status.go
@@ -15,7 +15,9 @@ import (
 
 // StatusID represents the status of an entity.
 type StatusID interface {
-	K8sPodStatusType | RelationStatusType | UnitAgentStatusType | WorkloadStatusType
+	K8sPodStatusType | RelationStatusType |
+		UnitAgentStatusType | WorkloadStatusType |
+		StorageFilesystemStatusType | StorageVolumeStatusType
 }
 
 // StatusInfo holds details about the status of an entity.
@@ -31,7 +33,7 @@ type UnitStatusID interface {
 	UnitAgentStatusType | WorkloadStatusType
 }
 
-// UnitAgentStatusInfo holds details about the status of a unit agent. This
+// UnitStatusInfo holds details about the status of a unit agent. This
 // indicates if the unit agent is present and currently active in the model.
 type UnitStatusInfo[T UnitStatusID] struct {
 	StatusInfo[T]

--- a/domain/status/storage.go
+++ b/domain/status/storage.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package status
+
+import (
+	"github.com/juju/juju/core/storage"
+	"github.com/juju/juju/internal/errors"
+)
+
+// StorageFilesystemStatusType represents the status of a filesystem
+// as recorded in the storage_filesystem_status_value lookup table.
+type StorageFilesystemStatusType int
+type StorageFilesystemStatusInfo struct {
+	FilesystemUUID storage.FilesystemUUID
+	StatusInfo     StatusInfo[StorageFilesystemStatusType]
+}
+
+const (
+	StorageFilesystemStatusTypePending StorageFilesystemStatusType = iota
+	StorageFilesystemStatusTypeError
+	StorageFilesystemStatusTypeAttaching
+	StorageFilesystemStatusTypeAttached
+	StorageFilesystemStatusTypeDetaching
+	StorageFilesystemStatusTypeDetached
+	StorageFilesystemStatusTypeDestroying
+)
+
+// EncodeStorageFilesystemStatus encodes a StorageFilesystemStatusType into its
+// integer id, as recorded in the storage_filesystem_status_value lookup table.
+func EncodeStorageFilesystemStatus(s StorageFilesystemStatusType) (int, error) {
+	switch s {
+	case StorageFilesystemStatusTypePending:
+		return 0, nil
+	case StorageFilesystemStatusTypeError:
+		return 1, nil
+	case StorageFilesystemStatusTypeAttaching:
+		return 2, nil
+	case StorageFilesystemStatusTypeAttached:
+		return 3, nil
+	case StorageFilesystemStatusTypeDetaching:
+		return 4, nil
+	case StorageFilesystemStatusTypeDetached:
+		return 5, nil
+	case StorageFilesystemStatusTypeDestroying:
+		return 6, nil
+	default:
+		return -1, errors.Errorf("unknown status %d", s)
+	}
+}
+
+// DecodeStorageFilesystemStatus decodes a StorageFilesystemStatusType from its
+// integer id, as recorded in the storage_filesystem_status_value lookup table.
+func DecodeStorageFilesystemStatus(s int) (StorageFilesystemStatusType, error) {
+	switch s {
+	case 0:
+		return StorageFilesystemStatusTypePending, nil
+	case 1:
+		return StorageFilesystemStatusTypeError, nil
+	case 2:
+		return StorageFilesystemStatusTypeAttaching, nil
+	case 3:
+		return StorageFilesystemStatusTypeAttached, nil
+	case 4:
+		return StorageFilesystemStatusTypeDetaching, nil
+	case 5:
+		return StorageFilesystemStatusTypeDetached, nil
+	case 6:
+		return StorageFilesystemStatusTypeDestroying, nil
+	default:
+		return -1, errors.Errorf("unknown status %d", s)
+	}
+}
+
+// StorageVolumeStatusType represents the status of a volume
+// as recorded in the storage_volume_status_value lookup table.
+type StorageVolumeStatusType int
+type StorageVolumeStatusInfo struct {
+	VolumeUUID storage.VolumeUUID
+	StatusInfo StatusInfo[StorageVolumeStatusType]
+}
+
+const (
+	StorageVolumeStatusTypePending StorageVolumeStatusType = iota
+	StorageVolumeStatusTypeError
+	StorageVolumeStatusTypeAttaching
+	StorageVolumeStatusTypeAttached
+	StorageVolumeStatusTypeDetaching
+	StorageVolumeStatusTypeDetached
+	StorageVolumeStatusTypeDestroying
+)
+
+// EncodeStorageVolumeStatus encodes a StorageVolumeStatusType into its
+// integer id, as recorded in the storage_volume_status_value lookup table.
+func EncodeStorageVolumeStatus(s StorageVolumeStatusType) (int, error) {
+	switch s {
+	case StorageVolumeStatusTypePending:
+		return 0, nil
+	case StorageVolumeStatusTypeError:
+		return 1, nil
+	case StorageVolumeStatusTypeAttaching:
+		return 2, nil
+	case StorageVolumeStatusTypeAttached:
+		return 3, nil
+	case StorageVolumeStatusTypeDetaching:
+		return 4, nil
+	case StorageVolumeStatusTypeDetached:
+		return 5, nil
+	case StorageVolumeStatusTypeDestroying:
+		return 6, nil
+	default:
+		return -1, errors.Errorf("unknown status %d", s)
+	}
+}
+
+// DecodeStorageVolumeStatus decodes a StorageVolumeStatusType from its
+// integer id, as recorded in the storage_volume_status_value lookup table.
+func DecodeStorageVolumeStatus(s int) (StorageVolumeStatusType, error) {
+	switch s {
+	case 0:
+		return StorageVolumeStatusTypePending, nil
+	case 1:
+		return StorageVolumeStatusTypeError, nil
+	case 2:
+		return StorageVolumeStatusTypeAttaching, nil
+	case 3:
+		return StorageVolumeStatusTypeAttached, nil
+	case 4:
+		return StorageVolumeStatusTypeDetaching, nil
+	case 5:
+		return StorageVolumeStatusTypeDetached, nil
+	case 6:
+		return StorageVolumeStatusTypeDestroying, nil
+	default:
+		return -1, errors.Errorf("unknown status %d", s)
+	}
+}

--- a/domain/status/storage_test.go
+++ b/domain/status/storage_test.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package status
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type storageStatusSuite struct {
+	schematesting.ModelSuite
+}
+
+func TestStorageStatusSuite(t *testing.T) {
+	tc.Run(t, &storageStatusSuite{})
+}
+
+// TestFilesystemStatusDBValues ensures there's no skew between what's in the
+// database table for filesystem status and the typed consts used in the
+// state packages.
+func (s *storageStatusSuite) TestFilesystemStatusDBValues(c *tc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, status FROM storage_filesystem_status_value")
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = rows.Close() }()
+
+	dbValues := make(map[StorageFilesystemStatusType]string)
+	for rows.Next() {
+		var (
+			id   int
+			name string
+		)
+		err := rows.Scan(&id, &name)
+		c.Assert(err, tc.ErrorIsNil)
+		dbValues[StorageFilesystemStatusType(id)] = name
+	}
+	c.Assert(dbValues, tc.DeepEquals, map[StorageFilesystemStatusType]string{
+		StorageFilesystemStatusTypePending:    "pending",
+		StorageFilesystemStatusTypeError:      "error",
+		StorageFilesystemStatusTypeAttaching:  "attaching",
+		StorageFilesystemStatusTypeAttached:   "attached",
+		StorageFilesystemStatusTypeDetaching:  "detaching",
+		StorageFilesystemStatusTypeDetached:   "detached",
+		StorageFilesystemStatusTypeDestroying: "destroying",
+	})
+}
+
+// TestEncodeDecodeFilesystemStatus ensures that Encode and Decode functions
+// correctly roundtrip and are consistent with the db lookup values.
+func (s *storageStatusSuite) TestEncodeDecodeFilesystemStatus(c *tc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id FROM storage_filesystem_status_value")
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var id int
+		err := rows.Scan(&id)
+		c.Assert(err, tc.ErrorIsNil)
+		decoded, err := DecodeStorageFilesystemStatus(id)
+		c.Assert(err, tc.ErrorIsNil)
+		encoded, err := EncodeStorageFilesystemStatus(decoded)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Assert(encoded, tc.Equals, id)
+	}
+}
+
+// TestVolumeStatusDBValues ensures there's no skew between what's in the
+// database table for volume status and the typed consts used in the
+// state packages.
+func (s *storageStatusSuite) TestVolumeStatusDBValues(c *tc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, status FROM storage_volume_status_value")
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = rows.Close() }()
+
+	dbValues := make(map[StorageVolumeStatusType]string)
+	for rows.Next() {
+		var (
+			id   int
+			name string
+		)
+		err := rows.Scan(&id, &name)
+		c.Assert(err, tc.ErrorIsNil)
+		dbValues[StorageVolumeStatusType(id)] = name
+	}
+	c.Assert(dbValues, tc.DeepEquals, map[StorageVolumeStatusType]string{
+		StorageVolumeStatusTypePending:    "pending",
+		StorageVolumeStatusTypeError:      "error",
+		StorageVolumeStatusTypeAttaching:  "attaching",
+		StorageVolumeStatusTypeAttached:   "attached",
+		StorageVolumeStatusTypeDetaching:  "detaching",
+		StorageVolumeStatusTypeDetached:   "detached",
+		StorageVolumeStatusTypeDestroying: "destroying",
+	})
+}
+
+// TestEncodeDecodeVolumeStatus ensures that Encode and Decode functions
+// correctly roundtrip and are consistent with the db lookup values.
+func (s *storageStatusSuite) TestEncodeDecodeVolumeStatus(c *tc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id FROM storage_volume_status_value")
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var id int
+		err := rows.Scan(&id)
+		c.Assert(err, tc.ErrorIsNil)
+		decoded, err := DecodeStorageVolumeStatus(id)
+		c.Assert(err, tc.ErrorIsNil)
+		encoded, err := EncodeStorageVolumeStatus(decoded)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Assert(encoded, tc.Equals, id)
+	}
+}


### PR DESCRIPTION
Follows on from https://github.com/juju/juju/pull/19833.

Add the storage status enums to the status domain and tests to ensure no skew from the db.
Also set storage status to pending when new storage is added as part of adding an application.

## QA steps

just unit tests at this stage

## Links

**Jira card:** [JUJU-7964](https://warthogs.atlassian.net/browse/JUJU-7964)
