### PR TITLE
feat: display and update application storage cmd apiserver

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -29,7 +29,7 @@ var facadeVersions = facades.FacadeVersions{
 	"AllModelWatcher":              {4},
 	"AllWatcher":                   {3},
 	"Annotations":                  {2},
-	"Application":                  {15, 16, 17, 18, 19, 20, 21},
+	"Application":                  {15, 16, 17, 18, 19, 20, 21, 22},
 	"ApplicationOffers":            {4, 5},
 	"ApplicationScaler":            {1},
 	"Backups":                      {3},

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2521,7 +2521,7 @@ func (s *ApplicationSuite) TestAPIv20DeployRejectsAttachStorage(c *gc.C) {
 	s.modelType = state.ModelTypeCAAS
 	defer s.setup(c).Finish()
 
-	api := &application.APIv20{APIv21: &application.APIv21{APIBase: s.api}}
+	api := &application.APIv20{APIv21: &application.APIv21{APIv22: &application.APIv22{APIBase: s.api}}}
 
 	_, err := api.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
@@ -2543,7 +2543,7 @@ func (s *ApplicationSuite) TestAPIv20ScaleApplicationsCompatibility(c *gc.C) {
 	app.EXPECT().ChangeScale(1, ([]names.StorageTag)(nil)).Return(2, nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	api := &application.APIv20{APIv21: &application.APIv21{APIBase: s.api}}
+	api := &application.APIv20{APIv21: &application.APIv21{APIv22: &application.APIv22{APIBase: s.api}}}
 
 	results, err := api.ScaleApplications(params.ScaleApplicationsParams{
 		Applications: []params.ScaleApplicationParams{{

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -119,6 +119,8 @@ type Application interface {
 	AgentTools() (*tools.Tools, error)
 	MergeBindings(*state.Bindings, bool) error
 	Relations() ([]Relation, error)
+	StorageConstraints() (map[string]state.StorageConstraints, error)
+	UpdateStorageConstraints(map[string]state.StorageConstraints) error
 }
 
 // Bindings defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -1441,6 +1441,21 @@ func (mr *MockApplicationMockRecorder) SetScale(arg0, arg1, arg2 any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetScale", reflect.TypeOf((*MockApplication)(nil).SetScale), arg0, arg1, arg2)
 }
 
+// StorageConstraints mocks base method.
+func (m *MockApplication) StorageConstraints() (map[string]state.StorageConstraints, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StorageConstraints")
+	ret0, _ := ret[0].(map[string]state.StorageConstraints)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StorageConstraints indicates an expected call of StorageConstraints.
+func (mr *MockApplicationMockRecorder) StorageConstraints() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageConstraints", reflect.TypeOf((*MockApplication)(nil).StorageConstraints))
+}
+
 // UnsetExposeSettings mocks base method.
 func (m *MockApplication) UnsetExposeSettings(arg0 []string) error {
 	m.ctrl.T.Helper()
@@ -1495,6 +1510,20 @@ func (m *MockApplication) UpdateCharmConfig(arg0 string, arg1 charm.Settings) er
 func (mr *MockApplicationMockRecorder) UpdateCharmConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCharmConfig", reflect.TypeOf((*MockApplication)(nil).UpdateCharmConfig), arg0, arg1)
+}
+
+// UpdateStorageConstraints mocks base method.
+func (m *MockApplication) UpdateStorageConstraints(arg0 map[string]state.StorageConstraints) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStorageConstraints", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStorageConstraints indicates an expected call of UpdateStorageConstraints.
+func (mr *MockApplicationMockRecorder) UpdateStorageConstraints(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStorageConstraints", reflect.TypeOf((*MockApplication)(nil).UpdateStorageConstraints), arg0)
 }
 
 // MockRemoteApplication is a mock of RemoteApplication interface.

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -34,10 +34,21 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Application", 21, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV21(ctx) // Added ScaleApplication attach storage support
 	}, reflect.TypeOf((*APIv21)(nil)))
+	registry.MustRegister("Application", 22, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV22(ctx) // Added GetApplicationStorage and UpdateApplicationStorage storage constraints support
+	}, reflect.TypeOf((*APIv22)(nil)))
+}
+
+func newFacadeV22(ctx facade.Context) (*APIv22, error) {
+	api, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv22{api}, nil
 }
 
 func newFacadeV21(ctx facade.Context) (*APIv21, error) {
-	api, err := newFacadeBase(ctx)
+	api, err := newFacadeV22(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/application/updatebase_mocks_test.go
+++ b/apiserver/facades/client/application/updatebase_mocks_test.go
@@ -483,6 +483,21 @@ func (mr *MockApplicationMockRecorder) SetScale(arg0, arg1, arg2 any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetScale", reflect.TypeOf((*MockApplication)(nil).SetScale), arg0, arg1, arg2)
 }
 
+// StorageConstraints mocks base method.
+func (m *MockApplication) StorageConstraints() (map[string]state.StorageConstraints, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StorageConstraints")
+	ret0, _ := ret[0].(map[string]state.StorageConstraints)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StorageConstraints indicates an expected call of StorageConstraints.
+func (mr *MockApplicationMockRecorder) StorageConstraints() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageConstraints", reflect.TypeOf((*MockApplication)(nil).StorageConstraints))
+}
+
 // UnsetExposeSettings mocks base method.
 func (m *MockApplication) UnsetExposeSettings(arg0 []string) error {
 	m.ctrl.T.Helper()
@@ -537,6 +552,20 @@ func (m *MockApplication) UpdateCharmConfig(arg0 string, arg1 charm.Settings) er
 func (mr *MockApplicationMockRecorder) UpdateCharmConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCharmConfig", reflect.TypeOf((*MockApplication)(nil).UpdateCharmConfig), arg0, arg1)
+}
+
+// UpdateStorageConstraints mocks base method.
+func (m *MockApplication) UpdateStorageConstraints(arg0 map[string]state.StorageConstraints) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStorageConstraints", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStorageConstraints indicates an expected call of UpdateStorageConstraints.
+func (mr *MockApplicationMockRecorder) UpdateStorageConstraints(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStorageConstraints", reflect.TypeOf((*MockApplication)(nil).UpdateStorageConstraints), arg0)
 }
 
 // MockCharm is a mock of Charm interface.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1127,7 +1127,7 @@
     {
         "Name": "Application",
         "Description": "",
-        "Version": 21,
+        "Version": 22,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -1282,6 +1282,17 @@
                         },
                         "Result": {
                             "$ref": "#/definitions/ApplicationGetResults"
+                        }
+                    }
+                },
+                "GetApplicationStorage": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationStorageGetResults"
                         }
                     }
                 },
@@ -1446,6 +1457,17 @@
                     "properties": {
                         "Params": {
                             "$ref": "#/definitions/UpdateChannelArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "UpdateApplicationStorage": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationStorageUpdateRequest"
                         },
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
@@ -2095,6 +2117,78 @@
                         "force",
                         "force-units",
                         "force-base"
+                    ]
+                },
+                "ApplicationStorageGetResult": {
+                    "type": "object",
+                    "properties": {
+                        "Error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "storage-constraints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/StorageConstraints"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-constraints",
+                        "Error"
+                    ]
+                },
+                "ApplicationStorageGetResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationStorageGetResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ApplicationStorageUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "storage-constraints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/StorageConstraints"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-tag",
+                        "storage-constraints"
+                    ]
+                },
+                "ApplicationStorageUpdateRequest": {
+                    "type": "object",
+                    "properties": {
+                        "storage-updates": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationStorageUpdate"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-updates"
                     ]
                 },
                 "ApplicationUnexpose": {

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -708,3 +708,32 @@ type PendingResourceUpload struct {
 	// Type of the resource, a string matching one of the resource.Type
 	Type string
 }
+
+// ApplicationStorageGetResult holds the storage constraints and any
+// error information for a single application.
+type ApplicationStorageGetResult struct {
+	StorageConstraints map[string]StorageConstraints `json:"storage-constraints"`
+	Error              *Error
+}
+
+// ApplicationStorageGetResults aggregates the per-application results
+// for a bulk storage get request. The number and order of results should match
+// the number and order of input entities.
+type ApplicationStorageGetResults struct {
+	Results []ApplicationStorageGetResult `json:"results"`
+}
+
+// ApplicationStorageUpdateRequest defines the parameters for updating
+// storage constraints on one or more applications in bulk.
+type ApplicationStorageUpdateRequest struct {
+	ApplicationStorageUpdates []ApplicationStorageUpdate `json:"storage-updates"`
+}
+
+// ApplicationStorageUpdate holds the desired storage constraint
+// updates for a single application.
+type ApplicationStorageUpdate struct {
+	ApplicationTag string `json:"application-tag"`
+
+	// Holds the application storage constraints where the key is the storage name.
+	StorageConstraints map[string]StorageConstraints `json:"storage-constraints"`
+}


### PR DESCRIPTION
This PR implements the api server to display and update application storage.

The card will be split into 3 PRs for better readability and fill in the placeholders for other parallel work :

**Server**
1. Implement API server logic to get and set application storage command (Current PR)

**Client**

2. Implement juju application-storage get/set client logic

3. Implement juju application-storage command interface


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
 
## Links
**Jira card:** https://warthogs.atlassian.net/browse/JUJU-8443
