### PR TITLE
feat(domain/operation): prune by maxSize

### DIFF
--- a/domain/operation/state/package_test.go
+++ b/domain/operation/state/package_test.go
@@ -222,6 +222,14 @@ func (s *baseSuite) addOperationMachineTask(c *tc.C, taskUUID, machineUUID strin
 	s.query(c, `INSERT INTO operation_machine_task (task_uuid, machine_uuid) VALUES (?, ?)`, taskUUID, machineUUID)
 }
 
+func (s *baseSuite) addFakeMetadataStore(c *tc.C, size int) string {
+	storeUUID := internaluuid.MustNewUUID().String()
+	s.query(c, `
+INSERT INTO object_store_metadata (uuid, sha_256, sha_384, size)
+VALUES (?, ?, ?, ?)`, storeUUID, storeUUID, storeUUID, size)
+	return storeUUID
+}
+
 // addOperationTaskOutputWithData adds object store metadata to the database with a path
 func (s *baseSuite) addOperationTaskOutputWithData(c *tc.C, taskUUID, sha256, sha384 string, size int,
 	path string) string {
@@ -239,10 +247,7 @@ VALUES (?, ?)`, path, storeUUID)
 // addOperationTaskOutput links a task to an object store metadata, return the
 // store metadata uuid
 func (s *baseSuite) addOperationTaskOutput(c *tc.C, taskUUID string) string {
-	storeUUID := internaluuid.MustNewUUID().String()
-	// Minimal valid object_store_metadata requires all uuid, sha_256 and sha_384 are unique
-	s.query(c, `INSERT INTO object_store_metadata (uuid, sha_256, sha_384, size) VALUES (?, ?, ?, 42)`,
-		storeUUID, storeUUID, storeUUID)
+	storeUUID := s.addFakeMetadataStore(c, 42)
 	s.query(c, `INSERT INTO operation_task_output (task_uuid, store_uuid) VALUES (?, ?)`, taskUUID, storeUUID)
 	return storeUUID
 }

--- a/domain/operation/state/prune.go
+++ b/domain/operation/state/prune.go
@@ -5,12 +5,27 @@ package state
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/canonical/sqlair"
+	"github.com/dustin/go-humanize"
 	"github.com/juju/collections/transform"
 
 	"github.com/juju/juju/internal/errors"
+)
+
+const (
+	// operationRowSizeFactorKiB is a reasonable value for average operation size,
+	// actually it is probably very large (I got ~310 bytes while estimating)
+	operationRowSizeFactorKiB = 1
+
+	// taskRowSizeFactorKiB is a reasonable value for average operation size,
+	// actually it is probably very large (I got ~375 bytes while estimating)
+	taskRowSizeFactorKiB = 1
+
+	// taskLogRowSizeFactorKiB, 1024 bytes is a generous value for average log size.
+	taskLogRowSizeFactorKiB = 1
 )
 
 // PruneOperations deletes operations older than maxAge and larger than maxSizeMB.
@@ -23,9 +38,10 @@ func (st *State) PruneOperations(ctx context.Context, maxAge time.Duration, maxS
 	}
 
 	// Prune by size
-	// TODO(gfouillet): implement it as followup:
-	//   - first pass should delete only completed operations up to the desired size
-	//   - second pass should delete from all operations, oldest first
+	err = st.pruneOperationsToKeepUnderSizeMiB(ctx, maxSizeMB)
+	if err != nil {
+		return errors.Errorf("pruning operation to keep size under the limit: %w", err)
+	}
 
 	// TODO(gfouillet): In a followup PR, we should return the storeUUIDs
 	//   freed by the state prune operation.
@@ -81,8 +97,8 @@ func (st *State) getCompletedOperationUUIDsOlderThan(ctx context.Context, tx *sq
 	SELECT &operation.uuid 
 	FROM   operation
 	WHERE  completed_at IS NOT NULL
-	AND    completed_at < $expires.at
-    `, operation{}, expiresAt)
+	AND    completed_at < $expires.at`,
+		operation{}, expiresAt)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -94,4 +110,152 @@ func (st *State) getCompletedOperationUUIDsOlderThan(ctx context.Context, tx *sq
 	}
 
 	return transform.Slice(operations, func(o operation) string { return o.UUID }), nil
+}
+
+// pruneOperationsToKeepUnderSizeMiB prunes operations to ensure the total size of
+// operations stays below the specified limit.
+// It retrieves the database and calculates the total size and average size of
+// operations. If pruning is required, it deletes a calculated number of
+// operations to meet the size constraint.
+// Returns an error if any issues occur during pruning.
+func (st *State) pruneOperationsToKeepUnderSizeMiB(ctx context.Context, maxSizeMiB int) error {
+	if maxSizeMiB <= 0 {
+		// size shouldn't be negative, but zero size is valid. In any case, we ignore
+		// the prune by size as done in 3.6
+		st.logger.Warningf(ctx, "Ignoring pruning by age ignored: zero or negative size (size(MB): %s)", maxSizeMiB)
+		return nil
+	}
+
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	maxSizeKiB := maxSizeMiB * humanize.KiByte
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		totalSizeKiB, averageOperationSizeKiB, err := st.estimateOperationSizeInKiB(ctx, tx)
+		if err != nil {
+			return errors.Errorf("estimating operation size: %w", err)
+		}
+		if totalSizeKiB <= maxSizeKiB {
+			return nil // nothing to do.
+		}
+		if averageOperationSizeKiB <= 0 {
+			// shouldn't happen since the only reason which would happen is that
+			// there is no operation in the database, so the totalSizeKiB should be
+			// zero and we would have already returned nil (it would be under maxSizeKiB
+			// which is strictly positive at this point
+			return errors.Errorf("estimated operation size is invalid: %d", averageOperationSizeKiB)
+		}
+
+		opsToDeleteCount := (totalSizeKiB - maxSizeKiB) / averageOperationSizeKiB
+
+		toDeleteUUIDs, err := st.getOperationToPruneUpTo(ctx, tx, opsToDeleteCount)
+		if err != nil {
+			return errors.Errorf("getting operation UUIDs to delete: %w", err)
+		}
+		return errors.Capture(st.deleteOperationByUUIDs(ctx, tx, toDeleteUUIDs))
+	})
+
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return nil
+}
+
+// estimateOperationSizeInKiB estimates the total size and average size (in KiB)
+// of operations in the database.
+// It calculates size based on row counts and associated object store sizes
+// for operations, tasks, and logs.
+func (st *State) estimateOperationSizeInKiB(ctx context.Context, tx *sqlair.TX) (int, int, error) {
+	opCount, err := st.count(ctx, tx, "operation")
+	if err != nil {
+		return 0, -1, errors.Errorf("counting operation: %w", err)
+	}
+	if opCount == 0 {
+		return 0, -1, nil
+	}
+	taskCount, err := st.count(ctx, tx, "operation_task")
+	if err != nil {
+		return 0, -1, errors.Errorf("counting operation task: %w", err)
+	}
+	taskLogCount, err := st.count(ctx, tx, "operation_task_log")
+	if err != nil {
+		return 0, -1, errors.Errorf("counting operation task log: %w", err)
+	}
+	objectStoreSizeKiB, err := st.computeObjectStoreSize(ctx, tx, humanize.KiByte)
+	if err != nil {
+		return 0, -1, errors.Errorf("computing object store size: %w", err)
+	}
+
+	// Get total size of operation datas
+	//  - number of operation row * size factor (estimated on the column of the table)
+	//  - number of task row * size factor (estimated on the column of the related table)
+	//  - sum of object_data_store(operation_task_output.store_uuid).size
+	//  - number of task_log row * size factor (estimated on the column of the related table)
+	totalSizeKiB := opCount*operationRowSizeFactorKiB +
+		taskCount*taskRowSizeFactorKiB +
+		taskLogCount*taskLogRowSizeFactorKiB +
+		objectStoreSizeKiB
+
+	// Estimate the average size of an operation
+	averageOperationSizeKiB := totalSizeKiB / opCount
+
+	return totalSizeKiB, averageOperationSizeKiB, nil
+}
+
+// computeObjectStoreSize computes the size of the content related to tasks in
+// the object store. The sizeFactor allows to convert the size in bytes to the
+// size in another ratio.
+func (st *State) computeObjectStoreSize(ctx context.Context, tx *sqlair.TX, sizeFactor int) (int, error) {
+	type result struct {
+		Size int `db:"size"`
+	}
+	stmt, err := st.Prepare(`
+WITH
+uuids AS (
+    SELECT store_uuid 
+    FROM operation_task_output
+)
+SELECT SUM(size) AS &result.size
+FROM   object_store_metadata
+WHERE  uuid IN uuids`, result{})
+	if err != nil {
+		return 0, errors.Capture(err)
+	}
+	var res result
+	if err := tx.Query(ctx, stmt).Get(&res); err != nil {
+		return 0, errors.Errorf("querying object store size for task content: %w", err)
+	}
+
+	return (res.Size + sizeFactor - 1) / sizeFactor, nil
+}
+
+// getOperationToPruneUpTo returns a list of UUIDs of operations to prune
+// up to count. Operations are ordered by their completion date if any, then by
+// their enqueued date (oldest first).
+func (st *State) getOperationToPruneUpTo(ctx context.Context, tx *sqlair.TX, count int) ([]string, error) {
+	type max struct {
+		Limit int `db:"limit"`
+	}
+	limit := max{Limit: count}
+	// Note: NULLS LAST is used to ensure that the oldest operation is deleted first.
+	//  see https://sqlite.org/lang_select.html
+	stmt, err := st.Prepare(`
+SELECT &uuid.uuid
+FROM   operation
+ORDER  BY 
+    completed_at ASC NULLS LAST, 
+    enqueued_at ASC
+LIMIT  $max.limit`, uuid{}, limit)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	var uuids []uuid
+	if err := tx.Query(ctx, stmt, limit).GetAll(&uuids); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, errors.Capture(err)
+	}
+	return transform.Slice(uuids, func(u uuid) string { return u.UUID }), nil
 }

--- a/domain/operation/state/prune_test.go
+++ b/domain/operation/state/prune_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/canonical/sqlair"
+	"github.com/dustin/go-humanize"
 	"github.com/juju/tc"
 )
 
@@ -16,8 +17,16 @@ type pruneByAgeSuite struct {
 	baseSuite
 }
 
+type pruneBySizeSuite struct {
+	baseSuite
+}
+
 func TestPruneByAgeSuite(t *testing.T) {
 	tc.Run(t, &pruneByAgeSuite{})
+}
+
+func TestPruneBySizeSuite(t *testing.T) {
+	tc.Run(t, &pruneBySizeSuite{})
 }
 
 // TestPruneCompletedOperationsOlderThan tests that the prune completed operation
@@ -95,4 +104,248 @@ func (s *pruneByAgeSuite) TestGetCompletedOperationOlderThanZeroAge(c *tc.C) {
 	// Assert: no error, no results
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(opUUIDs, tc.HasLen, 0)
+}
+
+// TestGetOperationToPruneUpToNoOperation tests that the get operation to prune
+// up to function returns no operation without errors when there is no
+// operation in the database.
+func (s *pruneBySizeSuite) TestGetOperationToPruneUpToNoOperation(c *tc.C) {
+	// Arrange: no operation in the database.
+
+	// Act: get operation to prune up to.
+	var opUUIDs []string
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		opUUIDs, err = s.state.getOperationToPruneUpTo(ctx, tx, 100)
+		return err
+	})
+
+	// Assert: no error, no operation to prune.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(opUUIDs, tc.HasLen, 0)
+}
+
+// TestGetOperationToPruneUpToLessOperationThanRequired tests that the get
+// operation to prune up to function returns the operation to prune when there
+// is less operation than the required number of operation.
+func (s *pruneBySizeSuite) TestGetOperationToPruneUpToLessOperationThanRequired(c *tc.C) {
+	// Arrange: few operations in the database.
+	opsToPrune := []string{
+		s.addOperation(c),
+		s.addCompletedOperation(c, time.Minute), // completed one minute ago
+		s.addOperation(c),
+	}
+
+	// Act: get operation to prune up to.
+	var opUUIDs []string
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		opUUIDs, err = s.state.getOperationToPruneUpTo(ctx, tx, 100)
+		return err
+	})
+
+	// Assert: no error, all operations retrieved
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(opUUIDs, tc.SameContents, opsToPrune)
+
+}
+
+// TestGetOperationToPruneUpToLessOperationMoreThanRequired tests that the get
+// operation to prune up to function returns prioritized operation when there is
+// more operation than the required number of operation.
+func (s *pruneBySizeSuite) TestGetOperationToPruneUpToLessOperationMoreThanRequired(c *tc.C) {
+	// Arrange: few operations in the database.
+
+	op1 := s.addOperation(c)
+	op2 := s.addCompletedOperation(c, time.Minute)
+	s.addOperation(c) // discarded (complete are priorized, and more recent than op1)
+	op3 := s.addCompletedOperation(c, 2*time.Minute)
+
+	// Act: get operation to prune up to.
+	var opUUIDs []string
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		opUUIDs, err = s.state.getOperationToPruneUpTo(ctx, tx, 3)
+		return err
+	})
+
+	// Assert: no error, all operations retrieved
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(opUUIDs, tc.SameContents, []string{op1, op2, op3})
+}
+
+// TestGetOperationToPruneUpTo tests that the get operation to prune up to
+// function returns prioritized operation when there is more operation than the
+// required number of operation.
+func (s *pruneBySizeSuite) TestGetOperationToPruneUpTo(c *tc.C) {
+	// Arrange: few operations in the database.
+
+	op1 := s.addCompletedOperation(c, time.Hour)
+	s.addCompletedOperation(c, time.Second) // discarded (more recent)
+	op2 := s.addCompletedOperation(c, time.Minute)
+	op3 := s.addCompletedOperation(c, 10*time.Minute)
+	s.addOperation(c) // discarded (complete are priorized)
+
+	// Act: get operation to prune up to.
+	var opUUIDs []string
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		opUUIDs, err = s.state.getOperationToPruneUpTo(ctx, tx, 3)
+		return err
+	})
+
+	// Assert: no error, all operations retrieved
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(opUUIDs, tc.SameContents, []string{op1, op2, op3})
+}
+
+// TestComputeObjectStoreSizeNoOutputs verifies size is zero when no outputs exist.
+func (s *pruneBySizeSuite) TestComputeObjectStoreSizeNoOutputs(c *tc.C) {
+	var size int
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		size, err = s.state.computeObjectStoreSize(ctx, tx, 1)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(size, tc.Equals, 0)
+}
+
+// TestComputeObjectStoreSizeSumsOnlyReferenced ensures only sizes referenced by operation_task_output are summed.
+func (s *pruneBySizeSuite) TestComputeObjectStoreSizeSumsOnlyReferenced(c *tc.C) {
+	// Arrange: create an operation and two tasks with outputs, plus an unreferenced object store entry.
+	opUUID := s.addOperation(c)
+	task1 := s.addOperationTask(c, opUUID)
+	task2 := s.addOperationTask(c, opUUID)
+	// Referenced outputs
+	s.addOperationTaskOutputWithData(c, task1, "sha1", "shaA", 1000, "/path/a")
+	s.addOperationTaskOutputWithData(c, task2, "sha2", "shaB", 3000, "/path/b")
+	// Unreferenced object store metadata, should be ignored by computeObjectStoreSize
+	s.addFakeMetadataStore(c, 999999)
+
+	var size int
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		size, err = s.state.computeObjectStoreSize(ctx, tx, 1)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(size, tc.Equals, 4000)
+}
+
+// TestComputeObjectStoreSizeConvertsToKiB verifies conversion using humanize.KiByte.
+func (s *pruneBySizeSuite) TestComputeObjectStoreSizeConvertsToKiB(c *tc.C) {
+	// Arrange
+	opUUID := s.addOperation(c)
+	task := s.addOperationTask(c, opUUID)
+	// Add output of 2078 bytes so 2078/1024 = 3 (integer division, rounded up) KiB
+	s.addOperationTaskOutputWithData(c, task, "sha3", "shaC", 2078, "/path/c")
+
+	var sizeKiB int
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		sizeKiB, err = s.state.computeObjectStoreSize(ctx, tx, humanize.KiByte)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(sizeKiB, tc.Equals, 3)
+}
+
+// TestEstimateOperationSizeEmptyDB ensures that when there are no operations,
+// the function returns total=0 and avg=-1 without error.
+func (s *pruneBySizeSuite) TestEstimateOperationSizeEmptyDB(c *tc.C) {
+	var total, avg int
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		total, avg, err = s.state.estimateOperationSizeInKiB(ctx, tx)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(total, tc.Equals, 0)
+	c.Check(avg, tc.Equals, -1)
+}
+
+// TestEstimateOperationSizeWithData verifies that row counts and object store
+// sizes are combined using the row size factors and KiB rounding for object store.
+func (s *pruneBySizeSuite) TestEstimateOperationSizeWithData(c *tc.C) {
+	// Arrange: 2 operations, 3 tasks, 5 logs, object store total 4000 bytes -> 4 KiB.
+	op1 := s.addOperation(c)
+	op2 := s.addOperation(c)
+	// Tasks
+	t1 := s.addOperationTask(c, op1)
+	t2 := s.addOperationTask(c, op1)
+	t3 := s.addOperationTask(c, op2)
+	// Logs (5 entries total)
+	s.addOperationTaskLog(c, t1, "log1")
+	s.addOperationTaskLog(c, t1, "log2")
+	s.addOperationTaskLog(c, t2, "log3")
+	s.addOperationTaskLog(c, t3, "log4")
+	s.addOperationTaskLog(c, t3, "log5")
+	// Object store referenced by two outputs: 1000 + 3000 bytes = 4000 bytes -> 4 KiB
+	s.addOperationTaskOutputWithData(c, t1, "shaA", "shaA3", 1000, "/a")
+	s.addOperationTaskOutputWithData(c, t2, "shaB", "shaB3", 3000, "/b")
+
+	var total, avg int
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		total, avg, err = s.state.estimateOperationSizeInKiB(ctx, tx)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	// Expect: total = op(2)*1 + task(3)*1 + log(5)*1 + object(4) = 14 KiB; avg = total/opCount = 7.
+	c.Check(total, tc.Equals, 2+3+5+4)
+	c.Check(avg, tc.Equals, (2+3+5+4)/2)
+}
+
+// TestPruneOperationsToKeepUnderSizeMiBIgnoresNonPositive ensures no pruning occurs when size limit is zero or negative.
+func (s *pruneBySizeSuite) TestPruneOperationsToKeepUnderSizeMiBIgnoresNonPositive(c *tc.C) {
+	// Arrange: add some operations to ensure there is data.
+	op1 := s.addOperation(c)
+	op2 := s.addOperation(c)
+
+	// Act: call with zero and negative; both should be no-ops and return nil.
+	err := s.state.pruneOperationsToKeepUnderSizeMiB(c.Context(), 0)
+	c.Assert(err, tc.ErrorIsNil)
+	err = s.state.pruneOperationsToKeepUnderSizeMiB(c.Context(), -5)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Assert: operations unchanged
+	c.Check(s.selectDistinctValues(c, "uuid", "operation"), tc.SameContents, []string{op1, op2})
+}
+
+// TestPruneOperationsToKeepUnderSizeMiBNoPruneWhenUnderLimit verifies no deletions when total size <= 1 MiB.
+func (s *pruneBySizeSuite) TestPruneOperationsToKeepUnderSizeMiBNoPruneWhenUnderLimit(c *tc.C) {
+	// Arrange: 2 operations, minimal data so total size is very small (<< 1 MiB).
+	op1 := s.addOperation(c)
+	op2 := s.addOperation(c)
+
+	// Act
+	err := s.state.pruneOperationsToKeepUnderSizeMiB(c.Context(), 1)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Assert: nothing deleted
+	c.Check(s.selectDistinctValues(c, "uuid", "operation"), tc.SameContents, []string{op1, op2})
+}
+
+// TestPruneOperationsToKeepUnderSizeMiBPrunesExpected ensures pruning deletes the correct number of oldest/prioritized operations.
+func (s *pruneBySizeSuite) TestPruneOperationsToKeepUnderSizeMiBPrunesExpected(c *tc.C) {
+	// Arrange:
+	// Create two operations: one completed long ago (opOld) and one not completed (opNew).
+	opOld := s.addCompletedOperation(c, time.Hour)
+	opNew := s.addOperation(c)
+	// Add a task and large output to push total size well over 1 MiB.
+	task := s.addOperationTask(c, opOld)
+	// 3072 KiB worth of bytes
+	bytes := 3072 * humanize.KiByte
+	s.addOperationTaskOutputWithData(c, task, "shaX", "shaY", bytes, "/big")
+
+	// Sanity: we now have object store ~3072 KiB + 2 ops + 1 task => total ~3075 KiB.
+	// For max=1 MiB (1024 KiB), deletion count should be 1 based on average size.
+
+	// Act
+	err := s.state.pruneOperationsToKeepUnderSizeMiB(c.Context(), 1)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Assert: exactly one operation should remain: the newer one (opNew). The older completed opOld is deleted first.
+	c.Check(s.selectDistinctValues(c, "uuid", "operation"), tc.SameContents, []string{opNew})
 }

--- a/domain/operation/state/state_test.go
+++ b/domain/operation/state/state_test.go
@@ -236,3 +236,39 @@ func (s *deleteOperationSuite) TestGetTaskUUIDsByOperationUUIDsNilInput(c *tc.C)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(taskUUIDs, tc.HasLen, 0)
 }
+
+// TestCountFewItems verifies that count returns the number of rows when there are a few items in the operation table.
+func (s *deleteOperationSuite) TestCountFewItems(c *tc.C) {
+	// Arrange: insert a few operations
+	s.addOperation(c)
+	s.addOperation(c)
+
+	// Act
+	var got int
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		got, err = s.state.count(ctx, tx, "operation")
+		return err
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.Equals, 2)
+}
+
+// TestCountNoItems verifies that count returns zero when the operation table has no rows.
+func (s *deleteOperationSuite) TestCountNoItems(c *tc.C) {
+	// Arrange: no operations are added
+
+	// Act
+	var got int
+	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		got, err = s.state.count(ctx, tx, "operation")
+		return err
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.Equals, 0)
+}


### PR DESCRIPTION
Follow up of #20611

Implements the prune by size.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Follow the step of #20552 to rune the pruner more often.

The log shouldn't show any error which would implies that the pruner method yield an error.

## Links

**Jira card:** JUJU-8357