### PR TITLE
feat: annotate offer error

### DIFF
--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -147,7 +147,7 @@ func (a *AuthContext) CheckOfferAccessCaveat(caveat string) (*offerPermissionChe
 func (a *AuthContext) CheckLocalAccessRequest(details *offerPermissionCheck) ([]checkers.Caveat, error) {
 	authlogger.Debugf("authenticate local offer access: %+v", details)
 	if err := a.checkOfferAccess(a.systemState.UserPermission, details.User, details.OfferUUID); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "offer access check for user %q to offer %q in model %q", details.User, details.OfferUUID, details.SourceModelUUID)
 	}
 
 	firstPartyCaveats := []checkers.Caveat{

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -210,7 +210,7 @@ permission: consume
 	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = authContext.CheckLocalAccessRequest(opc)
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(err, gc.ErrorMatches, `offer access check for user "mary" to offer "mysql-uuid" in model ".*": permission denied`)
 }
 
 func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {


### PR DESCRIPTION
This PR is a small one to improve the error message in cases where access to an offer is denied. In a support request for a cross-controller relation (probably applies to cross-model too), a user was having an issue where they created a relation with `juju relate grafana-agent-k8s <controller-name>:admin/<model>.prometheus-remote-write` and 
the error they are seeing in the debug-log is,
>controller-2: 16:37:52 ERROR juju.worker.remoterelations cmr error in remote application worker for prometheus-remote-write: watching status for offer: cannot get discharge from "https://10.146.0.6:17070/offeraccess": third party refused discharge: cannot discharge: permission denied

Because this is a cross-controller relation, the user needs to determine which user they authenticated as on the offering controller - that will be the user contained within the macaroon. Unfortunately because we don't include the information about who is hitting this access denied error, from the logs it is very difficult to tell what's gone wrong. If the user being denied access was included in the logs it would immediately become clear how to solve this.

For reference, the remainder of the support request mentions that the user tried to do the following,
>I tried to grant access from the cos model with `juju grant <user> consume admin/<model>.prometheus-remote-write` but I receive this error:
>```
>ERROR could not grant offer access: user "<user>" does not exist locally: user "<user>" not found
>```

This unfortunately wouldn't work because their user on the consuming controller is not the same one on the offering controller. A better error would immediately lead to better understanding.