### PR TITLE
docs: 3.6 fix crossreference style

### DIFF
--- a/docs/.sphinx/_static/css/crossref.css
+++ b/docs/.sphinx/_static/css/crossref.css
@@ -1,0 +1,9 @@
+.crossref {
+  display: block;
+  font-size: 0.85em;
+  /* font-style: oblique; */
+  margin-left: 1em;
+  margin-top: 1em;
+  margin-bottom: 1.5em;
+  opacity: 0.7;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,6 +267,7 @@ exclude_patterns = [
 
 html_css_files = [
     "css/pdf.css",
+    "css/crossref.css"
 ]
 
 

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -6,7 +6,9 @@ SOURCE: https://discourse.charmhub.io/t/juju-actions-opt-in-to-new-behaviour-fro
 TODO: Add more example outputs. (The doc above has many but they're from 2020, so they might not be the latest. And I don't quite get the first bit about the custom-defined action -- how does it get attached to the charm?
 -->
 
-> See also: {ref}`action`
+```{div} crossref
+See also: {ref}`action`
+```
 
 This document demonstrates how to manage actions.
 
@@ -64,7 +66,9 @@ The full schema is under the `properties` key of the root action. Actions rely o
 
 ```
 
-> See more: {ref}`command-juju-actions`
+```{div} crossref
+See more: {ref}`command-juju-actions`
+```
 
 ## Show details about an action
 
@@ -74,9 +78,9 @@ To see detailed information about an application action, use the `show-action` c
 juju show-action postgresql backup
 ```
 
-<!--add sample output-->
-
-> See more: {ref}`command-juju-show-action`
+```{div} crossref
+See more: {ref}`command-juju-show-action`
+```
 
 
 ## Run an action
@@ -88,7 +92,7 @@ juju show-action postgresql backup
 ```
 
 
-To run an action on a unit, use the `run` command followed by the name of the unit and the name of the action you want to run. 
+To run an action on a unit, use the `run` command followed by the name of the unit and the name of the action you want to run.
 
 ```text
 juju run mysql/3 backup
@@ -99,11 +103,15 @@ By using various options, you can choose to run the action in the background, sp
 Running an action returns the overall operation ID as well as the individual task ID(s) for each unit.
 
 
-> See more: {ref}`command-juju-run` (before `juju v.3.0`, `run-action`)
+```{div} crossref
+See more: {ref}`command-juju-run`
+```
 
 (manage-action-tasks)=
 ## Manage action tasks
-> See also: {ref}`task`
+```{div} crossref
+See also: {ref}`task`
+```
 
 ### Show details about a task
 
@@ -113,10 +121,11 @@ To drill down to the result of running an action on a specific unit (the stdout,
 juju show-task 1
 ```
 
-> See more: {ref}`command-juju-show-task`
+```{div} crossref
+See more: {ref}`command-juju-show-task`
+```
 
 ### Cancel a task
-
 
 Suppose you've run an action but would now like to cancel the resulting pending or running task. You can do so using the `cancel-task` command. For example:
 
@@ -124,14 +133,17 @@ Suppose you've run an action but would now like to cancel the resulting pending 
 juju cancel-task 1
 ```
 
-> See more: {ref}`command-juju-cancel-task`
+```{div} crossref
+See more: {ref}`command-juju-cancel-task`
+```
 
 (manage-action-operations)=
 ## Manage action operations
-> See also: {ref}`operation`
+```{div} crossref
+See also: {ref}`operation`
+```
 
 ### View the pending, running, or completed operations
-
 
 To view the pending, running, or completed status of each `juju run ... <action>` invocation, run the `operations` command:
 
@@ -141,7 +153,9 @@ juju operations
 
 This will show the operations corresponding to the actions for all the application units. You can filter this by passing various options (e.g., `--actions backup`, `--units mysql/0`, `--machines 0,1`, `--status pending,completed`, etc.).
 
-> See more: {ref}`command-juju-operations`
+```{div} crossref
+See more: {ref}`command-juju-operations`
+```
 
 ### Show details about an operation
 
@@ -153,10 +167,11 @@ juju show-operation 1
 
 As usual, by adding various options, you can specify an output format, choose to watch indefinitely or specify a timeout time, etc.
 
-> See more: {ref}`command-juju-show-operation`
+```{div} crossref
+See more: {ref}`command-juju-show-operation`
+```
 
 ## Debug an action
-
 
 To debug an action (or more), use the `debug-hooks` command followed by the name of the unit and the name(s) of the action(s). For example, if you want to check the `add-repo` action of the `git` charm, use:
 
@@ -164,4 +179,6 @@ To debug an action (or more), use the `debug-hooks` command followed by the name
 juju debug-hooks git/0 add-repo
 ```
 
-> See more: {ref}`command-juju-debug-code`, {ref}`command-juju-debug-hooks`
+```{div} crossref
+See more: {ref}`command-juju-debug-code`, {ref}`command-juju-debug-hooks`
+```

--- a/docs/howto/manage-credentials.md
+++ b/docs/howto/manage-credentials.md
@@ -8,7 +8,9 @@ This document shows how to manage credentials in Juju.
 (add-a-credential)=
 ## Add a credential
 
-> See also: {ref}`credential-definition`, {ref}`list-of-supported-clouds`
+```{div} crossref
+See also: {ref}`credential-definition`, {ref}`list-of-supported-clouds`
+```
 
 The procedure for how to add a cloud credential to Juju depends on whether the cloud is a machine (traditional, non-Kubernetes) cloud or rather a Kubernetes cloud.
 


### PR DESCRIPTION
In-line cross-reference links are often disruptive; in Juju docs we move them out-of-line, prefixed with "See...". Links are also usually not-at-issue content, importantly, of the kind we want to background rather than foreground; as documentation tooling usually only provides support for foregrounding (boxed text), in Juju docs we repurpose `>`  as a way to background, with the result that the "See..." notes are rendered after a vertical bar and with extra vertical space.

However, Daniele says `>` should only be used for blockquotes. Lukas in Design also notes that the overall effect is backgrounded only when compared to a boxed note -- relative to regular text the effect is rather one of emphasis.

This PR defines a custom directive designed to help us background our See... notes as intended by removing the vertical bar, having a slightly smaller font size, lower opacity, and a small left margin.

Before:
![image](https://github.com/user-attachments/assets/6f099150-25e3-4b16-a9c7-57e5071cbc6e)

Now:
![image](https://github.com/user-attachments/assets/6e045c64-d55e-4161-9636-d0661b07c5c1)

Before: 
![image](https://github.com/user-attachments/assets/f01f2b96-3eef-4318-81f9-f026f81bde7c)

Now: 
![image](https://github.com/user-attachments/assets/b3fd6fe7-036e-4588-ab07-0af2942f9137)
 

## QA steps

In `juju/docs`, run `make run` and follow the browser link.