### PR TITLE
feat: token auth for migrations

### DIFF
--- a/api/controller/migrationmaster/client.go
+++ b/api/controller/migrationmaster/client.go
@@ -111,6 +111,7 @@ func (c *Client) MigrationStatus() (migration.MigrationStatus, error) {
 			AuthTag:       authTag,
 			Password:      target.Password,
 			Macaroons:     macs,
+			Token:         target.Token,
 		},
 	}, nil
 }

--- a/api/controller/migrationmaster/client_test.go
+++ b/api/controller/migrationmaster/client_test.go
@@ -95,6 +95,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 					AuthTag:       names.NewUserTag("admin").String(),
 					Password:      "secret",
 					Macaroons:     string(macsJSON),
+					Token:         "token",
 				},
 			},
 			MigrationId:      "id",
@@ -122,6 +123,7 @@ func (s *ClientSuite) TestMigrationStatus(c *gc.C) {
 			CACert:        "cert",
 			AuthTag:       names.NewUserTag("admin"),
 			Password:      "secret",
+			Token:         "token",
 		},
 	})
 }

--- a/api/sessiontokenloginprovider.go
+++ b/api/sessiontokenloginprovider.go
@@ -82,7 +82,7 @@ func (p *sessionTokenLoginProvider) Login(ctx context.Context, caller base.APICa
 	if err == nil {
 		return result, nil
 	}
-	if params.IsCodeSessionTokenInvalid(err) {
+	if params.IsCodeSessionTokenInvalid(err) && p.output != nil {
 		// if we fail because of an invalid session token, we initiate a
 		// new device login.
 		if err := p.initiateDeviceLogin(ctx, caller); err != nil {
@@ -95,9 +95,6 @@ func (p *sessionTokenLoginProvider) Login(ctx context.Context, caller base.APICa
 }
 
 func (p *sessionTokenLoginProvider) printOutput(format string, params ...any) error {
-	if p.output == nil {
-		return errors.New("cannot present login details")
-	}
 	message := fmt.Sprintf(format, params...)
 	if len(message) > 0 && message[len(message)-1] != '\n' {
 		message += "\n"

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -670,6 +670,7 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 		AuthTag:         authTag,
 		Password:        specTarget.Password,
 		Macaroons:       macs,
+		Token:           specTarget.Token,
 	}
 
 	// Check if the migration is likely to succeed.
@@ -838,7 +839,8 @@ var runMigrationPreChecks = func(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	targetConn, err := api.Open(targetToAPIInfo(targetInfo), migration.ControllerDialOpts())
+	loginProvider := migration.NewLoginProvider(*targetInfo)
+	targetConn, err := api.Open(targetToAPIInfo(targetInfo), migration.ControllerDialOpts(loginProvider))
 	if err != nil {
 		return errors.Annotate(err, "connect to target controller")
 	}

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -512,6 +512,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 					CACert:          "cert1",
 					AuthTag:         names.NewUserTag("admin1").String(),
 					Password:        "secret1",
+					Token:           "token1",
 				},
 			}, {
 				ModelTag: model2.ModelTag().String(),
@@ -523,6 +524,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 					AuthTag:         names.NewUserTag("admin2").String(),
 					Macaroons:       string(macsJSON),
 					Password:        "secret2",
+					Token:           "token2",
 				},
 			},
 		},
@@ -557,6 +559,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 		c.Check(targetInfo.CACert, gc.Equals, spec.TargetInfo.CACert)
 		c.Check(targetInfo.AuthTag.String(), gc.Equals, spec.TargetInfo.AuthTag)
 		c.Check(targetInfo.Password, gc.Equals, spec.TargetInfo.Password)
+		c.Check(targetInfo.Token, gc.Equals, spec.TargetInfo.Token)
 
 		if spec.TargetInfo.Macaroons != "" {
 			macJSONdb, err := json.Marshal(targetInfo.Macaroons)

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -114,6 +114,7 @@ func (api *API) MigrationStatus() (params.MasterMigrationStatus, error) {
 				AuthTag:       target.AuthTag.String(),
 				Password:      target.Password,
 				Macaroons:     string(macsJSON),
+				Token:         target.Token,
 			},
 		},
 		MigrationId:      mig.Id(),

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -112,6 +112,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 	defer ctrl.Finish()
 
 	password := "secret"
+	token := "token"
 
 	mig := mocks.NewMockModelMigration(ctrl)
 
@@ -125,6 +126,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 		AuthTag:       names.NewUserTag("admin"),
 		Password:      password,
 		Macaroons:     []macaroon.Slice{{mac}},
+		Token:         token,
 	}
 
 	exp := mig.EXPECT()
@@ -151,6 +153,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 				AuthTag:       names.NewUserTag("admin").String(),
 				Password:      password,
 				Macaroons:     `[[{"l":"location","i":"id","s64":"qYAr8nQmJzPWKDppxigFtWaNv0dbzX7cJaligz98LLo"}]]`,
+				Token:         token,
 			},
 		},
 		MigrationId:      "ID",

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -43,6 +43,10 @@ type TargetInfo struct {
 	// Macaroons holds macaroons to use with AuthTag. At least one of
 	// Password or Macaroons must be set.
 	Macaroons []macaroon.Slice
+
+	// Token holds an optional token string to use for authentication
+	// specifically with a JIMM controller.
+	Token string
 }
 
 // Validate returns an error if the TargetInfo contains bad data. Nil
@@ -66,8 +70,8 @@ func (info *TargetInfo) Validate() error {
 		return errors.NotValidf("empty AuthTag")
 	}
 
-	if info.Password == "" && len(info.Macaroons) == 0 {
-		return errors.NotValidf("missing Password & Macaroons")
+	if info.Password == "" && len(info.Macaroons) == 0 && info.Token == "" {
+		return errors.NotValidf("missing Password, Macaroons or Token")
 	}
 
 	return nil

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -64,12 +64,13 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		},
 		"",
 	}, {
-		"Password & Macaroons",
+		"Empty Password, Macaroons & Token",
 		func(info *migration.TargetInfo) {
 			info.Password = ""
 			info.Macaroons = nil
+			info.Token = ""
 		},
-		"missing Password & Macaroons not valid",
+		"missing Password, Macaroons or Token not valid",
 	}, {
 		"Success - empty Password",
 		func(info *migration.TargetInfo) {
@@ -80,6 +81,27 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		"Success - empty Macaroons",
 		func(info *migration.TargetInfo) {
 			info.Macaroons = nil
+		},
+		"",
+	}, {
+		"Success - empty Macaroons and Token",
+		func(info *migration.TargetInfo) {
+			info.Macaroons = nil
+			info.Token = ""
+		},
+		"",
+	}, {
+		"Success - empty Macaroons and Password",
+		func(info *migration.TargetInfo) {
+			info.Macaroons = nil
+			info.Password = ""
+		},
+		"",
+	}, {
+		"Success - empty Password and Token",
+		func(info *migration.TargetInfo) {
+			info.Password = ""
+			info.Token = ""
 		},
 		"",
 	}, {
@@ -118,5 +140,6 @@ func makeValidTargetInfo(c *gc.C) migration.TargetInfo {
 		AuthTag:       names.NewUserTag("user"),
 		Password:      "password",
 		Macaroons:     []macaroon.Slice{{mac}},
+		Token:         "token",
 	}
 }

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -910,7 +910,8 @@ func (w *Worker) openAPIConnForModel(targetInfo coremigration.TargetInfo, modelU
 	if targetInfo.AuthTag.IsLocal() {
 		apiInfo.Tag = targetInfo.AuthTag
 	}
-	return w.config.APIOpen(apiInfo, migration.ControllerDialOpts())
+	loginProvider := migration.NewLoginProvider(targetInfo)
+	return w.config.APIOpen(apiInfo, migration.ControllerDialOpts(loginProvider))
 }
 
 func modelHasMigrated(phase coremigration.Phase) bool {

--- a/migration/dialopts.go
+++ b/migration/dialopts.go
@@ -7,15 +7,29 @@ import (
 	"time"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/core/migration"
 )
+
+// NewLoginProvider returns a LoginProvider for the target controller
+// using the given TargetInfo. If TargetInfo contains a session token,
+// it creates a SessionTokenLoginProvider for authenticating with JIMM controllers.
+// If no session token is present, it returns nil, which is treated as legacy
+// authentication i.e. username/password or macaroons.
+func NewLoginProvider(targetInfo migration.TargetInfo) api.LoginProvider {
+	if targetInfo.Token != "" {
+		return api.NewSessionTokenLoginProvider(targetInfo.Token, nil, nil)
+	}
+	return nil
+}
 
 // ControllerDialOpts returns dial parameters suitable for connecting
 // from the source controller to the target controller during model
 // migrations.
 // Except for the inclusion of RetryDelay the options mirror what is used
 // by the APICaller for logins.
-func ControllerDialOpts() api.DialOpts {
+func ControllerDialOpts(loginProvider api.LoginProvider) api.DialOpts {
 	return api.DialOpts{
+		LoginProvider:       loginProvider,
 		DialTimeout:         3 * time.Second,
 		DialAddressInterval: 200 * time.Millisecond,
 		Timeout:             time.Minute,

--- a/migration/dialopts_test.go
+++ b/migration/dialopts_test.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration_test
+
+import (
+	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/migration"
+	gc "gopkg.in/check.v1"
+)
+
+type DialOpsSuite struct{}
+
+var _ = gc.Suite(&DialOpsSuite{})
+
+func (d *DialOpsSuite) TestNewLoginProvider(c *gc.C) {
+	targetInfo := coremigration.TargetInfo{
+		Token: "test-session",
+	}
+	sessionTokenloginProvider := migration.NewLoginProvider(targetInfo)
+	c.Assert(sessionTokenloginProvider, gc.NotNil)
+
+	targetInfo.Token = ""
+	nilProvider := migration.NewLoginProvider(targetInfo)
+	c.Assert(nilProvider, gc.IsNil)
+}

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -37,6 +37,7 @@ type MigrationTargetInfo struct {
 	AuthTag         string   `json:"auth-tag"`
 	Password        string   `json:"password,omitempty"`
 	Macaroons       string   `json:"macaroons,omitempty"`
+	Token           string   `json:"token,omitempty"`
 }
 
 // MigrationSourceInfo holds the details required to connect to

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -161,6 +161,10 @@ type modelMigDoc struct {
 	// when authenticating.
 	TargetMacaroons string `bson:"target-macaroons,omitempty"`
 
+	// TargetToken holds an optional token to use for authentication
+	// with a JIMM controller.
+	TargetToken string `bson:"target-token,omitempty"`
+
 	// The list of users and their access-level to the model being migrated.
 	ModelUsers []modelMigUserDoc `bson:"model-users,omitempty"`
 }
@@ -295,6 +299,7 @@ func (mig *modelMigration) TargetInfo() (*migration.TargetInfo, error) {
 		AuthTag:         authTag,
 		Password:        mig.doc.TargetPassword,
 		Macaroons:       macs,
+		Token:           mig.doc.TargetToken,
 	}, nil
 }
 
@@ -760,6 +765,7 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 			TargetAuthTag:         spec.TargetInfo.AuthTag.String(),
 			TargetPassword:        spec.TargetInfo.Password,
 			TargetMacaroons:       macsJSON,
+			TargetToken:           spec.TargetInfo.Token,
 			ModelUsers:            userDocs,
 		}
 

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -52,6 +52,7 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 			AuthTag:         names.NewUserTag("user"),
 			Password:        "password",
 			Macaroons:       []macaroon.Slice{{mac}},
+			Token:           "token",
 		},
 	}
 	// Before we get into the tests, ensure that all the creation events have flowed through the system.


### PR DESCRIPTION
This PR addresses a gap in authentication between Juju and JAAS when migrating models.

When a model is migrated between 2 controllers, controller->controller authentication is required. Traditionally this is username/password or macaroons, however JIMM supports neither. Instead, a token (specifically a JWT) can be sent to JIMM. To permit this change we need the token present in state and to switch the login-provider when the token is not empty. As a refresher, the login-provider dictates the login logic and what API calls are made for login.

The changes in this PR are mainly centred around the introduction of a new `token` field in the API parameters which is then persisted to state and passed around as necessary. Since the token is a JWT in our case, it will include an expiry time and is therefore more secure than using a password.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Unable to QA this change as JAAS doesn't yet support the API methods for migrations (these are a WIP).

## Links

**Jira card:** [JUJU-8048](https://warthogs.atlassian.net/browse/JUJU-8048)
