### PR TITLE
fix: incorrect charm storage check

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -622,13 +622,9 @@ func validateCharmStorage(charmStorage map[string]internalcharm.Storage) error {
 				name,
 			)
 		}
-		if storage.CountMax < 0 {
-			return errors.Errorf(
-				"charm storage %q has a maximum count less than zero, negative storage count cannot be achieved",
-				name,
-			)
-		}
-		if storage.CountMin > storage.CountMax {
+		// We accept charms with negative storage for CountMax. This implies
+		// that the charm has not upper maximum for the storage count.
+		if storage.CountMax >= 0 && storage.CountMin > storage.CountMax {
 			return errors.Errorf(
 				"charm storage %q has a minimum count greater than maximum count, this is can't be achieved",
 				name,


### PR DESCRIPTION
In a previous commit the check to make sure the storage count max for a charm was a number greater or equal to zero was introduced. This was done to validate that data coming into the domain was safe.

However we have seen that it is valid for a charm to have defined this value as -1 to suggest no upper max count on storage exists.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

`juju deploy ubuntu`, confirm that no errors occur related to the charm.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-7679
