### PR TITLE
fix: setup gcloudcli in ci gating tests

### DIFF
--- a/tests/includes/gcloudcli.sh
+++ b/tests/includes/gcloudcli.sh
@@ -14,18 +14,18 @@ setup_gcloudcli_credential() {
 	local key_json_file_path
 
 	google_entry=$(cat "$HOME/.local/share/juju/credentials.yaml" | yq e '.credentials.google | to_entries | .[0].value' -)
-  #	The `file` field points to a JSON file, which contains the private key.
+	#	The `file` field points to a JSON file, which contains the private key.
 	key_json_file_path=$(echo "$google_entry" | yq e '.file' -)
 
-  # If credentials.yaml doesn't have a `file` field
-  # we assume that this yaml file has the contents expanded so we read from it.
-	if [[ "$key_json_file_path" == "null" || -z "$key_json_file_path" ]]; then
-    tmp_key_file=$(mktemp /tmp/google-key.XXXXXX.json)
-    echo "$google_entry" \
-      | yq e '.. | select(tag == "!!map") | with_entries(.key |= sub("-"; "_"))' -o=json - \
-      > "$tmp_key_file"
-    key_json_file_path="$tmp_key_file"
-  fi
+	# If credentials.yaml doesn't have a `file` field
+	# we assume that this yaml file has the contents expanded so we read from it.
+	if [[ $key_json_file_path == "null" || -z $key_json_file_path ]]; then
+		tmp_key_file=$(mktemp /tmp/google-key.XXXXXX.json)
+		echo "$google_entry" |
+			yq e '.. | select(tag == "!!map") | with_entries(.key |= sub("-"; "_"))' -o=json - \
+				>"$tmp_key_file"
+		key_json_file_path="$tmp_key_file"
+	fi
 
-  gcloud auth activate-service-account --key-file "$key_json_file_path"
+	gcloud auth activate-service-account --key-file "$key_json_file_path"
 }

--- a/tests/suites/cloud_gce/task.sh
+++ b/tests/suites/cloud_gce/task.sh
@@ -13,8 +13,8 @@ test_cloud_gce() {
 
 	setup_gcloudcli_credential
 
-  echo "==> Checking for dependencies"
-  check_dependencies juju gcloud
+	echo "==> Checking for dependencies"
+	check_dependencies juju gcloud
 
 	file="${TEST_DIR}/test-cloud-gce.log"
 


### PR DESCRIPTION
The `credentials.yaml` file in cloudcity already contains the expanded fields required for gcloud authentication. Our previous implementation assumed that the YAML file always contained a `file` field pointing to a service account key, which caused failures when the fields were already expanded instead.

This PR updates the logic to first check whether a file field exists. If it does, we use the referenced service account key. If not, we fall back to using the expanded fields directly from the YAML.

Fixes the failing gce tests in https://jenkins.juju.canonical.com/view/ci-runs/job/ci-gating-tests/4852/.