### PR TITLE
test: fix various test flakiness

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -407,29 +407,52 @@ func (s *MachineSuite) setupIgnoreAddresses(c *tc.C, expectedIgnoreValue bool) c
 	return ignoreAddressCh
 }
 
-func (s *MachineSuite) TestMachineAgentIgnoreAddresses(c *tc.C) {
-	for _, expectedIgnoreValue := range []bool{true, false} {
-		ignoreAddressCh := s.setupIgnoreAddresses(c, expectedIgnoreValue)
+func (s *MachineSuite) TestMachineAgentIgnoreAddressesTrue(c *tc.C) {
+	expectedIgnoreValue := true
+	ignoreAddressCh := s.setupIgnoreAddresses(c, expectedIgnoreValue)
 
-		m, _, _ := s.primeAgent(c, state.JobHostUnits)
-		ctrl, a := s.newAgent(c, m)
-		defer ctrl.Finish()
-		defer a.Stop()
-		doneCh := make(chan error)
-		go func() {
-			doneCh <- a.Run(cmdtesting.Context(c))
-		}()
+	m, _, _ := s.primeAgent(c, state.JobHostUnits)
+	ctrl, a := s.newAgent(c, m)
+	defer ctrl.Finish()
+	defer a.Stop()
+	doneCh := make(chan error)
+	go func() {
+		doneCh <- a.Run(cmdtesting.Context(c))
+	}()
 
-		select {
-		case ignoreMachineAddresses := <-ignoreAddressCh:
-			if ignoreMachineAddresses != expectedIgnoreValue {
-				c.Fatalf("expected ignore-machine-addresses = %v, got = %v", expectedIgnoreValue, ignoreMachineAddresses)
-			}
-		case <-time.After(coretesting.LongWait):
-			c.Fatalf("timed out waiting for the machiner to start")
+	select {
+	case ignoreMachineAddresses := <-ignoreAddressCh:
+		if ignoreMachineAddresses != expectedIgnoreValue {
+			c.Fatalf("expected ignore-machine-addresses = %v, got = %v", expectedIgnoreValue, ignoreMachineAddresses)
 		}
-		s.waitStopped(c, state.JobHostUnits, a, doneCh)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for the machiner to start")
 	}
+	s.waitStopped(c, state.JobHostUnits, a, doneCh)
+}
+
+func (s *MachineSuite) TestMachineAgentIgnoreAddressesFalse(c *tc.C) {
+	expectedIgnoreValue := false
+	ignoreAddressCh := s.setupIgnoreAddresses(c, expectedIgnoreValue)
+
+	m, _, _ := s.primeAgent(c, state.JobHostUnits)
+	ctrl, a := s.newAgent(c, m)
+	defer ctrl.Finish()
+	defer a.Stop()
+	doneCh := make(chan error)
+	go func() {
+		doneCh <- a.Run(cmdtesting.Context(c))
+	}()
+
+	select {
+	case ignoreMachineAddresses := <-ignoreAddressCh:
+		if ignoreMachineAddresses != expectedIgnoreValue {
+			c.Fatalf("expected ignore-machine-addresses = %v, got = %v", expectedIgnoreValue, ignoreMachineAddresses)
+		}
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for the machiner to start")
+	}
+	s.waitStopped(c, state.JobHostUnits, a, doneCh)
 }
 
 func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *tc.C) {

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -1115,7 +1115,7 @@ func (s *modelServiceSuite) TestGetUserModelSummary(c *tc.C) {
 	)
 
 	mc := tc.NewMultiChecker()
-	mc.AddExpr("_.Status.Since", tc.Ignore)
+	mc.AddExpr("_.ModelSummary.Status.Since", tc.Ignore)
 	summary, err := svc.GetUserModelSummary(c.Context(), userUUID)
 	c.Check(err, tc.ErrorIsNil)
 	c.Assert(summary, mc, coremodel.UserModelSummary{

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/juju/replicaset/v3 v3.0.1
 	github.com/juju/retry v1.0.1
 	github.com/juju/schema v1.2.0
-	github.com/juju/tc v0.0.0-20250523041547-7f66c35f9f03
+	github.com/juju/tc v0.0.0-20250528095810-3bfebf94677d
 	github.com/juju/testing v1.2.0
 	github.com/juju/txn/v3 v3.0.2
 	github.com/juju/utils/v4 v4.0.3

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,9 @@ github.com/juju/retry v1.0.1/go.mod h1:SssN1eYeK3A2qjnFGTiVMbdzGJ2BfluaJblJXvuvg
 github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/schema v1.2.0 h1:+XywM0pYzuhGebQiK1aR4Bj7Q7nLV5MihcOgq6dLLxs=
 github.com/juju/schema v1.2.0/go.mod h1:VdljuJLc45loM79LYm4yKKmPJwK1bPKRekvMVlfywU0=
-github.com/juju/tc v0.0.0-20250523041547-7f66c35f9f03 h1:x/rsZcDhRKEubIDOnSXRUMTs5I6/lGyT7Sd7xAmkazo=
 github.com/juju/tc v0.0.0-20250523041547-7f66c35f9f03/go.mod h1:YdExdo5XpLqX+BT6eCcS8HCqbZO09fP3mwoiJXv35Vg=
+github.com/juju/tc v0.0.0-20250528095810-3bfebf94677d h1:+ChT8zEcev6Wk6gKZPsenNXIst+kAJZU+RfW9sY8a0o=
+github.com/juju/tc v0.0.0-20250528095810-3bfebf94677d/go.mod h1:YdExdo5XpLqX+BT6eCcS8HCqbZO09fP3mwoiJXv35Vg=
 github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180517134105-72703b1e95eb/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=

--- a/internal/mongo/mongometrics/mgostatsmetrics_test.go
+++ b/internal/mongo/mongometrics/mgostatsmetrics_test.go
@@ -89,8 +89,7 @@ func (s *MgoStatsCollectorSuite) TestCollect(c *tc.C) {
 	c.Assert(metricFamilies, tc.HasLen, 9)
 
 	mc := tc.NewMultiChecker()
-	mc.AddExpr("_.CreatedTimestamp", tc.NotNil)
-	mc.AddExpr("_.CreatedTimestamp", tc.Ignore)
+	mc.AddExpr("_[_].Metric[_].Counter.CreatedTimestamp", tc.NotNil)
 	c.Assert(metricFamilies, mc, []*dto.MetricFamily{{
 		Name: stringptr("mgo_clusters"),
 		Help: stringptr("Current number of clusters"),

--- a/internal/objectstore/base_test.go
+++ b/internal/objectstore/base_test.go
@@ -200,9 +200,6 @@ func (s *baseObjectStoreSuite) TestLockingForTombKill(c *tc.C) {
 		clock:   clock.WallClock,
 	}
 
-	ctx, _ := w.scopedContext()
-	c.Assert(ctx.Err(), tc.ErrorIsNil)
-
 	wait := make(chan struct{})
 
 	go func() {
@@ -215,7 +212,7 @@ func (s *baseObjectStoreSuite) TestLockingForTombKill(c *tc.C) {
 		}
 	}()
 
-	err := w.withLock(ctx, "hash", func(ctx context.Context) error {
+	err := w.withLock(c.Context(), "hash", func(ctx context.Context) error {
 		close(block)
 		time.Sleep(time.Millisecond * 100)
 		return nil

--- a/internal/socketlistener/socketlistener_test.go
+++ b/internal/socketlistener/socketlistener_test.go
@@ -5,19 +5,16 @@ package socketlistener_test
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"net"
 	"net/http"
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v4/workertest"
-	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/core/logger"
 	coretesting "github.com/juju/juju/core/testing"
@@ -89,52 +86,46 @@ func (s *socketListenerSuite) TestStartStopWorker(c *tc.C) {
 // shutdown. An example of this, would be running a db query, that isn't letting
 // the handler return immediately.
 func (s *socketListenerSuite) TestEnsureShutdown(c *tc.C) {
-	for i := 0; i < 100; i++ {
-		tmpDir := c.MkDir()
-		socket := path.Join(tmpDir, "test.socket")
+	tmpDir := c.MkDir()
+	socket := path.Join(tmpDir, "test.socket")
 
-		start := make(chan struct{})
-		sl, err := socketlistener.NewSocketListener(socketlistener.Config{
-			Logger:     s.logger,
-			SocketName: socket,
-			RegisterHandlers: func(r *mux.Router) {
-				r.HandleFunc("/slow-handler", func(resp http.ResponseWriter, req *http.Request) {
-					// Signal that the handler has started.
-					close(start)
-					time.Sleep(time.Second)
-				}).Methods(http.MethodGet)
-			},
-			ShutdownTimeout: coretesting.LongWait,
-		})
-		c.Assert(err, tc.ErrorIsNil)
-		defer workertest.DirtyKill(c, sl)
-		var tomb tomb.Tomb
-		tomb.Go(func() error {
-			cl := client(socket)
-			// Ignore error, as we're only interested in the fact that the request
-			// was made.
-			cl.Get("http://localhost:8080/slow-handler")
-			return nil
-		})
+	start := make(chan struct{})
+	done := make(chan struct{})
+	sl, err := socketlistener.NewSocketListener(socketlistener.Config{
+		Logger:     s.logger,
+		SocketName: socket,
+		RegisterHandlers: func(r *mux.Router) {
+			r.HandleFunc("/slow-handler", func(resp http.ResponseWriter, req *http.Request) {
+				// Signal that the handler has started.
+				close(start)
+				<-done
+			}).Methods(http.MethodGet)
+		},
+		ShutdownTimeout: coretesting.LongWait,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, sl)
 
-		tomb.Go(func() error {
-			// Kill socket listener once handler has started.
-			select {
-			case <-start:
-			case <-time.After(coretesting.ShortWait):
-				return fmt.Errorf("took too long to start")
-			}
-			workertest.CleanKill(c, sl)
-			return nil
-		})
-		// Wait for server to cleanly shutdown
-		select {
-		case <-tomb.Dead():
-			c.Assert(tomb.Err(), tc.IsNil)
-		case <-time.After(coretesting.LongWait):
-			tomb.Kill(fmt.Errorf("took too long to finish"))
-			c.Errorf("took too long to finish")
-		}
+	go func() {
+		defer close(done)
+		cl := client(socket)
+		// Ignore error, as we're only interested in the fact that the request
+		// was made.
+		_, _ = cl.Get("http://localhost:8080/slow-handler")
+	}()
+
+	// Kill socket listener once handler has started.
+	select {
+	case <-start:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for listener to start")
+	}
+	workertest.CleanKill(c, sl)
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for caller to exit")
 	}
 }
 

--- a/internal/worker/dbreplaccessor/worker_test.go
+++ b/internal/worker/dbreplaccessor/worker_test.go
@@ -98,7 +98,7 @@ func (s *workerSuite) TestGetDBNotFound(c *tc.C) {
 
 	// The error isn't passed through, although we really should expose this
 	// in the runner.
-	c.Assert(err, tc.ErrorIs, worker.ErrDead)
+	c.Assert(err, tc.ErrorMatches, `worker "other" not found`)
 }
 
 func (s *workerSuite) TestGetDBFound(c *tc.C) {

--- a/internal/worker/httpserver/cert_test.go
+++ b/internal/worker/httpserver/cert_test.go
@@ -88,9 +88,9 @@ func (s *certSuite) TestAutocertFailure(c *tc.C) {
 	})
 
 	mc := tc.NewMultiChecker()
-	mc.AddExpr(`_.Level`, tc.Equals, tc.ExpectedValue)
-	mc.AddExpr(`_.Message`, tc.Matches, tc.ExpectedValue)
-	mc.AddExpr(`_._`, tc.Ignore)
+	mc.AddExpr(`_[_].Level`, tc.Equals, tc.ExpectedValue)
+	mc.AddExpr(`_[_].Message`, tc.Matches, tc.ExpectedValue)
+	mc.AddExpr(`_[_]._`, tc.Ignore)
 	// We will log the failure to get the certificate, thus assuring us that we actually tried.
 	c.Assert(entries, mc, []loggo.Entry{{
 		Level:   loggo.DEBUG,

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -1182,8 +1182,7 @@ func assertExpectedCallArgs(c *tc.C, stub *testhelpers.Stub, expectedCalls []tes
 
 		if call.FuncName == "MigrationTarget.Prechecks" {
 			mc := tc.NewMultiChecker()
-			mc.AddExpr("_.FacadeVersions", tc.Not(tc.HasLen), 0)
-
+			mc.AddExpr("_[0].FacadeVersions", tc.Not(tc.HasLen), 0)
 			c.Assert(stubCall.Args, mc, call.Args, tc.Commentf("call %s", call.FuncName))
 			continue
 		}


### PR DESCRIPTION
This change set deals with more test flakiness across the project:
1. Test: Update the tc dependency to bring in multi checker fixes.
2. Test: Fix usages of multi checker expression matching.
3. Test: Unroll machine agent ignore address table test.
4. Test: Rewrite socket listener shutdown test.
5. Test: Fix synchronisation point for provisioner task test.
6. Test: Fix object store TestLockingForTombKill by not racing with context cancel from the same tomb.

Two fixes relating to consistency of errors are also included in this change set:
1. Fix: Ensure dbreplaccessor errors correctly when db does not exist.
2. Fix: Ensure object store returns tomb.Dying consistently for tomb death during with lock call.