### PR TITLE
feat: disable remote relation worker

### DIFF
--- a/internal/worker/remoterelations/manifold.go
+++ b/internal/worker/remoterelations/manifold.go
@@ -62,6 +62,12 @@ type ManifoldConfig struct {
 
 	Logger logger.Logger
 	Clock  clock.Clock
+
+	// Active indicates if the worker should be started. This is only here so
+	// that we can work on implementing cross-model relations behind a flag,
+	// which prevents the dependency engine from starting the worker because
+	// of other errors.
+	Active bool
 }
 
 // Validate is called by start to check for bad configuration.
@@ -111,6 +117,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 		Start: func(context context.Context, getter dependency.Getter) (worker.Worker, error) {
 			if err := config.Validate(); err != nil {
 				return nil, errors.Trace(err)
+			}
+
+			if !config.Active {
+				return nil, dependency.ErrUninstall
 			}
 
 			var agent agent.Agent


### PR DESCRIPTION
Whilst we're working on CMR and the remote relations worker, we need to disable the worker, otherwise it causes the worker to bounce, which is not what we want. It makes testing other features harder because of all the noise in the controller logs.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy juju-qa-test
```

There should be no logs in the controller about the remote relations worker bouncing.

## Links


<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** [JUJU-8394](https://warthogs.atlassian.net/browse/JUJU-8394)
