### PR TITLE
fix: endpoint binding bug

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1745,11 +1745,7 @@ func (api *APIBase) MergeBindings(ctx context.Context, in params.ApplicationMerg
 			continue
 		}
 
-		bindings := transform.Map(arg.Bindings, func(k string, v string) (string, network.SpaceName) {
-			return k, network.SpaceName(v)
-		})
-
-		err = api.applicationService.MergeApplicationEndpointBindings(ctx, appID, bindings, arg.Force)
+		err = api.applicationService.MergeApplicationEndpointBindings(ctx, appID, transformBindings(arg.Bindings), arg.Force)
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			res[i].Error = apiservererrors.ParamsErrorf(params.CodeNotFound, "application %s not found", tag.Id())
 			continue

--- a/domain/application/state/application_endpoint.go
+++ b/domain/application/state/application_endpoint.go
@@ -261,7 +261,7 @@ func (st *State) mergeApplicationEndpointBindings(ctx context.Context, tx *sqlai
 
 	validateErr := st.validateUnitsInSpaces(ctx, tx, appID, slices.Collect(maps.Values(spacesToUUIDs)))
 	if !force && validateErr != nil {
-		return errors.Capture(err)
+		return errors.Capture(validateErr)
 	} else if force && validateErr != nil {
 		st.logger.Infof(ctx, "binding validation ignored due to force: %w", validateErr)
 	}


### PR DESCRIPTION
We were returning the wrong error, meaning fails were being missed

Minor refactor as a flyby

## QA steps

```
$ juju deploy juju-qa-test
$ juju add-space beta 
$ juju move-to-space ^Cta 10.51.194.0/24
$ juju bind juju-qa-test info=beta
ERROR unit "juju-qa-test/0" not in space "beta"
```