### PR TITLE
fix: add back removed network service from sshclient facade

### DIFF
--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -67,6 +67,7 @@ func internalFacade(
 		backend:              backend,
 		modelConfigService:   modelConfigService,
 		modelProviderService: modelProviderService,
+		networkService:       networkService,
 		controllerTag:        controllerTag,
 		modelTag:             modelTag,
 		authorizer:           auth,


### PR DESCRIPTION
In a previous patch
(https://github.com/juju/juju/pull/19875/files#diff-31a40e0448e00d7162e8f4e32b5703ff7f4a409b0d6b3c9377307ce2e6c42cd9L51) the network service injection was removed from the sshclient facade. 

This small patch brings it back in.


## QA steps

Bootstrap, add a machine and ssh into it:
```
juju bootstrap lxc c
juju add-model m
juju add-ssh-key "ssh-ed25519 ..."
juju add-machine
juju ssh 0
```