### PR TITLE
fix: k8s model container image updated to target controller during model migration

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -274,6 +274,7 @@ func (a *API) ProvisioningInfo(args params.Entities) (params.CAASApplicationProv
 }
 
 func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplicationProvisioningInfo, error) {
+	logger.Infof("alvin2 provisioningInfo api called, should be for app")
 	app, err := a.state.Application(appName.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -331,6 +332,20 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
+
+	logger.Infof("alvin2 application model: %#v", model)
+	logger.Infof("alvin2 application modelConfig: %#v", modelConfig)
+
+	imageRepo, exists := modelConfig.CAASImageRepo()
+	if !exists {
+		imageRepo = cfg.CAASImageRepo()
+		logger.Infof("alvin2 CAASImageRepo: %q", imageRepo)
+
+		if imageRepo == "" {
+			imageRepo = podcfg.JujudOCINamespace
+		}
+	}
+
 	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, modelConfig, vers)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting juju oci image path")
@@ -355,7 +370,8 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		return nil, errors.Annotatef(err, "getting application config")
 	}
 	base := app.Base()
-	imageRepoDetails, err := docker.NewImageRepoDetails(cfg.CAASImageRepo())
+	imageRepoDetails, err := docker.NewImageRepoDetails(imageRepo)
+	logger.Infof("alvin2 application imageRepoDetails: %#v", imageRepoDetails)
 	if err != nil {
 		return nil, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -274,7 +274,6 @@ func (a *API) ProvisioningInfo(args params.Entities) (params.CAASApplicationProv
 }
 
 func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplicationProvisioningInfo, error) {
-	logger.Infof("alvin2 provisioningInfo api called, should be for app")
 	app, err := a.state.Application(appName.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -333,13 +332,9 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		)
 	}
 
-	logger.Infof("alvin2 application model: %#v", model)
-	logger.Infof("alvin2 application modelConfig: %#v", modelConfig)
-
 	imageRepo, exists := modelConfig.CAASImageRepo()
 	if !exists {
 		imageRepo = cfg.CAASImageRepo()
-		logger.Infof("alvin2 CAASImageRepo: %q", imageRepo)
 
 		if imageRepo == "" {
 			imageRepo = podcfg.JujudOCINamespace
@@ -371,7 +366,6 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 	}
 	base := app.Base()
 	imageRepoDetails, err := docker.NewImageRepoDetails(imageRepo)
-	logger.Infof("alvin2 application imageRepoDetails: %#v", imageRepoDetails)
 	if err != nil {
 		return nil, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -345,7 +345,6 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting juju oci image path")
 	}
-
 	apiHostPorts, err := a.ctrlSt.APIHostPortsForAgents()
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting api addresses")

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -331,10 +331,11 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, vers)
+	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, modelConfig, vers)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting juju oci image path")
 	}
+
 	apiHostPorts, err := a.ctrlSt.APIHostPortsForAgents()
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting api addresses")

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -86,6 +86,7 @@ func (a *API) WatchModelOperatorProvisioningInfo() (params.NotifyWatchResult, er
 // ModelOperatorProvisioningInfo returns the information needed for provisioning
 // a new model operator into a caas cluster.
 func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) {
+	logger.Infof("alvin2 ModelOperatorProvisioningInfo called")
 	var result params.ModelOperatorInfo
 	controllerConf, err := a.ctrlState.ControllerConfig()
 	if err != nil {

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -86,7 +86,6 @@ func (a *API) WatchModelOperatorProvisioningInfo() (params.NotifyWatchResult, er
 // ModelOperatorProvisioningInfo returns the information needed for provisioning
 // a new model operator into a caas cluster.
 func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) {
-	logger.Infof("alvin2 ModelOperatorProvisioningInfo called")
 	var result params.ModelOperatorInfo
 	controllerConf, err := a.ctrlState.ControllerConfig()
 	if err != nil {
@@ -116,12 +115,10 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 	if err != nil {
 		return result, errors.Annotate(err, "getting api addresses")
 	}
-	logger.Infof("alvin original modelConfig: %q", modelConfig)
 
 	imageRepo, exists := modelConfig.CAASImageRepo()
 	if !exists {
 		imageRepo = controllerConf.CAASImageRepo()
-		logger.Infof("alvin CAASImageRepo: %q", imageRepo)
 
 		if imageRepo == "" {
 			imageRepo = podcfg.JujudOCINamespace
@@ -131,23 +128,18 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 			return result, errors.Trace(err)
 		}
 	}
-	logger.Infof("alvin imageRepo: %q", imageRepo)
-	logger.Infof("alvin later modelConfig: %q", modelConfig)
 
 	imageRef, err := podcfg.GetJujuOCIImagePath(controllerConf, modelConfig, vers)
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	logger.Infof("alvin imageRef: %q", imageRef)
 
 	imageRepoDetails, err := docker.NewImageRepoDetails(imageRepo)
 	if err != nil {
 		return result, errors.Annotatef(err, "parsing %s", imageRepo)
 	}
-	logger.Infof("alvin imageRepoDetails: %q", imageRepoDetails)
 
 	imageInfo := params.NewDockerImageInfo(imageRepoDetails, imageRef)
-	logger.Infof("alvin imageInfo: %q", imageInfo)
 
 	logger.Tracef("image info %v", imageInfo)
 

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -115,25 +115,39 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 	if err != nil {
 		return result, errors.Annotate(err, "getting api addresses")
 	}
+	logger.Infof("alvin original modelConfig: %q", modelConfig)
 
 	imageRepo, exists := modelConfig.CAASImageRepo()
 	if !exists {
 		imageRepo = controllerConf.CAASImageRepo()
-		if err := model.UpdateModelConfig(map[string]interface{}{config.ModelCAASImageRepo: controllerConf.CAASImageRepo()}, nil); err != nil {
+		logger.Infof("alvin CAASImageRepo: %q", imageRepo)
+
+		if imageRepo == "" {
+			imageRepo = podcfg.JujudOCINamespace
+		}
+
+		if err := model.UpdateModelConfig(map[string]interface{}{config.ModelCAASImageRepo: imageRepo}, nil); err != nil {
 			return result, errors.Trace(err)
 		}
 	}
+	logger.Infof("alvin imageRepo: %q", imageRepo)
+	logger.Infof("alvin later modelConfig: %q", modelConfig)
 
 	imageRef, err := podcfg.GetJujuOCIImagePath(controllerConf, modelConfig, vers)
 	if err != nil {
 		return result, errors.Trace(err)
 	}
+	logger.Infof("alvin imageRef: %q", imageRef)
 
 	imageRepoDetails, err := docker.NewImageRepoDetails(imageRepo)
 	if err != nil {
 		return result, errors.Annotatef(err, "parsing %s", imageRepo)
 	}
+	logger.Infof("alvin imageRepoDetails: %q", imageRepoDetails)
+
 	imageInfo := params.NewDockerImageInfo(imageRepoDetails, imageRef)
+	logger.Infof("alvin imageInfo: %q", imageInfo)
+
 	logger.Tracef("image info %v", imageInfo)
 
 	result = params.ModelOperatorInfo{

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -92,7 +92,7 @@ func (m *ModelOperatorSuite) TestProvisioningInfoImageRefSet(c *gc.C) {
 	vers, ok := modelConfig.AgentVersion()
 	c.Assert(ok, jc.IsTrue)
 
-	imageRepo := "docker.io/jujusolutions"
+	imageRepo := "ghcr.io/juju"
 	err = model.UpdateModelConfig(map[string]interface{}{"model-caas-image-repo": imageRepo}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -82,7 +82,6 @@ func (m *ModelOperatorSuite) TestProvisioningInfoImageRepoUnset(c *gc.C) {
 
 func (m *ModelOperatorSuite) TestProvisioningInfoImageRepoSet(c *gc.C) {
 	model, err := m.state.Model()
-
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelConfig, err := model.ModelConfig()

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -70,7 +70,7 @@ func (m *ModelOperatorSuite) TestProvisioningInfoImageRefUnset(c *gc.C) {
 	controllerConf, err := m.state.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
-	imagePath, err := podcfg.GetJujuOCIImagePath(controllerConf, info.Version)
+	imagePath, err := podcfg.GetJujuOCIImagePath(controllerConf, modelConfig, info.Version)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(imagePath, gc.Equals, info.ImageDetails.RegistryPath)
 
@@ -100,6 +100,13 @@ func (m *ModelOperatorSuite) TestProvisioningInfoImageRefSet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(info.ImageDetails.RegistryPath, gc.Equals, imageRef)
+
+	controllerConf, err := m.state.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+
+	imagePath, err := podcfg.GetJujuOCIImagePath(controllerConf, modelConfig, info.Version)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(imagePath, gc.Equals, info.ImageDetails.RegistryPath)
 
 	c.Assert(info.ImageDetails.Auth, gc.Equals, `xxxxx==`)
 	c.Assert(info.ImageDetails.Repository, gc.Equals, `test-account`)

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -53,7 +53,7 @@ func (m *ModelOperatorSuite) SetUpTest(c *gc.C) {
 	m.api = api
 }
 
-func (m *ModelOperatorSuite) TestProvisioningInfoImageRefUnset(c *gc.C) {
+func (m *ModelOperatorSuite) TestProvisioningInfoImageRepoUnset(c *gc.C) {
 	model, err := m.state.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -80,7 +80,7 @@ func (m *ModelOperatorSuite) TestProvisioningInfoImageRefUnset(c *gc.C) {
 	c.Assert(vers, jc.DeepEquals, info.Version)
 }
 
-func (m *ModelOperatorSuite) TestProvisioningInfoImageRefSet(c *gc.C) {
+func (m *ModelOperatorSuite) TestProvisioningInfoImageRepoSet(c *gc.C) {
 	model, err := m.state.Model()
 
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -92,24 +92,14 @@ func (m *ModelOperatorSuite) TestProvisioningInfoImageRefSet(c *gc.C) {
 	vers, ok := modelConfig.AgentVersion()
 	c.Assert(ok, jc.IsTrue)
 
-	imageRef := "docker.io/jujusolutions/jujud-operator:3.6.9"
-	err = model.UpdateModelConfig(map[string]interface{}{"container-image-reference": imageRef}, nil)
+	imageRepo := "docker.io/jujusolutions"
+	err = model.UpdateModelConfig(map[string]interface{}{"model-caas-image-repo": imageRepo}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	info, err := m.api.ModelOperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(info.ImageDetails.RegistryPath, gc.Equals, imageRef)
-
-	controllerConf, err := m.state.ControllerConfig()
-	c.Assert(err, jc.ErrorIsNil)
-
-	imagePath, err := podcfg.GetJujuOCIImagePath(controllerConf, modelConfig, info.Version)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(imagePath, gc.Equals, info.ImageDetails.RegistryPath)
-
-	c.Assert(info.ImageDetails.Auth, gc.Equals, `xxxxx==`)
-	c.Assert(info.ImageDetails.Repository, gc.Equals, `test-account`)
+	c.Assert(info.ImageDetails.Repository, gc.Equals, imageRepo)
 
 	c.Assert(vers, jc.DeepEquals, info.Version)
 }

--- a/apiserver/facades/controller/caasmodeloperator/state.go
+++ b/apiserver/facades/controller/caasmodeloperator/state.go
@@ -31,6 +31,7 @@ type CAASControllerState interface {
 type Model interface {
 	ModelConfig() (*config.Config, error)
 	WatchForModelConfigChanges() state.NotifyWatcher
+	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 }
 
 type stateShim struct {

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -106,7 +106,6 @@ func (a *API) WatchApplications() (params.StringsWatchResult, error) {
 
 // OperatorProvisioningInfo returns the info needed to provision an operator.
 func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorProvisioningInfoResults, error) {
-	logger.Infof("alvin OperatorProvisingInfo called")
 	var result params.OperatorProvisioningInfoResults
 	cfg, err := a.ctrlState.ControllerConfig()
 	if err != nil {
@@ -138,7 +137,6 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 	imageRepo, exists := modelConfig.CAASImageRepo()
 	if !exists {
 		imageRepo = controller.CAASImageRepo
-		logger.Infof("alvin CAASImageRepo: %q", imageRepo)
 
 		if imageRepo == "" {
 			imageRepo = podcfg.JujudOCINamespace
@@ -149,8 +147,6 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 	if err != nil {
 		return result, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}
-	logger.Infof("alvin2 OperatorProvisioningInfo model: %#v", model)
-	logger.Infof("alvin2 OperatorProvisioningInfo modelConfig: %#v", modelConfig)
 	registryPath, err := podcfg.GetJujuOCIImagePath(cfg, modelConfig, vers)
 	if err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -138,7 +138,7 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 	if err != nil {
 		return result, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}
-	registryPath, err := podcfg.GetJujuOCIImagePath(cfg, vers)
+	registryPath, err := podcfg.GetJujuOCIImagePath(cfg, modelConfig, vers)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -147,11 +147,11 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 	if err != nil {
 		return result, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}
-	registryPath, err := podcfg.GetJujuOCIImagePath(cfg, modelConfig, vers)
+	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, modelConfig, vers)
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	imageInfo := params.NewDockerImageInfo(imageRepoDetails, registryPath)
+	imageInfo := params.NewDockerImageInfo(imageRepoDetails, imagePath)
 	logger.Tracef("image info %v", imageInfo)
 
 	// PodSpec charms now use focal as the operator base until PodSpec is removed.

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -389,7 +389,7 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	registryPath, err := podcfg.GetJujuOCIImagePath(controllerCfg, vers)
+	registryPath, err := podcfg.GetJujuOCIImagePath(controllerCfg, modelConfig, vers)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -347,6 +347,7 @@ func (f *Facade) ProvisioningInfo(args params.Entities) (params.KubernetesProvis
 }
 
 func (f *Facade) provisioningInfo(model Model, tagString string) (*params.KubernetesProvisioningInfo, error) {
+	logger.Infof("alvin2 provisioningInfo facade called")
 	appTag, err := names.ParseApplicationTag(tagString)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -389,17 +390,31 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
+	logger.Infof("alvin2 facade model: %#v", model)
+	logger.Infof("alvin2 facade modelConfig: %#v", modelConfig)
+
+	imageRepo, exists := modelConfig.CAASImageRepo()
+	if !exists {
+		imageRepo = controllerCfg.CAASImageRepo()
+		logger.Infof("alvin CAASImageRepo: %q", imageRepo)
+
+		if imageRepo == "" {
+			imageRepo = podcfg.JujudOCINamespace
+		}
+	}
+
 	registryPath, err := podcfg.GetJujuOCIImagePath(controllerCfg, modelConfig, vers)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	imageRepoDetails, err := docker.NewImageRepoDetails(controllerCfg.CAASImageRepo())
+	imageRepoDetails, err := docker.NewImageRepoDetails(imageRepo)
 	if err != nil {
 		return nil, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}
-	imageRepo := params.NewDockerImageInfo(imageRepoDetails, registryPath)
-	logger.Tracef("imageRepo %v", imageRepo)
+
+	imageInfo := params.NewDockerImageInfo(imageRepoDetails, registryPath)
+	logger.Tracef("imageRepo %v", imageInfo)
 	filesystemParams, err := f.applicationFilesystemParams(app, controllerCfg, modelConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -436,7 +451,7 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		Constraints:          mergedCons,
 		Tags:                 resourceTags,
 		CharmModifiedVersion: app.CharmModifiedVersion(),
-		ImageRepo:            imageRepo,
+		ImageRepo:            imageInfo,
 	}
 	deployInfo := ch.Meta().Deployment
 	if deployInfo != nil {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -399,7 +399,7 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		}
 	}
 
-	registryPath, err := podcfg.GetJujuOCIImagePath(controllerCfg, modelConfig, vers)
+	imagePath, err := podcfg.GetJujuOCIImagePath(controllerCfg, modelConfig, vers)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -409,7 +409,7 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		return nil, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}
 
-	imageInfo := params.NewDockerImageInfo(imageRepoDetails, registryPath)
+	imageInfo := params.NewDockerImageInfo(imageRepoDetails, imagePath)
 	logger.Tracef("imageRepo %v", imageInfo)
 	filesystemParams, err := f.applicationFilesystemParams(app, controllerCfg, modelConfig)
 	if err != nil {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -347,7 +347,6 @@ func (f *Facade) ProvisioningInfo(args params.Entities) (params.KubernetesProvis
 }
 
 func (f *Facade) provisioningInfo(model Model, tagString string) (*params.KubernetesProvisioningInfo, error) {
-	logger.Infof("alvin2 provisioningInfo facade called")
 	appTag, err := names.ParseApplicationTag(tagString)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -390,13 +389,10 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	logger.Infof("alvin2 facade model: %#v", model)
-	logger.Infof("alvin2 facade modelConfig: %#v", modelConfig)
 
 	imageRepo, exists := modelConfig.CAASImageRepo()
 	if !exists {
 		imageRepo = controllerCfg.CAASImageRepo()
-		logger.Infof("alvin CAASImageRepo: %q", imageRepo)
 
 		if imageRepo == "" {
 			imageRepo = podcfg.JujudOCINamespace

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -652,7 +652,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "charm",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "docker.io/jujusolutions/charm-base:ubuntu-22.04",
+			Image:           "ghcr.io/juju/charm-base:ubuntu-22.04",
 			WorkingDir:      "/var/lib/juju",
 			Command:         []string{"/charm/bin/pebble"},
 			Args:            []string{"run", "--http", ":38812", "--verbose"},

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -244,8 +244,8 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	labels := map[string]string{"operator.juju.is/name": "gitlab", "operator.juju.is/target": "application"}
 	pod, err := provider.OperatorPod(
 		"gitlab", "gitlab", "10666", "/var/lib/juju",
-		coreresources.DockerImageDetails{RegistryPath: "docker.io/jujusolutions/jujud-operator"},
-		coreresources.DockerImageDetails{RegistryPath: "docker.io/jujusolutions/charm-base:ubuntu-20.04"},
+		coreresources.DockerImageDetails{RegistryPath: "ghcr.io/juju/jujud-operator"},
+		coreresources.DockerImageDetails{RegistryPath: "ghcr.io/juju/charm-base:ubuntu-20.04"},
 		labels, tags, "operator-service-account",
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -260,10 +260,10 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	c.Assert(pod.Spec.ServiceAccountName, gc.Equals, "operator-service-account")
 	c.Assert(pod.Spec.InitContainers, gc.HasLen, 1)
 	c.Assert(pod.Spec.InitContainers[0].VolumeMounts, gc.HasLen, 1)
-	c.Assert(pod.Spec.InitContainers[0].Image, gc.Equals, "docker.io/jujusolutions/jujud-operator")
+	c.Assert(pod.Spec.InitContainers[0].Image, gc.Equals, "ghcr.io/juju/jujud-operator")
 	c.Assert(pod.Spec.InitContainers[0].VolumeMounts[0].MountPath, gc.Equals, "/opt/juju")
 	c.Assert(pod.Spec.Containers, gc.HasLen, 1)
-	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "docker.io/jujusolutions/charm-base:ubuntu-20.04")
+	c.Assert(pod.Spec.Containers[0].Image, gc.Equals, "ghcr.io/juju/charm-base:ubuntu-20.04")
 	c.Assert(pod.Spec.Containers[0].VolumeMounts, gc.HasLen, 3)
 	c.Assert(pod.Spec.Containers[0].VolumeMounts[0].MountPath, gc.Equals, "/var/lib/juju/agents/application-gitlab/template-agent.conf")
 	c.Assert(pod.Spec.Containers[0].VolumeMounts[1].MountPath, gc.Equals, "/var/lib/juju/agents/application-gitlab/operator.yaml")

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -86,7 +86,6 @@ func GetJujuOCIImagePath(controllerCfg controller.Config, modelCfg *config.Confi
 	}
 
 	// Next check the deprecated "caas-operator-image-path" config
-	caasImageRepo := controllerCfg.CAASImageRepo()
 	imagePath, err := RebuildOldOperatorImagePath(
 		controllerCfg.CAASOperatorImagePath(), ver,
 	)
@@ -95,6 +94,7 @@ func GetJujuOCIImagePath(controllerCfg controller.Config, modelCfg *config.Confi
 	}
 
 	// Default to use controller config CAAS image repo.
+	caasImageRepo := controllerCfg.CAASImageRepo()
 	details, err := docker.NewImageRepoDetails(caasImageRepo)
 	if err != nil {
 		return "", errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -66,8 +66,6 @@ func IsCharmBaseImage(imagePath string) bool {
 
 // GetJujuOCIImagePath returns the jujud oci image path.
 func GetJujuOCIImagePath(controllerCfg controller.Config, modelCfg *config.Config, ver version.Number) (string, error) {
-	logger.Infof("alvin2 GetJujuOCIImagePath called")
-
 	// First check the model config.
 	if modelCfg != nil {
 		caasImageRepo, exists := modelCfg.CAASImageRepo()

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -66,6 +66,7 @@ func IsCharmBaseImage(imagePath string) bool {
 
 // GetJujuOCIImagePath returns the jujud oci image path.
 func GetJujuOCIImagePath(controllerCfg controller.Config, modelCfg *config.Config, ver version.Number) (string, error) {
+	logger.Infof("alvin2 GetJujuOCIImagePath called")
 
 	// First check the model config.
 	if modelCfg != nil {

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -52,9 +52,9 @@ func (*imageSuite) TestGetJujuOCIImagePath(c *gc.C) {
 
 func (*imageSuite) TestRebuildOldOperatorImagePath(c *gc.C) {
 	ver := version.MustParse("2.6-beta3")
-	path, err := podcfg.RebuildOldOperatorImagePath("docker.io/jujusolutions/jujud-operator:666", ver)
+	path, err := podcfg.RebuildOldOperatorImagePath("ghcr.io/juju/jujud-operator:666", ver)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, jc.DeepEquals, "docker.io/jujusolutions/jujud-operator:2.6-beta3")
+	c.Assert(path, jc.DeepEquals, "ghcr.io/juju/jujud-operator:2.6-beta3")
 }
 
 func (*imageSuite) TestImageForBase(c *gc.C) {
@@ -91,10 +91,10 @@ func (*imageSuite) TestRecoverRepoFromOperatorPath(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(repo, gc.Equals, "testing-repo:8080")
 
-	repo, err = podcfg.RecoverRepoFromOperatorPath("docker.io/jujusolutions/jujud-operator:2.6-beta3")
+	repo, err = podcfg.RecoverRepoFromOperatorPath("ghcr.io/juju/jujud-operator:2.6-beta3")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(repo, gc.Equals, "docker.io/jujusolutions")
+	c.Assert(repo, gc.Equals, "ghcr.io/juju")
 
-	_, err = podcfg.RecoverRepoFromOperatorPath("docker.io/jujusolutions/nope:2.6-beta3")
-	c.Assert(err, gc.ErrorMatches, `image path "docker.io/jujusolutions/nope:2.6-beta3" does not match the form somerepo/jujud-operator:\.\*`)
+	_, err = podcfg.RecoverRepoFromOperatorPath("ghcr.io/juju/nope:2.6-beta3")
+	c.Assert(err, gc.ErrorMatches, `image path "ghcr.io/juju/nope:2.6-beta3" does not match the form somerepo/jujud-operator:\.\*`)
 }

--- a/docker/registry/registry_test.go
+++ b/docker/registry/registry_test.go
@@ -40,7 +40,7 @@ func (s *registrySuite) TestSelectsAWSPrivate(c *gc.C) {
 
 func (s *registrySuite) TestSelectsDockerHub(c *gc.C) {
 	reg, err := registry.New(docker.ImageRepoDetails{
-		Repository: "docker.io/jujusolutions",
+		Repository: "ghcr.io/juju",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(reg, gc.NotNil)

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
@@ -426,9 +426,6 @@ Model configuration keys (affecting the controller model):
       type: string
       description: The URL at which the metadata used to locate container OS image ids
         is located
-    container-image-reference:
-      type: string
-      description: The container image repository. (default "")
     container-image-stream:
       type: string
       description: The simplestreams stream used to identify which image ids to search
@@ -566,6 +563,9 @@ Model configuration keys (affecting the controller model):
         - If 'requires-prompts' is present, clients will ask for confirmation before removing
         potentially valuable resources.
         (default "")
+    model-caas-image-repo:
+      type: string
+      description: The container image repository. (default "")
     net-bond-reconfigure-delay:
       type: int
       description: The amount of time in seconds to sleep between ifdown and ifup when

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
@@ -426,6 +426,9 @@ Model configuration keys (affecting the controller model):
       type: string
       description: The URL at which the metadata used to locate container OS image ids
         is located
+    container-image-reference:
+      type: string
+      description: The container image repository. (default "")
     container-image-stream:
       type: string
       description: The simplestreams stream used to identify which image ids to search

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/model-config.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/model-config.md
@@ -137,9 +137,6 @@ The following keys are available:
       type: string
       description: The URL at which the metadata used to locate container OS image ids
         is located
-    container-image-reference:
-      type: string
-      description: The container image repository. (default "")
     container-image-stream:
       type: string
       description: The simplestreams stream used to identify which image ids to search
@@ -277,6 +274,9 @@ The following keys are available:
         - If 'requires-prompts' is present, clients will ask for confirmation before removing
         potentially valuable resources.
         (default "")
+    model-caas-image-repo:
+      type: string
+      description: The container image repository. (default "")
     net-bond-reconfigure-delay:
       type: int
       description: The amount of time in seconds to sleep between ifdown and ifup when

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/model-config.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/model-config.md
@@ -137,6 +137,9 @@ The following keys are available:
       type: string
       description: The URL at which the metadata used to locate container OS image ids
         is located
+    container-image-reference:
+      type: string
+      description: The container image repository. (default "")
     container-image-stream:
       type: string
       description: The simplestreams stream used to identify which image ids to search

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -329,6 +329,9 @@ const (
 
 	// SecretBackendKey is used to specify the secret backend.
 	SecretBackendKey = "secret-backend"
+
+	// ContainerImageReference is used to specify the container image repository.
+	ContainerImageReference = "container-image-reference"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -596,6 +599,7 @@ var defaultConfigValues = map[string]interface{}{
 	ContainerImageStreamKey:                   "released",
 	ContainerImageMetadataURLKey:              "",
 	ContainerImageMetadataDefaultsDisabledKey: false,
+	ContainerImageReference:                   "",
 
 	// Log forward settings.
 	LogForwardEnabled: false,
@@ -1846,6 +1850,15 @@ func (c *Config) Telemetry() bool {
 	return !value
 }
 
+// ContainerImageReference returns the configured full image reference string for the container
+// and a boolean indicating whether the value was explicitly set in the config.
+func (c *Config) ContainerImageReference() (string, bool) {
+	if imageRepo, ok := c.defined[ContainerImageReference]; ok && imageRepo != "" {
+		return imageRepo.(string), true
+	}
+	return "", false
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1988,6 +2001,7 @@ var alwaysOptional = schema.Defaults{
 	ContainerImageStreamKey:                   schema.Omit,
 	ContainerImageMetadataURLKey:              schema.Omit,
 	ContainerImageMetadataDefaultsDisabledKey: schema.Omit,
+	ContainerImageReference:                   schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -2586,6 +2600,11 @@ CIDRs specifying what ingress can be applied to offers in this model.`,
 	},
 	SecretBackendKey: {
 		Description: `The name of the secret store backend. (default "auto")`,
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	ContainerImageReference: {
+		Description: `The container image repository. (default "")`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -330,8 +330,8 @@ const (
 	// SecretBackendKey is used to specify the secret backend.
 	SecretBackendKey = "secret-backend"
 
-	// ContainerImageReference is used to specify the container image repository.
-	ContainerImageReference = "container-image-reference"
+	// ModelCAASImageRepo is used to specify the model's container image repository.
+	ModelCAASImageRepo = "model-caas-image-repo"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -599,7 +599,7 @@ var defaultConfigValues = map[string]interface{}{
 	ContainerImageStreamKey:                   "released",
 	ContainerImageMetadataURLKey:              "",
 	ContainerImageMetadataDefaultsDisabledKey: false,
-	ContainerImageReference:                   "",
+	ModelCAASImageRepo:                        "",
 
 	// Log forward settings.
 	LogForwardEnabled: false,
@@ -1850,10 +1850,10 @@ func (c *Config) Telemetry() bool {
 	return !value
 }
 
-// ContainerImageReference returns the configured full image reference string for the container
+// CAASImageRepo returns the configured full image reference string for the container
 // and a boolean indicating whether the value was explicitly set in the config.
-func (c *Config) ContainerImageReference() (string, bool) {
-	if imageRepo, ok := c.defined[ContainerImageReference]; ok && imageRepo != "" {
+func (c *Config) CAASImageRepo() (string, bool) {
+	if imageRepo, ok := c.defined[ModelCAASImageRepo]; ok && imageRepo != "" {
 		return imageRepo.(string), true
 	}
 	return "", false
@@ -2001,7 +2001,7 @@ var alwaysOptional = schema.Defaults{
 	ContainerImageStreamKey:                   schema.Omit,
 	ContainerImageMetadataURLKey:              schema.Omit,
 	ContainerImageMetadataDefaultsDisabledKey: schema.Omit,
-	ContainerImageReference:                   schema.Omit,
+	ModelCAASImageRepo:                        schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -2603,7 +2603,7 @@ CIDRs specifying what ingress can be applied to offers in this model.`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	ContainerImageReference: {
+	ModelCAASImageRepo: {
 		Description: `The container image repository. (default "")`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,


### PR DESCRIPTION
This PR fixes an issue where k8s model container image gets updated to target controller during model migration. This is an issue especially where the container registry is different for both the migrated model image and the target controller image, if one of the container registry is not whitelisted in the user's network. Users would have to manually upgrade the model after migration now.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
### **Migration**
0.. Change OCI_REGISTRY_USERNAME in make_functions.sh to docker
`DOCKER_USERNAME=${DOCKER_USERNAME:-docker.io/jujusolutions}`

1. Bootstrap controller1 with docker image OCI namespace
```sh
make minikube-operator-update && juju bootstrap minikube minikubeoriginal --debug
```

2. Add a model
```sh
juju add-model minikubeoriginalmodel
```

3. Verify image of original model pod to be from docker
```sh
kubectl get pod $(kubectl get pods -n minikubeoriginalmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeoriginalmodel -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/jujud-operator:3.6.9
```

4. Deploy an application
```sh
juju deploy mysql-k8s
```

5. Verify image of mysql charm in original model to be from docker
```sh
kubectl get pod mysql-k8s-0 -n minikubeoriginalmodel  -o=jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-22.04 registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9a
```

6. Change OCI_REGISTRY_USERNAME in make_functions.sh to ghcr
`DOCKER_USERNAME=${DOCKER_USERNAME:-ghcr.io/juju}`

7. Bootstrap controller2 with updated image OCI namespace (After check out branch, version might be different from 3.6.9 depending on your juju client or simplestreams directory. Also remember to remove image if there is an existing docker image of the same name/repo + tag causing code to not be updated) 
```sh
[OPTIONAL] docker rmi [image_id]
make minikube-operator-update && juju bootstrap minikube minikubeupdated --debug
```

8. Add a model
```sh
juju add-model minikubeupdatedmodel
```

9. Verify image of updated model pod to be from ghcr
```sh
kubectl get pod $(kubectl get pods -n minikubeupdatedmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeupdatedmodel -o jsonpath="{.spec.containers[*].image}"

ghcr.io/juju/jujud-operator:3.6.9
```

10. Deploy an application
```sh
juju deploy mysql-k8s
```

11. Verify image of mysql charm in updated model to be from ghcr
```sh
kubectl get pod mysql-k8s-0 -n minikubeupdatedmodel  -o=jsonpath="{.spec.containers[*].image}"

ghcr.io/juju/charm-base:ubuntu-22.04 registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9
```

12. Migrate model from minikubeoriginal to minikubeupdated
```sh
juju switch minikubeoriginal
juju migrate minikubeoriginalmodel minikubeupdated
```

13. Verify image of original model pod to be still docker
```sh
kubectl get pod $(kubectl get pods -n minikubeoriginalmodel --no-headers | head -n 1 | awk '{print $1}') -n minikubeoriginalmodel -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/jujud-operator:3.6.9
```

14. Verify image of mysql charm in original model to be still docker
```sh
kubectl get pod mysql-k8s-0 -n minikubeoriginalmodel  -o=jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/charm-base:ubuntu-22.04 registry.jujucharms.com/charm/62ptdfbrjpw3n9tcnswjpart30jauc6wc5wbi/mysql-image@sha256:089fc04dd2d6f1559161ddf4720c1e06559aeb731ecae57b050c9c816e9833e9
```

15. Cherry pick relevant changes & bootstrap a 3.6.7 controller with docker image and relevant changes
```sh
make minikube-operator-update && juju bootstrap minikube minikubeoriginal367 --debug
```

16. Add a model in the 3.6.7 controller and deploy mysql
```sh
juju add-model && juju deploy mysql-k8s
```

17. Verify image of model to be 3.6.7 docker image
```sh
 kubectl get pod $(kubectl get pods -n minikubeoriginalmodel367 --no-headers | head -n 1 | awk '{print $1}') -n minikubeoriginalmodel367 -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/jujud-operator:3.6.7
```

18. Migrate a 3.6.7 docker model from controller with relevant changes to minikubeupdated
```sh
juju migrate minikubeoriginal367 minikubeupdated
```

19. Upgrade the minikubeoriginal367 to version 3.6.9
```sh
juju switch minikubeupdated
juju switch minikubeoriginal367
juju upgrade-model
```

20. Verify image of 3.6.7 docker image to be updated to 3.6.9 docker image in model
```sh
kubectl get pod $(kubectl get pods -n minikubeoriginalmodel367 --no-headers | head -n 1 | awk '{print $1}') -n minikubeoriginalmodel367 -o jsonpath="{.spec.containers[*].image}"

docker.io/jujusolutions/jujud-operator:3.6.9
```


## Links

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-7982

**Github issue:** https://github.com/juju/juju/issues/20206