### PR TITLE
fix: make adding a disk to a lxd container idempotent

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -157,24 +157,28 @@ func (c *Container) Mem() uint {
 // device described by the input arguments.
 // If the device already exists, an error is returned.
 func (c *Container) AddDisk(name, path, source, pool string, readOnly bool) error {
-	if _, ok := c.Devices[name]; ok {
-		return errors.Errorf("container %q already has a device %q", c.Name, name)
-	}
-
-	if c.Devices == nil {
-		c.Devices = map[string]device{}
-	}
-	c.Devices[name] = map[string]string{
+	dev := map[string]string{
 		"path":   path,
 		"source": source,
 		"type":   "disk",
 	}
 	if pool != "" {
-		c.Devices[name]["pool"] = pool
+		dev["pool"] = pool
 	}
 	if readOnly {
-		c.Devices[name]["readonly"] = "true"
+		dev["readonly"] = "true"
 	}
+	if existing, ok := c.Devices[name]; ok {
+		if !reflect.DeepEqual(existing, dev) {
+			return errors.Errorf("container %q already has a device %q", c.Name, name)
+		}
+		return nil
+	}
+
+	if c.Devices == nil {
+		c.Devices = map[string]device{}
+	}
+	c.Devices[name] = dev
 	return nil
 }
 

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -81,6 +81,23 @@ func (s *containerSuite) TestContainerAddDiskNoDevices(c *gc.C) {
 	c.Check(container.Devices["root"], gc.DeepEquals, expected)
 }
 
+func (s *containerSuite) TestContainerAddDiskIdempotent(c *gc.C) {
+	container := lxd.Container{}
+	for range 2 {
+		err := container.AddDisk("root", "/", "source", "default", true)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	expected := map[string]string{
+		"type":     "disk",
+		"path":     "/",
+		"source":   "source",
+		"pool":     "default",
+		"readonly": "true",
+	}
+	c.Check(container.Devices["root"], gc.DeepEquals, expected)
+}
+
 func (s *containerSuite) TestContainerAddDiskDevicePresentError(c *gc.C) {
 	container := lxd.Container{}
 	container.Name = "seeyounexttuesday"


### PR DESCRIPTION
The an upstream LXD bug https://github.com/canonical/lxd/issues/16003 which is being fixed. 
In testing the upstream fix, there's a LXD timing issue attaching a PCI device to a VM which can result in Juju attempting to attach the same disk a 2nd time to an in memory container struct. This PR makes that operation idempotent.

## QA steps

Very hard to reproduce.
A regression test is
`juju deploy postgresql --channel 16/stable --storage data=lxd,100M  --storage archive=lxd-btrfs,100M --storage logs=lxd-btrfs,100M --storage temp=tmpfs,100M --constraints="virt-type=virtual-machine"`

