### PR TITLE
fix: followup PR to set controllerUUID in missed places

### DIFF
--- a/apiserver/facades/controller/undertaker/mock_test.go
+++ b/apiserver/facades/controller/undertaker/mock_test.go
@@ -4,6 +4,7 @@
 package undertaker_test
 
 import (
+	"github.com/juju/utils/v3"
 	"time"
 
 	"github.com/juju/errors"
@@ -21,9 +22,10 @@ import (
 // mockState implements State interface and allows inspection of called
 // methods.
 type mockState struct {
-	model    *mockModel
-	removed  bool
-	isSystem bool
+	model          *mockModel
+	removed        bool
+	isSystem       bool
+	controllerUUID string
 
 	watcher state.NotifyWatcher
 }
@@ -39,8 +41,9 @@ func newMockState(modelOwner names.UserTag, modelName string, isSystem bool) *mo
 	}
 
 	st := &mockState{
-		model:    &model,
-		isSystem: isSystem,
+		model:          &model,
+		isSystem:       isSystem,
+		controllerUUID: utils.MustNewUUID().String(),
 		watcher: &mockWatcher{
 			changes: make(chan struct{}, 1),
 		},
@@ -92,6 +95,10 @@ func (m *mockState) WatchModelEntityReferences(mUUID string) state.NotifyWatcher
 
 func (m *mockState) ModelUUID() string {
 	return m.model.UUID()
+}
+
+func (m *mockState) ControllerUUID() string {
+	return m.controllerUUID
 }
 
 // mockModel implements Model interface and allows inspection of called

--- a/apiserver/facades/controller/undertaker/state.go
+++ b/apiserver/facades/controller/undertaker/state.go
@@ -38,6 +38,9 @@ type State interface {
 	// ModelUUID returns the model UUID for the model controlled
 	// by this state instance.
 	ModelUUID() string
+
+	// ControllerUUID returns the UUID of the controller.
+	ControllerUUID() string
 }
 
 type stateShim struct {

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -83,6 +83,7 @@ func (u *UndertakerAPI) ModelInfo() (params.UndertakerModelInfoResult, error) {
 		Life:           life.Value(model.Life().String()),
 		ForceDestroyed: model.ForceDestroyed(),
 		DestroyTimeout: model.DestroyTimeout(),
+		ControllerUUID: u.st.ControllerUUID(),
 	}
 
 	return result, nil

--- a/apiserver/facades/controller/undertaker/undertaker_test.go
+++ b/apiserver/facades/controller/undertaker/undertaker_test.go
@@ -114,6 +114,7 @@ func (s *undertakerSuite) TestModelInfo(c *gc.C) {
 		c.Assert(info.ForceDestroyed, gc.Equals, true)
 		c.Assert(info.DestroyTimeout, gc.NotNil)
 		c.Assert(*info.DestroyTimeout, gc.Equals, time.Minute)
+		c.Assert(info.ControllerUUID, gc.Equals, test.st.controllerUUID)
 	}
 }
 

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -106,14 +106,18 @@ func UpdateKubeCloudWithStorage(k8sCloud cloud.Cloud, storageParams KubeCloudSto
 func BaseKubeCloudOpenParams(cloud cloud.Cloud, credential cloud.Credential) (environs.OpenParams, error) {
 	// To get a k8s client, we need a config with minimal information.
 	// It's not used unless operating on a real model but we need to supply it.
-	uuid, err := utils.NewUUID()
+	modelUUID, err := utils.NewUUID()
+	if err != nil {
+		return environs.OpenParams{}, errors.Trace(err)
+	}
+	controllerUUID, err := utils.NewUUID()
 	if err != nil {
 		return environs.OpenParams{}, errors.Trace(err)
 	}
 	attrs := map[string]interface{}{
 		config.NameKey: "add-cloud",
 		config.TypeKey: "kubernetes",
-		config.UUIDKey: uuid.String(),
+		config.UUIDKey: modelUUID.String(),
 	}
 	cfg, err := config.New(config.UseDefaults, attrs)
 	if err != nil {
@@ -125,7 +129,8 @@ func BaseKubeCloudOpenParams(cloud cloud.Cloud, credential cloud.Credential) (en
 		return environs.OpenParams{}, errors.Trace(err)
 	}
 	openParams := environs.OpenParams{
-		Cloud: cloudSpec, Config: cfg,
+		ControllerUUID: controllerUUID.String(),
+		Cloud:          cloudSpec, Config: cfg,
 	}
 	return openParams, nil
 }

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -56,8 +56,9 @@ func prepare(ctx *cmd.Context, controllerName string, store jujuclient.ClientSto
 	// we'll do about simplestreams.MetadataValidator yet. Probably
 	// move it to the EnvironProvider interface.
 	return environs.New(context.TODO(), environs.OpenParams{
-		Cloud:  params.Cloud,
-		Config: cfg,
+		Cloud:          params.Cloud,
+		Config:         cfg,
+		ControllerUUID: bootstrapConfig.ControllerConfig.ControllerUUID(),
 	})
 }
 

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -61,8 +61,9 @@ type Tests struct {
 // Open opens an instance of the testing environment.
 func (t *Tests) Open(c *gc.C, ctx stdcontext.Context, cfg *config.Config) environs.Environ {
 	e, err := environs.New(ctx, environs.OpenParams{
-		Cloud:  t.CloudSpec(),
-		Config: cfg,
+		ControllerUUID: t.ControllerUUID,
+		Cloud:          t.CloudSpec(),
+		Config:         cfg,
 	})
 	c.Assert(err, gc.IsNil, gc.Commentf("opening environ %#v", cfg.AllAttrs()))
 	c.Assert(e, gc.NotNil)

--- a/internal/worker/undertaker/undertaker.go
+++ b/internal/worker/undertaker/undertaker.go
@@ -391,9 +391,15 @@ func (u *Undertaker) environ() (environs.CloudDestroyer, error) {
 		return nil, errors.Annotatef(err, "retrieving cloud spec for model %q (%s)", modelConfig.Name(), modelConfig.UUID())
 	}
 
+	modelInfo, err := u.config.Facade.ModelInfo()
+	if err != nil {
+		return nil, errors.Annotate(err, "retrieving model info")
+	}
+
 	environ, err := u.config.NewCloudDestroyerFunc(context.TODO(), environs.OpenParams{
-		Cloud:  cloudSpec,
-		Config: modelConfig,
+		ControllerUUID: modelInfo.Result.ControllerUUID,
+		Cloud:          cloudSpec,
+		Config:         modelConfig,
 	})
 	if err != nil {
 		return nil, errors.Annotatef(err, "creating environ for model %q (%s)", modelConfig.Name(), modelConfig.UUID())

--- a/rpc/params/undertaker.go
+++ b/rpc/params/undertaker.go
@@ -18,6 +18,7 @@ type UndertakerModelInfo struct {
 	Life           life.Value     `json:"life"`
 	ForceDestroyed bool           `json:"force-destroyed,omitempty"`
 	DestroyTimeout *time.Duration `json:"destroy-timeout,omitempty"`
+	ControllerUUID string         `json:"controller-uuid"`
 }
 
 // UndertakerModelInfoResult holds the result of an API call that returns an


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
