### PR TITLE
refactor(migration): cut over migration pre-check to DQLite

### DIFF
--- a/apiserver/facades/client/controller/service.go
+++ b/apiserver/facades/client/controller/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/juju/cloud"
 	corecontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
@@ -84,9 +83,12 @@ type ModelInfoService interface {
 
 // ApplicationService provides access to the application service.
 type ApplicationService interface {
-	// GetApplicationLifeByName returns the life value of the application with the
-	// given name.
-	GetApplicationLifeByName(ctx context.Context, name string) (life.Value, error)
+	// CheckAllApplicationsAndUnitsAreAlive checks that all applications and units
+	// in the model are alive, returning an error if any are not.
+	CheckAllApplicationsAndUnitsAreAlive(ctx context.Context) error
+
+	// GetUnitNamesForApplication returns a slice of the unit names for the given application
+	GetUnitNamesForApplication(ctx context.Context, appName string) ([]unit.Name, error)
 }
 
 // RelationService provides access to the relation service.

--- a/apiserver/facades/controller/migrationmaster/mocks/backend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/backend.go
@@ -17,7 +17,6 @@ import (
 	cloud "github.com/juju/juju/cloud"
 	controller "github.com/juju/juju/controller"
 	credential "github.com/juju/juju/core/credential"
-	life "github.com/juju/juju/core/life"
 	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
@@ -741,41 +740,79 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationLifeByName mocks base method.
-func (m *MockApplicationService) GetApplicationLifeByName(arg0 context.Context, arg1 string) (life.Value, error) {
+// CheckAllApplicationsAndUnitsAreAlive mocks base method.
+func (m *MockApplicationService) CheckAllApplicationsAndUnitsAreAlive(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationLifeByName", arg0, arg1)
-	ret0, _ := ret[0].(life.Value)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "CheckAllApplicationsAndUnitsAreAlive", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetApplicationLifeByName indicates an expected call of GetApplicationLifeByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationLifeByName(arg0, arg1 any) *MockApplicationServiceGetApplicationLifeByNameCall {
+// CheckAllApplicationsAndUnitsAreAlive indicates an expected call of CheckAllApplicationsAndUnitsAreAlive.
+func (mr *MockApplicationServiceMockRecorder) CheckAllApplicationsAndUnitsAreAlive(arg0 any) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationLifeByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationLifeByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationLifeByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAllApplicationsAndUnitsAreAlive", reflect.TypeOf((*MockApplicationService)(nil).CheckAllApplicationsAndUnitsAreAlive), arg0)
+	return &MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationLifeByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationLifeByNameCall struct {
+// MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall wrap *gomock.Call
+type MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) Return(arg0 life.Value, arg1 error) *MockApplicationServiceGetApplicationLifeByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) Return(arg0 error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) Do(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeByNameCall {
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) Do(f func(context.Context) error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) DoAndReturn(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeByNameCall {
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) DoAndReturn(f func(context.Context) error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitNamesForApplication mocks base method.
+func (m *MockApplicationService) GetUnitNamesForApplication(arg0 context.Context, arg1 string) ([]unit.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitNamesForApplication", arg0, arg1)
+	ret0, _ := ret[0].([]unit.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitNamesForApplication indicates an expected call of GetUnitNamesForApplication.
+func (mr *MockApplicationServiceMockRecorder) GetUnitNamesForApplication(arg0, arg1 any) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNamesForApplication", reflect.TypeOf((*MockApplicationService)(nil).GetUnitNamesForApplication), arg0, arg1)
+	return &MockApplicationServiceGetUnitNamesForApplicationCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitNamesForApplicationCall wrap *gomock.Call
+type MockApplicationServiceGetUnitNamesForApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Return(arg0 []unit.Name, arg1 error) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Do(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) DoAndReturn(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
@@ -41,45 +41,6 @@ func (m *MockPrecheckBackend) EXPECT() *MockPrecheckBackendMockRecorder {
 	return m.recorder
 }
 
-// AllApplications mocks base method.
-func (m *MockPrecheckBackend) AllApplications() ([]migration.PrecheckApplication, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllApplications")
-	ret0, _ := ret[0].([]migration.PrecheckApplication)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllApplications indicates an expected call of AllApplications.
-func (mr *MockPrecheckBackendMockRecorder) AllApplications() *MockPrecheckBackendAllApplicationsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllApplications", reflect.TypeOf((*MockPrecheckBackend)(nil).AllApplications))
-	return &MockPrecheckBackendAllApplicationsCall{Call: call}
-}
-
-// MockPrecheckBackendAllApplicationsCall wrap *gomock.Call
-type MockPrecheckBackendAllApplicationsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockPrecheckBackendAllApplicationsCall) Return(arg0 []migration.PrecheckApplication, arg1 error) *MockPrecheckBackendAllApplicationsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockPrecheckBackendAllApplicationsCall) Do(f func() ([]migration.PrecheckApplication, error)) *MockPrecheckBackendAllApplicationsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPrecheckBackendAllApplicationsCall) DoAndReturn(f func() ([]migration.PrecheckApplication, error)) *MockPrecheckBackendAllApplicationsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // AllMachines mocks base method.
 func (m *MockPrecheckBackend) AllMachines() ([]migration.PrecheckMachine, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/migrationmaster/service.go
+++ b/apiserver/facades/controller/migrationmaster/service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
@@ -44,9 +43,12 @@ type ModelService interface {
 
 // ApplicationService provides access to the application service.
 type ApplicationService interface {
-	// GetApplicationLifeByName returns the life value of the application with the
-	// given name.
-	GetApplicationLifeByName(ctx context.Context, name string) (life.Value, error)
+	// CheckAllApplicationsAndUnitsAreAlive checks that all applications and units
+	// in the model are alive, returning an error if any are not.
+	CheckAllApplicationsAndUnitsAreAlive(ctx context.Context) error
+
+	// GetUnitNamesForApplication returns a slice of the unit names for the given application
+	GetUnitNamesForApplication(ctx context.Context, appName string) ([]unit.Name, error)
 }
 
 // RelationService provides access to the relation service.

--- a/apiserver/facades/controller/migrationtarget/domain_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/domain_mock_test.go
@@ -15,7 +15,6 @@ import (
 
 	controller "github.com/juju/juju/controller"
 	crossmodel "github.com/juju/juju/core/crossmodel"
-	life "github.com/juju/juju/core/life"
 	machine "github.com/juju/juju/core/machine"
 	semversion "github.com/juju/juju/core/semversion"
 	unit "github.com/juju/juju/core/unit"
@@ -435,41 +434,79 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationLifeByName mocks base method.
-func (m *MockApplicationService) GetApplicationLifeByName(arg0 context.Context, arg1 string) (life.Value, error) {
+// CheckAllApplicationsAndUnitsAreAlive mocks base method.
+func (m *MockApplicationService) CheckAllApplicationsAndUnitsAreAlive(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationLifeByName", arg0, arg1)
-	ret0, _ := ret[0].(life.Value)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "CheckAllApplicationsAndUnitsAreAlive", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetApplicationLifeByName indicates an expected call of GetApplicationLifeByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationLifeByName(arg0, arg1 any) *MockApplicationServiceGetApplicationLifeByNameCall {
+// CheckAllApplicationsAndUnitsAreAlive indicates an expected call of CheckAllApplicationsAndUnitsAreAlive.
+func (mr *MockApplicationServiceMockRecorder) CheckAllApplicationsAndUnitsAreAlive(arg0 any) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationLifeByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationLifeByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationLifeByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAllApplicationsAndUnitsAreAlive", reflect.TypeOf((*MockApplicationService)(nil).CheckAllApplicationsAndUnitsAreAlive), arg0)
+	return &MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationLifeByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationLifeByNameCall struct {
+// MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall wrap *gomock.Call
+type MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) Return(arg0 life.Value, arg1 error) *MockApplicationServiceGetApplicationLifeByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) Return(arg0 error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) Do(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeByNameCall {
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) Do(f func(context.Context) error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) DoAndReturn(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeByNameCall {
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) DoAndReturn(f func(context.Context) error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitNamesForApplication mocks base method.
+func (m *MockApplicationService) GetUnitNamesForApplication(arg0 context.Context, arg1 string) ([]unit.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitNamesForApplication", arg0, arg1)
+	ret0, _ := ret[0].([]unit.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitNamesForApplication indicates an expected call of GetUnitNamesForApplication.
+func (mr *MockApplicationServiceMockRecorder) GetUnitNamesForApplication(arg0, arg1 any) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNamesForApplication", reflect.TypeOf((*MockApplicationService)(nil).GetUnitNamesForApplication), arg0, arg1)
+	return &MockApplicationServiceGetUnitNamesForApplicationCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitNamesForApplicationCall wrap *gomock.Call
+type MockApplicationServiceGetUnitNamesForApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Return(arg0 []unit.Name, arg1 error) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Do(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) DoAndReturn(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/facades"
-	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machine"
 	coremigration "github.com/juju/juju/core/migration"
@@ -66,9 +65,12 @@ type ControllerConfigService interface {
 
 // ApplicationService provides access to the application service.
 type ApplicationService interface {
-	// GetApplicationLifeByName returns the life value of the application with the
-	// given name.
-	GetApplicationLifeByName(ctx context.Context, name string) (life.Value, error)
+	// CheckAllApplicationsAndUnitsAreAlive checks that all applications and units
+	// in the model are alive, returning an error if any are not.
+	CheckAllApplicationsAndUnitsAreAlive(ctx context.Context) error
+
+	// GetUnitNamesForApplication returns a slice of the unit names for the given application
+	GetUnitNamesForApplication(ctx context.Context, appName string) ([]unit.Name, error)
 }
 
 // RelationService provides access to the relation service.

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -139,6 +139,13 @@ type ApplicationState interface {
 	// found.
 	GetApplicationLifeByName(ctx context.Context, appName string) (coreapplication.ID, life.Life, error)
 
+	// CheckAllApplicationsAndUnitsAreAlive checks that all applications and units
+	// in the model are alive, returning an error if any are not.
+	// The following errors may be returned:
+	// - [applicationerrors.ApplicationNotAlive] if any applications are not alive.
+	// - [applicationerrors.UnitNotAlive] if any units are not alive.
+	CheckAllApplicationsAndUnitsAreAlive(context.Context) error
+
 	// SetApplicationLife sets the life of the specified application.
 	SetApplicationLife(context.Context, coreapplication.ID, life.Life) error
 
@@ -912,6 +919,18 @@ func (s *Service) GetApplicationLifeByName(ctx context.Context, appName string) 
 		return "", errors.Errorf("getting life for %q: %w", appName, err)
 	}
 	return appLife.Value()
+}
+
+// CheckAllApplicationsAndUnitsAreAlive checks that all applications and units
+// in the model are alive, returning an error if any are not.
+// The following errors may be returned:
+// - [applicationerrors.ApplicationNotAlive] if any applications are not alive.
+// - [applicationerrors.UnitNotAlive] if any units are not alive.
+func (s *Service) CheckAllApplicationsAndUnitsAreAlive(ctx context.Context) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return s.st.CheckAllApplicationsAndUnitsAreAlive(ctx)
 }
 
 // IsSubordinateApplication returns true if the application is a subordinate

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -268,6 +268,44 @@ func (c *MockStateAttachStorageCall) DoAndReturn(f func(context.Context, storage
 	return c
 }
 
+// CheckAllApplicationsAndUnitsAreAlive mocks base method.
+func (m *MockState) CheckAllApplicationsAndUnitsAreAlive(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckAllApplicationsAndUnitsAreAlive", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckAllApplicationsAndUnitsAreAlive indicates an expected call of CheckAllApplicationsAndUnitsAreAlive.
+func (mr *MockStateMockRecorder) CheckAllApplicationsAndUnitsAreAlive(arg0 any) *MockStateCheckAllApplicationsAndUnitsAreAliveCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAllApplicationsAndUnitsAreAlive", reflect.TypeOf((*MockState)(nil).CheckAllApplicationsAndUnitsAreAlive), arg0)
+	return &MockStateCheckAllApplicationsAndUnitsAreAliveCall{Call: call}
+}
+
+// MockStateCheckAllApplicationsAndUnitsAreAliveCall wrap *gomock.Call
+type MockStateCheckAllApplicationsAndUnitsAreAliveCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateCheckAllApplicationsAndUnitsAreAliveCall) Return(arg0 error) *MockStateCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateCheckAllApplicationsAndUnitsAreAliveCall) Do(f func(context.Context) error) *MockStateCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateCheckAllApplicationsAndUnitsAreAliveCall) DoAndReturn(f func(context.Context) error) *MockStateCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateCAASApplication mocks base method.
 func (m *MockState) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 application0.AddCAASApplicationArg, arg3 []application0.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()

--- a/internal/migration/migration_mock_test.go
+++ b/internal/migration/migration_mock_test.go
@@ -16,7 +16,6 @@ import (
 
 	description "github.com/juju/description/v9"
 	controller "github.com/juju/juju/controller"
-	life "github.com/juju/juju/core/life"
 	machine "github.com/juju/juju/core/machine"
 	modelmigration "github.com/juju/juju/core/modelmigration"
 	semversion "github.com/juju/juju/core/semversion"
@@ -237,41 +236,79 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationLifeByName mocks base method.
-func (m *MockApplicationService) GetApplicationLifeByName(arg0 context.Context, arg1 string) (life.Value, error) {
+// CheckAllApplicationsAndUnitsAreAlive mocks base method.
+func (m *MockApplicationService) CheckAllApplicationsAndUnitsAreAlive(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationLifeByName", arg0, arg1)
-	ret0, _ := ret[0].(life.Value)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "CheckAllApplicationsAndUnitsAreAlive", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetApplicationLifeByName indicates an expected call of GetApplicationLifeByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationLifeByName(arg0, arg1 any) *MockApplicationServiceGetApplicationLifeByNameCall {
+// CheckAllApplicationsAndUnitsAreAlive indicates an expected call of CheckAllApplicationsAndUnitsAreAlive.
+func (mr *MockApplicationServiceMockRecorder) CheckAllApplicationsAndUnitsAreAlive(arg0 any) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationLifeByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationLifeByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationLifeByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAllApplicationsAndUnitsAreAlive", reflect.TypeOf((*MockApplicationService)(nil).CheckAllApplicationsAndUnitsAreAlive), arg0)
+	return &MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationLifeByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationLifeByNameCall struct {
+// MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall wrap *gomock.Call
+type MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) Return(arg0 life.Value, arg1 error) *MockApplicationServiceGetApplicationLifeByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) Return(arg0 error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) Do(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeByNameCall {
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) Do(f func(context.Context) error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationLifeByNameCall) DoAndReturn(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeByNameCall {
+func (c *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall) DoAndReturn(f func(context.Context) error) *MockApplicationServiceCheckAllApplicationsAndUnitsAreAliveCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitNamesForApplication mocks base method.
+func (m *MockApplicationService) GetUnitNamesForApplication(arg0 context.Context, arg1 string) ([]unit.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitNamesForApplication", arg0, arg1)
+	ret0, _ := ret[0].([]unit.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitNamesForApplication indicates an expected call of GetUnitNamesForApplication.
+func (mr *MockApplicationServiceMockRecorder) GetUnitNamesForApplication(arg0, arg1 any) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNamesForApplication", reflect.TypeOf((*MockApplicationService)(nil).GetUnitNamesForApplication), arg0, arg1)
+	return &MockApplicationServiceGetUnitNamesForApplicationCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitNamesForApplicationCall wrap *gomock.Call
+type MockApplicationServiceGetUnitNamesForApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Return(arg0 []unit.Name, arg1 error) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Do(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitNamesForApplicationCall) DoAndReturn(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/migration/precheck_shim.go
+++ b/internal/migration/precheck_shim.go
@@ -49,19 +49,6 @@ func (s *precheckShim) AllMachines() ([]PrecheckMachine, error) {
 	return out, nil
 }
 
-// AllApplications implements PrecheckBackend.
-func (s *precheckShim) AllApplications() ([]PrecheckApplication, error) {
-	apps, err := s.State.AllApplications()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	out := make([]PrecheckApplication, len(apps))
-	for i, app := range apps {
-		out[i] = &precheckAppShim{app}
-	}
-	return out, nil
-}
-
 // ControllerBackend implements PrecheckBackend.
 func (s *precheckShim) ControllerBackend() (PrecheckBackend, error) {
 	return PrecheckShim(s.controllerState, s.controllerState)
@@ -94,22 +81,4 @@ type modelShim struct {
 
 func (m modelShim) MigrationMode() (state.MigrationMode, error) {
 	return m.State().MigrationMode()
-}
-
-// precheckAppShim implements PrecheckApplication.
-type precheckAppShim struct {
-	*state.Application
-}
-
-// AllUnits implements PrecheckApplication.
-func (s *precheckAppShim) AllUnits() ([]PrecheckUnit, error) {
-	units, err := s.Application.AllUnits()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	out := make([]PrecheckUnit, len(units))
-	for i, unit := range units {
-		out[i] = unit
-	}
-	return out, nil
 }


### PR DESCRIPTION
Add a new service method, CheckAllApplicationsAndUnitsAreAlive, to optimise the pre-check phase of the migration. This reduces some complex logic, involving many many transactions down to a single transaction.

Wire this up to the migration pre-check.

This did, however, involve a refactor of checkRelations, which now needs to call GetUnitNamesForApplication many times (although I did add a cache). I'm not too worried about this because really the entire check should be pushed into a service call.

## QA steps

```
$ juju bootstrap lxd dst
$ juju bootstrap lxd src
$ juju add-model m
$ juju deploy juju-qa-test
(wait until active)
$ juju migrate m dst
Migration started with ID "94843b16-f3e7-48d8-82ab-9983b2c2f226:0"
```
The migration will fail, but not due to pre-checks. Check the debug logs for...
```
$ juju debug-log -m controller 
...
machine-0: 17:00:11 INFO juju.worker.migrationmaster.94843b logger-tags:migration performing source prechecks
machine-0: 17:00:11 INFO juju.worker.migrationmaster.94843b logger-tags:migration performing target prechecks
machine-0: 17:00:11 INFO juju.worker.migrationmaster.94843b logger-tags:migration setting migration phase to IMPORT
machine-0: 17:00:11 INFO juju.worker.migrationmaster.94843b logger-tags:migration exporting model
...
```