### PR TITLE
WIP feat: support controller node authentication

### DIFF
--- a/apiserver/common/password_test.go
+++ b/apiserver/common/password_test.go
@@ -39,7 +39,7 @@ func (s *passwordSuite) TestSetPasswordsForUnit(c *tc.C) {
 		SetUnitPassword(gomock.Any(), unit.Name("foo/1"), "password").
 		Return(nil)
 
-	changer := common.NewPasswordChanger(s.agentPasswordService, nil, alwaysAllow)
+	changer := common.NewPasswordChanger(s.agentPasswordService, nil, nil, alwaysAllow)
 	results, err := changer.SetPasswords(c.Context(), params.EntityPasswords{
 		Changes: []params.EntityPassword{{
 			Tag:      "unit-foo/1",
@@ -61,7 +61,7 @@ func (s *passwordSuite) TestSetPasswordsForUnitError(c *tc.C) {
 		SetUnitPassword(gomock.Any(), unit.Name("foo/1"), "password").
 		Return(internalerrors.Errorf("boom"))
 
-	changer := common.NewPasswordChanger(s.agentPasswordService, nil, alwaysAllow)
+	changer := common.NewPasswordChanger(s.agentPasswordService, nil, nil, alwaysAllow)
 	results, err := changer.SetPasswords(c.Context(), params.EntityPasswords{
 		Changes: []params.EntityPassword{{
 			Tag:      "unit-foo/1",
@@ -83,7 +83,7 @@ func (s *passwordSuite) TestSetPasswordsForUnitNotFoundError(c *tc.C) {
 		SetUnitPassword(gomock.Any(), unit.Name("foo/1"), "password").
 		Return(applicationerrors.UnitNotFound)
 
-	changer := common.NewPasswordChanger(s.agentPasswordService, nil, alwaysAllow)
+	changer := common.NewPasswordChanger(s.agentPasswordService, nil, nil, alwaysAllow)
 	results, err := changer.SetPasswords(c.Context(), params.EntityPasswords{
 		Changes: []params.EntityPassword{{
 			Tag:      "unit-foo/1",

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -41,6 +41,14 @@ type AgentPasswordService interface {
 	SetMachinePassword(context.Context, machine.Name, string) error
 }
 
+// ControllerNodeService defines the methods required to set a controller node's
+// password hash.
+type ControllerNodeService interface {
+	// SetPassword sets the password for the given machine. If the controller node
+	// does not exist, an error satisfying [controllernodeerrors.NotFound] is returned.
+	SetPassword(ctx context.Context, nodeID string, password string) error
+}
+
 // ControllerConfigService is the interface that gets ControllerConfig form DB.
 type ControllerConfigService interface {
 	ControllerConfig(context.Context) (controller.Config, error)
@@ -132,6 +140,7 @@ func NewAgentAPI(
 	st *state.State,
 	agentPasswordService AgentPasswordService,
 	controllerConfigService ControllerConfigService,
+	controllerNodeService ControllerNodeService,
 	externalControllerService ExternalControllerService,
 	rebootMachineService MachineRebootService,
 	modelConfigService ModelConfigService,
@@ -143,7 +152,7 @@ func NewAgentAPI(
 	}
 
 	return &AgentAPI{
-		PasswordChanger:    common.NewPasswordChanger(agentPasswordService, st, getCanChange),
+		PasswordChanger:    common.NewPasswordChanger(agentPasswordService, controllerNodeService, st, getCanChange),
 		RebootFlagClearer:  common.NewRebootFlagClearer(rebootMachineService, getCanChange),
 		ModelConfigWatcher: commonmodel.NewModelConfigWatcher(modelConfigService, watcherRegistry),
 		ControllerConfigAPI: common.NewControllerConfigAPI(

--- a/apiserver/facades/agent/agent/agent_test.go
+++ b/apiserver/facades/agent/agent/agent_test.go
@@ -40,7 +40,7 @@ func (s *agentSuite) TestSetUnitPassword(c *tc.C) {
 		Return(nil)
 
 	api := &AgentAPI{
-		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, alwaysAllow),
+		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, nil, alwaysAllow),
 	}
 
 	result, err := api.SetPasswords(c.Context(), params.EntityPasswords{
@@ -69,7 +69,7 @@ func (s *agentSuite) TestSetUnitPasswordUnitNotFound(c *tc.C) {
 		Return(applicationerrors.UnitNotFound)
 
 	api := &AgentAPI{
-		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, alwaysAllow),
+		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, nil, alwaysAllow),
 	}
 
 	result, err := api.SetPasswords(c.Context(), params.EntityPasswords{
@@ -98,7 +98,7 @@ func (s *agentSuite) TestSetMachinePassword(c *tc.C) {
 		Return(nil)
 
 	api := &AgentAPI{
-		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, alwaysAllow),
+		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, nil, alwaysAllow),
 	}
 
 	result, err := api.SetPasswords(c.Context(), params.EntityPasswords{
@@ -127,7 +127,7 @@ func (s *agentSuite) TestSetMachinePasswordMachineNotFound(c *tc.C) {
 		Return(machineerrors.MachineNotFound)
 
 	api := &AgentAPI{
-		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, alwaysAllow),
+		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, nil, alwaysAllow),
 	}
 
 	result, err := api.SetPasswords(c.Context(), params.EntityPasswords{

--- a/apiserver/facades/agent/agent/register.go
+++ b/apiserver/facades/agent/agent/register.go
@@ -33,6 +33,7 @@ func NewAgentAPIV3(ctx facade.ModelContext) (*AgentAPI, error) {
 		ctx.State(),
 		services.AgentPassword(),
 		services.ControllerConfig(),
+		services.ControllerNode(),
 		services.ExternalController(),
 		services.Machine(),
 		services.Config(),

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -175,7 +175,7 @@ func NewDeployerAPI(
 	}
 
 	return &DeployerAPI{
-		PasswordChanger:        common.NewPasswordChanger(agentPasswordService, st, getAuthFunc),
+		PasswordChanger:        common.NewPasswordChanger(agentPasswordService, nil, st, getAuthFunc),
 		APIAddresser:           common.NewAPIAddresser(controllerNodeService, watcherRegistry),
 		unitStatusSetter:       common.NewUnitStatusSetter(statusService, clock, getAuthFunc),
 		controllerConfigGetter: controllerConfigGetter,

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -144,7 +144,7 @@ func (s *deployerSuite) TestSetUnitPassword(c *tc.C) {
 		Return(nil)
 
 	api := &DeployerAPI{
-		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, alwaysAllow),
+		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, nil, alwaysAllow),
 	}
 
 	result, err := api.SetPasswords(c.Context(), params.EntityPasswords{
@@ -173,7 +173,7 @@ func (s *deployerSuite) TestSetUnitPasswordUnitNotFound(c *tc.C) {
 		Return(applicationerrors.UnitNotFound)
 
 	api := &DeployerAPI{
-		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, alwaysAllow),
+		PasswordChanger: common.NewPasswordChanger(s.passwordService, nil, nil, alwaysAllow),
 	}
 
 	result, err := api.SetPasswords(c.Context(), params.EntityPasswords{

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -196,7 +196,7 @@ func MakeProvisionerAPI(stdCtx context.Context, ctx facade.ModelContext) (*Provi
 		StatusSetter:         common.NewStatusSetter(st, getAuthFunc, ctx.Clock()),
 		StatusGetter:         common.NewStatusGetter(st, getAuthFunc),
 		DeadEnsurer:          common.NewDeadEnsurer(st, getAuthFunc, machineService),
-		PasswordChanger:      common.NewPasswordChanger(agentPasswordService, st, getAuthFunc),
+		PasswordChanger:      common.NewPasswordChanger(agentPasswordService, nil, st, getAuthFunc),
 		LifeGetter:           common.NewLifeGetter(applicationService, machineService, st, getAuthFunc, ctx.Logger()),
 		APIAddresser:         common.NewAPIAddresser(controllerNodeService, watcherRegistry),
 		ModelConfigWatcher:   modelConfigWatcher,

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -178,7 +178,7 @@ func NewStateCAASApplicationProvisionerAPI(stdCtx context.Context, ctx facade.Mo
 	)
 
 	apiGroup := &APIGroup{
-		PasswordChanger:    common.NewPasswordChanger(agentPasswordService, st, common.AuthFuncForTagKind(names.ApplicationTagKind)),
+		PasswordChanger:    common.NewPasswordChanger(agentPasswordService, nil, st, common.AuthFuncForTagKind(names.ApplicationTagKind)),
 		AgentEntityWatcher: common.NewAgentEntityWatcher(st, ctx.WatcherRegistry(), common.AuthFuncForTagKind(names.ApplicationTagKind)),
 		charmInfoAPI:       commonCharmsAPI,
 		appCharmInfoAPI:    appCharmInfoAPI,

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -60,7 +60,7 @@ func NewAPI(
 	return &API{
 		auth:                    authorizer,
 		APIAddresser:            common.NewAPIAddresser(controllerNodeService, watcherRegistry),
-		PasswordChanger:         common.NewPasswordChanger(agentPasswordService, st, common.AuthFuncForTagKind(names.ModelTagKind)),
+		PasswordChanger:         common.NewPasswordChanger(agentPasswordService, nil, st, common.AuthFuncForTagKind(names.ModelTagKind)),
 		controllerConfigService: controllerConfigService,
 		controllerNodeService:   controllerNodeService,
 		modelConfigService:      modelConfigService,

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -924,6 +924,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			ControllerUnitPassword:       bootstrap.IAASControllerUnitPassword,
 			BootstrapAddressFinderGetter: bootstrap.IAASAddressFinder,
 			SetMachineProvisioned:        bootstrap.IAASSetMachineProvisioned,
+			FinaliseControllerNode:       bootstrap.IAASFinaliseControllerNode,
 		})),
 
 		toolsVersionCheckerName: ifNotMigrating(toolsversionchecker.Manifold(toolsversionchecker.ManifoldConfig{
@@ -1131,6 +1132,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			ControllerUnitPassword:       bootstrap.CAASControllerUnitPassword,
 			BootstrapAddressFinderGetter: bootstrap.CAASAddressFinder,
 			SetMachineProvisioned:        bootstrap.CAASSetMachineProvisioned,
+			FinaliseControllerNode:       bootstrap.CAASFinaliseControllerNode,
 		})),
 
 		// TODO(caas) - when we support HA, only want this on primary

--- a/domain/agentpassword/service/service.go
+++ b/domain/agentpassword/service/service.go
@@ -101,7 +101,7 @@ func (s *Service) MatchesUnitPasswordHash(ctx context.Context, unitName unit.Nam
 }
 
 // SetMachinePassword sets the password for the given machine. If the machine does not
-// exist, an error satisfying [passworderrors.UnitNotFound] is returned.
+// exist, an error satisfying [passworderrors.MachineNotFound] is returned.
 func (s *Service) SetMachinePassword(ctx context.Context, machineName machine.Name, password string) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/agentpassword/state/state.go
+++ b/domain/agentpassword/state/state.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 
@@ -101,7 +100,7 @@ AND    password_hash = $validatePasswordHash.password_hash;
 	var count int
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, stmt, args).Get(&args); err != nil {
-			return errors.Errorf("setting password hash: %w", err)
+			return errors.Errorf("checking password hash: %w", err)
 		}
 		count = args.Count
 		return nil
@@ -256,17 +255,13 @@ AND       m.nonce = $validatePasswordHashWithNonce.nonce;
 	var valid bool
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, passwordStmt, args).Get(&result); err != nil {
-			return errors.Errorf("setting password hash: %w", err)
+			return errors.Errorf("checking password hash: %w", err)
 		}
-
-		fmt.Println("???>> result:", result)
 
 		// We've not found any rows, so the password does not match.
 		if result.MachineCount == 0 {
 			return nil
 		}
-
-		fmt.Println(">>> result:", result)
 
 		// If the machine count is greater than 0, then we can assume the
 		// password matches, but we also need to check the instance count.

--- a/domain/controllernode/errors/errors.go
+++ b/domain/controllernode/errors/errors.go
@@ -21,4 +21,8 @@ const (
 	// EmptyAPIAddresses describes an error that occurs when no API addresses
 	// are found.
 	EmptyAPIAddresses = errors.ConstError("no API addresses found")
+
+	// InvalidPassword describes an error that occurs when the password is not
+	// valid.
+	InvalidPassword = errors.ConstError("invalid password")
 )

--- a/domain/controllernode/state/types.go
+++ b/domain/controllernode/state/types.go
@@ -65,3 +65,10 @@ type controllerAPIAddressStr struct {
 	// Address is the address of the controller node.
 	Address string `db:"address"`
 }
+
+// controllerPasswordHash is the database representation of a controller with
+// a password hash. Used as input only.
+type controllerPasswordHash struct {
+	ControllerID string `db:"controller_id"`
+	PasswordHash string `db:"password_hash"`
+}

--- a/domain/controllernode/types.go
+++ b/domain/controllernode/types.go
@@ -12,3 +12,10 @@ type APIAddress struct {
 	// IsAgent indicates whether the address is available for agents.
 	IsAgent bool
 }
+
+// ControllerPasswordHash represents a hashed password.
+type ControllerPasswordHash string
+
+func (p ControllerPasswordHash) String() string {
+	return string(p)
+}

--- a/domain/schema/controller/sql/0009-controller-node.sql
+++ b/domain/schema/controller/sql/0009-controller-node.sql
@@ -1,7 +1,9 @@
 CREATE TABLE controller_node (
     controller_id TEXT NOT NULL PRIMARY KEY,
     dqlite_node_id TEXT,              -- This is the uint64 from Dqlite NodeInfo, stored as text.
-    dqlite_bind_address TEXT          -- IP address (no port) that Dqlite is bound to.
+    dqlite_bind_address TEXT,         -- IP address (no port) that Dqlite is bound to.
+    password_hash_algorithm_id TEXT,
+    password_hash TEXT
 );
 
 CREATE UNIQUE INDEX idx_controller_node_dqlite_node

--- a/internal/worker/bootstrap/service.go
+++ b/internal/worker/bootstrap/service.go
@@ -100,6 +100,9 @@ type ControllerNodeService interface {
 	// The following errors can be expected:
 	// - [controllernodeerrors.NotFound] if the controller node does not exist.
 	SetAPIAddresses(ctx context.Context, controllerID string, addrs network.SpaceHostPorts, mgmtSpace *network.SpaceInfo) error
+	// SetPassword sets the password for the given machine. If the controller node
+	// does not exist, an error satisfying [controllernodeerrors.NotFound] is returned.
+	SetPassword(ctx context.Context, controllerID string, password string) error
 }
 
 // CloudService is the interface that is used to interact with the

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -69,6 +69,7 @@ type WorkerConfig struct {
 	ControllerCharmDeployer    ControllerCharmDeployerFunc
 	PopulateControllerCharm    PopulateControllerCharmFunc
 	SetMachineProvisioned      SetMachineProvisionedFunc
+	FinaliseControllerNode     FinaliseControllerNodeFunc
 	CharmhubHTTPClient         HTTPClient
 	UnitPassword               string
 	ServiceManagerGetter       ServiceManagerGetterFunc
@@ -146,6 +147,9 @@ func (c *WorkerConfig) Validate() error {
 	}
 	if c.SetMachineProvisioned == nil {
 		return errors.NotValidf("nil SetMachineProvisioned")
+	}
+	if c.FinaliseControllerNode == nil {
+		return errors.NotValidf("nil FinaliseControllerNode")
 	}
 	if c.Logger == nil {
 		return errors.NotValidf("nil Logger")
@@ -277,6 +281,11 @@ func (w *bootstrapWorker) loop() error {
 	// Set the bootstrap machine as provisioned.
 	if err := w.cfg.SetMachineProvisioned(ctx, w.cfg.AgentPasswordService, w.cfg.MachineService, bootstrapParams, agentConfig); err != nil {
 		return errors.Annotatef(err, "setting machine as provisioned")
+	}
+
+	// Finalise the controller node.
+	if err := w.cfg.FinaliseControllerNode(ctx, w.cfg.ControllerNodeService, agentConfig); err != nil {
+		return errors.Annotatef(err, "finalising controller node")
 	}
 
 	// Convert the provider addresses that we got from the bootstrap instance

--- a/internal/worker/httpserverargs/authenticator.go
+++ b/internal/worker/httpserverargs/authenticator.go
@@ -31,6 +31,14 @@ type ControllerConfigService interface {
 	ControllerConfig(context.Context) (controller.Config, error)
 }
 
+// ControllerNodeService defines the methods required to check a controller
+// password hash.
+type ControllerNodeService interface {
+	// MatchesPassword checks if the password is valid or not against the password
+	// hash stored in the database for the given controller node.
+	MatchesPassword(ctx context.Context, nodeID string, password string) (bool, error)
+}
+
 // DomainServicesGetter defines methods for getting domain services
 // for a model.
 type DomainServicesGetter interface {
@@ -98,6 +106,7 @@ type NewStateAuthenticatorFunc func(
 	statePool *state.StatePool,
 	controllerModelUUID coremodel.UUID,
 	controllerConfigService ControllerConfigService,
+	controllerNodeService ControllerNodeService,
 	agentPasswordServiceGetter AgentPasswordServiceGetter,
 	accessService AccessService,
 	macaroonService MacaroonService,
@@ -114,6 +123,7 @@ func NewStateAuthenticator(
 	statePool *state.StatePool,
 	controllerModelUUID coremodel.UUID,
 	controllerConfigService ControllerConfigService,
+	controllerNodeService ControllerNodeService,
 	agentPasswordServiceGetter AgentPasswordServiceGetter,
 	accessService AccessService,
 	macaroonService MacaroonService,
@@ -130,7 +140,8 @@ func NewStateAuthenticator(
 		return nil, errors.Trace(err)
 	}
 
-	agentAuthGetter := authentication.NewAgentAuthenticatorGetter(passwordService, systemState, nil)
+	agentAuthGetter := authentication.NewAgentAuthenticatorGetter(
+		passwordService, controllerNodeService, systemState, nil)
 	stateAuthenticator, err := stateauthenticator.NewAuthenticator(
 		ctx,
 		statePool,

--- a/internal/worker/httpserverargs/manifold.go
+++ b/internal/worker/httpserverargs/manifold.go
@@ -79,6 +79,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		statePool:               statePool,
 		domainServicesGetter:    domainServicesGetter,
 		controllerConfigService: controllerDomainServices.ControllerConfig(),
+		controllerNodeService:   controllerDomainServices.ControllerNode(),
 		accessService:           controllerDomainServices.Access(),
 		macaroonService:         controllerDomainServices.Macaroon(),
 		mux:                     apiserverhttp.NewMux(),

--- a/internal/worker/httpserverargs/manifold_test.go
+++ b/internal/worker/httpserverargs/manifold_test.go
@@ -86,6 +86,7 @@ func (s *ManifoldSuite) newStateAuthenticator(
 	statePool *state.StatePool,
 	modelUUID model.UUID,
 	controllerConfig httpserverargs.ControllerConfigService,
+	controllerNodeService httpserverargs.ControllerNodeService,
 	agentPasswordServiceGetter httpserverargs.AgentPasswordServiceGetter,
 	accessService httpserverargs.AccessService,
 	macaroonService httpserverargs.MacaroonService,

--- a/internal/worker/httpserverargs/worker_test.go
+++ b/internal/worker/httpserverargs/worker_test.go
@@ -41,6 +41,7 @@ func (s *workerConfigSuite) SetUpTest(c *tc.C) {
 	s.config = workerConfig{
 		statePool:               &state.StatePool{},
 		controllerConfigService: &managedServices{},
+		controllerNodeService:   &managedServices{},
 		accessService:           &managedServices{},
 		macaroonService:         &managedServices{},
 		domainServicesGetter:    &managedServices{},
@@ -92,6 +93,7 @@ func startedAuthFunc(started chan struct{}) NewStateAuthenticatorFunc {
 		statePool *state.StatePool,
 		controllerModelUUID model.UUID,
 		controllerConfigService ControllerConfigService,
+		controllerNodeService ControllerNodeService,
 		agentPasswordServiceGetter AgentPasswordServiceGetter,
 		accessService AccessService,
 		macaroonService MacaroonService,


### PR DESCRIPTION
Controllers on Kubernetes are not machines. They require authentication via the
API using a controller agent tag with a password. This PR adds support for that.

## QA steps

- Bootstrap k8s.
- Check logs for `controller-0` agent API auth errors.