### PR TITLE
feat(domain/operation): add object store cleanup during pruning

### DIFF
--- a/domain/operation/service/service.go
+++ b/domain/operation/service/service.go
@@ -92,7 +92,8 @@ type State interface {
 	// log messages.
 	NamespaceForTaskLogWatcher() string
 	// PruneOperations deletes operations that are older than maxAge and larger than maxSizeMB (in megabytes).
-	PruneOperations(ctx context.Context, maxAge time.Duration, maxSizeMB int) error
+	// It returns the paths from objectStore that should be freed
+	PruneOperations(ctx context.Context, maxAge time.Duration, maxSizeMB int) ([]string, error)
 }
 
 // Service provides the API for managing operation

--- a/domain/operation/service/state_mock_test.go
+++ b/domain/operation/service/state_mock_test.go
@@ -594,11 +594,12 @@ func (c *MockStateNamespaceForTaskLogWatcherCall) DoAndReturn(f func() string) *
 }
 
 // PruneOperations mocks base method.
-func (m *MockState) PruneOperations(ctx context.Context, maxAge time.Duration, maxSizeMB int) error {
+func (m *MockState) PruneOperations(ctx context.Context, maxAge time.Duration, maxSizeMB int) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PruneOperations", ctx, maxAge, maxSizeMB)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PruneOperations indicates an expected call of PruneOperations.
@@ -614,19 +615,19 @@ type MockStatePruneOperationsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStatePruneOperationsCall) Return(arg0 error) *MockStatePruneOperationsCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockStatePruneOperationsCall) Return(arg0 []string, arg1 error) *MockStatePruneOperationsCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatePruneOperationsCall) Do(f func(context.Context, time.Duration, int) error) *MockStatePruneOperationsCall {
+func (c *MockStatePruneOperationsCall) Do(f func(context.Context, time.Duration, int) ([]string, error)) *MockStatePruneOperationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatePruneOperationsCall) DoAndReturn(f func(context.Context, time.Duration, int) error) *MockStatePruneOperationsCall {
+func (c *MockStatePruneOperationsCall) DoAndReturn(f func(context.Context, time.Duration, int) ([]string, error)) *MockStatePruneOperationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/operation/state/package_test.go
+++ b/domain/operation/state/package_test.go
@@ -237,11 +237,23 @@ func (s *baseSuite) addOperationTaskOutputWithData(c *tc.C, taskUUID, sha256, sh
 	s.query(c, `
 INSERT INTO object_store_metadata (uuid, sha_256, sha_384, size)
 VALUES (?, ?, ?, ?)`, storeUUID, sha256, sha384, size)
-	s.query(c, `
-INSERT INTO object_store_metadata_path (path, metadata_uuid)
-VALUES (?, ?)`, path, storeUUID)
+	s.addMetadataStorePath(c, storeUUID, path)
 	s.query(c, `INSERT INTO operation_task_output (task_uuid, store_uuid) VALUES (?, ?)`, taskUUID, storeUUID)
 	return storeUUID
+}
+
+// addOperationTaskOutput links a task to an object store metadata, return the
+// store metadata uuid
+func (s *baseSuite) addOperationTaskOutputWithPath(c *tc.C, taskUUID string, path string) string {
+	storeUUID := s.addFakeMetadataStore(c, 42)
+	s.query(c, `INSERT INTO operation_task_output (task_uuid, store_uuid) VALUES (?, ?)`, taskUUID, storeUUID)
+	s.addMetadataStorePath(c, storeUUID, path)
+	return storeUUID
+}
+
+// addMetadataStorePath links a store metadata to a path
+func (s *baseSuite) addMetadataStorePath(c *tc.C, storeUUID, path string) {
+	s.query(c, `INSERT INTO object_store_metadata_path (path, metadata_uuid) VALUES (?, ?)`, path, storeUUID)
 }
 
 // addOperationTaskOutput links a task to an object store metadata, return the

--- a/domain/operation/state/types.go
+++ b/domain/operation/state/types.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+// uuids represents a slice of UUIDs.
+type uuids []string
+
 // taskResult represents the result of joining operation with its tasks and
 // receivers.
 type taskResult struct {
@@ -59,4 +62,10 @@ type taskStatus struct {
 
 type nameArg struct {
 	Name string `db:"name"`
+}
+
+// path represents a path parameter for queries on the
+// object_store_metadata_path table.
+type path struct {
+	Path string `db:"path"`
 }


### PR DESCRIPTION
Enable object store cleanup when pruning operations based on age and size constraints, since the object store doesn't belong to the operation domain. We need to return paths from store which are associated to tasks, then use the object store injected in the domain to delete the actual data.

- Updated `PruneOperations` in `domain/operation/service/service.go` to return paths to be removed from the object store after state pruning.
- Modified `PruneOperations` in `domain/operation/state/state.go` to return store paths for cleanup.
- Extended task and operation deletion (`deleteTaskByUUIDs` and `deleteOperationByUUIDs`) to retrieve and return object store paths.
- Added `deleteStoreEntryByUUIDs` to handle deletion of object store metadata and return associated paths.
- Integrated service-layer object store removal in `domain/operation/service/prune.go`, processing paths returned after state pruning.
- Updated `prune_test.go` and `state_test.go` to test scenarios involving object store path removal.

This ensures object store metadata is properly cleaned up when operations or tasks are pruned.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Action not implemented yet, but we can use QA from

#20552

to check that the operationpruner worker doesn't bounce.

## Links
**Jira card:** JUJU-8357
