### PR TITLE
feat: add juju api connection sources

### DIFF
--- a/internal/worker/introspection/script.go
+++ b/internal/worker/introspection/script.go
@@ -196,6 +196,25 @@ juju_start_unit () {
   juju_agent --post units action=start $args
 }
 
+juju_api_connection_sources () {
+  if [ -x "$(which sudo)" ]; then
+    local num=${1:-10}
+    local port=${2:-17070}
+    echo "Selecting top $num IPs connected to port $port" >&2
+
+    sudo lsof -iTCP -sTCP:ESTABLISHED -nP \
+      | awk '{print $9}' \
+      | awk -F'->' -v port="$port" '{local=$1; remote=$2; split(local,l,":"); split(remote,r,":"); if (l[2]==port) print r[1]}' \
+      | sort \
+      | uniq -c \
+      | sort -nr \
+      | head -$num
+  else
+    echo "requires sudo to run"
+    return 1
+  fi
+}
+
 # This asks for the command of the current pid.
 # Can't use $0 nor $SHELL due to this being wrong in various situations.
 shell=$(ps -p "$$" -o comm --no-headers)
@@ -218,5 +237,6 @@ if [ "$shell" = "bash" ]; then
   export -f juju_unit_status
   export -f juju_start_unit
   export -f juju_stop_unit
+  export -f juju_api_connection_sources
 fi
 `


### PR DESCRIPTION
In order to allow others to introspect the connected established connections to the controller API server, offer out a common function. This requires sudo, so we check for sudo before running, this isn't the first time we done this, so we're walking over common ground.

Lastly, as the main API port can change, I've made it configurable along with the total number of connections.

AWK is a bit weird with passing env vars into the script so we have to setup a variable to pass it in.


## QA steps

```sh
$ juju bootstrap lxd test
$ juju ssh -m controller 0
$ juju_api_connection_sources
Selecting top 10 IPs connected to port 17070
      5 10.232.51.214
      1 127.0.0.1
      1 10.232.51.1
$ sudo su
$ source /etc/profile.d/juju-introspection.sh
$ juju_api_connection_sources
Selecting top 10 IPs connected to port 17070
      5 10.232.51.214
      1 127.0.0.1
      1 10.232.51.1
```
