### PR TITLE
chore: removed unused DeleteCharm domain method

### DIFF
--- a/domain/application/service/charm.go
+++ b/domain/application/service/charm.go
@@ -121,10 +121,6 @@ type CharmState interface {
 	// revision and the requiredSequencing flag must be set to false.
 	SetCharm(ctx context.Context, ch charm.Charm, downloadInfo *charm.DownloadInfo, requiresSequencing bool) (corecharm.ID, charm.CharmLocator, error)
 
-	// DeleteCharm removes the charm from the state. If the charm does not
-	// exist, a [applicationerrors.CharmNotFound]  error is returned.
-	DeleteCharm(ctx context.Context, id corecharm.ID) error
-
 	// ListCharmLocators returns a list of charm locators. The locator allows
 	// the reconstruction of the charm URL for the client response.
 	ListCharmLocators(ctx context.Context) ([]charm.CharmLocator, error)
@@ -704,20 +700,6 @@ func (s *Service) SetCharm(ctx context.Context, args charm.SetCharmArgs) (corech
 		return "", nil, errors.Capture(err)
 	}
 	return result.ID, warnings, nil
-}
-
-// DeleteCharm removes the charm from the state.
-// Returns an error if the charm does not exist.
-func (s *Service) DeleteCharm(ctx context.Context, locator charm.CharmLocator) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	args := argsFromLocator(locator)
-	id, err := s.getCharmID(ctx, args)
-	if err != nil {
-		return errors.Errorf("charm id: %w", err)
-	}
-	return s.st.DeleteCharm(ctx, id)
 }
 
 // ListCharmLocators returns a list of charm locators. The locator allows you to

--- a/domain/application/service/charm_test.go
+++ b/domain/application/service/charm_test.go
@@ -1317,23 +1317,6 @@ func (s *charmServiceSuite) TestSetCharmRelationToReservedNameOnRequiresInvalid(
 	c.Assert(err, tc.ErrorIs, applicationerrors.CharmRelationReservedNameMisuse)
 }
 
-func (s *charmServiceSuite) TestDeleteCharm(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	id := charmtesting.GenCharmID(c)
-
-	locator := charm.CharmLocator{
-		Name:     "foo",
-		Revision: 42,
-		Source:   charm.CharmHubSource,
-	}
-	s.state.EXPECT().GetCharmID(gomock.Any(), locator.Name, locator.Revision, locator.Source).Return(id, nil)
-	s.state.EXPECT().DeleteCharm(gomock.Any(), id).Return(nil)
-
-	err := s.service.DeleteCharm(c.Context(), locator)
-	c.Assert(err, tc.ErrorIsNil)
-}
-
 func (s *charmServiceSuite) TestListCharmLocatorsWithName(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -1256,15 +1256,6 @@ INSERT INTO charm_container_mount (
 	})
 }
 
-func (s *charmStateSuite) TestDeleteCharm(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-
-	id := charmtesting.GenCharmID(c)
-
-	err := st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIs, applicationerrors.CharmNotFound)
-}
-
 func (s *charmStateSuite) TestSetCharmDownloadInfoForCharmhub(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
@@ -1892,12 +1883,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadata(c *tc.C) {
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, err = st.GetCharmMetadata(c.Context(), id)
-	c.Assert(err, tc.ErrorIs, applicationerrors.CharmNotFound)
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithTagsAndCategories(c *tc.C) {
@@ -1933,12 +1918,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithTagsAndCategories(
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, err = st.GetCharmMetadata(c.Context(), id)
-	c.Assert(err, tc.ErrorIs, applicationerrors.CharmNotFound)
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithTerms(c *tc.C) {
@@ -1973,12 +1952,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithTerms(c *tc.C) {
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, err = st.GetCharmMetadata(c.Context(), id)
-	c.Assert(err, tc.ErrorIs, applicationerrors.CharmNotFound)
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithRelations(c *tc.C) {
@@ -2039,12 +2012,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithRelations(c *tc.C)
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_relation")
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithExtraBindings(c *tc.C) {
@@ -2086,12 +2053,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithExtraBindings(c *t
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_extra_binding")
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithNoProperties(c *tc.C) {
@@ -2149,12 +2110,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithNoPrope
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_storage")
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithProperties(c *tc.C) {
@@ -2214,13 +2169,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithPropert
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_storage")
-	assertTableEmpty(c, s.TxnRunner(), "charm_storage_property")
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithDevices(c *tc.C) {
@@ -2270,12 +2218,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithDevices(c *tc.C) {
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_device")
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithResources(c *tc.C) {
@@ -2323,12 +2265,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithResources(c *tc.C)
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_resource")
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithContainersWithNoMounts(c *tc.C) {
@@ -2372,12 +2308,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithContainersWithNoMo
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_container")
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithContainersWithMounts(c *tc.C) {
@@ -2441,13 +2371,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithContainersWithMoun
 	got, err := st.GetCharmMetadata(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_container")
-	assertTableEmpty(c, s.TxnRunner(), "charm_container_mount")
 }
 
 func (s *charmStateSuite) TestGetCharmManifest(c *tc.C) {
@@ -2518,12 +2441,6 @@ INSERT INTO charm_manifest_base (
 		}
 		return expected
 	})
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_manifest_base")
 }
 
 func (s *charmStateSuite) TestSetCharmThenGetCharmManifest(c *tc.C) {
@@ -2580,12 +2497,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmManifest(c *tc.C) {
 	got, err := st.GetCharmManifest(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_manifest_base")
 }
 
 func (s *charmStateSuite) TestGetCharmManifestCharmNotFound(c *tc.C) {
@@ -2624,11 +2535,6 @@ WHERE uuid = ?
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(profile, tc.DeepEquals, []byte(`{"profile": []}`))
 	c.Check(revision, tc.Equals, 42)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
 }
 
 func (s *charmStateSuite) TestGetCharmLXDProfileCharmNotFound(c *tc.C) {
@@ -2788,12 +2694,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmConfig(c *tc.C) {
 	got, err := st.GetCharmConfig(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_config")
 }
 
 func (s *charmStateSuite) TestGetCharmConfigCharmNotFound(c *tc.C) {
@@ -2913,12 +2813,6 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmActions(c *tc.C) {
 	got, err := st.GetCharmActions(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, expected)
-
-	err = st.DeleteCharm(c.Context(), id)
-	c.Assert(err, tc.ErrorIsNil)
-
-	assertTableEmpty(c, s.TxnRunner(), "charm")
-	assertTableEmpty(c, s.TxnRunner(), "charm_action")
 }
 
 func (s *charmStateSuite) TestGetCharmActionsCharmNotFound(c *tc.C) {


### PR DESCRIPTION
Removed unused DeleteCharm domain method

This is now handled by the removal domain

## QA steps

This just removes unused code, so passing unit tests is sufficient