### PR TITLE
fix(tests): ci gating tests followup

### DIFF
--- a/tests/includes/gcloudcli.sh
+++ b/tests/includes/gcloudcli.sh
@@ -28,4 +28,7 @@ setup_gcloudcli_credential() {
 	fi
 
 	gcloud auth activate-service-account --key-file "$key_json_file_path"
+
+	project_id=$(jq -r .project_id "$key_json_file_path")
+	gcloud config set project "$project_id"
 }


### PR DESCRIPTION
Fixes issue found in CI gating tests that blocks 3.6.10 release.

- [test-model-metrics-google](https://jenkins.juju.canonical.com/job/test-model-test-model-metrics-google/3386/consoleFull) => `gcloud compute networks list` requires the project to be set. We configure the project as part of gcloud CLI setup.