### PR TITLE
fix: detect space requirements for apps with only a default binding

### DIFF
--- a/domain/network/service/container.go
+++ b/domain/network/service/container.go
@@ -140,18 +140,18 @@ func (s *Service) spacesAndDevicesForMachine(
 
 	s.logger.Infof(ctx, "machine %q needs spaces %v", guestUUID, spaceNames)
 
-	nodeUUID, err := s.st.GetMachineNetNodeUUID(ctx, hostUUID.String())
+	hostNodeUUID, err := s.st.GetMachineNetNodeUUID(ctx, hostUUID.String())
 	if err != nil {
 		return "", nil, nil, errors.Errorf("retrieving net node for machine %q: %w", hostUUID, err)
 	}
 
-	nics, err := s.st.NICsInSpaces(ctx, nodeUUID)
+	nics, err := s.st.NICsInSpaces(ctx, hostNodeUUID)
 	if err != nil {
 		return "", nil, nil, errors.Errorf("retrieving NICs for machine %q: %w", hostUUID, err)
 	}
 
-	s.logger.Debugf(ctx, "devices by space for machine %q: %#v", guestUUID, nics)
-	return nodeUUID, spaceUUIDs, nics, nil
+	s.logger.Debugf(ctx, "devices by space for host machine %q: %#v", hostUUID, nics)
+	return hostNodeUUID, spaceUUIDs, nics, nil
 }
 
 // spaceRequirementsForMachine returns UUID-to-name for the *positive*

--- a/domain/network/state/container.go
+++ b/domain/network/state/container.go
@@ -93,10 +93,10 @@ SELECT DISTINCT
        s.name AS &spaceConstraint.space
 FROM   machine m
        JOIN unit u ON m.net_node_uuid = u.net_node_uuid
+       JOIN application a ON u.application_uuid = a.uuid
        JOIN all_bound b ON u.application_uuid = b.application_uuid
-       JOIN space s ON b.space_uuid = s.uuid
-WHERE  m.uuid = $entityUUID.uuid
-AND    s.name IS NOT NULL`
+       JOIN space s ON IFNULL(b.space_uuid, a.space_uuid) = s.uuid
+WHERE  m.uuid = $entityUUID.uuid`
 
 	stmt, err := st.Prepare(qry, mUUID, spaceConstraint{})
 	if err != nil {

--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -83,7 +83,7 @@ func (s *linkLayerBaseSuite) addApplicationEndpoint(
 	c *tc.C, applicationUUID coreapplication.ID, charmRelationUUID string, boundSpaceUUID string) string {
 	applicationEndpointUUID := uuid.MustNewUUID().String()
 	s.query(c, `
-INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid,space_uuid)
+INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid, space_uuid)
 VALUES (?, ?, ?, ?)
 `, applicationEndpointUUID, applicationUUID, charmRelationUUID, nilZeroPtr(boundSpaceUUID))
 	return applicationEndpointUUID


### PR DESCRIPTION
Trying to deploy an application with only the default binding set, into a container, was failing because we only factored explicitly bound endpoints when determining machine space requirements.

This patch makes a simple change to the binding detection SQL to rectify the omission of the application's default binding.

## QA steps

- Bootstrap to MAAS (I have spaces "primary" and "secondary").
- `juju switch controller`.
- `juju deploy ubuntu-lite --to lxd:0 --bind secondary`
- Deployment will succeed:
```
Model       Controller  Cloud/Region  Version      Timestamp
controller  officemaas  officemaas    4.0-beta7.1  14:01:29+02:00

App          Version  Status  Scale  Charm            Channel        Rev  Exposed  Message
controller            active      1  juju-controller  4.0/stable     117  no
ubuntu-lite  24.04    active      1  ubuntu-lite      latest/stable    2  no

Unit            Workload  Agent  Machine  Public address  Ports  Message
controller/0*   active    idle   0
ubuntu-lite/0*  active    idle   0/lxd/0

Machine  State    Address        Inst id              Base          AZ       Message
0        started  192.168.30.51  nuc-1                ubuntu@24.04  default  Deployed
0/lxd/0  started  192.168.40.48  juju-9fac66-0-lxd-0  ubuntu@24.04  default  Container started
```
