### PR TITLE
fix: incorrectly identified structure for sql statement

### DIFF
--- a/domain/network/state/unitaddress.go
+++ b/domain/network/state/unitaddress.go
@@ -121,7 +121,7 @@ func (st *State) GetUnitUUIDByName(ctx context.Context, name coreunit.Name) (cor
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		uuid, err = st.getUnitUUIDByName(ctx, tx, name)
 		if err != nil {
-			return errors.Errorf("querying unit name: %w", err)
+			return err
 		}
 		return err
 	})
@@ -140,7 +140,7 @@ func (st *State) getUnitUUIDByName(
 	unitName := unitName{Name: name}
 
 	query, err := st.Prepare(`
-SELECT &unitUUID.*
+SELECT &entityUUID.*
 FROM   unit
 WHERE  name = $unitName.name
 `, entityUUID{}, unitName)

--- a/domain/network/state/unitaddress_test.go
+++ b/domain/network/state/unitaddress_test.go
@@ -196,6 +196,23 @@ func (s *unitAddressSuite) TestGetUnitAddressesNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
+func (s *unitAddressSuite) TestGetUnitUUIDByName(c *tc.C) {
+	// Arrange
+	nodeUUID := s.addNetNode(c)
+	spaceUUID := s.addSpace(c)
+
+	charmUUID := s.addCharm(c)
+	appUUID := s.addApplication(c, charmUUID, spaceUUID)
+	expectedUnitUUID := s.addUnit(c, appUUID, charmUUID, nodeUUID)
+
+	// Act
+	obtainedUnitUUID, err := s.state.GetUnitUUIDByName(c.Context(), coreunit.Name(expectedUnitUUID.String()))
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtainedUnitUUID, tc.DeepEquals, expectedUnitUUID)
+}
+
 func (s *unitAddressSuite) addIPAddress(c *tc.C, nodeUUID, deviceUUID, subnetUUID string, scopeID, originID int) string {
 	ipAddrUUID := uuid.MustNewUUID().String()
 	addr := "10.0.0.1"


### PR DESCRIPTION
Update of structures used in sqlair statements gone wrong. Not found due to missing test. Added TestGetUnitUUIDByName to cover the code.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap, verify the following error is not seen in the controller logs:
```
ERROR juju.worker.apiaddresssetter cannot update api addresses: querying unit name: querying unit name: preparing query: preparing:: cannot prepare statement: output expression: parameter with type "unitUUID" missing (have "entityUUID", "unitName"): &unitUUID.* 
```

If seen, it'll happen before the `caas-storage-provisioner` errors start showing up. Within the first few minutes.