### PR TITLE
feat: remove k8s attach storage feature flag

### DIFF
--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -4,10 +4,7 @@
 package storage_test
 
 import (
-	"os"
-
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -17,8 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/storage"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	jujustorage "github.com/juju/juju/storage"
@@ -76,10 +71,6 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.callContext = context.NewEmptyCloudCallContext()
 	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
 	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
-
-	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.K8SAttachStorage)
-	c.Assert(err, jc.ErrorIsNil)
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *baseStorageSuite) storageMetadata() (poolmanager.PoolManager, jujustorage.ProviderRegistry, error) {

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v5"
 
@@ -21,7 +20,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -189,7 +187,7 @@ func (c *addUnitCommand) validateArgsByModelType() error {
 		return err
 	}
 	if modelType == model.CAAS {
-		if c.PlacementSpec != "" || (len(c.AttachStorage) != 0 && !featureflag.Enabled(feature.K8SAttachStorage)) {
+		if c.PlacementSpec != "" {
 			return errors.New("k8s models only support --num-units")
 		}
 	}

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -4,12 +4,10 @@
 package application_test
 
 import (
-	"os"
 	"strings"
 
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -19,8 +17,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/rpc/params"
@@ -258,10 +254,10 @@ func (s *AddUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, expectedError)
 
 	err = s.runAddUnit(c, "some-application-name", "--attach-storage", "foo/0")
-	c.Assert(err, gc.ErrorMatches, expectedError)
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.runAddUnit(c, "some-application-name", "--attach-storage", "foo/0", "-n", "2")
-	c.Assert(err, gc.ErrorMatches, expectedError)
+	c.Assert(err, gc.ErrorMatches, "--attach-storage cannot be used with -n")
 
 	err = s.runAddUnit(c, "some-application-name", "--attach-storage", "foo/0", "-n", "2", "--to", "lxd:1")
 	c.Assert(err, gc.ErrorMatches, expectedError)
@@ -292,12 +288,6 @@ func (s *AddUnitSuite) TestUnknownModelCallsRefresh(c *gc.C) {
 }
 
 func (s *AddUnitSuite) TestCAASAddUnitAttachStorage(c *gc.C) {
-	s.SetFeatureFlags(feature.K8SAttachStorage)
-	defer func() {
-		// Unset feature flag
-		os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
-		featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	}()
 	m := s.store.Models["arthur"].Models["king/sword"]
 	m.ModelType = model.CAAS
 	s.store.Models["arthur"].Models["king/sword"] = m

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
@@ -40,7 +39,6 @@ import (
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	apiparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/storage"
 )
@@ -732,9 +730,6 @@ func (c *DeployCommand) validateStorageByModelType() error {
 	}
 	if modelType == model.IAAS {
 		return nil
-	}
-	if len(c.AttachStorage) > 0 && !featureflag.Enabled(feature.K8SAttachStorage) {
-		return errors.New("--attach-storage cannot be used on k8s models")
 	}
 	return nil
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
@@ -60,8 +59,6 @@ import (
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/feature"
-	"github.com/juju/juju/juju/osenv"
 	jjtesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -1094,8 +1091,6 @@ var caasTests = []struct {
 	args    []string
 	message string
 }{
-	{[]string{"-m", "caas-model", "some-application-name", "--attach-storage", "foo/0"},
-		"--attach-storage cannot be used on k8s models"},
 	{[]string{"-m", "caas-model", "some-application-name", "--to", "a=b"},
 		regexp.QuoteMeta(`--to cannot be used on k8s models`)},
 }
@@ -1196,13 +1191,6 @@ func (s *CAASDeploySuite) TestDevices(c *gc.C) {
 }
 
 func (s *CAASDeploySuite) TestDeployAttachStorage(c *gc.C) {
-	s.SetFeatureFlags(feature.K8SAttachStorage)
-	defer func() {
-		// Unset feature flag
-		os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
-		featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	}()
-
 	repo := testcharms.RepoWithSeries("kubernetes")
 	charmDir := repo.ClonedDir(s.CharmsPath, "gitlab")
 

--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -8,15 +8,12 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v5"
 
 	apistorage "github.com/juju/juju/api/client/storage"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/storage"
 )
@@ -158,14 +155,6 @@ func (c *importFilesystemCommand) Info() *cmd.Info {
 
 // Run implements Command.Run.
 func (c *importFilesystemCommand) Run(ctx *cmd.Context) (err error) {
-	modelType, err := c.ModelType()
-	if err != nil {
-		return err
-	}
-	if modelType == model.CAAS && !featureflag.Enabled(feature.K8SAttachStorage) {
-		return errors.Errorf("Juju command %q not supported on container models", "import-filesystem")
-	}
-
 	api, err := c.newAPIFunc(&c.StorageCommandBase)
 	if err != nil {
 		return err

--- a/cmd/juju/storage/import_test.go
+++ b/cmd/juju/storage/import_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/feature"
 	_ "github.com/juju/juju/internal/provider/dummy"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -86,8 +85,6 @@ func (s *ImportFilesystemSuite) TestImportError(c *gc.C) {
 }
 
 func (s *ImportFilesystemSuite) TestImportSuccessCAAS(c *gc.C) {
-	s.SetFeatureFlags(feature.K8SAttachStorage)
-
 	store := jujuclienttesting.MinimalStore()
 	store.Models["arthur"] = &jujuclient.ControllerModels{
 		CurrentModel: "king/sword",
@@ -113,23 +110,6 @@ imported storage baz/0
 		}},
 		{"Close", nil},
 	})
-}
-
-func (s *ImportFilesystemSuite) TestImportErrorCAASNotSupport(c *gc.C) {
-	store := jujuclienttesting.MinimalStore()
-	store.Models["arthur"] = &jujuclient.ControllerModels{
-		CurrentModel: "king/sword",
-		Models: map[string]jujuclient.ModelDetails{"king/sword": {
-			ModelType: model.CAAS,
-		}},
-	}
-	s.store = store
-
-	ctx, err := s.run(c, "foo", "bar", "baz")
-	c.Assert(err, gc.ErrorMatches, "Juju command \"import-filesystem\" not supported on container models")
-
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (s *ImportFilesystemSuite) TestImportWithForce(c *gc.C) {

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -36,8 +36,3 @@ const RawK8sSpec = "raw-k8s-spec"
 
 // SSHJump indicates that the SSH jump feature is enabled.
 const SSHJump = "ssh-jump"
-
-// K8SAttachStorage enables the following on Kubernetes clouds:
-// - import-filesystem
-// - juju deploy and juju add-unit with the --attach-storage option
-const K8SAttachStorage = "k8s-attach-storage"

--- a/tests/suites/storage_k8s/task.sh
+++ b/tests/suites/storage_k8s/task.sh
@@ -11,7 +11,9 @@ test_storage_k8s() {
 		echo "==> Checking for dependencies"
 		check_dependencies juju
 
-		export JUJU_DEV_FEATURE_FLAGS=k8s-attach-storage
+		microk8s config >"${TEST_DIR}"/kube.conf
+		export KUBE_CONFIG="${TEST_DIR}"/kube.conf
+
 		test_import_filesystem
 		test_force_import_filesystem
 		test_deploy_attach_storage


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

Enable attach-storage functionality for Kubernetes models by default by removing the K8SAttachStorage feature flag. This allows import-filesystem, juju deploy, and juju add-unit commands to use --attach-storage on k8s models without requiring a feature flag.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

**e2e tests**:

```
cd ./tests
./main.sh -V -l lxd-k8s-ctrl storage_k8s test_add_unit_attach_storage
./main.sh -V -l lxd-k8s-ctrl storage_k8s test_import_filesystem
```

**unit tests**:

```sh
make run-go-tests TEST_PACKAGES=./cmd/juju/application TEST_FILTER=AddUnitSuite
make run-go-tests TEST_PACKAGES=./cmd/juju/application TEST_FILTER=CAASDeploySuite
make run-go-tests TEST_PACKAGES=./cmd/juju/storage TEST_FILTER=ImportFilesystemSuite
make run-go-tests TEST_PACKAGES=./apiserver/facades/client/storage TEST_FILTER=baseStorageSuite%  
```

## Links

blocked-by: #20633 

