### PR TITLE
test: fix a typo in the secret ci tests

### DIFF
--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -87,7 +87,7 @@ run_user_secrets() {
 	echo "data: $(cat /dev/zero | tr '\0' A | head -c 786430)" >"${TEST_DIR}/secret.txt"
 	secret_uri=$(juju add-secret big --file "${TEST_DIR}/secret.txt")
 	secret_short_uri=${secret_uri##*:}
-	check_contains "$(juju show-secret big --reveal | yq ".${secret_short_uri}.content.key" | grep -o A | wc -l)" 786430
+	check_contains "$(juju show-secret big --reveal | yq ".${secret_short_uri}.content.data" | grep -o A | wc -l)" 786430
 	juju --show-log remove-secret big
 
 	# test user secret revisions and grants.

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -29,7 +29,7 @@ run_secrets_vault() {
 	echo "data: $(cat /dev/zero | tr '\0' A | head -c 786430)" >"${TEST_DIR}/secret.txt"
 	secret_uri=$(juju add-secret big --file "${TEST_DIR}/secret.txt")
 	secret_short_uri=${secret_uri##*:}
-	check_contains "$(juju show-secret big --reveal | yq ".${secret_short_uri}.content.key" | grep -o A | wc -l)" 786430
+	check_contains "$(juju show-secret big --reveal | yq ".${secret_short_uri}.content.data" | grep -o A | wc -l)" 786430
 	check_contains "$(juju show-secret-backend myvault | yq -r .myvault.secrets)" 1
 	check_contains "$(juju list-secret-backends --format yaml | yq -r .myvault.secrets)" 1
 	check_contains "$(juju remove-secret-backend myvault 2>&1)" 'backend "myvault" still contains secret content'


### PR DESCRIPTION
A typo got left in the secret bash ci tests. This fixes that. The value key name to read should be "data" not "key".