### PR TITLE
feat: add missing action parameters to operation DDL

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -235,6 +235,10 @@ func ModelDDL() *schema.Schema {
 		triggerEntityLifecycleByFieldForTable("relation", "uuid", customNamespaceRelationRemovalLifecycle),
 		triggerEntityLifecycleByFieldForTable("model_life", "model_uuid", customNamespaceModelLifeRemovalLifecycle),
 		triggerEntityLifecycleByFieldForTable("storage_attachment", "unit_uuid", customNamespaceStorageAttachmentLifecycle),
+
+		// Action parameters are immutable, only insertions and deletions are
+		// allowed.
+		triggersForUnmodifiableTable("operation_parameter", "operation_parameter table is unmodifiable, only insertions and deletions are allowed"),
 	)
 
 	patches = append(patches, func() schema.Patch {

--- a/domain/schema/model/sql/0033-operation.sql
+++ b/domain/schema/model/sql/0033-operation.sql
@@ -132,6 +132,10 @@ CREATE TABLE operation_task_log (
 );
 
 -- operation_parameter holds the parameters passed to an operation.
+-- In the case of an action, these are the user-passed parameters, where the 
+-- keys should match the charm_action's parameters.
+-- In the case of an exec, these will contain the "command" and "timeout" 
+-- parameters.
 CREATE TABLE operation_parameter (
     operation_uuid TEXT NOT NULL,
     "key" TEXT NOT NULL,

--- a/domain/schema/model/sql/0033-operation.sql
+++ b/domain/schema/model/sql/0033-operation.sql
@@ -1,8 +1,9 @@
 -- An operation is an overview of an action or commands run on a remote
 -- target by the user. It will be linked to N number of tasks, depending
 -- on the number of entities it is run on.
--- An operation can be an action_operation or an exec_operation, but not
--- both.
+-- An operation can be an action (meaning there will be an entry in 
+-- operation_action) or not. If there is no entry, then the operation is an 
+-- exec.
 CREATE TABLE operation (
     uuid TEXT NOT NULL PRIMARY KEY,
     -- operation_id is a sequence number, and the sequence is shared with 

--- a/domain/schema/model/sql/0033-operation.sql
+++ b/domain/schema/model/sql/0033-operation.sql
@@ -32,16 +32,6 @@ CREATE TABLE operation_action (
     REFERENCES charm_action (charm_uuid, "key")
 );
 
--- operation_exec contains the commands for the operation to run.
-CREATE TABLE operation_exec (
-    operation_uuid TEXT NOT NULL PRIMARY KEY,
-    command TEXT NOT NULL,
-    timeout DATETIME,
-    CONSTRAINT fk_operation_uuid
-    FOREIGN KEY (operation_uuid)
-    REFERENCES operation (uuid)
-);
-
 -- A operation_task is the individual representation of an operation on a specific
 -- receiver. Either a machine or unit.
 CREATE TABLE operation_task (
@@ -108,13 +98,13 @@ CREATE TABLE operation_task_status (
     updated_at DATETIME,
     CONSTRAINT fk_task_uuid
     FOREIGN KEY (task_uuid)
-    REFERENCES task (uuid),
+    REFERENCES operation_task (uuid),
     CONSTRAINT fk_task_status
     FOREIGN KEY (status_id)
     REFERENCES operation_task_status_value (id)
 );
 
--- Status values for tasks.
+-- operation_task_status_value holds the possible status values for a task.
 CREATE TABLE operation_task_status_value (
     id INT PRIMARY KEY,
     status TEXT NOT NULL
@@ -138,4 +128,15 @@ CREATE TABLE operation_task_log (
     CONSTRAINT fk_task_uuid
     FOREIGN KEY (task_uuid)
     REFERENCES operation_task (uuid)
+);
+
+-- operation_parameter holds the parameters passed to an operation.
+CREATE TABLE operation_parameter (
+    operation_uuid TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (operation_uuid, "key"),
+    CONSTRAINT fk_operation_uuid
+    FOREIGN KEY (operation_uuid)
+    REFERENCES operation (uuid)
 );

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -307,7 +307,6 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 
 		// Operations
 		"operation_action",
-		"operation_exec",
 		"operation_machine_task",
 		"operation",
 		"operation_task",

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -305,7 +305,7 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"offer",
 		"offer_endpoint",
 
-		// Actions
+		// Operations
 		"operation_action",
 		"operation_exec",
 		"operation_machine_task",
@@ -316,6 +316,7 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"operation_task_status",
 		"operation_task_status_value",
 		"operation_unit_task",
+		"operation_parameter",
 	)
 	got := readEntityNames(c, s.DB(), "table")
 	wanted := expected.Union(internalTableNames)

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -681,6 +681,8 @@ func (s *modelSchemaSuite) TestModelTriggers(c *tc.C) {
 
 		"trg_ensure_single_app_per_offer",
 		"trg_offer_endpoint_immutable_update",
+
+		"trg_operation_parameter_immutable_update",
 	)
 
 	got := readEntityNames(c, s.DB(), "trigger")


### PR DESCRIPTION
Small patch to add a new table to the operation DDL, accounting for the action parameters.

The strategy I took is to have parameters linked to the operation table although only actions can have parameters, and it wouldn't harm execs because that table would hold no values for that operation UUID.

## QA steps
N/A.

## Links

**Jira card:** JUJU-8438
