### PR TITLE
feat: Adds to charms best practices concerning respecting model-config  settings

### DIFF
--- a/docs/reference/charm/charm-maturity.md
+++ b/docs/reference/charm/charm-maturity.md
@@ -189,6 +189,15 @@ The charm can expose provides/requires interfaces for integration ready to be ad
 | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | Newly proposed relations have been reviewed and approved by experts to ensure:<p>&#8226; The relation is ready for adoption by other charmers from a development best practice point of view.<p>&#8226;  No conflicts with existing relations of published charms.<p>&#8226;  Relation naming and structuring are consistent with existing relations.<p>&#8226; Tests cover integration with the applications consuming the relations. | A [Github project](https://github.com/canonical/charm-relation-interfaces) structures and defines the implementation of relations.<p>No new relation should conflict with the ones covered by the relation integration set [published on Github](https://github.com/canonical/charm-relation-interfaces).<p>&#8226; See more: [Charmcraft | Manage relations](https://canonical-charmcraft.readthedocs-hosted.com/stable/howto/manage-charms/#manage-relations), [Ops | Manage relations](https://ops.readthedocs.io/en/latest/howto/manage-relations.html)|
 
+
+#### The charm respects juju model-config
+
+Most developers are keenly aware of their own charm's configs, without being aware that juju model-config is another point of administrative control.
+
+| Objectives  | Tips, examples, further reading |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Avoid duplicating configuration options that is best controlled at a model perspective: <p>&#8226; juju-http-proxy, juju-https-proxy, juju-no-proxy should influence the charms behavior when the charm or charmed application makes any http request. | A [Github project](https://github.com/canonical/charms.proxylib) provides a library to help charms direct url requests and subprocess calls through the model configured proxy environment. |
+
 #### The charm upgrades the application safely
 
 The charm supports upgrading the workload and the application. An upgrade task preserves data and settings of both.
@@ -228,7 +237,3 @@ Engineers and administrators who operate an application at a production-grade le
 Everyone can publish charms to [https://charmhub.io/](https://charmhub.io/). Then, the charm can be accessed for deployments using Juju or via a web browser by its URL. If a charm is published in Charmhub.io and included in search results, the charm entry needs to be switched into the listed mode. To bring your charm into the listing, [reach out to the community](https://discourse.charmhub.io/c/charmhub-requests/46) to announce your charm and ask for a review by an experienced community member.
 
 The Stage 1- Important qualities reference is the requirement for switching a charm into the *listed* mode. The points listed in the first stage ensure a useful charm project is suitable for presentation on [https://charmhub.io/](https://charmhub.io/) and for testing by others.
-
-
-
-


### PR DESCRIPTION
Recommended to add a section to the docs concerning best-practices for a charm developer to remember there are model-config settings exposed to the charm: Notably `JUJU_HTTP_PROXY`, `JUJU_HTTPS_PROXY`, `JUJU_NO_PROXY`, and `JUJU_FTP_PROXY`.  

A best practices charm will include support for these features and may even support charm config to allow a specific application in the model to ignore them intentionally.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

~ - [ ] Code style: imports ordered, good names, simple structure, etc ~
~ - [ ] Comments saying why design decisions were made ~
~ - [ ] Go unit tests, with comments saying what you're testing ~
~ - [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing ~
~ - [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages ~

## Documentation changes

This links to a pure python library which helps to map these environment variables through to common tasks like making a `urlopen(...)` call or running `subprocess` or even adjusting a systemd service to include the settings from the juju environment variables provided in a charm hook. 

## Links

[KU-158](https://docs.google.com/document/d/1e_1H1rAvP2zWmN-mLS1dHivSjaRN4A-FK7c43tNMUpQ/edit?tab=t.0#heading=h.ukkze3jhzyn2)
