### PR TITLE
fix: race in provisioner task for deferred stopping logic

### DIFF
--- a/internal/provisionertask/provisioner_task_test.go
+++ b/internal/provisionertask/provisioner_task_test.go
@@ -1000,7 +1000,7 @@ func (s *ProvisionerTaskSuite) TestDedupStartInstance(c *tc.C) {
 		s.sendModelMachinesChange(c, "0")
 	}
 
-	// Allow StartInstance to complete.
+	// Allow StartInstance to complete, which will trigger deferred stop.
 	close(continueCh)
 
 	// Wait for StopInstances to be called.


### PR DESCRIPTION
A first race in the provisioner task was fixed in
https://github.com/juju/juju/pull/20024, along with a test that fires start and stop events much more aggresively than other tests. The initial idea for this test was to ensure that the first identified race was fixed (i.e. we didn't try to call `StartInstance` more than once for each start event).

It turns out this test has also highlited another race, this time for deferred stop instances.

The fix is to filter the list of dead machines passed to
`queueRemovalOfDeadMachines` when stop deferred is set for the newly
started machines. Which was previously just called with the machine
without checking if it was already stopping.
The filter method has also been updated so that it locks
the stopping machines list, thus protecting for concurrent queuing of
already stopping machines.


## QA steps

Unit tests should pass, this has only been discovered in jenkins thanks to the race test detector.
Running with a higher count would show failures easier:
```
go test  github.com/juju/juju/internal/provisionertask/... -cover -race -count 100
```

There was no need to add another unit test, because the previously added one already tests this scenario.
