### PR TITLE
chore: remove legacy state from API server authenticators

### DIFF
--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -62,10 +62,9 @@ func (f AgentAuthenticatorGetter) Authenticator() EntityAuthenticator {
 }
 
 // AuthenticatorForModel returns an authenticator for the given model.
-func (f AgentAuthenticatorGetter) AuthenticatorForModel(agentPasswordService AgentPasswordService, st *state.State) EntityAuthenticator {
+func (f AgentAuthenticatorGetter) AuthenticatorForModel(agentPasswordService AgentPasswordService) EntityAuthenticator {
 	return agentAuthenticator{
 		agentPasswordService: agentPasswordService,
-		state:                st,
 		logger:               f.logger,
 	}
 }

--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -141,7 +141,7 @@ func (a *agentAuthenticator) authenticateMachine(ctx context.Context, tag names.
 	// - If the machine is not provisioned, then we consider that the machine
 	//   is not provisioned (the password must match first before undertaking
 	//   the provisioning).
-	// - Any other error, is considered an internal server error.
+	// - Any other error is considered an internal server error.
 
 	valid, err := a.agentPasswordService.MatchesMachinePasswordHashWithNonce(ctx, machineName, credentials, nonce)
 	if errors.Is(err, agentpassworderrors.EmptyPassword) || errors.Is(err, agentpassworderrors.EmptyNonce) {
@@ -170,7 +170,7 @@ func (a *agentAuthenticator) fallbackAuth(ctx context.Context, authParams AuthPa
 	}
 	authenticator, ok := entity.(taggedAuthenticator)
 	if !ok {
-		return nil, errors.Trace(fmt.Errorf("Authenticate fallback: %w", apiservererrors.ErrBadRequest))
+		return nil, errors.Trace(fmt.Errorf("authenticate fallback: %w", apiservererrors.ErrBadRequest))
 	}
 	if !authenticator.PasswordValid(authParams.Credentials) {
 		return nil, errors.Trace(apiservererrors.ErrUnauthorized)

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -8,21 +8,14 @@ import (
 	"sync"
 
 	"github.com/juju/clock"
-	"github.com/juju/names/v6"
-	"github.com/juju/tc"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/juju/juju/apiserver/authentication"
-	authjwt "github.com/juju/juju/apiserver/authentication/jwt"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/apiserver/stateauthenticator"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
-	"github.com/juju/juju/core/permission"
 	coretrace "github.com/juju/juju/core/trace"
-	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/worker/trace"
 	"github.com/juju/juju/rpc"
@@ -112,57 +105,6 @@ func TestingAPIRoot(facades *facade.Registry) rpc.Root {
 	return root
 }
 
-// TestingAPIHandler gives you an APIHandler that isn't connected to
-// anything real. It's enough to let test some basic functionality though.
-func TestingAPIHandler(c *tc.C, pool *state.StatePool, st *state.State, sf services.DomainServices) (*apiHandler, *common.Resources) {
-	agentAuthGetter := authentication.NewAgentAuthenticatorGetter(nil, st, loggertesting.WrapCheckLog(c))
-	modelInfo, err := sf.ModelInfo().GetModelInfo(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
-	authenticator, err := stateauthenticator.NewAuthenticator(
-		c.Context(),
-		pool,
-		modelInfo.UUID,
-		sf.ControllerConfig(),
-		nil,
-		sf.Access(),
-		sf.Macaroon(),
-		agentAuthGetter,
-		clock.WallClock,
-	)
-	c.Assert(err, tc.ErrorIsNil)
-
-	srv := &Server{
-		httpAuthenticators:  []authentication.HTTPAuthenticator{authenticator},
-		loginAuthenticators: []authentication.LoginAuthenticator{authenticator},
-		shared: &sharedServerContext{
-			statePool:            pool,
-			domainServicesGetter: &StubDomainServicesGetter{},
-		},
-		tag: names.NewMachineTag("0"),
-	}
-	h, err := newAPIHandler(
-		c.Context(),
-		srv,
-		st,
-		nil,
-		sf,
-		nil,
-		coretrace.NoopTracer{},
-		nil,
-		nil,
-		nil,
-		modelInfo.UUID,
-		false,
-		6543,
-		"testing.invalid:1234",
-	)
-	c.Assert(err, tc.ErrorIsNil)
-
-	resources := h.Resources()
-	return h, resources
-}
-
 type StubDomainServicesGetter struct{}
 
 func (s *StubDomainServicesGetter) ServicesForModel(context.Context, model.UUID) (services.DomainServices, error) {
@@ -175,41 +117,6 @@ type StubTracerGetter struct {
 
 type StubObjectStoreGetter struct {
 	objectstore.ObjectStoreGetter
-}
-
-// TestingAPIHandlerWithEntity gives you the sane kind of APIHandler as
-// TestingAPIHandler but sets the passed entity as the apiHandler
-// entity.
-func TestingAPIHandlerWithEntity(
-	c *tc.C,
-	pool *state.StatePool,
-	st *state.State,
-	sf services.DomainServices,
-	entity state.Entity,
-) (*apiHandler, *common.Resources) {
-	h, hr := TestingAPIHandler(c, pool, st, sf)
-	h.authInfo.Entity = entity
-	h.authInfo.Delegator = &stateauthenticator.PermissionDelegator{AccessService: sf.Access()}
-	return h, hr
-}
-
-// TestingAPIHandlerWithToken gives you the sane kind of APIHandler as
-// TestingAPIHandler but sets the passed token as the apiHandler
-// login token.
-func TestingAPIHandlerWithToken(
-	c *tc.C,
-	pool *state.StatePool,
-	st *state.State,
-	sf services.DomainServices,
-	jwt jwt.Token,
-	delegator authentication.PermissionDelegator,
-) (*apiHandler, *common.Resources) {
-	h, hr := TestingAPIHandler(c, pool, st, sf)
-	user, err := names.ParseUserTag(jwt.Subject())
-	c.Assert(err, tc.ErrorIsNil)
-	h.authInfo.Entity = authjwt.TokenEntity{User: user}
-	h.authInfo.Delegator = delegator
-	return h, hr
 }
 
 // TestingUpgradingRoot returns a resricted srvRoot in an upgrade
@@ -290,21 +197,8 @@ func SetAllowModelAccess(server *Server, allow bool) {
 	server.allowModelAccess = allow
 }
 
-// DataDir exposes the server data dir.
-func DataDir(server *Server) string {
-	return server.dataDir
-}
-
 // Patcher defines an interface that matches the PatchValue method on
 // CleanupSuite
 type Patcher interface {
 	PatchValue(ptr, value interface{})
-}
-
-func AssertHasPermission(c *tc.C, handler *apiHandler, access permission.Access, tag names.Tag, expect bool) {
-	err := handler.HasPermission(c.Context(), access, tag)
-	c.Assert(err == nil, tc.Equals, expect)
-	if expect {
-		c.Assert(err, tc.ErrorIsNil)
-	}
 }

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -53,11 +53,13 @@ var AgentTags = []string{
 // This Authenticator only works with requests that have been handled
 // by one of the httpcontext.*ModelHandler handlers.
 type Authenticator struct {
-	statePool                           *state.StatePool
+	authContext *authContext
+
 	controllerConfigService             ControllerConfigService
 	agentPasswordServiceGetter          AgentPasswordServiceGetter
 	controllerModelAgentPasswordService authentication.AgentPasswordService
-	authContext                         *authContext
+
+	controllerModelUUID model.UUID
 }
 
 // ControllerConfigService is an interface that can be implemented by
@@ -123,12 +125,13 @@ func NewAuthenticator(
 	}
 
 	return &Authenticator{
-		statePool:                  statePool,
-		agentPasswordServiceGetter: agentPasswordServiceGetter,
-		controllerConfigService:    controllerConfigService,
-		authContext:                authContext,
+		authContext: authContext,
 
+		agentPasswordServiceGetter:          agentPasswordServiceGetter,
+		controllerConfigService:             controllerConfigService,
 		controllerModelAgentPasswordService: controllerModelAgentPasswordService,
+
+		controllerModelUUID: controllerModelUUID,
 	}, nil
 }
 
@@ -208,18 +211,12 @@ func (a *Authenticator) AuthenticateLoginRequest(
 		}
 	}()
 
-	st, err := a.statePool.Get(modelUUID.String())
-	if err != nil {
-		return authentication.AuthInfo{}, errors.Trace(err)
-	}
-	defer st.Release()
-
 	agentPasswordService, err := a.agentPasswordServiceGetter.GetAgentPasswordServiceForModel(ctx, modelUUID)
 	if err != nil {
 		return authentication.AuthInfo{}, errors.Trace(err)
 	}
 
-	authenticator := a.authContext.authenticatorForModel(serverHost, agentPasswordService, st.State)
+	authenticator := a.authContext.authenticatorForModel(serverHost, agentPasswordService)
 	authInfo, err := a.checkCreds(ctx, modelUUID, authParams, authenticator, agentPasswordService)
 	if err == nil {
 		return authInfo, nil
@@ -235,14 +232,9 @@ func (a *Authenticator) AuthenticateLoginRequest(
 
 	// If you're a model worker api-caller using the model controller agent tag
 	// to ask questions about the non-controller model that you're running in.
-	if (isMachineTag || isControllerAgentTag) && !st.IsController() {
-		systemState, errS := a.statePool.SystemState()
-		if errS != nil {
-			return authentication.AuthInfo{}, errors.Trace(err)
-		}
-
+	if (isMachineTag || isControllerAgentTag) && a.controllerModelUUID != modelUUID {
 		// Controller agents are allowed to log into any model.
-		authenticator := a.authContext.authenticatorForModel(serverHost, a.controllerModelAgentPasswordService, systemState)
+		authenticator := a.authContext.authenticatorForModel(serverHost, a.controllerModelAgentPasswordService)
 
 		var err2 error
 		authInfo, err2 = a.checkCreds(ctx, modelUUID, authParams, authenticator, a.controllerModelAgentPasswordService)
@@ -290,11 +282,11 @@ func (a *Authenticator) checkCreds(
 		}
 
 	case names.MachineTagKind:
-		controller, err := agentPasswordService.IsMachineController(ctx, machine.Name(entity.Tag().Id()))
+		ctrl, err := agentPasswordService.IsMachineController(ctx, machine.Name(entity.Tag().Id()))
 		if err != nil && !errors.Is(err, machineerrors.MachineNotFound) {
 			return authentication.AuthInfo{}, errors.Trace(err)
 		}
-		authInfo.Controller = controller
+		authInfo.Controller = ctrl
 
 	case names.ControllerAgentTagKind:
 		// If you're a controller agent, then we've already authenticated so

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/core/user"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 )
 
 // AgentPasswordServiceGetter defines the methods required to get an
@@ -97,7 +96,6 @@ type BakeryConfigService interface {
 // NewAuthenticator returns a new Authenticator using the given StatePool.
 func NewAuthenticator(
 	ctx context.Context,
-	statePool *state.StatePool,
 	controllerModelUUID model.UUID,
 	controllerConfigService ControllerConfigService,
 	agentPasswordServiceGetter AgentPasswordServiceGetter,

--- a/apiserver/stateauthenticator/authenticator_test.go
+++ b/apiserver/stateauthenticator/authenticator_test.go
@@ -20,14 +20,11 @@ import (
 	coreusertesting "github.com/juju/juju/core/user/testing"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/internal/testing"
-	statetesting "github.com/juju/juju/state/testing"
 )
 
 // TODO update these tests (moved from apiserver) to test
 // via the public interface, and then get rid of export_test.go.
 type agentAuthenticatorSuite struct {
-	statetesting.StateSuite
-
 	authenticator              *Authenticator
 	entityAuthenticator        *MockEntityAuthenticator
 	agentAuthenticatorGetter   *MockAgentAuthenticatorGetter
@@ -159,7 +156,7 @@ func (s *agentAuthenticatorSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.agentPasswordServiceGetter.EXPECT().GetAgentPasswordServiceForModel(gomock.Any(), gomock.Any()).Return(s.agentPasswordService, nil)
 
 	s.controllerConfigService = NewMockControllerConfigService(ctrl)
-	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(s.ControllerConfig, nil).AnyTimes()
+	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(testing.FakeControllerConfig(), nil).AnyTimes()
 
 	s.accessService = NewMockAccessService(ctrl)
 

--- a/apiserver/stateauthenticator/authenticator_test.go
+++ b/apiserver/stateauthenticator/authenticator_test.go
@@ -46,7 +46,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticateLoginRequestHandleNotSupported
 	defer s.setupMocks(c).Finish()
 
 	s.agentPasswordServiceGetter.EXPECT().GetAgentPasswordServiceForModel(gomock.Any(), gomock.Any()).Return(s.agentPasswordService, nil)
-	s.agentAuthenticatorGetter.EXPECT().AuthenticatorForModel(gomock.Any(), gomock.Any()).Return(s.entityAuthenticator)
+	s.agentAuthenticatorGetter.EXPECT().AuthenticatorForModel(gomock.Any()).Return(s.entityAuthenticator)
 
 	_, err := s.authenticator.AuthenticateLoginRequest(c.Context(), "", "", authentication.AuthParams{Token: "token"})
 	c.Assert(err, tc.ErrorIs, errors.NotSupported)

--- a/apiserver/stateauthenticator/authenticator_test.go
+++ b/apiserver/stateauthenticator/authenticator_test.go
@@ -169,7 +169,6 @@ func (s *agentAuthenticatorSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 	authenticator, err := NewAuthenticator(
 		c.Context(),
-		s.StatePool,
 		model.UUID(testing.ModelTag.Id()),
 		s.controllerConfigService,
 		s.agentPasswordServiceGetter,

--- a/apiserver/stateauthenticator/context.go
+++ b/apiserver/stateauthenticator/context.go
@@ -75,7 +75,7 @@ type AgentAuthenticatorGetter interface {
 	Authenticator() authentication.EntityAuthenticator
 
 	// AuthenticatorForModel returns an authenticator for the given model.
-	AuthenticatorForModel(authentication.AgentPasswordService, *state.State) authentication.EntityAuthenticator
+	AuthenticatorForModel(authentication.AgentPasswordService) authentication.EntityAuthenticator
 }
 
 // authContext holds authentication context shared
@@ -231,11 +231,11 @@ func (ctxt *authContext) DischargeCaveats(tag names.UserTag) []checkers.Caveat {
 
 // authenticatorForModel returns an authenticator.Authenticator for the API
 // connection associated with the specified API server host and model.
-func (ctxt *authContext) authenticatorForModel(serverHost string, agentPasswordService authentication.AgentPasswordService, st *state.State) authenticator {
+func (ctxt *authContext) authenticatorForModel(serverHost string, agentPasswordService authentication.AgentPasswordService) authenticator {
 	return authenticator{
 		ctxt:               ctxt,
 		serverHost:         serverHost,
-		agentAuthenticator: ctxt.agentAuthGetter.AuthenticatorForModel(agentPasswordService, st),
+		agentAuthenticator: ctxt.agentAuthGetter.AuthenticatorForModel(agentPasswordService),
 	}
 }
 

--- a/apiserver/stateauthenticator/context_integration_test.go
+++ b/apiserver/stateauthenticator/context_integration_test.go
@@ -89,7 +89,6 @@ func (s *macaroonAuthSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 	authenticator, err := NewAuthenticator(
 		c.Context(),
-		nil,
 		model.UUID(testing.ModelTag.Id()),
 		s.controllerConfigService,
 		s.agentPasswordServiceGetter,

--- a/apiserver/stateauthenticator/context_test.go
+++ b/apiserver/stateauthenticator/context_test.go
@@ -71,7 +71,6 @@ func (s *macaroonCommonSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 	authenticator, err := NewAuthenticator(
 		c.Context(),
-		nil,
 		model.UUID(testing.ModelTag.Id()),
 		s.controllerConfigService,
 		s.agentPasswordServiceGetter,

--- a/apiserver/stateauthenticator/services_mock_test.go
+++ b/apiserver/stateauthenticator/services_mock_test.go
@@ -22,7 +22,6 @@ import (
 	permission "github.com/juju/juju/core/permission"
 	user "github.com/juju/juju/core/user"
 	auth "github.com/juju/juju/internal/auth"
-	state "github.com/juju/juju/state"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -622,17 +621,17 @@ func (c *MockAgentAuthenticatorGetterAuthenticatorCall) DoAndReturn(f func() aut
 }
 
 // AuthenticatorForModel mocks base method.
-func (m *MockAgentAuthenticatorGetter) AuthenticatorForModel(arg0 authentication.AgentPasswordService, arg1 *state.State) authentication.EntityAuthenticator {
+func (m *MockAgentAuthenticatorGetter) AuthenticatorForModel(arg0 authentication.AgentPasswordService) authentication.EntityAuthenticator {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AuthenticatorForModel", arg0, arg1)
+	ret := m.ctrl.Call(m, "AuthenticatorForModel", arg0)
 	ret0, _ := ret[0].(authentication.EntityAuthenticator)
 	return ret0
 }
 
 // AuthenticatorForModel indicates an expected call of AuthenticatorForModel.
-func (mr *MockAgentAuthenticatorGetterMockRecorder) AuthenticatorForModel(arg0, arg1 any) *MockAgentAuthenticatorGetterAuthenticatorForModelCall {
+func (mr *MockAgentAuthenticatorGetterMockRecorder) AuthenticatorForModel(arg0 any) *MockAgentAuthenticatorGetterAuthenticatorForModelCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticatorForModel", reflect.TypeOf((*MockAgentAuthenticatorGetter)(nil).AuthenticatorForModel), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticatorForModel", reflect.TypeOf((*MockAgentAuthenticatorGetter)(nil).AuthenticatorForModel), arg0)
 	return &MockAgentAuthenticatorGetterAuthenticatorForModelCall{Call: call}
 }
 
@@ -648,13 +647,13 @@ func (c *MockAgentAuthenticatorGetterAuthenticatorForModelCall) Return(arg0 auth
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAgentAuthenticatorGetterAuthenticatorForModelCall) Do(f func(authentication.AgentPasswordService, *state.State) authentication.EntityAuthenticator) *MockAgentAuthenticatorGetterAuthenticatorForModelCall {
+func (c *MockAgentAuthenticatorGetterAuthenticatorForModelCall) Do(f func(authentication.AgentPasswordService) authentication.EntityAuthenticator) *MockAgentAuthenticatorGetterAuthenticatorForModelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAgentAuthenticatorGetterAuthenticatorForModelCall) DoAndReturn(f func(authentication.AgentPasswordService, *state.State) authentication.EntityAuthenticator) *MockAgentAuthenticatorGetterAuthenticatorForModelCall {
+func (c *MockAgentAuthenticatorGetterAuthenticatorForModelCall) DoAndReturn(f func(authentication.AgentPasswordService) authentication.EntityAuthenticator) *MockAgentAuthenticatorGetterAuthenticatorForModelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/httpserverargs/authenticator.go
+++ b/internal/worker/httpserverargs/authenticator.go
@@ -133,7 +133,6 @@ func NewStateAuthenticator(
 	agentAuthGetter := authentication.NewAgentAuthenticatorGetter(passwordService, systemState, nil)
 	stateAuthenticator, err := stateauthenticator.NewAuthenticator(
 		ctx,
-		statePool,
 		controllerModelUUID, controllerConfigService,
 		agentPasswordServiceGetter,
 		accessService,

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -380,7 +380,6 @@ func (s *ApiServerSuite) setupApiServer(c *tc.C, controllerCfg controller.Config
 
 	authenticator, err := stateauthenticator.NewAuthenticator(
 		c.Context(),
-		cfg.StatePool,
 		cfg.ControllerModelUUID,
 		factory.ControllerConfig(),
 		agentPasswordServiceGetter{


### PR DESCRIPTION
Legacy state is no longer required for server request authentication. It is removed accordingly.