### PR TITLE
fix(relation): fix `insertRelationUnit` behavior

### DIFF
--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -1909,7 +1909,18 @@ AND    u.uuid = $relationUnit.unit_uuid
 		return "", errors.Capture(err)
 	}
 
-	return uuid, tx.Query(ctx, insertStmt, insertRelationUnit).Run()
+	var outcome sqlair.Outcome
+	if err := tx.Query(ctx, insertStmt, insertRelationUnit).Get(&outcome); err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if num, err := outcome.Result().RowsAffected(); err != nil {
+		return "", errors.Capture(err)
+	} else if num != 1 {
+		return "", errors.Errorf("expected 1 row inserted, got %d", num)
+	}
+
+	return uuid, nil
 }
 
 // LeaveScope updates the given relation to indicate it is not in scope.


### PR DESCRIPTION
This patch fixes the behavior of insertRelationUnit. When called with a non-existent relation UUID or UnitUUID, this function would return a new UUID without any insertion, which can cause bugs. In such cases, the method should return an error.
It also verifies that if there is not exactly one insert, the method fails (this would mean the SQL query is wrong or maybe a symptom of data corruption)

Also, it introduces new tests for the `insertRelationUnit` method in the file `domain/relation/state/relation_test.go`. The following scenarios are addressed:
- Happy path (`TestInsertRelationUnitHappyPath`): Verifies that a unit can be inserted into a relation successfully.
- Non-existent relation UUID (`TestInsertRelationUnitRelationUUIDDoesntExist`): Ensures an error is returned when the relation UUID does not exist.
- Non-existent unit UUID (`TestInsertRelationUnitUnitUUIDDoesntExist`): Confirms an error is raised when the unit UUID does not exist.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unit test should pass.
