### PR TITLE
test: replace ntp with juju-qa-dummy-subordinate and fix ec2 spaces

### DIFF
--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -154,7 +154,7 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 			}
 			if origin.ID == "" || origin.Revision == nil || origin.Channel == nil || origin.Platform == nil {
 				logger.Errorf("charm %s has missing id(%s), revision (%p), channel (%p), or platform (%p), skipping",
-					curl, origin.Revision, origin.Channel, origin.Platform)
+					curl, origin.ID, origin.Revision, origin.Channel, origin.Platform)
 				continue
 			}
 			channel, err := charm.MakeChannel(origin.Channel.Track, origin.Channel.Risk, origin.Channel.Branch)

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -84,7 +84,8 @@ run_reboot_monitor_state_cleanup() {
 
 	juju deploy juju-qa-test --base ubuntu@22.04
 	juju deploy juju-qa-dummy-subordinate
-	juju integrate juju-qa-test dummy-subordinate
+	juju config dummy-subordinate token=becomegreen
+	juju integrate juju-qa-test:juju-info dummy-subordinate:juju-info
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 1)"
 	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test")"
 

--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -8,12 +8,19 @@ run_model_metrics() {
 	file="${TEST_DIR}/test-${testname}.log"
 	ensure "${testname}" "${file}"
 
-	# Deploy juju-qa-test with a different name, check that the metric send the charm name, not the application name.
-	juju deploy juju-qa-test app-juju-qa-test --base ubuntu@22.04
+	# Deploy ubuntu with a different name, check that the metric send the charm name, not the application name.
+	juju deploy ubuntu app-one --base ubuntu@22.04
+	juju deploy juju-qa-test
 	juju deploy juju-qa-dummy-subordinate
-	juju integrate juju-qa-test dummy-subordinate
-	wait_for "app-juju-qa-test" "$(idle_condition "app-juju-qa-test" 1)"
-	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "app-juju-qa-test")"
+	juju config dummy-subordinate token=becomegreen
+	juju relate dummy-subordinate app-one
+
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 2)"
+	wait_for "app-one" "$(idle_condition "app-one" 0)"
+	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "app-one" 0)"
+
+	juju relate dummy-subordinate:juju-info juju-qa-test:juju-info
+	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test" 1)"
 
 	juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE"
 
@@ -26,7 +33,7 @@ run_model_metrics() {
 	attempt=0
 	while true; do
 		OUT=$(juju debug-log -m controller --include-module juju.apiserver.charmrevisionupdater.client | grep metrics || true)
-		if echo "${OUT}" | grep -e '"metrics":{"relations":"dummy-subordinate,juju-qa-test","units":"2"}'-e '"model":{"applications":"2",' -e '"machines":"1",'; then
+		if echo "${OUT}" | grep -e '"metrics":{"relations":"juju-qa-test,ubuntu","units":"2"}' -e '"metrics":{"relations":"dummy-subordinate","units":"1"}' -e '"model":{"applications":"3",' -e '"machines":"2",'; then
 			break
 		fi
 		echo "${OUT}"

--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -4,6 +4,10 @@ test_spaces_ec2() {
 		return
 	fi
 
+	if [ "${BOOTSTRAP_REGION:-}" == "" ]; then
+		BOOTSTRAP_REGION=us-east-1
+	fi
+
 	setup_awscli_credential
 	# Ensure that the aws cli and juju both use the same aws region
 	export AWS_DEFAULT_REGION="${BOOTSTRAP_REGION}"

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -73,5 +73,5 @@ configure_multi_nic_netplan() {
 
 	# Wait for the interface to be detected by juju
 	echo "[+] waiting for juju to detect added NIC"
-	wait_for_machine_netif_count "$juju_machine_id" "3"
+	wait_for_machine_netif_count "$juju_machine_id" "2"
 }


### PR DESCRIPTION
The `ntp` charm was taking a long time to transition to `idle` state causing integration tests to timeout. We replace it with a simpler charm `juju-qa-dummy-subordinate` to test the model metrics.

I've introduced a new requires endpoint `juju-info` to `juju-qa-dummy-subordinate`. The charm needs to be uploaded to Charmhub. This allows it to relate to other applications, since all applications implicitly include a juju-info relation with a provider role.

This should fix https://jenkins.juju.canonical.com/job/test-model-test-model-metrics-google/3395/


As a driveby the ec2 spaces stuff are done here.


QA:

```
./main.sh -v model test_model
./main.sh -v spaces_ec2 test_spaces_ec2
```


The charm `metadata.yaml`, not part of this codebase looks like:

```
name: dummy-subordinate
maintainer: Juju-QA <redacted>
subordinate: true
summary: Dummy subordinate charm that accepts data
description: |
  This dummy subordinate charm is used to verify that a relationship is created correctly
requires:
  sink:
    interface: dummy-token
    scope: container
  juju-info:
    interface: juju-info
    scope: container
categories:
  - misc
series:
  - trusty
  - xenial
  - artful
  - bionic
  - eoan
  - focal
```