### PR TITLE
fix: race during worker start with context cancel occupies fortress forever

### DIFF
--- a/internal/worker/fortress/fortress.go
+++ b/internal/worker/fortress/fortress.go
@@ -159,6 +159,7 @@ func (ticket guestTicket) complete(finished func()) {
 	select {
 	case <-ticket.ctx.Done():
 		ticket.result <- ErrAborted
-	case ticket.result <- ticket.visit():
+	default:
+		ticket.result <- ticket.visit()
 	}
 }


### PR DESCRIPTION
If the cancellation of the context passed to `Occupy` happens-before
the call to worker `start` function returns, the worker is never killed
and it occupies the fortress forever.

Added test `TestSlowStartCancelContext` fails without the fix.