### PR TITLE
fix(application): validate application name length on deploy

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -680,6 +680,9 @@ func (c *DeployCommand) Init(args []string) error {
 		if err := names.ValidateApplicationName(args[1]); err != nil {
 			return errors.Trace(err)
 		}
+		if len(args[1]) > 63 {
+			return errors.New("application name is too long: Kubernetes resource names must be 63 characters or less")
+		}
 		c.ApplicationName = args[1]
 		fallthrough
 	case 1:

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -125,6 +125,9 @@ var initErrorTests = []struct {
 	}, {
 		args: []string{"bundle", "--map-machines", "foo"},
 		err:  `error in --map-machines: expected "existing" or "<bundle-id>=<machine-id>", got "foo"`,
+	}, {
+		args: []string{"craziness", strings.Repeat("a", 64)},
+		err:  `application name is too long: Kubernetes resource names must be 63 characters or less`,
 	},
 }
 


### PR DESCRIPTION
<!--  
The PR title should match: fix(application): add max length validation for application name

Please also ensure all commits in this PR comply with our conventional commits specification:  
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md  
-->

<!-- Why this change is needed and what it does. -->

This change adds a maximum length validation (63 characters) for application names in the DeployCommand.Init method to enforce Kubernetes resource naming limits.

The existing ValidateApplicationName method from the `juju/names` package performs detailed validation, but does not currently check for length.

I decided to keep the length validation here to avoid modifying the `juju/names` package for this specific Kubernetes constraint.

If desired, the length validation could be integrated into `juju/names`.

Additionally, the existing `TestInitErrors` test case has been enhanced to cover this new validation,
ensuring application names longer than 63 characters are properly rejected with a clear error.

This issue was originally found in version 3.6.7; if appropriate, this fix should also be backported to the 3.6 branch.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc  
- [ ] Comments saying why design decisions were made  
- [x] Go unit tests, with comments saying what you're testing  
- [ ] Integration tests, with comments saying what you're testing  
- [ ] doc.go added or updated in changed packages  

## QA steps

- Deploy charms with valid and invalid application names, including names longer than 63 characters, and verify appropriate errors are returned.

## Documentation changes

- None (validation change only).

## Links

**Issue:** Fixes #20002.

**Jira card:** [JUJU-8137](https://warthogs.atlassian.net/browse/JUJU-8137)


[JUJU-8137]: https://warthogs.atlassian.net/browse/JUJU-8137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ