### PR TITLE
feat: support import-filesystem for k8s

### DIFF
--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -4,7 +4,10 @@
 package storage_test
 
 import (
+	"os"
+
 	"github.com/juju/errors"
+	"github.com/juju/featureflag"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -14,6 +17,8 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/storage"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	jujustorage "github.com/juju/juju/storage"
@@ -71,6 +76,10 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.callContext = context.NewEmptyCloudCallContext()
 	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
 	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
+
+	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.K8SAttachStorage)
+	c.Assert(err, jc.ErrorIsNil)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *baseStorageSuite) storageMetadata() (poolmanager.PoolManager, jujustorage.ProviderRegistry, error) {

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/featureflag"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/apiserver/authentication"
@@ -19,6 +20,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -798,6 +800,13 @@ func (a *StorageAPI) importFilesystem(
 		}
 		volumeImporter, ok := volumeSource.(storage.VolumeImporter)
 		if !ok {
+			return nil, errors.NotSupportedf(
+				"importing volume with storage provider %q",
+				cfg.Provider(),
+			)
+		}
+		// Support import-filesystem on k8s only available when featureflag K8SAttachStorage enabled.
+		if cfg.Provider() == k8sconstants.StorageProviderType && !featureflag.Enabled(feature.K8SAttachStorage) {
 			return nil, errors.NotSupportedf(
 				"importing volume with storage provider %q",
 				cfg.Provider(),

--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -65,6 +65,13 @@ To import a filesystem, you must specify three things:
 
 Once a filesystem is imported, Juju will create an associated storage
 instance using the given storage name.
+
+For Kubernetes models, when importing a PersistentVolume, the following
+conditions must be met:
+
+ - the PersistentVolume's reclaim policy must be set to "Retain".
+ - the PersistentVolume must not be bound to any PersistentVolumeClaim.
+
 `
 	importFilesystemCommandExamples = `
 Import an existing filesystem backed by an EBS volume,
@@ -74,6 +81,10 @@ the volume and filesystem contained within.
 
     juju import-filesystem ebs vol-123456 pgdata
 
+Import an existing unbound PersistentVolume in a Kubernetes model,
+and assign it the "pgdata" storage name:
+
+    juju import-filesystem kubernetes pv-data-001 pgdata
 `
 
 	importFilesystemCommandAgs = `
@@ -84,7 +95,6 @@ the volume and filesystem contained within.
 // importFilesystemCommand imports filesystems into the model.
 type importFilesystemCommand struct {
 	StorageCommandBase
-	modelcmd.IAASOnlyCommand
 	newAPIFunc NewStorageImporterFunc
 
 	storagePool       string

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/import-filesystem.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/import-filesystem.md
@@ -25,6 +25,10 @@ the volume and filesystem contained within.
 
     juju import-filesystem ebs vol-123456 pgdata
 
+Import an existing unbound PersistentVolume in a Kubernetes model,
+and assign it the "pgdata" storage name:
+
+    juju import-filesystem kubernetes pv-data-001 pgdata
 
 
 ## Details
@@ -44,3 +48,9 @@ To import a filesystem, you must specify three things:
 
 Once a filesystem is imported, Juju will create an associated storage
 instance using the given storage name.
+
+For Kubernetes models, when importing a PersistentVolume, the following
+conditions must be met:
+
+ - the PersistentVolume's reclaim policy must be set to "Retain".
+ - the PersistentVolume must not be bound to any PersistentVolumeClaim.

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -36,3 +36,8 @@ const RawK8sSpec = "raw-k8s-spec"
 
 // SSHJump indicates that the SSH jump feature is enabled.
 const SSHJump = "ssh-jump"
+
+// K8SAttachStorage enables the following on Kubernetes clouds:
+// - import-filesystem
+// - juju deploy and juju add-unit with the --attach-storage option
+const K8SAttachStorage = "k8s-attach-storage"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -76,6 +76,7 @@ TEST_NAMES="agents \
             spaces_ec2 \
             static_analysis \
             storage \
+            storage_k8s \
             unit \
             upgrade \
             user"

--- a/tests/suites/storage_k8s/import.sh
+++ b/tests/suites/storage_k8s/import.sh
@@ -1,0 +1,55 @@
+test_import_filesystem() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# Ensure a bootstrap Juju model exists.
+	model_name="import-filesystem"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	# Create a PersistentVolume by deploying and deleting an application.
+	echo "Create persistent volume to be imported"
+	juju deploy postgresql-k8s --channel 14/stable --trust
+	# Ensure the storage is attached without waiting for the application to reach the active status.
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+
+	# Capture the provisioned PersistentVolume ID.
+	PV=$(juju storage --format json | jq -r '.volumes["0"]."provider-id"')
+
+	# Clean up: remove the application and associated storage (retain PV).
+	juju remove-application postgresql-k8s --no-prompt
+	wait_for "{}" ".applications"
+	juju remove-storage pgdata/0 --no-destroy
+	wait_for "{}" ".storage"
+
+	# Attempt to import the PersistentVolume: expect failure due to reclaim policy.
+	set +e
+	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
+	set -e
+	echo "${OUT}" | check \
+		"importing volume \"${PV}\" with reclaim policy \"Delete\" not supported \(must be \"Retain\"\)"
+
+	# Fix: update the PersistentVolume's reclaim policy to 'Retain'.
+	kubectl patch pv "${PV}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+
+	# Attempt to import the PersistentVolume: expect failure due to existing claimRef.
+	set +e
+	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
+	set -e
+	echo "${OUT}" | check \
+		"importing volume \"${PV}\" already bound to a claim not supported"
+
+	# Fix: delete the PVC and remove the claimRef from the PersistentVolume.
+	PVC=$(kubectl get pv "${PV}" -o jsonpath='{.spec.claimRef.name}')
+	kubectl delete pvc "${PVC}" -n "${model_name}"
+	kubectl patch pv "${PV}" --type merge -p '{"spec":{"claimRef": null}}'
+
+	# Final attempt: import the PersistentVolume successfully.
+	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
+
+	wait_for_storage "detached" '.storage["pgdata/1"]["status"].current'
+	wait_for_storage "${PV}" '.volumes["1"]."provider-id"'
+
+	# Destroy the test model.
+	destroy_model "${model_name}"
+}

--- a/tests/suites/storage_k8s/task.sh
+++ b/tests/suites/storage_k8s/task.sh
@@ -1,0 +1,23 @@
+test_storage_k8s() {
+	if [ "$(skip 'test_storage_k8s')" ]; then
+		echo "==> TEST SKIPPED: caas filesystem tests"
+		return
+	fi
+
+	set_verbosity
+
+	case "${BOOTSTRAP_PROVIDER:-}" in
+	"k8s")
+		echo "==> Checking for dependencies"
+		check_dependencies juju
+
+		microk8s config >"${TEST_DIR}"/kube.conf
+		export KUBE_CONFIG="${TEST_DIR}"/kube.conf
+
+		test_import_filesystem
+		;;
+	*)
+		echo "==> TEST SKIPPED: storage k8s tests, not a k8s provider"
+		;;
+	esac
+}


### PR DESCRIPTION
Add support for importing existing unbound PersistentVolumes (PVs) into Kubernetes models via the `import-filesystem` command.

For a PV to be eligible for import:
- The reclaim policy must be set to "Retain".
- The volume must not be bound to any PersistentVolumeClaim (PVC).

This change updates the Kubernetes storage provider to implement the VolumeImporter interface and enhances the CLI documentation.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

Environments/dependencies:

- juju kubernetes cloud controller, version 3.6
- kubectl

Steps:

```sh
juju deploy postgresql-k8s -n 1 --channel 14/stable  --trust
juju remove-application postgresql-k8s
juju remove-storage pgdata/0 --no-destroy

# replace {pv-name},{pvc-name} with real name
kubectl patch pv {pv-name} -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
kubectl delete pvc {pvc-name}
kubectl patch pv {pv-name} --type merge -p '{"spec":{"claimRef": null}}'

juju import-filesystem kubernetes {pv-name} pgdata
```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->
(Documentation change can be found on import-filesystem cmd changed)

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

The specification index are:

- SOLENG029 Juju support re-use existing pv on k8s cloud
- SOLENG032 User experience of re-using existing persistent volume in juju kubernetes cloud

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Partially Fixes #19521 .

<!-- Add a Jira card reference or link, otherwise remove this line. -->
