### PR TITLE
feat: allow schema hook to mutate patches

### DIFF
--- a/core/database/schema/query.go
+++ b/core/database/schema/query.go
@@ -129,11 +129,12 @@ func ensurePatchesAreApplied(ctx context.Context, tx *sql.Tx, current int, patch
 	// Apply missing patches.
 	for _, patch := range patches[current:] {
 		// If the context has any underlying errors, close out immediately.
-		if err := ctx.Err(); err != nil {
+		err := ctx.Err()
+		if err != nil {
 			return errors.Capture(err)
 		}
 
-		if err := hook(current, patch.stmt); err != nil {
+		if patch.stmt, err = hook(current, patch.stmt); err != nil {
 			return errors.Errorf("failed to execute hook (version %d): %w", current, err)
 		}
 

--- a/core/database/schema/query.go
+++ b/core/database/schema/query.go
@@ -31,9 +31,11 @@ func createSchemaTable(ctx context.Context, tx *sql.Tx) error {
 	return errors.Capture(err)
 }
 
-// queryCurrentVersion returns the highest patch version currently applied.
+// validateCurrentVersion checks that the input hashes match the
+// hashes of the patches that have been applied to the database.
+// It returns the highest patch version currently applied.
 // Zero means that no patches have been applied yet.
-func queryCurrentVersion(ctx context.Context, tx *sql.Tx, computedHashes []string) (int, error) {
+func validateCurrentVersion(ctx context.Context, tx *sql.Tx, computedHashes []string) (int, error) {
 	versions, err := selectSchemaVersions(ctx, tx)
 	if err != nil {
 		return -1, errors.Errorf("failed to fetch patch versions: %v", err)
@@ -107,35 +109,22 @@ func checkSchemaHashesMatch(versions []versionHash, computedHashes []string) err
 	return nil
 }
 
-// Apply any pending patch that was not yet applied.
-func ensurePatchesAreApplied(ctx context.Context, tx *sql.Tx, current int, patches []Patch, hook Hook) error {
+// ensurePatchesAreApplied applies any pending patch that was not yet applied.
+// It returns an error if the current version is more recent than the
+// expected version, or if any patch fails to apply.
+// The input hashes are assumed to be valid for the input patches.
+func ensurePatchesAreApplied(ctx context.Context, tx *sql.Tx, current int, patches []Patch, hashes []string) error {
 	if current > len(patches) {
-		return errors.Errorf(
-			"schema version '%d' is more recent than expected '%d'",
-			current, len(patches))
-
+		return errors.Errorf("schema version '%d' is more recent than expected '%d'", current, len(patches))
 	}
 
-	// If there are no patches, there's nothing to do.
 	if len(patches) == 0 {
 		return nil
 	}
 
-	// Compute the hashes of all patches, we can then verify that old patches
-	// haven't been tampered with before running new patches up to the current
-	// version.
-	hashes := computeHashes(patches)
-
-	// Apply missing patches.
 	for _, patch := range patches[current:] {
-		// If the context has any underlying errors, close out immediately.
-		err := ctx.Err()
-		if err != nil {
+		if err := ctx.Err(); err != nil {
 			return errors.Capture(err)
-		}
-
-		if patch.stmt, err = hook(current, patch.stmt); err != nil {
-			return errors.Errorf("failed to execute hook (version %d): %w", current, err)
 		}
 
 		if err := patch.run(ctx, tx); err != nil {

--- a/core/database/schema/query_test.go
+++ b/core/database/schema/query_test.go
@@ -110,10 +110,10 @@ func (s *querySuite) TestEnsurePatches(c *tc.C) {
 
 	var called bool
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		return ensurePatchesAreApplied(c.Context(), tx, 0, patches, func(i int, statement string) error {
+		return ensurePatchesAreApplied(c.Context(), tx, 0, patches, func(i int, statement string) (string, error) {
 			called = true
 			c.Check(i, tc.Equals, 0)
-			return nil
+			return statement, nil
 		})
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/core/database/schema/schema.go
+++ b/core/database/schema/schema.go
@@ -16,8 +16,7 @@ type Tx interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
-// Schema captures the schema of a database in terms of a series of ordered
-// updates.
+// Schema captures the schema of a database as a series of ordered updates.
 type Schema struct {
 	patches []Patch
 	hook    Hook
@@ -44,10 +43,11 @@ func MakePatch(statement string, args ...any) Patch {
 	}
 }
 
-// Hook is a callback that gets fired when a update gets applied.
-type Hook func(int, string) error
+// Hook is a callback that gets fired before an update gets applied.
+// It allows mutation of the DDL about to be run.
+type Hook func(int, string) (string, error)
 
-// New creates a new schema Schema with the given patches.
+// New creates a new [Schema] with the input patches.
 func New(patches ...Patch) *Schema {
 	return &Schema{
 		patches: patches,
@@ -61,11 +61,12 @@ func (s *Schema) Add(patches ...Patch) {
 	s.patches = append(s.patches, patches...)
 }
 
-// Hook instructs the schema to invoke the given function whenever a update is
-// about to be applied. The function gets passed the update version number and
-// the running transaction, and if it returns an error it will cause the schema
-// transaction to be rolled back. Any previously installed hook will be
-// replaced.
+// Hook instructs the schema to invoke the given function whenever an
+// update is about to be applied. The function gets passed the update
+// version number and the DDL that will be run.
+// It returns a modified DDL that will be run instead, and an error.
+// A non-nil error will cause the schema transaction to be rolled back.
+// Any previously installed hook will be replaced.
 func (s *Schema) Hook(hook Hook) {
 	s.hook = hook
 }
@@ -83,11 +84,11 @@ type ChangeSet struct {
 // Ensure makes sure that the actual schema in the given database matches the
 // one defined by our updates.
 //
-// All updates are applied transactionally. In case any error occurs the
+// All updates are applied transactionally. If an error occurs, the
 // transaction will be rolled back and the database will remain unchanged.
 //
-// A update will be applied only if it hasn't been current (currently applied
-// updates are tracked in the a 'schema' table, which gets automatically
+// An update will be applied only if it hasn't been current (currently applied
+// updates are tracked in the 'schema' table, which gets automatically
 // created).
 //
 // If no error occurs, the integer returned by this method is the
@@ -122,5 +123,5 @@ func (s *Schema) Ensure(ctx context.Context, runner database.TxnRunner) (ChangeS
 	}, errors.Capture(err)
 }
 
-// omitHook always returns a nil, omitting the error.
-func omitHook(int, string) error { return nil }
+// omitHook is a no-op hook that does not modify the DDL.
+func omitHook(_ int, ddl string) (string, error) { return ddl, nil }

--- a/core/database/schema/schema_test.go
+++ b/core/database/schema/schema_test.go
@@ -190,5 +190,5 @@ func (s *schemaSuite) TestEnsureHashBreaks(c *tc.C) {
 	schema.Add(MakePatch("CREATE TEMP TABLE baz (id INTEGER PRIMARY KEY);"))
 
 	_, err = schema.Ensure(c.Context(), s.TxnRunner())
-	c.Assert(err, tc.ErrorMatches, `failed to query current schema version: hash mismatch for version 2`)
+	c.Assert(err, tc.ErrorMatches, `querying current schema version: hash mismatch for version 2`)
 }

--- a/domain/schema/package_test.go
+++ b/domain/schema/package_test.go
@@ -35,9 +35,9 @@ func (s *schemaBaseSuite) NewCleanDB(c *tc.C) *sql.DB {
 
 func (s *schemaBaseSuite) applyDDL(c *tc.C, ddl *schema.Schema) {
 	if s.Verbose {
-		ddl.Hook(func(i int, statement string) error {
+		ddl.Hook(func(i int, statement string) (string, error) {
 			c.Logf("-- Applying schema change %d\n%s\n", i, statement)
-			return nil
+			return statement, nil
 		})
 	}
 	changeSet, err := ddl.Ensure(c.Context(), s.TxnRunner())

--- a/domain/schema/testing/schema.go
+++ b/domain/schema/testing/schema.go
@@ -22,9 +22,9 @@ type SchemaApplier struct {
 // Apply applies the schema to the database.
 func (s *SchemaApplier) Apply(c *tc.C, ctx context.Context, runner database.TxnRunner) {
 	if s.Verbose {
-		s.Schema.Hook(func(i int, statement string) error {
+		s.Schema.Hook(func(i int, statement string) (string, error) {
 			c.Logf("-- Applying schema change %d\n%s\n", i, statement)
-			return nil
+			return statement, nil
 		})
 	}
 

--- a/scripts/dqlite/cmd/main.go
+++ b/scripts/dqlite/cmd/main.go
@@ -70,9 +70,9 @@ func main() {
 		panic("unknown database type")
 	}
 	if !*quiteFlag {
-		schema.Hook(func(i int, stmt string) error {
+		schema.Hook(func(i int, stmt string) (string, error) {
 			fmt.Printf("-- Applied patch %d\n%s\n", i, stmt)
-			return nil
+			return stmt, nil
 		})
 	}
 

--- a/scripts/dqlite/cmd/main.go
+++ b/scripts/dqlite/cmd/main.go
@@ -71,7 +71,7 @@ func main() {
 	}
 	if !*quiteFlag {
 		schema.Hook(func(i int, stmt string) (string, error) {
-			fmt.Printf("-- Applied patch %d\n%s\n", i, stmt)
+			fmt.Printf("-- Applying patch %d\n%s\n", i, stmt)
 			return stmt, nil
 		})
 	}


### PR DESCRIPTION
This allows the hook set on a `Schema` definition to mutate the statements that are being applied to the database.

It **may** be used in the future to make dialectic changes based on database flavours.

In addition it is ensured that we only compute the hashes once before applying instead of twice. Hashes are computed after applying any hooks so that comparisons are always made between what is actually applied, not before mutations.

## QA steps

Covered by smoke test workflows.
