### PR TITLE
feat: implement domain method StartTask

### DIFF
--- a/domain/operation/service/service.go
+++ b/domain/operation/service/service.go
@@ -84,6 +84,12 @@ type State interface {
 	// query function which returns the list of task ids for the given machine.
 	InitialWatchStatementMachineTask() (string, string)
 
+	// StartTask sets the task start time and updates the status to running.
+	// The following errors may be returned:
+	// - [operationerrors.TaskNotFound] if the task does not exist.
+	// - [operationerrors.TaskNotPending] if the task is not pending.
+	StartTask(ctx context.Context, taskID string) error
+
 	// NamespaceForTaskAbortingWatcher returns the name space to be used
 	// for the TaskAbortingWatcher.
 	NamespaceForTaskAbortingWatcher() string

--- a/domain/operation/service/state_mock_test.go
+++ b/domain/operation/service/state_mock_test.go
@@ -632,6 +632,44 @@ func (c *MockStatePruneOperationsCall) DoAndReturn(f func(context.Context, time.
 	return c
 }
 
+// StartTask mocks base method.
+func (m *MockState) StartTask(ctx context.Context, taskID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartTask", ctx, taskID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartTask indicates an expected call of StartTask.
+func (mr *MockStateMockRecorder) StartTask(ctx, taskID any) *MockStateStartTaskCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartTask", reflect.TypeOf((*MockState)(nil).StartTask), ctx, taskID)
+	return &MockStateStartTaskCall{Call: call}
+}
+
+// MockStateStartTaskCall wrap *gomock.Call
+type MockStateStartTaskCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateStartTaskCall) Return(arg0 error) *MockStateStartTaskCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateStartTaskCall) Do(f func(context.Context, string) error) *MockStateStartTaskCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateStartTaskCall) DoAndReturn(f func(context.Context, string) error) *MockStateStartTaskCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockWatcherFactory is a mock of WatcherFactory interface.
 type MockWatcherFactory struct {
 	ctrl     *gomock.Controller

--- a/domain/operation/service/task.go
+++ b/domain/operation/service/task.go
@@ -15,8 +15,14 @@ import (
 )
 
 // StartTask marks a task as running and logs the time it was started.
-func (s *Service) StartTask(ctx context.Context, id string) error {
-	return coreerrors.NotImplemented
+func (s *Service) StartTask(ctx context.Context, taskID string) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc(),
+		trace.WithAttributes(
+			trace.StringAttr("task.id", taskID),
+		))
+	defer span.End()
+
+	return s.st.StartTask(ctx, taskID)
 }
 
 // FinishTask saves the result of a completed task.
@@ -32,7 +38,8 @@ func (s *Service) ReceiverFromTask(ctx context.Context, id string) (string, erro
 
 // GetPendingTaskByTaskID return a struct containing the data required to
 // run a task. The task must have a status of pending.
-// Returns TaskNotPending if the task exists but does not have
+// The following errors may be returned:
+// - [operationerrors.TaskNotPending] if the task exists but does not have
 // a pending status.
 func (s *Service) GetPendingTaskByTaskID(ctx context.Context, id string) (operation.TaskArgs, error) {
 	return operation.TaskArgs{}, coreerrors.NotImplemented

--- a/domain/operation/service/task_test.go
+++ b/domain/operation/service/task_test.go
@@ -127,3 +127,31 @@ func (s *serviceSuite) TestGetTaskWithOutput(c *tc.C) {
 	c.Check(task.Output["result"], tc.Equals, "success")
 	c.Check(task.Output["message"], tc.Equals, "Task completed successfully")
 }
+
+func (s *serviceSuite) TestStartTaskSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	taskID := "42"
+	s.state.EXPECT().StartTask(gomock.Any(), taskID).Return(nil)
+
+	// Act
+	err := s.service().StartTask(c.Context(), taskID)
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+}
+
+func (s *serviceSuite) TestStartTaskSuccessFails(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	taskID := "42"
+	s.state.EXPECT().StartTask(gomock.Any(), taskID).Return(errors.New("task start fail"))
+
+	// Act
+	err := s.service().StartTask(c.Context(), taskID)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, `task start fail`)
+}

--- a/domain/operation/state/package_test.go
+++ b/domain/operation/state/package_test.go
@@ -266,12 +266,12 @@ func (s *baseSuite) addOperationTaskOutput(c *tc.C, taskUUID string) string {
 
 // addOperationTaskStatus sets a status for the task with the given textual status name.
 func (s *baseSuite) addOperationTaskStatus(c *tc.C, taskUUID, status string) {
-	beforCount := s.getRowCount(c, "operation_task_status")
+	beforeCount := s.getRowCount(c, "operation_task_status")
 	// Map status to id via the table
 	s.query(c, `INSERT INTO operation_task_status (task_uuid, status_id, updated_at) 
 		SELECT ?, id, ? FROM operation_task_status_value WHERE status = ?`, taskUUID, s.state.clock.Now(), status)
 	afterCount := s.getRowCount(c, "operation_task_status")
-	c.Assert(afterCount, tc.Equals, beforCount+1, tc.Commentf("status %q is not valid, is any of %v", status,
+	c.Assert(afterCount, tc.Equals, beforeCount+1, tc.Commentf("status %q is not valid, is any of %v", status,
 		s.selectDistinctValues(c, "status", "operation_task_status_value")))
 }
 

--- a/domain/operation/state/types.go
+++ b/domain/operation/state/types.go
@@ -69,3 +69,9 @@ type nameArg struct {
 type path struct {
 	Path string `db:"path"`
 }
+
+// taskTime maps a task ID and time together
+type taskTime struct {
+	TaskID string    `db:"task_id"`
+	Time   time.Time `db:"time"`
+}


### PR DESCRIPTION
StartTask is called by the machine or uniter when it starts the task. The operation_task status is updated to Running and the StartedAt time set.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests, #20640 has not landed yet. It implements the domain methods for enqueuing an opera

## Links

**Jira card:** JUJU-8359
