### PR TITLE
docs: add sitemap config

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -4,3 +4,4 @@ sphinx-tabs
 sphinxext-rediraffe
 sphinx-new-tab-link
 sphinxcontrib.lightbox2
+sphinx-sitemap

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,6 +143,22 @@ slug = 'juju'
 html_static_path = [".sphinx/_static"]
 templates_path = [".sphinx/_templates"]
 
+#######################
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+#######################
+
+# Base URL of RTD hosted project
+
+html_baseurl = 'https://documentation.ubuntu.com/juju/'
+
+# URL scheme. Add language and version scheme elements.
+# When configured with RTD variables, check for RTD environment so manual runs succeed:
+
+if 'READTHEDOCS_VERSION' in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = '{version}{link}'
+else:
+    sitemap_url_scheme = 'MANUAL/{link}'
 
 #############
 # Redirects #
@@ -224,6 +240,7 @@ extensions = [
     # new_tab_link_show_external_link_icon must also be set to True
     'sphinx_new_tab_link',
     'sphinxcontrib.lightbox2',
+    'sphinx_sitemap',
     ]
 
 


### PR DESCRIPTION
> This PR should NOT be automaticatically forward-merged. (The starter pack developers are in talks with the Web team to figure out if having a sitemap for each version is fine.)

RTD creates sitemaps for projects but not subprojects. To address this, all projects under under documentation.ubuntu.com must generate their own sitemap. This PR does that for Juju docs.

Source:  https://github.com/canonical/sphinx-docs-starter-pack/blob/main/docs/how-to/set-up-sitemaps.rst

Thanks to @SecondSkoll for putting the fix together for us: https://github.com/juju/juju/commit/250f454ed5fc1267d435cc71dd18397f15ee260a 

## Links

**Jira card:** [JUJU-8056](https://warthogs.atlassian.net/browse/JUJU-8056)


[JUJU-8056]: https://warthogs.atlassian.net/browse/JUJU-8056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ