### PR TITLE
feat(Dqlite): add storage provision scope table;

### DIFF
--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -461,9 +461,6 @@ CREATE TABLE storage_volume_attachment_plan (
     life_id INT NOT NULL,
     device_type_id INT,
     block_device_uuid TEXT,
-    -- TODO: we may change provision_scope_id to NOT NULL in the future.
-    -- We leave it nullable for now to avoid too much code churn.
-    provision_scope_id INT,
     CONSTRAINT fk_storage_volume_attachment_plan_vol
     FOREIGN KEY (storage_volume_uuid)
     REFERENCES storage_volume (uuid),
@@ -478,10 +475,7 @@ CREATE TABLE storage_volume_attachment_plan (
     REFERENCES storage_volume_device_type (id),
     CONSTRAINT fk_storage_volume_attachment_plan_block
     FOREIGN KEY (block_device_uuid)
-    REFERENCES block_device (uuid),
-    CONSTRAINT fk_storage_volume_attachment_plan_provision_scope_id
-    FOREIGN KEY (provision_scope_id)
-    REFERENCES storage_provision_scope (id)
+    REFERENCES block_device (uuid)
 );
 
 CREATE TABLE storage_volume_attachment_plan_attr (

--- a/domain/schema/model/triggers/storage-triggers.gen.go
+++ b/domain/schema/model/triggers/storage-triggers.gen.go
@@ -117,7 +117,8 @@ WHEN
 	NEW.filesystem_id != OLD.filesystem_id OR
 	NEW.life_id != OLD.life_id OR
 	(NEW.provider_id != OLD.provider_id OR (NEW.provider_id IS NOT NULL AND OLD.provider_id IS NULL) OR (NEW.provider_id IS NULL AND OLD.provider_id IS NOT NULL)) OR
-	(NEW.size_mib != OLD.size_mib OR (NEW.size_mib IS NOT NULL AND OLD.size_mib IS NULL) OR (NEW.size_mib IS NULL AND OLD.size_mib IS NOT NULL)) 
+	(NEW.size_mib != OLD.size_mib OR (NEW.size_mib IS NOT NULL AND OLD.size_mib IS NULL) OR (NEW.size_mib IS NULL AND OLD.size_mib IS NOT NULL)) OR
+	(NEW.provision_scope_id != OLD.provision_scope_id OR (NEW.provision_scope_id IS NOT NULL AND OLD.provision_scope_id IS NULL) OR (NEW.provision_scope_id IS NULL AND OLD.provision_scope_id IS NOT NULL)) 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));
@@ -157,7 +158,8 @@ WHEN
 	NEW.net_node_uuid != OLD.net_node_uuid OR
 	NEW.life_id != OLD.life_id OR
 	(NEW.mount_point != OLD.mount_point OR (NEW.mount_point IS NOT NULL AND OLD.mount_point IS NULL) OR (NEW.mount_point IS NULL AND OLD.mount_point IS NOT NULL)) OR
-	(NEW.read_only != OLD.read_only OR (NEW.read_only IS NOT NULL AND OLD.read_only IS NULL) OR (NEW.read_only IS NULL AND OLD.read_only IS NOT NULL)) 
+	(NEW.read_only != OLD.read_only OR (NEW.read_only IS NOT NULL AND OLD.read_only IS NULL) OR (NEW.read_only IS NULL AND OLD.read_only IS NOT NULL)) OR
+	(NEW.provision_scope_id != OLD.provision_scope_id OR (NEW.provision_scope_id IS NOT NULL AND OLD.provision_scope_id IS NULL) OR (NEW.provision_scope_id IS NULL AND OLD.provision_scope_id IS NOT NULL)) 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));
@@ -199,7 +201,8 @@ WHEN
 	(NEW.size_mib != OLD.size_mib OR (NEW.size_mib IS NOT NULL AND OLD.size_mib IS NULL) OR (NEW.size_mib IS NULL AND OLD.size_mib IS NOT NULL)) OR
 	(NEW.hardware_id != OLD.hardware_id OR (NEW.hardware_id IS NOT NULL AND OLD.hardware_id IS NULL) OR (NEW.hardware_id IS NULL AND OLD.hardware_id IS NOT NULL)) OR
 	(NEW.wwn != OLD.wwn OR (NEW.wwn IS NOT NULL AND OLD.wwn IS NULL) OR (NEW.wwn IS NULL AND OLD.wwn IS NOT NULL)) OR
-	(NEW.persistent != OLD.persistent OR (NEW.persistent IS NOT NULL AND OLD.persistent IS NULL) OR (NEW.persistent IS NULL AND OLD.persistent IS NOT NULL)) 
+	(NEW.persistent != OLD.persistent OR (NEW.persistent IS NOT NULL AND OLD.persistent IS NULL) OR (NEW.persistent IS NULL AND OLD.persistent IS NOT NULL)) OR
+	(NEW.provision_scope_id != OLD.provision_scope_id OR (NEW.provision_scope_id IS NOT NULL AND OLD.provision_scope_id IS NULL) OR (NEW.provision_scope_id IS NULL AND OLD.provision_scope_id IS NOT NULL)) 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));
@@ -239,7 +242,8 @@ WHEN
 	NEW.net_node_uuid != OLD.net_node_uuid OR
 	NEW.life_id != OLD.life_id OR
 	(NEW.block_device_uuid != OLD.block_device_uuid OR (NEW.block_device_uuid IS NOT NULL AND OLD.block_device_uuid IS NULL) OR (NEW.block_device_uuid IS NULL AND OLD.block_device_uuid IS NOT NULL)) OR
-	(NEW.read_only != OLD.read_only OR (NEW.read_only IS NOT NULL AND OLD.read_only IS NULL) OR (NEW.read_only IS NULL AND OLD.read_only IS NOT NULL)) 
+	(NEW.read_only != OLD.read_only OR (NEW.read_only IS NOT NULL AND OLD.read_only IS NULL) OR (NEW.read_only IS NULL AND OLD.read_only IS NOT NULL)) OR
+	(NEW.provision_scope_id != OLD.provision_scope_id OR (NEW.provision_scope_id IS NOT NULL AND OLD.provision_scope_id IS NULL) OR (NEW.provision_scope_id IS NULL AND OLD.provision_scope_id IS NOT NULL)) 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -238,6 +238,7 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"storage_pool_attribute",
 		"storage_pool",
 		"storage_pool_origin",
+		"storage_provision_scope",
 		"storage_unit_owner",
 		"storage_volume_attachment_plan_attr",
 		"storage_volume_attachment_plan",
@@ -247,7 +248,6 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"storage_volume_status",
 		"storage_volume_status_value",
 		"unit_storage_directive",
-		"storage_provision_scope",
 
 		// Secret
 		"secret_rotate_policy",


### PR DESCRIPTION
We need to store the storage scope value in the database to maintain backward compatibility for provisioning watchers. These watchers are notified when changes occur to storage entities that they can provision.
To achieve this, this PR adds a new table `storage_provision_scope`. Two records(`model` and `machine` scope) are pre-inserted. A foreign key `provision_scope_id` is added to five storage tables:
- storage_volume
- storage_volume_attachment
- storage_filesystem
- storage_filesystem_attachment

Drive-by: fixed the FK typo on table `storage_volume_attachment_plan_attr`.

## Links

**Jira card:** [JUJU-8034](https://warthogs.atlassian.net/browse/JUJU-8034)


[JUJU-8034]: https://warthogs.atlassian.net/browse/JUJU-8034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ