### PR TITLE
feat: logging level for changestream pruner

### DIFF
--- a/internal/worker/changestreampruner/pruner.go
+++ b/internal/worker/changestreampruner/pruner.go
@@ -105,7 +105,7 @@ func (w *Pruner) loop() error {
 			return tomb.ErrDying
 
 		case <-timer.Chan():
-			w.logger.Debugf(ctx, "running changestream pruner")
+			w.logger.Tracef(ctx, "running changestream pruner")
 
 			newWindow, pruned, err := w.changeStreamService.Prune(ctx, window)
 			if errors.Is(err, context.Canceled) {
@@ -115,7 +115,7 @@ func (w *Pruner) loop() error {
 			}
 
 			if pruned > 0 {
-				w.logger.Infof(ctx, "pruned %d rows from change log", pruned)
+				w.logger.Debugf(ctx, "pruned %d rows from change log", pruned)
 			}
 
 			window = newWindow


### PR DESCRIPTION
The logging level for the changestream pruner was a bit high and becomes annoying in the every day running of a controller. You want to know that it's happening, you just don't want to be told about it every 5 seconds.


## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
```

The `"running changestream pruner"` log message should now be a trace level, so shouldn't be as distracting when viewing the logs.