### PR TITLE
feat: stub uniter action watcher in domain

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -214,6 +214,13 @@ type ApplicationService interface {
 	// upgrade to the latest version of the application charm even if they are in
 	// error state.
 	ShouldAllowCharmUpgradeOnError(ctx context.Context, appName string) (bool, error)
+
+	// WatchUnitActions watches for all updates to actions for the specified unit,
+	// emitting action ids.
+	//
+	// If the unit does not exist an error satisfying [applicationerrors.UnitNotFound]
+	// will be returned.
+	WatchUnitActions(ctx context.Context, unitName coreunit.Name) (watcher.StringsWatcher, error)
 }
 
 // NetworkService is the interface that is used to interact with the

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -1066,6 +1066,45 @@ func (c *MockApplicationServiceWatchApplicationConfigHashCall) DoAndReturn(f fun
 	return c
 }
 
+// WatchUnitActions mocks base method.
+func (m *MockApplicationService) WatchUnitActions(arg0 context.Context, arg1 unit.Name) (watcher.Watcher[[]string], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchUnitActions", arg0, arg1)
+	ret0, _ := ret[0].(watcher.Watcher[[]string])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchUnitActions indicates an expected call of WatchUnitActions.
+func (mr *MockApplicationServiceMockRecorder) WatchUnitActions(arg0, arg1 any) *MockApplicationServiceWatchUnitActionsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnitActions", reflect.TypeOf((*MockApplicationService)(nil).WatchUnitActions), arg0, arg1)
+	return &MockApplicationServiceWatchUnitActionsCall{Call: call}
+}
+
+// MockApplicationServiceWatchUnitActionsCall wrap *gomock.Call
+type MockApplicationServiceWatchUnitActionsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceWatchUnitActionsCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockApplicationServiceWatchUnitActionsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceWatchUnitActionsCall) Do(f func(context.Context, unit.Name) (watcher.Watcher[[]string], error)) *MockApplicationServiceWatchUnitActionsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceWatchUnitActionsCall) DoAndReturn(f func(context.Context, unit.Name) (watcher.Watcher[[]string], error)) *MockApplicationServiceWatchUnitActionsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // WatchUnitAddressesHash mocks base method.
 func (m *MockApplicationService) WatchUnitAddressesHash(arg0 context.Context, arg1 unit.Name) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/agent/uniter/uniter_legacy_test.go
+++ b/apiserver/facades/agent/uniter/uniter_legacy_test.go
@@ -274,35 +274,6 @@ func (s *uniterLegacySuite) TestWatchActionNotifications(c *tc.C) {
 func (s *uniterLegacySuite) TestWatchPreexistingActions(c *tc.C) {
 }
 
-func (s *uniterLegacySuite) TestWatchActionNotificationsMalformedTag(c *tc.C) {
-	args := params.Entities{Entities: []params.Entity{
-		{Tag: "ewenit-mysql-0"},
-	}}
-	results, err := s.uniter.WatchActionNotifications(c.Context(), args)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(results, tc.NotNil)
-	c.Assert(len(results.Results), tc.Equals, 1)
-	result := results.Results[0]
-	c.Assert(result.Error, tc.NotNil)
-	c.Assert(result.Error.Message, tc.Equals, `invalid actionreceiver tag "ewenit-mysql-0"`)
-}
-
-func (s *uniterLegacySuite) TestWatchActionNotificationsMalformedUnitName(c *tc.C) {
-	args := params.Entities{Entities: []params.Entity{
-		{Tag: "unit-mysql-01"},
-	}}
-	results, err := s.uniter.WatchActionNotifications(c.Context(), args)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(results, tc.NotNil)
-	c.Assert(len(results.Results), tc.Equals, 1)
-	result := results.Results[0]
-	c.Assert(result.Error, tc.NotNil)
-	c.Assert(result.Error.Message, tc.Equals, `invalid actionreceiver tag "unit-mysql-01"`)
-}
-
-func (s *uniterLegacySuite) TestWatchActionNotificationsNotUnit(c *tc.C) {
-}
-
 func (s *uniterLegacySuite) TestWatchActionNotificationsPermissionDenied(c *tc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "unit-nonexistentgarbage-0"},

--- a/domain/application/service/actions.go
+++ b/domain/application/service/actions.go
@@ -4,12 +4,32 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 
+	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/application/charm"
 	internalcharm "github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/errors"
 )
+
+// WatchUnitActions watches for all updates to actions for the specified unit,
+// emitting action ids.
+//
+// If the unit does not exist an error satisfying [applicationerrors.UnitNotFound]
+// will be returned.
+func (s *WatchableService) WatchUnitActions(
+	ctx context.Context, unitName coreunit.Name,
+) (watcher.StringsWatcher, error) {
+	_, err := s.st.GetUnitUUIDByName(ctx, unitName)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	// TODO: implement this watcher and consider moving to an actions domain.
+	return watcher.TODO[[]string](), nil
+}
 
 func decodeActions(actions charm.Actions) (internalcharm.Actions, error) {
 	if len(actions.Actions) == 0 {


### PR DESCRIPTION
This change stubs out the action watcher for units into the application
domain. It must return a watcher, even if that watcher never fires more
than the initial empty strings event.

This is required because the setup of the remote state watcher in the
uniter worker requires all watchers come up. Since k8s units are no
longer being dual written to mongo and dqlite, the mongo actions
watcher will fail, ensuring the uniter never starts.

This may not be the final living place for the actions watcher for the
uniter.

## QA steps

- Bootstrap lxd and deploy a charm.
- Make sure the unit comes up and settles.
- Check the log does not have any errors around watching actions:
  `ERROR juju.worker.dependency "uniter" manifold worker returned unexpected error: starting actions watcher`