### PR TITLE
[DRAFT] fix: crd cleanup on app removal 

### DIFF
--- a/caas/kubernetes/provider/application.go
+++ b/caas/kubernetes/provider/application.go
@@ -17,6 +17,7 @@ func (k *kubernetesClient) Application(name string, deploymentType caas.Deployme
 		k.LabelVersion(),
 		deploymentType,
 		k.client(),
+		k.extendedClient(),
 		k.newWatcher,
 		k.clock,
 		k.randomPrefix,

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1004,6 +1004,7 @@ func (a *app) serviceAccountExists() (exists bool, terminating bool, err error) 
 
 // Delete deletes the specified application.
 func (a *app) Delete() error {
+	logger.Infof("alvin Delete called for %s", a.name)
 	logger.Debugf("deleting %s application", a.name)
 	applier := a.newApplier()
 	switch a.deploymentType {

--- a/caas/kubernetes/provider/application/package_test.go
+++ b/caas/kubernetes/provider/application/package_test.go
@@ -55,9 +55,9 @@ func NewApplicationForTest(
 
 func PVCNames(client kubernetes.Interface, namespace, appName, storagePrefix string) (map[string]string, error) {
 	a := &app{
-		name:      appName,
-		namespace: namespace,
-		client:    client,
+		name:       appName,
+		namespace:  namespace,
+		coreClient: client,
 	}
 	return a.pvcNames(storagePrefix)
 }

--- a/caas/kubernetes/provider/application/package_test.go
+++ b/caas/kubernetes/provider/application/package_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	gc "gopkg.in/check.v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
@@ -41,7 +42,8 @@ func NewApplicationForTest(
 	modelName string,
 	labelVersion constants.LabelVersion,
 	deploymentType caas.DeploymentType,
-	client kubernetes.Interface,
+	coreClient kubernetes.Interface,
+	extendedClient clientset.Interface,
 	newWatcher k8swatcher.NewK8sWatcherFunc,
 	clock clock.Clock,
 	randomPrefix k8sutils.RandomPrefixFunc,
@@ -49,7 +51,7 @@ func NewApplicationForTest(
 ) ApplicationInterfaceForTest {
 	return newApplication(
 		name, namespace, modelUUID, modelName, labelVersion, deploymentType,
-		client, newWatcher, clock, randomPrefix, newApplier,
+		coreClient, extendedClient, newWatcher, clock, randomPrefix, newApplier,
 	)
 }
 

--- a/caas/kubernetes/provider/application/scale.go
+++ b/caas/kubernetes/provider/application/scale.go
@@ -25,14 +25,14 @@ func (a *app) Scale(scaleTo int) error {
 			context.Background(),
 			a.name,
 			int32(scaleTo),
-			scale.StatefulSetScalePatcher(a.client.AppsV1().StatefulSets(a.namespace)),
+			scale.StatefulSetScalePatcher(a.coreClient.AppsV1().StatefulSets(a.namespace)),
 		)
 	case caas.DeploymentStateless:
 		return scale.PatchReplicasToScale(
 			context.Background(),
 			a.name,
 			int32(scaleTo),
-			scale.DeploymentScalePatcher(a.client.AppsV1().Deployments(a.namespace)),
+			scale.DeploymentScalePatcher(a.coreClient.AppsV1().Deployments(a.namespace)),
 		)
 	default:
 		return errors.NotSupportedf(
@@ -46,7 +46,7 @@ func (a *app) Scale(scaleTo int) error {
 func (a *app) currentScale(ctx context.Context) (int, error) {
 	switch a.deploymentType {
 	case caas.DeploymentStateful:
-		ss, err := a.client.AppsV1().StatefulSets(a.namespace).Get(ctx, a.name, meta.GetOptions{})
+		ss, err := a.coreClient.AppsV1().StatefulSets(a.namespace).Get(ctx, a.name, meta.GetOptions{})
 		if k8serrors.IsNotFound(err) {
 			err = errors.WithType(err, errors.NotFound)
 		}

--- a/caas/kubernetes/provider/application/scale_test.go
+++ b/caas/kubernetes/provider/application/scale_test.go
@@ -20,7 +20,7 @@ func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
-	ss, err := s.client.AppsV1().StatefulSets(s.namespace).Get(
+	ss, err := s.coreClient.AppsV1().StatefulSets(s.namespace).Get(
 		context.Background(),
 		s.appName,
 		metav1.GetOptions{},
@@ -34,7 +34,7 @@ func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
-	dep, err := s.client.AppsV1().Deployments(s.namespace).Get(
+	dep, err := s.coreClient.AppsV1().Deployments(s.namespace).Get(
 		context.Background(),
 		s.appName,
 		metav1.GetOptions{},

--- a/caas/kubernetes/provider/application/trust.go
+++ b/caas/kubernetes/provider/application/trust.go
@@ -76,7 +76,7 @@ func (a *app) Trust(trust bool) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = applier.Run(context.Background(), a.client, false)
+	err = applier.Run(context.Background(), a.coreClient, a.extendedClient, false)
 	return errors.Annotatef(err, "configuring trust for %q", a.name)
 }
 
@@ -97,7 +97,7 @@ func (a *app) roleRules(trust bool) []rbacv1.PolicyRule {
 
 func (a *app) applyRoles(applier resources.Applier, trust bool) error {
 	role := resources.NewRole(a.serviceAccountName(), a.namespace, nil)
-	err := role.Get(context.Background(), a.client)
+	err := role.Get(context.Background(), a.coreClient, a.extendedClient)
 	if err != nil {
 		return errors.Annotatef(err, "getting service account role %q", a.serviceAccountName())
 	}
@@ -117,7 +117,7 @@ func (a *app) clusterRoleRules(trust bool) []rbacv1.PolicyRule {
 
 func (a *app) applyClusterRoles(applier resources.Applier, trust bool) error {
 	role := resources.NewClusterRole(a.qualifiedClusterName(), nil)
-	err := role.Get(context.Background(), a.client)
+	err := role.Get(context.Background(), a.coreClient, a.extendedClient)
 	if err != nil {
 		return errors.Annotatef(err, "getting service account cluster role %q", a.qualifiedClusterName())
 	}

--- a/caas/kubernetes/provider/application/trust_test.go
+++ b/caas/kubernetes/provider/application/trust_test.go
@@ -20,14 +20,14 @@ func (s *applicationSuite) TestTrust(c *gc.C) {
 	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
+	_, err := s.coreClient.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.appName,
 			Namespace: s.namespace,
 		},
 	}, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.client.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
+	_, err = s.coreClient.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: s.namespace + "-" + s.appName,
 		},
@@ -36,7 +36,7 @@ func (s *applicationSuite) TestTrust(c *gc.C) {
 
 	err = app.Trust(true)
 	c.Assert(err, jc.ErrorIsNil)
-	role, err := s.client.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
+	role, err := s.coreClient.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(role.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
 		{
@@ -45,7 +45,7 @@ func (s *applicationSuite) TestTrust(c *gc.C) {
 			Verbs:     []string{"*"},
 		},
 	})
-	clusterRole, err := s.client.RbacV1().ClusterRoles().Get(context.Background(), s.namespace+"-"+s.appName, metav1.GetOptions{})
+	clusterRole, err := s.coreClient.RbacV1().ClusterRoles().Get(context.Background(), s.namespace+"-"+s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clusterRole.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
 		{
@@ -68,7 +68,7 @@ func (s *applicationSuite) TestTrustClusterRoleNotFound(c *gc.C) {
 	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
+	_, err := s.coreClient.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.appName,
 			Namespace: s.namespace,
@@ -78,10 +78,10 @@ func (s *applicationSuite) TestTrustClusterRoleNotFound(c *gc.C) {
 
 	err = app.Trust(true)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	role, err := s.client.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
+	role, err := s.coreClient.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(role.Rules, jc.DeepEquals, []rbacv1.PolicyRule(nil))
-	_, err = s.client.RbacV1().ClusterRoles().Get(context.Background(), s.namespace+"-"+s.appName, metav1.GetOptions{})
+	_, err = s.coreClient.RbacV1().ClusterRoles().Get(context.Background(), s.namespace+"-"+s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -89,14 +89,14 @@ func (s *applicationSuite) TestRemoveTrust(c *gc.C) {
 	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
 	defer ctrl.Finish()
 
-	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
+	_, err := s.coreClient.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.appName,
 			Namespace: s.namespace,
 		},
 	}, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.client.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
+	_, err = s.coreClient.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: s.namespace + "-" + s.appName,
 		},
@@ -105,7 +105,7 @@ func (s *applicationSuite) TestRemoveTrust(c *gc.C) {
 
 	err = app.Trust(false)
 	c.Assert(err, jc.ErrorIsNil)
-	role, err := s.client.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
+	role, err := s.coreClient.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(role.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
 		{
@@ -127,7 +127,7 @@ func (s *applicationSuite) TestRemoveTrust(c *gc.C) {
 			Verbs:     []string{"create"},
 		},
 	})
-	clusterRole, err := s.client.RbacV1().ClusterRoles().Get(context.Background(), s.namespace+"-"+s.appName, metav1.GetOptions{})
+	clusterRole, err := s.coreClient.RbacV1().ClusterRoles().Get(context.Background(), s.namespace+"-"+s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(clusterRole.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
 		{

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -193,6 +193,8 @@ func (k *kubernetesClient) deleteCustomResourceDefinitions(selector k8slabels.Se
 	}, metav1.ListOptions{
 		LabelSelector: selector.String(),
 	})
+	logger.Infof("alvin2 deleteCustomResourceDefinitions selector is %s and err is %v", selector.String(), err)
+
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
@@ -231,6 +233,7 @@ func (k *kubernetesClient) deleteCustomResources(selectorGetter func(apiextensio
 			}, metav1.ListOptions{
 				LabelSelector: selector.String(),
 			})
+			logger.Infof("alvin2 deletecustomresource selector is %s and err is %v", selector.String(), err)
 			if err != nil && !k8serrors.IsNotFound(err) {
 				return errors.Trace(err)
 			}

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -58,7 +58,7 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		config.ImageDetails.BasicAuthConfig.Auth = docker.NewToken("xxxxxxxx===")
 	}
 	bridge := &modelOperatorBrokerBridge{
-		client: m.client,
+		coreClient: m.client,
 		ensureConfigMap: func(cm *core.ConfigMap) ([]func(), error) {
 			ensureConfigMapCalled = true
 			_, err := m.client.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, meta.CreateOptions{})

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -153,6 +153,7 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 		cRCleanups, err := cr.Ensure(
 			ctx,
 			k.client(),
+			k.extendedClient(),
 			resources.ClaimJujuOwnership,
 		)
 		cleanups = append(cleanups, cRCleanups...)
@@ -165,6 +166,7 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 		crbCleanups, err := clusterRoleBinding.Ensure(
 			ctx,
 			k.client(),
+			k.extendedClient(),
 			resources.ClaimJujuOwnership,
 		)
 		cleanups = append(cleanups, crbCleanups...)

--- a/caas/kubernetes/provider/resources/applier.go
+++ b/caas/kubernetes/provider/resources/applier.go
@@ -45,6 +45,7 @@ type operation struct {
 
 func (op *operation) process(ctx context.Context, coreAPI kubernetes.Interface, extendedAPI clientset.Interface, rollback Applier) error {
 	existingRes := op.resource.Clone()
+	logger.Infof("alvin existing Res: %+v", existingRes)
 	// TODO: consider to `list` using label selectors instead of `get` by `name`.
 	// Because it's not good for non namespaced resources.
 	err := existingRes.Get(ctx, coreAPI, extendedAPI)

--- a/caas/kubernetes/provider/resources/applier_test.go
+++ b/caas/kubernetes/provider/resources/applier_test.go
@@ -37,14 +37,14 @@ func (s *applierSuite) TestRun(c *gc.C) {
 
 	gomock.InOrder(
 		r1.EXPECT().Clone().Return(r1),
-		r1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(errors.NewNotFound(nil, "")),
-		r1.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil),
+		r1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.NewNotFound(nil, "")),
+		r1.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 
 		r2.EXPECT().Clone().Return(r2),
-		r2.EXPECT().Get(gomock.Any(), gomock.Any()).Return(errors.NewNotFound(nil, "")),
-		r2.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil),
+		r2.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.NewNotFound(nil, "")),
+		r2.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), jc.ErrorIsNil)
+	c.Assert(applier.Run(context.TODO(), nil, nil, false), jc.ErrorIsNil)
 }
 
 func (s *applierSuite) TestRunApplyFailedWithRollBackForNewResource(c *gc.C) {
@@ -65,16 +65,16 @@ func (s *applierSuite) TestRunApplyFailedWithRollBackForNewResource(c *gc.C) {
 
 	gomock.InOrder(
 		r1.EXPECT().Clone().Return(existingR1),
-		existingR1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(errors.NewNotFound(nil, "")),
-		r1.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(errors.New("something was wrong")),
+		existingR1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.NewNotFound(nil, "")),
+		r1.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("something was wrong")),
 
 		// rollback.
 		r1.EXPECT().Clone().Return(r1),
-		r1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
+		r1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 		// delete the new resource was just created.
-		r1.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil),
+		r1.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), gc.ErrorMatches, `something was wrong`)
+	c.Assert(applier.Run(context.TODO(), nil, nil, false), gc.ErrorMatches, `something was wrong`)
 }
 
 func (s *applierSuite) TestRunApplyResourceVersionChanged(c *gc.C) {
@@ -100,9 +100,9 @@ func (s *applierSuite) TestRunApplyResourceVersionChanged(c *gc.C) {
 
 	gomock.InOrder(
 		r1.EXPECT().Clone().Return(existingR1),
-		existingR1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
+		existingR1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), gc.ErrorMatches, `A r1: resource version conflict`)
+	c.Assert(applier.Run(context.TODO(), nil, nil, false), gc.ErrorMatches, `A r1: resource version conflict`)
 }
 
 func (s *applierSuite) TestRunApplyFailedWithRollBackForExistingResource(c *gc.C) {
@@ -123,16 +123,16 @@ func (s *applierSuite) TestRunApplyFailedWithRollBackForExistingResource(c *gc.C
 
 	gomock.InOrder(
 		r1.EXPECT().Clone().Return(existingR1),
-		existingR1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
-		r1.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(errors.New("something was wrong")),
+		existingR1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		r1.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("something was wrong")),
 
 		// rollback.
 		existingR1.EXPECT().Clone().Return(existingR1),
-		existingR1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
+		existingR1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 		// re-apply the old resource.
-		existingR1.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil),
+		existingR1.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), gc.ErrorMatches, `something was wrong`)
+	c.Assert(applier.Run(context.TODO(), nil, nil, false), gc.ErrorMatches, `something was wrong`)
 }
 
 func (s *applierSuite) TestRunDeleteFailedWithRollBack(c *gc.C) {
@@ -153,16 +153,16 @@ func (s *applierSuite) TestRunDeleteFailedWithRollBack(c *gc.C) {
 
 	gomock.InOrder(
 		r1.EXPECT().Clone().Return(existingR1),
-		existingR1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
-		r1.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(errors.New("something was wrong")),
+		existingR1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		r1.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("something was wrong")),
 
 		// rollback.
 		existingR1.EXPECT().Clone().Return(existingR1),
-		existingR1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
+		existingR1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 		// re-apply the old resource.
-		existingR1.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil),
+		existingR1.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), gc.ErrorMatches, `something was wrong`)
+	c.Assert(applier.Run(context.TODO(), nil, nil, false), gc.ErrorMatches, `something was wrong`)
 }
 
 func (s *applierSuite) TestApplySet(c *gc.C) {
@@ -195,12 +195,12 @@ func (s *applierSuite) TestApplySet(c *gc.C) {
 	applier.ApplySet([]resources.Resource{r1, r2}, []resources.Resource{r2Copy, r3})
 
 	gomock.InOrder(
-		r1.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
-		r1.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil),
-		r2.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil),
-		r2Copy.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil),
-		r3.EXPECT().Get(gomock.Any(), gomock.Any()).Return(errors.NotFoundf("missing aye")),
-		r3.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil),
+		r1.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		r1.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		r2.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		r2Copy.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		r3.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.NotFoundf("missing aye")),
+		r3.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 	)
-	c.Assert(applier.Run(context.TODO(), nil, false), jc.ErrorIsNil)
+	c.Assert(applier.Run(context.TODO(), nil, nil, false), jc.ErrorIsNil)
 }

--- a/caas/kubernetes/provider/resources/base_test.go
+++ b/caas/kubernetes/provider/resources/base_test.go
@@ -5,17 +5,23 @@ package resources_test
 
 import (
 	gc "gopkg.in/check.v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type resourceSuite struct {
-	coreClient kubernetes.Interface
+	coreClient     kubernetes.Interface
+	extendedClient clientset.Interface
 }
 
 func (s *resourceSuite) SetUpTest(c *gc.C) {
-	s.coreClient = newCombinedClientSet()
+	s.coreClient = fake.NewSimpleClientset()
+	s.extendedClient = apiextensionsfake.NewSimpleClientset()
 }
 
 func (s *resourceSuite) TearDownTest(c *gc.C) {
 	s.coreClient = nil
+	s.extendedClient = nil
 }

--- a/caas/kubernetes/provider/resources/base_test.go
+++ b/caas/kubernetes/provider/resources/base_test.go
@@ -5,17 +5,17 @@ package resources_test
 
 import (
 	gc "gopkg.in/check.v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes"
 )
 
 type resourceSuite struct {
-	client *fake.Clientset
+	coreClient kubernetes.Interface
 }
 
 func (s *resourceSuite) SetUpTest(c *gc.C) {
-	s.client = fake.NewSimpleClientset()
+	s.coreClient = newCombinedClientSet()
 }
 
 func (s *resourceSuite) TearDownTest(c *gc.C) {
-	s.client = nil
+	s.coreClient = nil
 }

--- a/caas/kubernetes/provider/resources/claim.go
+++ b/caas/kubernetes/provider/resources/claim.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 )
 
-// Claim represents an assertion over a generic Kubernetes object to assert
+// Claim represents an assertion over a generic kubernetes.Interface object to assert
 // ownership. These are used in Juju for cluster scoped resources to assert that
 // that Juju is not going to take ownership of an object that was not created by
 // itself.
@@ -27,7 +27,7 @@ type Claim interface {
 type ClaimFn func(obj interface{}) (bool, error)
 
 var (
-	// ClaimJujuOwnership asserts that the Kubernetes object has labels that
+	// ClaimJujuOwnership asserts that the kubernetes.Interface object has labels that
 	// in line with Juju management "ownership".
 	ClaimJujuOwnership = ClaimAggregateOr(
 		ClaimFn(claimIsManagedByJuju),
@@ -67,7 +67,7 @@ func claimHasJujuLabel(obj interface{}) (bool, error) {
 
 	metaObj, err := meta.Accessor(obj)
 	if err != nil {
-		return false, errors.Annotate(err, "asserting Kubernetes object has Juju labels")
+		return false, errors.Annotate(err, "asserting kubernetes.Interface object has Juju labels")
 	}
 	for k := range metaObj.GetLabels() {
 		if strings.Contains(k, "juju") {
@@ -77,7 +77,7 @@ func claimHasJujuLabel(obj interface{}) (bool, error) {
 	return false, nil
 }
 
-// claimIsManagedByJuju is a check to assert that the Kubernetes object provided
+// claimIsManagedByJuju is a check to assert that the kubernetes.Interface object provided
 // is managed by Juju by having the label key and value of
 // app.kubernetes.io/managed-by: juju.
 func claimIsManagedByJuju(obj interface{}) (bool, error) {
@@ -87,7 +87,7 @@ func claimIsManagedByJuju(obj interface{}) (bool, error) {
 
 	metaObj, err := meta.Accessor(obj)
 	if err != nil {
-		return false, errors.Annotate(err, "asserting Kubernetes object has managed by juju label")
+		return false, errors.Annotate(err, "asserting kubernetes.Interface object has managed by juju label")
 	}
 
 	val, has := metaObj.GetLabels()[constants.LabelKubernetesAppManaged]

--- a/caas/kubernetes/provider/resources/clusterrole_test.go
+++ b/caas/kubernetes/provider/resources/clusterrole_test.go
@@ -30,7 +30,7 @@ func (s *clusterRoleSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	clusterRoleResource := resources.NewClusterRole("role1", role)
-	c.Assert(clusterRoleResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(clusterRoleResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -38,7 +38,7 @@ func (s *clusterRoleSuite) TestApply(c *gc.C) {
 	// Update.
 	role.SetAnnotations(map[string]string{"a": "b"})
 	clusterRoleResource = resources.NewClusterRole("role1", role)
-	c.Assert(clusterRoleResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(clusterRoleResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -59,7 +59,7 @@ func (s *clusterRoleSuite) TestGet(c *gc.C) {
 
 	roleResource := resources.NewClusterRole("role1", &template)
 	c.Assert(len(roleResource.GetAnnotations()), gc.Equals, 0)
-	err = roleResource.Get(context.TODO(), s.coreClient)
+	err = roleResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(roleResource.GetName(), gc.Equals, `role1`)
 	c.Assert(roleResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -79,10 +79,10 @@ func (s *clusterRoleSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 
 	roleResource := resources.NewClusterRole("role1", &role)
-	err = roleResource.Delete(context.TODO(), s.coreClient)
+	err = roleResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = roleResource.Get(context.TODO(), s.coreClient)
+	err = roleResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
@@ -124,6 +124,7 @@ func (s *clusterRoleSuite) TestEnsureClusterRoleRegressionOnLabelChange(c *gc.C)
 	_, err := crApi.Ensure(
 		context.TODO(),
 		s.coreClient,
+		s.extendedClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -144,6 +145,7 @@ func (s *clusterRoleSuite) TestEnsureClusterRoleRegressionOnLabelChange(c *gc.C)
 	crApi.Ensure(
 		context.TODO(),
 		s.coreClient,
+		s.extendedClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/provider/resources/clusterrole_test.go
+++ b/caas/kubernetes/provider/resources/clusterrole_test.go
@@ -30,17 +30,17 @@ func (s *clusterRoleSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	clusterRoleResource := resources.NewClusterRole("role1", role)
-	c.Assert(clusterRoleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
+	c.Assert(clusterRoleResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	role.SetAnnotations(map[string]string{"a": "b"})
 	clusterRoleResource = resources.NewClusterRole("role1", role)
-	c.Assert(clusterRoleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(clusterRoleResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
+	result, err = s.coreClient.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -54,12 +54,12 @@ func (s *clusterRoleSuite) TestGet(c *gc.C) {
 	}
 	role1 := template
 	role1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.RbacV1().ClusterRoles().Create(context.TODO(), &role1, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().ClusterRoles().Create(context.TODO(), &role1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	roleResource := resources.NewClusterRole("role1", &template)
 	c.Assert(len(roleResource.GetAnnotations()), gc.Equals, 0)
-	err = roleResource.Get(context.TODO(), s.client)
+	err = roleResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(roleResource.GetName(), gc.Equals, `role1`)
 	c.Assert(roleResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -71,21 +71,21 @@ func (s *clusterRoleSuite) TestDelete(c *gc.C) {
 			Name: "role1",
 		},
 	}
-	_, err := s.client.RbacV1().ClusterRoles().Create(context.TODO(), &role, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().ClusterRoles().Create(context.TODO(), &role, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
+	result, err := s.coreClient.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 
 	roleResource := resources.NewClusterRole("role1", &role)
-	err = roleResource.Delete(context.TODO(), s.client)
+	err = roleResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = roleResource.Get(context.TODO(), s.client)
+	err = roleResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
+	_, err = s.coreClient.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -123,12 +123,12 @@ func (s *clusterRoleSuite) TestEnsureClusterRoleRegressionOnLabelChange(c *gc.C)
 	crApi := resources.NewClusterRole("test", clusterRole)
 	_, err := crApi.Ensure(
 		context.TODO(),
-		s.client,
+		s.coreClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	rrole, err := s.client.RbacV1().ClusterRoles().Get(
+	rrole, err := s.coreClient.RbacV1().ClusterRoles().Get(
 		context.TODO(),
 		"test",
 		metav1.GetOptions{},
@@ -143,12 +143,12 @@ func (s *clusterRoleSuite) TestEnsureClusterRoleRegressionOnLabelChange(c *gc.C)
 
 	crApi.Ensure(
 		context.TODO(),
-		s.client,
+		s.coreClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	rrole, err = s.client.RbacV1().ClusterRoles().Get(
+	rrole, err = s.coreClient.RbacV1().ClusterRoles().Get(
 		context.TODO(),
 		"test",
 		metav1.GetOptions{},

--- a/caas/kubernetes/provider/resources/clusterrolebinding_test.go
+++ b/caas/kubernetes/provider/resources/clusterrolebinding_test.go
@@ -30,17 +30,17 @@ func (s *clusterRoleBindingSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", roleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	c.Assert(rbResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	roleBinding.SetAnnotations(map[string]string{"a": "b"})
 	rbResource = resources.NewClusterRoleBinding("roleBinding1", roleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(rbResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err = s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -54,12 +54,12 @@ func (s *clusterRoleBindingSuite) TestGet(c *gc.C) {
 	}
 	roleBinding1 := template
 	roleBinding1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding1, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", &template)
 	c.Assert(len(rbResource.GetAnnotations()), gc.Equals, 0)
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rbResource.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(rbResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -71,21 +71,21 @@ func (s *clusterRoleBindingSuite) TestDelete(c *gc.C) {
 			Name: "roleBinding1",
 		},
 	}
-	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err := s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", &roleBinding)
-	err = rbResource.Delete(context.TODO(), s.client)
+	err = rbResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	_, err = s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -95,21 +95,21 @@ func (s *clusterRoleBindingSuite) TestDeleteWithoutPreconditions(c *gc.C) {
 			Name: "roleBinding1",
 		},
 	}
-	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err := s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", nil)
-	err = rbResource.Delete(context.TODO(), s.client)
+	err = rbResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	_, err = s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -129,12 +129,12 @@ func (s *clusterRoleBindingSuite) TestEnsureClusterRoleBindingRegressionOnLabelC
 	crbApi := resources.NewClusterRoleBinding("test", clusterRoleBinding)
 	_, err := crbApi.Ensure(
 		context.TODO(),
-		s.client,
+		s.coreClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	rroleBinding, err := s.client.RbacV1().ClusterRoleBindings().Get(
+	rroleBinding, err := s.coreClient.RbacV1().ClusterRoleBindings().Get(
 		context.TODO(),
 		"test",
 		metav1.GetOptions{},
@@ -149,12 +149,12 @@ func (s *clusterRoleBindingSuite) TestEnsureClusterRoleBindingRegressionOnLabelC
 
 	crbApi.Ensure(
 		context.TODO(),
-		s.client,
+		s.coreClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	rroleBinding, err = s.client.RbacV1().ClusterRoleBindings().Get(
+	rroleBinding, err = s.coreClient.RbacV1().ClusterRoleBindings().Get(
 		context.TODO(),
 		"test",
 		metav1.GetOptions{},
@@ -193,12 +193,12 @@ func (s *clusterRoleBindingSuite) TestEnsureRecreatesOnRoleRefChange(c *gc.C) {
 
 	_, err := clusterRoleBinding.Ensure(
 		context.TODO(),
-		s.client,
+		s.coreClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	rval, err := s.client.RbacV1().ClusterRoleBindings().Get(
+	rval, err := s.coreClient.RbacV1().ClusterRoleBindings().Get(
 		context.TODO(),
 		"test",
 		metav1.GetOptions{},
@@ -233,7 +233,7 @@ func (s *clusterRoleBindingSuite) TestEnsureRecreatesOnRoleRefChange(c *gc.C) {
 
 	_, err = clusterRoleBinding1.Ensure(
 		context.TODO(),
-		s.client,
+		s.coreClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/provider/resources/clusterrolebinding_test.go
+++ b/caas/kubernetes/provider/resources/clusterrolebinding_test.go
@@ -30,7 +30,7 @@ func (s *clusterRoleBindingSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", roleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(rbResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -38,7 +38,7 @@ func (s *clusterRoleBindingSuite) TestApply(c *gc.C) {
 	// Update.
 	roleBinding.SetAnnotations(map[string]string{"a": "b"})
 	rbResource = resources.NewClusterRoleBinding("roleBinding1", roleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(rbResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -59,7 +59,7 @@ func (s *clusterRoleBindingSuite) TestGet(c *gc.C) {
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", &template)
 	c.Assert(len(rbResource.GetAnnotations()), gc.Equals, 0)
-	err = rbResource.Get(context.TODO(), s.coreClient)
+	err = rbResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rbResource.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(rbResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -79,10 +79,10 @@ func (s *clusterRoleBindingSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", &roleBinding)
-	err = rbResource.Delete(context.TODO(), s.coreClient)
+	err = rbResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.coreClient)
+	err = rbResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
@@ -103,10 +103,10 @@ func (s *clusterRoleBindingSuite) TestDeleteWithoutPreconditions(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewClusterRoleBinding("roleBinding1", nil)
-	err = rbResource.Delete(context.TODO(), s.coreClient)
+	err = rbResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.coreClient)
+	err = rbResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
@@ -130,6 +130,7 @@ func (s *clusterRoleBindingSuite) TestEnsureClusterRoleBindingRegressionOnLabelC
 	_, err := crbApi.Ensure(
 		context.TODO(),
 		s.coreClient,
+		s.extendedClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -150,6 +151,7 @@ func (s *clusterRoleBindingSuite) TestEnsureClusterRoleBindingRegressionOnLabelC
 	crbApi.Ensure(
 		context.TODO(),
 		s.coreClient,
+		s.extendedClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -194,6 +196,7 @@ func (s *clusterRoleBindingSuite) TestEnsureRecreatesOnRoleRefChange(c *gc.C) {
 	_, err := clusterRoleBinding.Ensure(
 		context.TODO(),
 		s.coreClient,
+		s.extendedClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -234,6 +237,7 @@ func (s *clusterRoleBindingSuite) TestEnsureRecreatesOnRoleRefChange(c *gc.C) {
 	_, err = clusterRoleBinding1.Ensure(
 		context.TODO(),
 		s.coreClient,
+		s.extendedClient,
 		resources.ClaimFn(func(_ interface{}) (bool, error) { return true, nil }),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/provider/resources/customresourcedefinition.go
+++ b/caas/kubernetes/provider/resources/customresourcedefinition.go
@@ -1,0 +1,120 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/errors"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/status"
+)
+
+// StatefulSet extends the k8s statefulSet.
+type CustomResourceDefinition struct {
+	apiextensionsv1.CustomResourceDefinition
+}
+
+// NewStatefulSet creates a new statefulset resource.
+func NewCustomResourceDefinition(name string, in *apiextensionsv1.CustomResourceDefinition) *CustomResourceDefinition {
+	if in == nil {
+		in = &apiextensionsv1.CustomResourceDefinition{}
+	}
+	in.SetName(name)
+	return &CustomResourceDefinition{*in}
+}
+
+// Clone returns a copy of the resource.
+func (crd *CustomResourceDefinition) Clone() Resource {
+	clone := *crd
+	return &clone
+}
+
+// ID returns a comparable ID for the Resource
+func (crd *CustomResourceDefinition) ID() ID {
+	return ID{"CustomResourceDefinition", crd.Name, crd.Namespace}
+}
+
+// Apply patches the resource change.
+func (crd *CustomResourceDefinition) Apply(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) (err error) {
+	api := extendedClient.ApiextensionsV1().CustomResourceDefinitions()
+	existing, err := api.Get(ctx, crd.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		// Create if not found
+		created, err := api.Create(ctx, &crd.CustomResourceDefinition, metav1.CreateOptions{
+			FieldManager: JujuFieldManager,
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
+		crd.CustomResourceDefinition = *created
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Update if exists (set ResourceVersion to prevent conflict)
+	crd.ResourceVersion = existing.ResourceVersion
+	updated, err := api.Update(ctx, &crd.CustomResourceDefinition, metav1.UpdateOptions{
+		FieldManager: JujuFieldManager,
+	})
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "customresourcedefinition %q", crd.Name)
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	crd.CustomResourceDefinition = *updated
+	return nil
+}
+
+// Get refreshes the resource.
+func (crd *CustomResourceDefinition) Get(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	api := extendedClient.ApiextensionsV1().CustomResourceDefinitions()
+
+	res, err := api.Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return errors.NotFoundf("custom resource definition: %q", crd.Name)
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	crd.CustomResourceDefinition = *res
+	return nil
+}
+
+// Delete removes the resource.
+func (crd *CustomResourceDefinition) Delete(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	api := extendedClient.ApiextensionsV1().CustomResourceDefinitions()
+	err := api.Delete(ctx, crd.Name, metav1.DeleteOptions{
+		PropagationPolicy: k8sconstants.DefaultPropagationPolicy(),
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// Events emitted by the resource.
+func (crd *CustomResourceDefinition) Events(ctx context.Context, coreClient kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, coreClient, crd.Namespace, crd.Name, "CustomResourceDefinition")
+}
+
+// ComputeStatus returns a juju status for the resource.
+func (crd *CustomResourceDefinition) ComputeStatus(ctx context.Context, coreClient kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error) {
+	if crd.DeletionTimestamp != nil {
+		return "", status.Terminated, crd.DeletionTimestamp.Time, nil
+	}
+	return "", status.Active, now, nil
+}

--- a/caas/kubernetes/provider/resources/customresourcedefinition.go
+++ b/caas/kubernetes/provider/resources/customresourcedefinition.go
@@ -81,7 +81,6 @@ func (crd *CustomResourceDefinition) Apply(ctx context.Context, coreClient kuber
 // Get refreshes the resource.
 func (crd *CustomResourceDefinition) Get(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
 	api := extendedClient.ApiextensionsV1().CustomResourceDefinitions()
-
 	res, err := api.Get(context.TODO(), crd.Name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return errors.NotFoundf("custom resource definition: %q", crd.Name)
@@ -89,15 +88,23 @@ func (crd *CustomResourceDefinition) Get(ctx context.Context, coreClient kuberne
 		return errors.Trace(err)
 	}
 	crd.CustomResourceDefinition = *res
+	logger.Infof("alvin Get res: %+v", res)
 	return nil
 }
 
 // Delete removes the resource.
 func (crd *CustomResourceDefinition) Delete(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	logger.Infof("alvin crd in del is %+v", *crd)
 	api := extendedClient.ApiextensionsV1().CustomResourceDefinitions()
+
 	err := api.Delete(ctx, crd.Name, metav1.DeleteOptions{
 		PropagationPolicy: k8sconstants.DefaultPropagationPolicy(),
 	})
+	logger.Infof("alvin logger called for %s and err is %v", crd.Name, err)
+
+	err = crd.Get(ctx, coreClient, extendedClient)
+	logger.Infof("alvin Get err in Del is %v", err)
+	logger.Infof("alvin Get res after del in Del is %+v", *crd)
 	if k8serrors.IsNotFound(err) {
 		return nil
 	} else if err != nil {

--- a/caas/kubernetes/provider/resources/daemonset_test.go
+++ b/caas/kubernetes/provider/resources/daemonset_test.go
@@ -31,17 +31,17 @@ func (s *daemonsetSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewDaemonSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewDaemonSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *daemonsetSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.AppsV1().DaemonSets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.AppsV1().DaemonSets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewDaemonSet("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *daemonsetSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.AppsV1().DaemonSets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.AppsV1().DaemonSets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewDaemonSet("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/daemonset_test.go
+++ b/caas/kubernetes/provider/resources/daemonset_test.go
@@ -31,7 +31,7 @@ func (s *daemonsetSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewDaemonSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -39,7 +39,7 @@ func (s *daemonsetSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewDaemonSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *daemonsetSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewDaemonSet("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -84,10 +84,10 @@ func (s *daemonsetSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewDaemonSet("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.AppsV1().DaemonSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/deployment_test.go
+++ b/caas/kubernetes/provider/resources/deployment_test.go
@@ -31,7 +31,7 @@ func (s *deploymentSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewDeployment("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -39,7 +39,7 @@ func (s *deploymentSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewDeployment("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *deploymentSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewDeployment("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -84,10 +84,10 @@ func (s *deploymentSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewDeployment("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/deployment_test.go
+++ b/caas/kubernetes/provider/resources/deployment_test.go
@@ -31,17 +31,17 @@ func (s *deploymentSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewDeployment("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewDeployment("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *deploymentSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.AppsV1().Deployments("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.AppsV1().Deployments("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewDeployment("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *deploymentSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.AppsV1().Deployments("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.AppsV1().Deployments("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewDeployment("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.AppsV1().Deployments("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/events.go
+++ b/caas/kubernetes/provider/resources/events.go
@@ -17,7 +17,7 @@ const maxEventsToPage = 100
 
 // ListEventsForObject returns all the events for the specified object.
 func ListEventsForObject(
-	ctx context.Context, client kubernetes.Interface, namespace, name, kind string,
+	ctx context.Context, coreClient kubernetes.Interface, namespace, name, kind string,
 ) ([]corev1.Event, error) {
 	selector := fields.AndSelectors(
 		fields.OneTermEqualSelector("involvedObject.name", name),
@@ -28,7 +28,7 @@ func ListEventsForObject(
 	}
 	var items []corev1.Event
 	for len(items) < maxEventsToPage {
-		res, err := client.CoreV1().Events(namespace).List(ctx, opts)
+		res, err := coreClient.CoreV1().Events(namespace).List(ctx, opts)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/caas/kubernetes/provider/resources/events_test.go
+++ b/caas/kubernetes/provider/resources/events_test.go
@@ -36,11 +36,11 @@ func (s *eventsSuite) TestList(c *gc.C) {
 	for i := 0; i < 1000; i++ {
 		ev := template
 		ev.ObjectMeta.Name = strconv.Itoa(i)
-		_, err := s.client.CoreV1().Events("test").Create(context.TODO(), &ev, metav1.CreateOptions{})
+		_, err := s.coreClient.CoreV1().Events("test").Create(context.TODO(), &ev, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 		res = append(res, ev)
 	}
-	events, err := resources.ListEventsForObject(context.TODO(), s.client, "test", "test", "Pod")
+	events, err := resources.ListEventsForObject(context.TODO(), s.coreClient, "test", "test", "Pod")
 	c.Assert(err, jc.ErrorIsNil)
 
 	toInt := func(s string) int {

--- a/caas/kubernetes/provider/resources/interface.go
+++ b/caas/kubernetes/provider/resources/interface.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -27,17 +28,17 @@ type Resource interface {
 	// Clone returns a copy of the resource.
 	Clone() Resource
 	// Apply patches the resource change.
-	Apply(ctx context.Context, client kubernetes.Interface) error
+	Apply(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error
 	// Get refreshes the resource.
-	Get(ctx context.Context, client kubernetes.Interface) error
+	Get(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error
 	// Delete removes the resource.
-	Delete(ctx context.Context, client kubernetes.Interface) error
+	Delete(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error
 	// String returns a string format containing the name and type of the resource.
 	String() string
 	// ComputeStatus returns a juju status for the resource.
-	ComputeStatus(ctx context.Context, client kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error)
+	ComputeStatus(ctx context.Context, coreClient kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error)
 	// Events emitted by the object.
-	Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error)
+	Events(ctx context.Context, coreClient kubernetes.Interface) ([]corev1.Event, error)
 	// ID returns a comparable ID for the Resource
 	ID() ID
 }
@@ -52,7 +53,7 @@ type Applier interface {
 	// desired slice. All items in the desired slice are applied.
 	ApplySet(current []Resource, desired []Resource)
 	// Run processes the slice of the operations.
-	Run(ctx context.Context, client kubernetes.Interface, noRollback bool) error
+	Run(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface, noRollback bool) error
 }
 
 // ID represents a compareable identifier for Resources.

--- a/caas/kubernetes/provider/resources/mocks/resources_mock.go
+++ b/caas/kubernetes/provider/resources/mocks/resources_mock.go
@@ -19,7 +19,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubernetes "k8s.io/client-go/kubernetes"
 )
 
 // MockResource is a mock of Resource interface.
@@ -46,7 +45,7 @@ func (m *MockResource) EXPECT() *MockResourceMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockResource) Apply(arg0 context.Context, arg1 kubernetes.Interface) error {
+func (m *MockResource) Apply(arg0 context.Context, arg1 resources.kubernetes.Interface) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -74,7 +73,7 @@ func (mr *MockResourceMockRecorder) Clone() *gomock.Call {
 }
 
 // ComputeStatus mocks base method.
-func (m *MockResource) ComputeStatus(arg0 context.Context, arg1 kubernetes.Interface, arg2 time.Time) (string, status.Status, time.Time, error) {
+func (m *MockResource) ComputeStatus(arg0 context.Context, arg1 resources.kubernetes.Interface, arg2 time.Time) (string, status.Status, time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ComputeStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
@@ -91,7 +90,7 @@ func (mr *MockResourceMockRecorder) ComputeStatus(arg0, arg1, arg2 any) *gomock.
 }
 
 // Delete mocks base method.
-func (m *MockResource) Delete(arg0 context.Context, arg1 kubernetes.Interface) error {
+func (m *MockResource) Delete(arg0 context.Context, arg1 resources.kubernetes.Interface) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -105,7 +104,7 @@ func (mr *MockResourceMockRecorder) Delete(arg0, arg1 any) *gomock.Call {
 }
 
 // Events mocks base method.
-func (m *MockResource) Events(arg0 context.Context, arg1 kubernetes.Interface) ([]v1.Event, error) {
+func (m *MockResource) Events(arg0 context.Context, arg1 resources.kubernetes.Interface) ([]v1.Event, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Events", arg0, arg1)
 	ret0, _ := ret[0].([]v1.Event)
@@ -120,7 +119,7 @@ func (mr *MockResourceMockRecorder) Events(arg0, arg1 any) *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockResource) Get(arg0 context.Context, arg1 kubernetes.Interface) error {
+func (m *MockResource) Get(arg0 context.Context, arg1 resources.kubernetes.Interface) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -243,7 +242,7 @@ func (mr *MockApplierMockRecorder) Delete(arg0 ...any) *gomock.Call {
 }
 
 // Run mocks base method.
-func (m *MockApplier) Run(arg0 context.Context, arg1 kubernetes.Interface, arg2 bool) error {
+func (m *MockApplier) Run(arg0 context.Context, arg1 resources.kubernetes.Interface, arg2 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Run", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/caas/kubernetes/provider/resources/mocks/resources_mock.go
+++ b/caas/kubernetes/provider/resources/mocks/resources_mock.go
@@ -18,7 +18,9 @@ import (
 	status "github.com/juju/juju/core/status"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetes "k8s.io/client-go/kubernetes"
 )
 
 // MockResource is a mock of Resource interface.
@@ -45,17 +47,17 @@ func (m *MockResource) EXPECT() *MockResourceMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockResource) Apply(arg0 context.Context, arg1 resources.kubernetes.Interface) error {
+func (m *MockResource) Apply(arg0 context.Context, arg1 kubernetes.Interface, arg2 clientset.Interface) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", arg0, arg1)
+	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Apply indicates an expected call of Apply.
-func (mr *MockResourceMockRecorder) Apply(arg0, arg1 any) *gomock.Call {
+func (mr *MockResourceMockRecorder) Apply(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockResource)(nil).Apply), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockResource)(nil).Apply), arg0, arg1, arg2)
 }
 
 // Clone mocks base method.
@@ -73,7 +75,7 @@ func (mr *MockResourceMockRecorder) Clone() *gomock.Call {
 }
 
 // ComputeStatus mocks base method.
-func (m *MockResource) ComputeStatus(arg0 context.Context, arg1 resources.kubernetes.Interface, arg2 time.Time) (string, status.Status, time.Time, error) {
+func (m *MockResource) ComputeStatus(arg0 context.Context, arg1 kubernetes.Interface, arg2 time.Time) (string, status.Status, time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ComputeStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
@@ -90,21 +92,21 @@ func (mr *MockResourceMockRecorder) ComputeStatus(arg0, arg1, arg2 any) *gomock.
 }
 
 // Delete mocks base method.
-func (m *MockResource) Delete(arg0 context.Context, arg1 resources.kubernetes.Interface) error {
+func (m *MockResource) Delete(arg0 context.Context, arg1 kubernetes.Interface, arg2 clientset.Interface) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockResourceMockRecorder) Delete(arg0, arg1 any) *gomock.Call {
+func (mr *MockResourceMockRecorder) Delete(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockResource)(nil).Delete), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockResource)(nil).Delete), arg0, arg1, arg2)
 }
 
 // Events mocks base method.
-func (m *MockResource) Events(arg0 context.Context, arg1 resources.kubernetes.Interface) ([]v1.Event, error) {
+func (m *MockResource) Events(arg0 context.Context, arg1 kubernetes.Interface) ([]v1.Event, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Events", arg0, arg1)
 	ret0, _ := ret[0].([]v1.Event)
@@ -119,17 +121,17 @@ func (mr *MockResourceMockRecorder) Events(arg0, arg1 any) *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockResource) Get(arg0 context.Context, arg1 resources.kubernetes.Interface) error {
+func (m *MockResource) Get(arg0 context.Context, arg1 kubernetes.Interface, arg2 clientset.Interface) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockResourceMockRecorder) Get(arg0, arg1 any) *gomock.Call {
+func (mr *MockResourceMockRecorder) Get(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockResource)(nil).Get), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockResource)(nil).Get), arg0, arg1, arg2)
 }
 
 // GetObjectMeta mocks base method.
@@ -242,15 +244,15 @@ func (mr *MockApplierMockRecorder) Delete(arg0 ...any) *gomock.Call {
 }
 
 // Run mocks base method.
-func (m *MockApplier) Run(arg0 context.Context, arg1 resources.kubernetes.Interface, arg2 bool) error {
+func (m *MockApplier) Run(arg0 context.Context, arg1 kubernetes.Interface, arg2 clientset.Interface, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Run", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Run", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Run indicates an expected call of Run.
-func (mr *MockApplierMockRecorder) Run(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockApplierMockRecorder) Run(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockApplier)(nil).Run), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockApplier)(nil).Run), arg0, arg1, arg2, arg3)
 }

--- a/caas/kubernetes/provider/resources/persistentvolume_test.go
+++ b/caas/kubernetes/provider/resources/persistentvolume_test.go
@@ -30,7 +30,7 @@ func (s *persistentVolumeSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPersistentVolume("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -38,7 +38,7 @@ func (s *persistentVolumeSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPersistentVolume("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -59,7 +59,7 @@ func (s *persistentVolumeSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewPersistentVolume("ds1", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -79,10 +79,10 @@ func (s *persistentVolumeSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPersistentVolume("ds1", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/persistentvolume_test.go
+++ b/caas/kubernetes/provider/resources/persistentvolume_test.go
@@ -30,17 +30,17 @@ func (s *persistentVolumeSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPersistentVolume("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPersistentVolume("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -54,12 +54,12 @@ func (s *persistentVolumeSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().PersistentVolumes().Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().PersistentVolumes().Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewPersistentVolume("ds1", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -71,20 +71,20 @@ func (s *persistentVolumeSuite) TestDelete(c *gc.C) {
 			Name: "ds1",
 		},
 	}
-	_, err := s.client.CoreV1().PersistentVolumes().Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().PersistentVolumes().Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPersistentVolume("ds1", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.CoreV1().PersistentVolumes().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/persistentvolumeclaim_test.go
+++ b/caas/kubernetes/provider/resources/persistentvolumeclaim_test.go
@@ -32,7 +32,7 @@ func (s *persistentVolumeClaimSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -40,7 +40,7 @@ func (s *persistentVolumeClaimSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPersistentVolumeClaim("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -63,7 +63,7 @@ func (s *persistentVolumeClaimSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -85,10 +85,10 @@ func (s *persistentVolumeClaimSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/persistentvolumeclaim_test.go
+++ b/caas/kubernetes/provider/resources/persistentvolumeclaim_test.go
@@ -32,17 +32,17 @@ func (s *persistentVolumeClaimSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPersistentVolumeClaim("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -58,12 +58,12 @@ func (s *persistentVolumeClaimSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -77,21 +77,21 @@ func (s *persistentVolumeClaimSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPersistentVolumeClaim("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -110,12 +110,12 @@ func (s *persistentVolumeClaimSuite) TestList(c *gc.C) {
 		if i%3 == 0 {
 			pvc.ObjectMeta.Labels = map[string]string{"modulo": "three"}
 		}
-		_, err := s.client.CoreV1().PersistentVolumeClaims("test").Create(context.Background(), &pvc, metav1.CreateOptions{})
+		_, err := s.coreClient.CoreV1().PersistentVolumeClaims("test").Create(context.Background(), &pvc, metav1.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
 	// List PVCs filtered by the label
-	listed, err := resources.ListPersistentVolumeClaims(context.Background(), s.client, "test", metav1.ListOptions{
+	listed, err := resources.ListPersistentVolumeClaims(context.Background(), s.coreClient, "test", metav1.ListOptions{
 		LabelSelector: "modulo == three",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/provider/resources/pod_test.go
+++ b/caas/kubernetes/provider/resources/pod_test.go
@@ -34,7 +34,7 @@ func (s *podSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPod("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -42,7 +42,7 @@ func (s *podSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPod("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -65,7 +65,7 @@ func (s *podSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewPod("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -87,10 +87,10 @@ func (s *podSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPod("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/pod_test.go
+++ b/caas/kubernetes/provider/resources/pod_test.go
@@ -34,17 +34,17 @@ func (s *podSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewPod("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewPod("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -60,12 +60,12 @@ func (s *podSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().Pods("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().Pods("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewPod("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -79,21 +79,21 @@ func (s *podSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().Pods("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().Pods("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewPod("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -163,7 +163,7 @@ func TestPodConditionListJujuStatus(t *testing.T) {
 		},
 		{
 			// We are testing the juju status here when pod scheduling is still
-			// occurring. Kubernetes is still organising where to put our pod
+			// occurring. kubernetes.Interface is still organising where to put our pod
 			// so we expect a juju status of allocating and the pod scheduling
 			// message to be echoed.
 			Name: "pod scheduling status waiting",

--- a/caas/kubernetes/provider/resources/role.go
+++ b/caas/kubernetes/provider/resources/role.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,8 +49,8 @@ func (r *Role) ID() ID {
 }
 
 // Apply patches the resource change.
-func (r *Role) Apply(ctx context.Context, client kubernetes.Interface) error {
-	api := client.RbacV1().Roles(r.Namespace)
+func (r *Role) Apply(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	api := coreClient.RbacV1().Roles(r.Namespace)
 	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, &r.Role)
 	if err != nil {
 		return errors.Trace(err)
@@ -73,8 +74,8 @@ func (r *Role) Apply(ctx context.Context, client kubernetes.Interface) error {
 }
 
 // Get refreshes the resource.
-func (r *Role) Get(ctx context.Context, client kubernetes.Interface) error {
-	api := client.RbacV1().Roles(r.Namespace)
+func (r *Role) Get(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	api := coreClient.RbacV1().Roles(r.Namespace)
 	res, err := api.Get(ctx, r.Name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return errors.NewNotFound(err, "k8s")
@@ -86,8 +87,8 @@ func (r *Role) Get(ctx context.Context, client kubernetes.Interface) error {
 }
 
 // Delete removes the resource.
-func (r *Role) Delete(ctx context.Context, client kubernetes.Interface) error {
-	api := client.RbacV1().Roles(r.Namespace)
+func (r *Role) Delete(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	api := coreClient.RbacV1().Roles(r.Namespace)
 	err := api.Delete(ctx, r.Name, metav1.DeleteOptions{
 		PropagationPolicy: k8sconstants.DefaultPropagationPolicy(),
 	})
@@ -100,8 +101,8 @@ func (r *Role) Delete(ctx context.Context, client kubernetes.Interface) error {
 }
 
 // Events emitted by the resource.
-func (r *Role) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
-	return ListEventsForObject(ctx, client, r.Namespace, r.Name, "Role")
+func (r *Role) Events(ctx context.Context, coreClient kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, coreClient, r.Namespace, r.Name, "Role")
 }
 
 // ComputeStatus returns a juju status for the resource.

--- a/caas/kubernetes/provider/resources/role_test.go
+++ b/caas/kubernetes/provider/resources/role_test.go
@@ -31,17 +31,17 @@ func (s *roleSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	roleResource := resources.NewRole("role1", "test", role)
-	c.Assert(roleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	c.Assert(roleResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	role.SetAnnotations(map[string]string{"a": "b"})
 	roleResource = resources.NewRole("role1", "test", role)
-	c.Assert(roleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(roleResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	result, err = s.coreClient.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *roleSuite) TestGet(c *gc.C) {
 	}
 	role1 := template
 	role1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.RbacV1().Roles("test").Create(context.TODO(), &role1, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().Roles("test").Create(context.TODO(), &role1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	roleResource := resources.NewRole("role1", "test", &template)
 	c.Assert(len(roleResource.GetAnnotations()), gc.Equals, 0)
-	err = roleResource.Get(context.TODO(), s.client)
+	err = roleResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(roleResource.GetName(), gc.Equals, `role1`)
 	c.Assert(roleResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *roleSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.RbacV1().Roles("test").Create(context.TODO(), &role, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().Roles("test").Create(context.TODO(), &role, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	result, err := s.coreClient.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 
 	roleResource := resources.NewRole("role1", "test", &role)
-	err = roleResource.Delete(context.TODO(), s.client)
+	err = roleResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = roleResource.Get(context.TODO(), s.client)
+	err = roleResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	_, err = s.coreClient.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/role_test.go
+++ b/caas/kubernetes/provider/resources/role_test.go
@@ -31,7 +31,7 @@ func (s *roleSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	roleResource := resources.NewRole("role1", "test", role)
-	c.Assert(roleResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(roleResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -39,7 +39,7 @@ func (s *roleSuite) TestApply(c *gc.C) {
 	// Update.
 	role.SetAnnotations(map[string]string{"a": "b"})
 	roleResource = resources.NewRole("role1", "test", role)
-	c.Assert(roleResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(roleResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *roleSuite) TestGet(c *gc.C) {
 
 	roleResource := resources.NewRole("role1", "test", &template)
 	c.Assert(len(roleResource.GetAnnotations()), gc.Equals, 0)
-	err = roleResource.Get(context.TODO(), s.coreClient)
+	err = roleResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(roleResource.GetName(), gc.Equals, `role1`)
 	c.Assert(roleResource.GetNamespace(), gc.Equals, `test`)
@@ -84,10 +84,10 @@ func (s *roleSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 
 	roleResource := resources.NewRole("role1", "test", &role)
-	err = roleResource.Delete(context.TODO(), s.coreClient)
+	err = roleResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = roleResource.Get(context.TODO(), s.coreClient)
+	err = roleResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/rolebinding.go
+++ b/caas/kubernetes/provider/resources/rolebinding.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,8 +49,8 @@ func (rb *RoleBinding) ID() ID {
 }
 
 // Apply patches the resource change.
-func (rb *RoleBinding) Apply(ctx context.Context, client kubernetes.Interface) error {
-	api := client.RbacV1().RoleBindings(rb.Namespace)
+func (rb *RoleBinding) Apply(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	api := coreClient.RbacV1().RoleBindings(rb.Namespace)
 	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, &rb.RoleBinding)
 	if err != nil {
 		return errors.Trace(err)
@@ -73,8 +74,8 @@ func (rb *RoleBinding) Apply(ctx context.Context, client kubernetes.Interface) e
 }
 
 // Get refreshes the resource.
-func (rb *RoleBinding) Get(ctx context.Context, client kubernetes.Interface) error {
-	api := client.RbacV1().RoleBindings(rb.Namespace)
+func (rb *RoleBinding) Get(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	api := coreClient.RbacV1().RoleBindings(rb.Namespace)
 	res, err := api.Get(ctx, rb.Name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return errors.NewNotFound(err, "k8s")
@@ -86,8 +87,8 @@ func (rb *RoleBinding) Get(ctx context.Context, client kubernetes.Interface) err
 }
 
 // Delete removes the resource.
-func (rb *RoleBinding) Delete(ctx context.Context, client kubernetes.Interface) error {
-	api := client.RbacV1().RoleBindings(rb.Namespace)
+func (rb *RoleBinding) Delete(ctx context.Context, coreClient kubernetes.Interface, extendedClient clientset.Interface) error {
+	api := coreClient.RbacV1().RoleBindings(rb.Namespace)
 	err := api.Delete(ctx, rb.Name, metav1.DeleteOptions{
 		PropagationPolicy: k8sconstants.DefaultPropagationPolicy(),
 	})
@@ -100,8 +101,8 @@ func (rb *RoleBinding) Delete(ctx context.Context, client kubernetes.Interface) 
 }
 
 // Events emitted by the resource.
-func (rb *RoleBinding) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
-	return ListEventsForObject(ctx, client, rb.Namespace, rb.Name, "RoleBinding")
+func (rb *RoleBinding) Events(ctx context.Context, coreClient kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, coreClient, rb.Namespace, rb.Name, "RoleBinding")
 }
 
 // ComputeStatus returns a juju status for the resource.

--- a/caas/kubernetes/provider/resources/rolebinding_test.go
+++ b/caas/kubernetes/provider/resources/rolebinding_test.go
@@ -31,17 +31,17 @@ func (s *roleBindingSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	c.Assert(rbResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	RoleBinding.SetAnnotations(map[string]string{"a": "b"})
 	rbResource = resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(rbResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err = s.coreClient.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *roleBindingSuite) TestGet(c *gc.C) {
 	}
 	roleBinding1 := template
 	roleBinding1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.RbacV1().RoleBindings("test").Create(context.TODO(), &roleBinding1, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().RoleBindings("test").Create(context.TODO(), &roleBinding1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", &template)
 	c.Assert(len(rbResource.GetAnnotations()), gc.Equals, 0)
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rbResource.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(rbResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *roleBindingSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.RbacV1().RoleBindings("test").Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	_, err := s.coreClient.RbacV1().RoleBindings("test").Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	result, err := s.coreClient.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", &roleBinding)
-	err = rbResource.Delete(context.TODO(), s.client)
+	err = rbResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.client)
+	err = rbResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	_, err = s.coreClient.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/rolebinding_test.go
+++ b/caas/kubernetes/provider/resources/rolebinding_test.go
@@ -31,7 +31,7 @@ func (s *roleBindingSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(rbResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -39,7 +39,7 @@ func (s *roleBindingSuite) TestApply(c *gc.C) {
 	// Update.
 	RoleBinding.SetAnnotations(map[string]string{"a": "b"})
 	rbResource = resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
-	c.Assert(rbResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(rbResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *roleBindingSuite) TestGet(c *gc.C) {
 
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", &template)
 	c.Assert(len(rbResource.GetAnnotations()), gc.Equals, 0)
-	err = rbResource.Get(context.TODO(), s.coreClient)
+	err = rbResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rbResource.GetName(), gc.Equals, `roleBinding1`)
 	c.Assert(rbResource.GetNamespace(), gc.Equals, `test`)
@@ -84,10 +84,10 @@ func (s *roleBindingSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
 	rbResource := resources.NewRoleBinding("roleBinding1", "test", &roleBinding)
-	err = rbResource.Delete(context.TODO(), s.coreClient)
+	err = rbResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rbResource.Get(context.TODO(), s.coreClient)
+	err = rbResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/secret_test.go
+++ b/caas/kubernetes/provider/resources/secret_test.go
@@ -31,7 +31,7 @@ func (s *secretSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewSecret("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -39,7 +39,7 @@ func (s *secretSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewSecret("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *secretSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewSecret("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -84,10 +84,10 @@ func (s *secretSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewSecret("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/secret_test.go
+++ b/caas/kubernetes/provider/resources/secret_test.go
@@ -31,17 +31,17 @@ func (s *secretSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewSecret("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewSecret("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *secretSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().Secrets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().Secrets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewSecret("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *secretSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().Secrets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().Secrets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewSecret("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.CoreV1().Secrets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/service_test.go
+++ b/caas/kubernetes/provider/resources/service_test.go
@@ -31,7 +31,7 @@ func (s *serviceSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewService("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -39,7 +39,7 @@ func (s *serviceSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewService("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *serviceSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewService("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -84,10 +84,10 @@ func (s *serviceSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewService("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/service_test.go
+++ b/caas/kubernetes/provider/resources/service_test.go
@@ -31,17 +31,17 @@ func (s *serviceSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewService("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewService("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *serviceSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().Services("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewService("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *serviceSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().Services("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().Services("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewService("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.CoreV1().Services("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/serviceaccount_test.go
+++ b/caas/kubernetes/provider/resources/serviceaccount_test.go
@@ -31,17 +31,17 @@ func (s *serviceAccountSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	saResource := resources.NewServiceAccount("sa1", "test", sa)
-	c.Assert(saResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	c.Assert(saResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	sa.SetAnnotations(map[string]string{"a": "b"})
 	saResource = resources.NewServiceAccount("sa1", "test", sa)
-	c.Assert(saResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(saResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	result, err = s.coreClient.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `sa1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *serviceAccountSuite) TestGet(c *gc.C) {
 	}
 	sa1 := template
 	sa1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.CoreV1().ServiceAccounts("test").Create(context.TODO(), &sa1, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().ServiceAccounts("test").Create(context.TODO(), &sa1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	saResource := resources.NewServiceAccount("sa1", "test", &template)
 	c.Assert(len(saResource.GetAnnotations()), gc.Equals, 0)
-	err = saResource.Get(context.TODO(), s.client)
+	err = saResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saResource.GetName(), gc.Equals, `sa1`)
 	c.Assert(saResource.GetNamespace(), gc.Equals, `test`)
@@ -76,21 +76,21 @@ func (s *serviceAccountSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().ServiceAccounts("test").Create(context.TODO(), &sa, metav1.CreateOptions{})
+	_, err := s.coreClient.CoreV1().ServiceAccounts("test").Create(context.TODO(), &sa, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	result, err := s.coreClient.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `sa1`)
 
 	saResource := resources.NewServiceAccount("sa1", "test", &sa)
-	err = saResource.Delete(context.TODO(), s.client)
+	err = saResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = saResource.Get(context.TODO(), s.client)
+	err = saResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	_, err = s.coreClient.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }
 
@@ -101,7 +101,7 @@ func (s *serviceAccountSuite) TestUpdate(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.CoreV1().ServiceAccounts("test").Create(
+	_, err := s.coreClient.CoreV1().ServiceAccounts("test").Create(
 		context.TODO(),
 		&sa,
 		metav1.CreateOptions{},
@@ -113,10 +113,10 @@ func (s *serviceAccountSuite) TestUpdate(c *gc.C) {
 	}
 
 	saResource := resources.NewServiceAccount("sa1", "test", &sa)
-	err = saResource.Update(context.TODO(), s.client)
+	err = saResource.Update(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	rsa, err := s.client.CoreV1().ServiceAccounts("test").Get(
+	rsa, err := s.coreClient.CoreV1().ServiceAccounts("test").Get(
 		context.TODO(),
 		"sa1",
 		metav1.GetOptions{},
@@ -127,10 +127,10 @@ func (s *serviceAccountSuite) TestUpdate(c *gc.C) {
 
 func (s *serviceAccountSuite) TestEnsureCreatesNew(c *gc.C) {
 	sa := resources.NewServiceAccount("sa1", "test", &corev1.ServiceAccount{})
-	cleanups, err := sa.Ensure(context.TODO(), s.client)
+	cleanups, err := sa.Ensure(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obj, err := s.client.CoreV1().ServiceAccounts("test").Get(
+	obj, err := s.coreClient.CoreV1().ServiceAccounts("test").Get(
 		context.TODO(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(&sa.ServiceAccount, jc.DeepEquals, obj)
@@ -140,7 +140,7 @@ func (s *serviceAccountSuite) TestEnsureCreatesNew(c *gc.C) {
 	}
 
 	// Test cleanup removes service account
-	_, err = s.client.CoreV1().ServiceAccounts("test").Get(
+	_, err = s.coreClient.CoreV1().ServiceAccounts("test").Get(
 		context.TODO(), "sa1", metav1.GetOptions{})
 	c.Assert(k8serrors.IsNotFound(err), jc.IsTrue)
 }
@@ -153,7 +153,7 @@ func (s *serviceAccountSuite) TestEnsureUpdates(c *gc.C) {
 		},
 	}
 
-	_, err := s.client.CoreV1().ServiceAccounts("testing").Create(
+	_, err := s.coreClient.CoreV1().ServiceAccounts("testing").Create(
 		context.TODO(), sa, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -162,10 +162,10 @@ func (s *serviceAccountSuite) TestEnsureUpdates(c *gc.C) {
 	}
 
 	resource := resources.NewServiceAccount("sa2", "testing", sa)
-	_, err = resource.Ensure(context.TODO(), s.client)
+	_, err = resource.Ensure(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	obj, err := s.client.CoreV1().ServiceAccounts("testing").Get(
+	obj, err := s.coreClient.CoreV1().ServiceAccounts("testing").Get(
 		context.TODO(), sa.Name, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/caas/kubernetes/provider/resources/serviceaccount_test.go
+++ b/caas/kubernetes/provider/resources/serviceaccount_test.go
@@ -31,7 +31,7 @@ func (s *serviceAccountSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	saResource := resources.NewServiceAccount("sa1", "test", sa)
-	c.Assert(saResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(saResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -39,7 +39,7 @@ func (s *serviceAccountSuite) TestApply(c *gc.C) {
 	// Update.
 	sa.SetAnnotations(map[string]string{"a": "b"})
 	saResource = resources.NewServiceAccount("sa1", "test", sa)
-	c.Assert(saResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(saResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *serviceAccountSuite) TestGet(c *gc.C) {
 
 	saResource := resources.NewServiceAccount("sa1", "test", &template)
 	c.Assert(len(saResource.GetAnnotations()), gc.Equals, 0)
-	err = saResource.Get(context.TODO(), s.coreClient)
+	err = saResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saResource.GetName(), gc.Equals, `sa1`)
 	c.Assert(saResource.GetNamespace(), gc.Equals, `test`)
@@ -84,10 +84,10 @@ func (s *serviceAccountSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `sa1`)
 
 	saResource := resources.NewServiceAccount("sa1", "test", &sa)
-	err = saResource.Delete(context.TODO(), s.coreClient)
+	err = saResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = saResource.Get(context.TODO(), s.coreClient)
+	err = saResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
@@ -127,7 +127,7 @@ func (s *serviceAccountSuite) TestUpdate(c *gc.C) {
 
 func (s *serviceAccountSuite) TestEnsureCreatesNew(c *gc.C) {
 	sa := resources.NewServiceAccount("sa1", "test", &corev1.ServiceAccount{})
-	cleanups, err := sa.Ensure(context.TODO(), s.coreClient)
+	cleanups, err := sa.Ensure(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
 	obj, err := s.coreClient.CoreV1().ServiceAccounts("test").Get(
@@ -162,7 +162,7 @@ func (s *serviceAccountSuite) TestEnsureUpdates(c *gc.C) {
 	}
 
 	resource := resources.NewServiceAccount("sa2", "testing", sa)
-	_, err = resource.Ensure(context.TODO(), s.coreClient)
+	_, err = resource.Ensure(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
 	obj, err := s.coreClient.CoreV1().ServiceAccounts("testing").Get(

--- a/caas/kubernetes/provider/resources/statefulset_test.go
+++ b/caas/kubernetes/provider/resources/statefulset_test.go
@@ -31,7 +31,7 @@ func (s *statefulSetSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewStatefulSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -39,7 +39,7 @@ func (s *statefulSetSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewStatefulSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *statefulSetSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewStatefulSet("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -84,10 +84,10 @@ func (s *statefulSetSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewStatefulSet("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/caas/kubernetes/provider/resources/statefulset_test.go
+++ b/caas/kubernetes/provider/resources/statefulset_test.go
@@ -31,17 +31,17 @@ func (s *statefulSetSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewStatefulSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewStatefulSet("ds1", "test", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), gc.Equals, `test`)
@@ -57,12 +57,12 @@ func (s *statefulSetSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.AppsV1().StatefulSets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.AppsV1().StatefulSets("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewStatefulSet("ds1", "test", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
@@ -76,20 +76,20 @@ func (s *statefulSetSuite) TestDelete(c *gc.C) {
 			Namespace: "test",
 		},
 	}
-	_, err := s.client.AppsV1().StatefulSets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.AppsV1().StatefulSets("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewStatefulSet("ds1", "test", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.AppsV1().StatefulSets("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/storageclass_test.go
+++ b/caas/kubernetes/provider/resources/storageclass_test.go
@@ -30,17 +30,17 @@ func (s *storageClassSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewStorageClass("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
-	result, err := s.client.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	result, err := s.coreClient.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
 
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewStorageClass("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
 
-	result, err = s.client.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err = s.coreClient.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -54,12 +54,12 @@ func (s *storageClassSuite) TestGet(c *gc.C) {
 	}
 	ds1 := template
 	ds1.SetAnnotations(map[string]string{"a": "b"})
-	_, err := s.client.StorageV1().StorageClasses().Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	_, err := s.coreClient.StorageV1().StorageClasses().Create(context.TODO(), &ds1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dsResource := resources.NewStorageClass("ds1", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -71,20 +71,20 @@ func (s *storageClassSuite) TestDelete(c *gc.C) {
 			Name: "ds1",
 		},
 	}
-	_, err := s.client.StorageV1().StorageClasses().Create(context.TODO(), &ds, metav1.CreateOptions{})
+	_, err := s.coreClient.StorageV1().StorageClasses().Create(context.TODO(), &ds, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.client.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	result, err := s.coreClient.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewStorageClass("ds1", &ds)
-	err = dsResource.Delete(context.TODO(), s.client)
+	err = dsResource.Delete(context.TODO(), s.coreClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.client)
+	err = dsResource.Get(context.TODO(), s.coreClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = s.client.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
+	_, err = s.coreClient.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/storageclass_test.go
+++ b/caas/kubernetes/provider/resources/storageclass_test.go
@@ -30,7 +30,7 @@ func (s *storageClassSuite) TestApply(c *gc.C) {
 	}
 	// Create.
 	dsResource := resources.NewStorageClass("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 	result, err := s.coreClient.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
@@ -38,7 +38,7 @@ func (s *storageClassSuite) TestApply(c *gc.C) {
 	// Update.
 	ds.SetAnnotations(map[string]string{"a": "b"})
 	dsResource = resources.NewStorageClass("ds1", ds)
-	c.Assert(dsResource.Apply(context.TODO(), s.coreClient), jc.ErrorIsNil)
+	c.Assert(dsResource.Apply(context.TODO(), s.coreClient, s.extendedClient), jc.ErrorIsNil)
 
 	result, err = s.coreClient.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -59,7 +59,7 @@ func (s *storageClassSuite) TestGet(c *gc.C) {
 
 	dsResource := resources.NewStorageClass("ds1", &template)
 	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
 	c.Assert(dsResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
@@ -79,10 +79,10 @@ func (s *storageClassSuite) TestDelete(c *gc.C) {
 	c.Assert(result.GetName(), gc.Equals, `ds1`)
 
 	dsResource := resources.NewStorageClass("ds1", &ds)
-	err = dsResource.Delete(context.TODO(), s.coreClient)
+	err = dsResource.Delete(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = dsResource.Get(context.TODO(), s.coreClient)
+	err = dsResource.Get(context.TODO(), s.coreClient, s.extendedClient)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	_, err = s.coreClient.StorageV1().StorageClasses().Get(context.TODO(), "ds1", metav1.GetOptions{})

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -274,6 +274,8 @@ func appDead(appName string, app caas.Application,
 	if err != nil {
 		return errors.Trace(err)
 	}
+	err = broker.DeleteService(appName)
+	logger.Errorf("alvin delete svc err %v", err)
 	// Clear "has-resources" flag so state knows it can now remove the application.
 	err = facade.ClearApplicationResources(appName)
 	if err != nil {


### PR DESCRIPTION
When a charm creates custom resource definitions (CRDs) and is later removed, Juju does not currently clean up those CRDs. This task aims to address that gap by ensuring CRDs created by a charm are properly removed on application teardown.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

TBD

1. Check crds do not exist for namespace
```sh
kubectl get crds -n testcrdupdate
```

2. Checkout branch, push updated image and bootstrap a 3.6 controller.
```sh
make minikube-operator-update && juju bootstrap minikube testcrdupdate --debug && juju add-model testcrdupdate &&  juju deploy istio-k8s --trust
```

3. Check crds created 
```sh
kubectl get crds -n testcrdupdate
```

4. Remove application
```sh
juju remove-application istio-k8s
```

5. Check crds have been removed
```sh
kubectl get crds -n testcrdupdate
```



## Links

**Github issue:** [Github Issue juju/juju#20180](https://github.com/juju/juju/issues/20180)

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-8265