### PR TITLE
build(dqlite,musl): WIP bump musl to 1.2.5 and add riscv64 sha stub

### DIFF
--- a/scripts/dqlite/scripts/dqlite/dqlite-install.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-install.sh
@@ -14,6 +14,8 @@ sha() {
 		# s390x and ppc64le are failing to build, so are stuck on v1.18.0
 		s390x) echo "8561238d7cdc2036fee321b7f8f1b563500325b4b1ed172002a56aca79ddb936" ;;
 		ppc64le) echo "950f55a4aa10a7209ede86cf4c023ec1dc79a31317f9e6d5378d7897beb26b35" ;;
+    # riscv64 is not supported yet
+    riscv64) echo "TODO: paste sha for uploaded to s3 dqlite blob" ;;
 		*) { echo "Unsupported arch ${BUILD_ARCH}."; exit 1; } ;;
 	esac
 }

--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -4,7 +4,7 @@ set -e
 
 source "$(dirname $0)/../env.sh"
 
-MUSL_VERSION="1.2.4"
+MUSL_VERSION="1.2.5"
 MUSL_PRECOMPILED=${MUSL_PRECOMPILED:-"1"}
 MUSL_CROSS_COMPILE=${MUSL_CROSS_COMPILE:-"1"}
 


### PR DESCRIPTION
This PR: 
- set MUSL_VERSION=1.2.5 to pick up latest musl patch.
- add riscv64 case in sha() with TODO and note that it’s not supported yet.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# build juju
# bootstrap juju controller
# deploy something
```

## Links


**Jira card:** JUJU-
