### PR TITLE
refactor: implement model status state layer in status domain service

### DIFF
--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -643,3 +643,7 @@ type dbModelCloudCredentialUUID struct {
 	CloudUUID      corecloud.UUID  `db:"cloud_uuid"`
 	CredentialUUID credential.UUID `db:"cloud_credential_uuid"`
 }
+
+type dbModelCredentialInvalidStatus struct {
+	CredentialInvalid bool `db:"cloud_credential_invalid"`
+}

--- a/domain/status/state/controllerstate_test.go
+++ b/domain/status/state/controllerstate_test.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/juju/tc"
+
+	credentialstate "github.com/juju/juju/domain/credential/state"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	modeltesting "github.com/juju/juju/domain/model/state/testing"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	domainstatus "github.com/juju/juju/domain/status"
+)
+
+type controllerStateSuite struct {
+	schematesting.ControllerSuite
+}
+
+func TestControllerStateSuite(t *testing.T) {
+	tc.Run(t, &controllerStateSuite{})
+}
+
+func (s *controllerStateSuite) SetUpTest(c *tc.C) {
+	s.ControllerSuite.SetUpTest(c)
+}
+
+func (s *controllerStateSuite) TestGetModelStatusContext(c *tc.C) {
+	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "test-model")
+	st := NewControllerState(s.TxnRunnerFactory(), modelUUID)
+
+	mSt, err := st.GetModelStatusContext(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(mSt, tc.DeepEquals, domainstatus.ModelStatusContext{
+		IsDestroying:                 false,
+		IsMigrating:                  false,
+		HasInvalidCloudCredential:    false,
+		InvalidCloudCredentialReason: "",
+	})
+}
+
+func (s *controllerStateSuite) TestGetModelStatusContextModelNotFound(c *tc.C) {
+	st := NewControllerState(s.TxnRunnerFactory(), "non-existent-model-uuid")
+
+	_, err := st.GetModelStatusContext(c.Context())
+	c.Assert(err, tc.ErrorIs, modelerrors.NotFound)
+}
+
+func (s *controllerStateSuite) TestGetModelStatusContextDestroying(c *tc.C) {
+	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "test-model")
+	st := NewControllerState(s.TxnRunnerFactory(), modelUUID)
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE model SET life_id = 1 WHERE uuid = ?
+		`, modelUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	mSt, err := st.GetModelStatusContext(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(mSt, tc.DeepEquals, domainstatus.ModelStatusContext{
+		IsDestroying:                 true,
+		IsMigrating:                  false,
+		HasInvalidCloudCredential:    false,
+		InvalidCloudCredentialReason: "",
+	})
+}
+
+func (s *controllerStateSuite) TestGetModelStatusContextMigrating(c *tc.C) {
+	c.Skip("TODO: Implement this test when v_model_state model migration information is given in the database")
+}
+
+func (s *controllerStateSuite) TestGetModelStatusContextInvalidCredentials(c *tc.C) {
+	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "test-model")
+	st := NewControllerState(s.TxnRunnerFactory(), modelUUID)
+
+	credentialSt := credentialstate.NewState(s.TxnRunnerFactory())
+	err := credentialSt.InvalidateModelCloudCredential(
+		c.Context(),
+		modelUUID,
+		"invalid cloud credential",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	mSt, err := st.GetModelStatusContext(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(mSt, tc.DeepEquals, domainstatus.ModelStatusContext{
+		IsDestroying:                 false,
+		IsMigrating:                  false,
+		HasInvalidCloudCredential:    true,
+		InvalidCloudCredentialReason: "invalid cloud credential",
+	})
+}

--- a/domain/status/state/types.go
+++ b/domain/status/state/types.go
@@ -203,6 +203,10 @@ type applicationNameUnitCount struct {
 	UnitCount int    `db:"unit_count"`
 }
 
+type modelUUID struct {
+	UUID string `db:"uuid"`
+}
+
 type modelInfo struct {
 	Type string `db:"type"`
 }
@@ -242,4 +246,13 @@ type volumeStatusInfo struct {
 	StatusID   int        `db:"status_id"`
 	Message    string     `db:"message"`
 	UpdatedAt  *time.Time `db:"updated_at"`
+}
+
+// modelStatusContext represents a single row from the v_model_state view.
+// These information are used to determine a model's status.
+type modelStatusContext struct {
+	Destroying              bool   `db:"destroying"`
+	CredentialInvalid       bool   `db:"cloud_credential_invalid"`
+	CredentialInvalidReason string `db:"cloud_credential_invalid_reason"`
+	Migrating               bool   `db:"migrating"`
 }


### PR DESCRIPTION
# PR-2
The task of the below jira card aims to shift model status from the model domain to the status domain. The focus of the second PR here is on implementing the state layer of the services added in the parent PR.

Integrating the controller's state into the status service is necessary to correctly establish the model’s status, as the status is computed dynamically based on various environmental indicators.

It is important to note that the controller state is still model-scoped, as it pertains to a specific model within the controller, which is now provided to the status service.

Breakdown of jira card:
PR-1: Implement modelstatus service with controller state, refactor existing field names & method signatures, and add unit tests for service
PR-2: Implement modelstatus state and add unit tests for state
PR-3: Replace modelstatus calls in the model domain with calls to the status domain, and remove the old modelstatus from the model domain

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
NA (Will QA in the 3rd and last PR where the model status calls in model domains are replaced by status domain)

## Links

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-7965
**Parent PR** https://github.com/juju/juju/pull/19895
