### PR TITLE
feat: model logger for provider tracker

### DIFF
--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -528,13 +528,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:            httpserver.NewWorkerShim,
 		}),
 
-		logSinkName: ifDatabaseUpgradeComplete(logsink.Manifold(logsink.ManifoldConfig{
+		logSinkName: logsink.Manifold(logsink.ManifoldConfig{
 			AgentTag:       agentTag,
 			Clock:          config.Clock,
 			NewWorker:      logsink.NewWorker,
 			NewModelLogger: logsink.NewModelLogger,
 			LogSink:        config.LogSink,
-		})),
+		}),
 
 		apiServerName: apiserver.Manifold(apiserver.ManifoldConfig{
 			AgentName:              agentName,
@@ -799,6 +799,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// a model for upgrade scenarios.
 		providerTrackerName: providertracker.MultiTrackerManifold(providertracker.ManifoldConfig{
 			ProviderServiceFactoriesName: providerDomainServicesName,
+			LogSinkName:                  logSinkName,
 			NewWorker:                    providertracker.NewWorker,
 			NewTrackerWorker:             providertracker.NewTrackerWorker,
 			NewEphemeralProvider:         providertracker.NewEphemeralProvider,

--- a/cmd/jujud-controller/agent/machine/manifolds_test.go
+++ b/cmd/jujud-controller/agent/machine/manifolds_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
-	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
+	"github.com/juju/worker/v4/workertest"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agenttest"
@@ -366,7 +366,6 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *tc.C) {
 		"audit-config-updater",
 		"bootstrap",
 		"control-socket",
-		"log-sink",
 		"object-store",
 		"object-store-s3-caller",
 	)
@@ -499,7 +498,7 @@ func (*ManifoldsSuite) TestUpgradeGates(c *tc.C) {
 func assertGate(c *tc.C, manifold dependency.Manifold, unlocker gate.Unlocker) {
 	w, err := manifold.Start(c.Context(), nil)
 	c.Assert(err, tc.ErrorIsNil)
-	defer worker.Stop(w)
+	defer workertest.DirtyKill(c, w)
 
 	var waiter gate.Waiter
 	err = manifold.Output(w, &waiter)
@@ -1012,6 +1011,7 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"db-accessor",
 		"file-notify-watcher",
 		"is-controller-flag",
+		"log-sink",
 		"provider-services",
 		"query-logger",
 		"state-config-watcher",
@@ -1115,13 +1115,7 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"upgrade-steps-gate",
 	},
 
-	"log-sink": {
-		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
-	},
+	"log-sink": {},
 
 	"machine-action-runner": {
 		"agent",
@@ -1486,6 +1480,7 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"db-accessor",
 		"file-notify-watcher",
 		"is-controller-flag",
+		"log-sink",
 		"provider-services",
 		"provider-tracker",
 		"query-logger",
@@ -2048,6 +2043,7 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"db-accessor",
 		"file-notify-watcher",
 		"is-controller-flag",
+		"log-sink",
 		"provider-services",
 		"query-logger",
 		"state-config-watcher",
@@ -2125,13 +2121,7 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"trace",
 	},
 
-	"log-sink": {
-		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
-	},
+	"log-sink": {},
 
 	"logging-config-updater": {
 		"agent",
@@ -2421,6 +2411,7 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"db-accessor",
 		"file-notify-watcher",
 		"is-controller-flag",
+		"log-sink",
 		"provider-services",
 		"provider-tracker",
 		"query-logger",

--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -16,11 +16,13 @@ import (
 	"github.com/juju/juju/agent/engine"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/http"
 	"github.com/juju/juju/core/lease"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
+	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/pki"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/worker/agent"
@@ -192,6 +194,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Output: engine.ValueWorkerOutput,
 		},
 
+		logSinkName: dependency.Manifold{
+			Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
+				return engine.NewValueWorker(&singularLogSink{context: config.LoggingContext})
+			},
+			Output: engine.ValueWorkerOutput,
+		},
+
 		// The logging config updater listens for logging config updates
 		// for the model and configures the logging context appropriately.
 		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
@@ -327,6 +336,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		providerTrackerName: ifCredentialValid(ifResponsible(providertracker.SingularTrackerManifold(modelTag, providertracker.ManifoldConfig{
 			ProviderServiceFactoriesName: providerServiceFactoriesName,
+			LogSinkName:                  logSinkName,
 			NewWorker:                    providertracker.NewWorker,
 			NewTrackerWorker:             providertracker.NewTrackerWorker,
 			NewEphemeralProvider:         providertracker.NewEphemeralProvider,
@@ -496,6 +506,18 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	return result
 }
 
+type singularLogSink struct {
+	context corelogger.LoggerContext
+}
+
+func (s *singularLogSink) GetLogWriter(_ context.Context, _ model.UUID) (corelogger.LogWriter, error) {
+	return nil, internalerrors.Errorf("singularLogSink does not support GetLogWriter").Add(errors.NotSupported)
+}
+
+func (s *singularLogSink) GetLoggerContext(_ context.Context, _ model.UUID) (corelogger.LoggerContext, error) {
+	return s.context, nil
+}
+
 // clockManifold expresses a Clock as a ValueWorker manifold.
 func clockManifold(clock clock.Clock) dependency.Manifold {
 	return dependency.Manifold{
@@ -589,6 +611,7 @@ const (
 	removalName                  = "removal"
 	storageProvisionerName       = "storage-provisioner"
 	undertakerName               = "undertaker"
+	logSinkName                  = "log-sink"
 
 	caasFirewallerName             = "caas-firewaller"
 	caasModelOperatorName          = "caas-model-operator"

--- a/cmd/jujud-controller/agent/model/manifolds_test.go
+++ b/cmd/jujud-controller/agent/model/manifolds_test.go
@@ -52,6 +52,7 @@ func (s *ManifoldsSuite) TestIAASNames(c *tc.C) {
 		"is-responsible-flag",
 		"lease-manager",
 		"logging-config-updater",
+		"log-sink",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"migration-master",
@@ -96,6 +97,7 @@ func (s *ManifoldsSuite) TestCAASNames(c *tc.C) {
 		"is-responsible-flag",
 		"lease-manager",
 		"logging-config-updater",
+		"log-sink",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"migration-master",
@@ -125,6 +127,7 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *tc.C) {
 		// controller agents, "responsible" or not.
 		"domain-services",
 		"lease-manager",
+		"log-sink",
 		"http-client",
 		"valid-credential-flag",
 	)
@@ -156,7 +159,7 @@ func (s *ManifoldsSuite) TestClockWrapper(c *tc.C) {
 	c.Assert(ok, tc.IsTrue)
 	worker, err := manifold.Start(c.Context(), nil)
 	c.Assert(err, tc.ErrorIsNil)
-	defer workertest.CheckKill(c, worker)
+	defer workertest.DirtyKill(c, worker)
 
 	var aClock clock.Clock
 	err = manifold.Output(worker, &aClock)
@@ -223,6 +226,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"api-caller",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"provider-service-factories",
 		"valid-credential-flag",
 	},
@@ -232,6 +236,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"api-caller",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"provider-service-factories",
 		"provider-tracker",
 		"valid-credential-flag",
@@ -243,6 +248,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"not-dead-flag",
@@ -254,10 +260,11 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	"caas-model-operator": {
 		"agent",
 		"api-caller",
-		"provider-service-factories",
-		"provider-tracker",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
+		"provider-service-factories",
+		"provider-tracker",
 		"valid-credential-flag",
 	},
 
@@ -268,6 +275,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"not-dead-flag",
@@ -308,6 +316,8 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 		"not-dead-flag",
 	},
+
+	"log-sink": {},
 
 	"migration-fortress": {
 		"agent",
@@ -438,6 +448,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"api-caller",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"not-dead-flag",
@@ -452,6 +463,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"api-caller",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"provider-service-factories",
 		"valid-credential-flag",
 	},
@@ -462,6 +474,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"not-dead-flag",
@@ -476,6 +489,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"not-dead-flag",
@@ -498,6 +512,8 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 		"not-dead-flag",
 	},
+
+	"log-sink": {},
 
 	"migration-fortress": {
 		"agent",
@@ -576,6 +592,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
+		"log-sink",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"not-dead-flag",

--- a/internal/worker/providertracker/providerworker_test.go
+++ b/internal/worker/providertracker/providerworker_test.go
@@ -422,8 +422,9 @@ func (s *providerWorkerSuite) newWorker(c *tc.C, trackerType TrackerType) worker
 			atomic.AddInt64(&s.ephemeralCalled, 1)
 			return s.environ, nil
 		},
-		Logger: s.logger,
-		Clock:  clock.WallClock,
+		Logger:        s.logger,
+		LogSinkGetter: &stubLogSinkGetter{},
+		Clock:         clock.WallClock,
 	}, s.states)
 	c.Assert(err, tc.ErrorIsNil)
 


### PR DESCRIPTION
Logs for model level activities should be in the model logs. This allows the democratisation of the logs for owners of the model. Currently, all activity with in a controller are sent to the controller logs and it is only the model worker manager that can log to the model logs themselves. This is a good initial step, but there are workers that work on behalf of the model, that are not inside of the model worker manager. This introduces the concept of allow that to happen. The intention is to not have juju act as a black box for juju users that share a controller. Model owners are more likely to look at the model logs than a controller owner looking at the controller logs if they're managing multiple controllers (from first hand experience).

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy juju-qa-test
$ juju debug-log --replay
```

