### PR TITLE
feat: allow get db to fail

### DIFF
--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -122,14 +122,16 @@ const (
 // instances into the worker loop.
 type dbRequest struct {
 	op        opType
+	ctx       context.Context
 	namespace string
 	done      chan error
 }
 
 // makeDBGetRequest creates a new TrackedDB request for the input namespace.
-func makeDBGetRequest(namespace string) dbRequest {
+func makeDBGetRequest(ctx context.Context, namespace string) dbRequest {
 	return dbRequest{
 		op:        getOp,
+		ctx:       ctx,
 		namespace: namespace,
 		done:      make(chan error),
 	}
@@ -320,9 +322,14 @@ func (w *dbWorker) loop() (err error) {
 		// processed in order.
 		case req := <-w.dbRequests:
 			if req.op == getOp {
+				// Join the request context with the catacomb context. This
+				// ensures that if the caller cancels their context, we
+				// will honour that and not block indefinitely.
+				requestContext := joinContexts(ctx, req.ctx)
+
 				// Ensure the namespace exists or is allowed to open a new one
 				// before we attempt to open the database.
-				if err := w.ensureNamespace(ctx, req.namespace); err != nil {
+				if err := w.ensureNamespace(requestContext, req.namespace); err != nil {
 					select {
 					case req.done <- errors.Annotatef(err, "ensuring namespace %q", req.namespace):
 					case <-w.catacomb.Dying():
@@ -330,7 +337,7 @@ func (w *dbWorker) loop() (err error) {
 					}
 					continue
 				}
-				if err := w.openDatabase(ctx, req.namespace); err != nil {
+				if err := w.openDatabase(requestContext, req.namespace); err != nil {
 					select {
 					case req.done <- errors.Annotatef(err, "opening database for namespace %q", req.namespace):
 					case <-w.catacomb.Dying():
@@ -444,9 +451,17 @@ func (w *dbWorker) GetDB(ctx context.Context, namespace string) (database.TxnRun
 		return db, nil
 	}
 
+	// Set a timeout for the starting of the worker. This prevents us locking
+	// up indefinitely if something goes wrong. This will stall the controller
+	// completely if it's stuck on the controller database, but it will
+	// eventually timeout and return an error. Allowing another attempt later
+	// on.
+	ctx, cancel := context.WithTimeout(ctx, dbOpenTimeout)
+	defer cancel()
+
 	// Enqueue the request as it's either starting up and we need to wait longer
 	// or it's not running and we need to start it.
-	req := makeDBGetRequest(namespace)
+	req := makeDBGetRequest(ctx, namespace)
 	select {
 	case w.dbRequests <- req:
 	case <-w.catacomb.Dying():
@@ -693,14 +708,6 @@ func (w *dbWorker) startDqliteNode(ctx context.Context, options ...app.Option) e
 // database or ErrTryAgain to force the runner to retry starting the worker
 // again.
 func (w *dbWorker) openDatabase(ctx context.Context, namespace string) error {
-	// Set a timeout for the starting of the worker. This prevents us locking
-	// up indefinitely if something goes wrong. This will stall the controller
-	// completely if it's stuck on the controller database, but it will
-	// eventually timeout and return an error. Allowing another attempt later
-	// on.
-	ctx, cancel := context.WithTimeout(ctx, dbOpenTimeout)
-	defer cancel()
-
 	// Note: Do not be tempted to create the worker outside of the StartWorker
 	// function. This will create potential data race if openDatabase is called
 	// multiple times for the same namespace.
@@ -733,12 +740,6 @@ func (w *dbWorker) openDatabase(ctx context.Context, namespace string) error {
 	} else if err != nil {
 		return errors.Trace(err)
 	}
-
-	// Ensure that the worker starts up correctly, before returning.
-	if _, err := w.dbRunner.Worker(namespace, firstClosed(ctx.Done(), w.catacomb.Dying())); err != nil {
-		return errors.Trace(err)
-	}
-
 	return nil
 }
 
@@ -1075,4 +1076,46 @@ func (w *dbWorker) nodeService() *service.Service {
 			database.NewTxnRunnerFactoryForNamespace(w.workerFromCache, database.ControllerNS)),
 		w.cfg.Logger.Child("controllernode"),
 	)
+}
+
+type joinedContext struct {
+	worker, request context.Context
+}
+
+func joinContexts(a, b context.Context) context.Context {
+	return &joinedContext{worker: a, request: b}
+}
+
+// Deadline returns the time when work done on behalf of this context.
+// The deadline is always of the request, not the worker.
+func (j *joinedContext) Deadline() (deadline time.Time, ok bool) {
+	return j.request.Deadline()
+}
+
+// Done returns a channel that's closed when work done on behalf of this
+// context should be canceled. The channel is closed when either the
+// worker or the request is done.
+func (j *joinedContext) Done() <-chan struct{} {
+	return firstClosed(j.worker.Done(), j.request.Done())
+}
+
+// If Done is not yet closed, Err returns nil.
+// Returns the request error over the worker error if both are
+// closed.
+func (j *joinedContext) Err() error {
+	if err := j.request.Err(); err != nil {
+		return err
+	}
+	return j.worker.Err()
+}
+
+// Value returns the value associated with this context for key, or nil
+// if no value is associated with key. Successive calls to Value with
+// the same key returns the same result.
+// The request context takes precedence over the worker context.
+func (j *joinedContext) Value(key any) any {
+	if v := j.request.Value(key); v != nil {
+		return v
+	}
+	return j.worker.Value(key)
 }


### PR DESCRIPTION
~~Requires https://github.com/juju/juju/pull/20470 to land first.~~

----

It's entirely possible to block the dbaccessor loop, based on one bad actor. This can happen if the underlying database driver doesn't fulfill the request to open a database. There isn't anything we can do in this instance, other than to retry again if it fails. The problem might be alleviated by the incoming delete database pragma, but there is still a possibility of this happening even if that is resolved.

The end change (see commits of the evolution of idea - can be squashed) is to apply the timeout prior to the opening of the database.


## QA steps

> [!NOTE]
> This doesn't always work because there is another deadlock happening, but it does alleviate some of the time. Follow up work to fix that will follow.

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju destroy-model default
$ juju add-model default
```