### PR TITLE
docs: fix loal typo

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -479,7 +479,7 @@ The format is
 
 where the resource name is the name from the metadata.yaml file of the charm
 and where, depending on the type of the resource, the resource can be specified
-as follows: 
+as follows:
 
 (1) If the resource is type 'file', you can specify it by providing
   (a) the resource revision number or
@@ -494,7 +494,7 @@ as follows:
 Note: If you choose (1b) or (2b-c), i.e., a resource that is not from Charmhub:
 You will not be able to go back to using a resource from Charmhub.
 
-Note: If you choose (1b) or (2b): This uploads a file from your loal disk to the juju
+Note: If you choose (1b) or (2b): This uploads a file from your local disk to the juju
 controller to be streamed to the charm when "resource-get" is called by a hook.
 
 Note: If you choose (2b): You will need to specify:

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -64,7 +64,7 @@ The format is
 
 where the resource name is the name from the metadata.yaml file of the charm
 and where, depending on the type of the resource, the resource can be specified
-as follows: 
+as follows:
 
 (1) If the resource is type 'file', you can specify it by providing
 (a) the resource revision number or
@@ -79,7 +79,7 @@ as follows:
 Note: If you choose (1b) or (2b-c), i.e., a resource that is not from Charmhub:
 You will not be able to go back to using a resource from Charmhub.
 
-Note: If you choose (1b) or (2b): This uploads a file from your loal disk to the juju
+Note: If you choose (1b) or (2b): This uploads a file from your local disk to the juju
 controller to be streamed to the charm when "resource-get" is called by a hook.
 
 Note: If you choose (2b): You will need to specify:

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
@@ -24,7 +24,7 @@ The format is
 
 where the resource name is the name from the metadata.yaml file of the charm
 and where, depending on the type of the resource, the resource can be specified
-as follows: 
+as follows:
 
 (1) If the resource is type 'file', you can specify it by providing
 (a) the resource revision number or
@@ -39,7 +39,7 @@ as follows:
 Note: If you choose (1b) or (2b-c), i.e., a resource that is not from Charmhub:
 You will not be able to go back to using a resource from Charmhub.
 
-Note: If you choose (1b) or (2b): This uploads a file from your loal disk to the juju
+Note: If you choose (1b) or (2b): This uploads a file from your local disk to the juju
 controller to be streamed to the charm when "resource-get" is called by a hook.
 
 Note: If you choose (2b): You will need to specify:

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/deploy.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/deploy.md
@@ -224,7 +224,7 @@ The format is
 
 where the resource name is the name from the metadata.yaml file of the charm
 and where, depending on the type of the resource, the resource can be specified
-as follows: 
+as follows:
 
 (1) If the resource is type 'file', you can specify it by providing
   (a) the resource revision number or
@@ -239,7 +239,7 @@ as follows:
 Note: If you choose (1b) or (2b-c), i.e., a resource that is not from Charmhub:
 You will not be able to go back to using a resource from Charmhub.
 
-Note: If you choose (1b) or (2b): This uploads a file from your loal disk to the juju
+Note: If you choose (1b) or (2b): This uploads a file from your local disk to the juju
 controller to be streamed to the charm when "resource-get" is called by a hook.
 
 Note: If you choose (2b): You will need to specify:


### PR DESCRIPTION
This PR fixes the loal typo I saw while reading the Juju docs.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
