### PR TITLE
feat: populate device parents with incoming machine network config

### DIFF
--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -652,3 +652,10 @@ func (subs subnetGroups) subnetForIP(ip string) (string, error) {
 
 	return "", errors.Errorf("no subnet found for IP %q", ip)
 }
+
+type deviceParent struct {
+	// DeviceUUID is the UUID of the device.
+	DeviceUUID string `db:"device_uuid"`
+	// ParentUUID is the UUID of the parent device.
+	ParentUUID string `db:"parent_uuid"`
+}


### PR DESCRIPTION
Simple reads device/parent names, matches device UUIDs and populates `link_layer_device_parent`.

## QA steps

I tested on MAAS.
- Bootstrap.
- `juju switch controller`.
- `juju add-machine lxd:0 --constraints spaces=primary,secondary` (bridges correct networks).
- `juju ssh -m controller 0`.
- `juju_db_repl`.
- `.switch model-controller`
- `select * from link_layer_device`:
```
uuid                                    net_node_uuid                           namemtu      mac_address             device_type_id  virtual_port_type_id    is_auto_startis_enabled      is_default_gateway      gateway_address vlan_tag
4a8d218d-578a-4dc6-80b6-c4716bde200b    22aae6ba-199b-4890-8328-dfccb1064674    lo  65536    <nil>                   1               0                       true        true             false                   <nil>           0
503f43a4-3480-4dcd-804b-f1ea3464ed08    22aae6ba-199b-4890-8328-dfccb1064674    eno11500     b8:ae:ed:76:80:72       2               0                       true        true             false                   192.168.30.1    0
e1d52436-f677-4fc2-8ce0-357a6a73c715    22aae6ba-199b-4890-8328-dfccb1064674    enx00e07cc861de      1500    00:e0:7c:c8:61:de       2               0                   true             true            false                   <nil>           0
73339dc7-5faa-4b83-8b45-a36de3d36015    6fa96116-bb7e-42af-8c7d-76463fd76107    lo  65536    <nil>                   1               0                       true        true             false                   <nil>           0
89ecc4ec-c605-4324-8698-e6218da70805    6fa96116-bb7e-42af-8c7d-76463fd76107    eth01500     00:16:3e:48:03:60       2               0                       true        true             false                   192.168.40.1    0
57fbd03e-6445-473f-8185-a1f87287ff27    6fa96116-bb7e-42af-8c7d-76463fd76107    eth11500     00:16:3e:f6:b8:f0       2               0                       true        true             false                   <nil>           0
```
- `select * from link_layer_device_parent` to see the linkage:
```
```

## Links

**Jira card:** [JUJU-8043](https://warthogs.atlassian.net/browse/JUJU-8043)
