### PR TITLE
feat: get ca cert

### DIFF
--- a/domain/controller/service/package_mock_test.go
+++ b/domain/controller/service/package_mock_test.go
@@ -41,6 +41,45 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// GetCACert mocks base method.
+func (m *MockState) GetCACert(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCACert", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCACert indicates an expected call of GetCACert.
+func (mr *MockStateMockRecorder) GetCACert(arg0 any) *MockStateGetCACertCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCACert", reflect.TypeOf((*MockState)(nil).GetCACert), arg0)
+	return &MockStateGetCACertCall{Call: call}
+}
+
+// MockStateGetCACertCall wrap *gomock.Call
+type MockStateGetCACertCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetCACertCall) Return(arg0 string, arg1 error) *MockStateGetCACertCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetCACertCall) Do(f func(context.Context) (string, error)) *MockStateGetCACertCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetCACertCall) DoAndReturn(f func(context.Context) (string, error)) *MockStateGetCACertCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetControllerAgentInfo mocks base method.
 func (m *MockState) GetControllerAgentInfo(arg0 context.Context) (controller.ControllerAgentInfo, error) {
 	m.ctrl.T.Helper()

--- a/domain/controller/service/service.go
+++ b/domain/controller/service/service.go
@@ -23,6 +23,9 @@ type State interface {
 	// GetModelNamespaces returns the model namespaces of all models in the
 	// state.
 	GetModelNamespaces(ctx context.Context) ([]string, error)
+
+	// GetCACert returns the controller CA certificate.
+	GetCACert(ctx context.Context) (string, error)
 }
 
 // Service defines a service for interacting with the underlying state.
@@ -61,4 +64,12 @@ func (s *Service) GetModelNamespaces(ctx context.Context) ([]string, error) {
 	defer span.End()
 
 	return s.st.GetModelNamespaces(ctx)
+}
+
+// GetCACert returns the controller CA certificate.
+func (s *Service) GetCACert(ctx context.Context) (string, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return s.st.GetCACert(ctx)
 }

--- a/domain/controller/service/service_test.go
+++ b/domain/controller/service/service_test.go
@@ -74,3 +74,13 @@ func (s *serviceSuite) TestGetModelNamespaces(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(allNamespaces, tc.DeepEquals, namespaces)
 }
+
+func (s *serviceSuite) TestGetCACert(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetCACert(gomock.Any()).Return("the-cert", nil)
+
+	cert, err := NewService(s.state).GetCACert(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cert, tc.Equals, "the-cert")
+}

--- a/domain/controller/state/state_test.go
+++ b/domain/controller/state/state_test.go
@@ -29,7 +29,7 @@ func TestStateSuite(t *testing.T) {
 func (s *stateSuite) SetUpTest(c *tc.C) {
 	s.controllerModelUUID = coremodel.UUID(jujutesting.ModelTag.Id())
 	s.ControllerSuite.SetUpTest(c)
-	_ = s.ControllerSuite.SeedControllerTable(c, s.controllerModelUUID)
+	_ = s.SeedControllerTable(c, s.controllerModelUUID)
 }
 
 func (s *stateSuite) TestControllerModelUUID(c *tc.C) {
@@ -78,12 +78,21 @@ func (s *stateSuite) TestGetModelNamespacesNotFound(c *tc.C) {
 func (s *stateSuite) TestGetModelNamespaces(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "INSERT INTO namespace_list (namespace) VALUES ('namespace1'), ('namespace2')")
 		return err
 	})
+	c.Assert(err, tc.ErrorIsNil)
 
 	allNamespaces, err := st.GetModelNamespaces(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(allNamespaces, tc.DeepEquals, []string{"namespace1", "namespace2"})
+}
+
+func (s *stateSuite) TestGetCACert(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	cert, err := st.GetCACert(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cert, tc.Equals, "test-ca-cert")
 }

--- a/domain/controller/state/types.go
+++ b/domain/controller/state/types.go
@@ -16,6 +16,10 @@ type controllerControllerAgentInfo struct {
 	SystemIdentity string `db:"system_identity"`
 }
 
+type caCertValue struct {
+	CACert string `db:"ca_cert"`
+}
+
 type namespace struct {
 	Namespace string `db:"namespace"`
 }

--- a/domain/controllerconfig/state/state.go
+++ b/domain/controllerconfig/state/state.go
@@ -104,6 +104,8 @@ VALUES ($KeyValue.*)
 		switch k {
 		case controller.ControllerUUIDKey:
 			continue
+		case controller.CACertKey:
+			controllerValues.CACert = v
 		case controller.APIPort:
 			controllerValues.APIPort = sql.Null[string]{V: v, Valid: true}
 		default:
@@ -128,7 +130,10 @@ VALUES ($KeyValue.*)
 	}
 
 	updateControllerStmt, err := st.Prepare(`
-UPDATE controller SET api_port = $controllerValues.api_port`, controllerValues)
+UPDATE controller
+SET api_port = $controllerValues.api_port,
+    ca_cert = $controllerValues.ca_cert
+`, controllerValues)
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/controllerconfig/state/types.go
+++ b/domain/controllerconfig/state/types.go
@@ -19,4 +19,5 @@ type StringSlice []string
 
 type controllerValues struct {
 	APIPort sql.Null[string] `db:"api_port"`
+	CACert  string           `db:"ca_cert"`
 }

--- a/domain/schema/controller/sql/0004-controller.sql
+++ b/domain/schema/controller/sql/0004-controller.sql
@@ -4,6 +4,7 @@ CREATE TABLE controller (
     target_version TEXT NOT NULL,
     api_port TEXT,
     cert TEXT,
+    ca_cert TEXT,
     private_key TEXT,
     ca_private_key TEXT,
     system_identity TEXT

--- a/domain/schema/controller/sql/0008-controller-config.sql
+++ b/domain/schema/controller/sql/0008-controller-config.sql
@@ -15,6 +15,11 @@ SELECT
 FROM controller
 UNION ALL
 SELECT
+    'ca-cert' AS "key",
+    controller.ca_cert AS value
+FROM controller
+UNION ALL
+SELECT
     'api-port' AS "key",
     controller.api_port AS value
 FROM controller

--- a/domain/schema/testing/controllersuite.go
+++ b/domain/schema/testing/controllersuite.go
@@ -62,8 +62,8 @@ func (s *ControllerSuite) SeedControllerTable(c *tc.C, controllerModelUUID corem
 		_, err := tx.ExecContext(
 			ctx,
 			`
-INSERT INTO controller (uuid, model_uuid, target_version, api_port, cert, private_key, ca_private_key, system_identity) 
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO controller (uuid, model_uuid, target_version, api_port, cert, private_key, ca_cert, ca_private_key, system_identity) 
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `,
 			controllerUUID,
 			controllerModelUUID,
@@ -71,6 +71,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			controller.DefaultAPIPort,
 			"test-cert",
 			"test-private-key",
+			"test-ca-cert",
 			"test-ca-private-key",
 			"test-system-identity",
 		)


### PR DESCRIPTION
Move controller config CA cert out of the controller config and move it into a better location. That means we can access the CA cert from the controller domain. This has been a long standing issue where controller config becomes a dumping ground for key value pairs. Here, we're going to correctly locate the piece of information, but we're going to honor the old API interface.

This should be done for all key, value pairs in controller config, but we can do that over time.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> SELECT ca_cert FROM controller
ca_cert
-----BEGIN CERTIFICATE-----
MIIEEjCCAnqgAwIBAgIUfTlMFgZPmVL1MJwDENKE61mP5UAwDQYJKoZIhvcNAQEL
BQAwITENMAsGA1UEChMESnVqdTEQMA4GA1UEAxMHanVqdS1jYTAeFw0yNTA5MDUx
MTI1NDVaFw0zNTA5MDUxMTMwNDVaMCExDTALBgNVBAoTBEp1anUxEDAOBgNVBAMT
B2p1anUtY2EwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQDYupgUy9Bp
qapc7HaJ/uXA03RJSPSq/6t7dzOHOJa+l2Po+WI9GZKrdMB2Wxr41X19vYnxW0Af
8Q47qxXpMngWYxr8GWuaK2typagJTUXGhQkrUUPB62XPA2MXWAYQHoV//OGh5AFu
XcPHx9CK5YiqtEPa+efNrE5GU8DY/T8W49WB2OKT72HdwukJwaZhnQbgnooQdgk6
QCtqffNipCd3qm5eRm9YY2buA/Bh7rhF02rHeRl267vmbAKxGLaj6ok5gB/BlOlp
EEEeggSs5AffViqOOclpt9LFkt/i6d0daVuM1WdmFAkD4JQ12Pmj9DpWLzotrdkk
A42PPyUB3aSCONlYX5b+YkRJ3EbhchtjOwAJGsK7oTKIxuBGAoDmfixU7GoHeLwQ
dk3mPEtJQx6F6wMRxBI0P+g2NjnsV/W4w2SqBThDbk74Vyq6XBOzjNijB3xFjQFy
aysRQCNvqh8isSgXhIjfhINO8onImUGpABVOa8y4Hr17crgE0UyElbMCAwEAAaNC
MEAwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOJ+
S24w4VU8WVNSG8Y+KHOP3Uu1MA0GCSqGSIb3DQEBCwUAA4IBgQBGa6PPo7U8vBIs
6PmqYqMKuBLRR0+XU/miZbDemJbrM0u7Wuzyyo7GrVQvzeREfBAeQ/likfNelUMc
+l6nVU13QV0b0wMotU3YXeuafW56Ep2vTSMSBMxZJPdIrb3PAfg9n5pTIbEQSXHr
0C9j+o7j9V4Ztumr5vLV9z91Xpa1cty5n3ziGbaHGGqxzr+gZSjBg0CziToTId68
PQ5qNsuTYVBa+CoHfIcy/yRrwnRRO03nZyfMmO31DaBw3v+s6W49eqncTfkF3D1y
p+Jhr09rb2UYsyfM0HZcUK8SpdFnbojqc62rYoVn73c8gxv+Qzr7xZjGFCJ3+cOG
xN7ueBO4pxjwVJB5R50gBc08FlxAbs55gmvwGa90bsaEEWOYAZLKemBR6ZY/BgGX
XB8f7l7U83BwmE8XpBLOe0KfTCgrRoX+JVmEDcW76K2rUQord1QEBIFPRQNO8WWl
DOSun5HK5a7h7nxCyVI5XrnTrU4ZZeXtPfcLkvjkNP7DAC4eFVk=
-----END CERTIFICATE-----


repl (controller)> SELECT * FROM controller_config
key                                     value
object-store-type                       file
agent-logfile-max-size                  100M
agent-logfile-max-backups               2
system-ssh-keys                         ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII3wBqMnr+9k6OJgELpHc3zf5nqO5S2deq9rD705gBbg juju-system-key

audit-log-max-backups                   10
max-txn-log-size                        10M
query-tracing-enabled                   false
open-telemetry-sample-ratio             0.10
auditing-enabled                        true
max-agent-state-size                    524288
audit-log-capture-args                  false
prune-txn-sleep-time                    10ms
jujud-controller-snap-source            legacy
ssh-max-concurrent-connections          100
audit-log-max-size                      300M
model-logfile-max-size                  10M
prune-txn-query-count                   1000
max-prune-txn-passes                    100
set-numa-control-policy                 false
audit-log-exclude-methods               ReadOnlyMethods
query-tracing-threshold                 1s
max-charm-state-size                    2097152
open-telemetry-insecure                 false
open-telemetry-enabled                  false
ssh-server-port                         17022
max-debug-log-duration                  24h0m0s
open-telemetry-stack-traces             false
max-prune-txn-batch-size                1000000
migration-agent-wait-time               15m0s
model-logfile-max-backups               2
open-telemetry-tail-sampling-threshold  1ms
controller-name                         test
```

The controller-config should also be correct.

```sh
➜ juju controller-config
Attribute                  Value
agent-logfile-max-backups  2
agent-logfile-max-size     100M
api-port                   17070
audit-log-capture-args     false
audit-log-exclude-methods  ReadOnlyMethods
audit-log-max-backups      10
audit-log-max-size         300M
auditing-enabled           true
ca-cert                    |
  -----BEGIN CERTIFICATE-----
  MIIEEjCCAnqgAwIBAgIUfTlMFgZPmVL1MJwDENKE61mP5UAwDQYJKoZIhvcNAQEL
  BQAwITENMAsGA1UEChMESnVqdTEQMA4GA1UEAxMHanVqdS1jYTAeFw0yNTA5MDUx
  MTI1NDVaFw0zNTA5MDUxMTMwNDVaMCExDTALBgNVBAoTBEp1anUxEDAOBgNVBAMT
  B2p1anUtY2EwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQDYupgUy9Bp
  qapc7HaJ/uXA03RJSPSq/6t7dzOHOJa+l2Po+WI9GZKrdMB2Wxr41X19vYnxW0Af
  8Q47qxXpMngWYxr8GWuaK2typagJTUXGhQkrUUPB62XPA2MXWAYQHoV//OGh5AFu
  XcPHx9CK5YiqtEPa+efNrE5GU8DY/T8W49WB2OKT72HdwukJwaZhnQbgnooQdgk6
  QCtqffNipCd3qm5eRm9YY2buA/Bh7rhF02rHeRl267vmbAKxGLaj6ok5gB/BlOlp
  EEEeggSs5AffViqOOclpt9LFkt/i6d0daVuM1WdmFAkD4JQ12Pmj9DpWLzotrdkk
  A42PPyUB3aSCONlYX5b+YkRJ3EbhchtjOwAJGsK7oTKIxuBGAoDmfixU7GoHeLwQ
  dk3mPEtJQx6F6wMRxBI0P+g2NjnsV/W4w2SqBThDbk74Vyq6XBOzjNijB3xFjQFy
  aysRQCNvqh8isSgXhIjfhINO8onImUGpABVOa8y4Hr17crgE0UyElbMCAwEAAaNC
  MEAwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOJ+
  S24w4VU8WVNSG8Y+KHOP3Uu1MA0GCSqGSIb3DQEBCwUAA4IBgQBGa6PPo7U8vBIs
  6PmqYqMKuBLRR0+XU/miZbDemJbrM0u7Wuzyyo7GrVQvzeREfBAeQ/likfNelUMc
  +l6nVU13QV0b0wMotU3YXeuafW56Ep2vTSMSBMxZJPdIrb3PAfg9n5pTIbEQSXHr
  0C9j+o7j9V4Ztumr5vLV9z91Xpa1cty5n3ziGbaHGGqxzr+gZSjBg0CziToTId68
  PQ5qNsuTYVBa+CoHfIcy/yRrwnRRO03nZyfMmO31DaBw3v+s6W49eqncTfkF3D1y
  p+Jhr09rb2UYsyfM0HZcUK8SpdFnbojqc62rYoVn73c8gxv+Qzr7xZjGFCJ3+cOG
  xN7ueBO4pxjwVJB5R50gBc08FlxAbs55gmvwGa90bsaEEWOYAZLKemBR6ZY/BgGX
  XB8f7l7U83BwmE8XpBLOe0KfTCgrRoX+JVmEDcW76K2rUQord1QEBIFPRQNO8WWl
  DOSun5HK5a7h7nxCyVI5XrnTrU4ZZeXtPfcLkvjkNP7DAC4eFVk=
  -----END CERTIFICATE-----
controller-name                         test
controller-uuid                         5b32e69e-901c-4028-8912-2f5a8fda32fb
jujud-controller-snap-source            legacy
max-agent-state-size                    524288
max-charm-state-size                    2.097152e+06
max-debug-log-duration                  24h0m0s
max-prune-txn-batch-size                1e+06
max-prune-txn-passes                    100
max-txn-log-size                        10M
migration-agent-wait-time               15m0s
model-logfile-max-backups               2
model-logfile-max-size                  10M
object-store-type                       file
open-telemetry-enabled                  false
open-telemetry-insecure                 false
open-telemetry-sample-ratio             "0.10"
open-telemetry-stack-traces             false
open-telemetry-tail-sampling-threshold  1ms
prune-txn-query-count                   1000
prune-txn-sleep-time                    10ms
query-tracing-enabled                   false
query-tracing-threshold                 1s
set-numa-control-policy                 false
ssh-max-concurrent-connections          100
ssh-server-port                         17022
system-ssh-keys                         |
  ...
```


## Links


<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** [JUJU-8510](https://warthogs.atlassian.net/browse/JUJU-8510)
