### PR TITLE
refactor: move k8s image away from docker

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       CHARM_localhost: apache2
       CHARM_microk8s: snappass-test
-      DOCKER_REGISTRY: 10.152.183.69
+      OCI_REGISTRY: 10.152.183.69
       UPGRADE_FLAGS_localhost: --build-agent
       UPGRADE_FLAGS_microk8s: --agent-stream=develop
       MODEL_TYPE_localhost: iaas
@@ -139,7 +139,7 @@ jobs:
           # Wait for registry
           sg snap_microk8s "microk8s kubectl wait --for condition=available deployment registry -n container-registry --timeout 180s" || true
           sg snap_microk8s "microk8s kubectl describe pod -n container-registry"
-          curl https://${DOCKER_REGISTRY}/v2/
+          curl https://${OCI_REGISTRY}/v2/
 
       - name: Mirror docker images required for juju bootstrap
         if: matrix.cloud == 'microk8s'
@@ -152,16 +152,16 @@ jobs:
           BUILD_TEMP=$(mktemp -d)
           cp ~/certs/ca.crt $BUILD_TEMP/
           cat >$BUILD_TEMP/Dockerfile <<EOL
-            FROM docker.io/jujusolutions/jujud-operator:${SOURCE_JUJU_VERSION}
+            FROM ghcr.io/juju/jujud-operator:${SOURCE_JUJU_VERSION}
           
             COPY ca.crt /usr/local/share/ca-certificates/ca.crt
 
             RUN update-ca-certificates
           EOL
-          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}
-          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}
+          docker build $BUILD_TEMP -t ${OCI_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}
+          docker push ${OCI_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}
           
-          DOCKER_USERNAME=${DOCKER_REGISTRY}/test-repo make seed-repository
+          OCI_REGISTRY_USERNAME=${OCI_REGISTRY}/test-repo make seed-repository
 
       - name: Bootstrap Juju - localhost
         if: matrix.cloud == 'localhost'
@@ -190,7 +190,7 @@ jobs:
           sg snap_microk8s <<EOF
             juju bootstrap microk8s c \
               --constraints "arch=$(go env GOARCH)" \
-              --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
+              --config caas-image-repo="${OCI_REGISTRY}/test-repo" \
               --config features="[developer-mode]"
           EOF
           juju version
@@ -226,8 +226,11 @@ jobs:
         if: matrix.cloud == 'microk8s'
         env:
           TARGET_JUJU_VERSION: ${{ needs.setup.outputs.version }}
+          GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
+
+          echo "$GHCR_PAT" | docker login ghcr.io -u USERNAME --password-stdin
 
           make operator-image
 
@@ -235,14 +238,14 @@ jobs:
           BUILD_TEMP=$(mktemp -d)
           cp ~/certs/ca.crt $BUILD_TEMP/
           cat >$BUILD_TEMP/Dockerfile <<EOL
-            FROM docker.io/jujusolutions/jujud-operator:${TARGET_JUJU_VERSION}
-          
+            FROM ghcr.io/juju/jujud-operator:${TARGET_JUJU_VERSION}          
+
             COPY ca.crt /usr/local/share/ca-certificates/ca.crt
 
             RUN update-ca-certificates
           EOL
-          docker build $BUILD_TEMP -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}
-          docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}
+          docker build $BUILD_TEMP -t ${OCI_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}
+          docker push ${OCI_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}
 
       - name: Preflight
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -597,7 +597,7 @@ check-deps:
 
 # CAAS related targets
 export OCI_BUILDER         ?= $(shell (which podman 2>&1 > /dev/null && echo podman) || echo docker )
-DOCKER_USERNAME            ?= docker.io/jujusolutions
+OCI_REGISTRY_USERNAME            ?= ghcr.io/juju
 DOCKER_BUILDX_CONTEXT      ?= juju-make
 DOCKER_STAGING_DIR         ?= ${BUILD_DIR}/docker-staging
 JUJUD_STAGING_DIR          ?= ${DOCKER_STAGING_DIR}/jujud-operator
@@ -664,7 +664,7 @@ push-release-operator-image: operator-image
 
 .PHONY: seed-repository
 seed-repository:
-## seed-repository: Copy required juju images from docker.io/jujusolutions
+## seed-repository: Copy required juju images from oci repository
 	JUJU_DB_VERSION=$(JUJU_DB_VERSION) $(SEED_REPOSITORY)
 
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -105,7 +105,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	mc.AddExpr(`_.Results[0].CACert`, jc.Ignore)
 	c.Assert(result, mc, params.CAASApplicationProvisioningInfoResults{
 		Results: []params.CAASApplicationProvisioningInfo{{
-			ImageRepo:    params.DockerImageInfo{RegistryPath: "docker.io/jujusolutions/jujud-operator:2.6-beta3.666"},
+			ImageRepo:    params.DockerImageInfo{RegistryPath: "ghcr.io/juju/jujud-operator:2.6-beta3.666"},
 			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -137,10 +137,10 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfoResults{
 		Results: []params.OperatorProvisioningInfo{{
 			ImageDetails: params.DockerImageInfo{
-				RegistryPath: "docker.io/jujusolutions/jujud-operator:2.6-beta3.666",
+				RegistryPath: "ghcr.io/juju/jujud-operator:2.6-beta3.666",
 			},
 			BaseImageDetails: params.DockerImageInfo{
-				RegistryPath: "docker.io/jujusolutions/charm-base:ubuntu-20.04",
+				RegistryPath: "ghcr.io/juju/charm-base:ubuntu-20.04",
 			},
 			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -239,7 +239,7 @@ func (s *CAASProvisionerSuite) assertProvisioningInfo(c *gc.C, isRawK8sSpec bool
 			ServiceType:    "loadbalancer",
 		},
 		ImageRepo: params.DockerImageInfo{
-			RegistryPath: fmt.Sprintf("docker.io/jujusolutions/jujud-operator:%s", expectedVersion.String()),
+			RegistryPath: fmt.Sprintf("ghcr.io/juju/jujud-operator:%s", expectedVersion.String()),
 		},
 		Devices: []params.KubernetesDeviceParams{
 			{

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	JujudOCINamespace = "docker.io/jujusolutions"
+	JujudOCINamespace = "ghcr.io/juju"
 	JujudOCIName      = "jujud-operator"
 	JujudbOCIName     = "juju-db"
 	CharmBaseName     = "charm-base"

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -65,13 +65,13 @@ func (*imageSuite) TestImageForBase(c *gc.C) {
 		Track: "20.04", Risk: charm.Stable,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.DeepEquals, `docker.io/jujusolutions/charm-base:ubuntu-20.04`)
+	c.Assert(path, gc.DeepEquals, `ghcr.io/juju/charm-base:ubuntu-20.04`)
 
 	path, err = podcfg.ImageForBase("", charm.Base{Name: "ubuntu", Channel: charm.Channel{
 		Track: "20.04", Risk: charm.Edge,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.DeepEquals, `docker.io/jujusolutions/charm-base:ubuntu-20.04-edge`)
+	c.Assert(path, gc.DeepEquals, `ghcr.io/juju/charm-base:ubuntu-20.04-edge`)
 }
 
 func (*imageSuite) TestRecoverRepoFromOperatorPath(c *gc.C) {

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -69,10 +69,10 @@ func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 	podConfig.JujuVersion = version.MustParse("6.6.6.666")
 	path, err := podConfig.GetControllerImagePath()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.Equals, "docker.io/jujusolutions/jujud-operator:6.6.6.666")
+	c.Assert(path, gc.Equals, "ghcr.io/juju/jujud-operator:6.6.6.666")
 	path, err = podConfig.GetJujuDbOCIImagePath()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.Equals, "docker.io/jujusolutions/juju-db:9.9")
+	c.Assert(path, gc.Equals, "ghcr.io/juju/juju-db:9.9")
 }
 
 func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -11,9 +11,11 @@ JUJUD_BIN_DIR=${JUJUD_BIN_DIR:-${BUILD_DIR}/bin}
 JUJU_BUILD_NUMBER=${JUJU_BUILD_NUMBER:-}
 JUJU_DB_VERSION=${JUJU_DB_VERSION:-}
 
-# Docker variables
+# OCI variables
 OCI_BUILDER=${OCI_BUILDER:-docker}
-DOCKER_USERNAME=${DOCKER_USERNAME:-docker.io/jujusolutions}
+OCI_REGISTRY_USERNAME=${OCI_REGISTRY_USERNAME:-ghcr.io/juju}
+
+# Docker variables
 DOCKER_BUILDX_CONTEXT=${DOCKER_BUILDX_CONTEXT:-juju-make}
 DOCKER_STAGING_DIR="${BUILD_DIR}/docker-staging"
 DOCKER_BIN=${DOCKER_BIN:-$(which ${OCI_BUILDER} || true)}
@@ -62,7 +64,7 @@ juju_version() {
 
 operator_image_release_path() {
     juju_version=$(juju_version)
-    echo "${DOCKER_USERNAME}/jujud-operator:$(_image_version $juju_version)"
+    echo "${OCI_REGISTRY_USERNAME}/jujud-operator:$(_image_version $juju_version)"
 }
 
 operator_image_path() {
@@ -70,7 +72,7 @@ operator_image_path() {
     if [[ -z "${JUJU_BUILD_NUMBER}" ]] || [[ ${JUJU_BUILD_NUMBER} -eq 0 ]]; then
         operator_image_release_path
     else
-        echo "${DOCKER_USERNAME}/jujud-operator:$(_image_version "$juju_version").${JUJU_BUILD_NUMBER}"
+        echo "${OCI_REGISTRY_USERNAME}/jujud-operator:$(_image_version "$juju_version").${JUJU_BUILD_NUMBER}"
     fi
 }
 
@@ -154,15 +156,15 @@ build_push_operator_image() {
 
 seed_repository() {
   set -x
-  "$DOCKER_BIN" pull "docker.io/jujusolutions/juju-db:${JUJU_DB_VERSION}"
-	"$DOCKER_BIN" tag "docker.io/jujusolutions/juju-db:${JUJU_DB_VERSION}" "${DOCKER_USERNAME}/juju-db:${JUJU_DB_VERSION}"
-	"$DOCKER_BIN" push "${DOCKER_USERNAME}/juju-db:${JUJU_DB_VERSION}"
+  "$DOCKER_BIN" pull "ghcr.io/juju/juju-db:${JUJU_DB_VERSION}"
+	"$DOCKER_BIN" tag "ghcr.io/juju/juju-db:${JUJU_DB_VERSION}" "${OCI_REGISTRY_USERNAME}/juju-db:${JUJU_DB_VERSION}"
+	"$DOCKER_BIN" push "${OCI_REGISTRY_USERNAME}/juju-db:${JUJU_DB_VERSION}"
 
   # copy all the lts that are available
   for (( i = 18; ; i += 2 )); do
-    if "$DOCKER_BIN" pull "docker.io/jujusolutions/charm-base:ubuntu-$i.04" ; then
-      "$DOCKER_BIN" tag "docker.io/jujusolutions/charm-base:ubuntu-$i.04" "${DOCKER_USERNAME}/charm-base:ubuntu-$i.04"
-      "$DOCKER_BIN" push "${DOCKER_USERNAME}/charm-base:ubuntu-$i.04"
+    if "$DOCKER_BIN" pull "ghcr.io/juju/charm-base:ubuntu-$i.04" ; then
+      "$DOCKER_BIN" tag "ghcr.io/juju/charm-base:ubuntu-$i.04" "${OCI_REGISTRY_USERNAME}/charm-base:ubuntu-$i.04"
+      "$DOCKER_BIN" push "${OCI_REGISTRY_USERNAME}/charm-base:ubuntu-$i.04"
     else
       break
     fi

--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -31,8 +31,8 @@ timeout 110s sh <<EOT || echo "Timed out waiting to install microk8s image."
 echo "Wait for microk8s to be ready if needed."
 microk8s.status --wait-ready --timeout 30 2>&1
 juju_version=\$(/snap/bin/juju version | rev | cut -d- -f3- | rev)
-oci_image="docker.io/jujusolutions/jujud-operator:\$juju_version"
-mongo_image="docker.io/jujusolutions/juju-db:4.4"
+oci_image="ghcr.io/juju/jujud-operator:\$juju_version"
+mongo_image="ghcr.io/juju/juju-db:4.4"
 
 echo "Going to cache images: \$oci_image and \$mongo_image."
 echo "Pulling: \$oci_image."


### PR DESCRIPTION
Modify default k8s image from docker to ghcr. Currently for model migration, the pod image will be updated to that of the target controller. For controller upgrade, models and applications image will not be updated. For model upgrade, the models and applications image will be updated. 

Git workflow and make functions are also updated to ghcr to test pushing/pulling from the new container registry during CI.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
### **Migration**
1. Bootstrap controller1 with current image OCI namespace
```sh
juju bootstrap minikube minikubeoriginal --debug
```

2. Add a model
```sh
juju add-model minikubeoriginalmodel
```

3. Verify image of original model pod to be from docker
```sh
kubectl get pod $(kubectl get pods -n minikubeoriginalmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeoriginalmodel -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/jujud-operator:3.6-rc3
```

4. Deploy an application
```sh
juju deploy mysql-k8s
```

5. Verify image of mysql charm in original model to be from docker
```sh
kubectl get pod mysql-k8s-0 -n minikubeoriginalmodel  -o=jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-22.04 registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9a
```

6. Change docker username in make_functions.sh to ghcr
`DOCKER_USERNAME=${DOCKER_USERNAME:-ghcr.io/juju}`

7. Bootstrap controller2 with updated image OCI namespace (After check out branch, version might be different from 3.6-rc3 depending on your juju client or simplestreams directory. Also remember to remove image if there is an existing docker image of the same name/repo + tag causing code to not be updated) 
```sh
[OPTIONAL] docker rmi [image_id]
make minikube-operator-update && juju bootstrap minikube minikubeupdated --debug
```

8. Add a model
```sh
juju add-model minikubeupdatedmodel
```

9. Verify image of updated model pod to be from ghcr
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"

ghcr.io/juju/jujud-operator:3.6-rc3
```

10. Deploy an application
```sh
juju deploy mysql-k8s
```

11. Verify image of mysql charm in updated model to be from ghcr
```sh
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel  -o=jsonpath="{.spec.containers[*].image}"

ghcr.io/juju/charm-base:ubuntu-22.04 registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9
```

12. Migrate model from minikubeupdated to minikubeoriginal (Image is now updated from ghcr to docker)
```sh
juju migrate minikubeupdatedmodel minikubeoriginal
```

13. Verify image of updated model pod to be changed to docker now
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/jujud-operator:3.6-rc3
```

14. Verify image of mysql charm in original model to be from docker now
```sh
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel  -o=jsonpath="{.spec.containers[*].image}"
```

15. Migrate model from minikubeoriginal to minikubeupdated (Image is now updated from docker to ghcr)
```sh
juju switch minikubeoriginal
juju migrate minikubeoriginalmodel minikubeupdated
```

16. Verify image of original model pod to be changed to ghcr now
```
kubectl get pod $(kubectl get pods -n minikubeoriginalmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeoriginalmodel -o jsonpath="{.spec.containers[*].image}"

ghcr.io/juju/jujud-operator:3.6-rc3
```

17. Verify image of mysql charm in original model to be from ghcr now
```sh
kubectl get pod mysql-k8s-0 -n minikubeoriginalmodel  -o=jsonpath="{.spec.containers[*].image}"
```


### ***Upgrade Controller**
18. Verify image version of original controller is from docker
```sh
kubectl get pod $(kubectl get pods -n controller-minikubeoriginal7 --no-headers | head -n 1 | awk '{print $1}') -n controller-minikubeoriginal7 -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-24.04 docker.io/jujusolutions/juju-db:4.4 docker.io/jujusolutions/jujud-operator:3.6-rc3
```


19. Upgrade controller
```sh
juju upgrade-controller
```

20. Verify image of original controller is indeed upgraded to version 3.6.8
```sh
kubectl get pod $(kubectl get pods -n controller-minikubeoriginal7 --no-headers | head -n 1 | awk '{print $1}') -n controller-minikubeoriginal7 -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-24.04 docker.io/jujusolutions/juju-db:4.4 docker.io/jujusolutions/jujud-operator:3.6.8
```

21. Verify that images of updated model and mysql in original controller are not upgraded and still uses version 3.6-rc3 
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel7  -o yaml | grep image:
```

### ***Upgrade Model**
22. Upgrade controller
```sh
juju upgrade-model
```

23. Verify image version of model is upgraded to 3.6.8
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-24.04 docker.io/jujusolutions/juju-db:4.4 docker.io/jujusolutions/jujud-operator:3.6.8
```

24. Verify that image of app in model is upgraded to 3.6.8
```sh
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel  -o yaml | grep image:

    image: docker.io/jujusolutions/charm-base:ubuntu-22.04
    image: registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9
    image: docker.io/jujusolutions/jujud-operator:3.6.8
    image: jujusolutions/charm-base:ubuntu-22.04
    image: sha256:c83c3a912fbe97b4eaec22a50c4681e07f883d4ad9aae8a70ef6f5c4fef32ae5
    image: jujusolutions/jujud-operator:3.6.8
```

## Links

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-7982