### PR TITLE
chore(docs): only convert modified excalidraw files

### DIFF
--- a/docs/scripts/convert-excalidraw-to-svg-recursively.sh
+++ b/docs/scripts/convert-excalidraw-to-svg-recursively.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 # and converts them to SVG format using the excalidraw-brute-export-cli tool.
 
 find . -type f -name '*.excalidraw' | while IFS= read -r file; do
+  #check if file has diff in git environment
+  if git diff --quiet "$file"; then
+    echo "No changes detected in $file, skipping export."
+    continue
+  fi
+
   dir=$(dirname "$file")
   base=$(basename  "$file" .excalidraw)
   out="$dir/$base.svg"


### PR DESCRIPTION
The convert-excalidraw-to-svg-recursively.sh script now checks if an .excalidraw file has been modified before converting it to SVG.

This is achieved by using git diff --quiet on each file. The script will now only export files that have changes, which makes the documentation generation process more efficient by avoiding unnecessary work on unchanged diagrams.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# Just pass all GitHub checks
```

## Links

**Jira card:** JUJU-
