### PR TITLE
fix: remove last vestiges of bash shebang path

### DIFF
--- a/.github/verify-agent-version.sh
+++ b/.github/verify-agent-version.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/.github/verify-apache2.sh
+++ b/.github/verify-apache2.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/.github/verify-snappass-test.sh
+++ b/.github/verify-snappass-test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -eux
 

--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/leadershipclaimer/run.sh
+++ b/scripts/leadershipclaimer/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CONTROLLERS="10.132.183.12,10.132.183.101,10.132.183.127"
 UUID="a5fa603d-5385-4ffc-85b5-79f6ba0eafab"

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # juju_version will return only the version and not the architecture/substrate
 # of the juju version. If JUJU_VERSION is defined in CI this value will be used
 # otherwise we interrogate the juju binary on path.

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 [ -n "${GOPATH:-}" ] && export "PATH=${PATH}:${GOPATH}/bin"
 
 export SKIP_DESTROY="${SKIP_DESTROY:-}"

--- a/tests/suites/storage/model_storage_block.sh
+++ b/tests/suites/storage/model_storage_block.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test that model config default storage type is used when not specified.
 # This test verifies that when storage type is not explicitly specified,

--- a/tests/suites/storage/model_storage_filesystem.sh
+++ b/tests/suites/storage/model_storage_filesystem.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test that model config default storage type is used when not specified.
 # This test verifies that when storage type is not explicitly specified,


### PR DESCRIPTION
This commit removes the last remaining shebang lines in bash scripts that are assuming the path to the bash interpreter. This assumption tends to break on POSIX systems that install bash in a location that isn't the one hardcoded by the script.

The more portable and safer solution given the number of environments Juju scripts have to run on, is to use env to find bash on behalf of the script.

In follow up to #19870.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[] Comments saying why design decisions were made~
- ~[] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Not needed. Visual inspection is fine.

## Documentation changes

N/A
