### PR TITLE
docs: update homepage, how-to, ref to better expose topics

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -15,10 +15,11 @@ Manage credentials <manage-credentials>
 Manage metadata <manage-metadata>
 Manage controllers <manage-controllers>
 Manage the Juju dashboard <manage-the-juju-dashboard>
-Manage users <manage-users>
-Manage SSH keys <manage-ssh-keys>
 Manage models <manage-models>
+Manage secret backends <manage-secret-backends>
 Manage logs <manage-logs>
+Manage SSH keys <manage-ssh-keys>
+Manage users <manage-users>
 Manage charms or bundles <manage-charms>
 Manage applications <manage-applications>
 Manage resources <manage-charm-resources>
@@ -27,7 +28,6 @@ Manage relations <manage-relations>
 Manage offers <manage-offers>
 Manage units <manage-units>
 Manage secrets <manage-secrets>
-Manage secret backends <manage-secret-backends>
 Manage machines <manage-machines>
 Manage storage <manage-storage>
 Manage storage pools <manage-storage-pools>
@@ -47,10 +47,9 @@ Get a quick sense of how to do things in Juju, from preparing your deployment en
 
 - {ref}`Manage your deployment <manage-your-deployment>`
 
-(administering-juju)=
-## Administering Juju
+## Set up Juju
 
-Everything from how to install or upgrade the `juju` CLI and any desired plugins; connect clouds; bootstrap a Juju controller; stand up the Juju dashboard; plan and set up users, SSH keys, models, and secret backends; and get comfortable extracting and analyzing logs.
+Install the `juju` client and any plugins, add a cloud to the client, bootstrap a Juju controller, connect further clouds to the client or an existing controller, set up the Juju dashboard, add models, configure secret backends, configure logs.
 
 - {ref}`Manage the juju CLI <manage-juju>`
 - {ref}`Manage plugins <manage-plugins>`
@@ -59,21 +58,24 @@ Everything from how to install or upgrade the `juju` CLI and any desired plugins
 - {ref}`Manage metadata <manage-metadata>`
 - {ref}`Manage controllers <manage-controllers>`
 - {ref}`Manage the Juju dashboard <manage-the-juju-dashboard>`
-- {ref}`Manage users <manage-users>`
-- {ref}`Manage SSH keys <manage-ssh-keys>`
 - {ref}`Manage models <manage-models>`
 - {ref}`Manage secret backends <manage-secret-backends>`
 - {ref}`Manage logs <manage-logs>`
 
+## Handle authentication and authorization
 
-(building-with-juju)=
-## Building with Juju
+Set up SSH keys. Add users, service accounts, roles, and groups and control their access to controllers, clouds, models, or application offers.
 
-Deploy, configure, and maintain your infrastructure and applications with Juju.
+- {ref}`Manage SSH keys <manage-ssh-keys>`
+- {ref}`Manage users <manage-users>`
+
+## Deploy infrastructure and applications
+
+Deploy, configure, integrate, scale, etc., charmed applications. This will automatically provision infrastructure, but you can customise it before, during, or after deploy too.
 
 - {ref}`Manage charms or bundles <manage-charms>`
+- {ref}`Manage charm resources <manage-charm-resources>`
 - {ref}`Manage applications <manage-applications>`
-- {ref}`Manage resources <manage-charm-resources>`
 - {ref}`Manage actions <manage-actions>`
 - {ref}`Manage relations <manage-relations>`
 - {ref}`Manage offers <manage-offers>`
@@ -84,4 +86,3 @@ Deploy, configure, and maintain your infrastructure and applications with Juju.
 - {ref}`Manage storage pools <manage-storage-pools>`
 - {ref}`Manage spaces <manage-spaces>`
 - {ref}`Manage subnets <manage-subnets>`
-- {ref}`Manage logs <manage-logs>`

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,10 @@ Whether you are a CIO or SysAdmin, DevOps engineer, or SRE, Juju helps you take 
 
 ## In this documentation
 
+- **Set up Juju:** {ref}`Install juju <install-juju>`, {ref}`Bootstrap a controller <bootstrap-a-controller>`, {ref}`Connect a cloud <add-a-cloud>`, {ref}`Add a model <add-a-model>`
+- **Handle authentication and authorization:** {ref}`SSH keys <manage-ssh-keys>`, {ref}`Users <manage-users>`
+- **Deploy infrastructure and applications:** {ref}`Deploy <deploy-an-application>`, {ref}`Configure <configure-an-application>`, {ref}`Integrate <integrate-an-application-with-another-application>`, {ref}`Scale <scale-an-application>`, {ref}`Upgrade <upgrade-an-application>`, etc.
+
 
 ````{grid} 1 1 2 2
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,25 +12,9 @@
 
 ```
 
-Welcome to Juju Reference docs -- our cast of characters (tools, concepts, entities, and processes) for the Juju story!
-
-When you install the  {ref}`juju-cli`, and give Juju access to your {ref}`cloud <cloud>` (which can be any cloud from our long {ref}`list of supported clouds <list-of-supported-clouds>`, Kubernetes or otherwise), your Juju client bootstraps a {ref}`controller <controller>` into the cloud.
-
-The controller serves the Juju API. You can also interact with it via {ref}`the Juju dashboard <juju-dashboard>`, [the Terraform Provider for Juju](https://canonical-terraform-provider-juju.readthedocs-hosted.com), [Python Libjuju](https://pythonlibjuju.readthedocs.io/en/latest/), or [JAAS](https://canonical-jaas-documentation.readthedocs-hosted.com/). However you access it, the controller talks to clouds to provision infrastructure for you, and to [Charmhub](https://charmhub.io/) to retrieve {ref}`charms <charm>` for you.
-
-If you can access a Juju controller, you are a Juju {ref}`user <user>`. Depending on your {ref}`access level <user-access-levels>`, you can add further clouds to the controller, or create workspaces known as {ref}`models <model>`, etc., and eventually use the clouds and the charms to deploy, configure, scale, upgrade, etc., {ref}`applications <application>`, or to integrate applications within and between workspaces models and clouds. Possibilities are endless -- for example, you can deploy PostgreSQL on a Charmed Kubernetes that's on a Charmed OpenStack that's on a bare metal cloud such as {ref}`MAAS <cloud-maas>`, and then integrate it with an observability stack, to get a cloud-native, observed database on a resource-optimized private cloud with little effort and time.
-
-You don't have to worry about the infrastructure -- the Juju controller {ref}`agent <agent>` takes care of all of that automatically for you, with sensible defaults. But, if you care, Juju also lets you manually control {ref}`availability zones <zone>`, {ref}`machines <machine>`, {ref}`subnets <subnet>`, {ref}`spaces <space>`, {ref}`secret backends <secret-backend>`, {ref}`storage <storage>`, {ref}`SSH keys <ssh-key>`, etc.
-
-Whatever you provision contains a Juju {ref}`agent <agent>`, which is constantly in contact with the {ref}`controller agent <controller-agent>` to realize the state you declare to the controller using your Juju client. It does this through {ref}`workers <worker>`, a well-known pattern for watching and reacting to changes in state whose asynchronous nature ensures that your cloud operations run smoothly and in parallel.
-
-
-<!--
 ## Juju as a whole
 
 - {ref}`juju`
-
-
 
 ## Tools
 
@@ -83,9 +67,7 @@ Whatever you provision contains a Juju {ref}`agent <agent>`, which is constantly
 - {ref}`scaling`
 - {ref}`upgrading-things`
 
-
 ## Concepts
 
 - {ref}`high-availability`
 - {ref}`telemetry`
--->


### PR DESCRIPTION
> 3.6+

Update homepage, how-to index page, and reference index page to better expose topics.

PS The homepage and how-to page follow the general template that we have also used in TFJuju and JAAS.