### PR TITLE
feat: support for fetching storage entity life in provisioning

### DIFF
--- a/domain/storageprovisioning/errors/errors.go
+++ b/domain/storageprovisioning/errors/errors.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import (
+	"github.com/juju/juju/internal/errors"
+)
+
+const (
+	// FilesystemNotFound describes an error that occurs when no filesystem was
+	// found in the model.
+	FilesystemNotFound = errors.ConstError("filesystem not found")
+
+	// FilesystemAttachmentNotFound describes an error that occurs when no
+	// filesystem attachment was found in the model.
+	FilesystemAttachmentNotFound = errors.ConstError("filesystem attachment not found")
+
+	// VolumeNotFound describes an error that occurs when no volume was
+	// found in the model.
+	VolumeNotFound = errors.ConstError("volume not found")
+
+	// VolumeAttachmentNotFound describes an error that occurs when no
+	// volume attachment was found in the model.
+	VolumeAttachmentNotFound = errors.ConstError("volume attachment not found")
+)

--- a/domain/storageprovisioning/service/filesystem.go
+++ b/domain/storageprovisioning/service/filesystem.go
@@ -6,11 +6,15 @@ package service
 import (
 	"context"
 
-	"github.com/juju/juju/core/changestream"
-	"github.com/juju/juju/core/machine"
+	corechangestream "github.com/juju/juju/core/changestream"
+	coreerrors "github.com/juju/juju/core/errors"
+	corelife "github.com/juju/juju/core/life"
+	coremachine "github.com/juju/juju/core/machine"
+	corestorage "github.com/juju/juju/core/storage"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
-	"github.com/juju/juju/domain/life"
+	domainlife "github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/storageprovisioning"
 	"github.com/juju/juju/internal/errors"
@@ -37,16 +41,57 @@ type FilesystemState interface {
 	// filled out in the [storageprovisioning.FilesystemAttachmentID] struct.
 	GetFilesystemAttachmentIDs(ctx context.Context, uuids []string) (map[string]storageprovisioning.FilesystemAttachmentID, error)
 
+	// GetFilesystemAttachmentLife returns the current life value for a
+	// filesystem attachment uuid.
+	//
+	// The following errors may be returned:
+	// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemAttachmentNotFound]
+	// when no filesystem attachment exists for the provided uuid.
+	GetFilesystemAttachmentLife(
+		context.Context,
+		storageprovisioning.FilesystemAttachmentUUID,
+	) (domainlife.Life, error)
+
 	// GetFilesystemAttachmentLifeForNetNode returns a mapping of filesystem
 	// attachment uuids to the current life value for each machine provisioned
 	// filesystem attachment that is to be provisioned by the machine owning the
 	// supplied net node.
-	GetFilesystemAttachmentLifeForNetNode(ctx context.Context, netNodeUUID domainnetwork.NetNodeUUID) (map[string]life.Life, error)
+	GetFilesystemAttachmentLifeForNetNode(ctx context.Context, netNodeUUID domainnetwork.NetNodeUUID) (map[string]domainlife.Life, error)
+
+	// GetFilesystemAttachmentUUIDForIDUnit returns the filesystem attachment uuid
+	// for the supplied filesystem id which is attached to the given net node
+	// uuid.
+	//
+	// The following errors may be returned:
+	// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemAttachmentNotFound]
+	// when no filesystem attachment exists for the supplied values.
+	GetFilesystemAttachmentUUIDForIDNetNode(
+		context.Context,
+		string,
+		domainnetwork.NetNodeUUID,
+	) (storageprovisioning.FilesystemAttachmentUUID, error)
+
+	// GetFilesystemLife returns the current life value for a filesystem uuid.
+	//
+	// The following errors may be returned:
+	// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemNotFound]
+	// when no filesystem exists for the provided filesystem uuid.
+	GetFilesystemLife(
+		context.Context, storageprovisioning.FilesystemUUID,
+	) (domainlife.Life, error)
 
 	// GetFilesystemLifeForNetNode returns a mapping of filesystem ids to current
 	// life value for each machine provisioned filesystem that is to be
 	// provisioned by the machine owning the supplied net node.
-	GetFilesystemLifeForNetNode(ctx context.Context, netNodeUUID domainnetwork.NetNodeUUID) (map[string]life.Life, error)
+	GetFilesystemLifeForNetNode(ctx context.Context, netNodeUUID domainnetwork.NetNodeUUID) (map[string]domainlife.Life, error)
+
+	// GetFilesystemUUIDForID returns the uuid for a filesystem with the supplied
+	// id.
+	//
+	// The following errors may be returned:
+	// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemNotFound]
+	// when no filesystem exists for the provided filesystem uuid.
+	GetFilesystemUUIDForID(context.Context, string) (storageprovisioning.FilesystemUUID, error)
 
 	// InitialWatchStatementMachineProvisionedFilesystems returns both the
 	// namespace for watching filesystem life changes where the filesystem is
@@ -55,7 +100,7 @@ type FilesystemState interface {
 	//
 	// Only filesystems that can be provisioned by the machine connected to the
 	// supplied net node will be emitted.
-	InitialWatchStatementMachineProvisionedFilesystems(netNodeUUID domainnetwork.NetNodeUUID) (string, eventsource.Query[map[string]life.Life])
+	InitialWatchStatementMachineProvisionedFilesystems(netNodeUUID domainnetwork.NetNodeUUID) (string, eventsource.Query[map[string]domainlife.Life])
 
 	// InitialWatchStatementModelProvisionedFilesystems returns both the
 	// namespace for watching filesystem life changes where the filesystem is
@@ -70,7 +115,7 @@ type FilesystemState interface {
 	//
 	// Only filesystem attachments that can be provisioned by the machine
 	// connected to the supplied net node will be emitted.
-	InitialWatchStatementMachineProvisionedFilesystemAttachments(netNodeUUID domainnetwork.NetNodeUUID) (string, eventsource.Query[map[string]life.Life])
+	InitialWatchStatementMachineProvisionedFilesystemAttachments(netNodeUUID domainnetwork.NetNodeUUID) (string, eventsource.Query[map[string]domainlife.Life])
 
 	// InitialWatchStatementModelProvisionedFilesystemAttachments returns both
 	// the namespace for watching filesystem attachment life changes where the
@@ -101,6 +146,149 @@ func (s *Service) GetFilesystemAttachmentIDs(
 	return s.st.GetFilesystemAttachmentIDs(ctx, uuids)
 }
 
+// GetFilesystemAttachmentLife returns the current life value for a filesystem
+// attachment uuid.
+//
+// The following errors may be returned:
+// - [coreerrors.NotValid] when the filesystem attachment uuid is not valid.
+// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemAttachmentNotFound]
+// when no filesystem attachment exists for the provided uuid.
+func (s *Service) GetFilesystemAttachmentLife(
+	ctx context.Context,
+	uuid storageprovisioning.FilesystemAttachmentUUID,
+) (corelife.Value, error) {
+	if err := uuid.Validate(); err != nil {
+		return "", errors.Errorf(
+			"validating filesystem attachment uuid: %w", err,
+		).Add(coreerrors.NotValid)
+	}
+
+	life, err := s.st.GetFilesystemAttachmentLife(ctx, uuid)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+	return life.Value()
+}
+
+// GetFilesystemAttachmentUUIDForIDMachine returns the filesystem attachment
+// uuid for the supplied filesystem id which is attached to the machine.
+//
+// The following errors may be returned:
+// - [corestorage.InvalidStorageID] when the provided id is not valid.
+// - [coreerrors.NotValid] when the provided unit uuid is not valid.
+// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemAttachmentNotFound]
+// when no filesystem attachment exists for the supplied values.
+// - [github.com/juju/juju/domain/machine/errors.MachineNotFound] when no machine
+// exists for the provided machine uuid.
+func (s *Service) GetFilesystemAttachmentUUIDForIDMachine(
+	ctx context.Context,
+	id corestorage.ID,
+	machineUUID coremachine.UUID,
+) (storageprovisioning.FilesystemAttachmentUUID, error) {
+	if err := id.Validate(); err != nil {
+		return "", errors.Capture(err)
+	}
+	if err := machineUUID.Validate(); err != nil {
+		return "", errors.Capture(err)
+	}
+
+	netNodeUUID, err := s.st.GetMachineNetNodeUUID(ctx, machineUUID)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	uuid, err := s.st.GetFilesystemAttachmentUUIDForIDNetNode(
+		ctx, id.String(), netNodeUUID,
+	)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	return uuid, nil
+}
+
+// GetFilesystemAttachmentUUIDForIDUnit returns the filesystem attachment uuid
+// for the supplied filesystem id which is attached to the unit.
+//
+// The following errors may be returned:
+// - [corestorage.InvalidStorageID] when the provided id is not valid.
+// - [coreerrors.NotValid] when the provided unit uuid is not valid.
+// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemAttachmentNotFound]
+// when no filesystem attachment exists for the supplied values.
+// - [github.com/juju/juju/domain/application/errors.UnitNotFound] when no unit
+// exists for the provided unit uuid.
+func (s *Service) GetFilesystemAttachmentUUIDForIDUnit(
+	ctx context.Context,
+	id corestorage.ID,
+	unitUUID coreunit.UUID,
+) (storageprovisioning.FilesystemAttachmentUUID, error) {
+	if err := id.Validate(); err != nil {
+		return "", errors.Capture(err)
+	}
+	if err := unitUUID.Validate(); err != nil {
+		return "", errors.Capture(err)
+	}
+
+	netNodeUUID, err := s.st.GetUnitNetNodeUUID(ctx, unitUUID)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	uuid, err := s.st.GetFilesystemAttachmentUUIDForIDNetNode(
+		ctx, id.String(), netNodeUUID,
+	)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	return uuid, nil
+}
+
+// GetFilesystemLife returns the current life value for a filesystem uuid.
+//
+// The following errors may be returned:
+// - [coreerrors.NotValid] when the filesystem uuid is not valid.
+// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemNotFound]
+// when no filesystem exists for the provided filesystem uuid.
+func (s *Service) GetFilesystemLife(
+	ctx context.Context,
+	uuid storageprovisioning.FilesystemUUID,
+) (corelife.Value, error) {
+	if err := uuid.Validate(); err != nil {
+		return "", errors.Errorf(
+			"validating filesystem uuid: %w", err,
+		).Add(coreerrors.NotValid)
+	}
+
+	life, err := s.st.GetFilesystemLife(ctx, uuid)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+	return life.Value()
+}
+
+// GetFilesystemUUIDForID returns the uuid for a filesystem with the supplied
+// id.
+//
+// The following errors may be returned:
+// - [corestorage.InvalidStorageID] when the provided id is not valid.
+// - [github.com/juju/juju/domain/storageprovisioning/errors.FilesystemNotFound]
+// when no filesystem exists for the provided filesystem uuid.
+func (s *Service) GetFilesystemUUIDForID(
+	ctx context.Context, id corestorage.ID,
+) (storageprovisioning.FilesystemUUID, error) {
+	if err := id.Validate(); err != nil {
+		return "", errors.Capture(err)
+	}
+
+	uuid, err := s.st.GetFilesystemUUIDForID(ctx, id.String())
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	return uuid, nil
+}
+
 // WatchModelProvisionedFilesystems returns a watcher that emits filesystem IDs,
 // whenever a model provisioned filsystem's life changes.
 func (s *Service) WatchModelProvisionedFilesystems(
@@ -109,7 +297,7 @@ func (s *Service) WatchModelProvisionedFilesystems(
 	ns, initialQuery := s.st.InitialWatchStatementModelProvisionedFilesystems()
 	return s.watcherFactory.NewNamespaceWatcher(
 		initialQuery,
-		eventsource.NamespaceFilter(ns, changestream.All))
+		eventsource.NamespaceFilter(ns, corechangestream.All))
 }
 
 // WatchMachineProvisionedFilesystems returns a watcher that emits filesystem IDs,
@@ -121,7 +309,7 @@ func (s *Service) WatchModelProvisionedFilesystems(
 // - [github.com/juju/juju/domain/machine/errors.MachineNotFound] when no
 // machine exists for the provided machine uuid.
 func (s *Service) WatchMachineProvisionedFilesystems(
-	ctx context.Context, machineUUID machine.UUID,
+	ctx context.Context, machineUUID coremachine.UUID,
 ) (watcher.StringsWatcher, error) {
 	if err := machineUUID.Validate(); err != nil {
 		return nil, errors.Capture(err)
@@ -131,14 +319,14 @@ func (s *Service) WatchMachineProvisionedFilesystems(
 		return nil, errors.Capture(err)
 	}
 
-	lifeGetter := func(ctx context.Context) (map[string]life.Life, error) {
+	lifeGetter := func(ctx context.Context) (map[string]domainlife.Life, error) {
 		return s.st.GetFilesystemLifeForNetNode(ctx, netNodeUUID)
 	}
 
 	ns, initialLifeQuery := s.st.InitialWatchStatementMachineProvisionedFilesystems(netNodeUUID)
 	initialQuery, mapper := makeEntityLifePrerequisites(initialLifeQuery, lifeGetter)
 	filter := eventsource.PredicateFilter(
-		ns, changestream.All, eventsource.EqualsPredicate(netNodeUUID.String()),
+		ns, corechangestream.All, eventsource.EqualsPredicate(netNodeUUID.String()),
 	)
 
 	w, err := s.watcherFactory.NewNamespaceMapperWatcher(
@@ -158,7 +346,7 @@ func (s *Service) WatchModelProvisionedFilesystemAttachments(
 ) (watcher.StringsWatcher, error) {
 	ns, initialQuery := s.st.InitialWatchStatementModelProvisionedFilesystemAttachments()
 	return s.watcherFactory.NewNamespaceWatcher(initialQuery,
-		eventsource.NamespaceFilter(ns, changestream.All))
+		eventsource.NamespaceFilter(ns, corechangestream.All))
 }
 
 // WatchMachineProvisionedFilesystemAttachments returns a watcher that emits
@@ -171,7 +359,7 @@ func (s *Service) WatchModelProvisionedFilesystemAttachments(
 // - [github.com/juju/juju/domain/machine/errors.MachineNotFound] when no
 // machine exists for the provided machine UUUID.
 func (s *Service) WatchMachineProvisionedFilesystemAttachments(
-	ctx context.Context, machineUUID machine.UUID,
+	ctx context.Context, machineUUID coremachine.UUID,
 ) (watcher.StringsWatcher, error) {
 	if err := machineUUID.Validate(); err != nil {
 		return nil, errors.Capture(err)
@@ -181,14 +369,14 @@ func (s *Service) WatchMachineProvisionedFilesystemAttachments(
 		return nil, errors.Capture(err)
 	}
 
-	lifeGetter := func(ctx context.Context) (map[string]life.Life, error) {
+	lifeGetter := func(ctx context.Context) (map[string]domainlife.Life, error) {
 		return s.st.GetFilesystemAttachmentLifeForNetNode(ctx, netNodeUUID)
 	}
 
 	ns, initialLifeQuery := s.st.InitialWatchStatementMachineProvisionedFilesystemAttachments(netNodeUUID)
 	initialQuery, mapper := makeEntityLifePrerequisites(initialLifeQuery, lifeGetter)
 	filter := eventsource.PredicateFilter(
-		ns, changestream.All, eventsource.EqualsPredicate(netNodeUUID.String()),
+		ns, corechangestream.All, eventsource.EqualsPredicate(netNodeUUID.String()),
 	)
 
 	w, err := s.watcherFactory.NewNamespaceMapperWatcher(

--- a/domain/storageprovisioning/service/package_mock_test.go
+++ b/domain/storageprovisioning/service/package_mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	machine "github.com/juju/juju/core/machine"
+	unit "github.com/juju/juju/core/unit"
 	watcher "github.com/juju/juju/core/watcher"
 	eventsource "github.com/juju/juju/core/watcher/eventsource"
 	life "github.com/juju/juju/domain/life"
@@ -123,6 +124,45 @@ func (c *MockStateGetFilesystemAttachmentIDsCall) DoAndReturn(f func(context.Con
 	return c
 }
 
+// GetFilesystemAttachmentLife mocks base method.
+func (m *MockState) GetFilesystemAttachmentLife(arg0 context.Context, arg1 storageprovisioning.FilesystemAttachmentUUID) (life.Life, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFilesystemAttachmentLife", arg0, arg1)
+	ret0, _ := ret[0].(life.Life)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFilesystemAttachmentLife indicates an expected call of GetFilesystemAttachmentLife.
+func (mr *MockStateMockRecorder) GetFilesystemAttachmentLife(arg0, arg1 any) *MockStateGetFilesystemAttachmentLifeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilesystemAttachmentLife", reflect.TypeOf((*MockState)(nil).GetFilesystemAttachmentLife), arg0, arg1)
+	return &MockStateGetFilesystemAttachmentLifeCall{Call: call}
+}
+
+// MockStateGetFilesystemAttachmentLifeCall wrap *gomock.Call
+type MockStateGetFilesystemAttachmentLifeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetFilesystemAttachmentLifeCall) Return(arg0 life.Life, arg1 error) *MockStateGetFilesystemAttachmentLifeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetFilesystemAttachmentLifeCall) Do(f func(context.Context, storageprovisioning.FilesystemAttachmentUUID) (life.Life, error)) *MockStateGetFilesystemAttachmentLifeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetFilesystemAttachmentLifeCall) DoAndReturn(f func(context.Context, storageprovisioning.FilesystemAttachmentUUID) (life.Life, error)) *MockStateGetFilesystemAttachmentLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetFilesystemAttachmentLifeForNetNode mocks base method.
 func (m *MockState) GetFilesystemAttachmentLifeForNetNode(ctx context.Context, netNodeUUID network.NetNodeUUID) (map[string]life.Life, error) {
 	m.ctrl.T.Helper()
@@ -158,6 +198,84 @@ func (c *MockStateGetFilesystemAttachmentLifeForNetNodeCall) Do(f func(context.C
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetFilesystemAttachmentLifeForNetNodeCall) DoAndReturn(f func(context.Context, network.NetNodeUUID) (map[string]life.Life, error)) *MockStateGetFilesystemAttachmentLifeForNetNodeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetFilesystemAttachmentUUIDForIDNetNode mocks base method.
+func (m *MockState) GetFilesystemAttachmentUUIDForIDNetNode(arg0 context.Context, arg1 string, arg2 network.NetNodeUUID) (storageprovisioning.FilesystemAttachmentUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFilesystemAttachmentUUIDForIDNetNode", arg0, arg1, arg2)
+	ret0, _ := ret[0].(storageprovisioning.FilesystemAttachmentUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFilesystemAttachmentUUIDForIDNetNode indicates an expected call of GetFilesystemAttachmentUUIDForIDNetNode.
+func (mr *MockStateMockRecorder) GetFilesystemAttachmentUUIDForIDNetNode(arg0, arg1, arg2 any) *MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilesystemAttachmentUUIDForIDNetNode", reflect.TypeOf((*MockState)(nil).GetFilesystemAttachmentUUIDForIDNetNode), arg0, arg1, arg2)
+	return &MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall{Call: call}
+}
+
+// MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall wrap *gomock.Call
+type MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall) Return(arg0 storageprovisioning.FilesystemAttachmentUUID, arg1 error) *MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall) Do(f func(context.Context, string, network.NetNodeUUID) (storageprovisioning.FilesystemAttachmentUUID, error)) *MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall) DoAndReturn(f func(context.Context, string, network.NetNodeUUID) (storageprovisioning.FilesystemAttachmentUUID, error)) *MockStateGetFilesystemAttachmentUUIDForIDNetNodeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetFilesystemLife mocks base method.
+func (m *MockState) GetFilesystemLife(arg0 context.Context, arg1 storageprovisioning.FilesystemUUID) (life.Life, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFilesystemLife", arg0, arg1)
+	ret0, _ := ret[0].(life.Life)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFilesystemLife indicates an expected call of GetFilesystemLife.
+func (mr *MockStateMockRecorder) GetFilesystemLife(arg0, arg1 any) *MockStateGetFilesystemLifeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilesystemLife", reflect.TypeOf((*MockState)(nil).GetFilesystemLife), arg0, arg1)
+	return &MockStateGetFilesystemLifeCall{Call: call}
+}
+
+// MockStateGetFilesystemLifeCall wrap *gomock.Call
+type MockStateGetFilesystemLifeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetFilesystemLifeCall) Return(arg0 life.Life, arg1 error) *MockStateGetFilesystemLifeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetFilesystemLifeCall) Do(f func(context.Context, storageprovisioning.FilesystemUUID) (life.Life, error)) *MockStateGetFilesystemLifeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetFilesystemLifeCall) DoAndReturn(f func(context.Context, storageprovisioning.FilesystemUUID) (life.Life, error)) *MockStateGetFilesystemLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -201,6 +319,45 @@ func (c *MockStateGetFilesystemLifeForNetNodeCall) DoAndReturn(f func(context.Co
 	return c
 }
 
+// GetFilesystemUUIDForID mocks base method.
+func (m *MockState) GetFilesystemUUIDForID(arg0 context.Context, arg1 string) (storageprovisioning.FilesystemUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFilesystemUUIDForID", arg0, arg1)
+	ret0, _ := ret[0].(storageprovisioning.FilesystemUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFilesystemUUIDForID indicates an expected call of GetFilesystemUUIDForID.
+func (mr *MockStateMockRecorder) GetFilesystemUUIDForID(arg0, arg1 any) *MockStateGetFilesystemUUIDForIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilesystemUUIDForID", reflect.TypeOf((*MockState)(nil).GetFilesystemUUIDForID), arg0, arg1)
+	return &MockStateGetFilesystemUUIDForIDCall{Call: call}
+}
+
+// MockStateGetFilesystemUUIDForIDCall wrap *gomock.Call
+type MockStateGetFilesystemUUIDForIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetFilesystemUUIDForIDCall) Return(arg0 storageprovisioning.FilesystemUUID, arg1 error) *MockStateGetFilesystemUUIDForIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetFilesystemUUIDForIDCall) Do(f func(context.Context, string) (storageprovisioning.FilesystemUUID, error)) *MockStateGetFilesystemUUIDForIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetFilesystemUUIDForIDCall) DoAndReturn(f func(context.Context, string) (storageprovisioning.FilesystemUUID, error)) *MockStateGetFilesystemUUIDForIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetMachineNetNodeUUID mocks base method.
 func (m *MockState) GetMachineNetNodeUUID(arg0 context.Context, arg1 machine.UUID) (network.NetNodeUUID, error) {
 	m.ctrl.T.Helper()
@@ -240,6 +397,45 @@ func (c *MockStateGetMachineNetNodeUUIDCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
+// GetUnitNetNodeUUID mocks base method.
+func (m *MockState) GetUnitNetNodeUUID(arg0 context.Context, arg1 unit.UUID) (network.NetNodeUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitNetNodeUUID", arg0, arg1)
+	ret0, _ := ret[0].(network.NetNodeUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitNetNodeUUID indicates an expected call of GetUnitNetNodeUUID.
+func (mr *MockStateMockRecorder) GetUnitNetNodeUUID(arg0, arg1 any) *MockStateGetUnitNetNodeUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNetNodeUUID", reflect.TypeOf((*MockState)(nil).GetUnitNetNodeUUID), arg0, arg1)
+	return &MockStateGetUnitNetNodeUUIDCall{Call: call}
+}
+
+// MockStateGetUnitNetNodeUUIDCall wrap *gomock.Call
+type MockStateGetUnitNetNodeUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitNetNodeUUIDCall) Return(arg0 network.NetNodeUUID, arg1 error) *MockStateGetUnitNetNodeUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitNetNodeUUIDCall) Do(f func(context.Context, unit.UUID) (network.NetNodeUUID, error)) *MockStateGetUnitNetNodeUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitNetNodeUUIDCall) DoAndReturn(f func(context.Context, unit.UUID) (network.NetNodeUUID, error)) *MockStateGetUnitNetNodeUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetVolumeAttachmentIDs mocks base method.
 func (m *MockState) GetVolumeAttachmentIDs(ctx context.Context, uuids []string) (map[string]storageprovisioning.VolumeAttachmentID, error) {
 	m.ctrl.T.Helper()
@@ -275,6 +471,45 @@ func (c *MockStateGetVolumeAttachmentIDsCall) Do(f func(context.Context, []strin
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetVolumeAttachmentIDsCall) DoAndReturn(f func(context.Context, []string) (map[string]storageprovisioning.VolumeAttachmentID, error)) *MockStateGetVolumeAttachmentIDsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetVolumeAttachmentLife mocks base method.
+func (m *MockState) GetVolumeAttachmentLife(arg0 context.Context, arg1 storageprovisioning.VolumeAttachmentUUID) (life.Life, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAttachmentLife", arg0, arg1)
+	ret0, _ := ret[0].(life.Life)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeAttachmentLife indicates an expected call of GetVolumeAttachmentLife.
+func (mr *MockStateMockRecorder) GetVolumeAttachmentLife(arg0, arg1 any) *MockStateGetVolumeAttachmentLifeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAttachmentLife", reflect.TypeOf((*MockState)(nil).GetVolumeAttachmentLife), arg0, arg1)
+	return &MockStateGetVolumeAttachmentLifeCall{Call: call}
+}
+
+// MockStateGetVolumeAttachmentLifeCall wrap *gomock.Call
+type MockStateGetVolumeAttachmentLifeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetVolumeAttachmentLifeCall) Return(arg0 life.Life, arg1 error) *MockStateGetVolumeAttachmentLifeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetVolumeAttachmentLifeCall) Do(f func(context.Context, storageprovisioning.VolumeAttachmentUUID) (life.Life, error)) *MockStateGetVolumeAttachmentLifeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetVolumeAttachmentLifeCall) DoAndReturn(f func(context.Context, storageprovisioning.VolumeAttachmentUUID) (life.Life, error)) *MockStateGetVolumeAttachmentLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -357,6 +592,84 @@ func (c *MockStateGetVolumeAttachmentPlanLifeForNetNodeCall) DoAndReturn(f func(
 	return c
 }
 
+// GetVolumeAttachmentUUIDForIDNetNode mocks base method.
+func (m *MockState) GetVolumeAttachmentUUIDForIDNetNode(arg0 context.Context, arg1 string, arg2 network.NetNodeUUID) (storageprovisioning.VolumeAttachmentUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAttachmentUUIDForIDNetNode", arg0, arg1, arg2)
+	ret0, _ := ret[0].(storageprovisioning.VolumeAttachmentUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeAttachmentUUIDForIDNetNode indicates an expected call of GetVolumeAttachmentUUIDForIDNetNode.
+func (mr *MockStateMockRecorder) GetVolumeAttachmentUUIDForIDNetNode(arg0, arg1, arg2 any) *MockStateGetVolumeAttachmentUUIDForIDNetNodeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAttachmentUUIDForIDNetNode", reflect.TypeOf((*MockState)(nil).GetVolumeAttachmentUUIDForIDNetNode), arg0, arg1, arg2)
+	return &MockStateGetVolumeAttachmentUUIDForIDNetNodeCall{Call: call}
+}
+
+// MockStateGetVolumeAttachmentUUIDForIDNetNodeCall wrap *gomock.Call
+type MockStateGetVolumeAttachmentUUIDForIDNetNodeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetVolumeAttachmentUUIDForIDNetNodeCall) Return(arg0 storageprovisioning.VolumeAttachmentUUID, arg1 error) *MockStateGetVolumeAttachmentUUIDForIDNetNodeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetVolumeAttachmentUUIDForIDNetNodeCall) Do(f func(context.Context, string, network.NetNodeUUID) (storageprovisioning.VolumeAttachmentUUID, error)) *MockStateGetVolumeAttachmentUUIDForIDNetNodeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetVolumeAttachmentUUIDForIDNetNodeCall) DoAndReturn(f func(context.Context, string, network.NetNodeUUID) (storageprovisioning.VolumeAttachmentUUID, error)) *MockStateGetVolumeAttachmentUUIDForIDNetNodeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetVolumeLife mocks base method.
+func (m *MockState) GetVolumeLife(arg0 context.Context, arg1 storageprovisioning.VolumeUUID) (life.Life, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeLife", arg0, arg1)
+	ret0, _ := ret[0].(life.Life)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeLife indicates an expected call of GetVolumeLife.
+func (mr *MockStateMockRecorder) GetVolumeLife(arg0, arg1 any) *MockStateGetVolumeLifeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeLife", reflect.TypeOf((*MockState)(nil).GetVolumeLife), arg0, arg1)
+	return &MockStateGetVolumeLifeCall{Call: call}
+}
+
+// MockStateGetVolumeLifeCall wrap *gomock.Call
+type MockStateGetVolumeLifeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetVolumeLifeCall) Return(arg0 life.Life, arg1 error) *MockStateGetVolumeLifeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetVolumeLifeCall) Do(f func(context.Context, storageprovisioning.VolumeUUID) (life.Life, error)) *MockStateGetVolumeLifeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetVolumeLifeCall) DoAndReturn(f func(context.Context, storageprovisioning.VolumeUUID) (life.Life, error)) *MockStateGetVolumeLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetVolumeLifeForNetNode mocks base method.
 func (m *MockState) GetVolumeLifeForNetNode(ctx context.Context, netNodeUUID network.NetNodeUUID) (map[string]life.Life, error) {
 	m.ctrl.T.Helper()
@@ -392,6 +705,45 @@ func (c *MockStateGetVolumeLifeForNetNodeCall) Do(f func(context.Context, networ
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetVolumeLifeForNetNodeCall) DoAndReturn(f func(context.Context, network.NetNodeUUID) (map[string]life.Life, error)) *MockStateGetVolumeLifeForNetNodeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetVolumeUUIDForID mocks base method.
+func (m *MockState) GetVolumeUUIDForID(arg0 context.Context, arg1 string) (storageprovisioning.VolumeUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeUUIDForID", arg0, arg1)
+	ret0, _ := ret[0].(storageprovisioning.VolumeUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeUUIDForID indicates an expected call of GetVolumeUUIDForID.
+func (mr *MockStateMockRecorder) GetVolumeUUIDForID(arg0, arg1 any) *MockStateGetVolumeUUIDForIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeUUIDForID", reflect.TypeOf((*MockState)(nil).GetVolumeUUIDForID), arg0, arg1)
+	return &MockStateGetVolumeUUIDForIDCall{Call: call}
+}
+
+// MockStateGetVolumeUUIDForIDCall wrap *gomock.Call
+type MockStateGetVolumeUUIDForIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetVolumeUUIDForIDCall) Return(arg0 storageprovisioning.VolumeUUID, arg1 error) *MockStateGetVolumeUUIDForIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetVolumeUUIDForIDCall) Do(f func(context.Context, string) (storageprovisioning.VolumeUUID, error)) *MockStateGetVolumeUUIDForIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetVolumeUUIDForIDCall) DoAndReturn(f func(context.Context, string) (storageprovisioning.VolumeUUID, error)) *MockStateGetVolumeUUIDForIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/storageprovisioning/service/service.go
+++ b/domain/storageprovisioning/service/service.go
@@ -7,7 +7,8 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/changestream"
-	"github.com/juju/juju/core/machine"
+	coremachine "github.com/juju/juju/core/machine"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
@@ -34,7 +35,7 @@ type State interface {
 	// The following errors may be returned:
 	// - [github.com/juju/juju/domain/machine/errors.MachineNotFound] when no
 	// machine exists for the provided uuid.
-	CheckMachineIsDead(context.Context, machine.UUID) (bool, error)
+	CheckMachineIsDead(context.Context, coremachine.UUID) (bool, error)
 
 	// GetMachineNetNodeUUID retrieves the net node uuid associated with provided
 	// machine.
@@ -42,7 +43,15 @@ type State interface {
 	// The following errors may be returned:
 	// - [github.com/juju/juju/domain/machine/errors.MachineNotFound] when no
 	// machine exists for the provided uuid.
-	GetMachineNetNodeUUID(context.Context, machine.UUID) (domainnetwork.NetNodeUUID, error)
+	GetMachineNetNodeUUID(context.Context, coremachine.UUID) (domainnetwork.NetNodeUUID, error)
+
+	// GetUnitNetNodeUUID returns the node uuid associated with the supplied
+	// unit.
+	//
+	// The following errors may be returned:
+	// - [github.com/juju/juju/domain/application/errors.UnitNotFound] when no
+	// unit exists for the supplied unit uuid.
+	GetUnitNetNodeUUID(context.Context, coreunit.UUID) (domainnetwork.NetNodeUUID, error)
 
 	// NamespaceForWatchMachineCloudInstance returns the change stream namespace
 	// for watching machine cloud instance changes.
@@ -100,7 +109,7 @@ func NewService(st State, wf WatcherFactory) *Service {
 // - [machineerrors.MachineIsDead] when the machine is dead meaning it is about
 // to go away.
 func (s *Service) WatchMachineCloudInstance(
-	ctx context.Context, machineUUID machine.UUID,
+	ctx context.Context, machineUUID coremachine.UUID,
 ) (watcher.NotifyWatcher, error) {
 	dead, err := s.st.CheckMachineIsDead(ctx, machineUUID)
 	if err != nil {

--- a/domain/storageprovisioning/uuid.go
+++ b/domain/storageprovisioning/uuid.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioning
+
+import (
+	"github.com/juju/juju/internal/errors"
+	internaluuid "github.com/juju/juju/internal/uuid"
+)
+
+// FilesystemAttachmentUUID represents the unique id for a storage filesystem
+// attachment in the model.
+type FilesystemAttachmentUUID uuid
+
+// FilesystemUUID represents the unique id for a storage filesystem
+// in the model.
+type FilesystemUUID uuid
+
+// VolumeAttachmentUUID represents the unique id for a storage volume
+// attachment in the model.
+type VolumeAttachmentUUID uuid
+
+// VolumeUUID represents the unique id for a storage volume instance.
+type VolumeUUID uuid
+
+type uuid string
+
+// NewFileystemAttachmentUUID creates a new, valid storage filesystem attachment
+// identifier.
+func NewFilesystemAttachmentUUID() (FilesystemAttachmentUUID, error) {
+	u, err := newUUID()
+	return FilesystemAttachmentUUID(u), err
+}
+
+// NewFileystemUUID creates a new, valid storage filesystem identifier.
+func NewFileystemUUID() (FilesystemUUID, error) {
+	u, err := newUUID()
+	return FilesystemUUID(u), err
+}
+
+// NewVolumeAttachmentUUID creates a new, valid storage volume attachment
+// identifier.
+func NewVolumeAttachmentUUID() (VolumeAttachmentUUID, error) {
+	u, err := newUUID()
+	return VolumeAttachmentUUID(u), err
+}
+
+// NewVolumeUUID creates a new, valid storage volume identifier.
+func NewVolumeUUID() (VolumeUUID, error) {
+	u, err := newUUID()
+	return VolumeUUID(u), err
+}
+
+// newUUID creates a new UUID using the internal uuid package.
+func newUUID() (uuid, error) {
+	id, err := internaluuid.NewUUID()
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+	return uuid(id.String()), nil
+}
+
+// String returns the string representation of this uuid. This function
+// satisfies the [fmt.Stringer] interface.
+func (u FilesystemAttachmentUUID) String() string {
+	return uuid(u).String()
+}
+
+// String returns the string representation of this uuid. This function
+// satisfies the [fmt.Stringer] interface.
+func (u FilesystemUUID) String() string {
+	return uuid(u).String()
+}
+
+// String returns the string representation of this uuid. This function
+// satisfies the [fmt.Stringer] interface.
+func (u VolumeAttachmentUUID) String() string {
+	return uuid(u).String()
+}
+
+// String returns the string representation of this uuid. This function
+// satisfies the [fmt.Stringer] interface.
+func (u VolumeUUID) String() string {
+	return uuid(u).String()
+}
+
+// String returns the string representation of this uuid. This function
+// satisfies the [fmt.Stringer] interface.
+func (u uuid) String() string {
+	return string(u)
+}
+
+// Validate returns an error if the [FilesystemAttachmentUUID] is not valid.
+func (u FilesystemAttachmentUUID) Validate() error {
+	return uuid(u).validate()
+}
+
+// Validate returns an error if the [FilesystemUUID] is not valid.
+func (u FilesystemUUID) Validate() error {
+	return uuid(u).validate()
+}
+
+// Validate returns an error if the [VolumeAttachmentUUID] is not valid.
+func (u VolumeAttachmentUUID) Validate() error {
+	return uuid(u).validate()
+}
+
+// Validate returns an error if the [VolumeUUID] is not valid.
+func (u VolumeUUID) Validate() error {
+	return uuid(u).validate()
+}
+
+// validate checks that [uuid] is a valid uuid returning an error if it is not.
+func (u uuid) validate() error {
+	if u == "" {
+		return errors.New("empty uuid")
+	}
+	internaluuid.IsValidUUIDString(u.String())
+	if !internaluuid.IsValidUUIDString(string(u)) {
+		return errors.Errorf("invalid uuid %q", u)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR introduces support to Juju for fetching the current life value of storage entities in the model such as filesystems, volume and their respective attachments. This information is used by the storage provisioning worker to influence the operations it must be performed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Coming soon.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-8210
