### PR TITLE
chore: bump tc with multi checker improvements 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/juju/ratelimit v1.0.2
 	github.com/juju/retry v1.0.1
 	github.com/juju/schema v1.2.0
-	github.com/juju/tc v0.0.0-20250801052209-d17f0b681e82
+	github.com/juju/tc v0.0.0-20250910005042-c6c39811a0bb
 	github.com/juju/testing v1.2.0
 	github.com/juju/txn/v3 v3.0.2
 	github.com/juju/utils/v3 v3.2.2

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0
 github.com/juju/schema v1.2.0 h1:+XywM0pYzuhGebQiK1aR4Bj7Q7nLV5MihcOgq6dLLxs=
 github.com/juju/schema v1.2.0/go.mod h1:VdljuJLc45loM79LYm4yKKmPJwK1bPKRekvMVlfywU0=
 github.com/juju/tc v0.0.0-20250523041547-7f66c35f9f03/go.mod h1:YdExdo5XpLqX+BT6eCcS8HCqbZO09fP3mwoiJXv35Vg=
-github.com/juju/tc v0.0.0-20250801052209-d17f0b681e82 h1:U/ldm6f1zzGGiCffzgiUIDNu/vGHip4uBhtpsQm/S/g=
-github.com/juju/tc v0.0.0-20250801052209-d17f0b681e82/go.mod h1:YdExdo5XpLqX+BT6eCcS8HCqbZO09fP3mwoiJXv35Vg=
+github.com/juju/tc v0.0.0-20250910005042-c6c39811a0bb h1:MODn+eFe+VTDpBwoF74+UKNW+IBHyeg5dtirxXVnTSA=
+github.com/juju/tc v0.0.0-20250910005042-c6c39811a0bb/go.mod h1:YdExdo5XpLqX+BT6eCcS8HCqbZO09fP3mwoiJXv35Vg=
 github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180517134105-72703b1e95eb/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -1124,7 +1124,7 @@ func (s *Suite) TestLogTransferReportsProgress(c *tc.C) {
 
 	mc := tc.NewMultiChecker()
 	mc.AddExpr(`_[_]._`, tc.Ignore)
-	mc.AddExpr(`_[_].Message`, tc.Equals)
+	mc.AddExpr(`_[_].Message`, tc.Matches, tc.ExpectedValue)
 	c.Assert(logWriter.Log()[:3], mc, []loggo.Entry{
 		{Message: "successful, transferring logs to target controller \\(0 sent\\)"},
 		// This is a bit of a punt, but without accepting a range


### PR DESCRIPTION
Updates tc to include multi checker improvements.

Multi checker now applies all matching paths and always deeply compares.
It is also now possible to alter length checking through a `len(_.aMapOrSlice)` path
provided to `AddExpr`. For example you could `mc.AddExpr("len(_.Logs)", tc.Ignore)`
to only match elements that are obtained.

It is also now possible to change the default match from equality to another matcher,
with the `tc.Ignore` matcher as the most obvious. This can be done by creating a
multi checker with `tc.NewMultiCheckerWithDefault(tc.Ignore)`. This is now a
deep ignore checker by default.