### PR TITLE
feat: status history for controller model

### DIFF
--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
 	coretrace "github.com/juju/juju/core/trace"
+	"github.com/juju/juju/domain"
 	"github.com/juju/juju/environs"
 	internalbootstrap "github.com/juju/juju/internal/bootstrap"
 	"github.com/juju/juju/internal/charmhub"
@@ -887,12 +888,13 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			DomainServicesName:      domainServicesName,
 			HTTPClientName:          httpClientName,
 			BootstrapGateName:       isBootstrapGateName,
-			RequiresBootstrap:       bootstrap.RequiresBootstrap,
-			PopulateControllerCharm: bootstrap.PopulateIAASControllerCharm,
-			Logger:                  internallogger.GetLogger("juju.worker.bootstrap"),
-			Clock:                   config.Clock,
 			ProviderFactoryName:     providerTrackerName,
 			StorageRegistryName:     storageRegistryName,
+			RequiresBootstrap:       bootstrap.RequiresBootstrap,
+			PopulateControllerCharm: bootstrap.PopulateIAASControllerCharm,
+			StatusHistory:           domain.NewStatusHistory(internallogger.GetLogger("juju.services"), config.Clock),
+			Logger:                  internallogger.GetLogger("juju.worker.bootstrap"),
+			Clock:                   config.Clock,
 
 			AgentBinaryUploader:          bootstrap.IAASAgentBinaryUploader,
 			ControllerCharmDeployer:      bootstrap.IAASControllerCharmUploader,
@@ -1109,12 +1111,13 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			DomainServicesName:      domainServicesName,
 			HTTPClientName:          httpClientName,
 			BootstrapGateName:       isBootstrapGateName,
-			RequiresBootstrap:       bootstrap.RequiresBootstrap,
-			PopulateControllerCharm: bootstrap.PopulateCAASControllerCharm,
-			Logger:                  internallogger.GetLogger("juju.worker.bootstrap"),
-			Clock:                   config.Clock,
 			ProviderFactoryName:     providerTrackerName,
 			StorageRegistryName:     storageRegistryName,
+			RequiresBootstrap:       bootstrap.RequiresBootstrap,
+			PopulateControllerCharm: bootstrap.PopulateCAASControllerCharm,
+			StatusHistory:           domain.NewStatusHistory(internallogger.GetLogger("juju.services"), config.Clock),
+			Logger:                  internallogger.GetLogger("juju.worker.bootstrap"),
+			Clock:                   config.Clock,
 
 			AgentBinaryUploader:          bootstrap.CAASAgentBinaryUploader,
 			ControllerCharmDeployer:      bootstrap.CAASControllerCharmUploader,

--- a/internal/worker/bootstrap/manifold_test.go
+++ b/internal/worker/bootstrap/manifold_test.go
@@ -129,6 +129,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		AgentFinalizer: func(ctx context.Context, aps AgentPasswordService, ms MachineService, sip instancecfg.StateInitializationParams, c agent.Config) error {
 			return nil
 		},
+		StatusHistory: s.statusHistory,
 	}
 }
 

--- a/internal/worker/bootstrap/package_test.go
+++ b/internal/worker/bootstrap/package_test.go
@@ -4,11 +4,13 @@
 package bootstrap
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/domain"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/uuid"
@@ -55,7 +57,8 @@ type baseSuite struct {
 	httpClient                 *MockHTTPClient
 	httpClientGetter           *MockHTTPClientGetter
 
-	logger logger.Logger
+	statusHistory StatusHistory
+	logger        logger.Logger
 }
 
 func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
@@ -88,6 +91,36 @@ func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.httpClientGetter = NewMockHTTPClientGetter(ctrl)
 
 	s.logger = loggertesting.WrapCheckLog(c)
+	s.statusHistory = domain.NewStatusHistory(s.logger, clock.WallClock)
+
+	c.Cleanup(func() {
+		s.agent = nil
+		s.agentConfig = nil
+		s.controllerAgentBinaryStore = nil
+		s.objectStore = nil
+		s.objectStoreGetter = nil
+		s.storageRegistryGetter = nil
+		s.bootstrapUnlocker = nil
+		s.domainServices = nil
+		s.controllerConfigService = nil
+		s.cloudService = nil
+		s.storageService = nil
+		s.agentPasswordService = nil
+		s.applicationService = nil
+		s.controllerNodeService = nil
+		s.modelConfigService = nil
+		s.machineService = nil
+		s.keyManagerService = nil
+		s.userService = nil
+		s.networkService = nil
+		s.bakeryConfigService = nil
+		s.flagService = nil
+		s.httpClient = nil
+		s.httpClientGetter = nil
+
+		s.logger = nil
+		s.statusHistory = nil
+	})
 
 	return ctrl
 }

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -136,7 +136,8 @@ func (s *workerSuite) TestSeedAgentBinary(c *tc.C) {
 			PopulateControllerCharm: func(context.Context, bootstrap.ControllerCharmDeployer) error {
 				return nil
 			},
-			Logger: s.logger,
+			StatusHistory: s.statusHistory,
+			Logger:        s.logger,
 		},
 	}
 	cleanup, err := w.seedAgentBinary(c.Context(), c.MkDir())
@@ -336,7 +337,6 @@ func (s *workerSuite) newWorker(c *tc.C) worker.Worker {
 
 func (s *workerSuite) newWorkerWithFunc(c *tc.C, controllerCharmDeployerFunc ControllerCharmDeployerFunc) worker.Worker {
 	w, err := newWorker(WorkerConfig{
-		Logger:                     s.logger,
 		Agent:                      s.agent,
 		ObjectStoreGetter:          s.objectStoreGetter,
 		BootstrapUnlocker:          s.bootstrapUnlocker,
@@ -370,7 +370,9 @@ func (s *workerSuite) newWorkerWithFunc(c *tc.C, controllerCharmDeployerFunc Con
 		AgentFinalizer: func(ctx context.Context, aps AgentPasswordService, ms MachineService, sip instancecfg.StateInitializationParams, c agent.Config) error {
 			return nil
 		},
-		Clock: clock.WallClock,
+		StatusHistory: s.statusHistory,
+		Logger:        s.logger,
+		Clock:         clock.WallClock,
 	}, s.states)
 	c.Assert(err, tc.ErrorIsNil)
 	return w


### PR DESCRIPTION
We are unable to insert the status history for a controller model at the time of creation, so instead we need to do it in the bootstrap worker. This aligns the controller model with all other models. In fact the time used for insertion is actually correct, because the status indicates when the controller model is "available" which is indeed correct when we write the status.

----

This pull request introduces the recording of model status history during the bootstrap process. The main changes ensure that a `StatusHistory` interface is passed through the bootstrap worker's configuration, validated, and invoked to record the model's status as "Available" at the end of a successful bootstrap. Additionally, related test code and configuration validation are updated to support this new dependency.

**Status history recording integration:**

* Added a `StatusHistory` interface to the bootstrap worker and manifold configuration, ensuring status information can be recorded in a standardized way. This includes validation to require the presence of a `StatusHistory` implementation. [[1]](diffhunk://#diff-818a6000f94e7fdf20ceda11a9c702f970daf56b0a700efcabddc54049a55e33R74-R81) [[2]](diffhunk://#diff-818a6000f94e7fdf20ceda11a9c702f970daf56b0a700efcabddc54049a55e33R99) [[3]](diffhunk://#diff-818a6000f94e7fdf20ceda11a9c702f970daf56b0a700efcabddc54049a55e33R149-R157) [[4]](diffhunk://#diff-1d886eb1ed36dd80b610a7f508d63047b237e755aa059611e31869a118cbe7d4R77) [[5]](diffhunk://#diff-1d886eb1ed36dd80b610a7f508d63047b237e755aa059611e31869a118cbe7d4L147-R164)
* At the end of the bootstrap worker's main loop, the model's status is now recorded as `Available` using the `StatusHistory` interface, with errors logged as warnings if recording fails.

**Configuration and dependency wiring:**

* Updated the IAAS and CAAS manifold constructors to inject the new `StatusHistory` dependency from the domain layer, and ensured the correct ordering of configuration parameters. [[1]](diffhunk://#diff-e50517ed0e30987c3d6010dc5b66fe398f9a3dc7a22e89f8e07a506fd7cab07aR891-L895) [[2]](diffhunk://#diff-e50517ed0e30987c3d6010dc5b66fe398f9a3dc7a22e89f8e07a506fd7cab07aR1114-L1117)
* Updated imports to include required packages for status history and related types. [[1]](diffhunk://#diff-e50517ed0e30987c3d6010dc5b66fe398f9a3dc7a22e89f8e07a506fd7cab07aR35) [[2]](diffhunk://#diff-818a6000f94e7fdf20ceda11a9c702f970daf56b0a700efcabddc54049a55e33R23-R28) [[3]](diffhunk://#diff-1d886eb1ed36dd80b610a7f508d63047b237e755aa059611e31869a118cbe7d4R22-R29) [[4]](diffhunk://#diff-1aac26433c4db8469282493da7e6b28ef598e900e1f87a716c96f64161df2c14R7-R13)

**Testing and test setup:**

* Updated test suites to provide a mock or real `StatusHistory` implementation, and to clean up this dependency after each test. [[1]](diffhunk://#diff-b37ff6037e9b1f9de90d38caf60a6898ebb5b220ccd01577827bab6f8e5cff73R132) [[2]](diffhunk://#diff-1aac26433c4db8469282493da7e6b28ef598e900e1f87a716c96f64161df2c14R60) [[3]](diffhunk://#diff-1aac26433c4db8469282493da7e6b28ef598e900e1f87a716c96f64161df2c14R94-R123) [[4]](diffhunk://#diff-5813e18417bc51e013be3295aaa0772d9fa266cc4739f250a2f665589bf76fd8R139) [[5]](diffhunk://#diff-5813e18417bc51e013be3295aaa0772d9fa266cc4739f250a2f665589bf76fd8R373-R374)
* Ensured test worker creation includes the `StatusHistory` dependency.

**Code organization and validation:**

* Reordered validation checks in configuration validation methods to ensure the new dependency is checked and errors are surfaced clearly. [[1]](diffhunk://#diff-818a6000f94e7fdf20ceda11a9c702f970daf56b0a700efcabddc54049a55e33L117-L122) [[2]](diffhunk://#diff-1d886eb1ed36dd80b610a7f508d63047b237e755aa059611e31869a118cbe7d4L147-R164)
* Minor code cleanup, such as adding a generic pointer helper function.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju show-status-log --type model -m controller
Time                        Type   Status     Message
11 Aug 2025 10:28:08+01:00  model  available
```
