### PR TITLE
fix: shebang line for Dqlite scripts

### DIFF
--- a/scripts/dqlite/scripts/dqlite/build-lxd.sh
+++ b/scripts/dqlite/scripts/dqlite/build-lxd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/dqlite/scripts/dqlite/build.sh
+++ b/scripts/dqlite/scripts/dqlite/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/dqlite/scripts/dqlite/dqlite-build.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 
 build() {

--- a/scripts/dqlite/scripts/dqlite/dqlite-install.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/dqlite/scripts/dqlite/install-if-missing.sh
+++ b/scripts/dqlite/scripts/dqlite/install-if-missing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/dqlite/scripts/dqlite/install.sh
+++ b/scripts/dqlite/scripts/dqlite/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/dqlite/scripts/dqlite/push.sh
+++ b/scripts/dqlite/scripts/dqlite/push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/dqlite/scripts/musl/install-if-missing.sh
+++ b/scripts/dqlite/scripts/musl/install-if-missing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/dqlite/scripts/musl/install.sh
+++ b/scripts/dqlite/scripts/musl/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
The Dqlite bash scripts that we have for Juju 4.0 all assumed the location of the bash interpreter. This value changes based on the POSIX system. The safer shebang line is to evaluate with env.

Doing this our Dqlite scripts are now more portable. Found when producing a development container for Juju.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Running `make install` or `make build` will assert the script files.

## Documentation changes

N/A

## Links

