### PR TITLE
chore(testing): dump debug-log on wait_for timeout

### DIFF
--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -29,6 +29,10 @@ wait_for() {
 		elapsed=$(date -u +%s)-$start_time
 		if [[ ${elapsed} -ge ${timeout} ]]; then
 			echo "[-] $(red 'timed out waiting for')" "$(red "${name}")"
+			echo "    (controller) juju debug-log output"
+			juju debug-log -m controller --replay --no-tail 2>&1 | sed 's/^/    | /g'
+			echo "    (model) juju debug-log output"
+			juju debug-log --replay --no-tail 2>&1 | sed 's/^/    | /g'
 			exit 1
 		fi
 


### PR DESCRIPTION
This PR introduces extra debug info. When a wait_for operation times out in the testing scripts, it now dumps the juju debug-log for the controller and the current model. This provides valuable debugging information in CI when tests fail due to timeouts.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# just pass GitHub checks
```


## Links

**Jira card:** JUJU-
