### PR TITLE
docs: 3.6+ fix vm name in deployment env setup guide

### DIFF
--- a/docs/howto/manage-your-deployment.md
+++ b/docs/howto/manage-your-deployment.md
@@ -91,8 +91,8 @@ ubuntu@my-juju-vm:~$
 
 At any point:
 - To exit the shell, press {kbd}`mod` + {kbd}`C` (e.g., {kbd}`Ctrl`+{kbd}`C`) or type `exit`.
-- To stop the VM after exiting the VM shell, run `multipass stop charm-dev-vm`.
-- To restart the VM and re-open a shell into it, type `multipass shell charm-dev-vm`.
+- To stop the VM after exiting the VM shell, run `multipass stop my-juju-vm`.
+- To restart the VM and re-open a shell into it, type `multipass shell my-juju-vm`.
 
 ```
 ```{dropdown} Tips for troubleshooting
@@ -258,15 +258,15 @@ $ sudo snap install docker
 $ mkdir ~/my-charm
 
 # Mount it to the Multipass VM:
-$ multipass mount --type native ~/my-charm charm-dev-vm:~/my-charm
+$ multipass mount --type native ~/my-charm my-juju-vm:~/my-charm
 
 # Verify that it's indeed on the VM:
-ubuntu@charm-dev-vm:~$ ls
+ubuntu@my-juju-vm:~$ ls
 my-charm  snap
 
 # Going forward:
 # - Use your host machine (on Linux, `cd ~/my-charm`) to create and edit your charm files. This will allow you to use your favorite local editor.
-# - Use the Multipass VM shell (on Linux, `ubuntu@charm-dev-vm:~$ cd ~/my-charm`) to run Charmcraft and Juju commands.
+# - Use the Multipass VM shell (on Linux, `ubuntu@my-juju-vm:~$ cd ~/my-charm`) to run Charmcraft and Juju commands.
 
 ```
 
@@ -736,7 +736,7 @@ $ sudo gpasswd -d $USER snap_microk8s
 3. If earlier you decided to use Multipass, delete the Multipass VM:
 
 ```text
-multipass delete --purge charm-dev-vm
+multipass delete --purge my-juju-vm
 ```
 
 Then uninstall Multipass.


### PR DESCRIPTION
Issue https://github.com/juju/juju/pull/19436 appears as fixed through https://github.com/juju/juju/pull/19436 but the 3.6 docs don't seem to have this fix. I am not sure what happened there. This PR fixes the issue.