### PR TITLE
test: update juju-qa-bundle-test and pin ubuntu base

### DIFF
--- a/testcharms/charm-hub/bundles/juju-qa-bundle-test/bundle.yaml
+++ b/testcharms/charm-hub/bundles/juju-qa-bundle-test/bundle.yaml
@@ -1,37 +1,38 @@
 name: juju-qa-bundle-test
-series: jammy
+default-base: ubuntu@22.04
 applications:
   juju-qa-test:
     charm: juju-qa-test
     channel: 2.0/stable
     num_units: 1
     to:
-    - "0"
+      - "0"
     constraints: arch=amd64
   juju-qa-test-focal:
     charm: juju-qa-test
     channel: latest/candidate
     num_units: 1
-    series: focal
+    base: ubuntu@20.04
     to:
-    - "1"
+      - "1"
     constraints: arch=amd64
-  ntp:
-    charm: ntp
-    channel: stable
-  ntp-focal:
-    charm: ntp
-    channel: stable
-    series: focal
+  dummy-subordinate:
+    charm: juju-qa-dummy-subordinate
+    options:
+      token: token
+  dummy-subordinate-focal:
+    charm: juju-qa-dummy-subordinate
+    base: ubuntu@20.04
+    options:
+      token: token
 machines:
   "0":
     constraints: arch=amd64
-    series: jammy
   "1":
     constraints: arch=amd64
-    series: focal
+    base: ubuntu@20.04
 relations:
-- - ntp:juju-info
-  - juju-qa-test:juju-info
-- - ntp-focal:juju-info
-  - juju-qa-test-focal:juju-info
+  - - dummy-subordinate:juju-info
+    - juju-qa-test:juju-info
+  - - dummy-subordinate-focal:juju-info
+    - juju-qa-test-focal:juju-info

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -83,7 +83,7 @@ run_reboot_monitor_state_cleanup() {
 	ensure "${model_name}" "${file}"
 
 	juju deploy juju-qa-test --base ubuntu@22.04
-	juju deploy juju-qa-dummy-subordinate
+	juju deploy juju-qa-dummy-subordinate --base ubuntu@22.04
 	juju config dummy-subordinate token=becomegreen
 	juju integrate juju-qa-test:juju-info dummy-subordinate:juju-info
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 1)"

--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -10,8 +10,8 @@ run_model_metrics() {
 
 	# Deploy ubuntu with a different name, check that the metric send the charm name, not the application name.
 	juju deploy ubuntu app-one --base ubuntu@22.04
-	juju deploy juju-qa-test
-	juju deploy juju-qa-dummy-subordinate
+	juju deploy juju-qa-test --base ubuntu@22.04
+	juju deploy juju-qa-dummy-subordinate --base ubuntu@22.04
 	juju config dummy-subordinate token=becomegreen
 	juju relate dummy-subordinate app-one
 


### PR DESCRIPTION
In August 2025, a new revision (revision 6) of juju-qa-bundle-test was uploaded to charmhub but as part of that work, updating the changes in tree were missed by the author of that change. For example, the charmhub bundle has `ntp` charm removed but the tree still has it.

As a driveby I've copied across what we have in Charmhub (`ntp` charm is removed in favor of `dummy-subordinate`), and replaced the relations:

- `dummy-subordinate:info` to `dummy-subordinate:juju-info`
- `dummy-subordinate-focal:info` to `dummy-subordinate-focal:juju-info`

The new bundle that has the relations above have been uploaded to charmhub (revision 7).

This should make it easier now to version control the bundle.

We also pin the base to `22.04` because mysteriously juju isn't deploying the `juju-qa-dummy-subordinate` latest revision (see reboot.sh and metrics.sh).

This should be the latest piece of work to make the CI green for 3.6.10 release.

QA:

./main.sh -v model test_model
./main.sh -v hooks test_start_hook_fires_after_reboot
./main.sh -v deploy test_deploy_bundles