### PR TITLE
fix: missing availability zones for lxd machines

### DIFF
--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -409,9 +409,9 @@ func (env *environ) getHardwareCharacteristics(
 	mem := uint64(container.Mem())
 	location := container.Location
 	// In non-cluster mode, the container location has value as "none".
-	// Use the availability zone value from args to make it human friendly.
+	// Use the single server name to make it human friendly.
 	if location == "none" {
-		location = args.AvailabilityZone
+		location = env.server().Name()
 	}
 	return &instance.HardwareCharacteristics{
 		Arch:             &archStr,

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -107,7 +107,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	c.Assert(*res.Hardware.AvailabilityZone, jc.DeepEquals, "node01")
 }
 
-func (s *environBrokerSuite) TestStartInstanceUseZoneFromArgsWhenContainerLocationIsNone(c *gc.C) {
+func (s *environBrokerSuite) TestStartInstanceUseZoneFromServerNameWhenContainerLocationIsNone(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
@@ -121,8 +121,7 @@ func (s *environBrokerSuite) TestStartInstanceUseZoneFromArgsWhenContainerLocati
 	}
 
 	exp := svr.EXPECT()
-	exp.IsClustered().Times(2).Return(false)
-	exp.Name().Times(2).Return("node01")
+	exp.Name().Return("node01")
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
@@ -136,7 +135,6 @@ func (s *environBrokerSuite) TestStartInstanceUseZoneFromArgsWhenContainerLocati
 
 	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	args := s.GetStartInstanceArgs(c)
-	args.AvailabilityZone = "node01"
 	res, err := env.StartInstance(s.callCtx, args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.NotNil)


### PR DESCRIPTION
We missed setting `AvailabilityZone` field in `HardwareCharacteristics` struct. As a result we were getting empty string for availability zones. While the user reported it using LXD clustering, this was also apparent in non-clustered mode.

Missing values in `az` column:

```text
(base) ➜  juju-upstream git:(3.6) ✗ juju status
Model       Controller  Cloud/Region         Version  SLA          Timestamp
controller  az-test-3   localhost/localhost  3.6.9.4  unsupported  13:47:01+07:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable  116  yes      

Unit           Workload  Agent  Machine  Public address  Ports      Message
controller/0*  active    idle   0        10.120.73.16    17022/tcp  

Machine  State    Address                                 Inst id        Base          AZ  Message
0        started  10.120.73.16                            juju-74fa3f-0  ubuntu@22.04      Running
1        started  10.120.73.44                            juju-74fa3f-1  ubuntu@24.04      Running
2        started  fd42:31c4:f1f6:447d:216:3eff:fef8:a05e  juju-74fa3f-2  ubuntu@24.04      Running
```

## Checklist

- ~~[ ] Code style: imports ordered, good names, simple structure, etc~~
- ~~[ ] Comments saying why design decisions were made~~
- [x] Go unit tests, with comments saying what you're testing
- ~~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- ~~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

1. Bootstrap a controller to LXD.
2. Add a model: `juju add-model model1`
3. Deploy some machines:  `juju add-machine --constraints="virt-type=virtual-machine" --base=ubuntu@24.04 -n 3`
4. See `az` column populated

Non clustered LXD

```text
(base) ➜  juju-upstream git:(3.6) ✗ juju status
Model   Controller  Cloud/Region         Version  SLA          Timestamp
model1  az-test-3   localhost/localhost  3.6.9.1  unsupported  14:05:46+07:00

Machine  State    Address                                 Inst id        Base          AZ       Message
4        started  fd42:31c4:f1f6:447d:216:3eff:fec1:e807  juju-ceddda-4  ubuntu@24.04  K6501ZM  Running
5        started  fd42:31c4:f1f6:447d:216:3eff:fe1f:317c  juju-ceddda-5  ubuntu@24.04  K6501ZM  Running
6        started  fd42:31c4:f1f6:447d:216:3eff:fe08:d85e  juju-ceddda-6  ubuntu@24.04  K6501ZM  Running
```

Clustered LXD with 3 members in a cluster. Machines are started in az `adis-1` and `adis-3`.

```text
root@adis-3:~# juju status
Model   Controller  Cloud/Region         Version  SLA          Timestamp
model1  az-test     localhost/localhost  3.6.9.1  unsupported  01:21:24Z

Machine  State    Address       Inst id        Base          AZ      Message
0        started  240.5.0.65    juju-ea2d07-0  ubuntu@22.04  adis-3  Running
1        started  240.140.0.60  juju-ea2d07-1  ubuntu@22.04  adis-1  Running
```


## Documentation changes

N/A.

## Links

**Issue:** Fixes #20150.

**Jira card:** [JUJU-8243](https://warthogs.atlassian.net/browse/JUJU-8243)


[JUJU-8243]: https://warthogs.atlassian.net/browse/JUJU-8243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ