### PR TITLE
chore: skip broken stub tests

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -347,8 +347,9 @@ test_deploy_bundles() {
 
 		run "run_deploy_bundle"
 		run "run_deploy_bundle_overlay"
-		run "run_deploy_exported_charmhub_bundle_with_fixed_revisions"
-		run "run_deploy_exported_charmhub_bundle_with_float_revisions"
+		# TODO: Restore these tests once export-bundle is restored.
+		# run "run_deploy_exported_charmhub_bundle_with_fixed_revisions"
+		# run "run_deploy_exported_charmhub_bundle_with_float_revisions"
 		run "run_deploy_trusted_bundle"
 		run "run_deploy_charmhub_bundle"
 		run "run_deploy_multi_app_single_charm_bundle"


### PR DESCRIPTION
Our integration tests involving export-bundle have been replaced by stub tests, which just check export-bundle returns not implemented.

However, these stubs are failing. Skip them for now.

`export-bundle` functionality hasn't been implemented in 4.0 yet, and isn't currently in progress. No point failing our tests as a result