### PR TITLE
fix: ci gating bundle test aws

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -295,7 +295,10 @@ run_deploy_lxd_profile_bundle() {
 		wait_for "ubuntu" "$(idle_condition "ubuntu" 1 "${i}")"
 	done
 
-	lxd_profile_name="juju-${model_name}-lxd-profile"
+	short_uuid=$(juju models --format json |
+		jq -r --arg name "${model_name}" '.models[] | select(.["short-name"]==$name) | ."model-uuid"[0:6]')
+	lxd_profile_name="juju-${model_name}-${short_uuid}-lxd-profile"
+
 	for i in 0 1 2 3; do
 		machine_n_lxd0="$(machine_container_path "${i}" "${i}"/lxd/0)"
 		juju status --format=json | jq "${machine_n_lxd0}" | check "${lxd_profile_name}"


### PR DESCRIPTION
Small fix to use the correct LXD name in integration test.

Fixes: https://jenkins.juju.canonical.com/job/test-deploy-test-deploy-bundles-aws/8956/consoleFull