### PR TITLE
feat(agenttools): add latest_agent_version to domain

### DIFF
--- a/apiserver/facades/controller/agenttools/register.go
+++ b/apiserver/facades/controller/agenttools/register.go
@@ -20,12 +20,9 @@ func Register(registry facade.FacadeRegistry) {
 
 // newFacade is used to register the facade.
 func newFacade(ctx facade.ModelContext) (*AgentToolsAPI, error) {
-	st := ctx.State()
 	domainServices := ctx.DomainServices()
 	return NewAgentToolsAPI(
-		st,
 		tools.FindTools,
-		envVersionUpdate,
 		ctx.Auth(),
 		ctx.Logger().Child("model"),
 		domainServices.Machine(),

--- a/apiserver/facades/controller/agenttools/service.go
+++ b/apiserver/facades/controller/agenttools/service.go
@@ -30,4 +30,7 @@ type ModelAgentService interface {
 	// - [github.com/juju/juju/domain/model/errors.NotFound] - When the model does
 	// not exist.
 	GetModelTargetAgentVersion(ctx context.Context) (semversion.Number, error)
+
+	// UpdateLatestAgentVersion persists the latest available agent version.
+	UpdateLatestAgentVersion(context.Context, semversion.Number) error
 }

--- a/apiserver/facades/controller/agenttools/service_mock_test.go
+++ b/apiserver/facades/controller/agenttools/service_mock_test.go
@@ -204,3 +204,41 @@ func (c *MockModelAgentServiceGetModelTargetAgentVersionCall) DoAndReturn(f func
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// UpdateLatestAgentVersion mocks base method.
+func (m *MockModelAgentService) UpdateLatestAgentVersion(arg0 context.Context, arg1 semversion.Number) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLatestAgentVersion", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLatestAgentVersion indicates an expected call of UpdateLatestAgentVersion.
+func (mr *MockModelAgentServiceMockRecorder) UpdateLatestAgentVersion(arg0, arg1 any) *MockModelAgentServiceUpdateLatestAgentVersionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLatestAgentVersion", reflect.TypeOf((*MockModelAgentService)(nil).UpdateLatestAgentVersion), arg0, arg1)
+	return &MockModelAgentServiceUpdateLatestAgentVersionCall{Call: call}
+}
+
+// MockModelAgentServiceUpdateLatestAgentVersionCall wrap *gomock.Call
+type MockModelAgentServiceUpdateLatestAgentVersionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelAgentServiceUpdateLatestAgentVersionCall) Return(arg0 error) *MockModelAgentServiceUpdateLatestAgentVersionCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelAgentServiceUpdateLatestAgentVersionCall) Do(f func(context.Context, semversion.Number) error) *MockModelAgentServiceUpdateLatestAgentVersionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelAgentServiceUpdateLatestAgentVersionCall) DoAndReturn(f func(context.Context, semversion.Number) error) *MockModelAgentServiceUpdateLatestAgentVersionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/core/model/modelinfo.go
+++ b/core/model/modelinfo.go
@@ -47,6 +47,9 @@ type ModelInfo struct {
 
 	// AgentVersion is the Juju version for agent binaries in this model.
 	AgentVersion semversion.Number
+
+	// LatestAgentVersion is the latest known agent version for the model.
+	LatestAgentVersion semversion.Number
 }
 
 // ModelMetrics represents the metrics information set in the database.

--- a/domain/agentprovisioner/state/state_test.go
+++ b/domain/agentprovisioner/state/state_test.go
@@ -110,15 +110,16 @@ func (s *suite) TestModelID(c *tc.C) {
 	modelID := modeltesting.GenModelUUID(c)
 	modelSt := modelstate.NewModelState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 	err := modelSt.Create(c.Context(), model.ModelDetailArgs{
-		UUID:           modelID,
-		AgentVersion:   semversion.Number{Major: 4, Minor: 21, Patch: 67},
-		AgentStream:    modelagent.AgentStreamReleased,
-		ControllerUUID: uuid.MustNewUUID(),
-		Name:           "test-model",
-		Qualifier:      "prod",
-		Type:           coremodel.IAAS,
-		Cloud:          "aws",
-		CloudType:      "ec2",
+		UUID:               modelID,
+		LatestAgentVersion: semversion.Number{Major: 4, Minor: 21, Patch: 67},
+		AgentVersion:       semversion.Number{Major: 4, Minor: 21, Patch: 67},
+		AgentStream:        modelagent.AgentStreamReleased,
+		ControllerUUID:     uuid.MustNewUUID(),
+		Name:               "test-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 

--- a/domain/controllerupgrader/state/model_test.go
+++ b/domain/controllerupgrader/state/model_test.go
@@ -86,9 +86,10 @@ func (s *controllerModelStateSuite) setModelTargetAgentVersionAndStream(
 	db, err := domain.NewStateBase(s.TxnRunnerFactory()).DB()
 	c.Assert(err, tc.ErrorIsNil)
 
-	q := "INSERT INTO agent_version (*) VALUES ($M.stream_id, $M.target_version)"
+	q := "INSERT INTO agent_version (*) VALUES ($M.stream_id, $M.target_version, $M.latest_version)"
 
 	args := sqlair.M{
+		"latest_version": vers,
 		"target_version": vers,
 		"stream_id":      int(stream),
 	}

--- a/domain/keyupdater/state/state_test.go
+++ b/domain/keyupdater/state/state_test.go
@@ -103,18 +103,19 @@ func (s *stateSuite) TestGetModelId(c *tc.C) {
 
 	modelUUID := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            modelUUID,
-		AgentVersion:    jujuversion.Current,
-		AgentStream:     modelagent.AgentStreamReleased,
-		ControllerUUID:  uuid.MustNewUUID(),
-		Name:            "my-awesome-model",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       "ec2",
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               modelUUID,
+		LatestAgentVersion: jujuversion.Current,
+		AgentVersion:       jujuversion.Current,
+		AgentStream:        modelagent.AgentStreamReleased,
+		ControllerUUID:     uuid.MustNewUUID(),
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	}
 	err := mst.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -1254,18 +1254,19 @@ func (s *stateSuite) createTestModel(c *tc.C) coremodel.UUID {
 
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
-		AgentStream:     modelagent.AgentStreamReleased,
-		AgentVersion:    jujuversion.Current,
-		ControllerUUID:  uuid.MustNewUUID(),
-		Name:            "my-awesome-model",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       "ec2",
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     uuid.MustNewUUID(),
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -192,8 +192,9 @@ func CreateLocalModelRecordWithAgentStream(
 			// TODO (manadart 2024-01-13): Note that this comes from the arg.
 			// It is not populated in the return from the controller state.
 			// So that method should not return the core type.
-			AgentVersion: agentVersion,
-			AgentStream:  agentStreamArg,
+			AgentStream:        agentStreamArg,
+			AgentVersion:       agentVersion,
+			LatestAgentVersion: agentVersion,
 		}
 
 		return modelDB.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -457,7 +457,8 @@ func (s *ModelService) CreateModelWithAgentVersionStream(
 		// TODO (manadart 2024-01-13): Note that this comes from the arg.
 		// It is not populated in the return from the controller state.
 		// So that method should not return the core type.
-		AgentVersion: agentVersion,
+		AgentVersion:       agentVersion,
+		LatestAgentVersion: agentVersion,
 	}
 	return s.modelSt.Create(ctx, args)
 }

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -981,16 +981,17 @@ func (s *providerModelServiceSuite) TestCreateModel(c *tc.C) {
 		Type:           coremodel.IAAS,
 	}, nil)
 	s.mockModelState.EXPECT().Create(gomock.Any(), model.ModelDetailArgs{
-		UUID:           modelUUID,
-		ControllerUUID: controllerUUID,
-		Name:           "my-awesome-model",
-		Qualifier:      "prod",
-		Type:           coremodel.IAAS,
-		Cloud:          "aws",
-		CloudType:      "ec2",
-		CloudRegion:    "myregion",
-		AgentStream:    modelagent.AgentStreamReleased,
-		AgentVersion:   jujuversion.Current,
+		UUID:               modelUUID,
+		ControllerUUID:     controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
 	}).Return(nil)
 
 	s.mockModelState.EXPECT().GetControllerUUID(gomock.Any()).Return(controllerUUID, nil)
@@ -1027,16 +1028,17 @@ func (s *providerModelServiceSuite) TestCreateModelFailedErrorAlreadyExists(c *t
 		Type:           coremodel.IAAS,
 	}, nil)
 	s.mockModelState.EXPECT().Create(gomock.Any(), model.ModelDetailArgs{
-		UUID:           modelUUID,
-		ControllerUUID: controllerUUID,
-		Name:           "my-awesome-model",
-		Qualifier:      "prod",
-		Type:           coremodel.IAAS,
-		Cloud:          "aws",
-		CloudType:      "ec2",
-		CloudRegion:    "myregion",
-		AgentStream:    modelagent.AgentStreamReleased,
-		AgentVersion:   jujuversion.Current,
+		UUID:               modelUUID,
+		ControllerUUID:     controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
 	}).Return(modelerrors.AlreadyExists)
 
 	svc := NewProviderModelService(

--- a/domain/model/state/modelstate.go
+++ b/domain/model/state/modelstate.go
@@ -666,32 +666,34 @@ func (s *ModelState) GetModel(ctx context.Context) (coremodel.ModelInfo, error) 
 		return coremodel.ModelInfo{}, errors.Capture(err)
 	}
 
-	var m dbReadOnlyModel
-	roStmt, err := s.Prepare(`SELECT &dbReadOnlyModel.* FROM model`, m)
+	var model dbReadOnlyModel
+	roStmt, err := s.Prepare(`SELECT &dbReadOnlyModel.* FROM model`, model)
 	if err != nil {
 		return coremodel.ModelInfo{}, errors.Capture(err)
 	}
 
-	var v dbModelAgent
-	avStmt, err := s.Prepare(`SELECT &dbModelAgent.* FROM agent_version`, v)
+	var agentVersion dbModelAgent
+	avStmt, err := s.Prepare(`SELECT &dbModelAgent.* FROM agent_version`, agentVersion)
 	if err != nil {
 		return coremodel.ModelInfo{}, errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, roStmt).Get(&m)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return modelerrors.NotFound
-			}
+		err := tx.Query(ctx, roStmt).Get(&model)
+		if errors.Is(err, sql.ErrNoRows) {
+			return modelerrors.NotFound
+		} else if err != nil {
 			return errors.Capture(err)
 		}
 
-		err = tx.Query(ctx, avStmt).Get(&v)
+		err = tx.Query(ctx, avStmt).Get(&agentVersion)
 		if errors.Is(err, sql.ErrNoRows) {
 			return modelagenterrors.AgentVersionNotFound
+		} else if err != nil {
+			return errors.Capture(err)
 		}
-		return errors.Capture(err)
+
+		return nil
 	})
 
 	if err != nil {
@@ -700,36 +702,51 @@ func (s *ModelState) GetModel(ctx context.Context) (coremodel.ModelInfo, error) 
 		)
 	}
 
-	info := coremodel.ModelInfo{
-		UUID:              coremodel.UUID(m.UUID),
-		Name:              m.Name,
-		Qualifier:         coremodel.Qualifier(m.Qualifier),
-		Type:              coremodel.ModelType(m.Type),
-		Cloud:             m.Cloud,
-		CloudType:         m.CloudType,
-		CloudRegion:       m.CloudRegion,
-		CredentialName:    m.CredentialName,
-		IsControllerModel: m.IsControllerModel,
-		AgentVersion:      semversion.MustParse(v.TargetVersion),
+	agentVersionNumber, err := parseNullableVersion(agentVersion.TargetVersion)
+	if err != nil {
+		return coremodel.ModelInfo{}, errors.Errorf(
+			"parsing agent version %q: %w", agentVersion.TargetVersion.V, err,
+		)
 	}
 
-	if owner := m.CredentialOwner; owner != "" {
+	latestAgentVersionNumber, err := parseNullableVersion(agentVersion.LatestVersion)
+	if err != nil {
+		return coremodel.ModelInfo{}, errors.Errorf(
+			"parsing latest agent version %q: %w", agentVersion.LatestVersion.V, err,
+		)
+	}
+
+	info := coremodel.ModelInfo{
+		UUID:               coremodel.UUID(model.UUID),
+		Name:               model.Name,
+		Qualifier:          coremodel.Qualifier(model.Qualifier),
+		Type:               coremodel.ModelType(model.Type),
+		Cloud:              model.Cloud,
+		CloudType:          model.CloudType,
+		CloudRegion:        model.CloudRegion,
+		CredentialName:     model.CredentialName,
+		IsControllerModel:  model.IsControllerModel,
+		AgentVersion:       agentVersionNumber,
+		LatestAgentVersion: latestAgentVersionNumber,
+	}
+
+	if owner := model.CredentialOwner; owner != "" {
 		info.CredentialOwner, err = user.NewName(owner)
 		if err != nil {
 			return coremodel.ModelInfo{}, errors.Errorf(
 				"parsing model %q owner username %q: %w",
-				m.UUID, owner, err,
+				model.UUID, owner, err,
 			)
 		}
 	} else {
-		s.logger.Infof(ctx, "model %s: cloud credential owner name is empty", m.Name)
+		s.logger.Infof(ctx, "model %s: cloud credential owner name is empty", model.Name)
 	}
 
-	info.ControllerUUID, err = uuid.UUIDFromString(m.ControllerUUID)
+	info.ControllerUUID, err = uuid.UUIDFromString(model.ControllerUUID)
 	if err != nil {
 		return coremodel.ModelInfo{}, errors.Errorf(
 			"parsing controller uuid %q for model %q: %w",
-			m.ControllerUUID, m.UUID, err,
+			model.ControllerUUID, model.UUID, err,
 		)
 	}
 	return info, nil
@@ -984,10 +1001,15 @@ func InsertModelInfo(
 	// This is some defensive programming. The zero value of agent version is
 	// still valid but should really be considered null for the purposes of
 	// allowing the DDL to assert constraints.
-	var agentVersion sql.NullString
+	var agentVersion sql.Null[string]
 	if args.AgentVersion != semversion.Zero {
-		agentVersion.String = args.AgentVersion.String()
+		agentVersion.V = args.AgentVersion.String()
 		agentVersion.Valid = true
+	}
+	var latestVersion sql.Null[string]
+	if args.LatestAgentVersion != semversion.Zero {
+		latestVersion.V = args.LatestAgentVersion.String()
+		latestVersion.Valid = true
 	}
 
 	mID := dbUUID{UUID: args.UUID.String()}
@@ -1003,7 +1025,7 @@ func InsertModelInfo(
 		return errors.Errorf("read-only model record already exists: %w", modelerrors.AlreadyExists)
 	}
 
-	m := dbReadOnlyModel{
+	model := dbReadOnlyModel{
 		UUID:              args.UUID.String(),
 		ControllerUUID:    args.ControllerUUID.String(),
 		Name:              args.Name,
@@ -1017,16 +1039,17 @@ func InsertModelInfo(
 		IsControllerModel: args.IsControllerModel,
 	}
 
-	roStmt, err := preparer.Prepare("INSERT INTO model (*) VALUES ($dbReadOnlyModel.*)", m)
+	modelStmt, err := preparer.Prepare("INSERT INTO model (*) VALUES ($dbReadOnlyModel.*)", model)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	v := dbModelAgent{
+	modelAgentVersion := dbModelAgent{
 		StreamID:      int(args.AgentStream),
-		TargetVersion: args.AgentVersion.String(),
+		TargetVersion: agentVersion,
+		LatestVersion: latestVersion,
 	}
-	vStmt, err := preparer.Prepare("INSERT INTO agent_version (*) VALUES ($dbModelAgent.*)", v)
+	versionStmt, err := preparer.Prepare("INSERT INTO agent_version (*) VALUES ($dbModelAgent.*)", modelAgentVersion)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -1041,11 +1064,11 @@ func InsertModelInfo(
 		return errors.Capture(err)
 	}
 
-	if err := tx.Query(ctx, roStmt, m).Run(); err != nil {
+	if err := tx.Query(ctx, modelStmt, model).Run(); err != nil {
 		return errors.Errorf("creating model read-only record for %q: %w", args.UUID, err)
 	}
 
-	if err := tx.Query(ctx, vStmt, v).Run(); err != nil {
+	if err := tx.Query(ctx, versionStmt, modelAgentVersion).Run(); err != nil {
 		return errors.Errorf("creating agent_version record for %q: %w", args.UUID, err)
 	}
 
@@ -1084,4 +1107,11 @@ func (s *ModelState) IsControllerModel(ctx context.Context) (bool, error) {
 	}
 
 	return m.IsControllerModel, nil
+}
+
+func parseNullableVersion(version sql.Null[string]) (semversion.Number, error) {
+	if !version.Valid {
+		return semversion.Zero, nil
+	}
+	return semversion.Parse(version.V)
 }

--- a/domain/model/state/modelstate_test.go
+++ b/domain/model/state/modelstate_test.go
@@ -51,18 +51,19 @@ func (s *modelSuite) createTestModel(c *tc.C) coremodel.UUID {
 
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
-		AgentStream:     modelagent.AgentStreamReleased,
-		AgentVersion:    jujuversion.Current,
-		ControllerUUID:  s.controllerUUID,
-		Name:            "my-awesome-model",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       "ec2",
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -75,18 +76,19 @@ func (s *modelSuite) TestCreateAndReadModel(c *tc.C) {
 
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
-		AgentStream:     modelagent.AgentStreamReleased,
-		AgentVersion:    jujuversion.Current,
-		ControllerUUID:  s.controllerUUID,
-		Name:            "my-awesome-model",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       "ec2",
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -95,17 +97,18 @@ func (s *modelSuite) TestCreateAndReadModel(c *tc.C) {
 	model, err := state.GetModel(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(model, tc.DeepEquals, coremodel.ModelInfo{
-		UUID:            id,
-		AgentVersion:    jujuversion.Current,
-		ControllerUUID:  s.controllerUUID,
-		Name:            "my-awesome-model",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       "ec2",
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               id,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	})
 
 	// Ensure that we have a model life record.
@@ -126,18 +129,19 @@ func (s *modelSuite) TestDeleteModel(c *tc.C) {
 
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
-		AgentStream:     modelagent.AgentStreamReleased,
-		AgentVersion:    jujuversion.Current,
-		ControllerUUID:  s.controllerUUID,
-		Name:            "my-awesome-model",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       "ec2",
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -161,16 +165,17 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithSameUUID(c *tc.C) {
 
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:           id,
-		AgentStream:    modelagent.AgentStreamReleased,
-		AgentVersion:   jujuversion.Current,
-		ControllerUUID: s.controllerUUID,
-		Name:           "my-awesome-model",
-		Qualifier:      "prod",
-		Type:           coremodel.IAAS,
-		Cloud:          "aws",
-		CloudType:      "ec2",
-		CloudRegion:    "myregion",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -185,28 +190,30 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithDifferentUUID(c *tc.C) {
 	// Ensure that you can only ever insert one model.
 
 	err := state.Create(c.Context(), model.ModelDetailArgs{
-		UUID:         modeltesting.GenModelUUID(c),
-		AgentStream:  modelagent.AgentStreamReleased,
-		AgentVersion: jujuversion.Current,
-		Name:         "my-awesome-model",
-		Qualifier:    "prod",
-		Type:         coremodel.IAAS,
-		Cloud:        "aws",
-		CloudType:    "ec2",
-		CloudRegion:  "myregion",
+		UUID:               modeltesting.GenModelUUID(c),
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = state.Create(c.Context(), model.ModelDetailArgs{
-		UUID:         modeltesting.GenModelUUID(c),
-		AgentStream:  modelagent.AgentStreamReleased,
-		AgentVersion: jujuversion.Current,
-		Name:         "my-awesome-model",
-		Qualifier:    "prod",
-		Type:         coremodel.IAAS,
-		Cloud:        "aws",
-		CloudType:    "ec2",
-		CloudRegion:  "myregion",
+		UUID:               modeltesting.GenModelUUID(c),
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
 	})
 	c.Assert(err, tc.ErrorIs, modelerrors.AlreadyExists)
 }
@@ -219,16 +226,17 @@ func (s *modelSuite) TestCreateModelAndUpdate(c *tc.C) {
 
 	id := modeltesting.GenModelUUID(c)
 	err := state.Create(c.Context(), model.ModelDetailArgs{
-		UUID:           id,
-		AgentStream:    modelagent.AgentStreamReleased,
-		AgentVersion:   jujuversion.Current,
-		ControllerUUID: s.controllerUUID,
-		Name:           "my-awesome-model",
-		Qualifier:      "prod",
-		Type:           coremodel.IAAS,
-		Cloud:          "aws",
-		CloudType:      "ec2",
-		CloudRegion:    "myregion",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -245,15 +253,16 @@ func (s *modelSuite) TestCreateModelAndDelete(c *tc.C) {
 
 	id := modeltesting.GenModelUUID(c)
 	err := state.Create(c.Context(), model.ModelDetailArgs{
-		UUID:         id,
-		AgentStream:  modelagent.AgentStreamReleased,
-		AgentVersion: jujuversion.Current,
-		Name:         "my-awesome-model",
-		Qualifier:    "prod",
-		Type:         coremodel.IAAS,
-		Cloud:        "aws",
-		CloudType:    "ec2",
-		CloudRegion:  "myregion",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -291,17 +300,18 @@ func (s *modelSuite) TestGetModelMetrics(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(model, tc.DeepEquals, coremodel.ModelMetrics{
 		Model: coremodel.ModelInfo{
-			UUID:            id,
-			AgentVersion:    jujuversion.Current,
-			ControllerUUID:  s.controllerUUID,
-			Name:            "my-awesome-model",
-			Qualifier:       "prod",
-			Type:            coremodel.IAAS,
-			Cloud:           "aws",
-			CloudType:       "ec2",
-			CloudRegion:     "myregion",
-			CredentialOwner: usertesting.GenNewName(c, "myowner"),
-			CredentialName:  "mycredential",
+			UUID:               id,
+			AgentVersion:       jujuversion.Current,
+			LatestAgentVersion: jujuversion.Current,
+			ControllerUUID:     s.controllerUUID,
+			Name:               "my-awesome-model",
+			Qualifier:          "prod",
+			Type:               coremodel.IAAS,
+			Cloud:              "aws",
+			CloudType:          "ec2",
+			CloudRegion:        "myregion",
+			CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+			CredentialName:     "mycredential",
 		},
 		ApplicationCount: 1,
 		MachineCount:     0,
@@ -559,18 +569,19 @@ func (s *modelSuite) TestGetModelCloudType(c *tc.C) {
 	id := modeltesting.GenModelUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
-		UUID:            id,
-		AgentStream:     modelagent.AgentStreamReleased,
-		AgentVersion:    jujuversion.Current,
-		ControllerUUID:  s.controllerUUID,
-		Name:            "mymodel",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       cloudType,
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "mymodel",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          cloudType,
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -595,18 +606,19 @@ func (s *modelSuite) TestGetModelCloudRegionAndCredential(c *tc.C) {
 	uuid := modeltesting.GenModelUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
-		UUID:            uuid,
-		AgentStream:     modelagent.AgentStreamReleased,
-		AgentVersion:    jujuversion.Current,
-		ControllerUUID:  s.controllerUUID,
-		Name:            "mymodel",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       cloudType,
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               uuid,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "mymodel",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          cloudType,
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -640,19 +652,20 @@ func (s *modelSuite) TestIsControllerModelTrue(c *tc.C) {
 	uuid := modeltesting.GenModelUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
-		UUID:              uuid,
-		AgentStream:       modelagent.AgentStreamReleased,
-		AgentVersion:      jujuversion.Current,
-		ControllerUUID:    s.controllerUUID,
-		Name:              "mycontrollermodel",
-		Qualifier:         "prod",
-		Type:              coremodel.IAAS,
-		Cloud:             "aws",
-		CloudType:         cloudType,
-		CloudRegion:       "myregion",
-		CredentialOwner:   usertesting.GenNewName(c, "myowner"),
-		CredentialName:    "mycredential",
-		IsControllerModel: true,
+		UUID:               uuid,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "mycontrollermodel",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          cloudType,
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
+		IsControllerModel:  true,
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -669,19 +682,20 @@ func (s *modelSuite) TestIsControllerModelFalse(c *tc.C) {
 	uuid := modeltesting.GenModelUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
-		UUID:              uuid,
-		AgentStream:       modelagent.AgentStreamReleased,
-		AgentVersion:      jujuversion.Current,
-		ControllerUUID:    s.controllerUUID,
-		Name:              "mycontrollermodel",
-		Qualifier:         "prod",
-		Type:              coremodel.IAAS,
-		Cloud:             "aws",
-		CloudType:         cloudType,
-		CloudRegion:       "myregion",
-		CredentialOwner:   usertesting.GenNewName(c, "myowner"),
-		CredentialName:    "mycredential",
-		IsControllerModel: false,
+		UUID:               uuid,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "mycontrollermodel",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          cloudType,
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
+		IsControllerModel:  false,
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -720,19 +734,20 @@ func (s *modelSuite) TestGetControllerUUID(c *tc.C) {
 	uuid := modeltesting.GenModelUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
-		UUID:              uuid,
-		AgentStream:       modelagent.AgentStreamReleased,
-		AgentVersion:      jujuversion.Current,
-		ControllerUUID:    s.controllerUUID,
-		Name:              "mycontrollermodel",
-		Qualifier:         "prod",
-		Type:              coremodel.CAAS,
-		Cloud:             "aws",
-		CloudType:         cloudType,
-		CloudRegion:       "myregion",
-		CredentialOwner:   usertesting.GenNewName(c, "myowner"),
-		CredentialName:    "mycredential",
-		IsControllerModel: false,
+		UUID:               uuid,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "mycontrollermodel",
+		Qualifier:          "prod",
+		Type:               coremodel.CAAS,
+		Cloud:              "aws",
+		CloudType:          cloudType,
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
+		IsControllerModel:  false,
 	}
 	err := state.Create(c.Context(), args)
 	c.Check(err, tc.ErrorIsNil)
@@ -751,19 +766,20 @@ func (s *modelSuite) TestGetModelType(c *tc.C) {
 	uuid := modeltesting.GenModelUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
-		UUID:              uuid,
-		AgentStream:       modelagent.AgentStreamReleased,
-		AgentVersion:      jujuversion.Current,
-		ControllerUUID:    s.controllerUUID,
-		Name:              "mycontrollermodel",
-		Qualifier:         "prod",
-		Type:              coremodel.CAAS,
-		Cloud:             "aws",
-		CloudType:         cloudType,
-		CloudRegion:       "myregion",
-		CredentialOwner:   usertesting.GenNewName(c, "myowner"),
-		CredentialName:    "mycredential",
-		IsControllerModel: false,
+		UUID:               uuid,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "mycontrollermodel",
+		Qualifier:          "prod",
+		Type:               coremodel.CAAS,
+		Cloud:              "aws",
+		CloudType:          cloudType,
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
+		IsControllerModel:  false,
 	}
 	err := state.Create(c.Context(), args)
 	c.Check(err, tc.ErrorIsNil)
@@ -793,19 +809,20 @@ func (s *modelSuite) TestGetModelInfoSummary(c *tc.C) {
 	uuid := modeltesting.GenModelUUID(c)
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
-		UUID:              uuid,
-		AgentStream:       modelagent.AgentStreamReleased,
-		AgentVersion:      jujuversion.Current,
-		ControllerUUID:    s.controllerUUID,
-		Name:              "mycontrollermodel",
-		Qualifier:         "prod",
-		Type:              coremodel.CAAS,
-		Cloud:             "aws",
-		CloudType:         cloudType,
-		CloudRegion:       "myregion",
-		CredentialOwner:   usertesting.GenNewName(c, "myowner"),
-		CredentialName:    "mycredential",
-		IsControllerModel: false,
+		UUID:               uuid,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "mycontrollermodel",
+		Qualifier:          "prod",
+		Type:               coremodel.CAAS,
+		Cloud:              "aws",
+		CloudType:          cloudType,
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
+		IsControllerModel:  false,
 	}
 	err := state.Create(c.Context(), args)
 	c.Check(err, tc.ErrorIsNil)

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -370,7 +370,8 @@ type dbPermission struct {
 	ObjectType string `db:"object_type"`
 }
 
-// dbModelAgent represents a row from the controller model_agent table.
+// dbModelAgent represents a row from the model_agent table
+// with nullable values for the purpose of defensive programming.
 type dbModelAgent struct {
 	// StreamID is the unique identifier for the agent stream that is being used
 	// for model agents.
@@ -380,7 +381,10 @@ type dbModelAgent struct {
 	// being run in this model. It should not be considered "the" version that
 	// is being run for every agent as each agent needs to upgrade to this
 	// version.
-	TargetVersion string `db:"target_version"`
+	TargetVersion sql.Null[string] `db:"target_version"`
+
+	// LatestVersion describes the latest known agent version for the model.
+	LatestVersion sql.Null[string] `db:"latest_version"`
 }
 
 type dbModelSecretBackend struct {

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -131,6 +131,9 @@ type ModelDetailArgs struct {
 
 	// AgentVersion is the target version for agents running in this model.
 	AgentVersion semversion.Number
+
+	// LatestAgentVersion is the latest know agent version for the model.
+	LatestAgentVersion semversion.Number
 }
 
 // ModelImportArgs supplies the information needed for importing a model into a

--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -183,6 +183,9 @@ type State interface {
 		stream modelagent.AgentStream,
 	) error
 
+	// UpdateLatestAgentVersion persists the latest available agent version.
+	UpdateLatestAgentVersion(context.Context, semversion.Number) error
+
 	// SetUnitRunningAgentBinaryVersion sets the running agent version for the unit.
 	// The following error types can be expected:
 	// - [applicationerrors.UnitNotFound] - when the unit does not exist.
@@ -839,6 +842,13 @@ func (s *Service) UpgradeModelTargetAgentVersionStreamTo(
 		return errors.Capture(err)
 	}
 	return nil
+}
+
+// UpdateLatestAgentVersion persists the latest available agent version.
+func (s *Service) UpdateLatestAgentVersion(ctx context.Context, version semversion.Number) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+	return s.st.UpdateLatestAgentVersion(ctx, version)
 }
 
 // validateModelCanBeUpgraded checks if the current model is currently in a

--- a/domain/modelagent/service/service_mock_test.go
+++ b/domain/modelagent/service/service_mock_test.go
@@ -880,3 +880,41 @@ func (c *MockStateSetUnitRunningAgentBinaryVersionCall) DoAndReturn(f func(conte
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// UpdateLatestAgentVersion mocks base method.
+func (m *MockState) UpdateLatestAgentVersion(arg0 context.Context, arg1 semversion.Number) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLatestAgentVersion", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLatestAgentVersion indicates an expected call of UpdateLatestAgentVersion.
+func (mr *MockStateMockRecorder) UpdateLatestAgentVersion(arg0, arg1 any) *MockStateUpdateLatestAgentVersionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLatestAgentVersion", reflect.TypeOf((*MockState)(nil).UpdateLatestAgentVersion), arg0, arg1)
+	return &MockStateUpdateLatestAgentVersionCall{Call: call}
+}
+
+// MockStateUpdateLatestAgentVersionCall wrap *gomock.Call
+type MockStateUpdateLatestAgentVersionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateUpdateLatestAgentVersionCall) Return(arg0 error) *MockStateUpdateLatestAgentVersionCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateUpdateLatestAgentVersionCall) Do(f func(context.Context, semversion.Number) error) *MockStateUpdateLatestAgentVersionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateUpdateLatestAgentVersionCall) DoAndReturn(f func(context.Context, semversion.Number) error) *MockStateUpdateLatestAgentVersionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/domain/modelagent/state/types.go
+++ b/domain/modelagent/state/types.go
@@ -22,6 +22,16 @@ type agentVersionTarget struct {
 	TargetVersion string `db:"target_version"`
 }
 
+// latestAgentVersion represents a row from the latest_agent_version table.
+type latestAgentVersion struct {
+	Version string `db:"latest_version"`
+}
+
+type agentVersionInfo struct {
+	TargetVersion string `db:"target_version"`
+	LatestVersion string `db:"latest_version"`
+}
+
 // architectureMap provides a way to exchange one architecture value
 // for the other the database. i.e transfer from name to ID etc.
 type architectureMap struct {

--- a/domain/modelconfig/state/state_test.go
+++ b/domain/modelconfig/state/state_test.go
@@ -158,7 +158,7 @@ func (s *stateSuite) TestGetModelAgentVersionAndStreamNotFound(c *tc.C) {
 // version and stream is set it is reported back correctly with no errors.
 func (s *stateSuite) TestGetModelAgentVersionAndStream(c *tc.C) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, "INSERT INTO agent_version (stream_id, target_version) VALUES (0, '1.2.3')")
+		_, err := tx.ExecContext(ctx, "INSERT INTO agent_version (stream_id, target_version, latest_version) VALUES (0, '1.2.3', '1.2.3')")
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/modelmigration/state/state_test.go
+++ b/domain/modelmigration/state/state_test.go
@@ -45,18 +45,19 @@ func (s *migrationSuite) SetUpTest(c *tc.C) {
 
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
-		UUID:            id,
-		AgentStream:     modelagent.AgentStreamReleased,
-		AgentVersion:    jujuversion.Current,
-		ControllerUUID:  s.controllerUUID,
-		Name:            "my-awesome-model",
-		Qualifier:       "prod",
-		Type:            coremodel.IAAS,
-		Cloud:           "aws",
-		CloudType:       "ec2",
-		CloudRegion:     "myregion",
-		CredentialOwner: usertesting.GenNewName(c, "myowner"),
-		CredentialName:  "mycredential",
+		UUID:               id,
+		AgentStream:        modelagent.AgentStreamReleased,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+		ControllerUUID:     s.controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
+		CredentialName:     "mycredential",
 	}
 	err := state.Create(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/schema/model/sql/0027-agent-version.sql
+++ b/domain/schema/model/sql/0027-agent-version.sql
@@ -17,6 +17,7 @@ INSERT INTO agent_stream VALUES
 CREATE TABLE agent_version (
     stream_id INT NOT NULL,
     target_version TEXT NOT NULL,
+    latest_version TEXT NOT NULL,
     FOREIGN KEY (stream_id)
     REFERENCES agent_stream (id)
 );


### PR DESCRIPTION
In Mongo, there was a latest tools version property on models, that was occasionally updated and displayed in status.

This had not been replicated in the domain yet, so I have added it.

This means I have been able to completely decouple the agent tools facade from Mongo state

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju status --format yaml
model: 
  name: m
  type: iaas
  controller: lxd
  cloud: lxd
  region: localhost
  version: 4.0-beta6.1
...

$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> .switch model-m
repl (model-m)> SELECT * FROM latest_agent_version
version		
4.0-beta6.1	

repl (model-m)> SELECT * FROM agent_version
stream_id	target_version	
0		4.0-beta6.1	

repl (model-m)> UPDATE latest_agent_version SET version = "4.1.0"

$ juju status --format yaml
model: 
  name: m
  type: iaas
  controller: lxd
  cloud: lxd
  region: localhost
  version: 4.0-beta6.1
  upgrade-available: 4.1.0
```