### PR TITLE
feat: display and update application storage cmd client

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -3167,6 +3167,9 @@ func (api *APIBase) GetApplicationStorage(args params.Entities) (params.Applicat
 	return resp, nil
 }
 
+// GetApplicationStorage isn't on the v21 API.
+func (api *APIv21) GetApplicationStorage(_ struct{}) {}
+
 func (api *APIBase) updateOneApplicationStorage(storageUpdate params.ApplicationStorageUpdate) error {
 	appTag, err := names.ParseTag(storageUpdate.ApplicationTag)
 	if err != nil {
@@ -3215,3 +3218,6 @@ func (api *APIBase) UpdateApplicationStorage(args params.ApplicationStorageUpdat
 
 	return resp, nil
 }
+
+// UpdateApplicationStorage isn't on the v21 API.
+func (api *APIv21) UpdateApplicationStorage(_ struct{}) {}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1321,14 +1321,3 @@ func RemoveVirtualHostKey(c *gc.C, st *State, key *VirtualHostKey) {
 	err := st.db().RunTransaction(op)
 	c.Assert(err, gc.IsNil)
 }
-
-// UpdateStorageConstraints updates an application's storage constraints.
-// TODO(adisazhar123): I am using this to test WatchStorageConstraints. I will replace
-// this with Alvin's implementation once it lands.
-func UpdateStorageConstraints(st *State, application *Application, cons map[string]StorageConstraints) error {
-	key := application.storageConstraintsKey()
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		return []txn.Op{replaceStorageConstraintsOp(key, cons)}, nil
-	}
-	return st.db().Run(buildTxn)
-}


### PR DESCRIPTION
This PR implements the client to display and update application storage.

In addition, this PR also adds some functionality/tests as a followup to the prev PR (https://github.com/juju/juju/pull/20604):
1. Added the corresponding stub methods for application version 21 API struct to the new methods from being called in api ver 21 and below
2. Added concurrent update test cases using hooks to ensure that UpdateStorageConstraints still works as expected even with concurrent updates to the application charm.

The card has been split into 3 PRs for better readability and fill in the placeholders for other parallel work :

**Server**
1. Implement API server logic to get and set application storage command 

**Client**

2. Implement juju application-storage get/set client logic (Current PR)

**Comand**
3. Implement juju application-storage command interface


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
 
## Links
**Jira card:** https://warthogs.atlassian.net/browse/JUJU-8443
