### PR TITLE
feat: ensure we pass trust

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/apiserver/internal/charms"
+	coreapplication "github.com/juju/juju/core/application"
 	coreassumes "github.com/juju/juju/core/assumes"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/config"
@@ -25,6 +26,7 @@ import (
 	coreresource "github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/application"
 	applicationcharm "github.com/juju/juju/domain/application/charm"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs/bootstrap"
@@ -167,6 +169,9 @@ func DeployApplication(
 			return nil, errors.Trace(err)
 		}
 
+		attrs := args.ApplicationConfig.Attributes()
+		trust := attrs.GetBool(coreapplication.TrustConfigOptionName, false)
+
 		applicationArg := applicationservice.AddApplicationArgs{
 			ReferenceName:    chURL.Name,
 			Storage:          args.Storage,
@@ -177,6 +182,9 @@ func DeployApplication(
 			ApplicationStatus: &status.StatusInfo{
 				Status: status.Unset,
 				Since:  ptr(clock.Now()),
+			},
+			ApplicationSettings: application.ApplicationSettings{
+				Trust: trust,
 			},
 		}
 		if modelType == coremodel.CAAS {

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kr/pretty"
 
 	"github.com/juju/juju/apiserver/facade"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
 	corebase "github.com/juju/juju/core/base"
 	corecharm "github.com/juju/juju/core/charm"
@@ -29,6 +30,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/status"
 	jujuversion "github.com/juju/juju/core/version"
+	"github.com/juju/juju/domain/application"
 	applicationcharm "github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	applicationservice "github.com/juju/juju/domain/application/service"
@@ -155,6 +157,9 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(ctx context.Context, ar
 		}
 	}
 
+	attrs := dt.applicationConfig.Attributes()
+	trust := attrs.GetBool(coreapplication.TrustConfigOptionName, false)
+
 	applicationArg := applicationservice.AddApplicationArgs{
 		ReferenceName: dt.charmURL.Name,
 		Storage:       dt.storage,
@@ -171,6 +176,9 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(ctx context.Context, ar
 		ApplicationStatus: &status.StatusInfo{
 			Status: status.Unset,
 			Since:  ptr(api.clock.Now()),
+		},
+		ApplicationSettings: application.ApplicationSettings{
+			Trust: trust,
 		},
 	}
 


### PR DESCRIPTION
Trust wasn't being passed to the application settings from the deployment arguments.

----

This pull request introduces support for handling application trust settings during deployment in both `DeployApplication` and `DeployFromRepository` functions. The changes ensure that trust settings are extracted from application configuration and passed to the respective application arguments.

### Enhancements to Deployment Logic:

* **Support for Trust Settings in `DeployApplication`:**
  - Added logic to extract the `Trust` setting from application configuration attributes using `coreapplication.TrustConfigOptionName`.
  - Passed the extracted `Trust` value into the `ApplicationSettings` field of `applicationservice.AddApplicationArgs`.

* **Support for Trust Settings in `DeployFromRepository`:**
  - Added logic to extract the `Trust` setting from application configuration attributes using `coreapplication.TrustConfigOptionName`.
  - Passed the extracted `Trust` value into the `ApplicationSettings` field of `applicationservice.AddApplicationArgs`.

### Import Additions:

* **New Imports in `deploy.go`:**
  - Added `coreapplication` for accessing application-related constants.
  - Added `application` for defining `ApplicationSettings`.

* **New Imports in `deployrepository.go`:**
  - Added `coreapplication` for accessing application-related constants.
  - Added `application` for defining `ApplicationSettings`.

## QA steps

```
$ juju boostrap k8s test
$ juju add-model default
$ juju deploy ubuntu --trust
$ lxc exec <container> -- bash
$ source /etc/profile.d/juju-introspection.sh
$ juju_db_repl
repl (controller)> .switch model-default
repl (model-default)> SELECT * FROM application
uuid                                    name    life_id charm_uuid                              charm_modified_version  charm_upgrade_on_error space_uuid
ef99fef5-42f9-441b-8462-414572e709ee    ubuntu  0       c957ccd7-9482-4557-847a-4c833ba03885    <nil>                   false 656b4a82-e28c-53d6-a014-f0dd53417eb6

repl (model-default)> SELECT * FROM application_setting
application_uuid                        trust
ef99fef5-42f9-441b-8462-414572e709ee    true
```
