### PR TITLE
chore: pin postgresql-test-app to a specific channel and base

### DIFF
--- a/tests/suites/smoke_k8s_psql/deploy_postgresql.sh
+++ b/tests/suites/smoke_k8s_psql/deploy_postgresql.sh
@@ -9,7 +9,7 @@ run_postgresql_deploy() {
     juju deploy postgresql-k8s --trust --channel 16/edge
 
     # Deploy the postgresql-test-app charm
-    juju deploy postgresql-test-app
+    juju deploy postgresql-test-app --channel latest/edge --base ubuntu@22.04
 
     # Integrate the postgresql-k8s charm with the postgresql-test-app
     juju integrate postgresql-k8s postgresql-test-app:database


### PR DESCRIPTION
This PR updates the smoke test for postgresql-k8s to deploy the postgresql-test-app from the latest/edge channel with an ubuntu@22.04 base.

We need to use the edge channel to avoid compatibility issues between postgresql-test-app and Juju 4

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
# Smoke \ Postgresql K8s  github action should pass 
```

## Links

**Jira card:** JUJU-
