### PR TITLE
feat: allow edge snaps to be used as official builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ define link_flags_version
 -X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) \
 -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE) \
 -X $(PROJECT)/version.build=$(JUJU_BUILD_NUMBER) \
+-X $(PROJECT)/version.Grade=$(JUJU_GRADE) \
 -X $(PROJECT)/version.GoBuildTags=$(FINAL_BUILD_TAGS)
 endef
 

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -249,7 +249,7 @@ started upgrade to 3.9.99
 }
 
 func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c *gc.C) {
-	s.reset(c)
+	s.resetOfficial(c, true)
 
 	s.PatchValue(&jujuversion.Current, func() version.Number {
 		v := jujuversion.Current
@@ -258,7 +258,7 @@ func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionUploadLocalOffi
 	}())
 
 	s.PatchValue(&CheckCanImplicitUpload,
-		func(model.ModelType, bool, version.Number, version.Number) bool { return true },
+		func(model.ModelType, bool, version.Number, string, version.Number) bool { return true },
 	)
 
 	ctrl, cmd := s.upgradeControllerCommand(c, false)
@@ -303,6 +303,91 @@ started upgrade to %s
 `, builtVersion.Number, builtVersion.Number)[1:])
 }
 
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionUploadLocalNonOfficial(c *gc.C) {
+	s.reset(c)
+
+	s.PatchValue(&jujuversion.Current, func() version.Number {
+		v := jujuversion.Current
+		v.Build = 0
+		return v
+	}())
+
+	s.PatchValue(&CheckCanImplicitUpload,
+		func(model.ModelType, bool, version.Number, string, version.Number) bool { return true },
+	)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	c.Assert(agentVersion.Build, gc.Equals, 0)
+	builtVersion := coretesting.CurrentVersion()
+	targetVersion := builtVersion.Number
+	builtVersion.Build++
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), targetVersion,
+			"", false, false,
+		).Return(
+			version.Zero,
+			errors.NotFoundf("available agent tool, upload required"),
+		),
+	)
+
+	_, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", targetVersion.String(),
+	)
+	c.Assert(err, gc.ErrorMatches, "non official build not supported")
+}
+
+func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficialNoImplicitUpgrade(c *gc.C) {
+	s.resetOfficial(c, true)
+
+	s.PatchValue(&jujuversion.Current, func() version.Number {
+		v := jujuversion.Current
+		v.Build = 0
+		return v
+	}())
+
+	s.PatchValue(&CheckCanImplicitUpload,
+		func(model.ModelType, bool, version.Number, string, version.Number) bool { return false },
+	)
+
+	ctrl, cmd := s.upgradeControllerCommand(c, false)
+	defer ctrl.Finish()
+
+	agentVersion := coretesting.FakeVersionNumber
+	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"agent-version": agentVersion.String(),
+	})
+
+	c.Assert(agentVersion.Build, gc.Equals, 0)
+	builtVersion := coretesting.CurrentVersion()
+	targetVersion := builtVersion.Number
+	builtVersion.Build++
+	gomock.InOrder(
+		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
+		s.modelUpgrader.EXPECT().UpgradeModel(
+			coretesting.ModelTag.Id(), targetVersion,
+			"", false, false,
+		).Return(
+			version.Zero,
+			errors.NotFoundf("available agent tool, upload required"),
+		),
+	)
+
+	ctx, err := cmdtesting.RunCommand(c, cmd,
+		"--agent-version", targetVersion.String(),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "no upgrades available\n")
+}
+
 func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionAlreadyUpToDate(c *gc.C) {
 	s.reset(c)
 
@@ -338,7 +423,7 @@ func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionFailedExpectUpl
 	s.reset(c)
 
 	s.PatchValue(&CheckCanImplicitUpload,
-		func(model.ModelType, bool, version.Number, version.Number) bool { return true },
+		func(model.ModelType, bool, version.Number, string, version.Number) bool { return true },
 	)
 
 	ctrl, cmd := s.upgradeControllerCommand(c, false)
@@ -379,7 +464,7 @@ func (s *upgradeControllerSuite) TestUpgradeModelWithAgentVersionExpectUploadFai
 	s.reset(c)
 
 	s.PatchValue(&CheckCanImplicitUpload,
-		func(model.ModelType, bool, version.Number, version.Number) bool { return false },
+		func(model.ModelType, bool, version.Number, string, version.Number) bool { return false },
 	)
 
 	ctrl, cmd := s.upgradeControllerCommand(c, false)
@@ -478,7 +563,21 @@ cannot upgrade to "3.9.99" due to issues with these models:
 }
 
 func (s *upgradeControllerSuite) reset(c *gc.C) {
-	s.PatchValue(&sync.BuildAgentTarball, toolstesting.GetMockBuildTools(c))
+	s.resetOfficial(c, false)
+}
+
+func (s *upgradeControllerSuite) resetOfficial(c *gc.C, official bool) {
+	s.PatchValue(&sync.BuildAgentTarball, func(
+		build bool, stream string,
+		getForceVersion func(version.Number) version.Number,
+	) (*sync.BuiltAgent, error) {
+		result, err := toolstesting.GetMockBuildTools(c)(build, stream, getForceVersion)
+		if err != nil {
+			return nil, err
+		}
+		result.Official = official
+		return result, nil
+	})
 }
 
 func (s *upgradeControllerSuite) TestUpgradeModelWithBuildAgent(c *gc.C) {
@@ -688,6 +787,7 @@ func (s *upgradeControllerSuite) TestCheckCanImplicitUploadIAASModel(c *gc.C) {
 	canImplicitUpload := checkCanImplicitUpload(
 		model.CAAS, true,
 		version.MustParse("3.0.0"),
+		"",
 		version.MustParse("3.9.99.1"),
 	)
 	c.Check(canImplicitUpload, jc.IsFalse)
@@ -696,6 +796,7 @@ func (s *upgradeControllerSuite) TestCheckCanImplicitUploadIAASModel(c *gc.C) {
 	canImplicitUpload = checkCanImplicitUpload(
 		model.IAAS, false,
 		version.MustParse("3.9.99"),
+		"",
 		version.MustParse("3.0.0"),
 	)
 	c.Check(canImplicitUpload, jc.IsFalse)
@@ -704,6 +805,7 @@ func (s *upgradeControllerSuite) TestCheckCanImplicitUploadIAASModel(c *gc.C) {
 	canImplicitUpload = checkCanImplicitUpload(
 		model.IAAS, true,
 		version.MustParse("2.9.99"),
+		"",
 		version.MustParse("3.0.0"),
 	)
 	c.Check(canImplicitUpload, jc.IsFalse)
@@ -712,6 +814,7 @@ func (s *upgradeControllerSuite) TestCheckCanImplicitUploadIAASModel(c *gc.C) {
 	canImplicitUpload = checkCanImplicitUpload(
 		model.IAAS, true,
 		version.MustParse("3.0.0.1"),
+		"",
 		version.MustParse("3.0.0"),
 	)
 	c.Check(canImplicitUpload, jc.IsTrue)
@@ -720,6 +823,7 @@ func (s *upgradeControllerSuite) TestCheckCanImplicitUploadIAASModel(c *gc.C) {
 	canImplicitUpload = checkCanImplicitUpload(
 		model.IAAS, true,
 		version.MustParse("3.0.0"),
+		"",
 		version.MustParse("3.0.0.1"),
 	)
 	c.Check(canImplicitUpload, jc.IsTrue)
@@ -727,8 +831,30 @@ func (s *upgradeControllerSuite) TestCheckCanImplicitUploadIAASModel(c *gc.C) {
 	// both client and agent version with build number == 0.
 	canImplicitUpload = checkCanImplicitUpload(
 		model.IAAS, true,
-		version.MustParse("3.0.0"),
+		version.MustParse("3.1.0"),
+		"",
 		version.MustParse("3.0.0"),
 	)
 	c.Check(canImplicitUpload, jc.IsFalse)
+
+	// both client and agent version with build number == 0
+	// but grade is devel.
+	canImplicitUpload = checkCanImplicitUpload(
+		model.IAAS, true,
+		version.MustParse("3.1.0"),
+		"devel",
+		version.MustParse("3.0.0"),
+	)
+	c.Check(canImplicitUpload, jc.IsTrue)
+
+	// both client and agent version are the same
+	// but grade is devel.
+	canImplicitUpload = checkCanImplicitUpload(
+		model.IAAS, true,
+		version.MustParse("3.0.0.1"),
+		"devel",
+		version.MustParse("3.0.0.1"),
+	)
+	c.Check(canImplicitUpload, jc.IsTrue)
+
 }

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -275,7 +275,7 @@ func (s *upgradeModelSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDu
 	s.reset(c)
 
 	s.PatchValue(&CheckCanImplicitUpload,
-		func(model.ModelType, bool, version.Number, version.Number) bool { return false },
+		func(model.ModelType, bool, version.Number, string, version.Number) bool { return false },
 	)
 
 	ctrl, cmd := s.upgradeModelCommand(c, false)
@@ -612,57 +612,4 @@ func (s *upgradeModelSuite) TestResetPreviousUpgrade(c *gc.C) {
 	s.assertResetPreviousUpgrade(c, "N", false)
 	s.assertResetPreviousUpgrade(c, "no", false)
 	s.assertResetPreviousUpgrade(c, "foo", false)
-}
-
-func (s *upgradeModelSuite) TestCheckCanImplicitUploadIAASModel(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	// Not IAAS model.
-	canImplicitUpload := checkCanImplicitUpload(
-		model.CAAS, true,
-		version.MustParse("3.0.0"),
-		version.MustParse("3.9.99.1"),
-	)
-	c.Check(canImplicitUpload, jc.IsFalse)
-
-	// not official client.
-	canImplicitUpload = checkCanImplicitUpload(
-		model.IAAS, false,
-		version.MustParse("3.9.99"),
-		version.MustParse("3.0.0"),
-	)
-	c.Check(canImplicitUpload, jc.IsFalse)
-
-	// non newer client.
-	canImplicitUpload = checkCanImplicitUpload(
-		model.IAAS, true,
-		version.MustParse("2.9.99"),
-		version.MustParse("3.0.0"),
-	)
-	c.Check(canImplicitUpload, jc.IsFalse)
-
-	// client version with build number.
-	canImplicitUpload = checkCanImplicitUpload(
-		model.IAAS, true,
-		version.MustParse("3.0.0.1"),
-		version.MustParse("3.0.0"),
-	)
-	c.Check(canImplicitUpload, jc.IsTrue)
-
-	// agent version with build number.
-	canImplicitUpload = checkCanImplicitUpload(
-		model.IAAS, true,
-		version.MustParse("3.0.0"),
-		version.MustParse("3.0.0.1"),
-	)
-	c.Check(canImplicitUpload, jc.IsTrue)
-
-	// both client and agent version with build number == 0.
-	canImplicitUpload = checkCanImplicitUpload(
-		model.IAAS, true,
-		version.MustParse("3.0.0"),
-		version.MustParse("3.0.0"),
-	)
-	c.Check(canImplicitUpload, jc.IsFalse)
 }

--- a/cmd/juju/commands/version.go
+++ b/cmd/juju/commands/version.go
@@ -36,8 +36,12 @@ type versionDetail struct {
 	GitTreeState string `json:"git-tree-state,omitempty" yaml:"git-tree-state,omitempty"`
 	// Compiler reported by runtime.Compiler
 	Compiler string `json:"compiler" yaml:"compiler"`
-	// OfficialBuild is a monotonic integer set by Jenkins.
-	OfficialBuild int `json:"official-build,omitempty" yaml:"official-build,omitempty"`
+	// OfficialBuildNumber is a monotonic integer set by Jenkins.
+	OfficialBuildNumber int `json:"official-build-number,omitempty" yaml:"official-build-number,omitempty"`
+	// Official is true if this is an official build.
+	Official bool `json:"official" yaml:"official"`
+	// Grade reflects the snap grade value.
+	Grade string `json:"grade,omitempty" yaml:"grade,omitempty"`
 	// GoBuildTags is the build tags used to build the binary.
 	GoBuildTags string `json:"go-build-tags,omitempty" yaml:"go-build-tags,omitempty"`
 }
@@ -85,11 +89,14 @@ func (v *versionCommand) Init(args []string) error {
 		Release: coreos.HostOSTypeName(),
 	}
 	detail := versionDetail{
-		Version:      current,
-		GitCommit:    jujuversion.GitCommit,
-		GitTreeState: jujuversion.GitTreeState,
-		Compiler:     jujuversion.Compiler,
-		GoBuildTags:  jujuversion.GoBuildTags,
+		Version:             current,
+		GitCommit:           jujuversion.GitCommit,
+		GitTreeState:        jujuversion.GitTreeState,
+		Compiler:            jujuversion.Compiler,
+		GoBuildTags:         jujuversion.GoBuildTags,
+		OfficialBuildNumber: jujuversion.OfficialBuild,
+		Official:            isOfficialClient(),
+		Grade:               jujuversion.Grade,
 	}
 
 	v.version = detail.Version

--- a/cmd/juju/commands/version_test.go
+++ b/cmd/juju/commands/version_test.go
@@ -42,6 +42,7 @@ func (s *VersionSuite) TestVersionDetail(c *gc.C) {
 	s.PatchValue(&jujuversion.GitTreeState, "clean")
 	s.PatchValue(&jujuversion.Compiler, "gc")
 	s.PatchValue(&jujuversion.GoBuildTags, "a,b,c,d")
+	s.PatchValue(&jujuversion.Grade, "devel")
 	command := newVersionCommand()
 	cctx, err := cmdtesting.RunCommand(c, command, "--all")
 	c.Assert(err, jc.ErrorIsNil)
@@ -50,6 +51,8 @@ version: 2.99.0-%s-%s
 git-commit: 0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 git-tree-state: clean
 compiler: gc
+official: false
+grade: devel
 go-build-tags: a,b,c,d
 `[1:]
 	output := fmt.Sprintf(outputTemplate, coreos.HostOSTypeName(), arch.HostArch())
@@ -64,11 +67,12 @@ func (s *VersionSuite) TestVersionDetailJSON(c *gc.C) {
 	s.PatchValue(&jujuversion.GitTreeState, "clean")
 	s.PatchValue(&jujuversion.Compiler, "gc")
 	s.PatchValue(&jujuversion.GoBuildTags, "a,b,c,d")
+	s.PatchValue(&jujuversion.Grade, "devel")
 	command := newVersionCommand()
 	cctx, err := cmdtesting.RunCommand(c, command, "--all", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	outputTemplate := `
-{"version":"2.99.0-%s-%s","git-commit":"0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f","git-tree-state":"clean","compiler":"gc","go-build-tags":"a,b,c,d"}
+{"version":"2.99.0-%s-%s","git-commit":"0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f","git-tree-state":"clean","compiler":"gc","official":false,"grade":"devel","go-build-tags":"a,b,c,d"}
 `[1:]
 	output := fmt.Sprintf(outputTemplate, coreos.HostOSTypeName(), arch.HostArch())
 
@@ -82,6 +86,7 @@ func (s *VersionSuite) TestVersionDetailYAML(c *gc.C) {
 	s.PatchValue(&jujuversion.GitTreeState, "clean")
 	s.PatchValue(&jujuversion.Compiler, "gc")
 	s.PatchValue(&jujuversion.GoBuildTags, "a,b,c,d")
+	s.PatchValue(&jujuversion.Grade, "devel")
 	command := newVersionCommand()
 	cctx, err := cmdtesting.RunCommand(c, command, "--all", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
@@ -90,6 +95,8 @@ version: 2.99.0-%s-%s
 git-commit: 0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 git-tree-state: clean
 compiler: gc
+official: false
+grade: devel
 go-build-tags: a,b,c,d
 `[1:]
 	output := fmt.Sprintf(outputTemplate, coreos.HostOSTypeName(), arch.HostArch())

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/machinelock"
 	coreos "github.com/juju/juju/core/os"
+	"github.com/juju/juju/environs/tools"
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/sockets"
@@ -200,8 +201,12 @@ type versionDetail struct {
 	GitTreeState string `json:"git-tree-state,omitempty" yaml:"git-tree-state,omitempty"`
 	// Compiler reported by runtime.Compiler
 	Compiler string `json:"compiler" yaml:"compiler"`
-	// OfficialBuild is a monotonic integer set by Jenkins.
-	OfficialBuild int `json:"official-build,omitempty" yaml:"official-build,omitempty"`
+	// OfficialBuildNumber is a monotonic integer set by Jenkins.
+	OfficialBuildNumber int `json:"official-build-number,omitempty" yaml:"official-build-number,omitempty"`
+	// Official is true if this is an official build.
+	Official bool `json:"official" yaml:"official"`
+	// Grade reflects the snap grade value.
+	Grade string `json:"grade,omitempty" yaml:"grade,omitempty"`
 	// GoBuildTags is the build tags used to build the binary.
 	GoBuildTags string `json:"go-build-tags,omitempty" yaml:"go-build-tags,omitempty"`
 }
@@ -232,11 +237,14 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 		Release: coreos.HostOSTypeName(),
 	}
 	detail := versionDetail{
-		Version:      current.String(),
-		GitCommit:    jujuversion.GitCommit,
-		GitTreeState: jujuversion.GitTreeState,
-		Compiler:     jujuversion.Compiler,
-		GoBuildTags:  jujuversion.GoBuildTags,
+		Version:             current.String(),
+		GitCommit:           jujuversion.GitCommit,
+		GitTreeState:        jujuversion.GitTreeState,
+		Compiler:            jujuversion.Compiler,
+		GoBuildTags:         jujuversion.GoBuildTags,
+		OfficialBuildNumber: jujuversion.OfficialBuild,
+		Official:            isOfficial(),
+		Grade:               jujuversion.Grade,
 	}
 
 	jujud := jujucmd.NewSuperCommand(cmd.SuperCommandParams{
@@ -282,6 +290,17 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 
 	code = cmd.Main(jujud, ctx, args[1:])
 	return code, nil
+}
+
+func isOfficial() bool {
+	// If there's an error getting jujud version, play it safe.
+	// We pretend it's not official.
+	jujudPath, err := tools.ExistingJujuLocation()
+	if err != nil {
+		return false
+	}
+	_, err = tools.GetVersionFromFile(jujudPath)
+	return err == nil
 }
 
 // MainWrapper exists to preserve test functionality.

--- a/scripts/makeofficialjuju.bash
+++ b/scripts/makeofficialjuju.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Copyright 2025 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+jujud=$(which jujud)
+jujudpath=$(dirname "$(which jujud)")
+version=$($jujud version)
+hash=$(sha256sum $jujud | cut -d " " -f 1)
+cat > $jujudpath/jujud-versions.yaml <<EOF
+versions:
+  - version: $version
+    sha256: $hash
+EOF
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -401,6 +401,7 @@ parts:
       github.com/juju/juju/version.GitCommit: ""
       github.com/juju/juju/version.GitTreeState: ""
       github.com/juju/juju/version.build: ""
+      github.com/juju/juju/version.Grade: ""
     go-static: true
     go-strip: true
     go-buildtags: ["libsqlite3", "dqlite"]
@@ -440,6 +441,7 @@ parts:
       github.com/juju/juju/version.GitCommit: ""
       github.com/juju/juju/version.GitTreeState: ""
       github.com/juju/juju/version.build: ""
+      github.com/juju/juju/version.Grade: ""
     go-static: true
     go-strip: true
     override-build: |

--- a/version/version.go
+++ b/version/version.go
@@ -33,11 +33,19 @@ const (
 	TreeStateArchive = "archive"
 )
 
+const (
+	// GradeDevel reflects the snap "devel" grade value.
+	GradeDevel = "devel"
+)
+
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")
 
 // build is injected by Jenkins, it must be an integer or empty.
 var build string
+
+// Grade reflects the snap grade value.
+var Grade string
 
 // OfficialBuild is a monotonic number injected by Jenkins.
 var OfficialBuild = mustParseBuildInt(build)


### PR DESCRIPTION
We have a 3.5 deployment where an upgrade is needed to pull in a fix in order to unwedge a failed charm so that the model can then be migrated to 3.6.

We're not doing any more 3.5 releases. But what we can do is allow a 3.5 upgrade to be done via the jujud embedded in an edge snap. The edge snap would contain the necessary fix.

The issue this PR addresses is that for this to work, the jujud versions file needs to be accounted for properly in the snap to flag an official build, whilst also ensuring an edge snap version gets a build number so it's not seen as a stable juju version. We introduce a new "version.Grade" string on the compiled binaries. This is set during linking similar to the git commit sha and the value mirrors that of the snap grade. It's "devel" inside an edge snap and empty otherwise. These changes are client only thus will work with any controller.

To use the new behaviour, the upgrade-controller agent-version arg must be used. Assuming a 3.5.66 edge snap is installed, then

`juju upgrade-controller --agent-version 3.5.66` 

will automatically upload the jujud inside the snap as version "3.5.66.1" and upgrade the controller to that version.

If a new edge snap is installed for 3.5.66, then

`juju upgrade-controller --agent-version 3.5.66` 

will this time upload the jujud from the snap as version "3.5.66.2". And so on.

This PR also includes a script to make a self compiled version of juju "official" to allow for testing.

The `juju verson --all` command is enhanced to show the grade and official status of the juju binaries.

## QA steps

Ensure `$GOPATH/bin` is in the `$PATH`

```
export JUJU_GRADE=devel
make go-install
makeofficialjuju.sh
```

NB the edge snap build job does the above

```
juju version --all
jujud version --all
```

```
juju bootstrap lxd test --agent-version 3.5.7

juju upgrade-controller --agent-version 3.5.8
...
no prepackaged agent binaries available, using the local snap jujud 3.5.8.1
...

juju show-controller
```
controller version should be 3.5.8.1

upgrade again and version should be 3.5.8.2

## Documentation changes

This is a corner case scenario but we could enhance any existing docs.

## Links

**Jira card:** [JUJU-8252](https://warthogs.atlassian.net/browse/JUJU-8252)


[JUJU-8252]: https://warthogs.atlassian.net/browse/JUJU-8252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ