### PR TITLE
feat(tests): add postgresql k8s smoke test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -96,3 +96,15 @@ jobs:
           export SKIP_DESTROY=true
 
           sg snap_microk8s './main.sh -c microk8s -v smoke_k8s'
+
+      - name: Smoke test (MicroK8s) - PostgreSQL
+        if: matrix.cloud == 'microk8s'
+        shell: bash
+        run: |
+          cd tests
+          export MODEL_ARCH=$(go env GOARCH)
+
+          # Skip destroy to keep the environment up.
+          export SKIP_DESTROY=true
+
+          sg snap_microk8s './main.sh -c microk8s -v smoke_k8s_psql'

--- a/tests/suites/smoke_k8s_psql/README.md
+++ b/tests/suites/smoke_k8s_psql/README.md
@@ -1,0 +1,2 @@
+This is a new test suite for smoke testing k8s with PostgreSQL.
+

--- a/tests/suites/smoke_k8s_psql/deploy_postgresql.sh
+++ b/tests/suites/smoke_k8s_psql/deploy_postgresql.sh
@@ -1,0 +1,39 @@
+run_postgresql_deploy() {
+    echo
+
+    file="${2}"
+
+    ensure "test-postgresql-deploy" "${file}"
+
+    # Deploy the postgresql-k8s charm
+    juju deploy postgresql-k8s --trust --channel 16/edge
+
+    # Deploy the postgresql-test-app charm
+    juju deploy postgresql-test-app
+
+    # Integrate the postgresql-k8s charm with the postgresql-test-app
+    juju integrate postgresql-k8s postgresql-test-app:database
+
+    # Wait for the postgresql-k8s charm to become idle
+    wait_for "postgresql-k8s" "$(idle_condition "postgresql-k8s")"
+    wait_for "postgresql-test-app" "$(idle_condition "postgresql-test-app")"
+
+    destroy_model "test-postgresql-deploy"
+}
+
+test_deploy_postgresql() {
+  if [ "$(skip 'test_deploy_postgresql')" ]; then
+    echo "==> TEST SKIPPED: deploy postgresql tests"
+    return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    file="${1}"
+
+    run "run_postgresql_deploy" "${file}"
+  )
+}

--- a/tests/suites/smoke_k8s_psql/task.sh
+++ b/tests/suites/smoke_k8s_psql/task.sh
@@ -1,0 +1,19 @@
+test_smoke_k8s_psql() {
+	if [ "$(skip 'test_smoke_k8s_psql')" ]; then
+		echo "==> TEST SKIPPED: k8s postgresql smoke tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-smoke-k8s-psql.log"
+	echo "====> Logging to ${file}"
+	bootstrap "test-smoke-k8s-psql" "${file}"
+
+	test_deploy_postgresql "${file}"
+
+	destroy_controller "test-smoke-k8s-psql"
+}


### PR DESCRIPTION
This PR introduces a new smoke test suite, smoke_k8s_psql, designed to validate the deployment and functionality of the PostgreSQL charm on a Kubernetes substrate.

The new test suite includes the following steps:
- Deploys the postgresql-k8s charm.
- Deploys the postgresql-test-app charm.
- Establishes an integration between the two charms to verify that the database relation is working as expected.

Additionally, the CI workflow has been updated to incorporate this new test suite, which will be executed on MicroK8s as part of the regular smoke tests. This enhances our testing coverage for database charms on Kubernetes.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
# "Smoke test (MicroK8s) - PostgreSQL" GitHub action should pass
```

## Links

**Jira card:** JUJU-
