### PR TITLE
chore: fix the 3.6.7 release date

### DIFF
--- a/docs/reference/juju/juju-roadmap-and-releases.md
+++ b/docs/reference/juju/juju-roadmap-and-releases.md
@@ -28,6 +28,7 @@ ADD WHEN FIXED.
 <!--TEMPLATE (>= 3.6.7)
 ### 🔸 **Juju 3.6.X**  
 🗓️ <DATE>  <--leave this as TBC until released into stable!
+
 ⚙️ Features:
 * feat(secrets): handle NotFound errors in secret backend during `RemoveUserSecrets` by @ca-scribner in [#19169](https://github.com/juju/juju/pull/19169)
 * feat: open firewall ports for SSH server  proxy by @kian99 in [#19180](https://github.com/juju/juju/pull/19180)
@@ -66,7 +67,7 @@ Juju 3.6 series is LTS
 ```
 
 ### 🔸 **Juju 3.6.7**
-🗓️ 30 May 2025
+🗓️ 09 June 2025
 
 🛠️ Fixes:
 * fix: use pebble v1.19.1 by @jameinel in https://github.com/juju/juju/pull/19791


### PR DESCRIPTION
- Put the correct release date for 3.6.7.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# pass checks
```


## Links

**Jira card:** JUJU-
