### PR TITLE
fix: move WatchConsumedSecretsChanges to namespace mapper watcher

### DIFF
--- a/core/watcher/eventsource/legacy.go
+++ b/core/watcher/eventsource/legacy.go
@@ -92,31 +92,20 @@ type MultiWatcher[T any] struct {
 // NewMultiNotifyWatcher creates a NotifyWatcher that combines
 // each of the NotifyWatchers passed in. Each watcher's initial
 // event is consumed, and a single initial event is sent.
-// Deprecated: use NewMultiValueWatcher instead.
+// Deprecated: do not use, use NewNotifyMapperWatcher instead.
 func NewMultiNotifyWatcher(ctx context.Context, watchers ...Watcher[struct{}]) (*MultiWatcher[struct{}], error) {
 	applier := func(_, _ struct{}) struct{} {
 		return struct{}{}
 	}
-	return NewMultiWatcher[struct{}](ctx, applier, watchers...)
+	return newMultiWatcher[struct{}](ctx, applier, watchers...)
 }
 
-// NewMultiStringsWatcher creates a strings watcher (Watcher[[]string]) that
-// combines each of the (strings) watchers passed in. Each watcher's initial
-// event is consumed, and a single initial event is sent.
-// Deprecated: this should not be used. Use NewMultiValueWatcher instead.
-func NewMultiStringsWatcher(ctx context.Context, watchers ...Watcher[[]string]) (*MultiWatcher[[]string], error) {
-	applier := func(staging, in []string) []string {
-		return append(staging, in...)
-	}
-	return NewMultiWatcher[[]string](ctx, applier, watchers...)
-}
-
-// NewMultiWatcher creates a NotifyWatcher that combines
+// newMultiWatcher creates a NotifyWatcher that combines
 // each of the NotifyWatchers passed in. Each watcher's initial
 // event is consumed, and a single initial event is sent.
 // Subsequent events are not coalesced.
-// Deprecated: use NewMultiValueWatcher instead.
-func NewMultiWatcher[T any](ctx context.Context, applier Applier[T], watchers ...Watcher[T]) (*MultiWatcher[T], error) {
+// Deprecated: delete when NewMultiNotifyWatcher is gone.
+func newMultiWatcher[T any](ctx context.Context, applier Applier[T], watchers ...Watcher[T]) (*MultiWatcher[T], error) {
 	workers := make([]worker.Worker, len(watchers))
 	for i, w := range watchers {
 		_, err := ConsumeInitialEvent[T](ctx, w)

--- a/core/watcher/eventsource/legacy_test.go
+++ b/core/watcher/eventsource/legacy_test.go
@@ -51,44 +51,6 @@ func (*multiWatcherSuite) TestNotifyMultiWatcher(c *tc.C) {
 	workertest.CleanKill(c, w)
 }
 
-func (*multiWatcherSuite) TestStringsMultiWatcher(c *tc.C) {
-	ch0 := make(chan []string, 1)
-	w0 := watchertest.NewMockStringsWatcher(ch0)
-	defer workertest.DirtyKill(c, w0)
-
-	ch1 := make(chan []string, 1)
-	w1 := watchertest.NewMockStringsWatcher(ch1)
-	defer workertest.DirtyKill(c, w1)
-
-	// Initial events are consumed by the multiwatcher.
-	ch0 <- []string{}
-	ch1 <- []string{}
-
-	w, err := NewMultiStringsWatcher(c.Context(), w0, w1)
-	c.Assert(err, tc.ErrorIsNil)
-
-	wc := watchertest.NewStringsWatcherC(c, w)
-	defer workertest.DirtyKill(c, w)
-
-	wc.AssertChange()
-
-	ch0 <- []string{"a", "b"}
-	ch1 <- []string{"c", "d"}
-
-	wc.AssertChange("a", "b", "c", "d")
-
-	ch0 <- []string{"e"}
-	wc.AssertChange("e")
-	ch1 <- []string{"f"}
-	wc.AssertChange("f")
-
-	ch0 <- []string{"g"}
-	ch1 <- []string{"h"}
-	wc.AssertAtLeastOneChange()
-
-	workertest.CleanKill(c, w)
-}
-
 func (*multiWatcherSuite) TestMultiWatcherStop(c *tc.C) {
 	ch0 := make(chan struct{}, 1)
 	w0 := watchertest.NewMockNotifyWatcher(ch0)

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -51,7 +51,7 @@ func NewWatchableService(
 // WatchConsumedSecretsChanges watches secrets consumed by the specified unit
 // and returns a watcher which notifies of secret URIs that have had a new revision added.
 func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unitName coreunit.Name) (watcher.StringsWatcher, error) {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	_, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	tableLocal, queryLocal := s.secretState.InitialWatchStatementForConsumedSecretsChange(unitName)

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -520,6 +520,8 @@ func (s *watcherSuite) TestWatchConsumedSecretsChanges(c *tc.C) {
 	})
 	harness.Run(c, []string(nil))
 
+	c.Logf("check revision two of %s fires", uri1.String())
+
 	// Pretend that the agent restarted and the watcher is re-created.
 	w1, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
 	c.Assert(err, tc.IsNil)
@@ -527,22 +529,15 @@ func (s *watcherSuite) TestWatchConsumedSecretsChanges(c *tc.C) {
 	defer watchertest.CleanKill(c, w1)
 
 	harness1 := watchertest.NewHarness(s, watchertest.NewWatcherC(c, w1))
-	harness1.AddTest(func(c *tc.C) {}, func(w watchertest.WatcherC[[]string]) {
-		w.Check(
-			watchertest.StringSliceAssert(
-				uri1.String(),
-			),
-		)
-	})
-
 	harness1.AddTest(func(c *tc.C) {
 		// The consumed revision 2 is the updated current_revision.
 		saveConsumer(uri1, 2, "mediawiki/0")
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.AssertNoChange()
 	})
+	harness1.Run(c, []string{uri1.String()})
 
-	harness1.Run(c, []string(nil))
+	c.Log("check no uris are fired as all revisions are consumed")
 
 	// Pretend that the agent restarted and the watcher is re-created again.
 	// Since we comsume the latest revision already, so there should be no change.
@@ -593,7 +588,6 @@ func (s *watcherSuite) TestWatchConsumedRemoteSecretsChanges(c *tc.C) {
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.AssertNoChange()
 	})
-
 	// We update the remote secret revision to 2.
 	// A remote consumed secret change event of uri1 should be fired.
 	harness.AddTest(func(c *tc.C) {
@@ -606,7 +600,6 @@ func (s *watcherSuite) TestWatchConsumedRemoteSecretsChanges(c *tc.C) {
 			),
 		)
 	})
-
 	harness.Run(c, []string(nil))
 
 	// Pretend that the agent restarted and the watcher is re-created.
@@ -615,22 +608,13 @@ func (s *watcherSuite) TestWatchConsumedRemoteSecretsChanges(c *tc.C) {
 	defer watchertest.CleanKill(c, w1)
 
 	harness1 := watchertest.NewHarness(s, watchertest.NewWatcherC(c, w1))
-	harness1.AddTest(func(c *tc.C) {}, func(w watchertest.WatcherC[[]string]) {
-		w.Check(
-			watchertest.StringSliceAssert(
-				uri1.String(),
-			),
-		)
-	})
-
 	harness1.AddTest(func(c *tc.C) {
 		// The consumed revision 2 is the updated current_revision.
 		saveConsumer(uri1, 2, "mediawiki/0")
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.AssertNoChange()
 	})
-
-	harness1.Run(c, []string(nil))
+	harness1.Run(c, []string{uri1.String()})
 
 	// Pretend that the agent restarted and the watcher is re-created again.
 	// Since we consume the latest revision already, so there should be no


### PR DESCRIPTION
Move the consumed secrets changes watcher to a namespace mapper watcher
so that the initial events are correctly sent through rather than being tossed out.

This change removes flakiness on the consumed secrets changes watcher tests.

This change also, since it is no longer used, removes the deprecated `eventsource`
helper function `NewMultiStringsWatcher` and unexports `NewMultiWatcher`.

## QA steps

Unit tests.

## Links

**Jira card:** JUJU-7966
