### PR TITLE
fix: life worker reports wrong value

### DIFF
--- a/internal/worker/lifeflag/util_test.go
+++ b/internal/worker/lifeflag/util_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 )
 
-func newMockFacade(stub *testing.Stub, lifeResults ...life.Value) *mockFacade {
+func newMockFacade(stub *testing.Stub, lifeResults ...func() life.Value) *mockFacade {
 	return &mockFacade{
 		stub:        stub,
 		lifeResults: lifeResults,
@@ -22,7 +22,7 @@ func newMockFacade(stub *testing.Stub, lifeResults ...life.Value) *mockFacade {
 
 type mockFacade struct {
 	stub        *testing.Stub
-	lifeResults []life.Value
+	lifeResults []func() life.Value
 }
 
 func (mock *mockFacade) Life(entity names.Tag) (life.Value, error) {
@@ -36,7 +36,7 @@ func (mock *mockFacade) Life(entity names.Tag) (life.Value, error) {
 func (mock *mockFacade) nextLife() life.Value {
 	result := mock.lifeResults[0]
 	mock.lifeResults = mock.lifeResults[1:]
-	return result
+	return result()
 }
 
 func (mock *mockFacade) Watch(entity names.Tag) (watcher.NotifyWatcher, error) {


### PR DESCRIPTION
There is a race when the worker is shutting down between the local life value and what the actual life of the entity is at. If something called Check() during that period then it would report the wrong value.

The solution is to always update the entity life value even if we're about to exit the loop. This ensures that anything checking the current value outside of the loop in another goroutine will get the correct value.
