### PR TITLE
chore: add target token field to migration spec

### DIFF
--- a/api/controller/controller/controller.go
+++ b/api/controller/controller/controller.go
@@ -285,6 +285,7 @@ type MigrationSpec struct {
 	TargetUser            string
 	TargetPassword        string
 	TargetMacaroons       []macaroon.Slice
+	TargetToken           string
 }
 
 // Validate performs sanity checks on the migration configuration it
@@ -302,7 +303,7 @@ func (s *MigrationSpec) Validate() error {
 	if !names.IsValidUser(s.TargetUser) {
 		return errors.NotValidf("target user")
 	}
-	if s.TargetPassword == "" && len(s.TargetMacaroons) == 0 {
+	if s.TargetPassword == "" && len(s.TargetMacaroons) == 0 && s.TargetToken == "" {
 		return errors.NotValidf("missing authentication secrets")
 	}
 	return nil
@@ -335,6 +336,7 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 				AuthTag:         names.NewUserTag(spec.TargetUser).String(),
 				Password:        spec.TargetPassword,
 				Macaroons:       macsJSON,
+				Token:           spec.TargetToken,
 			},
 		}},
 	}


### PR DESCRIPTION
In a previous PR (https://github.com/juju/juju/pull/19935), a token field was introduced for authentication between controllers. I overlooked the addition of this field to the api client's MigrationSpec object.

This meant that while the controller supports the new field and the RPC params were updated to serialise/deserialise it correctly, anyone using Juju's Go client would be unable to set it. This PR simply adds the field to the `MigrationSpec` and populates it on the `params.InitiateMigrationArgs` struct when used. Additionally, there is some validation on the `MigrationSpec` object that at least 1 form of auth (password/macaroon and now token) is populated - this has also been updated.
