### PR TITLE
feat: remove unit shim in the uniter

### DIFF
--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -26,7 +26,6 @@ var (
 )
 
 type (
-	Backend                    backend
 	StorageStateInterface      storageInterface
 	StorageVolumeInterface     = storageVolumeInterface
 	StorageFilesystemInterface = storageFilesystemInterface
@@ -56,13 +55,13 @@ func NewTestAPI(
 }
 
 func NewStorageAPI(
-	backend backend,
 	storage storageAccess,
 	blockDeviceService blockDeviceService,
+	applicationService ApplicationService,
 	resources facade.Resources,
 	accessUnit common.GetAuthFunc,
 ) (*StorageAPI, error) {
-	return newStorageAPI(backend, storage, blockDeviceService, resources, accessUnit)
+	return newStorageAPI(storage, blockDeviceService, applicationService, resources, accessUnit)
 }
 
 func SetNewContainerBrokerFunc(api *UniterAPI, newBroker caas.NewContainerBrokerFunc) {

--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -108,7 +108,12 @@ func newUniterAPIWithServices(
 		return nil, errors.Trace(err)
 	}
 	storageAPI, err := newStorageAPI(
-		stateShim{st}, storageAccessor, context.DomainServices().BlockDevice(), resources, accessUnit)
+		storageAccessor,
+		context.DomainServices().BlockDevice(),
+		context.DomainServices().Application(),
+		resources,
+		accessUnit,
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -90,9 +90,11 @@ type ApplicationService interface {
 	// GetUnitPrincipal returns the unit's principal unit if it exists
 	GetUnitPrincipal(ctx context.Context, unitName coreunit.Name) (coreunit.Name, bool, error)
 
-	// GetUnitMachineName gets the name of the unit's machine. If the unit's
-	// machine cannot be found [applicationerrors.UnitMachineNotAssigned] is
-	// returned.
+	// GetUnitMachineName gets the name of the unit's machine.
+	//
+	// The following errors may be returned:
+	//   - [applicationerrors.UnitMachineNotAssigned] if the unit does not have a
+	//     machine assigned.
 	GetUnitMachineName(ctx context.Context, unitName coreunit.Name) (coremachine.Name, error)
 
 	// GetUnitMachineUUID gets the uuid of the unit's machine. If the unit's

--- a/apiserver/facades/agent/uniter/state.go
+++ b/apiserver/facades/agent/uniter/state.go
@@ -6,7 +6,6 @@ package uniter
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/core/blockdevice"
@@ -84,51 +83,10 @@ func (s *storageShim) FilesystemAccess() storageFilesystemInterface {
 	return s.fa
 }
 
-type backend interface {
-	Unit(string) (Unit, error)
-	ApplyOperation(state.ModelOperation) error
-}
-
-type Unit interface {
-	AssignedMachineId() (string, error)
-	ShouldBeAssigned() bool
-	StorageConstraints() (map[string]state.StorageConstraints, error)
-}
-
-type stateShim struct {
-	*state.State
-}
-
-func (s stateShim) Unit(name string) (Unit, error) {
-	return s.State.Unit(name)
-}
-
-// unitAssignedMachine returns the tag of the machine that the unit
-// is assigned to, or an error if the unit cannot be obtained or is
-// not assigned to a machine.
-func unitAssignedMachine(backend backend, tag names.UnitTag) (names.MachineTag, error) {
-	unit, err := backend.Unit(tag.Id())
-	if err != nil {
-		return names.MachineTag{}, errors.Trace(err)
-	}
-	mid, err := unit.AssignedMachineId()
-	if err != nil {
-		return names.MachineTag{}, errors.Trace(err)
-	}
-	return names.NewMachineTag(mid), nil
-}
-
 // unitStorageConstraints returns storage constraints for this unit,
 // or an error if the unit or its constraints cannot be obtained.
-func unitStorageConstraints(backend backend, u names.UnitTag) (map[string]state.StorageConstraints, error) {
-	unit, err := backend.Unit(u.Id())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	cons, err := unit.StorageConstraints()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return cons, nil
+func unitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error) {
+	// TODO(nvinuesa): This method must be filled when wiring up the storage
+	// domain.
+	return nil, nil
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2717,7 +2717,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(
 			return apiservererrors.ErrPerm
 		}
 
-		curCons, err := unitStorageConstraints(u.StorageAPI.backend, unitTag)
+		curCons, err := unitStorageConstraints(unitTag)
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
This patch removes the last usages of the unit legacy state in favor of the dqlite domain.

Note: The method `unitStorageConstraints()` is left as an empty method and will need to be implemented when wiring storage.


## QA steps

Storage is broken, so the unit tests in the uniter facade should be enough.

## Links

**Jira card:** JUJU-7819
