### PR TITLE
feat(errors-list): add tool to generate error constants list

### DIFF
--- a/scripts/errors-list/README.md
+++ b/scripts/errors-list/README.md
@@ -1,0 +1,75 @@
+# Juju Errors List Generator
+
+## Introduction
+
+The Juju codebase defines numerous error constants across different domain packages. As the codebase grows, it becomes increasingly difficult for developers to:
+
+1. Know what error constants already exist
+2. Choose the appropriate error constant for a given situation
+3. Maintain consistency in error handling across the codebase
+
+This script addresses these challenges by generating a comprehensive, searchable list of all error constants defined in the Juju codebase, making it easier to discover and reuse existing error definitions.
+
+## Features
+
+The errors-list generator:
+
+- Scans all `./domain/**/errors/*.go` files for error constants
+- Extracts error names, domains, and documentation comments
+- Generates a markdown table with all errors, their domains, and documentation
+- Provides links to the source files where each error is defined
+- Supports sorting errors alphabetically or by domain
+
+## Usage
+
+Run the script from the root of the Juju project:
+
+```bash
+go run scripts/errors-list/main.go
+```
+
+This will generate an `errors-list.md` file in the current directory containing a table of all error constants.
+
+### Specifying Project Directory
+
+You can specify a different project directory:
+
+```bash
+go run scripts/errors-list/main.go /path/to/juju
+```
+
+### Sorting Options
+
+By default, errors are sorted alphabetically by name. You can change the sorting with the `--sort` flag:
+
+```bash
+# Sort alphabetically (default)
+go run scripts/errors-list/main.go --sort alph
+
+# Sort by domain
+go run scripts/errors-list/main.go --sort domain
+```
+
+## Output
+
+The generated markdown file contains a table with the following columns:
+
+- **Error**: The name of the error constant
+- **Domain**: The domain package where the error is defined (with a link to the source file)
+- **Documentation**: The documentation comment for the error
+
+Example:
+
+```markdown
+| Error | Domain | Documentation |
+| ---- | ---- | ---- |
+| ApplicationNotFound | [application](domain/application/errors/errors.go) | application not found |
+| EndpointNotFound | [application](domain/application/errors/errors.go) | endpoint not found |
+```
+
+## Benefits
+
+- **Discoverability**: Easily find existing error constants
+- **Consistency**: Promote reuse of existing errors instead of creating duplicates
+- **Documentation**: Access error documentation in a single place
+- **Maintainability**: Understand the error landscape across the codebase

--- a/scripts/errors-list/main.go
+++ b/scripts/errors-list/main.go
@@ -1,0 +1,247 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ErrorInfo represents information about an error constant
+type ErrorInfo struct {
+	Name          string
+	Domain        string
+	FilePath      string
+	Documentation string
+}
+
+func main() {
+	// Define and parse command-line flags
+	sortFlag := flag.String("sort", "alph", "Sort errors by: 'alph' (alphabetically, default) or 'domain'")
+	flag.Parse()
+
+	// Determine the project directory (from remaining args after flags)
+	projectDir := "."
+	if flag.NArg() > 0 {
+		projectDir = flag.Arg(0)
+	}
+
+	// Find all error files in the domain directory
+	domainDir := filepath.Join(projectDir, "domain")
+	errorFiles, err := findErrorFiles(domainDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error finding error files: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse each file and extract error constants
+	var allErrors []ErrorInfo
+	for _, file := range errorFiles {
+		errors, err := parseErrorFile(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing file %s: %v\n", file, err)
+			continue
+		}
+		allErrors = append(allErrors, errors...)
+	}
+
+	// Sort errors based on the sort flag
+	switch *sortFlag {
+	case "domain":
+		// Sort by domain first, then by name
+		sort.Slice(allErrors, func(i, j int) bool {
+			if allErrors[i].Domain != allErrors[j].Domain {
+				return allErrors[i].Domain < allErrors[j].Domain
+			}
+			return allErrors[i].Name < allErrors[j].Name
+		})
+	case "alph", "":
+		// Sort alphabetically by name (default)
+		sort.Slice(allErrors, func(i, j int) bool {
+			return allErrors[i].Name < allErrors[j].Name
+		})
+	default:
+		fmt.Fprintf(os.Stderr, "Invalid sort option: %s. Using default (alphabetical).\n", *sortFlag)
+		sort.Slice(allErrors, func(i, j int) bool {
+			return allErrors[i].Name < allErrors[j].Name
+		})
+	}
+
+	// Generate markdown table
+	markdown := generateMarkdownTable(allErrors)
+
+	// Write to file
+	outputPath := filepath.Join(projectDir, "errors-list.md")
+	err = os.WriteFile(outputPath, []byte(markdown), 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing markdown file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print absolute path for clarity
+	absPath, _ := filepath.Abs(outputPath)
+	fmt.Printf("Generated %s successfully\n", absPath)
+}
+
+// findErrorFiles finds all error files matching the pattern ./domain/**/errors/*.go
+func findErrorFiles(root string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".go") &&
+			strings.Contains(path, "/errors/") &&
+			!strings.HasSuffix(path, "_test.go") &&
+			!strings.HasSuffix(path, "doc.go") {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	return files, err
+}
+
+// parseErrorFile parses a Go file and extracts error constants
+func parseErrorFile(filePath string) ([]ErrorInfo, error) {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	var errors []ErrorInfo
+	domain := extractDomain(filePath)
+
+	// Find all const blocks
+	for _, decl := range node.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.CONST {
+			continue
+		}
+
+		// Process each constant in the block
+		for _, spec := range genDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			// Check if this is an error constant
+			for i, name := range valueSpec.Names {
+				if i >= len(valueSpec.Values) {
+					continue
+				}
+
+				// Check if the value is a call to errors.ConstError
+				callExpr, ok := valueSpec.Values[i].(*ast.CallExpr)
+				if !ok {
+					continue
+				}
+
+				// Check if it's calling errors.ConstError
+				selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+				if !ok {
+					continue
+				}
+
+				ident, ok := selectorExpr.X.(*ast.Ident)
+				if !ok || ident.Name != "errors" || selectorExpr.Sel.Name != "ConstError" {
+					continue
+				}
+
+				// Extract documentation from comments
+				var doc string
+				if valueSpec.Doc != nil {
+					doc = valueSpec.Doc.Text()
+				} else if genDecl.Doc != nil && i == 0 {
+					doc = genDecl.Doc.Text()
+				}
+
+				// Clean up documentation
+				doc = cleanDocumentation(doc)
+
+				// Add to errors list
+				errors = append(errors, ErrorInfo{
+					Name:          name.Name,
+					Domain:        domain,
+					FilePath:      filePath,
+					Documentation: doc,
+				})
+			}
+		}
+	}
+
+	return errors, nil
+}
+
+// extractDomain extracts the domain name from the file path
+func extractDomain(filePath string) string {
+	// Extract domain from path like ./domain/application/errors/errors.go
+	parts := strings.Split(filePath, "/")
+	for i, part := range parts {
+		if part == "domain" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return "unknown"
+}
+
+// cleanDocumentation cleans up the documentation string
+func cleanDocumentation(doc string) string {
+	// Remove leading and trailing whitespace
+	doc = strings.TrimSpace(doc)
+
+	// Remove comment markers
+	doc = strings.ReplaceAll(doc, "// ", "")
+	doc = strings.ReplaceAll(doc, "//", "")
+
+	// Join multiple lines with spaces
+	lines := strings.Split(doc, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, " ")
+}
+
+// generateMarkdownTable generates a markdown table from the errors
+func generateMarkdownTable(errors []ErrorInfo) string {
+	var sb strings.Builder
+
+	// Write table header
+	sb.WriteString("# Juju Error Constants\n\n")
+	sb.WriteString("| Error | Domain | Documentation |\n")
+	sb.WriteString("| ---- | ---- | ---- |\n")
+
+	// Write table rows
+	for _, err := range errors {
+		// Create relative path for the link
+		relPath := err.FilePath
+		// Make the path relative to the domain directory
+		if strings.Contains(relPath, "/domain/") {
+			// Extract the path starting from "domain/"
+			index := strings.Index(relPath, "/domain/")
+			if index != -1 {
+				relPath = relPath[index+1:] // +1 to remove the leading slash
+			}
+		}
+
+		// Format the row
+		sb.WriteString(fmt.Sprintf("| %s | [%s](%s) | %s |\n",
+			err.Name,
+			err.Domain,
+			relPath,
+			err.Documentation))
+	}
+
+	return sb.String()
+}


### PR DESCRIPTION
Introduce a new script `scripts/errors-list/main.go` that scans the `domain` directory to identify all error constants defined across the codebase. The script generates a `errors-list.md` file in markdown format containing a searchable table of errors, grouped by domain and including their documentation.

Additionally, a `README.md` has been added in `scripts/errors-list/` to provide a detailed usage guide for the new tool.

> [!WARNING] 
> The script has been vibe coded. I didn't want to take time doing it, and I just needed it.
> However it can be useful since it address an issue I believe is affecting all of us in Juju 4.
> It will be useful to audit errors whenever we will take the time to do it.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run the script
`go run scripts/errors-list/main.go --sort domain`
OR
`go run scripts/errors-list/main.go`

Look at the content of error-list.md.

Find your preferred error.