### PR TITLE
feat:  support --attach-storage option for deploy application on k8s

### DIFF
--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -142,6 +142,7 @@ type ProvisioningInfo struct {
 	Tags                 map[string]string
 	Constraints          constraints.Value
 	Filesystems          []storage.KubernetesFilesystemParams
+	Volumes              []storage.KubernetesVolumeParams
 	Devices              []devices.KubernetesDeviceParams
 	Base                 corebase.Base
 	ImageDetails         resources.DockerImageDetails
@@ -186,12 +187,20 @@ func (c *Client) ProvisioningInfo(applicationName string) (ProvisioningInfo, err
 		Trust:                r.Trust,
 		Scale:                r.Scale,
 	}
+
 	for _, fs := range r.Filesystems {
 		f, err := filesystemFromParams(fs)
 		if err != nil {
 			return info, errors.Trace(err)
 		}
 		info.Filesystems = append(info.Filesystems, *f)
+	}
+	for _, vol := range r.Volumes {
+		v, err := volumeFromParams(vol)
+		if err != nil {
+			return info, errors.Trace(err)
+		}
+		info.Volumes = append(info.Volumes, *v)
 	}
 
 	for _, device := range r.Devices {
@@ -209,7 +218,6 @@ func (c *Client) ProvisioningInfo(applicationName string) (ProvisioningInfo, err
 		}
 		info.CharmURL = charmURL
 	}
-
 	return info, nil
 }
 
@@ -233,6 +241,7 @@ func filesystemFromParams(in params.KubernetesFilesystemParams) (*storage.Kubern
 }
 
 func filesystemAttachmentFromParams(in params.KubernetesFilesystemAttachmentParams) (*storage.KubernetesFilesystemAttachmentParams, error) {
+
 	return &storage.KubernetesFilesystemAttachmentParams{
 		AttachmentParams: storage.AttachmentParams{
 			Provider: storage.ProviderType(in.Provider),
@@ -240,6 +249,34 @@ func filesystemAttachmentFromParams(in params.KubernetesFilesystemAttachmentPara
 		},
 		Path: in.MountPoint,
 	}, nil
+}
+
+func volumeFromParams(in params.KubernetesVolumeParams) (*storage.KubernetesVolumeParams, error) {
+	params := &storage.KubernetesVolumeParams{
+		StorageName: in.StorageName,
+		Provider:    storage.ProviderType(in.Provider),
+		Size:        in.Size,
+		Attributes:  in.Attributes,
+		Tags:        in.Tags,
+	}
+	if in.Attachment != nil {
+		unitTag, err := names.ParseTag(in.Attachment.UnitTag)
+		if err != nil {
+			return nil, err
+		}
+		params.Attachment = &storage.KubernetesVolumeAttachmentParams{
+			VolumeAttachmentParams: storage.VolumeAttachmentParams{
+				AttachmentParams: storage.AttachmentParams{
+					Provider: storage.ProviderType(in.Provider),
+					Machine:  unitTag,
+					ReadOnly: in.Attachment.ReadOnly,
+				},
+				Volume:   names.NewVolumeTag(in.Attachment.VolumeTag),
+				VolumeId: in.Attachment.VolumeId,
+			},
+		}
+	}
+	return params, nil
 }
 
 // SetOperatorStatus updates the provisioning status of an operator.

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -457,11 +457,6 @@ func (c caasDeployParams) precheck(
 	registry storage.ProviderRegistry,
 	caasBroker CaasBrokerInterface,
 ) error {
-	if len(c.attachStorage) > 0 {
-		return errors.Errorf(
-			"AttachStorage may not be specified for container models",
-		)
-	}
 	if len(c.placement) > 1 {
 		return errors.Errorf(
 			"only 1 placement directive is supported for container models, got %d",

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -518,6 +518,12 @@ func (v caasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepo
 	if err := v.caasPrecheckFunc(dt); err != nil {
 		errs = append(errs, err)
 	}
+
+	attachStorage, attachStorageErrs := validateAndParseAttachStorage(arg.AttachStorage, dt.numUnits)
+	if len(attachStorageErrs) > 0 {
+		errs = append(errs, attachStorageErrs...)
+	}
+	dt.attachStorage = attachStorage
 	return dt, errs
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -307,6 +307,11 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		return nil, errors.Trace(err)
 	}
 
+	volumeParams, err := a.applicationVolumeParams(app, cfg, modelConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	devices, err := a.devicesParams(app)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -364,6 +369,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		CACert:               caCert,
 		Tags:                 resourceTags,
 		Filesystems:          filesystemParams,
+		Volumes:              volumeParams,
 		Devices:              devices,
 		Constraints:          mergedCons,
 		Base:                 params.Base{Name: base.OS, Channel: base.Channel},
@@ -533,6 +539,64 @@ func poolStorageProvider(poolManager poolmanager.PoolManager, registry storage.P
 	}
 	providerType := pool.Provider()
 	return providerType, pool.Attrs(), nil
+}
+
+func (a *API) applicationVolumeParams(
+	app Application,
+	controllerConfig controller.Config,
+	modelConfig *config.Config,
+) ([]params.KubernetesVolumeParams, error) {
+
+	units, err := app.AllUnits()
+	if err != nil {
+		return []params.KubernetesVolumeParams{}, err
+	}
+	var k8sVolParams []params.KubernetesVolumeParams
+	for _, unit := range units {
+		unitStorageAttachments, err := a.storage.UnitStorageAttachments(unit.Tag().(names.UnitTag))
+		if err != nil {
+			return []params.KubernetesVolumeParams{}, err
+		}
+		for _, unitStorageAttachment := range unitStorageAttachments {
+			storageTag := unitStorageAttachment.StorageInstance()
+			volume, err := a.storage.StorageInstanceVolume(storageTag)
+			if err != nil {
+				return []params.KubernetesVolumeParams{}, err
+			}
+
+			volumeInfo, err := volume.Info()
+			if errors.Is(err, errors.NotProvisioned) {
+				// Skip if the volume has not been provisioned; this indicates the user did not attach the storage.
+				continue
+			} else if err != nil {
+				return []params.KubernetesVolumeParams{}, err
+			}
+
+			storageName, err := names.StorageName(storageTag.Id())
+			if err != nil {
+				return []params.KubernetesVolumeParams{}, err
+			}
+			k8sVolParams = append(
+				k8sVolParams,
+				params.KubernetesVolumeParams{
+					StorageName: storageName,
+					Size:        volumeInfo.Size,
+					Provider:    volumeInfo.Pool,
+					// TODO: Add missing fields: Attributes, Tags
+					Attachment: &params.KubernetesVolumeAttachmentParams{
+						// Ignore ReadOnly field here because it's impossible to change
+						// PersistentVolume's accessMode after created.
+						Provider:  volumeInfo.Pool,
+						VolumeId:  volumeInfo.VolumeId,
+						VolumeTag: volume.VolumeTag().Id(),
+						UnitTag:   unit.Tag().String(),
+					},
+				},
+			)
+		}
+
+	}
+	return k8sVolParams, nil
 }
 
 func (a *API) applicationFilesystemParams(

--- a/caas/application.go
+++ b/caas/application.go
@@ -129,6 +129,9 @@ type ApplicationConfig struct {
 	// Filesystems is a set of parameters for filesystems that should be created.
 	Filesystems []storage.KubernetesFilesystemParams
 
+	// Volumes is a set of parameters for volumes that should be created.
+	Volumes []storage.KubernetesVolumeParams
+
 	// Devices is a set of parameters for Devices that is required.
 	Devices []devices.KubernetesDeviceParams
 

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -242,12 +242,13 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 		applier.Apply(&resources.StorageClass{StorageClass: sc})
 		return nil
 	}
-	var configureStorage = func(storageUniqueID string, handlePVC handlePVCFunc) error {
+	var configureStorage = func(storageUniqueID string, handlePVC handlePVCFunc, handlePVCVolume handlePVCVolumeFunc) error {
 		err := a.configureStorage(
 			storageUniqueID,
 			config.Filesystems,
+			config.Volumes,
 			storageClasses,
-			handleVolume, handleVolumeMount, handlePVC, handleStorageClass,
+			handleVolume, handleVolumeMount, handlePVC, handlePVCVolume, handleStorageClass,
 		)
 		return errors.Trace(err)
 	}
@@ -313,6 +314,22 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 					MountPath: mountPath,
 				}, nil
 			},
+			func(pvc corev1.PersistentVolumeClaim, pvcName string, volumeName string) error {
+				pvc.ObjectMeta.Name = pvcName
+				pvc.ObjectMeta.Namespace = a.namespace
+				pvc.Spec.VolumeName = volumeName
+
+				persistentVolumeClaim := resources.PersistentVolumeClaim{PersistentVolumeClaim: pvc}
+				err := persistentVolumeClaim.Get(context.Background(), a.client)
+				if errors.Is(err, errors.NotFound) {
+					logger.Debugf("pvc %s not found, create pvc with VolumeName %s", pvcName, volumeName)
+					persistentVolumeClaim.Spec.VolumeName = volumeName
+					applier.Apply(&persistentVolumeClaim)
+				} else if err != nil {
+					return errors.Trace(err)
+				}
+				return nil
+			},
 		); err != nil {
 			return errors.Trace(err)
 		}
@@ -337,7 +354,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 			numPods = pointer.Int32(int32(config.InitialScale))
 		}
 		// Config storage to update the podspec with storage info.
-		if err = configureStorage(storageUniqueID, handlePVCForStatelessResource); err != nil {
+		if err = configureStorage(storageUniqueID, handlePVCForStatelessResource, nil); err != nil {
 			return errors.Trace(err)
 		}
 		deployment := resources.Deployment{
@@ -374,7 +391,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 			return errors.Trace(err)
 		}
 		// Config storage to update the podspec with storage info.
-		if err = configureStorage(storageUniqueID, handlePVCForStatelessResource); err != nil {
+		if err = configureStorage(storageUniqueID, handlePVCForStatelessResource, nil); err != nil {
 			return errors.Trace(err)
 		}
 		daemonset := resources.DaemonSet{
@@ -1925,6 +1942,7 @@ func (a *app) getStorageUniqPrefix(getMeta func() (annotationGetter, error)) (st
 
 type handleVolumeFunc func(vol corev1.Volume, mountPath string, readOnly bool) (*corev1.VolumeMount, error)
 type handlePVCFunc func(pvc corev1.PersistentVolumeClaim, mountPath string, readOnly bool) (*corev1.VolumeMount, error)
+type handlePVCVolumeFunc func(pvc corev1.PersistentVolumeClaim, pvcName string, volumeName string) error
 type handleVolumeMountFunc func(string, corev1.VolumeMount) error
 type handleStorageClassFunc func(storagev1.StorageClass) error
 
@@ -1983,10 +2001,12 @@ func (a *app) pvcNames(storagePrefix string) (map[string]string, error) {
 func (a *app) configureStorage(
 	storageUniqueID string,
 	filesystems []jujustorage.KubernetesFilesystemParams,
+	volumes []jujustorage.KubernetesVolumeParams,
 	storageClasses []resources.StorageClass,
 	handleVolume handleVolumeFunc,
 	handleVolumeMount handleVolumeMountFunc,
 	handlePVC handlePVCFunc,
+	handlePVCVolume handlePVCVolumeFunc,
 	handleStorageClass handleStorageClassFunc,
 ) error {
 	storageClassMap := make(map[string]resources.StorageClass)
@@ -2055,6 +2075,14 @@ func (a *app) configureStorage(
 		if volumeMount != nil {
 			if err = handleVolumeMount(fs.StorageName, *volumeMount); err != nil {
 				return errors.Trace(err)
+			}
+		}
+
+		for _, volume := range volumes {
+			if volume.Attachment != nil && volume.StorageName == fs.StorageName {
+				// Replace unit-{appName}-{unitNumber} to {appName}-{storageName}-{uniqueId}-{appName}-{unitNumber}
+				pvcName := strings.Replace(volume.Attachment.Machine.String(), "unit", pvc.ObjectMeta.Name, 1)
+				handlePVCVolume(*pvc, pvcName, volume.Attachment.VolumeId)
 			}
 		}
 	}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -732,9 +732,6 @@ func (c *DeployCommand) validateStorageByModelType() error {
 	if modelType == model.IAAS {
 		return nil
 	}
-	if len(c.AttachStorage) > 0 {
-		return errors.New("--attach-storage cannot be used on k8s models")
-	}
 	return nil
 }
 

--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -65,6 +65,13 @@ To import a filesystem, you must specify three things:
 
 Once a filesystem is imported, Juju will create an associated storage
 instance using the given storage name.
+
+For Kubernetes models, when importing a PersistentVolume, the following
+conditions must be met:
+
+ - the PersistentVolume's reclaim policy must be set to "Retain".
+ - the PersistentVolume must not be bound to any PersistentVolumeClaim.
+
 `
 	importFilesystemCommandExamples = `
 Import an existing filesystem backed by an EBS volume,
@@ -74,6 +81,10 @@ the volume and filesystem contained within.
 
     juju import-filesystem ebs vol-123456 pgdata
 
+Import an existing unbound PersistentVolume in a Kubernetes model,
+and assign it the "pgdata" storage name:
+
+    juju import-filesystem kubernetes pv-data-001 pgdata
 `
 
 	importFilesystemCommandAgs = `
@@ -84,7 +95,6 @@ the volume and filesystem contained within.
 // importFilesystemCommand imports filesystems into the model.
 type importFilesystemCommand struct {
 	StorageCommandBase
-	modelcmd.IAASOnlyCommand
 	newAPIFunc NewStorageImporterFunc
 
 	storagePool       string

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/import-filesystem.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/import-filesystem.md
@@ -25,6 +25,10 @@ the volume and filesystem contained within.
 
     juju import-filesystem ebs vol-123456 pgdata
 
+Import an existing unbound PersistentVolume in a Kubernetes model,
+and assign it the "pgdata" storage name:
+
+    juju import-filesystem kubernetes pv-data-001 pgdata
 
 
 ## Details
@@ -44,3 +48,9 @@ To import a filesystem, you must specify three things:
 
 Once a filesystem is imported, Juju will create an associated storage
 instance using the given storage name.
+
+For Kubernetes models, when importing a PersistentVolume, the following
+conditions must be met:
+
+ - the PersistentVolume's reclaim policy must be set to "Retain".
+ - the PersistentVolume must not be bound to any PersistentVolumeClaim.

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -205,6 +205,7 @@ func appAlive(appName string, app caas.Application, password string, lastApplied
 		ResourceTags:         provisionInfo.Tags,
 		Constraints:          provisionInfo.Constraints,
 		Filesystems:          provisionInfo.Filesystems,
+		Volumes:              provisionInfo.Volumes,
 		Devices:              provisionInfo.Devices,
 		CharmBaseImagePath:   charmBaseImage,
 		Containers:           containers,

--- a/rpc/params/kubernetes.go
+++ b/rpc/params/kubernetes.go
@@ -71,8 +71,11 @@ type KubernetesVolumeParams struct {
 // KubernetesVolumeAttachmentParams holds the parameters for
 // creating a volume attachment.
 type KubernetesVolumeAttachmentParams struct {
-	Provider string `json:"provider"`
-	ReadOnly bool   `json:"read-only,omitempty"`
+	Provider  string `json:"provider"`
+	ReadOnly  bool   `json:"read-only,omitempty"`
+	UnitTag   string `json:"unit-tag,omitempty"`
+	VolumeId  string `json:"volume-id,omitempty"`
+	VolumeTag string `json:"volume-tag,omitempty"`
 }
 
 // KubernetesFilesystemInfo describes a storage filesystem in the cloud

--- a/storage/kubernetes.go
+++ b/storage/kubernetes.go
@@ -57,3 +57,16 @@ type KubernetesFilesystemInfo struct {
 	// Size is the size of the filesystem in MiB.
 	Size uint64
 }
+
+type KubernetesVolumeParams struct {
+	StorageName string
+	Size        uint64
+	Provider    ProviderType
+	Attributes  map[string]interface{}
+	Tags        map[string]string
+	Attachment  *KubernetesVolumeAttachmentParams
+}
+
+type KubernetesVolumeAttachmentParams struct {
+	VolumeAttachmentParams
+}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -76,6 +76,7 @@ TEST_NAMES="agents \
             spaces_ec2 \
             static_analysis \
             storage \
+            storage_k8s \
             unit \
             upgrade \
             user"

--- a/tests/suites/storage_k8s/deploy.sh
+++ b/tests/suites/storage_k8s/deploy.sh
@@ -1,6 +1,6 @@
-test_import_filesystem() {
-	if [ "$(skip 'test_import_filesystem')" ]; then
-		echo "==> TEST SKIPPED: test_import_filesystem"
+test_deploy_attach_storage() {
+	if [ "$(skip 'test_deploy_attach_storage')" ]; then
+		echo "==> TEST SKIPPED: test_deploy_attach_storage"
 		return
 	fi
 
@@ -8,7 +8,7 @@ test_import_filesystem() {
 	echo
 
 	# Ensure a bootstrap Juju model exists.
-	model_name="import-filesystem"
+	model_name="deploy-attach-storage"
 	file="${TEST_DIR}/test-${model_name}.log"
 	ensure "${model_name}" "${file}"
 
@@ -27,33 +27,22 @@ test_import_filesystem() {
 	juju remove-storage pgdata/0 --no-destroy
 	wait_for "{}" ".storage"
 
-	# Attempt to import the PersistentVolume: expect failure due to reclaim policy.
-	set +e
-	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
-	set -e
-	echo "${OUT}" | check \
-		"importing volume \"${PV}\" with reclaim policy \"Delete\" not supported \(must be \"Retain\"\)"
-
-	# Fix: update the PersistentVolume's reclaim policy to 'Retain'.
+        # Clean up: make sure PersistentVolume is in available status
 	kubectl patch pv "${PV}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
-
-	# Attempt to import the PersistentVolume: expect failure due to existing claimRef.
-	set +e
-	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
-	set -e
-	echo "${OUT}" | check \
-		"importing volume \"${PV}\" already bound to a claim not supported"
-
-	# Fix: delete the PVC and remove the claimRef from the PersistentVolume.
 	PVC=$(kubectl get pv "${PV}" -o jsonpath='{.spec.claimRef.name}')
 	kubectl delete pvc "${PVC}" -n "${model_name}"
 	kubectl patch pv "${PV}" --type merge -p '{"spec":{"claimRef": null}}'
 
-	# Final attempt: import the PersistentVolume successfully.
-	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
-
+        # Import filesystem as pgdata/1
+	juju import-filesystem kubernetes "${PV}" pgdata
 	wait_for_storage "detached" '.storage["pgdata/1"]["status"].current'
-	wait_for_storage "${PV}" '.volumes["1"]."provider-id"'
+
+	# Deploy with --attach-storage. The storage should be attach to the psql-k8s/0.
+	juju deploy postgresql-k8s --channel 14/stable --trust --attach-storage pgdata/1 psql-k8s
+	wait_for_storage "attached" '.storage["pgdata/1"]["status"].current'
+
+        OUT=$(kubectl get pv "${PV}" -o json | jq -r '.status.phase')
+        echo "${OUT}" | check "Bound"
 
 	# Destroy the test model.
 	destroy_model "${model_name}"

--- a/tests/suites/storage_k8s/import.sh
+++ b/tests/suites/storage_k8s/import.sh
@@ -1,0 +1,55 @@
+test_import_filesystem() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# Ensure a bootstrap Juju model exists.
+	model_name="import-filesystem"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	# Create a PersistentVolume by deploying and deleting an application.
+	echo "Create persistent volume to be imported"
+	juju deploy postgresql-k8s --channel 14/stable --trust
+	# Ensure the storage is attached without waiting for the application to reach the active status.
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+
+	# Capture the provisioned PersistentVolume ID.
+	PV=$(juju storage --format json | jq -r '.volumes["0"]."provider-id"')
+
+	# Clean up: remove the application and associated storage (retain PV).
+	juju remove-application postgresql-k8s --no-prompt
+	wait_for "{}" ".applications"
+	juju remove-storage pgdata/0 --no-destroy
+	wait_for "{}" ".storage"
+
+	# Attempt to import the PersistentVolume: expect failure due to reclaim policy.
+	set +e
+	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
+	set -e
+	echo "${OUT}" | check \
+		"importing volume \"${PV}\" with reclaim policy \"Delete\" not supported \(must be \"Retain\"\)"
+
+	# Fix: update the PersistentVolume's reclaim policy to 'Retain'.
+	kubectl patch pv "${PV}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+
+	# Attempt to import the PersistentVolume: expect failure due to existing claimRef.
+	set +e
+	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
+	set -e
+	echo "${OUT}" | check \
+		"importing volume \"${PV}\" already bound to a claim not supported"
+
+	# Fix: delete the PVC and remove the claimRef from the PersistentVolume.
+	PVC=$(kubectl get pv "${PV}" -o jsonpath='{.spec.claimRef.name}')
+	kubectl delete pvc "${PVC}" -n "${model_name}"
+	kubectl patch pv "${PV}" --type merge -p '{"spec":{"claimRef": null}}'
+
+	# Final attempt: import the PersistentVolume successfully.
+	OUT=$(juju import-filesystem kubernetes "${PV}" pgdata 2>&1)
+
+	wait_for_storage "detached" '.storage["pgdata/1"]["status"].current'
+	wait_for_storage "${PV}" '.volumes["1"]."provider-id"'
+
+	# Destroy the test model.
+	destroy_model "${model_name}"
+}

--- a/tests/suites/storage_k8s/task.sh
+++ b/tests/suites/storage_k8s/task.sh
@@ -1,0 +1,23 @@
+test_storage_k8s() {
+	if [ "$(skip 'test_storage_k8s')" ]; then
+		echo "==> TEST SKIPPED: caas filesystem tests"
+		return
+	fi
+
+	set_verbosity
+
+	case "${BOOTSTRAP_PROVIDER:-}" in
+	"k8s")
+		echo "==> Checking for dependencies"
+		check_dependencies juju
+
+		microk8s config >"${TEST_DIR}"/kube.conf
+		export KUBE_CONFIG="${TEST_DIR}"/kube.conf
+
+		test_import_filesystem
+		;;
+	*)
+		echo "==> TEST SKIPPED: storage k8s tests, not a k8s provider"
+		;;
+	esac
+}

--- a/tests/suites/storage_k8s/task.sh
+++ b/tests/suites/storage_k8s/task.sh
@@ -15,6 +15,7 @@ test_storage_k8s() {
 		export KUBE_CONFIG="${TEST_DIR}"/kube.conf
 
 		test_import_filesystem
+                test_deploy_attach_storage
 		;;
 	*)
 		echo "==> TEST SKIPPED: storage k8s tests, not a k8s provider"


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Environments/dependencies:

- juju kubernetes cloud controller, version 3.6
- kubectl

Steps: 

```
juju deploy postgresql-k8s -n 1 --channel 14/stable  --trust
juju remove-application postgresql-k8s
juju remove-storage pgdata/0 --no-destroy

# replace {pv-name},{pvc-name} with real name
kubectl patch pv {pv-name} -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
kubectl delete pvc {pvc-name}
kubectl patch pv {pv-name} --type merge -p '{"spec":{"claimRef": null}}'

juju import-filesystem kubernetes {pv-name} pgdata


juju deploy postgresql-k8s --channel 14/stable  --trust --attach-storage pgdata/1
```

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

The specification index are:

- SOLENG029 Juju support re-use existing pv on k8s cloud
- SOLENG032 User experience of re-using existing persistent volume in juju kubernetes cloud

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->

**Issue:** Partially Fixes #19521 .

Follow-up to: #19904

<!-- Add a Jira card reference or link, otherwise remove this line. -->


