### PR TITLE
feat: use state base prepare over sqlair

### DIFF
--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -835,7 +835,7 @@ AND    grant_to IN (
        WHERE  name = $permInOut.name
 )
 `
-	deletePermissionStmt, err := sqlair.Prepare(deletePermission, permInOut{})
+	deletePermissionStmt, err := st.Prepare(deletePermission, permInOut{})
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1257,7 +1257,7 @@ func (st *State) insertCloudServiceAddresses(
 		}
 	}
 
-	insertAddressStmt, err := sqlair.Prepare(`
+	insertAddressStmt, err := st.Prepare(`
 INSERT INTO ip_address (*)
 VALUES ($ipAddress.*);
 `, ipAddress{})

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -2460,7 +2460,7 @@ WHERE  device_uuid = $ipAddress.device_uuid;
 		return errors.Capture(err)
 	}
 
-	upsertAddressStmt, err := sqlair.Prepare(`
+	upsertAddressStmt, err := st.Prepare(`
 INSERT INTO ip_address (*)
 VALUES ($ipAddress.*)
 ON CONFLICT(uuid) DO UPDATE SET
@@ -2513,7 +2513,7 @@ AND unit_uuid = $unitK8sPodPort.unit_uuid;
 		return errors.Capture(err)
 	}
 
-	upsertStmt, err := sqlair.Prepare(`
+	upsertStmt, err := st.Prepare(`
 INSERT INTO k8s_pod_port (*)
 VALUES ($unitK8sPodPort.*)
 ON CONFLICT(unit_uuid, port)

--- a/domain/machine/state/reboot.go
+++ b/domain/machine/state/reboot.go
@@ -27,7 +27,7 @@ func (st *State) RequireMachineReboot(ctx context.Context, uuid machine.UUID) er
 	}
 	machineUUIDParam := entityUUID{uuid.String()}
 	setRebootFlag := `INSERT INTO machine_requires_reboot (machine_uuid) VALUES ($entityUUID.uuid)`
-	setRebootFlagStmt, err := sqlair.Prepare(setRebootFlag, machineUUIDParam)
+	setRebootFlagStmt, err := st.Prepare(setRebootFlag, machineUUIDParam)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -59,7 +59,7 @@ func (st *State) ClearMachineReboot(ctx context.Context, uuid machine.UUID) erro
 	}
 	machineUUIDParam := entityUUID{uuid.String()}
 	unsetRebootFlag := `DELETE FROM machine_requires_reboot WHERE machine_uuid = $entityUUID.uuid`
-	unsetRebootFlagStmt, err := sqlair.Prepare(unsetRebootFlag, machineUUIDParam)
+	unsetRebootFlagStmt, err := st.Prepare(unsetRebootFlag, machineUUIDParam)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -86,7 +86,7 @@ func (st *State) IsMachineRebootRequired(ctx context.Context, uuid machine.UUID)
 	var isRebootRequired bool
 	machineUUIDParam := entityUUID{uuid.String()}
 	isRebootFlag := `SELECT machine_uuid as &entityUUID.uuid  FROM machine_requires_reboot WHERE machine_uuid = $entityUUID.uuid`
-	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineUUIDParam)
+	isRebootFlagStmt, err := st.Prepare(isRebootFlag, machineUUIDParam)
 	if err != nil {
 		return false, errors.Capture(err)
 	}
@@ -130,14 +130,14 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid machine.UUID) 
 	// Prepare query to get parent UUID
 	machineUUIDParam := entityUUID{uuid.String()}
 	getParentQuery := `SELECT machine_parent.parent_uuid as &entityUUID.uuid  FROM machine_parent WHERE machine_uuid = $entityUUID.uuid`
-	getParentStmt, err := sqlair.Prepare(getParentQuery, machineUUIDParam)
+	getParentStmt, err := st.Prepare(getParentQuery, machineUUIDParam)
 	if err != nil {
 		return machine.ShouldDoNothing, errors.Errorf("requiring reboot action for machine %q: %w", uuid, err)
 	}
 
 	// Prepare query to check if a machine requires reboot
 	isRebootFlag := `SELECT machine_uuid as &entityUUID.uuid  FROM machine_requires_reboot WHERE machine_uuid = $entityUUID.uuid`
-	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineUUIDParam)
+	isRebootFlagStmt, err := st.Prepare(isRebootFlag, machineUUIDParam)
 	if err != nil {
 		return machine.ShouldDoNothing, errors.Errorf("requiring reboot action for machine %q: %w", uuid, err)
 	}

--- a/domain/storage/state/storagepool.go
+++ b/domain/storage/state/storagepool.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 
@@ -122,11 +121,11 @@ type keysToKeep []string
 
 func poolAttributesUpdater() (updatePoolAttributesFunc, error) {
 	// Delete any keys no longer in the attributes map.
-	deleteQuery := fmt.Sprintf(`
+	deleteQuery := `
 DELETE FROM  storage_pool_attribute
 WHERE        storage_pool_uuid = $M.uuid
 AND          key NOT IN ($keysToKeep[:])
-`)
+`
 
 	deleteStmt, err := sqlair.Prepare(deleteQuery, sqlair.M{}, keysToKeep{})
 	if err != nil {
@@ -234,7 +233,7 @@ func (st State) ReplaceStoragePool(ctx context.Context, pool domainstorage.Stora
 		return errors.Capture(err)
 	}
 
-	checkExistanceStmt, err := sqlair.Prepare(`
+	checkExistanceStmt, err := st.Prepare(`
 SELECT &storagePoolIdentifiers.*
 FROM   storage_pool 
 WHERE  uuid = $storagePoolIdentifiers.uuid`, storagePoolIdentifiers{})
@@ -281,7 +280,7 @@ func (st State) ListStoragePoolsWithoutBuiltins(ctx context.Context) ([]domainst
 		return nil, errors.Capture(err)
 	}
 
-	stmt, err := sqlair.Prepare(`
+	stmt, err := st.Prepare(`
 SELECT   (sp.*) AS (&storagePool.*),
          (sp_attr.*) AS (&poolAttribute.*)
 FROM     storage_pool sp
@@ -318,7 +317,7 @@ func (st State) ListStoragePools(ctx context.Context) ([]domainstorage.StoragePo
 		return nil, errors.Capture(err)
 	}
 
-	stmt, err := sqlair.Prepare(`
+	stmt, err := st.Prepare(`
 SELECT   (sp.*) AS (&storagePool.*),
          (sp_attr.*) AS (&poolAttribute.*)
 FROM     storage_pool sp
@@ -364,7 +363,7 @@ func (st State) ListStoragePoolsByNamesAndProviders(
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	stmt, err := sqlair.Prepare(`
+	stmt, err := st.Prepare(`
 SELECT   (sp.*) AS (&storagePool.*),
          (sp_attr.*) AS (&poolAttribute.*)
 FROM     storage_pool sp
@@ -412,7 +411,7 @@ func (st State) ListStoragePoolsByNames(
 		return nil, errors.Capture(err)
 	}
 
-	stmt, err := sqlair.Prepare(`
+	stmt, err := st.Prepare(`
 SELECT   (sp.*) AS (&storagePool.*),
          (sp_attr.*) AS (&poolAttribute.*)
 FROM     storage_pool sp
@@ -458,7 +457,7 @@ func (st State) ListStoragePoolsByProviders(
 		return nil, errors.Capture(err)
 	}
 
-	stmt, err := sqlair.Prepare(`
+	stmt, err := st.Prepare(`
 SELECT   (sp.*) AS (&storagePool.*),
          (sp_attr.*) AS (&poolAttribute.*)
 FROM     storage_pool sp

--- a/internal/worker/changestreampruner/worker.go
+++ b/internal/worker/changestreampruner/worker.go
@@ -150,9 +150,8 @@ func (w *Pruner) prune() (map[string]int64, error) {
 	}
 
 	query, err := sqlair.Prepare(`
-		SELECT namespace AS &ModelNamespace.namespace,
-               model_uuid AS &ModelNamespace.uuid
-        FROM model_namespace;
+SELECT namespace AS &ModelNamespace.namespace, model_uuid AS &ModelNamespace.uuid
+FROM model_namespace;
 	`, ModelNamespace{})
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
We shouldn't use sqlair Prepare directly because it's expensive, as we parse the statement every single time.
