### PR TITLE
feat: add public address found by provider

### DIFF
--- a/domain/network/state/linklayer_merge.go
+++ b/domain/network/state/linklayer_merge.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"database/sql"
 	"maps"
 	"net"
 	"slices"
@@ -17,6 +18,7 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain/network"
 	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/uuid"
 )
 
 // mergeLinkLayerDevice is a subset of linklayerdevice.LinkLayerDevice
@@ -39,10 +41,17 @@ type mergeLinkLayerDevice struct {
 // It contains only the fields that are used to identify and merge the addresses
 type mergeAddress struct {
 	UUID             string
+	Name             string
 	Value            string
 	ProviderID       string
 	ProviderSubnetID string
 	SubnetCIDR       string
+	AddressType      corenetwork.AddressType
+	ConfigType       corenetwork.AddressConfigType
+	Origin           corenetwork.Origin
+	Scope            corenetwork.Scope
+	IsSecondary      bool
+	IsShadow         bool
 }
 
 // mergeLinkLayerDevicesChanges contains the changes to be applied to the
@@ -75,6 +84,9 @@ type mergeAddressesChanges struct {
 	// subnetToUpdate holds a list of merge address where the subnet needs to be
 	// updated
 	subnetToUpdate []mergeAddress
+
+	// map of uuid of device to address
+	addressesToAdd map[string][]mergeAddress
 }
 
 // MergeLinkLayerDevice is part of the [service.LinkLayerDeviceState]
@@ -219,6 +231,10 @@ func (st *State) applyMergeLinkLayerChanges(
 	err = st.relinquishAddresses(ctx, tx, addressChanges.toRelinquish)
 	if err != nil {
 		return errors.Errorf("relinquishing addresses: %w", err)
+	}
+	err = st.addAddressFromProvider(ctx, tx, addressChanges.addressesToAdd)
+	if err != nil {
+		return errors.Errorf("adding addresses: %w", err)
 	}
 
 	// Process subnet updates
@@ -373,14 +389,17 @@ func (st *State) computeMergeAddressChanges(
 	result := mergeAddressesChanges{
 		providerIDsToAddOrUpdate: make(map[string]string),
 		toRelinquish:             nil,
+		addressesToAdd:           make(map[string][]mergeAddress),
 	}
 	for _, device := range existingDevices {
 		deviceName, addresses := device.Name, device.Addresses
 		incomings, _ := incomingAddresses[deviceName]
+		// Find updates to existing addresses.
 		for _, existing := range addresses {
 			matchIncoming, ok := findMatchingAddresses(existing, incomings)
-			// The address is no more known by the provider
-			if !ok {
+			// This device is no longer seen by the provider and the addresses
+			// do not have a machine origin.
+			if !ok && !hasAllMachineAddresses([]mergeAddress{existing}) {
 				result.toRelinquish = append(result.toRelinquish, existing.UUID)
 				continue
 			}
@@ -407,6 +426,13 @@ func (st *State) computeMergeAddressChanges(
 			if ipnet == nil || strings.HasPrefix(ipnet.String(), ip.String()) {
 				result.subnetToUpdate = append(result.subnetToUpdate, existing)
 				continue
+			}
+		}
+		// Find new addresses for the device.
+		for _, incoming := range incomings {
+			_, ok := findMatchingAddresses(incoming, addresses)
+			if !ok {
+				result.addressesToAdd[device.UUID] = append(result.addressesToAdd[device.UUID], incoming)
 			}
 		}
 	}
@@ -439,8 +465,9 @@ func (st *State) computeMergeLinkLayerDeviceChanges(
 		if !ok && namelessHWAddrs.Contains(device.MACAddress) {
 			continue
 		}
-		// If this device is no more seen by the provider
-		if !ok {
+		// This device is no longer seen by the provider and the addresses
+		// do not have a machine origin.
+		if !ok && !hasAllMachineAddresses(device.Addresses) {
 			lldChanges.deviceToRelinquish = append(lldChanges.deviceToRelinquish, device.UUID)
 			lldChanges.addressToRelinquish = append(lldChanges.addressToRelinquish,
 				transform.Slice(device.Addresses, func(a mergeAddress) string { return a.UUID })...)
@@ -482,11 +509,22 @@ func findMatchingAddresses(
 	incomings []mergeAddress,
 ) (mergeAddress, bool) {
 	for _, incoming := range incomings {
-		if strings.HasPrefix(existing.Value, incoming.Value) {
+		if strings.Split(existing.Value, "/")[0] == strings.Split(incoming.Value, "/")[0] {
 			return incoming, true
 		}
 	}
 	return mergeAddress{}, false
+}
+
+// hasAllMachineAddresses returns true if any of the addresses do
+// no have a machine origin
+func hasAllMachineAddresses(addresses []mergeAddress) bool {
+	for _, addr := range addresses {
+		if addr.Origin != "machine" {
+			return false
+		}
+	}
+	return true
 }
 
 // getExistingLinkLayerDevicesWithAddresses retrieves existing link layer devices for a given net node UUID.
@@ -509,6 +547,7 @@ func (st *State) getExistingLinkLayerDevicesWithAddresses(
 		ProviderID       string `db:"provider_id"`
 		ProviderSubnetID string `db:"provider_subnet_id"`
 		SubnetCIDR       string `db:"subnet_cidr"`
+		Origin           string `db:"origin"`
 	}
 	type netNode struct {
 		UUID string `db:"uuid"`
@@ -530,16 +569,18 @@ WHERE lld.net_node_uuid = $netNode.uuid
 	}
 	getAddressesStmt, err := st.Prepare(`
 SELECT
-	ip.uuid AS &address.uuid,
-	ip.device_uuid AS &address.device_uuid,
-	ip.address_value AS &address.address_value,
-	pip.provider_id AS &address.provider_id,
-	ps.provider_id AS &address.provider_subnet_id,
-	s.cidr AS &address.subnet_cidr
-FROM ip_address AS ip
+    ip.uuid AS &address.uuid,
+    ip.device_uuid AS &address.device_uuid,
+    ip.address_value AS &address.address_value,
+    pip.provider_id AS &address.provider_id,
+    ps.provider_id AS &address.provider_subnet_id,
+    s.cidr AS &address.subnet_cidr,
+    iao.name AS &address.origin
+FROM  ip_address AS ip
 LEFT JOIN provider_ip_address AS pip ON ip.uuid = pip.address_uuid
 LEFT JOIN provider_subnet AS ps ON ip.subnet_uuid = ps.subnet_uuid
 LEFT JOIN subnet AS s ON ip.subnet_uuid = s.uuid
+JOIN  ip_address_origin AS iao ON ip.origin_id = iao.id
 WHERE ip.net_node_uuid = $netNode.uuid`, address{}, netNode{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -580,6 +621,7 @@ WHERE ip.net_node_uuid = $netNode.uuid`, address{}, netNode{})
 						ProviderID:       a.ProviderID,
 						ProviderSubnetID: a.ProviderSubnetID,
 						SubnetCIDR:       a.SubnetCIDR,
+						Origin:           corenetwork.Origin(a.Origin),
 					}
 				}),
 		})
@@ -631,17 +673,25 @@ func (st *State) normalizeLinkLayerDevices(
 			if dev.MACAddress == nil {
 				st.logger.Debugf(ctx, "empty MACAddress for an incoming device")
 			}
+			macAddr := dereferenceOrEmpty(dev.MACAddress)
 			return mergeLinkLayerDevice{
 				Name:       dev.Name,
-				MACAddress: dereferenceOrEmpty(dev.MACAddress),
+				MACAddress: strings.ToLower(macAddr),
 				ProviderID: string(dereferenceOrEmpty(dev.ProviderID)),
 				Type:       dev.Type,
 				Addresses: transform.Slice(dev.Addrs,
 					func(addr network.NetAddr) mergeAddress {
 						return mergeAddress{
+							Name:             addr.InterfaceName,
 							Value:            addr.AddressValue,
 							ProviderID:       string(dereferenceOrEmpty(addr.ProviderID)),
 							ProviderSubnetID: string(dereferenceOrEmpty(addr.ProviderSubnetID)),
+							AddressType:      addr.AddressType,
+							ConfigType:       addr.ConfigType,
+							Origin:           addr.Origin,
+							Scope:            addr.Scope,
+							IsShadow:         addr.IsShadow,
+							IsSecondary:      addr.IsSecondary,
 						}
 					}),
 			}
@@ -767,4 +817,156 @@ SET subnet_uuid = (
 		UUID:             address.UUID,
 		ProviderSubnetID: address.ProviderSubnetID,
 	}).Run()
+}
+
+// subnetCIDRUUIDByProviderID returns a map of subnet provider IDs to a
+// struct including the subnet CIDR and UUID.
+func (st *State) subnetCIDRUUIDByProviderID(
+	ctx context.Context,
+	tx *sqlair.TX,
+	add map[string][]mergeAddress,
+) (map[string]providerSubnetCIDR, error) {
+	type ids []string
+	input := make(ids, 0)
+	for _, addrs := range add {
+		for _, addr := range addrs {
+			input = append(input, addr.ProviderSubnetID)
+		}
+	}
+	stmt, err := st.Prepare(`
+SELECT &providerSubnetCIDR.*
+FROM provider_subnet AS ps
+JOIN subnet AS s ON ps.subnet_uuid = s.uuid
+WHERE ps.provider_id IN ($ids[:])
+`, providerSubnetCIDR{}, ids{})
+	if err != nil {
+		return nil, errors.Errorf("preparing subnet query: %w", err)
+	}
+
+	output := []providerSubnetCIDR{}
+	err = tx.Query(ctx, stmt, input).GetAll(&output)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, errors.Capture(err)
+	}
+
+	result := transform.SliceToMap(output, func(in providerSubnetCIDR) (string, providerSubnetCIDR) {
+		return in.ProviderID, in
+	})
+
+	return result, nil
+}
+
+// ensureAddressSubnetSuffix return a address including the subnet's suffix
+// and the subnetUUID. If the address is not an IPv4 nor IPv6 address, no
+// suffix is added.
+func ensureAddressSubnetSuffix(value, subnetProviderID string, data map[string]providerSubnetCIDR) (string, string, error) {
+	// Getting the subnet is helpful, but not essential.
+	subnet, _ := data[subnetProviderID]
+
+	parts := strings.Split(value, "/")
+	if len(parts) == 2 {
+		// Best case, the address has a CIDR suffix.
+		return subnet.SubnetUUID, value, nil
+	}
+
+	// Find the CIDR suffix, try the subnetCIDR first, if
+	// not define based on address type.
+	var suffix string
+	subnetCIDRParts := strings.Split(subnet.CIDR, "/")
+	switch len(subnetCIDRParts) {
+	case 2:
+		suffix = subnetCIDRParts[1]
+	case 1:
+		addType := corenetwork.DeriveAddressType(value)
+		if addType == corenetwork.IPv4Address {
+			suffix = "/32"
+		} else if addType == corenetwork.IPv6Address {
+			suffix = "/128"
+		} else {
+			return subnet.SubnetUUID, value, nil
+		}
+	case 0:
+		return "", "", errors.Errorf("invalid subnet CIDR value: %q", subnet.CIDR)
+	}
+
+	addressValue := value + "/" + suffix
+	return subnet.SubnetUUID, addressValue, nil
+}
+
+func (st *State) addAddressFromProvider(ctx context.Context, tx *sqlair.TX, add map[string][]mergeAddress) error {
+	if len(add) == 0 {
+		return nil
+	}
+
+	subnets, err := st.subnetCIDRUUIDByProviderID(ctx, tx, add)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	lookups, err := st.getNetConfigLookups(ctx, tx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	providerIDAddrs := make(map[string]string)
+	ipAddresses := make([]ipAddress, 0)
+	for devUUID, addresses := range add {
+		for _, addr := range addresses {
+			ipAddrUUID, err := uuid.NewUUID()
+			if err != nil {
+				return errors.Capture(err)
+			}
+			subnetUUID, value, err := ensureAddressSubnetSuffix(addr.Value, addr.ProviderSubnetID, subnets)
+			if err != nil {
+				return errors.Capture(err)
+			}
+			var (
+				typeID, configID, scopeID, originID int
+			)
+			typeID = lookups.addrType[addr.AddressType]
+			configID = lookups.addrConfigType[addr.ConfigType]
+			scopeID = lookups.scope[addr.Scope]
+			originID = lookups.origin[addr.Origin]
+			ipAddresses = append(ipAddresses, ipAddress{
+				UUID:         ipAddrUUID.String(),
+				DeviceUUID:   devUUID,
+				AddressValue: value,
+				SubnetUUID:   nilZeroPtr(subnetUUID),
+				Type:         typeID,
+				ConfigType:   configID,
+				Origin:       originID,
+				Scope:        scopeID,
+				IsSecondary:  addr.IsSecondary,
+				IsShadow:     addr.IsShadow,
+			})
+			providerIDAddrs[addr.ProviderID] = ipAddrUUID.String()
+		}
+	}
+	// ensure address value subnet mask.
+	insertAddressStmt, err := sqlair.Prepare(`
+INSERT INTO ip_address
+SELECT
+    $ipAddress.uuid,
+    lld.net_node_uuid,
+    $ipAddress.device_uuid,
+    $ipAddress.address_value,
+    $ipAddress.subnet_uuid,
+    $ipAddress.type_id,
+    $ipAddress.config_type_id,
+    $ipAddress.origin_id,
+    $ipAddress.scope_id,
+    $ipAddress.is_secondary,
+    $ipAddress.is_shadow
+FROM  link_layer_device AS lld
+WHERE lld.uuid = $ipAddress.device_uuid
+;`, ipAddress{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	for _, ipAddress := range ipAddresses {
+		if err = tx.Query(ctx, insertAddressStmt, ipAddress).Run(); err != nil {
+			return errors.Capture(err)
+		}
+	}
+
+	return st.addProviderAddress(ctx, tx, providerIDAddrs)
 }

--- a/domain/network/state/linklayer_merge_test.go
+++ b/domain/network/state/linklayer_merge_test.go
@@ -183,10 +183,10 @@ func (s *mergeLinkLayerSuite) TestMergeLinkLayerDevice(c *tc.C) {
 	s.addProviderLinkLayerDevice(c, "provider-id-3", toRelinquishUUID)
 
 	// Add Ips addresses
-	eth01 := s.addIPAddress(c, device1UUID, netNodeUUID, "192.168.1.1/24")
-	eth02 := s.addIPAddress(c, device1UUID, netNodeUUID, "192.90.1.1/24")
-	eth11 := s.addIPAddress(c, device2UUID, netNodeUUID, "100.168.1.1/24")
-	eth21 := s.addIPAddress(c, toRelinquishUUID, netNodeUUID, "10.168.1.1/24")
+	eth01 := s.addIPAddress(c, device1UUID, netNodeUUID, "192.168.1.1/24", 0)
+	eth02 := s.addIPAddress(c, device1UUID, netNodeUUID, "192.90.1.1/24", 0)
+	eth11 := s.addIPAddress(c, device2UUID, netNodeUUID, "100.168.1.1/24", 0)
+	eth21 := s.addIPAddress(c, toRelinquishUUID, netNodeUUID, "10.168.1.1/24", 1)
 
 	s.addProviderIPAddress(c, eth01, "provider-ip-1")
 	// eth02 has no provider id
@@ -257,7 +257,93 @@ func (s *mergeLinkLayerSuite) TestMergeLinkLayerDevice(c *tc.C) {
 		}})
 }
 
-// testNoAddressToRelinquish tests the case where a provider without
+// TestMergeLinkLayerDeviceLiveData test with real data from an OCI cloud
+// config to fix bugs. Should result in an added public address to the
+// ethernet device and an added ProviderID for the same device.
+func (s *mergeLinkLayerSuite) TestMergeLinkLayerDeviceLiveData(c *tc.C) {
+	// Arrange
+	st := s.State(c)
+
+	// Create a net node
+	netNodeUUID := s.addNetNode(c)
+
+	// Create two existing devices
+	device1UUID := s.addLinkLayerDevice(c, netNodeUUID, "lo",
+		"", corenetwork.LoopbackDevice)
+	device2UUID := s.addLinkLayerDevice(c, netNodeUUID, "eth3",
+		"02:00:17:36:cc:0a", corenetwork.EthernetDevice)
+
+	inputProviderDeviceID := corenetwork.Id("ocid1.vnic.oc1.iad.abuwcljtrhnoqg7pf45j5xms7zu2xr3gosezqjvbx32d57o7wqzrgwxhlq2q")
+	inputProviderSubnetID := corenetwork.Id("ocid1.subnet.oc1.iad.aaaaaaaal62vw4qhuxgtqkinmwvgkxailche2rnarmgom2cpf7yns5gtepoq")
+
+	subnetUUID := s.addSubnet(c, "10.0.0.1/24")
+	s.addProviderSubnet(c, inputProviderSubnetID.String(), subnetUUID)
+
+	// Add Ips addresses
+	_ = s.addIPAddressWithSubnetAndOrigin(c, device2UUID, netNodeUUID, subnetUUID, "10.0.0.143/24", 0)
+	_ = s.addIPAddress(c, device1UUID, netNodeUUID, "127.0.0.1/8", 0)
+
+	c.Logf("heather data at setup %+v", s.fetchLinkLayerAddresses(c, netNodeUUID))
+
+	// Include an MAC Address in all caps to ensure we
+	// match strings correctly.
+	incoming := []network.NetInterface{{
+		MACAddress:  nilZeroPtr("02:00:17:36:CC:0A"),
+		ProviderID:  &inputProviderDeviceID,
+		IsAutoStart: true,
+		IsEnabled:   true,
+		Addrs: []network.NetAddr{{
+			AddressValue:     "10.0.0.143",
+			ProviderSubnetID: &inputProviderSubnetID,
+			AddressType:      "ipv4",
+			Origin:           "provider",
+			Scope:            "local-cloud",
+		}, {
+			AddressValue:     "150.136.104.181",
+			ProviderSubnetID: &inputProviderSubnetID,
+			AddressType:      "ipv4",
+			Origin:           "provider",
+			Scope:            "public",
+		}},
+	}}
+
+	// Act
+	//err := st.MergeLinkLayerDevice(c.Context(), netNodeUUID, incoming)
+	err := st.MergeLinkLayerDevice(context.TODO(), netNodeUUID, incoming)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(s.fetchLinkLayerDevices(c, netNodeUUID), tc.SameContents,
+		[]mergedLinkLayerDevice{
+			{
+				UUID: device1UUID,
+				Name: "lo",
+			}, {
+				UUID:       device2UUID,
+				Name:       "eth3",
+				ProviderID: inputProviderDeviceID.String(),
+				MacAddress: "02:00:17:36:cc:0a",
+			},
+		})
+
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_.UUID", tc.Not(tc.HasLen), 0)
+	c.Check(s.fetchLinkLayerAddresses(c, netNodeUUID), tc.UnorderedMatch[[]mergedLinkLayerAddress](mc),
+		[]mergedLinkLayerAddress{{
+			Address: "127.0.0.1/8",
+			Origin:  "machine",
+		}, {
+			Address:    "10.0.0.143/24",
+			SubnetUUID: subnetUUID,
+			Origin:     "machine",
+		}, {
+			Address:    "150.136.104.181/24",
+			SubnetUUID: subnetUUID,
+			Origin:     "provider",
+		}})
+}
+
+// TestNoAddressToRelinquish tests the case where a provider without
 // addresses is put to relinquish.
 func (s *mergeLinkLayerSuite) TestApplyLinkLayerChangesNoAddressToRelinquish(c *tc.C) {
 	// Arrange
@@ -265,7 +351,6 @@ func (s *mergeLinkLayerSuite) TestApplyLinkLayerChangesNoAddressToRelinquish(c *
 
 	// Create a net node
 	netNodeUUID := s.addNetNode(c)
-
 	// Create a device with an address
 	deviceUUID := s.addLinkLayerDevice(c, netNodeUUID, "eth0",
 		"00:11:22:33:44:55", corenetwork.EthernetDevice)
@@ -325,11 +410,11 @@ func (s *mergeLinkLayerSuite) TestApplyLinkLayerChanges(c *tc.C) {
 	// eth0 with two addresses, one will have its provider updated
 	// eth1 with two addresses, one will be relinquished
 	// eth2 with one addresses, one will be removed (reliquished)
-	eth01 := s.addIPAddress(c, eth0UUID, netNodeUUID, "192.168.1.1/24")
-	eth02 := s.addIPAddress(c, eth0UUID, netNodeUUID, "192.168.2.1/24")
-	eth11 := s.addIPAddress(c, eth1UUID, netNodeUUID, "100.168.1.1/24")
-	eth12 := s.addIPAddress(c, eth1UUID, netNodeUUID, "100.168.2.1/24")
-	eth21 := s.addIPAddress(c, eth2UUID, netNodeUUID, "10.168.2.1/24")
+	eth01 := s.addIPAddress(c, eth0UUID, netNodeUUID, "192.168.1.1/24", 0)
+	eth02 := s.addIPAddress(c, eth0UUID, netNodeUUID, "192.168.2.1/24", 0)
+	eth11 := s.addIPAddress(c, eth1UUID, netNodeUUID, "100.168.1.1/24", 0)
+	eth12 := s.addIPAddress(c, eth1UUID, netNodeUUID, "100.168.2.1/24", 0)
+	eth21 := s.addIPAddress(c, eth2UUID, netNodeUUID, "10.168.2.1/24", 0)
 
 	s.addProviderIPAddress(c, eth01, "old-eth0-ip-1")
 	s.addProviderIPAddress(c, eth02, "eth0-ip-2")
@@ -463,6 +548,69 @@ func (s *mergeLinkLayerSuite) TestComputeMergeAddressChangesNotToBeUpdated(c *tc
 	c.Check(changes.toRelinquish, tc.HasLen, 0)
 }
 
+func (s *mergeLinkLayerSuite) TestComputeMergeAddressChangesAddAddressToDevice(c *tc.C) {
+	// Arrange
+	st := s.State(c)
+
+	//Create existing devices
+	existingDevices := []mergeLinkLayerDevice{{
+		UUID:       "644e67c1-61ff-42d4-80ba-500a3f0709c8",
+		Name:       "ens3",
+		MACAddress: "00:00:17:02:27:25",
+		Type:       "ethernet",
+		Addresses: []mergeAddress{{
+			UUID:             "4cd973c2-4bc7-42b8-883b-522ebf6babe1",
+			Value:            "10.0.0.62/24",
+			ProviderSubnetID: "ocid1.subnet.oc1.iad.aaaaaaaadhchqase45ok75zjov4xglqeph72ukyd7pdu7oonfh33jhn2mg2q",
+			SubnetCIDR:       "10.0.0.0/24",
+			Origin:           "provider",
+		}},
+	}, {
+		UUID: "7e3a0ad6-c6d1-4bb6-803c-d894e58ad814",
+		Name: "lo",
+		Type: "loopback",
+		Addresses: []mergeAddress{{
+			UUID:   "8a9d046e-f081-42e1-8ef0-a8275fbc5f7a",
+			Value:  "127.0.0.1/8",
+			Origin: "machine",
+		}, {
+			UUID:   "d0d51fd3-55a9-4b75-826e-2107a18ab50f",
+			Value:  "::1/128",
+			Origin: "machine",
+		}},
+	}}
+
+	// Create incoming devices with the same name but different provider ID
+	incomingDevices := []mergeLinkLayerDevice{{
+		Name:       "ens3",
+		MACAddress: "00:00:17:02:27:25",
+		ProviderID: "ocid1.vnic.oc1.iad.abuwcljth7lncaabvogzmonqbwqnegdyh3ytkaegpiqrj5wuteaflxocbvva",
+		Addresses: []mergeAddress{{
+			Value:            "10.0.0.62",
+			ProviderSubnetID: "ocid1.subnet.oc1.iad.aaaaaaaadhchqase45ok75zjov4xglqeph72ukyd7pdu7oonfh33jhn2mg2q",
+			Origin:           "provider",
+		}, {
+			Value:            "129.80.21.95",
+			ProviderSubnetID: "ocid1.subnet.oc1.iad.aaaaaaaadhchqase45ok75zjov4xglqeph72ukyd7pdu7oonfh33jhn2mg2q",
+			Origin:           "provider",
+		}},
+	}}
+
+	// Act
+	changes := st.computeMergeAddressChanges(incomingDevices, existingDevices)
+
+	// Assert: Verify that no changes are made
+	c.Check(changes.providerIDsToAddOrUpdate, tc.HasLen, 0)
+	c.Check(changes.toRelinquish, tc.HasLen, 0)
+	c.Check(changes.addressesToAdd, tc.DeepEquals, map[string][]mergeAddress{
+		"644e67c1-61ff-42d4-80ba-500a3f0709c8": {{
+			Value:            "129.80.21.95",
+			ProviderSubnetID: "ocid1.subnet.oc1.iad.aaaaaaaadhchqase45ok75zjov4xglqeph72ukyd7pdu7oonfh33jhn2mg2q",
+			Origin:           "provider",
+		}},
+	})
+}
+
 // TestComputeMergeAddressChangesToBeRelinquished tests the case where some addresses
 // are to be relinquished.
 func (s *mergeLinkLayerSuite) TestComputeMergeAddressChangesToBeRelinquished(c *tc.C) {
@@ -478,11 +626,13 @@ func (s *mergeLinkLayerSuite) TestComputeMergeAddressChangesToBeRelinquished(c *
 					UUID:       "address1-uuid",
 					Value:      "192.168.1.1/24",
 					ProviderID: "provider-ip-1",
+					Origin:     "provider",
 				},
 				{
 					UUID:       "no-matching-uuid",
 					Value:      "192.168.1.2/24",
 					ProviderID: "no-matching-provider-id",
+					Origin:     "provider",
 				},
 			},
 		},
@@ -496,6 +646,7 @@ func (s *mergeLinkLayerSuite) TestComputeMergeAddressChangesToBeRelinquished(c *
 				{
 					Value:      "192.168.1.1",
 					ProviderID: "provider-ip-1",
+					Origin:     "provider",
 				},
 			},
 		},
@@ -586,6 +737,71 @@ func (s *mergeLinkLayerSuite) TestComputeMergeLLDChangesWithMatchingNameDifferen
 	// Assert: Verify that the provider ID is updated
 	c.Check(changes.toAddOrUpdate, tc.DeepEquals,
 		map[string]string{"new-provider-id-1": "device1-uuid"})
+	c.Check(changes.deviceToRelinquish, tc.HasLen, 0)
+	c.Check(changes.addressToRelinquish, tc.HasLen, 0)
+	c.Check(changes.newDevices, tc.HasLen, 0)
+}
+
+func (s *mergeLinkLayerSuite) TestComputeMergeLLDChangesOracleData(c *tc.C) {
+	// Arrange
+	st := s.State(c)
+
+	//Create existing devices
+	existingDevices := []mergeLinkLayerDevice{{
+		UUID:       "644e67c1-61ff-42d4-80ba-500a3f0709c8",
+		Name:       "ens3",
+		MACAddress: "00:00:17:02:27:25",
+		Type:       "ethernet",
+		Addresses: []mergeAddress{{
+			UUID:             "4cd973c2-4bc7-42b8-883b-522ebf6babe1",
+			Value:            "10.0.0.62/24",
+			ProviderSubnetID: "ocid1.subnet.oc1.iad.aaaaaaaadhchqase45ok75zjov4xglqeph72ukyd7pdu7oonfh33jhn2mg2q",
+			SubnetCIDR:       "10.0.0.0/24",
+			Origin:           "provider",
+		}},
+	}, {
+		UUID: "7e3a0ad6-c6d1-4bb6-803c-d894e58ad814",
+		Name: "lo",
+		Type: "loopback",
+		Addresses: []mergeAddress{{
+			UUID:   "8a9d046e-f081-42e1-8ef0-a8275fbc5f7a",
+			Value:  "127.0.0.1/8",
+			Origin: "machine",
+		}, {
+			UUID:   "d0d51fd3-55a9-4b75-826e-2107a18ab50f",
+			Value:  "::1/128",
+			Origin: "machine",
+		}},
+	}}
+
+	// Create incoming devices with the same name but different provider ID
+	incomingDevices := []mergeLinkLayerDevice{{
+		Name:       "ens3",
+		MACAddress: "00:00:17:02:27:25",
+		ProviderID: "ocid1.vnic.oc1.iad.abuwcljth7lncaabvogzmonqbwqnegdyh3ytkaegpiqrj5wuteaflxocbvva",
+		Addresses: []mergeAddress{{
+			Value:            "10.0.0.62",
+			ProviderSubnetID: "ocid1.subnet.oc1.iad.aaaaaaaadhchqase45ok75zjov4xglqeph72ukyd7pdu7oonfh33jhn2mg2q",
+			Origin:           "provider",
+		}, {
+			Value:            "129.80.21.95",
+			ProviderSubnetID: "ocid1.subnet.oc1.iad.aaaaaaaadhchqase45ok75zjov4xglqeph72ukyd7pdu7oonfh33jhn2mg2q",
+			Origin:           "provider",
+		}},
+	}}
+
+	// Create nameless hardware addresses
+	namelessHWAddrs := set.NewStrings()
+
+	// Act
+	ctx := c.Context()
+	changes := st.computeMergeLinkLayerDeviceChanges(ctx, existingDevices,
+		incomingDevices, namelessHWAddrs)
+
+	// Assert: Verify that the provider ID is updated
+	c.Check(changes.toAddOrUpdate, tc.DeepEquals,
+		map[string]string{
+			"ocid1.vnic.oc1.iad.abuwcljth7lncaabvogzmonqbwqnegdyh3ytkaegpiqrj5wuteaflxocbvva": "644e67c1-61ff-42d4-80ba-500a3f0709c8"})
 	c.Check(changes.deviceToRelinquish, tc.HasLen, 0)
 	c.Check(changes.addressToRelinquish, tc.HasLen, 0)
 	c.Check(changes.newDevices, tc.HasLen, 0)
@@ -687,6 +903,7 @@ func (s *mergeLinkLayerSuite) TestComputeMergeLLDChangesWithNoMatchingNameNoMatc
 					UUID:       "address1-uuid",
 					Value:      "192.168.1.1/24",
 					ProviderID: "provider-ip-1",
+					Origin:     "provider",
 				},
 			},
 		},
@@ -783,7 +1000,7 @@ func (s *mergeLinkLayerSuite) TestMergeLinkLayerDeviceProviderSubnetIDMatching(c
 		"00:11:22:33:44:55", corenetwork.EthernetDevice)
 
 	// Create an IP address with no subnet
-	s.addIPAddress(c, deviceUUID, netNodeUUID, "192.168.1.5/24")
+	s.addIPAddress(c, deviceUUID, netNodeUUID, "192.168.1.5/24", 0)
 
 	// Create incoming device with address that has provider subnet ID
 	incoming := []network.NetInterface{
@@ -1004,7 +1221,7 @@ func (s *mergeLinkLayerSuite) TestMergeLinkLayerDeviceProviderSubnetIDNotFound(c
 		"00:11:22:33:44:55", corenetwork.EthernetDevice)
 
 	// Create an IP address with no subnet
-	s.addIPAddress(c, deviceUUID, netNodeUUID, "192.168.1.5/24")
+	s.addIPAddress(c, deviceUUID, netNodeUUID, "192.168.1.5/24", 0)
 
 	// Create incoming device with address that has a non-existent provider subnet ID
 	incoming := []network.NetInterface{
@@ -1112,6 +1329,8 @@ func (s *mergeLinkLayerSuite) createNetAddr(value,
 	return network.NetAddr{
 		ProviderID:   &provider,
 		AddressValue: value,
+		AddressType:  corenetwork.IPv4Address,
+		Origin:       corenetwork.OriginProvider,
 	}
 }
 

--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -200,7 +200,7 @@ VALUES (?, ?)
 
 // addIPAddress adds an IP address to the database and returns its UUID.
 func (s *linkLayerBaseSuite) addIPAddress(
-	c *tc.C, deviceUUID, netNodeUUID, addressValue string,
+	c *tc.C, deviceUUID, netNodeUUID, addressValue string, origin int,
 ) string {
 	addressUUID := "address-" + addressValue + "-uuid"
 
@@ -210,7 +210,7 @@ INSERT INTO ip_address (
 	config_type_id, origin_id, scope_id, is_secondary, is_shadow
 )
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, addressUUID, deviceUUID, addressValue, netNodeUUID, nil, 0, 4, 0, 0,
+	`, addressUUID, deviceUUID, addressValue, netNodeUUID, nil, 0, 4, origin, 0,
 		false, false)
 
 	return addressUUID
@@ -225,6 +225,21 @@ func (s *linkLayerBaseSuite) addIPAddressWithSubnet(c *tc.C, deviceUUID, netNode
 		INSERT INTO ip_address (uuid, device_uuid, address_value, net_node_uuid, subnet_uuid, type_id, config_type_id, origin_id, scope_id, is_secondary, is_shadow)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, addressUUID, deviceUUID, addressValue, netNodeUUID, subnetUUID, 0, 4, 1, 0,
+		false, false)
+
+	return addressUUID
+}
+
+// addIPAddressWithSubnet adds an IP address to the database and returns its UUID.
+func (s *linkLayerBaseSuite) addIPAddressWithSubnetAndOrigin(c *tc.C, deviceUUID, netNodeUUID,
+	subnetUUID, addressValue string, origin int) string {
+
+	addressUUID := "address-" + addressValue + "-uuid"
+
+	s.query(c, `
+		INSERT INTO ip_address (uuid, device_uuid, address_value, net_node_uuid, subnet_uuid, type_id, config_type_id, origin_id, scope_id, is_secondary, is_shadow)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, addressUUID, deviceUUID, addressValue, netNodeUUID, subnetUUID, 0, 4, origin, 0,
 		false, false)
 
 	return addressUUID

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -66,6 +66,16 @@ type providerSubnet struct {
 	ProviderID corenetwork.Id `db:"provider_id"`
 }
 
+// providerSubnet represents a single row from the provider_subnet table.
+type providerSubnetCIDR struct {
+	// CIDR is the CIDR of the subnet.
+	CIDR string `db:"cidr"`
+	// SubnetUUID is the UUID of the subnet.
+	SubnetUUID string `db:"subnet_uuid"`
+	// ProviderID is the provider-specific subnet ID.
+	ProviderID string `db:"provider_id"`
+}
+
 // providerNetwork represents a single row from the provider_network table.
 type providerNetwork struct {
 	// ProviderNetworkUUID is the provider network UUID.
@@ -396,6 +406,20 @@ type ipAddressDML struct {
 	ConfigTypeID int     `db:"config_type_id"`
 	OriginID     int     `db:"origin_id"`
 	ScopeID      int     `db:"scope_id"`
+	IsSecondary  bool    `db:"is_secondary"`
+	IsShadow     bool    `db:"is_shadow"`
+}
+
+// ipAddress is for writing data to the ip_address table.
+type ipAddress struct {
+	UUID         string  `db:"uuid"`
+	DeviceUUID   string  `db:"device_uuid"`
+	AddressValue string  `db:"address_value"`
+	SubnetUUID   *string `db:"subnet_uuid"`
+	Type         int     `db:"type_id"`
+	ConfigType   int     `db:"config_type_id"`
+	Origin       int     `db:"origin_id"`
+	Scope        int     `db:"scope_id"`
 	IsSecondary  bool    `db:"is_secondary"`
 	IsShadow     bool    `db:"is_shadow"`
 }


### PR DESCRIPTION
Public addresses are not see by the machine itself, so add them to existing devices if not seen yet.

Beware of captialization when comparing incoming and exising data in MergeLinkLayerDevice. Use lower case in normalized data to ensure matching.

Drive by: Do not try to update the origin of addresses which are already machine typed and not seen by the provider. Otherwise we'll attempt work on all loopback devices every time MergeLinkLayerDevice runs.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap a public cloud, e.g. AWS or OCI, and run `juju ssh -m controller 0`. It should be successful.