### PR TITLE
docs: 3.6+ improve structure and look of our hook doc

### DIFF
--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -374,6 +374,8 @@ juju debug-hooks mysql/0 X-relation-changed  # for a specific hook
 The command launches a tmux session that will intercept matching hooks and/or
 actions, which you can then execute manually by running `./dispatch`.
 
+You can also view the environment variables for a specific event by running `debug-hooks` and waiting for the desired event to fire. If the next prompt looks like `root@database-0:/var/lib/juju#`, that means we are still waiting for an event to occur. If the prompt looks like `root@database-0:/var/lib/juju/agents/unit-database-0/charm#`, that means an event _has_ occurred, and we are inside the charm hook execution context. At this point, typing `printenv` will print out the environment variables.
+
 ```{ibnote}
 See more: {ref}`command-juju-debug-hooks`
 ```

--- a/docs/reference/action.md
+++ b/docs/reference/action.md
@@ -50,7 +50,7 @@ being triggered when the action is invoked.
 (action-execution)=
 ## Action execution
 
-Actions operate in an execution environment similar to a {ref}`hook <hook-execution>`. As such, they're executed with all the generic hook environment variables plus the following action-specific environment variables:
+Actions operate in an execution environment similar to a {ref}`hook <hook-execution>`. As such, they're executed with all the {ref}`generic environment variables <generic-environment-variables>` plus the following action-specific environment variables:
 
 * `JUJU_ACTION_NAME` holds the name of the action.
 * `JUJU_ACTION_UUID` holds the UUID of the action.

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -158,55 +158,10 @@ The documentation in this section will, where relevant, describe behaviour speci
 ## Hook execution
 
 Hooks are run with environment variables set by Juju to expose relevant contextual configuration to the charm.
+
 The Juju environment variables are set in addition to those supplied by the execution environment itself.
 
-````{tip}
-For the curious, or to debug charm behaviour, the environment variables for a specific event
-can be obtained by running
-
-    juju debug-hooks <unit name>
-
-and waiting for the desired event to fire. If the next prompt looks as below
-
-    root@database-0:/var/lib/juju#
-
-meaning that we are still waiting for an event to occur.
-
-As soon as that happens, the prompt will look similar to the below
-
-    root@database-0:/var/lib/juju/agents/unit-database-0/charm#
-
-meaning we're inside the charm hook execution context.
-
-At this point,  typing `printenv` will print out the environment variables.
-
-```{ibnote}
-See more: {ref}`debug-a-charm`
-```
-````
-
-The following environment variables are set for every hook:
-
-* PATH is the usual Unix path, prefixed by a directory containing command line tools through which the hooks can interact with Juju.
-* JUJU_CHARM_DIR holds the path to the charm directory.
-* JUJU_HOOK_NAME holds the name of the currently executing hook.
-* JUJU_UNIT_NAME holds the name of the local unit.
-* JUJU_CONTEXT_ID, JUJU_AGENT_SOCKET_NETWORK and JUJU_AGENT_SOCKET_ADDRESS are set (but should not be messed with: the command line tools won't work without them).
-* JUJU_API_ADDRESSES holds a space separated list of Juju API addresses.
-* JUJU_MODEL_UUID holds the UUID of the current model.
-* JUJU_MODEL_NAME holds the human friendly name of the current model.
-* JUJU_PRINCIPAL_UNIT holds the name of the principal unit if the current unit is a subordinate.
-* JUJU_MACHINE_ID holds the ID of the machine on which the local unit is running.
-* JUJU_AVAILABILITY_ZONE holds the cloud's availability zone where the machine has been provisioned.
-* CLOUD_API_VERSION holds the API version of the cloud endpoint.
-* JUJU_VERSION holds the version of the model hosting the local unit.
-* JUJU_CHARM_HTTP_PROXY holds the value of the `juju-http-proxy` model config attribute.
-* JUJU_CHARM_HTTPS_PROXY holds the value of the `juju-https-proxy` model config attribute.
-* JUJU_CHARM_FTP_PROXY holds the value of the `juju-ftp-proxy` model config attribute.
-* JUJU_CHARM_NO_PROXY holds the value of the `juju-no-proxy` model config attribute.
-
-Additionally, hooks will have extra environment variables set which correspond to the kind of hook.
-The operation of each hook kind is explained in the following sections, including any relevant additional environment variables.
+All hooks get a common set of environment variables; see {ref}`generic environment variables <generic-environment-variables>`. In addition, some hook( kind)s also get hook (kind) specific environment variables, as specified in the documentation for each hook.
 
 ## Hook ordering
 
@@ -226,14 +181,14 @@ In normal operation, a unit will run at least the `install`, `start`, `config-ch
 
 When a charm is first deployed, the following hooks are executed in order before a charm reaches its operation phase:
 
-* storage-attached (for machine charms if the unit has storage)
-* install
-* leader-elected (if the unit is a leader)
-* config-changed
-* start
+* {ref}`hook-storage-attached` (for machine charms if the unit has storage)
+* {ref}`hook-install`
+* {ref}`hook-leader-elected` (if the unit is a leader)
+* {ref}`hook-config-changed`
+* {ref}`hook-start`
 
 ```{note}
-Only machine charms have the behaviour where the `storage-attached` hook must run before the `install` hook.
+Only machine charms have the behaviour where the {ref}`hook-storage-attached` hook must run before the {ref}`hook-install` hook.
 See {ref}`storage hooks <storage-hooks>` for more details.
 ```
 
@@ -253,16 +208,16 @@ The `upgrade-charm` hook always runs once immediately after the charm directory
 contents have been changed by an unforced charm upgrade operation, and *may* do
 so after a forced upgrade; but will *not* be run after a forced upgrade from an
 existing error state. (Consequently, neither will the `config-changed` hook that
-would ordinarily follow the upgrade-charm.)
+would ordinarily follow the {ref}`hook-upgrade-charm` hook.)
 
 (teardown-phase)=
 ### Teardown phase
 
 When a unit is to be removed, the following hooks are executed:
 
-* `stop`
-* `storage-detaching` | `relation-broken` (in any order)
-* `remove`
+* {ref}`hook-stop`
+* {ref}`hook-storage-detaching` | {ref}`hook-relation-broken` (in any order)
+* {ref}`hook-remove`
 
 The `remove` event is the last event a unit will ever see before being removed.
 
@@ -312,8 +267,8 @@ For every endpoint defined by a charm, relation hook events are named after the 
 For each charm endpoint, any or all of the above relation hooks can be implemented.
 Relation hooks operate in an environment with additional environment variables available:
 
-* `JUJU_RELATION` holds the name of the relation. This is of limited value, because every relation hook already "knows" what charm relation it was written for; that is, in the `foo-relation-joined` hook, JUJU_RELATION is `foo`.
-* `JUJU_RELATION_ID` holds the ID of the relation. It is more useful, because it serves as unique identifier for a particular relation, and thereby allows the charm to handle distinct relations over a single endpoint. In hooks for the `foo` charm relation, JUJU_RELATION_ID always has the form "foo:<id>", where id uniquely but opaquely identifies the runtime relation currently in play.
+* `JUJU_RELATION` holds the name of the relation. This is of limited value, because every relation hook already "knows" what charm relation it was written for; that is, in the `foo-relation-joined` hook, `JUJU_RELATION` is `foo`.
+* `JUJU_RELATION_ID` holds the ID of the relation. It is more useful, because it serves as unique identifier for a particular relation, and thereby allows the charm to handle distinct relations over a single endpoint. In hooks for the `foo` charm relation, `JUJU_RELATION_ID` always has the form `foo:<id>`, where ID uniquely but opaquely identifies the runtime relation currently in play.
 * `JUJU_REMOTE_APP` holds the name of the related application.
 
 Furthermore, all relation hooks except `relation-created` and `relation-broken` are notifications about some specific unit of a related application, and operate in an environment with the following additional environment variables available:
@@ -1415,3 +1370,31 @@ TBA
 
 Any unit.
 
+
+
+## Hook and action environment variables
+
+### `<environment variable(s) specific to a hook (kind) or action>`
+
+See the documentation for the relevant hook or action.
+
+(generic-environment-variables)=
+### Generic environment variables
+
+* `PATH` is the usual Unix path, prefixed by a directory containing command line tools through which the hooks can interact with Juju.
+* `JUJU_CHARM_DIR` holds the path to the charm directory.
+* `JUJU_HOOK_NAME` holds the name of the currently executing hook.
+* `JUJU_UNIT_NAME` holds the name of the local unit.
+* `JUJU_CONTEXT_ID`, `JUJU_AGENT_SOCKET_NETWORK` and `JUJU_AGENT_SOCKET_ADDRESS` are set (but should not be messed with: the command line tools won't work without them).
+* `JUJU_API_ADDRESSES` holds a space separated list of Juju API addresses.
+* `JUJU_MODEL_UUID` holds the UUID of the current model.
+* `JUJU_MODEL_NAME` holds the human friendly name of the current model.
+* `JUJU_PRINCIPAL_UNIT` holds the name of the principal unit if the current unit is a subordinate.
+* `JUJU_MACHINE_ID` holds the ID of the machine on which the local unit is running.
+* `JUJU_AVAILABILITY_ZONE` holds the cloud's availability zone where the machine has been provisioned.
+* `CLOUD_API_VERSION` holds the API version of the cloud endpoint.
+* `JUJU_VERSION` holds the version of the model hosting the local unit.
+* `JUJU_CHARM_HTTP_PROXY` holds the value of the `juju-http-proxy` model config attribute.
+* `JUJU_CHARM_HTTPS_PROXY` holds the value of the `juju-https-proxy` model config attribute.
+* `JUJU_CHARM_FTP_PROXY` holds the value of the `juju-ftp-proxy` model config attribute.
+* `JUJU_CHARM_NO_PROXY` holds the value of the `juju-no-proxy` model config attribute.

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -370,7 +370,7 @@ If the leader unit is rescheduled, or removed entirely. When the new leader is e
 | :-------: | -------------------------- | ------------------------------------ |
 |  Removal of leader   | `juju remove-unit foo/0` (foo/0 being leader)  | `leader-settings-changed` (for all non leaders) |
 
-> Since this event needs leadership changes to trigger, check out {ref}`triggers for the leader-electe hook <hook-leader-elected>` as the same situations apply for `leader-settings-changed`.
+> Since this event needs leadership changes to trigger, check out the triggers for the {ref}`hook-leader-elected`, as the same situations apply for the {ref}`hook-leader-settings-changed` too.
 
 <!--
 *Which hooks can be guaranteed to have fired before it, if any?*?
@@ -859,8 +859,8 @@ The secret rotation interval is specified using a named rotation policy, one of:
 
 *Which environment variables is it executed with?*
 
-* JUJU_SECRET_ID holds the ID of the secret that needs rotation.
-* JUJU_SECRET_LABEL holds the label given to the secret by the owner.
+* `JUJU_SECRET_ID` holds the ID of the secret that needs rotation.
+* `JUJU_SECRET_LABEL` holds the label given to the secret by the owner.
 
 *Who gets it*?
 

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -261,8 +261,14 @@ In all cases we cover
 - Which environment variables is it executed with?
 - Who gets it?
 
+(leadership-hooks)=
+### Leadership hooks
+
+
 (hook-leader-deposed)=
 #### `leader-deposed`
+
+TBA
 
 <!--
 *What triggers it?*
@@ -282,8 +288,6 @@ TBA
 TBA
 -->
 
-(leadership-hooks)=
-### Leadership hooks
 
 (hook-leader-elected)=
 #### `leader-elected`

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -759,8 +759,8 @@ This event gives the consuming charm the chance to read the updated content of t
 
 *Which environment variables is it executed with?*
 
-* JUJU_SECRET_ID holds the ID of the secret that has a new revision.
-* JUJU_SECRET_LABEL holds the label given to the secret by the consumer.
+* `JUJU_SECRET_ID` holds the ID of the secret that has a new revision.
+* `JUJU_SECRET_LABEL` holds the label given to the secret by the consumer.
 
 The secret label can be set whenever a secret's content is read by passing `--label <label>` to the `secret-get` command.
 Thereafter, any subsequent `secret-changed` hooks will be run with this label.
@@ -799,9 +799,9 @@ Until the charm indeed removes the expired secret revision, Juju will continue t
 
 *Which environment variables is it executed with?*
 
-* JUJU_SECRET_ID holds the ID of the secret that is expiring.
-* JUJU_SECRET_REVISION holds the revision that is expiring.
-* JUJU_SECRET_LABEL holds the label given to the secret by the owner.
+* `JUJU_SECRET_ID` holds the ID of the secret that is expiring.
+* `JUJU_SECRET_REVISION` holds the revision that is expiring.
+* `JUJU_SECRET_LABEL` holds the label given to the secret by the owner.
 
 *Who gets it*?
 

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -144,13 +144,11 @@ All hooks share a lot of common behaviour in terms of the environment in which t
 are notified that a hook event has occurred, how errors are reported, and how a user might respond to
 a unit being in an error state due to a failed hook execution etc.
 
-Some hooks can also be grouped according to the Juju subsystem they represent. The hook kinds are
-* {ref}`leadership-hooks`
-* {ref}`relation-hooks`
-* {ref}`secret-hooks`
-* {ref}`storage-hooks`
-* {ref}`upgrade-series-hooks`
-* {ref}`workload-hooks`
+Some hooks can also be grouped according to the Juju subsystem they represent (leadership, relations, secrets, storage, series, workload/Pebble).
+
+```{ibnote}
+See more: {ref}`list-of-hooks`
+```
 
 (hook-execution)=
 ## Hook execution
@@ -159,7 +157,11 @@ Hooks are run with environment variables set by Juju to expose relevant contextu
 
 The Juju environment variables are set in addition to those supplied by the execution environment itself.
 
-All hooks get a common set of environment variables; see {ref}`generic environment variables <generic-environment-variables>`. In addition, some hook( kind)s also get hook (kind) specific environment variables, as specified in the documentation for each hook.
+All hooks get a common set of environment variables; in addition, some hook( kind)s also get hook (kind) specific environment variables, as specified in the documentation for each hook.
+
+```{ibnote}
+See more: {ref}`list-of-hooks`
+```
 
 ## Hook ordering
 
@@ -244,7 +246,15 @@ information or advice before signalling the error.
 
 This section gives the complete list of hooks.
 
-Where hooks belong to a kind, we nest them under that kind.
+Where hooks belong to a kind, we nest them under that kind; otherwise, under "other". Thus:
+
+* {ref}`leadership-hooks`
+* {ref}`relation-hooks`
+* {ref}`secret-hooks`
+* {ref}`storage-hooks`
+* {ref}`upgrade-series-hooks`
+* {ref}`workload-hooks`
+* {ref}`other-hooks`
 
 In all cases we cover
 - What triggers the hook?
@@ -1131,6 +1141,7 @@ As such, contrary to many other events, `-relation-changed` events are mostly tr
 ```
 -->
 
+(other-hooks)=
 ### Other hooks
 
 (hook-config-changed)=

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -302,7 +302,7 @@ The `leader-elected` event is emitted for a unit that is elected as leader. Toge
 
 
 
-- `leader-elected` is always emitted **after** peer-`relation-created` during the Startup phase. However, by the time `relation-created` runs, Juju may already have a leader. This means that, in peer-relation-created handlers, it might already be the case that `self.unit.is_leader()` returns `True` even though the unit did not receive a leadership event yet. If the starting unit is *not* leader, it will receive a {ref}``leader-settings-changed` <event-leader-settings-changed>` instead.
+- `leader-elected` is always emitted **after** peer-`relation-created` during the Startup phase. However, by the time `relation-created` runs, Juju may already have a leader. This means that, in peer-relation-created handlers, it might already be the case that `self.unit.is_leader()` returns `True` even though the unit did not receive a leadership event yet. If the starting unit is *not* leader, it will receive a {ref}`hook-leader-settings-changed` hook instead.
 
 |   Scenario  | Example Command                          | Resulting Events                     |
 | :-------: | -------------------------- | ------------------------------------ |
@@ -512,7 +512,7 @@ Hooks bound to this event should be the only ones that rely on remote relation s
 
 Charm authors should expect this event to fire many times during an application's life cycle. Units in an application are able to update relation data as needed, and a `relation-changed` event will fire every time the data in a relation changes. Since relation data can be updated on a per unit bases, a unit may receive multiple `relation-changed` events if it is related to multiple units in an application and all those units update their relation data.
 
-This event is guaranteed to follow immediately after each {ref}`hook-relation-joined`. So all `juju` commands that trigger `relation-joined` will also cause `relation-changed` to be fired. So typical scenarios include:
+This event is guaranteed to follow immediately after each {ref}`hook-relation-joined` hook. So all `juju` commands that trigger `relation-joined` will also cause `relation-changed` to be fired. So typical scenarios include:
 
 |   Scenario  | Example Command                          | Resulting Events                     |
 | :-------: | -------------------------- | ------------------------------------ |
@@ -946,7 +946,7 @@ TBA
 (upgrade-series-hooks)=
 ### Upgrade series hooks
 
-> Juju `3.6` or earlier only.
+> Juju `3.6` or earlier only. To be removed in Juju 4.
 
 These hooks are run to tell the charm the version of OS that the host machine will be upgraded to.
 
@@ -956,7 +956,6 @@ Upgrade series hooks operate in an environment with additional environment varia
 
 (hook-post-series-upgrade)=
 #### `post-series-upgrade`
-> Removed in Juju 4.
 
 *What triggers it?*
 
@@ -979,8 +978,6 @@ TBA
 
 (hook-pre-series-upgrade)=
 #### `pre-series-upgrade`
-> Removed in Juju 4.
-
 
 *What triggers it?*
 

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -241,6 +241,7 @@ having failed transiently (to ensure that they only request user intervention in
 the most trying circumstances) as well as careful to log any relevant
 information or advice before signalling the error.
 
+(list-of-hooks)=
 ## List of hooks
 <!-- > [Source](https://github.com/juju/juju/blob/main/internal/charm/hooks/hooks.go) -->
 

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -144,7 +144,7 @@ All hooks share a lot of common behaviour in terms of the environment in which t
 are notified that a hook event has occurred, how errors are reported, and how a user might respond to
 a unit being in an error state due to a failed hook execution etc.
 
-Some hooks can also be grouped according to the Juju subsystem they represent (leadership, relations, secrets, storage, series, workload/Pebble).
+Some hooks can also be grouped according to the Juju subsystem they represent (leadership, relations, secrets, storage, series upgrade, workload/Pebble).
 
 ```{ibnote}
 See more: {ref}`list-of-hooks`
@@ -157,7 +157,7 @@ Hooks are run with environment variables set by Juju to expose relevant contextu
 
 The Juju environment variables are set in addition to those supplied by the execution environment itself.
 
-All hooks get a common set of environment variables; in addition, some hook( kind)s also get hook (kind) specific environment variables, as specified in the documentation for each hook.
+All hooks get a common set of environment variables; in addition, some hooks (or hook kinds) also get hook (hook kind) specific environment variables, as specified in the documentation for each hook.
 
 ```{ibnote}
 See more: {ref}`list-of-hooks`
@@ -265,31 +265,6 @@ In all cases we cover
 (leadership-hooks)=
 ### Leadership hooks
 
-
-(hook-leader-deposed)=
-#### `leader-deposed`
-
-TBA
-
-<!--
-*What triggers it?*
-
-TBA
-
-*Which hooks can be guaranteed to have fired before it, if any?*?
-
-TBA
-
-*Which environment variables is it executed with?*
-
-TBA
-
-*Who gets it*?
-
-TBA
--->
-
-
 (hook-leader-elected)=
 #### `leader-elected`
 
@@ -300,8 +275,6 @@ The `leader-elected` event is emitted for a unit that is elected as leader. Toge
 > Leadership can change while a hook is running. (You could start a hook on unit/0 who is the leader, and while that hook is processing, you lose network connectivity for a long time [more than 30s], and then by the time the hook notices, Juju has already moved on to another leader.)
 
 > Juju doesn't guarantee that a leader will see every event: if the leader unit is overloaded long enough for the lease to expire (>30s), then Juju will elect a different leader. Events that fired in between would be received units that are not leader yet or not leader anymore.
-
-
 
 - `leader-elected` is always emitted **after** peer-`relation-created` during the Startup phase. However, by the time `relation-created` runs, Juju may already have a leader. This means that, in peer-relation-created handlers, it might already be the case that `self.unit.is_leader()` returns `True` even though the unit did not receive a leadership event yet. If the starting unit is *not* leader, it will receive a {ref}`hook-leader-settings-changed` hook instead.
 
@@ -347,7 +320,7 @@ TBA
 
 *Who gets it*?
 
-The leader unit, once Juju elects one.
+The leader unit, each time Juju elects one.
 
 
 (hook-leader-settings-changed)=
@@ -384,7 +357,7 @@ TBA
 
 *Who gets it*?
 
-All follower units, when a new leader is chosen.
+All follower units, each time a new leader is chosen.
 
 (relation-hooks)=
 ### Relation hooks
@@ -476,7 +449,7 @@ This hook is fired only once per unit per relation and is the exact inverse of `
 The hook indicates that the relation under consideration is no longer valid, and that the charm’s software must be configured as though the relation had never existed. It will only be called after every hook bound to `<endpoint>-relation-departed` has been run. If a hook bound to this event is being executed, it is guaranteed that no remote units are currently known locally.
 
 
-> It is important to note that the `relation-broken` hook might run even if no other units have ever joined the relation. This is not a bug: even if no remote units have ever joined, the fact of the unit’s participation can be detected in other hooks via the `relation-ids` tool, and the `-broken` hook needs to execute to allow the charm to clean up any optimistically-generated configuration.
+> It is important to note that the `relation-broken` hook might run even if no other units have ever joined the relation. This is not a bug: even if no remote units have ever joined, the fact of the unit’s participation can be detected in other hooks via the `relation-ids` hook command, and the `-broken` hook needs to execute to allow the charm to clean up any optimistically-generated configuration.
 
 > Also, it’s important to internalise the fact that there may be multiple relations in play with the same name, and that they’re independent: one `relation-broken` hook does not mean that *every* such relation is broken.
 
@@ -1428,7 +1401,7 @@ See the documentation for the relevant hook or action.
 * `JUJU_CHARM_DIR` holds the path to the charm directory.
 * `JUJU_HOOK_NAME` holds the name of the currently executing hook.
 * `JUJU_UNIT_NAME` holds the name of the local unit.
-* `JUJU_CONTEXT_ID`, `JUJU_AGENT_SOCKET_NETWORK` and `JUJU_AGENT_SOCKET_ADDRESS` are set (but should not be messed with: the command line tools won't work without them).
+* `JUJU_CONTEXT_ID`, `JUJU_AGENT_SOCKET_NETWORK` and `JUJU_AGENT_SOCKET_ADDRESS` are used by the hook commands to connect to the local agent.
 * `JUJU_API_ADDRESSES` holds a space separated list of Juju API addresses.
 * `JUJU_MODEL_UUID` holds the UUID of the current model.
 * `JUJU_MODEL_NAME` holds the human friendly name of the current model.
@@ -1436,7 +1409,7 @@ See the documentation for the relevant hook or action.
 * `JUJU_MACHINE_ID` holds the ID of the machine on which the local unit is running.
 * `JUJU_AVAILABILITY_ZONE` holds the cloud's availability zone where the machine has been provisioned.
 * `CLOUD_API_VERSION` holds the API version of the cloud endpoint.
-* `JUJU_VERSION` holds the version of the model hosting the local unit.
+* `JUJU_VERSION` holds the version of the agent for the local unit.
 * `JUJU_CHARM_HTTP_PROXY` holds the value of the `juju-http-proxy` model config attribute.
 * `JUJU_CHARM_HTTPS_PROXY` holds the value of the `juju-https-proxy` model config attribute.
 * `JUJU_CHARM_FTP_PROXY` holds the value of the `juju-ftp-proxy` model config attribute.

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -1194,7 +1194,7 @@ Therefore, ways to cause `install` to occur are:
 
 
 > Note:
-> - Typically, operations performed on `install` should also be considered for {ref}`hook-upgrade-charm`.
+> - Typically, operations performed on {ref}`hook-install` should also be considered for {ref}`hook-upgrade-charm`.
 > - In some cases, the {ref}`config-changed <hook-config-changed>` hook  can be used instead of `install` and `upgrade-charm` because it is guaranteed to fire after both.
 
 


### PR DESCRIPTION
Our hook doc has had multiple improvements. 

However, the structure is still very fragmented -- to get the story on a hook you need to read multiple sections. And there are still many formatting issues and poor linking. 

This PR addresses that by:

- moving the list of envvars out of Hook execution  and grouping them into generic and specific. This means the hook execution section can remain focused on the conceptual level and also that we have a clearer target to link to from every hook (i.e., for the generic list). PS I anticipate we'll want to iterate on this one more time as the generic list is in fact valid for both actions and hooks yet lives in the reference on hooks only. That will also require reworking the definition of an action to clarify the ways in which it is or it is not similar to a hook. That would be finishing the work we started a few months ago when we moved actions out of the list of hooks.
- moving the hook kind sections as levels inside List of hooks, with the hooks that do not form a natural kind grouped under "Other hooks" (though I believe we can potentially extract one more natural kind from there). This means the hook kind section can remain conceptual and lightweight. Also, we avoid duplication, which should improve both UX and DevEx (about UX: see, e.g., issue https://github.com/juju/juju/issues/19958 where the user saw our first mention of secrets high up but never the detailed bits that followed).
- adding in-line code formatting wherever relevant and/or cross-references to the hook-specific section. PS Sadly, in MyST Markdown hyperlinked text does cannot be code-formatted. For that we'll have to fix the upstream behavior of `{ref}`. So we can either hyperlink the name of a hook or in-line-code-format it, but not both.
- using specialized formatting for "Added in <version>" notes.

## Changes affecting content

In addition to the hook kinds the doc already recognized, I've also created a Leadership hooks section (not sure if this counts as a kind but we surely had a coherent group around that, so I thought it fit, but do let me know if I'm wrong!). And the non-kind section "Other hooks".

## Out-of-scope for this PR

This doc has countless other issues. This PR only aimed to fix structure and formatting, so any other issues (unless they're quick fixes) should be left for future work.