### PR TITLE
fix(remove): fix removal of unit whilst machine pending

### DIFF
--- a/internal/worker/deployer/deployer.go
+++ b/internal/worker/deployer/deployer.go
@@ -169,10 +169,12 @@ func (d *Deployer) changed(ctx context.Context, unitName string) error {
 			}
 		}
 	}
-	// The only units that should be deployed are those that (1) we are responsible
-	// for and (2) are Alive -- if we're responsible for a Dying unit that is not
-	// yet deployed, we should remove it immediately rather than undergo the hassle
-	// of deploying a unit agent purely so it can set itself to Dead.
+
+	// The only units that should be deployed are those that (1) we are
+	// responsible for and (2) are becoming Alive -- if we're responsible for a
+	// Dying unit that is not yet deployed, we should remove it immediately
+	// rather than undergo the hassle of deploying a unit agent purely so it can
+	// set itself to Dead.
 	if !d.deployed.Contains(unitName) {
 		if unitLife == life.Alive {
 			return d.deploy(ctx, unit)
@@ -187,7 +189,7 @@ func (d *Deployer) changed(ctx context.Context, unitName string) error {
 // panic if it observes inconsistent internal state.
 func (d *Deployer) deploy(ctx context.Context, unit Unit) error {
 	unitName := unit.Name()
-	if d.deployed.Contains(unit.Name()) {
+	if d.deployed.Contains(unitName) {
 		panic("must not re-deploy a deployed unit")
 	}
 	if err := unit.SetStatus(ctx, status.Waiting, status.MessageInstallingAgent, nil); err != nil {

--- a/internal/worker/deployer/nested.go
+++ b/internal/worker/deployer/nested.go
@@ -137,7 +137,7 @@ func NewNestedContext(config ContextConfig) (Context, error) {
 
 	// Stat all the units that context should have deployed and started.
 	units := nContext.deployedUnits()
-	config.Logger.Infof(context.TODO(), "new context: units %q, stopped %q", strings.Join(units.Values(), ", "))
+	config.Logger.Infof(context.TODO(), "new context: units %q", strings.Join(units.Values(), ", "))
 	for _, u := range units.SortedValues() {
 		if u == "" {
 			config.Logger.Warningf(context.TODO(), "empty unit")


### PR DESCRIPTION
fixes #20467

There was a bug in the deployer/uniter/removal domain which meant that a unit whose machine was still pending would deadlock if it was removed.

This is because of two compounding factors:
- The removal domain waits until the uniter has marked a unit as dead before removing it
- The deployer doesn't start the uniter for units that are dying

This means, if the unit is removed beforew it's uniter starts, it will never be marked as dead.

The way we resolve this is by fixing the deployer to be able to mark a unit as dead as well. This was actually how 3.6 behaved. See:

https://github.com/juju/juju/blob/2da8de8a4fd4f5dbbed42c6e5c355a37649f1d22/apiserver/facades/agent/deployer/deployer.go#L76

https://github.com/juju/juju/blob/2da8de8a4fd4f5dbbed42c6e5c355a37649f1d22/apiserver/common/remove.go#L56-L59

We can do this because we know that the deployer only calls unit.Remove for units that are not alive, and guards against the uniter existing

## QA steps

### Standard path (i.e. no regressions)
```
$ juju deploy juju-qa-test
(wait until active/idle)
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      lxd         lxd/localhost  4.0-beta7.1  14:05:18+01:00

App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  no       hello

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0*  active    idle   0        10.51.45.140           hello

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.140  juju-a55a86-0  ubuntu@20.04  jack  Running

$ juju remove-application juju-qa-test
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      lxd         lxd/localhost  4.0-beta7.1  14:05:46+01:00

Model "admin/m" is empty.
```
& verify no errors in logs

### Special path (i.e. verify bug is resolved)
```
$ juju deploy juju-qa-test
(do not wait this time)
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m2     lxd         lxd/localhost  4.0-beta7.1  14:06:22+01:00

App           Version  Status   Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           waiting    0/1  juju-qa-test  latest/stable   25  no       waiting for machine

Unit            Workload  Agent       Machine  Public address  Ports  Message
juju-qa-test/0  waiting   allocating  0                               waiting for machine

Machine  State    Address  Inst id        Base          AZ    Message
0        pending           juju-154974-0  ubuntu@20.04  jack  Running

$ juju deploy juju-qa-test
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m2     lxd         lxd/localhost  4.0-beta7.1  14:06:40+01:00

Model "admin/m2" is empty.
```
& verify again no errors in logs