### PR TITLE
refactor(tests): consolidate overlapping tests

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -9,6 +9,10 @@ run_deploy_bundle() {
 	ensure "test-bundles-deploy" "${file}"
 
 	juju deploy juju-qa-bundle-test
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/stable")"
+	wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "latest/candidate")"
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+	wait_for "juju-qa-test-focal" "$(idle_condition "juju-qa-test-focal")"
 	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test")"
 	wait_for "dummy-subordinate-focal" "$(idle_subordinate_condition "dummy-subordinate-focal" "juju-qa-test-focal")"
 
@@ -254,27 +258,6 @@ run_deploy_trusted_bundle() {
 	destroy_model "test-trusted-bundles-deploy"
 }
 
-run_deploy_charmhub_bundle() {
-	echo
-
-	model_name="test-charmhub-bundle-deploy"
-	file="${TEST_DIR}/${model_name}.log"
-
-	ensure "${model_name}" "${file}"
-
-	bundle=juju-qa-bundle-test
-	juju deploy "${bundle}"
-
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/stable")"
-	wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "latest/candidate")"
-	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-	wait_for "juju-qa-test-focal" "$(idle_condition "juju-qa-test-focal")"
-	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"
-	wait_for "ntp-focal" "$(idle_subordinate_condition "ntp-focal" "juju-qa-test-focal")"
-
-	destroy_model "${model_name}"
-}
-
 # run_deploy_lxd_profile_bundle is to deploy multiple units of the
 # same charm which has an lxdprofile in a bundle.  The scenario
 # created by the bundle was found to produce failure cases during
@@ -351,7 +334,6 @@ test_deploy_bundles() {
 		# run "run_deploy_exported_charmhub_bundle_with_fixed_revisions"
 		# run "run_deploy_exported_charmhub_bundle_with_float_revisions"
 		run "run_deploy_trusted_bundle"
-		run "run_deploy_charmhub_bundle"
 		run "run_deploy_multi_app_single_charm_bundle"
 
 		# LXD specific profile tests.


### PR DESCRIPTION
run_deploy_bundle and run_deploy_charmhub_bundle did almost exactly the same thing.

Combine these into a single test.

## QA steps

Integration test `run_deploy_charmhub_bundle` runs successfully

NOTE: a test further in the suite will fail