### PR TITLE
feat: add AddMachine service method in favor of create machine methods

### DIFF
--- a/apiserver/facades/agent/reboot/reboot_test.go
+++ b/apiserver/facades/agent/reboot/reboot_test.go
@@ -59,7 +59,12 @@ func TestRebootSuite(t *testing.T) {
 }
 
 func (s *rebootSuite) createMachine(c *tc.C) *testMachine {
-	_, mNames, err := s.machineService.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
+	_, mNames, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
 	uuid, err := s.machineService.GetMachineUUID(c.Context(), mNames[0])
 	c.Assert(err, tc.ErrorIsNil)
@@ -68,10 +73,14 @@ func (s *rebootSuite) createMachine(c *tc.C) *testMachine {
 }
 
 func (s *rebootSuite) createContainer(c *tc.C, parent *testMachine) *testMachine {
-	_, mNames, err := s.machineService.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mNames, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Directive: deployment.Placement{
 			Type:      deployment.PlacementTypeContainer,
 			Directive: parent.tag.Id(),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/apiserver/facades/agent/reboot/reboot_test.go
+++ b/apiserver/facades/agent/reboot/reboot_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/juju/juju/core/watcher/registry"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/deployment"
+	domainmachine "github.com/juju/juju/domain/machine"
 	"github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/domain/machine/state"
 	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
@@ -57,17 +59,26 @@ func TestRebootSuite(t *testing.T) {
 }
 
 func (s *rebootSuite) createMachine(c *tc.C) *testMachine {
-	uuid, name, err := s.machineService.CreateMachine(c.Context(), service.CreateMachineArgs{})
+	_, mNames, err := s.machineService.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
+	c.Assert(err, tc.ErrorIsNil)
+	uuid, err := s.machineService.GetMachineUUID(c.Context(), mNames[0])
 	c.Assert(err, tc.ErrorIsNil)
 
-	return s.setupMachine(c, names.NewMachineTag(name.String()), err, uuid)
+	return s.setupMachine(c, names.NewMachineTag(mNames[0].String()), err, uuid)
 }
 
-func (s *rebootSuite) createMachineWithParent(c *tc.C, parent *testMachine) *testMachine {
-	uuid, name, err := s.machineService.CreateMachineWithParent(c.Context(), service.CreateMachineArgs{}, coremachine.Name(parent.tag.Id()))
+func (s *rebootSuite) createContainer(c *tc.C, parent *testMachine) *testMachine {
+	_, mNames, err := s.machineService.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		Directive: deployment.Placement{
+			Type:      deployment.PlacementTypeContainer,
+			Directive: parent.tag.Id(),
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	uuid, err := s.machineService.GetMachineUUID(c.Context(), mNames[1])
 	c.Assert(err, tc.ErrorIsNil)
 
-	return s.setupMachine(c, names.NewMachineTag(name.String()), err, uuid)
+	return s.setupMachine(c, names.NewMachineTag(mNames[1].String()), err, uuid)
 }
 
 func (s *rebootSuite) setupMachine(c *tc.C, tag names.MachineTag, err error, uuid coremachine.UUID) *testMachine {
@@ -164,7 +175,7 @@ func (s *rebootSuite) TearDownSuite(c *tc.C) {
 // and asserts that the child machine receives the reboot event while the parent machine does not.
 func (s *rebootSuite) TestWatchForRebootEventFromChild(c *tc.C) {
 	parent := s.createMachine(c)
-	child := s.createMachineWithParent(c, parent)
+	child := s.createContainer(c, parent)
 
 	_, err := child.rebootAPI.RequestReboot(c.Context(), child.args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -178,7 +189,7 @@ func (s *rebootSuite) TestWatchForRebootEventFromChild(c *tc.C) {
 // and asserts that both the parent machine and child receives a reboot event.
 func (s *rebootSuite) TestWatchForRebootEventFromParent(c *tc.C) {
 	parent := s.createMachine(c)
-	child := s.createMachineWithParent(c, parent)
+	child := s.createContainer(c, parent)
 
 	_, err := parent.rebootAPI.RequestReboot(c.Context(), parent.args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -257,7 +268,7 @@ func (s *rebootSuite) TestClearReboot(c *tc.C) {
 // It also verifies that the proper rebootEvent are sent.
 func (s *rebootSuite) TestRebootRequestFromParent(c *tc.C) {
 	parent := s.createMachine(c)
-	child := s.createMachineWithParent(c, parent)
+	child := s.createContainer(c, parent)
 	// Request reboot on the root machine: all machines should see it
 	// parent should reboot
 	// child should shutdown
@@ -304,7 +315,7 @@ func (s *rebootSuite) TestRebootRequestFromParent(c *tc.C) {
 // It also check that the correct events are sent.
 func (s *rebootSuite) TestRebootRequestFromChild(c *tc.C) {
 	parent := s.createMachine(c)
-	child := s.createMachineWithParent(c, parent)
+	child := s.createContainer(c, parent)
 
 	// Request reboot on the container: container and nested container should see it
 	// parent should do nothing

--- a/apiserver/facades/agent/reboot/reboot_test.go
+++ b/apiserver/facades/agent/reboot/reboot_test.go
@@ -59,21 +59,21 @@ func TestRebootSuite(t *testing.T) {
 }
 
 func (s *rebootSuite) createMachine(c *tc.C) *testMachine {
-	_, mNames, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	res, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
 			Channel: "22.04",
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	uuid, err := s.machineService.GetMachineUUID(c.Context(), mNames[0])
+	uuid, err := s.machineService.GetMachineUUID(c.Context(), res.MachineName)
 	c.Assert(err, tc.ErrorIsNil)
 
-	return s.setupMachine(c, names.NewMachineTag(mNames[0].String()), err, uuid)
+	return s.setupMachine(c, names.NewMachineTag(res.MachineName.String()), err, uuid)
 }
 
 func (s *rebootSuite) createContainer(c *tc.C, parent *testMachine) *testMachine {
-	_, mNames, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	res, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Directive: deployment.Placement{
 			Type:      deployment.PlacementTypeContainer,
 			Directive: parent.tag.Id(),
@@ -84,10 +84,12 @@ func (s *rebootSuite) createContainer(c *tc.C, parent *testMachine) *testMachine
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	uuid, err := s.machineService.GetMachineUUID(c.Context(), mNames[1])
+	c.Assert(res.ChildMachineName, tc.NotNil)
+	childMachineName := *res.ChildMachineName
+	uuid, err := s.machineService.GetMachineUUID(c.Context(), childMachineName)
 	c.Assert(err, tc.ErrorIsNil)
 
-	return s.setupMachine(c, names.NewMachineTag(mNames[1].String()), err, uuid)
+	return s.setupMachine(c, names.NewMachineTag(childMachineName.String()), err, uuid)
 }
 
 func (s *rebootSuite) setupMachine(c *tc.C, tag names.MachineTag, err error, uuid coremachine.UUID) *testMachine {

--- a/apiserver/facades/agent/uniter/uniter_legacy_test.go
+++ b/apiserver/facades/agent/uniter/uniter_legacy_test.go
@@ -452,7 +452,7 @@ func (s *uniterLegacySuite) TestStorageAttachments(c *tc.C) {
 }
 
 func (s *uniterLegacySuite) TestOpenedMachinePortRangesByEndpoint(c *tc.C) {
-	_, _, err := s.machineService.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
+	_, _, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.applicationService.AddIAASUnits(c.Context(), "mysql",

--- a/apiserver/facades/agent/uniter/uniter_legacy_test.go
+++ b/apiserver/facades/agent/uniter/uniter_legacy_test.go
@@ -452,7 +452,7 @@ func (s *uniterLegacySuite) TestStorageAttachments(c *tc.C) {
 }
 
 func (s *uniterLegacySuite) TestOpenedMachinePortRangesByEndpoint(c *tc.C) {
-	_, _, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{})
+	_, err := s.machineService.AddMachine(c.Context(), domainmachine.AddMachineArgs{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.applicationService.AddIAASUnits(c.Context(), "mysql",

--- a/apiserver/facades/agent/uniter/uniter_legacy_test.go
+++ b/apiserver/facades/agent/uniter/uniter_legacy_test.go
@@ -19,6 +19,7 @@ import (
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher/watchertest"
 	applicationservice "github.com/juju/juju/domain/application/service"
+	domainmachine "github.com/juju/juju/domain/machine"
 	machineservice "github.com/juju/juju/domain/machine/service"
 	portservice "github.com/juju/juju/domain/port/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -451,7 +452,7 @@ func (s *uniterLegacySuite) TestStorageAttachments(c *tc.C) {
 }
 
 func (s *uniterLegacySuite) TestOpenedMachinePortRangesByEndpoint(c *tc.C) {
-	_, _, err := s.machineService.CreateMachine(c.Context(), machineservice.CreateMachineArgs{})
+	_, _, err := s.machineService.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.applicationService.AddIAASUnits(c.Context(), "mysql",

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/domain/application"
 	applicationcharm "github.com/juju/juju/domain/application/charm"
 	applicationservice "github.com/juju/juju/domain/application/service"
-	machineservice "github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/domain/relation"
 	"github.com/juju/juju/domain/removal"
 	"github.com/juju/juju/domain/resolve"
@@ -104,8 +103,6 @@ type NetworkService interface {
 // MachineService defines the methods that the facade assumes from the Machine
 // service.
 type MachineService interface {
-	// CreateMachine creates the specified machine.
-	CreateMachine(ctx context.Context, args machineservice.CreateMachineArgs) (machine.UUID, machine.Name, error)
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 	// GetHardwareCharacteristics returns the hardware characteristics of the

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -30,7 +30,6 @@ import (
 	application0 "github.com/juju/juju/domain/application"
 	charm0 "github.com/juju/juju/domain/application/charm"
 	service "github.com/juju/juju/domain/application/service"
-	service0 "github.com/juju/juju/domain/machine/service"
 	relation0 "github.com/juju/juju/domain/relation"
 	removal "github.com/juju/juju/domain/removal"
 	resolve "github.com/juju/juju/domain/resolve"
@@ -527,46 +526,6 @@ func NewMockMachineService(ctrl *gomock.Controller) *MockMachineService {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 	return m.recorder
-}
-
-// CreateMachine mocks base method.
-func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 service0.CreateMachineArgs) (machine.UUID, machine.Name, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
-	ret0, _ := ret[0].(machine.UUID)
-	ret1, _ := ret[1].(machine.Name)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CreateMachine indicates an expected call of CreateMachine.
-func (mr *MockMachineServiceMockRecorder) CreateMachine(arg0, arg1 any) *MockMachineServiceCreateMachineCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockMachineService)(nil).CreateMachine), arg0, arg1)
-	return &MockMachineServiceCreateMachineCall{Call: call}
-}
-
-// MockMachineServiceCreateMachineCall wrap *gomock.Call
-type MockMachineServiceCreateMachineCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 machine.Name, arg2 error) *MockMachineServiceCreateMachineCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, service0.CreateMachineArgs) (machine.UUID, machine.Name, error)) *MockMachineServiceCreateMachineCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, service0.CreateMachineArgs) (machine.UUID, machine.Name, error)) *MockMachineServiceCreateMachineCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
 }
 
 // GetHardwareCharacteristics mocks base method.

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -14,13 +14,11 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/controller"
 	corelogger "github.com/juju/juju/core/logger"
-	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/unit"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/blockcommand"
-	machineservice "github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -29,13 +27,6 @@ type NodeService interface {
 	// CurateNodes modifies the control place by adding and
 	// removing node entries based on the input slices.
 	CurateNodes(context.Context, []string, []string) error
-}
-
-// MachineService is the interface that is used to interact with the machine
-// domain.
-type MachineService interface {
-	// CreateMachine creates the specified machine.
-	CreateMachine(ctx context.Context, args machineservice.CreateMachineArgs) (machine.UUID, machine.Name, error)
 }
 
 // ApplicationService instances add units to an application in dqlite state.
@@ -76,7 +67,6 @@ type HighAvailabilityAPI struct {
 	controllerTag           names.ControllerTag
 	isControllerModel       bool
 	nodeService             NodeService
-	machineService          MachineService
 	applicationService      ApplicationService
 	controllerConfigService ControllerConfigService
 	networkService          NetworkService

--- a/apiserver/facades/client/highavailability/register.go
+++ b/apiserver/facades/client/highavailability/register.go
@@ -59,7 +59,6 @@ func newHighAvailabilityAPI(stdCtx context.Context, ctx facade.ModelContext) (*H
 		controllerTag:           names.NewControllerTag(ctx.ControllerUUID()),
 		isControllerModel:       ctx.IsControllerModelScoped(),
 		nodeService:             domainServices.ControllerNode(),
-		machineService:          domainServices.Machine(),
 		applicationService:      applicationService,
 		controllerConfigService: domainServices.ControllerConfig(),
 		networkService:          domainServices.Network(),

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -245,7 +245,7 @@ func (mm *MachineManagerAPI) saveMachineInfo(ctx context.Context, nonce string) 
 	if nonce != "" {
 		n = &nonce
 	}
-	_, _, err := mm.machineService.PlaceMachine(ctx, domainmachine.PlaceMachineArgs{
+	_, _, err := mm.machineService.AddMachine(ctx, domainmachine.AddMachineArgs{
 		Nonce: n,
 	})
 	return errors.Trace(err)

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -245,7 +245,7 @@ func (mm *MachineManagerAPI) saveMachineInfo(ctx context.Context, nonce string) 
 	if nonce != "" {
 		n = &nonce
 	}
-	_, _, err := mm.machineService.AddMachine(ctx, domainmachine.AddMachineArgs{
+	_, err := mm.machineService.AddMachine(ctx, domainmachine.AddMachineArgs{
 		Nonce: n,
 	})
 	return errors.Trace(err)

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -28,8 +28,8 @@ import (
 	"github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	domainmachine "github.com/juju/juju/domain/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
-	machineservice "github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 	"github.com/juju/juju/rpc/params"
@@ -245,10 +245,9 @@ func (mm *MachineManagerAPI) saveMachineInfo(ctx context.Context, nonce string) 
 	if nonce != "" {
 		n = &nonce
 	}
-	createMachineArgs := machineservice.CreateMachineArgs{
+	_, _, err := mm.machineService.PlaceMachine(ctx, domainmachine.PlaceMachineArgs{
 		Nonce: n,
-	}
-	_, _, err := mm.machineService.CreateMachine(ctx, createMachineArgs)
+	})
 	return errors.Trace(err)
 }
 

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
 	blockcommanderrors "github.com/juju/juju/domain/blockcommand/errors"
-	machineservice "github.com/juju/juju/domain/machine/service"
+	domainmachine "github.com/juju/juju/domain/machine"
 	"github.com/juju/juju/environs/config"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/storage"
@@ -153,9 +153,9 @@ func (s *AddMachineManagerSuite) TestAddMachines(c *tc.C) {
 		},
 	}).Return(m1, nil)
 	// Machine 666.
-	s.machineService.EXPECT().CreateMachine(gomock.Any(), machineservice.CreateMachineArgs{})
+	s.machineService.EXPECT().PlaceMachine(gomock.Any(), domainmachine.PlaceMachineArgs{})
 	// Machine 667.
-	s.machineService.EXPECT().CreateMachine(gomock.Any(), machineservice.CreateMachineArgs{})
+	s.machineService.EXPECT().PlaceMachine(gomock.Any(), domainmachine.PlaceMachineArgs{})
 	s.st.EXPECT().AddOneMachine(state.MachineTemplate{
 		Base: state.UbuntuBase("22.04"),
 		Volumes: []state.HostVolumeParams{

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -153,9 +153,9 @@ func (s *AddMachineManagerSuite) TestAddMachines(c *tc.C) {
 		},
 	}).Return(m1, nil)
 	// Machine 666.
-	s.machineService.EXPECT().PlaceMachine(gomock.Any(), domainmachine.PlaceMachineArgs{})
+	s.machineService.EXPECT().AddMachine(gomock.Any(), domainmachine.AddMachineArgs{})
 	// Machine 667.
-	s.machineService.EXPECT().PlaceMachine(gomock.Any(), domainmachine.PlaceMachineArgs{})
+	s.machineService.EXPECT().AddMachine(gomock.Any(), domainmachine.AddMachineArgs{})
 	s.st.EXPECT().AddOneMachine(state.MachineTemplate{
 		Base: state.UbuntuBase("22.04"),
 		Volumes: []state.HostVolumeParams{

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -1369,6 +1369,46 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 	return m.recorder
 }
 
+// AddMachine mocks base method.
+func (m *MockMachineService) AddMachine(arg0 context.Context, arg1 machine0.AddMachineArgs) (string, []machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddMachine", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].([]machine.Name)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// AddMachine indicates an expected call of AddMachine.
+func (mr *MockMachineServiceMockRecorder) AddMachine(arg0, arg1 any) *MockMachineServiceAddMachineCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMachine", reflect.TypeOf((*MockMachineService)(nil).AddMachine), arg0, arg1)
+	return &MockMachineServiceAddMachineCall{Call: call}
+}
+
+// MockMachineServiceAddMachineCall wrap *gomock.Call
+type MockMachineServiceAddMachineCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceAddMachineCall) Return(arg0 string, arg1 []machine.Name, arg2 error) *MockMachineServiceAddMachineCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceAddMachineCall) Do(f func(context.Context, machine0.AddMachineArgs) (string, []machine.Name, error)) *MockMachineServiceAddMachineCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceAddMachineCall) DoAndReturn(f func(context.Context, machine0.AddMachineArgs) (string, []machine.Name, error)) *MockMachineServiceAddMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DeleteMachine mocks base method.
 func (m *MockMachineService) DeleteMachine(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()
@@ -1559,46 +1599,6 @@ func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machin
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// PlaceMachine mocks base method.
-func (m *MockMachineService) PlaceMachine(arg0 context.Context, arg1 machine0.PlaceMachineArgs) (string, []machine.Name, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PlaceMachine", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].([]machine.Name)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// PlaceMachine indicates an expected call of PlaceMachine.
-func (mr *MockMachineServiceMockRecorder) PlaceMachine(arg0, arg1 any) *MockMachineServicePlaceMachineCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlaceMachine", reflect.TypeOf((*MockMachineService)(nil).PlaceMachine), arg0, arg1)
-	return &MockMachineServicePlaceMachineCall{Call: call}
-}
-
-// MockMachineServicePlaceMachineCall wrap *gomock.Call
-type MockMachineServicePlaceMachineCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServicePlaceMachineCall) Return(arg0 string, arg1 []machine.Name, arg2 error) *MockMachineServicePlaceMachineCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServicePlaceMachineCall) Do(f func(context.Context, machine0.PlaceMachineArgs) (string, []machine.Name, error)) *MockMachineServicePlaceMachineCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServicePlaceMachineCall) DoAndReturn(f func(context.Context, machine0.PlaceMachineArgs) (string, []machine.Name, error)) *MockMachineServicePlaceMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -24,7 +24,7 @@ import (
 	unit "github.com/juju/juju/core/unit"
 	service "github.com/juju/juju/domain/agentbinary/service"
 	blockcommand "github.com/juju/juju/domain/blockcommand"
-	service0 "github.com/juju/juju/domain/machine/service"
+	machine0 "github.com/juju/juju/domain/machine"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
 	charmhub "github.com/juju/juju/internal/charmhub"
@@ -1369,46 +1369,6 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 	return m.recorder
 }
 
-// CreateMachine mocks base method.
-func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 service0.CreateMachineArgs) (machine.UUID, machine.Name, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
-	ret0, _ := ret[0].(machine.UUID)
-	ret1, _ := ret[1].(machine.Name)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CreateMachine indicates an expected call of CreateMachine.
-func (mr *MockMachineServiceMockRecorder) CreateMachine(arg0, arg1 any) *MockMachineServiceCreateMachineCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockMachineService)(nil).CreateMachine), arg0, arg1)
-	return &MockMachineServiceCreateMachineCall{Call: call}
-}
-
-// MockMachineServiceCreateMachineCall wrap *gomock.Call
-type MockMachineServiceCreateMachineCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 machine.Name, arg2 error) *MockMachineServiceCreateMachineCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, service0.CreateMachineArgs) (machine.UUID, machine.Name, error)) *MockMachineServiceCreateMachineCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, service0.CreateMachineArgs) (machine.UUID, machine.Name, error)) *MockMachineServiceCreateMachineCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // DeleteMachine mocks base method.
 func (m *MockMachineService) DeleteMachine(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()
@@ -1599,6 +1559,46 @@ func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machin
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// PlaceMachine mocks base method.
+func (m *MockMachineService) PlaceMachine(arg0 context.Context, arg1 machine0.PlaceMachineArgs) (string, []machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PlaceMachine", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].([]machine.Name)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PlaceMachine indicates an expected call of PlaceMachine.
+func (mr *MockMachineServiceMockRecorder) PlaceMachine(arg0, arg1 any) *MockMachineServicePlaceMachineCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlaceMachine", reflect.TypeOf((*MockMachineService)(nil).PlaceMachine), arg0, arg1)
+	return &MockMachineServicePlaceMachineCall{Call: call}
+}
+
+// MockMachineServicePlaceMachineCall wrap *gomock.Call
+type MockMachineServicePlaceMachineCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServicePlaceMachineCall) Return(arg0 string, arg1 []machine.Name, arg2 error) *MockMachineServicePlaceMachineCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServicePlaceMachineCall) Do(f func(context.Context, machine0.PlaceMachineArgs) (string, []machine.Name, error)) *MockMachineServicePlaceMachineCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServicePlaceMachineCall) DoAndReturn(f func(context.Context, machine0.PlaceMachineArgs) (string, []machine.Name, error)) *MockMachineServicePlaceMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -25,6 +25,7 @@ import (
 	service "github.com/juju/juju/domain/agentbinary/service"
 	blockcommand "github.com/juju/juju/domain/blockcommand"
 	machine0 "github.com/juju/juju/domain/machine"
+	service0 "github.com/juju/juju/domain/machine/service"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
 	charmhub "github.com/juju/juju/internal/charmhub"
@@ -1370,13 +1371,12 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // AddMachine mocks base method.
-func (m *MockMachineService) AddMachine(arg0 context.Context, arg1 machine0.AddMachineArgs) (string, []machine.Name, error) {
+func (m *MockMachineService) AddMachine(arg0 context.Context, arg1 machine0.AddMachineArgs) (service0.AddMachineResults, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddMachine", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].([]machine.Name)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(service0.AddMachineResults)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // AddMachine indicates an expected call of AddMachine.
@@ -1392,19 +1392,19 @@ type MockMachineServiceAddMachineCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceAddMachineCall) Return(arg0 string, arg1 []machine.Name, arg2 error) *MockMachineServiceAddMachineCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
+func (c *MockMachineServiceAddMachineCall) Return(arg0 service0.AddMachineResults, arg1 error) *MockMachineServiceAddMachineCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceAddMachineCall) Do(f func(context.Context, machine0.AddMachineArgs) (string, []machine.Name, error)) *MockMachineServiceAddMachineCall {
+func (c *MockMachineServiceAddMachineCall) Do(f func(context.Context, machine0.AddMachineArgs) (service0.AddMachineResults, error)) *MockMachineServiceAddMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceAddMachineCall) DoAndReturn(f func(context.Context, machine0.AddMachineArgs) (string, []machine.Name, error)) *MockMachineServiceAddMachineCall {
+func (c *MockMachineServiceAddMachineCall) DoAndReturn(f func(context.Context, machine0.AddMachineArgs) (service0.AddMachineResults, error)) *MockMachineServiceAddMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/services.go
+++ b/apiserver/facades/client/machinemanager/services.go
@@ -11,12 +11,13 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/machine"
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/blockcommand"
-	machineservice "github.com/juju/juju/domain/machine/service"
+	domainmachine "github.com/juju/juju/domain/machine"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/charmhub"
@@ -95,8 +96,12 @@ type Authorizer interface {
 
 // MachineService is the interface that is used to interact with the machines.
 type MachineService interface {
-	// CreateMachine creates a machine with the given name.
-	CreateMachine(ctx context.Context, args machineservice.CreateMachineArgs) (coremachine.UUID, coremachine.Name, error)
+	// PlaceMachine places the net node and machines if required, depending
+	// on the placement.
+	// It returns the net node UUID for the machine and a list of child
+	// machine names that were created as part of the placement.
+	PlaceMachine(ctx context.Context, args domainmachine.PlaceMachineArgs) (string, []machine.Name, error)
+
 	// DeleteMachine deletes a machine with the given name.
 	DeleteMachine(context.Context, coremachine.Name) error
 

--- a/apiserver/facades/client/machinemanager/services.go
+++ b/apiserver/facades/client/machinemanager/services.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/machine"
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -96,11 +95,11 @@ type Authorizer interface {
 
 // MachineService is the interface that is used to interact with the machines.
 type MachineService interface {
-	// PlaceMachine places the net node and machines if required, depending
+	// AddMachine creates the net node and machines if required, depending
 	// on the placement.
 	// It returns the net node UUID for the machine and a list of child
 	// machine names that were created as part of the placement.
-	PlaceMachine(ctx context.Context, args domainmachine.PlaceMachineArgs) (string, []machine.Name, error)
+	AddMachine(ctx context.Context, args domainmachine.AddMachineArgs) (string, []coremachine.Name, error)
 
 	// DeleteMachine deletes a machine with the given name.
 	DeleteMachine(context.Context, coremachine.Name) error

--- a/apiserver/facades/client/machinemanager/services.go
+++ b/apiserver/facades/client/machinemanager/services.go
@@ -17,6 +17,7 @@ import (
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/blockcommand"
 	domainmachine "github.com/juju/juju/domain/machine"
+	machineservice "github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/charmhub"
@@ -99,7 +100,7 @@ type MachineService interface {
 	// on the placement.
 	// It returns the net node UUID for the machine and a list of child
 	// machine names that were created as part of the placement.
-	AddMachine(ctx context.Context, args domainmachine.AddMachineArgs) (string, []coremachine.Name, error)
+	AddMachine(ctx context.Context, args domainmachine.AddMachineArgs) (machineservice.AddMachineResults, error)
 
 	// DeleteMachine deletes a machine with the given name.
 	DeleteMachine(context.Context, coremachine.Name) error

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1159,7 +1159,7 @@ func (st *State) insertIAASUnit(
 	}
 
 	// Handle the placement of the net node and machines accompanying the unit.
-	placeMachineArgs := domainmachine.PlaceMachineArgs{
+	placeMachineArgs := domainmachine.AddMachineArgs{
 		Constraints: args.Constraints,
 		Directive:   args.Placement,
 		Platform:    args.Platform,

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -1041,7 +1041,7 @@ func (s *unitStateSuite) TestGetUnitNamesForNetNodeNoUnits(c *tc.C) {
 	var netNode string
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		placeMachineArgs := domainmachine.PlaceMachineArgs{
+		placeMachineArgs := domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementTypeUnset,
 			},

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -29,6 +29,7 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/application/state"
+	"github.com/juju/juju/domain/deployment"
 	domainmachine "github.com/juju/juju/domain/machine"
 	machineservice "github.com/juju/juju/domain/machine/service"
 	machinestate "github.com/juju/juju/domain/machine/state"
@@ -1053,9 +1054,19 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachine(c *tc.C) {
 	)
 	removalSt := removalstate.NewState(modelDB, loggertesting.WrapCheckLog(c))
 
-	_, mNames0, err := machineSvc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
+	_, mNames0, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
-	_, mNames1, err := machineSvc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
+	_, mNames1, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	ctx := c.Context()
@@ -1142,9 +1153,19 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachineSubordinates(c *tc.C) {
 	)
 	removalSt := removalstate.NewState(modelDB, loggertesting.WrapCheckLog(c))
 
-	_, mNames0, err := machineSvc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
+	_, mNames0, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
-	_, mNames1, err := machineSvc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
+	_, mNames1, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	ctx := c.Context()

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -1054,14 +1054,14 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachine(c *tc.C) {
 	)
 	removalSt := removalstate.NewState(modelDB, loggertesting.WrapCheckLog(c))
 
-	_, mNames0, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	res0, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
 			Channel: "22.04",
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	_, mNames1, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	res1, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
 			Channel: "22.04",
@@ -1070,7 +1070,7 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachine(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	ctx := c.Context()
-	watcher, err := svc.WatchUnitAddRemoveOnMachine(ctx, mNames0[0])
+	watcher, err := svc.WatchUnitAddRemoveOnMachine(ctx, res0.MachineName)
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
@@ -1079,17 +1079,17 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachine(c *tc.C) {
 		s.createIAASApplication(c, svc, "foo",
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames0[0].String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: res0.MachineName.String()},
 				},
 			},
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames1[0].String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: res1.MachineName.String()},
 				},
 			},
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames0[0].String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: res0.MachineName.String()},
 				},
 			},
 		)
@@ -1153,14 +1153,14 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachineSubordinates(c *tc.C) {
 	)
 	removalSt := removalstate.NewState(modelDB, loggertesting.WrapCheckLog(c))
 
-	_, mNames0, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	res0, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
 			Channel: "22.04",
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	_, mNames1, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	res1, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
 			Channel: "22.04",
@@ -1169,7 +1169,7 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachineSubordinates(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	ctx := c.Context()
-	watcher, err := svc.WatchUnitAddRemoveOnMachine(ctx, mNames0[0])
+	watcher, err := svc.WatchUnitAddRemoveOnMachine(ctx, res0.MachineName)
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
@@ -1178,12 +1178,12 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachineSubordinates(c *tc.C) {
 		s.createIAASApplication(c, svc, "foo",
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames0[0].String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: res0.MachineName.String()},
 				},
 			},
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames1[0].String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: res1.MachineName.String()},
 				},
 			},
 		)

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -29,6 +29,7 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/application/state"
+	domainmachine "github.com/juju/juju/domain/machine"
 	machineservice "github.com/juju/juju/domain/machine/service"
 	machinestate "github.com/juju/juju/domain/machine/state"
 	domainnetwork "github.com/juju/juju/domain/network"
@@ -1052,13 +1053,13 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachine(c *tc.C) {
 	)
 	removalSt := removalstate.NewState(modelDB, loggertesting.WrapCheckLog(c))
 
-	_, mn0, err := machineSvc.CreateMachine(c.Context(), machineservice.CreateMachineArgs{})
+	_, mNames0, err := machineSvc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
 	c.Assert(err, tc.ErrorIsNil)
-	_, mn1, err := machineSvc.CreateMachine(c.Context(), machineservice.CreateMachineArgs{})
+	_, mNames1, err := machineSvc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	ctx := c.Context()
-	watcher, err := svc.WatchUnitAddRemoveOnMachine(ctx, mn0)
+	watcher, err := svc.WatchUnitAddRemoveOnMachine(ctx, mNames0[0])
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
@@ -1067,17 +1068,17 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachine(c *tc.C) {
 		s.createIAASApplication(c, svc, "foo",
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mn0.String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames0[0].String()},
 				},
 			},
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mn1.String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames1[0].String()},
 				},
 			},
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mn0.String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames0[0].String()},
 				},
 			},
 		)
@@ -1141,13 +1142,13 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachineSubordinates(c *tc.C) {
 	)
 	removalSt := removalstate.NewState(modelDB, loggertesting.WrapCheckLog(c))
 
-	_, mn0, err := machineSvc.CreateMachine(c.Context(), machineservice.CreateMachineArgs{})
+	_, mNames0, err := machineSvc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
 	c.Assert(err, tc.ErrorIsNil)
-	_, mn1, err := machineSvc.CreateMachine(c.Context(), machineservice.CreateMachineArgs{})
+	_, mNames1, err := machineSvc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	ctx := c.Context()
-	watcher, err := svc.WatchUnitAddRemoveOnMachine(ctx, mn0)
+	watcher, err := svc.WatchUnitAddRemoveOnMachine(ctx, mNames0[0])
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
@@ -1156,12 +1157,12 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachineSubordinates(c *tc.C) {
 		s.createIAASApplication(c, svc, "foo",
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mn0.String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames0[0].String()},
 				},
 			},
 			service.AddIAASUnitArg{
 				AddUnitArg: service.AddUnitArg{
-					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mn1.String()},
+					Placement: &instance.Placement{Scope: instance.MachineScope, Directive: mNames1[0].String()},
 				},
 			},
 		)

--- a/domain/machine/service/params.go
+++ b/domain/machine/service/params.go
@@ -3,15 +3,11 @@
 
 package service
 
-import (
-	"github.com/juju/juju/domain/constraints"
-	"github.com/juju/juju/domain/deployment"
-)
+import "github.com/juju/juju/core/machine"
 
-// CreateMachineArgs contains arguments for creating a machine.
-type CreateMachineArgs struct {
-	Constraints constraints.Constraints
-	Directive   deployment.Placement
-	Platform    deployment.Platform
-	Nonce       *string
+// AddMachineResults contains the results of adding a machine, i.e. the
+// machine's name along with a (optional) child machine name.
+type AddMachineResults struct {
+	MachineName      machine.Name
+	ChildMachineName *machine.Name
 }

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -54,7 +54,7 @@ func NewProviderService(
 	}
 }
 
-// PlaceMachine places the net node and machines if required, depending
+// AddMachine creates the net node and machines if required, depending
 // on the placement.
 // It returns the net node UUID for the machine and a list of child
 // machine names that were created as part of the placement.
@@ -62,7 +62,7 @@ func NewProviderService(
 // The following errors can be expected:
 // - [machineerrors.MachineNotFound] if the parent machine (for container
 // placement) does not exist.
-func (s *ProviderService) PlaceMachine(ctx context.Context, args domainmachine.PlaceMachineArgs) (string, []machine.Name, error) {
+func (s *ProviderService) AddMachine(ctx context.Context, args domainmachine.AddMachineArgs) (string, []machine.Name, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -87,7 +87,7 @@ func (s *ProviderService) PlaceMachine(ctx context.Context, args domainmachine.P
 		return "", nil, errors.Errorf("prechecking instance for create machine: %w", err)
 	}
 
-	nodeUUID, machineNames, err := s.st.PlaceMachine(ctx, args)
+	nodeUUID, machineNames, err := s.st.AddMachine(ctx, args)
 	if err != nil {
 		return "", nil, errors.Capture(err)
 	}
@@ -99,16 +99,6 @@ func (s *ProviderService) PlaceMachine(ctx context.Context, args domainmachine.P
 	}
 
 	return nodeUUID, machineNames, nil
-}
-
-func (s *ProviderService) makeCreateMachineArgs(args CreateMachineArgs, machineUUID machine.UUID) (domainmachine.CreateMachineArgs, error) {
-	return domainmachine.CreateMachineArgs{
-		Nonce:       args.Nonce,
-		MachineUUID: machineUUID,
-		Platform:    args.Platform,
-		Directive:   args.Directive,
-		Constraints: args.Constraints,
-	}, nil
 }
 
 func encodeOSType(ostype deployment.OSType) (string, error) {

--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -70,7 +70,7 @@ func (s *providerServiceSuite) TestAddMachineProviderNotSupported(c *tc.C) {
 	}
 
 	service := NewProviderService(s.state, s.statusHistory, providerGetter, clock.WallClock, loggertesting.WrapCheckLog(c))
-	_, _, err := service.AddMachine(c.Context(), domainmachine.AddMachineArgs{})
+	_, err := service.AddMachine(c.Context(), domainmachine.AddMachineArgs{})
 	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
 }
 
@@ -84,7 +84,7 @@ func (s *providerServiceSuite) TestAddMachineProviderFailed(c *tc.C) {
 		},
 	}).Return(errors.Errorf("boom"))
 
-	_, _, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	_, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
 			Channel: "22.04",
@@ -106,15 +106,14 @@ func (s *providerServiceSuite) TestAddMachine(c *tc.C) {
 
 	s.expectCreateMachineStatusHistory(c, machine.Name("name"))
 
-	netNodeUUID, obtainedNames, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	res, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
 			Channel: "22.04",
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(netNodeUUID, tc.Equals, "netNodeUUID")
-	c.Check(obtainedNames[0], tc.Equals, machine.Name("name"))
+	c.Check(res.MachineName, tc.Equals, machine.Name("name"))
 }
 
 func (s *providerServiceSuite) TestAddMachineSuccessNonce(c *tc.C) {
@@ -136,7 +135,7 @@ func (s *providerServiceSuite) TestAddMachineSuccessNonce(c *tc.C) {
 
 	s.expectCreateMachineStatusHistory(c, machine.Name("name"))
 
-	netNodeUUID, obtainedNames, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	res, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Nonce: ptr("foo"),
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
@@ -144,8 +143,7 @@ func (s *providerServiceSuite) TestAddMachineSuccessNonce(c *tc.C) {
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(netNodeUUID, tc.Equals, "netNodeUUID")
-	c.Check(obtainedNames[0], tc.Equals, machine.Name("name"))
+	c.Check(res.MachineName, tc.Equals, machine.Name("name"))
 }
 
 // TestAddMachineError asserts that an error coming from the state layer is
@@ -163,7 +161,7 @@ func (s *providerServiceSuite) TestAddMachineError(c *tc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().AddMachine(gomock.Any(), gomock.Any()).Return("", nil, rErr)
 
-	_, _, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+	_, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:  deployment.Ubuntu,
 			Channel: "22.04",

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -29,15 +29,11 @@ import (
 
 // State describes retrieval and persistence methods for machines.
 type State interface {
-	// CreateMachine persists the input machine entity.
-	CreateMachine(context.Context, domainmachine.CreateMachineArgs) (machine.Name, error)
-
-	// CreateMachineWithparent persists the input machine entity, associating it
-	// with the parent machine.
-	// It returns a MachineAlreadyExists error if a machine with the same name
-	// already exists.
-	// It returns a MachineNotFound error if the parent machine does not exist.
-	CreateMachineWithParent(context.Context, domainmachine.CreateMachineArgs, string) (machine.Name, error)
+	// PlaceMachine places the net node and machines if required, depending
+	// on the placement.
+	// It returns the net node UUID for the machine and a list of child
+	// machine names that were created as part of the placement.
+	PlaceMachine(ctx context.Context, args domainmachine.PlaceMachineArgs) (string, []machine.Name, error)
 
 	// DeleteMachine deletes the input machine entity.
 	DeleteMachine(context.Context, machine.Name) error

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -33,7 +33,7 @@ type State interface {
 	// on the placement.
 	// It returns the net node UUID for the machine and a list of child
 	// machine names that were created as part of the placement.
-	PlaceMachine(ctx context.Context, args domainmachine.PlaceMachineArgs) (string, []machine.Name, error)
+	AddMachine(ctx context.Context, args domainmachine.AddMachineArgs) (string, []machine.Name, error)
 
 	// DeleteMachine deletes the input machine entity.
 	DeleteMachine(context.Context, machine.Name) error

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -48,6 +48,46 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// AddMachine mocks base method.
+func (m *MockState) AddMachine(ctx context.Context, args machine0.AddMachineArgs) (string, []machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddMachine", ctx, args)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].([]machine.Name)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// AddMachine indicates an expected call of AddMachine.
+func (mr *MockStateMockRecorder) AddMachine(ctx, args any) *MockStateAddMachineCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMachine", reflect.TypeOf((*MockState)(nil).AddMachine), ctx, args)
+	return &MockStateAddMachineCall{Call: call}
+}
+
+// MockStateAddMachineCall wrap *gomock.Call
+type MockStateAddMachineCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAddMachineCall) Return(arg0 string, arg1 []machine.Name, arg2 error) *MockStateAddMachineCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAddMachineCall) Do(f func(context.Context, machine0.AddMachineArgs) (string, []machine.Name, error)) *MockStateAddMachineCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAddMachineCall) DoAndReturn(f func(context.Context, machine0.AddMachineArgs) (string, []machine.Name, error)) *MockStateAddMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // AllMachineNames mocks base method.
 func (m *MockState) AllMachineNames(arg0 context.Context) ([]machine.Name, error) {
 	m.ctrl.T.Helper()
@@ -1286,46 +1326,6 @@ func (c *MockStateNamespaceForWatchMachineRebootCall) Do(f func() string) *MockS
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateNamespaceForWatchMachineRebootCall) DoAndReturn(f func() string) *MockStateNamespaceForWatchMachineRebootCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// PlaceMachine mocks base method.
-func (m *MockState) PlaceMachine(ctx context.Context, args machine0.PlaceMachineArgs) (string, []machine.Name, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PlaceMachine", ctx, args)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].([]machine.Name)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// PlaceMachine indicates an expected call of PlaceMachine.
-func (mr *MockStateMockRecorder) PlaceMachine(ctx, args any) *MockStatePlaceMachineCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlaceMachine", reflect.TypeOf((*MockState)(nil).PlaceMachine), ctx, args)
-	return &MockStatePlaceMachineCall{Call: call}
-}
-
-// MockStatePlaceMachineCall wrap *gomock.Call
-type MockStatePlaceMachineCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStatePlaceMachineCall) Return(arg0 string, arg1 []machine.Name, arg2 error) *MockStatePlaceMachineCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStatePlaceMachineCall) Do(f func(context.Context, machine0.PlaceMachineArgs) (string, []machine.Name, error)) *MockStatePlaceMachineCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatePlaceMachineCall) DoAndReturn(f func(context.Context, machine0.PlaceMachineArgs) (string, []machine.Name, error)) *MockStatePlaceMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -203,84 +203,6 @@ func (c *MockStateClearMachineRebootCall) DoAndReturn(f func(context.Context, ma
 	return c
 }
 
-// CreateMachine mocks base method.
-func (m *MockState) CreateMachine(arg0 context.Context, arg1 machine0.CreateMachineArgs) (machine.Name, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
-	ret0, _ := ret[0].(machine.Name)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateMachine indicates an expected call of CreateMachine.
-func (mr *MockStateMockRecorder) CreateMachine(arg0, arg1 any) *MockStateCreateMachineCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockState)(nil).CreateMachine), arg0, arg1)
-	return &MockStateCreateMachineCall{Call: call}
-}
-
-// MockStateCreateMachineCall wrap *gomock.Call
-type MockStateCreateMachineCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateCreateMachineCall) Return(arg0 machine.Name, arg1 error) *MockStateCreateMachineCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateCreateMachineCall) Do(f func(context.Context, machine0.CreateMachineArgs) (machine.Name, error)) *MockStateCreateMachineCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateMachineCall) DoAndReturn(f func(context.Context, machine0.CreateMachineArgs) (machine.Name, error)) *MockStateCreateMachineCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// CreateMachineWithParent mocks base method.
-func (m *MockState) CreateMachineWithParent(arg0 context.Context, arg1 machine0.CreateMachineArgs, arg2 string) (machine.Name, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMachineWithParent", arg0, arg1, arg2)
-	ret0, _ := ret[0].(machine.Name)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateMachineWithParent indicates an expected call of CreateMachineWithParent.
-func (mr *MockStateMockRecorder) CreateMachineWithParent(arg0, arg1, arg2 any) *MockStateCreateMachineWithParentCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachineWithParent", reflect.TypeOf((*MockState)(nil).CreateMachineWithParent), arg0, arg1, arg2)
-	return &MockStateCreateMachineWithParentCall{Call: call}
-}
-
-// MockStateCreateMachineWithParentCall wrap *gomock.Call
-type MockStateCreateMachineWithParentCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateCreateMachineWithParentCall) Return(arg0 machine.Name, arg1 error) *MockStateCreateMachineWithParentCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateCreateMachineWithParentCall) Do(f func(context.Context, machine0.CreateMachineArgs, string) (machine.Name, error)) *MockStateCreateMachineWithParentCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateMachineWithParentCall) DoAndReturn(f func(context.Context, machine0.CreateMachineArgs, string) (machine.Name, error)) *MockStateCreateMachineWithParentCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // DeleteMachine mocks base method.
 func (m *MockState) DeleteMachine(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()
@@ -1364,6 +1286,46 @@ func (c *MockStateNamespaceForWatchMachineRebootCall) Do(f func() string) *MockS
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateNamespaceForWatchMachineRebootCall) DoAndReturn(f func() string) *MockStateNamespaceForWatchMachineRebootCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// PlaceMachine mocks base method.
+func (m *MockState) PlaceMachine(ctx context.Context, args machine0.PlaceMachineArgs) (string, []machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PlaceMachine", ctx, args)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].([]machine.Name)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PlaceMachine indicates an expected call of PlaceMachine.
+func (mr *MockStateMockRecorder) PlaceMachine(ctx, args any) *MockStatePlaceMachineCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlaceMachine", reflect.TypeOf((*MockState)(nil).PlaceMachine), ctx, args)
+	return &MockStatePlaceMachineCall{Call: call}
+}
+
+// MockStatePlaceMachineCall wrap *gomock.Call
+type MockStatePlaceMachineCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStatePlaceMachineCall) Return(arg0 string, arg1 []machine.Name, arg2 error) *MockStatePlaceMachineCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStatePlaceMachineCall) Do(f func(context.Context, machine0.PlaceMachineArgs) (string, []machine.Name, error)) *MockStatePlaceMachineCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStatePlaceMachineCall) DoAndReturn(f func(context.Context, machine0.PlaceMachineArgs) (string, []machine.Name, error)) *MockStatePlaceMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	coremachinetesting "github.com/juju/juju/core/machine/testing"
-	domainmachine "github.com/juju/juju/domain/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 )
 
@@ -39,13 +38,9 @@ func (s *stateSuite) TestGetHardwareCharacteristics(c *tc.C) {
 
 func (s *stateSuite) TestGetHardwareCharacteristicsWithoutAvailabilityZone(c *tc.C) {
 	// Create a reference machine.
-	machineUUID := coremachinetesting.GenUUID(c)
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: machineUUID,
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, _ := s.addMachine(c)
 
-	err = s.state.SetMachineCloudInstance(
+	err := s.state.SetMachineCloudInstance(
 		c.Context(),
 		machineUUID.String(),
 		instance.Id("123"),
@@ -95,13 +90,9 @@ func (s *stateSuite) TestSetInstanceData(c *tc.C) {
 	db := s.DB()
 
 	// Create a reference machine.
-	machineUUID := coremachinetesting.GenUUID(c)
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: machineUUID,
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, _ := s.addMachine(c)
 	// Add a reference AZ.
-	_, err = db.ExecContext(c.Context(), "INSERT INTO availability_zone VALUES('deadbeef-0bad-400d-8000-4b1d0d06f00d', 'az-1')")
+	_, err := db.ExecContext(c.Context(), "INSERT INTO availability_zone VALUES('deadbeef-0bad-400d-8000-4b1d0d06f00d', 'az-1')")
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = s.state.SetMachineCloudInstance(
@@ -174,13 +165,9 @@ func (s *stateSuite) TestSetInstanceDataEmptyInstanceID(c *tc.C) {
 	db := s.DB()
 
 	// Create a reference machine.
-	machineUUID := coremachinetesting.GenUUID(c)
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: machineUUID,
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, _ := s.addMachine(c)
 
-	err = s.state.SetMachineCloudInstance(
+	err := s.state.SetMachineCloudInstance(
 		c.Context(),
 		machineUUID.String(),
 		instance.Id(""),
@@ -204,13 +191,9 @@ func (s *stateSuite) TestSetInstanceDataEmptyDisplayName(c *tc.C) {
 	db := s.DB()
 
 	// Create a reference machine.
-	machineUUID := coremachinetesting.GenUUID(c)
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: machineUUID,
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, _ := s.addMachine(c)
 
-	err = s.state.SetMachineCloudInstance(
+	err := s.state.SetMachineCloudInstance(
 		c.Context(),
 		machineUUID.String(),
 		instance.Id("1"),
@@ -235,13 +218,9 @@ func (s *stateSuite) TestSetInstanceDataEmptyUniqueIndex(c *tc.C) {
 	// violate the unique index on the machine_cloud_instance table.
 	for range 10 {
 		// Create a reference machine.
-		machineUUID := coremachinetesting.GenUUID(c)
-		_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-			MachineUUID: machineUUID,
-		})
-		c.Assert(err, tc.ErrorIsNil)
+		machineUUID, _ := s.addMachine(c)
 
-		err = s.state.SetMachineCloudInstance(
+		err := s.state.SetMachineCloudInstance(
 			c.Context(),
 			machineUUID.String(),
 			instance.Id(""),
@@ -255,13 +234,9 @@ func (s *stateSuite) TestSetInstanceDataEmptyUniqueIndex(c *tc.C) {
 
 func (s *stateSuite) TestSetInstanceDataAlreadyExists(c *tc.C) {
 	// Create a reference machine.
-	machineUUID := coremachinetesting.GenUUID(c)
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: machineUUID,
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, _ := s.addMachine(c)
 
-	err = s.state.SetMachineCloudInstance(
+	err := s.state.SetMachineCloudInstance(
 		c.Context(),
 		machineUUID.String(),
 		instance.Id("1"),
@@ -320,13 +295,9 @@ func (s *stateSuite) TestInstanceIdSuccess(c *tc.C) {
 }
 
 func (s *stateSuite) TestInstanceIdError(c *tc.C) {
-	machineUUID := coremachinetesting.GenUUID(c)
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: machineUUID,
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, _ := s.addMachine(c)
 
-	_, err = s.state.GetInstanceID(c.Context(), machineUUID.String())
+	_, err := s.state.GetInstanceID(c.Context(), machineUUID.String())
 	c.Assert(err, tc.ErrorIs, machineerrors.NotProvisioned)
 }
 
@@ -340,13 +311,9 @@ func (s *stateSuite) TestInstanceNameSuccess(c *tc.C) {
 }
 
 func (s *stateSuite) TestInstanceNameError(c *tc.C) {
-	machineUUID := coremachinetesting.GenUUID(c)
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: machineUUID,
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, _ := s.addMachine(c)
 
-	_, _, err = s.state.GetInstanceIDAndName(c.Context(), machineUUID.String())
+	_, _, err := s.state.GetInstanceIDAndName(c.Context(), machineUUID.String())
 	c.Assert(err, tc.ErrorIs, machineerrors.NotProvisioned)
 }
 
@@ -354,13 +321,9 @@ func (s *stateSuite) ensureInstance(c *tc.C) (machine.UUID, machine.Name) {
 	db := s.DB()
 
 	// Create a reference machine.
-	machineUUID := coremachinetesting.GenUUID(c)
-	machineName, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: machineUUID,
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, machineName := s.addMachine(c)
 	// Add a reference AZ.
-	_, err = db.ExecContext(c.Context(), "INSERT INTO availability_zone VALUES('deadbeef-0bad-400d-8000-4b1d0d06f00d', 'az-1')")
+	_, err := db.ExecContext(c.Context(), "INSERT INTO availability_zone VALUES('deadbeef-0bad-400d-8000-4b1d0d06f00d', 'az-1')")
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = s.state.SetMachineCloudInstance(

--- a/domain/machine/state/placement.go
+++ b/domain/machine/state/placement.go
@@ -36,7 +36,7 @@ func PlaceMachine(
 	tx *sqlair.TX,
 	preparer domain.Preparer,
 	clock clock.Clock,
-	args domainmachine.PlaceMachineArgs,
+	args domainmachine.AddMachineArgs,
 ) (string, []coremachine.Name, error) {
 	switch args.Directive.Type {
 	case deployment.PlacementTypeUnset:

--- a/domain/machine/state/placement_test.go
+++ b/domain/machine/state/placement_test.go
@@ -42,7 +42,7 @@ func (s *placementSuite) SetUpTest(c *tc.C) {
 
 func (s *placementSuite) TestPlaceNetNodeMachinesInvalidPlacement(c *tc.C) {
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementType(666),
 			},
@@ -61,7 +61,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnset(c *tc.C) {
 	)
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		netNode, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		netNode, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementTypeUnset,
 			},
@@ -94,7 +94,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetWithPlatform(c *tc.C) {
 	}
 
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementTypeUnset,
 			},
@@ -114,7 +114,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetWithNonce(c *tc.C) {
 		err          error
 	)
 	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		_, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementTypeUnset,
 			},
@@ -135,7 +135,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetWithPlatformMissingArchite
 	}
 
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementTypeUnset,
 			},
@@ -155,7 +155,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetWithPlatformMissingBase(c 
 	}
 
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementTypeUnset,
 			},
@@ -177,7 +177,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetMultipleTimes(c *tc.C) {
 	var netNodes []string
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		for range total {
-			netNode, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+			netNode, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 				Directive: deployment.Placement{
 					Type: deployment.PlacementTypeUnset,
 				},
@@ -214,7 +214,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetMultipleTimesWithGaps(c *t
 	createMachines := func() {
 		err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 			for range stepTotal {
-				netNode, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+				netNode, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 					Directive: deployment.Placement{
 						Type: deployment.PlacementTypeUnset,
 					},
@@ -298,7 +298,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesExistingMachine(c *tc.C) {
 	var netNode string
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		netNode, _, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		netNode, _, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementTypeUnset,
 			},
@@ -313,7 +313,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesExistingMachine(c *tc.C) {
 	)
 	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		resultNetNode, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		resultNetNode, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type:      deployment.PlacementTypeMachine,
 				Directive: "0",
@@ -330,7 +330,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesExistingMachineNotFound(c *tc.C
 	// Try and place a machine that doesn't exist.
 
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type:      deployment.PlacementTypeMachine,
 				Directive: "0",
@@ -349,7 +349,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainer(c *tc.C) {
 	)
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		netNode, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		netNode, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type:      deployment.PlacementTypeContainer,
 				Container: deployment.ContainerTypeLXD,
@@ -382,7 +382,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainerWithDirective(c *tc.C)
 
 	// Insert a machine with no placement, then place a container on it.
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type: deployment.PlacementTypeUnset,
 			},
@@ -397,7 +397,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainerWithDirective(c *tc.C)
 	)
 	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		netNode, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		netNode, machineNames, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type:      deployment.PlacementTypeContainer,
 				Container: deployment.ContainerTypeLXD,
@@ -423,7 +423,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainerWithDirective(c *tc.C)
 
 func (s *placementSuite) TestPlaceNetNodeMachinesContainerWithDirectiveMachineNotFound(c *tc.C) {
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		_, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type:      deployment.PlacementTypeContainer,
 				Container: deployment.ContainerTypeLXD,
@@ -444,7 +444,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainerMultipleTimes(c *tc.C)
 	var netNodes []string
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		for range total {
-			netNode, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+			netNode, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 				Directive: deployment.Placement{
 					Type:      deployment.PlacementTypeContainer,
 					Container: deployment.ContainerTypeLXD,
@@ -486,7 +486,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainerMultipleTimesWithGaps(
 	createMachines := func() {
 		err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 			for range stepTotal {
-				netNode, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+				netNode, _, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 					Directive: deployment.Placement{
 						Type:      deployment.PlacementTypeContainer,
 						Container: deployment.ContainerTypeLXD,
@@ -591,7 +591,7 @@ func (s *placementSuite) TestPlaceNetNodeMachinesProvider(c *tc.C) {
 	var netNode string
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		netNode, _, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
+		netNode, _, err = PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.AddMachineArgs{
 			Directive: deployment.Placement{
 				Type:      deployment.PlacementTypeProvider,
 				Directive: "zone=eu-west-1",

--- a/domain/machine/state/reboot_test.go
+++ b/domain/machine/state/reboot_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/core/machine"
 	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/domain/deployment"
 	domainmachine "github.com/juju/juju/domain/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/internal/errors"
@@ -28,36 +30,30 @@ func (s *stateSuite) TestIsMachineRebootRequiredNoMachine(c *tc.C) {
 
 func (s *stateSuite) TestRequireMachineReboot(c *tc.C) {
 	// Setup: Create a machine.
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "deadbeef",
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	mUUID := s.createMachine(c)
 
 	// Call the function under test
-	err = s.state.RequireMachineReboot(c.Context(), "deadbeef")
+	err := s.state.RequireMachineReboot(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Verify: Check if the machine needs reboot
-	isRebootNeeded, err := s.state.IsMachineRebootRequired(c.Context(), "deadbeef")
+	isRebootNeeded, err := s.state.IsMachineRebootRequired(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(isRebootNeeded, tc.IsTrue)
 }
 
 func (s *stateSuite) TestRequireMachineRebootIdempotent(c *tc.C) {
 	// Setup: Create a machine.
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "deadbeef",
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	mUUID := s.createMachine(c)
 
 	// Call the function under test, twice (idempotency)
-	err = s.state.RequireMachineReboot(c.Context(), "deadbeef")
+	err := s.state.RequireMachineReboot(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	err = s.state.RequireMachineReboot(c.Context(), "deadbeef")
+	err = s.state.RequireMachineReboot(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Verify: Check if the machine needs reboot
-	isRebootNeeded, err := s.state.IsMachineRebootRequired(c.Context(), "deadbeef")
+	isRebootNeeded, err := s.state.IsMachineRebootRequired(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(isRebootNeeded, tc.IsTrue)
 }
@@ -88,40 +84,34 @@ func (s *stateSuite) TestRequireMachineRebootSeveralMachine(c *tc.C) {
 
 func (s *stateSuite) TestCancelMachineReboot(c *tc.C) {
 	// Setup: Create a machine and add its ID to the reboot table.
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "deadbeef",
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	err = s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, "deadbeef"))
+	mUUID := s.createMachine(c)
+	err := s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, mUUID))
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Call the function under test
-	err = s.state.ClearMachineReboot(c.Context(), "deadbeef")
+	err = s.state.ClearMachineReboot(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Verify: Check if the machine needs reboot
-	isRebootNeeded, err := s.state.IsMachineRebootRequired(c.Context(), "deadbeef")
+	isRebootNeeded, err := s.state.IsMachineRebootRequired(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(isRebootNeeded, tc.IsFalse)
 }
 
 func (s *stateSuite) TestCancelMachineRebootIdempotent(c *tc.C) {
 	// Setup: Create a machine and add its ID to the reboot table.
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "deadbeef",
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	err = s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, "deadbeef"))
+	mUUID := s.createMachine(c)
+	err := s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, mUUID))
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Call the function under test, twice (idempotency)
-	err = s.state.ClearMachineReboot(c.Context(), "deadbeef")
+	err = s.state.ClearMachineReboot(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	err = s.state.ClearMachineReboot(c.Context(), "deadbeef")
+	err = s.state.ClearMachineReboot(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Verify: Check if the machine needs reboot
-	isRebootNeeded, err := s.state.IsMachineRebootRequired(c.Context(), "deadbeef")
+	isRebootNeeded, err := s.state.IsMachineRebootRequired(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(isRebootNeeded, tc.IsFalse)
 }
@@ -158,13 +148,10 @@ func (s *stateSuite) TestRebootNotOrphan(c *tc.C) {
 	description := "orphan, non-rebooting machine, should do nothing"
 
 	// Setup: machines and parent if any and setup reboot if required in test case
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "deadbeef",
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	mUUID := s.createMachine(c)
 
 	// Call the function under test
-	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), "deadbeef")
+	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("use case: %s", description))
 
 	// Verify: Check which machine needs reboot
@@ -175,15 +162,12 @@ func (s *stateSuite) TestRebootOrphan(c *tc.C) {
 	description := "orphan, rebooting machine, should reboot"
 
 	// Setup: machines and parent if any and setup reboot if required in test case
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "deadbeef",
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	err = s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, "deadbeef"))
+	mUUID := s.createMachine(c)
+	err := s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, mUUID))
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Call the function under test
-	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), "deadbeef")
+	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), mUUID)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("use case: %s", description))
 
 	// Verify: Check which machine needs reboot
@@ -194,17 +178,10 @@ func (s *stateSuite) TestRebootNotParentChild(c *tc.C) {
 	description := "non-rebooting machine with non-rebooting parent, should do nothing"
 
 	// Setup: machines and parent if any and setup reboot if required in test case
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "parent-uuid",
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = s.state.CreateMachineWithParent(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "child-uuid",
-	}, "parent-uuid")
-	c.Assert(err, tc.ErrorIsNil)
+	_, childUUID := s.createContainer(c)
 
 	// Call the function under test
-	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), "child-uuid")
+	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), childUUID)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("use case: %s", description))
 
 	// Verify: Check which machine needs reboot
@@ -215,20 +192,13 @@ func (s *stateSuite) TestRebootChildNotParent(c *tc.C) {
 	description := "rebooting machine with non-rebooting parent, should reboot"
 
 	// Setup: machines and parent if any and setup reboot if required in test case
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "parent-uuid",
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = s.state.CreateMachineWithParent(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "child-uuid",
-	}, "parent-uuid")
-	c.Assert(err, tc.ErrorIsNil)
+	_, childUUID := s.createContainer(c)
 
-	err = s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, "child-uuid"))
+	err := s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, childUUID))
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Call the function under test
-	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), "child-uuid")
+	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), childUUID)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("use case: %s", description))
 
 	// Verify: Check which machine needs reboot
@@ -239,20 +209,13 @@ func (s *stateSuite) TestRebootParentNotChild(c *tc.C) {
 	description := "non-rebooting machine with rebooting parent, should shutdown"
 
 	// Setup: machines and parent if any and setup reboot if required in test case
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "parent-uuid",
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = s.state.CreateMachineWithParent(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "child-uuid",
-	}, "parent-uuid")
-	c.Assert(err, tc.ErrorIsNil)
+	parentUUID, childUUID := s.createContainer(c)
 
-	err = s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, "parent-uuid"))
+	err := s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, parentUUID))
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Call the function under test
-	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), "child-uuid")
+	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), childUUID)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("use case: %s", description))
 
 	// Verify: Check which machine needs reboot
@@ -263,22 +226,15 @@ func (s *stateSuite) TestRebootParentChild(c *tc.C) {
 	description := "rebooting machine with rebooting parent, should shutdown"
 
 	// Setup: machines and parent if any and setup reboot if required in test case
-	_, err := s.state.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "parent-uuid",
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = s.state.CreateMachineWithParent(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "child-uuid",
-	}, "parent-uuid")
-	c.Assert(err, tc.ErrorIsNil)
+	parentUUID, childUUID := s.createContainer(c)
 
-	err = s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, "parent-uuid"))
+	err := s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, parentUUID))
 	c.Assert(err, tc.ErrorIsNil)
-	err = s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, "child-uuid"))
+	err = s.runQuery(c, fmt.Sprintf(`INSERT INTO machine_requires_reboot (machine_uuid) VALUES ("%s")`, childUUID))
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Call the function under test
-	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), "child-uuid")
+	rebootAction, err := s.state.ShouldRebootOrShutdown(c.Context(), childUUID)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("use case: %s", description))
 
 	// Verify: Check which machine needs reboot
@@ -309,4 +265,26 @@ func (s *stateSuite) TestRebootLogicGrandParentNotSupported(c *tc.C) {
 
 	// Verify: grand parent are not supported
 	c.Assert(errors.Is(err, machineerrors.GrandParentNotSupported), tc.Equals, true, tc.Commentf("obtained error: %v", err))
+}
+
+func (s *stateSuite) createMachine(c *tc.C) machine.UUID {
+	_, mNames, err := s.state.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{})
+	c.Assert(err, tc.ErrorIsNil)
+	uuid, err := s.state.GetMachineUUID(c.Context(), mNames[0])
+	c.Assert(err, tc.ErrorIsNil)
+	return uuid
+}
+
+func (s *stateSuite) createContainer(c *tc.C) (machine.UUID, machine.UUID) {
+	_, mNames, err := s.state.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		Directive: deployment.Placement{
+			Type: deployment.PlacementTypeContainer,
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	parentUUID, err := s.state.GetMachineUUID(c.Context(), mNames[0])
+	c.Assert(err, tc.ErrorIsNil)
+	childUUID, err := s.state.GetMachineUUID(c.Context(), mNames[1])
+	c.Assert(err, tc.ErrorIsNil)
+	return parentUUID, childUUID
 }

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -47,7 +47,7 @@ func NewState(factory coredb.TxnRunnerFactory, clock clock.Clock, logger logger.
 	}
 }
 
-// PlaceMachine places the net node and machines if required, depending
+// AddMachine creates the net node and machines if required, depending
 // on the placement.
 // It returns the net node UUID for the machine and a list of child
 // machine names that were created as part of the placement.
@@ -55,7 +55,7 @@ func NewState(factory coredb.TxnRunnerFactory, clock clock.Clock, logger logger.
 // The following errors can be expected:
 // - [machineerrors.MachineNotFound] if the parent machine (for container
 // placement) does not exist.
-func (st *State) PlaceMachine(ctx context.Context, args domainmachine.PlaceMachineArgs) (string, []machine.Name, error) {
+func (st *State) AddMachine(ctx context.Context, args domainmachine.AddMachineArgs) (string, []machine.Name, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", nil, errors.Capture(err)
@@ -74,26 +74,6 @@ func (st *State) PlaceMachine(ctx context.Context, args domainmachine.PlaceMachi
 	}
 
 	return netNodeUUID, machineNames, nil
-}
-
-// CreateMachine creates or updates the specified machine.
-// Adds a row to machine table, as well as a row to the net_node table.
-func (st *State) CreateMachine(ctx context.Context, args domainmachine.CreateMachineArgs) (machine.Name, error) {
-	db, err := st.DB()
-	if err != nil {
-		return "", errors.Capture(err)
-	}
-
-	var machineName machine.Name
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		_, machineName, err = CreateMachine(ctx, tx, st, st.clock, args)
-		return err
-	})
-	if err != nil {
-		return "", errors.Capture(err)
-	}
-
-	return machineName, nil
 }
 
 // DeleteMachine deletes the specified machine and any dependent child records.

--- a/domain/machine/types.go
+++ b/domain/machine/types.go
@@ -28,8 +28,8 @@ type CreateMachineArgs struct {
 	Nonce       *string
 }
 
-// PlaceMachineArgs contains arguments for placing a machine.
-type PlaceMachineArgs struct {
+// AddMachineArgs contains arguments for adding a machine.
+type AddMachineArgs struct {
 	Constraints constraints.Constraints
 	Directive   deployment.Placement
 	Platform    deployment.Platform

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -64,7 +64,7 @@ func (s *watcherSuite) TestWatchModelMachines(c *tc.C) {
 	// Should fire when a machine is created.
 	var mName0 []machine.Name
 	harness.AddTest(func(c *tc.C) {
-		_, mName0, err = s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		_, mName0, err = s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 			Platform: deployment.Platform{
 				Channel: "24.04",
 				OSType:  deployment.Ubuntu,
@@ -77,7 +77,7 @@ func (s *watcherSuite) TestWatchModelMachines(c *tc.C) {
 	})
 	var mName1 []machine.Name
 	harness.AddTest(func(c *tc.C) {
-		_, mName1, err = s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		_, mName1, err = s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 			Platform: deployment.Platform{
 				Channel: "24.04",
 				OSType:  deployment.Ubuntu,
@@ -97,7 +97,7 @@ func (s *watcherSuite) TestWatchModelMachines(c *tc.C) {
 	})
 	// Should not fire on containers.
 	harness.AddTest(func(c *tc.C) {
-		_, _, err = s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		_, _, err = s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 			Platform: deployment.Platform{
 				Channel: "24.04",
 				OSType:  deployment.Ubuntu,
@@ -125,7 +125,7 @@ func (s *watcherSuite) TestWatchModelMachines(c *tc.C) {
 }
 
 func (s *watcherSuite) TestWatchModelMachinesInitialEventMachine(c *tc.C) {
-	_, mName0, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mName0, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -178,7 +178,7 @@ func (s *watcherSuite) TestWatchModelMachinesInitialEventMachine(c *tc.C) {
 // }
 
 func (s *watcherSuite) TestWatchModelMachineLifeStartTimesInitialEvent(c *tc.C) {
-	_, mName0, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mName0, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -204,7 +204,7 @@ func (s *watcherSuite) TestWatchModelMachineLifeStartTimes(c *tc.C) {
 	var mName0 []machine.Name
 	harness.AddTest(func(c *tc.C) {
 		var err error
-		_, mName0, err = s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		_, mName0, err = s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 			Platform: deployment.Platform{
 				Channel: "24.04",
 				OSType:  deployment.Ubuntu,
@@ -245,7 +245,7 @@ func (s *watcherSuite) TestWatchModelMachineLifeStartTimes(c *tc.C) {
 
 func (s *watcherSuite) TestMachineCloudInstanceWatchWithSet(c *tc.C) {
 	// Create a machineUUID and set its cloud instance.
-	_, mNames, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mNames, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -278,7 +278,7 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithSet(c *tc.C) {
 
 func (s *watcherSuite) TestMachineCloudInstanceWatchWithDelete(c *tc.C) {
 	// Create a machineUUID and set its cloud instance.
-	_, mNames, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mNames, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -313,7 +313,7 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithDelete(c *tc.C) {
 }
 
 func (s *watcherSuite) TestWatchLXDProfiles(c *tc.C) {
-	_, mNames0, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mNames0, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -325,7 +325,7 @@ func (s *watcherSuite) TestWatchLXDProfiles(c *tc.C) {
 	err = s.svc.SetMachineCloudInstance(c.Context(), machineUUIDm0, instance.Id("123"), "", "nonce", nil)
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, mNames1, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mNames1, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -378,7 +378,7 @@ func (s *watcherSuite) TestWatchLXDProfiles(c *tc.C) {
 // The tests are run using the watchertest harness.
 func (s *watcherSuite) TestWatchMachineForReboot(c *tc.C) {
 	// Create machine hierarchy to reboot from parent, with a child (which will be watched) and a control child
-	_, mNames, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mNames, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -393,7 +393,7 @@ func (s *watcherSuite) TestWatchMachineForReboot(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	childUUID, err := s.svc.GetMachineUUID(c.Context(), mNames[1])
 	c.Assert(err, tc.ErrorIsNil)
-	_, controlContainerNames, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, controlContainerNames, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -474,7 +474,7 @@ func (s *watcherSuite) TestWatchMachineLife(c *tc.C) {
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
 
 	harness.AddTest(func(c *tc.C) {
-		_, _, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		_, _, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 			Platform: deployment.Platform{
 				Channel: "24.04",
 				OSType:  deployment.Ubuntu,
@@ -487,7 +487,7 @@ func (s *watcherSuite) TestWatchMachineLife(c *tc.C) {
 
 	// Create a second machine, make sure it doesn't trigger a change.
 	harness.AddTest(func(c *tc.C) {
-		_, _, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		_, _, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 			Platform: deployment.Platform{
 				Channel: "24.04",
 				OSType:  deployment.Ubuntu,
@@ -516,7 +516,7 @@ func (s *watcherSuite) TestWatchMachineContainerLifeInit(c *tc.C) {
 }
 
 func (s *watcherSuite) TestWatchMachineContainerLifeInitMachine(c *tc.C) {
-	_, mName, err := s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+	_, mName, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			Channel: "24.04",
 			OSType:  deployment.Ubuntu,
@@ -598,7 +598,7 @@ func (s *watcherSuite) TestWatchMachineContainerLifeNoDispatch(c *tc.C) {
 
 	harness.AddTest(func(c *tc.C) {
 		var err error
-		_, _, err = s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		_, _, err = s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 			Platform: deployment.Platform{
 				Channel: "24.04",
 				OSType:  deployment.Ubuntu,
@@ -610,7 +610,7 @@ func (s *watcherSuite) TestWatchMachineContainerLifeNoDispatch(c *tc.C) {
 	})
 
 	harness.AddTest(func(c *tc.C) {
-		_, _, err = s.svc.PlaceMachine(c.Context(), domainmachine.PlaceMachineArgs{
+		_, _, err = s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 			Platform: deployment.Platform{
 				Channel: "24.04",
 				OSType:  deployment.Ubuntu,

--- a/domain/port/state/state_test.go
+++ b/domain/port/state/state_test.go
@@ -69,33 +69,30 @@ func (s *stateSuite) SetUpTest(c *tc.C) {
 
 	machineSt := machinestate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
-	_, err = machineSt.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "uuid0",
+	netNodeUUID0, machineNames0, err := machineSt.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			Channel: "24.04",
+			OSType:  deployment.Ubuntu,
+		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	_, err = machineSt.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "uuid1",
+	machineUUID0, err := machineSt.GetMachineUUID(c.Context(), machineNames0[0])
+	c.Assert(err, tc.ErrorIsNil)
+	netNodeUUID1, machineNames1, err := machineSt.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			Channel: "24.04",
+			OSType:  deployment.Ubuntu,
+		},
 	})
+	c.Assert(err, tc.ErrorIsNil)
+	machineUUID1, err := machineSt.GetMachineUUID(c.Context(), machineNames1[0])
 	c.Assert(err, tc.ErrorIsNil)
 
-	machineUUIDs = []string{"uuid0", "uuid1"}
-	netNodeUUIDs = []string{s.getNetNodeUUID(c, "uuid0"), s.getNetNodeUUID(c, "uuid1")}
+	machineUUIDs = []string{machineUUID0.String(), machineUUID1.String()}
+	netNodeUUIDs = []string{netNodeUUID0, netNodeUUID1}
 
 	s.appUUID = s.createApplicationWithRelations(c, appNames[0], "ep0", "ep1", "ep2")
 	s.unitUUID, s.unitName = s.createUnit(c, netNodeUUIDs[0], appNames[0])
-}
-
-func (s *baseSuite) getNetNodeUUID(c *tc.C, mUUID string) string {
-	var netNodeUUID string
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT net_node_uuid FROM machine WHERE uuid = ?", mUUID).Scan(&netNodeUUID)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	return netNodeUUID
 }
 
 func (s *baseSuite) createApplicationWithRelations(c *tc.C, appName string, relations ...string) coreapplication.ID {

--- a/domain/port/state/updateunitports_test.go
+++ b/domain/port/state/updateunitports_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
 	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/deployment"
 	domainmachine "github.com/juju/juju/domain/machine"
 	machinestate "github.com/juju/juju/domain/machine/state"
 	porterrors "github.com/juju/juju/domain/port/errors"
@@ -52,17 +53,27 @@ func (s *updateUnitPortsSuite) SetUpTest(c *tc.C) {
 
 	machineSt := machinestate.NewState(s.TxnRunnerFactory(), clock.WallClock, logger.GetLogger("juju.test.machine"))
 
-	_, err = machineSt.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "uuid0",
+	netNodeUUID0, machineNames0, err := machineSt.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			Channel: "24.04",
+			OSType:  deployment.Ubuntu,
+		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	_, err = machineSt.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "uuid1",
+	machineUUID0, err := machineSt.GetMachineUUID(c.Context(), machineNames0[0])
+	c.Assert(err, tc.ErrorIsNil)
+	netNodeUUID1, machineNames1, err := machineSt.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			Channel: "24.04",
+			OSType:  deployment.Ubuntu,
+		},
 	})
+	c.Assert(err, tc.ErrorIsNil)
+	machineUUID1, err := machineSt.GetMachineUUID(c.Context(), machineNames1[0])
 	c.Assert(err, tc.ErrorIsNil)
 
-	machineUUIDs = []string{"uuid0", "uuid1"}
-	netNodeUUIDs = []string{s.getNetNodeUUID(c, "uuid0"), s.getNetNodeUUID(c, "uuid1")}
+	machineUUIDs = []string{machineUUID0.String(), machineUUID1.String()}
+	netNodeUUIDs = []string{netNodeUUID0, netNodeUUID1}
 
 	s.appUUID = s.createApplicationWithRelations(c, appNames[0], "ep0", "ep1", "ep2")
 	s.unitUUID, s.unitName = s.createUnit(c, netNodeUUIDs[0], appNames[0])

--- a/domain/port/watcher_test.go
+++ b/domain/port/watcher_test.go
@@ -87,30 +87,27 @@ func (s *watcherSuite) SetUpTest(c *tc.C) {
 
 	machineSt := machinestate.NewState(s.TxnRunnerFactory(), clock.WallClock, logger.GetLogger("juju.test.machine"))
 
-	_, err = machineSt.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "uuid0",
+	netNodeUUID0, machineNames0, err := machineSt.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			Channel: "24.04",
+			OSType:  deployment.Ubuntu,
+		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	_, err = machineSt.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
-		MachineUUID: "uuid1",
+	machineUUID0, err := machineSt.GetMachineUUID(c.Context(), machineNames0[0])
+	c.Assert(err, tc.ErrorIsNil)
+	netNodeUUID1, machineNames1, err := machineSt.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			Channel: "24.04",
+			OSType:  deployment.Ubuntu,
+		},
 	})
+	c.Assert(err, tc.ErrorIsNil)
+	machineUUID1, err := machineSt.GetMachineUUID(c.Context(), machineNames1[0])
 	c.Assert(err, tc.ErrorIsNil)
 
-	machineUUIDs = []string{"uuid0", "uuid1"}
-	netNodeUUIDs = []string{s.getNetNodeUUID(c, "uuid0"), s.getNetNodeUUID(c, "uuid1")}
-}
-
-func (s *watcherSuite) getNetNodeUUID(c *tc.C, mUUID machine.UUID) string {
-	var netNodeUUID string
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT net_node_uuid FROM machine WHERE uuid = ?", mUUID).Scan(&netNodeUUID)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	return netNodeUUID
+	machineUUIDs = []string{machineUUID0.String(), machineUUID1.String()}
+	netNodeUUIDs = []string{netNodeUUID0, netNodeUUID1}
 }
 
 func (s *watcherSuite) createApplicationWithRelations(c *tc.C, appName string, relations ...string) coreapplication.ID {

--- a/domain/status/state/modelstate_test.go
+++ b/domain/status/state/modelstate_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	corelife "github.com/juju/juju/core/life"
 	coremachine "github.com/juju/juju/core/machine"
-	machinetesting "github.com/juju/juju/core/machine/testing"
 	"github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	corerelation "github.com/juju/juju/core/relation"
@@ -2483,14 +2482,16 @@ func (s *modelStateSuite) addRelationToApplication(c *tc.C, appUUID coreapplicat
 
 func (s *modelStateSuite) createMachine(c *tc.C) (coremachine.UUID, coremachine.Name) {
 	machineState := machinestate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-	mUUID := machinetesting.GenUUID(c)
-	name, err := machineState.CreateMachine(c.Context(), domainmachine.CreateMachineArgs{
+
+	_, machineNames, err := machineState.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
 			OSType:       deployment.Ubuntu,
 			Architecture: architecture.AMD64,
 		},
-		MachineUUID: mUUID,
 	})
+	c.Assert(err, tc.ErrorIsNil)
+	name := machineNames[0]
+	mUUID, err := machineState.GetMachineUUID(c.Context(), name)
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = machineState.SetMachineCloudInstance(


### PR DESCRIPTION
This patch refactors the machine domain to use the same logic every time we want to place a new machine. Since the logic is defined in the machine placement (sub-) domain, we don't allow manual creation of machines with parents. In any case this wasn't actually needed, because a machine with a parent is always a container, which is taken care of by the `AddMachine` method.

As a fly-by, the `CreateMachine` method in the state layer was only used in tests, so it's removed. Usages replaced by `AddMachine`.



## QA steps

This is only a first step towards having validated arguments when creating machines. Deployment should work as usual:

```
juju bootstrap lxd c
juju add-model m
juju deploy ubuntu
```


## Links

**Jira card:** JUJU-8227
