### PR TITLE
docs: add client ref, add changes from autogen, fix formatting in ref…

### DIFF
--- a/docs/explanation/juju-architecture.md
+++ b/docs/explanation/juju-architecture.md
@@ -1,11 +1,10 @@
 (juju-architecture)=
 # Juju architecture
 
-
 (bootstrapping)=
 ## Bootstrapping
 
-In Juju, **bootstrapping** refers to the process whereby a Juju client creates a {ref}`controller <controller>` on a specific {ref}`cloud <cloud>`.
+In Juju, **bootstrapping** refers to the process whereby a Juju {ref}`client <client>` creates a {ref}`controller <controller>` on a specific {ref}`cloud <cloud>`.
 
 A controller is needed to perform any further Juju operations, such as deploying an application.
 

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -1,0 +1,14 @@
+(client)=
+# Client
+
+A Juju **client** is any software that implements th Juju client apiserver contract and is able to talk to a Juju {ref}`controller <controller>`.
+
+This currently includes:
+
+- {ref}`the juju CLI <juju-cli>`
+- JIMM, the central management component of [JAAS](https://documentation.ubuntu.com/jaas/)
+- [Jubilant](https://documentation.ubuntu.com/jubilant/)
+- the [Terraform Provider for Juju](https://documentation.ubuntu.com/terraform-provider-juju/latest/)
+- [Python Libjuju](https://pythonlibjuju.readthedocs.io/en/latest/) (legacy; please use [Jubilant](https://documentation.ubuntu.com/jubilant/))
+
+Note: While the various clients generally aim for feature parity, there are still differences between them coming from the nature of the client (e.g., interactive vs. declarative vs. programmatic). Also, the only client that can currently bootstrap a Juju cotroller is the `juju` CLI client.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -35,6 +35,7 @@
 - {ref}`application`
 - {ref}`bundle`
 - {ref}`charm`
+- {ref}`client`
 - {ref}`cloud`
 - {ref}`configuration`
 - {ref}`cloud`

--- a/docs/reference/secret.md
+++ b/docs/reference/secret.md
@@ -12,7 +12,7 @@ In Juju, (starting with Juju 3.0) a **secret** is a sensitive bit of information
 (charm-secret)=
 ### Charm secret
 
-```{versionadded} `3.0.0`
+```{versionadded} 3.0.0
 ```
 
 A **charm secret** is a secret created by a charm. A charm secret is shared with another charm (the secret 'observer') over relation data. The secret is tied to the lifecycle of the relation.


### PR DESCRIPTION
https://github.com/juju/juju/issues/20563 pointed out that a link in our juju.is middle pages was broken because the target in Juju -- a reference page for "client" -- no longer existed. I forget why we deleted it but, upon reevaluation, I've decided to reinstate it, so this PR adds a new reference doc for "Client", which should fix the issue.

# Drive-by improvements

When I was building the docs I noticed changes to a hook command, model config, and CLI command doc. I think this happened because whoever modified the source forgot to also update the autogenerated doc by running `make run`, so this PR fixes that. In the future everyone should be more careful about that.

The PR also fixes a formatting issue I noticed in our entity reference doc on secrets. 