### PR TITLE
refactor(modelmanager): cut over modelmanager to DQLite

### DIFF
--- a/apiserver/common/model/machine_test.go
+++ b/apiserver/common/model/machine_test.go
@@ -5,22 +5,17 @@ package model_test
 
 import (
 	"testing"
-	"time"
 
-	"github.com/juju/errors"
-	"github.com/juju/names/v6"
-	"github.com/juju/naturalsort"
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/apiserver/common/model"
 	"github.com/juju/juju/core/instance"
+	corelife "github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machine"
-	"github.com/juju/juju/core/objectstore"
+	machinetesting "github.com/juju/juju/core/machine/testing"
 	"github.com/juju/juju/core/status"
-	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 )
 
 type machineSuite struct {
@@ -48,139 +43,15 @@ func (s *machineSuite) setupMocks(c *tc.C) *gomock.Controller {
 func (s *machineSuite) TestMachineHardwareInfo(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	one := uint64(1)
-	amd64 := "amd64"
-	gig := uint64(1024)
-	hw := &instance.HardwareCharacteristics{
-		Arch:     &amd64,
-		Mem:      &gig,
-		CpuCores: &one,
-		CpuPower: &one,
-	}
-	st := mockState{
-		machines: map[string]*fakeMachine{
-			"1": {id: "1", life: state.Alive, containerType: instance.NONE,
-				hw: hw,
-			},
-			"2": {id: "2", life: state.Alive, containerType: instance.LXD},
-			"3": {life: state.Dying},
-		},
-	}
+	machine1Name := machine.Name("1")
+	machine1UUID := machinetesting.GenUUID(c)
+	machine2Name := machine.Name("2")
+	machine2UUID := machinetesting.GenUUID(c)
+	machine3Name := machine.Name("3")
 
-	s.statusService.EXPECT().GetAllMachineStatuses(gomock.Any()).Return(map[machine.Name]status.StatusInfo{}, nil)
-
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "one-two-three", nil)
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("uuid-2", nil)
-	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine.UUID("uuid-2")).Return("456", "four-five-six", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(hw, nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine.UUID("uuid-2")).Return(&instance.HardwareCharacteristics{}, nil)
-	info, err := model.ModelMachineInfo(c.Context(), &st, s.machineService, s.statusService)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(info, tc.DeepEquals, []params.ModelMachineInfo{
-		{
-			Id:          "1",
-			InstanceId:  "123",
-			DisplayName: "one-two-three",
-			Status:      "unknown",
-			Hardware: &params.MachineHardware{
-				Arch:     &amd64,
-				Mem:      &gig,
-				Cores:    &one,
-				CpuPower: &one,
-			},
-		}, {
-			Id:          "2",
-			InstanceId:  "456",
-			DisplayName: "four-five-six",
-			Status:      "unknown",
-		},
-	})
-}
-
-func (s *machineSuite) TestMachineMachineNotFound(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	one := uint64(1)
-	amd64 := "amd64"
-	gig := uint64(1024)
-	hw := &instance.HardwareCharacteristics{
-		Arch:     &amd64,
-		Mem:      &gig,
-		CpuCores: &one,
-		CpuPower: &one,
-	}
-	st := mockState{
-		machines: map[string]*fakeMachine{
-			"1": {id: "1", life: state.Alive, containerType: instance.NONE,
-				hw: hw,
-			},
-		},
-	}
-
-	s.statusService.EXPECT().GetAllMachineStatuses(gomock.Any()).Return(map[machine.Name]status.StatusInfo{}, nil)
-
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "one-two-three", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(hw, machineerrors.MachineNotFound)
-	_, err := model.ModelMachineInfo(c.Context(), &st, s.machineService, s.statusService)
-	c.Assert(err, tc.ErrorIs, errors.NotFound)
-}
-
-func (s *machineSuite) TestMachineHardwareInfoMachineNotFound(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	one := uint64(1)
-	amd64 := "amd64"
-	gig := uint64(1024)
-	hw := &instance.HardwareCharacteristics{
-		Arch:     &amd64,
-		Mem:      &gig,
-		CpuCores: &one,
-		CpuPower: &one,
-	}
-	st := mockState{
-		machines: map[string]*fakeMachine{
-			"1": {id: "1", life: state.Alive, containerType: instance.NONE,
-				hw: hw,
-			},
-		},
-	}
-	s.statusService.EXPECT().GetAllMachineStatuses(gomock.Any()).Return(map[machine.Name]status.StatusInfo{}, nil)
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", machineerrors.MachineNotFound)
-	_, err := model.ModelMachineInfo(c.Context(), &st, s.machineService, s.statusService)
-	c.Assert(err, tc.ErrorIs, errors.NotFound)
-}
-
-func (s *machineSuite) TestMachineInstanceInfo(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	st := mockState{
-		machines: map[string]*fakeMachine{
-			"1": {
-				id:     "1",
-				instId: "123",
-			},
-			"2": {
-				id:          "2",
-				instId:      "456",
-				displayName: "four-five-six",
-			},
-		},
-		controllerNodes: map[string]*mockControllerNode{
-			"1": {
-				id:        "1",
-				hasVote:   true,
-				wantsVote: true,
-			},
-			"2": {
-				id:        "2",
-				hasVote:   false,
-				wantsVote: true,
-			},
-		},
-	}
-
+	s.machineService.EXPECT().AllMachineNames(gomock.Any()).Return([]machine.Name{
+		machine1Name, machine2Name, machine3Name,
+	}, nil)
 	s.statusService.EXPECT().GetAllMachineStatuses(gomock.Any()).Return(map[machine.Name]status.StatusInfo{
 		"1": {
 			Status:  status.Down,
@@ -192,22 +63,46 @@ func (s *machineSuite) TestMachineInstanceInfo(c *tc.C) {
 		},
 	}, nil)
 
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "", nil)
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("uuid-2", nil)
-	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine.UUID("uuid-2")).Return("456", "four-five-six", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(&instance.HardwareCharacteristics{}, nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine.UUID("uuid-2")).Return(&instance.HardwareCharacteristics{}, nil)
-	info, err := model.ModelMachineInfo(c.Context(), &st, s.machineService, s.statusService)
+	s.machineService.EXPECT().GetMachineLife(gomock.Any(), machine1Name).Return(corelife.Alive, nil)
+	s.machineService.EXPECT().GetMachineLife(gomock.Any(), machine2Name).Return(corelife.Alive, nil)
+	s.machineService.EXPECT().GetMachineLife(gomock.Any(), machine3Name).Return(corelife.Dying, nil)
+
+	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine1Name).Return(machine1UUID, nil)
+	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine2Name).Return(machine2UUID, nil)
+
+	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine1UUID).Return("123", "one-two-three", nil)
+	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine2UUID).Return("456", "four-five-six", nil)
+
+	s.machineService.EXPECT().GetSupportedContainersTypes(gomock.Any(), machine1UUID).Return([]instance.ContainerType{}, nil)
+	s.machineService.EXPECT().GetSupportedContainersTypes(gomock.Any(), machine2UUID).Return([]instance.ContainerType{instance.LXD}, nil)
+
+	one := uint64(1)
+	amd64 := "amd64"
+	gig := uint64(1024)
+	hw := &instance.HardwareCharacteristics{
+		Arch:     &amd64,
+		Mem:      &gig,
+		CpuCores: &one,
+		CpuPower: &one,
+	}
+	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine1UUID).Return(hw, nil)
+
+	info, err := model.ModelMachineInfo(c.Context(), s.machineService, s.statusService)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(info, tc.DeepEquals, []params.ModelMachineInfo{
 		{
-			Id:         "1",
-			InstanceId: "123",
-			Status:     "down",
-			Message:    "it's down",
-		},
-		{
+			Id:          "1",
+			InstanceId:  "123",
+			DisplayName: "one-two-three",
+			Status:      "down",
+			Message:     "it's down",
+			Hardware: &params.MachineHardware{
+				Arch:     &amd64,
+				Mem:      &gig,
+				Cores:    &one,
+				CpuPower: &one,
+			},
+		}, {
 			Id:          "2",
 			InstanceId:  "456",
 			DisplayName: "four-five-six",
@@ -215,229 +110,4 @@ func (s *machineSuite) TestMachineInstanceInfo(c *tc.C) {
 			Message:     "it's allocating",
 		},
 	})
-}
-
-func (s *machineSuite) TestMachineInstanceInfoWithEmptyDisplayName(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	st := mockState{
-		machines: map[string]*fakeMachine{
-			"1": {
-				id:          "1",
-				instId:      "123",
-				displayName: "",
-			},
-		},
-		controllerNodes: map[string]*mockControllerNode{
-			"1": {
-				id:        "1",
-				hasVote:   true,
-				wantsVote: true,
-			},
-		},
-	}
-
-	s.statusService.EXPECT().GetAllMachineStatuses(gomock.Any()).Return(map[machine.Name]status.StatusInfo{}, nil)
-
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(&instance.HardwareCharacteristics{}, nil)
-	info, err := model.ModelMachineInfo(c.Context(), &st, s.machineService, s.statusService)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(info, tc.DeepEquals, []params.ModelMachineInfo{
-		{
-			Id:          "1",
-			InstanceId:  "123",
-			DisplayName: "",
-			Status:      "unknown",
-		},
-	})
-}
-
-func (s *machineSuite) TestMachineInstanceInfoWithSetDisplayName(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	st := mockState{
-		machines: map[string]*fakeMachine{
-			"1": {
-				id:          "1",
-				instId:      "123",
-				displayName: "snowflake",
-			},
-		},
-		controllerNodes: map[string]*mockControllerNode{
-			"1": {
-				id:        "1",
-				hasVote:   true,
-				wantsVote: true,
-			},
-		},
-	}
-
-	s.statusService.EXPECT().GetAllMachineStatuses(gomock.Any()).Return(map[machine.Name]status.StatusInfo{}, nil)
-
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "snowflake", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(&instance.HardwareCharacteristics{}, nil)
-	info, err := model.ModelMachineInfo(c.Context(), &st, s.machineService, s.statusService)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(info, tc.DeepEquals, []params.ModelMachineInfo{
-		{
-			Id:          "1",
-			InstanceId:  "123",
-			DisplayName: "snowflake",
-			Status:      "unknown",
-		},
-	})
-}
-
-func (s *machineSuite) TestMachineInstanceInfoWithHAPrimary(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	st := mockState{
-		machines: map[string]*fakeMachine{
-			"1": {
-				id:          "1",
-				instId:      "123",
-				displayName: "snowflake",
-			},
-		},
-		controllerNodes: map[string]*mockControllerNode{
-			"1": {
-				id:        "1",
-				hasVote:   true,
-				wantsVote: true,
-			},
-			"2": {
-				id:        "1",
-				hasVote:   true,
-				wantsVote: true,
-			},
-		},
-		haPrimaryMachineF: func() (names.MachineTag, error) {
-			return names.NewMachineTag("1"), nil
-		},
-	}
-
-	s.statusService.EXPECT().GetAllMachineStatuses(gomock.Any()).Return(map[machine.Name]status.StatusInfo{}, nil)
-
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("1")).Return("uuid-1", nil)
-	s.machineService.EXPECT().GetInstanceIDAndName(gomock.Any(), machine.UUID("uuid-1")).Return("123", "snowflake", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), machine.UUID("uuid-1")).Return(&instance.HardwareCharacteristics{}, nil)
-	info, err := model.ModelMachineInfo(c.Context(), &st, s.machineService, s.statusService)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(info, tc.DeepEquals, []params.ModelMachineInfo{
-		{
-			Id:          "1",
-			InstanceId:  "123",
-			DisplayName: "snowflake",
-			Status:      "unknown",
-		},
-	})
-}
-
-type mockState struct {
-	model.ModelManagerBackend
-	machines          map[string]*fakeMachine
-	controllerNodes   map[string]*mockControllerNode
-	haPrimaryMachineF func() (names.MachineTag, error)
-}
-
-func (st *mockState) AllMachines() (machines []model.Machine, _ error) {
-	// Ensure we get machines in id order.
-	var ids []string
-	for id := range st.machines {
-		ids = append(ids, id)
-	}
-	naturalsort.Sort(ids)
-	for _, id := range ids {
-		machines = append(machines, st.machines[id])
-	}
-	return machines, nil
-}
-
-func (st *mockState) ControllerNodes() ([]model.ControllerNode, error) {
-	var result []model.ControllerNode
-	for _, n := range st.controllerNodes {
-		result = append(result, n)
-	}
-	return result, nil
-}
-
-func (st *mockState) HAPrimaryMachine() (names.MachineTag, error) {
-	if st.haPrimaryMachineF == nil {
-		return names.MachineTag{}, nil
-	}
-	return st.haPrimaryMachineF()
-}
-
-type mockControllerNode struct {
-	id        string
-	hasVote   bool
-	wantsVote bool
-}
-
-func (m *mockControllerNode) Id() string {
-	return m.id
-}
-
-func (m *mockControllerNode) WantsVote() bool {
-	return m.wantsVote
-}
-
-func (m *mockControllerNode) HasVote() bool {
-	return m.hasVote
-}
-
-type fakeMachine struct {
-	state.Machine
-	id                 string
-	life               state.Life
-	containerType      instance.ContainerType
-	hw                 *instance.HardwareCharacteristics
-	instId             instance.Id
-	displayName        string
-	destroyErr         error
-	forceDestroyErr    error
-	forceDestroyCalled bool
-	destroyCalled      bool
-}
-
-func (m *fakeMachine) Id() string {
-	return m.id
-}
-
-func (m *fakeMachine) Life() state.Life {
-	return m.life
-}
-
-func (m *fakeMachine) InstanceId() (instance.Id, error) {
-	return m.instId, nil
-}
-
-func (m *fakeMachine) InstanceNames() (instance.Id, string, error) {
-	instId, err := m.InstanceId()
-	return instId, m.displayName, err
-}
-
-func (m *fakeMachine) HardwareCharacteristics() (*instance.HardwareCharacteristics, error) {
-	return m.hw, nil
-}
-
-func (m *fakeMachine) ForceDestroy(time.Duration) error {
-	m.forceDestroyCalled = true
-	if m.forceDestroyErr != nil {
-		return m.forceDestroyErr
-	}
-	m.life = state.Dying
-	return nil
-}
-
-func (m *fakeMachine) Destroy(_ objectstore.ObjectStore) error {
-	m.destroyCalled = true
-	if m.destroyErr != nil {
-		return m.destroyErr
-	}
-	m.life = state.Dying
-	return nil
 }

--- a/apiserver/common/model/modelstatus.go
+++ b/apiserver/common/model/modelstatus.go
@@ -179,7 +179,7 @@ func (c *ModelStatusAPI) modelStatus(ctx context.Context, tag string) (params.Mo
 	if err != nil {
 		return status, errors.Trace(err)
 	}
-	modelMachines, err := ModelMachineInfo(ctx, st, machineService, statusService)
+	modelMachines, err := ModelMachineInfo(ctx, machineService, statusService)
 	if err != nil {
 		return status, errors.Trace(err)
 	}

--- a/apiserver/common/model/modelstatus_test.go
+++ b/apiserver/common/model/modelstatus_test.go
@@ -169,6 +169,7 @@ func (s *modelStatusSuite) TestModelStatusRunsForAllModels(c *tc.C) {
 		Type: coremodel.IAAS,
 	}, nil)
 
+	s.machineService.EXPECT().AllMachineNames(gomock.Any()).Return([]machine.Name{}, nil)
 	s.statusService.EXPECT().GetAllMachineStatuses(gomock.Any()).Return(map[machine.Name]status.StatusInfo{}, nil)
 
 	modelStatusAPI := model.NewModelStatusAPI(

--- a/apiserver/common/model/service_mock_test.go
+++ b/apiserver/common/model/service_mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	instance "github.com/juju/juju/core/instance"
+	life "github.com/juju/juju/core/life"
 	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
 	status "github.com/juju/juju/core/status"
@@ -45,6 +46,45 @@ func NewMockMachineService(ctrl *gomock.Controller) *MockMachineService {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 	return m.recorder
+}
+
+// AllMachineNames mocks base method.
+func (m *MockMachineService) AllMachineNames(arg0 context.Context) ([]machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllMachineNames", arg0)
+	ret0, _ := ret[0].([]machine.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllMachineNames indicates an expected call of AllMachineNames.
+func (mr *MockMachineServiceMockRecorder) AllMachineNames(arg0 any) *MockMachineServiceAllMachineNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachineNames", reflect.TypeOf((*MockMachineService)(nil).AllMachineNames), arg0)
+	return &MockMachineServiceAllMachineNamesCall{Call: call}
+}
+
+// MockMachineServiceAllMachineNamesCall wrap *gomock.Call
+type MockMachineServiceAllMachineNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceAllMachineNamesCall) Return(arg0 []machine.Name, arg1 error) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceAllMachineNamesCall) Do(f func(context.Context) ([]machine.Name, error)) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]machine.Name, error)) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetHardwareCharacteristics mocks base method.
@@ -126,6 +166,45 @@ func (c *MockMachineServiceGetInstanceIDAndNameCall) DoAndReturn(f func(context.
 	return c
 }
 
+// GetMachineLife mocks base method.
+func (m *MockMachineService) GetMachineLife(arg0 context.Context, arg1 machine.Name) (life.Value, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineLife", arg0, arg1)
+	ret0, _ := ret[0].(life.Value)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineLife indicates an expected call of GetMachineLife.
+func (mr *MockMachineServiceMockRecorder) GetMachineLife(arg0, arg1 any) *MockMachineServiceGetMachineLifeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineLife", reflect.TypeOf((*MockMachineService)(nil).GetMachineLife), arg0, arg1)
+	return &MockMachineServiceGetMachineLifeCall{Call: call}
+}
+
+// MockMachineServiceGetMachineLifeCall wrap *gomock.Call
+type MockMachineServiceGetMachineLifeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceGetMachineLifeCall) Return(arg0 life.Value, arg1 error) *MockMachineServiceGetMachineLifeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceGetMachineLifeCall) Do(f func(context.Context, machine.Name) (life.Value, error)) *MockMachineServiceGetMachineLifeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceGetMachineLifeCall) DoAndReturn(f func(context.Context, machine.Name) (life.Value, error)) *MockMachineServiceGetMachineLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetMachineUUID mocks base method.
 func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
@@ -161,6 +240,45 @@ func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machin
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetSupportedContainersTypes mocks base method.
+func (m *MockMachineService) GetSupportedContainersTypes(arg0 context.Context, arg1 machine.UUID) ([]instance.ContainerType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSupportedContainersTypes", arg0, arg1)
+	ret0, _ := ret[0].([]instance.ContainerType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSupportedContainersTypes indicates an expected call of GetSupportedContainersTypes.
+func (mr *MockMachineServiceMockRecorder) GetSupportedContainersTypes(arg0, arg1 any) *MockMachineServiceGetSupportedContainersTypesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedContainersTypes", reflect.TypeOf((*MockMachineService)(nil).GetSupportedContainersTypes), arg0, arg1)
+	return &MockMachineServiceGetSupportedContainersTypesCall{Call: call}
+}
+
+// MockMachineServiceGetSupportedContainersTypesCall wrap *gomock.Call
+type MockMachineServiceGetSupportedContainersTypesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceGetSupportedContainersTypesCall) Return(arg0 []instance.ContainerType, arg1 error) *MockMachineServiceGetSupportedContainersTypesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceGetSupportedContainersTypesCall) Do(f func(context.Context, machine.UUID) ([]instance.ContainerType, error)) *MockMachineServiceGetSupportedContainersTypesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceGetSupportedContainersTypesCall) DoAndReturn(f func(context.Context, machine.UUID) ([]instance.ContainerType, error)) *MockMachineServiceGetSupportedContainersTypesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/controller/service.go
+++ b/apiserver/facades/client/controller/service.go
@@ -171,6 +171,10 @@ type MachineService interface {
 	// specified machine.
 	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
 
+	// GetSupportedContainersTypes returns the supported container types for the
+	// provider.
+	GetSupportedContainersTypes(context.Context, machine.UUID) ([]instance.ContainerType, error)
+
 	// WatchModelMachines watches for additions or updates to non-container
 	// machines. It is used by workers that need to factor life value changes,
 	// and so does not factor machine removals, which are considered to be

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -49,7 +49,6 @@ type mockState struct {
 	cloudUsers      map[string]permission.Access
 	model           *mockModel
 	controllerModel *mockModel
-	machines        []commonmodel.Machine
 	controllerNodes []commonmodel.ControllerNode
 }
 
@@ -125,11 +124,6 @@ func (st *mockState) Model() (commonmodel.Model, error) {
 func (st *mockState) ModelTag() names.ModelTag {
 	st.MethodCall(st, "ModelTag")
 	return st.model.ModelTag()
-}
-
-func (st *mockState) AllMachines() ([]commonmodel.Machine, error) {
-	st.MethodCall(st, "AllMachines")
-	return st.machines, st.NextErr()
 }
 
 func (st *mockState) Close() error {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -897,21 +897,12 @@ func (m *ModelManagerAPI) ModelInfo(ctx context.Context, args params.Entities) (
 			return modelInfo, nil
 		}
 
-		st, release, err := m.state.GetBackend(tag.Id())
-		if errors.Is(err, errors.NotFound) {
-			return params.ModelInfo{}, errors.Trace(apiservererrors.ErrPerm)
-		} else if err != nil {
-			return params.ModelInfo{}, errors.Trace(err)
-		}
-		defer release()
-
 		modelUUID := coremodel.UUID(tag.Id())
 		modelDomainServices, err := m.domainServicesGetter.DomainServicesForModel(ctx, modelUUID)
 		if err != nil {
 			return params.ModelInfo{}, errors.Trace(err)
 		}
-		// TODO: remove mongo state from the commonmodel.ModelMachineInfo.
-		if modelInfo.Machines, err = commonmodel.ModelMachineInfo(ctx, st, modelDomainServices.Machine(), modelDomainServices.Status()); err != nil {
+		if modelInfo.Machines, err = commonmodel.ModelMachineInfo(ctx, modelDomainServices.Machine(), modelDomainServices.Status()); err != nil {
 			return params.ModelInfo{}, err
 		}
 

--- a/apiserver/facades/client/modelmanager/service_mock_test.go
+++ b/apiserver/facades/client/modelmanager/service_mock_test.go
@@ -19,6 +19,7 @@ import (
 	assumes "github.com/juju/juju/core/assumes"
 	credential "github.com/juju/juju/core/credential"
 	instance "github.com/juju/juju/core/instance"
+	life "github.com/juju/juju/core/life"
 	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
 	semversion "github.com/juju/juju/core/semversion"
@@ -1833,6 +1834,45 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 	return m.recorder
 }
 
+// AllMachineNames mocks base method.
+func (m *MockMachineService) AllMachineNames(arg0 context.Context) ([]machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllMachineNames", arg0)
+	ret0, _ := ret[0].([]machine.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllMachineNames indicates an expected call of AllMachineNames.
+func (mr *MockMachineServiceMockRecorder) AllMachineNames(arg0 any) *MockMachineServiceAllMachineNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachineNames", reflect.TypeOf((*MockMachineService)(nil).AllMachineNames), arg0)
+	return &MockMachineServiceAllMachineNamesCall{Call: call}
+}
+
+// MockMachineServiceAllMachineNamesCall wrap *gomock.Call
+type MockMachineServiceAllMachineNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceAllMachineNamesCall) Return(arg0 []machine.Name, arg1 error) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceAllMachineNamesCall) Do(f func(context.Context) ([]machine.Name, error)) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]machine.Name, error)) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetHardwareCharacteristics mocks base method.
 func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
@@ -1912,6 +1952,45 @@ func (c *MockMachineServiceGetInstanceIDAndNameCall) DoAndReturn(f func(context.
 	return c
 }
 
+// GetMachineLife mocks base method.
+func (m *MockMachineService) GetMachineLife(arg0 context.Context, arg1 machine.Name) (life.Value, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineLife", arg0, arg1)
+	ret0, _ := ret[0].(life.Value)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineLife indicates an expected call of GetMachineLife.
+func (mr *MockMachineServiceMockRecorder) GetMachineLife(arg0, arg1 any) *MockMachineServiceGetMachineLifeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineLife", reflect.TypeOf((*MockMachineService)(nil).GetMachineLife), arg0, arg1)
+	return &MockMachineServiceGetMachineLifeCall{Call: call}
+}
+
+// MockMachineServiceGetMachineLifeCall wrap *gomock.Call
+type MockMachineServiceGetMachineLifeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceGetMachineLifeCall) Return(arg0 life.Value, arg1 error) *MockMachineServiceGetMachineLifeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceGetMachineLifeCall) Do(f func(context.Context, machine.Name) (life.Value, error)) *MockMachineServiceGetMachineLifeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceGetMachineLifeCall) DoAndReturn(f func(context.Context, machine.Name) (life.Value, error)) *MockMachineServiceGetMachineLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetMachineUUID mocks base method.
 func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (machine.UUID, error) {
 	m.ctrl.T.Helper()
@@ -1947,6 +2026,45 @@ func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machin
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetSupportedContainersTypes mocks base method.
+func (m *MockMachineService) GetSupportedContainersTypes(arg0 context.Context, arg1 machine.UUID) ([]instance.ContainerType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSupportedContainersTypes", arg0, arg1)
+	ret0, _ := ret[0].([]instance.ContainerType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSupportedContainersTypes indicates an expected call of GetSupportedContainersTypes.
+func (mr *MockMachineServiceMockRecorder) GetSupportedContainersTypes(arg0, arg1 any) *MockMachineServiceGetSupportedContainersTypesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedContainersTypes", reflect.TypeOf((*MockMachineService)(nil).GetSupportedContainersTypes), arg0, arg1)
+	return &MockMachineServiceGetSupportedContainersTypesCall{Call: call}
+}
+
+// MockMachineServiceGetSupportedContainersTypesCall wrap *gomock.Call
+type MockMachineServiceGetSupportedContainersTypesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceGetSupportedContainersTypesCall) Return(arg0 []instance.ContainerType, arg1 error) *MockMachineServiceGetSupportedContainersTypesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceGetSupportedContainersTypesCall) Do(f func(context.Context, machine.UUID) ([]instance.ContainerType, error)) *MockMachineServiceGetSupportedContainersTypesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceGetSupportedContainersTypesCall) DoAndReturn(f func(context.Context, machine.UUID) ([]instance.ContainerType, error)) *MockMachineServiceGetSupportedContainersTypesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/core/credential"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
@@ -277,27 +278,37 @@ type NetworkService interface {
 // MachineService defines the methods that the facade assumes from the Machine
 // service.
 type MachineService interface {
+	// AllMachineNames returns the names of all machines in the model.
+	AllMachineNames(context.Context) ([]machine.Name, error)
+
+	// GetMachineLife returns the GetMachineLife status of the specified machine.
+	GetMachineLife(context.Context, machine.Name) (life.Value, error)
+
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
+	GetMachineUUID(context.Context, machine.Name) (machine.UUID, error)
 
 	// GetInstanceIDAndName returns the cloud specific instance ID and display
 	// name for this machine.
-	GetInstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
+	GetInstanceIDAndName(context.Context, machine.UUID) (instance.Id, string, error)
 
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)
+
+	// GetSupportedContainersTypes returns the supported container types for the
+	// provider.
+	GetSupportedContainersTypes(context.Context, machine.UUID) ([]instance.ContainerType, error)
 
 	// WatchModelMachines watches for additions or updates to non-container
 	// machines. It is used by workers that need to factor life value changes,
 	// and so does not factor machine removals, which are considered to be
 	// after their transition to the dead state.
 	// It emits machine names rather than UUIDs.
-	WatchModelMachines(ctx context.Context) (watcher.StringsWatcher, error)
+	WatchModelMachines(context.Context) (watcher.StringsWatcher, error)
 
 	// WatchModelMachineLifeAndStartTimes returns a string watcher that emits machine names
 	// for changes to machine life or agent start times.
-	WatchModelMachineLifeAndStartTimes(ctx context.Context) (watcher.StringsWatcher, error)
+	WatchModelMachineLifeAndStartTimes(context.Context) (watcher.StringsWatcher, error)
 }
 
 // StatusService returns the status of a applications, and units and machines.

--- a/apiserver/facades/controller/firewaller/interface.go
+++ b/apiserver/facades/controller/firewaller/interface.go
@@ -30,17 +30,12 @@ type State interface {
 	state.ModelMachinesWatcher
 	GetMacaroon(entity names.Tag) (*macaroon.Macaroon, error)
 	KeyRelation(string) (Relation, error)
-	Machine(string) (Machine, error)
 }
 
 type Relation interface {
 	status.StatusSetter
 	Endpoints() []relation.Endpoint
 	WatchUnits(applicationName string) (relation.RelationUnitsWatcher, error)
-}
-
-type Machine interface {
-	Id() string
 }
 
 // NetworkService is the interface that is used to interact with the
@@ -58,6 +53,9 @@ type NetworkService interface {
 // MachineService defines the methods that the facade assumes from the Machine
 // service.
 type MachineService interface {
+	// AllMachineNames returns the names of all machines in the model.
+	AllMachineNames(context.Context) ([]machine.Name, error)
+
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	GetMachineUUID(ctx context.Context, name machine.Name) (machine.UUID, error)
 
@@ -71,6 +69,10 @@ type MachineService interface {
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
 	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
+
+	// GetSupportedContainersTypes returns the supported container types for the
+	// provider.
+	GetSupportedContainersTypes(context.Context, machine.UUID) ([]instance.ContainerType, error)
 
 	// IsMachineManuallyProvisioned returns whether the machine is a manual
 	// machine.
@@ -140,10 +142,6 @@ type MacaroonGetter interface {
 type stateShim struct {
 	*state.State
 	MacaroonGetter
-}
-
-func (st stateShim) Machine(id string) (Machine, error) {
-	return st.State.Machine(id)
 }
 
 func (st stateShim) KeyRelation(key string) (Relation, error) {

--- a/apiserver/facades/controller/firewaller/package_mock_test.go
+++ b/apiserver/facades/controller/firewaller/package_mock_test.go
@@ -123,45 +123,6 @@ func (c *MockStateKeyRelationCall) DoAndReturn(f func(string) (firewaller.Relati
 	return c
 }
 
-// Machine mocks base method.
-func (m *MockState) Machine(arg0 string) (firewaller.Machine, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Machine", arg0)
-	ret0, _ := ret[0].(firewaller.Machine)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Machine indicates an expected call of Machine.
-func (mr *MockStateMockRecorder) Machine(arg0 any) *MockStateMachineCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockState)(nil).Machine), arg0)
-	return &MockStateMachineCall{Call: call}
-}
-
-// MockStateMachineCall wrap *gomock.Call
-type MockStateMachineCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateMachineCall) Return(arg0 firewaller.Machine, arg1 error) *MockStateMachineCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateMachineCall) Do(f func(string) (firewaller.Machine, error)) *MockStateMachineCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateMachineCall) DoAndReturn(f func(string) (firewaller.Machine, error)) *MockStateMachineCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // WatchModelMachineStartTimes mocks base method.
 func (m *MockState) WatchModelMachineStartTimes(arg0 time.Duration) state.StringsWatcher {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/firewaller/service_mock_test.go
+++ b/apiserver/facades/controller/firewaller/service_mock_test.go
@@ -492,6 +492,45 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 	return m.recorder
 }
 
+// AllMachineNames mocks base method.
+func (m *MockMachineService) AllMachineNames(arg0 context.Context) ([]machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllMachineNames", arg0)
+	ret0, _ := ret[0].([]machine.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllMachineNames indicates an expected call of AllMachineNames.
+func (mr *MockMachineServiceMockRecorder) AllMachineNames(arg0 any) *MockMachineServiceAllMachineNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachineNames", reflect.TypeOf((*MockMachineService)(nil).AllMachineNames), arg0)
+	return &MockMachineServiceAllMachineNamesCall{Call: call}
+}
+
+// MockMachineServiceAllMachineNamesCall wrap *gomock.Call
+type MockMachineServiceAllMachineNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceAllMachineNamesCall) Return(arg0 []machine.Name, arg1 error) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceAllMachineNamesCall) Do(f func(context.Context) ([]machine.Name, error)) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]machine.Name, error)) *MockMachineServiceAllMachineNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetHardwareCharacteristics mocks base method.
 func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
@@ -684,6 +723,45 @@ func (c *MockMachineServiceGetMachineUUIDCall) Do(f func(context.Context, machin
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (machine.UUID, error)) *MockMachineServiceGetMachineUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetSupportedContainersTypes mocks base method.
+func (m *MockMachineService) GetSupportedContainersTypes(arg0 context.Context, arg1 machine.UUID) ([]instance.ContainerType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSupportedContainersTypes", arg0, arg1)
+	ret0, _ := ret[0].([]instance.ContainerType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSupportedContainersTypes indicates an expected call of GetSupportedContainersTypes.
+func (mr *MockMachineServiceMockRecorder) GetSupportedContainersTypes(arg0, arg1 any) *MockMachineServiceGetSupportedContainersTypesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedContainersTypes", reflect.TypeOf((*MockMachineService)(nil).GetSupportedContainersTypes), arg0, arg1)
+	return &MockMachineServiceGetSupportedContainersTypesCall{Call: call}
+}
+
+// MockMachineServiceGetSupportedContainersTypesCall wrap *gomock.Call
+type MockMachineServiceGetSupportedContainersTypesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceGetSupportedContainersTypesCall) Return(arg0 []instance.ContainerType, arg1 error) *MockMachineServiceGetSupportedContainersTypesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceGetSupportedContainersTypesCall) Do(f func(context.Context, machine.UUID) ([]instance.ContainerType, error)) *MockMachineServiceGetSupportedContainersTypesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceGetSupportedContainersTypesCall) DoAndReturn(f func(context.Context, machine.UUID) ([]instance.ContainerType, error)) *MockMachineServiceGetSupportedContainersTypesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/tools"
 )
@@ -55,11 +54,6 @@ func (m *Machine) Id() string {
 // Base returns the os base running on the machine.
 func (m *Machine) Base() Base {
 	return m.doc.Base
-}
-
-// ContainerType returns the type of container hosting this machine.
-func (m *Machine) ContainerType() instance.ContainerType {
-	return instance.ContainerType(m.doc.ContainerType)
 }
 
 // Tag returns a tag identifying the machine. The String method provides a


### PR DESCRIPTION
The modelmanager common facade still used MOngo to query for machine data.

Cut this over to use DQLite instead

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy juju-qa-test
```