### PR TITLE
test: remove status pattern usage from CI test

### DIFF
--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -20,7 +20,7 @@ run_relation_data_exchange() {
 	wait_for "dummy-source" "$(idle_condition "dummy-source" 0)"
 
 	echo "Get the leader unit name"
-	non_leader_dummy_sink_unit=$(juju status dummy-sink --format json | jq -r '.applications."dummy-sink".units | to_entries[] | select(.value.leader!=true) | .key')
+	non_leader_dummy_sink_unit=$(juju status --format json | jq -r '.applications."dummy-sink".units | to_entries[] | select(.value.leader!=true) | .key')
 	dummy_sink_relation_id=$(juju exec --unit "dummy-sink/leader" 'relation-ids source')
 	dummy_source_relation_id=$(juju exec --unit "dummy-source/leader" 'relation-ids sink')
 	# stop there


### PR DESCRIPTION
Simple fix for the relation data exchange integration test - just remove the pattern usage.