### PR TITLE
feat: seed controller target version on bootstrap

### DIFF
--- a/domain/controllerconfig/bootstrap/bootstrap.go
+++ b/domain/controllerconfig/bootstrap/bootstrap.go
@@ -66,6 +66,9 @@ func InsertInitialControllerConfig(cfg jujucontroller.Config, controllerModelUUI
 			"INSERT INTO controller_version (*) VALUES ($dbControllerVersion.*)",
 			setControllerVersionInput,
 		)
+		if err != nil {
+			return errors.Capture(err)
+		}
 
 		updateKeyValues := make([]dbKeyValue, 0)
 		for k, v := range values {

--- a/domain/controllerconfig/bootstrap/bootstrap_test.go
+++ b/domain/controllerconfig/bootstrap/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/controller"
 	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
+	jujuversion "github.com/juju/juju/core/version"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/testing"
 )
@@ -45,6 +46,11 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *tc.C) {
 
 	c.Check(dbModelUUID, tc.Equals, modelUUID.String())
 	c.Check(dbUUID, tc.Equals, testing.ControllerTag.Id())
+
+	var controllerVersion string
+	row = s.DB().QueryRow("SELECT target_version FROM controller_version")
+	c.Check(row.Scan(&controllerVersion), tc.ErrorIsNil)
+	c.Check(controllerVersion, tc.Equals, jujuversion.Current.String())
 }
 
 func (s *bootstrapSuite) TestValidModelUUID(c *tc.C) {

--- a/domain/schema/controller/sql/0008-controller-config.sql
+++ b/domain/schema/controller/sql/0008-controller-config.sql
@@ -1,16 +1,16 @@
-CREATE TABLE controller_config (
-    "key" TEXT NOT NULL PRIMARY KEY,
-    value TEXT
-);
-
 CREATE TABLE controller (
     uuid TEXT NOT NULL PRIMARY KEY,
     model_uuid TEXT NOT NULL
 );
 
--- A unique constraint over a constant index ensures only 1 entry matching the 
+-- A unique constraint over a constant index ensures only 1 entry matching the
 -- condition can exist.
 CREATE UNIQUE INDEX idx_singleton_controller ON controller ((1));
+
+CREATE TABLE controller_config (
+    "key" TEXT NOT NULL PRIMARY KEY,
+    value TEXT
+);
 
 CREATE VIEW v_controller_config AS
 SELECT
@@ -22,3 +22,13 @@ SELECT
     'controller-uuid' AS "key",
     controller.uuid AS value
 FROM controller;
+
+-- Tracks the target binary version for the controller. Can only ever be at most
+-- one reccord in the table by virtue of the controller table only supporting
+-- one controller.
+CREATE TABLE controller_version (
+    controller_uuid TEXT NOT NULL PRIMARY KEY,
+    target_version TEXT NOT NULL,
+    FOREIGN KEY (controller_uuid)
+    REFERENCES controller(uuid)
+);

--- a/domain/schema/controller/sql/0008-controller-config.sql
+++ b/domain/schema/controller/sql/0008-controller-config.sql
@@ -30,5 +30,5 @@ CREATE TABLE controller_version (
     controller_uuid TEXT NOT NULL PRIMARY KEY,
     target_version TEXT NOT NULL,
     FOREIGN KEY (controller_uuid)
-    REFERENCES controller(uuid)
+    REFERENCES controller (uuid)
 );

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -73,6 +73,7 @@ func (s *controllerSchemaSuite) TestControllerTables(c *tc.C) {
 		// Controller config
 		"controller",
 		"controller_config",
+		"controller_version",
 
 		// Controller nodes
 		"controller_node",


### PR DESCRIPTION
This PR introduces a new step in the controller config bootstrap for setting the initial controller' target version value. The target version is used to answer the question about what version all of the controllers in a cluster should be running.  This value must be initially set on bootstrap as all operations that work off this value expect it to have been previously set.

PR #19924 needs to have landed before this PR. Commits in this PR will go away once landed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Coming soon, waiting to make sure no DDL changes are needed before committing to this.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-7993
