### PR TITLE
fix: fix secrets expiry watcher;

### DIFF
--- a/state/secrets.go
+++ b/state/secrets.go
@@ -3071,7 +3071,8 @@ func (w *secretsExpiryWatcher) merge(details []corewatcher.SecretTriggerChange, 
 				if knownDetails.willExpire {
 					details[i] = deletedDetails
 				} else {
-					details = append(details[:i], details[i+1:]...)
+					details[i] = details[len(details)-1]
+					details = details[:len(details)-1]
 				}
 				return details, nil
 			}


### PR DESCRIPTION
This PR enhances the merge method of the secrets expiry watcher.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju exec --unit snappass-test/0 -- secret-add foo=bar --owner=unit
secret://05193507-8b23-473a-855f-ab19e03d7796/d38amqnmp25c7876aijg

juju exec --unit snappass-test/0 -- secret-add foo=bar1 --owner=unit
secret://05193507-8b23-473a-855f-ab19e03d7796/d38an1nmp25c7876aik0

juju exec --unit snappass-test/0 -- secret-set d38an1nmp25c7876aik0 --expire=1m

juju exec --unit snappass-test/0 -- secret-set d38amqnmp25c7876aijg --expire=1m

juju show-status-log snappass-test/0
Time                        Type       Status     Message
...
22 Sep 2025 11:51:26+10:00  juju-unit  idle
22 Sep 2025 11:51:54+10:00  juju-unit  executing  running action juju-exec
22 Sep 2025 11:51:54+10:00  juju-unit  idle
22 Sep 2025 11:52:26+10:00  juju-unit  executing  running secret-expired hook for d38an1nmp25c7876aik0/1
22 Sep 2025 11:52:26+10:00  juju-unit  executing  running secret-expired hook for d38amqnmp25c7876aijg/1

```