### PR TITLE
refactor: rename all DOCKER_USERNAME to OCI_REGISTRY_USERNAME

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -5,7 +5,7 @@ name: Test Kubeflow
 on: workflow_dispatch
 
 env:
-  DOCKER_USERNAME: docker.io/jujuqabot
+  OCI_REGISTRY_USERNAME: docker.io/jujuqabot
   JUJU_BUILD_NUMBER: 888
 
 permissions:
@@ -66,7 +66,7 @@ jobs:
       run: |
         sg microk8s <<EOF
           set -eux
-          JUJU_BUILD_NUMBER=$JUJU_BUILD_NUMBER DOCKER_USERNAME=$DOCKER_USERNAME make microk8s-operator-update
+          JUJU_BUILD_NUMBER=$JUJU_BUILD_NUMBER OCI_REGISTRY_USERNAME=$OCI_REGISTRY_USERNAME make microk8s-operator-update
           microk8s.ctr images list | grep juju
           juju version --all
 
@@ -81,7 +81,7 @@ jobs:
           set -eux
 
           microk8s kubectl wait --for=condition=available -nkube-system deployment/coredns deployment/hostpath-provisioner --timeout=10m
-          juju bootstrap microk8s --debug uk8s --config=caas-image-repo=$DOCKER_USERNAME --config test-mode=true --model-default test-mode=true
+          juju bootstrap microk8s --debug uk8s --config=caas-image-repo=$OCI_REGISTRY_USERNAME --config test-mode=true --model-default test-mode=true
 
           juju add-model kubeflow microk8s --config logging-config="<root>=DEBUG;unit=DEBUG"
           juju deploy kubeflow-lite --trust --revision 60

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Update microk8s operator image
         if: matrix.cloud == 'microk8s'
         run: |
-          # TODO: use temporary Docker account (set DOCKER_USERNAME env var)
+          # TODO: use temporary Docker account (set OCI_REGISTRY_USERNAME env var)
           sg snap_microk8s 'make microk8s-operator-update'
 
       - name: Smoke test (LXD)


### PR DESCRIPTION
Modify default k8s image from docker to ghcr. Currently for model migration, the pod image will be updated to that of the target controller. For controller upgrade, models and applications image will not be updated. For model upgrade, the models and applications image will be updated. 

Git workflow and make functions are also updated to ghcr to test pushing/pulling from the new container registry during CI.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
### **Migration**
1. Bootstrap controller1 with current image OCI namespace
```sh
juju bootstrap minikube minikubeoriginal --debug
```

2. Add a model
```sh
juju add-model minikubeoriginalmodel
```

3. Verify image of original model pod to be from docker
```sh
kubectl get pod $(kubectl get pods -n minikubeoriginalmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeoriginalmodel -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/jujud-operator:3.6-rc3
```

4. Deploy an application
```sh
juju deploy mysql-k8s
```

5. Verify image of mysql charm in original model to be from docker
```sh
kubectl get pod mysql-k8s-0 -n minikubeoriginalmodel  -o=jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-22.04 registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9a
```

6. Change docker username in make_functions.sh to ghcr
`DOCKER_USERNAME=${DOCKER_USERNAME:-ghcr.io/juju}`

7. Bootstrap controller2 with updated image OCI namespace (After check out branch, version might be different from 3.6-rc3 depending on your juju client or simplestreams directory. Also remember to remove image if there is an existing docker image of the same name/repo + tag causing code to not be updated) 
```sh
[OPTIONAL] docker rmi [image_id]
make minikube-operator-update && juju bootstrap minikube minikubeupdated --debug
```

8. Add a model
```sh
juju add-model minikubeupdatedmodel
```

9. Verify image of updated model pod to be from ghcr
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"

ghcr.io/juju/jujud-operator:3.6-rc3
```

10. Deploy an application
```sh
juju deploy mysql-k8s
```

11. Verify image of mysql charm in updated model to be from ghcr
```sh
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel  -o=jsonpath="{.spec.containers[*].image}"

ghcr.io/juju/charm-base:ubuntu-22.04 registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9
```

12. Migrate model from minikubeupdated to minikubeoriginal (Image is now updated from ghcr to docker)
```sh
juju migrate minikubeupdatedmodel minikubeoriginal
```

13. Verify image of updated model pod to be changed to docker now
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/jujud-operator:3.6-rc3
```

14. Verify image of mysql charm in original model to be from docker now
```sh
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel  -o=jsonpath="{.spec.containers[*].image}"
```

15. Migrate model from minikubeoriginal to minikubeupdated (Image is now updated from docker to ghcr)
```sh
juju switch minikubeoriginal
juju migrate minikubeoriginalmodel minikubeupdated
```

16. Verify image of original model pod to be changed to ghcr now
```
kubectl get pod $(kubectl get pods -n minikubeoriginalmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeoriginalmodel -o jsonpath="{.spec.containers[*].image}"

ghcr.io/juju/jujud-operator:3.6-rc3
```

17. Verify image of mysql charm in original model to be from ghcr now
```sh
kubectl get pod mysql-k8s-0 -n minikubeoriginalmodel  -o=jsonpath="{.spec.containers[*].image}"
```


### ***Upgrade Controller**
18. Verify image version of original controller is from docker
```sh
kubectl get pod $(kubectl get pods -n controller-minikubeoriginal7 --no-headers | head -n 1 | awk '{print $1}') -n controller-minikubeoriginal7 -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-24.04 docker.io/jujusolutions/juju-db:4.4 docker.io/jujusolutions/jujud-operator:3.6-rc3
```


19. Upgrade controller
```sh
juju upgrade-controller
```

20. Verify image of original controller is indeed upgraded to version 3.6.8
```sh
kubectl get pod $(kubectl get pods -n controller-minikubeoriginal7 --no-headers | head -n 1 | awk '{print $1}') -n controller-minikubeoriginal7 -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-24.04 docker.io/jujusolutions/juju-db:4.4 docker.io/jujusolutions/jujud-operator:3.6.8
```

21. Verify that images of updated model and mysql in original controller are not upgraded and still uses version 3.6-rc3 
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel7  -o yaml | grep image:
```

### ***Upgrade Model**
22. Upgrade controller
```sh
juju upgrade-model
```

23. Verify image version of model is upgraded to 3.6.8
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-24.04 docker.io/jujusolutions/juju-db:4.4 docker.io/jujusolutions/jujud-operator:3.6.8
```

24. Verify that image of app in model is upgraded to 3.6.8
```sh
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel  -o yaml | grep image:

    image: docker.io/jujusolutions/charm-base:ubuntu-22.04
    image: registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9
    image: docker.io/jujusolutions/jujud-operator:3.6.8
    image: jujusolutions/charm-base:ubuntu-22.04
    image: sha256:c83c3a912fbe97b4eaec22a50c4681e07f883d4ad9aae8a70ef6f5c4fef32ae5
    image: jujusolutions/jujud-operator:3.6.8
```

## Links

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-7982