### PR TITLE
fix: charm facade CheckCharmPlacement

### DIFF
--- a/apiserver/facades/client/charms/register.go
+++ b/apiserver/facades/client/charms/register.go
@@ -64,6 +64,7 @@ func makeFacadeBase(_ context.Context, ctx facade.ModelContext) (*API, error) {
 		authorizer:         authorizer,
 		modelConfigService: domainServices.Config(),
 		applicationService: applicationService,
+		machineService:     domainServices.Machine(),
 		charmhubHTTPClient: charmhubHTTPClient,
 		newCharmHubRepository: func(cfg repository.CharmHubRepositoryConfig) (corecharm.Repository, error) {
 			return repository.NewCharmHubRepository(cfg)

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -138,6 +138,10 @@ type State interface {
 	// list of profiles for the given machine without any checks.
 	SetAppliedLXDProfileNames(ctx context.Context, mUUID string, profileNames []string) error
 
+	// GetMachineArchesForApplication returns a list of architectures which are
+	// included across the machines of the given application.
+	GetMachineArchesForApplication(ctx context.Context, appUUID string) ([]arch.Arch, error)
+
 	// NamespaceForWatchMachineCloudInstance returns the namespace for watching
 	// machine cloud instance changes.
 	NamespaceForWatchMachineCloudInstance() string
@@ -437,13 +441,11 @@ func (s *Service) SetAppliedLXDProfileNames(ctx context.Context, mUUID machine.U
 
 // GetMachineArchesForApplication returns a list of architectures which are
 // included across the machines of the given application.
-//
-// TODO: Implement this method.
 func (s *Service) GetMachineArchesForApplication(ctx context.Context, appUUID application.ID) ([]arch.Arch, error) {
 	_, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return nil, errors.Errorf("GetMachineArchesForApplication not implemented")
+	return s.st.GetMachineArchesForApplication(ctx, appUUID.String())
 }
 
 // GetAllProvisionedMachineInstanceID returns all provisioned machine

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	agentbinary "github.com/juju/juju/core/agentbinary"
+	arch "github.com/juju/juju/core/arch"
 	base "github.com/juju/juju/core/base"
 	instance "github.com/juju/juju/core/instance"
 	machine "github.com/juju/juju/core/machine"
@@ -551,6 +552,45 @@ func (c *MockStateGetLXDProfilesForMachineCall) Do(f func(context.Context, strin
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetLXDProfilesForMachineCall) DoAndReturn(f func(context.Context, string) ([]internal.CreateLXDProfileDetails, error)) *MockStateGetLXDProfilesForMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetMachineArchesForApplication mocks base method.
+func (m *MockState) GetMachineArchesForApplication(ctx context.Context, appUUID string) ([]arch.Arch, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineArchesForApplication", ctx, appUUID)
+	ret0, _ := ret[0].([]arch.Arch)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineArchesForApplication indicates an expected call of GetMachineArchesForApplication.
+func (mr *MockStateMockRecorder) GetMachineArchesForApplication(ctx, appUUID any) *MockStateGetMachineArchesForApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineArchesForApplication", reflect.TypeOf((*MockState)(nil).GetMachineArchesForApplication), ctx, appUUID)
+	return &MockStateGetMachineArchesForApplicationCall{Call: call}
+}
+
+// MockStateGetMachineArchesForApplicationCall wrap *gomock.Call
+type MockStateGetMachineArchesForApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetMachineArchesForApplicationCall) Return(arg0 []arch.Arch, arg1 error) *MockStateGetMachineArchesForApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetMachineArchesForApplicationCall) Do(f func(context.Context, string) ([]arch.Arch, error)) *MockStateGetMachineArchesForApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetMachineArchesForApplicationCall) DoAndReturn(f func(context.Context, string) ([]arch.Arch, error)) *MockStateGetMachineArchesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/state/lxdprofile_test.go
+++ b/domain/machine/state/lxdprofile_test.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state
+package state_test
 
 import (
 	stdtesting "testing"

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -164,15 +164,15 @@ VALUES ($instanceTag.*)
 		return errors.Capture(err)
 	}
 
-	azName := availabilityZoneName{}
+	azName := nameAndUUID{}
 	if hardwareCharacteristics != nil && hardwareCharacteristics.AvailabilityZone != nil {
 		az := *hardwareCharacteristics.AvailabilityZone
-		azName = availabilityZoneName{Name: az}
+		azName = nameAndUUID{Name: az}
 	}
 	retrieveAZUUID := `
-SELECT &availabilityZoneName.uuid
+SELECT &nameAndUUID.uuid
 FROM   availability_zone
-WHERE  availability_zone.name = $availabilityZoneName.name
+WHERE  availability_zone.name = $nameAndUUID.name
 `
 	retrieveAZUUIDStmt, err := st.Prepare(retrieveAZUUID, azName)
 	if err != nil {
@@ -227,7 +227,7 @@ WHERE  availability_zone.name = $availabilityZoneName.name
 		if hardwareCharacteristics != nil &&
 			hardwareCharacteristics.AvailabilityZone != nil && *hardwareCharacteristics.AvailabilityZone != "" {
 
-			var azUUID availabilityZoneName
+			var azUUID nameAndUUID
 			if err := tx.Query(ctx, retrieveAZUUIDStmt, azName).Get(&azUUID); err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
 					return errors.Errorf("%w %q for machine %q", networkerrors.AvailabilityZoneNotFound, *hardwareCharacteristics.AvailabilityZone, mUUID)

--- a/domain/machine/state/package_test.go
+++ b/domain/machine/state/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state
+package state_test
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/machine/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -20,13 +21,13 @@ import (
 type baseSuite struct {
 	schematesting.ModelSuite
 
-	state *State
+	state *state.State
 }
 
 func (s *baseSuite) SetUpTest(c *tc.C) {
 	s.ModelSuite.SetUpTest(c)
 
-	s.state = NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+	s.state = state.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 }
 
 // runQuery executes the provided SQL query string using the current state's database connection.
@@ -61,4 +62,8 @@ func (s *baseSuite) addMachine(c *tc.C, machineName, netNodeUUID string) string 
 	s.runQuery(c, `INSERT INTO machine (uuid, name, life_id, net_node_uuid) VALUES (?,?,?,?)`,
 		machineUUID, machineName, life.Alive, netNodeUUID)
 	return machineUUID
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/domain/machine/state/pollinginfo_test.go
+++ b/domain/machine/state/pollinginfo_test.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state
+package state_test
 
 import (
 	stdtesting "testing"

--- a/domain/machine/state/reboot_test.go
+++ b/domain/machine/state/reboot_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state
+package state_test
 
 import (
 	"github.com/juju/tc"
@@ -55,8 +55,8 @@ func (s *stateSuite) TestRequireMachineRebootIdempotent(c *tc.C) {
 
 func (s *stateSuite) TestRequireMachineRebootSeveralMachine(c *tc.C) {
 	// Setup: Create several machines.
-	machineUUID0, _ := s.addMachine(c)
-	machineUUID1, _ := s.addMachine(c)
+	machineUUID0, _, _ := s.addMachine(c)
+	machineUUID1, _, _ := s.addMachine(c)
 
 	// Call the function under test
 	err := s.state.RequireMachineReboot(c.Context(), machineUUID1)
@@ -105,8 +105,8 @@ func (s *stateSuite) TestCancelMachineRebootIdempotent(c *tc.C) {
 
 func (s *stateSuite) TestCancelMachineRebootSeveralMachine(c *tc.C) {
 	// Setup: Create several machine with a given IDs,  add both ids in the reboot table
-	machineUUID0, _ := s.addMachine(c)
-	machineUUID1, _ := s.addMachine(c)
+	machineUUID0, _, _ := s.addMachine(c)
+	machineUUID1, _, _ := s.addMachine(c)
 	s.runQuery(c, `INSERT INTO machine_requires_reboot (machine_uuid) VALUES (?)`, machineUUID0)
 	s.runQuery(c, `INSERT INTO machine_requires_reboot (machine_uuid) VALUES (?)`, machineUUID1)
 

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -80,10 +80,9 @@ func (d *instanceDataResult) toHardwareCharacteristics() *instance.HardwareChara
 	}
 }
 
-// machineLife represents the struct to be used for the life_id column within
+// entityLife represents the struct to be used for the life_id column within
 // the sqlair statements in the machine domain.
-type machineLife struct {
-	UUID   string    `db:"uuid"`
+type entityLife struct {
 	LifeID life.Life `db:"life_id"`
 }
 
@@ -115,7 +114,7 @@ type setMachineStatus struct {
 	MachineUUID string     `db:"machine_uuid"`
 }
 
-type availabilityZoneName struct {
+type nameAndUUID struct {
 	UUID string `db:"uuid"`
 	Name string `db:"name"`
 }
@@ -181,6 +180,10 @@ type createMachine struct {
 	UUID        string           `db:"uuid"`
 	Nonce       sql.Null[string] `db:"nonce"`
 	LifeID      int64            `db:"life_id"`
+}
+
+type archName struct {
+	Arch string `db:"architecture"`
 }
 
 type machinePlatformUUID struct {


### PR DESCRIPTION
The CheckCharmPlacement facade would call a machine service method that was not yet implemented.

Implement this method, and wire it up. This removes a block on refresh

As a flyby, tidy up machine state tests somewhat

## QA steps

```
$ juju deploy juju-qa-test --revision 25 --channel latest/stable
$ juju refresh juju-qa-test --revision 26
ERROR invalid channel for "juju-qa-test": empty channel not valid
```
^ this error indicates the client called CheckCharmPlacement, which returned with no errors