### PR TITLE
refactor: rename k8s provider package to 'kubernetes'

### DIFF
--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -134,7 +134,7 @@ func (*OpenSuite) TestNewKubernetes(c *gc.C) {
 			Type: k8sconstants.CAASProviderType,
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, "cloud environ provider provider.kubernetesEnvironProvider not valid")
+	c.Assert(err, gc.ErrorMatches, "cloud environ provider kubernetes.kubernetesEnvironProvider not valid")
 	c.Assert(env, gc.IsNil)
 }
 

--- a/internal/provider/kubernetes/admissionregistration.go
+++ b/internal/provider/kubernetes/admissionregistration.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/admissionregistration_test.go
+++ b/internal/provider/kubernetes/admissionregistration_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"encoding/base64"

--- a/internal/provider/kubernetes/application.go
+++ b/internal/provider/kubernetes/application.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"github.com/juju/juju/caas"

--- a/internal/provider/kubernetes/base_test.go
+++ b/internal/provider/kubernetes/base_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"fmt"

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"context"

--- a/internal/provider/kubernetes/builtin.go
+++ b/internal/provider/kubernetes/builtin.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"bytes"

--- a/internal/provider/kubernetes/builtin_test.go
+++ b/internal/provider/kubernetes/builtin_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"io"

--- a/internal/provider/kubernetes/cloud.go
+++ b/internal/provider/kubernetes/cloud.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	jujuclock "github.com/juju/clock"

--- a/internal/provider/kubernetes/cloud_test.go
+++ b/internal/provider/kubernetes/cloud_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"fmt"

--- a/internal/provider/kubernetes/config.go
+++ b/internal/provider/kubernetes/config.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"github.com/juju/schema"

--- a/internal/provider/kubernetes/configmap.go
+++ b/internal/provider/kubernetes/configmap.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/connection.go
+++ b/internal/provider/kubernetes/connection.go
@@ -1,7 +1,7 @@
 // Copyright 2021 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/constraints.go
+++ b/internal/provider/kubernetes/constraints.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"github.com/juju/juju/core/constraints"

--- a/internal/provider/kubernetes/constraints_test.go
+++ b/internal/provider/kubernetes/constraints_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"strings"

--- a/internal/provider/kubernetes/controller_upgrade.go
+++ b/internal/provider/kubernetes/controller_upgrade.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/controller_upgrade_test.go
+++ b/internal/provider/kubernetes/controller_upgrade_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/credentials.go
+++ b/internal/provider/kubernetes/credentials.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	jujuclock "github.com/juju/clock"

--- a/internal/provider/kubernetes/credentials_test.go
+++ b/internal/provider/kubernetes/credentials_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"path/filepath"

--- a/internal/provider/kubernetes/customresourcedefinitions.go
+++ b/internal/provider/kubernetes/customresourcedefinitions.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/customresourcedefinitions_test.go
+++ b/internal/provider/kubernetes/customresourcedefinitions_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"context"

--- a/internal/provider/kubernetes/daemonset.go
+++ b/internal/provider/kubernetes/daemonset.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/detectcloud.go
+++ b/internal/provider/kubernetes/detectcloud.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"github.com/juju/errors"

--- a/internal/provider/kubernetes/detectcloud_test.go
+++ b/internal/provider/kubernetes/detectcloud_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"os"

--- a/internal/provider/kubernetes/errors.go
+++ b/internal/provider/kubernetes/errors.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"github.com/juju/errors"

--- a/internal/provider/kubernetes/events.go
+++ b/internal/provider/kubernetes/events.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/export_test.go
+++ b/internal/provider/kubernetes/export_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/ingress.go
+++ b/internal/provider/kubernetes/ingress.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/ingress_test.go
+++ b/internal/provider/kubernetes/ingress_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	jc "github.com/juju/testing/checkers"

--- a/internal/provider/kubernetes/init.go
+++ b/internal/provider/kubernetes/init.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	k8slabels "k8s.io/apimachinery/pkg/labels"

--- a/internal/provider/kubernetes/init_test.go
+++ b/internal/provider/kubernetes/init_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	gc "gopkg.in/check.v1"

--- a/internal/provider/kubernetes/k8s.go
+++ b/internal/provider/kubernetes/k8s.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"bytes"

--- a/internal/provider/kubernetes/k8s_test.go
+++ b/internal/provider/kubernetes/k8s_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	stdcontext "context"

--- a/internal/provider/kubernetes/klog.go
+++ b/internal/provider/kubernetes/klog.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"strings"

--- a/internal/provider/kubernetes/labels.go
+++ b/internal/provider/kubernetes/labels.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/provider/kubernetes/metadata.go
+++ b/internal/provider/kubernetes/metadata.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/metadata_test.go
+++ b/internal/provider/kubernetes/metadata_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"context"

--- a/internal/provider/kubernetes/modeloperator.go
+++ b/internal/provider/kubernetes/modeloperator.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/modeloperator_external_test.go
+++ b/internal/provider/kubernetes/modeloperator_external_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"time"

--- a/internal/provider/kubernetes/modeloperator_test.go
+++ b/internal/provider/kubernetes/modeloperator_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/modeloperator_upgrade.go
+++ b/internal/provider/kubernetes/modeloperator_upgrade.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"github.com/juju/names/v5"

--- a/internal/provider/kubernetes/modeloperator_upgrade_test.go
+++ b/internal/provider/kubernetes/modeloperator_upgrade_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/namespaces.go
+++ b/internal/provider/kubernetes/namespaces.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/operator.go
+++ b/internal/provider/kubernetes/operator.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/operator_test.go
+++ b/internal/provider/kubernetes/operator_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"fmt"

--- a/internal/provider/kubernetes/operator_upgrade.go
+++ b/internal/provider/kubernetes/operator_upgrade.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/operator_upgrade_test.go
+++ b/internal/provider/kubernetes/operator_upgrade_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/package_test.go
+++ b/internal/provider/kubernetes/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"testing"

--- a/internal/provider/kubernetes/precheck.go
+++ b/internal/provider/kubernetes/precheck.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"strings"

--- a/internal/provider/kubernetes/precheck_test.go
+++ b/internal/provider/kubernetes/precheck_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	jc "github.com/juju/testing/checkers"

--- a/internal/provider/kubernetes/provider.go
+++ b/internal/provider/kubernetes/provider.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	stdcontext "context"

--- a/internal/provider/kubernetes/provider_test.go
+++ b/internal/provider/kubernetes/provider_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"github.com/juju/testing"

--- a/internal/provider/kubernetes/providerconfig.go
+++ b/internal/provider/kubernetes/providerconfig.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"fmt"

--- a/internal/provider/kubernetes/rbac.go
+++ b/internal/provider/kubernetes/rbac.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/rbac_test.go
+++ b/internal/provider/kubernetes/rbac_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	jc "github.com/juju/testing/checkers"

--- a/internal/provider/kubernetes/resources.go
+++ b/internal/provider/kubernetes/resources.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/resources_test.go
+++ b/internal/provider/kubernetes/resources_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	jc "github.com/juju/testing/checkers"

--- a/internal/provider/kubernetes/secrets.go
+++ b/internal/provider/kubernetes/secrets.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/secrets_test.go
+++ b/internal/provider/kubernetes/secrets_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"context"

--- a/internal/provider/kubernetes/services.go
+++ b/internal/provider/kubernetes/services.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/services_test.go
+++ b/internal/provider/kubernetes/services_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/statefulsets.go
+++ b/internal/provider/kubernetes/statefulsets.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/storage.go
+++ b/internal/provider/kubernetes/storage.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/storage_test.go
+++ b/internal/provider/kubernetes/storage_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"github.com/juju/errors"

--- a/internal/provider/kubernetes/teardown.go
+++ b/internal/provider/kubernetes/teardown.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/teardown_test.go
+++ b/internal/provider/kubernetes/teardown_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	"context"

--- a/internal/provider/kubernetes/template.go
+++ b/internal/provider/kubernetes/template.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"fmt"

--- a/internal/provider/kubernetes/template_test.go
+++ b/internal/provider/kubernetes/template_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package kubernetes_test
 
 import (
 	jc "github.com/juju/testing/checkers"

--- a/internal/provider/kubernetes/upgrade.go
+++ b/internal/provider/kubernetes/upgrade.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"

--- a/internal/provider/kubernetes/upgrade_test.go
+++ b/internal/provider/kubernetes/upgrade_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"fmt"

--- a/internal/provider/kubernetes/volume.go
+++ b/internal/provider/kubernetes/volume.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider
+package kubernetes
 
 import (
 	"context"


### PR DESCRIPTION
The kubernetes provider package is renamed to "kubernetes" to be consistent with the other providers and what's in main.

## QA steps

unit tests