### PR TITLE
feat: wire unit public and private address in uniter

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -195,6 +195,28 @@ type ApplicationService interface {
 	// upgrade to the latest version of the application charm even if they are in
 	// error state.
 	ShouldAllowCharmUpgradeOnError(ctx context.Context, appName string) (bool, error)
+
+	// GetUnitPublicAddress returns the public address for the specified unit.
+	// For k8s provider, it will return the first public address of the cloud
+	// service if any, the first public address of the cloud container otherwise.
+	// For machines provider, it will return the first public address of the
+	// machine.
+	//
+	// The following errors may be returned:
+	// - [applicationerrors.UnitNotFound] if the unit does not exist
+	// - [network.NoAddressError] if the unit has no public address associated
+	GetUnitPublicAddress(ctx context.Context, unitName coreunit.Name) (network.SpaceAddress, error)
+
+	// GetUnitPrivateAddress returns the private address for the specified unit.
+	// For k8s provider, it will return the first private address of the cloud
+	// service if any, the first private address of the cloud container otherwise.
+	// For machines provider, it will return the first private address of the
+	// machine.
+	//
+	// The following errors may be returned:
+	// - [applicationerrors.UnitNotFound] if the unit does not exist
+	// - [network.NoAddressError] if the unit has no private address associated
+	GetUnitPrivateAddress(ctx context.Context, unitName coreunit.Name) (network.SpaceAddress, error)
 }
 
 type ResolveService interface {

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -19,6 +19,7 @@ import (
 	life "github.com/juju/juju/core/life"
 	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
+	network "github.com/juju/juju/core/network"
 	relation "github.com/juju/juju/core/relation"
 	status "github.com/juju/juju/core/status"
 	unit "github.com/juju/juju/core/unit"
@@ -711,6 +712,84 @@ func (c *MockApplicationServiceGetUnitPrincipalCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetUnitPrincipalCall) DoAndReturn(f func(context.Context, unit.Name) (unit.Name, bool, error)) *MockApplicationServiceGetUnitPrincipalCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitPrivateAddress mocks base method.
+func (m *MockApplicationService) GetUnitPrivateAddress(arg0 context.Context, arg1 unit.Name) (network.SpaceAddress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitPrivateAddress", arg0, arg1)
+	ret0, _ := ret[0].(network.SpaceAddress)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitPrivateAddress indicates an expected call of GetUnitPrivateAddress.
+func (mr *MockApplicationServiceMockRecorder) GetUnitPrivateAddress(arg0, arg1 any) *MockApplicationServiceGetUnitPrivateAddressCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitPrivateAddress", reflect.TypeOf((*MockApplicationService)(nil).GetUnitPrivateAddress), arg0, arg1)
+	return &MockApplicationServiceGetUnitPrivateAddressCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitPrivateAddressCall wrap *gomock.Call
+type MockApplicationServiceGetUnitPrivateAddressCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitPrivateAddressCall) Return(arg0 network.SpaceAddress, arg1 error) *MockApplicationServiceGetUnitPrivateAddressCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitPrivateAddressCall) Do(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockApplicationServiceGetUnitPrivateAddressCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitPrivateAddressCall) DoAndReturn(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockApplicationServiceGetUnitPrivateAddressCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitPublicAddress mocks base method.
+func (m *MockApplicationService) GetUnitPublicAddress(arg0 context.Context, arg1 unit.Name) (network.SpaceAddress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitPublicAddress", arg0, arg1)
+	ret0, _ := ret[0].(network.SpaceAddress)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitPublicAddress indicates an expected call of GetUnitPublicAddress.
+func (mr *MockApplicationServiceMockRecorder) GetUnitPublicAddress(arg0, arg1 any) *MockApplicationServiceGetUnitPublicAddressCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitPublicAddress", reflect.TypeOf((*MockApplicationService)(nil).GetUnitPublicAddress), arg0, arg1)
+	return &MockApplicationServiceGetUnitPublicAddressCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitPublicAddressCall wrap *gomock.Call
+type MockApplicationServiceGetUnitPublicAddressCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitPublicAddressCall) Return(arg0 network.SpaceAddress, arg1 error) *MockApplicationServiceGetUnitPublicAddressCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitPublicAddressCall) Do(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockApplicationServiceGetUnitPublicAddressCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitPublicAddressCall) DoAndReturn(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockApplicationServiceGetUnitPublicAddressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
This small patch wires the unit address (public/private) retrieval to the dqlite application domain.

Tests were added to the uniter facade for the 3 updated methods.

## QA steps

Relating two units should be enough since they'll get the addresses and network info:

```
juju bootstrap lxd c
juju add-model m
juju deploy juju-qa-dummy-source src --config token="foo"
juju deploy juju-qa-dummy-sink sink
juju integrate src sink
```

## Links
**Jira card:** JUJU-7819
