### PR TITLE
feat: remote relations worker

### DIFF
--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -283,6 +283,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewControllerConnection:  apicaller.NewExternalControllerConnection,
 			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
 			NewWorker:                remoterelations.NewWorker,
+			Clock:                    config.Clock,
 			Logger:                   config.LoggingContext.GetLogger("juju.worker.remoterelations", corelogger.CMR),
 		})),
 		removalName: ifNotMigrating(removal.Manifold(removal.ManifoldConfig{

--- a/internal/worker/remoterelations/manifold.go
+++ b/internal/worker/remoterelations/manifold.go
@@ -28,6 +28,7 @@ type ManifoldConfig struct {
 	NewRemoteRelationsFacade func(base.APICaller) RemoteRelationsFacade
 	NewWorker                func(Config) (worker.Worker, error)
 	Logger                   logger.Logger
+	Clock                    clock.Clock
 }
 
 // Validate is called by start to check for bad configuration.
@@ -49,6 +50,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	return nil
 }
@@ -72,7 +76,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		ModelUUID:                agent.CurrentConfig().Model().Id(),
 		RelationsFacade:          config.NewRemoteRelationsFacade(apiConn),
 		NewRemoteModelFacadeFunc: remoteRelationsFacadeForModelFunc(config.NewControllerConnection),
-		Clock:                    clock.WallClock,
+		Clock:                    config.Clock,
 		Logger:                   config.Logger,
 	})
 	if err != nil {

--- a/internal/worker/remoterelations/manifold_test.go
+++ b/internal/worker/remoterelations/manifold_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v4"
@@ -38,6 +39,7 @@ func (s *ManifoldConfigSuite) validConfig(c *tc.C) ManifoldConfig {
 		NewControllerConnection:  func(context.Context, *api.Info) (api.Connection, error) { return nil, nil },
 		NewRemoteRelationsFacade: func(base.APICaller) RemoteRelationsFacade { return nil },
 		NewWorker:                func(Config) (worker.Worker, error) { return nil, nil },
+		Clock:                    clock.WallClock,
 		Logger:                   loggertesting.WrapCheckLog(c),
 	}
 }
@@ -69,6 +71,11 @@ func (s *ManifoldConfigSuite) TestMissingNewWorker(c *tc.C) {
 func (s *ManifoldConfigSuite) TestMissingNewControllerConnection(c *tc.C) {
 	s.config.NewControllerConnection = nil
 	s.checkNotValid(c, "nil NewControllerConnection not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingClock(c *tc.C) {
+	s.config.Clock = nil
+	s.checkNotValid(c, "nil Clock not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingLogger(c *tc.C) {

--- a/internal/worker/remoterelations/manifold_test.go
+++ b/internal/worker/remoterelations/manifold_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package remoterelations_test
+package remoterelations
 
 import (
 	"context"
@@ -15,12 +15,11 @@ import (
 	"github.com/juju/juju/api/base"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
-	"github.com/juju/juju/internal/worker/remoterelations"
 )
 
 type ManifoldConfigSuite struct {
 	testhelpers.IsolationSuite
-	config remoterelations.ManifoldConfig
+	config ManifoldConfig
 }
 
 func TestManifoldConfigSuite(t *testing.T) {
@@ -32,13 +31,13 @@ func (s *ManifoldConfigSuite) SetUpTest(c *tc.C) {
 	s.config = s.validConfig(c)
 }
 
-func (s *ManifoldConfigSuite) validConfig(c *tc.C) remoterelations.ManifoldConfig {
-	return remoterelations.ManifoldConfig{
+func (s *ManifoldConfigSuite) validConfig(c *tc.C) ManifoldConfig {
+	return ManifoldConfig{
 		AgentName:                "agent",
 		APICallerName:            "api-caller",
 		NewControllerConnection:  func(context.Context, *api.Info) (api.Connection, error) { return nil, nil },
-		NewRemoteRelationsFacade: func(base.APICaller) remoterelations.RemoteRelationsFacade { return nil },
-		NewWorker:                func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
+		NewRemoteRelationsFacade: func(base.APICaller) RemoteRelationsFacade { return nil },
+		NewWorker:                func(Config) (worker.Worker, error) { return nil, nil },
 		Logger:                   loggertesting.WrapCheckLog(c),
 	}
 }

--- a/internal/worker/remoterelations/mock_test.go
+++ b/internal/worker/remoterelations/mock_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package remoterelations_test
+package remoterelations
 
 import (
 	"context"
@@ -390,7 +390,7 @@ func (m *mockRemoteRelationsFacade) WatchConsumedSecretsChanges(_ context.Contex
 
 type mockWatcher struct {
 	testhelpers.Stub
-	tomb.Tomb
+	tomb       tomb.Tomb
 	mu         sync.Mutex
 	terminated bool
 }
@@ -403,10 +403,14 @@ func (w *mockWatcher) killed() bool {
 
 func (w *mockWatcher) Kill() {
 	w.MethodCall(w, "Kill")
-	w.Tomb.Kill(nil)
+	w.tomb.Kill(nil)
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.terminated = true
+}
+
+func (w *mockWatcher) Wait() error {
+	return w.tomb.Wait()
 }
 
 func (w *mockWatcher) Stop() error {
@@ -414,8 +418,8 @@ func (w *mockWatcher) Stop() error {
 	if err := w.NextErr(); err != nil {
 		return err
 	}
-	w.Tomb.Kill(nil)
-	return w.Tomb.Wait()
+	w.tomb.Kill(nil)
+	return w.tomb.Wait()
 }
 
 type mockStringsWatcher struct {
@@ -425,8 +429,8 @@ type mockStringsWatcher struct {
 
 func newMockStringsWatcher() *mockStringsWatcher {
 	w := &mockStringsWatcher{changes: make(chan []string, 5)}
-	w.Tomb.Go(func() error {
-		<-w.Tomb.Dying()
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
 		return nil
 	})
 	return w
@@ -446,8 +450,8 @@ func newMockSecretsRevisionWatcher() *mockSecretsRevisionWatcher {
 	w := &mockSecretsRevisionWatcher{
 		changes: make(chan []watcher.SecretRevisionChange, 1),
 	}
-	w.Tomb.Go(func() error {
-		<-w.Tomb.Dying()
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
 		return nil
 	})
 	return w
@@ -479,15 +483,15 @@ func newMockRemoteRelationWatcher() *mockRemoteRelationWatcher {
 	w := &mockRemoteRelationWatcher{
 		changes: make(chan params.RemoteRelationChangeEvent, 1),
 	}
-	w.Tomb.Go(func() error {
-		<-w.Tomb.Dying()
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
 		return nil
 	})
 	return w
 }
 
 func (w *mockRemoteRelationWatcher) kill(err error) {
-	w.Tomb.Kill(err)
+	w.tomb.Kill(err)
 }
 
 func (w *mockRemoteRelationWatcher) Changes() <-chan params.RemoteRelationChangeEvent {
@@ -504,8 +508,8 @@ func newMockRelationStatusWatcher() *mockRelationStatusWatcher {
 	w := &mockRelationStatusWatcher{
 		changes: make(chan []watcher.RelationStatusChange, 1),
 	}
-	w.Tomb.Go(func() error {
-		<-w.Tomb.Dying()
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
 		return nil
 	})
 	return w
@@ -525,8 +529,8 @@ func newMockOfferStatusWatcher() *mockOfferStatusWatcher {
 	w := &mockOfferStatusWatcher{
 		changes: make(chan []watcher.OfferStatusChange, 1),
 	}
-	w.Tomb.Go(func() error {
-		<-w.Tomb.Dying()
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
 		return nil
 	})
 	return w

--- a/internal/worker/remoterelations/remoterelations.go
+++ b/internal/worker/remoterelations/remoterelations.go
@@ -69,6 +69,7 @@ type RemoteModelRelationsFacade interface {
 }
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.
+// This is the local model's view of the remote relations API.
 type RemoteRelationsFacade interface {
 	// ImportRemoteEntity adds an entity to the remote entities collection
 	// with the specified opaque token.
@@ -314,6 +315,7 @@ func (w *Worker) handleApplicationChanges(ctx context.Context, applicationIds []
 				remoteRelationUnitChanges:         make(chan RelationUnitChangeEvent),
 				localModelFacade:                  w.config.RelationsFacade,
 				newRemoteModelRelationsFacadeFunc: w.config.NewRemoteModelFacadeFunc,
+				clock:                             w.config.Clock,
 				logger:                            logger,
 			}
 			if err := catacomb.Invoke(catacomb.Plan{

--- a/internal/worker/remoterelations/remoterelations_test.go
+++ b/internal/worker/remoterelations/remoterelations_test.go
@@ -1011,8 +1011,8 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *tc.C, dying 
 	c.Assert(err, tc.ErrorIsNil)
 	// Not resumed yet.
 	c.Assert(s.stub.Calls(), tc.HasLen, 0)
-	err = s.config.Clock.(*testclock.Clock).WaitAdvance(10*time.Second, coretesting.LongWait, 1)
-	c.Assert(err, tc.ErrorIsNil)
+	// We ignore this error, because the wait advance may not trigger anything.
+	_ = s.config.Clock.(*testclock.Clock).WaitAdvance(10*time.Second, coretesting.LongWait, 1)
 
 	mac, err := testing.NewMacaroon("test")
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/worker/remoterelations/remoterelationsworker.go
+++ b/internal/worker/remoterelations/remoterelationsworker.go
@@ -102,10 +102,9 @@ func (w *remoteRelationsWorker) loop() error {
 			// We only care about the most recent change.
 			change := relChanges[len(relChanges)-1]
 			w.logger.Debugf(ctx, "relation status changed for %v: %v", w.relationTag, change)
-			suspended := change.Suspended
 
-			w.mu.Lock()
-			w.mostRecentEvent = RelationUnitChangeEvent{
+			suspended := change.Suspended
+			event := RelationUnitChangeEvent{
 				Tag: w.relationTag,
 				RemoteRelationChangeEvent: params.RemoteRelationChangeEvent{
 					RelationToken:           w.remoteRelationToken,
@@ -115,8 +114,10 @@ func (w *remoteRelationsWorker) loop() error {
 					SuspendedReason:         change.SuspendedReason,
 				},
 			}
+
+			w.mu.Lock()
 			w.changeSince = w.clock.Now()
-			event := w.mostRecentEvent
+			w.mostRecentEvent = event
 			w.mu.Unlock()
 
 			select {

--- a/internal/worker/remoterelations/remoterelationsworker.go
+++ b/internal/worker/remoterelations/remoterelationsworker.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/names/v6"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/catacomb"
@@ -33,7 +34,9 @@ type remoteRelationsWorker struct {
 	applicationToken    string
 	relationsWatcher    watcher.RelationStatusWatcher
 	changes             chan<- RelationUnitChangeEvent
-	logger              logger.Logger
+
+	clock  clock.Clock
+	logger logger.Logger
 }
 
 func newRemoteRelationsWorker(
@@ -42,14 +45,16 @@ func newRemoteRelationsWorker(
 	remoteRelationToken string,
 	relationsWatcher watcher.RelationStatusWatcher,
 	changes chan<- RelationUnitChangeEvent,
+	clock clock.Clock,
 	logger logger.Logger,
-) (*remoteRelationsWorker, error) {
+) (ReportableWorker, error) {
 	w := &remoteRelationsWorker{
 		relationsWatcher:    relationsWatcher,
 		relationTag:         relationTag,
 		remoteRelationToken: remoteRelationToken,
 		applicationToken:    applicationToken,
 		changes:             changes,
+		clock:               clock,
 		logger:              logger,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
@@ -93,10 +98,12 @@ func (w *remoteRelationsWorker) loop() error {
 				w.logger.Warningf(ctx, "relation status watcher event with no changes")
 				continue
 			}
+
 			// We only care about the most recent change.
 			change := relChanges[len(relChanges)-1]
 			w.logger.Debugf(ctx, "relation status changed for %v: %v", w.relationTag, change)
 			suspended := change.Suspended
+
 			w.mu.Lock()
 			w.mostRecentEvent = RelationUnitChangeEvent{
 				Tag: w.relationTag,
@@ -108,9 +115,10 @@ func (w *remoteRelationsWorker) loop() error {
 					SuspendedReason:         change.SuspendedReason,
 				},
 			}
-			w.changeSince = time.Now()
+			w.changeSince = w.clock.Now()
 			event := w.mostRecentEvent
 			w.mu.Unlock()
+
 			select {
 			case <-w.catacomb.Dying():
 				return w.catacomb.ErrDying()

--- a/rpc/params/crossmodel.go
+++ b/rpc/params/crossmodel.go
@@ -366,7 +366,7 @@ type RemoteRelationChangeEvent struct {
 	ForceCleanup *bool `json:"force-cleanup,omitempty"`
 
 	// UnitCount is the number of units still in relation scope.
-	UnitCount *int `json:"unit-count"`
+	UnitCount int `json:"unit-count"`
 
 	// Suspended is the current suspended status of the relation.
 	Suspended *bool `json:"suspended,omitempty"`


### PR DESCRIPTION
This is step 1 of refactoring the remote relations worker. Now that we have the domain services at the model manager worker level, we don't need to perform facade calls for the local model. This set of changes attempts to start simplifying some of the code we've accreted over time. Some of this could potentially be made simpler by solidify our abstractions, using runners instead of adding to the catacomb directly.

I changed all the sub unit workers to return a very generic `ReportableWorker` instead of the concrete implementation. Although this is consider bad practice (accept interfaces, return concrete types), I need to be sure that nothing is reaching beyond it's boundary attempting to get a non-public field for access somewhere.

Additionally, each remote unit worker, now creates the watcher that it will own (via the catacomb), so that it's very obvious what a local vs remote units worker performs. From this, we can start to see where the macaroon is used for each worker:

 - local relation units worker will emit the macaroon for any of it's changes to the remote facade.
 - remote relation units worker will subscribe to a remote watcher using it's macaroon.

Each units worker could be little state machines that advance the relation change, but this can't currently happen because of the requirement to sequence changes in the main loop.

----

Also I'm not happy that the remote relation worker and the remote relation units worker send events on the same channel. I'd of rather they where split up, but it's just a gripe.

----

There is also a drastic lack of unit tests in this package. Something that'll try to solve in future changes.

## QA steps

Ensure the existing tests pass. This isn't wired up, so it's not actually running anything.


## Links


<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** [JUJU-8394](https://warthogs.atlassian.net/browse/JUJU-8394)


[JUJU-8394]: https://warthogs.atlassian.net/browse/JUJU-8394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ