### PR TITLE
fix: discrepancy between charm reference name and name

### DIFF
--- a/apiserver/facades/client/application/application_get.go
+++ b/apiserver/facades/client/application/application_get.go
@@ -5,18 +5,15 @@ package application
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 
 	coreapplication "github.com/juju/juju/core/application"
-	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/domain/application/architecture"
 	applicationcharm "github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/internal/charm"
@@ -284,42 +281,6 @@ func (c *domainCharm) Revision() int {
 
 func (c *domainCharm) IsUploaded() bool {
 	return c.available
-}
-
-func (c *domainCharm) URL() string {
-	schema := charm.Local.String()
-	if c.locator.Source == applicationcharm.CharmHubSource {
-		schema = charm.CharmHub.String()
-	}
-
-	name := c.charm.Meta().Name
-	if name == "" {
-		panic(fmt.Sprintf("charm name is empty %+v", c.charm))
-	}
-
-	var a string
-	switch c.locator.Architecture {
-	case architecture.AMD64:
-		a = arch.AMD64
-	case architecture.ARM64:
-		a = arch.ARM64
-	case architecture.PPC64EL:
-		a = arch.PPC64EL
-	case architecture.S390X:
-		a = arch.S390X
-	case architecture.RISCV64:
-		a = arch.RISCV64
-	default:
-		// If there is no architecture set, we should ignore it.
-	}
-
-	curl := &charm.URL{
-		Schema:       schema,
-		Name:         name,
-		Revision:     c.locator.Revision,
-		Architecture: a,
-	}
-	return curl.String()
 }
 
 func (c *domainCharm) Version() string {

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
-	"github.com/juju/juju/apiserver/internal/charms"
 	coreapplication "github.com/juju/juju/core/application"
 	coreassumes "github.com/juju/juju/core/assumes"
 	corecharm "github.com/juju/juju/core/charm"
@@ -110,18 +109,9 @@ func DeployApplication(
 		}
 	}
 
-	chURL, err := charm.ParseURL(args.Charm.URL())
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	var downloadInfo *applicationcharm.DownloadInfo
 	if args.CharmOrigin.Source == corecharm.CharmHub {
-		locator, err := charms.CharmLocatorFromURL(args.Charm.URL())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		downloadInfo, err = applicationService.GetCharmDownloadInfo(ctx, locator)
+		downloadInfo, err = applicationService.GetCharmDownloadInfo(ctx, args.Charm.locator)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -141,7 +131,7 @@ func DeployApplication(
 	}
 
 	applicationArg := applicationservice.AddApplicationArgs{
-		ReferenceName:    chURL.Name,
+		ReferenceName:    args.Charm.locator.Name,
 		DownloadInfo:     downloadInfo,
 		PendingResources: pendingResources,
 		EndpointBindings: args.EndpointBindings,


### PR DESCRIPTION
For the vast majority of charms, the name of the charm in charmhub is the same as the name of the charm in it's metadata. However, there are exceptions (and it's a supported use case).

However, sometimes we conflate the two. For example, when constructing the charm url of a 'domainCharm' in the apiserver, we would use the charm metadata name, but really this should (arguably) be the reference name. However, this is not clear.

Anyway, I have fixed this by removing the URL method from domainCharm, so the question is moot. Instead, we use the charm identifier returned from the domain service, instead of attempting to reconstruct it.

## QA steps

```
$ cat ./bundle.yaml
name: juju-qa-bundle-test
applications:
  dummy-subordinate:
    charm: juju-qa-dummy-subordinate

$ juju deploy ./bundle.yaml
Located charm "juju-qa-dummy-subordinate" in charm-hub, channel latest/stable
Executing changes:
- upload charm juju-qa-dummy-subordinate from charm-hub with architecture=amd64
- deploy application dummy-subordinate from charm-hub using juju-qa-dummy-subordinate
Deploy of bundle completed.
```
