### PR TITLE
test: use 'provider' container networking on supported clouds by default in ci tests

### DIFF
--- a/tests/ENV.md
+++ b/tests/ENV.md
@@ -2,19 +2,20 @@ The following is a list of environment variables that are used to control
 behaviour in the Bash tests. This list may not be complete, and as always, the
 definitive source is the code.
 
-| Variable name                | Description                                                                        |
-|------------------------------|------------------------------------------------------------------------------------|
-| `BOOTSTRAP_ADDITIONAL_ARGS`  | Additional arguments passed to `juju bootstrap`.                                   |
-| `BOOTSTRAP_ARCH`             | Architecture to bootstrap on - passed to `--bootstrap-constraints`.                |
-| `BOOTSTRAP_CLOUD`            | The cloud to use when bootstrapping (i.e. the first argument to `juju bootstrap`). |
-| `BOOTSTRAP_PROVIDER`         | The provider to use when bootstrapping (see the `provider` package).               |
-| `BOOTSTRAP_REUSE`            | Reuse an existing controller when asked to bootstrap (true/false).                 |
-| `BOOTSTRAP_REUSE_LOCAL`      | The name of a local controller to reuse for testing. Set using the `-l` flag.      |
-| `BOOTSTRAP_SERIES`           | Series to use for the controller. Set using the `-S` flag.                         |
-| `CONTROLLER_CHARM_CHANNEL`   | The channel to pull the controller charm from (CaaS only).                         |
-| `CONTROLLER_CHARM_PATH_CAAS` | The Charmhub charm name to pull the controller charm from (CaaS only).             |
-| `CONTROLLER_CHARM_PATH_IAAS` | Path to a locally built controller charm to use (IaaS only).                       |
-| `KILL_CONTROLLER`            | If `'true'`, controllers will be forcibly killed during teardown.                  |
-| `MODEL_ARCH`                 | Will be set as a model constraint on newly added models.                           |
-| `OPERATOR_IMAGE_ACCOUNT`     | Passed as the value of `--config caas-image-repo` when bootstrapping.              |
-| `TEST_INSPECT`               | If set, pause before teardown to allow inspection of the controller.               |
+| Variable name                 | Description                                                                        |
+|-------------------------------|------------------------------------------------------------------------------------|
+| `BOOTSTRAP_ADDITIONAL_ARGS`   | Additional arguments passed to `juju bootstrap`.                                   |
+| `BOOTSTRAP_ARCH`              | Architecture to bootstrap on - passed to `--bootstrap-constraints`.                |
+| `BOOTSTRAP_CLOUD`             | The cloud to use when bootstrapping (i.e. the first argument to `juju bootstrap`). |
+| `BOOTSTRAP_PROVIDER`          | The provider to use when bootstrapping (see the `provider` package).               |
+| `BOOTSTRAP_REUSE`             | Reuse an existing controller when asked to bootstrap (true/false).                 |
+| `BOOTSTRAP_REUSE_LOCAL`       | The name of a local controller to reuse for testing. Set using the `-l` flag.      |
+| `BOOTSTRAP_SERIES`            | Series to use for the controller. Set using the `-S` flag.                         |
+| `CONTROLLER_CHARM_CHANNEL`    | The channel to pull the controller charm from (CaaS only).                         |
+| `CONTROLLER_CHARM_PATH_CAAS`  | The Charmhub charm name to pull the controller charm from (CaaS only).             |
+| `CONTROLLER_CHARM_PATH_IAAS`  | Path to a locally built controller charm to use (IaaS only).                       |
+| `KILL_CONTROLLER`             | If `'true'`, controllers will be forcibly killed during teardown.                  |
+| `MODEL_ARCH`                  | Will be set as a model constraint on newly added models.                           |
+| `OPERATOR_IMAGE_ACCOUNT`      | Passed as the value of `--config caas-image-repo` when bootstrapping.              |
+| `TEST_INSPECT`                | If set, pause before teardown to allow inspection of the controller.               |
+| `CONTAINER_NETWORKING_METHOD` | If set, the default container networking method (`local`, `provider`, or `fan`).   |

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -59,6 +59,16 @@ ensure() {
 # ```
 bootstrap() {
 	local cloud name output model bootstrapped_name
+	# Handle provider aliases.
+	case "${BOOTSTRAP_PROVIDER:-}" in
+	"aws")
+		BOOTSTRAP_PROVIDER="ec2"
+		;;
+	"google")
+		BOOTSTRAP_PROVIDER="gce"
+		;;
+	esac
+
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"ec2")
 		cloud="aws"
@@ -319,6 +329,17 @@ pre_bootstrap() {
 	else
 		if [[ -n ${CONTROLLER_CHARM_PATH_IAAS:-} ]]; then
 			export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --controller-charm-path=${CONTROLLER_CHARM_PATH_IAAS}"
+		fi
+		case "${BOOTSTRAP_PROVIDER:-}" in
+		"ec2" | "gce" | "openstack")
+			# Don't use fan unless we really need to.
+			if [[ -z ${CONTAINER_NETWORKING_METHOD:-} ]]; then
+				CONTAINER_NETWORKING_METHOD="local"
+			fi
+			;;
+		esac
+		if [[ -n ${CONTAINER_NETWORKING_METHOD:-} ]]; then
+			export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default container-networking-method=${CONTAINER_NETWORKING_METHOD}"
 		fi
 	fi
 


### PR DESCRIPTION
We don't have any ci tests which use fan networking for containers. On AWS and Google clouds, upstream kernel changes have broken fan. The Juju ci tests have an option added which makes the use of fan opt in. None of the tests use it right now, but we can re-tool Jenkins to run a test job with fan enabled if we want to do just a smoke test. To do that, we use the CONTAINER_NETWORKING_METHOD env var:
```
export CONTAINER_NETWORKING_METHOD=fan
./main.sh -v -p aws network
```

Also includes a drive by fix to make the allowed clouds match the doc, ie either "aws" or "ec2" can be used.

## QA steps

`./main.sh -v -p aws network`

