### PR TITLE
feat: remove use of the state pool in http context

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -776,12 +776,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	modelToolsDownloadHandler := srv.monitoredHandler(newToolsDownloadHandler(httpCtxt), "tools")
 
 	resourceAuthFunc := func(req *http.Request, tagKinds ...string) (names.Tag, error) {
-		_, entity, err := httpCtxt.stateForRequestAuthenticatedTag(req, tagKinds...)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		return entity.Tag(), nil
+		return httpCtxt.authenticatedTagFromRequest(req, tagKinds...)
 	}
 	resourceChangeAllowedFunc := func(ctx context.Context) error {
 		serviceFactory, err := httpCtxt.domainServicesForRequest(ctx)

--- a/apiserver/debuglog_tailer.go
+++ b/apiserver/debuglog_tailer.go
@@ -35,7 +35,6 @@ func handleDebugLogRequest(
 	socket debugLogSocket,
 	logTailerFunc logTailerFunc,
 	stop <-chan struct{},
-	stateClosing <-chan struct{},
 ) error {
 	tailerParams := makeLogTailerParams(reqParams)
 	tailer, err := logTailerFunc(tailerParams)
@@ -54,8 +53,6 @@ func handleDebugLogRequest(
 	var lineCount uint
 	for {
 		select {
-		case <-stateClosing:
-			return nil
 		case <-stop:
 			return nil
 		case <-timeout:

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -41,14 +41,13 @@ func newAgentLogWriteFunc(
 }
 
 func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
-	st, entity, err := ctxt.stateForRequestAuthenticatedAgent(req)
+	authTag, err := ctxt.authenticatedAgentFromRequest(req)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer func() { _ = st.Release() }()
 
 	modelUUID, _ := httpcontext.RequestModelUUID(req.Context())
-	s.entity = entity.Tag().String()
+	s.entity = authTag.String()
 	s.modelUUID = coremodel.UUID(modelUUID)
 
 	if s.recordLogWriter, err = s.modelLogger.GetLogWriter(req.Context(), s.modelUUID); err != nil {


### PR DESCRIPTION
It's not longer used for http context, remove and refactor the authentication which was tied in.

Authentication methods have been renamed to suit their current purpose as follows:
- stateForRequestAuthenticatedTag -> authenticatedTagFromRequest 
- stateAndEntityForRequestAuthenticatedUser -> authenticatedUserFromRequest 
- stateForRequestAuthenticatedAgent -> authenticatedAgentFromRequest

## Checklist
- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Test charm resources:

```
$ juju deploy juju-qa-test --config foo-file=true

# what the unit status log to verify the resource has been seen
$ juju show-status-log qa/1
Time                   Type       Status       Message
...
24 Jul 2025 18:45:51Z  workload   active       resource line one: testing two.
```
Verify that `juju debug-log` is successful.

The contents of the resource file should display in the juju status output as a message, however something isn't working correctly there. Unrelated to this change. It reproduces with the edge snap.

## Links

**Jira card:** JUJU-8262
