### PR TITLE
chore: change UpdateCloudService to take provider addresses

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -80,7 +80,7 @@ func (s *CAASProvisionerSuite) setUpFacade(c *tc.C) *gomock.Controller {
 
 	var err error
 	facade, err := caasunitprovisioner.NewFacade(
-		s.watcherRegistry, s.resources, s.authorizer, nil, s.applicationService, s.st, s.clock, loggertesting.WrapCheckLog(c))
+		s.watcherRegistry, s.resources, s.authorizer, s.applicationService, s.st, s.clock, loggertesting.WrapCheckLog(c))
 	c.Assert(err, tc.ErrorIsNil)
 	s.facade = facade
 	return ctrl
@@ -91,7 +91,7 @@ func (s *CAASProvisionerSuite) TestPermission(c *tc.C) {
 		Tag: names.NewMachineTag("0"),
 	}
 	_, err := caasunitprovisioner.NewFacade(
-		nil, s.resources, s.authorizer, nil, nil, s.st, s.clock, loggertesting.WrapCheckLog(c))
+		nil, s.resources, s.authorizer, nil, s.st, s.clock, loggertesting.WrapCheckLog(c))
 	c.Assert(err, tc.ErrorMatches, "permission denied")
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/register.go
+++ b/apiserver/facades/controller/caasunitprovisioner/register.go
@@ -24,7 +24,6 @@ func newStateFacade(ctx facade.ModelContext) (*Facade, error) {
 		ctx.WatcherRegistry(),
 		ctx.Resources(),
 		ctx.Auth(),
-		ctx.DomainServices().Network(),
 		applicationService,
 		stateShim{ctx.State()},
 		ctx.Clock(),

--- a/apiserver/facades/controller/caasunitprovisioner/service_mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/service_mock_test.go
@@ -71,7 +71,7 @@ func (mr *MockApplicationServiceMockRecorder) SetApplicationScale(arg0, arg1, ar
 }
 
 // UpdateCloudService mocks base method.
-func (m *MockApplicationService) UpdateCloudService(arg0 context.Context, arg1, arg2 string, arg3 network.SpaceAddresses) error {
+func (m *MockApplicationService) UpdateCloudService(arg0 context.Context, arg1, arg2 string, arg3 network.ProviderAddresses) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCloudService", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -80,11 +80,10 @@ type ApplicationState interface {
 	// doesn't exist.
 	GetStoragePoolByName(ctx context.Context, name string) (domainstorage.StoragePoolDetails, error)
 
-	// UpsertCloudService updates the cloud service for the specified
-	// application, returning an error satisfying
-	// [applicationerrors.ApplicationNotFoundError] if the application doesn't
-	// exist.
-	UpsertCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error
+	// UpsertCloudService updates the cloud service for the specified application.
+	// The following errors may be returned:
+	// - [applicationerrors.ApplicationNotFound] if the application doesn't exist
+	UpsertCloudService(ctx context.Context, appName, providerID string, sAddrs network.ProviderAddresses) error
 
 	// GetUnitAndK8sServiceAddresses returns the addresses of the specified unit.
 	// The addresses are taken by unioning the net node UUIDs of the cloud service
@@ -805,9 +804,10 @@ func (s *Service) GetCharmByApplicationID(ctx context.Context, id coreapplicatio
 	), locator, nil
 }
 
-// UpdateCloudService updates the cloud service for the specified application, returning an error
-// satisfying [applicationerrors.ApplicationNotFoundError] if the application doesn't exist.
-func (s *Service) UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error {
+// UpsertCloudService updates the cloud service for the specified application.
+// The following errors may be returned:
+// - [applicationerrors.ApplicationNotFound] if the application doesn't exist
+func (s *Service) UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.ProviderAddresses) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -4827,7 +4827,7 @@ func (c *MockStateUpdateCAASUnitCall) DoAndReturn(f func(context.Context, unit.N
 }
 
 // UpsertCloudService mocks base method.
-func (m *MockState) UpsertCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error {
+func (m *MockState) UpsertCloudService(ctx context.Context, appName, providerID string, sAddrs network.ProviderAddresses) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertCloudService", ctx, appName, providerID, sAddrs)
 	ret0, _ := ret[0].(error)
@@ -4853,13 +4853,13 @@ func (c *MockStateUpsertCloudServiceCall) Return(arg0 error) *MockStateUpsertClo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpsertCloudServiceCall) Do(f func(context.Context, string, string, network.SpaceAddresses) error) *MockStateUpsertCloudServiceCall {
+func (c *MockStateUpsertCloudServiceCall) Do(f func(context.Context, string, string, network.ProviderAddresses) error) *MockStateUpsertCloudServiceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpsertCloudServiceCall) DoAndReturn(f func(context.Context, string, string, network.SpaceAddresses) error) *MockStateUpsertCloudServiceCall {
+func (c *MockStateUpsertCloudServiceCall) DoAndReturn(f func(context.Context, string, string, network.ProviderAddresses) error) *MockStateUpsertCloudServiceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -919,10 +919,10 @@ WHERE application_uuid = $applicationScale.application_uuid
 	return errors.Capture(err)
 }
 
-// UpsertCloudService updates the cloud service for the specified application,
-// returning an error satisfying [applicationerrors.ApplicationNotFoundError] if
-// the application doesn't exist.
-func (st *State) UpsertCloudService(ctx context.Context, applicationName, providerID string, sAddrs network.SpaceAddresses) error {
+// UpsertCloudService updates the cloud service for the specified application.
+// The following errors may be returned:
+// - [applicationerrors.ApplicationNotFound] if the application doesn't exist
+func (st *State) UpsertCloudService(ctx context.Context, applicationName, providerID string, sAddrs network.ProviderAddresses) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Capture(err)
@@ -1029,7 +1029,7 @@ func (st *State) upsertCloudServiceAddresses(
 	tx *sqlair.TX,
 	serviceInfo cloudService,
 	applicationName string,
-	addresses network.SpaceAddresses,
+	addresses network.ProviderAddresses,
 ) error {
 	var linkLayerDeviceUUID dbUUID
 	queryLinkLayerDeviceFromServiceStmt, err := st.Prepare(`
@@ -1126,7 +1126,7 @@ WHERE device_uuid IN (
 }
 
 func (st *State) insertCloudServiceAddresses(
-	ctx context.Context, tx *sqlair.TX, linkLayerDeviceUUID string, netNodeUUID string, addresses network.SpaceAddresses) error {
+	ctx context.Context, tx *sqlair.TX, linkLayerDeviceUUID string, netNodeUUID string, addresses network.ProviderAddresses) error {
 	if len(addresses) == 0 {
 		return nil
 	}

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -980,7 +980,7 @@ func (s *applicationStateSuite) TestGetApplicationLifeNotFound(c *tc.C) {
 
 func (s *applicationStateSuite) TestUpsertCloudServiceNew(c *tc.C) {
 	appID := s.createIAASApplication(c, "foo", life.Alive)
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{})
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{})
 	c.Assert(err, tc.ErrorIsNil)
 	var providerID string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -996,9 +996,9 @@ func (s *applicationStateSuite) TestUpsertCloudServiceNew(c *tc.C) {
 
 func (s *applicationStateSuite) TestUpsertCloudServiceExisting(c *tc.C) {
 	appID := s.createIAASApplication(c, "foo", life.Alive)
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{})
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{})
 	c.Assert(err, tc.ErrorIsNil)
-	err = s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{})
+	err = s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{})
 	c.Assert(err, tc.ErrorIsNil)
 	var providerID string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -1015,9 +1015,9 @@ func (s *applicationStateSuite) TestUpsertCloudServiceExisting(c *tc.C) {
 func (s *applicationStateSuite) TestUpsertCloudServiceAnother(c *tc.C) {
 	appID := s.createIAASApplication(c, "foo", life.Alive)
 	s.createIAASApplication(c, "bar", life.Alive)
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{})
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{})
 	c.Assert(err, tc.ErrorIsNil)
-	err = s.state.UpsertCloudService(c.Context(), "foo", "another-provider-id", network.SpaceAddresses{})
+	err = s.state.UpsertCloudService(c.Context(), "foo", "another-provider-id", network.ProviderAddresses{})
 	c.Assert(err, tc.ErrorIsNil)
 	var providerIds []string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -1043,8 +1043,8 @@ func (s *applicationStateSuite) TestUpsertCloudServiceAnother(c *tc.C) {
 func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingEmptyAddresses(c *tc.C) {
 	appID := s.createIAASApplication(c, "foo", life.Alive)
 	s.createIAASApplication(c, "bar", life.Alive)
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{
-		network.SpaceAddress{
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
+		{
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.1",
 				ConfigType: network.ConfigStatic,
@@ -1052,7 +1052,7 @@ func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingEmptyAddress
 				Scope:      network.ScopeCloudLocal,
 			},
 		},
-		network.SpaceAddress{
+		{
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.2",
 				ConfigType: network.ConfigDHCP,
@@ -1094,7 +1094,7 @@ WHERE application_uuid = ?
 
 	checkAddresses(c, "10.0.0.1", "10.0.0.2")
 
-	err = s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{})
+	err = s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{})
 	c.Assert(err, tc.ErrorIsNil)
 	// Since no addresses were passed as input, the previous addresses should
 	// be returned.
@@ -1104,8 +1104,8 @@ WHERE application_uuid = ?
 func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingWithAddresses(c *tc.C) {
 	appID := s.createIAASApplication(c, "foo", life.Alive)
 	s.createIAASApplication(c, "bar", life.Alive)
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{
-		network.SpaceAddress{
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
+		{
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.1",
 				ConfigType: network.ConfigStatic,
@@ -1113,7 +1113,7 @@ func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingWithAddresse
 				Scope:      network.ScopeCloudLocal,
 			},
 		},
-		network.SpaceAddress{
+		{
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.2",
 				ConfigType: network.ConfigDHCP,
@@ -1155,8 +1155,8 @@ WHERE application_uuid = ?
 
 	checkAddresses(c, "10.0.0.1", "10.0.0.2")
 
-	err = s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{
-		network.SpaceAddress{
+	err = s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
+		{
 			MachineAddress: network.MachineAddress{
 				Value:      "192.168.0.0",
 				ConfigType: network.ConfigStatic,
@@ -1164,7 +1164,7 @@ WHERE application_uuid = ?
 				Scope:      network.ScopeCloudLocal,
 			},
 		},
-		network.SpaceAddress{
+		{
 			MachineAddress: network.MachineAddress{
 				Value:      "192.168.0.1",
 				ConfigType: network.ConfigDHCP,
@@ -1180,7 +1180,7 @@ WHERE application_uuid = ?
 }
 
 func (s *applicationStateSuite) TestUpsertCloudServiceNotFound(c *tc.C) {
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.SpaceAddresses{})
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
@@ -3669,7 +3669,13 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudService(c *tc.C) {
 		UnitName: "foo/0",
 	})
 
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.NewSpaceAddresses("10.0.0.1"))
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+			},
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	var netNodeUUID string
@@ -3684,7 +3690,7 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudService(c *tc.C) {
 
 	hash, err := s.state.GetAddressesHash(c.Context(), appID, netNodeUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(hash, tc.Equals, "1736435babfcd8930c0ab8225855eed6296efc9d7db0e2c8aa06c0a58f44e540")
+	c.Check(hash, tc.Equals, "6a6a947ce7d1aa01e1da0984ecf037c76fa1b9f2136b3113cd7e8ab312239686")
 }
 
 func (s *applicationStateSuite) TestGetAddressesHashCloudServiceWithEndpointBindings(c *tc.C) {
@@ -3692,7 +3698,13 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudServiceWithEndpointBind
 		UnitName: "foo/0",
 	})
 
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.NewSpaceAddresses("10.0.0.1"))
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+			},
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	var netNodeUUID string
@@ -3729,7 +3741,7 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudServiceWithEndpointBind
 
 	hash, err := s.state.GetAddressesHash(c.Context(), appID, netNodeUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(hash, tc.Equals, "e2c67728743f8ed832062d28a75766548ba3ad09e2fe9126268f0de3fb3a8afb")
+	c.Check(hash, tc.Equals, "e174cad78a387fb380d0f9cf277a7edb759549f6afdafdfc4adf0c243e18d375")
 }
 
 func (s *applicationStateSuite) TestHashAddresses(c *tc.C) {
@@ -3778,7 +3790,13 @@ func (s *applicationStateSuite) TestGetNetNodeFromK8sService(c *tc.C) {
 		UnitName: "foo/0",
 	})
 
-	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.NewSpaceAddresses("10.0.0.1"))
+	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+			},
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Also insert the unit net node to make sure the k8s service one is

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -809,7 +809,13 @@ func (s *watcherSuite) TestWatchCloudServiceAddressesHash(c *tc.C) {
 	ctx := c.Context()
 
 	// Add a cloud service to get an initial state.
-	err := svc.UpdateCloudService(ctx, "foo", "foo-provider", network.NewSpaceAddresses("10.0.0.1"))
+	err := svc.UpdateCloudService(ctx, "foo", "foo-provider", network.ProviderAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+			},
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	watcher, err := svc.WatchUnitAddressesHash(ctx, "foo/0")
@@ -819,7 +825,13 @@ func (s *watcherSuite) TestWatchCloudServiceAddressesHash(c *tc.C) {
 
 	harness.AddTest(func(c *tc.C) {
 		// Change the address for the cloud service should trigger a change.
-		err := svc.UpdateCloudService(ctx, "foo", "foo-provider", network.NewSpaceAddresses("192.168.0.1"))
+		err := svc.UpdateCloudService(ctx, "foo", "foo-provider", network.ProviderAddresses{
+			{
+				MachineAddress: network.MachineAddress{
+					Value: "192.168.0.1",
+				},
+			},
+		})
 		c.Assert(err, tc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.AssertChange()
@@ -856,7 +868,7 @@ func (s *watcherSuite) TestWatchCloudServiceAddressesHash(c *tc.C) {
 	})
 
 	// Hash of the initial state.
-	harness.Run(c, []string{"722ba9e367e446b51bd7a473ab0a6002f8eb2f848a03169d7dfa63b7a88e3e8a"})
+	harness.Run(c, []string{"e9daa2b006ff0740cebfce4a761243bc032d518221fdfa16df53e3aa701591cc"})
 }
 
 func (s *watcherSuite) TestWatchUnitAddressesHashBadName(c *tc.C) {

--- a/internal/bootstrap/bootstrap_mock_test.go
+++ b/internal/bootstrap/bootstrap_mock_test.go
@@ -773,7 +773,7 @@ func (c *MockApplicationServiceResolveControllerCharmDownloadCall) DoAndReturn(f
 }
 
 // UpdateCloudService mocks base method.
-func (m *MockApplicationService) UpdateCloudService(arg0 context.Context, arg1, arg2 string, arg3 network.SpaceAddresses) error {
+func (m *MockApplicationService) UpdateCloudService(arg0 context.Context, arg1, arg2 string, arg3 network.ProviderAddresses) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCloudService", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -799,13 +799,13 @@ func (c *MockApplicationServiceUpdateCloudServiceCall) Return(arg0 error) *MockA
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceUpdateCloudServiceCall) Do(f func(context.Context, string, string, network.SpaceAddresses) error) *MockApplicationServiceUpdateCloudServiceCall {
+func (c *MockApplicationServiceUpdateCloudServiceCall) Do(f func(context.Context, string, string, network.ProviderAddresses) error) *MockApplicationServiceUpdateCloudServiceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceUpdateCloudServiceCall) DoAndReturn(f func(context.Context, string, string, network.SpaceAddresses) error) *MockApplicationServiceUpdateCloudServiceCall {
+func (c *MockApplicationServiceUpdateCloudServiceCall) DoAndReturn(f func(context.Context, string, string, network.ProviderAddresses) error) *MockApplicationServiceUpdateCloudServiceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -983,7 +983,7 @@ func (c *MockCAASApplicationServiceUpdateCAASUnitCall) DoAndReturn(f func(contex
 }
 
 // UpdateCloudService mocks base method.
-func (m *MockCAASApplicationService) UpdateCloudService(arg0 context.Context, arg1, arg2 string, arg3 network.SpaceAddresses) error {
+func (m *MockCAASApplicationService) UpdateCloudService(arg0 context.Context, arg1, arg2 string, arg3 network.ProviderAddresses) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCloudService", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -1009,13 +1009,13 @@ func (c *MockCAASApplicationServiceUpdateCloudServiceCall) Return(arg0 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASApplicationServiceUpdateCloudServiceCall) Do(f func(context.Context, string, string, network.SpaceAddresses) error) *MockCAASApplicationServiceUpdateCloudServiceCall {
+func (c *MockCAASApplicationServiceUpdateCloudServiceCall) Do(f func(context.Context, string, string, network.ProviderAddresses) error) *MockCAASApplicationServiceUpdateCloudServiceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASApplicationServiceUpdateCloudServiceCall) DoAndReturn(f func(context.Context, string, string, network.SpaceAddresses) error) *MockCAASApplicationServiceUpdateCloudServiceCall {
+func (c *MockCAASApplicationServiceUpdateCloudServiceCall) DoAndReturn(f func(context.Context, string, string, network.ProviderAddresses) error) *MockCAASApplicationServiceUpdateCloudServiceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -34,7 +34,7 @@ type ApplicationService interface {
 
 	// UpdateCloudService updates the cloud service for the specified application, returning an error
 	// satisfying [applicationerrors.ApplicationNotFoundError] if the application doesn't exist.
-	UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error
+	UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.ProviderAddresses) error
 }
 
 // IAASApplicationService instances create an IAAS application.
@@ -61,7 +61,7 @@ type CAASApplicationService interface {
 
 	// UpdateCloudService updates the cloud service for the specified application, returning an error
 	// satisfying [applicationerrors.ApplicationNotFoundError] if the application doesn't exist.
-	UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error
+	UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.ProviderAddresses) error
 }
 
 // ModelConfigService provides access to the model configuration.

--- a/internal/worker/bootstrap/bootstrap_mock_test.go
+++ b/internal/worker/bootstrap/bootstrap_mock_test.go
@@ -836,7 +836,7 @@ func (c *MockApplicationServiceUpdateCAASUnitCall) DoAndReturn(f func(context.Co
 }
 
 // UpdateCloudService mocks base method.
-func (m *MockApplicationService) UpdateCloudService(arg0 context.Context, arg1, arg2 string, arg3 network.SpaceAddresses) error {
+func (m *MockApplicationService) UpdateCloudService(arg0 context.Context, arg1, arg2 string, arg3 network.ProviderAddresses) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCloudService", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -862,13 +862,13 @@ func (c *MockApplicationServiceUpdateCloudServiceCall) Return(arg0 error) *MockA
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceUpdateCloudServiceCall) Do(f func(context.Context, string, string, network.SpaceAddresses) error) *MockApplicationServiceUpdateCloudServiceCall {
+func (c *MockApplicationServiceUpdateCloudServiceCall) Do(f func(context.Context, string, string, network.ProviderAddresses) error) *MockApplicationServiceUpdateCloudServiceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceUpdateCloudServiceCall) DoAndReturn(f func(context.Context, string, string, network.SpaceAddresses) error) *MockApplicationServiceUpdateCloudServiceCall {
+func (c *MockApplicationServiceUpdateCloudServiceCall) DoAndReturn(f func(context.Context, string, string, network.ProviderAddresses) error) *MockApplicationServiceUpdateCloudServiceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/bootstrap/service.go
+++ b/internal/worker/bootstrap/service.go
@@ -77,7 +77,7 @@ type ApplicationService interface {
 
 	// UpdateCloudService updates the cloud service for the specified application, returning an error
 	// satisfying [applicationerrors.ApplicationNotFoundError] if the application doesn't exist.
-	UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error
+	UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.ProviderAddresses) error
 }
 
 // BakeryConfigService describes the service used to initialise the


### PR DESCRIPTION
The method UpdateCloudService used to take space addresses as input, but this is wrong and we never use the space in the addresses. This patch changes the signature to take provider addresses instead.

Taking provider addresses means that we no longer need to assign the alpha space to the retrieved addresses from the providers during bootstrap.

__Note: This patch originates from this comment https://github.com/juju/juju/pull/19808#discussion_r2108616618.__



## QA steps

No change in functionality, so bootstrapping without any errors in the logs should be enough.

