### PR TITLE
refactor: action becomes operation in status descriptions

### DIFF
--- a/core/status/status.go
+++ b/core/status/status.go
@@ -45,12 +45,12 @@ type ModificationStatusGetter interface {
 }
 
 const (
-	// Status values common to machine and unit agents, and actions.
+	// Status values common to machine and unit agents, and tasks.
 
 	// Error means the entity requires human intervention
 	// in order to operate correctly.
 	//
-	// The action did not get run due to an error.
+	// The task did not get run due to an error.
 	Error Status = "error"
 )
 
@@ -67,13 +67,13 @@ const (
 )
 
 const (
-	// Status values specific to machine agents and actions.
+	// Status values specific to machine agents and tasks.
 
 	// Pending is set when:
 	//
 	// The machine is not yet participating in the model.
 	//
-	// The action first is queued.
+	// The task first is queued.
 	Pending Status = "pending"
 )
 
@@ -92,7 +92,7 @@ const (
 )
 
 const (
-	// Status values specific to unit agents and actions.
+	// Status values specific to unit agents and tasks.
 
 	// Failed is set when:
 	//
@@ -100,7 +100,7 @@ const (
 	// activity, but it cannot be detected. It might also be that the unit agent
 	// detected an unrecoverable condition and managed to tell the Juju server about it.
 	//
-	// The action did not complete successfully.
+	// The task did not completed successfully.
 	Failed Status = "failed"
 )
 
@@ -118,8 +118,8 @@ const (
 	Rebooting Status = "rebooting"
 
 	// Executing is set when:
-	// The agent is running a hook or action. The human-readable message should reflect
-	// which hook or action is being run.
+	// The agent is running a hook or task. The human-readable message should reflect
+	// which hook or task is being run.
 	Executing Status = "executing"
 
 	// Idle is set when:
@@ -231,19 +231,22 @@ const (
 )
 
 const (
-	// Status values specific to actions.
+	// Status values specific to tasks. The combined status of an operation's
+	// tasks result in the operation's status.
 
-	// Completed indicates that the action ran to completion as intended.
+	// Completed indicates that the task ran to completion as intended.
 	Completed Status = "completed"
 
-	// Cancelled means that the Action was cancelled before being run.
+	// Cancelled means that the task was cancelled before being run.
 	Cancelled Status = "cancelled"
 
-	// Aborting indicates that the Action is running but should be
+	// Aborting indicates that the task is running but should be
 	// aborted.
 	Aborting Status = "aborting"
 
-	// Aborted indicates the Action was aborted.
+	// Aborted indicates the task was aborted.
+	// TODO: is this really used? What is the difference between aborted
+	// and cancelled?
 	Aborted Status = "aborted"
 )
 
@@ -257,7 +260,7 @@ const (
 )
 
 const (
-	// Status values that are common to instances and actions.
+	// Status values that are common to instances and tasks.
 
 	// Running indicates that the entity is currently running.
 	Running Status = "running"
@@ -322,6 +325,24 @@ func (s Status) KnownMachineStatus() bool {
 		Pending,
 		Stopped,
 		Down:
+		return true
+	}
+	return false
+}
+
+// KnownTaskStatus returns true if status has a known value for
+// a task or operation.
+func (s Status) KnownTaskStatus() bool {
+	switch s {
+	case
+		Aborting,
+		Aborted,
+		Cancelled,
+		Completed,
+		Error,
+		Failed,
+		Pending,
+		Running:
 		return true
 	}
 	return false

--- a/core/status/status_history.go
+++ b/core/status/status_history.go
@@ -95,6 +95,8 @@ const (
 	KindFilesystem HistoryKind = "filesystem"
 	// KindVolume represents an entry for a volume.
 	KindVolume HistoryKind = "volume"
+	// KindTask represents a task in an operation.
+	KindTask HistoryKind = "task"
 )
 
 // String returns a string representation of the HistoryKind.
@@ -109,7 +111,7 @@ func (k HistoryKind) Valid() bool {
 		KindApplication, KindSAAS,
 		KindMachineInstance, KindMachine,
 		KindContainerInstance, KindContainer,
-		KindFilesystem, KindVolume:
+		KindFilesystem, KindVolume, KindTask:
 		return true
 	}
 	return false
@@ -130,5 +132,6 @@ func AllHistoryKind() map[HistoryKind]string {
 		KindContainer:         "statuses from the containers only and not their host machines",
 		KindFilesystem:        "statuses from the specified filesystem",
 		KindVolume:            "statuses from the specified volume",
+		KindTask:              "statuses for the task",
 	}
 }

--- a/core/status/status_test.go
+++ b/core/status/status_test.go
@@ -150,6 +150,57 @@ func (s *StatusSuite) TestKnownInstanceStatus(c *tc.C) {
 	}
 }
 
+// TestKnownTaskStatus asserts that the KnownTaskStatus method checks
+// for the correct statuses for instances.
+func (s *StatusSuite) TestKnownTaskStatus(c *tc.C) {
+	for _, t := range []struct {
+		status status.Status
+		known  bool
+	}{
+		{status.Active, false},
+		{status.Allocating, false},
+		{status.Attached, false},
+		{status.Attaching, false},
+		{status.Available, false},
+		{status.Blocked, false},
+		{status.Broken, false},
+		{status.Busy, false},
+		{status.Destroying, false},
+		{status.Detached, false},
+		{status.Detaching, false},
+		{status.Down, false},
+		{status.Empty, false},
+		{status.Executing, false},
+		{status.Idle, false},
+		{status.Joined, false},
+		{status.Joining, false},
+		{status.Lost, false},
+		{status.Maintenance, false},
+		{status.Provisioning, false},
+		{status.ProvisioningError, false},
+		{status.Rebooting, false},
+		{status.Suspended, false},
+		{status.Suspending, false},
+		{status.Started, false},
+		{status.Stopped, false},
+		{status.Terminated, false},
+		{status.Waiting, false},
+		{status.Unknown, false},
+		{status.Unset, false},
+
+		{status.Aborting, true},
+		{status.Aborted, true},
+		{status.Cancelled, true},
+		{status.Completed, true},
+		{status.Error, true},
+		{status.Failed, true},
+		{status.Pending, true},
+		{status.Running, true},
+	} {
+		c.Check(t.status.KnownTaskStatus(), tc.Equals, t.known, tc.Commentf("checking status %q", t.status))
+	}
+}
+
 // TestKnownMachineStatus asserts that the KnownMachineStatus method checks for the correct statuses for machines.
 func (s *StatusSuite) TestKnownMachineStatus(c *tc.C) {
 	for _, t := range []struct {


### PR DESCRIPTION
Formerlly called action statuses are now the status for the operation domain covering both operations and tasks. Update comments accordingly.

Tasks have individual statuses while Operations have a status which is derived from the combined statuses of all of its tasks. Eventually we'll need a method for the logic of deriving the Operations status.

Add a new KnownTaskStatus method to verify which apply to operations and tasks.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

There is no change to current behavior. Unit tests should continue to pass.
