### PR TITLE
feat: add support for gce service account credentials

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -67,6 +67,12 @@ const (
 	// a JSON file.
 	JSONFileAuthType AuthType = "jsonfile"
 
+	// ServiceAccountAuthType is an authentication type used by sourcing
+	// a bearer token from a cloud metadata service tied to an instance's
+	// attached service account.
+	// You only get these credentials by running within that machine.
+	ServiceAccountAuthType AuthType = "service-account"
+
 	// ClientCertificateAuthType is an authentication type using client
 	// certificates.
 	ClientCertificateAuthType AuthType = "clientcertificate"
@@ -379,11 +385,14 @@ func PublicCloudMetadata(searchPath ...string) (result map[string]Cloud, fallbac
 		// Azure managed identity auth types, add it manually.
 		// This is a short term compatibility fix.
 		for name, cld := range result {
-			if cld.Type != "azure" || cld.AuthTypes.Contains(ManagedIdentityAuthType) {
-				continue
+			if cld.Type == "azure" && !cld.AuthTypes.Contains(ManagedIdentityAuthType) {
+				cld.AuthTypes = append(cld.AuthTypes, ManagedIdentityAuthType)
+				result[name] = cld
 			}
-			cld.AuthTypes = append(cld.AuthTypes, ManagedIdentityAuthType)
-			result[name] = cld
+			if cld.Type == "gce" && !cld.AuthTypes.Contains(ServiceAccountAuthType) {
+				cld.AuthTypes = append(cld.AuthTypes, ServiceAccountAuthType)
+				result[name] = cld
+			}
 		}
 
 	}()

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -300,6 +300,8 @@ func transformModelCloudSpecForInstanceRoles(
 		notSupportedAuthType = authType == cloud.InstanceRoleAuthType
 	case "azure":
 		notSupportedAuthType = authType == cloud.ManagedIdentityAuthType
+	case "gce":
+		notSupportedAuthType = authType == cloud.ServiceAccountAuthType
 	}
 	if notSupportedAuthType {
 		if modelCloudSpec.Type != controllerCloudSpec.Type ||

--- a/docs/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju.md
@@ -41,9 +41,24 @@ Attributes:
 - `file`: path to the `.json` file containing a service account key for your project
 Path (required)
 
+```{ibnote}
+See more:
+- {ref}`gce-appendix-workflow-2`
+```
+
 ### If you want to use environment variables:
 
 `CLOUDSDK_COMPUTE_REGION` <p> - `GOOGLE_APPLICATION_CREDENTIALS=<link to JSON credentials file>`
+
+#### `service-account`
+> *Requirements:*
+> - Juju 3.6+.
+> - A service account with sufficient privileges. See more: {ref}`gce-appendix-service-account`
+> - The `add-credential` steps must be run from a jump host running in Google Cloud in order to allow the cloud metadata endpoint to be reached.
+
+```{ibnote}
+See more: {ref}`gce-appendix-workflow-1`
+```
 
 <!--
 ## Notes on `juju bootstrap`
@@ -128,3 +143,44 @@ See first: {ref}`storage-provider`
 Configuration options:
 
 - `type`. Value is `pd-ssd`. Warning: [bug](https://github.com/juju/juju/issues/20349).
+
+(gce-appendix-example-authentication-workflows)=
+## Appendix: Example authentication workflows
+
+(gce-appendix-workflow-1)=
+### Workflow 1 -- Service account only (recommended)
+> *Requirements:*
+> - Juju 3.6+.
+> - A service account with sufficient privileges. See more: {ref}`gce-appendix-service-account`
+> - The `add-credential` steps must be run from a jump host running in Google Cloud in order to allow the cloud metadata endpoint to be reached.
+
+1. Run `juju add-credential google`; choose `service-account`; supply the service account email.
+2. Bootstrap as usual.
+
+```{tip}
+**Did you know?** With this workflow where you provide the service account during `add-credential` you avoid the need for either your Juju client or your Juju controller to store your credential secrets. Relatedly, the user running `add-credential` / `bootstrap` doesn't need to have any credential secrets supplied to them.
+```
+```{tip}
+To configure workload machines to use a different (less privileged) service account, use the `instance-role` constraint. This can be set on the model to apply to all (non controller) machines in the model.
+```
+
+(gce-appendix-workflow-2)=
+### Workflow 2 -- Bootstrap using normal credential; use service account thereafter
+> *Requirements:*
+> - Juju 3.6+.
+> - A service account with sufficient privileges. See more: {ref}`gce-appendix-service-account`
+
+1. Bootstrap with the arg `--bootstrap-constraints="instance-role=auto"`
+2. The controller machines will be created and attached to the project's default service account. 
+3. Alternatively you can specify a different service account instead of `auto`.
+
+```{tip}
+To configure workload machines to use a different (less privileged) service account, use the `instance-role` constraint. This can be set on the model to apply to all (non controller) machines in the model.
+```
+
+(gce-appendix-service-account)=
+## Appendix: Service account requirements
+
+To enlist a service account to provide the privileges required by Juju, the following scopes must be assigned:
+- `https://www.googleapis.com/auth/compute`
+- `https://www.googleapis.com/auth/devstorage.full_control`

--- a/docs/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju.md
@@ -167,7 +167,7 @@ Newly-created models configured in this way use "Azure Managed Disks". See [Azur
 ## Appendix: Example authentication workflows
 
 (azure-appendix-workflow-1)=
-### Worflow 1 -- Managed identity only (recommended)
+### Workflow 1 -- Managed identity only (recommended)
 > *Requirements:*
 > - Juju 3.6+.
 > - A managed identity. See more: {ref}`azure-appendix-create-a-managed-identity`
@@ -175,7 +175,7 @@ Newly-created models configured in this way use "Azure Managed Disks". See [Azur
 > - The `add-credential` steps must be run from either [the Azure Cloud Shell^](https://shell.azure.com/) or a jump host running in Azure in order to allow the cloud metadata endpoint to be reached.
 
 1. Run `juju add-credential azure`; choose `managed-identity`; supply the requested information (the `managed-identity-path` must be of the form `<resourcegroup>/<identityname>`).
-1. Bootstrap as usual.
+2. Bootstrap as usual.
 
 ```{tip}
 **Did you know?** With this workflow where you provide the managed identity during `add-credential` you avoid the need for either your Juju client or your Juju controller to store your credential secrets. Relatedly, the user running `add-credential` / `bootstrap` doesn't need to have any credential secrets supplied to them.
@@ -192,7 +192,7 @@ Newly-created models configured in this way use "Azure Managed Disks". See [Azur
         - If you have the `azure` CLI and you are logged in and you want to use the currently logged in user: Run `/snap/juju/current/bin/juju add-credential azure`; choose `interactive`, then leave the subscription ID field empty -- Juju will fill this in for you.
          - Otherwise: Run `juju add-credential azure`, choose `interactive`, then provide the subscription ID -- Juju will open up a browser and you’ll be prompted to log in to Azure.
     - `service-principal-secret`: Run `juju add-credential azure`, then choose `service-principal-secret` and supply all the requested information.
-1. During bootstrap, provide the managed identity to the controller by using the `instance-role` constraint.
+2. During bootstrap, provide the managed identity to the controller by using the `instance-role` constraint.
 
 ```{tip}
 
@@ -208,7 +208,7 @@ Newly-created models configured in this way use "Azure Managed Disks". See [Azur
         - If you have the `azure` CLI and you are logged in and you want to use the currently logged in user: Run `/snap/juju/current/bin/juju add-credential azure`; choose `interactive`, then leave the subscription ID field empty -- Juju will fill this in for you.
          - Otherwise: Run `juju add-credential azure`, choose `interactive`, then provide the subscription ID -- Juju will open up a browser and you’ll be prompted to log in to Azure.
     - `service-principal-secret`: Run `juju add-credential azure`, then choose `service-principal-secret` and supply all the requested information.
-1. Bootstrap as usual.
+2. Bootstrap as usual.
 
 
 (azure-appendix-create-a-managed-identity)=

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -578,6 +578,9 @@ func bootstrapIAAS(
 			if args.CloudCredential.AuthType() == cloud.ManagedIdentityAuthType {
 				return errors.NotSupportedf("instance role constraint with managed identity credential")
 			}
+			if args.CloudCredential.AuthType() == cloud.ServiceAccountAuthType {
+				return errors.NotSupportedf("instance role constraint with service account credential")
+			}
 		}
 		instanceRoleEnviron, ok := environ.(environs.InstanceRole)
 		if !ok || !instanceRoleEnviron.SupportsInstanceRoles(callCtx) {

--- a/internal/provider/gce/credentials.go
+++ b/internal/provider/gce/credentials.go
@@ -25,6 +25,9 @@ const (
 
 	// The contents of the file for "jsonfile" auth-type.
 	credAttrFile = "file"
+
+	// The service account for getting an in-cluster token.
+	credServiceAccount = "service-account"
 )
 
 type environProviderCredentials struct{}
@@ -54,6 +57,10 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 				Description: "path to the .json file containing a service account key for your project\nPath",
 				FilePath:    true,
 			},
+		}},
+		cloud.ServiceAccountAuthType: {{
+			Name:           credServiceAccount,
+			CredentialAttr: cloud.CredentialAttr{Description: "service account name"},
 		}},
 	}
 }

--- a/internal/provider/gce/credentials_test.go
+++ b/internal/provider/gce/credentials_test.go
@@ -34,7 +34,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
-	envtesting.AssertProviderAuthTypes(c, s.provider, "oauth2", "jsonfile")
+	envtesting.AssertProviderAuthTypes(c, s.provider, "oauth2", "jsonfile", "service-account")
 }
 
 var sampleCredentialAttributes = map[string]string{
@@ -67,6 +67,12 @@ func (s *credentialsSuite) TestJSONFileCredentialsValid(c *gc.C) {
 		// by the credentials schema. That is left to the provider.
 		// The file does need to be an absolute path though and exist.
 		"file": filename,
+	})
+}
+
+func (s *credentialsSuite) TestServiceAccountCredentialsValid(c *gc.C) {
+	envtesting.AssertProviderCredentialsValid(c, s.provider, "service-account", map[string]string{
+		"service-account": "foo",
 	})
 }
 

--- a/internal/provider/gce/environ.go
+++ b/internal/provider/gce/environ.go
@@ -164,31 +164,36 @@ func newEnviron(cloud environscloudspec.CloudSpec, cfg *config.Config) (*environ
 }
 
 // SetCloudSpec is specified in the environs.Environ interface.
-func (e *environ) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.CloudSpec) error {
-	e.lock.Lock()
-	defer e.lock.Unlock()
+func (env *environ) SetCloudSpec(ctx stdcontext.Context, spec environscloudspec.CloudSpec) error {
+	env.lock.Lock()
+	defer env.lock.Unlock()
 
-	e.cloud = spec
+	env.cloud = spec
 	credAttrs := spec.Credential.Attributes()
-	if spec.Credential.AuthType() == jujucloud.JSONFileAuthType {
+	switch spec.Credential.AuthType() {
+	case jujucloud.JSONFileAuthType:
 		contents := credAttrs[credAttrFile]
 		credential, err := parseJSONAuthFile(strings.NewReader(contents))
 		if err != nil {
 			return errors.Trace(err)
 		}
 		credAttrs = credential.Attributes()
+	case jujucloud.ServiceAccountAuthType:
+		if serviceAccount := credAttrs[credServiceAccount]; serviceAccount == "" {
+			return errors.NotValidf("credential with missing service account")
+		}
 	}
 
 	credential := &google.Credentials{
-		ClientID:    credAttrs[credAttrClientID],
-		ProjectID:   credAttrs[credAttrProjectID],
-		ClientEmail: credAttrs[credAttrClientEmail],
-		PrivateKey:  []byte(credAttrs[credAttrPrivateKey]),
+		ClientID:       credAttrs[credAttrClientID],
+		ProjectID:      credAttrs[credAttrProjectID],
+		ClientEmail:    credAttrs[credAttrClientEmail],
+		PrivateKey:     []byte(credAttrs[credAttrPrivateKey]),
+		ServiceAccount: credAttrs[credServiceAccount],
 	}
 
 	connectionConfig := google.ConnectionConfig{
-		Region:    spec.Region,
-		ProjectID: credential.ProjectID,
+		Region: spec.Region,
 
 		// TODO (Stickupkid): Pass the http.Client through on the construction
 		// of the environ.
@@ -198,12 +203,9 @@ func (e *environ) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.Clou
 		),
 	}
 
-	// TODO (stickupkid): Pass the context through the method call.
-	ctx := stdcontext.Background()
-
 	// Connect and authenticate.
 	var err error
-	e.gce, err = newConnection(ctx, connectionConfig, credential)
+	env.gce, err = newConnection(ctx, connectionConfig, credential)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/provider/gce/environ_broker.go
+++ b/internal/provider/gce/environ_broker.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/core/constraints"
@@ -55,7 +56,7 @@ func (env *environ) StartInstance(ctx context.ProviderCallContext, args environs
 
 	// Build the result.
 	hwc := env.getHardwareCharacteristics(spec, envInst)
-	logger.Infof("started instance %q in zone %q", inst.Name, *hwc.AvailabilityZone)
+	logger.Infof("started instance %q in zone %q", inst.GetName(), *hwc.AvailabilityZone)
 	result := environs.StartInstanceResult{
 		Instance: envInst,
 		Hardware: hwc,
@@ -166,6 +167,48 @@ func formatMachineType(zone, name string) string {
 	return fmt.Sprintf("zones/%s/machineTypes/%s", zone, name)
 }
 
+func (env *environ) serviceAccount(ctx context.ProviderCallContext, args environs.StartInstanceParams) (string, error) {
+	var serviceAccount string
+
+	// For controllers, the service account can come from the credential.
+	if args.InstanceConfig.IsController() {
+		if env.cloud.Credential.AuthType() == cloud.ServiceAccountAuthType {
+			serviceAccount = env.cloud.Credential.Attributes()[credServiceAccount]
+			if serviceAccount != "" {
+				logger.Debugf("using credential service account: %s", serviceAccount)
+			}
+		} else if args.InstanceConfig.Bootstrap != nil && args.InstanceConfig.Bootstrap.BootstrapMachineConstraints.HasInstanceRole() {
+			serviceAccount = *args.InstanceConfig.Bootstrap.BootstrapMachineConstraints.InstanceRole
+			if serviceAccount != "" {
+				logger.Debugf("using bootstrap service account: %s", serviceAccount)
+			}
+		}
+	}
+	if serviceAccount != "" {
+		return serviceAccount, nil
+	}
+
+	// Next use the constraint value if supplied.
+	if args.Constraints.HasInstanceRole() {
+		serviceAccount = *args.Constraints.InstanceRole
+		if serviceAccount != "" {
+			logger.Debugf("using constraints service account: %s", serviceAccount)
+		}
+	}
+	if serviceAccount != "" {
+		return serviceAccount, nil
+	}
+
+	// Fallback to the project default.
+	var err error
+	serviceAccount, err = env.gce.DefaultServiceAccount(ctx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	logger.Debugf("using project service account: %s", serviceAccount)
+	return serviceAccount, nil
+}
+
 // startInstance is where the new physical instance is actually
 // provisioned, relative to the provided args and spec. Info for that
 // low-level instance is returned.
@@ -219,11 +262,10 @@ func (env *environ) startInstance(
 		}}
 	}
 
-	serviceAccount, err := env.gce.DefaultServiceAccount(ctx)
+	serviceAccount, err := env.serviceAccount(ctx, args)
 	if err != nil {
 		return nil, google.HandleCredentialError(errors.Trace(err), ctx)
 	}
-	logger.Debugf("using project service account: %s", serviceAccount)
 
 	hasAccelerator, err := env.hasAccelerator(ctx, args.AvailabilityZone, instanceTypeName)
 	if err != nil {
@@ -243,7 +285,8 @@ func (env *environ) startInstance(
 	}
 	if serviceAccount != "" {
 		instArg.ServiceAccounts = []*computepb.ServiceAccount{{
-			Email: &serviceAccount,
+			Email:  &serviceAccount,
+			Scopes: google.Scopes,
 		}}
 	}
 
@@ -386,13 +429,13 @@ func (env *environ) AllInstances(ctx context.ProviderCallContext) ([]instances.I
 		google.StatusUp,
 	}
 	filters := append(instStatuses, nonLiveStatuses...)
-	instances, err := getInstances(env, ctx, filters...)
+	instances, err := env.instances(ctx, filters...)
 	return instances, errors.Trace(err)
 }
 
 // AllRunningInstances implements environs.InstanceBroker.
 func (env *environ) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-	instances, err := getInstances(env, ctx)
+	instances, err := env.instances(ctx)
 	return instances, errors.Trace(err)
 }
 

--- a/internal/provider/gce/environ_broker_test.go
+++ b/internal/provider/gce/environ_broker_test.go
@@ -13,9 +13,11 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/core/arch"
 	corebase "github.com/juju/juju/core/base"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/environs"
@@ -126,6 +128,10 @@ func (s *environBrokerSuite) startInstanceArg(c *gc.C, prefix string, hasGpuSupp
 		Tags: &computepb.Tags{Items: []string{"juju-" + s.ModelUUID, instName}},
 		ServiceAccounts: []*computepb.ServiceAccount{{
 			Email: ptr("fred@google.com"),
+			Scopes: []string{
+				"https://www.googleapis.com/auth/compute",
+				"https://www.googleapis.com/auth/devstorage.full_control",
+			},
 		}},
 		Scheduling: scheduling,
 	}
@@ -258,6 +264,91 @@ func (s *environBrokerSuite) TestStartInstanceVolumeAvailabilityZone(c *gc.C) {
 	result, err := env.StartInstance(s.CallCtx, s.StartInstArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*result.Hardware.AvailabilityZone, gc.Equals, derivedZones[0])
+}
+
+func (s *environBrokerSuite) TestStartInstanceServiceAccount(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	err := gce.FinishInstanceConfig(env, s.StartInstArgs, s.spec)
+	c.Assert(err, jc.ErrorIsNil)
+	s.SetCredential(env, jujucloud.NewCredential(
+		jujucloud.ServiceAccountAuthType, map[string]string{
+			"service-account": "foo@googledev.com",
+		}))
+
+	s.expectImageMetadata()
+	s.MockService.EXPECT().NetworkSubnetworks(gomock.Any(), "us-east1", "/path/to/vpc").
+		Return([]*computepb.Subnetwork{{
+			SelfLink: ptr("/path/to/subnet1"),
+		}, {
+			SelfLink: ptr("/path/to/subnet2"),
+		}}, nil)
+
+	s.MockService.EXPECT().
+		MachineType(gomock.Any(), "home-zone", s.spec.InstanceType.Name).
+		Return(&computepb.MachineType{
+			Name:         ptr(s.spec.InstanceType.Name),
+			Accelerators: nil,
+		}, nil)
+
+	instArg := s.startInstanceArg(c, s.Prefix(env), false)
+	instArg.ServiceAccounts[0].Email = ptr("foo@googledev.com")
+	// Can't copy instArg as it contains a mutex.
+	instResult := s.startInstanceArg(c, s.Prefix(env), false)
+	instResult.Zone = ptr("path/to/home-zone")
+	instResult.Disks = []*computepb.AttachedDisk{{
+		DiskSizeGb: ptr(int64(s.spec.InstanceType.RootDisk / 1024)),
+	}}
+
+	s.MockService.EXPECT().AddInstance(gomock.Any(), instArg).Return(instResult, nil)
+
+	s.StartInstArgs.AvailabilityZone = "home-zone"
+	result, err := env.StartInstance(s.CallCtx, s.StartInstArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*result.Hardware.AvailabilityZone, gc.Equals, "home-zone")
+}
+
+func (s *environBrokerSuite) TestStartInstanceInstanceRoleCredential(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	err := gce.FinishInstanceConfig(env, s.StartInstArgs, s.spec)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.expectImageMetadata()
+	s.MockService.EXPECT().NetworkSubnetworks(gomock.Any(), "us-east1", "/path/to/vpc").
+		Return([]*computepb.Subnetwork{{
+			SelfLink: ptr("/path/to/subnet1"),
+		}, {
+			SelfLink: ptr("/path/to/subnet2"),
+		}}, nil)
+
+	s.MockService.EXPECT().
+		MachineType(gomock.Any(), "home-zone", s.spec.InstanceType.Name).
+		Return(&computepb.MachineType{
+			Name:         ptr(s.spec.InstanceType.Name),
+			Accelerators: nil,
+		}, nil)
+
+	instArg := s.startInstanceArg(c, s.Prefix(env), false)
+	instArg.ServiceAccounts[0].Email = ptr("foo@googledev.com")
+	// Can't copy instArg as it contains a mutex.
+	instResult := s.startInstanceArg(c, s.Prefix(env), false)
+	instResult.Zone = ptr("path/to/home-zone")
+	instResult.Disks = []*computepb.AttachedDisk{{
+		DiskSizeGb: ptr(int64(s.spec.InstanceType.RootDisk / 1024)),
+	}}
+
+	s.MockService.EXPECT().AddInstance(gomock.Any(), instArg).Return(instResult, nil)
+
+	s.StartInstArgs.AvailabilityZone = "home-zone"
+	s.StartInstArgs.Constraints = constraints.MustParse("instance-role=foo@googledev.com")
+	result, err := env.StartInstance(s.CallCtx, s.StartInstArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*result.Hardware.AvailabilityZone, gc.Equals, "home-zone")
 }
 
 func (s *environBrokerSuite) TestFinishInstanceConfig(c *gc.C) {

--- a/internal/provider/gce/environ_identity_test.go
+++ b/internal/provider/gce/environ_identity_test.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gce_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/testing"
+)
+
+func (s *environSuite) TestSupportsInstanceRole(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	c.Assert(env.SupportsInstanceRoles(s.CallCtx), jc.IsTrue)
+}
+
+func (s *environSuite) TestCreateAutoInstanceRole(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	s.MockService.EXPECT().DefaultServiceAccount(gomock.Any()).Return("fred@googledev.com", nil)
+
+	p := environs.BootstrapParams{
+		ControllerConfig: map[string]interface{}{
+			controller.ControllerUUIDKey: testing.ControllerTag.Id(),
+		},
+	}
+	res, err := env.CreateAutoInstanceRole(s.CallCtx, p)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.Equals, "fred@googledev.com")
+}

--- a/internal/provider/gce/environ_instance.go
+++ b/internal/provider/gce/environ_instance.go
@@ -37,7 +37,7 @@ func (env *environ) Instances(ctx context.ProviderCallContext, ids []instance.Id
 		return nil, environs.ErrNoInstances
 	}
 
-	all, err := getInstances(env, ctx)
+	all, err := env.instances(ctx)
 	if err != nil {
 		// We don't return the error since we need to pack one instance
 		// for each ID into the result. If there is a problem then we
@@ -66,10 +66,6 @@ func (env *environ) Instances(ctx context.ProviderCallContext, ids []instance.Id
 		err = environs.ErrPartialInstances
 	}
 	return results, err
-}
-
-var getInstances = func(env *environ, ctx context.ProviderCallContext, statusFilters ...string) ([]instances.Instance, error) {
-	return env.instances(ctx, statusFilters...)
 }
 
 func (env *environ) gceInstances(ctx context.ProviderCallContext, statusFilters ...string) ([]*computepb.Instance, error) {

--- a/internal/provider/gce/identity.go
+++ b/internal/provider/gce/identity.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gce
+
+import (
+	"github.com/juju/errors"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+)
+
+// SupportsInstanceRoles indicates if Instance Roles are supported by this
+// environ.
+func (env *environ) SupportsInstanceRoles(_ context.ProviderCallContext) bool {
+	return true
+}
+
+// CreateAutoInstanceRole is responsible for setting up an instance role on
+// behalf of the user.
+func (env *environ) CreateAutoInstanceRole(
+	ctx context.ProviderCallContext,
+	args environs.BootstrapParams,
+) (string, error) {
+	serviceAccount, err := env.gce.DefaultServiceAccount(ctx)
+	return serviceAccount, errors.Trace(err)
+}
+
+// FinaliseBootstrapCredential is responsible for performing and finalisation
+// steps to a credential being passed to a newly bootstrapped controller. This
+// was introduced to help with the transformation to instance roles.
+func (env *environ) FinaliseBootstrapCredential(
+	ctx environs.BootstrapContext,
+	args environs.BootstrapParams,
+	cred *jujucloud.Credential,
+) (*jujucloud.Credential, error) {
+	if !args.BootstrapConstraints.HasInstanceRole() || cred == nil {
+		return cred, nil
+	}
+
+	serviceAccountName := *args.BootstrapConstraints.InstanceRole
+	newCred := jujucloud.NewCredential(jujucloud.ServiceAccountAuthType, map[string]string{
+		credServiceAccount: serviceAccountName,
+	})
+	return &newCred, nil
+}

--- a/internal/provider/gce/identity_test.go
+++ b/internal/provider/gce/identity_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gce_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/environs"
+	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/internal/provider/gce"
+)
+
+type identitySuite struct {
+	gce.BaseSuite
+}
+
+var _ = gc.Suite(&identitySuite{})
+
+func (s *identitySuite) TestFinaliseBootstrapCredentialInstanceRole(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	ctx := envtesting.BootstrapTODOContext(c)
+	args := environs.BootstrapParams{
+		BootstrapConstraints: constraints.MustParse("instance-role=fred@googledev.com"),
+	}
+	cred := &jujucloud.Credential{}
+	got, err := env.FinaliseBootstrapCredential(ctx, args, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	want := jujucloud.NewCredential("service-account", map[string]string{
+		"service-account": "fred@googledev.com",
+	})
+	c.Assert(got, jc.DeepEquals, &want)
+}
+
+func (s *identitySuite) TestFinaliseBootstrapCredentialNoInstanceRole(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	ctx := envtesting.BootstrapTODOContext(c)
+	args := environs.BootstrapParams{}
+	cred := &jujucloud.Credential{}
+	got, err := env.FinaliseBootstrapCredential(ctx, args, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, jc.DeepEquals, cred)
+}

--- a/internal/provider/gce/internal/google/auth.go
+++ b/internal/provider/gce/internal/google/auth.go
@@ -9,7 +9,8 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-var scopes = []string{
+// Scopes are define the permissions needed by the instance service account.
+var Scopes = []string{
 	"https://www.googleapis.com/auth/compute",
 	"https://www.googleapis.com/auth/devstorage.full_control",
 }
@@ -26,6 +27,6 @@ func newJWTConfig(creds *Credentials) (*jwt.Config, error) {
 
 	return google.JWTConfigFromJSON(
 		jsonKey,
-		scopes...,
+		Scopes...,
 	)
 }

--- a/internal/provider/gce/internal/google/auth_test.go
+++ b/internal/provider/gce/internal/google/auth_test.go
@@ -35,18 +35,21 @@ func (s *authSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *authSuite) TestNewRESTClient(c *gc.C) {
-	_, err := newRESTClient(context.TODO(), s.Credentials, jujuhttp.NewClient(), compute.NewNetworksRESTClient)
+	cfg, err := newJWTConfig(s.Credentials)
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := context.Background()
+	_, err = newRESTClient(ctx, cfg.TokenSource(ctx), jujuhttp.NewClient(), compute.NewNetworksRESTClient)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *authSuite) TestCreateJWTConfig(c *gc.C) {
 	cfg, err := newJWTConfig(s.Credentials)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.Scopes, jc.DeepEquals, scopes)
+	c.Assert(cfg.Scopes, jc.DeepEquals, Scopes)
 }
 
 func (s *authSuite) TestCreateJWTConfigWithNoJSONKey(c *gc.C) {
 	cfg, err := newJWTConfig(&Credentials{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.Scopes, jc.DeepEquals, scopes)
+	c.Assert(cfg.Scopes, jc.DeepEquals, Scopes)
 }

--- a/internal/provider/gce/internal/google/config.go
+++ b/internal/provider/gce/internal/google/config.go
@@ -34,6 +34,9 @@ type Credentials struct {
 	// JSONKey is the content of the JSON key file for these credentials.
 	JSONKey []byte
 
+	// ServiceAccount is the service account to use for the in-cluster access token.
+	ServiceAccount string
+
 	// ClientID is the GCE account's OAuth ID. It is part of the OAuth
 	// config used in the OAuth-wrapping network transport.
 	ClientID string
@@ -185,10 +188,6 @@ type ConnectionConfig struct {
 	// Region is the GCE region in which to operate for the connection.
 	Region string
 
-	// ProjectID is the project ID to use in all GCE API requests for
-	// the connection.
-	ProjectID string
-
 	// HTTPClient is the client to use for all GCE connections.
 	HTTPClient *jujuhttp.Client
 }
@@ -203,9 +202,6 @@ type ConnectionConfig struct {
 func (gc ConnectionConfig) Validate() error {
 	if gc.Region == "" {
 		return NewMissingConfigValue(OSEnvRegion, "Region")
-	}
-	if gc.ProjectID == "" {
-		return NewMissingConfigValue(OSEnvProjectID, "ProjectID")
 	}
 	if gc.HTTPClient == nil {
 		return errors.NotFoundf("connection config http.Client")

--- a/internal/provider/gce/internal/google/config_connection_test.go
+++ b/internal/provider/gce/internal/google/config_connection_test.go
@@ -21,7 +21,6 @@ var _ = gc.Suite(&connConfigSuite{})
 func (*connConfigSuite) TestValidateValid(c *gc.C) {
 	cfg := google.ConnectionConfig{
 		Region:     "spam",
-		ProjectID:  "eggs",
 		HTTPClient: jujuhttp.NewClient(),
 	}
 	err := cfg.Validate()
@@ -30,21 +29,9 @@ func (*connConfigSuite) TestValidateValid(c *gc.C) {
 }
 
 func (*connConfigSuite) TestValidateMissingRegion(c *gc.C) {
-	cfg := google.ConnectionConfig{
-		ProjectID: "eggs",
-	}
+	cfg := google.ConnectionConfig{}
 	err := cfg.Validate()
 
 	c.Assert(err, gc.FitsTypeOf, &google.InvalidConfigValueError{})
 	c.Check(err.(*google.InvalidConfigValueError).Key, gc.Equals, "GCE_REGION")
-}
-
-func (*connConfigSuite) TestValidateMissingProjectID(c *gc.C) {
-	cfg := google.ConnectionConfig{
-		Region: "spam",
-	}
-	err := cfg.Validate()
-
-	c.Assert(err, gc.FitsTypeOf, &google.InvalidConfigValueError{})
-	c.Check(err.(*google.InvalidConfigValueError).Key, gc.Equals, "GCE_PROJECT_ID")
 }

--- a/internal/provider/gce/internal/google/conn.go
+++ b/internal/provider/gce/internal/google/conn.go
@@ -10,9 +10,12 @@ import (
 
 	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
+	"cloud.google.com/go/compute/metadata"
 	"github.com/googleapis/gax-go/v2/callctx"
 	"github.com/juju/errors"
 	jujuhttp "github.com/juju/http/v2"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 	transporthttp "google.golang.org/api/transport/http"
 )
@@ -38,35 +41,39 @@ type Connection struct {
 // result in an error. All errors that happen while authenticating and
 // connecting are returned by Connect.
 func Connect(ctx context.Context, connCfg ConnectionConfig, creds *Credentials) (*Connection, error) {
-	projects, err := newRESTClient(ctx, creds, connCfg.HTTPClient, compute.NewProjectsRESTClient)
+	tokenSource, projectID, err := tokenSourceFromCreds(ctx, connCfg.HTTPClient, creds)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	zones, err := newRESTClient(ctx, creds, connCfg.HTTPClient, compute.NewZonesRESTClient)
+	projects, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewProjectsRESTClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	instances, err := newRESTClient(ctx, creds, connCfg.HTTPClient, compute.NewInstancesRESTClient)
+	zones, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewZonesRESTClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	machineTypes, err := newRESTClient(ctx, creds, connCfg.HTTPClient, compute.NewMachineTypesRESTClient)
+	instances, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewInstancesRESTClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	disks, err := newRESTClient(ctx, creds, connCfg.HTTPClient, compute.NewDisksRESTClient)
+	machineTypes, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewMachineTypesRESTClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	firewalls, err := newRESTClient(ctx, creds, connCfg.HTTPClient, compute.NewFirewallsRESTClient)
+	disks, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewDisksRESTClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	networks, err := newRESTClient(ctx, creds, connCfg.HTTPClient, compute.NewNetworksRESTClient)
+	firewalls, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewFirewallsRESTClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	subnetworks, err := newRESTClient(ctx, creds, connCfg.HTTPClient, compute.NewSubnetworksRESTClient)
+	networks, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewNetworksRESTClient)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	subnetworks, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewSubnetworksRESTClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -80,9 +87,29 @@ func Connect(ctx context.Context, connCfg ConnectionConfig, creds *Credentials) 
 		firewalls:    firewalls,
 		networks:     networks,
 		subnetworks:  subnetworks,
-		projectID:    connCfg.ProjectID,
+		projectID:    projectID,
 	}
 	return conn, nil
+}
+
+func tokenSourceFromCreds(ctx context.Context, httpClient *jujuhttp.Client, creds *Credentials) (oauth2.TokenSource, string, error) {
+	// If we're using a service account, get the token from the metadata service.
+	if creds.ServiceAccount != "" {
+		meta := metadata.NewClient(httpClient.Client())
+		projectID, err := meta.ProjectIDWithContext(ctx)
+		if err != nil {
+			return nil, "", errors.Trace(err)
+		}
+		ts := google.ComputeTokenSource(creds.ServiceAccount, Scopes...)
+		return ts, projectID, nil
+	}
+
+	cfg, err := newJWTConfig(creds)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	ts := cfg.TokenSource(ctx)
+	return ts, creds.ProjectID, nil
 }
 
 type newClientFunc[T any] func(ctx context.Context, opts ...option.ClientOption) (*T, error)
@@ -90,17 +117,13 @@ type newClientFunc[T any] func(ctx context.Context, opts ...option.ClientOption)
 // newRESTClient opens a new low-level connection to the GCE API using
 // the input credentials and returns it.
 // This includes building the OAuth-wrapping network transport.
-func newRESTClient[T any](ctx context.Context, creds *Credentials, httpClient *jujuhttp.Client, newClient newClientFunc[T]) (*T, error) {
-	cfg, err := newJWTConfig(creds)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
+func newRESTClient[T any](ctx context.Context, tokenSource oauth2.TokenSource, httpClient *jujuhttp.Client, newClient newClientFunc[T]) (*T, error) {
 	// We're substituting the transport, with a wrapped GCE specific version of
 	// the original http.Client.
 	newHttpClient := *httpClient.Client()
 
-	tsOpt := option.WithTokenSource(cfg.TokenSource(ctx))
+	tsOpt := option.WithTokenSource(tokenSource)
+	var err error
 	if newHttpClient.Transport, err = transporthttp.NewTransport(ctx, newHttpClient.Transport, tsOpt); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/provider/gce/provider.go
+++ b/internal/provider/gce/provider.go
@@ -74,6 +74,10 @@ func validateCloudSpec(spec environscloudspec.CloudSpec) error {
 	}
 	switch authType := spec.Credential.AuthType(); authType {
 	case cloud.OAuth2AuthType, cloud.JSONFileAuthType:
+	case cloud.ServiceAccountAuthType:
+		if spec.Credential.Attributes()[credServiceAccount] == "" {
+			return errors.NotValidf("missing service account name")
+		}
 	default:
 		return errors.NotSupportedf("%q auth-type", authType)
 	}

--- a/internal/provider/gce/provider_test.go
+++ b/internal/provider/gce/provider_test.go
@@ -75,6 +75,12 @@ func (s *providerSuite) TestOpenUnsupportedCredential(c *gc.C) {
 	s.testOpenError(c, s.spec, `validating cloud spec: "userpass" auth-type not supported`)
 }
 
+func (s *providerSuite) TestMissingServiceAccount(c *gc.C) {
+	credential := cloud.NewCredential(cloud.ServiceAccountAuthType, map[string]string{})
+	s.spec.Credential = &credential
+	s.testOpenError(c, s.spec, `validating cloud spec: missing service account name not valid`)
+}
+
 func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec, expect string) {
 	_, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  spec,

--- a/internal/provider/gce/testing_test.go
+++ b/internal/provider/gce/testing_test.go
@@ -238,3 +238,7 @@ func (s *BaseSuite) GoogleInstance(c *gc.C, inst instances.Instance) *computepb.
 	c.Assert(ok, jc.IsTrue)
 	return envInst.base
 }
+
+func (s *BaseSuite) SetCredential(env *environ, cred cloud.Credential) {
+	env.cloud.Credential = &cred
+}

--- a/tests/suites/cloud_gce/service_account.sh
+++ b/tests/suites/cloud_gce/service_account.sh
@@ -1,0 +1,48 @@
+run_serviceaccount_credential() {
+	echo
+
+	file="${TEST_DIR}/test-serviceaccount-credential.log"
+
+	export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --bootstrap-constraints=instance-role=auto"
+	bootstrap "test-serviceaccount-gce" "${file}"
+
+	projectServiceAccount=$(gcloud compute project-info describe --format json | jq -r .defaultServiceAccount)
+	credServiceAccount=$(juju show-credential --controller "$BOOTSTRAPPED_JUJU_CTRL_NAME" | yq '.controller-credentials .google .default .content .service-account')
+	check_contains "$credServiceAccount" "$projectServiceAccount"
+
+	juju switch "test-serviceaccount-gce"
+	juju deploy ubuntu
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	juju switch controller
+	juju enable-ha
+	wait_for_controller_machines 3
+	wait_for_ha 3
+
+	for m in "0" "1" "2"; do
+		instId=$(juju show-machine $m | yq '.machines .'"$m"' .instance-id')
+		az=$(juju show-machine $m | yq '.machines .'"$m"' .hardware' | awk '{ delete vars; for(i = 1; i <= NF; ++i) { n = index($i, "="); if(n) { vars[substr($i, 1, n - 1)] = substr($i, n + 1) } } az = vars["availability-zone"] } { print az }')
+		instServiceAccount=$(gcloud compute instances describe --zone "${az}" "${instId}" --format json | jq -r '.serviceAccounts[0].email')
+		check_contains "$instServiceAccount" "$projectServiceAccount"
+	done
+
+	destroy_controller "test-serviceaccount-gce"
+}
+
+test_serviceaccount_credential() {
+	if [ "$(skip 'test_serviceaccount_credential')" ]; then
+		echo "==> TEST SKIPPED: service account credential"
+		return
+	fi
+
+	setup_gcloudcli_credential
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju gcloud
+
+		cd .. || exit
+
+		run "run_serviceaccount_credential" "$@"
+}

--- a/tests/suites/cloud_gce/task.sh
+++ b/tests/suites/cloud_gce/task.sh
@@ -20,8 +20,11 @@ test_cloud_gce() {
 	bootstrap "test-cloud-gce" "${file}"
 
 	test_pro_images
-
 	test_deploy_gpu_instance
 
 	destroy_controller "test-cloud-gce"
+
+	# This test bootstraps a custom controller.
+	test_serviceaccount_credential
+
 }


### PR DESCRIPTION
The gce provider gains support for using service accounts to confer the necessary privileges to allow an api client created in the controller to manage the cloud resources needed by Juju.

A new gce credential auth type of "service-account" is added. This has a single attribute which is the service account to use. The credential can be created and used directly if done on a jump host in the cloud, or the "instance-role" bootstrap constraint can be used if bootstrapping outside the cloud, similar to how managed identity works on Azure.

If instance-role is "auto:, the project's default service account is used, or else a different one can be specified.
To use a different service account for workload machines, use the instance-role constraint when deploying or adding a machine, or set the model constraint to do it for all model machines.

## QA steps

Run the ci test added in the PR.

## Documentation changes

Included in the PR.

## Links

**Jira card:** [JUJU-8505](https://warthogs.atlassian.net/browse/JUJU-8505)
