### PR TITLE
fix(docs): improve excalidraw conversion script with dependency auto-installation

### DIFF
--- a/docs/Makefile.sp
+++ b/docs/Makefile.sp
@@ -72,7 +72,7 @@ sp-convert-excalidraw-to-svg:
 
 sp-install: $(VENVDIR)
 
-sp-run: sp-install
+sp-run: sp-install sp-convert-excalidraw-to-svg
 	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.

--- a/docs/scripts/convert-excalidraw-to-svg-recursively.sh
+++ b/docs/scripts/convert-excalidraw-to-svg-recursively.sh
@@ -4,24 +4,50 @@ set -euo pipefail
 # This script recursively finds all .excalidraw files in the current directory
 # and converts them to SVG format using the excalidraw-brute-export-cli tool.
 
-find . -type f -name '*.excalidraw' | while IFS= read -r file; do
-  #check if file has diff in git environment
-  if git diff --quiet "$file"; then
-    echo "No changes detected in $file, skipping export."
+# Find all .excalidraw filenames in the current directory that are modified in the git diff and drop the .excalidraw
+# extension
+excalidraw_files_without_extension=$(git diff --name-only --relative HEAD -- '*.excalidraw' | sed 's/\.excalidraw$//')
+
+# Find all original .svg filenames in the current directory that are modified in the git diff and drop the .svg
+# extension
+svg_files_without_extension=$(git diff --name-status --relative HEAD -- '*.svg' | awk '{print $2}' | sed 's/\.svg$//')
+
+# Unite list of excalidraw_files_without_extension and svg_files_without_extension excluding duplicates
+files_without_extention=$(echo -e "$excalidraw_files_without_extension\n$svg_files_without_extension" | sort -u)
+
+# If no files are found, exit the script
+if [ -z "$files_without_extention" ]; then
+  echo "No .excalidraw files to convert, exiting."
+  exit 0
+fi
+
+# Check if excalidraw-brute-export-cli is available, install dependencies if needed
+if ! npx --no-install excalidraw-brute-export-cli --help &>/dev/null; then
+  echo "excalidraw-brute-export-cli not found, installing dependencies..."
+  npx playwright install-deps
+  echo "Dependencies installed successfully."
+fi
+
+# Explicitly install Playwright browsers, to avoid issues with missing browsers in cache
+echo "Installing Playwright browsers..."
+npx playwright install
+
+echo "Starting conversion of .excalidraw files to .svg..."
+echo $files_without_extention | tr ' ' '\n' | while IFS= read -r file; do
+  # Check if the excalidraw file exists
+  if [[ ! -f "$file.excalidraw" ]]; then
+    echo "File $file.excalidraw does not exist, skipping."
     continue
   fi
 
-  dir=$(dirname "$file")
-  base=$(basename  "$file" .excalidraw)
-  out="$dir/$base.svg"
-  echo "Exporting → $file  to  $out"
+  echo "Exporting → $file.excalidraw  to  $file.svg"
   npx excalidraw-brute-export-cli \
-        -i "$file" \
+        -i "$file.excalidraw" \
         --background 0 \
         --embed-scene 1 \
         --dark-mode 0 \
         --scale 1 \
         --format svg \
         --quiet \
-        -o "$out"
+        -o "$file.svg"
 done


### PR DESCRIPTION
This PR enhances the developer documentation workflow by ensuring all diagrams are 
properly converted without manual intervention, improving the reliability of 
'make docs' and related build targets.

- Add automatic detection and installation of excalidraw-brute-export-cli dependencies
- First install Playwright dependencies with 'npx playwright install-deps'
- Then explicitly install Playwright browsers with 'npx playwright install'
- Track both modified excalidraw files and SVG files using git diff
- Skip conversion for non-existent excalidraw files
- Provide clear logging for each step of the process
- Exit early if no files need conversion

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

```sh
# from juju folder
rm docs/tutorial/tutorial-setup.svg
cd docs
make html
# removed file should be re-created
```

**Jira card:** JUJU-