### PR TITLE
fix(tests): update postgresql-test-app deployment in smoke tests

### DIFF
--- a/tests/suites/smoke_k8s_psql/deploy_postgresql.sh
+++ b/tests/suites/smoke_k8s_psql/deploy_postgresql.sh
@@ -9,14 +9,14 @@ run_postgresql_deploy() {
     juju deploy postgresql-k8s --trust --channel 16/edge
 
     # Deploy the postgresql-test-app charm
-    juju deploy postgresql-test-app
+    juju deploy postgresql-test-app --channel latest/edge/pr368 --base ubuntu@22.04
 
     # Integrate the postgresql-k8s charm with the postgresql-test-app
     juju integrate postgresql-k8s postgresql-test-app:database
 
     # Wait for the postgresql-k8s charm to become idle
-    wait_for "postgresql-k8s" "$(idle_condition "postgresql-k8s")"
-    wait_for "postgresql-test-app" "$(idle_condition "postgresql-test-app")"
+    wait_for "postgresql-test-app" "$(active_idle_condition "postgresql-test-app" 0 0)"
+    wait_for "postgresql-k8s" "$(active_idle_condition "postgresql-k8s" 0 0)"
 
     destroy_model "test-postgresql-deploy"
 }


### PR DESCRIPTION
The juju deploy command for the postgresql-test-app is updated to specify a channel and a base OS. This ensures that the smoke test uses a consistent and specific version that fixes compatibility problems with Juju 4.


## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
# Postgresql K8s smoke test (GitHub action) should pass
```

## Links

**Jira card:** JUJU-
