### PR TITLE
docs: add ref for cloud canonical k8s

### DIFF
--- a/docs/reference/cloud/list-of-supported-clouds/index.md
+++ b/docs/reference/cloud/list-of-supported-clouds/index.md
@@ -10,10 +10,10 @@ Starting with Juju 3, providers Rackspace and CloudSigma are no longer supported
 ```{toctree}
 :hidden:
 
-
 Amazon EC2 <the-amazon-ec2-cloud-and-juju>
 Amazon EKS <the-amazon-eks-cloud-and-juju>
 Equinix Metal <the-equinix-metal-cloud-and-juju>
+Canonical K8s <the-canonical-ks-cloud-and-juju>
 Google GCE <the-google-gce-cloud-and-juju>
 Google GKE <the-google-gke-cloud-and-juju>
 LXD <the-lxd-cloud-and-juju>
@@ -25,18 +25,15 @@ Microsoft AKS <the-microsoft-aks-cloud-and-juju>
 OpenStack <the-openstack-cloud-and-juju>
 Oracle OCI <the-oracle-oci-cloud-and-juju>
 VMware vSphere <the-vmware-vsphere-cloud-and-juju>
-
 ```
 
-
-
 Juju supports all of the following clouds. Click to find out more about using your cloud(s) of interest with Juju.
-
 
 |                                             | machine cloud | {ref}`Kubernetes cloud <kubernetes-clouds-and-juju>` |
 |---------------------------------------------|---------------|------------------------------------------------------|
 | {ref}`Amazon EC2 <cloud-ec2>`               | &#x2611;      |                                                      |
 | {ref}`Amazon EKS <cloud-kubernetes-eks>`    |               | &#x2611;                                             |
+| {ref}`Canonical K8s <cloud-canonical-k8s>`  |               | &#x2611;                                             |
 | {ref}`Equinix Metal <cloud-equinix>`        | &#x2611;      |                                                      |
 | {ref}`Google GCE <cloud-gce>`               | &#x2611;      |                                                      |
 | {ref}`Google GKE <cloud-kubernetes-gke>`    |               | &#x2611;                                             |
@@ -50,9 +47,8 @@ Juju supports all of the following clouds. Click to find out more about using yo
 | {ref}`Oracle OCI <cloud-oci>`               | &#x2611;      |                                                      |
 | {ref}`VMware vSphere <cloud-vsphere>`       | &#x2611;      |                                                      |
 
-
 <!--
-(see also [the OpenStack website](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/install-juju.html); or [MicroStack](https://microstack.run/))    
+(see also [the OpenStack website](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/install-juju.html); or [MicroStack](https://microstack.run/))
 -->
 
 

--- a/docs/reference/cloud/list-of-supported-clouds/the-canonical-ks-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-canonical-ks-cloud-and-juju.md
@@ -1,0 +1,32 @@
+(cloud-canonical-k8s)=
+# The Canonical Kubernetes cloud and Juju
+
+This document describes details specific to using a Canonical Kubernetes cloud with Juju.
+
+> See more: [Canonical Kubernetes documentation](https://documentation.ubuntu.com/canonical-kubernetes/)
+
+When using this cloud with Juju, it is important to keep in mind that it is a (1) Kubernetes cloud and (2) not some other cloud.
+
+> See more: {ref}`cloud-differences`
+
+As the differences related to (1) are already documented generically in the rest of the docs, here we record just those that follow from (2).
+
+
+## Requirements
+
+### Services that must enabled
+
+- `dns`
+- `ingress` (technically not required, but you need it if you want to do anything meaningful)
+- `local-storage`
+- `network`
+
+## Notes on `juju add-k8s`
+
+Before you bootstrap:
+
+- You need to create a custom `containerd` path, e.g., `export containerdBaseDir="/run/containerd-k8s"`.
+
+- For most purposes, you should also resize `/run`, e.g., `sudo mount -o remount,size=10G /run`.
+
+> See more: https://github.com/canonical/k8s-snap/issues/1612


### PR DESCRIPTION
> 3.6+ (i.e., please merge forward)

Canonical Kubernetes has been around for a while, and Juju does support it, yet our docs make no mention of it. This PR adds a cloud reference doc for it. 

PS The reference can be evolved further (e.g., with an example setup). We will do that in a future PR. For now this is sufficient to signal support and to link to from juju.is/docs.