### PR TITLE
feat: actions ddl

### DIFF
--- a/domain/schema/model/sql/0033_action.sql
+++ b/domain/schema/model/sql/0033_action.sql
@@ -1,0 +1,129 @@
+-- An operation is an overview of an action or commands run on a remote
+-- target by the user. It will be linked to N number of tasks, depending
+-- on the number of entities it is run on.
+-- An operation can be an action_operation or an exec_operation, but not
+-- both.
+CREATE TABLE operation (
+    uuid TEXT NOT NULL PRIMARY KEY,
+    summary TEXT,
+    enqueued_at TIMESTAMP NOT NULL,
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    parallel BOOLEAN DEFAULT false,
+    execution_group TEXT
+);
+
+-- operation_action is a join table to link an operation to its charm_action.
+CREATE TABLE operation_action (
+    operation_uuid TEXT NOT NULL PRIMARY KEY,
+    charm_uuid TEXT NOT NULL,
+    charm_action_key TEXT NOT NULL,
+    CONSTRAINT fk_operation_uuid
+    FOREIGN KEY (operation_uuid)
+    REFERENCES operation (uuid),
+    CONSTRAINT fk_charm_action
+    FOREIGN KEY (charm_uuid, charm_action_key)
+    REFERENCES charm_action (charm_uuid, "key")
+);
+
+-- operation_exec contains the commands for the operation to run.
+CREATE TABLE operation_exec (
+    operation_uuid TEXT NOT NULL PRIMARY KEY,
+    command TEXT NOT NULL,
+    timeout DATETIME,
+    CONSTRAINT fk_operation_uuid
+    FOREIGN KEY (operation_uuid)
+    REFERENCES operation (uuid)
+);
+
+-- A operation_task is the individual representation of an operation on a specific
+-- receiver. Either a machine or unit.
+CREATE TABLE operation_task (
+    uuid TEXT NOT NULL PRIMARY KEY,
+    operation_uuid TEXT NOT NULL,
+    enqueued_at DATETIME NOT NULL,
+    started_at DATETIME,
+    completed_at DATETIME,
+    CONSTRAINT fk_operation
+    FOREIGN KEY (operation_uuid)
+    REFERENCES operation (uuid)
+);
+
+-- operation_unit_task is a join table to link a task with its unit receiver.
+CREATE TABLE operation_unit_task (
+    task_uuid TEXT NOT NULL,
+    unit_uuid TEXT NOT NULL,
+    PRIMARY KEY (task_uuid, unit_uuid),
+    CONSTRAINT fk_task_uuid
+    FOREIGN KEY (task_uuid)
+    REFERENCES operation_task (uuid),
+    CONSTRAINT fk_unit_uuid
+    FOREIGN KEY (unit_uuid)
+    REFERENCES unit (uuid)
+);
+
+-- operation_machine_task is a join table to link a task with its machine receiver.
+CREATE TABLE operation_machine_task (
+    task_uuid TEXT NOT NULL,
+    machine_uuid TEXT NOT NULL,
+    PRIMARY KEY (task_uuid, machine_uuid),
+    CONSTRAINT fk_task_uuid
+    FOREIGN KEY (task_uuid)
+    REFERENCES operation_task (uuid),
+    CONSTRAINT fk_machine_uuid
+    FOREIGN KEY (machine_uuid)
+    REFERENCES machine (uuid)
+);
+
+-- operation_task_output is a join table to link a task with where
+-- its output is stored.
+CREATE TABLE operation_task_output (
+    task_uuid TEXT NOT NULL PRIMARY KEY,
+    store_uuid TEXT NOT NULL,
+    CONSTRAINT fk_task_uuid
+    FOREIGN KEY (task_uuid)
+    REFERENCES operation_task (uuid),
+    CONSTRAINT fk_store_uuid
+    FOREIGN KEY (store_uuid)
+    REFERENCES object_store_metadata (uuid)
+);
+
+-- operation_task_status is the status of the task.
+CREATE TABLE operation_task_status (
+    task_uuid TEXT NOT NULL PRIMARY KEY,
+    status_id INT NOT NULL,
+    message TEXT,
+    updated_at DATETIME,
+    CONSTRAINT fk_task_uuid
+    FOREIGN KEY (task_uuid)
+    REFERENCES task (uuid),
+    CONSTRAINT fk_task_status
+    FOREIGN KEY (status_id)
+    REFERENCES task_status_value (id)
+);
+
+-- Status values for tasks.
+CREATE TABLE operation_task_status_value (
+    id INT PRIMARY KEY,
+    status TEXT NOT NULL
+);
+
+INSERT INTO operation_task_status_value VALUES
+(0, 'error'),
+(1, 'running'),
+(2, 'pending'),
+(3, 'failed'),
+(4, 'cancelled'),
+(5, 'completed'),
+(6, 'aborting'),
+(7, 'aborted');
+
+-- operation_task_log holds log messages of the task.
+CREATE TABLE operation_task_log (
+    task_uuid TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_task_uuid
+    FOREIGN KEY (task_uuid)
+    REFERENCES operation_task (uuid)
+);

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -304,6 +304,18 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		// Offers
 		"offer",
 		"offer_endpoint",
+
+		// Actions
+		"operation_action",
+		"operation_exec",
+		"operation_machine_task",
+		"operation",
+		"operation_task",
+		"operation_task_log",
+		"operation_task_output",
+		"operation_task_status",
+		"operation_task_status_value",
+		"operation_unit_task",
 	)
 	got := readEntityNames(c, s.DB(), "table")
 	wanted := expected.Union(internalTableNames)


### PR DESCRIPTION
An operation is a charm action or a command is run on a machine or unit. Action operations are linked to a charm action. Operations have a status, usually the combination of the statuses of its tasks.

A task represents individual receivers of the operation being run. It can be a unit or a machine. It has status and a log of messages.

The output of each task is stored in the object store.

The former ActionNotifications collection can be handled by an appropriate watcher filter, thus not included. 

## Checklist
- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## Links

**Jira card:** JUJU-6909
