### PR TITLE
chore: fix wrong release date for 3.6.6

### DIFF
--- a/docs/reference/juju/juju-roadmap-and-releases.md
+++ b/docs/reference/juju/juju-roadmap-and-releases.md
@@ -47,7 +47,7 @@ See the full list in the [milestone page](https://launchpad.net/juju/+milestone/
 Juju 3.6 series is LTS
 ```
 
-### 🔸 **Juju 3.6.6** - 14 May 2025
+### 🔸 **Juju 3.6.6** - 29 May 2025
 ⚙️ Features:
 * feat(secrets): handle NotFound errors in secret backend during `RemoveUserSecrets` by @ca-scribner in [#19169](https://github.com/juju/juju/pull/19169)
 * feat: open firewall ports for SSH server  proxy by @kian99 in [#19180](https://github.com/juju/juju/pull/19180)


### PR DESCRIPTION
This PR just fixes the date.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
# just need to pass checks
```

## Links

**Jira card:** JUJU-
