### PR TITLE
feat: prevent unsubscribe from dead-locking

### DIFF
--- a/internal/changestream/eventmultiplexer/package_test.go
+++ b/internal/changestream/eventmultiplexer/package_test.go
@@ -5,14 +5,12 @@ package eventmultiplexer
 
 import (
 	"sync/atomic"
-	time "time"
 
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/core/changestream"
 	domaintesting "github.com/juju/juju/domain/schema/testing"
-	jujutesting "github.com/juju/juju/internal/testing"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -typed -package eventmultiplexer -destination change_mock_test.go github.com/juju/juju/core/changestream Term
@@ -72,8 +70,7 @@ func (s *baseSuite) dispatchTerm(c *tc.C, terms chan<- changestream.Term) <-chan
 
 		select {
 		case terms <- s.term:
-		case <-time.After(jujutesting.ShortWait):
-			c.Fatal("timed out waiting to enqueue event")
+		case <-c.Context().Done():
 		}
 	}()
 	return done

--- a/internal/changestream/eventmultiplexer/subscription.go
+++ b/internal/changestream/eventmultiplexer/subscription.go
@@ -115,7 +115,6 @@ func (s *subscription) dispatch(ctx context.Context, changes ChangeSet) error {
 		}
 
 	case s.changes <- changes:
-
 	}
 	return nil
 }
@@ -123,6 +122,6 @@ func (s *subscription) dispatch(ctx context.Context, changes ChangeSet) error {
 // close closes the active channel, which will signal to the consumer that the
 // subscription is no longer active.
 func (s *subscription) close() error {
-	s.Kill()
+	s.tomb.Kill(nil)
 	return s.Wait()
 }

--- a/internal/changestream/stream/stream.go
+++ b/internal/changestream/stream/stream.go
@@ -394,6 +394,9 @@ func (s *Stream) loop() error {
 			case s.terms <- term:
 			}
 
+			// TODO (stickupkid): For certain setups, we may want to run
+			// runtime.Gosched() here to allow other goroutines to run.
+
 			select {
 			case <-s.tomb.Dying():
 				return tomb.ErrDying


### PR DESCRIPTION
If a subscription is falling behind, we want to be able to pull the subscription from the event multiplexer. Unfortunately, if there are a lot of terms being processed, along with a lot of subscriptions, there is a fight for processing. The solution here, is to extract subscription management out of the same loop as the changes. We can at least give a better chance of unsubscribing causing issues. Also, it should allow the changes to run with less iteruptions.

There are downsides. We now have to introduce mutexes. Thus our lock-less event dispatching is no more. Though, we do have better fine grained control of when the congestion happens.

To prevent a subscription from bringing down the event multiplexer, I've introduced the runner package. There is still work to do around clean unsubscribing, but it's better than before.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
