### PR TITLE
fix: prevent changestream restarting

### DIFF
--- a/internal/worker/changestream/worker_test.go
+++ b/internal/worker/changestream/worker_test.go
@@ -139,6 +139,23 @@ func (s *workerSuite) TestEventSource(c *tc.C) {
 	close(done)
 }
 
+func (s *workerSuite) TestEventSourceEmptyNamespace(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectClock()
+
+	s.dbGetter.EXPECT().GetDB("").Return(s.TxnRunner(), errors.NotValid)
+
+	w := s.newWorker(c, 1)
+	defer workertest.CleanKill(c, w)
+
+	stream, ok := w.(changestream.WatchableDBGetter)
+	c.Assert(ok, tc.IsTrue, tc.Commentf("worker does not implement ChangeStream"))
+
+	_, err := stream.GetWatchableDB("")
+	c.Assert(err, tc.ErrorIs, errors.NotFound)
+}
+
 func (s *workerSuite) TestEventSourceCalledTwice(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 


### PR DESCRIPTION
The changestream would attempt to restart the worker if the namespace for the database was not valid. Essentially, if the call to GetDB returns an error that should prevent a restart, then we need to handle it in the ShouldRestart function. If the restart happens during the start of the worker, and there is a subsequent call to get the change stream from the runner, it will keep waiting until the abort channel is called. This is problematic. We should audit all runner start worker methods to ensure that any error returned back from the function is handled correctly.

At the very least, all runners should be correctly wired up to the loggers.


## QA steps

The tests should pass, but @jack-w-shaw draft PR should not lockup when attempting to access a model database with an invalid namespace.
