### PR TITLE
feat(application): cut over the CharmRelations facade

### DIFF
--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -695,6 +695,37 @@ func (s *applicationSuite) TestGetCharmURLOriginNoOptionals(c *tc.C) {
 	})
 }
 
+func (s *applicationSuite) TestCharmRelations(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.setupAPI(c)
+
+	appID := applicationtesting.GenApplicationUUID(c)
+	rels := []string{"foo", "bar"}
+
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "doink").Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationEndpointNames(gomock.Any(), appID).Return(rels, nil)
+
+	res, err := s.api.CharmRelations(c.Context(), params.ApplicationCharmRelations{
+		ApplicationName: "doink",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.CharmRelations, tc.SameContents, rels)
+}
+
+func (s *applicationSuite) TestCharmRelationsAppNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.setupAPI(c)
+
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "doink").Return("", applicationerrors.ApplicationNotFound)
+
+	_, err := s.api.CharmRelations(c.Context(), params.ApplicationCharmRelations{
+		ApplicationName: "doink",
+	})
+	c.Assert(err, tc.Satisfies, params.IsCodeNotFound)
+}
+
 func (s *applicationSuite) TestGetApplicationConstraintsAppNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -14,7 +14,6 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
-	"github.com/juju/juju/domain/relation"
 	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/configschema"
 	"github.com/juju/juju/state"
@@ -38,7 +37,6 @@ type Backend interface {
 type Application interface {
 	AddUnit(state.AddUnitParams) (Unit, error)
 	DestroyOperation(objectstore.ObjectStore) *state.DestroyApplicationOperation
-	Endpoints() ([]relation.Endpoint, error)
 	SetCharm(state.SetCharmConfig, objectstore.ObjectStore) error
 	SetConstraints(constraints.Value) error
 	UpdateCharmConfig(charm.Settings) error

--- a/apiserver/facades/client/application/legacy_mock_test.go
+++ b/apiserver/facades/client/application/legacy_mock_test.go
@@ -16,7 +16,6 @@ import (
 	config "github.com/juju/juju/core/config"
 	constraints "github.com/juju/juju/core/constraints"
 	objectstore "github.com/juju/juju/core/objectstore"
-	relation "github.com/juju/juju/domain/relation"
 	charm "github.com/juju/juju/internal/charm"
 	configschema "github.com/juju/juju/internal/configschema"
 	state "github.com/juju/juju/state"
@@ -337,45 +336,6 @@ func (c *MockApplicationDestroyOperationCall) Do(f func(objectstore.ObjectStore)
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationDestroyOperationCall) DoAndReturn(f func(objectstore.ObjectStore) *state.DestroyApplicationOperation) *MockApplicationDestroyOperationCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// Endpoints mocks base method.
-func (m *MockApplication) Endpoints() ([]relation.Endpoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Endpoints")
-	ret0, _ := ret[0].([]relation.Endpoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Endpoints indicates an expected call of Endpoints.
-func (mr *MockApplicationMockRecorder) Endpoints() *MockApplicationEndpointsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Endpoints", reflect.TypeOf((*MockApplication)(nil).Endpoints))
-	return &MockApplicationEndpointsCall{Call: call}
-}
-
-// MockApplicationEndpointsCall wrap *gomock.Call
-type MockApplicationEndpointsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationEndpointsCall) Return(arg0 []relation.Endpoint, arg1 error) *MockApplicationEndpointsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationEndpointsCall) Do(f func() ([]relation.Endpoint, error)) *MockApplicationEndpointsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationEndpointsCall) DoAndReturn(f func() ([]relation.Endpoint, error)) *MockApplicationEndpointsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -301,6 +301,13 @@ type ApplicationService interface {
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationEndpointBindings(context.Context, coreapplication.ID) (map[string]string, error)
 
+	// GetApplicationEndpointNames returns the names of the endpoints for the given
+	// application.
+	// The following errors may be returned:
+	//   - [applicationerrors.ApplicationNotFound] is returned if the application
+	//     doesn't exist.
+	GetApplicationEndpointNames(context.Context, coreapplication.ID) ([]string, error)
+
 	// GetExposedEndpoints returns map where keys are endpoint names (or the ""
 	// value which represents all endpoints) and values are ExposedEndpoint
 	// instances that specify which sources (spaces or CIDRs) can access the

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -1229,6 +1229,45 @@ func (c *MockApplicationServiceGetApplicationEndpointBindingsCall) DoAndReturn(f
 	return c
 }
 
+// GetApplicationEndpointNames mocks base method.
+func (m *MockApplicationService) GetApplicationEndpointNames(arg0 context.Context, arg1 application.ID) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationEndpointNames", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationEndpointNames indicates an expected call of GetApplicationEndpointNames.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationEndpointNames(arg0, arg1 any) *MockApplicationServiceGetApplicationEndpointNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationEndpointNames", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationEndpointNames), arg0, arg1)
+	return &MockApplicationServiceGetApplicationEndpointNamesCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationEndpointNamesCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationEndpointNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationEndpointNamesCall) Return(arg0 []string, arg1 error) *MockApplicationServiceGetApplicationEndpointNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationEndpointNamesCall) Do(f func(context.Context, application.ID) ([]string, error)) *MockApplicationServiceGetApplicationEndpointNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationEndpointNamesCall) DoAndReturn(f func(context.Context, application.ID) ([]string, error)) *MockApplicationServiceGetApplicationEndpointNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetApplicationIDByName mocks base method.
 func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -361,6 +361,13 @@ type ApplicationState interface {
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationEndpointBindings(context.Context, coreapplication.ID) (map[string]string, error)
 
+	// GetApplicationEndpointNames returns the names of the endpoints for the given
+	// application.
+	// The following errors may be returned:
+	//   - [applicationerrors.ApplicationNotFound] is returned if the application
+	//     doesn't exist.
+	GetApplicationEndpointNames(context.Context, coreapplication.ID) ([]string, error)
+
 	// NamespaceForWatchNetNodeAddress returns the namespace identifier for
 	// net node address changes, which is the ip_address table.
 	NamespaceForWatchNetNodeAddress() string
@@ -1418,6 +1425,20 @@ func (s *Service) GetApplicationEndpointBindings(ctx context.Context, appID core
 
 	bindings, err := s.st.GetApplicationEndpointBindings(ctx, appID)
 	return bindings, errors.Capture(err)
+}
+
+// GetApplicationEndpointNames returns the names of the endpoints for the given
+// application.
+// The following errors may be returned:
+//   - [applicationerrors.ApplicationNotFound] is returned if the application
+//     doesn't exist.
+func (s *Service) GetApplicationEndpointNames(ctx context.Context, appUUID coreapplication.ID) ([]string, error) {
+	if err := appUUID.Validate(); err != nil {
+		return nil, errors.Errorf("validating application UUID: %w", err)
+	}
+
+	eps, err := s.st.GetApplicationEndpointNames(ctx, appUUID)
+	return eps, errors.Capture(err)
 }
 
 // GetDeviceConstraints returns the device constraints for an application.

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -1059,6 +1059,27 @@ func (s *applicationServiceSuite) TestGetApplicationEndpointBindings(c *tc.C) {
 	})
 }
 
+func (s *applicationServiceSuite) TestGetApplicationEndpointNames(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationEndpointNames(gomock.Any(), appID).Return([]string{"foo", "bar"}, nil)
+
+	eps, err := s.service.GetApplicationEndpointNames(c.Context(), appID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(eps, tc.SameContents, []string{"foo", "bar"})
+}
+
+func (s *applicationServiceSuite) TestGetApplicationEndpointNamesAppNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationEndpointNames(gomock.Any(), appID).Return(nil, applicationerrors.ApplicationNotFound)
+
+	_, err := s.service.GetApplicationEndpointNames(c.Context(), appID)
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
 func (s *applicationServiceSuite) TestGetDeviceConstraintsAppNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -886,6 +886,45 @@ func (c *MockStateGetApplicationEndpointBindingsCall) DoAndReturn(f func(context
 	return c
 }
 
+// GetApplicationEndpointNames mocks base method.
+func (m *MockState) GetApplicationEndpointNames(arg0 context.Context, arg1 application.ID) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationEndpointNames", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationEndpointNames indicates an expected call of GetApplicationEndpointNames.
+func (mr *MockStateMockRecorder) GetApplicationEndpointNames(arg0, arg1 any) *MockStateGetApplicationEndpointNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationEndpointNames", reflect.TypeOf((*MockState)(nil).GetApplicationEndpointNames), arg0, arg1)
+	return &MockStateGetApplicationEndpointNamesCall{Call: call}
+}
+
+// MockStateGetApplicationEndpointNamesCall wrap *gomock.Call
+type MockStateGetApplicationEndpointNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetApplicationEndpointNamesCall) Return(arg0 []string, arg1 error) *MockStateGetApplicationEndpointNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetApplicationEndpointNamesCall) Do(f func(context.Context, application.ID) ([]string, error)) *MockStateGetApplicationEndpointNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetApplicationEndpointNamesCall) DoAndReturn(f func(context.Context, application.ID) ([]string, error)) *MockStateGetApplicationEndpointNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetApplicationIDAndNameByUnitName mocks base method.
 func (m *MockState) GetApplicationIDAndNameByUnitName(ctx context.Context, name unit.Name) (application.ID, string, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/state/application_endpoint_test.go
+++ b/domain/application/state/application_endpoint_test.go
@@ -456,6 +456,36 @@ func (s *applicationEndpointStateSuite) TestGetEndpointBindingsApplicationNotFou
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
+func (s *applicationEndpointStateSuite) TestGetApplicationEndpointNames(c *tc.C) {
+	// Arrange: create two application endpoints
+	s.addRelation(c, "foo")
+	s.addRelation(c, "bar")
+
+	// Act:
+	eps, err := s.state.GetApplicationEndpointNames(c.Context(), s.appID)
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(eps, tc.SameContents, []string{"foo", "bar"})
+}
+
+func (s *applicationEndpointStateSuite) TestGetApplicationEndpointNamesApplicationNoEndpoints(c *tc.C) {
+	// Act:
+	eps, err := s.state.GetApplicationEndpointNames(c.Context(), s.appID)
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(eps, tc.HasLen, 0)
+}
+
+func (s *applicationEndpointStateSuite) TestGetApplicationEndpointNamesApplicationNotFound(c *tc.C) {
+	// Act:
+	_, err := s.state.GetApplicationEndpointNames(c.Context(), "bad-uuid")
+
+	// Assert:
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
 func (s *applicationEndpointStateSuite) addApplicationEndpoint(c *tc.C, spaceUUID, relationUUID string) string {
 	endpointUUID := uuid.MustNewUUID().String()
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -1132,21 +1132,20 @@ func (s *State) NamespaceForWatchCharm() string {
 
 func (s *State) getCharmIDByApplicationID(ctx context.Context, tx *sqlair.TX, appID application.ID) (corecharm.ID, error) {
 	query := `
-SELECT c.uuid AS &charmID.*
-FROM application a
-JOIN charm c ON a.charm_uuid = c.uuid
-WHERE a.uuid = $applicationID.uuid;
+SELECT charm_uuid AS &charmUUID.*
+FROM application
+WHERE uuid = $applicationID.uuid;
 `
 	ident := applicationID{ID: appID}
-	stmt, err := s.Prepare(query, charmID{}, ident)
+	stmt, err := s.Prepare(query, charmUUID{}, ident)
 	if err != nil {
 		return "", errors.Errorf("preparing query: %w", err)
 	}
-	var charmID charmID
-	if err := tx.Query(ctx, stmt, ident).Get(&charmID); errors.Is(err, sqlair.ErrNoRows) {
-		return "", applicationerrors.CharmNotFound
+	var charmUUID charmUUID
+	if err := tx.Query(ctx, stmt, ident).Get(&charmUUID); errors.Is(err, sqlair.ErrNoRows) {
+		return "", applicationerrors.ApplicationNotFound
 	} else if err != nil {
 		return "", errors.Errorf("getting charm ID by application ID: %w", err)
 	}
-	return charmID.UUID, nil
+	return charmUUID.UUID, nil
 }

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -3636,7 +3636,7 @@ func (s *charmStateSuite) TestGetCharmIDByApplicationIDNotFound(c *tc.C) {
 		_, err := st.getCharmIDByApplicationID(c.Context(), tx, applicationtesting.GenApplicationUUID(c))
 		return err
 	})
-	c.Assert(err, tc.ErrorIs, applicationerrors.CharmNotFound)
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
 func (s *charmStateSuite) TestGetCharmIDByApplicationID(c *tc.C) {

--- a/state/application.go
+++ b/state/application.go
@@ -573,20 +573,6 @@ func (a *Application) Endpoints() (eps []relation.Endpoint, err error) {
 	return eps, nil
 }
 
-// Endpoint returns the relation endpoint with the supplied name, if it exists.
-func (a *Application) Endpoint(relationName string) (relation.Endpoint, error) {
-	eps, err := a.Endpoints()
-	if err != nil {
-		return relation.Endpoint{}, err
-	}
-	for _, ep := range eps {
-		if ep.Name == relationName {
-			return ep, nil
-		}
-	}
-	return relation.Endpoint{}, errors.Errorf("application %q has no %q relation", a, relationName)
-}
-
 func (a *Application) checkStorageUpgrade(newMeta, oldMeta *charm.Meta, units []*Unit) (_ []txn.Op, err error) {
 	// Make sure no storage instances are added or removed.
 


### PR DESCRIPTION
Cut over another application facade to be backed with DQLite.

## QA steps

It turns out this facade endpoint is not currently used by our client.

Apply the following diff:
```diff
diff --git a/cmd/juju/application/show.go b/cmd/juju/application/show.go
index 772a5e6094..13845c151b 100644
--- a/cmd/juju/application/show.go
+++ b/cmd/juju/application/show.go
@@ -97,6 +97,7 @@ func (c *showApplicationCommand) SetFlags(f *gnuflag.FlagSet) {
 type ApplicationsInfoAPI interface {
        Close() error
        ApplicationsInfo(context.Context, []names.ApplicationTag) ([]params.ApplicationInfoResult, error)
+       CharmRelations(context.Context, string) ([]string, error)
 }
 
 func (c *showApplicationCommand) newApplicationAPI(ctx context.Context) (ApplicationsInfoAPI, error) {
@@ -119,6 +120,14 @@ func (c *showApplicationCommand) Run(ctx *cmd.Context) error {
                return err
        }
 
+       appName := tags[0].Id()
+       relations, err := client.CharmRelations(ctx, appName)
+       if err != nil {
+               return errors.Trace(err)
+       }
+       c.out.Write(ctx, relations)
+       return nil
+
        results, err := client.ApplicationsInfo(ctx, tags)
        if err != nil {
                return errors.Trace(err)
```
build juju, and run:
```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy postgresql
$ juju show-application postgresql
- cos-agent
- database
- db
- db-admin
- replication-offer
- certificates
- replication
- s3-parameters
- tracing
- upgrade
- database-peers
- restart
- juju-info
```