### PR TITLE
fix: action DDL references wrong table in FK

### DIFF
--- a/domain/schema/model/sql/0033_action.sql
+++ b/domain/schema/model/sql/0033_action.sql
@@ -99,7 +99,7 @@ CREATE TABLE operation_task_status (
     REFERENCES task (uuid),
     CONSTRAINT fk_task_status
     FOREIGN KEY (status_id)
-    REFERENCES task_status_value (id)
+    REFERENCES operation_task_status_value (id)
 );
 
 -- Status values for tasks.


### PR DESCRIPTION
This small patch fixes a wrong reference in the operation task status foreign key to table operation_task_status_value.

This was discovered when trying to implement the action (list and cancel) domain.


## QA steps

N/A.

## Links

**Jira card:** JUJU-8438
