### PR TITLE
feat: check block model destroy

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -755,6 +755,10 @@ func (m *ModelManagerAPI) DestroyModels(ctx context.Context, args params.Destroy
 			}
 		}
 
+		if err := m.check.DestroyAllowed(ctx); err != nil {
+			return errors.Trace(err)
+		}
+
 		var argForce bool
 		if force != nil {
 			argForce = *force


### PR DESCRIPTION
During destruction of a model, we must check to ensure it's not blocked. Otherwise we can end up destroying a model which should have been blocked.

----

This pull request adds a validation step to ensure that model destruction is allowed before proceeding with the operation in the `DestroyModels` method of the `ModelManagerAPI`.

### Validation Enhancements:
* [`apiserver/facades/client/modelmanager/modelmanager.go`](diffhunk://#diff-f910322f8b09cf7b5110c879eeec8ac33366c408b0e6809126cea1762d6d716aR758-R761): Added a call to `m.check.DestroyAllowed(ctx)` to validate whether model destruction is permitted. If the validation fails, the method returns an error, preventing further execution.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju disable-command all "Model locked down"
$ juju destroy-model test
```

This shouldn't destroy the model.

## Links



<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** [JUJU-8121](https://warthogs.atlassian.net/browse/JUJU-8121)

[JUJU-8121]: https://warthogs.atlassian.net/browse/JUJU-8121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ