### PR TITLE
feat(dqlite): storage attachment watchers for uniter

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/domain/relation"
 	"github.com/juju/juju/domain/removal"
 	"github.com/juju/juju/domain/resolve"
+	"github.com/juju/juju/domain/storageprovisioning"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -606,27 +607,26 @@ type StorageProvisioningService interface {
 		ctx context.Context, unitUUID coreunit.UUID, storageID string,
 	) (domainlife.Life, error)
 
+	// GetStorageAttachmentUUIDForUnit returns the UUID of the storage attachment for the
+	// given storage ID and unit UUID.
+	//
+	// The following errors may be returned:
+	// - [applicationerrors.UnitNotFound] if the unit does not exist.
+	// - [storageprovisioningerrors.StorageInstanceNotFound] if the storage
+	// instance does not exist for the provided storage ID.
+	// - [storageprovisioningerrors.StorageAttachmentNotFound] if the
+	// storage attachment does not exist.
+	GetStorageAttachmentUUIDForUnit(
+		ctx context.Context, storageID string, unitUUID coreunit.UUID,
+	) (storageprovisioning.StorageAttachmentUUID, error)
+
 	// WatchStorageAttachmentsForUnit returns a watcher that emits the storage IDs
 	// for the provided unit when the unit's storage attachments are changed.
-	//
-	// The following errors may be returned:
-	// - [applicationerrors.UnitNotFound] if the unit does not exist.
 	WatchStorageAttachmentsForUnit(ctx context.Context, unitUUID coreunit.UUID) (watcher.StringsWatcher, error)
 
-	// WatchStorageAttachmentForUnit returns a notification watcher for the
-	// storage attachment of a unit.
-	//
-	// The following errors may be returned:
-	// - [github.com/juju/juju/core/errors.NotValid] when the provided unit uuid
-	// is not valid.
-	// - [github.com/juju/juju/domain/storageprovisioning/errors.StorageInstanceNotFound] if the storage
-	// instance does not exist for the provided storage ID.
-	// - [applicationerrors.UnitNotFound] if the unit does not exist.
-	// - [github.com/juju/juju/domain/storageprovisioning/errors.StorageAttachmentNotFound] if the
-	// storage attachment does not exist.
-	WatchStorageAttachmentForUnit(
-		ctx context.Context,
-		storageID string,
-		unitUUID coreunit.UUID,
+	// WatchStorageAttachment returns a notification watcher for the
+	// storage attachment.
+	WatchStorageAttachment(
+		ctx context.Context, uuid storageprovisioning.StorageAttachmentUUID,
 	) (watcher.NotifyWatcher, error)
 }

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -33,6 +33,7 @@ import (
 	relation0 "github.com/juju/juju/domain/relation"
 	removal "github.com/juju/juju/domain/removal"
 	resolve "github.com/juju/juju/domain/resolve"
+	storageprovisioning "github.com/juju/juju/domain/storageprovisioning"
 	charm0 "github.com/juju/juju/internal/charm"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -3041,41 +3042,80 @@ func (c *MockStorageProvisioningServiceGetStorageAttachmentLifeCall) DoAndReturn
 	return c
 }
 
-// WatchStorageAttachmentForUnit mocks base method.
-func (m *MockStorageProvisioningService) WatchStorageAttachmentForUnit(arg0 context.Context, arg1 string, arg2 unit.UUID) (watcher.Watcher[struct{}], error) {
+// GetStorageAttachmentUUIDForUnit mocks base method.
+func (m *MockStorageProvisioningService) GetStorageAttachmentUUIDForUnit(arg0 context.Context, arg1 string, arg2 unit.UUID) (storageprovisioning.StorageAttachmentUUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchStorageAttachmentForUnit", arg0, arg1, arg2)
-	ret0, _ := ret[0].(watcher.Watcher[struct{}])
+	ret := m.ctrl.Call(m, "GetStorageAttachmentUUIDForUnit", arg0, arg1, arg2)
+	ret0, _ := ret[0].(storageprovisioning.StorageAttachmentUUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchStorageAttachmentForUnit indicates an expected call of WatchStorageAttachmentForUnit.
-func (mr *MockStorageProvisioningServiceMockRecorder) WatchStorageAttachmentForUnit(arg0, arg1, arg2 any) *MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall {
+// GetStorageAttachmentUUIDForUnit indicates an expected call of GetStorageAttachmentUUIDForUnit.
+func (mr *MockStorageProvisioningServiceMockRecorder) GetStorageAttachmentUUIDForUnit(arg0, arg1, arg2 any) *MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchStorageAttachmentForUnit", reflect.TypeOf((*MockStorageProvisioningService)(nil).WatchStorageAttachmentForUnit), arg0, arg1, arg2)
-	return &MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageAttachmentUUIDForUnit", reflect.TypeOf((*MockStorageProvisioningService)(nil).GetStorageAttachmentUUIDForUnit), arg0, arg1, arg2)
+	return &MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall{Call: call}
 }
 
-// MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall wrap *gomock.Call
-type MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall struct {
+// MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall wrap *gomock.Call
+type MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall {
+func (c *MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall) Return(arg0 storageprovisioning.StorageAttachmentUUID, arg1 error) *MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall) Do(f func(context.Context, string, unit.UUID) (watcher.Watcher[struct{}], error)) *MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall {
+func (c *MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall) Do(f func(context.Context, string, unit.UUID) (storageprovisioning.StorageAttachmentUUID, error)) *MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall) DoAndReturn(f func(context.Context, string, unit.UUID) (watcher.Watcher[struct{}], error)) *MockStorageProvisioningServiceWatchStorageAttachmentForUnitCall {
+func (c *MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall) DoAndReturn(f func(context.Context, string, unit.UUID) (storageprovisioning.StorageAttachmentUUID, error)) *MockStorageProvisioningServiceGetStorageAttachmentUUIDForUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// WatchStorageAttachment mocks base method.
+func (m *MockStorageProvisioningService) WatchStorageAttachment(arg0 context.Context, arg1 storageprovisioning.StorageAttachmentUUID) (watcher.Watcher[struct{}], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchStorageAttachment", arg0, arg1)
+	ret0, _ := ret[0].(watcher.Watcher[struct{}])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchStorageAttachment indicates an expected call of WatchStorageAttachment.
+func (mr *MockStorageProvisioningServiceMockRecorder) WatchStorageAttachment(arg0, arg1 any) *MockStorageProvisioningServiceWatchStorageAttachmentCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchStorageAttachment", reflect.TypeOf((*MockStorageProvisioningService)(nil).WatchStorageAttachment), arg0, arg1)
+	return &MockStorageProvisioningServiceWatchStorageAttachmentCall{Call: call}
+}
+
+// MockStorageProvisioningServiceWatchStorageAttachmentCall wrap *gomock.Call
+type MockStorageProvisioningServiceWatchStorageAttachmentCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStorageProvisioningServiceWatchStorageAttachmentCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockStorageProvisioningServiceWatchStorageAttachmentCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStorageProvisioningServiceWatchStorageAttachmentCall) Do(f func(context.Context, storageprovisioning.StorageAttachmentUUID) (watcher.Watcher[struct{}], error)) *MockStorageProvisioningServiceWatchStorageAttachmentCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStorageProvisioningServiceWatchStorageAttachmentCall) DoAndReturn(f func(context.Context, storageprovisioning.StorageAttachmentUUID) (watcher.Watcher[struct{}], error)) *MockStorageProvisioningServiceWatchStorageAttachmentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/storage_test.go
+++ b/apiserver/facades/agent/uniter/storage_test.go
@@ -20,6 +20,7 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	domainlife "github.com/juju/juju/domain/life"
 	storageprovisioningerrors "github.com/juju/juju/domain/storageprovisioning/errors"
+	storageprovisioningtesting "github.com/juju/juju/domain/storageprovisioning/testing"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
 )
@@ -56,7 +57,7 @@ func (s *storageSuite) getAPI(c *tc.C) (*StorageAPI, *gomock.Controller) {
 			}, nil
 		},
 	)
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	return api, ctrl
 }
 
@@ -79,7 +80,7 @@ func (s *storageSuite) TestUnitStorageAttachments(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -92,7 +93,7 @@ func (s *storageSuite) TestUnitStorageAttachments(c *tc.C) {
 			{Tag: unitTag.String()},
 		},
 	})
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(attachments, tc.DeepEquals, params.StorageAttachmentIdsResults{
 		Results: []params.StorageAttachmentIdsResult{
 			{
@@ -115,7 +116,7 @@ func (s *storageSuite) TestUnitStorageAttachmentsWithInvalidUnitName(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(
 		"", coreunit.InvalidUnitName,
@@ -138,7 +139,7 @@ func (s *storageSuite) TestUnitStorageAttachmentsWithUnitNotFound(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(
 		"", applicationerrors.UnitNotFound,
@@ -161,7 +162,7 @@ func (s *storageSuite) TestUnitStorageAttachmentsWithInvalidUnitUUID(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -186,7 +187,7 @@ func (s *storageSuite) TestUnitStorageAttachmentsWithUnitNotFound2(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -211,7 +212,7 @@ func (s *storageSuite) TestUnitStorageAttachmentsWithInvalidStorageID(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -236,7 +237,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -252,7 +253,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *tc.C) {
 			},
 		},
 	})
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
 			{
@@ -268,7 +269,7 @@ func (s *storageSuite) TestStorageAttachmentLifeWithInvalidUnitName(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(
 		"", coreunit.InvalidUnitName,
@@ -294,7 +295,7 @@ func (s *storageSuite) TestStorageAttachmentLifeWithUnitNotFound(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(
 		"", applicationerrors.UnitNotFound,
@@ -320,7 +321,7 @@ func (s *storageSuite) TestStorageAttachmentLifeWithInvalidUnitUUID(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -348,7 +349,7 @@ func (s *storageSuite) TestStorageAttachmentLifeWithUnitNotFound2(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -376,7 +377,7 @@ func (s *storageSuite) TestStorageAttachmentLifeWithStorageInstanceNotFound(c *t
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -404,7 +405,7 @@ func (s *storageSuite) TestStorageAttachmentLifeWithAttachmentNotFound(c *tc.C) 
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -436,7 +437,7 @@ func (s *storageSuite) TestWatchUnitStorageAttachments(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
@@ -464,7 +465,7 @@ func (s *storageSuite) TestWatchUnitStorageAttachmentsWithUnitNotFound(c *tc.C) 
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return("", applicationerrors.UnitNotFound)
 
@@ -481,32 +482,7 @@ func (s *storageSuite) TestWatchUnitStorageAttachmentsWithUnitNotFound(c *tc.C) 
 	c.Assert(result.Error.Code, tc.Equals, params.CodeNotFound)
 }
 
-func (s *storageSuite) TestWatchUnitStorageAttachmentsWithUnitNotFound2(c *tc.C) {
-	api, ctrl := s.getAPI(c)
-	defer ctrl.Finish()
-
-	unitTag := names.NewUnitTag("wordpress/0")
-	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
-	unitUUID := unittesting.GenUnitUUID(c)
-
-	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.mockStorageProvisioningService.EXPECT().WatchStorageAttachmentsForUnit(gomock.Any(), unitUUID).Return(nil, applicationerrors.UnitNotFound)
-
-	results, err := api.WatchUnitStorageAttachments(c.Context(), params.Entities{
-		Entities: []params.Entity{
-			{
-				Tag: unitTag.String(),
-			},
-		},
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(results.Results, tc.HasLen, 1)
-	result := results.Results[0]
-	c.Assert(result.Error.Code, tc.Equals, params.CodeNotFound)
-}
-
-func (s *storageSuite) TestWatchStorageAttachmentsForUnit(c *tc.C) {
+func (s *storageSuite) TestWatchStorageAttachments(c *tc.C) {
 	api, ctrl := s.getAPI(c)
 	defer ctrl.Finish()
 
@@ -516,12 +492,16 @@ func (s *storageSuite) TestWatchStorageAttachmentsForUnit(c *tc.C) {
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
+	storageAttachmentUUID := storageprovisioningtesting.GenStorageAttachmentUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.mockStorageProvisioningService.EXPECT().WatchStorageAttachmentForUnit(gomock.Any(),
-		"foo/1", unitUUID,
+	s.mockStorageProvisioningService.EXPECT().GetStorageAttachmentUUIDForUnit(
+		gomock.Any(), "foo/1", unitUUID,
+	).Return(storageAttachmentUUID, nil)
+	s.mockStorageProvisioningService.EXPECT().WatchStorageAttachment(
+		gomock.Any(), storageAttachmentUUID,
 	).Return(sourceWatcher, nil)
 	s.mockWatcherRegistry.EXPECT().Register(gomock.Any(), sourceWatcher).Return("66", nil)
 
@@ -540,19 +520,19 @@ func (s *storageSuite) TestWatchStorageAttachmentsForUnit(c *tc.C) {
 	c.Assert(result.NotifyWatcherId, tc.Equals, "66")
 }
 
-func (s *storageSuite) TestWatchStorageAttachmentsForUnitWithInvalidUnitName(c *tc.C) {
+func (s *storageSuite) TestWatchStorageAttachmentsWithInvalidUnitUUID(c *tc.C) {
 	api, ctrl := s.getAPI(c)
 	defer ctrl.Finish()
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.mockStorageProvisioningService.EXPECT().WatchStorageAttachmentForUnit(gomock.Any(),
-		"foo/1", unitUUID,
-	).Return(nil, coreerrors.NotValid)
+	s.mockStorageProvisioningService.EXPECT().GetStorageAttachmentUUIDForUnit(
+		gomock.Any(), "foo/1", unitUUID,
+	).Return("", coreerrors.NotValid)
 
 	results, err := api.WatchStorageAttachments(c.Context(), params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{
@@ -568,19 +548,19 @@ func (s *storageSuite) TestWatchStorageAttachmentsForUnitWithInvalidUnitName(c *
 	c.Assert(result.Error.Code, tc.Equals, params.CodeNotValid)
 }
 
-func (s *storageSuite) TestWatchStorageAttachmentsForUnitWithUnitNotFound(c *tc.C) {
+func (s *storageSuite) TestWatchStorageAttachmentsWithUnitNotFound(c *tc.C) {
 	api, ctrl := s.getAPI(c)
 	defer ctrl.Finish()
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.mockStorageProvisioningService.EXPECT().WatchStorageAttachmentForUnit(gomock.Any(),
-		"foo/1", unitUUID,
-	).Return(nil, coreerrors.NotFound)
+	s.mockStorageProvisioningService.EXPECT().GetStorageAttachmentUUIDForUnit(
+		gomock.Any(), "foo/1", unitUUID,
+	).Return("", applicationerrors.UnitNotFound)
 
 	results, err := api.WatchStorageAttachments(c.Context(), params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{
@@ -596,19 +576,19 @@ func (s *storageSuite) TestWatchStorageAttachmentsForUnitWithUnitNotFound(c *tc.
 	c.Assert(result.Error.Code, tc.Equals, params.CodeNotFound)
 }
 
-func (s *storageSuite) TestWatchStorageAttachmentsForUnitWithStorageInstanceNotFound(c *tc.C) {
+func (s *storageSuite) TestWatchStorageAttachmentsWithStorageInstanceNotFound(c *tc.C) {
 	api, ctrl := s.getAPI(c)
 	defer ctrl.Finish()
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.mockStorageProvisioningService.EXPECT().WatchStorageAttachmentForUnit(gomock.Any(),
-		"foo/1", unitUUID,
-	).Return(nil, storageprovisioningerrors.StorageInstanceNotFound)
+	s.mockStorageProvisioningService.EXPECT().GetStorageAttachmentUUIDForUnit(
+		gomock.Any(), "foo/1", unitUUID,
+	).Return("", storageprovisioningerrors.StorageInstanceNotFound)
 
 	results, err := api.WatchStorageAttachments(c.Context(), params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{
@@ -624,19 +604,19 @@ func (s *storageSuite) TestWatchStorageAttachmentsForUnitWithStorageInstanceNotF
 	c.Assert(result.Error.Code, tc.Equals, params.CodeNotFound)
 }
 
-func (s *storageSuite) TestWatchStorageAttachmentsForUnitWithStorageAttachmentNotFound(c *tc.C) {
+func (s *storageSuite) TestWatchStorageAttachmentsWithStorageAttachmentNotFound(c *tc.C) {
 	api, ctrl := s.getAPI(c)
 	defer ctrl.Finish()
 
 	unitTag := names.NewUnitTag("wordpress/0")
 	unitName, err := coreunit.NewName(unitTag.Id())
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	s.mockApplicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.mockStorageProvisioningService.EXPECT().WatchStorageAttachmentForUnit(gomock.Any(),
-		"foo/1", unitUUID,
-	).Return(nil, storageprovisioningerrors.StorageAttachmentNotFound)
+	s.mockStorageProvisioningService.EXPECT().GetStorageAttachmentUUIDForUnit(
+		gomock.Any(), "foo/1", unitUUID,
+	).Return("", storageprovisioningerrors.StorageAttachmentNotFound)
 
 	results, err := api.WatchStorageAttachments(c.Context(), params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -638,10 +638,6 @@ func (s *modelSchemaSuite) TestModelTriggers(c *tc.C) {
 		"trg_log_machine_insert_life_start_time",
 		"trg_log_machine_update_life_start_time",
 		"trg_log_machine_delete_life_start_time",
-
-		"trg_log_custom_storage_attachment_unit_uuid_lifecycle_delete",
-		"trg_log_custom_storage_attachment_unit_uuid_lifecycle_insert",
-		"trg_log_custom_storage_attachment_unit_uuid_lifecycle_update",
 	)
 
 	// These are additional triggers that are not change log triggers, but

--- a/domain/storageprovisioning/service/package_mock_test.go
+++ b/domain/storageprovisioning/service/package_mock_test.go
@@ -749,41 +749,41 @@ func (c *MockStateGetStorageAttachmentLifeForUnitCall) DoAndReturn(f func(contex
 	return c
 }
 
-// GetStorageAttachmentUUID mocks base method.
-func (m *MockState) GetStorageAttachmentUUID(ctx context.Context, storageID, unitUUID string) (string, error) {
+// GetStorageAttachmentUUIDForUnit mocks base method.
+func (m *MockState) GetStorageAttachmentUUIDForUnit(ctx context.Context, storageID, unitUUID string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStorageAttachmentUUID", ctx, storageID, unitUUID)
+	ret := m.ctrl.Call(m, "GetStorageAttachmentUUIDForUnit", ctx, storageID, unitUUID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetStorageAttachmentUUID indicates an expected call of GetStorageAttachmentUUID.
-func (mr *MockStateMockRecorder) GetStorageAttachmentUUID(ctx, storageID, unitUUID any) *MockStateGetStorageAttachmentUUIDCall {
+// GetStorageAttachmentUUIDForUnit indicates an expected call of GetStorageAttachmentUUIDForUnit.
+func (mr *MockStateMockRecorder) GetStorageAttachmentUUIDForUnit(ctx, storageID, unitUUID any) *MockStateGetStorageAttachmentUUIDForUnitCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageAttachmentUUID", reflect.TypeOf((*MockState)(nil).GetStorageAttachmentUUID), ctx, storageID, unitUUID)
-	return &MockStateGetStorageAttachmentUUIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageAttachmentUUIDForUnit", reflect.TypeOf((*MockState)(nil).GetStorageAttachmentUUIDForUnit), ctx, storageID, unitUUID)
+	return &MockStateGetStorageAttachmentUUIDForUnitCall{Call: call}
 }
 
-// MockStateGetStorageAttachmentUUIDCall wrap *gomock.Call
-type MockStateGetStorageAttachmentUUIDCall struct {
+// MockStateGetStorageAttachmentUUIDForUnitCall wrap *gomock.Call
+type MockStateGetStorageAttachmentUUIDForUnitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetStorageAttachmentUUIDCall) Return(arg0 string, arg1 error) *MockStateGetStorageAttachmentUUIDCall {
+func (c *MockStateGetStorageAttachmentUUIDForUnitCall) Return(arg0 string, arg1 error) *MockStateGetStorageAttachmentUUIDForUnitCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetStorageAttachmentUUIDCall) Do(f func(context.Context, string, string) (string, error)) *MockStateGetStorageAttachmentUUIDCall {
+func (c *MockStateGetStorageAttachmentUUIDForUnitCall) Do(f func(context.Context, string, string) (string, error)) *MockStateGetStorageAttachmentUUIDForUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetStorageAttachmentUUIDCall) DoAndReturn(f func(context.Context, string, string) (string, error)) *MockStateGetStorageAttachmentUUIDCall {
+func (c *MockStateGetStorageAttachmentUUIDForUnitCall) DoAndReturn(f func(context.Context, string, string) (string, error)) *MockStateGetStorageAttachmentUUIDForUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/storageprovisioning/service/volume_test.go
+++ b/domain/storageprovisioning/service/volume_test.go
@@ -277,7 +277,7 @@ func (s *volumeSuite) TestWatchVolumeAttachmentPlansNotFound(c *tc.C) {
 // TestGetVolumeParams ensures the params are passed back without error.
 func (s *volumeSuite) TestGetVolumeParams(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	svc := NewService(s.state, s.watcherFactory)
+	svc := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c))
 	volUUID := domaintesting.GenVolumeUUID(c)
 
 	s.state.EXPECT().GetVolumeParams(gomock.Any(), volUUID).Return(
@@ -306,7 +306,7 @@ func (s *volumeSuite) TestGetVolumeParams(c *tc.C) {
 // TestGetVolumeParams tests that a volume not found error is passed through.
 func (s *filesystemSuite) TestGetVolumeParamsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	svc := NewService(s.state, s.watcherFactory)
+	svc := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c))
 	volUUID := domaintesting.GenVolumeUUID(c)
 
 	s.state.EXPECT().GetVolumeParams(gomock.Any(), volUUID).Return(
@@ -322,7 +322,7 @@ func (s *filesystemSuite) TestGetVolumeParamsNotFound(c *tc.C) {
 // returned.
 func (s *volumeSuite) TestGetVolumeAttachmentParams(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	svc := NewService(s.state, s.watcherFactory)
+	svc := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c))
 	vaUUID := domaintesting.GenVolumeAttachmentUUID(c)
 
 	s.state.EXPECT().GetVolumeAttachmentParams(gomock.Any(), vaUUID).Return(
@@ -348,7 +348,7 @@ func (s *volumeSuite) TestGetVolumeAttachmentParams(c *tc.C) {
 // found error is passed through.
 func (s *volumeSuite) TestGetVolumeAttachmentParamsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	svc := NewService(s.state, s.watcherFactory)
+	svc := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c))
 	vaUUID := domaintesting.GenVolumeAttachmentUUID(c)
 
 	s.state.EXPECT().GetVolumeAttachmentParams(gomock.Any(), vaUUID).Return(
@@ -411,7 +411,7 @@ func (s *volumeSuite) TestGetVolumeAttachment(c *tc.C) {
 	}
 	s.state.EXPECT().GetVolumeAttachment(c.Context(), vaUUID).Return(va, nil)
 
-	rval, err := NewService(s.state, s.watcherFactory).
+	rval, err := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c)).
 		GetVolumeAttachment(c.Context(), vaUUID)
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(rval, tc.DeepEquals, va)
@@ -420,7 +420,7 @@ func (s *volumeSuite) TestGetVolumeAttachment(c *tc.C) {
 func (s *volumeSuite) TestGetVolumeAttachmentNotValid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	_, err := NewService(s.state, s.watcherFactory).
+	_, err := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c)).
 		GetVolumeAttachment(c.Context(), "")
 	c.Check(err, tc.ErrorIs, coreerrors.NotValid)
 }
@@ -628,7 +628,7 @@ func (s *volumeSuite) TestGetVolumeUUIDForID(c *tc.C) {
 	volUUID := domaintesting.GenVolumeUUID(c)
 	s.state.EXPECT().GetVolumeUUIDForID(c.Context(), "123").Return(volUUID, nil)
 
-	rval, err := NewService(s.state, s.watcherFactory).
+	rval, err := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c)).
 		GetVolumeUUIDForID(c.Context(), "123")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(rval, tc.Equals, volUUID)
@@ -650,7 +650,7 @@ func (s *volumeSuite) TestGetVolume(c *tc.C) {
 	s.state.EXPECT().GetVolumeUUIDForID(c.Context(), "123").Return(volUUID, nil)
 	s.state.EXPECT().GetVolume(c.Context(), volUUID).Return(vol, nil)
 
-	rval, err := NewService(s.state, s.watcherFactory).
+	rval, err := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c)).
 		GetVolumeByID(c.Context(), "123")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(rval, tc.DeepEquals, vol)
@@ -662,7 +662,7 @@ func (s *volumeSuite) TestGetVolumeNotFound(c *tc.C) {
 	s.state.EXPECT().GetVolumeUUIDForID(c.Context(), "123").Return(
 		"", storageprovisioningerrors.VolumeNotFound)
 
-	_, err := NewService(s.state, s.watcherFactory).
+	_, err := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c)).
 		GetVolumeByID(c.Context(), "123")
 	c.Assert(err, tc.ErrorIs, storageprovisioningerrors.VolumeNotFound)
 }
@@ -685,7 +685,7 @@ func (s *volumeSuite) TestSetVolumeProvisionedInfo(c *tc.C) {
 	s.state.EXPECT().SetVolumeProvisionedInfo(
 		c.Context(), volUUID, info).Return(nil)
 
-	err := NewService(s.state, s.watcherFactory).
+	err := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c)).
 		SetVolumeProvisionedInfo(c.Context(), "123", info)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -698,7 +698,7 @@ func (s *volumeSuite) TestSetVolumeProvisionedInfoNotFound(c *tc.C) {
 	s.state.EXPECT().GetVolumeUUIDForID(c.Context(), "123").Return(
 		"", storageprovisioningerrors.VolumeNotFound)
 
-	err := NewService(s.state, s.watcherFactory).
+	err := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c)).
 		SetVolumeProvisionedInfo(c.Context(), "123", info)
 	c.Assert(err, tc.ErrorIs, storageprovisioningerrors.VolumeNotFound)
 }

--- a/domain/storageprovisioning/state/base_test.go
+++ b/domain/storageprovisioning/state/base_test.go
@@ -488,57 +488,6 @@ func (s *baseSuite) changeVolumeInfo(
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-// newModelFilesystem creates a new filesystem in the model with model
-// provision scope. Return is the uuid and filesystem id of the entity.
-func (s *baseSuite) newModelFilesystem(c *tc.C) (
-	storageprovisioning.FilesystemUUID, string,
-) {
-	fsUUID := domaintesting.GenFilesystemUUID(c)
-
-	fsID := fmt.Sprintf("foo/%s", fsUUID.String())
-
-	_, err := s.DB().Exec(`
-INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
-VALUES (?, ?, 0, 0)
-	`,
-		fsUUID.String(), fsID)
-	c.Assert(err, tc.ErrorIsNil)
-
-	return fsUUID, fsID
-}
-
-func (s *baseSuite) newModelFilesystemAttachmentWithMount(
-	c *tc.C,
-	fsUUID storageprovisioning.FilesystemUUID,
-	netNodeUUID domainnetwork.NetNodeUUID,
-	mountPoint string,
-	readOnly bool,
-) storageprovisioning.FilesystemAttachmentUUID {
-	attachmentUUID := domaintesting.GenFilesystemAttachmentUUID(c)
-
-	_, err := s.DB().ExecContext(
-		c.Context(),
-		`
-INSERT INTO storage_filesystem_attachment (uuid,
-                                           storage_filesystem_uuid,
-                                           net_node_uuid,
-                                           life_id,
-                                           mount_point,
-                                           read_only,
-                                           provision_scope_id)
-VALUES (?, ?, ?, 0, ?, ?, 0)
-`,
-		attachmentUUID.String(),
-		fsUUID,
-		netNodeUUID.String(),
-		mountPoint,
-		readOnly,
-	)
-	c.Assert(err, tc.ErrorIsNil)
-
-	return attachmentUUID
-}
-
 type preparer struct{}
 
 func (p preparer) Prepare(query string, typeSamples ...any) (*sqlair.Statement, error) {

--- a/domain/storageprovisioning/state/filesystem_test.go
+++ b/domain/storageprovisioning/state/filesystem_test.go
@@ -1079,3 +1079,54 @@ WHERE  uuid = ?
 	)
 	c.Assert(err, tc.ErrorIsNil)
 }
+
+// newModelFilesystem creates a new filesystem in the model with model
+// provision scope. Return is the uuid and filesystem id of the entity.
+func (s *filesystemSuite) newModelFilesystem(c *tc.C) (
+	storageprovisioning.FilesystemUUID, string,
+) {
+	fsUUID := domaintesting.GenFilesystemUUID(c)
+
+	fsID := fmt.Sprintf("foo/%s", fsUUID.String())
+
+	_, err := s.DB().Exec(`
+INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, 0)
+	`,
+		fsUUID.String(), fsID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return fsUUID, fsID
+}
+
+func (s *baseSuite) newModelFilesystemAttachmentWithMount(
+	c *tc.C,
+	fsUUID storageprovisioning.FilesystemUUID,
+	netNodeUUID domainnetwork.NetNodeUUID,
+	mountPoint string,
+	readOnly bool,
+) storageprovisioning.FilesystemAttachmentUUID {
+	attachmentUUID := domaintesting.GenFilesystemAttachmentUUID(c)
+
+	_, err := s.DB().ExecContext(
+		c.Context(),
+		`
+INSERT INTO storage_filesystem_attachment (uuid,
+                                           storage_filesystem_uuid,
+                                           net_node_uuid,
+                                           life_id,
+                                           mount_point,
+                                           read_only,
+                                           provision_scope_id)
+VALUES (?, ?, ?, 0, ?, ?, 0)
+`,
+		attachmentUUID.String(),
+		fsUUID,
+		netNodeUUID.String(),
+		mountPoint,
+		readOnly,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return attachmentUUID
+}

--- a/domain/storageprovisioning/state/state_test.go
+++ b/domain/storageprovisioning/state/state_test.go
@@ -411,7 +411,6 @@ func (s *stateSuite) TestInitialWatchStatementForUnitStorageAttachments(c *tc.C)
 
 	stmt, q := st.InitialWatchStatementForUnitStorageAttachments(c.Context(), unitUUID.String())
 	c.Assert(stmt, tc.Equals, "custom_storage_attachment_unit_uuid_lifecycle")
-	c.Assert(q, tc.NotNil)
 	result, err := q(c.Context(), s.TxnRunner())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result, tc.DeepEquals, map[string]domainlife.Life{
@@ -430,7 +429,7 @@ func (s *stateSuite) TestInitialWatchStatementForUnitStorageAttachmentsWithUnitN
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *stateSuite) TestGetStorageAttachmentUUID(c *tc.C) {
+func (s *stateSuite) TestGetStorageAttachmentUUIDForUnit(c *tc.C) {
 	netNodeUUID := s.newNetNode(c)
 	appUUID, charmUUID := s.newApplication(c, "foo")
 	unitUUID, _ := s.newUnitWithNetNode(c, "foo/0", appUUID, netNodeUUID)
@@ -441,7 +440,7 @@ func (s *stateSuite) TestGetStorageAttachmentUUID(c *tc.C) {
 	storageID := s.getStorageID(c, storageInstanceUUID)
 
 	st := NewState(s.TxnRunnerFactory())
-	attachmentUUID, err := st.GetStorageAttachmentUUID(
+	attachmentUUID, err := st.GetStorageAttachmentUUIDForUnit(
 		c.Context(), storageID, unitUUID.String(),
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -458,7 +457,7 @@ func (s *stateSuite) TestGetStorageAttachmentUUIDWithStorageAttachmentNotFound(c
 	storageID := s.getStorageID(c, storageInstanceUUID)
 
 	st := NewState(s.TxnRunnerFactory())
-	_, err := st.GetStorageAttachmentUUID(
+	_, err := st.GetStorageAttachmentUUIDForUnit(
 		c.Context(), storageID, unitUUID.String(),
 	)
 	c.Assert(err, tc.ErrorIs, storageprovisioningerrors.StorageAttachmentNotFound)
@@ -473,7 +472,7 @@ func (s *stateSuite) TestGetStorageAttachmentUUIDWithUnitNotFound(c *tc.C) {
 	storageID := s.getStorageID(c, storageInstanceUUID)
 
 	st := NewState(s.TxnRunnerFactory())
-	_, err := st.GetStorageAttachmentUUID(
+	_, err := st.GetStorageAttachmentUUIDForUnit(
 		c.Context(), storageID, unitUUID.String(),
 	)
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
@@ -483,7 +482,7 @@ func (s *stateSuite) TestGetStorageAttachmentUUIDWithStorageInstanceNotFound(c *
 	unitUUID := unittesting.GenUnitUUID(c)
 
 	st := NewState(s.TxnRunnerFactory())
-	_, err := st.GetStorageAttachmentUUID(
+	_, err := st.GetStorageAttachmentUUIDForUnit(
 		c.Context(), "foo/1", unitUUID.String(),
 	)
 	c.Assert(err, tc.ErrorIs, storageprovisioningerrors.StorageInstanceNotFound)

--- a/domain/storageprovisioning/state/types.go
+++ b/domain/storageprovisioning/state/types.go
@@ -31,8 +31,8 @@ func (l attachmentLives) Iter(yield func(string, life.Life) bool) {
 }
 
 type storageAttachmentLife struct {
-	ID   string    `db:"storage_id"`
-	Life life.Life `db:"life_id"`
+	StorageInstanceID string    `db:"storage_id"`
+	Life              life.Life `db:"life_id"`
 }
 
 type storageAttachmentLives []storageAttachmentLife
@@ -41,7 +41,7 @@ type storageAttachmentLives []storageAttachmentLife
 // [storageAttachmentLives].
 func (l storageAttachmentLives) Iter(yield func(string, life.Life) bool) {
 	for _, v := range l {
-		if !yield(v.ID, v.Life) {
+		if !yield(v.StorageInstanceID, v.Life) {
 			return
 		}
 	}

--- a/domain/storageprovisioning/state/volume_test.go
+++ b/domain/storageprovisioning/state/volume_test.go
@@ -914,25 +914,8 @@ func (s *volumeSuite) TestSetVolumeProvisionedInfoNotFound(c *tc.C) {
 
 	st := NewState(s.TxnRunnerFactory())
 
-<<<<<<< HEAD
 	info := domainstorageprovisioning.VolumeProvisionedInfo{}
 	err := st.SetVolumeProvisionedInfo(c.Context(), volUUID, info)
-=======
-	_, err := st.GetVolumeUUIDForStorageID(c.Context(), "foo/1")
-	c.Assert(err, tc.ErrorIs, storageprovisioningerrors.StorageInstanceNotFound)
-}
-
-func (s *volumeSuite) TestGetVolumeUUIDForStorageIDWithVolumeNotFound(c *tc.C) {
-	charmUUID := s.newCharm(c)
-	s.newCharmStorage(c, charmUUID, "mystorage", "block", false, "")
-	poolUUID := s.newStoragePool(c, "rootfs", "rootfs", nil)
-	storageInstanceUUID := s.newStorageInstanceForCharmWithPool(c, charmUUID, poolUUID, "mystorage")
-
-	storageID := s.getStorageID(c, storageInstanceUUID)
-	st := NewState(s.TxnRunnerFactory())
-
-	_, err := st.GetVolumeUUIDForStorageID(c.Context(), storageID)
->>>>>>> dcbccc3634 (feat: fix state tests;)
 	c.Assert(err, tc.ErrorIs, storageprovisioningerrors.VolumeNotFound)
 }
 

--- a/domain/storageprovisioning/watcher_test.go
+++ b/domain/storageprovisioning/watcher_test.go
@@ -697,18 +697,18 @@ func (s *watcherSuite) TestWatchStorageAttachmentsForUnit(c *tc.C) {
 	harness.Run(c, []string(nil))
 }
 
-func (s *watcherSuite) TestWatchStorageAttachmentForUnitForVolume(c *tc.C) {
+func (s *watcherSuite) TestWatchStorageAttachmentForVolume(c *tc.C) {
 	svc := s.setupService(c)
 
 	appUUID, charmUUID := s.newApplication(c, "foo")
 	unitUUID, _, netNodeUUID := s.newUnitWithNetNode(c, "foo/0", appUUID, charmUUID)
 	poolUUID := s.newStoragePool(c, "foo", "foo", nil)
-	storageInstanceUUID, storageID := s.newStorageInstanceWithCharmUUID(c, charmUUID, poolUUID)
-	_ = s.newStorageAttachment(c, storageInstanceUUID, unitUUID, domainlife.Alive)
+	storageInstanceUUID, _ := s.newStorageInstanceWithCharmUUID(c, charmUUID, poolUUID)
+	storageAttachmentUUID := s.newStorageAttachment(c, storageInstanceUUID, unitUUID, domainlife.Alive)
 	volumeUUID, _ := s.newMachineVolume(c)
 
-	watcher, err := svc.WatchStorageAttachmentForUnit(
-		c.Context(), storageID, unitUUID,
+	watcher, err := svc.WatchStorageAttachment(
+		c.Context(), storageAttachmentUUID,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -789,18 +789,18 @@ func (s *watcherSuite) TestWatchStorageAttachmentForUnitForVolume(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
-func (s *watcherSuite) TestWatchStorageAttachmentForUnitForFilesystem(c *tc.C) {
+func (s *watcherSuite) TestWatchStorageAttachmentForFilesystem(c *tc.C) {
 	svc := s.setupService(c)
 
 	appUUID, charmUUID := s.newApplication(c, "foo")
 	unitUUID, _, netNodeUUID := s.newUnitWithNetNode(c, "foo/0", appUUID, charmUUID)
 	poolUUID := s.newStoragePool(c, "foo", "foo", nil)
-	storageInstanceUUID, storageID := s.newStorageInstanceWithCharmUUID(c, charmUUID, poolUUID)
-	_ = s.newStorageAttachment(c, storageInstanceUUID, unitUUID, domainlife.Alive)
+	storageInstanceUUID, _ := s.newStorageInstanceWithCharmUUID(c, charmUUID, poolUUID)
+	storageAttachmentUUID := s.newStorageAttachment(c, storageInstanceUUID, unitUUID, domainlife.Alive)
 	fsUUID, _ := s.newMachineFilesystem(c)
 
-	watcher, err := svc.WatchStorageAttachmentForUnit(
-		c.Context(), storageID, unitUUID,
+	watcher, err := svc.WatchStorageAttachment(
+		c.Context(), storageAttachmentUUID,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -1713,14 +1713,14 @@ func (s *watcherSuite) newStorageAttachment(
 	storageInstanceUUID domainstorage.StorageInstanceUUID,
 	unitUUID coreunit.UUID,
 	life domainlife.Life,
-) string {
+) storageprovisioning.StorageAttachmentUUID {
 	saUUID := domaintesting.GenStorageAttachmentUUID(c)
 	_, err := s.DB().Exec(`
 INSERT INTO storage_attachment (uuid, storage_instance_uuid, unit_uuid, life_id)
 VALUES (?, ?, ?, ?)`,
 		saUUID.String(), storageInstanceUUID.String(), unitUUID.String(), life)
 	c.Assert(err, tc.ErrorIsNil)
-	return saUUID.String()
+	return saUUID
 }
 
 func (s *watcherSuite) newStorageInstanceFilesystem(


### PR DESCRIPTION
This PR implements the WatchStorageAttachments and WatchUnitStorageAttachments watchers for the uniter facade.
It also includes the relevant domain service and state methods implementation.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Not fully testable yet.


## Documentation changes

No

## Links

**Jira card:** [JUJU-8305](https://warthogs.atlassian.net/browse/JUJU-8305)


[JUJU-8305]: https://warthogs.atlassian.net/browse/JUJU-8305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ