### PR TITLE
fix(apiserver/client): return correct unit public address

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1005,14 +1005,13 @@ func (c *statusContext) unitMachineID(unit statusservice.Unit) coremachine.Name 
 }
 
 func (c *statusContext) unitPublicAddress(unit statusservice.Unit) string {
-	_, ok := c.allMachines[c.unitMachineID(unit)]
+	m, ok := c.allMachines[c.unitMachineID(unit)]
 	if !ok {
 		return ""
 	}
-	// TODO (stickupkid): Return the public address of the unit's machine.
-	// We don't care if the machine doesn't have an address yet.
-	// addr, _ := machine.PublicAddress()
-	// return addr.Value
+	if len(m.IPAddresses) > 0 {
+		return m.IPAddresses[0]
+	}
 	return ""
 }
 


### PR DESCRIPTION
Ensure `unitPublicAddress` in `status.go` returns the correct public address for a unit's machine.

- Updated `unitPublicAddress` function in `status.go` to return the first IP address in `m.IPAddresses` if any.
- Removed outdated comment and unused references to `PublicAddress`, simplifying the logic flow.

Note: We get the public address as the first IPAddress returned by the status service for a Machine, since all IPAddresses are already filtered and sorted to return the best matching public address here:

https://github.com/juju/juju/blob/e75583673ecbe401c5261b83e1b09d44b285464b/domain/status/state/modelstate.go#L2048-L2052

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

- Bootstrap a lxd controller
- Add a model
- Deploy an application
- Check `juju status` results. Once the machine for the application is available, the Public Address column for Unit table should be populated with the machine address.

## Links

**Jira card:** JUJU-8397
