### PR TITLE
test: use agent-stream='testing' when doing ci tests for a specific sha

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -279,7 +279,7 @@ pre_bootstrap() {
 
 	if [[ -n ${SHORT_GIT_COMMIT:-} ]]; then
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/"
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-stream=build-${SHORT_GIT_COMMIT}"
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-stream=testing"
 	fi
 
 	if [[ -n ${BOOTSTRAP_ARCH:-} ]]; then


### PR DESCRIPTION
Backport https://github.com/juju/juju/pull/20310:
- use agent-stream='testing' when doing ci tests for a specific sha
