### PR TITLE
feat: wire the deployer unit removal

### DIFF
--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -5,6 +5,7 @@ package deployer
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -23,6 +24,7 @@ import (
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/removal"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -44,17 +46,26 @@ type ControllerConfigGetter interface {
 
 // ApplicationService removes a unit from the dqlite database.
 type ApplicationService interface {
-	GetUnitLife(context.Context, coreunit.Name) (life.Value, error)
-	EnsureUnitDead(context.Context, coreunit.Name, leadership.Revoker) error
-	RemoveUnit(context.Context, coreunit.Name, leadership.Revoker) error
+	// GetUnitLife looks up the life of the specified unit.
+	//
+	// The following errors may be returned:
+	// - [applicationerrors.UnitNotFound] if the unit doesn't exist.
+	GetUnitLife(ctx context.Context, unitName coreunit.Name) (life.Value, error)
 
 	// WatchUnitAddRemoveOnMachine returns a watcher that observes changes to
 	// the units on a specified machine, emitting the names of the units. That
 	// is, we emit unit names only when a unit is created or deleted on the
 	// specified machine.
+	//
 	// The following errors may be returned:
 	// - [applicationerrors.MachineNotFound] if the machine does not exist
 	WatchUnitAddRemoveOnMachine(context.Context, machine.Name) (watcher.StringsWatcher, error)
+
+	// GetUnitUUID returns the UUID for the named unit.
+	//
+	// The following errors may be returned:
+	// - [applicationerrors.UnitNotFound] if the unit doesn't exist.
+	GetUnitUUID(ctx context.Context, unitName coreunit.Name) (coreunit.UUID, error)
 }
 
 type StatusService interface {
@@ -65,6 +76,19 @@ type StatusService interface {
 	// SetUnitWorkloadStatus sets the workload status of the specified unit, returning an
 	// error satisfying [applicationerrors.UnitNotFound] if the unit doesn't exist.
 	SetUnitWorkloadStatus(context.Context, coreunit.Name, corestatus.StatusInfo) error
+}
+
+// RemovalService defines operations for removing juju entities.
+type RemovalService interface {
+	// RemoveUnit checks if a unit with the input name exists.
+	// If it does, the unit is guaranteed after this call to be:
+	// - No longer alive.
+	// - Removed or scheduled to be removed with the input force qualification.
+	// The input wait duration is the time that we will give for the normal
+	// life-cycle advancement and removal to finish before forcefully removing the
+	// unit. This duration is ignored if the force argument is false.
+	// The UUID for the scheduled removal job is returned.
+	RemoveUnit(ctx context.Context, unitUUID coreunit.UUID, force bool, wait time.Duration) (removal.UUID, error)
 }
 
 // DeployerAPI provides access to the Deployer API facade.
@@ -78,6 +102,7 @@ type DeployerAPI struct {
 
 	controllerConfigGetter ControllerConfigGetter
 	applicationService     ApplicationService
+	removalService         RemovalService
 	leadershipRevoker      leadership.Revoker
 
 	store           objectstore.ObjectStore
@@ -94,6 +119,7 @@ func NewDeployerAPI(
 	controllerConfigGetter ControllerConfigGetter,
 	applicationService ApplicationService,
 	statusService StatusService,
+	removalService RemovalService,
 	authorizer facade.Authorizer,
 	st *state.State,
 	store objectstore.ObjectStore,
@@ -136,6 +162,7 @@ func NewDeployerAPI(
 		unitStatusSetter:       common.NewUnitStatusSetter(statusService, clock, getAuthFunc),
 		controllerConfigGetter: controllerConfigGetter,
 		applicationService:     applicationService,
+		removalService:         removalService,
 		leadershipRevoker:      leadershipRevoker,
 		canRead:                auth,
 		canWrite:               auth,
@@ -291,8 +318,8 @@ func getAllUnits(st *state.State, tag names.Tag) ([]string, error) {
 	return nil, errors.Errorf("cannot obtain units of machine %q: %v", tag, watch.Err())
 }
 
-// Remove removes every given unit from state, calling EnsureDead
-// first, then Remove.
+// Remove removes every given unit from the application domain, this is ensured
+// by the removal domain.
 func (d *DeployerAPI) Remove(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
@@ -312,55 +339,17 @@ func (d *DeployerAPI) Remove(ctx context.Context, args params.Entities) (params.
 			continue
 		}
 
-		// TODO(units) - remove me.
-		// Dual write to state.
-		// We need to set the unit life to Dead in state **first**
-		// because the life watcher is currently looking at state
-		// not dqlite.
-		unit, err := d.st.Unit(tag.Id())
-		if err != nil {
-			if errors.Is(err, errors.NotFound) {
-				err = apiservererrors.ErrPerm
-			}
-			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-		if unit.Life() == state.Alive {
-			result.Results[i].Error = apiservererrors.ServerError(errors.Errorf("cannot remove unit %q: still alive", tag.Id()))
-			continue
-		}
-		if err := unit.EnsureDead(); err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-
-		unitName, err := coreunit.NewName(tag.Id())
+		unitUUID, err := d.applicationService.GetUnitUUID(ctx, coreunit.Name(tag.Id()))
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		// Given the way dual write works, we need this for now.
-		if err = d.applicationService.EnsureUnitDead(ctx, unitName, d.leadershipRevoker); err != nil {
-			if errors.Is(err, applicationerrors.UnitNotFound) {
-				err = errors.NotFoundf("unit %s", unitName)
-			}
-			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-		// This is the call we will keep once mongo is removed.
-		// We will need to remove the alive check.
-		if err = d.applicationService.RemoveUnit(ctx, unitName, d.leadershipRevoker); err != nil {
-			if errors.Is(err, applicationerrors.UnitNotFound) {
-				err = errors.NotFoundf("unit %s", unitName)
-			}
-			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
 
-		// TODO(units) - remove me.
-		if err := unit.Remove(d.store); err != nil {
+		_, err = d.removalService.RemoveUnit(ctx, unitUUID, false, 0)
+		if errors.Is(err, applicationerrors.UnitNotFound) {
+			result.Results[i].Error = apiservererrors.ServerError(errors.NotFoundf("unit %q", tag.Id()))
+		} else if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
 		}
 	}
 	return result, nil

--- a/apiserver/facades/agent/deployer/domain_mock_test.go
+++ b/apiserver/facades/agent/deployer/domain_mock_test.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	controller "github.com/juju/juju/controller"
-	leadership "github.com/juju/juju/core/leadership"
 	life "github.com/juju/juju/core/life"
 	machine "github.com/juju/juju/core/machine"
 	unit "github.com/juju/juju/core/unit"
@@ -107,44 +106,6 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// EnsureUnitDead mocks base method.
-func (m *MockApplicationService) EnsureUnitDead(arg0 context.Context, arg1 unit.Name, arg2 leadership.Revoker) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureUnitDead", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnsureUnitDead indicates an expected call of EnsureUnitDead.
-func (mr *MockApplicationServiceMockRecorder) EnsureUnitDead(arg0, arg1, arg2 any) *MockApplicationServiceEnsureUnitDeadCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureUnitDead", reflect.TypeOf((*MockApplicationService)(nil).EnsureUnitDead), arg0, arg1, arg2)
-	return &MockApplicationServiceEnsureUnitDeadCall{Call: call}
-}
-
-// MockApplicationServiceEnsureUnitDeadCall wrap *gomock.Call
-type MockApplicationServiceEnsureUnitDeadCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceEnsureUnitDeadCall) Return(arg0 error) *MockApplicationServiceEnsureUnitDeadCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceEnsureUnitDeadCall) Do(f func(context.Context, unit.Name, leadership.Revoker) error) *MockApplicationServiceEnsureUnitDeadCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceEnsureUnitDeadCall) DoAndReturn(f func(context.Context, unit.Name, leadership.Revoker) error) *MockApplicationServiceEnsureUnitDeadCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetUnitLife mocks base method.
 func (m *MockApplicationService) GetUnitLife(arg0 context.Context, arg1 unit.Name) (life.Value, error) {
 	m.ctrl.T.Helper()
@@ -184,40 +145,41 @@ func (c *MockApplicationServiceGetUnitLifeCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// RemoveUnit mocks base method.
-func (m *MockApplicationService) RemoveUnit(arg0 context.Context, arg1 unit.Name, arg2 leadership.Revoker) error {
+// GetUnitUUID mocks base method.
+func (m *MockApplicationService) GetUnitUUID(arg0 context.Context, arg1 unit.Name) (unit.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveUnit", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetUnitUUID", arg0, arg1)
+	ret0, _ := ret[0].(unit.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// RemoveUnit indicates an expected call of RemoveUnit.
-func (mr *MockApplicationServiceMockRecorder) RemoveUnit(arg0, arg1, arg2 any) *MockApplicationServiceRemoveUnitCall {
+// GetUnitUUID indicates an expected call of GetUnitUUID.
+func (mr *MockApplicationServiceMockRecorder) GetUnitUUID(arg0, arg1 any) *MockApplicationServiceGetUnitUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUnit", reflect.TypeOf((*MockApplicationService)(nil).RemoveUnit), arg0, arg1, arg2)
-	return &MockApplicationServiceRemoveUnitCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitUUID", reflect.TypeOf((*MockApplicationService)(nil).GetUnitUUID), arg0, arg1)
+	return &MockApplicationServiceGetUnitUUIDCall{Call: call}
 }
 
-// MockApplicationServiceRemoveUnitCall wrap *gomock.Call
-type MockApplicationServiceRemoveUnitCall struct {
+// MockApplicationServiceGetUnitUUIDCall wrap *gomock.Call
+type MockApplicationServiceGetUnitUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceRemoveUnitCall) Return(arg0 error) *MockApplicationServiceRemoveUnitCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockApplicationServiceGetUnitUUIDCall) Return(arg0 unit.UUID, arg1 error) *MockApplicationServiceGetUnitUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceRemoveUnitCall) Do(f func(context.Context, unit.Name, leadership.Revoker) error) *MockApplicationServiceRemoveUnitCall {
+func (c *MockApplicationServiceGetUnitUUIDCall) Do(f func(context.Context, unit.Name) (unit.UUID, error)) *MockApplicationServiceGetUnitUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceRemoveUnitCall) DoAndReturn(f func(context.Context, unit.Name, leadership.Revoker) error) *MockApplicationServiceRemoveUnitCall {
+func (c *MockApplicationServiceGetUnitUUIDCall) DoAndReturn(f func(context.Context, unit.Name) (unit.UUID, error)) *MockApplicationServiceGetUnitUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/deployer/register.go
+++ b/apiserver/facades/agent/deployer/register.go
@@ -42,15 +42,12 @@ func NewDeployerFacade(ctx facade.ModelContext) (*DeployerAPI, error) {
 
 	domainServices := ctx.DomainServices()
 
-	controllerConfigGetter := domainServices.ControllerConfig()
-	applicationService := domainServices.Application()
-	statusService := domainServices.Status()
-
 	return NewDeployerAPI(
 		domainServices.AgentPassword(),
-		controllerConfigGetter,
-		applicationService,
-		statusService,
+		domainServices.ControllerConfig(),
+		domainServices.Application(),
+		domainServices.Status(),
+		domainServices.Removal(),
 		authorizer,
 		st,
 		ctx.ObjectStore(),


### PR DESCRIPTION
This patch replaces the legacy state removal for units with the removal service, and at the same time get rid of the removal from the application domain.


## QA steps

Unit removal is currently broken on main, so the deployer methods (via the deployer worker) are not being called. Unit tests should pass though.

## Links

**Jira card:** JUJU-7819
