### PR TITLE
fix: include IPv6 addresses in controller api addresses

### DIFF
--- a/core/network/address.go
+++ b/core/network/address.go
@@ -777,7 +777,7 @@ func DeriveAddressType(value string) AddressType {
 
 // ScopeMatchPublic is an address scope matching function for determining the
 // extent to which the input address' scope satisfies a requirement for public
-// accessibility.
+// accessibility. Prefers IPv4 over IPv6.
 func ScopeMatchPublic(addr Address) ScopeMatch {
 	switch addr.AddressScope() {
 	case ScopePublic:
@@ -795,6 +795,21 @@ func ScopeMatchPublic(addr Address) ScopeMatch {
 			return secondFallbackScopeIPv4
 		}
 		return secondFallbackScope
+	}
+	return invalidScope
+}
+
+// ScopeMatchAllPublic is an address scope matching function for determining the
+// extent to which the input address' scope satisfies a requirement for public
+// accessibility. IPv4 or IPv6 addresses are weighted the same in matching.
+func ScopeMatchAllPublic(addr Address) ScopeMatch {
+	switch addr.AddressScope() {
+	case ScopePublic:
+		return exactScopeIPv4
+	case ScopeCloudLocal:
+		return firstFallbackScopeIPv4
+	case ScopeFanLocal, ScopeUnknown:
+		return secondFallbackScopeIPv4
 	}
 	return invalidScope
 }

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -622,6 +622,46 @@ var selectInternalAddressesTests = []selectInternalAddressesTest{
 		matcher:  network.ScopeMatchCloudLocal,
 		expected: nil,
 	},
+	{
+		about: "IPv4 cloud-local addresses if no public addresses are found",
+		addresses: []network.SpaceAddress{
+			network.NewSpaceAddress("fc00::1", network.WithScope(network.ScopeCloudLocal)),
+			//network.NewSpaceAddress("fc00::42", network.WithScope(network.ScopePublic)),
+			network.NewSpaceAddress("169.254.1.1", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("192.168.1.37", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+		},
+		matcher: network.ScopeMatchPublic,
+		expected: []network.SpaceAddress{
+			network.NewSpaceAddress("169.254.1.1", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("192.168.1.37", network.WithScope(network.ScopeCloudLocal)),
+		},
+	},
+	{
+		about: "IPv6 public addresses takes precedence over IPv4 local-cloud",
+		addresses: []network.SpaceAddress{
+			network.NewSpaceAddress("fc00::42", network.WithScope(network.ScopePublic)),
+			network.NewSpaceAddress("169.254.1.1", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+		},
+		matcher: network.ScopeMatchPublic,
+		expected: []network.SpaceAddress{
+			network.NewSpaceAddress("fc00::42", network.WithScope(network.ScopePublic)),
+		},
+	},
+	{
+		about: "Both IPv4 and IPv6 local-cloud if no public addresses are found",
+		addresses: []network.SpaceAddress{
+			network.NewSpaceAddress("fc00::42", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("169.254.1.1", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+		},
+		matcher: network.ScopeMatchAllPublic,
+		expected: []network.SpaceAddress{
+			network.NewSpaceAddress("fc00::42", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("169.254.1.1", network.WithScope(network.ScopeCloudLocal)),
+		},
+	},
 }
 
 func (s *AddressSuite) TestSelectInternalAddresses(c *tc.C) {

--- a/domain/network/service/unitaddress.go
+++ b/domain/network/service/unitaddress.go
@@ -84,9 +84,8 @@ func (s *Service) GetUnitPublicAddresses(ctx context.Context, unitName unit.Name
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-
 	// First match the scope, then sort by origin.
-	matchedAddrs := addrs.AllMatchingScope(network.ScopeMatchPublic)
+	matchedAddrs := addrs.AllMatchingScope(network.ScopeMatchAllPublic)
 	if len(matchedAddrs) == 0 {
 		return nil, network.NoAddressError(string(network.ScopePublic))
 	}

--- a/domain/network/service/unitaddress_test.go
+++ b/domain/network/service/unitaddress_test.go
@@ -120,7 +120,7 @@ func (s *unitAddressSuite) TestGetPublicAddressMatchingAddress(c *tc.C) {
 		{
 			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
-				Value:      "10.0.0.1",
+				Value:      "10.0.0.1/24",
 				ConfigType: network.ConfigStatic,
 				Type:       network.IPv4Address,
 				Scope:      network.ScopeMachineLocal,
@@ -129,7 +129,7 @@ func (s *unitAddressSuite) TestGetPublicAddressMatchingAddress(c *tc.C) {
 		{
 			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
-				Value:      "54.32.1.2",
+				Value:      "54.32.1.2/24",
 				ConfigType: network.ConfigDHCP,
 				Type:       network.IPv4Address,
 				Scope:      network.ScopePublic,
@@ -138,7 +138,7 @@ func (s *unitAddressSuite) TestGetPublicAddressMatchingAddress(c *tc.C) {
 		{
 			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
-				Value:      "54.32.1.3",
+				Value:      "54.32.1.3/24",
 				ConfigType: network.ConfigDHCP,
 				Type:       network.IPv4Address,
 				Scope:      network.ScopeCloudLocal,
@@ -327,6 +327,15 @@ func (s *unitAddressSuite) TestGetPublicAddresses(c *tc.C) {
 		{
 			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
+				Value:      "fd42:13c3:1760:6d89:216:3eff:fec7:fd68/64",
+				ConfigType: network.ConfigDHCP,
+				Type:       network.IPv6Address,
+				Scope:      network.ScopePublic,
+			},
+		},
+		{
+			SpaceID: network.AlphaSpaceId,
+			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.2",
 				ConfigType: network.ConfigDHCP,
 				Type:       network.IPv4Address,
@@ -350,7 +359,7 @@ func (s *unitAddressSuite) TestGetPublicAddresses(c *tc.C) {
 	addrs, err := s.service(c).GetUnitPublicAddresses(c.Context(), unitName)
 	c.Assert(err, tc.ErrorIsNil)
 	// The two public addresses should be returned.
-	c.Check(addrs, tc.DeepEquals, unitAddresses[0:2])
+	c.Check(addrs, tc.DeepEquals, unitAddresses[0:3])
 }
 
 func (s *unitAddressSuite) TestGetPublicAddressesCloudLocal(c *tc.C) {


### PR DESCRIPTION
Controller API addresses should include both IPv4 and IPv6 values.

AllMatchingScope only returns SpaceAddresses with an exact ScopeMatch on the logic in the ScopeMatcher. If the exact ScopeMatch is unavailable, the next ScopeMatch in preference is returned. However, the current ScopeMatchPublic matcher differentiates between IPv4 and IPv6 with preference for IPv4.

Create a new ScopeMatcher to remove the preference for IPv4 addresses when using the AllMatchingScope method with SpaceAddresses.

This will allow for IPv6 addresses to be written to the controller_api_address table. They are then returned by to all callers of the various GetAPIAddresses methods in the controllernode domain.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Bootstrap juju, once available ssh to the controller/0 unit. View the `apiaddresses` in the `/var/lib/juju/agents/unit-controller-0/agent.conf` and `/var/lib/juju/agents/machine-0/agent.conf` files to see IPv4 and IPv6 addresses.