### PR TITLE
fix(scripts/dlv): strip CIDR from `remote_host` in `juju.sh`

### DIFF
--- a/scripts/dlv/juju.sh
+++ b/scripts/dlv/juju.sh
@@ -71,6 +71,7 @@ fi
 
 # find out the remote host to ssh to
 remote_host=$(juju status -m ${target_model} --format=json | jq -r ".machines[\"${target_machine}\"][\"ip-addresses\"][0]")
+remote_host=${remote_host%%/*}
 
 if [ -z $target_socket ]; then
     echo "No target specified, trying to figure it out"
@@ -79,7 +80,7 @@ if [ -z $target_socket ]; then
     cmd="find /var/lib/juju/ -type s -name '*.socketd' 2> /dev/null || true"
 
     # Run the command over SSH and capture the output
-    output=$(ssh -o StrictHostKeyChecking=no -i ${identity_key} "ubuntu@$remote_host" "$cmd")
+    output=$(ssh -o StrictHostKeyChecking=no -i ${identity_key} "ubuntu@${remote_host}" "$cmd")
 
     # Capture the number of results
     result_count=$(echo "$output" | wc -l)


### PR DESCRIPTION
Ensure the `remote_host` variable in `scripts/dlv/juju.sh` contains only the IP address by stripping the CIDR suffix.
Additionally, updated the SSH command to wrap the `remote_host` variable in braces for consistent syntax.

This prevents potential issues when handling IPs with CIDR notations.

## QA steps

* build juju in debug mode `DEBUG_JUJU=1 make install`
* boostratp lxd
* try to automagically connect dlv to the controller throuhg `./scripts/dlv/juju.sh`
