### PR TITLE
docs: add caution banner for 3.5 EOL

### DIFF
--- a/docs/reference/juju/juju-roadmap-and-releases.md
+++ b/docs/reference/juju/juju-roadmap-and-releases.md
@@ -355,7 +355,7 @@ See the full list in these milestone pages:
 
 ```{caution}
 
-Juju 3.5 series is in security maintenance until 30 Apr 2025
+Juju 3.5 series is EOL
 
 ```
 


### PR DESCRIPTION
Small update to include the EOL caution banner on 3.5 roadmap.


## Documentation changes

Add 3.5 EOL caution banner on roadmap and releases page.

## Links
N/A
