### PR TITLE
chore: fix flaky tests in provisionertask

### DIFF
--- a/internal/worker/computeprovisioner/computeprovisioner.go
+++ b/internal/worker/computeprovisioner/computeprovisioner.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"github.com/juju/worker/v4"
@@ -175,6 +176,7 @@ func (p *environProvisioner) getStartTask(ctx context.Context, workerCount int) 
 			RetryDelay: retryStrategyDelay,
 			RetryCount: retryStrategyCount,
 		},
+		Clock:               clock.WallClock,
 		NumProvisionWorkers: workerCount, // event callback is currently only being used by tests
 	})
 	if err != nil {

--- a/internal/worker/containerprovisioner/containerprovisioner.go
+++ b/internal/worker/containerprovisioner/containerprovisioner.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"github.com/juju/worker/v4"
@@ -276,6 +277,7 @@ func (p *containerProvisioner) getStartTask(ctx context.Context, workerCount int
 			RetryDelay: retryStrategyDelay,
 			RetryCount: retryStrategyCount,
 		},
+		Clock:               clock.WallClock,
 		NumProvisionWorkers: workerCount, // event callback is currently only being used by tests
 	})
 	if err != nil {


### PR DESCRIPTION
Provisonertask has been more flaky lately. This fixes some of it, but there
is still some at stress due likely due to polling with sleeps. More work is
needed here, but this resolves most of the issues.

## QA steps

Stress test `./internal/provisionertask`.

