### PR TITLE
refactor(uniter): cut over some uniter facade endpoints

### DIFF
--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -1,18 +1,42 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package uniter_test
+package uniter
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
+	gomock "go.uber.org/mock/gomock"
+
+	"github.com/juju/juju/apiserver/common"
+	applicationtesting "github.com/juju/juju/core/application/testing"
+	"github.com/juju/juju/core/life"
+	corerelation "github.com/juju/juju/core/relation"
+	corestatus "github.com/juju/juju/core/status"
+	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/relation"
+	"github.com/juju/juju/internal/charm"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
+	"github.com/juju/juju/rpc/params"
 )
 
 // uniterSuite implements common testing suite for all API
 // versions. It's not intended to be used directly or registered as a
 // suite, but embedded.
-type uniterGoalStateSuite struct{}
+type uniterGoalStateSuite struct {
+	testhelpers.IsolationSuite
+
+	applicationService *MockApplicationService
+	relationService    *MockRelationService
+	statusService      *MockStatusService
+
+	uniter *UniterAPI
+}
 
 func TestUniterGoalStateSuite(t *testing.T) {
 	tc.Run(t, &uniterGoalStateSuite{})
@@ -28,42 +52,604 @@ Given the initial state where:
 - An authoriser is congured to mock a logged in mysql unit
 
 This suite is missing tests for the following scenarios:
-- TestGoalStatesNoRelation: when no relations exist,
-  - GoalStates with the mysql/0 unit tag returns a "waiting" status for the unit only
-  - GoalStates with the wordpress/0 unit tag returns an unauthorized error
-
-- TestPeerUnitsNoRelation: when another mysql unit is deplouye to machine 1,
-  - GoalStates with the mysql/0 unit tag returns a "waiting" status for both mysql units
-  - GoalStates with the wordpress/0 unit tag returns an unauthorized error
-
-- TestGoalStatesSingleRelation: when a relation is added between the wordpress and mysql units,
-  - GoalStates with the mysql/0 unit tag returns a "waiting" status for the unit AND
-    (a waiting status for the wordpress unit AND a joining status for the relation between the units
-    indexed under the correct relation name)
-  - GoalStates with the wordpress/0 unit tag returns an unauthorized error
-
-- TestGoalStatesDeadUnitsExcluded: when a unit is destroyed, it's status is no longer
-  included in the GoalStates result
-
-- TestGoalStatesSingleRelationDyingUnits: when a unit is dying, it's status is included
-  in the GoalStates result, but it's goal status is switched to dying
-
 - TestGoalStatesCrossModelRelation: when a relation is added between the mysql unit and a cross-model
   relation is established, but relations are included in the GoalStates result with the URL as the key
   for the cmr relation (where previously the application name was used)
-
-- TestGoalStatesMultipleRelations: when:
-  - a second wordpress unit is added to machine 1
-  - a second wordpress application is deployed with a single unit to machine 1
-  - a second mysql application is deployed with a single unit to machine 2
-  - both wordpress applications are related to the original mysql application
-  - both mysql applications are related to the logging application
-then:
-  - GoalStates with the mysql/0 unit tag returns a "waiting" status for the unit AND (
-    the two related wordpress applications AND their three units have the expected statuses indexed
-    under the endpoint key AND the related loggin application and unit have the expected statuses
-    indexed under a different endpoint key
-  - GoalStates with the wordpress/0 unit tag returns an unauthorized error
-    )
 `)
+}
+
+func (s *uniterGoalStateSuite) TestGoalStatesNoRelation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	now := time.Now()
+
+	// arrange: an applications with a principal units in 'waiting' workload status
+	unitName := coreunit.Name("wordpress/0")
+	appID := applicationtesting.GenApplicationUUID(c)
+
+	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			unitName: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+		}, nil)
+
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "wordpress").
+		Return([]coreunit.Name{unitName}, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), unitName).Return(life.Alive, nil)
+
+	s.relationService.EXPECT().GetGoalStateRelationDataForApplication(gomock.Any(), appID).
+		Return([]relation.GoalStateRelationData{}, nil)
+
+	// act:
+	result, err := s.uniter.GoalStates(c.Context(), params.Entities{
+		Entities: []params.Entity{{
+			Tag: names.NewUnitTag(unitName.String()).String(),
+		}},
+	})
+
+	// assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.GoalStateResults{
+		Results: []params.GoalStateResult{{
+			Result: &params.GoalState{
+				Units: params.UnitsGoalState{
+					unitName.String(): params.GoalStateStatus{
+						Status: corestatus.Waiting.String(),
+						Since:  &now,
+					},
+				},
+				Relations: map[string]params.UnitsGoalState{},
+			},
+		}},
+	})
+}
+
+func (s *uniterGoalStateSuite) TestGoalStatesPeerUnitsNotRelation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	now := time.Now()
+
+	// arrange: an application with two principal units in 'waiting' workload status
+	// with a peer relation between them
+	unitName := coreunit.Name("wordpress/0")
+	otherUnitName := coreunit.Name("wordpress/1")
+	appID := applicationtesting.GenApplicationUUID(c)
+
+	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			unitName: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+			otherUnitName: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+		}, nil)
+
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "wordpress").
+		Return([]coreunit.Name{unitName, otherUnitName}, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), otherUnitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), unitName).Return(life.Alive, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), otherUnitName).Return(life.Alive, nil)
+
+	// arrange the peer relation
+	s.relationService.EXPECT().GetGoalStateRelationDataForApplication(gomock.Any(), appID).
+		Return([]relation.GoalStateRelationData{{
+			EndpointIdentifiers: []corerelation.EndpointIdentifier{
+				{
+					ApplicationName: "wordpress",
+					EndpointName:    "wordpress-peer",
+					Role:            charm.RolePeer,
+				},
+			},
+			Status: corestatus.Joining,
+			Since:  &now,
+		}}, nil)
+
+	// act:
+	result, err := s.uniter.GoalStates(c.Context(), params.Entities{
+		Entities: []params.Entity{{
+			Tag: names.NewUnitTag(unitName.String()).String(),
+		}},
+	})
+
+	// assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.GoalStateResults{
+		Results: []params.GoalStateResult{{
+			Result: &params.GoalState{
+				Units: params.UnitsGoalState{
+					unitName.String(): params.GoalStateStatus{
+						Status: corestatus.Waiting.String(),
+						Since:  &now,
+					},
+					otherUnitName.String(): params.GoalStateStatus{
+						Status: corestatus.Waiting.String(),
+						Since:  &now,
+					},
+				},
+				Relations: map[string]params.UnitsGoalState{},
+			},
+		}},
+	})
+}
+
+func (s *uniterGoalStateSuite) TestGoalStatesSingleRelation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	now := time.Now()
+
+	// arrange: an application with a single principal unit in 'waiting' workload status
+	// with a 'joining' relation to another unit in 'waiting' workload status
+
+	unitName := coreunit.Name("wordpress/0")
+	otherUnitName := coreunit.Name("mysql/0")
+	appID := applicationtesting.GenApplicationUUID(c)
+	otherAppID := applicationtesting.GenApplicationUUID(c)
+
+	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "wordpress").Return(otherAppID, nil)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "mysql").Return(otherAppID, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			unitName: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+		}, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), otherAppID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			otherUnitName: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+		}, nil)
+
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "wordpress").
+		Return([]coreunit.Name{unitName}, nil)
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "mysql").
+		Return([]coreunit.Name{otherUnitName}, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), otherUnitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), unitName).Return(life.Alive, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), otherUnitName).Return(life.Alive, nil)
+
+	// arrange the relation
+	s.relationService.EXPECT().GetGoalStateRelationDataForApplication(gomock.Any(), appID).
+		Return([]relation.GoalStateRelationData{{
+			EndpointIdentifiers: []corerelation.EndpointIdentifier{
+				{
+					ApplicationName: "wordpress",
+					EndpointName:    "db",
+					Role:            charm.RoleRequirer,
+				},
+				{
+					ApplicationName: "mysql",
+					EndpointName:    "db",
+					Role:            charm.RoleProvider,
+				},
+			},
+			Status: corestatus.Joining,
+			Since:  &now,
+		}}, nil)
+
+	// act:
+	result, err := s.uniter.GoalStates(c.Context(), params.Entities{
+		Entities: []params.Entity{{
+			Tag: names.NewUnitTag(unitName.String()).String(),
+		}},
+	})
+
+	// assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.GoalStateResults{
+		Results: []params.GoalStateResult{{
+			Result: &params.GoalState{
+				Units: params.UnitsGoalState{
+					unitName.String(): params.GoalStateStatus{
+						Status: corestatus.Waiting.String(),
+						Since:  &now,
+					},
+				},
+				Relations: map[string]params.UnitsGoalState{
+					"db": {
+						"mysql": {
+							Status: corestatus.Joining.String(),
+							Since:  &now,
+						},
+						"mysql/0": {
+							Status: corestatus.Waiting.String(),
+							Since:  &now,
+						},
+					},
+				},
+			},
+		}},
+	})
+}
+
+func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	now := time.Now()
+
+	// arrange: an application with a principal unit in 'waiting' workload status
+	// and a dead unit
+
+	unitName := coreunit.Name("wordpress/0")
+	deadUnitName := coreunit.Name("wordpress/1")
+	appID := applicationtesting.GenApplicationUUID(c)
+
+	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			unitName: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+			deadUnitName: {
+				Status: corestatus.Unknown,
+				Since:  &now,
+			},
+		}, nil)
+
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "wordpress").
+		Return([]coreunit.Name{unitName, deadUnitName}, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), deadUnitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), unitName).Return(life.Alive, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), deadUnitName).Return(life.Dead, nil)
+
+	// arrange the peer relation
+	s.relationService.EXPECT().GetGoalStateRelationDataForApplication(gomock.Any(), appID).
+		Return([]relation.GoalStateRelationData{{
+			EndpointIdentifiers: []corerelation.EndpointIdentifier{
+				{
+					ApplicationName: "wordpress",
+					EndpointName:    "wordpress-peer",
+					Role:            charm.RolePeer,
+				},
+			},
+			Status: corestatus.Waiting,
+			Since:  &now,
+		}}, nil)
+
+	// act:
+	result, err := s.uniter.GoalStates(c.Context(), params.Entities{
+		Entities: []params.Entity{{
+			Tag: names.NewUnitTag(unitName.String()).String(),
+		}},
+	})
+
+	// assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.GoalStateResults{
+		Results: []params.GoalStateResult{{
+			Result: &params.GoalState{
+				Units: params.UnitsGoalState{
+					unitName.String(): params.GoalStateStatus{
+						Status: corestatus.Waiting.String(),
+						Since:  &now,
+					},
+				},
+				Relations: map[string]params.UnitsGoalState{},
+			},
+		}},
+	})
+}
+
+func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	now := time.Now()
+
+	// arrange: an application with a principal unit in 'waiting' workload status
+	// and a dying unit
+
+	unitName := coreunit.Name("wordpress/0")
+	dyingUnitName := coreunit.Name("wordpress/1")
+	appID := applicationtesting.GenApplicationUUID(c)
+
+	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			unitName: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+			dyingUnitName: {
+				Status: corestatus.Unknown,
+				Since:  &now,
+			},
+		}, nil)
+
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "wordpress").
+		Return([]coreunit.Name{unitName, dyingUnitName}, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), dyingUnitName).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), unitName).Return(life.Alive, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), dyingUnitName).Return(life.Dying, nil)
+
+	// arrange the peer relation
+	s.relationService.EXPECT().GetGoalStateRelationDataForApplication(gomock.Any(), appID).
+		Return([]relation.GoalStateRelationData{{
+			EndpointIdentifiers: []corerelation.EndpointIdentifier{
+				{
+					ApplicationName: "wordpress",
+					EndpointName:    "wordpress-peer",
+					Role:            charm.RolePeer,
+				},
+			},
+			Status: corestatus.Waiting,
+			Since:  &now,
+		}}, nil)
+
+	// act:
+	result, err := s.uniter.GoalStates(c.Context(), params.Entities{
+		Entities: []params.Entity{{
+			Tag: names.NewUnitTag(unitName.String()).String(),
+		}},
+	})
+
+	// assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.GoalStateResults{
+		Results: []params.GoalStateResult{{
+			Result: &params.GoalState{
+				Units: params.UnitsGoalState{
+					unitName.String(): params.GoalStateStatus{
+						Status: corestatus.Waiting.String(),
+						Since:  &now,
+					},
+					dyingUnitName.String(): params.GoalStateStatus{
+						Status: "dying",
+						Since:  &now,
+					},
+				},
+				Relations: map[string]params.UnitsGoalState{},
+			},
+		}},
+	})
+}
+
+func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	now := time.Now()
+
+	// arrange:
+	// - A 'wordpress' applications with two units
+	//   - So the wordpress application has a peer relation
+	// - Two 'mysql' applications, one with two units, and one with one unit
+	// - A 'logging' application with a single unit
+	// - Our wordpress application is related to both mysql applications
+	// - Our wordpress application is related to the logging application
+
+	wpUnit := coreunit.Name("wordpress/0")
+	otherWpUnit := coreunit.Name("wordpress/1")
+	wpAppID := applicationtesting.GenApplicationUUID(c)
+	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), wpUnit).Return(wpAppID, nil)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "wordpress").Return(wpAppID, nil).MinTimes(1)
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "wordpress").
+		Return([]coreunit.Name{wpUnit, otherWpUnit}, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), wpUnit).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), otherWpUnit).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), wpUnit).Return(life.Alive, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), otherWpUnit).Return(life.Alive, nil)
+
+	mysqlUnit := coreunit.Name("mysql/0")
+	otherMysqlUnit := coreunit.Name("mysql/1")
+	mysqlAppID := applicationtesting.GenApplicationUUID(c)
+	otherAppMysqlUnit := coreunit.Name("other-mysql/0")
+	otherMysqlAppID := applicationtesting.GenApplicationUUID(c)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "mysql").Return(mysqlAppID, nil)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "other-mysql").Return(otherMysqlAppID, nil)
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "mysql").
+		Return([]coreunit.Name{mysqlUnit, otherMysqlUnit}, nil)
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "other-mysql").
+		Return([]coreunit.Name{otherAppMysqlUnit}, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), mysqlUnit).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), otherMysqlUnit).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), otherAppMysqlUnit).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), mysqlUnit).Return(life.Alive, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), otherMysqlUnit).Return(life.Alive, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), otherAppMysqlUnit).Return(life.Alive, nil)
+
+	loggingUnit := coreunit.Name("logging/0")
+	loggingAppID := applicationtesting.GenApplicationUUID(c)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "logging").Return(loggingAppID, nil)
+	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "logging").
+		Return([]coreunit.Name{loggingUnit}, nil)
+	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), loggingUnit).Return("", false, nil)
+	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), loggingUnit).Return(life.Alive, nil)
+
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), wpAppID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			wpUnit: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+			otherWpUnit: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+		}, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), mysqlAppID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			mysqlUnit: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+			otherMysqlUnit: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+		}, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), otherMysqlAppID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			otherAppMysqlUnit: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+		}, nil)
+	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), loggingAppID).
+		Return(map[coreunit.Name]corestatus.StatusInfo{
+			loggingUnit: {
+				Status: corestatus.Waiting,
+				Since:  &now,
+			},
+		}, nil)
+
+	// Arrange the relations
+	s.relationService.EXPECT().GetGoalStateRelationDataForApplication(gomock.Any(), wpAppID).
+		Return([]relation.GoalStateRelationData{
+			{
+				EndpointIdentifiers: []corerelation.EndpointIdentifier{
+					{
+						ApplicationName: "wordpress",
+						EndpointName:    "wordpress-peer",
+						Role:            charm.RolePeer,
+					},
+				},
+				Status: corestatus.Joining,
+				Since:  &now,
+			},
+			{
+				EndpointIdentifiers: []corerelation.EndpointIdentifier{
+					{
+						ApplicationName: "wordpress",
+						EndpointName:    "db",
+						Role:            charm.RoleRequirer,
+					},
+					{
+						ApplicationName: "mysql",
+						EndpointName:    "db",
+						Role:            charm.RoleProvider,
+					},
+				},
+				Status: corestatus.Joining,
+				Since:  &now,
+			}, {
+				EndpointIdentifiers: []corerelation.EndpointIdentifier{
+					{
+						ApplicationName: "wordpress",
+						EndpointName:    "db",
+						Role:            charm.RoleRequirer,
+					}, {
+						ApplicationName: "other-mysql",
+						EndpointName:    "db",
+						Role:            charm.RoleProvider,
+					},
+				},
+				Status: corestatus.Joining,
+				Since:  &now,
+			}, {
+				EndpointIdentifiers: []corerelation.EndpointIdentifier{
+					{
+						ApplicationName: "wordpress",
+						EndpointName:    "logging",
+						Role:            charm.RoleRequirer,
+					}, {
+						ApplicationName: "logging",
+						EndpointName:    "logging",
+						Role:            charm.RoleProvider,
+					},
+				},
+				Status: corestatus.Joining,
+				Since:  &now,
+			},
+		}, nil)
+
+	// Act:
+	result, err := s.uniter.GoalStates(c.Context(), params.Entities{
+		Entities: []params.Entity{{
+			Tag: names.NewUnitTag(wpUnit.String()).String(),
+		}},
+	})
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.GoalStateResults{
+		Results: []params.GoalStateResult{{
+			Result: &params.GoalState{
+				Units: params.UnitsGoalState{
+					wpUnit.String(): params.GoalStateStatus{
+						Status: corestatus.Waiting.String(),
+						Since:  &now,
+					},
+					otherWpUnit.String(): params.GoalStateStatus{
+						Status: corestatus.Waiting.String(),
+						Since:  &now,
+					},
+				},
+				Relations: map[string]params.UnitsGoalState{
+					"db": {
+						"mysql": params.GoalStateStatus{
+							Status: corestatus.Joining.String(),
+							Since:  &now,
+						},
+						"mysql/0": params.GoalStateStatus{
+							Status: corestatus.Waiting.String(),
+							Since:  &now,
+						},
+						"mysql/1": params.GoalStateStatus{
+							Status: corestatus.Waiting.String(),
+							Since:  &now,
+						},
+						"other-mysql": params.GoalStateStatus{
+							Status: corestatus.Joining.String(),
+							Since:  &now,
+						},
+						"other-mysql/0": params.GoalStateStatus{
+							Status: corestatus.Waiting.String(),
+							Since:  &now,
+						},
+					},
+					"logging": {
+						"logging": params.GoalStateStatus{
+							Status: corestatus.Joining.String(),
+							Since:  &now,
+						},
+						"logging/0": params.GoalStateStatus{
+							Status: corestatus.Waiting.String(),
+							Since:  &now,
+						},
+					},
+				},
+			},
+		}},
+	})
+}
+
+func (s *uniterGoalStateSuite) setupMocks(c *tc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+
+	s.applicationService = NewMockApplicationService(ctrl)
+	s.relationService = NewMockRelationService(ctrl)
+	s.statusService = NewMockStatusService(ctrl)
+
+	authFunc := func(ctx context.Context) (common.AuthFunc, error) {
+		return func(tag names.Tag) bool {
+			return true
+		}, nil
+	}
+
+	s.uniter = &UniterAPI{
+		applicationService: s.applicationService,
+		relationService:    s.relationService,
+		statusService:      s.statusService,
+		accessApplication:  authFunc,
+		accessUnit:         authFunc,
+		logger:             loggertesting.WrapCheckLog(c),
+	}
+
+	c.Cleanup(func() {
+		s.applicationService = nil
+		s.relationService = nil
+		s.statusService = nil
+		s.uniter = nil
+	})
+
+	return ctrl
 }

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -115,6 +115,9 @@ type ApplicationService interface {
 	// returned.
 	GetUnitMachineUUID(ctx context.Context, unitName coreunit.Name) (coremachine.UUID, error)
 
+	// GetUnitNamesForApplication returns a slice of the unit names for the given application
+	GetUnitNamesForApplication(ctx context.Context, appName string) ([]coreunit.Name, error)
+
 	// EnsureUnitDead is called by the unit agent just before it terminates.
 	EnsureUnitDead(ctx context.Context, unitName coreunit.Name, leadershipRevoker leadership.Revoker) error
 

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -676,6 +676,45 @@ func (c *MockApplicationServiceGetUnitMachineUUIDCall) DoAndReturn(f func(contex
 	return c
 }
 
+// GetUnitNamesForApplication mocks base method.
+func (m *MockApplicationService) GetUnitNamesForApplication(arg0 context.Context, arg1 string) ([]unit.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitNamesForApplication", arg0, arg1)
+	ret0, _ := ret[0].([]unit.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitNamesForApplication indicates an expected call of GetUnitNamesForApplication.
+func (mr *MockApplicationServiceMockRecorder) GetUnitNamesForApplication(arg0, arg1 any) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNamesForApplication", reflect.TypeOf((*MockApplicationService)(nil).GetUnitNamesForApplication), arg0, arg1)
+	return &MockApplicationServiceGetUnitNamesForApplicationCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitNamesForApplicationCall wrap *gomock.Call
+type MockApplicationServiceGetUnitNamesForApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Return(arg0 []unit.Name, arg1 error) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Do(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) DoAndReturn(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetUnitPrincipal mocks base method.
 func (m *MockApplicationService) GetUnitPrincipal(arg0 context.Context, arg1 unit.Name) (unit.Name, bool, error) {
 	m.ctrl.T.Helper()

--- a/state/state.go
+++ b/state/state.go
@@ -1009,7 +1009,7 @@ func (st *State) AddApplication(
 
 	if err = st.db().Run(buildTxn); err == nil {
 		// Refresh to pick the txn-revno.
-		if err = app.Refresh(); err != nil {
+		if err = app.refresh(); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return app, nil

--- a/state/storage.go
+++ b/state/storage.go
@@ -610,7 +610,7 @@ func validateRemoveOwnerStorageInstanceOps(si *storageInstance) ([]txn.Op, error
 		if app.Life() != Alive {
 			return nil, nil
 		}
-		ch, _, err := app.Charm()
+		ch, _, err := app.charm()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
The uniter facades still relied on Mongo for a couple of reads. This is not longer necessary. Cut these call sites over to DQLite.

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m 
$ juju deploy juju-qa-dummy-source
$ juju deploy juju-qa-dummy-sink
$ juju config dummy-source token=tok
$ juju integrate dummy-sink dummy-source
$ juju status --relations
Model  Controller  Cloud/Region   Version      Timestamp
m      lxd         lxd/localhost  4.0-beta6.1  11:22:00+01:00

App           Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
dummy-sink             active      1  juju-qa-dummy-sink    latest/stable    7  no       Token is tok
dummy-source           active      1  juju-qa-dummy-source  latest/stable    6  no       Token is tok

Unit             Workload  Agent  Machine  Public address  Ports  Message
dummy-sink/0*    active    idle                                   Token is tok
dummy-source/0*  active    idle                                   Token is tok

Machine  State    Address       Inst id        Base          AZ  Message
0        started  10.51.45.38   juju-90df72-0  ubuntu@20.04      Running
1        started  10.51.45.214  juju-90df72-1  ubuntu@20.04      Running

Integration provider  Requirer           Interface    Type     Message
dummy-sink:source     dummy-source:sink  dummy-token  regular  
```