### PR TITLE
fix: style guide

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -4,7 +4,8 @@ All code **must** be formatted using `go fmt`.
 
 #### Line length
 
-Line length must not exceed 80 characters.
+Line length must not exceed 120 characters for code, and 80 characters for
+comments.
 
 ### Imports
 


### PR DESCRIPTION
Insisting that code lines must not exceed 80 characters is a bit extreme. The rule we should be following is 120 for code, and 80 for comments.