### PR TITLE
feat(network): introduce unit relation infos API in network domain

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	domainapplication "github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/charm"
+	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/relation"
 	"github.com/juju/juju/domain/resolve"
 	"github.com/juju/juju/domain/unitstate"
@@ -247,6 +248,19 @@ type NetworkService interface {
 	// - [applicationerrors.UnitNotFound] if the unit does not exist
 	// - [network.NoAddressError] if the unit has no private address associated
 	GetUnitPrivateAddress(ctx context.Context, unitName coreunit.Name) (network.SpaceAddress, error)
+
+	// GetUnitRelationInfos retrieves network relation information for a given unit and specified endpoints.
+	// It returns exactly one info for each endpoint names passed in argument,
+	// but doesn't enforce the order. Each info has an endpoint name that should match
+	// one of the endpoint names, one info for each endpoint names.
+	//
+	// The following errors may be returned:
+	// - [applicationerrors.UnitNotFound] if the unit does not exist
+	GetUnitRelationInfos(ctx context.Context, unitName coreunit.Name, endpointNames []string) ([]domainnetwork.Info, error)
+
+	// UpdateUnitRelationInfos updates the relation network information for
+	// the specified unit.
+	UpdateUnitRelationInfos(context context.Context, name coreunit.Name) error
 }
 
 type ResolveService interface {

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -26,6 +26,7 @@ import (
 	watcher "github.com/juju/juju/core/watcher"
 	application0 "github.com/juju/juju/domain/application"
 	charm "github.com/juju/juju/domain/application/charm"
+	network0 "github.com/juju/juju/domain/network"
 	relation0 "github.com/juju/juju/domain/relation"
 	resolve "github.com/juju/juju/domain/resolve"
 	charm0 "github.com/juju/juju/internal/charm"
@@ -2790,6 +2791,83 @@ func (c *MockNetworkServiceGetUnitPublicAddressCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockNetworkServiceGetUnitPublicAddressCall) DoAndReturn(f func(context.Context, unit.Name) (network.SpaceAddress, error)) *MockNetworkServiceGetUnitPublicAddressCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitRelationInfos mocks base method.
+func (m *MockNetworkService) GetUnitRelationInfos(arg0 context.Context, arg1 unit.Name, arg2 []string) ([]network0.Info, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitRelationInfos", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]network0.Info)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitRelationInfos indicates an expected call of GetUnitRelationInfos.
+func (mr *MockNetworkServiceMockRecorder) GetUnitRelationInfos(arg0, arg1, arg2 any) *MockNetworkServiceGetUnitRelationInfosCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitRelationInfos", reflect.TypeOf((*MockNetworkService)(nil).GetUnitRelationInfos), arg0, arg1, arg2)
+	return &MockNetworkServiceGetUnitRelationInfosCall{Call: call}
+}
+
+// MockNetworkServiceGetUnitRelationInfosCall wrap *gomock.Call
+type MockNetworkServiceGetUnitRelationInfosCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockNetworkServiceGetUnitRelationInfosCall) Return(arg0 []network0.Info, arg1 error) *MockNetworkServiceGetUnitRelationInfosCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockNetworkServiceGetUnitRelationInfosCall) Do(f func(context.Context, unit.Name, []string) ([]network0.Info, error)) *MockNetworkServiceGetUnitRelationInfosCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockNetworkServiceGetUnitRelationInfosCall) DoAndReturn(f func(context.Context, unit.Name, []string) ([]network0.Info, error)) *MockNetworkServiceGetUnitRelationInfosCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// UpdateUnitRelationInfos mocks base method.
+func (m *MockNetworkService) UpdateUnitRelationInfos(arg0 context.Context, arg1 unit.Name) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUnitRelationInfos", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateUnitRelationInfos indicates an expected call of UpdateUnitRelationInfos.
+func (mr *MockNetworkServiceMockRecorder) UpdateUnitRelationInfos(arg0, arg1 any) *MockNetworkServiceUpdateUnitRelationInfosCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnitRelationInfos", reflect.TypeOf((*MockNetworkService)(nil).UpdateUnitRelationInfos), arg0, arg1)
+	return &MockNetworkServiceUpdateUnitRelationInfosCall{Call: call}
+}
+
+// MockNetworkServiceUpdateUnitRelationInfosCall wrap *gomock.Call
+type MockNetworkServiceUpdateUnitRelationInfosCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockNetworkServiceUpdateUnitRelationInfosCall) Return(arg0 error) *MockNetworkServiceUpdateUnitRelationInfosCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockNetworkServiceUpdateUnitRelationInfosCall) Do(f func(context.Context, unit.Name) error) *MockNetworkServiceUpdateUnitRelationInfosCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockNetworkServiceUpdateUnitRelationInfosCall) DoAndReturn(f func(context.Context, unit.Name) error) *MockNetworkServiceUpdateUnitRelationInfosCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/network/service/info.go
+++ b/domain/network/service/info.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/collections/transform"
+
+	"github.com/juju/juju/core/trace"
+	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/network"
+	internalerrors "github.com/juju/juju/internal/errors"
+)
+
+// GetUnitRelationInfos retrieves network relation information for a given unit
+// and specified endpoints.
+// It returns exactly one info for each endpoint names passed in argument,
+// but doesn't enforce the order. Each info has an endpoint name that should match
+// one of the endpoint names, one info for each endpoint names.
+//
+// The following errors may be returned:
+// - [applicationerrors.UnitNotFound] if the unit does not exist
+func (s *Service) GetUnitRelationInfos(
+	ctx context.Context,
+	unitName coreunit.Name,
+	endpointNames []string,
+) ([]network.Info, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	// todo(gfouillet): Implements the whole functionality
+	//   this is just a placeholder for the facade works
+	addr, err := s.GetUnitPublicAddress(ctx, unitName)
+	if err != nil {
+		return nil, internalerrors.Errorf("getting unit public address: %w", err)
+	}
+
+	return transform.Slice(endpointNames, func(endpoint string) network.Info {
+		return network.Info{
+			EndpointName:     endpoint,
+			IngressAddresses: []string{addr.String()},
+		}
+	}), nil
+}
+
+// UpdateUnitRelationInfos updates the relation network information for
+// the specified unit.
+func (s *Service) UpdateUnitRelationInfos(context context.Context, name coreunit.Name) error {
+	return nil // To be implemented
+}

--- a/domain/network/types.go
+++ b/domain/network/types.go
@@ -77,3 +77,53 @@ const (
 	NonVirtualPortType VirtualPortType = iota
 	OpenVswitchVirtualPortType
 )
+
+// Info represents network relationship details for a specific endpoint.
+type Info struct {
+
+	// EndpointName specifies the name of the network endpoint associated with
+	// the current Info instance.
+	EndpointName string
+
+	// DeviceInfos is a collection of device-specific information
+	// associated with an endpoint.
+	DeviceInfos []DeviceInfo
+
+	// IngressAddresses represents the list of ingress addresses
+	// associated with a network endpoint.
+	IngressAddresses []string
+
+	// EgressSubnets specifies a list of subnets used for outgoing network
+	// traffic from the endpoint.
+	EgressSubnets []string
+}
+
+// DeviceInfo represents information about a network device.
+type DeviceInfo struct {
+	// Name specifies the network device's human-readable name or identifier.
+	Name string
+
+	// MACAddress specifies the hardware MAC address of a network
+	// interface (e.g., "aa:bb:cc:dd:ee:ff").
+	MACAddress string
+
+	// Addresses specifies a list of network addresses and related information
+	// associated with the device.
+	Addresses []AddressInfo
+}
+
+// AddressInfo represents network address details.
+type AddressInfo struct {
+
+	// Hostname defines the DNS-resolvable name of the network address,
+	// typically used for identifying a device or service.
+	Hostname string
+
+	// Value represents a string value, often used to specify network-related
+	// information or data.
+	Value string
+
+	// CIDR specifies the subnet in CIDR notation, indicating the network
+	// portion of the associated IP address.
+	CIDR string
+}


### PR DESCRIPTION
Added `GetUnitRelationInfos` and `UpdateUnitRelationInfos` methods in `domain/network/service/info.go` to manage relation network information for units. These changes enhance network service capabilities by allowing retrieval and update of network relation details linked to unit endpoints.

It pushes down to the service the actual placedholder code which only retrieve the public address.

The state layer work will be done in a future patch.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Full QA is not available yet, it will requires state works.

However, Unit tests should pass, and you should be able to boostrap, deploy apps and relate then, then add units without having any changes in behavior.

```sh
juju bootstrap lxd lxd
juju add-model m
juju deploy juju-qa-dummy-source src
juju deploy juju-qa-dummy-sink sink
juju relate sink src
juju config src token="Hey"
juju add-unit src
juju add-unit sink
```

```sh
# in another terminal
watch -n1 juju status --color --relations
```

## Links

**Jira card:** JUJU-7725
