### PR TITLE
docs: 3.6 clean up cli docs

### DIFF
--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -37,38 +37,38 @@ depending on the options provided:
   - provision a new machine from the cloud (default, see "Provisioning
     a new machine")
   - create an operating system container (see "Container creation")
-  - connect to a live computer and allocate it as a machine (see "Manual 
+  - connect to a live computer and allocate it as a machine (see "Manual
     provisioning")
 
 The add-machine command is unavailable in k8s clouds. Provisioning
-a new machine is unavailable on the manual cloud provider. 
+a new machine is unavailable on the manual cloud provider.
 
-Once the add-machine command has finished, the machine's ID can be 
-used as a placement directive for deploying applications. Machine IDs 
+Once the add-machine command has finished, the machine's ID can be
+used as a placement directive for deploying applications. Machine IDs
 are also accessible via 'juju status' and 'juju machines'.
 
 
 Provisioning a new machine
 
-When add-machine is called without arguments, Juju provisions a new 
-machine instance from the current cloud. The machine's specifications, 
+When add-machine is called without arguments, Juju provisions a new
+machine instance from the current cloud. The machine's specifications,
 including whether the machine is virtual or physical depends on the cloud.
 
-To control which instance type is provisioned, use the --constraints and 
+To control which instance type is provisioned, use the --constraints and
 --base options. --base can be specified using the OS name and the version of
 the OS, separated by @. For example, --base ubuntu@22.04.
 
 To add storage volumes to the instance, provide a whitespace-delimited
-list of storage constraints to the --disks option. 
+list of storage constraints to the --disks option.
 
-Add "placement directives" as an argument give Juju additional information 
-about how to allocate the machine in the cloud. For example, one can direct 
+Add "placement directives" as an argument give Juju additional information
+about how to allocate the machine in the cloud. For example, one can direct
 the MAAS provider to acquire a particular node by specifying its hostname.
 
 
 Manual provisioning
 
-Call add-machine with the address of a network-accessible computer to 
+Call add-machine with the address of a network-accessible computer to
 allocate that machine to the model.
 
 Manual provisioning is the process of installing Juju on an existing machine
@@ -78,29 +78,25 @@ access the new machine over the network.
 
 Container creation
 
-If a operating system container type is specified (e.g. "lxd" or "kvm"), 
-then add-machine will allocate a container of that type on a new machine 
-instance. Both the new instance, and the new container will be available 
+If a operating system container type is specified (e.g. "lxd" or "kvm"),
+then add-machine will allocate a container of that type on a new machine
+instance. Both the new instance, and the new container will be available
 as machines in the model.
 
 It is also possible to add containers to existing machines using the format
 <container-type>:<machine-id>. Constraints cannot be combined this mode.
 
-
-Further reading:
-	https://juju.is/docs/reference/commands/add-machine
-	https://juju.is/docs/reference/constraints
 `
 
 const addMachineExamples = `
 Start a new machine by requesting one from the cloud provider:
 
 	juju add-machine
-	
+
 Start 2 new machines:
 
 	juju add-machine -n 2
-	
+
 Start a LXD container on a new machine instance and add both as machines:
 
 	juju add-machine lxd
@@ -108,39 +104,39 @@ Start a LXD container on a new machine instance and add both as machines:
 Start two machine instances, each hosting a LXD container, then add all four as machines:
 
 	juju add-machine lxd -n 2
-	
+
 Create a container on machine 4 and add it as a machine:
 
 	juju add-machine lxd:4
-	
+
 Start a new machine and require that it has 8GB RAM:
 
 	juju add-machine --constraints mem=8G
-	
+
 Start a new machine within the "us-east-1a" availability zone:
 
 	juju add-machine --constraints zones=us-east-1a
-	
+
 Start a new machine with at least 4 CPU cores and 16GB RAM, and request three storage volumes to be attached to it. Two are large capacity (1TB) HDD and one is a lower capacity (100GB) SSD. Note: 'ebs' and 'ebs-ssd' are storage pools specific to AWS.
 
 	juju add-machine --constraints="cores=4 mem=16G" --disks="ebs,1T,2 ebs-ssd,100G,1"
-	
+
 Allocate a machine to the model via SSH:
 
 	juju add-machine ssh:user@10.10.0.3
-	
+
 Allocate a machine specifying the private key to use during the connection:
 
 	juju add-machine ssh:user@10.10.0.3 --private-key /tmp/id_rsa
-	
+
 Allocate a machine specifying a public key to set in the list of authorized keys in the machine:
 
 	juju add-machine ssh:user@10.10.0.3 --public-key /tmp/id_rsa.pub
-	
+
 Allocate a machine specifying a public key to set in the list of authorized keys and the private key to used during the connection:
 
 	juju add-machine ssh:user@10.10.0.3 --public-key /tmp/id_rsa.pub --private-key /tmp/id_rsa
-	
+
 Allocate a machine to the model. Note: specific to MAAS.
 
 	juju add-machine host.internal

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -31,23 +31,23 @@ func NewAddCommand() cmd.Command {
 
 const (
 	addCommandDoc = `
-Add storage to a pre-existing unit within a model. Storage is allocated from 
-a storage pool, using parameters provided within a "storage directive". (Use 
-'juju deploy --storage=<storage-directive>' to provision storage during the 
+Add storage to a pre-existing unit within a model. Storage is allocated from
+a storage pool, using parameters provided within a "storage directive". (Use
+'juju deploy --storage=<storage-directive>' to provision storage during the
 deployment process).
 
 	juju add-storage <unit> <storage-directive>
 
-<unit> is the ID of a unit that is already in the model. 
+<unit> is the ID of a unit that is already in the model.
 
-<storage-directive> describes to the charm how to refer to the storage, 
+<storage-directive> describes to the charm how to refer to the storage,
 and where to provision it from. <storage-directive> takes the following form:
-	
+
     <storage-name>[=<storage-constraint>]
 
-<storage-name> is defined in the charm's metadata.yaml file.   
+<storage-name> is defined in the charm's metadata.yaml file.
 
-<storage-constraint> is a description of how Juju should provision storage 
+<storage-constraint> is a description of how Juju should provision storage
 instances for the unit. They are made up of up to three parts: <storage-pool>,
 <count>, and <size>. They can be provided in any order, but we recommend the
 following:
@@ -61,17 +61,17 @@ storage constraints are also valid:
    <count>,<size>
    <size>
 
-<storage-pool> is the storage pool to provision storage instances from. Must 
-be a name from 'juju storage-pools'.  The default pool is available via 
+<storage-pool> is the storage pool to provision storage instances from. Must
+be a name from 'juju storage-pools'.  The default pool is available via
 executing 'juju model-config storage-default-block-source'.
 
 <count> is the number of storage instances to provision from <storage-pool> of
 <size>. Must be a positive integer. The default count is "1". May be restricted
 by the charm, which can specify a maximum number of storage instances per unit.
 
-<size> is the number of bytes to provision per storage instance. Must be a 
+<size> is the number of bytes to provision per storage instance. Must be a
 positive number, followed by a size suffix.  Valid suffixes include M, G, T,
-and P.  Defaults to "1024M", or the which can specify a minimum size required 
+and P.  Defaults to "1024M", or the which can specify a minimum size required
 by the charm.
 `
 
@@ -88,10 +88,6 @@ Add a storage instance from the (AWS-specific) ebs-ssd storage pool for "brick" 
 
     juju add-storage gluster/0 brick=ebs-ssd
 
-
-Further reading:
-
-https://juju.is/docs/storage
 `
 
 	addCommandAgs = `<unit> <storage-directive>`

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/add-machine.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/add-machine.md
@@ -26,11 +26,11 @@ Provision a new machine or assign one to the model.
 Start a new machine by requesting one from the cloud provider:
 
 	juju add-machine
-	
+
 Start 2 new machines:
 
 	juju add-machine -n 2
-	
+
 Start a LXD container on a new machine instance and add both as machines:
 
 	juju add-machine lxd
@@ -38,39 +38,39 @@ Start a LXD container on a new machine instance and add both as machines:
 Start two machine instances, each hosting a LXD container, then add all four as machines:
 
 	juju add-machine lxd -n 2
-	
+
 Create a container on machine 4 and add it as a machine:
 
 	juju add-machine lxd:4
-	
+
 Start a new machine and require that it has 8GB RAM:
 
 	juju add-machine --constraints mem=8G
-	
+
 Start a new machine within the "us-east-1a" availability zone:
 
 	juju add-machine --constraints zones=us-east-1a
-	
+
 Start a new machine with at least 4 CPU cores and 16GB RAM, and request three storage volumes to be attached to it. Two are large capacity (1TB) HDD and one is a lower capacity (100GB) SSD. Note: 'ebs' and 'ebs-ssd' are storage pools specific to AWS.
 
 	juju add-machine --constraints="cores=4 mem=16G" --disks="ebs,1T,2 ebs-ssd,100G,1"
-	
+
 Allocate a machine to the model via SSH:
 
 	juju add-machine ssh:user@10.10.0.3
-	
+
 Allocate a machine specifying the private key to use during the connection:
 
 	juju add-machine ssh:user@10.10.0.3 --private-key /tmp/id_rsa
-	
+
 Allocate a machine specifying a public key to set in the list of authorized keys in the machine:
 
 	juju add-machine ssh:user@10.10.0.3 --public-key /tmp/id_rsa.pub
-	
+
 Allocate a machine specifying a public key to set in the list of authorized keys and the private key to used during the connection:
 
 	juju add-machine ssh:user@10.10.0.3 --public-key /tmp/id_rsa.pub --private-key /tmp/id_rsa
-	
+
 Allocate a machine to the model. Note: specific to MAAS.
 
 	juju add-machine host.internal
@@ -84,38 +84,38 @@ depending on the options provided:
   - provision a new machine from the cloud (default, see "Provisioning
     a new machine")
   - create an operating system container (see "Container creation")
-  - connect to a live computer and allocate it as a machine (see "Manual 
+  - connect to a live computer and allocate it as a machine (see "Manual
     provisioning")
 
 The add-machine command is unavailable in k8s clouds. Provisioning
-a new machine is unavailable on the manual cloud provider. 
+a new machine is unavailable on the manual cloud provider.
 
-Once the add-machine command has finished, the machine's ID can be 
-used as a placement directive for deploying applications. Machine IDs 
+Once the add-machine command has finished, the machine's ID can be
+used as a placement directive for deploying applications. Machine IDs
 are also accessible via 'juju status' and 'juju machines'.
 
 
 Provisioning a new machine
 
-When add-machine is called without arguments, Juju provisions a new 
-machine instance from the current cloud. The machine's specifications, 
+When add-machine is called without arguments, Juju provisions a new
+machine instance from the current cloud. The machine's specifications,
 including whether the machine is virtual or physical depends on the cloud.
 
-To control which instance type is provisioned, use the --constraints and 
+To control which instance type is provisioned, use the --constraints and
 --base options. --base can be specified using the OS name and the version of
 the OS, separated by @. For example, --base ubuntu@22.04.
 
 To add storage volumes to the instance, provide a whitespace-delimited
-list of storage constraints to the --disks option. 
+list of storage constraints to the --disks option.
 
-Add "placement directives" as an argument give Juju additional information 
-about how to allocate the machine in the cloud. For example, one can direct 
+Add "placement directives" as an argument give Juju additional information
+about how to allocate the machine in the cloud. For example, one can direct
 the MAAS provider to acquire a particular node by specifying its hostname.
 
 
 Manual provisioning
 
-Call add-machine with the address of a network-accessible computer to 
+Call add-machine with the address of a network-accessible computer to
 allocate that machine to the model.
 
 Manual provisioning is the process of installing Juju on an existing machine
@@ -125,15 +125,10 @@ access the new machine over the network.
 
 Container creation
 
-If a operating system container type is specified (e.g. "lxd" or "kvm"), 
-then add-machine will allocate a container of that type on a new machine 
-instance. Both the new instance, and the new container will be available 
+If a operating system container type is specified (e.g. "lxd" or "kvm"),
+then add-machine will allocate a container of that type on a new machine
+instance. Both the new instance, and the new container will be available
 as machines in the model.
 
 It is also possible to add containers to existing machines using the format
 &lt;container-type&gt;:&lt;machine-id&gt;. Constraints cannot be combined this mode.
-
-
-Further reading:
-	https://juju.is/docs/reference/commands/add-machine
-	https://juju.is/docs/reference/constraints

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/add-storage.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/add-storage.md
@@ -29,30 +29,26 @@ Add a storage instance from the (AWS-specific) ebs-ssd storage pool for "brick" 
     juju add-storage gluster/0 brick=ebs-ssd
 
 
-Further reading:
-
-https://juju.is/docs/storage
-
 
 ## Details
 
-Add storage to a pre-existing unit within a model. Storage is allocated from 
-a storage pool, using parameters provided within a "storage directive". (Use 
-'juju deploy --storage=&lt;storage-directive&gt;' to provision storage during the 
+Add storage to a pre-existing unit within a model. Storage is allocated from
+a storage pool, using parameters provided within a "storage directive". (Use
+'juju deploy --storage=&lt;storage-directive&gt;' to provision storage during the
 deployment process).
 
 	juju add-storage &lt;unit&gt; &lt;storage-directive&gt;
 
-&lt;unit&gt; is the ID of a unit that is already in the model. 
+&lt;unit&gt; is the ID of a unit that is already in the model.
 
-&lt;storage-directive&gt; describes to the charm how to refer to the storage, 
+&lt;storage-directive&gt; describes to the charm how to refer to the storage,
 and where to provision it from. &lt;storage-directive&gt; takes the following form:
-	
+
     <storage-name>[=<storage-constraint>]
 
-&lt;storage-name&gt; is defined in the charm's metadata.yaml file.   
+&lt;storage-name&gt; is defined in the charm's metadata.yaml file.
 
-&lt;storage-constraint&gt; is a description of how Juju should provision storage 
+&lt;storage-constraint&gt; is a description of how Juju should provision storage
 instances for the unit. They are made up of up to three parts: &lt;storage-pool&gt;,
 &lt;count&gt;, and &lt;size&gt;. They can be provided in any order, but we recommend the
 following:
@@ -66,15 +62,15 @@ storage constraints are also valid:
    &lt;count&gt;,&lt;size&gt;
    &lt;size&gt;
 
-&lt;storage-pool&gt; is the storage pool to provision storage instances from. Must 
-be a name from 'juju storage-pools'.  The default pool is available via 
+&lt;storage-pool&gt; is the storage pool to provision storage instances from. Must
+be a name from 'juju storage-pools'.  The default pool is available via
 executing 'juju model-config storage-default-block-source'.
 
 &lt;count&gt; is the number of storage instances to provision from &lt;storage-pool&gt; of
 &lt;size&gt;. Must be a positive integer. The default count is "1". May be restricted
 by the charm, which can specify a maximum number of storage instances per unit.
 
-&lt;size&gt; is the number of bytes to provision per storage instance. Must be a 
+&lt;size&gt; is the number of bytes to provision per storage instance. Must be a
 positive number, followed by a size suffix.  Valid suffixes include M, G, T,
-and P.  Defaults to "1024M", or the which can specify a minimum size required 
+and P.  Defaults to "1024M", or the which can specify a minimum size required
 by the charm.


### PR DESCRIPTION
Our CLI docs suffer from a variety of issues that affect both the looks and the content. 

This PR addresses this by
- fixing all linkcheck errors
- fixing all formatting errors (many occur because of the primitive way we do the CLI help in the code, but there are ways to ensure a decent look either way, so this PR does that)
- make the Details section lighter by (a) removing redundant detail (e.g., when a flag already defined in the Options sections is defined again in-line) and (b) removing detail that's really about the Juju controller rather than the client (this detail should instead go into our reference for the relevant concept or entity, and we can link to it from our various clients, which are essentially just different ways to turn knobs in the controller).

