### PR TITLE
feat: changestream pruner

### DIFF
--- a/internal/worker/changestreampruner/manifold_test.go
+++ b/internal/worker/changestreampruner/manifold_test.go
@@ -6,11 +6,14 @@ package changestreampruner
 import (
 	"testing"
 
+	clock "github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v4"
 	"go.uber.org/goleak"
 
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/logger"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -43,6 +46,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	cfg = s.getConfig(c)
 	cfg.NewWorker = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.NewModelPruner = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 }
 
 func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
@@ -52,6 +59,16 @@ func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
 		Logger:     loggertesting.WrapCheckLog(c),
 		NewWorker: func(WorkerConfig) (worker.Worker, error) {
 			return nil, nil
+		},
+		NewModelPruner: func(
+			db coredatabase.TxnRunner,
+			namespace string,
+			initialWindow window,
+			updateWindow WindowUpdaterFunc,
+			clock clock.Clock,
+			logger logger.Logger,
+		) worker.Worker {
+			return nil
 		},
 	}
 }

--- a/internal/worker/changestreampruner/package_test.go
+++ b/internal/worker/changestreampruner/package_test.go
@@ -31,7 +31,7 @@ type baseSuite struct {
 // with the controller schema.
 func (s *baseSuite) SetUpTest(c *tc.C) {
 	s.DqliteSuite.SetUpTest(c)
-	s.DqliteSuite.ApplyDDL(c, &domaintesting.SchemaApplier{
+	s.ApplyDDL(c, &domaintesting.SchemaApplier{
 		Schema:  schema.ControllerDDL(),
 		Verbose: s.Verbose,
 	})
@@ -70,4 +70,18 @@ func (s *baseSuite) expectDBGetTimes(namespace string, txnRunner coredatabase.Tx
 
 func (s *baseSuite) expectClock() {
 	s.clock.EXPECT().Now().Return(time.Now()).AnyTimes()
+}
+
+func (s *baseSuite) expectTimerImmediate() {
+	s.clock.EXPECT().NewTimer(gomock.Any()).Return(s.timer)
+	s.timer.EXPECT().Chan().DoAndReturn(func() <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	s.timer.EXPECT().Chan().DoAndReturn(func() <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		return ch
+	})
+	s.timer.EXPECT().Stop().Return(true).AnyTimes()
 }

--- a/internal/worker/changestreampruner/pruner.go
+++ b/internal/worker/changestreampruner/pruner.go
@@ -1,0 +1,201 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package changestreampruner
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"gopkg.in/tomb.v2"
+
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/logger"
+)
+
+type modelPruner struct {
+	tomb tomb.Tomb
+
+	db        coredatabase.TxnRunner
+	namespace string
+
+	window       window
+	updateWindow WindowUpdaterFunc
+
+	clock  clock.Clock
+	logger logger.Logger
+}
+
+// NewModelPruner creates a new modelPruner for the given database and
+// namespace.
+func NewModelPruner(
+	db coredatabase.TxnRunner,
+	namespace string,
+	window window,
+	clock clock.Clock,
+	logger logger.Logger,
+) *modelPruner {
+	w := &modelPruner{
+		db:        db,
+		namespace: namespace,
+
+		window: window,
+
+		clock:  clock,
+		logger: logger,
+	}
+
+	w.tomb.Go(w.loop)
+	return w
+}
+
+func (w *modelPruner) loop() error {
+	ctx := w.tomb.Context(context.Background())
+
+	if err := w.db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// Locate the lowest watermark, this is the watermark that we will
+		// use to prune the change log.
+		lowest, window, err := w.locateLowestWatermark(ctx, tx)
+		if err != nil {
+			return errors.Annotatef(err, "failed to locate lowest watermark for namespace %s", w.namespace)
+		}
+
+		// Update the current window, this is used to determine if the
+		// change stream is keeping up with the pruner.
+		w.updateWindow(window)
+
+		// Prune the change log, using the lowest watermark.
+		pruned, err := w.deleteChangeLog(ctx, tx, lowest)
+		if err != nil {
+			return errors.Annotatef(err, "failed to prune change log")
+		}
+		if pruned > 0 {
+			w.logger.Infof(ctx, "pruned %d rows from change log", pruned)
+		}
+		return nil
+	}); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+var selectWitnessQuery = sqlair.MustPrepare(`SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_log_witness;`, Watermark{})
+
+func (w *modelPruner) locateLowestWatermark(ctx context.Context, tx *sqlair.TX) (Watermark, window, error) {
+	// Gather all the valid watermarks, post row pruning. These include
+	// the controller id which we know are valid based on the
+	// controller_node table. If at any point we delete rows from the
+	// change_log_witness table, the change stream will put the witness
+	// back in place after the next change log is written.
+	var watermarks []Watermark
+	if err := tx.Query(ctx, selectWitnessQuery).GetAll(&watermarks); errors.Is(err, sqlair.ErrNoRows) {
+		// Nothing to do if there are no watermarks.
+		return Watermark{}, window{}, nil
+	} else if err != nil {
+		return Watermark{}, window{}, errors.Trace(err)
+	}
+
+	// Gather all the watermarks that are within the windowed time period.
+	// If there are no watermarks within the window, then we can assume
+	// that the stream is keeping up and we don't need to prune anything.
+	sorted := sortWatermarks(watermarks)
+
+	// Find the first and last watermark in the sorted list, this is our
+	// window. It should hold the start and the end of the window.
+	watermarkView := window{
+		start: sorted[0].UpdatedAt,
+		end:   sorted[len(sorted)-1].UpdatedAt,
+	}
+
+	// If the watermark is outside of the window, we should log a warning
+	// message to indicate that the change stream is not keeping up. Only if
+	// the watermark is different from the last window, as we don't want to
+	// spam the logs if there are no changes.
+	now := w.clock.Now()
+	timeView := window{
+		start: now.Add(-defaultWindowDuration),
+		end:   now,
+	}
+	if !timeView.Contains(watermarkView) && !watermarkView.Equals(w.window) {
+		w.logger.Warningf(ctx, "watermarks %q are outside of window, check logs to see if the change stream is keeping up", sorted[0].ControllerID)
+	}
+
+	return sorted[0], watermarkView, nil
+}
+
+var deleteQuery = sqlair.MustPrepare(`DELETE FROM change_log WHERE id <= $M.id;`, sqlair.M{})
+
+func (w *modelPruner) deleteChangeLog(ctx context.Context, tx *sqlair.TX, lowest Watermark) (int64, error) {
+	// Delete all the change logs that are lower than the lowest watermark.
+	var outcome sqlair.Outcome
+	if err := tx.Query(ctx, deleteQuery, sqlair.M{"id": lowest.LowerBound}).Get(&outcome); err != nil {
+		return -1, errors.Trace(err)
+	}
+	pruned, err := outcome.Result().RowsAffected()
+	return pruned, errors.Trace(err)
+}
+
+// scopedContext returns a context that is in the scope of the worker lifetime.
+// It returns a cancellable context that is cancelled when the action has
+// completed.
+func (w *Pruner) scopedContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return w.catacomb.Context(ctx), cancel
+}
+
+func sortWatermarks(watermarks []Watermark) []Watermark {
+	// If there is only one watermark, just use that one and return out early.
+	if len(watermarks) == 1 {
+		return watermarks
+	}
+
+	// Sort the watermarks by the lower bound.
+	sort.Slice(watermarks, func(i, j int) bool {
+		if watermarks[i].LowerBound == watermarks[j].LowerBound {
+			return watermarks[i].UpdatedAt.Before(watermarks[j].UpdatedAt)
+		}
+		return watermarks[i].LowerBound < watermarks[j].LowerBound
+	})
+
+	return watermarks
+}
+
+// ModelNamespace represents a model and the associated DQlite namespace that it
+// uses.
+type ModelNamespace struct {
+	UUID      string `db:"uuid"`
+	Namespace string `db:"namespace"`
+}
+
+// Watermark represents a row from the change_log_witness table.
+type Watermark struct {
+	ControllerID string    `db:"controller_id"`
+	LowerBound   int64     `db:"lower_bound"`
+	UpdatedAt    time.Time `db:"updated_at"`
+}
+
+type window struct {
+	start, end time.Time
+}
+
+// Contains returns true if the window contains the given time.
+func (w window) Contains(o window) bool {
+	if w.Equals(o) {
+		return true
+	}
+	return w.start.Before(o.start) && w.end.After(o.end)
+}
+
+// Equals returns true if the window is equal to the given window.
+func (w window) Equals(o window) bool {
+	return w.start.Equal(o.start) && w.end.Equal(o.end)
+}
+
+func (w window) String() string {
+	return w.start.Format(time.RFC3339) + " -> " + w.end.Format(time.RFC3339)
+}

--- a/internal/worker/changestreampruner/pruner_test.go
+++ b/internal/worker/changestreampruner/pruner_test.go
@@ -1,0 +1,591 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package changestreampruner
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+	"go.uber.org/goleak"
+)
+
+type prunerWorkerSuite struct {
+	baseSuite
+}
+
+func TestPrunerWorkerSuite(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tc.Run(t, &prunerWorkerSuite{})
+}
+
+/*
+func (s *prunerWorkerSuite) TestPrune(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectControllerDBGet()
+
+	pruner := s.newPruner(c)
+	defer workertest.CleanKill(c, pruner)
+
+	err := pruner.prune(c.Context())
+	c.Check(err, tc.ErrorIsNil)
+}
+
+func (s *prunerWorkerSuite) TestPruneModelList(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	txnRunner, db := s.OpenDB(c)
+	defer db.Close()
+
+	s.ApplyDDLForRunner(c, txnRunner)
+
+	s.expectControllerDBGet()
+	s.expectClock()
+
+	pruner := s.newPruner(c)
+
+	now := time.Now()
+
+	s.insertControllerNodes(c, 1)
+	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "foo")
+	s.expectDBGet(modelUUID.String(), txnRunner)
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1002, UpdatedAt: now.Add(-time.Minute)})
+	s.truncateChangeLog(c, s.TxnRunner())
+	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
+
+	result, err := pruner.prune()
+	c.Check(err, tc.ErrorIsNil)
+
+	// This ensures that we always prune the controller namespace.
+	c.Check(result, tc.DeepEquals, map[string]int64{
+		coredatabase.ControllerNS: 3,
+		modelUUID.String():        0,
+	})
+}
+
+func (s *prunerWorkerSuite) TestPruneModelListWithChangeLogItems(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	txnRunner, db := s.OpenDB(c)
+	defer db.Close()
+
+	s.ApplyDDLForRunner(c, txnRunner)
+
+	s.expectControllerDBGet()
+	s.expectClock()
+
+	pruner := s.newPruner(c)
+
+	now := time.Now()
+
+	s.insertControllerNodes(c, 1)
+	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "foo")
+	s.expectDBGet(modelUUID.String(), txnRunner)
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1002, UpdatedAt: now.Add(-time.Minute)})
+	s.truncateChangeLog(c, s.TxnRunner())
+	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
+
+	s.insertChangeLogWitness(c, txnRunner, Watermark{ControllerID: "0", LowerBound: 1003, UpdatedAt: now.Add(-time.Second)})
+	s.truncateChangeLog(c, txnRunner)
+	s.insertChangeLogItems(c, txnRunner, 0, 6, now)
+
+	result, err := pruner.prune()
+	c.Check(err, tc.ErrorIsNil)
+
+	// This ensures that we always prune the controller namespace.
+	c.Check(result, tc.DeepEquals, map[string]int64{
+		coredatabase.ControllerNS: 3,
+		modelUUID.String():        4,
+	})
+}
+
+func (s *prunerWorkerSuite) TestPruneModel(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectDBGet("foo", s.TxnRunner())
+
+	pruner := s.newPruner(c)
+
+	result, err := pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(0))
+}
+
+func (s *prunerWorkerSuite) TestPruneModelGetDBError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.dbGetter.EXPECT().GetDB(gomock.Any(), "foo").Return(nil, errors.New("boom"))
+
+	pruner := s.newPruner(c)
+
+	_, err := pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorMatches, "boom")
+}
+
+func (s *prunerWorkerSuite) TestPruneModelChangeLogWitness(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectDBGet("foo", s.TxnRunner())
+	s.expectClock()
+
+	pruner := s.newPruner(c)
+
+	now := time.Now()
+
+	s.insertControllerNodes(c, 2)
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1, UpdatedAt: now})
+
+	result, err := pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(1))
+
+	s.expectChangeLogWitnesses(c, s.TxnRunner(), []Watermark{{
+		ControllerID: "0",
+		LowerBound:   1,
+		UpdatedAt:    now,
+	}})
+}
+
+func (s *prunerWorkerSuite) TestPruneModelLogsWarning(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// We request the db
+
+	s.expectDBGetTimes("foo", s.TxnRunner(), 3)
+	s.expectClock()
+
+	var entries []string
+	recorder := loggertesting.RecordLog(func(s string, a ...any) {
+		entries = append(entries, s)
+	})
+
+	pruner := s.newPrunerWithLogger(c, loggertesting.WrapCheckLog(recorder))
+
+	now := time.Now()
+
+	s.insertControllerNodes(c, 2)
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))})
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "3", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration + time.Minute))})
+
+	s.insertChangeLogItems(c, s.TxnRunner(), 0, 1, now)
+
+	result, err := pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(1))
+
+	// Should not prune anything as there are no new changes. Notice that the
+	// warning is not logged.
+
+	result, err = pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(0))
+
+	// Add some new changes and it should log the warning.
+
+	now = time.Now()
+
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 2, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))})
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "3", LowerBound: 2, UpdatedAt: now.Add(-(defaultWindowDuration + time.Minute))})
+
+	s.insertChangeLogItems(c, s.TxnRunner(), 1, 1, now)
+
+	result, err = pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(1))
+
+	c.Check(entries, tc.DeepEquals, []string{
+		"WARNING: namespace %s watermarks %q are outside of window, check logs to see if the change stream is keeping up",
+		"WARNING: namespace %s watermarks %q are outside of window, check logs to see if the change stream is keeping up",
+	})
+}
+
+func (s *prunerWorkerSuite) TestPruneModelRemovesChangeLogItems(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectDBGet("foo", s.TxnRunner())
+	s.expectClock()
+
+	pruner := s.newPruner(c)
+
+	now := time.Now()
+
+	totalCtrlNodes := 2
+	s.insertControllerNodes(c, totalCtrlNodes)
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1002, UpdatedAt: now.Add(-time.Minute)})
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "3", LowerBound: 1003, UpdatedAt: now.Add(-time.Second)})
+
+	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
+
+	result, err := pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(3+totalCtrlNodes))
+
+	s.expectChangeLogItems(c, s.TxnRunner(), 7, 1003, 1010)
+}
+
+func (s *prunerWorkerSuite) TestPruneModelRemovesChangeLogItemsWithMultipleWatermarks(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectDBGet("foo", s.TxnRunner())
+	s.expectClock()
+
+	pruner := s.newPruner(c)
+
+	now := time.Now()
+
+	totalCtrlNodes := 2
+	s.insertControllerNodes(c, totalCtrlNodes)
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1005, UpdatedAt: now.Add(-time.Minute)})
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "1", LowerBound: 1002, UpdatedAt: now.Add(-time.Second)})
+
+	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
+
+	result, err := pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(3+totalCtrlNodes))
+
+	s.expectChangeLogItems(c, s.TxnRunner(), 7, 1003, 1010)
+}
+
+func (s *prunerWorkerSuite) TestPruneModelRemovesChangeLogItemsWithMultipleWatermarksWithOneOutsideWindow(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectDBGet("foo", s.TxnRunner())
+	s.expectClock()
+
+	pruner := s.newPruner(c)
+
+	now := time.Now()
+
+	totalCtrlNodes := 3
+	s.insertControllerNodes(c, totalCtrlNodes)
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1005, UpdatedAt: now.Add(-time.Minute)})
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "1", LowerBound: 1002, UpdatedAt: now.Add(-time.Second)})
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "2", LowerBound: 1001, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))})
+
+	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
+
+	result, err := pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(2+totalCtrlNodes))
+
+	s.expectChangeLogItems(c, s.TxnRunner(), 8, 1002, 1010)
+}
+
+func (s *prunerWorkerSuite) TestPruneModelRemovesChangeLogItemsWithMultipleWatermarksMoreWatermarks(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectDBGet("foo", s.TxnRunner())
+	s.expectClock()
+
+	pruner := s.newPruner(c)
+
+	now := time.Now()
+
+	totalCtrlNodes := 3
+	s.insertControllerNodes(c, totalCtrlNodes)
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1005, UpdatedAt: now.Add(-time.Minute)})
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "1", LowerBound: 1002, UpdatedAt: now.Add(-time.Second)})
+	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "2", LowerBound: 1001, UpdatedAt: now.Add(-time.Second)})
+
+	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
+
+	result, err := pruner.pruneModel(c.Context(), "foo")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(result, tc.Equals, int64(2+totalCtrlNodes))
+
+	s.expectChangeLogItems(c, s.TxnRunner(), 8, 1002, 1010)
+}
+
+func (s *prunerWorkerSuite) TestWindowContains(c *tc.C) {
+	now := time.Now()
+	testCases := []struct {
+		window   window
+		other    window
+		expected bool
+	}{{
+		window:   window{start: now, end: now},
+		other:    window{start: now, end: now},
+		expected: true,
+	}, {
+		window:   window{start: now.Add(-time.Minute), end: now.Add(time.Minute)},
+		other:    window{start: now, end: now},
+		expected: true,
+	}, {
+		window:   window{start: now.Add(time.Minute), end: now.Add(-time.Minute)},
+		other:    window{start: now, end: now},
+		expected: false,
+	}, {
+		window:   window{start: now.Add(time.Minute), end: now.Add(time.Minute)},
+		other:    window{start: now, end: now},
+		expected: false,
+	}, {
+		window:   window{start: now.Add(-time.Minute), end: now.Add(-time.Minute)},
+		other:    window{start: now, end: now},
+		expected: false,
+	}, {
+		window:   window{start: now, end: now.Add(time.Minute * 2)},
+		other:    window{start: now.Add(time.Minute), end: now.Add(time.Minute + time.Second)},
+		expected: true,
+	}, {
+		window:   window{start: now, end: now.Add(time.Minute * 2)},
+		other:    window{start: now.Add(time.Nanosecond), end: now.Add((time.Minute * 2) - time.Nanosecond)},
+		expected: true,
+	}, {
+		window:   window{start: now, end: now.Add(time.Minute * 2)},
+		other:    window{start: now, end: now.Add((time.Minute * 2) - time.Nanosecond)},
+		expected: false,
+	}, {
+		window:   window{start: now, end: now.Add(time.Minute * 2)},
+		other:    window{start: now.Add(time.Nanosecond), end: now.Add(time.Minute * 2)},
+		expected: false,
+	}}
+	for i, test := range testCases {
+		c.Logf("test %d", i)
+
+		got := test.window.Contains(test.other)
+		c.Check(got, tc.Equals, test.expected)
+	}
+}
+
+func (s *prunerWorkerSuite) TestWindowEquals(c *tc.C) {
+	now := time.Now()
+	testCases := []struct {
+		window   window
+		other    window
+		expected bool
+	}{{
+		window:   window{start: now, end: now},
+		other:    window{start: now, end: now},
+		expected: true,
+	}, {
+		window:   window{start: now.Add(-time.Minute), end: now.Add(time.Minute)},
+		other:    window{start: now, end: now},
+		expected: false,
+	}}
+	for i, test := range testCases {
+		c.Logf("test %d", i)
+
+		got := test.window.Equals(test.other)
+		c.Check(got, tc.Equals, test.expected)
+	}
+}
+
+func (s *prunerWorkerSuite) TestLowestWatermark(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	now := time.Now()
+	testCases := []struct {
+		watermarks []Watermark
+		expected   []Watermark
+	}{{
+		watermarks: []Watermark{
+			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
+		},
+		expected: []Watermark{
+			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
+		},
+	}, {
+		watermarks: []Watermark{
+			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
+			{ControllerID: "1", LowerBound: 1, UpdatedAt: now},
+		},
+		expected: []Watermark{
+			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
+			{ControllerID: "1", LowerBound: 1, UpdatedAt: now},
+		},
+	}, {
+		watermarks: []Watermark{
+			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
+			{ControllerID: "1", LowerBound: 10, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
+		},
+		expected: []Watermark{
+			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
+			{ControllerID: "1", LowerBound: 10, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
+		},
+	}, {
+		watermarks: []Watermark{
+			{ControllerID: "0", LowerBound: 2, UpdatedAt: now},
+			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration - time.Second))},
+		},
+		expected: []Watermark{
+			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration - time.Second))},
+			{ControllerID: "0", LowerBound: 2, UpdatedAt: now},
+		},
+	}, {
+		watermarks: []Watermark{
+			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
+			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration - time.Second))},
+		},
+		expected: []Watermark{
+			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration - time.Second))},
+			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
+		},
+	}, {
+		watermarks: []Watermark{
+			{ControllerID: "0", LowerBound: 2, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
+			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
+		},
+		// TODO (stickupkid): This should be false, but we need a strategy for
+		// removing nodes that are not keeping up. We're logging a warning
+		// instead.
+		expected: []Watermark{
+			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
+			{ControllerID: "0", LowerBound: 2, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
+		},
+	}}
+
+	for i, test := range testCases {
+		c.Logf("test %d", i)
+
+		got := sortWatermarks("foo", test.watermarks)
+		c.Check(got, tc.DeepEquals, test.expected)
+	}
+}
+
+func (s *prunerWorkerSuite) newPruner(c *tc.C) *Pruner {
+	return s.newPrunerWithLogger(c, loggertesting.WrapCheckLog(c))
+}
+
+func (s *prunerWorkerSuite) newPrunerWithLogger(c *tc.C, logger logger.Logger) *Pruner {
+	return &Pruner{
+		cfg: WorkerConfig{
+			DBGetter: s.dbGetter,
+			NewModelPruner: func(db coredatabase.TxnRunner, namespace string, initialWindow window, updateWindow func(window), clock clock.Clock, logger logger.Logger) worker.Worker {
+				return workertest.NewErrorWorker(nil)
+			},
+			Clock:  s.clock,
+			Logger: logger,
+		},
+		windows: make(map[string]window),
+	}
+}
+
+func (s *prunerWorkerSuite) insertControllerNodes(c *tc.C, amount int) {
+	query, err := sqlair.Prepare(`
+INSERT INTO controller_node (controller_id, dqlite_node_id, dqlite_bind_address)
+VALUES ($M.ctrl_id, $M.node_id, $M.addr)
+			`, sqlair.M{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		for i := 0; i < amount; i++ {
+			err := tx.Query(ctx, query, sqlair.M{
+				"ctrl_id": strconv.Itoa(i + 1),
+				"node_id": i,
+				"addr":    fmt.Sprintf("127.0.1.%d", i+2),
+			}).Run()
+			c.Assert(err, tc.ErrorIsNil)
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *prunerWorkerSuite) insertChangeLogWitness(c *tc.C, runner coredatabase.TxnRunner, watermarks ...Watermark) {
+	query, err := sqlair.Prepare(`
+INSERT INTO change_log_witness (controller_id, lower_bound, updated_at)
+VALUES ($M.ctrl_id, $M.lower_bound, $M.updated_at)
+ON CONFLICT (controller_id) DO UPDATE SET lower_bound = $M.lower_bound, updated_at = $M.updated_at;
+			`, sqlair.M{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		for _, watermark := range watermarks {
+			err := tx.Query(ctx, query, sqlair.M{
+				"ctrl_id":     watermark.ControllerID,
+				"lower_bound": watermark.LowerBound,
+				"updated_at":  watermark.UpdatedAt,
+			}).Run()
+			c.Assert(err, tc.ErrorIsNil)
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *prunerWorkerSuite) insertChangeLogItems(c *tc.C, runner coredatabase.TxnRunner, start, amount int, now time.Time) {
+	query, err := sqlair.Prepare(`
+INSERT INTO change_log (id, edit_type_id, namespace_id, changed, created_at)
+VALUES ($M.id, 4, 10002, 0, $M.created_at);
+			`, sqlair.M{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		for i := start; i < amount; i++ {
+			err := tx.Query(ctx, query, sqlair.M{
+				"id":         i + 1000,
+				"created_at": now,
+			}).Run()
+			c.Assert(err, tc.ErrorIsNil)
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *prunerWorkerSuite) expectChangeLogWitnesses(c *tc.C, runner coredatabase.TxnRunner, watermarks []Watermark) {
+	query, err := sqlair.Prepare(`
+SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_log_witness;
+`, Watermark{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	var got []Watermark
+	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, query).GetAll(&got)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, watermarks)
+}
+
+func (s *prunerWorkerSuite) expectChangeLogItems(c *tc.C, runner coredatabase.TxnRunner, amount, lowerBound, upperBound int) {
+	query, err := sqlair.Prepare(`
+SELECT (id, edit_type_id, namespace_id, changed, created_at) AS (&ChangeLogItem.*) FROM change_log;
+	`, ChangeLogItem{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	var got []ChangeLogItem
+	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, query).GetAll(&got)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(len(got), tc.Equals, amount)
+	for i, item := range got {
+		if item.ID < lowerBound || item.ID > upperBound {
+			c.Errorf("item %d: id %d not in range %d-%d", i, item.ID, lowerBound, upperBound)
+		}
+
+		c.Check(item.EditTypeID, tc.Equals, 4)
+		c.Check(item.Namespace, tc.Equals, 10002)
+		c.Check(item.Changed, tc.Equals, 0)
+	}
+}
+
+func (s *prunerWorkerSuite) truncateChangeLog(c *tc.C, runner coredatabase.TxnRunner) {
+	query, err := sqlair.Prepare(`DELETE FROM change_log;`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, query).Run()
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+type ChangeLogItem struct {
+	ID         int       `db:"id"`
+	EditTypeID int       `db:"edit_type_id"`
+	Namespace  int       `db:"namespace_id"`
+	Changed    int       `db:"changed"`
+	CreatedAt  time.Time `db:"created_at"`
+}
+*/

--- a/internal/worker/changestreampruner/worker.go
+++ b/internal/worker/changestreampruner/worker.go
@@ -5,26 +5,24 @@ package changestreampruner
 
 import (
 	"context"
-	"sort"
+	"sync"
 	"time"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/retry"
-	"gopkg.in/tomb.v2"
+	"github.com/juju/worker/v4"
+	"github.com/juju/worker/v4/catacomb"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
+	internalworker "github.com/juju/juju/internal/worker"
 )
 
 const (
-	// defaultPruneMinInterval is the default minimum interval at which the
+	// defaultPruneMinInterval is the default interval at which the
 	// pruner will run.
-	defaultPruneMinInterval = time.Second * 5
-	// defaultPruneMaxInterval is the default maximum interval at which the
-	// pruner will run.
-	defaultPruneMaxInterval = time.Second * 30
+	defaultPruneInterval = time.Second * 10
 
 	// defaultWindowDuration is the default duration of the window in which
 	// the pruner will select the lower bound of the watermark. If any
@@ -33,10 +31,8 @@ const (
 	defaultWindowDuration = time.Minute * 10
 )
 
-var (
-	// backOffStrategy is the default backoff strategy used by the pruner.
-	backOffStrategy = retry.ExpBackoff(defaultPruneMinInterval, defaultPruneMaxInterval, 1.5, false)
-)
+// WindowUpdaterFunc is a function that updates the current window.
+type WindowUpdaterFunc func(window)
 
 // DBGetter describes the ability to supply a sql.DB
 // reference for a particular database.
@@ -45,15 +41,19 @@ type DBGetter = coredatabase.DBGetter
 // WorkerConfig encapsulates the configuration options for the
 // changestream worker.
 type WorkerConfig struct {
-	DBGetter DBGetter
-	Clock    clock.Clock
-	Logger   logger.Logger
+	DBGetter       DBGetter
+	Clock          clock.Clock
+	Logger         logger.Logger
+	NewModelPruner NewModelPrunerFunc
 }
 
 // Validate ensures that the config values are valid.
 func (c *WorkerConfig) Validate() error {
 	if c.DBGetter == nil {
 		return errors.NotValidf("missing DBGetter")
+	}
+	if c.NewModelPruner == nil {
+		return errors.NotValidf("missing NewModelPruner")
 	}
 	if c.Clock == nil {
 		return errors.NotValidf("missing clock")
@@ -66,84 +66,126 @@ func (c *WorkerConfig) Validate() error {
 
 // Pruner defines a worker that will truncate the change log.
 type Pruner struct {
-	tomb tomb.Tomb
+	catacomb catacomb.Catacomb
 
 	cfg WorkerConfig
+
+	runner *worker.Runner
 
 	// windows holds the last window for each namespace. This is used to
 	// determine if the change stream is keeping up with the pruner. If the
 	// watermark is outside of the window, we should log a warning message.
 	windows map[string]window
+	mutex   sync.Mutex
 }
 
 // New creates a new Pruner.
 func newWorker(cfg WorkerConfig) (*Pruner, error) {
-	var err error
-	if err = cfg.Validate(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	pruner := &Pruner{
+	runner, err := worker.NewRunner(worker.RunnerParams{
+		Name:          "changestream-pruner",
+		IsFatal:       func(err error) bool { return false },
+		ShouldRestart: internalworker.ShouldRunnerRestart,
+		Clock:         cfg.Clock,
+		Logger:        internalworker.WrapLogger(cfg.Logger),
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w := &Pruner{
 		cfg:     cfg,
+		runner:  runner,
 		windows: make(map[string]window),
 	}
 
-	pruner.tomb.Go(pruner.loop)
+	if err := catacomb.Invoke(catacomb.Plan{
+		Name: "changestream-pruner",
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{runner},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
 
-	return pruner, nil
+	return w, nil
 }
 
 // Kill is part of the worker.Worker interface.
 func (w *Pruner) Kill() {
-	w.tomb.Kill(nil)
+	w.catacomb.Kill(nil)
 }
 
 // Wait is part of the worker.Worker interface.
 func (w *Pruner) Wait() error {
-	return w.tomb.Wait()
+	return w.catacomb.Wait()
 }
 
 func (w *Pruner) loop() error {
-	timer := w.cfg.Clock.NewTimer(defaultPruneMinInterval)
+	ctx, cancel := w.scopedContext()
+	defer cancel()
+
+	timer := w.cfg.Clock.NewTimer(defaultPruneInterval)
 	defer timer.Stop()
 
-	var attempts int
 	for {
 		select {
-		case <-w.tomb.Dying():
-			return tomb.ErrDying
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
 
 		case <-timer.Chan():
 			// Attempt to prune, if there is any critical error, kill the
 			// worker, which should force a restart.
-			pruned, err := w.prune()
-			if err != nil {
+			if err := w.prune(ctx); err != nil {
 				return errors.Trace(err)
 			}
-
-			// If nothing was pruned, increment the attempts counter, otherwise
-			// reset it. This should wind out the backoff strategy if there is
-			// nothing to prune, thus reducing the frequency of the pruner.
-			if len(pruned) == 0 {
-				attempts++
-			} else {
-				attempts = 0
-			}
-
-			timer.Reset(backOffStrategy(0, attempts))
 		}
 	}
 }
 
-func (w *Pruner) prune() (map[string]int64, error) {
-	ctx, cancel := w.scopedContext()
-	defer cancel()
-
+func (w *Pruner) prune(ctx context.Context) error {
 	traceEnabled := w.cfg.Logger.IsLevelEnabled(logger.TRACE)
 	if traceEnabled {
 		w.cfg.Logger.Tracef(ctx, "Starting pruning change log")
 	}
 
+	modelNamespaces, err := w.getModelNamespaces(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, mn := range modelNamespaces {
+		err := w.runner.StartWorker(ctx, mn.Namespace, func(ctx context.Context) (worker.Worker, error) {
+			db, err := w.cfg.DBGetter.GetDB(ctx, mn.Namespace)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			w.mutex.Lock()
+			currentWindow := w.windows[mn.Namespace]
+			w.mutex.Unlock()
+
+			return w.cfg.NewModelPruner(
+				db,
+				mn.Namespace,
+				currentWindow,
+				w.updateWindow(mn.Namespace),
+				w.cfg.Clock,
+				w.cfg.Logger.Child(mn.Namespace),
+			), nil
+		})
+		if err != nil && !errors.Is(err, errors.AlreadyExists) {
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
+}
+
+func (w *Pruner) getModelNamespaces(ctx context.Context) ([]ModelNamespace, error) {
 	db, err := w.cfg.DBGetter.GetDB(ctx, coredatabase.ControllerNS)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -171,188 +213,13 @@ FROM model_namespace;
 		{Namespace: coredatabase.ControllerNS},
 	}, modelNamespaces...)
 
-	// Prune each and every model found in the model list.
-	pruned := make(map[string]int64)
-	modelNames := make(map[string]struct{})
-	for _, mn := range modelNamespaces {
-		// Store the model name in a map. We can't use pruned map for the
-		// tracking of namespaces, because if there is an error we might
-		// accidentally remove a window for a model that hasn't been deleted.
-		modelNames[mn.Namespace] = struct{}{}
-
-		p, err := w.pruneModel(ctx, mn.Namespace)
-		if err != nil {
-			// If the database is dead, continue on to the next model, as we
-			// don't want to kill the worker.
-			if errors.Is(err, coredatabase.ErrDBDead) {
-				continue
-			}
-			// If there is an error, continue on to the next model, as we don't
-			// want to kill the worker.
-			w.cfg.Logger.Infof(ctx, "Error pruning model %q: %v", mn.UUID, err)
-			continue
-		}
-
-		if traceEnabled {
-			w.cfg.Logger.Tracef(ctx, "Pruned %d change logs for model %q", pruned, mn.UUID)
-		}
-
-		pruned[mn.Namespace] = p
-	}
-
-	// Ensure we clean up the windows for any models that have been deleted.
-	// The absence of a model in the modelNames list indicates that the model
-	// has been deleted and we should remove the window.
-	for namespace := range w.windows {
-		if _, ok := modelNames[namespace]; !ok {
-			delete(w.windows, namespace)
-		}
-	}
-
-	if traceEnabled {
-		w.cfg.Logger.Tracef(ctx, "Finished pruning change log")
-	}
-
-	return pruned, nil
+	return modelNamespaces, nil
 }
 
-func (w *Pruner) pruneModel(ctx context.Context, namespace string) (int64, error) {
-	db, err := w.cfg.DBGetter.GetDB(ctx, namespace)
-	if err != nil {
-		return -1, errors.Trace(err)
+func (w *Pruner) updateWindow(namespace string) WindowUpdaterFunc {
+	return func(newWindow window) {
+		w.mutex.Lock()
+		defer w.mutex.Unlock()
+		w.windows[namespace] = newWindow
 	}
-
-	var pruned int64
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		// Locate the lowest watermark, this is the watermark that we will
-		// use to prune the change log.
-		lowest, err := w.locateLowestWatermark(ctx, tx, namespace)
-		if err != nil {
-			return errors.Annotatef(err, "failed to locate lowest watermark")
-		}
-
-		// Prune the change log, using the lowest watermark.
-		pruned, err = w.deleteChangeLog(ctx, tx, lowest)
-		return errors.Annotatef(err, "failed to prune change log")
-	})
-	return pruned, errors.Trace(err)
-}
-
-var selectWitnessQuery = sqlair.MustPrepare(`SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_log_witness;`, Watermark{})
-
-func (w *Pruner) locateLowestWatermark(ctx context.Context, tx *sqlair.TX, namespace string) (Watermark, error) {
-	// Gather all the valid watermarks, post row pruning. These include
-	// the controller id which we know are valid based on the
-	// controller_node table. If at any point we delete rows from the
-	// change_log_witness table, the change stream will put the witness
-	// back in place after the next change log is written.
-	var watermarks []Watermark
-	if err := tx.Query(ctx, selectWitnessQuery).GetAll(&watermarks); errors.Is(err, sqlair.ErrNoRows) {
-		// Nothing to do if there are no watermarks.
-		return Watermark{}, nil
-	} else if err != nil {
-		return Watermark{}, errors.Trace(err)
-	}
-
-	// Gather all the watermarks that are within the windowed time period.
-	// If there are no watermarks within the window, then we can assume
-	// that the stream is keeping up and we don't need to prune anything.
-	sorted := sortWatermarks(namespace, watermarks)
-
-	// Find the first and last watermark in the sorted list, this is our
-	// window. It should hold the start and the end of the window.
-	watermarkView := window{
-		start: sorted[0].UpdatedAt,
-		end:   sorted[len(sorted)-1].UpdatedAt,
-	}
-
-	// If the watermark is outside of the window, we should log a warning
-	// message to indicate that the change stream is not keeping up. Only if
-	// the watermark is different from the last window, as we don't want to
-	// spam the logs if there are no changes.
-	now := w.cfg.Clock.Now()
-	timeView := window{
-		start: now.Add(-defaultWindowDuration),
-		end:   now,
-	}
-	if !timeView.Contains(watermarkView) && !watermarkView.Equals(w.windows[namespace]) {
-		w.cfg.Logger.Warningf(ctx, "namespace %s watermarks %q are outside of window, check logs to see if the change stream is keeping up", namespace, sorted[0].ControllerID)
-	}
-
-	// Save the last window for the next iteration.
-	w.windows[namespace] = watermarkView
-
-	return sorted[0], nil
-}
-
-var deleteQuery = sqlair.MustPrepare(`DELETE FROM change_log WHERE id <= $M.id;`, sqlair.M{})
-
-func (w *Pruner) deleteChangeLog(ctx context.Context, tx *sqlair.TX, lowest Watermark) (int64, error) {
-	// Delete all the change logs that are lower than the lowest watermark.
-	var outcome sqlair.Outcome
-	if err := tx.Query(ctx, deleteQuery, sqlair.M{"id": lowest.LowerBound}).Get(&outcome); err != nil {
-		return -1, errors.Trace(err)
-	}
-	pruned, err := outcome.Result().RowsAffected()
-	return pruned, errors.Trace(err)
-}
-
-// scopedContext returns a context that is in the scope of the worker lifetime.
-// It returns a cancellable context that is cancelled when the action has
-// completed.
-func (w *Pruner) scopedContext() (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-	return w.tomb.Context(ctx), cancel
-}
-
-func sortWatermarks(namespace string, watermarks []Watermark) []Watermark {
-	// If there is only one watermark, just use that one and return out early.
-	if len(watermarks) == 1 {
-		return watermarks
-	}
-
-	// Sort the watermarks by the lower bound.
-	sort.Slice(watermarks, func(i, j int) bool {
-		if watermarks[i].LowerBound == watermarks[j].LowerBound {
-			return watermarks[i].UpdatedAt.Before(watermarks[j].UpdatedAt)
-		}
-		return watermarks[i].LowerBound < watermarks[j].LowerBound
-	})
-
-	return watermarks
-}
-
-// ModelNamespace represents a model and the associated DQlite namespace that it
-// uses.
-type ModelNamespace struct {
-	UUID      string `db:"uuid"`
-	Namespace string `db:"namespace"`
-}
-
-// Watermark represents a row from the change_log_witness table.
-type Watermark struct {
-	ControllerID string    `db:"controller_id"`
-	LowerBound   int64     `db:"lower_bound"`
-	UpdatedAt    time.Time `db:"updated_at"`
-}
-
-type window struct {
-	start, end time.Time
-}
-
-// Contains returns true if the window contains the given time.
-func (w window) Contains(o window) bool {
-	if w.Equals(o) {
-		return true
-	}
-	return w.start.Before(o.start) && w.end.After(o.end)
-}
-
-// Equals returns true if the window is equal to the given window.
-func (w window) Equals(o window) bool {
-	return w.start.Equal(o.start) && w.end.Equal(o.end)
-}
-
-func (w window) String() string {
-	return w.start.Format(time.RFC3339) + " -> " + w.end.Format(time.RFC3339)
 }

--- a/internal/worker/changestreampruner/worker_test.go
+++ b/internal/worker/changestreampruner/worker_test.go
@@ -3,21 +3,17 @@
 package changestreampruner
 
 import (
-	"context"
-	"fmt"
-	"strconv"
 	"testing"
-	"time"
 
-	"github.com/canonical/sqlair"
+	clock "github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
+	"github.com/juju/worker/v4"
+	"github.com/juju/worker/v4/workertest"
 	"go.uber.org/goleak"
-	gomock "go.uber.org/mock/gomock"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
-	modeltesting "github.com/juju/juju/domain/model/state/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -33,620 +29,67 @@ func TestWorkerSuite(t *testing.T) {
 func (s *workerSuite) TestValidateConfig(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cfg := s.getConfig(c)
+	cfg := s.getConfig(c, nil)
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
+	cfg = s.getConfig(c, nil)
 	cfg.Clock = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
-	cfg = s.getConfig(c)
+	cfg = s.getConfig(c, nil)
 	cfg.Logger = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
-	cfg = s.getConfig(c)
+	cfg = s.getConfig(c, nil)
 	cfg.DBGetter = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
-}
 
-func (s *workerSuite) getConfig(c *tc.C) WorkerConfig {
-	return WorkerConfig{
-		DBGetter: s.dbGetter,
-		Clock:    s.clock,
-		Logger:   loggertesting.WrapCheckLog(c),
-	}
+	cfg = s.getConfig(c, nil)
+	cfg.NewModelPruner = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 }
 
 func (s *workerSuite) TestPrune(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	s.expectClock()
+	s.expectTimerImmediate()
 	s.expectControllerDBGet()
 
-	pruner := s.newPruner(c)
-
-	result, err := pruner.prune()
-	c.Check(err, tc.ErrorIsNil)
-
-	// This ensures that we always prune the controller namespace.
-	c.Check(result, tc.DeepEquals, map[string]int64{
-		coredatabase.ControllerNS: 0,
-	})
-}
-
-func (s *workerSuite) TestPruneControllerNS(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.expectControllerDBGet()
-	s.expectClock()
-
-	pruner := s.newPruner(c)
-
-	now := time.Now()
-
-	s.insertControllerNodes(c, 1)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1002, UpdatedAt: now.Add(-time.Minute)})
-	s.truncateChangeLog(c, s.TxnRunner())
-	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
-
-	result, err := pruner.prune()
-	c.Check(err, tc.ErrorIsNil)
-
-	// This ensures that we always prune the controller namespace.
-	c.Check(result, tc.DeepEquals, map[string]int64{
-		coredatabase.ControllerNS: 3,
-	})
-}
-
-func (s *workerSuite) TestPruneModelList(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	txnRunner, db := s.OpenDB(c)
-	defer db.Close()
-
-	s.ApplyDDLForRunner(c, txnRunner)
-
-	s.expectControllerDBGet()
-	s.expectClock()
-
-	pruner := s.newPruner(c)
-
-	now := time.Now()
-
-	s.insertControllerNodes(c, 1)
-	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "foo")
-	s.expectDBGet(modelUUID.String(), txnRunner)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1002, UpdatedAt: now.Add(-time.Minute)})
-	s.truncateChangeLog(c, s.TxnRunner())
-	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
-
-	result, err := pruner.prune()
-	c.Check(err, tc.ErrorIsNil)
-
-	// This ensures that we always prune the controller namespace.
-	c.Check(result, tc.DeepEquals, map[string]int64{
-		coredatabase.ControllerNS: 3,
-		modelUUID.String():        0,
-	})
-}
-
-func (s *workerSuite) TestPruneModelListWithChangeLogItems(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	txnRunner, db := s.OpenDB(c)
-	defer db.Close()
-
-	s.ApplyDDLForRunner(c, txnRunner)
-
-	s.expectControllerDBGet()
-	s.expectClock()
-
-	pruner := s.newPruner(c)
-
-	now := time.Now()
-
-	s.insertControllerNodes(c, 1)
-	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "foo")
-	s.expectDBGet(modelUUID.String(), txnRunner)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1002, UpdatedAt: now.Add(-time.Minute)})
-	s.truncateChangeLog(c, s.TxnRunner())
-	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
-
-	s.insertChangeLogWitness(c, txnRunner, Watermark{ControllerID: "0", LowerBound: 1003, UpdatedAt: now.Add(-time.Second)})
-	s.truncateChangeLog(c, txnRunner)
-	s.insertChangeLogItems(c, txnRunner, 0, 6, now)
-
-	result, err := pruner.prune()
-	c.Check(err, tc.ErrorIsNil)
-
-	// This ensures that we always prune the controller namespace.
-	c.Check(result, tc.DeepEquals, map[string]int64{
-		coredatabase.ControllerNS: 3,
-		modelUUID.String():        4,
-	})
-}
-
-func (s *workerSuite) TestPruneModel(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.expectDBGet("foo", s.TxnRunner())
-
-	pruner := s.newPruner(c)
-
-	result, err := pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(0))
-}
-
-func (s *workerSuite) TestPruneModelGetDBError(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.dbGetter.EXPECT().GetDB(gomock.Any(), "foo").Return(nil, errors.New("boom"))
-
-	pruner := s.newPruner(c)
-
-	_, err := pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorMatches, "boom")
-}
-
-func (s *workerSuite) TestPruneModelChangeLogWitness(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.expectDBGet("foo", s.TxnRunner())
-	s.expectClock()
-
-	pruner := s.newPruner(c)
-
-	now := time.Now()
-
-	s.insertControllerNodes(c, 2)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1, UpdatedAt: now})
-
-	result, err := pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(1))
-
-	s.expectChangeLogWitnesses(c, s.TxnRunner(), []Watermark{{
-		ControllerID: "0",
-		LowerBound:   1,
-		UpdatedAt:    now,
-	}})
-}
-
-func (s *workerSuite) TestPruneModelLogsWarning(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	// We request the db
-
-	s.expectDBGetTimes("foo", s.TxnRunner(), 3)
-	s.expectClock()
-
-	var entries []string
-	recorder := loggertesting.RecordLog(func(s string, a ...any) {
-		entries = append(entries, s)
-	})
-
-	pruner := s.newPrunerWithLogger(c, loggertesting.WrapCheckLog(recorder))
-
-	now := time.Now()
-
-	s.insertControllerNodes(c, 2)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))})
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "3", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration + time.Minute))})
-
-	s.insertChangeLogItems(c, s.TxnRunner(), 0, 1, now)
-
-	result, err := pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(1))
-
-	// Should not prune anything as there are no new changes. Notice that the
-	// warning is not logged.
-
-	result, err = pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(0))
-
-	// Add some new changes and it should log the warning.
-
-	now = time.Now()
-
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 2, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))})
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "3", LowerBound: 2, UpdatedAt: now.Add(-(defaultWindowDuration + time.Minute))})
-
-	s.insertChangeLogItems(c, s.TxnRunner(), 1, 1, now)
-
-	result, err = pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(1))
-
-	c.Check(entries, tc.DeepEquals, []string{
-		"WARNING: namespace %s watermarks %q are outside of window, check logs to see if the change stream is keeping up",
-		"WARNING: namespace %s watermarks %q are outside of window, check logs to see if the change stream is keeping up",
-	})
-}
-
-func (s *workerSuite) TestPruneModelRemovesChangeLogItems(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.expectDBGet("foo", s.TxnRunner())
-	s.expectClock()
-
-	pruner := s.newPruner(c)
-
-	now := time.Now()
-
-	totalCtrlNodes := 2
-	s.insertControllerNodes(c, totalCtrlNodes)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1002, UpdatedAt: now.Add(-time.Minute)})
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "3", LowerBound: 1003, UpdatedAt: now.Add(-time.Second)})
-
-	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
-
-	result, err := pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(3+totalCtrlNodes))
-
-	s.expectChangeLogItems(c, s.TxnRunner(), 7, 1003, 1010)
-}
-
-func (s *workerSuite) TestPruneModelRemovesChangeLogItemsWithMultipleWatermarks(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.expectDBGet("foo", s.TxnRunner())
-	s.expectClock()
-
-	pruner := s.newPruner(c)
-
-	now := time.Now()
-
-	totalCtrlNodes := 2
-	s.insertControllerNodes(c, totalCtrlNodes)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1005, UpdatedAt: now.Add(-time.Minute)})
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "1", LowerBound: 1002, UpdatedAt: now.Add(-time.Second)})
-
-	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
-
-	result, err := pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(3+totalCtrlNodes))
-
-	s.expectChangeLogItems(c, s.TxnRunner(), 7, 1003, 1010)
-}
-
-func (s *workerSuite) TestPruneModelRemovesChangeLogItemsWithMultipleWatermarksWithOneOutsideWindow(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.expectDBGet("foo", s.TxnRunner())
-	s.expectClock()
-
-	pruner := s.newPruner(c)
-
-	now := time.Now()
-
-	totalCtrlNodes := 3
-	s.insertControllerNodes(c, totalCtrlNodes)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1005, UpdatedAt: now.Add(-time.Minute)})
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "1", LowerBound: 1002, UpdatedAt: now.Add(-time.Second)})
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "2", LowerBound: 1001, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))})
-
-	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
-
-	result, err := pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(2+totalCtrlNodes))
-
-	s.expectChangeLogItems(c, s.TxnRunner(), 8, 1002, 1010)
-}
-
-func (s *workerSuite) TestPruneModelRemovesChangeLogItemsWithMultipleWatermarksMoreWatermarks(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.expectDBGet("foo", s.TxnRunner())
-	s.expectClock()
-
-	pruner := s.newPruner(c)
-
-	now := time.Now()
-
-	totalCtrlNodes := 3
-	s.insertControllerNodes(c, totalCtrlNodes)
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "0", LowerBound: 1005, UpdatedAt: now.Add(-time.Minute)})
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "1", LowerBound: 1002, UpdatedAt: now.Add(-time.Second)})
-	s.insertChangeLogWitness(c, s.TxnRunner(), Watermark{ControllerID: "2", LowerBound: 1001, UpdatedAt: now.Add(-time.Second)})
-
-	s.insertChangeLogItems(c, s.TxnRunner(), 0, 10, now)
-
-	result, err := pruner.pruneModel(c.Context(), "foo")
-	c.Check(err, tc.ErrorIsNil)
-	c.Check(result, tc.Equals, int64(2+totalCtrlNodes))
-
-	s.expectChangeLogItems(c, s.TxnRunner(), 8, 1002, 1010)
-}
-
-func (s *workerSuite) TestWindowContains(c *tc.C) {
-	now := time.Now()
-	testCases := []struct {
-		window   window
-		other    window
-		expected bool
-	}{{
-		window:   window{start: now, end: now},
-		other:    window{start: now, end: now},
-		expected: true,
-	}, {
-		window:   window{start: now.Add(-time.Minute), end: now.Add(time.Minute)},
-		other:    window{start: now, end: now},
-		expected: true,
-	}, {
-		window:   window{start: now.Add(time.Minute), end: now.Add(-time.Minute)},
-		other:    window{start: now, end: now},
-		expected: false,
-	}, {
-		window:   window{start: now.Add(time.Minute), end: now.Add(time.Minute)},
-		other:    window{start: now, end: now},
-		expected: false,
-	}, {
-		window:   window{start: now.Add(-time.Minute), end: now.Add(-time.Minute)},
-		other:    window{start: now, end: now},
-		expected: false,
-	}, {
-		window:   window{start: now, end: now.Add(time.Minute * 2)},
-		other:    window{start: now.Add(time.Minute), end: now.Add(time.Minute + time.Second)},
-		expected: true,
-	}, {
-		window:   window{start: now, end: now.Add(time.Minute * 2)},
-		other:    window{start: now.Add(time.Nanosecond), end: now.Add((time.Minute * 2) - time.Nanosecond)},
-		expected: true,
-	}, {
-		window:   window{start: now, end: now.Add(time.Minute * 2)},
-		other:    window{start: now, end: now.Add((time.Minute * 2) - time.Nanosecond)},
-		expected: false,
-	}, {
-		window:   window{start: now, end: now.Add(time.Minute * 2)},
-		other:    window{start: now.Add(time.Nanosecond), end: now.Add(time.Minute * 2)},
-		expected: false,
-	}}
-	for i, test := range testCases {
-		c.Logf("test %d", i)
-
-		got := test.window.Contains(test.other)
-		c.Check(got, tc.Equals, test.expected)
+	ch := make(chan string, 1)
+
+	pruner := s.newPruner(c, ch)
+	defer workertest.CleanKill(c, pruner)
+
+	select {
+	case <-c.Context().Done():
+		c.Fatal("context closed before pruner could start")
+	case ns := <-ch:
+		c.Check(ns, tc.Equals, coredatabase.ControllerNS)
 	}
 }
 
-func (s *workerSuite) TestWindowEquals(c *tc.C) {
-	now := time.Now()
-	testCases := []struct {
-		window   window
-		other    window
-		expected bool
-	}{{
-		window:   window{start: now, end: now},
-		other:    window{start: now, end: now},
-		expected: true,
-	}, {
-		window:   window{start: now.Add(-time.Minute), end: now.Add(time.Minute)},
-		other:    window{start: now, end: now},
-		expected: false,
-	}}
-	for i, test := range testCases {
-		c.Logf("test %d", i)
-
-		got := test.window.Equals(test.other)
-		c.Check(got, tc.Equals, test.expected)
+func (s *workerSuite) getConfig(c *tc.C, ch chan string) WorkerConfig {
+	return WorkerConfig{
+		DBGetter: s.dbGetter,
+		NewModelPruner: func(
+			_ coredatabase.TxnRunner,
+			namespace string,
+			_ window,
+			_ WindowUpdaterFunc,
+			_ clock.Clock,
+			_ logger.Logger,
+		) worker.Worker {
+			ch <- namespace
+			return workertest.NewErrorWorker(nil)
+		},
+		Clock:  s.clock,
+		Logger: loggertesting.WrapCheckLog(c),
 	}
 }
 
-func (s *workerSuite) TestLowestWatermark(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	now := time.Now()
-	testCases := []struct {
-		watermarks []Watermark
-		expected   []Watermark
-	}{{
-		watermarks: []Watermark{
-			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
-		},
-		expected: []Watermark{
-			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
-		},
-	}, {
-		watermarks: []Watermark{
-			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
-			{ControllerID: "1", LowerBound: 1, UpdatedAt: now},
-		},
-		expected: []Watermark{
-			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
-			{ControllerID: "1", LowerBound: 1, UpdatedAt: now},
-		},
-	}, {
-		watermarks: []Watermark{
-			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
-			{ControllerID: "1", LowerBound: 10, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
-		},
-		expected: []Watermark{
-			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
-			{ControllerID: "1", LowerBound: 10, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
-		},
-	}, {
-		watermarks: []Watermark{
-			{ControllerID: "0", LowerBound: 2, UpdatedAt: now},
-			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration - time.Second))},
-		},
-		expected: []Watermark{
-			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration - time.Second))},
-			{ControllerID: "0", LowerBound: 2, UpdatedAt: now},
-		},
-	}, {
-		watermarks: []Watermark{
-			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
-			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration - time.Second))},
-		},
-		expected: []Watermark{
-			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration - time.Second))},
-			{ControllerID: "0", LowerBound: 1, UpdatedAt: now},
-		},
-	}, {
-		watermarks: []Watermark{
-			{ControllerID: "0", LowerBound: 2, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
-			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
-		},
-		// TODO (stickupkid): This should be false, but we need a strategy for
-		// removing nodes that are not keeping up. We're logging a warning
-		// instead.
-		expected: []Watermark{
-			{ControllerID: "1", LowerBound: 1, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
-			{ControllerID: "0", LowerBound: 2, UpdatedAt: now.Add(-(defaultWindowDuration + time.Second))},
-		},
-	}}
-
-	for i, test := range testCases {
-		c.Logf("test %d", i)
-
-		got := sortWatermarks("foo", test.watermarks)
-		c.Check(got, tc.DeepEquals, test.expected)
-	}
-}
-
-func (s *workerSuite) newPruner(c *tc.C) *Pruner {
-	return s.newPrunerWithLogger(c, loggertesting.WrapCheckLog(c))
-}
-
-func (s *workerSuite) newPrunerWithLogger(c *tc.C, logger logger.Logger) *Pruner {
-	return &Pruner{
-		cfg: WorkerConfig{
-			DBGetter: s.dbGetter,
-			Clock:    s.clock,
-			Logger:   logger,
-		},
-		windows: make(map[string]window),
-	}
-}
-
-func (s *workerSuite) insertControllerNodes(c *tc.C, amount int) {
-	query, err := sqlair.Prepare(`
-INSERT INTO controller_node (controller_id, dqlite_node_id, dqlite_bind_address)
-VALUES ($M.ctrl_id, $M.node_id, $M.addr)
-			`, sqlair.M{})
+func (s *workerSuite) newPruner(c *tc.C, ch chan string) *Pruner {
+	w, err := newWorker(s.getConfig(c, ch))
 	c.Assert(err, tc.ErrorIsNil)
-
-	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		for i := 0; i < amount; i++ {
-			err := tx.Query(ctx, query, sqlair.M{
-				"ctrl_id": strconv.Itoa(i + 1),
-				"node_id": i,
-				"addr":    fmt.Sprintf("127.0.1.%d", i+2),
-			}).Run()
-			c.Assert(err, tc.ErrorIsNil)
-		}
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *workerSuite) insertChangeLogWitness(c *tc.C, runner coredatabase.TxnRunner, watermarks ...Watermark) {
-	query, err := sqlair.Prepare(`
-INSERT INTO change_log_witness (controller_id, lower_bound, updated_at)
-VALUES ($M.ctrl_id, $M.lower_bound, $M.updated_at)
-ON CONFLICT (controller_id) DO UPDATE SET lower_bound = $M.lower_bound, updated_at = $M.updated_at;
-			`, sqlair.M{})
-	c.Assert(err, tc.ErrorIsNil)
-
-	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		for _, watermark := range watermarks {
-			err := tx.Query(ctx, query, sqlair.M{
-				"ctrl_id":     watermark.ControllerID,
-				"lower_bound": watermark.LowerBound,
-				"updated_at":  watermark.UpdatedAt,
-			}).Run()
-			c.Assert(err, tc.ErrorIsNil)
-		}
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *workerSuite) insertChangeLogItems(c *tc.C, runner coredatabase.TxnRunner, start, amount int, now time.Time) {
-	query, err := sqlair.Prepare(`
-INSERT INTO change_log (id, edit_type_id, namespace_id, changed, created_at)
-VALUES ($M.id, 4, 10002, 0, $M.created_at);
-			`, sqlair.M{})
-	c.Assert(err, tc.ErrorIsNil)
-
-	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		for i := start; i < amount; i++ {
-			err := tx.Query(ctx, query, sqlair.M{
-				"id":         i + 1000,
-				"created_at": now,
-			}).Run()
-			c.Assert(err, tc.ErrorIsNil)
-		}
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *workerSuite) expectChangeLogWitnesses(c *tc.C, runner coredatabase.TxnRunner, watermarks []Watermark) {
-	query, err := sqlair.Prepare(`
-SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_log_witness;
-`, Watermark{})
-	c.Assert(err, tc.ErrorIsNil)
-
-	var got []Watermark
-	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, query).GetAll(&got)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(got, tc.DeepEquals, watermarks)
-}
-
-func (s *workerSuite) expectChangeLogItems(c *tc.C, runner coredatabase.TxnRunner, amount, lowerBound, upperBound int) {
-	query, err := sqlair.Prepare(`
-SELECT (id, edit_type_id, namespace_id, changed, created_at) AS (&ChangeLogItem.*) FROM change_log;
-	`, ChangeLogItem{})
-	c.Assert(err, tc.ErrorIsNil)
-
-	var got []ChangeLogItem
-	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, query).GetAll(&got)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(len(got), tc.Equals, amount)
-	for i, item := range got {
-		if item.ID < lowerBound || item.ID > upperBound {
-			c.Errorf("item %d: id %d not in range %d-%d", i, item.ID, lowerBound, upperBound)
-		}
-
-		c.Check(item.EditTypeID, tc.Equals, 4)
-		c.Check(item.Namespace, tc.Equals, 10002)
-		c.Check(item.Changed, tc.Equals, 0)
-	}
-}
-
-func (s *workerSuite) truncateChangeLog(c *tc.C, runner coredatabase.TxnRunner) {
-	query, err := sqlair.Prepare(`DELETE FROM change_log;`)
-	c.Assert(err, tc.ErrorIsNil)
-
-	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return tx.Query(ctx, query).Run()
-	})
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-type ChangeLogItem struct {
-	ID         int       `db:"id"`
-	EditTypeID int       `db:"edit_type_id"`
-	Namespace  int       `db:"namespace_id"`
-	Changed    int       `db:"changed"`
-	CreatedAt  time.Time `db:"created_at"`
+	return w
 }


### PR DESCRIPTION
The changestream pruner does not handle the removal of models very well. This is because the strategy has evolved since this was written. It is expected that each model should be a worker runner and handle the database going missing. This is inline with other workers (i.e. the removal worker).

This should ensure that the we don't prevent the leaking of the change log items when a model becomes dead.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
