### PR TITLE
feat(refresh): update endpoint bindings on refresh

### DIFF
--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1621,6 +1621,19 @@ func (st *State) SetApplicationCharm(ctx context.Context, id coreapplication.ID,
 		}
 
 		//TODO(storage) - update charm and storage directive for app
+
+		err = st.updateDefaultSpace(ctx, tx, id, params.EndpointBindings)
+		if err != nil {
+			return errors.Errorf("updating default space: %w", err)
+		}
+		err = st.updateApplicationEndpointBindings(ctx, tx, updateApplicationEndpointsParams{
+			appID:    id,
+			bindings: params.EndpointBindings,
+		})
+		if err != nil {
+			return errors.Capture(err)
+		}
+
 		return nil
 	}); err != nil {
 		return errors.Capture(err)

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -457,4 +457,8 @@ type UpdateCharmParams struct {
 	// CharmUpgradeOnError indicates whether the charm must be upgraded
 	// even when on error.
 	CharmUpgradeOnError bool
+
+	// EndpointBindings is an operator-defined map of endpoint names to
+	// space names that should be merged with any existing bindings.
+	EndpointBindings map[string]network.SpaceName
 }


### PR DESCRIPTION
For some reason, the "juju refresh" command has a --bind flag, which updates the application's endpoint bindings.

This had not been implemented in the DQLite domain. Implement it now.

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy juju-qa-test
$ juju show-application juju-qa-test
juju-qa-test:
  charm: juju-qa-test
  base: ubuntu@20.04
  principal: true
  exposed: false
  remote: false
  life: alive
  endpoint-bindings:
    "": alpha
    info: alpha
    juju-info: alpha

$ juju add-space beta
$ juju move-to-space beta 172.17.0.0/16
$ juju refresh juju-qa-test --bind "info=beta" --channel latest
$ juju show-application juju-qa-test
juju-qa-test:
  charm: juju-qa-test
  base: ubuntu@20.04
  principal: true
  exposed: false
  remote: false
  life: alive
  endpoint-bindings:
    "": alpha
    info: beta
    juju-info: alpha
```