### PR TITLE
(draft) chore: merge forward lxd profile 3.6

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1093,6 +1093,7 @@ type containerProfileHandler struct {
 	result             params.ContainerProfileResults
 	modelName          string
 	logger             logger.Logger
+	modelTag           names.ModelTag
 }
 
 // ProcessOneContainer implements perContainerHandler.ProcessOneContainer
@@ -1136,7 +1137,7 @@ func (h *containerProfileHandler) ProcessOneContainer(
 				Description: profile.Description,
 				Devices:     profile.Devices,
 			},
-			Name: lxdprofile.Name(h.modelName, appName, revision),
+			Name: lxdprofile.Name(h.modelName, h.modelTag.ShortId(), appName, revision),
 		})
 	}
 
@@ -1172,6 +1173,7 @@ func (api *ProvisionerAPI) GetContainerProfileInfo(ctx context.Context, args par
 		return c.result, errors.Trace(err)
 	}
 	c.modelName = modelInfo.Name
+	c.modelTag = names.NewModelTag(modelInfo.UUID.String())
 
 	if err := api.processEachContainer(ctx, args, c); err != nil {
 		return c.result, errors.Trace(err)

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -303,6 +303,7 @@ func (s *provisionerMockSuite) TestGetContainerProfileInfo(c *tc.C) {
 		result:             res,
 		modelName:          "testme",
 		logger:             loggertesting.WrapCheckLog(c),
+		modelTag:           coretesting.ModelTag,
 	}
 	err := ctx.ProcessOneContainer(c.Context(), 0, "0/lxd/0")
 	c.Assert(err, tc.ErrorIsNil)
@@ -310,7 +311,7 @@ func (s *provisionerMockSuite) TestGetContainerProfileInfo(c *tc.C) {
 	c.Assert(res.Results[0].Error, tc.IsNil)
 	c.Assert(res.Results[0].LXDProfiles, tc.HasLen, 1)
 	profile := res.Results[0].LXDProfiles[0]
-	c.Check(profile.Name, tc.Equals, "juju-testme-application-3")
+	c.Check(profile.Name, tc.Equals, "juju-testme-deadbe-application-3")
 	c.Check(profile.Profile.Config, tc.DeepEquals,
 		map[string]string{
 			"security.nesting":    "true",

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -169,7 +169,7 @@ func (api *ProvisionerAPI) getProvisioningInfoBase(
 
 	// TODO (storage): get volumes and volume attachments from the model
 
-	if result.CharmLXDProfiles, err = api.machineService.UpdateLXDProfiles(ctx, modelInfo.Name, machineName.String()); err != nil {
+	if result.CharmLXDProfiles, err = api.machineService.UpdateLXDProfiles(ctx, modelInfo.Name, modelInfo.UUID.String(), machineName.String()); err != nil {
 		return result, errors.Errorf("cannot write lxd profiles: %w", err)
 	}
 

--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -146,7 +146,7 @@ type MachineService interface {
 	// given machine if the providers supports it. A slice of profile names
 	// is returned. If the provider does not support LXDProfiles, no error
 	// is returned.
-	UpdateLXDProfiles(ctx context.Context, modelName, machineID string) ([]string, error)
+	UpdateLXDProfiles(ctx context.Context, modelName, modelUUID, machineID string) ([]string, error)
 
 	// GetBootstrapEnviron returns the bootstrap environ.
 	GetBootstrapEnviron(ctx context.Context) (environs.BootstrapEnviron, error)

--- a/apiserver/facades/agent/provisioner/service_mock_test.go
+++ b/apiserver/facades/agent/provisioner/service_mock_test.go
@@ -1200,18 +1200,18 @@ func (c *MockMachineServiceShouldKeepInstanceCall) DoAndReturn(f func(context.Co
 }
 
 // UpdateLXDProfiles mocks base method.
-func (m *MockMachineService) UpdateLXDProfiles(arg0 context.Context, arg1, arg2 string) ([]string, error) {
+func (m *MockMachineService) UpdateLXDProfiles(arg0 context.Context, arg1, arg2, arg3 string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLXDProfiles", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateLXDProfiles", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateLXDProfiles indicates an expected call of UpdateLXDProfiles.
-func (mr *MockMachineServiceMockRecorder) UpdateLXDProfiles(arg0, arg1, arg2 any) *MockMachineServiceUpdateLXDProfilesCall {
+func (mr *MockMachineServiceMockRecorder) UpdateLXDProfiles(arg0, arg1, arg2, arg3 any) *MockMachineServiceUpdateLXDProfilesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLXDProfiles", reflect.TypeOf((*MockMachineService)(nil).UpdateLXDProfiles), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLXDProfiles", reflect.TypeOf((*MockMachineService)(nil).UpdateLXDProfiles), arg0, arg1, arg2, arg3)
 	return &MockMachineServiceUpdateLXDProfilesCall{Call: call}
 }
 
@@ -1227,13 +1227,13 @@ func (c *MockMachineServiceUpdateLXDProfilesCall) Return(arg0 []string, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceUpdateLXDProfilesCall) Do(f func(context.Context, string, string) ([]string, error)) *MockMachineServiceUpdateLXDProfilesCall {
+func (c *MockMachineServiceUpdateLXDProfilesCall) Do(f func(context.Context, string, string, string) ([]string, error)) *MockMachineServiceUpdateLXDProfilesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceUpdateLXDProfilesCall) DoAndReturn(f func(context.Context, string, string) ([]string, error)) *MockMachineServiceUpdateLXDProfilesCall {
+func (c *MockMachineServiceUpdateLXDProfilesCall) DoAndReturn(f func(context.Context, string, string, string) ([]string, error)) *MockMachineServiceUpdateLXDProfilesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -260,7 +260,7 @@ var (
 		},
 		"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 		"lxd-profiles": M{
-			"juju-controller-lxd-profile-1": M{
+			"juju-controller-deadbe-lxd-profile-1": M{
 				"config": M{
 					"environment.http_proxy": "",
 					"linux.kernel_modules":   "openvswitch,nbd,ip_tables,ip6_tables",
@@ -2869,7 +2869,7 @@ var statusTests = []testCase{
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addCharmHubCharm{"lxd-profile"},
-		setCharmProfiles{"1", []string{"juju-controller-lxd-profile-1"}},
+		setCharmProfiles{"1", []string{"juju-controller-deadbe-lxd-profile-1"}},
 		addApplication{name: "lxd-profile", charm: "lxd-profile"},
 		setApplicationExposed{"lxd-profile", true},
 		addAliveUnit{"lxd-profile", "1"},
@@ -2893,7 +2893,7 @@ var statusTests = []testCase{
 						"exposed":       true,
 						"charm-name":    "lxd-profile",
 						"charm-rev":     1,
-						"charm-profile": "juju-controller-lxd-profile-1",
+						"charm-profile": "juju-controller-deadbe-lxd-profile-1",
 						"base":          M{"name": "ubuntu", "channel": "12.10"},
 						"application-status": M{
 							"current": "active",
@@ -3460,7 +3460,7 @@ func (as addApplication) step(c *tc.C, ctx *ctx) {
 		EndpointBindings: make(map[string]string),
 	}
 	if as.charm == "lxd-profile" {
-		app.CharmProfile = "juju-controller-lxd-profile-1"
+		app.CharmProfile = "juju-controller-deadbe-lxd-profile-1"
 	}
 	if info.charm.Meta().Subordinate {
 		ctx.subordinateApps[as.name] = &app

--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -18,14 +18,14 @@ import (
 const AppName = "juju"
 
 // Prefix is used to prefix all the lxd profile programmable profiles. If a
-// profile doesn't have the prefix, then it will be removed when ensuring the
+// profile doesn't have the prefix, then it will be removed when ensuring
 // the validity of the names (see FilterLXDProfileNames)
 var Prefix = fmt.Sprintf("%s-", AppName)
 
 // Name returns a serialisable name that we can use to identify profiles
-// juju-<model>-<application>-<charm-revision>
-func Name(modelName, appName string, revision int) string {
-	return fmt.Sprintf("%s%s-%s-%d", Prefix, modelName, appName, revision)
+// juju-<model>-<shortModelID>-<application>-<charm-revision>
+func Name(modelName, shortModelID string, appName string, revision int) string {
+	return fmt.Sprintf("%s%s-%s-%s-%d", Prefix, modelName, shortModelID, appName, revision)
 }
 
 // FilterLXDProfileNames ensures that the LXD profile names are unique yet preserve
@@ -104,7 +104,7 @@ func ProfileReplaceRevision(profile string, rev int) (string, error) {
 	return strings.Join(append(notRev, strconv.Itoa(rev)), "-"), nil
 }
 
-// MatchProfileNameByApp returns the first profile which matches the provided
+// MatchProfileNameByAppName MatchProfileNameByApp returns the first profile which matches the provided
 // appName.  No match returns an empty string.
 // Assumes there is not more than one profile for the same application.
 func MatchProfileNameByAppName(names []string, appName string) (string, error) {

--- a/core/lxdprofile/name_test.go
+++ b/core/lxdprofile/name_test.go
@@ -42,35 +42,35 @@ func (*LXDProfileNameSuite) TestProfileNames(c *tc.C) {
 		},
 		{
 			input: []string{
-				lxdprofile.Name("foo", "bar", 1),
+				lxdprofile.Name("foo", "shortid", "bar", 1),
 			},
 			output: []string{
-				lxdprofile.Name("foo", "bar", 1),
+				lxdprofile.Name("foo", "shortid", "bar", 1),
 			},
 		},
 		{
 			input: []string{
 				"default",
-				lxdprofile.Name("foo", "bar", 1),
-				lxdprofile.Name("foo", "bar", 1),
-				lxdprofile.Name("aaa", "bbb", 100),
+				lxdprofile.Name("foo", "shortid", "bar", 1),
+				lxdprofile.Name("foo", "shortid", "bar", 1),
+				lxdprofile.Name("aaa", "shortid2", "bbb", 100),
 			},
 			output: []string{
-				lxdprofile.Name("foo", "bar", 1),
-				lxdprofile.Name("aaa", "bbb", 100),
+				lxdprofile.Name("foo", "shortid", "bar", 1),
+				lxdprofile.Name("aaa", "shortid2", "bbb", 100),
 			},
 		},
 		{
 			input: []string{
 				"default",
-				lxdprofile.Name("foo", "bar", 1),
-				lxdprofile.Name("foo", "bar", 1),
+				lxdprofile.Name("foo", "shortid", "bar", 1),
+				lxdprofile.Name("foo", "shortid", "bar", 1),
 				"some-other-profile",
-				lxdprofile.Name("aaa", "bbb", 100),
+				lxdprofile.Name("aaa", "shortid2", "bbb", 100),
 			},
 			output: []string{
-				lxdprofile.Name("foo", "bar", 1),
-				lxdprofile.Name("aaa", "bbb", 100),
+				lxdprofile.Name("foo", "shortid", "bar", 1),
+				lxdprofile.Name("aaa", "shortid2", "bbb", 100),
 			},
 		},
 	}
@@ -98,11 +98,11 @@ func (*LXDProfileNameSuite) TestIsValidName(c *tc.C) {
 			output: false,
 		},
 		{
-			input:  lxdprofile.Name("foo", "bar", 1),
+			input:  lxdprofile.Name("foo", "shortid", "bar", 1),
 			output: true,
 		},
 		{
-			input:  lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 100),
+			input:  lxdprofile.Name("aaa-zzz", "shortid", "b312--?123!!bb-x__xx-012-y123yy", 100),
 			output: true,
 		},
 	}
@@ -131,11 +131,11 @@ func (*LXDProfileNameSuite) TestProfileRevision(c *tc.C) {
 			err:   "not a juju profile name: \"juju-model\"",
 		},
 		{
-			input:  lxdprofile.Name("foo", "bar", 1),
+			input:  lxdprofile.Name("foo", "shortid", "bar", 1),
 			output: 1,
 		},
 		{
-			input:  lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 100),
+			input:  lxdprofile.Name("aaa-zzz", "shortid", "b312--?123!!bb-x__xx-012-y123yy", 100),
 			output: 100,
 		},
 	}
@@ -171,14 +171,14 @@ func (*LXDProfileNameSuite) TestProfileReplaceRevision(c *tc.C) {
 			err:   "not a juju profile name: \"juju-model\"",
 		},
 		{
-			input:    lxdprofile.Name("foo", "bar", 1),
+			input:    lxdprofile.Name("foo", "shortid", "bar", 1),
 			inputRev: 4,
-			output:   lxdprofile.Name("foo", "bar", 4),
+			output:   lxdprofile.Name("foo", "shortid", "bar", 4),
 		},
 		{
-			input:    lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 123),
+			input:    lxdprofile.Name("aaa-zzz", "shortid", "b312--?123!!bb-x__xx-012-y123yy", 123),
 			inputRev: 312,
-			output:   lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 312),
+			output:   lxdprofile.Name("aaa-zzz", "shortid", "b312--?123!!bb-x__xx-012-y123yy", 312),
 		},
 	}
 	for k, testCase := range testCases {
@@ -219,29 +219,29 @@ func (*LXDProfileNameSuite) TestMatchProfileNameByAppName(c *tc.C) {
 			input: []string{
 				"default",
 				"juju-model",
-				lxdprofile.Name("foo", "bar", 2),
+				lxdprofile.Name("foo", "shortid", "bar", 2),
 			},
 			inputApp: "bar",
-			output:   lxdprofile.Name("foo", "bar", 2),
+			output:   lxdprofile.Name("foo", "shortid", "bar", 2),
 		},
 		{
 			input: []string{
 				"default",
 				"juju-model",
-				lxdprofile.Name("foo", "nonebar", 2),
-				lxdprofile.Name("foo", "bar", 2),
+				lxdprofile.Name("foo", "shortid", "nonebar", 2),
+				lxdprofile.Name("foo", "shortid", "bar", 2),
 			},
 			inputApp: "bar",
-			output:   lxdprofile.Name("foo", "bar", 2),
+			output:   lxdprofile.Name("foo", "shortid", "bar", 2),
 		},
 		{
 			input: []string{
 				"default",
 				"juju-model",
-				lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 123),
+				lxdprofile.Name("aaa-zzz", "shortid", "b312--?123!!bb-x__xx-012-y123yy", 123),
 			},
 			inputApp: "b312--?123!!bb-x__xx-012-y123yy",
-			output:   lxdprofile.Name("aaa-zzz", "b312--?123!!bb-x__xx-012-y123yy", 123),
+			output:   lxdprofile.Name("aaa-zzz", "shortid", "b312--?123!!bb-x__xx-012-y123yy", 123),
 		},
 	}
 	for k, testCase := range testCases {

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 
 	"github.com/juju/clock"
+	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/base"
@@ -213,7 +214,7 @@ func (s *ProviderService) GetInstanceTypesFetcher(ctx context.Context) (environs
 // given machine if the providers supports it. A slice of profile names
 // is returned. If the provider does not support LXDProfiles, no error
 // is returned.
-func (s *ProviderService) UpdateLXDProfiles(ctx context.Context, modelName, machineID string) ([]string, error) {
+func (s *ProviderService) UpdateLXDProfiles(ctx context.Context, modelName, modelUUID, machineID string) ([]string, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -235,8 +236,9 @@ func (s *ProviderService) UpdateLXDProfiles(ctx context.Context, modelName, mach
 	// write the same profile at the same time. Previously this code
 	// had a lock, but the services must not contain state.
 	var pNames []string
+	modelTag := names.NewModelTag(modelUUID)
 	for _, arg := range profileArgs {
-		pName := lxdprofile.Name(modelName, arg.ApplicationName, arg.CharmRevision)
+		pName := lxdprofile.Name(modelName, modelTag.ShortId(), arg.ApplicationName, arg.CharmRevision)
 		profile, err := decodeLXDProfile(arg.LXDProfile)
 		if err != nil {
 			return nil, errors.Errorf("decoding LXD profile for machine %s: %w", machineID, err)

--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -29,6 +29,7 @@ import (
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	statushistory "github.com/juju/juju/internal/statushistory"
 	"github.com/juju/juju/internal/testhelpers"
+	coretesting "github.com/juju/juju/internal/testing"
 )
 
 type providerServiceSuite struct {
@@ -392,8 +393,8 @@ func (s *lxdProviderServiceSuite) TestUpdateLXDProfiles(c *tc.C) {
 			LXDProfile:      []byte(`{"config": {"foo":"baz"}, "description": "another"}`),
 		},
 	}
-	pName0 := "juju-test-ubuntu-4"
-	pName1 := "juju-test-test-8"
+	pName0 := "juju-test-deadbe-ubuntu-4"
+	pName1 := "juju-test-deadbe-test-8"
 	s.state.EXPECT().GetLXDProfilesForMachine(gomock.Any(), machineID).Return(result, nil)
 	s.lxdProfileProvider.EXPECT().MaybeWriteLXDProfile(pName0, lxdprofile.Profile{
 		Config:      map[string]string{"foo": "bar"},
@@ -411,7 +412,7 @@ func (s *lxdProviderServiceSuite) TestUpdateLXDProfiles(c *tc.C) {
 	service := NewProviderService(s.state, nil, nil, providerGetter, nil, loggertesting.WrapCheckLog(c))
 
 	// Act
-	obtainedProfileNames, err := service.UpdateLXDProfiles(c.Context(), "test", machineID)
+	obtainedProfileNames, err := service.UpdateLXDProfiles(c.Context(), "test", coretesting.ModelTag.Id(), machineID)
 
 	// Assert:
 	c.Assert(err, tc.IsNil)
@@ -429,7 +430,7 @@ func (s *lxdProviderServiceSuite) TestUpdateLXDProfilesNoSupport(c *tc.C) {
 	service := NewProviderService(s.state, nil, nil, providerGetter, nil, loggertesting.WrapCheckLog(c))
 
 	// Act
-	_, err := service.UpdateLXDProfiles(c.Context(), "blue", "7")
+	_, err := service.UpdateLXDProfiles(c.Context(), "blue", coretesting.ModelTag.Id(), "7")
 
 	// Assert: no work is done and the method doesn't fail
 	c.Assert(err, tc.IsNil)
@@ -446,7 +447,7 @@ func (s *lxdProviderServiceSuite) TestUpdateLXDProfilesFail(c *tc.C) {
 	service := NewProviderService(s.state, nil, nil, providerGetter, nil, loggertesting.WrapCheckLog(c))
 
 	// Act
-	_, err := service.UpdateLXDProfiles(c.Context(), "blue", "7")
+	_, err := service.UpdateLXDProfiles(c.Context(), "blue", coretesting.ModelTag.Id(), "7")
 
 	// Assert
 	c.Assert(err, tc.ErrorMatches, "getting provider: boom")

--- a/internal/container/broker/lxd-broker_test.go
+++ b/internal/container/broker/lxd-broker_test.go
@@ -297,7 +297,7 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfileReturnsLXDProfileNames(c
 	mockApi := mocks.NewMockAPICalls(ctrl)
 	mockManager := testing.NewMockTestLXDManager(ctrl)
 	mockManager.EXPECT().LXDProfileNames(containerTag.Id()).Return([]string{
-		lxdprofile.Name("foo", "bar", 1),
+		lxdprofile.Name("foo", "shortid", "bar", 1),
 	}, nil)
 
 	broker, err := broker.NewLXDBroker(
@@ -311,6 +311,6 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfileReturnsLXDProfileNames(c
 	profileNames, err := nameRetriever.LXDProfileNames(containerTag.Id())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(profileNames, tc.DeepEquals, []string{
-		lxdprofile.Name("foo", "bar", 1),
+		lxdprofile.Name("foo", "shortid", "bar", 1),
 	})
 }

--- a/internal/container/lxd/manager.go
+++ b/internal/container/lxd/manager.go
@@ -458,7 +458,7 @@ func (m *containerManager) AssignLXDProfiles(
 	if err := m.server.UpdateContainerProfiles(instID, profilesNames); err != nil {
 		return report(errors.Trace(err))
 	}
-
+	logger.Debugf(context.TODO(), "profiles to delete %+v", deleteProfiles)
 	for _, name := range deleteProfiles {
 		if err := m.server.DeleteProfile(name); err != nil {
 			// Most likely the failure is because the profile is already in use.

--- a/internal/provider/lxd/environ.go
+++ b/internal/provider/lxd/environ.go
@@ -5,6 +5,7 @@ package lxd
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/url"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/canonical/lxd/shared/api"
 	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/base"
@@ -29,7 +31,11 @@ import (
 
 var _ environs.HardwareCharacteristicsDetector = (*environ)(nil)
 
-const bootstrapMessage = `To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/`
+const (
+	bootstrapMessage = `To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/`
+	// profileNotFound is needed because LXD doesn't have typed errors.
+	profileNotFound = "Profile not found"
+)
 
 type baseProvider interface {
 	// BootstrapEnv bootstraps a Juju environment.
@@ -137,7 +143,7 @@ func (env *environ) initProfile(ctx context.Context) error {
 }
 
 func (env *environ) profileName() string {
-	return "juju-" + env.Name()
+	return fmt.Sprintf("juju-%s-%s", env.name, names.NewModelTag(env.uuid).ShortId())
 }
 
 // Name returns the name of the environ.
@@ -227,6 +233,10 @@ func (env *environ) Destroy(ctx context.Context) error {
 			return errors.Annotate(env.HandleCredentialError(ctx, err), "destroying LXD filesystems for model")
 		}
 	}
+	if err := env.DestroyProfiles(ctx); err != nil {
+		return errors.Annotate(env.HandleCredentialError(ctx, err), "destroying LXD profiles for model")
+	}
+
 	return nil
 }
 
@@ -268,6 +278,36 @@ func (env *environ) destroyHostedModelResources(ctx context.Context, controllerU
 	logger.Debugf(ctx, "removing instances: %v", names)
 
 	return errors.Trace(env.server().RemoveContainers(names))
+}
+
+// DestroyProfiles deletes the LXD profiles associated with this model.
+// It includes the: model profile `juju-<modelname>-<id>`and
+// charm profiles `juju-<modelname>-<id>-<appname>-<rev>`.
+func (env *environ) DestroyProfiles(ctx context.Context) error {
+	server := env.server()
+	profiles, err := server.GetProfileNames()
+	if err != nil {
+		return errors.Annotate(err, "get profiles")
+	}
+
+	for _, profile := range profiles {
+		if !strings.HasPrefix(profile, env.profileName()) {
+			continue
+		}
+
+		err := server.DeleteProfile(profile)
+		if err != nil {
+			if strings.Contains(err.Error(), profileNotFound) {
+				continue
+			}
+
+			logger.Errorf(ctx, "failed to delete profile %q due to %s, it may need to be deleted manually through the provider", profile, err.Error())
+		}
+
+		logger.Infof(ctx, "deleted profile %q", profile)
+	}
+
+	return nil
 }
 
 // lxdAvailabilityZone wraps a LXD cluster member as an availability zone.
@@ -482,6 +522,7 @@ func (env *environ) AssignLXDProfiles(instID string, profilesNames []string, pro
 		return report(errors.Trace(err))
 	}
 
+	logger.Debugf(context.TODO(), "profiles to delete  %+v", deleteProfiles)
 	for _, name := range deleteProfiles {
 		if err := server.DeleteProfile(name); err != nil {
 			// most likely the failure is because the profile is already in use

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -646,10 +646,10 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *tc.C) {
 		if profiles[0] != "default" {
 			return false
 		}
-		if profiles[1] != "juju-" {
+		if profiles[1] != "juju-model-2d02ee" {
 			return false
 		}
-		return profiles[2] == "juju-model-test-0"
+		return profiles[2] == "juju-model-2d02ee-test-0"
 	}
 
 	exp := svr.EXPECT()
@@ -665,7 +665,7 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *tc.C) {
 	)
 
 	args := s.GetStartInstanceArgs(c)
-	args.CharmLXDProfiles = []string{"juju-model-test-0"}
+	args.CharmLXDProfiles = []string{"juju-model-2d02ee-test-0"}
 
 	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{}, invalidator)
 	res, err := env.StartInstance(c.Context(), args)

--- a/internal/provider/lxd/environ_test.go
+++ b/internal/provider/lxd/environ_test.go
@@ -4,11 +4,14 @@
 package lxd_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/canonical/lxd/shared/api"
 	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
+	"github.com/juju/utils/v3"
 	"go.uber.org/mock/gomock"
 
 	corebase "github.com/juju/juju/core/base"
@@ -41,6 +44,10 @@ func (s *environSuite) TestName(c *tc.C) {
 	c.Check(s.Env.Name(), tc.Equals, "lxd")
 }
 
+func (s *environSuite) TearDownTest(c *tc.C) {
+	s.Client.ProfileNames = nil
+	s.BaseSuite.TearDownTest(c)
+}
 func (s *environSuite) TestProvider(c *tc.C) {
 	defer s.SetupMocks(c).Finish()
 
@@ -122,6 +129,59 @@ func (s *environSuite) TestBootstrapAPI(c *tc.C) {
 	}})
 }
 
+func (s *environSuite) TestDestroyProfiles(c *tc.C) {
+	defer s.SetupMocks(c).Finish()
+	profileName := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(s.Config.UUID()).ShortId())
+	profileNameOtherModel := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(utils.MustNewUUID().String()))
+
+	s.Client.ProfileNames = []string{profileName, profileName + "-watermelon-0", profileName + "-strawberry-1", profileNameOtherModel, profileNameOtherModel + "-peach-4"}
+
+	callCtx := c.Context()
+	err := s.Env.DestroyProfiles(callCtx)
+	c.Assert(err, tc.IsNil)
+
+	s.Stub.CheckCalls(c, []testhelpers.StubCall{
+		{"GetProfileNames", []interface{}{}},
+		{"DeleteProfile", []interface{}{profileName}},
+		{"DeleteProfile", []interface{}{profileName + "-watermelon-0"}},
+		{"DeleteProfile", []interface{}{profileName + "-strawberry-1"}},
+	})
+}
+
+func (s *environSuite) TestDestroyProfilesShouldNotFailIfDeleteProfileReturnsErr(c *tc.C) {
+	defer s.SetupMocks(c).Finish()
+	profileName := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(s.Config.UUID()).ShortId())
+	profileNameOtherModel := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(utils.MustNewUUID().String()))
+
+	s.Client.ProfileNames = []string{profileName, profileName + "-watermelon-0", profileName + "-strawberry-1", profileNameOtherModel, profileNameOtherModel + "-peach-4"}
+
+	s.Client.Stub.SetErrors(nil, nil, fmt.Errorf("profile is in use"))
+
+	callCtx := c.Context()
+	err := s.Env.DestroyProfiles(callCtx)
+	c.Assert(err, tc.IsNil)
+
+	s.Stub.CheckCalls(c, []testhelpers.StubCall{
+		{"GetProfileNames", []interface{}{}},
+		{"DeleteProfile", []interface{}{profileName}},
+		{"DeleteProfile", []interface{}{profileName + "-watermelon-0"}},
+		{"DeleteProfile", []interface{}{profileName + "-strawberry-1"}},
+	})
+}
+
+func (s *environSuite) TestDestroyProfilesReturnErr(c *tc.C) {
+	defer s.SetupMocks(c).Finish()
+	s.Client.Stub.SetErrors(fmt.Errorf("connection err"))
+
+	callCtx := c.Context()
+	err := s.Env.DestroyProfiles(callCtx)
+	c.Assert(err, tc.ErrorMatches, "get profiles: connection err")
+
+	s.Stub.CheckCalls(c, []testhelpers.StubCall{
+		{"GetProfileNames", []interface{}{}},
+	})
+}
+
 func (s *environSuite) TestDestroy(c *tc.C) {
 	defer s.SetupMocks(c).Finish()
 
@@ -138,6 +198,9 @@ func (s *environSuite) TestDestroy(c *tc.C) {
 			},
 		}},
 	}
+	profileName := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(s.Config.UUID()).ShortId())
+	profileNameOtherModel := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(utils.MustNewUUID().String()).ShortId())
+	s.Client.ProfileNames = []string{profileName, profileName + "-watermelon-0", profileName + "-strawberry-1", profileNameOtherModel, profileNameOtherModel + "-peach-4"}
 
 	callCtx := c.Context()
 	err := s.Env.Destroy(callCtx)
@@ -150,6 +213,10 @@ func (s *environSuite) TestDestroy(c *tc.C) {
 		{FuncName: "GetStoragePoolVolumes", Args: []interface{}{"juju"}},
 		{FuncName: "DeleteStoragePoolVolume", Args: []interface{}{"juju", "custom", "ours"}},
 		{FuncName: "GetStoragePoolVolumes", Args: []interface{}{"juju-zfs"}},
+		{FuncName: "GetProfileNames", Args: []interface{}{}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName + "-watermelon-0"}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName + "-strawberry-1"}},
 	})
 }
 
@@ -233,6 +300,9 @@ func (s *environSuite) TestDestroyController(c *tc.C) {
 	machine2.Config["user.juju-controller-uuid"] = "not-" + s.Config.UUID()
 
 	s.Client.Containers = append(s.Client.Containers, *machine0, *machine1, *machine2)
+	profileName := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(s.Config.UUID()).ShortId())
+	profileNameOtherModel := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(utils.MustNewUUID().String()).ShortId())
+	s.Client.ProfileNames = []string{profileName, profileName + "-watermelon-0", profileName + "-strawberry-1", profileNameOtherModel, profileNameOtherModel + "-peach-4"}
 
 	callCtx := c.Context()
 	err := s.Env.DestroyController(callCtx, s.Config.UUID())
@@ -244,6 +314,10 @@ func (s *environSuite) TestDestroyController(c *tc.C) {
 		{FuncName: "GetStoragePools", Args: nil},
 		{FuncName: "GetStoragePoolVolumes", Args: []interface{}{"juju"}},
 		{FuncName: "GetStoragePoolVolumes", Args: []interface{}{"juju-zfs"}},
+		{FuncName: "GetProfileNames", Args: []interface{}{}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName + "-watermelon-0"}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName + "-strawberry-1"}},
 		{FuncName: "AliveContainers", Args: []interface{}{"juju-"}},
 		{FuncName: "RemoveContainers", Args: []interface{}{[]string{machine1.Name}}},
 		{FuncName: "StorageSupported", Args: nil},
@@ -281,7 +355,10 @@ func (s *environSuite) TestDestroyControllerInvalidCredentialsHostedModels(c *tc
 	s.Client.Containers = append(s.Client.Containers, *machine0)
 
 	// RemoveContainers will error not-auth.
-	s.Client.Stub.SetErrors(nil, nil, nil, nil, nil, errTestUnAuth)
+	s.Client.Stub.SetErrors(nil, nil, nil, nil, nil, nil, nil, nil, nil, errTestUnAuth)
+	profileName := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(s.Config.UUID()).ShortId())
+	profileNameOtherModel := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(utils.MustNewUUID().String()).ShortId())
+	s.Client.ProfileNames = []string{profileName, profileName + "-watermelon-0", profileName + "-strawberry-1", profileNameOtherModel, profileNameOtherModel + "-peach-4"}
 
 	err := s.Env.DestroyController(c.Context(), s.Config.UUID())
 	c.Assert(err, tc.ErrorMatches, "not authorized")
@@ -296,6 +373,10 @@ func (s *environSuite) TestDestroyControllerInvalidCredentialsHostedModels(c *tc
 		{FuncName: "GetStoragePools", Args: nil},
 		{FuncName: "GetStoragePoolVolumes", Args: []interface{}{"juju"}},
 		{FuncName: "GetStoragePoolVolumes", Args: []interface{}{"juju-zfs"}},
+		{FuncName: "GetProfileNames", Args: []interface{}{}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName + "-watermelon-0"}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName + "-strawberry-1"}},
 		{FuncName: "AliveContainers", Args: []interface{}{"juju-"}},
 		{FuncName: "RemoveContainers", Args: []interface{}{[]string{}}},
 	})
@@ -305,6 +386,10 @@ func (s *environSuite) TestDestroyControllerInvalidCredentialsHostedModels(c *tc
 		"GetStoragePools",
 		"GetStoragePoolVolumes",
 		"GetStoragePoolVolumes",
+		"GetProfileNames",
+		"DeleteProfile",
+		"DeleteProfile",
+		"DeleteProfile",
 		"AliveContainers",
 		"RemoveContainers")
 }
@@ -336,7 +421,10 @@ func (s *environSuite) TestDestroyControllerInvalidCredentialsDestroyFilesystem(
 	s.Client.Containers = append(s.Client.Containers, *machine0)
 
 	// RemoveContainers will error not-auth.
-	s.Client.Stub.SetErrors(nil, nil, nil, nil, nil, nil, nil, nil, errTestUnAuth)
+	s.Client.Stub.SetErrors(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, errTestUnAuth)
+	profileName := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(s.Config.UUID()).ShortId())
+	profileNameOtherModel := fmt.Sprintf("juju-%s-%s", s.Env.Name(), names.NewModelTag(utils.MustNewUUID().String()).ShortId())
+	s.Client.ProfileNames = []string{profileName, profileName + "-watermelon-0", profileName + "-strawberry-1", profileNameOtherModel, profileNameOtherModel + "-peach-4"}
 
 	err := s.Env.DestroyController(c.Context(), s.Config.UUID())
 	c.Assert(err, tc.ErrorMatches, ".*not authorized")
@@ -351,6 +439,10 @@ func (s *environSuite) TestDestroyControllerInvalidCredentialsDestroyFilesystem(
 		{FuncName: "GetStoragePools", Args: nil},
 		{FuncName: "GetStoragePoolVolumes", Args: []interface{}{"juju"}},
 		{FuncName: "GetStoragePoolVolumes", Args: []interface{}{"juju-zfs"}},
+		{FuncName: "GetProfileNames", Args: []interface{}{}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName + "-watermelon-0"}},
+		{FuncName: "DeleteProfile", Args: []interface{}{profileName + "-strawberry-1"}},
 		{FuncName: "AliveContainers", Args: []interface{}{"juju-"}},
 		{FuncName: "RemoveContainers", Args: []interface{}{[]string{}}},
 		{FuncName: "StorageSupported", Args: nil},
@@ -405,8 +497,8 @@ func TestEnvironCloudProfileSuite(t *testing.T) {
 }
 func (s *environCloudProfileSuite) TestSetCloudSpecCreateProfile(c *tc.C) {
 	defer s.setup(c, nil).Finish()
-	s.expectHasProfileFalse("juju-controller")
-	s.expectCreateProfile("juju-controller", nil)
+	s.expectHasProfileFalse("juju-controller-2d02ee")
+	s.expectCreateProfile("juju-controller-2d02ee", nil)
 
 	err := s.cloudSpecEnv.SetCloudSpec(c.Context(), lxdCloudSpec())
 	c.Assert(err, tc.ErrorIsNil)
@@ -414,8 +506,8 @@ func (s *environCloudProfileSuite) TestSetCloudSpecCreateProfile(c *tc.C) {
 
 func (s *environCloudProfileSuite) TestSetCloudSpecCreateProfileErrorSucceeds(c *tc.C) {
 	defer s.setup(c, nil).Finish()
-	s.expectForProfileCreateRace("juju-controller")
-	s.expectCreateProfile("juju-controller", errors.New("The profile already exists"))
+	s.expectForProfileCreateRace("juju-controller-2d02ee")
+	s.expectCreateProfile("juju-controller-2d02ee", errors.New("The profile already exists"))
 
 	err := s.cloudSpecEnv.SetCloudSpec(c.Context(), lxdCloudSpec())
 	c.Assert(err, tc.ErrorIsNil)
@@ -423,8 +515,8 @@ func (s *environCloudProfileSuite) TestSetCloudSpecCreateProfileErrorSucceeds(c 
 
 func (s *environCloudProfileSuite) TestSetCloudSpecUsesConfiguredProject(c *tc.C) {
 	defer s.setup(c, map[string]interface{}{"project": "my-project"}).Finish()
-	s.expectHasProfileFalse("juju-controller")
-	s.expectCreateProfile("juju-controller", nil)
+	s.expectHasProfileFalse("juju-controller-2d02ee")
+	s.expectCreateProfile("juju-controller-2d02ee", nil)
 
 	err := s.cloudSpecEnv.SetCloudSpec(c.Context(), lxdCloudSpec())
 	c.Assert(err, tc.ErrorIsNil)
@@ -513,13 +605,13 @@ func (s *environProfileSuite) TestLXDProfileNames(c *tc.C) {
 
 	exp := s.svr.EXPECT()
 	exp.GetContainerProfiles("testname").Return([]string{
-		lxdprofile.Name("foo", "bar", 1),
+		lxdprofile.Name("foo", "shortid", "bar", 1),
 	}, nil)
 
 	result, err := s.lxdEnv.LXDProfileNames("testname")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result, tc.DeepEquals, []string{
-		lxdprofile.Name("foo", "bar", 1),
+		lxdprofile.Name("foo", "shortid", "bar", 1),
 	})
 }
 

--- a/internal/provider/lxd/package_mock_test.go
+++ b/internal/provider/lxd/package_mock_test.go
@@ -1014,6 +1014,45 @@ func (c *MockServerGetProfileCall) DoAndReturn(f func(string) (*api.Profile, str
 	return c
 }
 
+// GetProfileNames mocks base method.
+func (m *MockServer) GetProfileNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProfileNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProfileNames indicates an expected call of GetProfileNames.
+func (mr *MockServerMockRecorder) GetProfileNames() *MockServerGetProfileNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProfileNames", reflect.TypeOf((*MockServer)(nil).GetProfileNames))
+	return &MockServerGetProfileNamesCall{Call: call}
+}
+
+// MockServerGetProfileNamesCall wrap *gomock.Call
+type MockServerGetProfileNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockServerGetProfileNamesCall) Return(arg0 []string, arg1 error) *MockServerGetProfileNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockServerGetProfileNamesCall) Do(f func() ([]string, error)) *MockServerGetProfileNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockServerGetProfileNamesCall) DoAndReturn(f func() ([]string, error)) *MockServerGetProfileNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetServer mocks base method.
 func (m *MockServer) GetServer() (*api.Server, string, error) {
 	m.ctrl.T.Helper()

--- a/internal/provider/lxd/provider.go
+++ b/internal/provider/lxd/provider.go
@@ -27,6 +27,13 @@ import (
 	"github.com/juju/juju/internal/provider/lxd/lxdnames"
 )
 
+const (
+	// ProviderVersion1 introduces unique profile names.
+	ProviderVersion1 = 1
+
+	currentProviderVersion = ProviderVersion1
+)
+
 // LXCConfigReader reads files required for the LXC configuration.
 type LXCConfigReader interface {
 	// ReadConfig takes a path and returns a LXCConfig.
@@ -139,7 +146,7 @@ func NewProvider() environs.CloudEnvironProvider {
 
 // Version is part of the EnvironProvider interface.
 func (*environProvider) Version() int {
-	return 0
+	return currentProviderVersion
 }
 
 // Open implements environs.EnvironProvider.

--- a/internal/provider/lxd/server.go
+++ b/internal/provider/lxd/server.go
@@ -86,6 +86,7 @@ type Server interface {
 	GetNetworkState(name string) (*lxdapi.NetworkState, error)
 	GetInstance(name string) (*lxdapi.Instance, string, error)
 	GetInstanceState(name string) (*lxdapi.InstanceState, string, error)
+	GetProfileNames() (names []string, err error)
 
 	// UseProject ensures that this server will use the input project.
 	// See: https://documentation.ubuntu.com/lxd/en/latest/projects.

--- a/internal/provider/lxd/testing_test.go
+++ b/internal/provider/lxd/testing_test.go
@@ -410,6 +410,7 @@ type StubClient struct {
 	ServerVer          string
 	NetworkNames       []string
 	NetworkState       map[string]api.NetworkState
+	ProfileNames       []string
 }
 
 func (conn *StubClient) FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error) {
@@ -521,6 +522,11 @@ func (conn *StubClient) DeleteProfile(name string) error {
 func (conn *StubClient) HasProfile(name string) (bool, error) {
 	conn.AddCall("HasProfile", name)
 	return false, conn.NextErr()
+}
+
+func (conn *StubClient) GetProfileNames() ([]string, error) {
+	conn.AddCall("GetProfileNames")
+	return conn.ProfileNames, conn.NextErr()
 }
 
 func (conn *StubClient) ReplaceOrAddContainerProfile(name, oldProfile, newProfile string) error {
@@ -776,6 +782,8 @@ func (s *EnvironSuite) NewEnviron(c *tc.C,
 		ecfgUnlocked:          eCfg,
 		namespace:             namespace,
 		cloud:                 cloudSpec,
+		uuid:                  eCfg.UUID(),
+		name:                  "model",
 	}
 }
 
@@ -809,6 +817,7 @@ func (s *EnvironSuite) NewEnvironWithServerFactory(c *tc.C,
 		provider:              &provid,
 		ecfgUnlocked:          eCfg,
 		namespace:             namespace,
+		uuid:                  eCfg.UUID(),
 	}
 }
 

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1383,6 +1383,17 @@ type CharmProfilingInfoResult struct {
 	Error           *Error              `json:"error"`
 }
 
+// CharmProfilingInfoResultV4 has the same data as CharmProfilingInfoResult with
+// the addition of a ModelUUID field.
+type CharmProfilingInfoResultV4 struct {
+	InstanceId      instance.Id         `json:"instance-id"`
+	ModelName       string              `json:"model-name"`
+	ModelUUID       string              `json:"model-uuid"`
+	ProfileChanges  []ProfileInfoResult `json:"profile-changes"`
+	CurrentProfiles []string            `json:"current-profiles"`
+	Error           *Error              `json:"error"`
+}
+
 // WatchContainerStartArg contains arguments for watching for container start
 // events on a CAAS application.
 type WatchContainerStartArg struct {


### PR DESCRIPTION
This is my playground so I can rule out any failing tests or checks that are caused by other commits

Cherry picked #20357.

I have discarded:
- instancemutater worker and facades
- provisioer and provisioninginfo facades
- upgrader

LXD profiles in main is already broken. I will add this to the risk registry.


```
# Conflicts:
#	api/agent/instancemutater/machine.go
#	api/facadeversions.go
#	apiserver/facades/agent-schema.json
#	apiserver/facades/agent/instancemutater/instancemutater.go
#	apiserver/facades/agent/instancemutater/instancemutater_test.go
#	apiserver/facades/agent/instancemutater/interface.go
#	apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
#	apiserver/facades/agent/instancemutater/package_test.go
#	apiserver/facades/agent/instancemutater/register.go
#	apiserver/facades/agent/provisioner/export_test.go
#	apiserver/facades/agent/provisioner/provisioner.go
#	apiserver/facades/agent/provisioner/provisioner_test.go
#	apiserver/facades/agent/provisioner/provisioninginfo.go
#	apiserver/facades/agent/provisioner/provisioninginfo_test.go
#	apiserver/facades/client/client/status.go
#	apiserver/facades/controller/undertaker/mock_test.go
#	apiserver/facades/controller/undertaker/undertaker_test.go
#	cmd/juju/status/status_internal_test.go
#	internal/container/broker/lxd-broker_test.go
#	internal/provider/lxd/environ.go
#	internal/provider/lxd/environ_broker.go
#	internal/provider/lxd/environ_test.go
#	internal/provider/lxd/testing_test.go
#	internal/provider/lxd/upgrades_test.go
#	internal/worker/instancemutater/mutater.go
#	internal/worker/instancemutater/mutater_test.go
#	internal/worker/instancemutater/worker_test.go
#	upgrades/upgradevalidation/mocks/lxd_mock.go
```