### PR TITLE
feat: store storage scope against the instance

### DIFF
--- a/domain/annotation/state/state_test.go
+++ b/domain/annotation/state/state_test.go
@@ -442,9 +442,9 @@ VALUES (?, ?, ?, ?, ?)
 func (s *stateSuite) ensureStorage(c *tc.C, name, uuid, charmUUID string) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO storage_instance (uuid, storage_id, storage_type, requested_size_mib, charm_uuid, storage_name, life_id)
-VALUES (?, ?, ?, ?, ?, ?, ?)
-		`, uuid, name+"/0", "loop", 100, charmUUID, name, 0)
+INSERT INTO storage_instance (uuid, storage_id, storage_type, requested_size_mib, charm_uuid, storage_name, life_id, scope_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`, uuid, name+"/0", "loop", 100, charmUUID, name, 0, 0)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -41,7 +41,6 @@ import (
 	internalcharm "github.com/juju/juju/internal/charm"
 	charmresource "github.com/juju/juju/internal/charm/resource"
 	"github.com/juju/juju/internal/errors"
-	"github.com/juju/juju/internal/storage"
 )
 
 // ApplicationState describes retrieval and persistence methods for
@@ -639,7 +638,7 @@ func makeResourcesArgs(resolvedResources ResolvedResources) []application.AddApp
 }
 
 // makeStorageArgs creates a slice of ApplicationStorageArg from a map of storage directives.
-func makeStorageArgs(storage map[string]storage.Directive) []application.ApplicationStorageArg {
+func makeStorageArgs(storage map[string]domainstorage.StorageDirectiveAndScope) []application.ApplicationStorageArg {
 	var result []application.ApplicationStorageArg
 	for name, stor := range storage {
 		result = append(result, application.ApplicationStorageArg{
@@ -647,6 +646,7 @@ func makeStorageArgs(storage map[string]storage.Directive) []application.Applica
 			PoolNameOrType: stor.Pool,
 			Size:           stor.Size,
 			Count:          stor.Count,
+			Scope:          stor.Scope,
 		})
 	}
 	return result

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -243,7 +243,7 @@ func (s *ProviderService) makeApplicationArg(
 	if err != nil {
 		return "", application.BaseAddApplicationArg{}, errors.Errorf("getting model type: %w", err)
 	}
-	appArg, err := makeCreateApplicationArgs(ctx, s.st, s.storageRegistryGetter, modelType, charm, origin, args)
+	appArg, err := s.makeCreateApplicationArgs(ctx, modelType, charm, origin, args)
 	if err != nil {
 		return "", application.BaseAddApplicationArg{}, errors.Errorf("creating application args: %w", err)
 	}
@@ -282,10 +282,8 @@ func (s *ProviderService) makeApplicationArg(
 	return name, appArg, nil
 }
 
-func makeCreateApplicationArgs(
+func (s *Service) makeCreateApplicationArgs(
 	ctx context.Context,
-	state State,
-	storageRegistryGetter corestorage.ModelStorageRegistryGetter,
 	modelType coremodel.ModelType,
 	charm internalcharm.Charm,
 	origin corecharm.Origin,
@@ -299,10 +297,10 @@ func makeCreateApplicationArgs(
 	meta := charm.Meta()
 
 	var err error
-	if storageDirectives, err = addDefaultStorageDirectives(ctx, state, modelType, storageDirectives, meta.Storage); err != nil {
+	if storageDirectives, err = s.addDefaultStorageDirectives(ctx, modelType, storageDirectives, meta.Storage); err != nil {
 		return application.BaseAddApplicationArg{}, errors.Errorf("adding default storage directives: %w", err)
 	}
-	storageDirectivesAndScope, err := validateStorageDirectives(ctx, state, storageRegistryGetter, modelType, storageDirectives, meta)
+	storageDirectivesAndScope, err := s.validateStorageDirectives(ctx, modelType, storageDirectives, meta)
 	if err != nil {
 		return application.BaseAddApplicationArg{}, errors.Errorf("invalid storage directives: %w", err)
 	}

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -302,7 +302,8 @@ func makeCreateApplicationArgs(
 	if storageDirectives, err = addDefaultStorageDirectives(ctx, state, modelType, storageDirectives, meta.Storage); err != nil {
 		return application.BaseAddApplicationArg{}, errors.Errorf("adding default storage directives: %w", err)
 	}
-	if err := validateStorageDirectives(ctx, state, storageRegistryGetter, modelType, storageDirectives, meta); err != nil {
+	storageDirectivesAndScope, err := validateStorageDirectives(ctx, state, storageRegistryGetter, modelType, storageDirectives, meta)
+	if err != nil {
 		return application.BaseAddApplicationArg{}, errors.Errorf("invalid storage directives: %w", err)
 	}
 
@@ -360,7 +361,7 @@ func makeCreateApplicationArgs(
 		EndpointBindings:  args.EndpointBindings,
 		Resources:         makeResourcesArgs(args.ResolvedResources),
 		PendingResources:  args.PendingResources,
-		Storage:           makeStorageArgs(storageDirectives),
+		Storage:           makeStorageArgs(storageDirectivesAndScope),
 		Config:            applicationConfig,
 		Settings:          args.ApplicationSettings,
 		Status:            applicationStatus,

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -694,6 +694,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationWithStorageBlock(c *tc.C
 				PoolNameOrType: "loop",
 				Size:           10,
 				Count:          1,
+				Scope:          domainstorage.StorageScopeHost,
 			}},
 			StoragePoolKind: map[string]storage.StorageKind{
 				"loop": storage.StorageKindBlock,
@@ -806,6 +807,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationWithStorageBlockDefaultS
 				PoolNameOrType: "fast",
 				Size:           10,
 				Count:          2,
+				Scope:          domainstorage.StorageScopeModel,
 			}},
 			StoragePoolKind: map[string]storage.StorageKind{
 				"fast": storage.StorageKindBlock,
@@ -922,6 +924,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationWithStorageFilesystem(c 
 				PoolNameOrType: "rootfs",
 				Size:           10,
 				Count:          1,
+				Scope:          domainstorage.StorageScopeHost,
 			}},
 			StoragePoolKind: map[string]storage.StorageKind{
 				"rootfs": storage.StorageKindFilesystem,
@@ -1035,6 +1038,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationWithStorageFilesystemDef
 				PoolNameOrType: "fast",
 				Size:           10,
 				Count:          2,
+				Scope:          domainstorage.StorageScopeModel,
 			}},
 			StoragePoolKind: map[string]storage.StorageKind{
 				"fast": storage.StorageKindBlock,

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -823,14 +823,13 @@ func isValidReferenceName(name string) bool {
 
 // addDefaultStorageDirectives fills in default values, replacing any empty/missing values
 // in the specified directives.
-func addDefaultStorageDirectives(
+func (s *Service) addDefaultStorageDirectives(
 	ctx context.Context,
-	state State,
 	modelType coremodel.ModelType,
 	allDirectives map[string]storage.Directive,
 	storage map[string]internalcharm.Storage,
 ) (map[string]storage.Directive, error) {
-	defaults, err := state.StorageDefaults(ctx)
+	defaults, err := s.st.StorageDefaults(ctx)
 	if err != nil {
 		return nil, errors.Errorf("getting storage defaults: %w", err)
 	}
@@ -839,20 +838,18 @@ func addDefaultStorageDirectives(
 
 // validateStorageDirectives ensures the supplied storage is valid for the specified
 // charm and fills in the scope of the supplied storage.
-func validateStorageDirectives(
+func (s *Service) validateStorageDirectives(
 	ctx context.Context,
-	state State,
-	storageRegistryGetter corestorage.ModelStorageRegistryGetter,
 	modelType coremodel.ModelType,
 	allDirectives map[string]storage.Directive,
 	meta *internalcharm.Meta,
 ) (map[string]domainstorage.StorageDirectiveAndScope, error) {
-	registry, err := storageRegistryGetter.GetStorageRegistry(ctx)
+	registry, err := s.storageRegistryGetter.GetStorageRegistry(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	validator, err := domainstorage.NewStorageDirectivesValidator(modelType, registry, state)
+	validator, err := domainstorage.NewStorageDirectivesValidator(modelType, registry, s.st)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -247,6 +247,7 @@ func (st *State) insertUnitStorage(
 				StorageName:      t.params.Name,
 				RequestedSizeMIB: t.params.Size,
 				LifeID:           life.Alive,
+				ScopeID:          int(t.params.Scope),
 				CharmUUID:        appCharm.CharmUUID,
 			}
 			// PoolNameOrType has already been validated to either be

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -897,6 +897,7 @@ type storageInstance struct {
 	CharmUUID        corecharm.ID     `db:"charm_uuid"`
 	StorageName      corestorage.Name `db:"storage_name"`
 	LifeID           life.Life        `db:"life_id"`
+	ScopeID          int              `db:"scope_id"`
 	StoragePoolUUID  *string          `db:"storage_pool_uuid"`
 	StorageType      *string          `db:"storage_type"`
 	RequestedSizeMIB uint64           `db:"requested_size_mib"`

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/status"
+	domainstorage "github.com/juju/juju/domain/storage"
 	internalcharm "github.com/juju/juju/internal/charm"
 	charmresource "github.com/juju/juju/internal/charm/resource"
 	"github.com/juju/juju/internal/storage"
@@ -102,6 +103,7 @@ type ApplicationStorageArg struct {
 	PoolNameOrType string
 	Size           uint64
 	Count          uint64
+	Scope          domainstorage.StorageScope
 }
 
 // CharmOrigin represents the origin of a charm.

--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -136,6 +136,18 @@ SELECT
 FROM unit_storage_directive AS usd
 LEFT JOIN storage_pool AS sp ON usd.storage_pool_uuid = sp.uuid;
 
+CREATE TABLE storage_scope (
+    id INT PRIMARY KEY,
+    scope TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_storage_scope
+ON storage_scope (scope);
+
+INSERT INTO storage_scope VALUES
+(0, 'model'),
+(1, 'host');
+
 CREATE TABLE storage_instance (
     uuid TEXT NOT NULL PRIMARY KEY,
     charm_uuid TEXT NOT NULL,
@@ -143,6 +155,7 @@ CREATE TABLE storage_instance (
     -- storage_id is created from the storage name and a unique id number.
     storage_id TEXT NOT NULL,
     life_id INT NOT NULL,
+    scope_id INT NOT NULL,
     -- One of storage_pool_uuid or storage_type must be set.
     -- Storage types are provider sourced, so we do not use a lookup with ID.
     -- This constitutes "repeating data" and would tend to indicate
@@ -158,6 +171,9 @@ CREATE TABLE storage_instance (
     CONSTRAINT fk_storage_instance_life
     FOREIGN KEY (life_id)
     REFERENCES life (id),
+    CONSTRAINT fk_storage_instance_scope
+    FOREIGN KEY (scope_id)
+    REFERENCES storage_scope (id),
     CONSTRAINT fk_storage_instance_storage_pool
     FOREIGN KEY (storage_pool_uuid)
     REFERENCES storage_pool (uuid),
@@ -176,6 +192,7 @@ SELECT
     si.storage_name,
     si.storage_id,
     si.life_id,
+    si.scope_id,
     si.requested_size_mib,
     COALESCE(sp.name, si.storage_type) AS storage_pool
 FROM storage_instance AS si

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -232,6 +232,7 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"storage_instance",
 		"storage_pool_attribute",
 		"storage_pool",
+		"storage_scope",
 		"storage_unit_owner",
 		"storage_volume_attachment_plan_attr",
 		"storage_volume_attachment_plan",

--- a/domain/status/state/storage_test.go
+++ b/domain/status/state/storage_test.go
@@ -189,11 +189,11 @@ func (s *storageSuite) createStorageInstance(c *tc.C, storageName, charmUUID cor
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO storage_instance (
     uuid, charm_uuid, storage_name, storage_id,
-    life_id, requested_size_mib, storage_type
-) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    life_id, requested_size_mib, storage_type, scope_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 			storageUUID, charmUUID, storageName,
 			fmt.Sprintf("%s/%d", storageName, s.storageInstCount),
-			life.Alive, 100, "pool")
+			life.Alive, 100, "pool", 0)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/storage/storagescope.go
+++ b/domain/storage/storagescope.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+// StorageScope represents the storage scope
+// as recorded in the storage scope lookup table.
+type StorageScope int
+
+const (
+	// StorageScopeModel storage must be managed by a model level
+	// storage provisioner.
+	StorageScopeModel StorageScope = iota
+	// StorageScopeHost storage must be managed from within the host.
+	StorageScopeHost
+)

--- a/domain/storage/storagescope_test.go
+++ b/domain/storage/storagescope_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type storageScope struct {
+	schematesting.ModelSuite
+}
+
+func TestStorageScope(t *testing.T) {
+	tc.Run(t, &storageScope{})
+}
+
+// TestStorageScopeDBValues ensures there's no skew between what's in the
+// database table for storage_scope and the typed consts used in the storage domain.
+func (s *storageScope) TestStorageScopeDBValues(c *tc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, scope FROM storage_scope")
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = rows.Close() }()
+
+	dbValues := make(map[StorageScope]string)
+	for rows.Next() {
+		var (
+			id    int
+			value string
+		)
+
+		c.Assert(rows.Scan(&id, &value), tc.ErrorIsNil)
+		dbValues[StorageScope(id)] = value
+	}
+	c.Assert(dbValues, tc.DeepEquals, map[StorageScope]string{
+		StorageScopeModel: "model",
+		StorageScopeHost:  "host",
+	})
+}

--- a/domain/storage/types.go
+++ b/domain/storage/types.go
@@ -91,6 +91,13 @@ func DefaultStoragePools(registry storage.ProviderRegistry) ([]*storage.Config, 
 	return result, nil
 }
 
+// StorageDirectiveAndScope holds a storage directive and
+// the scope of the underlying storage type.
+type StorageDirectiveAndScope struct {
+	storage.Directive
+	Scope StorageScope
+}
+
 // ModelDetails describes details about a model.
 type ModelDetails struct {
 	ModelUUID      string


### PR DESCRIPTION
The storage instance table contains the pool or storage type.
Along with the type of storage, we also need to record the scope of the storage via a look up table.

A new `storage_scope` table is introduced, with values for "model" and "host" scoped storage.
When an application with storage is added, the storage provider is determined as part of the workflow to ensure the requested storage s compatible with the charm. At this point, the storage scope can also be determined and this is added to the storage directive info to persist.

## QA steps

bootstrap
juju deploy postgresql --storage pgdata=rootfs
```
select * from storage_instance
uuid                                    charm_uuid                              storage_name    storage_id      life_id scope_id        storage_pool_uuid       storage_type    requested_size_mib
fdc30022-166b-4547-8d32-4e82a0e84c95    eaeb54f2-e414-42b7-8418-f1e52d45911e    pgdata          pgdata/0        0       1               <nil>                   rootfs          1024
```

## Links

**Jira card:** [JUJU-8034](https://warthogs.atlassian.net/browse/JUJU-8034)


[JUJU-8034]: https://warthogs.atlassian.net/browse/JUJU-8034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ