### PR TITLE
refactor(firewaller): drop Mongo-backed facade in firewaller

### DIFF
--- a/api/controller/firewaller/unit.go
+++ b/api/controller/firewaller/unit.go
@@ -6,11 +6,9 @@ package firewaller
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/core/life"
-	"github.com/juju/juju/rpc/params"
 )
 
 // Unit represents a juju unit as seen by a firewaller worker.
@@ -52,26 +50,4 @@ func (u *Unit) Application() (*Application, error) {
 		tag:    applicationTag,
 	}
 	return app, nil
-}
-
-// AssignedMachine returns the tag of this unit's assigned machine (if
-// any), or a CodeNotAssigned error.
-func (u *Unit) AssignedMachine(ctx context.Context) (names.MachineTag, error) {
-	var results params.StringResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: u.tag.String()}},
-	}
-	emptyTag := names.NewMachineTag("")
-	err := u.client.facade.FacadeCall(ctx, "GetAssignedMachine", args, &results)
-	if err != nil {
-		return emptyTag, err
-	}
-	if len(results.Results) != 1 {
-		return emptyTag, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return emptyTag, result.Error
-	}
-	return names.ParseMachineTag(result.Result)
 }

--- a/api/controller/firewaller/unit_test.go
+++ b/api/controller/firewaller/unit_test.go
@@ -80,42 +80,6 @@ func (s *unitSuite) TestRefresh(c *tc.C) {
 	c.Assert(calls, tc.Equals, 2)
 }
 
-func (s *unitSuite) TestAssignedMachine(c *tc.C) {
-	calls := 0
-	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, tc.Equals, "Firewaller")
-		c.Check(version, tc.Equals, 0)
-		c.Check(id, tc.Equals, "")
-		c.Assert(arg, tc.DeepEquals, params.Entities{
-			Entities: []params.Entity{{Tag: "unit-mysql-666"}},
-		})
-		if calls > 0 {
-			c.Check(request, tc.Equals, "GetAssignedMachine")
-			c.Assert(result, tc.FitsTypeOf, &params.StringResults{})
-			*(result.(*params.StringResults)) = params.StringResults{
-				Results: []params.StringResult{{Result: "machine-666"}},
-			}
-		} else {
-			c.Check(request, tc.Equals, "Life")
-			c.Assert(result, tc.FitsTypeOf, &params.LifeResults{})
-			*(result.(*params.LifeResults)) = params.LifeResults{
-				Results: []params.LifeResult{{Life: life.Alive}},
-			}
-		}
-		calls++
-		return nil
-	})
-	tag := names.NewUnitTag("mysql/666")
-	client, err := firewaller.NewClient(apiCaller)
-	c.Assert(err, tc.ErrorIsNil)
-	u, err := client.Unit(c.Context(), tag)
-	c.Assert(err, tc.ErrorIsNil)
-	m, err := u.AssignedMachine(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(m.Id(), tc.Equals, "666")
-	c.Assert(calls, tc.Equals, 2)
-}
-
 func (s *unitSuite) TestApplication(c *tc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, tc.Equals, "Firewaller")

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1297,7 +1297,7 @@ func (st *State) insertIAASUnit(
 	// Handle the placement of the net node and machines accompanying the unit.
 	nodeUUID, err := st.placeMachine(ctx, tx, args.Placement)
 	if err != nil {
-		return errors.Errorf("getting net node UUID from placement %q: %w", args.Placement, err)
+		return errors.Errorf("getting net node UUID from placement %+v: %w", args.Placement, err)
 	}
 
 	if err := st.insertUnit(ctx, tx, appUUID, unitUUID, nodeUUID, insertUnitArg{

--- a/internal/worker/firewaller/interface.go
+++ b/internal/worker/firewaller/interface.go
@@ -121,6 +121,15 @@ type ApplicationService interface {
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetExposedEndpoints(ctx context.Context, appName string) (map[string]application.ExposedEndpoint, error)
+
+	// GetUnitMachineName gets the name of the unit's machine.
+	//
+	// The following errors may be returned:
+	//   - [applicationerrors.UnitMachineNotAssigned] if the unit does not have a
+	//     machine assigned.
+	//   - [applicationerrors.UnitNotFound] if the unit cannot be found.
+	//   - [applicationerrors.UnitIsDead] if the unit is dead.
+	GetUnitMachineName(context.Context, unit.Name) (machine.Name, error)
 }
 
 // EnvironFirewaller defines methods to allow the worker to perform
@@ -161,7 +170,6 @@ type Unit interface {
 	Life() life.Value
 	Refresh(ctx context.Context) error
 	Application() (Application, error)
-	AssignedMachine(context.Context) (names.MachineTag, error)
 }
 
 // Application represents a model application.

--- a/internal/worker/firewaller/mocks/domain_mocks.go
+++ b/internal/worker/firewaller/mocks/domain_mocks.go
@@ -246,6 +246,45 @@ func (c *MockApplicationServiceGetExposedEndpointsCall) DoAndReturn(f func(conte
 	return c
 }
 
+// GetUnitMachineName mocks base method.
+func (m *MockApplicationService) GetUnitMachineName(arg0 context.Context, arg1 unit.Name) (machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitMachineName", arg0, arg1)
+	ret0, _ := ret[0].(machine.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitMachineName indicates an expected call of GetUnitMachineName.
+func (mr *MockApplicationServiceMockRecorder) GetUnitMachineName(arg0, arg1 any) *MockApplicationServiceGetUnitMachineNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitMachineName", reflect.TypeOf((*MockApplicationService)(nil).GetUnitMachineName), arg0, arg1)
+	return &MockApplicationServiceGetUnitMachineNameCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitMachineNameCall wrap *gomock.Call
+type MockApplicationServiceGetUnitMachineNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitMachineNameCall) Return(arg0 machine.Name, arg1 error) *MockApplicationServiceGetUnitMachineNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitMachineNameCall) Do(f func(context.Context, unit.Name) (machine.Name, error)) *MockApplicationServiceGetUnitMachineNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitMachineNameCall) DoAndReturn(f func(context.Context, unit.Name) (machine.Name, error)) *MockApplicationServiceGetUnitMachineNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // IsApplicationExposed mocks base method.
 func (m *MockApplicationService) IsApplicationExposed(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/worker/firewaller/mocks/entity_mocks.go
+++ b/internal/worker/firewaller/mocks/entity_mocks.go
@@ -259,45 +259,6 @@ func (c *MockUnitApplicationCall) DoAndReturn(f func() (firewaller.Application, 
 	return c
 }
 
-// AssignedMachine mocks base method.
-func (m *MockUnit) AssignedMachine(arg0 context.Context) (names.MachineTag, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignedMachine", arg0)
-	ret0, _ := ret[0].(names.MachineTag)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AssignedMachine indicates an expected call of AssignedMachine.
-func (mr *MockUnitMockRecorder) AssignedMachine(arg0 any) *MockUnitAssignedMachineCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedMachine", reflect.TypeOf((*MockUnit)(nil).AssignedMachine), arg0)
-	return &MockUnitAssignedMachineCall{Call: call}
-}
-
-// MockUnitAssignedMachineCall wrap *gomock.Call
-type MockUnitAssignedMachineCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockUnitAssignedMachineCall) Return(arg0 names.MachineTag, arg1 error) *MockUnitAssignedMachineCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockUnitAssignedMachineCall) Do(f func(context.Context) (names.MachineTag, error)) *MockUnitAssignedMachineCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitAssignedMachineCall) DoAndReturn(f func(context.Context) (names.MachineTag, error)) *MockUnitAssignedMachineCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // Life mocks base method.
 func (m *MockUnit) Life() life.Value {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The firewaller worker api used to call the controller facade GetAssignedMachine to get the machine id a unit is assigned to. This facade was backed by Mongo.

However, the firewaller have direct access to the application service. So I have dropped the facade entirely, and instead use the service to get the assigned machine directly.

As a flyby, restructure the firewaller to used machine names instead of machine tags, since tags are an api thing, and we are trying to gradually bypass the api for the firewaller.

## QA steps

```
$ juju bootstrap aws aws
$ juju add-model m
$ juju deploy mysql
```
The unit will likely go into error state. If it does:
```
$ juju resolve mysql/0 --no-retry
```
Then:
```
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      aws         aws/eu-west-2  4.0-beta6.1  14:54:18+01:00

App    Version          Status  Scale  Charm  Channel     Rev  Exposed  Message
mysql  8.0.41-0ubun...  active      1  mysql  8.0/stable  366  no       Primary

Unit      Workload  Agent  Machine  Public address  Ports           Message
mysql/0*  active    idle                            3306,33060/tcp  Primary

Machine  State    Address       Inst id              Base          AZ          Message
0        started  18.175.51.20  i-035c45d3e38b7ff95  ubuntu@22.04  eu-west-2c  running

$ juju expose mysql
```
and check controller debug logs for:
```
machine-0: 14:55:37 INFO juju.provider.ec2 opened ports in security group juju-91fbaf54-4467-44a9-8c03-830594edd362-0: [3306/tcp from 0.0.0.0/0,::/0 33060/tcp from 0.0.0.0/0,::/0]
```