### PR TITLE
Move k8s-attach-storage feature flag from controller to cli

### DIFF
--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/apiserver/authentication"
@@ -20,7 +19,6 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -800,13 +798,6 @@ func (a *StorageAPI) importFilesystem(
 		}
 		volumeImporter, ok := volumeSource.(storage.VolumeImporter)
 		if !ok {
-			return nil, errors.NotSupportedf(
-				"importing volume with storage provider %q",
-				cfg.Provider(),
-			)
-		}
-		// Support import-filesystem on k8s only available when featureflag K8SAttachStorage enabled.
-		if cfg.Provider() == k8sconstants.StorageProviderType && !featureflag.Enabled(feature.K8SAttachStorage) {
 			return nil, errors.NotSupportedf(
 				"importing volume with storage provider %q",
 				cfg.Provider(),

--- a/tests/suites/storage_k8s/task.sh
+++ b/tests/suites/storage_k8s/task.sh
@@ -14,6 +14,7 @@ test_storage_k8s() {
 		microk8s config >"${TEST_DIR}"/kube.conf
 		export KUBE_CONFIG="${TEST_DIR}"/kube.conf
 
+		export JUJU_DEV_FEATURE_FLAGS=k8s-attach-storage
 		test_import_filesystem
 		;;
 	*)


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

Remove k8s-attach-storage feature flag from controller package & add to cli package.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

```sh
juju deploy postgresql-k8s -n 1 --channel 14/stable  --trust
juju remove-application postgresql-k8s
juju remove-storage pgdata/0 --no-destroy

# replace {pv-name},{pvc-name} with real name
kubectl patch pv {pv-name} -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
kubectl delete pvc {pvc-name}
kubectl patch pv {pv-name} --type merge -p '{"spec":{"claimRef": null}}'

# This import should be blocked
juju import-filesystem kubernetes {pv-name} pgdata

# This import should succeed because the k8s-attach-storage feature is enabled.
JUJU_DEV_FEATURE_FLAGS=k8s-attach-storage juju import-filesystem kubernetes {pv-name} pgdata
```
