### PR TITLE
feat: network domain state methods for DevicesToBridge

### DIFF
--- a/domain/network/service/container.go
+++ b/domain/network/service/container.go
@@ -39,7 +39,7 @@ type ContainerState interface {
 
 	// NICsInSpaces returns the link-layer devices on the machine with the
 	// input net node UUID, indexed by the spaces that they are in.
-	NICsInSpaces(ctx context.Context, netNode string) (map[string][]network.NetInterface, error)
+	NICsInSpaces(ctx context.Context, nodeUUID string) (map[string][]network.NetInterface, error)
 
 	// GetContainerNetworkingMethod returns the model's configured value
 	// for container-networking-method.

--- a/domain/network/state/container.go
+++ b/domain/network/state/container.go
@@ -6,6 +6,8 @@ package state
 import (
 	"context"
 
+	"github.com/canonical/sqlair"
+
 	"github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/network/internal"
 	"github.com/juju/juju/internal/errors"
@@ -16,7 +18,54 @@ import (
 func (st *State) GetMachineSpaceConstraints(
 	ctx context.Context, machineUUID string,
 ) ([]internal.SpaceName, []internal.SpaceName, error) {
-	return nil, nil, errors.Errorf("implement me")
+	db, err := st.DB()
+	if err != nil {
+		return nil, nil, errors.Capture(err)
+	}
+
+	mUUID := entityUUID{UUID: machineUUID}
+
+	qry := `
+SELECT (space, exclude) AS (&spaceConstraint.*),
+       s.uuid AS &spaceConstraint.uuid
+FROM   constraint_space cs
+       JOIN machine_constraint m ON cs.constraint_uuid = m.constraint_uuid
+	   JOIN space s ON cs.space = s.name	
+WHERE  m.machine_uuid = $entityUUID.uuid`
+
+	stmt, err := st.Prepare(qry, mUUID, spaceConstraint{})
+	if err != nil {
+		return nil, nil, errors.Errorf("preparing machine space constraints statement: %w", err)
+	}
+
+	var cons []spaceConstraint
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, stmt, mUUID).GetAll(&cons); err != nil {
+			if !errors.Is(err, sqlair.ErrNoRows) {
+				return errors.Errorf("querying machine space constraints: %w", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, errors.Capture(err)
+	}
+
+	var pos, neg []internal.SpaceName
+	for _, con := range cons {
+		sn := internal.SpaceName{
+			UUID: con.SpaceUUID,
+			Name: con.SpaceName,
+		}
+
+		if con.Exclude {
+			neg = append(neg, sn)
+			continue
+		}
+		pos = append(pos, sn)
+	}
+
+	return pos, neg, nil
 }
 
 // GetMachineAppBindings returns the bound spaces for applications

--- a/domain/network/state/container_test.go
+++ b/domain/network/state/container_test.go
@@ -1,9 +1,19 @@
 package state
 
 import (
+	coreunit "github.com/juju/juju/core/unit"
+	coreunittesting "github.com/juju/juju/core/unit/testing"
+	"github.com/juju/juju/internal/charm"
 	"testing"
 
 	"github.com/juju/tc"
+
+	coreapplication "github.com/juju/juju/core/application"
+	coreapplicationtesting "github.com/juju/juju/core/application/testing"
+	corecharm "github.com/juju/juju/core/charm"
+	corecharmtesting "github.com/juju/juju/core/charm/testing"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/uuid"
 )
 
 type containerSuite struct {
@@ -17,7 +27,7 @@ func TestContainerSuite(t *testing.T) {
 func (s *containerSuite) TestGetMachineSpaceConstraints(c *tc.C) {
 	db := s.DB()
 
-	// Arrange. Set up two spaces a machine with those as
+	// Arrange. Set up two spaces and a machine with those as
 	// positive and negative constraints respectively.
 	nUUID := s.addNetNode(c)
 	mUUID := s.addMachine(c, "0", nUUID)
@@ -51,4 +61,122 @@ func (s *containerSuite) TestGetMachineSpaceConstraints(c *tc.C) {
 	c.Assert(neg, tc.HasLen, 1)
 	c.Check(pos[0].UUID, tc.Equals, posSpace)
 	c.Check(neg[0].UUID, tc.Equals, negSpace)
+}
+
+func (s *containerSuite) TestGetMachineAppBindings(c *tc.C) {
+	db := s.DB()
+
+	// Arrange. Set up a unit of an application with a bound endpoint,
+	// assigned to a machine. Ensure the machine has a NIC connected
+	// to the bound space.
+	cUUID := s.addCharm(c)
+	rUUID := s.addCharmRelation(c, cUUID, charm.Relation{
+		Name:  "whatever",
+		Role:  charm.RoleProvider,
+		Scope: charm.ScopeGlobal,
+	})
+
+	spUUID := s.addSpace(c)
+	subUUID := s.addSubnet(c, "192.168.10.0/24", spUUID)
+
+	appUUID := s.addApplication(c, cUUID, "app1")
+	_ = s.addApplicationEndpoint(c, appUUID, rUUID, spUUID)
+
+	nUUID := s.addNetNode(c)
+	mUUID := s.addMachine(c, "0", nUUID)
+	_ = s.addUnit(c, "app1/0", appUUID, cUUID, nUUID)
+
+	dUUID := s.addLinkLayerDevice(c, nUUID, "eth0", "mac-address", network.EthernetDevice)
+	addrUUID := s.addIPAddress(c, dUUID, nUUID, "192.168.10.10/24")
+
+	ctx := c.Context()
+
+	_, err := db.ExecContext(ctx, "UPDATE ip_address SET subnet_uuid = ? WHERE uuid = ?", subUUID, addrUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act
+	bound, err := s.state.GetMachineAppBindings(ctx, mUUID.String())
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(bound, tc.HasLen, 1)
+	c.Check(bound[0].UUID, tc.Equals, spUUID)
+}
+
+// addCharm inserts a new charm into the database and returns the UUID.
+func (s *containerSuite) addCharm(c *tc.C) corecharm.ID {
+	charmUUID := corecharmtesting.GenCharmID(c)
+	// The UUID is also used as the reference_name as there is a unique
+	// constraint on the reference_name, revision and source_id.
+	s.query(c, `
+INSERT INTO charm (uuid, reference_name, architecture_id) 
+VALUES (?, ?, 0)
+`, charmUUID, charmUUID)
+	return charmUUID
+}
+
+// addCharmRelation inserts a new charm relation into the database with the
+// given UUID and attributes. Returns the relation UUID.
+func (s *containerSuite) addCharmRelation(c *tc.C, charmUUID corecharm.ID, r charm.Relation) string {
+	charmRelationUUID := uuid.MustNewUUID().String()
+	s.query(c, `
+INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, interface, optional, capacity, scope_id) 
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`, charmRelationUUID, charmUUID, r.Name, encodeRoleID(r.Role), r.Interface, r.Optional, r.Limit, encodeScopeID(r.Scope))
+	return charmRelationUUID
+}
+
+// addApplication adds a new application to the database with the specified
+// charm UUID and application name. It returns the application UUID.
+func (s *containerSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appName string) coreapplication.ID {
+	appUUID := coreapplicationtesting.GenApplicationUUID(c)
+	s.query(c, `
+INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) 
+VALUES (?, ?, ?, ?, ?)
+`, appUUID, appName, 0 /* alive */, charmUUID.String(), network.AlphaSpaceId)
+	return appUUID
+}
+
+// addApplicationEndpoint inserts a new application endpoint into the
+// database with the specified UUIDs. Returns the endpoint uuid.
+func (s *containerSuite) addApplicationEndpoint(
+	c *tc.C, applicationUUID coreapplication.ID, charmRelationUUID string, boundSpaceUUID string) string {
+	applicationEndpointUUID := uuid.MustNewUUID().String()
+	s.query(c, `
+INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid,space_uuid)
+VALUES (?, ?, ?, ?)
+`, applicationEndpointUUID, applicationUUID, charmRelationUUID, boundSpaceUUID)
+	return applicationEndpointUUID
+}
+
+// addUnit adds a new unit to the specified application in the database with
+// the given UUID and name. Returns the unit uuid.
+func (s *containerSuite) addUnit(
+	c *tc.C, unitName coreunit.Name, appUUID coreapplication.ID, charmUUID corecharm.ID, nodeUUID string,
+) coreunit.UUID {
+	unitUUID := coreunittesting.GenUnitUUID(c)
+	s.query(c, `
+INSERT INTO unit (uuid, name, life_id, application_uuid, charm_uuid, net_node_uuid)
+VALUES (?, ?, ?, ?, ?, ?)
+`, unitUUID, unitName, 0 /* alive */, appUUID, charmUUID, nodeUUID)
+	return unitUUID
+}
+
+// encodeRoleID returns the ID used in the database for the given charm role.
+// This reflects the contents of the charm_relation_role table.
+func encodeRoleID(role charm.RelationRole) int {
+	return map[charm.RelationRole]int{
+		charm.RoleProvider: 0,
+		charm.RoleRequirer: 1,
+		charm.RolePeer:     2,
+	}[role]
+}
+
+// encodeScopeID returns the ID used in the database for the given charm scope.
+// This reflects the contents of the charm_relation_scope table.
+func encodeScopeID(role charm.RelationScope) int {
+	return map[charm.RelationScope]int{
+		charm.ScopeGlobal:    0,
+		charm.ScopeContainer: 1,
+	}[role]
 }

--- a/domain/network/state/container_test.go
+++ b/domain/network/state/container_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package state
 
 import (
@@ -156,6 +159,19 @@ func (s *containerSuite) TestNICsInSpaces(c *tc.C) {
 		}},
 	})
 
+}
+
+func (s *containerSuite) TestGetContainerNetworkingMethod(c *tc.C) {
+	db := s.DB()
+
+	ctx := c.Context()
+
+	_, err := db.ExecContext(ctx, "INSERT INTO model_config VALUES ('container-networking-method', 'provider')")
+	c.Assert(err, tc.ErrorIsNil)
+
+	conf, err := s.state.GetContainerNetworkingMethod(ctx)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(conf, tc.Equals, "provider")
 }
 
 // addCharm inserts a new charm into the database and returns the UUID.

--- a/domain/network/state/container_test.go
+++ b/domain/network/state/container_test.go
@@ -1,0 +1,54 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+)
+
+type containerSuite struct {
+	linkLayerBaseSuite
+}
+
+func TestContainerSuite(t *testing.T) {
+	tc.Run(t, &containerSuite{})
+}
+
+func (s *containerSuite) TestGetMachineSpaceConstraints(c *tc.C) {
+	db := s.DB()
+
+	// Arrange. Set up two spaces a machine with those as
+	// positive and negative constraints respectively.
+	nUUID := s.addNetNode(c)
+	mUUID := s.addMachine(c, "0", nUUID)
+	posSpace := s.addSpace(c)
+	negSpace := s.addSpace(c)
+	conUUID := "constraint-uuid"
+
+	ctx := c.Context()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO "constraint" (uuid) VALUES (?)`, conUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO machine_constraint (machine_uuid, constraint_uuid) VALUES (?, ?)",
+		mUUID, conUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for i, s := range []string{posSpace, negSpace} {
+		exclude := i != 0
+
+		_, err := db.ExecContext(ctx, "INSERT INTO constraint_space (constraint_uuid, space, exclude) VALUES (?, ?, ?)",
+			conUUID, s, exclude)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	// Act
+	pos, neg, err := s.state.GetMachineSpaceConstraints(ctx, mUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Assert
+	c.Assert(pos, tc.HasLen, 1)
+	c.Assert(neg, tc.HasLen, 1)
+	c.Check(pos[0].UUID, tc.Equals, posSpace)
+	c.Check(neg[0].UUID, tc.Equals, negSpace)
+}

--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/juju/juju/core/machine"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/core/machine"
 	machinetesting "github.com/juju/juju/core/machine/testing"
 	corenetwork "github.com/juju/juju/core/network"
 	schematesting "github.com/juju/juju/domain/schema/testing"

--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -89,8 +89,7 @@ func (s *linkLayerBaseSuite) checkRowCount(c *tc.C, table string, expected int) 
 
 // addLinkLayerDevice adds a link layer device to the database and returns its UUID.
 func (s *linkLayerBaseSuite) addLinkLayerDevice(
-	c *tc.C, netNodeUUID, name, macAddress string,
-	deviceType corenetwork.LinkLayerDeviceType,
+	c *tc.C, netNodeUUID, name, macAddress string, deviceType corenetwork.LinkLayerDeviceType,
 ) string {
 	deviceUUID := "device-" + name + "-uuid"
 
@@ -100,11 +99,10 @@ func (s *linkLayerBaseSuite) addLinkLayerDevice(
 	mtu := int64(1500)
 
 	s.query(c, `
-		INSERT INTO link_layer_device (uuid, net_node_uuid, name, mtu, 
-		                               mac_address, device_type_id, 
-		                               virtual_port_type_id, is_auto_start, 
-		                               is_enabled, is_default_gateway, gateway_address, vlan_tag)
-		                               	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO link_layer_device (
+	uuid, net_node_uuid, name, mtu, mac_address, device_type_id, virtual_port_type_id, 
+    is_auto_start, is_enabled, is_default_gateway, gateway_address, vlan_tag)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, deviceUUID, netNodeUUID, name, mtu, macAddress, deviceTypeID, 0, true,
 		true, false, nil, 0)
 
@@ -140,8 +138,8 @@ func (s *linkLayerBaseSuite) addProviderLinkLayerDevice(
 	c *tc.C, providerID, deviceUUID string,
 ) {
 	s.query(c, `
-		INSERT INTO provider_link_layer_device (provider_id, device_uuid)
-		VALUES (?, ?)
+INSERT INTO provider_link_layer_device (provider_id, device_uuid)
+VALUES (?, ?)
 	`, providerID, deviceUUID)
 }
 
@@ -152,8 +150,11 @@ func (s *linkLayerBaseSuite) addIPAddress(
 	addressUUID := "address-" + addressValue + "-uuid"
 
 	s.query(c, `
-		INSERT INTO ip_address (uuid, device_uuid, address_value, net_node_uuid, subnet_uuid, type_id, config_type_id, origin_id, scope_id, is_secondary, is_shadow)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO ip_address (
+	uuid, device_uuid, address_value, net_node_uuid, subnet_uuid, type_id, 
+	config_type_id, origin_id, scope_id, is_secondary, is_shadow
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, addressUUID, deviceUUID, addressValue, netNodeUUID, nil, 0, 4, 0, 0,
 		false, false)
 
@@ -165,8 +166,8 @@ func (s *mergeLinkLayerSuite) addProviderIPAddress(
 	c *tc.C, addressUUID, providerID string,
 ) {
 	s.query(c, `
-		INSERT INTO provider_ip_address (provider_id, address_uuid)
-		VALUES (?, ?)
+INSERT INTO provider_ip_address (provider_id, address_uuid)
+VALUES (?, ?)
 	`, providerID, addressUUID)
 
 	s.query(c, `

--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/juju/juju/core/machine"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/tc"
@@ -61,10 +62,11 @@ func (s *linkLayerBaseSuite) addNetNode(c *tc.C) string {
 	return netNodeUUID
 }
 
-func (s *linkLayerBaseSuite) addMachine(c *tc.C, name, netNodeUUID string) {
-	machineUUID := machinetesting.GenUUID(c).String()
+func (s *linkLayerBaseSuite) addMachine(c *tc.C, name, netNodeUUID string) machine.UUID {
+	machineUUID := machinetesting.GenUUID(c)
 	s.query(c, "INSERT INTO machine (uuid, net_node_uuid, name, life_id) VALUES (?, ?, ? ,?)",
-		machineUUID, netNodeUUID, name, 0)
+		machineUUID.String(), netNodeUUID, name, 0)
+	return machineUUID
 }
 
 func (s *linkLayerBaseSuite) addSpace(c *tc.C) string {

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -768,6 +768,14 @@ type spaceAddress struct {
 	SubnetCIDR sql.NullString `db:"cidr"`
 }
 
+// spaceConstraint represents a row from the constraint_space table
+// joined with the space table to get the space's UUID.
+type spaceConstraint struct {
+	SpaceUUID string `db:"uuid"`
+	SpaceName string `db:"space"`
+	Exclude   bool   `db:"exclude"`
+}
+
 func nilstr[T ~string](s *string) *T {
 	var res *T
 	if s != nil {

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -768,8 +768,8 @@ type spaceAddress struct {
 	SubnetCIDR sql.NullString `db:"cidr"`
 }
 
-// spaceConstraint represents a row from the constraint_space table
-// joined with the space table to get the space's UUID.
+// spaceConstraint represents a space name/UUID pair and its
+// role as a constraint (whether included or excluded).
 type spaceConstraint struct {
 	SpaceUUID string `db:"uuid"`
 	SpaceName string `db:"space"`


### PR DESCRIPTION
This implements the following network domain state methods that service the `DevicesToBridge` service method:
- `GetMachineSpaceConstraints`
- `GetMachineAppBindings`
- `NICsInSpaces`
- `GetContainerNetworkingMethod`

## Checklist

Final wire-up in next patch. Unit tests verify these changes.

## Links

**Jira card:** [JUJU-7723](https://warthogs.atlassian.net/browse/JUJU-7723)


[JUJU-7723]: https://warthogs.atlassian.net/browse/JUJU-7723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ