### PR TITLE
feat: add DeriveNetIP to core network

### DIFF
--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -226,7 +226,7 @@ func (s *AddressSuite) TestNewAddresses(c *tc.C) {
 		network.IPv6Address,
 		network.ScopeMachineLocal,
 	}, {
-		[]string{"192.168.1.1", "192.168.178.255", "10.5.1.1", "172.16.1.1"},
+		[]string{"192.168.1.1", "192.168.178.255", "192.168.178.255/8", "10.5.1.1", "172.16.1.1"},
 		network.IPv4Address,
 		network.ScopeCloudLocal,
 	}, {
@@ -234,11 +234,11 @@ func (s *AddressSuite) TestNewAddresses(c *tc.C) {
 		network.IPv6Address,
 		network.ScopeCloudLocal,
 	}, {
-		[]string{"8.8.8.8", "8.8.4.4"},
+		[]string{"8.8.8.8", "8.8.4.4", "8.8.8.8/32"},
 		network.IPv4Address,
 		network.ScopePublic,
 	}, {
-		[]string{"2001:db8::1", "64:ff9b::1", "2002::1"},
+		[]string{"2001:db8::1", "64:ff9b::1", "64:ff9b::1/24", "2002::1"},
 		network.IPv6Address,
 		network.ScopePublic,
 	}, {
@@ -976,6 +976,10 @@ func (s *AddressSuite) TestAddressValueForCIDR(c *tc.C) {
 	val, err := network.NewMachineAddress("172.31.37.53", network.WithCIDR("172.31.37.0/20")).ValueWithMask()
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(val, tc.Equals, "172.31.37.53/20")
+
+	val2, err := network.NewMachineAddress("172.31.37.53/20", network.WithCIDR("172.31.37.0/20")).ValueWithMask()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(val2, tc.Equals, "172.31.37.53/20")
 }
 
 func (s *AddressSuite) TestCIDRAddressType(c *tc.C) {
@@ -1413,4 +1417,16 @@ func (s *AddressSuite) TestIsLocalAddress(c *tc.C) {
 
 		c.Check(isLocal, tc.Equals, tt.expected)
 	}
+}
+
+func (s *AddressSuite) TestSimpleNewMachineAddress(c *tc.C) {
+	addr := network.NewMachineAddress("10.3.5.4/8")
+	c.Check(addr.Value, tc.Equals, "10.3.5.4/8")
+	c.Check(addr.IP().String(), tc.Equals, "10.3.5.4")
+	c.Check(addr.AddressType(), tc.Equals, network.IPv4Address)
+
+	addr = network.NewMachineAddress("2001:db8::1/8")
+	c.Check(addr.Value, tc.Equals, "2001:db8::1/8")
+	c.Check(addr.IP().String(), tc.Equals, "2001:db8::1")
+	c.Check(addr.AddressType(), tc.Equals, network.IPv6Address)
 }

--- a/environs/manual/addresses.go
+++ b/environs/manual/addresses.go
@@ -4,8 +4,6 @@
 package manual
 
 import (
-	"net"
-
 	"github.com/juju/juju/core/network"
 )
 
@@ -13,7 +11,7 @@ import (
 // hostname, depending on whether it is an IP or a resolvable
 // hostname. The address is given public scope.
 func HostAddress(hostname string) (network.ProviderAddress, error) {
-	if ip := net.ParseIP(hostname); ip != nil {
+	if ip := network.DeriveNetIP(hostname); ip != nil {
 		addr := network.ProviderAddress{
 			MachineAddress: network.MachineAddress{
 				Value: ip.String(),

--- a/environs/manual/addresses_test.go
+++ b/environs/manual/addresses_test.go
@@ -61,8 +61,22 @@ func (s *addressesSuite) TestHostAddressIPv4(c *tc.C) {
 	c.Assert(addr, tc.Equals, network.NewMachineAddress("127.0.0.1", network.WithScope(network.ScopePublic)).AsProviderAddress())
 }
 
+func (s *addressesSuite) TestHostAddressIPv4WithMask(c *tc.C) {
+	addr, err := manual.HostAddress("127.0.0.1/24")
+	c.Assert(s.netLookupHostCalled, tc.Equals, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(addr, tc.Equals, network.NewMachineAddress("127.0.0.1", network.WithScope(network.ScopePublic)).AsProviderAddress())
+}
+
 func (s *addressesSuite) TestHostAddressIPv6(c *tc.C) {
 	addr, err := manual.HostAddress("::1")
+	c.Assert(s.netLookupHostCalled, tc.Equals, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(addr, tc.Equals, network.NewMachineAddress("::1", network.WithScope(network.ScopePublic)).AsProviderAddress())
+}
+
+func (s *addressesSuite) TestHostAddressIPv6WithMask(c *tc.C) {
+	addr, err := manual.HostAddress("::1/24")
 	c.Assert(s.netLookupHostCalled, tc.Equals, 0)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(addr, tc.Equals, network.NewMachineAddress("::1", network.WithScope(network.ScopePublic)).AsProviderAddress())


### PR DESCRIPTION
DeriveNetIP replaces calls to net.IP now that a network address value can be hostname (juju-4febc8-0), an ip address (192.168.0.6), or an ip address with subnetmask (192.168.0.6/24).

When handling a MachineAddress.Value, please use `DeriveNetIP` rather than `net.ParseIP` for consistent results.

MachineAddress updated to use this. Fixing some subtle bugs. E.g. if the MachineAddress value was in the form `192.168.0.5/24`, NewMachineAddress would fail to find the correct ip type; the `IP()` method would return nil with the same value. 

## Checklist
- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

All unit tests should pass. No change to current behavior.