### PR TITLE
feat(machine): refactor migration export to export data from DQLite

### DIFF
--- a/domain/machine/modelmigration/export_test.go
+++ b/domain/machine/modelmigration/export_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	coremachine "github.com/juju/juju/core/machine"
+	machinetesting "github.com/juju/juju/core/machine/testing"
 	"github.com/juju/juju/domain/machine"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -44,32 +45,6 @@ func (s *exportSuite) newExportOperation(c *tc.C) *exportOperation {
 	}
 }
 
-func (s *exportSuite) TestFailGetInstanceIDForExport(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	dst := description.NewModel(description.ModelArgs{})
-
-	machineNames := []coremachine.Name{"deadbeef"}
-	machineUUIDs := []coremachine.UUID{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
-
-	dst.AddMachine(description.MachineArgs{
-		Id: string(machineNames[0]),
-	})
-
-	s.service.EXPECT().GetMachines(gomock.Any()).Return([]machine.ExportMachine{
-		{
-			Name: machineNames[0],
-			UUID: machineUUIDs[0],
-		},
-	}, nil)
-	s.service.EXPECT().GetInstanceID(gomock.Any(), machineUUIDs[0]).
-		Return("", errors.New("boom"))
-
-	op := s.newExportOperation(c)
-	err := op.Execute(c.Context(), dst)
-	c.Assert(err, tc.ErrorMatches, "retrieving instance ID for machine \"deadbeef\": boom")
-}
-
 func (s *exportSuite) TestFailGetHardwareCharacteristicsForExport(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -84,18 +59,17 @@ func (s *exportSuite) TestFailGetHardwareCharacteristicsForExport(c *tc.C) {
 
 	s.service.EXPECT().GetMachines(gomock.Any()).Return([]machine.ExportMachine{
 		{
-			Name: machineNames[0],
-			UUID: machineUUIDs[0],
+			Name:       machineNames[0],
+			UUID:       machineUUIDs[0],
+			InstanceID: "inst-0",
 		},
 	}, nil)
-	s.service.EXPECT().GetInstanceID(gomock.Any(), machineUUIDs[0]).
-		Return("inst-0", nil)
 	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), machineUUIDs[0]).
 		Return(nil, errors.New("boom"))
 
 	op := s.newExportOperation(c)
 	err := op.Execute(c.Context(), dst)
-	c.Assert(err, tc.ErrorMatches, "retrieving hardware characteristics for machine \"deadbeef\": boom")
+	c.Assert(err, tc.ErrorMatches, ".*retrieving hardware characteristics for machine \"deadbeef\": boom")
 }
 
 func (s *exportSuite) TestExport(c *tc.C) {
@@ -103,20 +77,18 @@ func (s *exportSuite) TestExport(c *tc.C) {
 
 	dst := description.NewModel(description.ModelArgs{})
 
-	machineNames := []coremachine.Name{"deadbeef"}
-	machineUUIDs := []coremachine.UUID{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
+	machineName := coremachine.Name("0")
+	machineUUID := machinetesting.GenUUID(c)
 
-	dst.AddMachine(description.MachineArgs{
-		Id: string(machineNames[0]),
-	})
-
-	s.service.EXPECT().GetInstanceID(gomock.Any(), machineUUIDs[0]).
-		Return("inst-0", nil)
 	s.service.EXPECT().GetMachines(gomock.Any()).Return([]machine.ExportMachine{
 		{
-			Name:  machineNames[0],
-			UUID:  machineUUIDs[0],
-			Nonce: "a nonce",
+			Name:         machineName,
+			UUID:         machineUUID,
+			Nonce:        "a nonce",
+			PasswordHash: "shhhh!",
+			Placement:    "place it here",
+			Base:         "ubuntu@24.04/stable",
+			InstanceID:   "inst-0",
 		},
 	}, nil)
 	tags := []string{"tag0", "tag1"}
@@ -131,7 +103,7 @@ func (s *exportSuite) TestExport(c *tc.C) {
 		AvailabilityZone: ptr("az-1"),
 		VirtType:         ptr("vm"),
 	}
-	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), machineUUIDs[0]).
+	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), machineUUID).
 		Return(&hc, nil)
 
 	op := s.newExportOperation(c)
@@ -141,8 +113,11 @@ func (s *exportSuite) TestExport(c *tc.C) {
 	actualMachines := dst.Machines()
 	c.Assert(actualMachines, tc.HasLen, 1)
 
-	c.Check(actualMachines[0].Id(), tc.Equals, machineNames[0].String())
+	c.Check(actualMachines[0].Id(), tc.Equals, machineName.String())
 	c.Check(actualMachines[0].Nonce(), tc.Equals, "a nonce")
+	c.Check(actualMachines[0].PasswordHash(), tc.Equals, "shhhh!")
+	c.Check(actualMachines[0].Placement(), tc.Equals, "place it here")
+	c.Check(actualMachines[0].Base(), tc.Equals, "ubuntu@24.04/stable")
 
 	cloudInstance := actualMachines[0].Instance()
 	c.Check(cloudInstance.Architecture(), tc.Equals, "amd64")
@@ -154,4 +129,77 @@ func (s *exportSuite) TestExport(c *tc.C) {
 	c.Check(cloudInstance.Tags(), tc.SameContents, tags)
 	c.Check(cloudInstance.AvailabilityZone(), tc.Equals, "az-1")
 	c.Check(cloudInstance.VirtType(), tc.Equals, "vm")
+}
+
+func (s *exportSuite) TestExportContainer(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	dst := description.NewModel(description.ModelArgs{})
+
+	machineName := coremachine.Name("0")
+	machineUUID := machinetesting.GenUUID(c)
+	containerName := coremachine.Name("0/lxd/0")
+	containerUUID := machinetesting.GenUUID(c)
+
+	// NOTE: We return the container machine first, to check the export code can
+	// handle this.
+	s.service.EXPECT().GetMachines(gomock.Any()).Return([]machine.ExportMachine{
+		{
+			Name:         containerName,
+			UUID:         containerUUID,
+			Nonce:        "another nonce",
+			PasswordHash: "shhhh!",
+			Placement:    "place it there",
+			Base:         "ubuntu@24.04/stable",
+			InstanceID:   "inst-0",
+		},
+		{
+			Name:         machineName,
+			UUID:         machineUUID,
+			Nonce:        "a nonce",
+			PasswordHash: "shhhh!",
+			Placement:    "place it here",
+			Base:         "ubuntu@24.04/stable",
+			InstanceID:   "inst-0",
+		},
+	}, nil)
+
+	tags := []string{"tag0", "tag1"}
+	hc := instance.HardwareCharacteristics{
+		Arch:             ptr("amd64"),
+		Mem:              ptr(uint64(1024)),
+		RootDisk:         ptr(uint64(2048)),
+		RootDiskSource:   ptr("/"),
+		CpuCores:         ptr(uint64(4)),
+		CpuPower:         ptr(uint64(16)),
+		Tags:             &tags,
+		AvailabilityZone: ptr("az-1"),
+		VirtType:         ptr("vm"),
+	}
+	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), machineUUID).
+		Return(&hc, nil)
+	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), containerUUID).
+		Return(&hc, nil)
+
+	op := s.newExportOperation(c)
+	err := op.Execute(c.Context(), dst)
+	c.Assert(err, tc.ErrorIsNil)
+
+	actualMachines := dst.Machines()
+	c.Assert(actualMachines, tc.HasLen, 1)
+
+	c.Check(actualMachines[0].Id(), tc.Equals, machineName.String())
+	c.Check(actualMachines[0].Nonce(), tc.Equals, "a nonce")
+	c.Check(actualMachines[0].PasswordHash(), tc.Equals, "shhhh!")
+	c.Check(actualMachines[0].Placement(), tc.Equals, "place it here")
+	c.Check(actualMachines[0].Base(), tc.Equals, "ubuntu@24.04/stable")
+
+	actualContainers := actualMachines[0].Containers()
+	c.Assert(actualContainers, tc.HasLen, 1)
+
+	c.Check(actualContainers[0].Id(), tc.Equals, containerName.String())
+	c.Check(actualContainers[0].Nonce(), tc.Equals, "another nonce")
+	c.Check(actualContainers[0].PasswordHash(), tc.Equals, "shhhh!")
+	c.Check(actualContainers[0].Placement(), tc.Equals, "place it there")
+	c.Check(actualContainers[0].Base(), tc.Equals, "ubuntu@24.04/stable")
 }

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -207,10 +207,14 @@ type machinePlacement struct {
 }
 
 type exportMachine struct {
-	Name   string `db:"name"`
-	UUID   string `db:"uuid"`
-	LifeID int    `db:"life_id"`
-	Nonce  string `db:"nonce"`
+	Name               string `db:"name"`
+	UUID               string `db:"uuid"`
+	Nonce              string `db:"nonce"`
+	PasswordHash       string `db:"password_hash"`
+	PlacementDirective string `db:"directive"`
+	OSName             string `db:"os_name"`
+	Channel            string `db:"channel"`
+	InstanceID         string `db:"instance_id"`
 }
 
 type machineHostName struct {

--- a/domain/machine/types.go
+++ b/domain/machine/types.go
@@ -14,9 +14,13 @@ const ManualInstancePrefix = "manual:"
 // ExportMachine represents a machine that is being exported to another
 // controller.
 type ExportMachine struct {
-	Name  machine.Name
-	UUID  machine.UUID
-	Nonce string
+	Name         machine.Name
+	UUID         machine.UUID
+	Nonce        string
+	PasswordHash string
+	Placement    string
+	Base         string
+	InstanceID   string
 }
 
 // CreateMachineArgs contains arguments for creating a machine.

--- a/domain/status/modelmigration/migrations_mock_test.go
+++ b/domain/status/modelmigration/migrations_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	machine "github.com/juju/juju/core/machine"
 	status "github.com/juju/juju/core/status"
 	unit "github.com/juju/juju/core/unit"
 	gomock "go.uber.org/mock/gomock"
@@ -251,6 +252,46 @@ func (c *MockExportServiceExportApplicationStatusesCall) Do(f func(context.Conte
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockExportServiceExportApplicationStatusesCall) DoAndReturn(f func(context.Context) (map[string]status.StatusInfo, error)) *MockExportServiceExportApplicationStatusesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ExportMachineStatuses mocks base method.
+func (m *MockExportService) ExportMachineStatuses(arg0 context.Context) (map[machine.Name]status.StatusInfo, map[machine.Name]status.StatusInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExportMachineStatuses", arg0)
+	ret0, _ := ret[0].(map[machine.Name]status.StatusInfo)
+	ret1, _ := ret[1].(map[machine.Name]status.StatusInfo)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ExportMachineStatuses indicates an expected call of ExportMachineStatuses.
+func (mr *MockExportServiceMockRecorder) ExportMachineStatuses(arg0 any) *MockExportServiceExportMachineStatusesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportMachineStatuses", reflect.TypeOf((*MockExportService)(nil).ExportMachineStatuses), arg0)
+	return &MockExportServiceExportMachineStatusesCall{Call: call}
+}
+
+// MockExportServiceExportMachineStatusesCall wrap *gomock.Call
+type MockExportServiceExportMachineStatusesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceExportMachineStatusesCall) Return(arg0, arg1 map[machine.Name]status.StatusInfo, arg2 error) *MockExportServiceExportMachineStatusesCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceExportMachineStatusesCall) Do(f func(context.Context) (map[machine.Name]status.StatusInfo, map[machine.Name]status.StatusInfo, error)) *MockExportServiceExportMachineStatusesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceExportMachineStatusesCall) DoAndReturn(f func(context.Context) (map[machine.Name]status.StatusInfo, map[machine.Name]status.StatusInfo, error)) *MockExportServiceExportMachineStatusesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
Originally, the domain model migration script would rely on data from Mongo as the source of truth. However, we no longer write machines to Mongo.

## QA steps

Unfortunately model migration doesn't currently work, so the bets we can do is passing unit test