### PR TITLE
chore: remove legacy state Model from modelmanager facades 

### DIFF
--- a/apiserver/common/model/modeldestroy.go
+++ b/apiserver/common/model/modeldestroy.go
@@ -73,7 +73,7 @@ func DestroyController(
 			}
 		}
 	}
-	return destroyModel(ctx, st, blockCommandService, modelInfoService, state.DestroyModelParams{
+	return destroyControllerModel(ctx, st, blockCommandService, modelInfoService, state.DestroyModelParams{
 		DestroyHostedModels: destroyHostedModels,
 		DestroyStorage:      destroyStorage,
 		Force:               force,
@@ -82,27 +82,7 @@ func DestroyController(
 	})
 }
 
-// DestroyModel sets the model to Dying, such that the model's resources will
-// be destroyed and the model removed from the controller.
-func DestroyModel(
-	ctx context.Context,
-	st ModelManagerBackend,
-	blockCommandService BlockCommandService,
-	modelInfoService ModelInfoService,
-	destroyStorage *bool,
-	force *bool,
-	maxWait *time.Duration,
-	timeout *time.Duration,
-) error {
-	return destroyModel(ctx, st, blockCommandService, modelInfoService, state.DestroyModelParams{
-		DestroyStorage: destroyStorage,
-		Force:          force,
-		MaxWait:        common.MaxWait(maxWait),
-		Timeout:        timeout,
-	})
-}
-
-func destroyModel(
+func destroyControllerModel(
 	ctx context.Context,
 	st ModelManagerBackend,
 	blockCommandService BlockCommandService,

--- a/apiserver/common/model/modelmanagerinterface.go
+++ b/apiserver/common/model/modelmanagerinterface.go
@@ -23,7 +23,6 @@ import (
 // All the interface methods are defined directly on state.State
 // and are reproduced here for use in tests.
 type ModelManagerBackend interface {
-	NewModel(state.ModelArgs) (Model, ModelManagerBackend, error)
 	Model() (Model, error)
 	GetBackend(string) (ModelManagerBackend, func() bool, error)
 

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -308,7 +308,6 @@ func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedModelsWithBl
 			coremodel.UUID(s.otherModelUUID),
 		}, nil,
 	)
-	s.mockModelInfoService.EXPECT().HasValidCredential(gomock.Any()).Return(true, nil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
 	s.BlockRemoveObject(c, "TestBlockRemoveObject")

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/common/model"
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/client/controller"
 	"github.com/juju/juju/apiserver/facades/client/controller/mocks"
@@ -303,7 +302,6 @@ func (s *destroyControllerSuite) TestDestroyControllerLeavesBlocksIfNotKillAll(c
 
 func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedModelsWithBlock(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	domainServices := s.DefaultModelDomainServices(c)
 	s.mockModelService.EXPECT().ListModelUUIDs(gomock.Any()).Return(
 		[]coremodel.UUID{
 			coremodel.UUID(s.ControllerUUID),
@@ -312,17 +310,10 @@ func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedModelsWithBl
 	)
 	s.mockModelInfoService.EXPECT().HasValidCredential(gomock.Any()).Return(true, nil)
 
-	err := model.DestroyModel(
-		c.Context(), model.NewModelManagerBackend(s.otherModel, s.StatePool()),
-		domainServices.BlockCommand(), s.mockModelInfoService,
-		nil, nil, nil, nil,
-	)
-	c.Assert(err, tc.ErrorIsNil)
-
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
 	s.BlockRemoveObject(c, "TestBlockRemoveObject")
 
-	err = s.controller.DestroyController(c.Context(), params.DestroyControllerArgs{})
+	err := s.controller.DestroyController(c.Context(), params.DestroyControllerArgs{})
 	c.Assert(err, tc.ErrorMatches, "found blocks in controller models")
 	c.Assert(s.ControllerModel(c).Life(), tc.Equals, state.Alive)
 }
@@ -330,13 +321,6 @@ func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedModelsWithBl
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedModelsWithBlockFail(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	domainServices := s.DefaultModelDomainServices(c)
-
-	err := model.DestroyModel(
-		c.Context(), model.NewModelManagerBackend(s.otherModel, s.StatePool()),
-		domainServices.BlockCommand(), domainServices.ModelInfo(),
-		nil, nil, nil, nil,
-	)
-	c.Assert(err, tc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
 	s.BlockRemoveObject(c, "TestBlockRemoveObject")
@@ -347,7 +331,7 @@ func (s *destroyControllerSuite) TestDestroyControllerNoHostedModelsWithBlockFai
 			coremodel.UUID(s.otherModelUUID),
 		}, nil,
 	)
-	err = s.controller.DestroyController(c.Context(), params.DestroyControllerArgs{})
+	err := s.controller.DestroyController(c.Context(), params.DestroyControllerArgs{})
 	c.Assert(params.IsCodeOperationBlocked(err), tc.IsTrue)
 
 	numBlocks, err := domainServices.BlockCommand().GetBlocks(c.Context())

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -6,16 +6,9 @@ package modelmanager_test
 import (
 	"testing"
 
-	"github.com/juju/description/v10"
-	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
-	commonmodel "github.com/juju/juju/apiserver/common/model"
 	"github.com/juju/juju/core/objectstore"
-	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/internal/testhelpers"
-	"github.com/juju/juju/state"
 )
 
 type modelInfoSuite struct{}
@@ -33,59 +26,6 @@ func (s *modelInfoSuite) TestStub(c *tc.C) {
 - Test ModelInfo() ErrorNoAccess;
 - Test ModelInfo() - running migration status;
 `)
-}
-
-type fakeModelDescription struct {
-	description.Model `yaml:"-"`
-
-	ModelUUID string `yaml:"model-uuid"`
-}
-
-type mockModel struct {
-	testhelpers.Stub
-	owner  names.UserTag
-	life   state.Life
-	tag    names.ModelTag
-	status status.StatusInfo
-	cfg    *config.Config
-}
-
-func (m *mockModel) ModelTag() names.ModelTag {
-	m.MethodCall(m, "ModelTag")
-	return m.tag
-}
-
-func (m *mockModel) Type() state.ModelType {
-	m.MethodCall(m, "Type")
-	return state.ModelTypeIAAS
-}
-
-func (m *mockModel) Life() state.Life {
-	m.MethodCall(m, "Life")
-	return m.life
-}
-
-func (m *mockModel) Status() (status.StatusInfo, error) {
-	m.MethodCall(m, "Status")
-	return m.status, m.NextErr()
-}
-
-func (m *mockModel) Destroy(args state.DestroyModelParams) error {
-	m.MethodCall(m, "Destroy", args)
-	return m.NextErr()
-}
-
-func (m *mockModel) UUID() string {
-	m.MethodCall(m, "UUID")
-	return m.cfg.UUID()
-}
-
-type mockCredentialShim struct {
-	commonmodel.ModelManagerBackend
-}
-
-func (s mockCredentialShim) InvalidateModelCredential(reason string) error {
-	return nil
 }
 
 type mockObjectStore struct {

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -10,12 +10,9 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
-	"github.com/juju/juju/apiserver/common"
 	commonmodel "github.com/juju/juju/apiserver/common/model"
 	"github.com/juju/juju/core/objectstore"
-	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/state"
@@ -38,118 +35,10 @@ func (s *modelInfoSuite) TestStub(c *tc.C) {
 `)
 }
 
-type mockState struct {
-	testhelpers.Stub
-
-	environs.EnvironConfigGetter
-	common.APIHostPortsForAgentsGetter
-
-	controllerUUID  string
-	cloudUsers      map[string]permission.Access
-	model           *mockModel
-	controllerModel *mockModel
-	controllerNodes []commonmodel.ControllerNode
-}
-
 type fakeModelDescription struct {
 	description.Model `yaml:"-"`
 
 	ModelUUID string `yaml:"model-uuid"`
-}
-
-func (st *mockState) ControllerModelTag() names.ModelTag {
-	st.MethodCall(st, "ControllerModelTag")
-	return st.controllerModel.tag
-}
-
-func (st *mockState) Export(store objectstore.ObjectStore) (description.Model, error) {
-	st.MethodCall(st, "Export")
-	return &fakeModelDescription{ModelUUID: st.model.UUID()}, nil
-}
-
-func (st *mockState) AllModelUUIDs() ([]string, error) {
-	st.MethodCall(st, "AllModelUUIDs")
-	return []string{st.model.UUID()}, st.NextErr()
-}
-
-func (st *mockState) GetBackend(modelUUID string) (commonmodel.ModelManagerBackend, func() bool, error) {
-	st.MethodCall(st, "GetBackend", modelUUID)
-	err := st.NextErr()
-	return st, func() bool { return true }, err
-}
-
-func (st *mockState) GetModel(modelUUID string) (commonmodel.Model, func() bool, error) {
-	st.MethodCall(st, "GetModel", modelUUID)
-	return st.model, func() bool { return true }, st.NextErr()
-}
-
-func (st *mockState) AllVolumes() ([]state.Volume, error) {
-	st.MethodCall(st, "AllVolumes")
-	return nil, st.NextErr()
-}
-
-func (st *mockState) AllFilesystems() ([]state.Filesystem, error) {
-	st.MethodCall(st, "AllFilesystems")
-	return nil, st.NextErr()
-}
-
-func (st *mockState) NewModel(args state.ModelArgs) (commonmodel.Model, commonmodel.ModelManagerBackend, error) {
-	st.MethodCall(st, "NewModel", args)
-	st.model.tag = names.NewModelTag(args.UUID.String())
-	err := st.NextErr()
-	return st.model, st, err
-}
-
-func (st *mockState) ControllerTag() names.ControllerTag {
-	st.MethodCall(st, "ControllerTag")
-	return names.NewControllerTag(st.controllerUUID)
-}
-
-func (st *mockState) IsController() bool {
-	st.MethodCall(st, "IsController")
-	return st.controllerUUID == st.model.UUID()
-}
-
-func (st *mockState) ControllerNodes() ([]commonmodel.ControllerNode, error) {
-	st.MethodCall(st, "ControllerNodes")
-	return st.controllerNodes, st.NextErr()
-}
-
-func (st *mockState) Model() (commonmodel.Model, error) {
-	st.MethodCall(st, "Model")
-	return st.model, st.NextErr()
-}
-
-func (st *mockState) ModelTag() names.ModelTag {
-	st.MethodCall(st, "ModelTag")
-	return st.model.ModelTag()
-}
-
-func (st *mockState) Close() error {
-	st.MethodCall(st, "Close")
-	return st.NextErr()
-}
-
-func (st *mockState) DumpAll() (map[string]interface{}, error) {
-	st.MethodCall(st, "DumpAll")
-	return map[string]interface{}{
-		"models": "lots of data",
-	}, st.NextErr()
-}
-
-func (st *mockState) HAPrimaryMachine() (names.MachineTag, error) {
-	st.MethodCall(st, "HAPrimaryMachine")
-	return names.MachineTag{}, nil
-}
-
-func (st *mockState) ConstraintsBySpaceName(spaceName string) ([]*state.Constraints, error) {
-	st.MethodCall(st, "ConstraintsBySpaceName", spaceName)
-	return nil, st.NextErr()
-}
-
-func (st *mockState) InvalidateModelCredential(reason string) error {
-	st.MethodCall(st, "InvalidateModelCredential", reason)
-	return nil
 }
 
 type mockModel struct {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/apiserver/common"
-	commonmodel "github.com/juju/juju/apiserver/common/model"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facades/client/modelmanager"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -50,14 +49,11 @@ import (
 	"github.com/juju/juju/internal/uuid"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 )
 
 type modelManagerSuite struct {
 	testhelpers.IsolationSuite
 
-	st                   *mockState
-	ctlrSt               *mockState
 	accessService        *MockAccessService
 	modelService         *MockModelService
 	modelDefaultService  *MockModelDefaultsService
@@ -116,37 +112,6 @@ func (s *modelManagerSuite) SetUpTest(c *tc.C) {
 
 	attrs := coretesting.FakeConfig()
 	attrs["agent-version"] = jujuversion.Current.String()
-	cfg, err := config.New(config.UseDefaults, attrs)
-	c.Assert(err, tc.ErrorIsNil)
-
-	controllerModel := &mockModel{
-		owner: names.NewUserTag("admin"),
-		life:  state.Alive,
-		cfg:   cfg,
-		status: corestatus.StatusInfo{
-			Status: corestatus.Available,
-			Since:  &time.Time{},
-		},
-	}
-
-	s.st = &mockState{
-		controllerModel: controllerModel,
-		model: &mockModel{
-			owner: names.NewUserTag("admin"),
-			life:  state.Alive,
-			tag:   coretesting.ModelTag,
-			cfg:   cfg,
-			status: corestatus.StatusInfo{
-				Status: corestatus.Available,
-				Since:  &time.Time{},
-			},
-		},
-	}
-	s.ctlrSt = &mockState{
-		model:           s.st.model,
-		controllerModel: controllerModel,
-		cloudUsers:      map[string]permission.Access{},
-	}
 
 	s.authoriser = apiservertesting.FakeAuthorizer{Tag: jujutesting.AdminUser}
 }
@@ -164,7 +129,6 @@ func (s *modelManagerSuite) setUpAPIWithUser(c *tc.C, user names.UserTag) *gomoc
 	cred := cloud.NewEmptyCredential()
 	s.api = modelmanager.NewModelManagerAPI(
 		c.Context(),
-		s.st,
 		user.Name() == "admin",
 		user,
 		s.modelStatusAPI,
@@ -317,23 +281,6 @@ func (s *modelManagerSuite) expectCreateModelOnModelDB(
 	networkService.EXPECT().ReloadSpaces(gomock.Any())
 }
 
-func (s *modelManagerSuite) getModelArgs(c *tc.C) state.ModelArgs {
-	return getModelArgsFor(c, s.st)
-}
-
-func getModelArgsFor(c *tc.C, mockState *mockState) state.ModelArgs {
-	for _, v := range mockState.Calls() {
-		if v.Args == nil {
-			continue
-		}
-		if newModelArgs, ok := v.Args[0].(state.ModelArgs); ok {
-			return newModelArgs
-		}
-	}
-	c.Fatal("failed to find state.ModelArgs")
-	panic("unreachable")
-}
-
 func (s *modelManagerSuite) TestCreateModelQualifierMismatch(c *tc.C) {
 	ctrl := s.setUpAPI(c)
 	defer ctrl.Finish()
@@ -381,9 +328,6 @@ func (s *modelManagerSuite) TestCreateModelArgsWithCloud(c *tc.C) {
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
-
-	newModelArgs := s.getModelArgs(c)
-	c.Assert(newModelArgs.CloudName, tc.Equals, "dummy")
 }
 
 func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *tc.C) {
@@ -400,9 +344,6 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *tc.C) {
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
-
-	newModelArgs := s.getModelArgs(c)
-	c.Assert(newModelArgs.CloudRegion, tc.Equals, "dummy-region")
 }
 
 func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdmin(c *tc.C) {
@@ -419,11 +360,6 @@ func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdmin(c *tc.C) {
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
-
-	newModelArgs := s.getModelArgs(c)
-	c.Assert(newModelArgs.CloudCredential, tc.Equals, names.NewCloudCredentialTag(
-		"dummy/admin/some-credential",
-	))
 }
 
 func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersion(c *tc.C) {
@@ -452,9 +388,6 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersion(c *tc.C) {
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
-
-	newModelArgs := s.getModelArgs(c)
-	c.Assert(newModelArgs.CloudName, tc.Equals, "dummy")
 }
 
 func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersionAndStream(c *tc.C) {
@@ -484,9 +417,6 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersionAndStream(c *tc.C
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
-
-	newModelArgs := s.getModelArgs(c)
-	c.Assert(newModelArgs.CloudName, tc.Equals, "dummy")
 }
 
 func (s *modelManagerSuite) TestModelDefaults(c *tc.C) {
@@ -723,23 +653,23 @@ func (s *modelManagerSuite) TestModelStatus(c *tc.C) {
 	s.domainServices.EXPECT().Machine().Return(s.machineService).AnyTimes()
 	s.modelStatusAPI.EXPECT().ModelStatus(gomock.Any(), params.Entities{
 		Entities: []params.Entity{
-			{Tag: s.st.ModelTag().String()},
+			{Tag: "foo"},
 		},
 	}).Return(params.ModelStatusResults{
 		Results: []params.ModelStatus{
-			{ModelTag: s.st.ModelTag().String()},
+			{ModelTag: "foo"},
 		},
 	}, nil)
 
 	results, err := s.api.ModelStatus(c.Context(), params.Entities{
 		Entities: []params.Entity{
-			{Tag: s.st.ModelTag().String()},
+			{Tag: "foo"},
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, params.ModelStatusResults{
 		Results: []params.ModelStatus{
-			{ModelTag: s.st.ModelTag().String()},
+			{ModelTag: "foo"},
 		},
 	})
 }
@@ -1004,13 +934,11 @@ func (s *modelManagerStateSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 func (s *modelManagerStateSuite) setAPIUser(c *tc.C, user names.UserTag) {
 	s.authoriser.Tag = user
-	st := commonmodel.NewModelManagerBackend(s.ControllerModel(c), s.StatePool())
 
 	domainServices := s.ControllerDomainServices(c)
 
 	s.modelmanager = modelmanager.NewModelManagerAPI(
 		c.Context(),
-		mockCredentialShim{ModelManagerBackend: st},
 		user.Name() == "admin",
 		user,
 		s.modelStatusAPI,

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -117,6 +117,7 @@ func newFacadeV11(stdCtx context.Context, ctx facade.MultiModelContext) (*ModelM
 			NetworkService:       domainServices.Network(),
 			MachineService:       domainServices.Machine(),
 			ApplicationService:   domainServices.Application(),
+			RemovalService:       domainServices.Removal(),
 		},
 		common.NewBlockChecker(domainServices.BlockCommand()),
 		auth,

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -102,7 +102,6 @@ func newFacadeV11(stdCtx context.Context, ctx facade.MultiModelContext) (*ModelM
 
 	return NewModelManagerAPI(
 		stdCtx,
-		backend,
 		isAdmin,
 		apiUser,
 		modelStatusAPI,

--- a/apiserver/facades/client/modelmanager/service_mock_test.go
+++ b/apiserver/facades/client/modelmanager/service_mock_test.go
@@ -1773,6 +1773,44 @@ func (c *MockModelDomainServicesNetworkCall) DoAndReturn(f func() modelmanager.N
 	return c
 }
 
+// RemovalService mocks base method.
+func (m *MockModelDomainServices) RemovalService() modelmanager.RemovalService {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemovalService")
+	ret0, _ := ret[0].(modelmanager.RemovalService)
+	return ret0
+}
+
+// RemovalService indicates an expected call of RemovalService.
+func (mr *MockModelDomainServicesMockRecorder) RemovalService() *MockModelDomainServicesRemovalServiceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovalService", reflect.TypeOf((*MockModelDomainServices)(nil).RemovalService))
+	return &MockModelDomainServicesRemovalServiceCall{Call: call}
+}
+
+// MockModelDomainServicesRemovalServiceCall wrap *gomock.Call
+type MockModelDomainServicesRemovalServiceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDomainServicesRemovalServiceCall) Return(arg0 modelmanager.RemovalService) *MockModelDomainServicesRemovalServiceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDomainServicesRemovalServiceCall) Do(f func() modelmanager.RemovalService) *MockModelDomainServicesRemovalServiceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDomainServicesRemovalServiceCall) DoAndReturn(f func() modelmanager.RemovalService) *MockModelDomainServicesRemovalServiceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Status mocks base method.
 func (m *MockModelDomainServices) Status() modelmanager.StatusService {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/domain/blockcommand"
 	"github.com/juju/juju/domain/model"
 	"github.com/juju/juju/domain/modeldefaults"
+	"github.com/juju/juju/domain/removal"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/domain/status"
 	"github.com/juju/juju/internal/services"
@@ -55,6 +56,9 @@ type ModelDomainServices interface {
 
 	// Status returns the status service.
 	Status() StatusService
+
+	// Removal returns the removal service.
+	RemovalService() RemovalService
 }
 
 // DomainServicesGetter is a factory for creating model services.
@@ -348,6 +352,19 @@ type ApplicationService interface {
 	GetSupportedFeatures(ctx context.Context) (assumes.FeatureSet, error)
 }
 
+// RemovalService defines operations for removing juju entities.
+type RemovalService interface {
+	// RemoveModel checks if a model with the input name exists.
+	// If it does, the model is guaranteed after this call to be:
+	// - No longer alive.
+	// - Removed or scheduled to be removed with the input force qualification.
+	// The input wait duration is the time that we will give for the normal
+	// life-cycle advancement and removal to finish before forcefully removing the
+	// model. This duration is ignored if the force argument is false.
+	// The UUID for the scheduled removal job is returned.
+	RemoveModel(ctx context.Context, modelUUID coremodel.UUID, force bool, wait time.Duration) (removal.UUID, error)
+}
+
 // Services holds the services needed by the model manager api.
 type Services struct {
 	// DomainServicesGetter is an interface for interacting with a factory for
@@ -379,6 +396,8 @@ type Services struct {
 	// ModelAgentService is an interface for interacting with the model agent
 	// service.
 	ModelAgentService ModelAgentService
+	// RemovalService is an interface for interacting with the removal service.
+	RemovalService RemovalService
 }
 
 // BlockCommandService defines methods for interacting with block commands.
@@ -433,4 +452,8 @@ func (s domainServices) BlockCommand() BlockCommandService {
 
 func (s domainServices) Status() StatusService {
 	return s.domainServices.Status()
+}
+
+func (s domainServices) RemovalService() RemovalService {
+	return s.domainServices.Removal()
 }


### PR DESCRIPTION
This patch removes the legacy state.Model() call for the modelmanager
facades.

The main impact is that since one of the facades is DestroyModels(), and
we're not calling (legacy)model.Destroy() anymore, we replaced it with
the removal service.
Since the removal service is not yet fully finished for model destroy
(there are some issues removing the associated machines, for example),
model destroy is not fully functional.

## QA steps

The only impacted facade by this change is the model destroy, and since the removal service (which replaced the legacy model.Destroy()) is not fully functional, this cannot be QAd. Following patches will fix the removal service and this will be QAable again.

Creating a model and deploying must be functional though:

```
juju bootstrap lxd c
juju add-model m
juju deploy "juju-qa-test" --revision 22 --channel stable "juju-qa-test"
```


## Links

**Jira card:** JUJU-8276
