### PR TITLE
feat: new table DDL for model agent information

### DIFF
--- a/domain/schema/model/sql/0031-agent-.sql
+++ b/domain/schema/model/sql/0031-agent-.sql
@@ -1,0 +1,14 @@
+
+-- model_agent represents information about the agent that runs on behalf of a
+-- model.
+CREATE TABLE model_agent (
+    model_uuid TEXT NOT NULL,
+    password_hash_algorithm_id TEXT,
+    password_hash TEXT,
+    CONSTRAINT fk_model_uuid
+    FOREIGN KEY (model_uuid)
+    REFERENCES model (uuid),
+    CONSTRAINT fk_model_agent_password_hash_algorithm
+    FOREIGN KEY (password_hash_algorithm_id)
+    REFERENCES password_hash_algorithm (id)
+);

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -74,6 +74,7 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 
 		// Model
 		"model",
+		"model_agent",
 		"agent_stream",
 		"agent_version",
 


### PR DESCRIPTION
Introduces a new table to the model database to track information about the agent that runs on behalf of a model. In this scenario we are interested in tracking the agent password hash of the model.

I avoided the model table in the model database like we do for unit and machine because this table is readonly. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A, check that the ddl makes sense.

## Documentation changes

N/A

