### PR TITLE
feat: migration watcher api addresses from sqlite

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -169,12 +169,12 @@ func TestingRestrictedRoot(check func(string, string) error) rpc.Root {
 
 // PatchGetMigrationBackend overrides the getMigrationBackend function
 // to support testing.
-func PatchGetMigrationBackend(p Patcher, ctrlSt controllerBackend, st migrationBackend) {
+func PatchGetMigrationBackend(p Patcher, ctx context.Context, controllerNodeService ControllerNodeService, st migrationBackend) {
 	p.PatchValue(&getMigrationBackend, func(*state.State) migrationBackend {
 		return st
 	})
-	p.PatchValue(&getControllerBackend, func(pool *state.StatePool) (controllerBackend, error) {
-		return ctrlSt, nil
+	p.PatchValue(&getAllAPIAddressesForClients, func(context.Context, ControllerNodeService) ([]string, error) {
+		return controllerNodeService.GetAllAPIAddressesForClients(ctx)
 	})
 }
 

--- a/apiserver/service.go
+++ b/apiserver/service.go
@@ -28,6 +28,14 @@ type ControllerConfigService interface {
 	WatchControllerConfig(context.Context) (watcher.StringsWatcher, error)
 }
 
+// ControllerNodeService defines API address functionality required by the
+// migration watchers.
+type ControllerNodeService interface {
+	// GetAllAPIAddressesForClients returns a string slice of api
+	// addresses available for agents.
+	GetAllAPIAddressesForClients(ctx context.Context) ([]string, error)
+}
+
 // ProxyService defines the methods required to get proxy details.
 type ProxyService interface {
 	// GetConnectionProxyInfo returns the proxy information for the controller.


### PR DESCRIPTION
Update the MigrationStatusWatcher to use the ControllerNodeService for API Addresses for clients.

The tests are old style and a mess. Once the watcher no longer requires state, they should be rewritten.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Setup and run a migration from  4.0 -> 4.0. The migration minion worker should be up and running (not bouncing).

```
juju debug-log -m controller --replay --include-module juju.worker.migrationminion
```

## Links

**Jira card:** JUJU-7932
