### PR TITLE
fix: missing agent support for agent upgrader facade

### DIFF
--- a/apiserver/facades/agent/upgrader/register.go
+++ b/apiserver/facades/agent/upgrader/register.go
@@ -35,7 +35,8 @@ func newUpgraderFacade(stdCtx context.Context, ctx facade.ModelContext) (Upgrade
 	auth := ctx.Auth()
 
 	if !auth.AuthMachineAgent() &&
-		!auth.AuthUnitAgent() {
+		!auth.AuthUnitAgent() &&
+		!auth.AuthModelAgent() {
 		return nil, apiservererrors.ErrPerm
 	}
 


### PR DESCRIPTION
PR #19284 incorrectly removed model agent support from the agent upgrader facade. This looks to have been caused by a fat finger mistake when applying PR feedback.

Commit adds `AuthModelAgent` back into the allowed set of agents for the facade.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Bootstrap a Juju controller to a Kubernetes cluster.
2. Add a new model to the controller called "foobar"
3. Look at the logs for the model operator pod in K8s foobar namespace and confirm that the manifold upgrader work is not flapping around and happy.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-7630
