### PR TITLE
test: use agent-stream='testing' when doing ci tests for a specific sha

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -323,7 +323,7 @@ pre_bootstrap() {
 
 	if [[ -n ${SHORT_GIT_COMMIT:-} ]]; then
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/"
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-stream=build-${SHORT_GIT_COMMIT}"
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-stream=testing"
 	fi
 
 	if [[ -n ${BOOTSTRAP_ARCH} ]]; then


### PR DESCRIPTION
Historically, simplestream metadata for running ci tests on jenkins has used a content id of the form `build-<commitsha>`.
This requires juju to use a model config `agent-stream=build<sha>`. However, we now validate agent stream ad only allow one of released, proposed, devel, testing.

There's ostensibly no need to use the sha in the content id because the metadata and agent tarballs are in a bucket named after the sha anyway. So we can just use the "testing" stream.

This will require our qa jenkins to be updated to generate the new stream content, plus other supported juju branches to be updated also.

## QA steps

The code path here is only for testing on our qa jenkins.