### PR TITLE
refactor: remove e/n/i network configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/distribution/reference v0.5.0
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.16.0
@@ -115,7 +116,6 @@ require (
 	golang.org/x/tools v0.36.0
 	google.golang.org/api v0.238.0
 	google.golang.org/grpc v1.73.0
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/errgo.v1 v1.0.1
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.67.0
@@ -168,7 +168,6 @@ require (
 	github.com/cosiner/argv v0.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d // indirect
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -291,6 +290,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250505200425-f936aa4a68b2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/juju/environschema.v1 v1.0.1 // indirect

--- a/internal/cloudconfig/cloudinit/export_test.go
+++ b/internal/cloudconfig/cloudinit/export_test.go
@@ -5,7 +5,5 @@
 package cloudinit
 
 var (
-	NetworkInterfacesFile       = &networkInterfacesFile
-	SystemNetworkInterfacesFile = &systemNetworkInterfacesFile
-	JujuNetplanFile             = &jujuNetplanFile
+	JujuNetplanFile = &jujuNetplanFile
 )

--- a/internal/cloudconfig/cloudinit/network_ubuntu.go
+++ b/internal/cloudconfig/cloudinit/network_ubuntu.go
@@ -5,10 +5,8 @@
 package cloudinit
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -22,122 +20,8 @@ import (
 var logger = internallogger.GetLogger("juju.cloudconfig.cloudinit")
 
 var (
-	systemNetworkInterfacesFile = "/etc/network/interfaces"
-	networkInterfacesFile       = systemNetworkInterfacesFile + "-juju"
-	jujuNetplanFile             = "/etc/netplan/99-juju.yaml"
+	jujuNetplanFile = "/etc/netplan/99-juju.yaml"
 )
-
-// GenerateENITemplate renders an e/n/i template config for one or more network
-// interfaces, using the given non-empty interfaces list.
-func GenerateENITemplate(interfaces corenetwork.InterfaceInfos) (string, error) {
-	if len(interfaces) == 0 {
-		return "", errors.Errorf("missing container network config")
-	}
-	logger.Debugf(context.TODO(), "generating /e/n/i template from %#v", interfaces)
-
-	prepared, err := PrepareNetworkConfigFromInterfaces(interfaces)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	var output bytes.Buffer
-	gateway4Handled := false
-	gateway6Handled := false
-	hasV4Interface := false
-	hasV6Interface := false
-	for _, name := range prepared.InterfaceNames {
-		output.WriteString("\n")
-		if name == "lo" {
-			output.WriteString("auto ")
-			autoStarted := strings.Join(prepared.AutoStarted, " ")
-			output.WriteString(autoStarted + "\n\n")
-			output.WriteString("iface lo inet loopback\n")
-
-			dnsServers := strings.Join(prepared.DNSServers, " ")
-			if dnsServers != "" {
-				output.WriteString("  dns-nameservers ")
-				output.WriteString(dnsServers + "\n")
-			}
-
-			dnsSearchDomains := strings.Join(prepared.DNSSearchDomains, " ")
-			if dnsSearchDomains != "" {
-				output.WriteString("  dns-search ")
-				output.WriteString(dnsSearchDomains + "\n")
-			}
-			continue
-		}
-
-		address, hasAddress := prepared.NameToAddress[name]
-		if !hasAddress {
-			output.WriteString("iface " + name + " inet manual\n")
-			continue
-		} else if address == string(corenetwork.ConfigDHCP) {
-			output.WriteString("iface " + name + " inet dhcp\n")
-			// We're expecting to get a default gateway
-			// from the DHCP lease.
-			gateway4Handled = true
-			continue
-		}
-
-		_, network, err := net.ParseCIDR(address)
-		if err != nil {
-			return "", errors.Annotatef(err, "invalid address for interface %q: %q", name, address)
-		}
-
-		isIpv4 := network.IP.To4() != nil
-
-		if isIpv4 {
-			output.WriteString("iface " + name + " inet static\n")
-			hasV4Interface = true
-		} else {
-			output.WriteString("iface " + name + " inet6 static\n")
-			hasV6Interface = true
-		}
-		output.WriteString("  address " + address + "\n")
-
-		if isIpv4 {
-			if !gateway4Handled && prepared.Gateway4Address != "" {
-				gatewayIP := net.ParseIP(prepared.Gateway4Address)
-				if network.Contains(gatewayIP) {
-					output.WriteString("  gateway " + prepared.Gateway4Address + "\n")
-					gateway4Handled = true // write it only once
-				}
-			}
-		} else {
-			if !gateway6Handled && prepared.Gateway6Address != "" {
-				gatewayIP := net.ParseIP(prepared.Gateway6Address)
-				if network.Contains(gatewayIP) {
-					output.WriteString("  gateway " + prepared.Gateway6Address + "\n")
-					gateway4Handled = true // write it only once
-				}
-			}
-		}
-
-		if mtu, ok := prepared.NameToMTU[name]; ok {
-			output.WriteString(fmt.Sprintf("  mtu %d\n", mtu))
-		}
-
-		for _, route := range prepared.NameToRoutes[name] {
-			output.WriteString(fmt.Sprintf("  post-up ip route add %s via %s metric %d\n",
-				route.DestinationCIDR, route.GatewayIP, route.Metric))
-			output.WriteString(fmt.Sprintf("  pre-down ip route del %s via %s metric %d\n",
-				route.DestinationCIDR, route.GatewayIP, route.Metric))
-		}
-	}
-
-	generatedConfig := output.String()
-	logger.Debugf(context.TODO(), "generated network config:\n%s", generatedConfig)
-
-	if hasV4Interface && !gateway4Handled {
-		logger.Infof(context.TODO(), "generated network config has no ipv4 gateway")
-	}
-
-	if hasV6Interface && !gateway6Handled {
-		logger.Infof(context.TODO(), "generated network config has no ipv6 gateway")
-	}
-
-	return generatedConfig, nil
-}
 
 // GenerateNetplan renders a netplan file for the input non-empty collection
 // of interfaces.
@@ -241,7 +125,7 @@ func PrepareNetworkConfigFromInterfaces(interfaces corenetwork.InterfaceInfos) (
 	autoStarted := set.NewStrings("lo")
 
 	// We need to check if we have a host-provided default GW and use it.
-	// Otherwise we'll use the first device with a gateway address,
+	// Otherwise, we'll use the first device with a gateway address,
 	// it'll be filled in the second loop.
 	for _, info := range interfaces {
 		if info.IsDefaultGateway {
@@ -311,153 +195,35 @@ func PrepareNetworkConfigFromInterfaces(interfaces corenetwork.InterfaceInfos) (
 }
 
 // AddNetworkConfig adds configuration scripts for specified interfaces
-// to cloudconfig - using boot text files and boot commands. It currently
-// supports e/n/i and netplan.
+// to cloudconfig - using boot text files and boot commands.
 func (cfg *ubuntuCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error {
 	if len(interfaces) != 0 {
-		eni, err := GenerateENITemplate(interfaces)
-		if err != nil {
-			return errors.Trace(err)
-		}
 		netPlan, err := GenerateNetplan(interfaces, cfg.useNetplanHWAddrMatch)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		cfg.AddBootTextFile(jujuNetplanFile, netPlan, 0644)
-		cfg.AddBootTextFile(systemNetworkInterfacesFile+".templ", eni, 0644)
-		cfg.AddBootTextFile(systemNetworkInterfacesFile+".py", NetworkInterfacesScript, 0744)
-		cfg.AddBootCmd(populateNetworkInterfaces(systemNetworkInterfacesFile))
+		cfg.AddBootCmd(populateNetworkInterfaces())
 	}
 	return nil
 }
 
-// Note: we sleep to mitigate against LP #1337873 and LP #1269921.
-// Note2: wait with anything that's hard to revert for as long as possible,
-// we've seen weird failure modes and IMHO it's impossible to avoid them all,
-// but we could do as much as we can to 1. avoid them 2. make the machine boot
-// if we mess up
-func populateNetworkInterfaces(networkFile string) string {
-	s := `
-if [ ! -f /sbin/ifup ]; then
-  echo "No /sbin/ifup, applying netplan configuration."
-  netplan generate
-  netplan apply
-  for i in {1..5}; do
-    hostip=$(hostname -I)
-    if [ -z "$hostip" ]; then
-      sleep 1
-    else
-      echo "Got IP addresses $hostip"
-      break
-    fi
-  done
-else
-  if [ -f /usr/bin/python ]; then
-    python %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+func populateNetworkInterfaces() string {
+	return `
+echo "Applying netplan configuration."
+netplan generate
+netplan apply
+for i in {1..5}; do
+  hostip=$(hostname -I)
+  if [ -z "$hostip" ]; then
+    sleep 1
   else
-    python3 %[1]s.py --interfaces-file %[1]s --output-file %[1]s.out
+    echo "Got IP addresses $hostip"
+    break
   fi
-  ifdown -a
-  sleep 1.5
-  mv %[1]s.out %[1]s
-  ifup -a
-fi
-`
-	return fmt.Sprintf(s, networkFile)
+done
+`[1:]
 }
-
-const NetworkInterfacesScript = `from __future__ import print_function, unicode_literals
-import subprocess, re, argparse, os, time, shutil
-from string import Formatter
-
-INTERFACES_FILE="/etc/network/interfaces"
-IP_LINE = re.compile(r"^\d+: (.*?):")
-IP_HWADDR = re.compile(r".*link/ether ((\w{2}|:){11})")
-COMMAND = "ip -oneline link"
-RETRIES = 3
-WAIT = 5
-
-# Python3 vs Python2
-try:
-    strdecode = str.decode
-except AttributeError:
-    strdecode = str
-
-def ip_parse(ip_output):
-    """parses the output of the ip command
-    and returns a hwaddr->nic-name dict"""
-    devices = dict()
-    print("Parsing ip command output {}".format(ip_output))
-    for ip_line in ip_output:
-        ip_line_str = strdecode(ip_line, "utf-8")
-        match = IP_LINE.match(ip_line_str)
-        if match is None:
-            continue
-        nic_name = match.group(1).split('@')[0]
-        match = IP_HWADDR.match(ip_line_str)
-        if match is None:
-            continue
-        nic_hwaddr = match.group(1)
-        devices[nic_hwaddr] = nic_name
-    print("Found the following devices: {}".format(devices))
-    return devices
-
-def replace_ethernets(interfaces_file, output_file, devices, fail_on_missing):
-    """check if the contents of interfaces_file contain template
-    keys corresponding to hwaddresses and replace them with
-    the proper device name"""
-    with open(interfaces_file + ".templ", "r") as templ_file:
-        interfaces = templ_file.read()
-
-    formatter = Formatter()
-    hwaddrs = [v[1] for v in formatter.parse(interfaces) if v[1]]
-    print("Found the following hwaddrs: {}".format(hwaddrs))
-    device_replacements = dict()
-    for hwaddr in hwaddrs:
-        hwaddr_clean = hwaddr[3:].replace("_", ":")
-        if devices.get(hwaddr_clean, None):
-            device_replacements[hwaddr] = devices[hwaddr_clean]
-        else:
-            if fail_on_missing:
-                print("Can not find device with MAC {}, will retry".format(hwaddr_clean))
-                return False
-            else:
-                print("WARNING: Can not find device with MAC {} when expected".format(hwaddr_clean))
-                device_replacements[hwaddr] = hwaddr
-    formatted = interfaces.format(**device_replacements)
-    print("Used the values in: {}".format(device_replacements))
-    print("to generate new interfaces file:")
-    print(formatted)
-
-    with open(output_file, "w") as intf_out_file:
-        intf_out_file.write(formatted)
-
-    if not os.path.exists(interfaces_file + ".bak"):
-        try:
-            shutil.copyfile(interfaces_file, interfaces_file + ".bak")
-        except OSError:  # silently ignore if the file is missing
-            pass
-    return True
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--interfaces-file", dest="intf_file", default=INTERFACES_FILE)
-    parser.add_argument("--output-file", dest="out_file", default=INTERFACES_FILE+".out")
-    parser.add_argument("--command", default=COMMAND)
-    parser.add_argument("--retries", default=RETRIES)
-    parser.add_argument("--wait", default=WAIT)
-    args = parser.parse_args()
-    retries = int(args.retries)
-    for tries in range(retries):
-        ip_output = ip_parse(subprocess.check_output(args.command.split()).splitlines())
-        if replace_ethernets(args.intf_file, args.out_file, ip_output, (tries != retries - 1)):
-            break
-        else:
-            time.sleep(float(args.wait))
-
-if __name__ == "__main__":
-    main()
-`
 
 const CloudInitNetworkConfigDisabled = `config: "disabled"
 `


### PR DESCRIPTION
This removes the old network configuration fallback to use ifconfig and etc/network/interfaces.

We only support images running Netplan, so this is just redundant cloud-init processing.

## QA steps

Tested with containers on MAAS (spaces are _primary_ and _secondary_).
- Bootstrap.
- `juju switch controller`.
- `juju add-machine lxd:0 --constraints spaces=primary,secondary`.
- Once up, check the container's cloud-init logs for errors.
- Netplan should be sound:
```
# cat /etc/netplan/99-juju.yaml
network:
  version: 2
  ethernets:
    eth0:
      addresses:
      - 192.168.40.68/24
      gateway4: 192.168.40.1
      nameservers:
        search: [maas]
        addresses: [192.168.40.2]
    eth1:
      addresses:
      - 192.168.30.71/24
      gateway4: 192.168.30.1
      nameservers:
        search: [maas]
        addresses: [192.168.30.2]
```