### PR TITLE
test: disallow db access in change stream tests

### DIFF
--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/juju/juju/domain/model"
 	statecontroller "github.com/juju/juju/domain/model/state/controller"
 	modelstatetesting "github.com/juju/juju/domain/model/state/testing"
-	"github.com/juju/juju/internal/changestream/testing"
+	"github.com/juju/juju/domain/schema/testing"
 	jujudb "github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/secrets/provider/juju"
 	"github.com/juju/juju/internal/uuid"

--- a/domain/removal/state/controller/state_test.go
+++ b/domain/removal/state/controller/state_test.go
@@ -24,7 +24,6 @@ import (
 	statecontroller "github.com/juju/juju/domain/model/state/controller"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/domain/secretbackend/bootstrap"
-	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/secrets/provider/juju"
 	"github.com/juju/juju/internal/uuid"
@@ -39,7 +38,7 @@ func TestStateSuite(t *testing.T) {
 }
 
 type baseSuite struct {
-	changestreamtesting.ControllerSuite
+	schematesting.ControllerSuite
 
 	uuid coremodel.UUID
 }

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/tc"
 
 	coreapplication "github.com/juju/juju/core/application"
-	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
@@ -35,8 +34,7 @@ func TestApplicationSuite(t *testing.T) {
 }
 
 func (s *applicationSuite) TestApplicationExists(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
@@ -51,8 +49,7 @@ func (s *applicationSuite) TestApplicationExists(c *tc.C) {
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app")
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
@@ -73,8 +70,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccess(c *
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWithAliveUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",
 		applicationservice.AddIAASUnitArg{},
 		applicationservice.AddIAASUnitArg{},
@@ -100,8 +96,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWithAliveAndDyingUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",
 		applicationservice.AddIAASUnitArg{},
 		applicationservice.AddIAASUnitArg{},
@@ -138,8 +133,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWithAliveAndDyingUnitsWithLastMachine(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",
 		applicationservice.AddIAASUnitArg{},
 		applicationservice.AddIAASUnitArg{
@@ -175,8 +169,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 // Ensure that if another application is using the machine, it will not be
 // set to dying.
 func (s *applicationSuite) TestEnsureApplicationOnMultipleMachines(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID1 := s.createIAASApplication(c, svc, "foo",
 		applicationservice.AddIAASUnitArg{},
 	)
@@ -244,12 +237,11 @@ func (s *applicationSuite) TestEnsureApplicationOnMultipleMachines(c *tc.C) {
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWithRelations(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	appSvc := s.setupApplicationService(c, factory)
+	appSvc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, appSvc, "app1")
 	s.createIAASApplication(c, appSvc, "app2")
 
-	relSvc := s.setupRelationService(c, factory)
+	relSvc := s.setupRelationService(c)
 	_, _, err := relSvc.AddRelation(c.Context(), "app1:foo", "app2:bar")
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -271,8 +263,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeDyingSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app")
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
@@ -301,8 +292,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNotExistsSuccess(
 }
 
 func (s *applicationSuite) TestApplicationRemovalNormalSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
@@ -367,8 +357,7 @@ where  r.uuid = ?`, "removal-uuid",
 }
 
 func (s *applicationSuite) TestGetApplicationLifeSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	// Set the application to "dying" manually.
@@ -390,8 +379,7 @@ func (s *applicationSuite) TestGetApplicationLifeNotFound(c *tc.C) {
 }
 
 func (s *applicationSuite) TestDeleteIAASApplication(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app")
 
 	s.advanceApplicationLife(c, appUUID, life.Dead)
@@ -408,8 +396,7 @@ func (s *applicationSuite) TestDeleteIAASApplication(c *tc.C) {
 }
 
 func (s *applicationSuite) TestDeleteIAASApplicationWithUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",
 		applicationservice.AddIAASUnitArg{},
 	)
@@ -444,12 +431,11 @@ func (s *applicationSuite) TestDeleteIAASApplicationWithUnits(c *tc.C) {
 }
 
 func (s *applicationSuite) TestDeleteIAASApplicationWithRelations(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	appSvc := s.setupApplicationService(c, factory)
+	appSvc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, appSvc, "app1")
 	s.createIAASApplication(c, appSvc, "app2")
 
-	relSvc := s.setupRelationService(c, factory)
+	relSvc := s.setupRelationService(c)
 	ep1, ep2, err := relSvc.AddRelation(c.Context(), "app1:foo", "app2:bar")
 	c.Assert(err, tc.ErrorIsNil)
 	relUUID, err := relSvc.GetRelationUUIDForRemoval(c.Context(), relation.GetRelationUUIDForRemovalArgs{
@@ -482,8 +468,7 @@ func (s *applicationSuite) TestDeleteIAASApplicationWithRelations(c *tc.C) {
 }
 
 func (s *applicationSuite) TestDeleteIAASApplicationMultipleRemovesCharm(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID1 := s.createIAASApplication(c, svc, "foo",
 		applicationservice.AddIAASUnitArg{},
 	)
@@ -517,8 +502,7 @@ func (s *applicationSuite) TestDeleteIAASApplicationMultipleRemovesCharm(c *tc.C
 }
 
 func (s *applicationSuite) TestDeleteCAASApplication(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createCAASApplication(c, svc, "some-app", applicationservice.AddUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -545,8 +529,7 @@ func (s *applicationSuite) TestDeleteCAASApplication(c *tc.C) {
 }
 
 func (s *applicationSuite) TestDeleteCAASApplicationWithUnit(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createCAASApplication(c, svc, "some-app", applicationservice.AddUnitArg{})
 
 	s.advanceApplicationLife(c, appUUID, life.Dead)
@@ -558,10 +541,8 @@ func (s *applicationSuite) TestDeleteCAASApplicationWithUnit(c *tc.C) {
 }
 
 func (s *applicationSuite) TestDeleteApplicationWithObjectstoreResource(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-
 	// Arrange: Two apps that share a resource object
-	appSvc := s.setupApplicationService(c, factory)
+	appSvc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, appSvc, "some-app")
 	s.advanceApplicationLife(c, appUUID, life.Dead)
 
@@ -600,10 +581,8 @@ func (s *applicationSuite) TestDeleteApplicationWithObjectstoreResource(c *tc.C)
 }
 
 func (s *applicationSuite) TestDeleteApplicationWithSharedObjectstoreResource(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-
 	// Arrange: Two apps that share a resource object store entry
-	appSvc := s.setupApplicationService(c, factory)
+	appSvc := s.setupApplicationService(c)
 
 	appUUID1 := s.createIAASApplication(c, appSvc, "some-app")
 	s.advanceApplicationLife(c, appUUID1, life.Dead)

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/tc"
 
-	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/instance"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/deployment"
@@ -31,8 +30,7 @@ func TestMachineSuite(t *testing.T) {
 }
 
 func (s *machineSuite) TestMachineExists(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -48,8 +46,7 @@ func (s *machineSuite) TestMachineExists(c *tc.C) {
 }
 
 func (s *machineSuite) TestGetMachineLifeSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -75,8 +72,7 @@ func (s *machineSuite) TestGetMachineLifeNotFound(c *tc.C) {
 }
 
 func (s *machineSuite) TestGetInstanceLifeSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -102,8 +98,7 @@ func (s *machineSuite) TestGetInstanceLifeNotFound(c *tc.C) {
 }
 
 func (s *machineSuite) TestGetMachineNetworkInterfacesNoHardwareDevices(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -115,8 +110,7 @@ func (s *machineSuite) TestGetMachineNetworkInterfacesNoHardwareDevices(c *tc.C)
 }
 
 func (s *machineSuite) TestGetMachineNetworkInterfaces(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -148,8 +142,7 @@ VALUES ('abc', ?, ?, ?, ?, ?, ?)`, netNodeUUID, "lld-name", 1500, "00:11:22:33:4
 }
 
 func (s *machineSuite) TestGetMachineNetworkInterfacesMultiple(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -187,8 +180,7 @@ VALUES ('def', ?, ?, ?, ?, ?, ?)`, netNodeUUID, "lld-name2", 1500, "66:11:22:33:
 }
 
 func (s *machineSuite) TestGetMachineNetworkInterfacesContainer(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID0 := s.createIAASApplication(c, svc, "some-app1", applicationservice.AddIAASUnitArg{})
 	appUUID1 := s.createIAASApplication(c, svc, "some-app2", applicationservice.AddIAASUnitArg{
 		AddUnitArg: applicationservice.AddUnitArg{
@@ -245,8 +237,7 @@ VALUES ('def', ?, ?, ?, ?, ?, ?)`, netNodeUUID, "lld-name-1", 1500, "11:11:22:33
 }
 
 func (s *machineSuite) TestEnsureMachineNotAliveCascade(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -263,8 +254,7 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascade(c *tc.C) {
 }
 
 func (s *machineSuite) TestEnsureMachineNotAliveCascadeCoHostedUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",
 		applicationservice.AddIAASUnitArg{},
 		applicationservice.AddIAASUnitArg{
@@ -294,8 +284,7 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeCoHostedUnits(c *tc.C) {
 }
 
 func (s *machineSuite) TestEnsureMachineNotAliveCascadeChildMachines(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",
 		applicationservice.AddIAASUnitArg{},
 		applicationservice.AddIAASUnitArg{
@@ -327,8 +316,7 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeChildMachines(c *tc.C) {
 }
 
 func (s *machineSuite) TestEnsureMachineNotAliveCascadeDoesNotSetOtherUnitsToDying(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID0 := s.createIAASApplication(c, svc, "foo", applicationservice.AddIAASUnitArg{})
 	machineUUID0 := s.getMachineUUIDFromApp(c, appUUID0)
 
@@ -412,8 +400,7 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithoutForceFailsForMachi
 }
 
 func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithoutForceFailsForMachineHostingUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "foo", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -427,8 +414,7 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithoutForceFailsForMachi
 }
 
 func (s *machineSuite) TestMachineRemovalNormalSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
@@ -563,8 +549,7 @@ func (s *machineSuite) TestMarkMachineAsDeadMachineHasContainers(c *tc.C) {
 }
 
 func (s *machineSuite) TestMarkMachineAsDeadMachineHasUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -579,8 +564,7 @@ func (s *machineSuite) TestMarkMachineAsDeadMachineHasUnits(c *tc.C) {
 }
 
 func (s *machineSuite) TestMarkMachineAsDeadMachineHasUnitsWithDeadUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -663,8 +647,7 @@ func (s *machineSuite) TestMarkInstanceAsDeadMachineHasContainers(c *tc.C) {
 }
 
 func (s *machineSuite) TestMarkInstanceAsDeadMachineHasUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
@@ -808,8 +791,7 @@ func (s *machineSuite) TestDeleteMachineWithContainers(c *tc.C) {
 }
 
 func (s *machineSuite) TestDeleteMachineWithUnits(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -116,13 +116,13 @@ func (s *machineSuite) TestGetMachineNetworkInterfaces(c *tc.C) {
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		var netNodeUUID string
-		err := s.DB().QueryRowContext(ctx, `
+		err := tx.QueryRowContext(ctx, `
 SELECT net_node_uuid FROM machine WHERE uuid = ?`, machineUUID.String()).Scan(&netNodeUUID)
 		if err != nil {
 			return err
 		}
 
-		_, err = s.DB().ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO link_layer_device (uuid, net_node_uuid, name, mtu, mac_address, device_type_id, virtual_port_type_id) 
 VALUES ('abc', ?, ?, ?, ?, ?, ?)`, netNodeUUID, "lld-name", 1500, "00:11:22:33:44:55", 0, 0)
 		if err != nil {
@@ -148,19 +148,19 @@ func (s *machineSuite) TestGetMachineNetworkInterfacesMultiple(c *tc.C) {
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		var netNodeUUID string
-		err := s.DB().QueryRowContext(ctx, `
+		err := tx.QueryRowContext(ctx, `
 SELECT net_node_uuid FROM machine WHERE uuid = ?`, machineUUID.String()).Scan(&netNodeUUID)
 		if err != nil {
 			return err
 		}
 
-		_, err = s.DB().ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO link_layer_device (uuid, net_node_uuid, name, mtu, mac_address, device_type_id, virtual_port_type_id) 
 VALUES ('abc', ?, ?, ?, ?, ?, ?)`, netNodeUUID, "lld-name1", 1500, "00:11:22:33:44:55", 0, 0)
 		if err != nil {
 			return err
 		}
-		_, err = s.DB().ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO link_layer_device (uuid, net_node_uuid, name, mtu, mac_address, device_type_id, virtual_port_type_id) 
 VALUES ('def', ?, ?, ?, ?, ?, ?)`, netNodeUUID, "lld-name2", 1500, "66:11:22:33:44:56", 0, 0)
 		if err != nil {
@@ -192,26 +192,26 @@ func (s *machineSuite) TestGetMachineNetworkInterfacesContainer(c *tc.C) {
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		var netNodeUUID string
-		err := s.DB().QueryRowContext(ctx, `
+		err := tx.QueryRowContext(ctx, `
 SELECT net_node_uuid FROM machine WHERE uuid = ?`, machineUUID0.String()).Scan(&netNodeUUID)
 		if err != nil {
 			return err
 		}
 
-		_, err = s.DB().ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO link_layer_device (uuid, net_node_uuid, name, mtu, mac_address, device_type_id, virtual_port_type_id) 
 VALUES ('abc', ?, ?, ?, ?, ?, ?)`, netNodeUUID, "lld-name-0", 1500, "00:11:22:33:44:55", 0, 0)
 		if err != nil {
 			return err
 		}
 
-		err = s.DB().QueryRowContext(ctx, `
+		err = tx.QueryRowContext(ctx, `
 SELECT net_node_uuid FROM machine WHERE uuid = ?`, machineUUID1.String()).Scan(&netNodeUUID)
 		if err != nil {
 			return err
 		}
 
-		_, err = s.DB().ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO link_layer_device (uuid, net_node_uuid, name, mtu, mac_address, device_type_id, virtual_port_type_id) 
 VALUES ('def', ?, ?, ?, ?, ?, ?)`, netNodeUUID, "lld-name-1", 1500, "11:11:22:33:44:66", 0, 0)
 		if err != nil {

--- a/domain/removal/state/model/model_test.go
+++ b/domain/removal/state/model/model_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/tc"
 
-	"github.com/juju/juju/core/changestream"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/life"
 	modelerrors "github.com/juju/juju/domain/model/errors"
@@ -64,8 +63,7 @@ func (s *modelSuite) TestGetModelLifeNotFound(c *tc.C) {
 }
 
 func (s *modelSuite) TestEnsureModelNotAliveCascade(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 
 	s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
@@ -173,8 +171,7 @@ where  r.uuid = ?`, removalUUID,
 }
 
 func (s *modelSuite) TestDeleteModel(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUID := s.getAllUnitUUIDs(c, appUUID)[0]

--- a/domain/removal/state/model/unit_test.go
+++ b/domain/removal/state/model/unit_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/tc"
 
-	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
@@ -30,8 +29,7 @@ func TestUnitSuite(t *testing.T) {
 }
 
 func (s *unitSuite) TestUnitExists(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -50,8 +48,7 @@ func (s *unitSuite) TestUnitExists(c *tc.C) {
 }
 
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccessLastUnit(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -130,8 +127,7 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`
 }
 
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccessLastUnitParentMachine(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	app1UUID := s.createIAASApplication(c, svc, "foo",
 		applicationservice.AddIAASUnitArg{},
 	)
@@ -174,8 +170,7 @@ INSERT INTO machine_parent (machine_uuid, parent_uuid) VALUES (?, ?)
 // but we want to ensure that the state machine is resilient to this
 // situation.
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccessLastUnitMachineAlreadyDying(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",
 		applicationservice.AddIAASUnitArg{},
 	)
@@ -202,8 +197,7 @@ func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccessLastUnitMachineAlr
 }
 
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",
 		applicationservice.AddIAASUnitArg{},
 		applicationservice.AddIAASUnitArg{
@@ -237,8 +231,7 @@ func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccess(c *tc.C) {
 }
 
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeDyingSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -263,8 +256,7 @@ func (s *unitSuite) TestEnsureUnitNotAliveCascadeNotExistsSuccess(c *tc.C) {
 }
 
 func (s *unitSuite) TestUnitRemovalNormalSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -333,8 +325,7 @@ where  r.uuid = ?`, "removal-uuid",
 }
 
 func (s *unitSuite) TestGetUnitLifeSuccess(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -363,8 +354,7 @@ func (s *unitSuite) TestGetUnitLifeNotFound(c *tc.C) {
 }
 
 func (s *unitSuite) TestMarkUnitAsDead(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -401,8 +391,7 @@ func (s *unitSuite) TestDeleteUnitNotFound(c *tc.C) {
 }
 
 func (s *unitSuite) TestDeleteIAASUnit(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -426,8 +415,7 @@ func (s *unitSuite) TestDeleteIAASUnit(c *tc.C) {
 }
 
 func (s *unitSuite) TestDeleteSubordinateUnit(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID1 := s.createIAASApplication(c, svc, "foo", applicationservice.AddIAASUnitArg{})
 	appUUID2 := s.createIAASSubordinateApplication(c, svc, "baz", applicationservice.AddIAASUnitArg{})
 
@@ -454,8 +442,7 @@ func (s *unitSuite) TestDeleteSubordinateUnit(c *tc.C) {
 }
 
 func (s *unitSuite) TestDeleteIAASUnitWithSubordinates(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID1 := s.createIAASApplication(c, svc, "foo", applicationservice.AddIAASUnitArg{})
 	appUUID2 := s.createIAASSubordinateApplication(c, svc, "baz", applicationservice.AddIAASUnitArg{})
 
@@ -496,8 +483,7 @@ func (s *unitSuite) TestDeleteIAASUnitWithSubordinates(c *tc.C) {
 }
 
 func (s *unitSuite) TestDeleteIAASUnitWithSubordinatesNotDying(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID1 := s.createIAASApplication(c, svc, "foo", applicationservice.AddIAASUnitArg{})
 	appUUID2 := s.createIAASSubordinateApplication(c, svc, "baz", applicationservice.AddIAASUnitArg{})
 
@@ -522,8 +508,7 @@ func (s *unitSuite) TestDeleteIAASUnitWithSubordinatesNotDying(c *tc.C) {
 }
 
 func (s *unitSuite) TestDeleteCAASUnit(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createCAASApplication(c, svc, "some-app", applicationservice.AddUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
@@ -551,8 +536,7 @@ func (s *unitSuite) TestDeleteCAASUnit(c *tc.C) {
 }
 
 func (s *unitSuite) TestGetApplicationNameAndUnitNameByUnitUUID(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)

--- a/domain/removal/state/model/unit_test.go
+++ b/domain/removal/state/model/unit_test.go
@@ -72,8 +72,7 @@ func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccessLastUnit(c *tc.C) 
 }
 
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeStorageAttachmentsDying(c *tc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "pelican")
-	svc := s.setupApplicationService(c, factory)
+	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)

--- a/internal/changestream/testing/controllermodelsuite.go
+++ b/internal/changestream/testing/controllermodelsuite.go
@@ -22,6 +22,10 @@ type ControllerModelSuite struct {
 	watchableDBs map[string]*TestWatchableDB
 }
 
+// DB shadows [testing.ControllerModelSuite] DB to ensure that change stream
+// testing is performed through a txn runner.
+func (s *ControllerModelSuite) DB() {}
+
 // SetUpTest is responsible for setting up a testing database suite initialised
 // with the controller schema.
 func (s *ControllerModelSuite) SetUpTest(c *tc.C) {

--- a/internal/changestream/testing/controllersuite.go
+++ b/internal/changestream/testing/controllersuite.go
@@ -23,6 +23,10 @@ type ControllerSuite struct {
 	watchableDB *TestWatchableDB
 }
 
+// DB shadows [testing.ControllerSuite] DB to ensure that change stream testing
+// is performed through a txn runner.
+func (s *ControllerSuite) DB() {}
+
 // SetUpTest is responsible for setting up a testing database suite initialised
 // with the controller schema.
 func (s *ControllerSuite) SetUpTest(c *tc.C) {

--- a/internal/changestream/testing/modelsuite.go
+++ b/internal/changestream/testing/modelsuite.go
@@ -25,6 +25,10 @@ type ModelSuite struct {
 	watchableDB *TestWatchableDB
 }
 
+// DB shadows [testing.ModelSuite] DB to ensure that change stream testing is
+// performed through a txn runner.
+func (s *ModelSuite) DB() {}
+
 // SetUpTest is responsible for setting up a testing database suite initialised
 // with the model schema.
 func (s *ModelSuite) SetUpTest(c *tc.C) {


### PR DESCRIPTION
A source of flaky tests is the misuse of `sql.DB` inside change stream tests,
as these tests have concurrent database access due to the change stream
infrastructure running, queries outside of a txn can fail.

This prevents access to the `sql.DB` when running change stream testing.

The rest of this change is fixing up the fallout.

## QA steps

Unit tests.