### PR TITLE
docs: add lastmod to sitemap config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,6 +160,8 @@ if 'READTHEDOCS_VERSION' in os.environ:
 else:
     sitemap_url_scheme = 'MANUAL/{link}'
 
+sitemap_show_lastmod = True
+
 #############
 # Redirects #
 #############


### PR DESCRIPTION
In https://github.com/juju/juju/pull/19938/files we added a sitemap config. At Massi's request, this PR updates that config to take advantage of the recently added lastmod feature: https://canonical-starter-pack.readthedocs-hosted.com/latest/how-to/set-up-sitemaps/#lastmod-configuration 

