### PR TITLE
fix: fix bundle deploy integration test

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -9,8 +9,8 @@ run_deploy_bundle() {
 	ensure "test-bundles-deploy" "${file}"
 
 	juju deploy juju-qa-bundle-test
-	wait_for "juju-qa-test" ".applications | keys[0]"
-	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"
+	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test")"
+	wait_for "dummy-subordinate-focal" "$(idle_subordinate_condition "dummy-subordinate-focal" "juju-qa-test-focal")"
 
 	destroy_model "test-bundles-deploy"
 }


### PR DESCRIPTION
The bundle we used for the bundle deploy integration test uses a charm which was deprecated (and broken).

I have updated this bundle to use only charms we control. However, this required a small change to the job

## QA steps

```
./main.sh -v deploy test_deploy_bundles
```