### PR TITLE
refactor: rename get all api server addresses methods related to agents

### DIFF
--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -18,11 +18,11 @@ import (
 // APIAddressAccessor describes methods that allow agents to maintain
 // up-to-date information on how to connect to the Juju API server.
 type APIAddressAccessor interface {
-	// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+	// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 	// addresses that are available for agents. The map is keyed by controller
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
-	GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error)
+	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 
 	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
@@ -55,7 +55,7 @@ func NewAPIAddresser(getter APIAddressAccessor, watcherRegistry facade.WatcherRe
 
 // APIHostPorts returns the API server addresses.
 func (a *APIAddresser) APIHostPorts(ctx context.Context) (params.APIHostPortsResult, error) {
-	srvs, err := a.apiAddressAccessor.GetAllAPIAddressesForAgents(ctx)
+	srvs, err := a.apiAddressAccessor.GetAllAPIAddressesByControllerIDForAgents(ctx)
 	if err != nil {
 		return params.APIHostPortsResult{}, err
 	}

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -24,10 +24,10 @@ type APIAddressAccessor interface {
 	// for each controller node.
 	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 
 	// WatchControllerAPIAddresses returns a watcher that observes changes to the
 	// controller ip addresses.
@@ -103,7 +103,7 @@ func (a *APIAddresser) WatchAPIHostPorts(ctx context.Context) (params.NotifyWatc
 
 // APIAddresses returns the list of addresses used to connect to the API.
 func (a *APIAddresser) APIAddresses(ctx context.Context) (params.StringsResult, error) {
-	addrs, err := a.apiAddressAccessor.GetAllAPIAddressesForAgentsInPreferredOrder(ctx)
+	addrs, err := a.apiAddressAccessor.GetAllAPIAddressesForAgents(ctx)
 	if err != nil {
 		return params.StringsResult{}, err
 	}

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -49,7 +49,7 @@ func (s *apiAddresserSuite) TestAPIHostPorts(c *tc.C) {
 		"one": {"10.2.3.54:1"},
 		"two": {"192.168.5.7:2"},
 	}
-	s.apiAddressAccessor.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(res, nil)
+	s.apiAddressAccessor.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(res, nil)
 	expected := [][]params.HostPort{
 		{{
 			Address: params.Address{Value: "10.2.3.54"},

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -31,7 +31,7 @@ func (s *apiAddresserSuite) TestAPIAddresses(c *tc.C) {
 	defer s.setupMock(c).Finish()
 	// Arrange
 	res := []string{"10.2.3.43:1", "10.4.7.178:2"}
-	s.apiAddressAccessor.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(res, nil)
+	s.apiAddressAccessor.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(res, nil)
 	addresser := s.getAddresser()
 
 	// Act

--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -23,10 +23,10 @@ type ControllerConfigService interface {
 
 // APIHostPortsForAgentsGetter represents a way to get controller api addresses.
 type APIHostPortsForAgentsGetter interface {
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 }
 
 // ExternalControllerService defines the methods that the controller
@@ -167,7 +167,7 @@ func ControllerAPIInfo(
 		return nil, "", errors.Trace(err)
 	}
 
-	addrs, err := apiHostPortsGetter.GetAllAPIAddressesForAgentsInPreferredOrder(ctx)
+	addrs, err := apiHostPortsGetter.GetAllAPIAddressesForAgents(ctx)
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -90,7 +90,7 @@ func (s *controllerConfigSuite) TestControllerConfigFetchError(c *tc.C) {
 
 func (s *controllerConfigSuite) expectControllerInfo() {
 	addrs := []string{"192.168.1.1:17070"}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil)
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(map[string]interface{}{
 		controller.CACertKey: testing.CACert,
 	}, nil)

--- a/apiserver/common/mocks/common_mock.go
+++ b/apiserver/common/mocks/common_mock.go
@@ -608,41 +608,41 @@ func (m *MockAPIHostPortsForAgentsGetter) EXPECT() *MockAPIHostPortsForAgentsGet
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder mocks base method.
-func (m *MockAPIHostPortsForAgentsGetter) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 context.Context) ([]string, error) {
+// GetAllAPIAddressesForAgents mocks base method.
+func (m *MockAPIHostPortsForAgentsGetter) GetAllAPIAddressesForAgents(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgentsInPreferredOrder", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder indicates an expected call of GetAllAPIAddressesForAgentsInPreferredOrder.
-func (mr *MockAPIHostPortsForAgentsGetterMockRecorder) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 any) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall {
+// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
+func (mr *MockAPIHostPortsForAgentsGetterMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgentsInPreferredOrder", reflect.TypeOf((*MockAPIHostPortsForAgentsGetter)(nil).GetAllAPIAddressesForAgentsInPreferredOrder), arg0)
-	return &MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockAPIHostPortsForAgentsGetter)(nil).GetAllAPIAddressesForAgents), arg0)
+	return &MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall{Call: call}
 }
 
-// MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall wrap *gomock.Call
-type MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall struct {
+// MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall wrap *gomock.Call
+type MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall) Return(arg0 []string, arg1 error) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall) Return(arg0 []string, arg1 error) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall) Do(f func(context.Context) ([]string, error)) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) ([]string, error)) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/common/package_mock.go
+++ b/apiserver/common/package_mock.go
@@ -40,41 +40,41 @@ func (m *MockAPIAddressAccessor) EXPECT() *MockAPIAddressAccessorMockRecorder {
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgents mocks base method.
-func (m *MockAPIAddressAccessor) GetAllAPIAddressesForAgents(arg0 context.Context) (map[string][]string, error) {
+// GetAllAPIAddressesByControllerIDForAgents mocks base method.
+func (m *MockAPIAddressAccessor) GetAllAPIAddressesByControllerIDForAgents(arg0 context.Context) (map[string][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesByControllerIDForAgents", arg0)
 	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
-func (mr *MockAPIAddressAccessorMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
+// GetAllAPIAddressesByControllerIDForAgents indicates an expected call of GetAllAPIAddressesByControllerIDForAgents.
+func (mr *MockAPIAddressAccessorMockRecorder) GetAllAPIAddressesByControllerIDForAgents(arg0 any) *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockAPIAddressAccessor)(nil).GetAllAPIAddressesForAgents), arg0)
-	return &MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesByControllerIDForAgents", reflect.TypeOf((*MockAPIAddressAccessor)(nil).GetAllAPIAddressesByControllerIDForAgents), arg0)
+	return &MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall{Call: call}
 }
 
-// MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall wrap *gomock.Call
-type MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall struct {
+// MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall wrap *gomock.Call
+type MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/common/package_mock.go
+++ b/apiserver/common/package_mock.go
@@ -79,41 +79,41 @@ func (c *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall) Do
 	return c
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder mocks base method.
-func (m *MockAPIAddressAccessor) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 context.Context) ([]string, error) {
+// GetAllAPIAddressesForAgents mocks base method.
+func (m *MockAPIAddressAccessor) GetAllAPIAddressesForAgents(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgentsInPreferredOrder", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder indicates an expected call of GetAllAPIAddressesForAgentsInPreferredOrder.
-func (mr *MockAPIAddressAccessorMockRecorder) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 any) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall {
+// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
+func (mr *MockAPIAddressAccessorMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgentsInPreferredOrder", reflect.TypeOf((*MockAPIAddressAccessor)(nil).GetAllAPIAddressesForAgentsInPreferredOrder), arg0)
-	return &MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockAPIAddressAccessor)(nil).GetAllAPIAddressesForAgents), arg0)
+	return &MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall{Call: call}
 }
 
-// MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall wrap *gomock.Call
-type MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall struct {
+// MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall wrap *gomock.Call
+type MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall) Return(arg0 []string, arg1 error) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) Return(arg0 []string, arg1 error) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall) Do(f func(context.Context) ([]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) ([]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -404,7 +404,7 @@ func NewToolsURLGetter(modelUUID string, a APIHostPortsForAgentsGetter) *toolsUR
 
 // ToolsURLs returns a list of tools URLs pointing at an API server.
 func (t *toolsURLGetter) ToolsURLs(ctx context.Context, v semversion.Binary) ([]string, error) {
-	addrs, err := t.apiHostPortsGetter.GetAllAPIAddressesForAgentsInPreferredOrder(ctx)
+	addrs, err := t.apiHostPortsGetter.GetAllAPIAddressesForAgents(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -323,7 +323,7 @@ func (s *getUrlSuite) setup(c *tc.C) *gomock.Controller {
 func (s *getUrlSuite) TestToolsURLGetterNoAPIHostPorts(c *tc.C) {
 	defer s.setup(c).Finish()
 
-	s.apiHostPortsGetter.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(nil, nil)
+	s.apiHostPortsGetter.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(nil, nil)
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
 	_, err := g.ToolsURLs(c.Context(), coretesting.CurrentVersion())
@@ -333,7 +333,7 @@ func (s *getUrlSuite) TestToolsURLGetterNoAPIHostPorts(c *tc.C) {
 func (s *getUrlSuite) TestToolsURLGetterAPIHostPortsError(c *tc.C) {
 	defer s.setup(c).Finish()
 
-	s.apiHostPortsGetter.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(nil, errors.New("oh noes"))
+	s.apiHostPortsGetter.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(nil, errors.New("oh noes"))
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
 	_, err := g.ToolsURLs(c.Context(), coretesting.CurrentVersion())
@@ -344,7 +344,7 @@ func (s *getUrlSuite) TestToolsURLGetter(c *tc.C) {
 	defer s.setup(c).Finish()
 
 	addrs := []string{"0.1.2.3:1234"}
-	s.apiHostPortsGetter.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil)
+	s.apiHostPortsGetter.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil)
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
 	current := coretesting.CurrentVersion()

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -53,10 +53,10 @@ type ControllerConfigService interface {
 
 // ControllerNodeService represents a way to get controller api addresses.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 }
 
 // CloudService provides access to clouds.

--- a/apiserver/facades/agent/caasagent/common_mock_test.go
+++ b/apiserver/facades/agent/caasagent/common_mock_test.go
@@ -305,41 +305,41 @@ func (m *MockAPIHostPortsForAgentsGetter) EXPECT() *MockAPIHostPortsForAgentsGet
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder mocks base method.
-func (m *MockAPIHostPortsForAgentsGetter) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 context.Context) ([]string, error) {
+// GetAllAPIAddressesForAgents mocks base method.
+func (m *MockAPIHostPortsForAgentsGetter) GetAllAPIAddressesForAgents(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgentsInPreferredOrder", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder indicates an expected call of GetAllAPIAddressesForAgentsInPreferredOrder.
-func (mr *MockAPIHostPortsForAgentsGetterMockRecorder) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 any) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall {
+// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
+func (mr *MockAPIHostPortsForAgentsGetterMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgentsInPreferredOrder", reflect.TypeOf((*MockAPIHostPortsForAgentsGetter)(nil).GetAllAPIAddressesForAgentsInPreferredOrder), arg0)
-	return &MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockAPIHostPortsForAgentsGetter)(nil).GetAllAPIAddressesForAgents), arg0)
+	return &MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall{Call: call}
 }
 
-// MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall wrap *gomock.Call
-type MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall struct {
+// MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall wrap *gomock.Call
+type MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall) Return(arg0 []string, arg1 error) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall) Return(arg0 []string, arg1 error) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall) Do(f func(context.Context) ([]string, error)) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) ([]string, error)) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockAPIHostPortsForAgentsGetterGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -31,10 +31,10 @@ type ControllerConfigService interface {
 
 // ControllerNodeService represents a way to get controller api addresses.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 }
 
 // ApplicationService instances implement an application service.
@@ -130,7 +130,7 @@ func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntro
 		return errResp(err)
 	}
 
-	addrs, err := f.controllerNodeService.GetAllAPIAddressesForAgentsInPreferredOrder(ctx)
+	addrs, err := f.controllerNodeService.GetAllAPIAddressesForAgents(ctx)
 	if err != nil {
 		return errResp(err)
 	}

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -109,7 +109,7 @@ func (s *CAASApplicationSuite) TestUnitIntroduction(c *tc.C) {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controllerCfg, nil)
 
 	addrs := []string{"10.6.6.6:17070"}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil)
 	vers := semversion.MustParse("6.6.6")
 	s.modelAgentService.EXPECT().GetModelTargetAgentVersion(gomock.Any()).Return(vers, nil)
 

--- a/apiserver/facades/agent/caasapplication/package_mock_test.go
+++ b/apiserver/facades/agent/caasapplication/package_mock_test.go
@@ -269,41 +269,41 @@ func (m *MockControllerNodeService) EXPECT() *MockControllerNodeServiceMockRecor
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder mocks base method.
-func (m *MockControllerNodeService) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 context.Context) ([]string, error) {
+// GetAllAPIAddressesForAgents mocks base method.
+func (m *MockControllerNodeService) GetAllAPIAddressesForAgents(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgentsInPreferredOrder", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder indicates an expected call of GetAllAPIAddressesForAgentsInPreferredOrder.
-func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
+func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgentsInPreferredOrder", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgentsInPreferredOrder), arg0)
-	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgents), arg0)
+	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsCall{Call: call}
 }
 
-// MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall wrap *gomock.Call
-type MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall struct {
+// MockControllerNodeServiceGetAllAPIAddressesForAgentsCall wrap *gomock.Call
+type MockControllerNodeServiceGetAllAPIAddressesForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) Return(arg0 []string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Return(arg0 []string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) Do(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -86,10 +86,10 @@ type ControllerNodeService interface {
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
 	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 	// WatchControllerAPIAddresses returns a watcher that observes changes to the
 	// controller ip addresses.
 	WatchControllerAPIAddresses(context.Context) (watcher.NotifyWatcher, error)

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -81,11 +81,11 @@ type ApplicationService interface {
 // ControllerNodeService defines the methods on the controller node service
 // that are needed by APIAddresser used by the deployer API.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+	// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 	// addresses that are available for agents. The map is keyed by controller
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
-	GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error)
+	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -43,10 +43,10 @@ type ControllerNodeService interface {
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
 	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 	// WatchControllerAPIAddresses returns a watcher that observes changes to the
 	// controller ip addresses.
 	WatchControllerAPIAddresses(context.Context) (watcher.NotifyWatcher, error)

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -38,11 +38,11 @@ type ControllerConfigService interface {
 // ControllerNodeService defines the methods on the controller node service
 // that are needed by APIAddresser used by the machiner API.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+	// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 	// addresses that are available for agents. The map is keyed by controller
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
-	GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error)
+	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.

--- a/apiserver/facades/agent/provisioner/common_mock_test.go
+++ b/apiserver/facades/agent/provisioner/common_mock_test.go
@@ -40,41 +40,41 @@ func (m *MockAPIAddressAccessor) EXPECT() *MockAPIAddressAccessorMockRecorder {
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgents mocks base method.
-func (m *MockAPIAddressAccessor) GetAllAPIAddressesForAgents(arg0 context.Context) (map[string][]string, error) {
+// GetAllAPIAddressesByControllerIDForAgents mocks base method.
+func (m *MockAPIAddressAccessor) GetAllAPIAddressesByControllerIDForAgents(arg0 context.Context) (map[string][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesByControllerIDForAgents", arg0)
 	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
-func (mr *MockAPIAddressAccessorMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
+// GetAllAPIAddressesByControllerIDForAgents indicates an expected call of GetAllAPIAddressesByControllerIDForAgents.
+func (mr *MockAPIAddressAccessorMockRecorder) GetAllAPIAddressesByControllerIDForAgents(arg0 any) *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockAPIAddressAccessor)(nil).GetAllAPIAddressesForAgents), arg0)
-	return &MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesByControllerIDForAgents", reflect.TypeOf((*MockAPIAddressAccessor)(nil).GetAllAPIAddressesByControllerIDForAgents), arg0)
+	return &MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall{Call: call}
 }
 
-// MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall wrap *gomock.Call
-type MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall struct {
+// MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall wrap *gomock.Call
+type MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/provisioner/common_mock_test.go
+++ b/apiserver/facades/agent/provisioner/common_mock_test.go
@@ -79,41 +79,41 @@ func (c *MockAPIAddressAccessorGetAllAPIAddressesByControllerIDForAgentsCall) Do
 	return c
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder mocks base method.
-func (m *MockAPIAddressAccessor) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 context.Context) ([]string, error) {
+// GetAllAPIAddressesForAgents mocks base method.
+func (m *MockAPIAddressAccessor) GetAllAPIAddressesForAgents(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgentsInPreferredOrder", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder indicates an expected call of GetAllAPIAddressesForAgentsInPreferredOrder.
-func (mr *MockAPIAddressAccessorMockRecorder) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 any) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall {
+// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
+func (mr *MockAPIAddressAccessorMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgentsInPreferredOrder", reflect.TypeOf((*MockAPIAddressAccessor)(nil).GetAllAPIAddressesForAgentsInPreferredOrder), arg0)
-	return &MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockAPIAddressAccessor)(nil).GetAllAPIAddressesForAgents), arg0)
+	return &MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall{Call: call}
 }
 
-// MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall wrap *gomock.Call
-type MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall struct {
+// MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall wrap *gomock.Call
+type MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall) Return(arg0 []string, arg1 error) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) Return(arg0 []string, arg1 error) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall) Do(f func(context.Context) ([]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) ([]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockAPIAddressAccessorGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -562,7 +562,7 @@ func (s *withControllerSuite) TestAPIAddresses(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
 	addrs := []string{"0.1.2.3:1234"}
-	s.apiAddressAccessor.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil)
+	s.apiAddressAccessor.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil)
 	provisioner := &ProvisionerAPI{APIAddresser: common.NewAPIAddresser(s.apiAddressAccessor, nil)}
 
 	// Act

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -59,10 +59,10 @@ type ControllerNodeService interface {
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
 	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 	// WatchControllerAPIAddresses returns a watcher that observes changes to the
 	// controller ip addresses.
 	WatchControllerAPIAddresses(context.Context) (watcher.NotifyWatcher, error)

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -54,11 +54,11 @@ type ControllerConfigService interface {
 // ControllerNodeService defines the methods on the controller node service
 // that are needed by APIAddresser used by the uniter API.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+	// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 	// addresses that are available for agents. The map is keyed by controller
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
-	GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error)
+	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.

--- a/apiserver/facades/client/controller/service.go
+++ b/apiserver/facades/client/controller/service.go
@@ -37,10 +37,10 @@ type ControllerConfigService interface {
 
 // ControllerNodeService represents a way to get controller api addresses.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 }
 
 // UpgradeService provides a subset of the upgrade domain service methods.

--- a/apiserver/facades/client/machinemanager/instanceconfig.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig.go
@@ -125,7 +125,7 @@ func InstanceConfig(
 	}
 
 	// Get the API connection info; attempt all API addresses.
-	apiAddrsForAgents, err := services.ControllerNodeService.GetAllAPIAddressesForAgents(ctx)
+	apiAddrsForAgents, err := services.ControllerNodeService.GetAllAPIAddressesByControllerIDForAgents(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting API addresses")
 	}

--- a/apiserver/facades/client/machinemanager/instanceconfig_test.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig_test.go
@@ -110,7 +110,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *tc.C) {
 	addrs := []string{"1.2.3.4:1"}
 	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil).MinTimes(1)
 	addrs2 := map[string][]string{"one": {"1.2.3.4:1"}}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
 	s.ctrlSt.EXPECT().ControllerTag().Return(coretesting.ControllerTag).AnyTimes()
 
 	s.keyUpdaterService.EXPECT().GetAuthorisedKeysForMachine(

--- a/apiserver/facades/client/machinemanager/instanceconfig_test.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig_test.go
@@ -108,7 +108,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *tc.C) {
 	s.st.EXPECT().ToolsStorage(gomock.Any()).Return(storageCloser, nil)
 
 	addrs := []string{"1.2.3.4:1"}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil).MinTimes(1)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil).MinTimes(1)
 	addrs2 := map[string][]string{"one": {"1.2.3.4:1"}}
 	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
 	s.ctrlSt.EXPECT().ControllerTag().Return(coretesting.ControllerTag).AnyTimes()

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -862,7 +862,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScript(c *tc.C) {
 	s.st.EXPECT().ToolsStorage(gomock.Any()).Return(storageCloser, nil)
 
 	addrs := []string{"0.2.4.6:1"}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil).AnyTimes()
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil).AnyTimes()
 	addrs2 := map[string][]string{"one": {"0.2.4.6:1"}}
 	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
 	s.keyUpdaterService.EXPECT().GetAuthorisedKeysForMachine(
@@ -930,7 +930,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScriptDisablePackageCo
 	s.st.EXPECT().ToolsStorage(gomock.Any()).Return(storageCloser, nil)
 
 	addrs := []string{"0.2.4.6:1"}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil).MinTimes(1)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil).MinTimes(1)
 	addrs2 := map[string][]string{"one": {"0.2.4.6:1"}}
 	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
 

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -864,7 +864,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScript(c *tc.C) {
 	addrs := []string{"0.2.4.6:1"}
 	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil).AnyTimes()
 	addrs2 := map[string][]string{"one": {"0.2.4.6:1"}}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
 	s.keyUpdaterService.EXPECT().GetAuthorisedKeysForMachine(
 		gomock.Any(), coremachine.Name("0"),
 	).Return([]string{
@@ -932,7 +932,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScriptDisablePackageCo
 	addrs := []string{"0.2.4.6:1"}
 	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil).MinTimes(1)
 	addrs2 := map[string][]string{"one": {"0.2.4.6:1"}}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(addrs2, nil).MinTimes(1)
 
 	s.keyUpdaterService.EXPECT().GetAuthorisedKeysForMachine(
 		gomock.Any(), coremachine.Name("0"),

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -2172,41 +2172,41 @@ func (m *MockControllerNodeService) EXPECT() *MockControllerNodeServiceMockRecor
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgents mocks base method.
-func (m *MockControllerNodeService) GetAllAPIAddressesForAgents(arg0 context.Context) (map[string][]string, error) {
+// GetAllAPIAddressesByControllerIDForAgents mocks base method.
+func (m *MockControllerNodeService) GetAllAPIAddressesByControllerIDForAgents(arg0 context.Context) (map[string][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesByControllerIDForAgents", arg0)
 	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
-func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+// GetAllAPIAddressesByControllerIDForAgents indicates an expected call of GetAllAPIAddressesByControllerIDForAgents.
+func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesByControllerIDForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgents), arg0)
-	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesByControllerIDForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesByControllerIDForAgents), arg0)
+	return &MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall{Call: call}
 }
 
-// MockControllerNodeServiceGetAllAPIAddressesForAgentsCall wrap *gomock.Call
-type MockControllerNodeServiceGetAllAPIAddressesForAgentsCall struct {
+// MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall wrap *gomock.Call
+type MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -2211,41 +2211,41 @@ func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall)
 	return c
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder mocks base method.
-func (m *MockControllerNodeService) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 context.Context) ([]string, error) {
+// GetAllAPIAddressesForAgents mocks base method.
+func (m *MockControllerNodeService) GetAllAPIAddressesForAgents(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgentsInPreferredOrder", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder indicates an expected call of GetAllAPIAddressesForAgentsInPreferredOrder.
-func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
+func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgentsInPreferredOrder", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgentsInPreferredOrder), arg0)
-	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgents), arg0)
+	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsCall{Call: call}
 }
 
-// MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall wrap *gomock.Call
-type MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall struct {
+// MockControllerNodeServiceGetAllAPIAddressesForAgentsCall wrap *gomock.Call
+type MockControllerNodeServiceGetAllAPIAddressesForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) Return(arg0 []string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Return(arg0 []string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) Do(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/services.go
+++ b/apiserver/facades/client/machinemanager/services.go
@@ -51,10 +51,10 @@ type ControllerNodeService interface {
 	// for each controller node.
 	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 }
 
 // KeyUpdaterService is responsible for returning information about the ssh keys

--- a/apiserver/facades/client/machinemanager/services.go
+++ b/apiserver/facades/client/machinemanager/services.go
@@ -45,11 +45,11 @@ type ControllerConfigService interface {
 
 // ControllerNodeService represents a way to get controller api addresses.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+	// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 	// addresses that are available for agents. The map is keyed by controller
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
-	GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error)
+	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 
 	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -463,7 +463,7 @@ func (a *API) provisioningInfo(ctx context.Context, appTag names.ApplicationTag)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting juju oci image path")
 	}
-	addrs, err := a.controllerNodeService.GetAllAPIAddressesForAgentsInPreferredOrder(ctx)
+	addrs, err := a.controllerNodeService.GetAllAPIAddressesForAgents(ctx)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting api addresses")
 	}

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -200,7 +200,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *tc.C) {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(coretesting.FakeControllerConfig(), nil)
 	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(s.fakeModelConfig())
 	addrs := []string{"10.0.0.1:1"}
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil)
 
 	modelInfo := model.ModelInfo{
 		UUID: model.UUID(coretesting.ModelTag.Id()),

--- a/apiserver/facades/controller/caasapplicationprovisioner/service.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service.go
@@ -47,10 +47,10 @@ type ControllerConfigService interface {
 
 // ControllerNodeService represents a way to get controller api addresses.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 	// WatchControllerAPIAddresses returns a watcher that observes changes to the
 	// controller ip addresses.
 	WatchControllerAPIAddresses(context.Context) (watcher.NotifyWatcher, error)

--- a/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
@@ -558,19 +558,19 @@ func (m *MockControllerNodeService) EXPECT() *MockControllerNodeServiceMockRecor
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder mocks base method.
-func (m *MockControllerNodeService) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 context.Context) ([]string, error) {
+// GetAllAPIAddressesForAgents mocks base method.
+func (m *MockControllerNodeService) GetAllAPIAddressesForAgents(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgentsInPreferredOrder", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder indicates an expected call of GetAllAPIAddressesForAgentsInPreferredOrder.
-func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 any) *gomock.Call {
+// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
+func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgentsInPreferredOrder", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgentsInPreferredOrder), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgents), arg0)
 }
 
 // WatchControllerAPIAddresses mocks base method.

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -52,7 +52,7 @@ func (m *ModelOperatorSuite) TestProvisioningInfo(c *tc.C) {
 	m.expectControllerConfig()
 
 	addrs := []string{"addresses:1"}
-	m.controllerNodeService.EXPECT().GetAllAPIAddressesForAgentsInPreferredOrder(gomock.Any()).Return(addrs, nil)
+	m.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil)
 	m.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(config.New(false, map[string]any{
 		config.NameKey:         "controller",
 		config.UUIDKey:         "deadbeef-0bad-400d-8000-4b1d0d06f00d",

--- a/apiserver/facades/controller/caasmodeloperator/service.go
+++ b/apiserver/facades/controller/caasmodeloperator/service.go
@@ -37,11 +37,11 @@ type ControllerConfigService interface {
 // ControllerNodeService defines the methods on the controller node service
 // that are needed by APIAddresser used by the caasmodeloperator API.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+	// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 	// addresses that are available for agents. The map is keyed by controller
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
-	GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error)
+	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.

--- a/apiserver/facades/controller/caasmodeloperator/service.go
+++ b/apiserver/facades/controller/caasmodeloperator/service.go
@@ -42,10 +42,10 @@ type ControllerNodeService interface {
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
 	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
-	// GetAllAPIAddressesForAgentsInPreferredOrder returns a string of api
+	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
-	GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error)
+	GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error)
 	// WatchControllerAPIAddresses returns a watcher that observes changes to the
 	// controller ip addresses.
 	WatchControllerAPIAddresses(context.Context) (watcher.NotifyWatcher, error)

--- a/apiserver/facades/controller/caasmodeloperator/service_mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/service_mock_test.go
@@ -423,41 +423,41 @@ func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall)
 	return c
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder mocks base method.
-func (m *MockControllerNodeService) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 context.Context) ([]string, error) {
+// GetAllAPIAddressesForAgents mocks base method.
+func (m *MockControllerNodeService) GetAllAPIAddressesForAgents(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgentsInPreferredOrder", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder indicates an expected call of GetAllAPIAddressesForAgentsInPreferredOrder.
-func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgentsInPreferredOrder(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
+func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgentsInPreferredOrder", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgentsInPreferredOrder), arg0)
-	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgents), arg0)
+	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsCall{Call: call}
 }
 
-// MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall wrap *gomock.Call
-type MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall struct {
+// MockControllerNodeServiceGetAllAPIAddressesForAgentsCall wrap *gomock.Call
+type MockControllerNodeServiceGetAllAPIAddressesForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) Return(arg0 []string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Return(arg0 []string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) Do(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsInPreferredOrderCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/caasmodeloperator/service_mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/service_mock_test.go
@@ -384,41 +384,41 @@ func (m *MockControllerNodeService) EXPECT() *MockControllerNodeServiceMockRecor
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgents mocks base method.
-func (m *MockControllerNodeService) GetAllAPIAddressesForAgents(arg0 context.Context) (map[string][]string, error) {
+// GetAllAPIAddressesByControllerIDForAgents mocks base method.
+func (m *MockControllerNodeService) GetAllAPIAddressesByControllerIDForAgents(arg0 context.Context) (map[string][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesByControllerIDForAgents", arg0)
 	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
-func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+// GetAllAPIAddressesByControllerIDForAgents indicates an expected call of GetAllAPIAddressesByControllerIDForAgents.
+func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesByControllerIDForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgents), arg0)
-	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesByControllerIDForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesByControllerIDForAgents), arg0)
+	return &MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall{Call: call}
 }
 
-// MockControllerNodeServiceGetAllAPIAddressesForAgentsCall wrap *gomock.Call
-type MockControllerNodeServiceGetAllAPIAddressesForAgentsCall struct {
+// MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall wrap *gomock.Call
+type MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/controllernode/service/package_mock_test.go
+++ b/domain/controllernode/service/package_mock_test.go
@@ -159,41 +159,41 @@ func (c *MockStateGetAPIAddressesForAgentsCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// GetAllAPIAddressesForAgents mocks base method.
-func (m *MockState) GetAllAPIAddressesForAgents(arg0 context.Context) (map[string][]string, error) {
+// GetAllAPIAddressesByControllerIDForAgents mocks base method.
+func (m *MockState) GetAllAPIAddressesByControllerIDForAgents(arg0 context.Context) (map[string][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesByControllerIDForAgents", arg0)
 	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
-func (mr *MockStateMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockStateGetAllAPIAddressesForAgentsCall {
+// GetAllAPIAddressesByControllerIDForAgents indicates an expected call of GetAllAPIAddressesByControllerIDForAgents.
+func (mr *MockStateMockRecorder) GetAllAPIAddressesByControllerIDForAgents(arg0 any) *MockStateGetAllAPIAddressesByControllerIDForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockState)(nil).GetAllAPIAddressesForAgents), arg0)
-	return &MockStateGetAllAPIAddressesForAgentsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesByControllerIDForAgents", reflect.TypeOf((*MockState)(nil).GetAllAPIAddressesByControllerIDForAgents), arg0)
+	return &MockStateGetAllAPIAddressesByControllerIDForAgentsCall{Call: call}
 }
 
-// MockStateGetAllAPIAddressesForAgentsCall wrap *gomock.Call
-type MockStateGetAllAPIAddressesForAgentsCall struct {
+// MockStateGetAllAPIAddressesByControllerIDForAgentsCall wrap *gomock.Call
+type MockStateGetAllAPIAddressesByControllerIDForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetAllAPIAddressesForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockStateGetAllAPIAddressesForAgentsCall {
+func (c *MockStateGetAllAPIAddressesByControllerIDForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockStateGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockStateGetAllAPIAddressesForAgentsCall {
+func (c *MockStateGetAllAPIAddressesByControllerIDForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockStateGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockStateGetAllAPIAddressesForAgentsCall {
+func (c *MockStateGetAllAPIAddressesByControllerIDForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockStateGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -260,10 +260,10 @@ func (s *Service) GetAllAPIAddressesByControllerIDForAgents(ctx context.Context)
 	return s.st.GetAllAPIAddressesByControllerIDForAgents(ctx)
 }
 
-// GetAllAPIAddressesForAgentsInPreferredOrder returns a string slice of api
+// GetAllAPIAddressesForAgents returns a string slice of api
 // addresses available for agents ordered to prefer local-cloud scoped
 // addresses and IPv4 over IPv6 for each machine.
-func (s *Service) GetAllAPIAddressesForAgentsInPreferredOrder(ctx context.Context) ([]string, error) {
+func (s *Service) GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error) {
 	agentAddrs, err := s.st.GetAllAPIAddressesWithScopeForAgents(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -73,11 +73,11 @@ type State interface {
 	// controller node.
 	GetAPIAddresses(ctx context.Context, ctrlID string) ([]string, error)
 
-	// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+	// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 	// addresses that are available for agents. The map is keyed by controller
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
-	GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error)
+	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 
 	// GetAPIAddressesForAgents returns the list of API address strings including
 	// port for the provided controller node that are available for agents.
@@ -252,12 +252,12 @@ func (s *Service) GetAPIAddresses(ctx context.Context, nodeID string) ([]string,
 	return s.st.GetAPIAddresses(ctx, nodeID)
 }
 
-// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 // addresses that are available for agents. The map is keyed by controller ID,
 // and the values are slices of strings representing the API addresses for each
 // controller node.
-func (s *Service) GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error) {
-	return s.st.GetAllAPIAddressesForAgents(ctx)
+func (s *Service) GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error) {
+	return s.st.GetAllAPIAddressesByControllerIDForAgents(ctx)
 }
 
 // GetAllAPIAddressesForAgentsInPreferredOrder returns a string slice of api

--- a/domain/controllernode/service/service_test.go
+++ b/domain/controllernode/service/service_test.go
@@ -472,11 +472,11 @@ func (s *serviceSuite) TestGetAPIAddressesForAgentsError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
-func (s *serviceSuite) TestGetAllAPIAddressesForAgents(c *tc.C) {
+func (s *serviceSuite) TestGetAllAPIAddressesByControllerIDForAgents(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := NewService(s.state, loggertesting.WrapCheckLog(c))
 
-	s.state.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+	s.state.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 		"1": {
 			"10.0.0.1:17070",
 		},
@@ -485,7 +485,7 @@ func (s *serviceSuite) TestGetAllAPIAddressesForAgents(c *tc.C) {
 		},
 	}, nil)
 
-	apiAddrs, err := svc.GetAllAPIAddressesForAgents(c.Context())
+	apiAddrs, err := svc.GetAllAPIAddressesByControllerIDForAgents(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(apiAddrs, tc.DeepEquals, map[string][]string{
 		"1": {
@@ -501,9 +501,9 @@ func (s *serviceSuite) TestGetAllAPIAddressesForAgentsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := NewService(s.state, loggertesting.WrapCheckLog(c))
 
-	s.state.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(nil, internalerrors.Errorf("boom"))
+	s.state.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(nil, internalerrors.Errorf("boom"))
 
-	_, err := svc.GetAllAPIAddressesForAgents(c.Context())
+	_, err := svc.GetAllAPIAddressesByControllerIDForAgents(c.Context())
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 

--- a/domain/controllernode/service/service_test.go
+++ b/domain/controllernode/service/service_test.go
@@ -497,7 +497,7 @@ func (s *serviceSuite) TestGetAllAPIAddressesByControllerIDForAgents(c *tc.C) {
 	})
 }
 
-func (s *serviceSuite) TestGetAllAPIAddressesForAgentsError(c *tc.C) {
+func (s *serviceSuite) TestGetAllAPIAddressesByControllerIDForAgentsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := NewService(s.state, loggertesting.WrapCheckLog(c))
 
@@ -507,7 +507,7 @@ func (s *serviceSuite) TestGetAllAPIAddressesForAgentsError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
-func (s *serviceSuite) TestGetAllAPIAddressesForAgentsInPreferredOrder(c *tc.C) {
+func (s *serviceSuite) TestGetAllAPIAddressesForAgents(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := NewService(s.state, loggertesting.WrapCheckLog(c))
 
@@ -534,20 +534,20 @@ func (s *serviceSuite) TestGetAllAPIAddressesForAgentsInPreferredOrder(c *tc.C) 
 	s.state.EXPECT().GetAllAPIAddressesWithScopeForAgents(gomock.Any()).Return(args, nil)
 
 	// Act
-	apiAddrs, err := svc.GetAllAPIAddressesForAgentsInPreferredOrder(c.Context())
+	apiAddrs, err := svc.GetAllAPIAddressesForAgents(c.Context())
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(apiAddrs, tc.DeepEquals, []string{"10.0.0.1:17070", "10.0.0.7:17070", "10.0.0.43:17070"})
 }
 
-func (s *serviceSuite) TestGetAllAPIAddressesForAgentsInPreferredOrderError(c *tc.C) {
+func (s *serviceSuite) TestGetAllAPIAddressesForAgentsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := NewService(s.state, loggertesting.WrapCheckLog(c))
 
 	s.state.EXPECT().GetAllAPIAddressesWithScopeForAgents(gomock.Any()).Return(nil, internalerrors.Errorf("boom"))
 
-	_, err := svc.GetAllAPIAddressesForAgentsInPreferredOrder(c.Context())
+	_, err := svc.GetAllAPIAddressesForAgents(c.Context())
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -422,11 +422,11 @@ WHERE controller_id = $controllerID.controller_id
 	return decodeAPIAddresses(result), nil
 }
 
-// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 // addresses that are available for agents. The map is keyed by controller ID,
 // and the values are slices of strings representing the API addresses for each
 // controller node.
-func (st *State) GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error) {
+func (st *State) GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -449,7 +449,7 @@ func (s *stateSuite) TestSetAPIAddressControllerNodeExists(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	s.checkControllerAPIAddress(c, controllerID, addrs)
 
-	agentAddresses, err := s.state.GetAllAPIAddressesForAgents(c.Context())
+	agentAddresses, err := s.state.GetAllAPIAddressesByControllerIDForAgents(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(agentAddresses, tc.DeepEquals, map[string][]string{
 		"1": {
@@ -471,7 +471,7 @@ func (s *stateSuite) TestSetAPIAddressControllerNodeExists(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	s.checkControllerAPIAddress(c, controllerID, newAddrs)
 
-	agentAddresses, err = s.state.GetAllAPIAddressesForAgents(c.Context())
+	agentAddresses, err = s.state.GetAllAPIAddressesByControllerIDForAgents(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(agentAddresses, tc.DeepEquals, map[string][]string{
 		"1": {
@@ -504,7 +504,7 @@ func (s *stateSuite) TestGetAllAPIAddressesForAgent(c *tc.C) {
 		c.Assert(err, tc.ErrorIsNil)
 	}
 
-	agentAddresses, err := s.state.GetAllAPIAddressesForAgents(c.Context())
+	agentAddresses, err := s.state.GetAllAPIAddressesByControllerIDForAgents(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(agentAddresses, tc.DeepEquals, map[string][]string{
 		"1": {
@@ -524,7 +524,7 @@ func (s *stateSuite) TestGetAllAPIAddressesForAgent(c *tc.C) {
 
 func (s *stateSuite) TestGetAllAPIAddressesForAgentEmptyAddress(c *tc.C) {
 	// If we set an empty address then it should not be included in the
-	// GetAllAPIAddressesForAgents result.
+	// GetAllAPIAddressesByControllerIDForAgents result.
 
 	var controllerIDs []string
 	for i := 1; i < 5; i++ {
@@ -555,7 +555,7 @@ func (s *stateSuite) TestGetAllAPIAddressesForAgentEmptyAddress(c *tc.C) {
 		c.Assert(err, tc.ErrorIsNil)
 	}
 
-	agentAddresses, err := s.state.GetAllAPIAddressesForAgents(c.Context())
+	agentAddresses, err := s.state.GetAllAPIAddressesByControllerIDForAgents(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(agentAddresses, tc.DeepEquals, map[string][]string{
 		"1": {

--- a/internal/worker/apiremotecaller/package_mocks_test.go
+++ b/internal/worker/apiremotecaller/package_mocks_test.go
@@ -212,41 +212,41 @@ func (m *MockControllerNodeService) EXPECT() *MockControllerNodeServiceMockRecor
 	return m.recorder
 }
 
-// GetAllAPIAddressesForAgents mocks base method.
-func (m *MockControllerNodeService) GetAllAPIAddressesForAgents(arg0 context.Context) (map[string][]string, error) {
+// GetAllAPIAddressesByControllerIDForAgents mocks base method.
+func (m *MockControllerNodeService) GetAllAPIAddressesByControllerIDForAgents(arg0 context.Context) (map[string][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAPIAddressesForAgents", arg0)
+	ret := m.ctrl.Call(m, "GetAllAPIAddressesByControllerIDForAgents", arg0)
 	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllAPIAddressesForAgents indicates an expected call of GetAllAPIAddressesForAgents.
-func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+// GetAllAPIAddressesByControllerIDForAgents indicates an expected call of GetAllAPIAddressesByControllerIDForAgents.
+func (mr *MockControllerNodeServiceMockRecorder) GetAllAPIAddressesByControllerIDForAgents(arg0 any) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesForAgents), arg0)
-	return &MockControllerNodeServiceGetAllAPIAddressesForAgentsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAPIAddressesByControllerIDForAgents", reflect.TypeOf((*MockControllerNodeService)(nil).GetAllAPIAddressesByControllerIDForAgents), arg0)
+	return &MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall{Call: call}
 }
 
-// MockControllerNodeServiceGetAllAPIAddressesForAgentsCall wrap *gomock.Call
-type MockControllerNodeServiceGetAllAPIAddressesForAgentsCall struct {
+// MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall wrap *gomock.Call
+type MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) Return(arg0 map[string][]string, arg1 error) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) Do(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesForAgentsCall {
+func (c *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall) DoAndReturn(f func(context.Context) (map[string][]string, error)) *MockControllerNodeServiceGetAllAPIAddressesByControllerIDForAgentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/apiremotecaller/worker.go
+++ b/internal/worker/apiremotecaller/worker.go
@@ -30,11 +30,11 @@ const (
 // that provides information about the controller nodes. This is used to
 // determine which nodes are available for remote API calls.
 type ControllerNodeService interface {
-	// GetAllAPIAddressesForAgents returns a map of controller IDs to their API
+	// GetAllAPIAddressesByControllerIDForAgents returns a map of controller IDs to their API
 	// addresses that are available for agents. The map is keyed by controller
 	// ID, and the values are slices of strings representing the API addresses
 	// for each controller node.
-	GetAllAPIAddressesForAgents(ctx context.Context) (map[string][]string, error)
+	GetAllAPIAddressesByControllerIDForAgents(ctx context.Context) (map[string][]string, error)
 	// WatchControllerNodes returns a watcher that observes changes to the
 	// controller nodes.
 	WatchControllerNodes(context.Context) (watcher.NotifyWatcher, error)
@@ -192,7 +192,7 @@ func (w *remoteWorker) loop() error {
 			w.cfg.Logger.Debugf(ctx, "remoteWorker API server change")
 
 			// Get the latest API addresses for all controller nodes.
-			servers, err := w.cfg.ControllerNodeService.GetAllAPIAddressesForAgents(ctx)
+			servers, err := w.cfg.ControllerNodeService.GetAllAPIAddressesByControllerIDForAgents(ctx)
 			if errors.Is(err, controllernodeerrors.EmptyAPIAddresses) {
 				// There should be at least one controller address available
 				// (itself), so if we get an empty addresses error then we can't

--- a/internal/worker/apiremotecaller/worker_test.go
+++ b/internal/worker/apiremotecaller/worker_test.go
@@ -97,7 +97,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesWithNoServers(c *tc.C) {
 	watcher := watchertest.NewMockNotifyWatcher(ch)
 	s.controllerNodeService.EXPECT().WatchControllerNodes(gomock.Any()).Return(watcher, nil)
 
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{}, nil)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{}, nil)
 
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)
@@ -128,7 +128,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesWithNoServerError(c *tc.C) {
 	watcher := watchertest.NewMockNotifyWatcher(ch)
 	s.controllerNodeService.EXPECT().WatchControllerNodes(gomock.Any()).Return(watcher, nil)
 
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{}, controllernodeerrors.EmptyAPIAddresses)
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{}, controllernodeerrors.EmptyAPIAddresses)
 
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)
@@ -159,7 +159,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesWhilstMatchingOrigin(c *tc.C) {
 	watcher := watchertest.NewMockNotifyWatcher(ch)
 	s.controllerNodeService.EXPECT().WatchControllerNodes(gomock.Any()).Return(watcher, nil)
 
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 		"0": {
 			"10.0.0.0:17070",
 		},
@@ -199,7 +199,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChanges(c *tc.C) {
 	watcher := watchertest.NewMockNotifyWatcher(ch)
 	s.controllerNodeService.EXPECT().WatchControllerNodes(gomock.Any()).Return(watcher, nil)
 
-	s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+	s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 		"0": {
 			"10.0.0.0:17070",
 		},
@@ -279,7 +279,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesUpdatesAddress(c *tc.C) {
 	done2 := make(chan struct{})
 
 	gomock.InOrder(
-		s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+		s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 			"0": {
 				"192.168.0.1",
 			},
@@ -290,7 +290,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesUpdatesAddress(c *tc.C) {
 		s.remote.EXPECT().UpdateAddresses([]string{"192.168.0.17"}).DoAndReturn(func(s []string) {
 			close(done1)
 		}),
-		s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+		s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 			"0": {
 				"192.168.0.1",
 			},
@@ -357,7 +357,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesRemovesOldAddress(c *tc.C) {
 	done2 := make(chan struct{})
 
 	gomock.InOrder(
-		s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+		s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 			"0": {
 				"192.168.0.1",
 			},
@@ -368,7 +368,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesRemovesOldAddress(c *tc.C) {
 		s.remote.EXPECT().UpdateAddresses([]string{"192.168.0.17"}).DoAndReturn(func(s []string) {
 			close(done1)
 		}),
-		s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+		s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 			"0": {
 				"192.168.0.1",
 			},
@@ -452,7 +452,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesWithSameAddress(c *tc.C) {
 	done2 := make(chan struct{})
 
 	gomock.InOrder(
-		s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+		s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 			"0": {
 				"192.168.0.1",
 			},
@@ -463,7 +463,7 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesWithSameAddress(c *tc.C) {
 		s.remote.EXPECT().UpdateAddresses([]string{"192.168.0.17"}).DoAndReturn(func(s []string) {
 			close(done1)
 		}),
-		s.controllerNodeService.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(map[string][]string{
+		s.controllerNodeService.EXPECT().GetAllAPIAddressesByControllerIDForAgents(gomock.Any()).Return(map[string][]string{
 			"0": {
 				"192.168.0.1",
 			},


### PR DESCRIPTION
Renaming methods in preparation for a new GetAllAPIAddressesByControllerIDForClients in an upcoming PR.

- GetAllAPIAddressesForAgents -> GetAllAPIAddressesByControllerIDForAgents
- GetAllAPIAddressesForAgentsInPreferredOrder -> GetAllAPIAddressesForAgents

Now `GetAllAPIAddressesForAgents` and `GetAllAPIAddressesForClients` match by having the same return types and do the same type of thing.


## Checklist
- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

No changes to current functionality, all unit tests should pass.

## Links

**Jira card:** JUJU-7932
