### PR TITLE
fix: relation watcher used by uniter must work while unit is dying

### DIFF
--- a/domain/relation/errors/errors.go
+++ b/domain/relation/errors/errors.go
@@ -82,9 +82,9 @@ const (
 	// not valid.
 	UnitUUIDNotValid = errors.ConstError("unit UUID not valid")
 
-	// UnitNotAlive describes an error that occurs when trying to update a
-	// unit that is not alive.
-	UnitNotAlive = errors.ConstError("unit not alive")
+	// UnitDead describes an error that occurs when trying to update a
+	// unit that is dead.
+	UnitDead = errors.ConstError("unit is dead")
 
 	// UnitNotFound describes an error when the unit cannot be found.
 	UnitNotFound = errors.ConstError("unit not found")

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -2555,8 +2555,7 @@ AND    re.relation_uuid = $relationAndApplicationUUID.relation_uuid
 // empty.
 //
 // The following error types can be expected to be returned:
-//   - [relationerrors.UnitNotAlive] if the unit is dead or dying, or
-//     not found.
+//   - [relationerrors.UnitDead] if the unit is dead or not found.
 func (st *State) GetPrincipalSubordinateApplicationIDs(
 	ctx context.Context,
 	unitUUID unit.UUID,
@@ -2569,10 +2568,10 @@ func (st *State) GetPrincipalSubordinateApplicationIDs(
 	var principalAppID, subordinateAppID application.ID
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if alive, err := st.checkLife(ctx, tx, "unit", unitUUID.String(), life.IsAlive); err != nil {
+		if alive, err := st.checkLife(ctx, tx, "unit", unitUUID.String(), life.IsNotDead); err != nil {
 			return errors.Errorf("cannot check unit %q life: %w", unitUUID, err)
 		} else if !alive {
-			return errors.Errorf("unit %s is not alive", unitUUID).Add(relationerrors.UnitNotAlive)
+			return errors.Errorf("unit %s is dead", unitUUID).Add(relationerrors.UnitDead)
 		}
 		var principalUnit bool
 		principalAppID, err = st.getPrincipalApplicationOfUnit(ctx, tx, unitUUID)


### PR DESCRIPTION
If a uniter worker restarts while a unit is dying, the uniter tries to
re-establish remote state watchers. The `WatchLifeSuspendedStatus`
watcher in the relation domain incorrectly checks if the unit is alive,
where it should check the unit is not dead. This change fixes that.

Without this change, if the uniter worker restarts during dying phase
of the unit, it will be forever stuck in a restart loop.

## QA steps

Remove a unit and force the uniter to crash before the remove hook
completes. The uniter worker should not get stuck in a restart loop.