### PR TITLE
refactor: more efficient SQL in storageprovisioning domain

### DIFF
--- a/domain/status/service/storage_test.go
+++ b/domain/status/service/storage_test.go
@@ -472,7 +472,7 @@ func (s *storageServiceSuite) TestGetFilesystemStatusesMultiple(c *tc.C) {
 
 	res, err := s.service.GetFilesystemStatuses(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(res, tc.DeepEquals, []Filesystem{
+	c.Check(res, tc.UnorderedMatch[[]Filesystem](tc.DeepEquals), []Filesystem{
 		{
 			ID:   "1",
 			Life: corelife.Alive,


### PR DESCRIPTION
Replaces a two queries in the `storageprovisioning` domain.

### In GetFilesystemTemplatesForApplication
Plan for the old:
```
id      parent  notused detail
2       0       0       CO-ROUTINE app_fs_template
3       2       0       COMPOUND QUERY
4       3       0       LEFT-MOST SUBQUERY
10      4       0       SEARCH asd USING INDEX idx_application_storage_directive (application_uuid=?)
17      4       0       SEARCH cs USING INDEX sqlite_autoindex_charm_storage_1 (charm_uuid=? AND name=?)
33      3       0       UNION USING TEMP B-TREE
40      33      0       SEARCH asd USING INDEX idx_application_storage_directive (application_uuid=?)
47      33      0       SEARCH sp USING INDEX sqlite_autoindex_storage_pool_1 (uuid=?)
53      33      0       SEARCH cs USING INDEX sqlite_autoindex_charm_storage_1 (charm_uuid=? AND name=?)
81      0       0       SCAN app_fs_template
```

Plan for the new:
```
6       0       0       SCAN asd
14      0       0       SEARCH cs USING INDEX sqlite_autoindex_charm_storage_1 (charm_uuid=? AND name=?)
20      0       0       SEARCH sp USING INDEX sqlite_autoindex_storage_pool_1 (uuid=?) LEFT-JOIN
```
### In GetFilesystemAttachmentIDs
Plan for the old:
```
id      parent  notused detail
2       0       0       CO-ROUTINE (subquery-2)
3       2       0       COMPOUND QUERY
4       3       0       LEFT-MOST SUBQUERY
12      4       0       SEARCH sfa USING INDEX sqlite_autoindex_storage_filesystem_attachment_1 (uuid=?)
31      4       0       SEARCH m USING INDEX idx_machine_net_node (net_node_uuid=?)
36      4       0       SEARCH sf USING INDEX sqlite_autoindex_storage_filesystem_1 (uuid=?)
48      3       0       UNION USING TEMP B-TREE
56      48      0       SEARCH sfa USING INDEX sqlite_autoindex_storage_filesystem_attachment_1 (uuid=?)
75      48      0       SEARCH sf USING INDEX sqlite_autoindex_storage_filesystem_1 (uuid=?)
80      48      0       SEARCH m USING COVERING INDEX idx_machine_net_node (net_node_uuid=?) LEFT-JOIN
88      48      0       SEARCH u USING INDEX idx_unit_net_node (net_node_uuid=?)
113     0       0       SCAN (subquery-2)
```

Plan for the new:
```
id      parent  notused detail
9       0       0       SEARCH sfa USING INDEX sqlite_autoindex_storage_filesystem_attachment_1 (uuid=?)
28      0       0       SEARCH sf USING INDEX sqlite_autoindex_storage_filesystem_1 (uuid=?)
33      0       0       SEARCH m USING INDEX idx_machine_net_node (net_node_uuid=?) LEFT-JOIN
40      0       0       SEARCH u USING INDEX idx_unit_net_node (net_node_uuid=?) LEFT-JOIN
```

## QA steps

Unit tests are sufficient to verify that the queries produce equivalent results to the old.