### PR TITLE
feat: storage provisioning state implementation

### DIFF
--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -350,6 +350,9 @@ CREATE TABLE storage_volume_attachment (
     REFERENCES storage_provision_scope (id)
 );
 
+CREATE INDEX idx_storage_volume_attachment_net_node_uuid
+ON storage_volume_attachment (net_node_uuid);
+
 CREATE TABLE storage_filesystem_status_value (
     id INT PRIMARY KEY,
     status TEXT NOT NULL
@@ -439,6 +442,9 @@ CREATE TABLE storage_filesystem_attachment (
     FOREIGN KEY (provision_scope_id)
     REFERENCES storage_provision_scope (id)
 );
+
+CREATE INDEX idx_storage_filesystem_attachment_net_node_uuid
+ON storage_filesystem_attachment (net_node_uuid);
 
 CREATE TABLE storage_volume_device_type (
     id INT PRIMARY KEY,

--- a/domain/storageprovisioning/state/base_test.go
+++ b/domain/storageprovisioning/state/base_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	machinetesting "github.com/juju/juju/core/machine/testing"
+	"github.com/juju/juju/core/network"
+	domainnetwork "github.com/juju/juju/domain/network"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/uuid"
+	"github.com/juju/tc"
+)
+
+// baseSuite defines a set of common helper methods for storage provisioning
+// tests. Base suite does not seed a starting state and does not run any tests.
+type baseSuite struct {
+	schematesting.ModelSuite
+}
+
+// newMachineWithNetNode creates a new machine in the model attached to the
+// supplied net node. The newly created machines uuid is returned along with the
+// name.
+func (s *baseSuite) newMachineWithNetNode(c *tc.C, netNodeUUID string) (string, string) {
+	machineUUID := machinetesting.GenUUID(c)
+	name := "mfoo-" + machineUUID.String()
+
+	_, err := s.DB().ExecContext(
+		c.Context(),
+		"INSERT INTO machine (uuid, name, net_node_uuid, life_id) VALUES (?, ?, ?, 0)",
+		machineUUID.String(),
+		name,
+		netNodeUUID,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return machineUUID.String(), name
+}
+
+// newNetNode creates a new net node in the model for referencing to storage
+// entity attachments. The net node is not associated with any machine or units.
+func (s *baseSuite) newNetNode(c *tc.C) string {
+	nodeUUID, err := domainnetwork.NewNetNodeUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(
+		c.Context(),
+		"INSERT INTO net_node VALUES (?)",
+		nodeUUID.String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return nodeUUID.String()
+}
+
+// newApplication creates a new application in the model returning the uuid of
+// the new application.
+func (s *baseSuite) newApplication(c *tc.C, name string) string {
+	appUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, source_id, reference_name, revision, architecture_id)
+VALUES (?, 0, ?, 1, 0)`, appUUID.String(), name)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_metadata (charm_uuid, name)
+VALUES (?, 'myapp')`, appUUID.String())
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO application (uuid, charm_uuid, name, life_id, space_uuid)
+VALUES (?, ?, ?, "0", ?)`, appUUID.String(), appUUID.String(), name, network.AlphaSpaceId)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	return appUUID.String()
+}
+
+// newUnitWithNetNode creates a new unit in the model for the provided
+// application uuid. The new unit will use the supplied net node. Returned is
+// the new uuid of the unit.
+func (s *baseSuite) newUnitWithNetNode(c *tc.C, name, appUUID, netNodeUUID string) string {
+	var charmUUID string
+	err := s.DB().QueryRowContext(
+		c.Context(),
+		"SELECT charm_uuid FROM application WHERE uuid = ?",
+		appUUID,
+	).Scan(&charmUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	unitUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(
+		c.Context(), `
+INSERT INTO unit (uuid, name, application_uuid, charm_uuid, net_node_uuid, life_id)
+VALUES (?, ?, ?, ?, ?, 0)
+`,
+		unitUUID.String(), name, appUUID, charmUUID, netNodeUUID,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return unitUUID.String()
+}

--- a/domain/storageprovisioning/state/filesystem.go
+++ b/domain/storageprovisioning/state/filesystem.go
@@ -1,0 +1,288 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"maps"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/watcher/eventsource"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/storageprovisioning"
+	"github.com/juju/juju/internal/errors"
+)
+
+// GetFilesystemAttachmentIDs returns the
+// [storageprovisioning.FilesystemAttachmentID] information for each filesystem
+// attachment uuid supplied. If a uuid does not exist or isn't attached to
+// either a machine or a unit then it will not exist in the result.
+func (st *State) GetFilesystemAttachmentIDs(
+	ctx context.Context, uuids []string,
+) (map[string]storageprovisioning.FilesystemAttachmentID, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	uuidInputs := filesystemAttachmentUUIDs(uuids)
+
+	q := `
+SELECT &filesystemAttachmentIDs.* FROM (
+	SELECT sfa.uuid,
+	       sf.filesystem_id,
+		   m.name AS machine_name,
+		   NULL AS unit_name
+	FROM   storage_filesystem_attachment sfa
+	JOIN   storage_filesystem sf ON sfa.storage_filesystem_uuid = sf.uuid
+	JOIN   machine m ON sfa.net_node_uuid = m.net_node_uuid
+	WHERE  sfa.uuid IN ($filesystemAttachmentUUIDs[:])
+	UNION
+	SELECT      sfa.uuid,
+	            sf.filesystem_id,
+		        NULL AS machine_name,
+		        u.name AS unit_name
+	FROM        storage_filesystem_attachment sfa
+	JOIN        storage_filesystem sf ON sfa.storage_filesystem_uuid = sf.uuid
+	LEFT JOIN   machine m ON sfa.net_node_uuid != m.net_node_uuid
+	JOIN        unit u ON sfa.net_node_uuid = u.net_node_uuid
+	WHERE       sfa.uuid IN ($filesystemAttachmentUUIDs[:])
+)
+`
+
+	uuidToIDsStmt, err := st.Prepare(q, filesystemAttachmentIDs{}, uuidInputs)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var dbVals []filesystemAttachmentIDs
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, uuidToIDsStmt, uuidInputs).GetAll(&dbVals)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	rval := make(map[string]storageprovisioning.FilesystemAttachmentID, len(dbVals))
+	for _, v := range dbVals {
+		id := storageprovisioning.FilesystemAttachmentID{
+			FilesystemID: v.FilesystemID,
+		}
+		if v.MachineName.Valid {
+			id.MachineName = &v.MachineName.String
+		}
+		if v.UnitName.Valid {
+			id.UnitName = &v.UnitName.String
+		}
+
+		rval[v.UUID] = id
+	}
+	return rval, nil
+}
+
+// GetFilesystemAttachmentLifeForNetNode returns a mapping of filesystem
+// attachment uuids to the current life value for each machine provisioned
+// filesystem attachment that is to be provisioned by the machine owning the
+// supplied net node.
+func (st *State) GetFilesystemAttachmentLifeForNetNode(
+	ctx context.Context,
+	netNodeUUID string,
+) (map[string]life.Life, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return st.getFilesystemAttachmentLifeForNetNode(ctx, db, netNodeUUID)
+}
+
+// getFilesystemAttachmentLifeForNetNode returns a mapping of filesystem
+// attachment uuids to the current life value for each machine provisioned
+// filesystem attachment that is to be provisioned by the machine owning the
+// supplied net node.
+func (st *State) getFilesystemAttachmentLifeForNetNode(
+	ctx context.Context,
+	db domain.TxnRunner,
+	netNodeUUID string,
+) (map[string]life.Life, error) {
+	netNodeInput := netNodeUUIDRef{UUID: netNodeUUID}
+	stmt, err := st.Prepare(`
+SELECT DISTINCT &attachmentLife.*
+FROM            storage_filesystem_attachment
+WHERE           provision_scope_id=1
+AND             net_node_uuid=$netNodeUUIDRef.net_node_uuid
+		`, attachmentLife{}, netNodeInput)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	var fsAttachmentLives attachmentLives
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		exists, err := st.checkNetNodeExists(ctx, tx, netNodeUUID)
+		if err != nil {
+			return err
+		} else if !exists {
+			return errors.Errorf("net node %q does not exist", netNodeUUID)
+		}
+		err = tx.Query(ctx, stmt, netNodeInput).GetAll(&fsAttachmentLives)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return maps.Collect(fsAttachmentLives.Iter), nil
+}
+
+// GetFilesystemLifeForNetNode returns a mapping of filesystem ids to current
+// life value for each machine provisioned filesystem that is to be
+// provisioned by the machine owning the supplied net node.
+func (st *State) GetFilesystemLifeForNetNode(
+	ctx context.Context,
+	netNodeUUID string,
+) (map[string]life.Life, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return st.getFilesystemLifeForNetNode(ctx, db, netNodeUUID)
+}
+
+// getFilesystemLifeForNetNode returns a mapping of filesystem ids to current
+// life value for each machine provisioned filesystem that is to be
+// provisioned by the machine owning the supplied net node.
+func (st *State) getFilesystemLifeForNetNode(
+	ctx context.Context,
+	db domain.TxnRunner,
+	netNodeUUID string,
+) (map[string]life.Life, error) {
+	netNodeInput := netNodeUUIDRef{UUID: netNodeUUID}
+	stmt, err := st.Prepare(`
+SELECT DISTINCT (sf.filesystem_id, sf.life_id) AS (&filesystemLife.*)
+FROM            storage_filesystem sf
+JOIN            storage_filesystem_attachment sfa ON sf.uuid=sfa.storage_filesystem_uuid
+WHERE           sf.provision_scope_id=1
+AND             sfa.net_node_uuid=$netNodeUUIDRef.net_node_uuid
+		`, filesystemLife{}, netNodeUUIDRef{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	var fsLives filesystemLives
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		exists, err := st.checkNetNodeExists(ctx, tx, netNodeUUID)
+		if err != nil {
+			return err
+		} else if !exists {
+			return errors.Errorf("net node %q does not exist", netNodeUUID)
+		}
+		err = tx.Query(ctx, stmt, netNodeInput).GetAll(&fsLives)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return maps.Collect(fsLives.Iter), nil
+}
+
+// InitialWatchStatementMachineProvisionedFilesystems returns both the
+// namespace for watching filesystem life changes where the filesystem is
+// machine provisioned. On top of this the initial query for getting all
+// filesystems in the model that are machine provisioned is returned.
+//
+// Only filesystems that can be provisioned by the machine connected to the
+// supplied net node will be emitted.
+func (st *State) InitialWatchStatementMachineProvisionedFilesystems(
+	netNodeUUID string,
+) (string, eventsource.Query[map[string]life.Life]) {
+	query := func(ctx context.Context, db database.TxnRunner) (
+		map[string]life.Life, error,
+	) {
+		return st.getFilesystemLifeForNetNode(ctx, db, netNodeUUID)
+	}
+	return "storage_filesystem_life_machine_provisioning", query
+}
+
+// InitialWatchStatementModelProvisionedFilesystems returns both the namespace
+// for watching filesystem life changes where the filesystem is model
+// provisioned. On top of this the initial query for getting all filesystems
+// in the model that model provisioned is returned.
+func (st *State) InitialWatchStatementModelProvisionedFilesystems() (string, eventsource.NamespaceQuery) {
+	query := func(ctx context.Context, db database.TxnRunner) ([]string, error) {
+		stmt, err := st.Prepare(`
+			SELECT &filesystemID.* FROM storage_filesystem WHERE provision_scope_id=0
+		`, filesystemID{})
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		var fsIDs []filesystemID
+		err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			err := tx.Query(ctx, stmt).GetAll(&fsIDs)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		rval := make([]string, 0, len(fsIDs))
+		for _, v := range fsIDs {
+			rval = append(rval, v.ID)
+		}
+		return rval, nil
+	}
+	return "storage_filesystem_life_model_provisioning", query
+}
+
+func (st *State) InitialWatchStatementModelProvisionedFilesystemAttachments() (string, eventsource.NamespaceQuery) {
+	query := func(ctx context.Context, db database.TxnRunner) ([]string, error) {
+		stmt, err := st.Prepare(`
+SELECT &attachmentUUID.*
+FROM   storage_filesystem_attachment
+WHERE  provision_scope_id=0
+		`, attachmentUUID{})
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		var fsAttachmentUUIDs []attachmentUUID
+		err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			err := tx.Query(ctx, stmt).GetAll(&fsAttachmentUUIDs)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		rval := make([]string, 0, len(fsAttachmentUUIDs))
+		for _, v := range fsAttachmentUUIDs {
+			rval = append(rval, v.UUID)
+		}
+		return rval, nil
+	}
+	return "storage_filesystem_attachment_life_model_provisioning", query
+}
+
+func (st *State) InitialWatchStatementMachineProvisionedFilesystemAttachments(
+	netNodeUUID string,
+) (string, eventsource.Query[map[string]life.Life]) {
+	query := func(ctx context.Context, db database.TxnRunner) (map[string]life.Life, error) {
+		return st.getFilesystemAttachmentLifeForNetNode(ctx, db, netNodeUUID)
+	}
+	return "storage_filesystem_attachment_life_machine_provisioning", query
+}

--- a/domain/storageprovisioning/state/filesystem_test.go
+++ b/domain/storageprovisioning/state/filesystem_test.go
@@ -1,0 +1,567 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/domain/life"
+	domainlife "github.com/juju/juju/domain/life"
+	domainnetwork "github.com/juju/juju/domain/network"
+	"github.com/juju/juju/domain/storageprovisioning"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// filesystemSuite provides a set of tests for asserting the state interface
+// for filesystems in the model.
+type filesystemSuite struct {
+	baseSuite
+}
+
+// TestFilesystemSuite runs the tests in [filesystemSuite].
+func TestFilesystemSuite(t *testing.T) {
+	tc.Run(t, &filesystemSuite{})
+}
+
+// TestGetFilesystemAttachmentIDsOnlyUnits tests that when requesting ids for a
+// filesystem attachment and no machines are using the net node the unit name is
+// reported.
+func (s *filesystemSuite) TestGetFilesystemAttachmentIDsOnlyUnits(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	appUUID := s.newApplication(c, "foo")
+	s.newUnitWithNetNode(c, "foo/0", appUUID, netNodeUUID)
+
+	fsUUID, fsID := s.newMachineFilesystem(c)
+	fsaUUID := s.newMachineFilesystemAttachment(c, fsUUID, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetFilesystemAttachmentIDs(c.Context(), []string{fsaUUID})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, map[string]storageprovisioning.FilesystemAttachmentID{
+		fsaUUID: {
+			FilesystemID: fsID,
+			MachineName:  nil,
+			UnitName:     ptr("foo/0"),
+		},
+	})
+}
+
+// TestGetFilesystemAttachmentIDsOnlyMachines tests that when requesting ids for a
+// filesystem attachment and the net node is attached to a machine the machine
+// name is set.
+func (s *filesystemSuite) TestGetFilesystemAttachmentIDsOnlyMachines(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	_, machineName := s.newMachineWithNetNode(c, netNodeUUID)
+
+	fsUUID, fsID := s.newMachineFilesystem(c)
+	fsaUUID := s.newMachineFilesystemAttachment(c, fsUUID, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetFilesystemAttachmentIDs(c.Context(), []string{fsaUUID})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, map[string]storageprovisioning.FilesystemAttachmentID{
+		fsaUUID: {
+			FilesystemID: fsID,
+			MachineName:  ptr(machineName),
+			UnitName:     nil,
+		},
+	})
+}
+
+// TestGetFilesystemAttachmentIDsMachineNotUnit tests that when requesting ids for a
+// filesystem attachment and the net node is attached to a machine the machine
+// name is set. This should remain true when the net node is also used by a
+// unit. This is a valid case when units are assigned to a machine.
+func (s *filesystemSuite) TestGetFilesystemAttachmentIDsMachineNotUnit(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	_, machineName := s.newMachineWithNetNode(c, netNodeUUID)
+	appUUID := s.newApplication(c, "foo")
+	s.newUnitWithNetNode(c, "foo/0", appUUID, netNodeUUID)
+
+	fsUUID, fsID := s.newMachineFilesystem(c)
+	fsaUUID := s.newMachineFilesystemAttachment(c, fsUUID, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetFilesystemAttachmentIDs(c.Context(), []string{fsaUUID})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, map[string]storageprovisioning.FilesystemAttachmentID{
+		fsaUUID: {
+			FilesystemID: fsID,
+			MachineName:  ptr(machineName),
+			UnitName:     nil,
+		},
+	})
+}
+
+// TestGetFilesystemAttachmentIDsMixed tests that when requesting ids for a
+// mixed set of filesystem attachments uuids the machine name and unit name are
+// correctly set.
+func (s *filesystemSuite) TestGetFilesystemAttachmentIDsMixed(c *tc.C) {
+	netNodeUUID1 := s.newNetNode(c)
+	netNodeUUID2 := s.newNetNode(c)
+	_, machineName := s.newMachineWithNetNode(c, netNodeUUID1)
+	appUUID := s.newApplication(c, "foo")
+	s.newUnitWithNetNode(c, "foo/0", appUUID, netNodeUUID2)
+
+	fs1UUID, fsID1 := s.newMachineFilesystem(c)
+	fsa1UUID := s.newMachineFilesystemAttachment(c, fs1UUID, netNodeUUID1)
+
+	fs2UUID, fsID2 := s.newMachineFilesystem(c)
+	fsa2UUID := s.newMachineFilesystemAttachment(c, fs2UUID, netNodeUUID2)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetFilesystemAttachmentIDs(c.Context(), []string{
+		fsa1UUID, fsa2UUID,
+	})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, map[string]storageprovisioning.FilesystemAttachmentID{
+		fsa1UUID: {
+			FilesystemID: fsID1,
+			MachineName:  ptr(machineName),
+			UnitName:     nil,
+		},
+		fsa2UUID: {
+			FilesystemID: fsID2,
+			MachineName:  nil,
+			UnitName:     ptr("foo/0"),
+		},
+	})
+}
+
+// TestGetFilesystemAttachmentIDsNotMachineOrUnit tests that when requesting
+// ids for a filesystem attachment that is using a net node not attached to a
+// machine or unit the uuid is dropped from the final result.
+func (s *filesystemSuite) TestGetFilesystemAttachmentIDsNotMachineOrUnit(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	fsUUID, _ := s.newMachineFilesystem(c)
+	fsaUUID := s.newMachineFilesystemAttachment(c, fsUUID, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetFilesystemAttachmentIDs(c.Context(), []string{fsaUUID})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.HasLen, 0)
+}
+
+// TestGetFilesystemAttachmentIDsNotFound tests that when requesting ids for
+// filesystem attachment uuids that don't exist the uuids are excluded from the
+// result with no error returned.
+func (s *filesystemSuite) TestGetFilesystemAttachmentIDsNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetFilesystemAttachmentIDs(c.Context(), []string{"no-exist"})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.HasLen, 0)
+}
+
+// TestGetFilesystemAttachmentLifeForNetNode tests that the correct life is
+// reported for each model provisioned filesystem attachment associated with the
+// given net node.
+//
+// We also inject a life change during the test to make sure that it is
+// reflected.
+func (s *filesystemSuite) TestGetFilesystemAttachmentLifeForNetNode(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	fsUUID1, _ := s.newMachineFilesystem(c)
+	fsUUID2, _ := s.newMachineFilesystem(c)
+	fsUUID3, _ := s.newMachineFilesystem(c)
+	fsaUUID1 := s.newMachineFilesystemAttachment(c, fsUUID1, netNodeUUID)
+	fsaUUID2 := s.newMachineFilesystemAttachment(c, fsUUID2, netNodeUUID)
+	fsaUUID3 := s.newMachineFilesystemAttachment(c, fsUUID3, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	lives, err := st.GetFilesystemAttachmentLifeForNetNode(
+		c.Context(), netNodeUUID,
+	)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(lives, tc.DeepEquals, map[string]domainlife.Life{
+		fsaUUID1: domainlife.Alive,
+		fsaUUID2: domainlife.Alive,
+		fsaUUID3: domainlife.Alive,
+	})
+
+	// Apply a life change to one of the attachments and check the change comes
+	// out.
+	s.changeFilesystemAttachmentLife(c, fsaUUID1, life.Dying)
+	lives, err = st.GetFilesystemAttachmentLifeForNetNode(
+		c.Context(), netNodeUUID,
+	)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(lives, tc.DeepEquals, map[string]domainlife.Life{
+		fsaUUID1: domainlife.Dying,
+		fsaUUID2: domainlife.Alive,
+		fsaUUID3: domainlife.Alive,
+	})
+}
+
+// TestGetFilesystemAttachmentLifeNoResults tests that when no attachment lives
+// exist for a net node an empty result is returned with no error.
+func (s *filesystemSuite) TestGetFilesystemAttachmentLifeNoResults(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	st := NewState(s.TxnRunnerFactory())
+	lives, err := st.GetFilesystemAttachmentLifeForNetNode(c.Context(), netNodeUUID)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(lives, tc.HasLen, 0)
+}
+
+// TestGetFilesystemLifeForNetNode tests if we can get the filesystem life for
+// filesystems attached to a specified machine's net node.
+func (s *filesystemSuite) TestGetFilesystemLifeForNetNode(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	netNodeUUID := s.newNetNode(c)
+	fsOneUUID, fsOneID := s.newMachineFilesystem(c)
+	_ = s.newMachineFilesystemAttachment(c, fsOneUUID, netNodeUUID)
+	fsTwoUUID, fsTwoID := s.newMachineFilesystem(c)
+	_ = s.newMachineFilesystemAttachment(c, fsTwoUUID, netNodeUUID)
+	fsThreeUUID, fsThreeID := s.newMachineFilesystem(c)
+	_ = s.newMachineFilesystemAttachment(c, fsThreeUUID, netNodeUUID)
+
+	s.changeFilesystemLife(c, fsTwoUUID, domainlife.Dying)
+	s.changeFilesystemLife(c, fsThreeUUID, domainlife.Dead)
+
+	// Add unrelated filesystems.
+	_, _ = s.newModelFilesystem(c)
+	fsIDOtherMachine, _ := s.newMachineFilesystem(c)
+	_ = s.newMachineFilesystemAttachment(c, fsIDOtherMachine, s.newNetNode(c))
+
+	fsUUIDs, err := st.GetFilesystemLifeForNetNode(c.Context(), netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsUUIDs, tc.DeepEquals, map[string]domainlife.Life{
+		fsOneID:   domainlife.Alive,
+		fsTwoID:   domainlife.Dying,
+		fsThreeID: domainlife.Dead,
+	})
+}
+
+// TestInitialWatchStatementMachineProvisionedFilesystems tests the initial query
+// for machine provisioned filesystems watcher returns only the filesystem UUIDs
+// attached to the specified machine net node.
+func (s *filesystemSuite) TestInitialWatchStatementMachineProvisionedFilesystems(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	netNodeUUID := s.newNetNode(c)
+	fsOneUUID, fsOneID := s.newMachineFilesystem(c)
+	_ = s.newMachineFilesystemAttachment(c, fsOneUUID, netNodeUUID)
+	fsTwoUUID, fsTwoID := s.newMachineFilesystem(c)
+	_ = s.newMachineFilesystemAttachment(c, fsTwoUUID, netNodeUUID)
+
+	// Add unrelated filesystems.
+	_, _ = s.newModelFilesystem(c)
+	fsIDOtherMachine, _ := s.newMachineFilesystem(c)
+	_ = s.newMachineFilesystemAttachment(c, fsIDOtherMachine, s.newNetNode(c))
+
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedFilesystems(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_filesystem_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	fsUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsUUIDs, tc.DeepEquals, map[string]domainlife.Life{
+		fsOneID: domainlife.Alive,
+		fsTwoID: domainlife.Alive,
+	})
+}
+
+// TestInitialWatchStatementMachineProvisionedFilesystemsNone tests the initial
+// query for machine provisioned filesystems watcher does not return an error
+// when no machine provisioned filesystems are attached to the specified machine
+// net node.
+func (s *filesystemSuite) TestInitialWatchStatementMachineProvisionedFilesystemsNone(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	netNodeUUID := s.newNetNode(c)
+
+	// Add unrelated filesystems.
+	_, _ = s.newModelFilesystem(c)
+	fsIDOtherMachine, _ := s.newMachineFilesystem(c)
+	s.newMachineFilesystemAttachment(c, fsIDOtherMachine, s.newNetNode(c))
+
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedFilesystems(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_filesystem_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	fsUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsUUIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementMachineProvisionedFilesystemsNetNodeMissing tests
+// the initial query for machine provisioned filesystems watcher errors when the
+// net node specified is not found.
+func (s *filesystemSuite) TestInitialWatchStatementMachineProvisionedFilesystemsNetNodeMissing(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	netNodeUUID := uuid.MustNewUUID().String()
+
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedFilesystems(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_filesystem_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	_, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.NotNil)
+}
+
+// TestInitialWatchStatementModelProvisionedFilesystemsNone tests the initial
+// query for a model provisioned filsystem watcher returns no error when there
+// is not any model provisioned filesystems.
+func (s *filesystemSuite) TestInitialWatchStatementModelProvisionedFilesystemsNone(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	_, _ = s.newMachineFilesystem(c)
+
+	ns, initialQuery := st.InitialWatchStatementModelProvisionedFilesystems()
+	c.Check(ns, tc.Equals, "storage_filesystem_life_model_provisioning")
+
+	db := s.TxnRunner()
+	fsIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementModelProvisionedFilesystems tests the initial query
+// for a model provisioned filsystem watcher returns only the filesystem IDs for
+// the model provisoned filesystems.
+func (s *filesystemSuite) TestInitialWatchStatementModelProvisionedFilesystems(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	_, fsOneID := s.newModelFilesystem(c)
+	_, fsTwoID := s.newModelFilesystem(c)
+	_, _ = s.newMachineFilesystem(c)
+
+	ns, initialQuery := st.InitialWatchStatementModelProvisionedFilesystems()
+	c.Check(ns, tc.Equals, "storage_filesystem_life_model_provisioning")
+
+	db := s.TxnRunner()
+	fsIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsIDs, tc.SameContents, []string{fsOneID, fsTwoID})
+}
+
+// TestInitialWatchStatementMachineProvisionedFilesystemAttachments tests the
+// initial query for machine provisioned filesystem attachments watcher returns
+// only the filesystem attachment UUIDs attached to the specified net node.
+func (s *filesystemSuite) TestInitialWatchStatementMachineProvisionedFilesystemAttachments(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	fsOneUUID, _ := s.newMachineFilesystem(c)
+	fsaOneUUID := s.newMachineFilesystemAttachment(c, fsOneUUID, netNodeUUID)
+	fsTwoUUID, _ := s.newMachineFilesystem(c)
+	fsaTwoUUID := s.newMachineFilesystemAttachment(c, fsTwoUUID, netNodeUUID)
+
+	// Add unrelated filesystems.
+	_, _ = s.newModelFilesystem(c)
+	fsIDOtherMachine, _ := s.newMachineFilesystem(c)
+	_ = s.newMachineFilesystemAttachment(c, fsIDOtherMachine, s.newNetNode(c))
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedFilesystemAttachments(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_filesystem_attachment_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	fsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsaUUIDs, tc.DeepEquals, map[string]domainlife.Life{
+		fsaTwoUUID: domainlife.Alive,
+		fsaOneUUID: domainlife.Alive,
+	})
+}
+
+// TestInitialWatchStatementMachineProvisionedFilesystemAttachmentsNone tests
+// the initial query for machine provisioned filesystem attachments watcher does
+// not return an error when no machine provisioned filesystem attachments are
+// attached to the specified net node.
+func (s *filesystemSuite) TestInitialWatchStatementMachineProvisionedFilesystemAttachmentsNone(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+
+	// Add unrelated filesystems.
+	_, _ = s.newModelFilesystem(c)
+	fsIDOtherMachine, _ := s.newMachineFilesystem(c)
+	s.newMachineFilesystemAttachment(c, fsIDOtherMachine, s.newNetNode(c))
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedFilesystemAttachments(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_filesystem_attachment_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	fsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsaUUIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementMachineProvisionedFilesystemAttachmentsNetNodeMissing
+// tests the initial query for machine provisioned filesystem attachmewnts
+// watcher errors when the net node specified is not found.
+func (s *filesystemSuite) TestInitialWatchStatementMachineProvisionedFilesystemAttachmentsNetNodeMissing(c *tc.C) {
+	netNodeUUID, err := domainnetwork.NewNetNodeUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedFilesystemAttachments(
+		netNodeUUID.String(),
+	)
+	c.Check(ns, tc.Equals, "storage_filesystem_attachment_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	_, err = initialQuery(c.Context(), db)
+	// We don't focus on what the error is as no specific error type is offered
+	// as part of the contract. We just care that an error occured.
+	c.Assert(err, tc.NotNil)
+}
+
+// TestInitialWatchStatementModelProvisionedFilesystemAttachmentsNone tests the
+// initial query for a model provisioned filsystem attachment watcher returns no
+// error when there is no model provisioned filesystem attachments.
+func (s *filesystemSuite) TestInitialWatchStatementModelProvisionedFilesystemAttachmentsNone(c *tc.C) {
+	// Create a machine based filesystem attachment to assert  this doesn't show
+	// up.
+	netNode := s.newNetNode(c)
+	fsUUID, _ := s.newMachineFilesystem(c)
+	s.newMachineFilesystemAttachment(c, fsUUID, netNode)
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementModelProvisionedFilesystemAttachments()
+	c.Check(ns, tc.Equals, "storage_filesystem_attachment_life_model_provisioning")
+
+	db := s.TxnRunner()
+	fsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsaUUIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementModelProvisionedFilesystemAttachments tests the
+// initial query for a model provisioned filsystem attachment watcher returns
+// only the filesystem attachment uuids for the model provisoned filesystem
+// attachments.
+func (s *filesystemSuite) TestInitialWatchStatementModelProvisionedFilesystemAttachments(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	st := NewState(s.TxnRunnerFactory())
+	fsOneUUID, _ := s.newModelFilesystem(c)
+	fsTwoUUID, _ := s.newModelFilesystem(c)
+	fsThreeUUID, _ := s.newMachineFilesystem(c)
+	fsaOneUUID := s.newModelFilesystemAttachment(c, fsOneUUID, netNodeUUID)
+	fsaTwoUUID := s.newModelFilesystemAttachment(c, fsTwoUUID, netNodeUUID)
+	s.newMachineFilesystemAttachment(c, fsThreeUUID, netNodeUUID)
+
+	ns, initialQuery := st.InitialWatchStatementModelProvisionedFilesystemAttachments()
+	c.Check(ns, tc.Equals, "storage_filesystem_attachment_life_model_provisioning")
+
+	db := s.TxnRunner()
+	fsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fsaUUIDs, tc.SameContents, []string{fsaOneUUID, fsaTwoUUID})
+}
+
+// changeFilesystemLife is a utility function for updating the life value of a
+// filesystem.
+func (s *filesystemSuite) changeFilesystemLife(
+	c *tc.C, uuid string, life domainlife.Life,
+) {
+	_, err := s.DB().Exec(`
+UPDATE storage_filesystem
+SET    life_id = ?
+WHERE  uuid = ?
+`,
+		int(life), uuid)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// changeFilesystemAttachmentLife is a utility function for updating the life
+// value of a filesystem attachment. This is used to trigger an update trigger
+// for a filesystem attachment.
+func (s *filesystemSuite) changeFilesystemAttachmentLife(
+	c *tc.C, uuid string, life domainlife.Life,
+) {
+	_, err := s.DB().Exec(`
+UPDATE storage_filesystem_attachment
+SET    life_id = ?
+WHERE  uuid = ?
+`,
+		int(life), uuid)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// newMachineFilesystem creates a new filesystem in the model with machine
+// provision scope. Returned is the uuid and filesystem id of the entity.
+func (s *filesystemSuite) newMachineFilesystem(c *tc.C) (string, string) {
+	fsUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	fsID := fmt.Sprintf("foo/%s", fsUUID.String())
+
+	_, err = s.DB().Exec(`
+INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, 1)
+	`,
+		fsUUID.String(), fsID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return fsUUID.String(), fsID
+}
+
+// newModelFilesystem creates a new filesystem in the model with model
+// provision scope. Return is the uuid and filesystem id of the entity.
+func (s *filesystemSuite) newModelFilesystem(c *tc.C) (string, string) {
+	fsUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	fsID := fmt.Sprintf("foo/%s", fsUUID.String())
+
+	_, err = s.DB().Exec(`
+INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, 0)
+	`,
+		fsUUID.String(), fsID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return fsUUID.String(), fsID
+}
+
+// newMachineFilesystemAttachment creates a new filesystem attachment that has
+// machine provision scope. The attachment is associated with the provided
+// filesystem uuid and net node uuid.
+func (s *filesystemSuite) newMachineFilesystemAttachment(
+	c *tc.C, fsUUID string, netNodeUUID string,
+) string {
+	attachmentUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(
+		c.Context(),
+		`
+INSERT INTO storage_filesystem_attachment (uuid,
+										   storage_filesystem_uuid,
+										   net_node_uuid,
+										   life_id,
+										   provision_scope_id)
+VALUES (?, ?, ?, 0, 1)
+`,
+		attachmentUUID.String(), fsUUID, netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return attachmentUUID.String()
+}
+
+// newModelFilesystemAttachment creates a new filesystem attachment that has
+// model provision scope. The attachment is associated with the provided
+// filesystem uuid and net node uuid.
+func (s *filesystemSuite) newModelFilesystemAttachment(
+	c *tc.C, fsUUID string, netNodeUUID string,
+) string {
+	attachmentUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(
+		c.Context(),
+		`
+INSERT INTO storage_filesystem_attachment (uuid,
+                                           storage_filesystem_uuid,
+                                           net_node_uuid,
+                                           life_id,
+                                           provision_scope_id)
+VALUES (?, ?, ?, 0, 0)
+`,
+		attachmentUUID.String(), fsUUID, netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return attachmentUUID.String()
+}

--- a/domain/storageprovisioning/state/package_test.go
+++ b/domain/storageprovisioning/state/package_test.go
@@ -1,0 +1,8 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/domain/storageprovisioning/state/state.go
+++ b/domain/storageprovisioning/state/state.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/machine"
+	"github.com/juju/juju/domain"
+	domainlife "github.com/juju/juju/domain/life"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
+	"github.com/juju/juju/internal/errors"
+)
+
+type State struct {
+	*domain.StateBase
+}
+
+// CheckMachineIsDead checks to see if a machine is not dead returning
+// true when the life of the machine is dead.
+//
+// The following errors may be returned:
+// - [github.com/juju/juju/domain/machine/errors.MachineNotFound] when no
+// machine exists for the provided uuid.
+func (st *State) CheckMachineIsDead(
+	ctx context.Context, uuid machine.UUID,
+) (bool, error) {
+	db, err := st.DB()
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	var (
+		input       = machineUUID{UUID: uuid.String()}
+		machineLife machineLife
+	)
+	stmt, err := st.Prepare(
+		"SELECT $machineLife.* FROM machine WHERE uuid = machineUUIDVal.uuid",
+		input, machineLife,
+	)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, input).Get(&machineLife)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("machine %q does not exist", uuid).Add(
+				machineerrors.MachineNotFound,
+			)
+		}
+		return err
+	})
+
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	return domainlife.Life(machineLife.LifeId) == domainlife.Dead, nil
+}
+
+// GetMachineNetNodeUUID retrieves the net node uuid associated with provided
+// machine.
+//
+// The following errors may be returned:
+// - [machineerrors.MachineNotFound] when no machine exists for the provided
+// uuid.
+func (st *State) GetMachineNetNodeUUID(
+	ctx context.Context, uuid machine.UUID,
+) (string, error) {
+	db, err := st.DB()
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	var (
+		input = machineUUID{UUID: uuid.String()}
+		dbVal netNodeUUIDRef
+	)
+	stmt, err := st.Prepare(
+		"SELECT netNodeUUIDRef.* FROM machine WHERE uuid = $machineUUID.uuid",
+		input, dbVal,
+	)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, input).Get(&dbVal)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("machine %q does not exist", uuid).Add(
+				machineerrors.MachineNotFound,
+			)
+		}
+		return err
+	})
+
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	return dbVal.UUID, nil
+}
+
+func (st *State) NamespaceForWatchMachineCloudInstance() string {
+	return "machine_cloud_instance"
+}
+
+// checkNetNodeExists checks if the provided net node uuid exists in the
+// database during a txn. False is returned when the net node does not exist.
+func (st *State) checkNetNodeExists(
+	ctx context.Context,
+	tx *sqlair.TX,
+	uuid string,
+) (bool, error) {
+	input := netNodeUUID{UUID: uuid}
+
+	checkStmt, err := st.Prepare(
+		"SELECT &netNodeUUID.* FROM net_node WHERE uuid = $netNodeUUID.uuid",
+		input,
+	)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, checkStmt, input).Get(&input)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	return true, nil
+}
+
+// NewState creates and returns a new [State] for provisioning storage in the
+// model.
+func NewState(
+	factory database.TxnRunnerFactory,
+) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+	}
+}

--- a/domain/storageprovisioning/state/state_test.go
+++ b/domain/storageprovisioning/state/state_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/tc"
+
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// stateSuite provides a test suite for testing the commonality parts of [State].
+type stateSuite struct {
+	schematesting.ModelSuite
+}
+
+// TestStateSuite registers and runs all of the tests located in [stateSuite].
+func TestStateSuite(t *testing.T) {
+	tc.Run(t, &stateSuite{})
+}
+
+// TestCheckNetNodeNotExist tests that the [State.checkNetNodeExists] method
+// returns false when the net node does not exist.
+func (s *stateSuite) TestCheckNetNodeNotExist(c *tc.C) {
+	netNodeUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory())
+
+	var exists bool
+	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		exists, err = st.checkNetNodeExists(ctx, tx, netNodeUUID.String())
+		return err
+	})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+}
+
+// TestCheckNetNodeExists tests that when a net node exists
+// [State.checkNetNodeExists] returns true.
+func (s *stateSuite) TestCheckNetNodeExists(c *tc.C) {
+	netNodeUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(
+		c.Context(),
+		"INSERT INTO net_node (uuid) VALUES (?)",
+		netNodeUUID.String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory())
+
+	var exists bool
+	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		exists, err = st.checkNetNodeExists(ctx, tx, netNodeUUID.String())
+		return err
+	})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, true)
+}

--- a/domain/storageprovisioning/state/types.go
+++ b/domain/storageprovisioning/state/types.go
@@ -1,0 +1,162 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"database/sql"
+
+	"github.com/juju/juju/domain/life"
+)
+
+// attachmentLife represents the current life value of either a filesystem or
+// volume attachment in the model.
+type attachmentLife struct {
+	UUID string    `db:"uuid"`
+	Life life.Life `db:"life_id"`
+}
+
+// attachmentLives is a convenience type that facilitates transforming a slice
+// of [attachmentLives] values to a map.
+type attachmentLives []attachmentLife
+
+// Iter provides a seq2 implementation for iterating the values of
+// [attachmentLives].
+func (l attachmentLives) Iter(yield func(string, life.Life) bool) {
+	for _, v := range l {
+		if !yield(v.UUID, v.Life) {
+			return
+		}
+	}
+}
+
+// attachmentUUID represents the UUID of a storage attachment in the model. This
+// is used for either volume or filesystem attachments.
+type attachmentUUID struct {
+	UUID string `db:"uuid"`
+}
+
+// filesystemAttachmentIDs represents the ids of attachment points to a
+// filesystem attachment. This information includes the filesystem ID the
+// attachment is for. As well as this either the machine or unit name the
+// attachment for is included.
+type filesystemAttachmentIDs struct {
+	UUID         string         `db:"uuid"`
+	FilesystemID string         `db:"filesystem_id"`
+	MachineName  sql.NullString `db:"machine_name"`
+	UnitName     sql.NullString `db:"unit_name"`
+}
+
+// filesystemAttachmentUUIDs represents a slice of filesystem attachment UUIDs.
+// This type exists so that we can provide sqlair with a named type to process a
+// slice of strings.
+type filesystemAttachmentUUIDs []string
+
+// filesystemID represents the filesystem id value for a storage filesystem
+// instance.
+type filesystemID struct {
+	ID string `db:"filesystem_id"`
+}
+
+// filesystemLife represents the current life value and filesystem id for a
+// storage filesystem instance in the model.
+type filesystemLife struct {
+	ID   string    `db:"filesystem_id"`
+	Life life.Life `db:"life_id"`
+}
+
+// filesystemLives is a convenience type that facilitates transforming a slice
+// of [filesystemLife] values to a map.
+type filesystemLives []filesystemLife
+
+// Iter provides a seq2 implementation for iterating the values of
+// [filesystemLives].
+func (l filesystemLives) Iter(yield func(string, life.Life) bool) {
+	for _, v := range l {
+		if !yield(v.ID, v.Life) {
+			return
+		}
+	}
+}
+
+// machineLife represents the current life value of a machine in the model.
+type machineLife struct {
+	LifeId int `db:"life_id"`
+}
+
+// machineUUID represents the UUID of a record in the machine table.
+type machineUUID struct {
+	UUID string `db:"uuid"`
+}
+
+// netNodeUUIDRef represents a reference to a network node uuid in a storage
+// entity table.
+type netNodeUUIDRef struct {
+	UUID string `db:"net_node_uuid"`
+}
+
+// netNodeUUID represents the UUID of a record in the network node table.
+type netNodeUUID struct {
+	UUID string `db:"uuid"`
+}
+
+// volumeAttachmentIDs represents the ids of attachment points to a
+// volume attachment. This information includes the volume ID the
+// attachment is for. As well as this either the machine or unit name the
+// attachment for is included.
+type volumeAttachmentIDs struct {
+	UUID        string         `db:"uuid"`
+	VolumeID    string         `db:"volume_id"`
+	MachineName sql.NullString `db:"machine_name"`
+	UnitName    sql.NullString `db:"unit_name"`
+}
+
+// volumeAttachmentPlanLife represents the life of a volume attachment plan in
+// the model and the volume id for the volume the attachment plan is for.
+type volumeAttachmentPlanLife struct {
+	VolumeID string    `db:"volume_id"`
+	Life     life.Life `db:"life_id"`
+}
+
+type volumeAttachmentPlanLives []volumeAttachmentPlanLife
+
+// Iter provides a seq2 implementation for iterating the values of
+// [volumeAttachmentPlanLife].
+func (l volumeAttachmentPlanLives) Iter(yield func(string, life.Life) bool) {
+	for _, v := range l {
+		if !yield(v.VolumeID, v.Life) {
+			return
+		}
+	}
+}
+
+// volumeAttachmentUUIDs represents a slice of volume attachment UUIDs.
+// This type exists so that we can provide sqlair with a named type to process a
+// slice of strings.
+type volumeAttachmentUUIDs []string
+
+// volumeID represents the volume id value for a storage volume instance.
+type volumeID struct {
+	ID string `db:"volume_id"`
+}
+
+// volumeLife represents the current life value and volume id for a storage
+// volume instance in the model.
+type volumeLife struct {
+	ID   string    `db:"volume_id"`
+	Life life.Life `db:"life_id"`
+}
+
+// volumeLives is a convenience type that facilitates transforming a slice
+// of [volumeLife] values to a map.
+type volumeLives []volumeLife
+
+// Iter provides a seq2 implementation for iterating the values of
+// [volumeLives].
+func (l volumeLives) Iter(yield func(string, life.Life) bool) {
+	for _, v := range l {
+		if !yield(v.ID, v.Life) {
+			return
+		}
+	}
+}

--- a/domain/storageprovisioning/state/volume.go
+++ b/domain/storageprovisioning/state/volume.go
@@ -1,0 +1,361 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"maps"
+
+	"github.com/canonical/sqlair"
+
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/watcher/eventsource"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/storageprovisioning"
+	"github.com/juju/juju/internal/errors"
+)
+
+// GetVolumeAttachmentIDs returns the [storageprovisioning.VolumeAttachmentID]
+// information for each volume attachment uuid supplied. If a uuid does not
+// exist or isn't attached to either a machine or a unit then it will not exist
+// in the result.
+func (st *State) GetVolumeAttachmentIDs(
+	ctx context.Context, uuids []string,
+) (map[string]storageprovisioning.VolumeAttachmentID, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	uuidInputs := volumeAttachmentUUIDs(uuids)
+
+	q := `
+SELECT &volumeAttachmentIDs.* FROM (
+	SELECT sva.uuid,
+	       sv.volume_id,
+		   m.name AS machine_name,
+		   NULL AS unit_name
+	FROM   storage_volume_attachment sva
+	JOIN   storage_volume sv ON sva.storage_volume_uuid = sv.uuid
+	JOIN   machine m ON sva.net_node_uuid = m.net_node_uuid
+	WHERE  sva.uuid IN ($volumeAttachmentUUIDs[:])
+	UNION
+	SELECT      sva.uuid,
+	            sv.volume_id,
+		        NULL AS machine_name,
+		        u.name AS unit_name
+	FROM        storage_volume_attachment sva
+	JOIN        storage_volume sv ON sva.storage_volume_uuid = sv.uuid
+	LEFT JOIN   machine m ON sva.net_node_uuid != m.net_node_uuid
+	JOIN        unit u ON sva.net_node_uuid = u.net_node_uuid
+	WHERE       sva.uuid IN ($volumeAttachmentUUIDs[:])
+)
+`
+
+	uuidToIDsStmt, err := st.Prepare(q, volumeAttachmentIDs{}, uuidInputs)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var dbVals []volumeAttachmentIDs
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, uuidToIDsStmt, uuidInputs).GetAll(&dbVals)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	rval := make(map[string]storageprovisioning.VolumeAttachmentID, len(dbVals))
+	for _, v := range dbVals {
+		id := storageprovisioning.VolumeAttachmentID{
+			VolumeID: v.VolumeID,
+		}
+		if v.MachineName.Valid {
+			id.MachineName = &v.MachineName.String
+		}
+		if v.UnitName.Valid {
+			id.UnitName = &v.UnitName.String
+		}
+
+		rval[v.UUID] = id
+	}
+	return rval, nil
+}
+
+// GetVolumeAttachmentLifeForNetNode returns a mapping of volume
+// attachment uuid to the current life value for each machine provisioned
+// volume attachment that is to be provisioned by the machine owning the
+// supplied net node.
+func (st *State) GetVolumeAttachmentLifeForNetNode(
+	ctx context.Context, netNodeUUID string,
+) (map[string]life.Life, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return st.getVolumeAttachmentLifeForNetNode(ctx, db, netNodeUUID)
+}
+
+// getVolumeAttachmentLifeForNetNode returns a mapping of volume attachment uuid
+// to the current life value for each machine provisioned volume attachment that
+// is to be provisioned by the machine owning the supplied net node.
+func (st *State) getVolumeAttachmentLifeForNetNode(
+	ctx context.Context,
+	db domain.TxnRunner,
+	netNodeUUID string,
+) (map[string]life.Life, error) {
+	netNodeInput := netNodeUUIDRef{UUID: netNodeUUID}
+	stmt, err := st.Prepare(`
+SELECT DISTINCT &attachmentLife.*
+FROM            storage_volume_attachment
+WHERE           provision_scope_id=1
+AND             net_node_uuid=$netNodeUUIDRef.net_node_uuid
+		`, attachmentLife{}, netNodeInput)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	var volAttachmentLives attachmentLives
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		exists, err := st.checkNetNodeExists(ctx, tx, netNodeUUID)
+		if err != nil {
+			return err
+		} else if !exists {
+			return errors.Errorf("net node %q does not exist", netNodeUUID)
+		}
+		err = tx.Query(ctx, stmt, netNodeInput).GetAll(&volAttachmentLives)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return maps.Collect(volAttachmentLives.Iter), nil
+}
+
+// GetVolumeAttachmentPlanLifeForNetNode returns a mapping of volume
+// attachment plan volume id to the current life value for each volume
+// attachment plan. The volume id of the attachment plans is returned instead of
+// the uuid because the caller for the watcher works off of this information.
+func (st *State) GetVolumeAttachmentPlanLifeForNetNode(
+	ctx context.Context, netNodeUUID string,
+) (map[string]life.Life, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return st.getVolumeAttachmentPlanLifeForNetNode(ctx, db, netNodeUUID)
+}
+
+// getVolumeAttachmentPlanLifeForNetNode returns a mapping of volume
+// attachment plan volume id to the current life value for each volume
+// attachment plan. The volume id of the attachment plan is returned instead of
+// the uuid because the caller for the watcher works off of this information.
+func (st *State) getVolumeAttachmentPlanLifeForNetNode(
+	ctx context.Context,
+	db domain.TxnRunner,
+	netNodeUUID string,
+) (map[string]life.Life, error) {
+	netNodeInput := netNodeUUIDRef{UUID: netNodeUUID}
+	stmt, err := st.Prepare(`
+SELECT DISTINCT (sv.volume_id, svap.life_id) AS (&volumeAttachmentPlanLife.*)
+FROM            storage_volume_attachment_plan svap
+JOIN            storage_volume sv ON svap.storage_volume_uuid=sv.uuid
+WHERE           svap.provision_scope_id=1
+AND             svap.net_node_uuid=$netNodeUUIDRef.net_node_uuid
+		`, volumeAttachmentPlanLife{}, netNodeInput)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var volAttachmentPlanLives volumeAttachmentPlanLives
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		exists, err := st.checkNetNodeExists(ctx, tx, netNodeUUID)
+		if err != nil {
+			return err
+		} else if !exists {
+			return errors.Errorf("net node %q does not exist", netNodeUUID)
+		}
+		err = tx.Query(ctx, stmt, netNodeInput).GetAll(&volAttachmentPlanLives)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return maps.Collect(volAttachmentPlanLives.Iter), nil
+}
+
+// GetVolumeLifeForNetNode returns a mapping of volume id to current life value
+// for each machine provisioned volume that is to be provisioned by the machine
+// owning the supplied net node.
+func (st *State) GetVolumeLifeForNetNode(
+	ctx context.Context, netNodeUUID string,
+) (map[string]life.Life, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return st.getVolumeLifeForNetNode(ctx, db, netNodeUUID)
+}
+
+// getVolumeLifeForNetNode returns a mapping of volume id to current life value
+// for each machine provisioned volume that is to be provisioned by the machine
+// owning the supplied net node.
+func (st *State) getVolumeLifeForNetNode(
+	ctx context.Context,
+	db domain.TxnRunner,
+	netNodeUUID string,
+) (map[string]life.Life, error) {
+	netNodeInput := netNodeUUIDRef{UUID: netNodeUUID}
+	stmt, err := st.Prepare(`
+SELECT DISTINCT (sv.volume_id, sv.life_id) AS (&volumeLife.*)
+FROM            storage_volume sv
+JOIN            storage_volume_attachment sva ON sv.uuid=sva.storage_volume_uuid
+WHERE           sv.provision_scope_id=1
+AND             sva.net_node_uuid=$netNodeUUIDRef.net_node_uuid
+		`, volumeLife{}, netNodeInput)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	var volLives volumeLives
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		exists, err := st.checkNetNodeExists(ctx, tx, netNodeUUID)
+		if err != nil {
+			return err
+		} else if !exists {
+			return errors.Errorf("net node %q does not exist", netNodeUUID)
+		}
+		err = tx.Query(ctx, stmt, netNodeInput).GetAll(&volLives)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return maps.Collect(volLives.Iter), nil
+}
+
+// InitialWatchStatementMachineProvisionedVolumes returns both the namespace for
+// watching volume life changes where the volume is machine provisioned. On top
+// of this the initial query for getting all volumes in the model that are
+// machine provisioned is returned.
+//
+// Only volumes that can be provisioned by the machine connected to the
+// supplied net node will be emitted.
+func (st *State) InitialWatchStatementMachineProvisionedVolumes(netNodeUUID string) (string, eventsource.Query[map[string]life.Life]) {
+	query := func(
+		ctx context.Context,
+		db database.TxnRunner,
+	) (map[string]life.Life, error) {
+		return st.getVolumeLifeForNetNode(ctx, db, netNodeUUID)
+	}
+	return "storage_volume_life_machine_provisioning", query
+}
+
+// InitialWatchStatementModelProvisionedVolumes returns both the namespace for
+// watching volume life changes where the volume is model provisioned. On top of
+// this the initial query for getting all volumes in the model that are model
+// provisioned is returned.
+func (st *State) InitialWatchStatementModelProvisionedVolumes() (string, eventsource.NamespaceQuery) {
+	query := func(ctx context.Context, db database.TxnRunner) ([]string, error) {
+		stmt, err := st.Prepare(`
+			SELECT &volumeID.* FROM storage_volume WHERE provision_scope_id=0
+		`, volumeID{})
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		var volIDs []volumeID
+		err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			err := tx.Query(ctx, stmt).GetAll(&volIDs)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		rval := make([]string, 0, len(volIDs))
+		for _, v := range volIDs {
+			rval = append(rval, v.ID)
+		}
+		return rval, nil
+	}
+	return "storage_volume_life_model_provisioning", query
+}
+
+// InitialWatchStatementMachineProvisionedVolumeAttachments returns both the
+// namespace for watching volume attachment life changes where the volume
+// attachment is machine provisioned. On top of this the initial query for
+// getting all volume attachments in the model that are machine provisioned is
+// returned.
+//
+// Only volume attachments that can be provisioned by the machine connected to
+// the supplied net node will be emitted.
+func (st *State) InitialWatchStatementMachineProvisionedVolumeAttachments(netNodeUUID string) (string, eventsource.Query[map[string]life.Life]) {
+	query := func(ctx context.Context, db database.TxnRunner) (map[string]life.Life, error) {
+		return st.getVolumeAttachmentLifeForNetNode(ctx, db, netNodeUUID)
+	}
+	return "storage_volume_attachment_life_machine_provisioning", query
+}
+
+// InitialWatchStatementModelProvisionedVolumeAttachments returns both the
+// namespace for watching volume attachment life changes where the volume
+// attachment is model provisioned. On top of this the initial query for getting
+// all volume attachments in the model that are model provisioned is returned.
+func (st *State) InitialWatchStatementModelProvisionedVolumeAttachments() (string, eventsource.NamespaceQuery) {
+	query := func(ctx context.Context, db database.TxnRunner) ([]string, error) {
+		stmt, err := st.Prepare(`
+SELECT &attachmentUUID.*
+FROM   storage_volume_attachment
+WHERE  provision_scope_id=0
+		`, attachmentUUID{})
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		var volAttachmentUUIDs []attachmentUUID
+		err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			err := tx.Query(ctx, stmt).GetAll(&volAttachmentUUIDs)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		rval := make([]string, 0, len(volAttachmentUUIDs))
+		for _, v := range volAttachmentUUIDs {
+			rval = append(rval, v.UUID)
+		}
+		return rval, nil
+	}
+	return "storage_volume_attachment_life_model_provisioning", query
+}
+
+// InitialWatchStatementVolumeAttachmentPlans returns both the namespace for
+// watching volume attachment plan life changes. On top of this the initial
+// query for getting all volume attachment plan volume ids in the model that
+// are for the given net node uuid.
+func (st *State) InitialWatchStatementVolumeAttachmentPlans(netNodeUUID string) (string, eventsource.Query[map[string]life.Life]) {
+	query := func(ctx context.Context, db database.TxnRunner) (map[string]life.Life, error) {
+		return st.getVolumeAttachmentPlanLifeForNetNode(ctx, db, netNodeUUID)
+	}
+	return "storage_volume_attachment_plan_life_machine_provisioning", query
+}

--- a/domain/storageprovisioning/state/volume_test.go
+++ b/domain/storageprovisioning/state/volume_test.go
@@ -1,0 +1,658 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/juju/juju/domain/life"
+	domainlife "github.com/juju/juju/domain/life"
+	domainnetwork "github.com/juju/juju/domain/network"
+	"github.com/juju/juju/domain/storageprovisioning"
+	"github.com/juju/juju/internal/uuid"
+	"github.com/juju/tc"
+)
+
+// volumeSuite provides a set of tests for asserting the state interface for
+// volumes in the model.
+type volumeSuite struct {
+	baseSuite
+}
+
+// TestVolumeSuite runs the tests defined in [volumeSuite].
+func TestVolumeSuite(t *testing.T) {
+	tc.Run(t, &volumeSuite{})
+}
+
+// TestGetVolumeAttachmentIDsOnlyUnits tests that when requesting ids for a
+// volume attachment and no machines are using the net node the unit name is
+// reported.
+func (s *volumeSuite) TestGetVolumeAttachmentIDsOnlyUnits(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	appUUID := s.newApplication(c, "foo")
+	s.newUnitWithNetNode(c, "foo/0", appUUID, netNodeUUID)
+
+	vsUUID, vsID := s.newMachineVolume(c)
+	vsaUUID := s.newMachineVolumeAttachment(c, vsUUID, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetVolumeAttachmentIDs(c.Context(), []string{vsaUUID})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, map[string]storageprovisioning.VolumeAttachmentID{
+		vsaUUID: {
+			VolumeID:    vsID,
+			MachineName: nil,
+			UnitName:    ptr("foo/0"),
+		},
+	})
+}
+
+// TestGetVolumeAttachmentIDsOnlyMachines tests that when requesting ids for a
+// volume attachment and the net node is attached to a machine the machine
+// name is set.
+func (s *volumeSuite) TestGetVolumeAttachmentIDsOnlyMachines(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	_, machineName := s.newMachineWithNetNode(c, netNodeUUID)
+
+	vsUUID, vsID := s.newMachineVolume(c)
+	vsaUUID := s.newMachineVolumeAttachment(c, vsUUID, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetVolumeAttachmentIDs(c.Context(), []string{vsaUUID})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, map[string]storageprovisioning.VolumeAttachmentID{
+		vsaUUID: {
+			VolumeID:    vsID,
+			MachineName: ptr(machineName),
+			UnitName:    nil,
+		},
+	})
+}
+
+// TestGetVolumeAttachmentIDsMachineNotUnit tests that when requesting ids for a
+// volume attachment and the net node is attached to a machine the machine
+// name is set. This should remain true when the net node is also used by a
+// unit. This is a valid case when units are assigned to a machine.
+func (s *volumeSuite) TestGetVolumeAttachmentIDsMachineNotUnit(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	_, machineName := s.newMachineWithNetNode(c, netNodeUUID)
+	appUUID := s.newApplication(c, "foo")
+	s.newUnitWithNetNode(c, "foo/0", appUUID, netNodeUUID)
+
+	vsUUID, vsID := s.newMachineVolume(c)
+	vsaUUID := s.newMachineVolumeAttachment(c, vsUUID, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetVolumeAttachmentIDs(c.Context(), []string{vsaUUID})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, map[string]storageprovisioning.VolumeAttachmentID{
+		vsaUUID: {
+			VolumeID:    vsID,
+			MachineName: ptr(machineName),
+			UnitName:    nil,
+		},
+	})
+}
+
+// TestGetVolumeAttachmentIDsMixed tests that when requesting ids for a
+// mixed set of volume attachments uuids the machine name and unit name are
+// correctly set.
+func (s *volumeSuite) TestGetVolumeAttachmentIDsMixed(c *tc.C) {
+	netNodeUUID1 := s.newNetNode(c)
+	netNodeUUID2 := s.newNetNode(c)
+	_, machineName := s.newMachineWithNetNode(c, netNodeUUID1)
+	appUUID := s.newApplication(c, "foo")
+	s.newUnitWithNetNode(c, "foo/0", appUUID, netNodeUUID2)
+
+	vsOneUUID, vsOneID := s.newMachineVolume(c)
+	vsaOneUUID := s.newMachineVolumeAttachment(c, vsOneUUID, netNodeUUID1)
+
+	vsTwoUUID, vsTwoID := s.newMachineVolume(c)
+	vsaTwoUUID := s.newMachineVolumeAttachment(c, vsTwoUUID, netNodeUUID2)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetVolumeAttachmentIDs(c.Context(), []string{
+		vsaOneUUID, vsaTwoUUID,
+	})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, map[string]storageprovisioning.VolumeAttachmentID{
+		vsaOneUUID: {
+			VolumeID:    vsOneID,
+			MachineName: ptr(machineName),
+			UnitName:    nil,
+		},
+		vsaTwoUUID: {
+			VolumeID:    vsTwoID,
+			MachineName: nil,
+			UnitName:    ptr("foo/0"),
+		},
+	})
+}
+
+// TestGetVolumeAttachmentIDsNotMachineOrUnit tests that when requesting
+// ids for a volume attachment that is using a net node not attached to a
+// machine or unit the uuid is dropped from the final result.
+func (s *volumeSuite) TestGetVolumeAttachmentIDsNotMachineOrUnit(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	vsUUID, _ := s.newMachineVolume(c)
+	vsaUUID := s.newMachineVolumeAttachment(c, vsUUID, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetVolumeAttachmentIDs(c.Context(), []string{vsaUUID})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.HasLen, 0)
+}
+
+// TestGetVolumeAttachmentIDsNotFound tests that when requesting ids for
+// volume attachment uuids that don't exist the uuids are excluded from the
+// result with no error returned.
+func (s *volumeSuite) TestGetVolumeAttachmentIDsNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	result, err := st.GetVolumeAttachmentIDs(c.Context(), []string{"no-exist"})
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.HasLen, 0)
+}
+
+// TestGetVolumeAttachmentLifeForNetNode tests that the correct life is
+// reported for each model provisioned volume attachment associated with the
+// given net node.
+//
+// We also inject a life change during the test to make sure that it is
+// reflected.
+func (s *volumeSuite) TestGetVolumeAttachmentLifeForNetNode(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	vsUUID1, _ := s.newMachineVolume(c)
+	vsUUID2, _ := s.newMachineVolume(c)
+	vsUUID3, _ := s.newMachineVolume(c)
+	vsaUUID1 := s.newMachineVolumeAttachment(c, vsUUID1, netNodeUUID)
+	vsaUUID2 := s.newMachineVolumeAttachment(c, vsUUID2, netNodeUUID)
+	vsaUUID3 := s.newMachineVolumeAttachment(c, vsUUID3, netNodeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	lives, err := st.GetVolumeAttachmentLifeForNetNode(
+		c.Context(), netNodeUUID,
+	)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(lives, tc.DeepEquals, map[string]domainlife.Life{
+		vsaUUID1: domainlife.Alive,
+		vsaUUID2: domainlife.Alive,
+		vsaUUID3: domainlife.Alive,
+	})
+
+	// Apply a life change to one of the attachments and check the change comes
+	// out.
+	s.changeVolumeAttachmentLife(c, vsaUUID1, life.Dying)
+	lives, err = st.GetVolumeAttachmentLifeForNetNode(
+		c.Context(), netNodeUUID,
+	)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(lives, tc.DeepEquals, map[string]domainlife.Life{
+		vsaUUID1: domainlife.Dying,
+		vsaUUID2: domainlife.Alive,
+		vsaUUID3: domainlife.Alive,
+	})
+}
+
+// TestGetVolumeAttachmentLifeNoResults tests that when no attachment lives
+// exist for a net node an empty result is returned with no error.
+func (s *volumeSuite) TestGetVolumeAttachmentLifeNoResults(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	st := NewState(s.TxnRunnerFactory())
+	lives, err := st.GetVolumeAttachmentLifeForNetNode(c.Context(), netNodeUUID)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(lives, tc.HasLen, 0)
+}
+
+// TestGetVolumeLifeForNetNode tests if we can get the volume life for
+// volumes attached to a specified machine's net node.
+func (s *volumeSuite) TestGetVolumeLifeForNetNode(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	netNodeUUID := s.newNetNode(c)
+	vsOneUUID, vsOneID := s.newMachineVolume(c)
+	_ = s.newMachineVolumeAttachment(c, vsOneUUID, netNodeUUID)
+	vsTwoUUID, vsTwoID := s.newMachineVolume(c)
+	_ = s.newMachineVolumeAttachment(c, vsTwoUUID, netNodeUUID)
+	vsThreeUUID, vsThreeID := s.newMachineVolume(c)
+	_ = s.newMachineVolumeAttachment(c, vsThreeUUID, netNodeUUID)
+
+	s.changeVolumeLife(c, vsTwoUUID, domainlife.Dying)
+	s.changeVolumeLife(c, vsThreeUUID, domainlife.Dead)
+
+	// Add unrelated volumes.
+	_, _ = s.newModelVolume(c)
+	vsIDOtherMachine, _ := s.newMachineVolume(c)
+	_ = s.newMachineVolumeAttachment(c, vsIDOtherMachine, s.newNetNode(c))
+
+	vsUUIDs, err := st.GetVolumeLifeForNetNode(c.Context(), netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsUUIDs, tc.DeepEquals, map[string]domainlife.Life{
+		vsOneID:   domainlife.Alive,
+		vsTwoID:   domainlife.Dying,
+		vsThreeID: domainlife.Dead,
+	})
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumes tests the initial query
+// for machine provisioned volumes watcher returns only the volume UUIDs
+// attached to the specified machine net node.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumes(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	netNodeUUID := s.newNetNode(c)
+	vsOneUUID, vsOneID := s.newMachineVolume(c)
+	_ = s.newMachineVolumeAttachment(c, vsOneUUID, netNodeUUID)
+	vsTwoUUID, vsTwoID := s.newMachineVolume(c)
+	_ = s.newMachineVolumeAttachment(c, vsTwoUUID, netNodeUUID)
+
+	// Add unrelated volumes.
+	_, _ = s.newModelVolume(c)
+	vsIDOtherMachine, _ := s.newMachineVolume(c)
+	_ = s.newMachineVolumeAttachment(c, vsIDOtherMachine, s.newNetNode(c))
+
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedVolumes(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_volume_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	vsUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsUUIDs, tc.DeepEquals, map[string]domainlife.Life{
+		vsOneID: domainlife.Alive,
+		vsTwoID: domainlife.Alive,
+	})
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumesNone tests the initial
+// query for machine provisioned volumes watcher does not return an error
+// when no machine provisioned volumes are attached to the specified machine
+// net node.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumesNone(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	netNodeUUID := s.newNetNode(c)
+
+	// Add unrelated volumes.
+	_, _ = s.newModelVolume(c)
+	vsIDOtherMachine, _ := s.newMachineVolume(c)
+	s.newMachineVolumeAttachment(c, vsIDOtherMachine, s.newNetNode(c))
+
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedVolumes(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_volume_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	vsUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsUUIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumesNetNodeMissing tests
+// the initial query for machine provisioned volumes watcher errors when the
+// net node specified is not found.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumesNetNodeMissing(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	netNodeUUID := uuid.MustNewUUID().String()
+
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedVolumes(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_volume_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	_, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.NotNil)
+}
+
+// TestInitialWatchStatementModelProvisionedVolumesNone tests the initial
+// query for a model provisioned filsystem watcher returns no error when there
+// is not any model provisioned volumes.
+func (s *volumeSuite) TestInitialWatchStatementModelProvisionedVolumesNone(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	_, _ = s.newMachineVolume(c)
+
+	ns, initialQuery := st.InitialWatchStatementModelProvisionedVolumes()
+	c.Check(ns, tc.Equals, "storage_volume_life_model_provisioning")
+
+	db := s.TxnRunner()
+	vsIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementModelProvisionedVolumes tests the initial query
+// for a model provisioned filsystem watcher returns only the volume IDs for
+// the model provisoned volumes.
+func (s *volumeSuite) TestInitialWatchStatementModelProvisionedVolumes(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	_, vsOneID := s.newModelVolume(c)
+	_, vsTwoID := s.newModelVolume(c)
+	_, _ = s.newMachineVolume(c)
+
+	ns, initialQuery := st.InitialWatchStatementModelProvisionedVolumes()
+	c.Check(ns, tc.Equals, "storage_volume_life_model_provisioning")
+
+	db := s.TxnRunner()
+	vsIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsIDs, tc.SameContents, []string{vsOneID, vsTwoID})
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumeAttachments tests the
+// initial query for machine provisioned volume attachments watcher returns
+// only the volume attachment UUIDs attached to the specified net node.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumeAttachments(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	vsOneUUID, _ := s.newMachineVolume(c)
+	vsaOneUUID := s.newMachineVolumeAttachment(c, vsOneUUID, netNodeUUID)
+	vsTwoUUID, _ := s.newMachineVolume(c)
+	vsaTwoUUID := s.newMachineVolumeAttachment(c, vsTwoUUID, netNodeUUID)
+
+	// Add unrelated volumes.
+	_, _ = s.newModelVolume(c)
+	vsIDOtherMachine, _ := s.newMachineVolume(c)
+	_ = s.newMachineVolumeAttachment(c, vsIDOtherMachine, s.newNetNode(c))
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedVolumeAttachments(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_volume_attachment_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	vsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsaUUIDs, tc.DeepEquals, map[string]domainlife.Life{
+		vsaTwoUUID: domainlife.Alive,
+		vsaOneUUID: domainlife.Alive,
+	})
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumeAttachmentsNone tests
+// the initial query for machine provisioned volume attachments watcher does
+// not return an error when no machine provisioned volume attachments are
+// attached to the specified net node.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumeAttachmentsNone(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+
+	// Add unrelated volumes.
+	_, _ = s.newModelVolume(c)
+	vsIDOtherMachine, _ := s.newMachineVolume(c)
+	s.newMachineVolumeAttachment(c, vsIDOtherMachine, s.newNetNode(c))
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedVolumeAttachments(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_volume_attachment_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	vsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsaUUIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumeAttachmentsNetNodeMissing
+// tests the initial query for machine provisioned volume attachmewnts
+// watcher errors when the net node specified is not found.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumeAttachmentsNetNodeMissing(c *tc.C) {
+	netNodeUUID, err := domainnetwork.NewNetNodeUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementMachineProvisionedVolumeAttachments(
+		netNodeUUID.String(),
+	)
+	c.Check(ns, tc.Equals, "storage_volume_attachment_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	_, err = initialQuery(c.Context(), db)
+	// We don't focus on what the error is as no specific error type is offered
+	// as part of the contract. We just care that an error occured.
+	c.Assert(err, tc.NotNil)
+}
+
+// TestInitialWatchStatementModelProvisionedVolumeAttachmentsNone tests the
+// initial query for a model provisioned filsystem attachment watcher returns no
+// error when there is no model provisioned volume attachments.
+func (s *volumeSuite) TestInitialWatchStatementModelProvisionedVolumeAttachmentsNone(c *tc.C) {
+	// Create a machine based volume attachment to assert  this doesn't show
+	// up.
+	netNode := s.newNetNode(c)
+	vsUUID, _ := s.newMachineVolume(c)
+	s.newMachineVolumeAttachment(c, vsUUID, netNode)
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementModelProvisionedVolumeAttachments()
+	c.Check(ns, tc.Equals, "storage_volume_attachment_life_model_provisioning")
+
+	db := s.TxnRunner()
+	vsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsaUUIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementModelProvisionedVolumeAttachments tests the
+// initial query for a model provisioned filsystem attachment watcher returns
+// only the volume attachment uuids for the model provisoned volume
+// attachments.
+func (s *volumeSuite) TestInitialWatchStatementModelProvisionedVolumeAttachments(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	st := NewState(s.TxnRunnerFactory())
+	vsOneUUID, _ := s.newModelVolume(c)
+	vsTwoUUID, _ := s.newModelVolume(c)
+	vsThreeUUID, _ := s.newMachineVolume(c)
+	vsaOneUUID := s.newModelVolumeAttachment(c, vsOneUUID, netNodeUUID)
+	vsaTwoUUID := s.newModelVolumeAttachment(c, vsTwoUUID, netNodeUUID)
+	s.newMachineVolumeAttachment(c, vsThreeUUID, netNodeUUID)
+
+	ns, initialQuery := st.InitialWatchStatementModelProvisionedVolumeAttachments()
+	c.Check(ns, tc.Equals, "storage_volume_attachment_life_model_provisioning")
+
+	db := s.TxnRunner()
+	vsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsaUUIDs, tc.SameContents, []string{vsaOneUUID, vsaTwoUUID})
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumeAttachmentPlans tests the
+// initial query for machine provisioned volume attachment plans watcher returns
+// only the volume ids attached to the specified net node.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumeAttachmentPlans(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	vsOneUUID, vOneID := s.newMachineVolume(c)
+	s.newVolumeAttachmentPlan(c, vsOneUUID, netNodeUUID)
+	vsTwoUUID, vTwoID := s.newMachineVolume(c)
+	s.newVolumeAttachmentPlan(c, vsTwoUUID, netNodeUUID)
+
+	// Add unrelated volumes.
+	_, _ = s.newModelVolume(c)
+	vsIDOtherMachine, _ := s.newMachineVolume(c)
+	_ = s.newVolumeAttachmentPlan(c, vsIDOtherMachine, s.newNetNode(c))
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementVolumeAttachmentPlans(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_volume_attachment_plan_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	vsaUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(vsaUUIDs, tc.DeepEquals, map[string]domainlife.Life{
+		vOneID: domainlife.Alive,
+		vTwoID: domainlife.Alive,
+	})
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumeAttachmentPlansNone tests
+// the initial query for machine provisioned volume attachment plans watcher
+// does not return an error when no machine provisioned volume attachments are
+// attached to the specified net node.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumeAttachmentPlansNone(c *tc.C) {
+	netNodeUUID := s.newNetNode(c)
+	// Add unrelated volumes.
+	vsUUID, _ := s.newMachineVolume(c)
+	s.newVolumeAttachmentPlan(c, vsUUID, s.newNetNode(c))
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementVolumeAttachmentPlans(netNodeUUID)
+	c.Check(ns, tc.Equals, "storage_volume_attachment_plan_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	planUUIDs, err := initialQuery(c.Context(), db)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(planUUIDs, tc.HasLen, 0)
+}
+
+// TestInitialWatchStatementMachineProvisionedVolumeAttachmentPlansNetNodeMissing
+// tests the initial query for machine provisioned volume attachmewnt plans
+// watcher errors when the net node specified is not found.
+func (s *volumeSuite) TestInitialWatchStatementMachineProvisionedVolumeAttachmentPlansNetNodeMissing(c *tc.C) {
+	netNodeUUID, err := domainnetwork.NewNetNodeUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory())
+	ns, initialQuery := st.InitialWatchStatementVolumeAttachmentPlans(
+		netNodeUUID.String(),
+	)
+	c.Check(ns, tc.Equals, "storage_volume_attachment_plan_life_machine_provisioning")
+
+	db := s.TxnRunner()
+	_, err = initialQuery(c.Context(), db)
+	// We don't focus on what the error is as no specific error type is offered
+	// as part of the contract. We just care that an error occured.
+	c.Assert(err, tc.NotNil)
+}
+
+// changeVolumeLife is a utility function for updating the life value of a
+// volume.
+func (s *volumeSuite) changeVolumeLife(
+	c *tc.C, uuid string, life domainlife.Life,
+) {
+	_, err := s.DB().Exec(`
+UPDATE storage_volume
+SET    life_id = ?
+WHERE  uuid = ?
+`,
+		int(life), uuid)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// changeVolumeAttachmentLife is a utility function for updating the life
+// value of a volume attachment. This is used to trigger an update trigger
+// for a volume attachment.
+func (s *volumeSuite) changeVolumeAttachmentLife(
+	c *tc.C, uuid string, life domainlife.Life,
+) {
+	_, err := s.DB().Exec(`
+UPDATE storage_volume_attachment
+SET    life_id = ?
+WHERE  uuid = ?
+`,
+		int(life), uuid)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// newMachineVolume creates a new volume in the model with machine
+// provision scope. Returned is the uuid and volume id of the entity.
+func (s *volumeSuite) newMachineVolume(c *tc.C) (string, string) {
+	vsUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	vsID := fmt.Sprintf("foo/%s", vsUUID.String())
+
+	_, err = s.DB().Exec(`
+INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, 1)
+	`,
+		vsUUID.String(), vsID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return vsUUID.String(), vsID
+}
+
+// newModelVolume creates a new volume in the model with model
+// provision scope. Return is the uuid and volume id of the entity.
+func (s *volumeSuite) newModelVolume(c *tc.C) (string, string) {
+	vsUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	vsID := fmt.Sprintf("foo/%s", vsUUID.String())
+
+	_, err = s.DB().Exec(`
+INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, 0)
+	`,
+		vsUUID.String(), vsID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return vsUUID.String(), vsID
+}
+
+// newMachineVolumeAttachment creates a new volume attachment that has
+// machine provision scope. The attachment is associated with the provided
+// volume uuid and net node uuid.
+func (s *volumeSuite) newMachineVolumeAttachment(
+	c *tc.C, vsUUID string, netNodeUUID string,
+) string {
+	attachmentUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(
+		c.Context(),
+		`
+INSERT INTO storage_volume_attachment (uuid,
+									   storage_volume_uuid,
+									   net_node_uuid,
+									   life_id,
+									   provision_scope_id)
+VALUES (?, ?, ?, 0, 1)
+`,
+		attachmentUUID.String(), vsUUID, netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return attachmentUUID.String()
+}
+
+// newModelVolumeAttachment creates a new volume attachment that has
+// model provision scope. The attachment is associated with the provided
+// volume uuid and net node uuid.
+func (s *volumeSuite) newModelVolumeAttachment(
+	c *tc.C, vsUUID string, netNodeUUID string,
+) string {
+	attachmentUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(
+		c.Context(),
+		`
+INSERT INTO storage_volume_attachment (uuid,
+                                       storage_volume_uuid,
+                                       net_node_uuid,
+                                       life_id,
+                                       provision_scope_id)
+VALUES (?, ?, ?, 0, 0)
+`,
+		attachmentUUID.String(), vsUUID, netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return attachmentUUID.String()
+}
+
+// newVolumeAttachmentPlan creates a new volume attachment plan. The attachment
+// plan is associated with the provided volume uuid and net node uuid.
+func (s *volumeSuite) newVolumeAttachmentPlan(
+	c *tc.C, volumeUUID, netNodeUUID string,
+) string {
+	attachmentUUID, err := uuid.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(
+		c.Context(),
+		`
+INSERT INTO storage_volume_attachment_plan (uuid,
+									        storage_volume_uuid,
+									        net_node_uuid,
+									        life_id,
+									        provision_scope_id)
+VALUES (?, ?, ?, 0, 1)
+`,
+		attachmentUUID.String(), volumeUUID, netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return attachmentUUID.String()
+}


### PR DESCRIPTION
Provides the implementation of the storage provisioner domain state layer. This first pass is concerned with just providing the detail that is required for watching storage in the model and provisioning. Future PRs will add the steps required for fetching information about storage entities.

Because of the way the facade works for storage provisioning we need to provide a means for attachments to be translated from their uuid value to an id of the parent storage type. This also needs to include information about the attached machine or unit name.

Volume attachment plans work a little differently. If we are able to just output the volume id in the watcher we can skip having to have the facade come back to the database and translate the attachment plan uuid to an id. This is possible because we assume attachment plans are only for machines and so the facade already has the machine tag.

A follow up PR is incoming to add integration tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests for the time being.

## Documentation changes

N/A

## Links

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-8070 JUJU-8071 JUJU-8077 JUJU-8075 JUJU-8073 JUJU-8074 JUJU-8076 JUJU-8078 JUJU-8083
