### PR TITLE
feat(status): Wire up network devices status with dqlite

### DIFF
--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
+	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/port"
 	domainrelation "github.com/juju/juju/domain/relation"
 	statusservice "github.com/juju/juju/domain/status/service"
@@ -102,6 +103,9 @@ type NetworkService interface {
 	GetAllSpaces(ctx context.Context) (network.SpaceInfos, error)
 	// GetAllSubnets returns all the subnets for the model.
 	GetAllSubnets(ctx context.Context) (network.SubnetInfos, error)
+	// GetAllDevicesByMachineNames retrieves a mapping of machine names to their
+	// associated network interfaces in the model.
+	GetAllDevicesByMachineNames(ctx context.Context) (map[machine.Name][]domainnetwork.NetInterface, error)
 }
 
 // PortService defines the methods that the facade assumes from the Port

--- a/apiserver/facades/client/client/service_mock_test.go
+++ b/apiserver/facades/client/client/service_mock_test.go
@@ -14,10 +14,12 @@ import (
 	reflect "reflect"
 
 	blockdevice "github.com/juju/juju/core/blockdevice"
+	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
 	relation "github.com/juju/juju/core/relation"
 	status "github.com/juju/juju/core/status"
+	network0 "github.com/juju/juju/domain/network"
 	relation0 "github.com/juju/juju/domain/relation"
 	service "github.com/juju/juju/domain/status/service"
 	gomock "go.uber.org/mock/gomock"
@@ -106,6 +108,45 @@ func NewMockNetworkService(ctrl *gomock.Controller) *MockNetworkService {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetworkService) EXPECT() *MockNetworkServiceMockRecorder {
 	return m.recorder
+}
+
+// GetAllDevicesByMachineNames mocks base method.
+func (m *MockNetworkService) GetAllDevicesByMachineNames(arg0 context.Context) (map[machine.Name][]network0.NetInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllDevicesByMachineNames", arg0)
+	ret0, _ := ret[0].(map[machine.Name][]network0.NetInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllDevicesByMachineNames indicates an expected call of GetAllDevicesByMachineNames.
+func (mr *MockNetworkServiceMockRecorder) GetAllDevicesByMachineNames(arg0 any) *MockNetworkServiceGetAllDevicesByMachineNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllDevicesByMachineNames", reflect.TypeOf((*MockNetworkService)(nil).GetAllDevicesByMachineNames), arg0)
+	return &MockNetworkServiceGetAllDevicesByMachineNamesCall{Call: call}
+}
+
+// MockNetworkServiceGetAllDevicesByMachineNamesCall wrap *gomock.Call
+type MockNetworkServiceGetAllDevicesByMachineNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockNetworkServiceGetAllDevicesByMachineNamesCall) Return(arg0 map[machine.Name][]network0.NetInterface, arg1 error) *MockNetworkServiceGetAllDevicesByMachineNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockNetworkServiceGetAllDevicesByMachineNamesCall) Do(f func(context.Context) (map[machine.Name][]network0.NetInterface, error)) *MockNetworkServiceGetAllDevicesByMachineNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockNetworkServiceGetAllDevicesByMachineNamesCall) DoAndReturn(f func(context.Context) (map[machine.Name][]network0.NetInterface, error)) *MockNetworkServiceGetAllDevicesByMachineNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetAllSpaces mocks base method.

--- a/domain/network/state/linklayer.go
+++ b/domain/network/state/linklayer.go
@@ -294,7 +294,7 @@ SELECT
  ps.provider_id AS &getIpAddress.provider_subnet_id,
  ia.device_uuid AS &getIpAddress.device_uuid,
  ia.address_value AS &getIpAddress.address_value,
- ia.subnet_uuid AS &getIpAddress.subnet_uuid,
+ s.name AS &getIpAddress.space,
  iat.name AS &getIpAddress.type,
  iact.name AS &getIpAddress.config_type,
  iao.name AS &getIpAddress.origin,
@@ -308,6 +308,8 @@ JOIN ip_address_origin AS iao ON ia.origin_id = iao.id
 JOIN ip_address_scope AS ias ON ia.scope_id = ias.id
 LEFT JOIN provider_ip_address AS pia ON ia.uuid = pia.address_uuid
 LEFT JOIN provider_subnet as ps ON ia.subnet_uuid = ps.subnet_uuid
+LEFT JOIN subnet as sub ON ia.subnet_uuid = sub.uuid
+LEFT JOIN space as s ON sub.space_uuid = s.uuid
 `, getIpAddress{})
 	if err != nil {
 		return nil, errors.Errorf("preparing IP address select statement: %w", err)

--- a/domain/network/state/linklayer_test.go
+++ b/domain/network/state/linklayer_test.go
@@ -615,6 +615,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			return network.NetAddr{
 				InterfaceName: in.InterfaceName,
 				AddressValue:  in.AddressValue,
+				Space:         in.Space,
 			}
 		})
 	}
@@ -628,9 +629,11 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	c.Check(filterNetAddr(eth0.Addrs), tc.SameContents, []network.NetAddr{{
 		InterfaceName: "eth0",
 		AddressValue:  "192.168.1.10/24",
+		Space:         "alpha",
 	}, {
 		InterfaceName: "eth0",
 		AddressValue:  "192.168.1.11/24",
+		Space:         "alpha",
 	}})
 	c.Check(eth0.DNSSearchDomains, tc.SameContents, []string{"search1.maas.net", "search2.maas.net"})
 	c.Check(eth0.DNSAddresses, tc.SameContents, []string{"8.8.8.8", "8.8.4.4"})
@@ -646,6 +649,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		{
 			InterfaceName: "eth0-bridge",
 			AddressValue:  "192.168.2.10/24",
+			Space:         "alpha",
 		},
 	})
 	c.Check(bridge.DNSSearchDomains, tc.SameContents, []string{"search3.maas.net"})
@@ -661,10 +665,12 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		{
 			InterfaceName: "eth1",
 			AddressValue:  "192.168.3.10/24",
+			Space:         "alpha",
 		},
 		{
 			InterfaceName: "eth1",
 			AddressValue:  "192.168.3.11/24",
+			Space:         "alpha",
 		},
 	})
 	c.Check(eth1.DNSSearchDomains, tc.SameContents, []string{"search4.maas.net", "search5.maas.net"})

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -654,11 +654,11 @@ type getIpAddress struct {
 	ProviderSubnetID *string `db:"provider_subnet_id"`
 	DeviceUUID       string  `db:"device_uuid"`
 	AddressValue     string  `db:"address_value"`
-	SubnetUUID       *string `db:"subnet_uuid"`
 	Type             string  `db:"type"`
 	ConfigType       string  `db:"config_type"`
 	Origin           string  `db:"origin"`
 	Scope            string  `db:"scope"`
+	Space            string  `db:"space"`
 	IsSecondary      bool    `db:"is_secondary"`
 	IsShadow         bool    `db:"is_shadow"`
 }
@@ -705,6 +705,7 @@ func dmlToNetAddr(addr getIpAddress, deviceName string) network.NetAddr {
 		Scope:            corenetwork.Scope(addr.Scope),
 		IsSecondary:      addr.IsSecondary,
 		IsShadow:         addr.IsShadow,
+		Space:            addr.Space,
 	}
 }
 

--- a/domain/network/types.go
+++ b/domain/network/types.go
@@ -26,6 +26,7 @@ type NetAddr struct {
 	Scope       network.Scope
 	IsSecondary bool
 	IsShadow    bool
+	Space       string
 }
 
 // NetInterface represents a physical or virtual


### PR DESCRIPTION
This patch introduces the new `GetAllDevicesByMachineNames` method to the `NetworkService`
interface in `apiserver/facades/client/client/service.go`,
allowing retrieval of machine-to-network-interface mappings.

It suppress any remaining dependencies to mongodb to fetch linklayerdevices and ip addresses
information.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Bootstrap, add a model and few machine.
Wait for machines to be up and running

Check `juju status --format yaml`.

Results should be the same after the change than after using the same procedure on 3.6

## Links

**Jira card:** JUJU-7726
