### PR TITLE
docs: add related links on homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+relatedlinks: "[Juju &nbsp; ecosystem &nbsp; docs](https://juju.is/docs), [Terraform &nbsp; Provider &nbsp; Juju &nbsp; docs](https://documentation.ubuntu.com/terraform-provider-juju/), [JAAS &nbsp; docs](https://documentation.ubuntu.com/jaas/), [Jubilant &nbsp; docs](https://documentation.ubuntu.com/jubilant/), [Charmcraft &nbsp; docs](https://documentation.ubuntu.com/charmcraft/), [Ops &nbsp; docs](https://documentation.ubuntu.com/ops/)"
+---
+
 (home)=
 # Juju documentation
 


### PR DESCRIPTION
People often find our Juju lifecycle manager docs but sometimes miss our Juju ecosystem docs and as a result struggle to find our charm building docs (we do also link to them from Manage a charm > Build a charm, but it's easy to miss). This PR addresses this issue by surfacing these links on our docs homepage under the right-hand margin "RELATED LINKS" block, as in the screenshot below (see RTD docs build in the CI to preview this in context).

<img width="377" height="372" alt="image" src="https://github.com/user-attachments/assets/bd72c089-8165-4a19-8c05-8472fc61a0d2" />
