### PR TITLE
docs: fix error in howto overview

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -64,7 +64,7 @@ Install the `juju` client and any plugins, add a cloud to the client, bootstrap 
 
 ## Handle authentication and authorization
 
-Set up SSH keys. Add users, service accounts, roles, and groups and control their access to controllers, clouds, models, or application offers.
+Set up SSH keys. Add users and control their access to controllers, clouds, models, or application offers.
 
 - {ref}`Manage SSH keys <manage-ssh-keys>`
 - {ref}`Manage users <manage-users>`


### PR DESCRIPTION
Our new howto index page had a copy-paste error in the Authentication and Authorization section (I accidentally included the bit about service accounts etc., which is true of Terraform Provider Juju but not here). This PR removes that.