### PR TITLE
feat: add default IPv6 k8s subnet

### DIFF
--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1064,7 +1064,7 @@ func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingEmptyAddress
 	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
 		{
 			MachineAddress: network.MachineAddress{
-				Value:      "10.0.0.1",
+				Value:      "10.0.0.1/8",
 				ConfigType: network.ConfigStatic,
 				Type:       network.IPv4Address,
 				Scope:      network.ScopeCloudLocal,
@@ -1072,7 +1072,7 @@ func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingEmptyAddress
 		},
 		{
 			MachineAddress: network.MachineAddress{
-				Value:      "10.0.0.2",
+				Value:      "10.0.0.2/8",
 				ConfigType: network.ConfigDHCP,
 				Type:       network.IPv6Address,
 				Scope:      network.ScopeLinkLocal,
@@ -1110,13 +1110,13 @@ WHERE application_uuid = ?
 		c.Assert(resultAddresses, tc.SameContents, expectedAddresses)
 	}
 
-	checkAddresses(c, "10.0.0.1", "10.0.0.2")
+	checkAddresses(c, "10.0.0.1/8", "10.0.0.2/8")
 
 	err = s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{})
 	c.Assert(err, tc.ErrorIsNil)
 	// Since no addresses were passed as input, the previous addresses should
 	// be returned.
-	checkAddresses(c, "10.0.0.1", "10.0.0.2")
+	checkAddresses(c, "10.0.0.1/8", "10.0.0.2/8")
 }
 
 func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingWithAddresses(c *tc.C) {
@@ -1125,7 +1125,7 @@ func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingWithAddresse
 	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
 		{
 			MachineAddress: network.MachineAddress{
-				Value:      "10.0.0.1",
+				Value:      "10.0.0.1/24",
 				ConfigType: network.ConfigStatic,
 				Type:       network.IPv4Address,
 				Scope:      network.ScopeCloudLocal,
@@ -1133,7 +1133,7 @@ func (s *applicationStateSuite) TestUpsertCloudServiceUpdateExistingWithAddresse
 		},
 		{
 			MachineAddress: network.MachineAddress{
-				Value:      "10.0.0.2",
+				Value:      "10.0.0.2/24",
 				ConfigType: network.ConfigDHCP,
 				Type:       network.IPv6Address,
 				Scope:      network.ScopeLinkLocal,
@@ -1171,12 +1171,12 @@ WHERE application_uuid = ?
 		c.Assert(resultAddresses, tc.SameContents, expectedAddresses)
 	}
 
-	checkAddresses(c, "10.0.0.1", "10.0.0.2")
+	checkAddresses(c, "10.0.0.1/24", "10.0.0.2/24")
 
 	err = s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
 		{
 			MachineAddress: network.MachineAddress{
-				Value:      "192.168.0.0",
+				Value:      "192.168.0.0/24",
 				ConfigType: network.ConfigStatic,
 				Type:       network.IPv4Address,
 				Scope:      network.ScopeCloudLocal,
@@ -1184,7 +1184,7 @@ WHERE application_uuid = ?
 		},
 		{
 			MachineAddress: network.MachineAddress{
-				Value:      "192.168.0.1",
+				Value:      "192.168.0.1/24",
 				ConfigType: network.ConfigDHCP,
 				Type:       network.IPv6Address,
 				Scope:      network.ScopeLinkLocal,
@@ -1194,7 +1194,7 @@ WHERE application_uuid = ?
 	c.Assert(err, tc.ErrorIsNil)
 	// Since no addresses were passed as input, the previous addresses should
 	// be returned.
-	checkAddresses(c, "192.168.0.0", "192.168.0.1")
+	checkAddresses(c, "192.168.0.0/24", "192.168.0.1/24")
 }
 
 func (s *applicationStateSuite) TestUpsertCloudServiceNotFound(c *tc.C) {
@@ -3721,11 +3721,10 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudService(c *tc.C) {
 			UnitName: "foo/0",
 		})
 
+	network.NewMachineAddress("10.0.0.1/24")
 	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
 		{
-			MachineAddress: network.MachineAddress{
-				Value: "10.0.0.1",
-			},
+			MachineAddress: network.NewMachineAddress("10.0.0.1/24"),
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -3742,7 +3741,7 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudService(c *tc.C) {
 
 	hash, err := s.state.GetAddressesHash(c.Context(), appID, netNodeUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(hash, tc.Equals, "6a6a947ce7d1aa01e1da0984ecf037c76fa1b9f2136b3113cd7e8ab312239686")
+	c.Check(hash, tc.Equals, "6e97876f0c817d2ba3b4d736f3fceb639049997e609803028673eeaeeaa01cf5")
 }
 
 func (s *applicationStateSuite) TestGetAddressesHashCloudServiceWithEndpointBindings(c *tc.C) {
@@ -3751,9 +3750,7 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudServiceWithEndpointBind
 	})
 	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
 		{
-			MachineAddress: network.MachineAddress{
-				Value: "10.0.0.1",
-			},
+			MachineAddress: network.NewMachineAddress("10.0.0.1/24"),
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -3792,7 +3789,7 @@ func (s *applicationStateSuite) TestGetAddressesHashCloudServiceWithEndpointBind
 
 	hash, err := s.state.GetAddressesHash(c.Context(), appID, netNodeUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(hash, tc.Equals, "e174cad78a387fb380d0f9cf277a7edb759549f6afdafdfc4adf0c243e18d375")
+	c.Check(hash, tc.Equals, "55d79355f44aa2d2799338219e2c2d2e67f61d3de026bf0415093d2de9d01afc")
 }
 
 func (s *applicationStateSuite) TestHashAddresses(c *tc.C) {
@@ -3843,9 +3840,7 @@ func (s *applicationStateSuite) TestGetNetNodeFromK8sService(c *tc.C) {
 
 	err := s.state.UpsertCloudService(c.Context(), "foo", "provider-id", network.ProviderAddresses{
 		{
-			MachineAddress: network.MachineAddress{
-				Value: "10.0.0.1",
-			},
+			MachineAddress: network.NewMachineAddress("10.0.0.1/8"),
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/application/state/package_test.go
+++ b/domain/application/state/package_test.go
@@ -378,6 +378,11 @@ func (s *baseSuite) createSubnetForCAASModel(c *tc.C) {
 
 		subnetUUID := uuid.MustNewUUID().String()
 		_, err := tx.ExecContext(ctx, "INSERT INTO subnet (uuid, cidr) VALUES (?, ?)", subnetUUID, "0.0.0.0/0")
+		if err != nil {
+			return err
+		}
+		subnetUUID2 := uuid.MustNewUUID().String()
+		_, err = tx.ExecContext(ctx, "INSERT INTO subnet (uuid, cidr) VALUES (?, ?)", subnetUUID2, "::/0")
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -217,6 +217,11 @@ type spaceAddress struct {
 	SubnetCIDR   sql.NullString              `db:"cidr"`
 }
 
+type subnet struct {
+	UUID string `db:"uuid"`
+	CIDR string `db:"cidr"`
+}
+
 // These structs represent the persistent charm schema in the database.
 
 // charmID represents a single charm row from the charm table, that only

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -864,9 +864,7 @@ func (s *watcherSuite) TestWatchCloudServiceAddressesHash(c *tc.C) {
 	// Add a cloud service to get an initial state.
 	err := svc.UpdateCloudService(ctx, "foo", "foo-provider", network.ProviderAddresses{
 		{
-			MachineAddress: network.MachineAddress{
-				Value: "10.0.0.1",
-			},
+			MachineAddress: network.NewMachineAddress("10.0.0.1"),
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -880,9 +878,7 @@ func (s *watcherSuite) TestWatchCloudServiceAddressesHash(c *tc.C) {
 		// Change the address for the cloud service should trigger a change.
 		err := svc.UpdateCloudService(ctx, "foo", "foo-provider", network.ProviderAddresses{
 			{
-				MachineAddress: network.MachineAddress{
-					Value: "192.168.0.1",
-				},
+				MachineAddress: network.NewMachineAddress("192.168.0.1"),
 			},
 		})
 		c.Assert(err, tc.ErrorIsNil)
@@ -921,7 +917,7 @@ func (s *watcherSuite) TestWatchCloudServiceAddressesHash(c *tc.C) {
 	})
 
 	// Hash of the initial state.
-	harness.Run(c, []string{"e9daa2b006ff0740cebfce4a761243bc032d518221fdfa16df53e3aa701591cc"})
+	harness.Run(c, []string{"722ba9e367e446b51bd7a473ab0a6002f8eb2f848a03169d7dfa63b7a88e3e8a"})
 }
 
 func (s *watcherSuite) TestWatchUnitAddressesHashBadName(c *tc.C) {
@@ -1602,6 +1598,11 @@ func (s *watcherSuite) createSubnetForCAASModel(c *tc.C) {
 
 		subnetUUID := uuid.MustNewUUID().String()
 		_, err := tx.ExecContext(ctx, "INSERT INTO subnet (uuid, cidr) VALUES (?, ?)", subnetUUID, "0.0.0.0/0")
+		if err != nil {
+			return err
+		}
+		subnetUUID2 := uuid.MustNewUUID().String()
+		_, err = tx.ExecContext(ctx, "INSERT INTO subnet (uuid, cidr) VALUES (?, ?)", subnetUUID2, "::/0")
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/provider/kubernetes/networking.go
+++ b/internal/provider/kubernetes/networking.go
@@ -26,7 +26,11 @@ func (environNetworking) Subnets(_ context.Context, _ []network.Id) ([]network.S
 	// in Kubernetes is improved.
 	return []network.SubnetInfo{
 		{
-			CIDR: "0.0.0.0/0",
+			CIDR:       "0.0.0.0/0",
+			ProviderId: "subnet-placeholder-0.0.0.0/0",
+		}, {
+			CIDR:       "::/0",
+			ProviderId: "subnet-placeholder-::/0",
 		},
 	}, nil
 }

--- a/internal/provider/kubernetes/networking_test.go
+++ b/internal/provider/kubernetes/networking_test.go
@@ -41,7 +41,11 @@ func (s *k8sNetworkingSuite) TestSubnets(c *tc.C) {
 	c.Assert(err, tc.IsNil)
 	c.Assert(result, tc.DeepEquals, []network.SubnetInfo{
 		{
-			CIDR: "0.0.0.0/0",
+			CIDR:       "0.0.0.0/0",
+			ProviderId: "subnet-placeholder-0.0.0.0/0",
+		}, {
+			CIDR:       "::/0",
+			ProviderId: "subnet-placeholder-::/0",
 		},
 	})
 }


### PR DESCRIPTION
Follow on to #19950.

Add a default IPv6 subnet for Kubernetes. Required adding a unique default ProviderIDs to allow the AddSubnet method to work properly. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1) Bootstrap Kubernetes.

2) Check that the bootstrap process correctly inserted the subnet into the controller model. 
Note: bootstrap will fail if the subnet does not exist
```
repl (controller)> .switch model-controller
repl (model-controller)> select * from subnet
uuid					cidr		vlan_tag	space_uuid
0197644d-f668-7bc8-a639-c951752a548c	0.0.0.0/0	0		656b4a82-e28c-53d6-a014-f0dd53417eb6
0197644d-f668-7bd8-a984-1b2a6516393a	::/0		0		656b4a82-e28c-53d6-a014-f0dd53417eb6

repl (model-controller)> select * from provider_subnet
provider_id			subnet_uuid
subnet-placeholder-0.0.0.0/0	0197644d-f668-7bc8-a639-c951752a548c
subnet-placeholder-::/0		0197644d-f668-7bd8-a984-1b2a6516393a
``` 

## Links

**Jira card:** JUJU-7942
