### PR TITLE
refactor: add SubnetUUID type

### DIFF
--- a/domain/network/service/subnet.go
+++ b/domain/network/service/subnet.go
@@ -6,11 +6,10 @@ package service
 import (
 	"context"
 
-	"github.com/google/uuid"
-
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/trace"
+	domainnetork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -20,11 +19,11 @@ func (s *Service) AddSubnet(ctx context.Context, args network.SubnetInfo) (netwo
 	defer span.End()
 
 	if args.ID == "" {
-		uuid, err := uuid.NewV7()
+		subUUID, err := domainnetork.NewSubnetUUID()
 		if err != nil {
 			return "", errors.Errorf("creating uuid for new subnet with CIDR %q: %w", args.CIDR, err)
 		}
-		args.ID = network.Id(uuid.String())
+		args.ID = network.Id(subUUID.String())
 	}
 
 	if err := s.st.AddSubnet(ctx, args); err != nil && !errors.Is(err, coreerrors.AlreadyExists) {
@@ -67,7 +66,7 @@ func (s *Service) UpdateSubnet(ctx context.Context, uuid string, spaceUUID netwo
 	return errors.Capture(s.st.UpdateSubnet(ctx, uuid, spaceUUID))
 }
 
-// Remove deletes a subnet identified by its uuid.
+// RemoveSubnet deletes a subnet identified by its UUID.
 func (s *Service) RemoveSubnet(ctx context.Context, uuid string) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/network/uuid.go
+++ b/domain/network/uuid.go
@@ -30,6 +30,25 @@ func (u uuid) validate() error {
 	return nil
 }
 
+// SubnetUUID uniquely identifies a subnet.
+type SubnetUUID uuid
+
+// NewSubnetUUID creates a new, valid subnet identifier.
+func NewSubnetUUID() (SubnetUUID, error) {
+	u, err := newUUID()
+	return SubnetUUID(u), err
+}
+
+// Validate returns an error if the receiver is not a valid UUID.
+func (u SubnetUUID) Validate() error {
+	return uuid(u).validate()
+}
+
+// String returns the identifier in string form.
+func (u SubnetUUID) String() string {
+	return string(u)
+}
+
 // NetNodeUUID uniquely identifies a net node.
 type NetNodeUUID uuid
 

--- a/domain/network/uuid_test.go
+++ b/domain/network/uuid_test.go
@@ -26,6 +26,25 @@ type subTest struct {
 	err  *string
 }
 
+func (s *uuidSuite) TestSubnetUUIDValidate(c *tc.C) {
+	for i, test := range getSubTests() {
+		c.Logf("test %d: %q", i, test.uuid)
+
+		c.Run(fmt.Sprintf("Test%d", i), func(t *testing.T) {
+			c := &tc.TBC{TB: t}
+
+			err := SubnetUUID(test.uuid).Validate()
+
+			if test.err == nil {
+				c.Check(err, tc.IsNil)
+				return
+			}
+
+			c.Check(err, tc.ErrorMatches, *test.err)
+		})
+	}
+}
+
 func (s *uuidSuite) TestInterfaceUUIDValidate(c *tc.C) {
 	for i, test := range getSubTests() {
 		c.Logf("test %d: %q", i, test.uuid)


### PR DESCRIPTION
Adds a subnet UUID type to the network domain.

This is required for machine network configuration persistence, rather than repeating usage of Google's UUID package.

A UUID type for spaces has been added to core/network already. We will do the requisite conversion between the core and domain packages at a later time, at which point we'll figure out what to do with `network.Id`.