### PR TITLE
feat(facades/operation): wire up run and list operation

### DIFF
--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -43,15 +43,6 @@ type ApplicationService interface {
 	// If the charm does not exist, a [applicationerrors.CharmNotFound] error is
 	// returned.
 	GetCharmActions(ctx context.Context, locator applicationcharm.CharmLocator) (internalcharm.Actions, error)
-
-	// GetAllUnitNames returns a slice of all unit names in the model.
-	GetAllUnitNames(ctx context.Context) ([]unit.Name, error)
-
-	// GetUnitNamesForApplication returns a slice of the unit names for the given application
-	// The following errors may be returned:
-	// - [applicationerrors.ApplicationIsDead] if the application is dead
-	// - [applicationerrors.ApplicationNotFound] if the application does not exist
-	GetUnitNamesForApplication(ctx context.Context, name string) ([]unit.Name, error)
 }
 
 // ModelInfoService provides access to information about the model.

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -5,13 +5,15 @@ package action
 
 import (
 	"context"
+	"strings"
 
-	"github.com/juju/errors"
+	jujuerrors "github.com/juju/errors"
 	"github.com/juju/names/v6"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
-	coreunit "github.com/juju/juju/core/unit"
-	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/operation"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -19,80 +21,153 @@ import (
 // an operation, each action running as a task on the designated ActionReceiver.
 // We return the ID of the overall operation and each individual task.
 func (a *ActionAPI) EnqueueOperation(ctx context.Context, arg params.Actions) (params.EnqueuedActions, error) {
-	operationId, actionResults, err := a.enqueue(ctx, arg)
-	if err != nil {
-		return params.EnqueuedActions{}, err
-	}
-	results := params.EnqueuedActions{
-		OperationTag: names.NewOperationTag(operationId).String(),
-		Actions:      actionResults.Results,
-	}
-	return results, nil
-}
-
-func (a *ActionAPI) enqueue(ctx context.Context, arg params.Actions) (string, params.ActionResults, error) {
 	if err := a.checkCanWrite(ctx); err != nil {
-		return "", params.ActionResults{}, errors.Trace(err)
+		return params.EnqueuedActions{}, errors.Capture(err)
 	}
 
-	return "", params.ActionResults{}, errors.NotSupportedf("actions in Dqlite")
+	if len(arg.Actions) == 0 {
+		return params.EnqueuedActions{}, apiservererrors.ServerError(errors.New("no actions specified"))
+	}
+
+	const leader = "/leader"
+	actionResults := make([]params.ActionResult, len(arg.Actions))
+	actionResultByUnitName := make(map[string]*params.ActionResult)
+	runParams := make([]operation.RunArgs, 0, len(arg.Actions))
+	for i, action := range arg.Actions {
+		taskParams := operation.TaskArgs{
+			ActionName:     action.Name,
+			Parameters:     action.Parameters,
+			IsParallel:     action.Parallel == nil || *action.Parallel, // default is parallel
+			ExecutionGroup: zeroNilPtr(action.ExecutionGroup),
+		}
+
+		if strings.HasSuffix(action.Receiver, leader) {
+			receiver := strings.TrimSuffix(action.Receiver, leader)
+			actionResultByUnitName[action.Receiver] = &actionResults[i]
+			runParams = append(runParams, operation.RunArgs{
+				Target:   operation.Target{LeaderUnit: []string{receiver}},
+				TaskArgs: taskParams,
+			})
+			continue
+		}
+
+		unitTag, err := names.ParseUnitTag(action.Receiver)
+		if err != nil {
+			actionResults[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		actionResultByUnitName[unitTag.Id()] = &actionResults[i]
+		runParams = append(runParams, operation.RunArgs{
+			Target: operation.Target{
+				Units: []unit.Name{unit.Name(unitTag.Id())},
+			},
+			TaskArgs: taskParams,
+		})
+
+	}
+
+	// If no valid run params (all receivers invalid), do not call service; return per-action errors.
+	if len(runParams) == 0 {
+		return params.EnqueuedActions{Actions: actionResults}, nil
+	}
+
+	result, err := a.operationService.Run(ctx, runParams)
+	if err != nil {
+		return params.EnqueuedActions{}, errors.Capture(err)
+	}
+
+	for _, unitResult := range result.Units {
+		targetName := unitResult.ReceiverName.String()
+		if unitResult.IsLeader {
+			targetName = unitResult.ReceiverName.Application() + leader
+		}
+		ar := actionResultByUnitName[targetName]
+		if ar == nil {
+			return params.EnqueuedActions{}, errors.Errorf("unexpected result for %q", targetName)
+		}
+		*ar = toActionResult(names.NewUnitTag(unitResult.ReceiverName.String()), unitResult.TaskInfo)
+	}
+	// Mark missing results
+	for key, ar := range actionResultByUnitName {
+		if ar != nil && ar.Action == nil && ar.Error == nil {
+			ar.Error = apiservererrors.ServerError(jujuerrors.NotFoundf("missing result for %q", key))
+		}
+	}
+	return params.EnqueuedActions{
+		OperationTag: names.NewOperationTag(result.OperationID).String(),
+		Actions:      actionResults,
+	}, nil
 }
 
 // ListOperations fetches the called actions for specified apps/units.
 func (a *ActionAPI) ListOperations(ctx context.Context, arg params.OperationQueryArgs) (params.OperationResults, error) {
 	if err := a.checkCanRead(ctx); err != nil {
-		return params.OperationResults{}, errors.Trace(err)
+		return params.OperationResults{}, errors.Capture(err)
 	}
 
-	var receiverTags []names.Tag
-	for _, name := range arg.Units {
-		receiverTags = append(receiverTags, names.NewUnitTag(name))
+	args := operation.QueryArgs{
+		Target:      makeOperationTarget(arg.Applications, arg.Machines, arg.Units),
+		ActionNames: arg.ActionNames,
+		Status:      arg.Status,
+		Limit:       arg.Limit,
+		Offset:      arg.Offset,
 	}
-	for _, id := range arg.Machines {
-		receiverTags = append(receiverTags, names.NewMachineTag(id))
-	}
-
-	var unitNames []coreunit.Name
-	if len(arg.ActionNames) == 0 && len(arg.Applications) == 0 && len(receiverTags) == 0 {
-		var err error
-		unitNames, err = a.applicationService.GetAllUnitNames(ctx)
-		if err != nil {
-			return params.OperationResults{}, errors.Trace(err)
-		}
-	} else {
-		for _, aName := range arg.Applications {
-			appUnitName, err := a.applicationService.GetUnitNamesForApplication(ctx, aName)
-			if errors.Is(err, applicationerrors.ApplicationNotFound) {
-				return params.OperationResults{}, errors.NotFoundf("application %q", aName)
-			} else if err != nil {
-				return params.OperationResults{}, errors.Trace(err)
-			}
-			unitNames = append(unitNames, appUnitName...)
-		}
-	}
-	for _, unitName := range unitNames {
-		tag := names.NewUnitTag(unitName.String())
-		receiverTags = append(receiverTags, tag)
+	result, err := a.operationService.GetOperations(ctx, args)
+	if err != nil {
+		return params.OperationResults{}, errors.Capture(err)
 	}
 
-	return params.OperationResults{}, errors.NotSupportedf("actions in Dqlite")
+	return toOperationResults(result), errors.Capture(err)
 }
 
 // Operations fetches the specified operation ids.
 func (a *ActionAPI) Operations(ctx context.Context, arg params.Entities) (params.OperationResults, error) {
 	if err := a.checkCanRead(ctx); err != nil {
-		return params.OperationResults{}, errors.Trace(err)
+		return params.OperationResults{}, errors.Capture(err)
 	}
-	results := params.OperationResults{Results: make([]params.OperationResult, len(arg.Entities))}
 
+	results := params.OperationResults{Results: make([]params.OperationResult, len(arg.Entities))}
+	// Map from operation tag string to all result slots (to support duplicate tags)
+	tagToResults := make(map[string][]*params.OperationResult)
+
+	operationIds := make([]string, 0, len(arg.Entities))
 	for i, entity := range arg.Entities {
-		_, err := names.ParseOperationTag(entity.Tag)
+		operationTag, err := names.ParseOperationTag(entity.Tag)
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
+		tagStr := operationTag.String()
+		tagToResults[tagStr] = append(tagToResults[tagStr], &results.Results[i])
+		operationIds = append(operationIds, operationTag.Id())
+	}
 
-		results.Results[i].Error = apiservererrors.ServerError(errors.NotSupportedf("actions in Dqlite"))
+	if len(operationIds) == 0 {
+		return results, nil
+	}
+
+	result, err := a.operationService.GetOperationsByIDs(ctx, operationIds)
+	if err != nil {
+		return params.OperationResults{}, errors.Capture(err)
+	}
+	facadeResult := toOperationResults(result)
+	// Fill in all matching slots for each returned operation
+	for _, r := range facadeResult.Results {
+		slots := tagToResults[r.OperationTag]
+		if len(slots) == 0 {
+			return params.OperationResults{}, errors.Errorf("unexpected result for %q", r.OperationTag)
+		}
+		for _, slot := range slots {
+			*slot = r
+		}
+	}
+	// Mark any slots that did not receive a result as NotFound
+	for tag, slots := range tagToResults {
+		for _, slot := range slots {
+			if slot.OperationTag == "" && slot.Error == nil {
+				slot.Error = apiservererrors.ServerError(jujuerrors.NotFoundf("missing result for %q", tag))
+			}
+		}
 	}
 	return results, nil
 }

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -1,22 +1,37 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package action_test
+package action
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
+	gomock "go.uber.org/mock/gomock"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	modeltesting "github.com/juju/juju/core/model/testing"
+	"github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/operation"
+	"github.com/juju/juju/rpc/params"
 )
 
 type operationSuite struct {
+	MockBaseSuite
+	client *ActionAPI
 }
 
 func TestOperationSuite(t *testing.T) {
+	// Keep legacy runner but now we populate with real tests
 	tc.Run(t, &operationSuite{})
 }
 
 func (s *operationSuite) TestStub(c *tc.C) {
+	defer s.setupMocks(c).Finish()
 	c.Skip(`This suite is missing tests for the following scenarios:
 - ListOperations querying by status.
 - ListOperations querying by action names.
@@ -30,3 +45,294 @@ func (s *operationSuite) TestStub(c *tc.C) {
 - EnqueueOperation with a unit specified with a leader receiver
 `)
 }
+
+// TestEnqueue_PermissionDenied verifies that enqueuing an operation without proper permission returns ErrPerm.
+func (s *operationSuite) TestEnqueue_PermissionDenied(c *tc.C) {
+
+	defer s.setupMocks(c).Finish()
+	// Arrange : FakeAuthorizer without write permission should yield ErrPerm
+	auth := apiservertesting.FakeAuthorizer{Tag: names.NewUserTag("readonly")}
+	api, err := NewActionAPI(auth, s.Leadership, s.ApplicationService, s.BlockCommandService, s.ModelInfoService,
+		s.OperationService, modeltesting.GenModelUUID(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act
+	_, err = api.EnqueueOperation(context.Background(), params.Actions{Actions: []params.Action{{Receiver: "app/0", Name: "do"}}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, apiservererrors.ErrPerm)
+}
+
+// TestEnqueue_NoActions verifies that enqueuing an operation with no actions results
+// in an appropriate error response.
+func (s *operationSuite) TestEnqueue_NoActions(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+
+	// Act
+	_, err := api.EnqueueOperation(c.Context(), params.Actions{})
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, "no actions specified")
+}
+
+// TestEnqueue_SingleUnit verifies the enqueue operation for a single unit with
+// actions, parameters, and execution groups.
+func (s *operationSuite) TestEnqueue_SingleUnit(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange:
+	api := s.NewActionAPI(c)
+	taskArgs := operation.TaskArgs{
+		ActionName:     "do",
+		Parameters:     map[string]interface{}{"k": "v"},
+		IsParallel:     true,
+		ExecutionGroup: "grp",
+	}
+	s.OperationService.EXPECT().Run(gomock.Any(), []operation.RunArgs{{
+		Target: operation.Target{
+			Units: []unit.Name{"app/0"},
+		},
+		TaskArgs: taskArgs,
+	},
+	}).Return(operation.RunResult{
+		OperationID: "1",
+		Units: []operation.UnitTaskResult{{
+			ReceiverName: "app/0",
+			TaskInfo: operation.TaskInfo{
+				ID:       "1",
+				TaskArgs: taskArgs,
+			}}}}, nil)
+
+	// Act
+	res, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{
+		Receiver:       "unit-app-0",
+		Name:           "do",
+		Parameters:     map[string]interface{}{"k": "v"},
+		Parallel:       ptr(true),
+		ExecutionGroup: ptr("grp")}}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.OperationTag, tc.Equals, "operation-1")
+	c.Assert(res.Actions, tc.HasLen, 1)
+	c.Check(res.Actions[0].Error, tc.IsNil)
+	c.Check(res.Actions[0].Action, tc.DeepEquals, &params.Action{
+		Tag:            "action-1",
+		Receiver:       "unit-app-0",
+		Name:           "do",
+		Parameters:     map[string]interface{}{"k": "v"},
+		Parallel:       ptr(true),
+		ExecutionGroup: ptr("grp"),
+	})
+}
+
+// TestEnqueue_LeaderReceiver verifies the enqueue operation behavior when
+// the receiver is the leader unit of an application.
+func (s *operationSuite) TestEnqueue_LeaderReceiver(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	taskArgs := operation.TaskArgs{
+		ActionName: "do",
+	}
+	s.OperationService.EXPECT().Run(gomock.Any(), []operation.RunArgs{{
+		Target: operation.Target{
+			LeaderUnit: []string{"myapp"},
+		},
+		TaskArgs: taskArgs,
+	},
+	}).Return(operation.RunResult{
+		OperationID: "2",
+		Units: []operation.UnitTaskResult{{
+			ReceiverName: "myapp/0",
+			IsLeader:     true,
+			TaskInfo: operation.TaskInfo{
+				ID:       "1",
+				TaskArgs: taskArgs,
+			}}}}, nil)
+
+	// Act
+	res, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{Receiver: "myapp/leader",
+		Name: "do", Parallel: ptr(false)}}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.OperationTag, tc.Equals, "operation-2")
+	c.Assert(len(res.Actions), tc.Equals, 1)
+	c.Assert(res.Actions[0].Error, tc.IsNil)
+	c.Assert(res.Actions[0].Action, tc.NotNil)
+	c.Check(res.Actions[0].Action.Receiver, tc.Equals, "unit-myapp-0")
+}
+
+// TestEnqueue_Defaults verifies the enqueue operation applies default values
+// for isParallel and ExecutionGroup parameters.
+func (s *operationSuite) TestEnqueue_Defaults(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange:
+	api := s.NewActionAPI(c)
+	taskArgs := operation.TaskArgs{
+		ActionName:     "do-default",
+		IsParallel:     true, // defaulted to true
+		ExecutionGroup: "",   // defaulted to ""
+	}
+	s.OperationService.EXPECT().Run(gomock.Any(), []operation.RunArgs{{
+		Target: operation.Target{
+			Units: []unit.Name{"app/0"},
+		},
+		TaskArgs: taskArgs,
+	}}).Return(operation.RunResult{OperationID: "404" /*placeholder, we check the input args */}, nil)
+
+	// Act
+	_, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{
+		Receiver: "unit-app-0",
+		Name:     "do-default",
+		// default values for isParallel and Execution group
+	}}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestEnqueue_MultipleActions validates the enqueue operation for multiple
+// actions with correct execution order and parameters.
+func (s *operationSuite) TestEnqueue_MultipleActions(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, got []operation.RunArgs) (operation.RunResult, error) {
+			c.Assert(len(got), tc.Equals, 3)
+			// order: leader, app/2, app/0
+			c.Assert(got[0].LeaderUnit, tc.DeepEquals, []string{"app"})
+			c.Assert(got[1].Units, tc.DeepEquals, []unit.Name{"app/2"})
+			c.Assert(got[2].Units, tc.DeepEquals, []unit.Name{"app/0"})
+			ti1 := operation.TaskInfo{ID: "1", TaskArgs: got[0].TaskArgs}
+			ti2 := operation.TaskInfo{ID: "2", TaskArgs: got[1].TaskArgs}
+			ti3 := operation.TaskInfo{ID: "3", TaskArgs: got[2].TaskArgs}
+			return operation.RunResult{OperationID: "3",
+				Units: []operation.UnitTaskResult{
+					{ReceiverName: "app/0", TaskInfo: ti3},
+					{ReceiverName: "app/2", TaskInfo: ti2},
+					{ReceiverName: "app/9", IsLeader: true, TaskInfo: ti1},
+				},
+			}, nil
+		})
+
+	// Act
+	res, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{Receiver: "app/leader",
+		Name: "x"}, {Receiver: "unit-app-2", Name: "y"}, {Receiver: "unit-app-0", Name: "z"}}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(res.Actions), tc.Equals, 3)
+	c.Check(res.Actions[0].Action.Name, tc.Equals, "x")
+	c.Check(res.Actions[0].Action.Receiver, tc.Equals, "unit-app-9")
+	c.Check(res.Actions[1].Action.Name, tc.Equals, "y")
+	c.Check(res.Actions[1].Action.Receiver, tc.Equals, "unit-app-2")
+	c.Check(res.Actions[2].Action.Name, tc.Equals, "z")
+	c.Check(res.Actions[2].Action.Receiver, tc.Equals, "unit-app-0")
+}
+
+// TestEnqueue_SomeInvalid validates the behavior of the EnqueueOperation method
+// when some provided actions are invalid (receiver with a bad tag)
+func (s *operationSuite) TestEnqueue_SomeInvalid(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, got []operation.RunArgs) (operation.RunResult, error) {
+			c.Assert(len(got), tc.Equals, 1)
+			ti := operation.TaskInfo{ID: "1", TaskArgs: got[0].TaskArgs}
+			return operation.RunResult{OperationID: "4", Units: []operation.UnitTaskResult{{ReceiverName: unit.Name(
+				"app/3"), TaskInfo: ti}}}, nil
+		})
+
+	// Act
+	res, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{Receiver: "badformat/0",
+		Name: "do"}, {Receiver: "unit-app-3", Name: "do"}}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.OperationTag, tc.Equals, "operation-4")
+	c.Assert(res.Actions[0].Error, tc.NotNil)
+	c.Assert(res.Actions[1].Error, tc.IsNil)
+}
+
+// TestEnqueue_AllInvalid_NoServiceCall verifies that no service call is made
+// when all actions have invalid receivers.
+func (s *operationSuite) TestEnqueue_AllInvalid_NoServiceCall(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	// Ensure Run is not called
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).Times(0)
+
+	// Act: all tag receiver are invalid
+	res, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{Receiver: "bad1", Name: "do"}, {Receiver: "also/bad", Name: "do"}}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.OperationTag, tc.Equals, "")
+	c.Assert(res.Actions[0].Error, tc.NotNil)
+	c.Assert(res.Actions[1].Error, tc.NotNil)
+}
+
+// TestEnqueue_ServiceError checks that EnqueueOperation returns an error when the OperationService.Run fails.
+func (s *operationSuite) TestEnqueue_ServiceError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).Return(operation.RunResult{}, fmt.Errorf("boom"))
+	_, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{Receiver: "unit-app-0",
+		Name: "do"}}})
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
+// TestEnqueue_UnexpectedExtraResult verifies the behavior when an unexpected
+// extra result is returned during operation execution.
+func (s *operationSuite) TestEnqueue_UnexpectedExtraResult(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, got []operation.RunArgs) (operation.RunResult, error) {
+			return operation.RunResult{
+				OperationID: "5",
+				Units: []operation.UnitTaskResult{
+					{
+						ReceiverName: "otherapp/9", // this result is not expected
+						TaskInfo:     operation.TaskInfo{ID: "0"},
+					}}}, nil
+		})
+	_, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{Receiver: "unit-app-0",
+		Name: "do"}}})
+	c.Assert(err, tc.ErrorMatches, "unexpected result for \"otherapp/9\"")
+}
+
+// TestEnqueue_MissingResultPerActionError verifies that EnqueueOperation
+// returns an error when results are missing for actions.
+func (s *operationSuite) TestEnqueue_MissingResultPerActionError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	api := s.NewActionAPI(c)
+	// Arrange
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, got []operation.RunArgs) (operation.RunResult, error) {
+			// only return app/0 result; missing app/1
+			ti := operation.TaskInfo{ID: "0", TaskArgs: got[0].TaskArgs}
+			return operation.RunResult{OperationID: "8", Units: []operation.UnitTaskResult{{ReceiverName: unit.Name(
+				"app/0"), TaskInfo: ti}}}, nil
+		})
+
+	// Act
+	res, err := api.EnqueueOperation(c.Context(), params.Actions{Actions: []params.Action{{Receiver: "unit-app-0",
+		Name: "do"}, {Receiver: "unit-app-1", Name: "do"}}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.OperationTag, tc.Equals, "operation-8")
+	c.Assert(res.Actions[0].Error, tc.IsNil)
+	c.Assert(res.Actions[1].Error, tc.NotNil)
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
@@ -14,6 +15,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/machine"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/operation"
@@ -333,6 +335,327 @@ func (s *operationSuite) TestEnqueue_MissingResultPerActionError(c *tc.C) {
 	c.Assert(res.OperationTag, tc.Equals, "operation-8")
 	c.Assert(res.Actions[0].Error, tc.IsNil)
 	c.Assert(res.Actions[1].Error, tc.NotNil)
+}
+
+// TestListOperations_PermissionDenied verifies ListOperations returns ErrPerm
+// and does not call service when read permission is denied.
+func (s *operationSuite) TestListOperations_PermissionDenied(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	// Authorizer without read permission
+	auth := apiservertesting.FakeAuthorizer{Tag: names.NewUserTag("readonly")}
+	api, err := NewActionAPI(auth, s.Leadership, s.ApplicationService, s.BlockCommandService, s.ModelInfoService, s.OperationService, modeltesting.GenModelUUID(c))
+	c.Assert(err, tc.ErrorIsNil)
+	// Ensure List is not called
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Times(0)
+
+	// Act
+	_, err = api.ListOperations(c.Context(), params.OperationQueryArgs{Applications: []string{"app"}})
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, apiservererrors.ErrPerm)
+}
+
+// TestListOperations_NoFilters verifies that no filters pass an empty target
+// and no other filters, and empty result is returned.
+func (s *operationSuite) TestListOperations_NoFilters(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, qp operation.QueryArgs) (operation.QueryResult, error) {
+			c.Check(qp.Target.Applications, tc.HasLen, 0)
+			c.Check(qp.Target.Machines, tc.HasLen, 0)
+			c.Check(qp.Target.Units, tc.HasLen, 0)
+			c.Check(qp.ActionNames, tc.IsNil)
+			c.Check(qp.Status, tc.IsNil)
+			c.Check(qp.Limit, tc.IsNil)
+			c.Check(qp.Offset, tc.IsNil)
+			return operation.QueryResult{}, nil
+		})
+
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestListOperations_ApplicationsFilter ensures application names flow into
+// Target.Applications.
+func (s *operationSuite) TestListOperations_ApplicationsFilter(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	apps := []string{"app-a", "app-b"}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, qp operation.QueryArgs) (operation.QueryResult, error) {
+			c.Check(qp.Target.Applications, tc.DeepEquals, apps)
+			return operation.QueryResult{}, nil
+		})
+
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{Applications: apps})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestListOperations_UnitsFilter verifies string unit names convert to
+// []unit.Name in Target.Units.
+func (s *operationSuite) TestListOperations_UnitsFilter(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	units := []string{"app-a/0", "app-b/3"}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, qp operation.QueryArgs) (operation.QueryResult, error) {
+			c.Check(qp.Target.Units, tc.DeepEquals, []unit.Name{"app-a/0", "app-b/3"})
+			return operation.QueryResult{}, nil
+		})
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{Units: units})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestListOperations_MachinesFilter verifies string machine names convert
+// to []machine.Name in Target.Machines.
+func (s *operationSuite) TestListOperations_MachinesFilter(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	machines := []string{"0", "42"}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, qp operation.QueryArgs) (operation.QueryResult, error) {
+			c.Check(qp.Target.Machines, tc.DeepEquals, []machine.Name{"0", "42"})
+			return operation.QueryResult{}, nil
+		})
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{Machines: machines})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestListOperations_ActionNamesFilter confirms actions filter passes through.
+func (s *operationSuite) TestListOperations_ActionNamesFilter(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	names := []string{"backup", "reindex"}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, qp operation.QueryArgs) (operation.QueryResult, error) {
+			c.Check(qp.ActionNames, tc.DeepEquals, names)
+			return operation.QueryResult{}, nil
+		})
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{ActionNames: names})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestListOperations_StatusFilter confirms status filter passes through.
+func (s *operationSuite) TestListOperations_StatusFilter(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	status := []string{"running", "completed"}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, qp operation.QueryArgs) (operation.QueryResult, error) {
+			c.Check(qp.Status, tc.DeepEquals, status)
+			return operation.QueryResult{}, nil
+		})
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{Status: status})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestListOperations_LimitOffset verifies Limit and Offset pointers pass unchanged.
+func (s *operationSuite) TestListOperations_LimitOffset(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	limit := 10
+	offset := 20
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, qp operation.QueryArgs) (operation.QueryResult, error) {
+			c.Check(qp.Limit, tc.DeepEquals, ptr(10))
+			c.Check(qp.Offset, tc.DeepEquals, ptr(20))
+			return operation.QueryResult{}, nil
+		})
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{Limit: &limit, Offset: &offset})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestListOperations_CombinedFilters ensures multiple filters are passed
+// together without modification.
+func (s *operationSuite) TestListOperations_CombinedFilters(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	apps := []string{"a"}
+	units := []string{"a/0"}
+	machines := []string{"1"}
+	actionNames := []string{"do"}
+	status := []string{"running"}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, qp operation.QueryArgs) (operation.QueryResult, error) {
+			c.Check(qp.Target.Applications, tc.DeepEquals, apps)
+			c.Check(qp.ActionNames, tc.DeepEquals, actionNames)
+			c.Check(qp.Status, tc.DeepEquals, status)
+			c.Check(qp.Target.Units, tc.DeepEquals, []unit.Name{"a/0"})
+			c.Check(qp.Target.Machines, tc.DeepEquals, []machine.Name{"1"})
+			return operation.QueryResult{}, nil
+		})
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{
+		Applications: apps,
+		Units:        units,
+		Machines:     machines,
+		ActionNames:  actionNames,
+		Status:       status})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestListOperations_ServiceError ensures service error is propagated.
+func (s *operationSuite) TestListOperations_ServiceError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return(operation.QueryResult{}, fmt.Errorf("boom"))
+	// Act
+	_, err := api.ListOperations(c.Context(), params.OperationQueryArgs{})
+	// Assert
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
+// TestListOperations_MappingSingleOperation validates mapping of
+// OperationInfo with unit and machine actions into params.
+func (s *operationSuite) TestListOperations_MappingSingleOperation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	tiM := operation.TaskInfo{ID: "1", TaskArgs: operation.TaskArgs{ActionName: "m-act"}}
+	tiU := operation.TaskInfo{ID: "2", TaskArgs: operation.TaskArgs{ActionName: "u-act"}}
+	qr := operation.QueryResult{Operations: []operation.OperationInfo{{
+		OperationID: "123",
+		Summary:     "s",
+		Status:      "completed",
+		Machines:    []operation.MachineTaskResult{{ReceiverName: "2", TaskInfo: tiM}},
+		Units:       []operation.UnitTaskResult{{ReceiverName: "app/0", TaskInfo: tiU}},
+	}}}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return(qr, nil)
+	// Act
+	res, err := api.ListOperations(c.Context(), params.OperationQueryArgs{})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(res.Results), tc.Equals, 1)
+	c.Check(res.Results[0].OperationTag, tc.Equals, "operation-123")
+	c.Check(res.Results[0].Summary, tc.Equals, "s")
+	c.Check(res.Results[0].Status, tc.Equals, "completed")
+	c.Check(len(res.Results[0].Actions), tc.Equals, 2)
+	// machine action
+	c.Check(res.Results[0].Actions[0].Action.Receiver, tc.Equals, "machine-2")
+	c.Check(res.Results[0].Actions[0].Action.Name, tc.Equals, "m-act")
+	c.Check(res.Results[0].Actions[0].Action.Tag, tc.Equals, names.NewActionTag("1").String())
+	// unit action
+	c.Check(res.Results[0].Actions[1].Action.Receiver, tc.Equals, "unit-app-0")
+	c.Check(res.Results[0].Actions[1].Action.Name, tc.Equals, "u-act")
+	c.Check(res.Results[0].Actions[1].Action.Tag, tc.Equals, names.NewActionTag("2").String())
+}
+
+// TestListOperations_TruncatedPassThrough ensures Truncated flag propagates.
+func (s *operationSuite) TestListOperations_TruncatedPassThrough(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	qr := operation.QueryResult{Truncated: true}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return(qr, nil)
+	// Act
+	res, err := api.ListOperations(c.Context(), params.OperationQueryArgs{})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.Truncated, tc.Equals, true)
+}
+
+// TestListOperations_OperationErrorMapping validates mapping of operation-level error to params.Error.
+func (s *operationSuite) TestListOperations_OperationErrorMapping(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	qr := operation.QueryResult{Operations: []operation.OperationInfo{{OperationID: "1", Error: fmt.Errorf("op-fail")}}}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return(qr, nil)
+	// Act
+	res, err := api.ListOperations(c.Context(), params.OperationQueryArgs{})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.Results, tc.HasLen, 1)
+	c.Assert(res.Results[0].Error, tc.NotNil)
+	c.Assert(res.Results[0].Error.Message, tc.Matches, ".*op-fail.*")
+}
+
+// TestListOperations_ActionFieldMapping ensures TaskInfo fields map into
+// ActionResult fields.
+func (s *operationSuite) TestListOperations_ActionFieldMapping(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	when := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
+	log := []operation.TaskLog{{Timestamp: when, Message: "log1"}}
+	ti := operation.TaskInfo{
+		ID:       "1",
+		TaskArgs: operation.TaskArgs{ActionName: "run"},
+		Status:   "running",
+		Message:  "in progress",
+		Log:      log,
+		Output:   map[string]interface{}{"k": "v"},
+		Error:    fmt.Errorf("task-fail")}
+	qr := operation.QueryResult{
+		Operations: []operation.OperationInfo{{
+			OperationID: "1",
+			Units: []operation.UnitTaskResult{{
+				ReceiverName: "app/1",
+				TaskInfo:     ti,
+			}}}}}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return(qr, nil)
+
+	// Act
+	res, err := api.ListOperations(c.Context(), params.OperationQueryArgs{})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.Results, tc.HasLen, 1)
+	acts := res.Results[0].Actions
+	c.Assert(acts, tc.HasLen, 1)
+	ar := acts[0]
+	c.Check(ar.Status, tc.Equals, "running")
+	c.Check(ar.Message, tc.Equals, "in progress")
+	c.Check(ar.Log, tc.HasLen, 1)
+	c.Check(ar.Log[0].Timestamp.Equal(when), tc.Equals, true)
+	c.Check(ar.Log[0].Message, tc.Equals, "log1")
+	c.Check(ar.Output["k"], tc.Equals, "v")
+	c.Assert(ar.Error, tc.NotNil)
+	c.Check(ar.Error.Message, tc.Matches, ".*task-fail.*")
+}
+
+// TestListOperations_EmptyOperations verifies that an empty operations slice results in empty results.
+func (s *operationSuite) TestListOperations_EmptyOperations(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	qr := operation.QueryResult{Operations: []operation.OperationInfo{}, Truncated: false}
+	s.OperationService.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return(qr, nil)
+	// Act
+	res, err := api.ListOperations(c.Context(), params.OperationQueryArgs{})
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(res.Results), tc.Equals, 0)
+	c.Assert(res.Truncated, tc.Equals, false)
 }
 
 func ptr[T any](v T) *T { return &v }

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -31,22 +31,6 @@ func TestOperationSuite(t *testing.T) {
 	tc.Run(t, &operationSuite{})
 }
 
-func (s *operationSuite) TestStub(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-	c.Skip(`This suite is missing tests for the following scenarios:
-- ListOperations querying by status.
-- ListOperations querying by action names.
-- ListOperations querying by application names.
-- ListOperations querying by unit names.
-- ListOperations querying by machines.
-- ListOperations querying with multiple filters - result is union.
-- Operations based on input entity tags.
-- EnqueueOperation with some units
-- EnqueueOperation but AddAction fails
-- EnqueueOperation with a unit specified with a leader receiver
-`)
-}
-
 // TestEnqueue_PermissionDenied verifies that enqueuing an operation without proper permission returns ErrPerm.
 func (s *operationSuite) TestEnqueue_PermissionDenied(c *tc.C) {
 

--- a/apiserver/facades/client/action/package_mock_test.go
+++ b/apiserver/facades/client/action/package_mock_test.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	model "github.com/juju/juju/core/model"
-	unit "github.com/juju/juju/core/unit"
 	charm "github.com/juju/juju/domain/application/charm"
 	operation "github.com/juju/juju/domain/operation"
 	charm0 "github.com/juju/juju/internal/charm"
@@ -43,45 +42,6 @@ func NewMockApplicationService(ctrl *gomock.Controller) *MockApplicationService 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
-}
-
-// GetAllUnitNames mocks base method.
-func (m *MockApplicationService) GetAllUnitNames(arg0 context.Context) ([]unit.Name, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllUnitNames", arg0)
-	ret0, _ := ret[0].([]unit.Name)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAllUnitNames indicates an expected call of GetAllUnitNames.
-func (mr *MockApplicationServiceMockRecorder) GetAllUnitNames(arg0 any) *MockApplicationServiceGetAllUnitNamesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUnitNames", reflect.TypeOf((*MockApplicationService)(nil).GetAllUnitNames), arg0)
-	return &MockApplicationServiceGetAllUnitNamesCall{Call: call}
-}
-
-// MockApplicationServiceGetAllUnitNamesCall wrap *gomock.Call
-type MockApplicationServiceGetAllUnitNamesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetAllUnitNamesCall) Return(arg0 []unit.Name, arg1 error) *MockApplicationServiceGetAllUnitNamesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetAllUnitNamesCall) Do(f func(context.Context) ([]unit.Name, error)) *MockApplicationServiceGetAllUnitNamesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetAllUnitNamesCall) DoAndReturn(f func(context.Context) ([]unit.Name, error)) *MockApplicationServiceGetAllUnitNamesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
 }
 
 // GetCharmActions mocks base method.
@@ -158,45 +118,6 @@ func (c *MockApplicationServiceGetCharmLocatorByApplicationNameCall) Do(f func(c
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetCharmLocatorByApplicationNameCall) DoAndReturn(f func(context.Context, string) (charm.CharmLocator, error)) *MockApplicationServiceGetCharmLocatorByApplicationNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetUnitNamesForApplication mocks base method.
-func (m *MockApplicationService) GetUnitNamesForApplication(arg0 context.Context, arg1 string) ([]unit.Name, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitNamesForApplication", arg0, arg1)
-	ret0, _ := ret[0].([]unit.Name)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUnitNamesForApplication indicates an expected call of GetUnitNamesForApplication.
-func (mr *MockApplicationServiceMockRecorder) GetUnitNamesForApplication(arg0, arg1 any) *MockApplicationServiceGetUnitNamesForApplicationCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNamesForApplication", reflect.TypeOf((*MockApplicationService)(nil).GetUnitNamesForApplication), arg0, arg1)
-	return &MockApplicationServiceGetUnitNamesForApplicationCall{Call: call}
-}
-
-// MockApplicationServiceGetUnitNamesForApplicationCall wrap *gomock.Call
-type MockApplicationServiceGetUnitNamesForApplicationCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Return(arg0 []unit.Name, arg1 error) *MockApplicationServiceGetUnitNamesForApplicationCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetUnitNamesForApplicationCall) Do(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetUnitNamesForApplicationCall) DoAndReturn(f func(context.Context, string) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/action/package_mock_test.go
+++ b/apiserver/facades/client/action/package_mock_test.go
@@ -363,3 +363,159 @@ func (c *MockOperationServiceGetActionCall) DoAndReturn(f func(context.Context, 
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// GetOperations mocks base method.
+func (m *MockOperationService) GetOperations(arg0 context.Context, arg1 operation.QueryArgs) (operation.QueryResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperations", arg0, arg1)
+	ret0, _ := ret[0].(operation.QueryResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOperations indicates an expected call of GetOperations.
+func (mr *MockOperationServiceMockRecorder) GetOperations(arg0, arg1 any) *MockOperationServiceGetOperationsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperations", reflect.TypeOf((*MockOperationService)(nil).GetOperations), arg0, arg1)
+	return &MockOperationServiceGetOperationsCall{Call: call}
+}
+
+// MockOperationServiceGetOperationsCall wrap *gomock.Call
+type MockOperationServiceGetOperationsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOperationServiceGetOperationsCall) Return(arg0 operation.QueryResult, arg1 error) *MockOperationServiceGetOperationsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOperationServiceGetOperationsCall) Do(f func(context.Context, operation.QueryArgs) (operation.QueryResult, error)) *MockOperationServiceGetOperationsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOperationServiceGetOperationsCall) DoAndReturn(f func(context.Context, operation.QueryArgs) (operation.QueryResult, error)) *MockOperationServiceGetOperationsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetOperationsByIDs mocks base method.
+func (m *MockOperationService) GetOperationsByIDs(arg0 context.Context, arg1 []string) (operation.QueryResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperationsByIDs", arg0, arg1)
+	ret0, _ := ret[0].(operation.QueryResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOperationsByIDs indicates an expected call of GetOperationsByIDs.
+func (mr *MockOperationServiceMockRecorder) GetOperationsByIDs(arg0, arg1 any) *MockOperationServiceGetOperationsByIDsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationsByIDs", reflect.TypeOf((*MockOperationService)(nil).GetOperationsByIDs), arg0, arg1)
+	return &MockOperationServiceGetOperationsByIDsCall{Call: call}
+}
+
+// MockOperationServiceGetOperationsByIDsCall wrap *gomock.Call
+type MockOperationServiceGetOperationsByIDsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOperationServiceGetOperationsByIDsCall) Return(arg0 operation.QueryResult, arg1 error) *MockOperationServiceGetOperationsByIDsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOperationServiceGetOperationsByIDsCall) Do(f func(context.Context, []string) (operation.QueryResult, error)) *MockOperationServiceGetOperationsByIDsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOperationServiceGetOperationsByIDsCall) DoAndReturn(f func(context.Context, []string) (operation.QueryResult, error)) *MockOperationServiceGetOperationsByIDsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Run mocks base method.
+func (m *MockOperationService) Run(arg0 context.Context, arg1 []operation.RunArgs) (operation.RunResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Run", arg0, arg1)
+	ret0, _ := ret[0].(operation.RunResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Run indicates an expected call of Run.
+func (mr *MockOperationServiceMockRecorder) Run(arg0, arg1 any) *MockOperationServiceRunCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockOperationService)(nil).Run), arg0, arg1)
+	return &MockOperationServiceRunCall{Call: call}
+}
+
+// MockOperationServiceRunCall wrap *gomock.Call
+type MockOperationServiceRunCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOperationServiceRunCall) Return(arg0 operation.RunResult, arg1 error) *MockOperationServiceRunCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOperationServiceRunCall) Do(f func(context.Context, []operation.RunArgs) (operation.RunResult, error)) *MockOperationServiceRunCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOperationServiceRunCall) DoAndReturn(f func(context.Context, []operation.RunArgs) (operation.RunResult, error)) *MockOperationServiceRunCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RunOnAllMachines mocks base method.
+func (m *MockOperationService) RunOnAllMachines(arg0 context.Context, arg1 operation.TaskArgs) (operation.RunResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunOnAllMachines", arg0, arg1)
+	ret0, _ := ret[0].(operation.RunResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunOnAllMachines indicates an expected call of RunOnAllMachines.
+func (mr *MockOperationServiceMockRecorder) RunOnAllMachines(arg0, arg1 any) *MockOperationServiceRunOnAllMachinesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunOnAllMachines", reflect.TypeOf((*MockOperationService)(nil).RunOnAllMachines), arg0, arg1)
+	return &MockOperationServiceRunOnAllMachinesCall{Call: call}
+}
+
+// MockOperationServiceRunOnAllMachinesCall wrap *gomock.Call
+type MockOperationServiceRunOnAllMachinesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOperationServiceRunOnAllMachinesCall) Return(arg0 operation.RunResult, arg1 error) *MockOperationServiceRunOnAllMachinesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOperationServiceRunOnAllMachinesCall) Do(f func(context.Context, operation.TaskArgs) (operation.RunResult, error)) *MockOperationServiceRunOnAllMachinesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOperationServiceRunOnAllMachinesCall) DoAndReturn(f func(context.Context, operation.TaskArgs) (operation.RunResult, error)) *MockOperationServiceRunOnAllMachinesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/apiserver/facades/client/action/package_test.go
+++ b/apiserver/facades/client/action/package_test.go
@@ -45,7 +45,7 @@ func (s *MockBaseSuite) NewActionAPI(c *tc.C) *ActionAPI {
 	modelUUID := modeltesting.GenModelUUID(c)
 
 	s.Authorizer.EXPECT().AuthClient().Return(true)
-	s.Authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.Authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	api, err := newActionAPI(s.Authorizer, LeaderFactory(s.Leadership), s.ApplicationService, s.BlockCommandService,
 		s.ModelInfoService, s.OperationService, modelUUID)

--- a/apiserver/facades/client/action/package_test.go
+++ b/apiserver/facades/client/action/package_test.go
@@ -5,6 +5,7 @@ package action
 
 import (
 	"github.com/juju/tc"
+	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
@@ -27,8 +28,25 @@ type MockBaseSuite struct {
 	OperationService    *MockOperationService
 }
 
+func (s *MockBaseSuite) setupMocks(c *tc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+
+	s.BlockCommandService = NewMockBlockCommandService(ctrl)
+	s.ApplicationService = NewMockApplicationService(ctrl)
+	s.ModelInfoService = NewMockModelInfoService(ctrl)
+	s.OperationService = NewMockOperationService(ctrl)
+	s.Leadership = NewMockReader(ctrl)
+	s.Authorizer = facademocks.NewMockAuthorizer(ctrl)
+
+	return ctrl
+}
+
 func (s *MockBaseSuite) NewActionAPI(c *tc.C) *ActionAPI {
 	modelUUID := modeltesting.GenModelUUID(c)
+
+	s.Authorizer.EXPECT().AuthClient().Return(true)
+	s.Authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
 	api, err := newActionAPI(s.Authorizer, LeaderFactory(s.Leadership), s.ApplicationService, s.BlockCommandService,
 		s.ModelInfoService, s.OperationService, modelUUID)
 	c.Assert(err, tc.ErrorIsNil)

--- a/apiserver/facades/client/action/package_test.go
+++ b/apiserver/facades/client/action/package_test.go
@@ -29,7 +29,8 @@ type MockBaseSuite struct {
 
 func (s *MockBaseSuite) NewActionAPI(c *tc.C) *ActionAPI {
 	modelUUID := modeltesting.GenModelUUID(c)
-	api, err := newActionAPI(s.Authorizer, LeaderFactory(s.Leadership), s.ApplicationService, s.BlockCommandService, s.ModelInfoService, s.OperationService, modelUUID)
+	api, err := newActionAPI(s.Authorizer, LeaderFactory(s.Leadership), s.ApplicationService, s.BlockCommandService,
+		s.ModelInfoService, s.OperationService, modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	return api
@@ -44,7 +45,8 @@ func NewActionAPI(
 	operationService OperationService,
 	modelUUID coremodel.UUID,
 ) (*ActionAPI, error) {
-	return newActionAPI(authorizer, LeaderFactory(leadership), applicationService, blockCommandService, modelInfoService, operationService, modelUUID)
+	return newActionAPI(authorizer, LeaderFactory(leadership), applicationService, blockCommandService,
+		modelInfoService, operationService, modelUUID)
 }
 
 type FakeLeadership struct {

--- a/apiserver/facades/client/action/run_test.go
+++ b/apiserver/facades/client/action/run_test.go
@@ -4,12 +4,24 @@
 package action
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	stdtesting "testing"
+	"time"
 
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	gomock "go.uber.org/mock/gomock"
 
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/machine"
+	modeltesting "github.com/juju/juju/core/model/testing"
+	coreoperation "github.com/juju/juju/core/operation"
+	"github.com/juju/juju/core/unit"
+	blockcommanderrors "github.com/juju/juju/domain/blockcommand/errors"
+	"github.com/juju/juju/domain/operation"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
 )
@@ -22,28 +34,40 @@ func TestRunSuite(t *stdtesting.T) {
 	tc.Run(t, &runSuite{})
 }
 
-func (s *runSuite) TestBlockRunOnAllMachines(c *tc.C) {
+func (s *runSuite) NewActionAPI(c *tc.C) *ActionAPI {
+	// Don't block
+	s.BlockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("",
+		blockcommanderrors.NotFound).AnyTimes()
+	return s.MockBaseSuite.NewActionAPI(c)
+}
+
+// TestRun_BlockOnAllMachines ensures RunOnAllMachines is blocked when a
+// change block is active.
+func (s *runSuite) TestRun_BlockOnAllMachines(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	// Arrange
-	client := s.NewActionAPI(c)
+	// Arrange: Use parent mock action API to handle specifically the block changes
+	client := s.MockBaseSuite.NewActionAPI(c)
 
 	// block all changes
-	s.blockAllChanges(c, "TestBlockRunOnAllMachines")
+	s.blockAllChanges(c, "TestRun_BlockOnAllMachines")
 	_, err := client.RunOnAllMachines(
 		c.Context(),
 		params.RunParams{
 			Commands: "hostname",
 			Timeout:  testing.LongWait,
 		})
-	s.assertBlocked(c, err, "TestBlockRunOnAllMachines")
+	s.assertBlocked(c, err, "TestRun_BlockOnAllMachines")
 }
 
-func (s *runSuite) TestBlockRunMachineAndApplication(c *tc.C) {
+// TestBlockRunMachineAndApplication ensures Run is blocked with mixed
+// targets when a change block is active.
+func (s *runSuite) TestRun_BlockMachineAndApplication(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	client := s.NewActionAPI(c)
+	// Arrange: Use parent mock action API to handle specifically the block changes
+	client := s.MockBaseSuite.NewActionAPI(c)
 
 	// block all changes
-	s.blockAllChanges(c, "TestBlockRunMachineAndApplication")
+	s.blockAllChanges(c, "TestRun_BlockMachineAndApplication")
 	_, err := client.Run(
 		c.Context(),
 		params.RunParams{
@@ -52,16 +76,216 @@ func (s *runSuite) TestBlockRunMachineAndApplication(c *tc.C) {
 			Machines:     []string{"0"},
 			Applications: []string{"magic"},
 		})
-	s.assertBlocked(c, err, "TestBlockRunMachineAndApplication")
+	s.assertBlocked(c, err, "TestRun_BlockMachineAndApplication")
 }
 
-func (s *runSuite) TestStub(c *tc.C) {
-	c.Skip(`This suite is missing tests for the following scenarios:
-Running juju-exec with machine, application and unit targets.
-Running juju-exec against all machines.
-Running "Run" requires administrator privilege.
-Running "RunOnAllMachines" requires administrator privilege.
-`)
+// TestRun_PermissionDenied verifies Run enforces admin permission and
+// does not call OperationService when denied.
+func (s *runSuite) TestRun_PermissionDenied(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	auth := apiservertesting.FakeAuthorizer{Tag: names.NewUserTag("readonly")}
+	api, err := NewActionAPI(auth, s.Leadership, s.ApplicationService,
+		s.BlockCommandService, s.ModelInfoService, s.OperationService,
+		modeltesting.GenModelUUID(c))
+	c.Assert(err, tc.ErrorIsNil)
+	// Ensure the service is not called
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).Times(0)
+
+	// Act
+	_, err = api.Run(c.Context(), params.RunParams{Commands: "echo x", Timeout: time.Second})
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, apiservererrors.ErrPerm)
+}
+
+// TestRun_RejectNestedExec ensures commands containing juju-exec/juju-run
+// are rejected by Run.
+func (s *runSuite) TestRun_RejectNestedExec(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).Times(0)
+
+	// Act
+	_, err1 := api.Run(c.Context(), params.RunParams{Commands: "foo; juju-exec bar", Timeout: time.Second})
+	_, err2 := api.Run(c.Context(), params.RunParams{Commands: "x && juju-run y", Timeout: time.Second})
+
+	// Assert
+	c.Assert(err1, tc.ErrorMatches, "cannot use \".*\" as an action command")
+	c.Assert(err2, tc.ErrorMatches, "cannot use \".*\" as an action command")
+}
+
+// TestRun_SuccessMapping verifies input mapping to OperationService.Run and
+// output mapping to params.EnqueuedActions.
+func (s *runSuite) TestRun_SuccessMapping(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	runParams := params.RunParams{
+		Applications:   []string{"a1", "a2"},
+		Machines:       []string{"0", "42"},
+		Units:          []string{"app/1", "db/0"},
+		Commands:       "echo hello",
+		Timeout:        5 * time.Second,
+		Parallel:       func(b bool) *bool { return &b }(false),
+		ExecutionGroup: func(s string) *string { return &s }("eg-1"),
+	}
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, got []operation.RunArgs) (operation.RunResult, error) {
+			c.Assert(len(got), tc.Equals, 1)
+			rp := got[0]
+			c.Check(rp.Applications, tc.DeepEquals, []string{"a1", "a2"})
+			c.Check(rp.Machines, tc.DeepEquals, []machine.Name{"0", "42"})
+			c.Check(rp.Units, tc.DeepEquals, []unit.Name{"app/1", "db/0"})
+			c.Check(rp.ActionName, tc.Equals, coreoperation.JujuExecActionName)
+			c.Check(rp.IsParallel, tc.Equals, false)
+			c.Check(rp.ExecutionGroup, tc.Equals, "eg-1")
+			c.Check(rp.Parameters["command"], tc.Equals, "echo hello")
+			c.Check(rp.Parameters["timeout"], tc.Equals, (5 * time.Second).Nanoseconds())
+			return operation.RunResult{OperationID: "1"}, nil
+		})
+
+	// Act
+	res, err := api.Run(c.Context(), runParams)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(res.OperationTag, tc.Equals, "operation-1")
+	c.Check(len(res.Actions), tc.Equals, 0)
+}
+
+// TestRun_Defaults verifies defaulting for Parallel and ExecutionGroup.
+func (s *runSuite) TestRun_Defaults(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	runParams := params.RunParams{Commands: "whoami", Timeout: time.Second}
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, got []operation.RunArgs) (operation.RunResult, error) {
+			rp := got[0]
+			c.Check(rp.IsParallel, tc.Equals, true)
+			c.Check(rp.ExecutionGroup, tc.Equals, "")
+			c.Check(rp.ActionName, tc.Equals, coreoperation.JujuExecActionName)
+			c.Check(rp.Parameters["command"], tc.Equals, "whoami")
+			c.Check(rp.Parameters["timeout"], tc.Equals, (1 * time.Second).Nanoseconds())
+			return operation.RunResult{OperationID: "2"}, nil
+		})
+
+	// Act
+	res, err := api.Run(c.Context(), runParams)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(res.OperationTag, tc.Equals, "operation-2")
+}
+
+// TestRun_ResultMapping ensures toEnqueuedActions maps unit and machine
+// results correctly.
+func (s *runSuite) TestRun_ResultMapping(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).Return(
+		operation.RunResult{
+			OperationID: "9",
+			Machines: []operation.MachineTaskResult{{
+				ReceiverName: "2",
+				TaskInfo: operation.TaskInfo{ID: "1",
+					TaskArgs: operation.TaskArgs{ActionName: coreoperation.JujuExecActionName}},
+			}},
+			Units: []operation.UnitTaskResult{{
+				ReceiverName: "app/0",
+				TaskInfo: operation.TaskInfo{ID: "1",
+					TaskArgs: operation.TaskArgs{ActionName: coreoperation.JujuExecActionName}},
+			}},
+		}, nil)
+
+	// Act
+	res, err := api.Run(c.Context(), params.RunParams{Commands: "true", Timeout: time.Second})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(res.OperationTag, tc.Equals, "operation-9")
+	c.Assert(res.Actions, tc.HasLen, 2)
+	// machine action
+	c.Check(res.Actions[0].Action.Receiver, tc.Equals, "machine-2")
+	c.Check(res.Actions[0].Action.Tag, tc.Equals, names.NewActionTag("1").String())
+	// unit action
+	c.Check(res.Actions[1].Action.Receiver, tc.Equals, "unit-app-0")
+	c.Check(res.Actions[1].Action.Tag, tc.Equals, names.NewActionTag("1").String())
+}
+
+// TestRun_ServiceError verifies service error is propagated by Run.
+func (s *runSuite) TestRun_ServiceError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).Return(
+		operation.RunResult{}, fmt.Errorf("boom"))
+
+	// Act
+	_, err := api.Run(c.Context(), params.RunParams{Commands: "echo x", Timeout: time.Second})
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
+// TestRun_EmptyTarget passes through empty target slices when filters are
+// empty.
+func (s *runSuite) TestRun_EmptyTarget(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, got []operation.RunArgs) (operation.RunResult, error) {
+			rp := got[0]
+			c.Check(rp.Applications, tc.HasLen, 0)
+			c.Check(rp.Machines, tc.HasLen, 0)
+			c.Check(rp.Units, tc.HasLen, 0)
+			return operation.RunResult{}, errors.New("no target")
+		})
+
+	// Act
+	_, err := api.Run(c.Context(), params.RunParams{Commands: "true", Timeout: time.Second})
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, "no target")
+}
+
+// TestRun_BlockServiceError ensures a non-NotFound block service error
+// is propagated and service Run is not called.
+func (s *runSuite) TestRun_BlockServiceError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange: use parent mock action API to handle specifically the block changes
+	api := s.MockBaseSuite.NewActionAPI(c)
+	s.BlockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("block-fail"))
+	s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).Times(0)
+
+	// Act
+	_, err := api.Run(c.Context(), params.RunParams{Commands: "echo x", Timeout: time.Second})
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, "block-fail")
+}
+
+// TestRun_TimeoutConversion checks precise timeout conversion to ns for a few
+// edge values.
+func (s *runSuite) TestRun_TimeoutConversion(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// Arrange
+	api := s.NewActionAPI(c)
+	times := []time.Duration{0, 123 * time.Millisecond, 1 * time.Nanosecond}
+	for _, t := range times {
+		s.OperationService.EXPECT().Run(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, got []operation.RunArgs) (operation.RunResult, error) {
+				c.Check(got[0].Parameters["timeout"], tc.Equals, t.Nanoseconds())
+				return operation.RunResult{}, errors.New("no target") // ignore result
+			})
+
+		// Act
+		_, _ = api.Run(c.Context(), params.RunParams{Commands: "cmd", Timeout: t})
+	}
 }
 
 func (s *runSuite) assertBlocked(c *tc.C, err error, msg string) {

--- a/domain/operation/service/query.go
+++ b/domain/operation/service/query.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/juju/domain/operation"
+	"github.com/juju/juju/internal/errors"
+)
+
+// GetOperations returns a list of operations on specified entities, filtered by the
+// given parameters.
+func (s *Service) GetOperations(ctx context.Context, params operation.QueryArgs) (operation.QueryResult, error) {
+	return operation.QueryResult{}, errors.New("actions in Dqlite not supported")
+}
+
+// GetOperationsByIDs returns a list of specified operations, identified by their IDs.
+func (s *Service) GetOperationsByIDs(ctx context.Context, operationIDs []string) (operation.QueryResult, error) {
+	return operation.QueryResult{}, errors.New("actions in Dqlite not supported")
+}

--- a/domain/operation/service/run.go
+++ b/domain/operation/service/run.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/juju/domain/operation"
+	"github.com/juju/juju/internal/errors"
+)
+
+// Run creates an operation with tasks for various machines and units, using the provided parameters.
+func (s *Service) Run(ctx context.Context, args []operation.RunArgs) (operation.RunResult,
+	error) {
+	return operation.RunResult{}, errors.New("actions in Dqlite not supported")
+}
+
+// RunOnAllMachines creates an operation with tasks based on the provided parameters on all machines.
+func (s *Service) RunOnAllMachines(ctx context.Context, args operation.TaskArgs) (operation.RunResult, error) {
+	return operation.RunResult{}, errors.New("actions in Dqlite not supported")
+}

--- a/domain/operation/service/stub_test.go
+++ b/domain/operation/service/stub_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+)
+
+type stubSuite struct {
+}
+
+func TestStubSuite(t *testing.T) {
+	// Keep legacy runner but now we populate with real tests
+	tc.Run(t, &stubSuite{})
+}
+
+// TestStub lists all tests that were done in the facade, which should be done here
+// once implemented, are in the state layer (depending on the implementation)
+// They are no longer needed in the facade.
+func (s *stubSuite) TestStub(c *tc.C) {
+	c.Skip(`This suite is missing tests for the following scenarios:
+- ListOperations querying by status.
+- ListOperations querying by action names.
+- ListOperations querying by application names.
+- ListOperations querying by unit names.
+- ListOperations querying by machines.
+- ListOperations querying with multiple filters - result is union.
+- Operations based on input entity tags.
+- EnqueueOperation with some units
+- EnqueueOperation but AddAction fails
+- EnqueueOperation with a unit specified with a leader receiver
+`)
+}

--- a/domain/operation/types.go
+++ b/domain/operation/types.go
@@ -3,7 +3,13 @@
 
 package operation
 
-import "github.com/juju/juju/internal/uuid"
+import (
+	"time"
+
+	"github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/unit"
+	"github.com/juju/juju/internal/uuid"
+)
 
 // Action represents a domain action.
 type Action struct {
@@ -11,4 +17,99 @@ type Action struct {
 	UUID uuid.UUID
 	// Receiver is the action receiver (unit / machine).
 	Receiver string
+}
+
+// QueryArgs represents the parameters used for querying operations.
+type QueryArgs struct {
+	Target
+	ActionNames []string
+	Status      []string
+
+	// These attributes are used to support client side
+	// batching of results.
+	Limit  *int
+	Offset *int
+}
+
+// QueryResult represents the result of a query operation.
+type QueryResult struct {
+	Operations []OperationInfo
+	Truncated  bool
+}
+
+// OperationInfo represents the information about an operation.
+type OperationInfo struct {
+	OperationID string
+	Summary     string
+	Fail        string
+	Enqueued    time.Time
+	Started     time.Time
+	Completed   time.Time
+	Status      string
+	Machines    []MachineTaskResult
+	Units       []UnitTaskResult
+	Truncated   bool
+	Error       error
+}
+
+// RunArgs represents the parameters used for running operations.
+type RunArgs struct {
+	Target
+	TaskArgs
+}
+
+// TaskArgs represents the parameters used for running tasks.
+type TaskArgs struct {
+	ActionName     string
+	Parameters     map[string]interface{}
+	IsParallel     bool
+	ExecutionGroup string
+}
+
+// RunResult represents the result of a run operation.
+type RunResult struct {
+	OperationID string
+	Machines    []MachineTaskResult
+	Units       []UnitTaskResult
+}
+
+// MachineTaskResult represents the result of a machine task.
+type MachineTaskResult struct {
+	TaskInfo
+	ReceiverName machine.Name
+}
+
+// UnitTaskResult represents the result of a unit task.
+type UnitTaskResult struct {
+	TaskInfo
+	ReceiverName unit.Name
+	IsLeader     bool
+}
+
+// TaskInfo represents the information about a task.
+type TaskInfo struct {
+	TaskArgs
+	ID        string
+	Enqueued  time.Time
+	Started   time.Time
+	Completed time.Time
+	Status    string
+	Message   string
+	Log       []TaskLog
+	Output    map[string]interface{}
+	Error     error
+}
+
+// TaskLog represents a log message for a task.
+type TaskLog struct {
+	Timestamp time.Time
+	Message   string
+}
+
+// Target represents various targets for operations.
+type Target struct {
+	Applications []string
+	Machines     []machine.Name
+	Units        []unit.Name
+	LeaderUnit   []string
 }


### PR DESCRIPTION
This PR introduce 
* interfaces in domain to handle various Run and List method to manage operations.
* logic to take advantage of those to operate operation through API `EnqueueOperation`, `ListOperation`, `Operations`, `Run`, `RunOnAllMachines`
* Unit test to enforce behavior of the facade on various transformation between API structs to domain structs.

This is a big one, sorry for that, because it finally ships JUJU-6923 and JUJU-6922

To make it more digest, focus on non-test code.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Not available yet, need to implement domain function first.

Unit test should pass.

## Links

**Jira card:** JUJU-6923, JUJU-6922
