### PR TITLE
feat(docs): export dark-mode SVGs in Excalidraw converter

### DIFF
--- a/docs/scripts/convert-excalidraw-to-svg-recursively.sh
+++ b/docs/scripts/convert-excalidraw-to-svg-recursively.sh
@@ -13,10 +13,10 @@ excalidraw_files_without_extension=$(git diff --name-only --relative HEAD -- '*.
 svg_files_without_extension=$(git diff --name-status --relative HEAD -- '*.svg' | awk '{print $2}' | sed 's/\.svg$//')
 
 # Unite list of excalidraw_files_without_extension and svg_files_without_extension excluding duplicates
-files_without_extention=$(echo -e "$excalidraw_files_without_extension\n$svg_files_without_extension" | sort -u)
+files_without_extension=$(echo -e "$excalidraw_files_without_extension\n$svg_files_without_extension" | sort -u)
 
 # If no files are found, exit the script
-if [ -z "$files_without_extention" ]; then
+if [ -z "$files_without_extension" ]; then
   echo "No .excalidraw files to convert, exiting."
   exit 0
 fi
@@ -33,13 +33,14 @@ echo "Installing Playwright browsers..."
 npx playwright install
 
 echo "Starting conversion of .excalidraw files to .svg..."
-echo $files_without_extention | tr ' ' '\n' | while IFS= read -r file; do
+echo $files_without_extension | tr ' ' '\n' | while IFS= read -r file; do
   # Check if the excalidraw file exists
   if [[ ! -f "$file.excalidraw" ]]; then
     echo "File $file.excalidraw does not exist, skipping."
     continue
   fi
 
+  # Generate the normal SVG file from the excalidraw file
   echo "Exporting → $file.excalidraw  to  $file.svg"
   npx excalidraw-brute-export-cli \
         -i "$file.excalidraw" \
@@ -50,4 +51,15 @@ echo $files_without_extention | tr ' ' '\n' | while IFS= read -r file; do
         --format svg \
         --quiet \
         -o "$file.svg"
+  # Generate the dark mode SVG file from the excalidraw file
+  echo "Exporting → $file.excalidraw  to  $file.dark.svg"
+  npx excalidraw-brute-export-cli \
+        -i "$file.excalidraw" \
+        --background 0 \
+        --embed-scene 1 \
+        --dark-mode 1 \
+        --scale 1 \
+        --format svg \
+        --quiet \
+        -o "$file.dark.svg"
 done


### PR DESCRIPTION
- Add generation of $file.dark.svg using --dark-mode 1
- Keep existing light export ($file.svg) with --dark-mode 0

QA steps:
```
# generate 2 svgs (<filename>.svg, <filename>.dark.svg) for some exalidraw file
# next, you need to change the figure description to use two versions of SVGs
```
Here is the example of new way to specify figures:
````
```{figure} tutorial-setup.svg
  :figclass: only-light
  :align: center
  :alt: Juju consists of a client and a controller and needs access to a cloud and to Charmhub
  _Juju consists of at least a client and a controller, and needs access to a cloud (anything that can provide compute, networking, and storage) and to Charmhub (the charm store; or a local source of charms)._
```
```{figure} tutorial-setup.dark.svg
  :figclass: only-dark
  :align: center
  :alt: Juju consists of a client and a controller and needs access to a cloud and to Charmhub
  _Juju consists of at least a client and a controller, and needs access to a cloud (anything that can provide compute, networking, and storage) and to Charmhub (the charm store; or a local source of charms)._
```
````
 



## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
...


## Links

<
**Jira card:** JUJU-
