### PR TITLE
feat: prevent worker lock ups

### DIFF
--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -131,7 +131,7 @@ func makeDBGetRequest(namespace string) dbRequest {
 	return dbRequest{
 		op:        getOp,
 		namespace: namespace,
-		done:      make(chan error),
+		done:      make(chan error, 1),
 	}
 }
 
@@ -140,7 +140,7 @@ func makeDBDelRequest(namespace string) dbRequest {
 	return dbRequest{
 		op:        delOp,
 		namespace: namespace,
-		done:      make(chan error),
+		done:      make(chan error, 1),
 	}
 }
 

--- a/internal/worker/dbreplaccessor/worker.go
+++ b/internal/worker/dbreplaccessor/worker.go
@@ -66,7 +66,7 @@ type dbRequest struct {
 func makeDBGetRequest(namespace string) dbRequest {
 	return dbRequest{
 		namespace: namespace,
-		done:      make(chan error),
+		done:      make(chan error, 1),
 	}
 }
 

--- a/internal/worker/fortress/fortress.go
+++ b/internal/worker/fortress/fortress.go
@@ -51,7 +51,7 @@ func (f *fortress) Lockdown(ctx context.Context) error {
 
 // Visit is part of the Guest interface.
 func (f *fortress) Visit(ctx context.Context, visit Visit) error {
-	result := make(chan error)
+	result := make(chan error, 1)
 	select {
 	case <-f.tomb.Dying():
 		return ErrShutdown
@@ -68,7 +68,7 @@ func (f *fortress) Visit(ctx context.Context, visit Visit) error {
 
 // allowGuests communicates Guard-interface requests to the main loop.
 func (f *fortress) allowGuests(ctx context.Context, allowGuests bool) error {
-	result := make(chan error)
+	result := make(chan error, 1)
 	select {
 	case <-f.tomb.Dying():
 		return ErrShutdown

--- a/internal/worker/httpclient/worker.go
+++ b/internal/worker/httpclient/worker.go
@@ -173,7 +173,7 @@ func (w *httpClientWorker) GetHTTPClient(ctx context.Context, purpose corehttp.P
 	// or it's not running and we need to start it.
 	req := httpClientRequest{
 		purpose: purpose,
-		done:    make(chan error),
+		done:    make(chan error, 1),
 	}
 	select {
 	case w.httpClientRequests <- req:

--- a/internal/worker/logsink/worker.go
+++ b/internal/worker/logsink/worker.go
@@ -166,7 +166,7 @@ func (w *LogSink) getLogSink(ctx context.Context, modelUUID model.UUID) (LogSink
 	// or it's not running and we need to start it.
 	req := request{
 		modelUUID: modelUUID,
-		done:      make(chan error),
+		done:      make(chan error, 1),
 	}
 	select {
 	case w.requests <- req:

--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -244,7 +244,7 @@ func (w *objectStoreWorker) GetObjectStore(ctx context.Context, namespace string
 	// or it's not running and we need to start it.
 	req := objectStoreRequest{
 		namespace: namespace,
-		done:      make(chan error),
+		done:      make(chan error, 1),
 	}
 	select {
 	case w.objectStoreRequests <- req:

--- a/internal/worker/providertracker/providerworker.go
+++ b/internal/worker/providertracker/providerworker.go
@@ -196,7 +196,7 @@ func (w *providerWorker) ProviderForModel(ctx context.Context, namespace string)
 	// or it's not running and we need to start it.
 	req := trackerRequest{
 		namespace: namespace,
-		done:      make(chan error),
+		done:      make(chan error, 1),
 	}
 	select {
 	case w.requests <- req:

--- a/internal/worker/storageregistry/worker.go
+++ b/internal/worker/storageregistry/worker.go
@@ -178,7 +178,7 @@ func (w *storageRegistryWorker) GetStorageRegistry(ctx context.Context, namespac
 	// or it's not running and we need to start it.
 	req := storageRegistryRequest{
 		namespace: namespace,
-		done:      make(chan error),
+		done:      make(chan error, 1),
 	}
 	select {
 	case w.storageRegistryRequests <- req:

--- a/internal/worker/trace/worker.go
+++ b/internal/worker/trace/worker.go
@@ -207,7 +207,7 @@ func (w *tracerWorker) GetTracer(ctx context.Context, namespace coretrace.Tracer
 	// or it's not running and we need to start it.
 	req := traceRequest{
 		namespace: ns,
-		done:      make(chan error),
+		done:      make(chan error, 1),
 	}
 	select {
 	case w.tracerRequests <- req:


### PR DESCRIPTION
With the addition of context to the methods for accessing a worker runner guarded resource, we need to ensure that we don't prevent the loop from locking up on a write to a channel. The problem is that the caller to dbaccessor.GetDB (as an example), cancels the call, the worker loop is still running, attempting to send a error to a channel that nobody is reading. This was totally fine when we didn't have a context, as the tomb or the catacomb dying was the only thing that could cancel the request. The solution is simple, we buffer the channel. We know that we'll want to reiceve and error, if it's nil or not, doesn't matter. The reality is that we should send the error, thus unblocking the main loop.

## QA steps

I generally wait before adding model and deploying an application, before destroying a model, but it should work either way.

```sh
$ juju bootstrap lxd test
$ for i in {1..10}; do juju add-model "model-$i" && juju deploy juju-qa-test; done
$ for i in {1..10}; do juju destroy-model --no-prompt "model-$i"; done
```

Now for the important part:

```sh
$ juju add-model test
```