### PR TITLE
fix: add status caching from 2.9 into 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ tests/tmp.*
 *.charm
 *.bundle
 *.log
-.envrc
 dqlite-deps.tar.bz2
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ tests/tmp.*
 *.charm
 *.bundle
 *.log
-dqlite-deps.tar.bz2
 .envrc
+dqlite-deps.tar.bz2

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -229,6 +229,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	var noStatus params.FullStatus
 	var context statusContext
 	context.cachedModel = c.modelCache
+	context.appCharmCache = map[string]string{}
 
 	m, err := c.stateAccessor.Model()
 	if err != nil {
@@ -737,6 +738,9 @@ type statusContext struct {
 	storageInstances []state.StorageInstance
 	volumes          []state.Volume
 	filesystems      []state.Filesystem
+
+	// Cache the map from an application to its charm information
+	appCharmCache map[string]string
 }
 
 // fetchMachines returns a map from top level machine id to machines, where machines[0] is the host
@@ -1630,6 +1634,27 @@ func (context *statusContext) processUnits(units map[string]*state.Unit, applica
 	return unitsMap
 }
 
+func (context *statusContext) getAppCharm(unit *state.Unit) (string, error) {
+	appName := unit.ApplicationName()
+	charmStr, ok := context.appCharmCache[appName]
+	if ok {
+		return charmStr, nil
+	}
+	app, err := unit.Application()
+	if err != nil {
+		context.appCharmCache[appName] = ""
+		return "", err
+	}
+	appCharm, _, err := app.Charm()
+	if err != nil {
+		context.appCharmCache[appName] = ""
+		return "", err
+	}
+	charmStr = appCharm.URL()
+	context.appCharmCache[appName] = charmStr
+	return charmStr, nil
+}
+
 func (context *statusContext) unitMachineID(unit *state.Unit) string {
 	// This should never happen, but guarding against segfaults if for
 	// some reason the unit isn't in the context.
@@ -1705,18 +1730,12 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 			subUnit := context.unitByName(name)
 			// subUnit may be nil if subordinate was filtered out.
 			if subUnit != nil {
-				subUnitAppCharm := ""
-				subUnitApp, err := subUnit.Application()
-				if err == nil {
-					if subUnitAppCh, _, err := subUnitApp.Charm(); err == nil {
-						subUnitAppCharm = subUnitAppCh.URL()
-					} else {
-						logger.Debugf("error fetching subordinate application charm for %q: %q", subUnit.ApplicationName(), err.Error())
-					}
-				} else {
-					// We can still run processUnit with an empty string for
-					// the ApplicationCharm.
-					logger.Debugf("error fetching subordinate application for %q: %q", subUnit.ApplicationName(), err.Error())
+				subUnitAppCharm, err := context.getAppCharm(subUnit)
+				if err != nil {
+					// We can still run processUnit with an
+					// empty string for the ApplicationCharm
+					logger.Debugf("error fetching subordinate application charm for %q: %q",
+						subUnit.ApplicationName(), err.Error())
 				}
 				result.Subordinates[name] = context.processUnit(subUnit, subUnitAppCharm, true)
 			}

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -144,7 +144,7 @@ func (s *storageSuite) TestStorageListAttachmentError(c *gc.C) {
 	s.storageAccessor.storageInstanceAttachments = func(tag names.StorageTag) ([]state.StorageAttachment, error) {
 		s.stub.AddCall(storageInstanceAttachmentsCall)
 		c.Assert(tag, jc.DeepEquals, s.storageTag)
-		return []state.StorageAttachment{}, errors.Errorf("list test error")
+		return []state.StorageAttachment{}, errors.New("list test error")
 	}
 
 	found, err := s.api.ListStorageDetails(

--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -199,7 +199,7 @@ func (cfg *centOSCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 
 	pkgs := cfg.Packages()
 	if len(pkgs) > 0 {
-		cmds = append([]string{LogProgressCmd("%s", fmt.Sprintf("Installing %s", strings.Join(pkgs, ", ")))}, cmds...)
+		cmds = append([]string{LogProgressCmd("Installing %s", strings.Join(pkgs, ", "))}, cmds...)
 	}
 	for _, pkg := range pkgs {
 		cmds = append(cmds, "package_manager_loop "+pkgCmder.InstallCmd(pkg))

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -145,7 +145,7 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 
 	// If a mirror is specified, rewrite sources.list and rename cached index files.
 	if newMirror := cfg.PackageMirror(); newMirror != "" {
-		cmds = append(cmds, LogProgressCmd("%s", fmt.Sprintf("Changing apt mirror to %q", newMirror)))
+		cmds = append(cmds, LogProgressCmd("Changing apt mirror to %q", newMirror))
 		cmds = append(cmds, pkgCmder.SetMirrorCommands(newMirror, newMirror)...)
 	}
 
@@ -223,7 +223,7 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 	}
 
 	if len(pkgCmds) > 0 {
-		pkgCmds = append([]string{LogProgressCmd("%s", fmt.Sprintf("Installing %s", strings.Join(pkgNames, ", ")))}, pkgCmds...)
+		pkgCmds = append([]string{LogProgressCmd("Installing %s", strings.Join(pkgNames, ", "))}, pkgCmds...)
 		cmds = append(cmds, pkgCmds...)
 		// setting DEBIAN_FRONTEND=noninteractive prevents debconf
 		// from prompting, always taking default values instead.

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -161,7 +161,7 @@ func (d *deployCharm) deploy(
 
 	if errors.IsAlreadyExists(err) {
 		// Would be nice to be able to access the app name here
-		return errors.Wrapf(err, errors.Errorf(`
+		return errors.Wrapf(err, errors.New(`
 deploy application using an alias name:
     juju deploy <application> <alias>
 or use remove-application to remove the existing one and try again.`,
@@ -497,8 +497,8 @@ func (c *repositoryCharm) compatibilityPrepareAndDeploy(ctx *cmd.Context, deploy
 			channel = fmt.Sprintf(" in channel %s", channel)
 		}
 
-		ctx.Infof("%s", fmt.Sprintf("%q from %s charm %q, revision %d%s on %s would be deployed",
-			name, origin.Source, curl.Name, curl.Revision, channel, origin.Base.DisplayString()))
+		ctx.Infof("%q from %s charm %q, revision %d%s on %s would be deployed",
+			name, origin.Source, curl.Name, curl.Revision, channel, origin.Base.DisplayString())
 		return nil
 	}
 

--- a/cmd/juju/block/protection.go
+++ b/cmd/juju/block/protection.go
@@ -99,7 +99,7 @@ func ProcessBlockedError(err error, block Block) error {
 	}
 	if params.IsCodeOperationBlocked(err) {
 		msg := fmt.Sprintf("%v\n%v", err, blockedMessages[block])
-		logger.Infof(msg)
+		logger.Infof("%s", msg)
 		return errors.New(msg)
 	}
 	return err

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -1018,7 +1018,7 @@ to create a new model to deploy %sworkloads.
 	defer func() {
 		if resultErr != nil {
 			if c.KeepBrokenEnvironment {
-				ctx.Infof("%s", `
+				ctx.Infof(`
 bootstrap failed but --keep-broken was specified.
 This means that cloud resources are left behind, but not registered to
 your local client, as the controller was not successfully created.
@@ -1027,7 +1027,7 @@ their IP address for diagnosis and investigation.
 When you are ready to clean up the failed controller, use your cloud console or
 equivalent CLI tools to terminate the instances and remove remaining resources.
 
-See `[1:]+"`juju kill-controller`"+`.`)
+See %s.`[1:], "`juju kill-controller`")
 			} else {
 				logger.Errorf("%v", resultErr)
 				logger.Debugf("(error details: %v)", errors.Details(resultErr))

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -58,7 +58,7 @@ func checkModelConfig(cfg *config.Config) error {
 		}
 	}
 	if _, ok := cfg.AgentVersion(); !ok {
-		return errors.Errorf("agent-version must always be set in state")
+		return errors.New("agent-version must always be set in state")
 	}
 	for attr := range allAttrs {
 		if controller.ControllerOnlyAttribute(attr) {


### PR DESCRIPTION
This brings in my changes on 2.9 into juju 3.6 and resolves the conflicts between the two branches.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

This is the same QA steps as #19963, adapted for 3.6.

Start with a 3.6. controller, running a stock build. Deploy a bunch of units and a lot of subordinates, and then see how long it takes to run `juju status`. Then you can upgrade the controller to this version of Juju and see whether it had a large impact or not. I will use values from my personal testing.

First, the stock 3.6 controller, with a couple of primary units.
```sh
$ sudo snap refresh juju --channel 3.6
$ /snap/bin/juju bootstrap lxd lxd36
$ /snap/bin/juju add-model test
$ /snap/bin/juju deploy juju-qa-dummy-sink --base ubuntu@22.04
$ /snap/bin/juju deploy juju-qa-dummy-source --base ubuntu@22.04
$ /snap/bin/juju relate dummy-sink dummy-source
```

You could use --to 0 to avoid lots of containers, but it makes the hooks take a bit longer because they all end up single threaded. Now, we use another dummy subordinate charm to just increase the number of subordinates that we have running. 

Double check that it created everything as expected:
```sh
$ juju deploy juju-qa-simple-subordinate ss1 --base ubuntu@22.04 --channel edge
$ juju relate ss1 dummy-sink
$ juju relate ss1 dummy-source
$ watch --color /snap/bin/juju status --color
```

Scale up a bit. 9 total subordinates (10 units per machine). Wait for it to settle
```sh
$ for i in `seq 2 9`; do juju deploy juju-qa-simple-subordinate ss$i --base ubuntu@22.04 --channel edge; juju relate dummy-sink ss$i; juju relate dummy-source ss$i; done
$ watch --color /snap/bin/juju status --color
```

Add primary units, which then also cause us to have a lot of subordinates:
```sh
$ juju add-unit dummy-sink --to 0; juju add-unit dummy-source --to 1
$ watch --color /snap/bin/juju status --color
```
Note whether you want to create more containers, or keep adding in place.

In my testing, I scaled up to 10 primaries, so a total of 200 units.
```sh
$ for i in `seq 2 9`; do juju add-unit dummy-sink --to 0; juju add-unit dummy-source --to 1; done
$ watch --color /snap/bin/juju status --color
Model  Controller  Cloud/Region         Version  SLA          Timestamp
test   lxd36       localhost/localhost  3.6.7    unsupported  10:31:30-04:00

App           Version  Status   Scale  Charm                       Channel        Rev  Exposed  Message
dummy-sink             waiting     10  juju-qa-dummy-sink          latest/stable    7  no       Waiting for token
dummy-source           blocked     10  juju-qa-dummy-source        latest/stable    6  no       Set the token
ss1                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
ss2                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
ss3                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
ss4                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
ss5                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
ss6                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
ss7                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
ss8                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
ss9                    active      20  juju-qa-simple-subordinate  latest/edge      2  no
...
```
This step did take quite a while, even with 2 containers running simultaneously.

Time how long it takes to run `juju status`. On my machine, it was still pretty fast, so I ran it in a loop 10 times and timed that. Note that 3.6 already had fixed things so we don't read ControllerConfig on every Charm call, so it is a bit faster by default:
```sh
$ time (for i in `seq 10`; do juju status >/dev/null; done)

real    0m1.810s
user    0m0.527s
sys     0m0.307s
$ time (for i in `seq 10`; do juju status >/dev/null; done)

real    0m1.859s
user    0m0.470s
sys     0m0.378s
$ time (for i in `seq 10`; do juju status >/dev/null; done)

real    0m1.829s
user    0m0.477s
sys     0m0.357s
```

Upgrade to the proposed version of Juju, and then run the timing tests again:
```sh
$ ~/go/bin/juju upgrade-controller --build-agent
$ watch --color juju status -m controller --color
...
controller  lxd29       localhost/localhost  2.9.52.1  unsupported  16:50:23-04:00  upgraded on "2025-06-11T20:50:23Z"
```
$ time (for i in `seq 10`; do juju status >/dev/null; done)

real    0m1.436s
user    0m0.531s
sys     0m0.344s
$ time (for i in `seq 10`; do juju status >/dev/null; done)

real    0m1.395s
user    0m0.506s
sys     0m0.336s
$ time (for i in `seq 10`; do juju status >/dev/null; done)

real    0m1.408s
user    0m0.498s
sys     0m0.364s
```


## Documentation changes

None

## Links

None
