### PR TITLE
feat: allow different service account on bootstrap for gce

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -578,9 +578,6 @@ func bootstrapIAAS(
 			if args.CloudCredential.AuthType() == cloud.ManagedIdentityAuthType {
 				return errors.NotSupportedf("instance role constraint with managed identity credential")
 			}
-			if args.CloudCredential.AuthType() == cloud.ServiceAccountAuthType {
-				return errors.NotSupportedf("instance role constraint with service account credential")
-			}
 		}
 		instanceRoleEnviron, ok := environ.(environs.InstanceRole)
 		if !ok || !instanceRoleEnviron.SupportsInstanceRoles(callCtx) {

--- a/internal/provider/gce/environ_broker.go
+++ b/internal/provider/gce/environ_broker.go
@@ -154,15 +154,15 @@ func (env *environ) serviceAccount(ctx context.ProviderCallContext, args environ
 
 	// For controllers, the service account can come from the credential.
 	if args.InstanceConfig.IsController() {
-		if env.cloud.Credential.AuthType() == cloud.ServiceAccountAuthType {
-			serviceAccount = env.cloud.Credential.Attributes()[credServiceAccount]
-			if serviceAccount != "" {
-				logger.Debugf("using credential service account: %s", serviceAccount)
-			}
-		} else if args.InstanceConfig.Bootstrap != nil && args.InstanceConfig.Bootstrap.BootstrapMachineConstraints.HasInstanceRole() {
+		if args.InstanceConfig.Bootstrap != nil && args.InstanceConfig.Bootstrap.BootstrapMachineConstraints.HasInstanceRole() {
 			serviceAccount = *args.InstanceConfig.Bootstrap.BootstrapMachineConstraints.InstanceRole
 			if serviceAccount != "" {
 				logger.Debugf("using bootstrap service account: %s", serviceAccount)
+			}
+		} else if env.cloud.Credential.AuthType() == cloud.ServiceAccountAuthType {
+			serviceAccount = env.cloud.Credential.Attributes()[credServiceAccount]
+			if serviceAccount != "" {
+				logger.Debugf("using credential service account: %s", serviceAccount)
 			}
 		}
 	}

--- a/internal/provider/gce/environ_vpc.go
+++ b/internal/provider/gce/environ_vpc.go
@@ -70,10 +70,6 @@ but will be used anyway because vpc-id-force=true is also specified.
 )
 
 func validateBootstrapVPC(ctx environs.BootstrapContext, conn ComputeService, region, vpcID string, force bool) error {
-	if vpcID == google.NetworkDefaultName {
-		ctx.Infof("Using GCE default VPC in region %q", region)
-	}
-
 	err := validateVPC(ctx.Context(), conn, region, vpcID, true)
 	switch {
 	case errors.Is(err, errorVPCNotUsable):

--- a/internal/provider/gce/identity.go
+++ b/internal/provider/gce/identity.go
@@ -35,7 +35,8 @@ func (env *environ) FinaliseBootstrapCredential(
 	args environs.BootstrapParams,
 	cred *jujucloud.Credential,
 ) (*jujucloud.Credential, error) {
-	if !args.BootstrapConstraints.HasInstanceRole() || cred == nil {
+	if !args.BootstrapConstraints.HasInstanceRole() ||
+		cred == nil || cred.AuthType() == jujucloud.ServiceAccountAuthType {
 		return cred, nil
 	}
 

--- a/internal/provider/gce/identity_test.go
+++ b/internal/provider/gce/identity_test.go
@@ -39,6 +39,27 @@ func (s *identitySuite) TestFinaliseBootstrapCredentialInstanceRole(c *gc.C) {
 	c.Assert(got, jc.DeepEquals, &want)
 }
 
+func (s *identitySuite) TestFinaliseBootstrapCredentialInstanceRoleAndServiceAccount(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	ctx := envtesting.BootstrapTODOContext(c)
+	args := environs.BootstrapParams{
+		BootstrapConstraints: constraints.MustParse("instance-role=fred@googledev.com"),
+	}
+	cred := jujucloud.NewCredential(jujucloud.ServiceAccountAuthType, map[string]string{
+		"service-account": "fred@googledev.com",
+	})
+	got, err := env.FinaliseBootstrapCredential(ctx, args, &cred)
+	c.Assert(err, jc.ErrorIsNil)
+	want := jujucloud.NewCredential("service-account", map[string]string{
+		"service-account": "fred@googledev.com",
+	})
+	c.Assert(got, jc.DeepEquals, &want)
+}
+
 func (s *identitySuite) TestFinaliseBootstrapCredentialNoInstanceRole(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
When bootstrapping on gce from a jump host, some companies require a different service account to spawn the controller to the service account used with the final credential.

This PR tweaks the bootstrap workflow to allow one service account to be specified in the bootstrap constraints to spawn the controller, and a different service account in the credential stored in the model to operate the cloud thereafter. 

Includes a drive by log fix.


## QA steps

You'll need 2 different service accounts to fully test. Will be verified on customer site.
On a jump host in gce:

```
juju add-credential google
-> choose service-account
-> enter service account email

juju bootstrap google --bootstrap-constraints="instance-role=someotherserviceaccount"
juju show-credential 
-> expect credential added above
juju deploy ubuntu
```