### PR TITLE
feat: caas scale unit attach storage

### DIFF
--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -956,8 +956,8 @@ func (s *applicationSuite) TestScaleApplication(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	args := params.ScaleApplicationsParams{
-		Applications: []params.ScaleApplicationParams{
+	args := params.ScaleApplicationsParamsV2{
+		Applications: []params.ScaleApplicationParamsV2{
 			{ApplicationTag: "application-foo", Scale: 5, Force: true},
 		}}
 	result := new(params.ScaleApplicationResults)
@@ -969,7 +969,11 @@ func (s *applicationSuite) TestScaleApplication(c *gc.C) {
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
 	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
 
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(21).AnyTimes()
+
 	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
 	res, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,
@@ -981,12 +985,129 @@ func (s *applicationSuite) TestScaleApplication(c *gc.C) {
 	})
 }
 
+func (s *applicationSuite) TestScaleApplicationAttachStorage(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.ScaleApplicationsParamsV2{
+		Applications: []params.ScaleApplicationParamsV2{
+			{ApplicationTag: "application-foo", ScaleChange: 1, Force: true, AttachStorage: []string{"foo/1"}},
+		}}
+	result := new(params.ScaleApplicationResults)
+	results := params.ScaleApplicationResults{
+		Results: []params.ScaleApplicationResult{
+			{Info: &params.ScaleApplicationInfo{Scale: 1}},
+		},
+	}
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(21).AnyTimes()
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
+
+	res, err := client.ScaleApplication(application.ScaleApplicationParams{
+		ApplicationName: "foo",
+		ScaleChange:     1,
+		Force:           true,
+		AttachStorage:   []string{"foo/1"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, jc.DeepEquals, params.ScaleApplicationResult{
+		Info: &params.ScaleApplicationInfo{Scale: 1},
+	})
+}
+
+func (s *applicationSuite) TestScaleApplicationAttachStorageMultipleUnits(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(21).AnyTimes()
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
+
+	_, err := client.ScaleApplication(application.ScaleApplicationParams{
+		ApplicationName: "foo",
+		ScaleChange:     2,
+		Force:           true,
+		AttachStorage:   []string{"foo/1"},
+	})
+	c.Assert(err, gc.ErrorMatches, "cannot attach existing storage when more than one unit is requested")
+}
+
+func (s *applicationSuite) TestScaleApplicationAttachStorageAPIVersionNotSupported(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(20).AnyTimes()
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
+
+	_, err := client.ScaleApplication(application.ScaleApplicationParams{
+		ApplicationName: "foo",
+		ScaleChange:     1,
+		Force:           true,
+		AttachStorage:   []string{"foo/1"},
+	})
+	c.Assert(err, gc.ErrorMatches, "scale application with attach storage on this version of Juju not implemented")
+}
+
+func (s *applicationSuite) TestScaleApplicationV21WithAttachStorage(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.ScaleApplicationsParamsV2{
+		Applications: []params.ScaleApplicationParamsV2{
+			{
+				ApplicationTag: "application-foo",
+				ScaleChange:    1,
+				Force:          true,
+				AttachStorage:  []string{"foo/1"},
+			},
+		}}
+	result := new(params.ScaleApplicationResults)
+	results := params.ScaleApplicationResults{
+		Results: []params.ScaleApplicationResult{
+			{Info: &params.ScaleApplicationInfo{Scale: 2}},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
+
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(21).AnyTimes()
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
+
+	res, err := client.ScaleApplication(application.ScaleApplicationParams{
+		ApplicationName: "foo",
+		ScaleChange:     1,
+		Force:           true,
+		AttachStorage:   []string{"foo/1"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, jc.DeepEquals, params.ScaleApplicationResult{
+		Info: &params.ScaleApplicationInfo{Scale: 2},
+	})
+}
+
 func (s *applicationSuite) TestChangeScaleApplication(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	args := params.ScaleApplicationsParams{
-		Applications: []params.ScaleApplicationParams{
+	args := params.ScaleApplicationsParamsV2{
+		Applications: []params.ScaleApplicationParamsV2{
 			{ApplicationTag: "application-foo", ScaleChange: 5},
 		}}
 	result := new(params.ScaleApplicationResults)
@@ -998,7 +1119,11 @@ func (s *applicationSuite) TestChangeScaleApplication(c *gc.C) {
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
 	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
 
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(21).AnyTimes()
+
 	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
 	res, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		ScaleChange:     5,
@@ -1013,8 +1138,8 @@ func (s *applicationSuite) TestScaleApplicationArity(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	args := params.ScaleApplicationsParams{
-		Applications: []params.ScaleApplicationParams{
+	args := params.ScaleApplicationsParamsV2{
+		Applications: []params.ScaleApplicationParamsV2{
 			{ApplicationTag: "application-foo", Scale: 5},
 		}}
 	result := new(params.ScaleApplicationResults)
@@ -1027,7 +1152,11 @@ func (s *applicationSuite) TestScaleApplicationArity(c *gc.C) {
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
 	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
 
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(21).AnyTimes()
+
 	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
 	_, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,
@@ -1074,14 +1203,18 @@ func (s *applicationSuite) TestScaleApplicationError(c *gc.C) {
 			{Error: &params.Error{Message: "boom"}},
 		},
 	}
-	args := params.ScaleApplicationsParams{
-		Applications: []params.ScaleApplicationParams{
+	args := params.ScaleApplicationsParamsV2{
+		Applications: []params.ScaleApplicationParamsV2{
 			{ApplicationTag: "application-foo", Scale: 5},
 		}}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
 	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
 
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(21).AnyTimes()
+
 	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
 	_, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,
@@ -1095,14 +1228,18 @@ func (s *applicationSuite) TestScaleApplicationCallError(c *gc.C) {
 
 	result := new(params.ScaleApplicationResults)
 	results := params.ScaleApplicationResults{}
-	args := params.ScaleApplicationsParams{
-		Applications: []params.ScaleApplicationParams{
+	args := params.ScaleApplicationsParamsV2{
+		Applications: []params.ScaleApplicationParamsV2{
 			{ApplicationTag: "application-foo", Scale: 5},
 		}}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
 	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(errors.New("boom"))
 
+	mockClientFacade := mocks.NewMockClientFacade(ctrl)
+	mockClientFacade.EXPECT().BestAPIVersion().Return(21).AnyTimes()
+
 	client := application.NewClientFromCaller(mockFacadeCaller)
+	client.ClientFacade = mockClientFacade
 	_, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,

--- a/api/controller/caasapplicationprovisioner/client_test.go
+++ b/api/controller/caasapplicationprovisioner/client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/docker"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/storage"
 )
 
 type provisionerSuite struct {
@@ -634,4 +635,138 @@ func (s *provisionerSuite) TestProvisionerConfig(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.CAASApplicationProvisionerConfig{
 		UnmanagedApplications: params.Entities{Entities: []params.Entity{{Tag: "application-controller"}}},
 	})
+}
+
+func (s *provisionerSuite) TestFilesystemProvisioningInfo(c *gc.C) {
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASApplicationProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "FilesystemProvisioningInfo")
+		c.Assert(a, jc.DeepEquals, params.Entity{Tag: "application-gitlab"})
+		c.Assert(result, gc.FitsTypeOf, &params.CAASApplicationFilesystemProvisioningInfo{})
+		*(result.(*params.CAASApplicationFilesystemProvisioningInfo)) = params.CAASApplicationFilesystemProvisioningInfo{
+			Filesystems: []params.KubernetesFilesystemParams{
+				{
+					StorageName: "data",
+					Provider:    "kubernetes",
+					Size:        1024,
+					Attributes:  map[string]interface{}{"storage-class": "fast"},
+					Tags:        map[string]string{"env": "prod"},
+					Attachment: &params.KubernetesFilesystemAttachmentParams{
+						Provider:   "kubernetes",
+						MountPoint: "/data",
+						ReadOnly:   false,
+					},
+				},
+			},
+			FilesystemUnitAttachments: map[string][]params.KubernetesFilesystemUnitAttachmentParams{
+				"data": {
+					{
+						UnitTag:  "unit-gitlab-0",
+						VolumeId: "pvc-data-0",
+					},
+					{
+						UnitTag:  "unit-gitlab-1",
+						VolumeId: "pvc-data-1",
+					},
+				},
+			},
+		}
+		return nil
+	})
+	info, err := client.FilesystemProvisioningInfo("gitlab")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, caasapplicationprovisioner.FilesystemProvisioningInfo{
+		Filesystems: []storage.KubernetesFilesystemParams{
+			{
+				StorageName:  "data",
+				Provider:     storage.ProviderType("kubernetes"),
+				Size:         1024,
+				Attributes:   map[string]interface{}{"storage-class": "fast"},
+				ResourceTags: map[string]string{"env": "prod"},
+				Attachment: &storage.KubernetesFilesystemAttachmentParams{
+					AttachmentParams: storage.AttachmentParams{
+						Provider: storage.ProviderType("kubernetes"),
+						ReadOnly: false,
+					},
+					Path: "/data",
+				},
+			},
+		},
+		FilesystemUnitAttachments: map[string][]storage.KubernetesFilesystemUnitAttachmentParams{
+			"data": {
+				{UnitName: "gitlab/0", VolumeId: "pvc-data-0"},
+				{UnitName: "gitlab/1", VolumeId: "pvc-data-1"},
+			},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestFilesystemProvisioningInfoEmpty(c *gc.C) {
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASApplicationProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "FilesystemProvisioningInfo")
+		c.Assert(a, jc.DeepEquals, params.Entity{Tag: "application-gitlab"})
+		c.Assert(result, gc.FitsTypeOf, &params.CAASApplicationFilesystemProvisioningInfo{})
+		*(result.(*params.CAASApplicationFilesystemProvisioningInfo)) = params.CAASApplicationFilesystemProvisioningInfo{}
+		return nil
+	})
+	info, err := client.FilesystemProvisioningInfo("gitlab")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, caasapplicationprovisioner.FilesystemProvisioningInfo{})
+}
+
+func (s *provisionerSuite) TestFilesystemProvisioningInfoWithoutAttachment(c *gc.C) {
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASApplicationProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "FilesystemProvisioningInfo")
+		c.Assert(a, jc.DeepEquals, params.Entity{Tag: "application-gitlab"})
+		c.Assert(result, gc.FitsTypeOf, &params.CAASApplicationFilesystemProvisioningInfo{})
+		*(result.(*params.CAASApplicationFilesystemProvisioningInfo)) = params.CAASApplicationFilesystemProvisioningInfo{
+			Filesystems: []params.KubernetesFilesystemParams{
+				{
+					StorageName: "logs",
+					Provider:    "local",
+					Size:        512,
+				},
+			},
+		}
+		return nil
+	})
+	info, err := client.FilesystemProvisioningInfo("gitlab")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, caasapplicationprovisioner.FilesystemProvisioningInfo{
+		Filesystems: []storage.KubernetesFilesystemParams{
+			{
+				StorageName: "logs",
+				Provider:    storage.ProviderType("local"),
+				Size:        512,
+			},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestFilesystemProvisioningInfoInvalidUnitTag(c *gc.C) {
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASApplicationProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "FilesystemProvisioningInfo")
+		c.Assert(a, jc.DeepEquals, params.Entity{Tag: "application-gitlab"})
+		c.Assert(result, gc.FitsTypeOf, &params.CAASApplicationFilesystemProvisioningInfo{})
+		*(result.(*params.CAASApplicationFilesystemProvisioningInfo)) = params.CAASApplicationFilesystemProvisioningInfo{
+			FilesystemUnitAttachments: map[string][]params.KubernetesFilesystemUnitAttachmentParams{
+				"data": {
+					{
+						UnitTag:  "invalid-tag",
+						VolumeId: "pvc-data-0",
+					},
+				},
+			},
+		}
+		return nil
+	})
+	_, err := client.FilesystemProvisioningInfo("gitlab")
+	c.Assert(err, gc.ErrorMatches, `"invalid-tag" is not a valid tag`)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -29,7 +29,7 @@ var facadeVersions = facades.FacadeVersions{
 	"AllModelWatcher":              {4},
 	"AllWatcher":                   {3},
 	"Annotations":                  {2},
-	"Application":                  {15, 16, 17, 18, 19, 20},
+	"Application":                  {15, 16, 17, 18, 19, 20, 21},
 	"ApplicationOffers":            {4, 5},
 	"ApplicationScaler":            {1},
 	"Backups":                      {3},

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -965,7 +965,9 @@ func (s *applicationSuite) apiv16() *application.APIv16 {
 			APIv18: &application.APIv18{
 				APIv19: &application.APIv19{
 					APIv20: &application.APIv20{
-						APIBase: s.applicationAPI,
+						APIv21: &application.APIv21{
+							APIBase: s.applicationAPI,
+						},
 					},
 				},
 			},

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -115,7 +115,7 @@ type Application interface {
 	UpdateCharmConfig(string, charm.Settings) error
 	UpdateApplicationConfig(coreconfig.ConfigAttributes, []string, environschema.Fields, schema.Defaults) error
 	SetScale(int, int64, bool) error
-	ChangeScale(int) (int, error)
+	ChangeScale(int, []names.StorageTag) (int, error)
 	AgentTools() (*tools.Tools, error)
 	MergeBindings(*state.Bindings, bool) error
 	Relations() ([]Relation, error)

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -393,13 +393,13 @@ func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepository
 }
 
 func validateAndParseAttachStorage(input []string, numUnits int) ([]names.StorageTag, []error) {
-	// Parse storage tags in AttachStorage.
-	if len(input) > 0 && numUnits != 1 {
-		return nil, []error{errors.Errorf("AttachStorage is non-empty, but NumUnits is %d", numUnits)}
-	}
 	if len(input) == 0 {
 		return nil, nil
 	}
+	if len(input) > 0 && numUnits != 1 {
+		return nil, []error{errors.Errorf("AttachStorage is non-empty, but NumUnits is %d", numUnits)}
+	}
+	// Parse storage tags in AttachStorage.
 	attachStorage := make([]names.StorageTag, len(input))
 	errs := make([]error, 0)
 	for i, stor := range input {
@@ -518,6 +518,12 @@ func (v caasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepo
 	if err := v.caasPrecheckFunc(dt); err != nil {
 		errs = append(errs, err)
 	}
+
+	attachStorage, attachStorageErrs := validateAndParseAttachStorage(arg.AttachStorage, dt.numUnits)
+	if len(attachStorageErrs) > 0 {
+		errs = append(errs, attachStorageErrs...)
+	}
+	dt.attachStorage = attachStorage
 	return dt, errs
 }
 

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -1083,18 +1083,18 @@ func (mr *MockApplicationMockRecorder) ApplicationTag() *gomock.Call {
 }
 
 // ChangeScale mocks base method.
-func (m *MockApplication) ChangeScale(arg0 int) (int, error) {
+func (m *MockApplication) ChangeScale(arg0 int, arg1 []names.StorageTag) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeScale", arg0)
+	ret := m.ctrl.Call(m, "ChangeScale", arg0, arg1)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ChangeScale indicates an expected call of ChangeScale.
-func (mr *MockApplicationMockRecorder) ChangeScale(arg0 any) *gomock.Call {
+func (mr *MockApplicationMockRecorder) ChangeScale(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeScale", reflect.TypeOf((*MockApplication)(nil).ChangeScale), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeScale", reflect.TypeOf((*MockApplication)(nil).ChangeScale), arg0, arg1)
 }
 
 // Charm mocks base method.

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -31,10 +31,21 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Application", 20, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV20(ctx) // Remove remote space
 	}, reflect.TypeOf((*APIv20)(nil)))
+	registry.MustRegister("Application", 21, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV21(ctx) // Added ScaleApplication attach storage support
+	}, reflect.TypeOf((*APIv21)(nil)))
+}
+
+func newFacadeV21(ctx facade.Context) (*APIv21, error) {
+	api, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv21{api}, nil
 }
 
 func newFacadeV20(ctx facade.Context) (*APIv20, error) {
-	api, err := newFacadeBase(ctx)
+	api, err := newFacadeV21(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/application/updatebase_mocks_test.go
+++ b/apiserver/facades/client/application/updatebase_mocks_test.go
@@ -125,18 +125,18 @@ func (mr *MockApplicationMockRecorder) ApplicationTag() *gomock.Call {
 }
 
 // ChangeScale mocks base method.
-func (m *MockApplication) ChangeScale(arg0 int) (int, error) {
+func (m *MockApplication) ChangeScale(arg0 int, arg1 []names.StorageTag) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeScale", arg0)
+	ret := m.ctrl.Call(m, "ChangeScale", arg0, arg1)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ChangeScale indicates an expected call of ChangeScale.
-func (mr *MockApplicationMockRecorder) ChangeScale(arg0 any) *gomock.Call {
+func (mr *MockApplicationMockRecorder) ChangeScale(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeScale", reflect.TypeOf((*MockApplication)(nil).ChangeScale), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeScale", reflect.TypeOf((*MockApplication)(nil).ChangeScale), arg0, arg1)
 }
 
 // Charm mocks base method.

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -232,6 +232,7 @@ type mockApplication struct {
 	watcher              *statetesting.MockNotifyWatcher
 	charmPending         bool
 	provisioningState    *state.ApplicationProvisioningState
+	unitAttachmentInfos  []state.UnitAttachmentInfo
 }
 
 func (a *mockApplication) CharmPendingToBeDownloaded() bool {
@@ -375,6 +376,11 @@ func (a *mockApplication) SetProvisioningState(ps state.ApplicationProvisioningS
 func (a *mockApplication) ProvisioningState() *state.ApplicationProvisioningState {
 	a.MethodCall(a, "ProvisioningState")
 	return a.provisioningState
+}
+
+func (a *mockApplication) GetUnitAttachmentInfos() ([]state.UnitAttachmentInfo, error) {
+	a.MethodCall(a, "GetUnitAttachmentInfos")
+	return a.unitAttachmentInfos, a.NextErr()
 }
 
 type mockCharm struct {

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -56,6 +56,7 @@ type Application interface {
 	CharmPendingToBeDownloaded() bool
 	SetOperatorStatus(status.StatusInfo) error
 	AllUnits() ([]Unit, error)
+	GetUnitAttachmentInfos() ([]state.UnitAttachmentInfo, error)
 	UpdateUnits(unitsOp *state.UpdateUnitsOperation) error
 	StorageConstraints() (map[string]state.StorageConstraints, error)
 	DeviceConstraints() (map[string]state.DeviceConstraints, error)
@@ -139,6 +140,10 @@ func (a *applicationShim) AllUnits() ([]Unit, error) {
 		res = append(res, unit)
 	}
 	return res, nil
+}
+
+func (a *applicationShim) GetUnitAttachmentInfos() ([]state.UnitAttachmentInfo, error) {
+	return a.Application.GetUnitAttachmentInfos()
 }
 
 // StorageBackend provides the subset of backend storage

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1127,7 +1127,7 @@
     {
         "Name": "Application",
         "Description": "",
-        "Version": 20,
+        "Version": 21,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -1355,7 +1355,7 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/ScaleApplicationsParams"
+                            "$ref": "#/definitions/ScaleApplicationsParamsV2"
                         },
                         "Result": {
                             "$ref": "#/definitions/ScaleApplicationResults"
@@ -3139,11 +3139,17 @@
                         "num-units"
                     ]
                 },
-                "ScaleApplicationParams": {
+                "ScaleApplicationParamsV2": {
                     "type": "object",
                     "properties": {
                         "application-tag": {
                             "type": "string"
+                        },
+                        "attach-storage": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "force": {
                             "type": "boolean"
@@ -3186,13 +3192,13 @@
                     },
                     "additionalProperties": false
                 },
-                "ScaleApplicationsParams": {
+                "ScaleApplicationsParamsV2": {
                     "type": "object",
                     "properties": {
                         "applications": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ScaleApplicationParams"
+                                "$ref": "#/definitions/ScaleApplicationParamsV2"
                             }
                         }
                     },

--- a/caas/application.go
+++ b/caas/application.go
@@ -48,6 +48,16 @@ type Application interface {
 	// Service returns the service associated with the application.
 	Service() (*Service, error)
 
+	// EnsurePVCs ensures that Persistent Volume Claims (PVCs) are created for the given
+	// filesystems and unit attachments. It creates PVCs based on the provided filesystem
+	// parameters and handles volume attachments for StatefulSet applications. Returns a
+	// cleanup function that can be used to delete the created PVCs if rollback is needed,
+	// and any error encountered during the process.
+	EnsurePVCs(
+		[]storage.KubernetesFilesystemParams,
+		map[string][]storage.KubernetesFilesystemUnitAttachmentParams,
+	) error
+
 	ServiceInterface
 }
 

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -15,6 +15,7 @@ import (
 
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
+	storage "github.com/juju/juju/storage"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 )
@@ -83,6 +84,20 @@ func (m *MockApplication) Ensure(arg0 caas.ApplicationConfig) error {
 func (mr *MockApplicationMockRecorder) Ensure(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockApplication)(nil).Ensure), arg0)
+}
+
+// EnsurePVCs mocks base method.
+func (m *MockApplication) EnsurePVCs(arg0 []storage.KubernetesFilesystemParams, arg1 map[string][]storage.KubernetesFilesystemUnitAttachmentParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsurePVCs", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsurePVCs indicates an expected call of EnsurePVCs.
+func (mr *MockApplicationMockRecorder) EnsurePVCs(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsurePVCs", reflect.TypeOf((*MockApplication)(nil).EnsurePVCs), arg0, arg1)
 }
 
 // Exists mocks base method.

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
@@ -39,6 +40,7 @@ import (
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	apiparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/storage"
 )
@@ -731,7 +733,7 @@ func (c *DeployCommand) validateStorageByModelType() error {
 	if modelType == model.IAAS {
 		return nil
 	}
-	if len(c.AttachStorage) > 0 {
+	if len(c.AttachStorage) > 0 && !featureflag.Enabled(feature.K8SAttachStorage) {
 		return errors.New("--attach-storage cannot be used on k8s models")
 	}
 	return nil

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -75,9 +75,6 @@ func (d *deployCharm) deploy(
 		if err != nil {
 			continue
 		}
-		if len(d.attachStorage) > 0 {
-			return errors.NotSupportedf("attaching storage to %s container", string(t))
-		}
 		for _, s := range d.storage {
 			if !provider.AllowedContainerProvider(storage.ProviderType(s.Pool)) {
 				return errors.NotSupportedf("adding storage of type %q to %s container", s.Pool, string(t))

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/add-unit.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/add-unit.md
@@ -11,7 +11,7 @@ Adds one or more units to a deployed application.
 ### Options
 | Flag | Default | Usage |
 | --- | --- | --- |
-| `--attach-storage` |  | (Machine models only) Specify an existing storage volume to attach to the deployed unit. |
+| `--attach-storage` |  |  Specify an existing storage volume to attach to the deployed unit. |
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 | `-n`, `--num-units` | 1 | Specify the number of units to add. |
 | `--to` |  | (Machine models only) Specify a comma-separated list of placement directives. If the length of this list is less than `-n`, the remaining units will be added in the default way (i.e., to new machines). |

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/deploy.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/deploy.md
@@ -12,7 +12,7 @@ Deploys a new application or bundle.
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
-| `--attach-storage` |  | (Machine models only) Specify an existing storage volume to attach to the deployed unit. |
+| `--attach-storage` |  | Specify an existing storage volume to attach to the deployed unit. |
 | `--base` |  | The base on which to deploy |
 | `--bind` |  | Configure application endpoint bindings to spaces |
 | `--channel` |  | Channel to use when deploying a charm or bundle from Charmhub |

--- a/internal/provider/kubernetes/application/application.go
+++ b/internal/provider/kubernetes/application/application.go
@@ -2222,13 +2222,7 @@ func (a *app) configureStorage(
 		}
 
 		name := a.volumeName(fs.StorageName)
-		pvcNameGetter := func(volName string) string {
-			if n, ok := pvcNames[volName]; ok {
-				logger.Debugf("using existing persistent volume claim %q (volume %q)", n, volName)
-				return n
-			}
-			return fmt.Sprintf("%s-%s", volName, storageUniqueID)
-		}
+		pvcNameGetter := a.pvcNameGetter(pvcNames, storageUniqueID)
 
 		vol, pvc, sc, err := a.filesystemToVolumeInfo(name, fs, storageClassMap, pvcNameGetter)
 		if err != nil {
@@ -2324,4 +2318,64 @@ func (a *app) filesystemToVolumeInfo(
 		Spec: *pvcSpec,
 	}
 	return nil, pvc, newStorageClass, nil
+}
+
+// handleVolumeAttachment processes volume attachments for a given storage by creating
+// or validating PVCs for each unit attachment. It generates PVC names following the
+// StatefulSet volumeClaimTemplates naming convention to ensure proper binding. Returns
+// a slice of applied PVC resources and any error encountered during processing.
+func (a *app) handleVolumeAttachment(
+	applier resources.Applier,
+	filesystemUnitAttachments map[string][]jujustorage.KubernetesFilesystemUnitAttachmentParams,
+	pvc corev1.PersistentVolumeClaim,
+	storageName string,
+) error {
+	unitAttachments, ok := filesystemUnitAttachments[storageName]
+	if !ok {
+		return nil
+	}
+
+	for _, attachment := range unitAttachments {
+		// Convert {appName}/{unitNumber} to {appName}-{storageName}-{uniqueId}-{appName}-{unitNumber}.
+		// The resulting pvcName will follow the naming convention used by StatefulSet volumeClaimTemplates,
+		// ensuring the created PVC is correctly bound to the application's StatefulSet.
+		pvcName := strings.Replace(attachment.UnitName, "/", "-", 1)
+		pvcName = pvc.ObjectMeta.Name + "-" + pvcName
+
+		// Create the PVC if not found; otherwise, validate the existing volumeName.
+		persistentVolumeClaim := resources.NewPersistentVolumeClaim(
+			a.client.CoreV1().PersistentVolumeClaims(a.namespace),
+			a.namespace,
+			pvcName,
+			&pvc,
+		)
+
+		err := persistentVolumeClaim.Get(context.Background())
+		if errors.Is(err, errors.NotFound) {
+			logger.Debugf("pvc %s not found, create pvc with VolumeName %s", pvcName, attachment.VolumeId)
+			persistentVolumeClaim.Spec.VolumeName = attachment.VolumeId
+			applier.Apply(persistentVolumeClaim)
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+
+		if persistentVolumeClaim.Spec.VolumeName != attachment.VolumeId {
+			return errors.AlreadyExistsf("PVC %q with volumeName %q", pvcName, pvc.Spec.VolumeName)
+		}
+		if _, err := utils.MatchStorageMetaLabelVersion(persistentVolumeClaim.ObjectMeta, storageName); err != nil {
+			return errors.Annotatef(
+				err, "ensuring PersistentVolumeClaim %q with labels %v", pvcName, persistentVolumeClaim.ObjectMeta.Labels)
+		}
+	}
+	return nil
+}
+
+func (a *app) pvcNameGetter(pvcNames map[string]string, storageUniqueID string) func(string) string {
+	return func(volName string) string {
+		if n, ok := pvcNames[volName]; ok {
+			logger.Debugf("using existing persistent volume claim %q (volume %q)", n, volName)
+			return n
+		}
+		return fmt.Sprintf("%s-%s", volName, storageUniqueID)
+	}
 }

--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -597,6 +597,10 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 					ServiceName:         "gitlab-endpoints",
 				},
 			})
+
+			// No pvc is created.
+			_, err = s.client.CoreV1().PersistentVolumeClaims("test").Get(context.TODO(), "gitlab-database-appuuid-gitlab-0", metav1.GetOptions{})
+			c.Assert(err, gc.ErrorMatches, "persistentvolumeclaims \"gitlab-database-appuuid-gitlab-0\" not found")
 		},
 	)
 	s.assertDelete(c, app)

--- a/internal/provider/kubernetes/application/scale.go
+++ b/internal/provider/kubernetes/application/scale.go
@@ -10,9 +10,12 @@ import (
 	"github.com/juju/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/internal/provider/kubernetes/resources"
 	"github.com/juju/juju/internal/provider/kubernetes/scale"
+	"github.com/juju/juju/storage"
 )
 
 // Scale scales the Application's unit to the value specificied. Scale must
@@ -81,4 +84,62 @@ func (a *app) UnitsToRemove(ctx context.Context, desiredScale int) ([]string, er
 	}
 
 	return unitsToRemove, nil
+}
+
+// EnsurePVCs ensures that Persistent Volume Claims (PVCs) are created for the given
+// filesystems and unit attachments. It creates PVCs based on the provided filesystem
+// parameters and handles volume attachments for StatefulSet applications. Returns a
+// cleanup function that can be used to delete the created PVCs if rollback is needed,
+// and any error encountered during the process.
+func (a *app) EnsurePVCs(
+	filesystems []storage.KubernetesFilesystemParams,
+	filesystemUnitAttachments map[string][]storage.KubernetesFilesystemUnitAttachmentParams,
+) error {
+	applier := a.newApplier()
+
+	ss, err := a.getStatefulSet()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	storageUniqueID, err := a.getStorageUniqPrefix(func() (annotationGetter, error) {
+		return ss, nil
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	pvcNames, err := a.pvcNames(storageUniqueID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	pvcNameGetter := a.pvcNameGetter(pvcNames, storageUniqueID)
+
+	storageClasses, err := resources.ListStorageClass(context.Background(), a.client.StorageV1().StorageClasses(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	storageClassMap := make(map[string]resources.StorageClass)
+	for _, v := range storageClasses {
+		storageClassMap[v.Name] = v
+	}
+
+	for _, fs := range filesystems {
+		name := a.volumeName(fs.StorageName)
+		_, pvc, _, err := a.filesystemToVolumeInfo(name, fs, storageClassMap, pvcNameGetter)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if pvc != nil {
+			err := a.handleVolumeAttachment(applier, filesystemUnitAttachments, *pvc, fs.StorageName)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	if err := applier.Run(context.Background(), false); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }

--- a/internal/provider/kubernetes/application/scale_test.go
+++ b/internal/provider/kubernetes/application/scale_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/storage"
 )
 
 func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
@@ -63,4 +64,40 @@ func (s *applicationSuite) TestCurrentScale(c *gc.C) {
 	units, err = app.UnitsToRemove(context.Background(), 3)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 0)
+}
+
+func (s *applicationSuite) TestEnsurePVCs(c *gc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
+
+	// Test EnsurePVCs with filesystem params and unit attachments
+	filesystems := []storage.KubernetesFilesystemParams{
+		{
+			StorageName: "database",
+			Size:        1024, // 1GiB in MiB
+			Provider:    storage.ProviderType("kubernetes"),
+			Attributes:  map[string]interface{}{"storage-class": "fast"},
+		},
+	}
+
+	filesystemUnitAttachments := map[string][]storage.KubernetesFilesystemUnitAttachmentParams{
+		"database": {
+			{
+				UnitName: "gitlab/0",
+				VolumeId: "test-volume-id",
+			},
+		},
+	}
+
+	err := app.EnsurePVCs(filesystems, filesystemUnitAttachments)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Verify PVC was created
+	pvcList, err := s.client.CoreV1().PersistentVolumeClaims(s.namespace).List(context.Background(), metav1.ListOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pvcList.Items, gc.HasLen, 1)
+
+	pvc := pvcList.Items[0]
+	c.Assert(pvc.Spec.VolumeName, gc.Equals, "test-volume-id")
+	c.Assert(pvc.Name, gc.Matches, "gitlab-database-.*-gitlab-0")
 }

--- a/internal/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -118,6 +118,21 @@ func (mr *MockCAASProvisionerFacadeMockRecorder) DestroyUnits(arg0 any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyUnits", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).DestroyUnits), arg0)
 }
 
+// FilesystemProvisioningInfo mocks base method.
+func (m *MockCAASProvisionerFacade) FilesystemProvisioningInfo(arg0 string) (caasapplicationprovisioner.FilesystemProvisioningInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FilesystemProvisioningInfo", arg0)
+	ret0, _ := ret[0].(caasapplicationprovisioner.FilesystemProvisioningInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FilesystemProvisioningInfo indicates an expected call of FilesystemProvisioningInfo.
+func (mr *MockCAASProvisionerFacadeMockRecorder) FilesystemProvisioningInfo(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilesystemProvisioningInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).FilesystemProvisioningInfo), arg0)
+}
+
 // Life mocks base method.
 func (m *MockCAASProvisionerFacade) Life(arg0 string) (life.Value, error) {
 	m.ctrl.T.Helper()

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -48,6 +48,7 @@ type CAASUnitProvisionerFacade interface {
 // CAASProvisionerFacade exposes CAAS provisioning functionality to a worker.
 type CAASProvisionerFacade interface {
 	ProvisioningInfo(string) (api.ProvisioningInfo, error)
+	FilesystemProvisioningInfo(string) (api.FilesystemProvisioningInfo, error)
 	WatchApplications() (watcher.StringsWatcher, error)
 	SetPassword(string, string) error
 	Life(string) (life.Value, error)

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -421,6 +421,11 @@ type ScaleApplicationsParams struct {
 	Applications []ScaleApplicationParams `json:"applications"`
 }
 
+// ScaleApplicationsParamsV2 holds bulk parameters for the Application.ScaleApplication call.
+type ScaleApplicationsParamsV2 struct {
+	Applications []ScaleApplicationParamsV2 `json:"applications"`
+}
+
 // ScaleApplicationParams holds parameters for the Application.ScaleApplication call.
 type ScaleApplicationParams struct {
 	// ApplicationTag holds the tag of the application to scale.
@@ -435,6 +440,28 @@ type ScaleApplicationParams struct {
 	// Force controls whether or not scaling of an application
 	// will be forced, i.e. ignore operational errors.
 	Force bool `json:"force"`
+}
+
+// ScaleApplicationParamsV2 holds parameters for the Application.ScaleApplication call.
+// V2 support attach storage.
+type ScaleApplicationParamsV2 struct {
+	// ApplicationTag holds the tag of the application to scale.
+	ApplicationTag string `json:"application-tag"`
+
+	// Scale is the number of units which should be running.
+	Scale int `json:"scale"`
+
+	// Scale is the number of units which should be added/removed from the existing count.
+	ScaleChange int `json:"scale-change,omitempty"`
+
+	// Force controls whether or not scaling of an application
+	// will be forced, i.e. ignore operational errors.
+	Force bool `json:"force"`
+
+	// AttachStorage contains IDs of existing storage that should be
+	// attached to the application unit that will be deployed. This
+	// may be non-empty only if NumUnits is 1.
+	AttachStorage []string `json:"attach-storage,omitempty"`
 }
 
 // ScaleApplicationResults contains the results of a ScaleApplication

--- a/rpc/params/caas.go
+++ b/rpc/params/caas.go
@@ -62,6 +62,25 @@ type CAASApplicationProvisioningInfo struct {
 	Error                *Error                       `json:"error,omitempty"`
 }
 
+// KubernetesFilesystemUnitAttachmentParams holds the parameters for
+// creating a filesystem attachment for the unit.
+type KubernetesFilesystemUnitAttachmentParams struct {
+	// UnitTag is the tag identifying the unit to attach the filesystem to.
+	UnitTag string `json:"unit-tag"`
+
+	// VolumeId is the storage provider's unique identifier for the volume.
+	VolumeId string `json:"volume-id"`
+}
+
+// CAASApplicationFilesystemProvisioningInfo holds info needed to provision a caas application filesystem.
+type CAASApplicationFilesystemProvisioningInfo struct {
+	// Filesystems contains the filesystem specifications to be provisioned.
+	Filesystems []KubernetesFilesystemParams `json:"filesystems,omitempty"`
+
+	// FilesystemUnitAttachments maps filesystem IDs to unit attachment parameters.
+	FilesystemUnitAttachments map[string][]KubernetesFilesystemUnitAttachmentParams `json:"filesystem-unit-attachments,omitempty"`
+}
+
 // DockerImageInfo holds the details for a Docker resource type.
 type DockerImageInfo struct {
 	// RegistryPath holds the path of the Docker image (including host and sha256) in a docker registry.

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -5166,25 +5166,58 @@ func (s *CAASApplicationSuite) TestSetScale(c *gc.C) {
 }
 
 func (s *CAASApplicationSuite) TestInvalidChangeScale(c *gc.C) {
-	newScale, err := s.app.ChangeScale(-1)
+	newScale, err := s.app.ChangeScale(-1, []names.StorageTag{})
 	c.Assert(err, gc.ErrorMatches, "cannot remove more units than currently exist not valid")
 	c.Assert(newScale, gc.Equals, 0)
 }
 
 func (s *CAASApplicationSuite) TestChangeScale(c *gc.C) {
-	newScale, err := s.app.ChangeScale(5)
+	newScale, err := s.app.ChangeScale(5, []names.StorageTag{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newScale, gc.Equals, 5)
 	err = s.app.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.app.GetScale(), gc.Equals, 5)
 
-	newScale, err = s.app.ChangeScale(-4)
+	newScale, err = s.app.ChangeScale(-4, []names.StorageTag{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newScale, gc.Equals, 1)
 	err = s.app.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.app.GetScale(), gc.Equals, 1)
+}
+
+func (s *CAASApplicationSuite) TestChangeScaleAttachStorage(c *gc.C) {
+	ch, sb, st := s.setupCharmWithNewStorageBackend(c)
+	storageTags := s.addExistingFilesystems(c, sb, 3, "database")
+
+	f := factory.NewFactory(st, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{Name: "cockroachdb", Charm: ch})
+	err := app.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newScale, err := app.ChangeScale(1, []names.StorageTag{storageTags[0]})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newScale, gc.Equals, 1)
+
+	newScale, err = app.ChangeScale(1, []names.StorageTag{storageTags[1]})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newScale, gc.Equals, 2)
+
+	newScale, err = app.ChangeScale(1, []names.StorageTag{storageTags[2]})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newScale, gc.Equals, 3)
+
+	units, err := app.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	for i, unit := range units {
+		attachments, err := sb.UnitStorageAttachments(unit.UnitTag())
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(attachments[0].Unit(), gc.Equals,
+			names.NewUnitTag(fmt.Sprintf("cockroachdb/%d", i)),
+		)
+		c.Assert(attachments[0].StorageInstance(), gc.Equals, storageTags[i])
+	}
 }
 
 func (s *CAASApplicationSuite) TestWatchScale(c *gc.C) {
@@ -5531,6 +5564,95 @@ func (s *CAASApplicationSuite) TestDestroyQueuesUnitCleanup(c *gc.C) {
 
 	// App dying until units are gone.
 	assertLife(c, s.app, state.Dying)
+}
+
+func (s *CAASApplicationSuite) TestGetUnitAttachmentInfosWithoutAttachStorage(c *gc.C) {
+	app := s.setupApplicationWithAttachStorage(c, 2, []names.StorageTag{})
+	infos, err := app.GetUnitAttachmentInfos()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(infos, gc.HasLen, 0)
+}
+
+func (s *CAASApplicationSuite) TestGetUnitAttachmentInfosWithAttachStorage(c *gc.C) {
+	app := s.setupApplicationWithAttachStorage(c, 1, []names.StorageTag{names.NewStorageTag("database/0")})
+	infos, err := app.GetUnitAttachmentInfos()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(infos, gc.DeepEquals, []state.UnitAttachmentInfo{{Unit: "cockroachdb/0", VolumeId: "pv-database-0", StorageId: "database/0"}})
+}
+
+func (s *CAASApplicationSuite) addExistingFilesystems(c *gc.C, sb *state.StorageBackend, num int, storageName string) []names.StorageTag {
+	storageTags := make([]names.StorageTag, num+1)
+	for i := 0; i < num; i++ {
+		fsInfo := state.FilesystemInfo{
+			Size: 100,
+			Pool: "kubernetes",
+		}
+		volumeInfo := state.VolumeInfo{
+			VolumeId:   fmt.Sprintf("pv-%s-%d", storageName, i),
+			Size:       100,
+			Pool:       "kubernetes",
+			Persistent: true,
+		}
+		storageTag, err := sb.AddExistingFilesystem(fsInfo, &volumeInfo, storageName)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(storageTag.Id(), gc.Equals, fmt.Sprintf("database/%d", i))
+		storageTags[i] = storageTag
+	}
+	return storageTags
+}
+
+func (s *CAASApplicationSuite) setupCharmWithNewStorageBackend(c *gc.C) (*state.Charm, *state.StorageBackend, *state.State) {
+	registry := &storage.StaticProviderRegistry{
+		Providers: map[storage.ProviderType]storage.Provider{
+			"kubernetes": &dummy.StorageProvider{
+				StorageScope: storage.ScopeEnviron,
+				IsDynamic:    true,
+				IsReleasable: true,
+				SupportsFunc: func(k storage.StorageKind) bool {
+					return k == storage.StorageKindBlock
+				},
+			},
+		},
+	}
+
+	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{
+		CloudName: "caascloud",
+	})
+	s.AddCleanup(func(_ *gc.C) { _ = st.Close() })
+
+	pm := poolmanager.New(state.NewStateSettings(st), registry)
+	_, err := pm.Create("kubernetes", "kubernetes", map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	s.policy = testing.MockPolicy{
+		GetStorageProviderRegistry: func() (storage.ProviderRegistry, error) {
+			return registry, nil
+		},
+	}
+
+	sb, err := state.NewStorageBackend(st)
+	c.Assert(err, jc.ErrorIsNil)
+	ch := state.AddTestingCharmForSeries(c, st, "quantal", "cockroachdb")
+	return ch, sb, st
+}
+
+func (s *CAASApplicationSuite) setupApplicationWithAttachStorage(c *gc.C, unitNum int, attachStorage []names.StorageTag) *state.Application {
+	ch, sb, st := s.setupCharmWithNewStorageBackend(c)
+	s.addExistingFilesystems(c, sb, 3, "database")
+
+	cockroachdb := state.AddTestingApplicationWithAttachStorage(c, st, "cockroachdb", ch, unitNum,
+		map[string]state.StorageConstraints{
+			"database": {
+				Pool:  "kubernetes",
+				Size:  100,
+				Count: 0,
+			},
+		},
+		attachStorage,
+	)
+	units, err := cockroachdb.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, unitNum)
+	return cockroachdb
 }
 
 func (s *ApplicationSuite) TestSetOperatorStatusNonCAAS(c *gc.C) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -338,6 +338,22 @@ func AddTestingApplicationWithStorage(c *gc.C, st *State, name string, ch *Charm
 	})
 }
 
+func AddTestingApplicationWithAttachStorage(
+	c *gc.C, st *State, name string, ch *Charm,
+	numUnits int,
+	storage map[string]StorageConstraints,
+	attachStorage []names.StorageTag,
+) *Application {
+	return addTestingApplication(c, addTestingApplicationParams{
+		st:            st,
+		name:          name,
+		ch:            ch,
+		attachStorage: attachStorage,
+		numUnits:      numUnits,
+		storage:       storage,
+	})
+}
+
 func AddTestingApplicationWithDevices(c *gc.C, st *State, name string, ch *Charm, devices map[string]DeviceConstraints) *Application {
 	return addTestingApplication(c, addTestingApplicationParams{
 		st:      st,
@@ -357,14 +373,15 @@ func AddTestingApplicationWithBindings(c *gc.C, st *State, name string, ch *Char
 }
 
 type addTestingApplicationParams struct {
-	st       *State
-	name     string
-	ch       *Charm
-	origin   *CharmOrigin
-	bindings map[string]string
-	storage  map[string]StorageConstraints
-	devices  map[string]DeviceConstraints
-	numUnits int
+	st            *State
+	name          string
+	ch            *Charm
+	origin        *CharmOrigin
+	bindings      map[string]string
+	storage       map[string]StorageConstraints
+	devices       map[string]DeviceConstraints
+	numUnits      int
+	attachStorage []names.StorageTag
 }
 
 func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Application {
@@ -405,6 +422,7 @@ func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Applica
 		Storage:          params.storage,
 		Devices:          params.devices,
 		NumUnits:         params.numUnits,
+		AttachStorage:    params.attachStorage,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return app

--- a/storage/kubernetes.go
+++ b/storage/kubernetes.go
@@ -57,3 +57,12 @@ type KubernetesFilesystemInfo struct {
 	// Size is the size of the filesystem in MiB.
 	Size uint64
 }
+
+// KubernetesFilesystemUnitAttachmentParams describes a unit filesystem attachment.
+type KubernetesFilesystemUnitAttachmentParams struct {
+	// UnitName is the name of the unit which the volume is attached to.
+	UnitName string
+
+	// VolumeId is the storage provider's unique identifier for the volume.
+	VolumeId string
+}

--- a/tests/suites/storage_k8s/add-unit.sh
+++ b/tests/suites/storage_k8s/add-unit.sh
@@ -1,0 +1,213 @@
+test_add_unit_attach_storage() {
+	if [ "$(skip 'test_add_unit_attach_storage')" ]; then
+		echo "==> TEST SKIPPED: test_add_unit_attach_storage"
+		return
+	fi
+
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# Ensure a bootstrap Juju model exists.
+	model_name="add-unit-attach-storage"
+	second_model_name="add-unit-attach-storage-second"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	# Create a PersistentVolume by deploying and deleting an application.
+	juju deploy postgresql-k8s --channel 14/stable --trust -n 3
+	# Ensure the storage is attached without waiting for the application to reach the active status.
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+	wait_for_storage "attached" '.storage["pgdata/1"]["status"].current'
+	wait_for_storage "attached" '.storage["pgdata/2"]["status"].current'
+
+	# Capture the provisioned PersistentVolume ID.
+	PV_0=$(juju storage --format json | jq -r '.volumes["0"]."provider-id"')
+	PV_1=$(juju storage --format json | jq -r '.volumes["1"]."provider-id"')
+	PV_2=$(juju storage --format json | jq -r '.volumes["2"]."provider-id"')
+
+	# Clean up: remove the application and associated storage (retain PV).
+	juju remove-application postgresql-k8s --no-prompt --force
+	wait_for "{}" ".applications"
+	juju remove-storage pgdata/0 --no-destroy
+	juju remove-storage pgdata/1 --no-destroy
+	juju remove-storage pgdata/2 --no-destroy
+	wait_for "{}" ".storage"
+
+	# Prepare PersistentVolumes for reuse: set reclaim policy to Retain and remove claimRef.
+	for pv in "${PV_0}" "${PV_1}" "${PV_2}"; do
+		kubectl patch pv "${pv}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+		PVC=$(kubectl get pv "${pv}" -o jsonpath='{.spec.claimRef.name}')
+		kubectl delete pvc "${PVC}" -n "${model_name}" --ignore-not-found=true
+		kubectl patch pv "${pv}" --type merge -p '{"spec":{"claimRef": null}}'
+	done
+
+	juju add-model "${second_model_name}"
+	juju switch "${second_model_name}"
+
+	for pv in "${PV_0}" "${PV_1}" "${PV_2}"; do
+		juju import-filesystem kubernetes "${pv}" pgdata
+	done
+
+	# Deploy with --attach-storage. The storage should be attached to the psql-k8s/0 unit.
+	juju deploy postgresql-k8s --channel 14/stable --trust --attach-storage pgdata/0 psql-k8s
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+
+	juju add-unit psql-k8s --attach-storage pgdata/1
+	wait_for_storage "attached" '.storage["pgdata/1"]["status"].current'
+	juju add-unit psql-k8s --attach-storage pgdata/2
+	wait_for_storage "attached" '.storage["pgdata/2"]["status"].current'
+
+	# Verify PVs are bound and PVCs have correct labels
+	for pv in "${PV_0}" "${PV_1}" "${PV_2}"; do
+		OUT=$(kubectl get pv "${pv}" -o json | jq '.status.phase')
+		echo "${OUT}" | check "Bound"
+
+		NEW_PVC=$(kubectl get pv "${pv}" -o jsonpath='{.spec.claimRef.name}')
+		PVC_JSON=$(kubectl get pvc -n "${second_model_name}" "${NEW_PVC}" -o json)
+
+		echo "${PVC_JSON}" | jq '.metadata.labels."storage.juju.is/name"' | check "pgdata"
+		echo "${PVC_JSON}" | jq '.metadata.labels."app.kubernetes.io/managed-by"' | check "juju"
+		echo "${PVC_JSON}" | jq '.metadata.annotations."juju-storage-owner"' | check "psql-k8s"
+	done
+
+	# Verify volume provider IDs match the original PVs
+	for i in 0 1 2; do
+		eval "expected_pv=\$PV_${i}"
+		OUT=$(juju storage --format json | jq ".volumes.\"${i}\".\"provider-id\"")
+		# shellcheck disable=SC2154
+		echo "${OUT}" | check "${expected_pv}"
+	done
+
+	# Destroy the test model.
+	destroy_model "${model_name}"
+	destroy_model "${second_model_name}"
+}
+
+test_add_unit_duplicate_pvc_exists() {
+	if [ "$(skip 'test_add_unit_duplicate_pvc_exists')" ]; then
+		echo "==> TEST SKIPPED: test_add_unit_duplicate_pvc_exists"
+		return
+	fi
+
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# Ensure a bootstrap Juju model exists.
+	model_name="add-unit-duplicate-pvc-exists"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	# Create a PersistentVolume by deploying and deleting an application.
+	juju deploy postgresql-k8s --channel 14/stable --trust
+	# Ensure the storage is attached without waiting for the application to reach the active status.
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+
+	# Capture the provisioned PersistentVolume ID.
+	PV=$(juju storage --format json | jq -r '.volumes["0"]."provider-id"')
+	PVC=$(kubectl get pv "${PV}" -o jsonpath='{.spec.claimRef.name}')
+
+	juju remove-unit postgresql-k8s --num-units 1 --force
+	wait_for "null" '.applications."postgresql-k8s".units'
+
+	# Patch PVC to have incorrect label to simulate duplicate PVC scenario
+	kubectl patch pvc "${PVC}" \
+		-n "${model_name}" \
+		-p '{"metadata":{"labels":{"storage.juju.is/name":"not-pgdata"}}}'
+
+	# Avoid race condition of attaching storage before kubectl patching completes
+	attempt=0
+	until kubectl get pvc "${PVC}" -n "${model_name}" -o json | jq -r '.metadata.labels."storage.juju.is/name"' | grep -q "not-pgdata"; do
+		echo "[+] (attempt ${attempt}) waiting for PVC patch to complete"
+		sleep "${SHORT_TIMEOUT}"
+		attempt=$((attempt + 1))
+
+		if [[ ${attempt} -gt 10 ]]; then
+			echo "ERROR: failed waiting for PVC patch to complete"
+			exit 1
+		fi
+	done
+
+	# Should not scale due to wrong label value
+	juju add-unit postgresql-k8s --attach-storage pgdata/0
+	sleep "${SHORT_TIMEOUT}"
+	OUT=$(kubectl get statefulset -n "${model_name}" postgresql-k8s -o jsonpath='{.spec.replicas}')
+	echo "${OUT}" | check 0
+
+	# Fix the PVC label to allow successful attachment
+	kubectl patch pvc "${PVC}" \
+		-n "${model_name}" \
+		-p '{"metadata":{"labels":{"storage.juju.is/name":"pgdata"}}}'
+
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+
+	# Destroy the test model.
+	destroy_model "${model_name}"
+}
+
+test_add_unit_attach_storage_scaling_race_condition() {
+	if [ "$(skip 'test_add_unit_attach_storage_scaling_race_condition')" ]; then
+		echo "==> TEST SKIPPED: test_add_unit_attach_storage_scaling_race_condition"
+		return
+	fi
+
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# Ensure a bootstrap Juju model exists.
+	model_name="add-unit-attach-storage-scaling-race-condition"
+	second_model_name="add-unit-attach-storage-scaling-race-condition-second"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	# Create a PersistentVolume by deploying and deleting an application.
+	juju deploy postgresql-k8s --channel 14/stable --trust -n 3
+	# Ensure the storage is attached without waiting for the application to reach the active status.
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+	wait_for_storage "attached" '.storage["pgdata/1"]["status"].current'
+	wait_for_storage "attached" '.storage["pgdata/2"]["status"].current'
+
+	# Capture the provisioned PersistentVolume ID.
+	PV_0=$(juju storage --format json | jq -r '.volumes["0"]."provider-id"')
+	PV_1=$(juju storage --format json | jq -r '.volumes["1"]."provider-id"')
+	PV_2=$(juju storage --format json | jq -r '.volumes["2"]."provider-id"')
+
+	# Clean up: remove the application and associated storage (retain PV).
+	juju remove-application postgresql-k8s --no-prompt --force
+	wait_for "{}" ".applications"
+	juju remove-storage pgdata/0 --no-destroy
+	juju remove-storage pgdata/1 --no-destroy
+	juju remove-storage pgdata/2 --no-destroy
+	wait_for "{}" ".storage"
+
+	# Prepare PersistentVolumes for reuse: set reclaim policy to Retain and remove claimRef.
+	for pv in "${PV_0}" "${PV_1}" "${PV_2}"; do
+		kubectl patch pv "${pv}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+		PVC=$(kubectl get pv "${pv}" -o jsonpath='{.spec.claimRef.name}')
+		kubectl delete pvc "${PVC}" -n "${model_name}" --ignore-not-found=true
+		kubectl patch pv "${pv}" --type merge -p '{"spec":{"claimRef": null}}'
+	done
+
+	juju add-model "${second_model_name}"
+	juju switch "${second_model_name}"
+
+	for pv in "${PV_0}" "${PV_1}" "${PV_2}"; do
+		juju import-filesystem kubernetes "${pv}" pgdata
+	done
+
+	# Deploy with --attach-storage. The storage should be attached to the psql-k8s/0 unit.
+	juju deploy postgresql-k8s --channel 14/stable --trust --attach-storage pgdata/0 psql-k8s
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+
+	# Add unit and remove them immediately to make sure it wouldn't break the juju.
+	juju add-unit psql-k8s --attach-storage pgdata/1
+	wait_for_storage "attached" '.storage["pgdata/1"]["status"].current'
+	juju add-unit psql-k8s --attach-storage pgdata/2
+	wait_for_storage "attached" '.storage["pgdata/2"]["status"].current'
+	juju remove-unit psql-k8s --num-units 2 && juju remove-unit psql-k8s --num-units 1
+	wait_for_storage "detached" '.storage["pgdata/0"]["status"].current'
+	wait_for "null" '.applications."psql-k8s".units'
+
+	# Destroy the test model.
+	destroy_model "${model_name}"
+	destroy_model "${second_model_name}"
+}

--- a/tests/suites/storage_k8s/deploy.sh
+++ b/tests/suites/storage_k8s/deploy.sh
@@ -1,0 +1,78 @@
+test_deploy_attach_storage() {
+	if [ "$(skip 'test_deploy_attach_storage')" ]; then
+		echo "==> TEST SKIPPED: test_deploy_attach_storage"
+		return
+	fi
+
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# Ensure a bootstrap Juju model exists.
+	model_name="deploy-attach-storage"
+	second_model_name="deploy-attach-storage-second"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	# Create a PersistentVolume by deploying and deleting an application.
+	echo "Create persistent volume to be imported"
+	juju deploy postgresql-k8s --channel 14/stable --trust
+	# Ensure the storage is attached without waiting for the application to reach the active status.
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+
+	# Capture the provisioned PersistentVolume ID.
+	PV=$(juju storage --format json | jq -r '.volumes["0"]."provider-id"')
+
+	# Clean up: remove the application and associated storage (retain PV).
+	juju remove-application postgresql-k8s --no-prompt
+	wait_for "{}" ".applications"
+	juju remove-storage pgdata/0 --no-destroy
+	wait_for "{}" ".storage"
+
+	# Clean up: make sure PersistentVolume is in available status
+	kubectl patch pv "${PV}" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+	PVC=$(kubectl get pv "${PV}" -o jsonpath='{.spec.claimRef.name}')
+	kubectl delete pvc "${PVC}" -n "${model_name}"
+	kubectl patch pv "${PV}" --type merge -p '{"spec":{"claimRef": null}}'
+
+	# Import filesystem as pgdata/0 in second model.
+	juju add-model "${second_model_name}"
+	juju switch "${second_model_name}"
+	juju import-filesystem kubernetes "${PV}" pgdata
+	wait_for_storage "detached" '.storage["pgdata/0"]["status"].current'
+
+	# Deploy with --attach-storage. The storage should be attached to the psql-k8s/0 unit.
+	juju deploy postgresql-k8s --channel 14/stable --trust --attach-storage pgdata/0 psql-k8s
+	wait_for_storage "attached" '.storage["pgdata/0"]["status"].current'
+
+	OUT=$(kubectl get pv "${PV}" -o json | jq '.status.phase')
+	echo "${OUT}" | check "Bound"
+
+	# Make sure new PV/PVC is used by the postgresql-k8s charm
+	NEW_PVC=$(kubectl get pv "${PV}" -o jsonpath='{.spec.claimRef.name}')
+	OUT=$(
+		kubectl get pvc -n "${second_model_name}" "${NEW_PVC}" -o json |
+			jq '.metadata.labels."storage.juju.is/name"'
+	)
+	echo "${OUT}" | check "pgdata"
+
+	OUT=$(
+		kubectl get pvc -n "${second_model_name}" "${NEW_PVC}" -o json |
+			jq '.metadata.labels."app.kubernetes.io/managed-by"'
+	)
+	echo "${OUT}" | check "juju"
+	OUT=$(
+		kubectl get pvc -n "${second_model_name}" "${NEW_PVC}" -o json |
+			jq '.metadata.annotations."juju-storage-owner"'
+	)
+	echo "${OUT}" | check "psql-k8s"
+
+	# Make sure pv name have been update in volumes.
+	OUT=$(
+		juju storage --format json | jq '.volumes."0"."provider-id"'
+	)
+	echo "${OUT}" | check "${PV}"
+
+	# Destroy the test model.
+	destroy_model "${second_model_name}"
+	destroy_model "${model_name}"
+}

--- a/tests/suites/storage_k8s/import.sh
+++ b/tests/suites/storage_k8s/import.sh
@@ -1,4 +1,9 @@
 test_import_filesystem() {
+	if [ "$(skip 'test_import_filesystem')" ]; then
+		echo "==> TEST SKIPPED: test_import_filesystem"
+		return
+	fi
+
 	# Echo out to ensure nice output to the test suite.
 	echo
 

--- a/tests/suites/storage_k8s/task.sh
+++ b/tests/suites/storage_k8s/task.sh
@@ -17,6 +17,10 @@ test_storage_k8s() {
 		export JUJU_DEV_FEATURE_FLAGS=k8s-attach-storage
 		test_import_filesystem
 		test_force_import_filesystem
+		test_deploy_attach_storage
+		test_add_unit_attach_storage
+		test_add_unit_duplicate_pvc_exists
+		test_add_unit_attach_storage_scaling_race_condition
 		;;
 	*)
 		echo "==> TEST SKIPPED: storage k8s tests, not a k8s provider"


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

Enable storage attachment functionality for Kubernetes applications during deployment and add-unit operations. This allows users to specify attach storage when deploying or scaling applications in CAAS environments.
    
Life-cycle improvements:
- Deploy applications with initialScale 0, unifying deployment and scaling flows
- Ensure PVC provisioning completes before scaling to target replicas
- Add FilesystemProvisioningInfo API for pre-scale storage preparation
- Implement ensureScaleWithFsAttachments for storage-aware scaling

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Integration test

### Environment

- juju k8s cloud deployment

### Integration test
```
cd ./tests

./main.sh -V -l k8s-ctrl storage_k8s test_deploy_attach_storage
./main.sh -V -l k8s-ctrl storage_k8s test_add_unit_attach_storage
./main.sh -V -l k8s-ctrl storage_k8s test_add_unit_duplicate_pvc_exists
./main.sh -V -l k8s-ctrl storage_k8s test_add_unit_attach_storage_scaling_race_condition
```

### Unit test
```sh
# api
make run-go-tests TEST_PACKAGES=./api/client/application TEST_FILTER=applicationSuite
make run-go-tests TEST_PACKAGES=./api/controller/caasapplicationprovisioner TEST_FILTER=provisionerSuite
# apiserver
make run-go-tests TEST_PACKAGES=./apiserver/facades/client/application TEST_FILTER=ApplicationSuite
make run-go-tests TEST_PACKAGES=./apiserver/facades/controller/caasapplicationprovisioner TEST_FILTER=CAASApplicationProvisionerSuite
make run-go-tests TEST_PACKAGES=./apiserver/facades/client/application TEST_FILTER=validatorSuite

# caas
make run-go-tests TEST_PACKAGES=./internal/provider/kubernetes/application TEST_FILTER=applicationSuite
make run-go-tests TEST_PACKAGES=./internal/provider/kubernetes/utils TEST_FILTER=LabelSuite
# cmd
make run-go-tests TEST_PACKAGES=./cmd/juju/application TEST_FILTER=AddUnitSuite
make run-go-tests TEST_PACKAGES=./cmd/juju/application TEST_FILTER=CAASDeploySuite
# internal
make run-go-tests TEST_PACKAGES=./internal/worker/caasapplicationprovisioner TEST_FILTER=OpsSuite
make run-go-tests TEST_PACKAGES=./state TEST_FILTER=CAASApplicationSuite
```


## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

Support `--attach-storage` on add-unit & deploy command.

## Links

PartiallyFixes: #19521 
Depends on: #20479
