### PR TITLE
fix(deploy): fix a bug in deploy with --bind flag

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -134,7 +134,6 @@ func DeployApplication(
 		NumUnits:          args.NumUnits,
 		Placement:         args.Placement,
 		Resources:         args.Resources,
-		EndpointBindings:  args.EndpointBindings,
 	}
 
 	if !args.Charm.Meta().Subordinate {

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -130,7 +130,6 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(ctx context.Context, ar
 		CharmConfig:       dt.charmSettings,
 		CharmOrigin:       stOrigin,
 		Constraints:       dt.constraints,
-		EndpointBindings:  dt.endpoints,
 		Name:              dt.applicationName,
 		NumUnits:          dt.numUnits,
 		Placement:         dt.placement,
@@ -403,12 +402,7 @@ func (v *deployFromRepositoryValidator) validate(ctx context.Context, arg params
 	dt.placement = arg.Placement
 	dt.storage = arg.Storage
 	if len(arg.EndpointBindings) > 0 {
-		bindings, err := v.newStateBindings(v.state, arg.EndpointBindings)
-		if err != nil {
-			errs = append(errs, err)
-		} else {
-			dt.endpoints = bindings.Map()
-		}
+		dt.endpoints = arg.EndpointBindings
 	}
 
 	// Resolve resources and validate against the charm metadata.

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -100,10 +100,6 @@ type NetworkService interface {
 	// An error is returned if the space does not exist or if there was a problem
 	// accessing its information.
 	Space(ctx context.Context, uuid string) (*network.SpaceInfo, error)
-	// SpaceByName returns a space from state that matches the input name.
-	// An error is returned that satisfied errors.NotFound if the space was not found
-	// or an error static any problems fetching the given space.
-	SpaceByName(ctx context.Context, name string) (*network.SpaceInfo, error)
 	// GetAllSpaces returns all spaces for the model.
 	GetAllSpaces(ctx context.Context) (network.SpaceInfos, error)
 }

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -143,45 +143,6 @@ func (c *MockNetworkServiceSpaceCall) DoAndReturn(f func(context.Context, string
 	return c
 }
 
-// SpaceByName mocks base method.
-func (m *MockNetworkService) SpaceByName(arg0 context.Context, arg1 string) (*network.SpaceInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SpaceByName", arg0, arg1)
-	ret0, _ := ret[0].(*network.SpaceInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SpaceByName indicates an expected call of SpaceByName.
-func (mr *MockNetworkServiceMockRecorder) SpaceByName(arg0, arg1 any) *MockNetworkServiceSpaceByNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceByName", reflect.TypeOf((*MockNetworkService)(nil).SpaceByName), arg0, arg1)
-	return &MockNetworkServiceSpaceByNameCall{Call: call}
-}
-
-// MockNetworkServiceSpaceByNameCall wrap *gomock.Call
-type MockNetworkServiceSpaceByNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockNetworkServiceSpaceByNameCall) Return(arg0 *network.SpaceInfo, arg1 error) *MockNetworkServiceSpaceByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockNetworkServiceSpaceByNameCall) Do(f func(context.Context, string) (*network.SpaceInfo, error)) *MockNetworkServiceSpaceByNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkServiceSpaceByNameCall) DoAndReturn(f func(context.Context, string) (*network.SpaceInfo, error)) *MockNetworkServiceSpaceByNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // MockStorageInterface is a mock of StorageInterface interface.
 type MockStorageInterface struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
In the apiserver, the deploy facade would map our endpoint binding space names to space ids. This was an accommodation for Mongo.

However, the application service expects endpoint bindings with space names, not ids. This leads to a failure to deploy with bindings other than the default.

Fortunately, we no longer need to write our endpoint bindings to Mongo, as we are very close to fully cutting over to DQLite.

So drop the writing of endpoint bindings to Mongo, and drop the translation to space ids.

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju add-space beta
$ juju move-to-space beta 172.17.0.0/16
$ juju deploy postgresql --bind "database=beta"
Deployed "postgresql" from charm-hub charm "postgresql", revision 553 in channel 14/stable on ubuntu@22.04/stable

$ juju show-application postgresql
postgresql:
  charm: postgresql
  base: ubuntu@22.04
  principal: true
  exposed: false
  remote: false
  life: alive
  endpoint-bindings:
    "": alpha
    certificates: alpha
    cos-agent: alpha
    database: beta
    database-peers: alpha
    db: alpha
    db-admin: alpha
    juju-info: alpha
    replication: alpha
    replication-offer: alpha
    restart: alpha
    s3-parameters: alpha
    tracing: alpha
    upgrade: alpha
```
