### PR TITLE
fix: set application constraints when creating app

### DIFF
--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -777,6 +777,10 @@ func (s *ProviderService) makeIAASApplicationArg(ctx context.Context,
 	if err != nil {
 		return "", application.AddIAASApplicationArg{}, nil, errors.Errorf("preparing IAAS application args: %w", err)
 	}
+	addIAASApplicationArgs := application.AddIAASApplicationArg{
+		BaseAddApplicationArg: arg,
+	}
+	addIAASApplicationArgs.Constraints = constraints.DecodeConstraints(cons)
 
 	storageDirectives := makeStorageDirectiveFromApplicationArg(
 		charm.Meta().Storage,
@@ -789,9 +793,7 @@ func (s *ProviderService) makeIAASApplicationArg(ctx context.Context,
 		return "", application.AddIAASApplicationArg{}, nil, errors.Errorf("making IAAS unit args: %w", err)
 	}
 
-	return appName, application.AddIAASApplicationArg{
-		BaseAddApplicationArg: arg,
-	}, unitArgs, nil
+	return appName, addIAASApplicationArgs, unitArgs, nil
 }
 
 func (s *ProviderService) makeCAASApplicationArg(
@@ -833,6 +835,11 @@ func (s *ProviderService) makeCAASApplicationArg(
 	if err != nil {
 		return "", application.AddCAASApplicationArg{}, nil, errors.Errorf("preparing CAAS application args: %w", err)
 	}
+	addCAASApplicationArg := application.AddCAASApplicationArg{
+		BaseAddApplicationArg: arg,
+		Scale:                 len(units),
+	}
+	addCAASApplicationArg.Constraints = constraints.DecodeConstraints(cons)
 
 	storageDirectives := makeStorageDirectiveFromApplicationArg(
 		charm.Meta().Storage,
@@ -844,10 +851,7 @@ func (s *ProviderService) makeCAASApplicationArg(
 	if err != nil {
 		return "", application.AddCAASApplicationArg{}, nil, errors.Errorf("making CAAS unit args: %w", err)
 	}
-	return appName, application.AddCAASApplicationArg{
-		BaseAddApplicationArg: arg,
-		Scale:                 len(units),
-	}, unitArgs, nil
+	return appName, addCAASApplicationArg, unitArgs, nil
 }
 
 func (s *ProviderService) validateCreateApplicationArgs(

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1099,6 +1099,7 @@ func makeCreateApplicationArgs(
 	return application.BaseAddApplicationArg{
 		Charm:             ch,
 		CharmDownloadInfo: args.DownloadInfo,
+		Constraints:       constraints.DecodeConstraints(args.Constraints),
 		Platform:          platformArg,
 		Channel:           channelArg,
 		EndpointBindings:  args.EndpointBindings,

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -134,6 +134,9 @@ func (s *providerServiceSuite) TestCreateCAASApplication(c *tc.C) {
 				"":         "default",
 				"provider": "beta",
 			},
+			Constraints: constraints.Constraints{
+				Arch: ptr("arm64"),
+			},
 		},
 		Scale: 1,
 	}
@@ -323,6 +326,11 @@ func (s *providerServiceSuite) TestCreateIAASApplication(c *tc.C) {
 				DownloadSize:       42,
 			},
 			Platform: platform,
+			Constraints: constraints.Constraints{
+				CpuCores: ptr(uint64(4)),
+				CpuPower: ptr(uint64(75)),
+				Arch:     ptr("arm64"),
+			},
 		},
 	}
 
@@ -422,6 +430,11 @@ func (s *providerServiceSuite) TestCreateIAASApplicationMachineScope(c *tc.C) {
 				DownloadSize:       42,
 			},
 			Platform: platform,
+			Constraints: constraints.Constraints{
+				CpuCores: ptr(uint64(4)),
+				CpuPower: ptr(uint64(75)),
+				Arch:     ptr("arm64"),
+			},
 		},
 	}
 
@@ -915,6 +928,11 @@ func (s *providerServiceSuite) TestCreateIAASApplicationPendingResources(c *tc.C
 			},
 			Platform:         platform,
 			PendingResources: []resource.UUID{resourceUUID},
+			Constraints: constraints.Constraints{
+				CpuCores: ptr(uint64(4)),
+				CpuPower: ptr(uint64(75)),
+				Arch:     ptr("arm64"),
+			},
 		},
 	}
 

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -2593,6 +2593,10 @@ func (st *State) SetApplicationConstraints(ctx context.Context, appID coreapplic
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := st.checkApplicationNotDead(ctx, tx, appID); err != nil {
+			return errors.Capture(err)
+		}
+
 		return st.setApplicationConstraints(ctx, tx, appID, cons)
 	})
 }
@@ -2698,10 +2702,6 @@ ON CONFLICT (application_uuid) DO NOTHING
 	insertAppConstraintsStmt, err := st.Prepare(insertAppConstraintsQuery, setApplicationConstraint{})
 	if err != nil {
 		return errors.Errorf("preparing insert application constraints query: %w", err)
-	}
-
-	if err := st.checkApplicationNotDead(ctx, tx, appID); err != nil {
-		return errors.Capture(err)
 	}
 
 	var containerTypeID containerTypeID

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -341,6 +341,9 @@ func (st *State) insertApplication(
 	if err := st.insertPeerRelations(ctx, tx, appDetails.UUID); err != nil {
 		return errors.Errorf("inserting peer relation for application %q: %w", name, err)
 	}
+	if err := st.setApplicationConstraints(ctx, tx, appDetails.UUID, args.Constraints); err != nil {
+		return errors.Errorf("setting constraints for application %q: %w", name, err)
+	}
 	if err := st.insertDeviceConstraints(ctx, tx, appUUID, args.Devices); err != nil {
 		return errors.Errorf("inserting device constraints for application %q: %w", appUUID, err)
 	}
@@ -2589,6 +2592,18 @@ func (st *State) SetApplicationConstraints(ctx context.Context, appID coreapplic
 		return errors.Capture(err)
 	}
 
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return st.setApplicationConstraints(ctx, tx, appID, cons)
+	})
+}
+
+func (st *State) setApplicationConstraints(
+	ctx context.Context,
+	tx *sqlair.TX,
+	appID coreapplication.ID,
+	cons constraints.Constraints,
+) error {
+
 	cUUID, err := uuid.NewUUID()
 	if err != nil {
 		return errors.Capture(err)
@@ -2685,95 +2700,93 @@ ON CONFLICT (application_uuid) DO NOTHING
 		return errors.Errorf("preparing insert application constraints query: %w", err)
 	}
 
-	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if err := st.checkApplicationNotDead(ctx, tx, appID); err != nil {
+	if err := st.checkApplicationNotDead(ctx, tx, appID); err != nil {
+		return errors.Capture(err)
+	}
+
+	var containerTypeID containerTypeID
+	if cons.Container != nil {
+		err = tx.Query(ctx, selectContainerTypeIDStmt, containerTypeVal{Value: string(*cons.Container)}).Get(&containerTypeID)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			st.logger.Warningf(ctx, "cannot set constraints, container type %q does not exist", *cons.Container)
+			return applicationerrors.InvalidApplicationConstraints
+		}
+		if err != nil {
 			return errors.Capture(err)
 		}
+	}
 
-		var containerTypeID containerTypeID
-		if cons.Container != nil {
-			err = tx.Query(ctx, selectContainerTypeIDStmt, containerTypeVal{Value: string(*cons.Container)}).Get(&containerTypeID)
+	// First check if the constraint already exists, in that case
+	// we need to update it, unsetting the nil values.
+	var retrievedConstraintUUID constraintUUID
+	err = tx.Query(ctx, selectConstraintUUIDStmt, applicationUUID{ApplicationUUID: appID.String()}).Get(&retrievedConstraintUUID)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Capture(err)
+	} else if err == nil {
+		cUUIDStr = retrievedConstraintUUID.ConstraintUUID
+	}
+
+	// Cleanup tags, spaces and zones from their join tables.
+	if err := tx.Query(ctx, deleteConstraintTagsStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, deleteConstraintSpacesStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, deleteConstraintZonesStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
+		return errors.Capture(err)
+	}
+
+	constraints := encodeConstraints(cUUIDStr, cons, containerTypeID.ID)
+
+	if err := tx.Query(ctx, insertConstraintsStmt, constraints).Run(); err != nil {
+		return errors.Capture(err)
+	}
+
+	if cons.Tags != nil {
+		for _, tag := range *cons.Tags {
+			constraintTag := setConstraintTag{ConstraintUUID: cUUIDStr, Tag: tag}
+			if err := tx.Query(ctx, insertConstraintTagsStmt, constraintTag).Run(); err != nil {
+				return errors.Capture(err)
+			}
+		}
+	}
+
+	if cons.Spaces != nil {
+		for _, space := range *cons.Spaces {
+			// Make sure the space actually exists.
+			var spaceUUID spaceUUID
+			err := tx.Query(ctx, selectSpaceStmt, spaceName{Name: space.SpaceName}).Get(&spaceUUID)
 			if errors.Is(err, sqlair.ErrNoRows) {
-				st.logger.Warningf(ctx, "cannot set constraints, container type %q does not exist", *cons.Container)
+				st.logger.Warningf(ctx, "cannot set constraints, space %q does not exist", space)
 				return applicationerrors.InvalidApplicationConstraints
 			}
 			if err != nil {
 				return errors.Capture(err)
 			}
-		}
 
-		// First check if the constraint already exists, in that case
-		// we need to update it, unsetting the nil values.
-		var retrievedConstraintUUID constraintUUID
-		err := tx.Query(ctx, selectConstraintUUIDStmt, applicationUUID{ApplicationUUID: appID.String()}).Get(&retrievedConstraintUUID)
-		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Capture(err)
-		} else if err == nil {
-			cUUIDStr = retrievedConstraintUUID.ConstraintUUID
-		}
-
-		// Cleanup tags, spaces and zones from their join tables.
-		if err := tx.Query(ctx, deleteConstraintTagsStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
-			return errors.Capture(err)
-		}
-		if err := tx.Query(ctx, deleteConstraintSpacesStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
-			return errors.Capture(err)
-		}
-		if err := tx.Query(ctx, deleteConstraintZonesStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
-			return errors.Capture(err)
-		}
-
-		constraints := encodeConstraints(cUUIDStr, cons, containerTypeID.ID)
-
-		if err := tx.Query(ctx, insertConstraintsStmt, constraints).Run(); err != nil {
-			return errors.Capture(err)
-		}
-
-		if cons.Tags != nil {
-			for _, tag := range *cons.Tags {
-				constraintTag := setConstraintTag{ConstraintUUID: cUUIDStr, Tag: tag}
-				if err := tx.Query(ctx, insertConstraintTagsStmt, constraintTag).Run(); err != nil {
-					return errors.Capture(err)
-				}
+			constraintSpace := setConstraintSpace{ConstraintUUID: cUUIDStr, Space: space.SpaceName, Exclude: space.Exclude}
+			if err := tx.Query(ctx, insertConstraintSpacesStmt, constraintSpace).Run(); err != nil {
+				return errors.Capture(err)
 			}
 		}
+	}
 
-		if cons.Spaces != nil {
-			for _, space := range *cons.Spaces {
-				// Make sure the space actually exists.
-				var spaceUUID spaceUUID
-				err := tx.Query(ctx, selectSpaceStmt, spaceName{Name: space.SpaceName}).Get(&spaceUUID)
-				if errors.Is(err, sqlair.ErrNoRows) {
-					st.logger.Warningf(ctx, "cannot set constraints, space %q does not exist", space)
-					return applicationerrors.InvalidApplicationConstraints
-				}
-				if err != nil {
-					return errors.Capture(err)
-				}
-
-				constraintSpace := setConstraintSpace{ConstraintUUID: cUUIDStr, Space: space.SpaceName, Exclude: space.Exclude}
-				if err := tx.Query(ctx, insertConstraintSpacesStmt, constraintSpace).Run(); err != nil {
-					return errors.Capture(err)
-				}
+	if cons.Zones != nil {
+		for _, zone := range *cons.Zones {
+			constraintZone := setConstraintZone{ConstraintUUID: cUUIDStr, Zone: zone}
+			if err := tx.Query(ctx, insertConstraintZonesStmt, constraintZone).Run(); err != nil {
+				return errors.Capture(err)
 			}
 		}
+	}
 
-		if cons.Zones != nil {
-			for _, zone := range *cons.Zones {
-				constraintZone := setConstraintZone{ConstraintUUID: cUUIDStr, Zone: zone}
-				if err := tx.Query(ctx, insertConstraintZonesStmt, constraintZone).Run(); err != nil {
-					return errors.Capture(err)
-				}
-			}
-		}
-
-		return errors.Capture(
-			tx.Query(ctx, insertAppConstraintsStmt, setApplicationConstraint{
-				ApplicationUUID: appID.String(),
-				ConstraintUUID:  cUUIDStr,
-			}).Run(),
-		)
-	})
+	return errors.Capture(
+		tx.Query(ctx, insertAppConstraintsStmt, setApplicationConstraint{
+			ApplicationUUID: appID.String(),
+			ConstraintUUID:  cUUIDStr,
+		}).Run(),
+	)
 }
 
 // GetDeviceConstraints returns the device constraints for an application.

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -73,6 +73,11 @@ func (s *applicationStateSuite) TestCreateIAASApplication(c *tc.C) {
 	}
 	ctx := c.Context()
 
+	cons := constraints.Constraints{
+		CpuCores: ptr(uint64(42)),
+		Mem:      ptr(uint64(3072)),
+	}
+
 	id, machineNames, err := s.state.CreateIAASApplication(ctx, "666", application.AddIAASApplicationArg{
 		BaseAddApplicationArg: application.BaseAddApplicationArg{
 			Platform: platform,
@@ -90,7 +95,8 @@ func (s *applicationStateSuite) TestCreateIAASApplication(c *tc.C) {
 				DownloadURL:        "http://example.com/charm",
 				DownloadSize:       666,
 			},
-			Channel: channel,
+			Channel:     channel,
+			Constraints: cons,
 		},
 	}, nil)
 	c.Assert(err, tc.ErrorIsNil)
@@ -112,6 +118,11 @@ func (s *applicationStateSuite) TestCreateIAASApplication(c *tc.C) {
 	c.Check(sts, tc.DeepEquals, status.StatusInfo[status.WorkloadStatusType]{
 		Status: status.WorkloadStatusUnset,
 	})
+
+	// Constraints should be set.
+	constraints, err := s.state.GetApplicationConstraints(c.Context(), id)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(constraints, tc.DeepEquals, cons)
 }
 
 func (s *applicationStateSuite) TestCreateCAASApplication(c *tc.C) {
@@ -127,6 +138,10 @@ func (s *applicationStateSuite) TestCreateCAASApplication(c *tc.C) {
 	}
 	ctx := c.Context()
 
+	cons := constraints.Constraints{
+		CpuCores: ptr(uint64(42)),
+		Mem:      ptr(uint64(3072)),
+	}
 	id, err := s.state.CreateCAASApplication(ctx, "666", application.AddCAASApplicationArg{
 		BaseAddApplicationArg: application.BaseAddApplicationArg{
 			Platform: platform,
@@ -144,7 +159,8 @@ func (s *applicationStateSuite) TestCreateCAASApplication(c *tc.C) {
 				DownloadURL:        "http://example.com/charm",
 				DownloadSize:       666,
 			},
-			Channel: channel,
+			Channel:     channel,
+			Constraints: cons,
 		},
 		Scale: 1,
 	}, nil)
@@ -165,6 +181,11 @@ func (s *applicationStateSuite) TestCreateCAASApplication(c *tc.C) {
 	c.Check(sts, tc.DeepEquals, status.StatusInfo[status.WorkloadStatusType]{
 		Status: status.WorkloadStatusUnset,
 	})
+
+	// Constraints should be set.
+	constraints, err := s.state.GetApplicationConstraints(c.Context(), id)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(constraints, tc.DeepEquals, cons)
 }
 
 func (s *applicationStateSuite) TestCreateApplicationWithConfigAndSettings(c *tc.C) {
@@ -2888,13 +2909,29 @@ func (s *applicationStateSuite) TestConstraintFull(c *tc.C) {
 			return err
 		}
 		_, err = tx.ExecContext(ctx, addZoneConsStmt, "constraint-uuid", "zone1")
-		if err != nil {
-			return err
-		}
-
-		addAppConstraintStmt := `INSERT INTO application_constraint (application_uuid, constraint_uuid) VALUES (?, ?)`
-		_, err = tx.ExecContext(ctx, addAppConstraintStmt, id, "constraint-uuid")
 		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.SetApplicationConstraints(c.Context(), id, constraints.Constraints{
+		AllocatePublicIP: ptr(true),
+		Arch:             ptr("amd64"),
+		CpuCores:         ptr(uint64(2)),
+		CpuPower:         ptr(uint64(42)),
+		Mem:              ptr(uint64(8)),
+		ImageID:          ptr("image-id"),
+		Tags:             ptr([]string{"tag0", "tag1"}),
+		Spaces: ptr([]constraints.SpaceConstraint{
+			{SpaceName: "space0", Exclude: false},
+			{SpaceName: "space1", Exclude: true},
+		}),
+		Zones:          ptr([]string{"zone0", "zone1"}),
+		RootDisk:       ptr(uint64(256)),
+		RootDiskSource: ptr("root-disk-source"),
+		InstanceRole:   ptr("instance-role"),
+		InstanceType:   ptr("instance-type"),
+		Container:      ptr(instance.LXD),
+		VirtType:       ptr("virt-type"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -2923,15 +2960,11 @@ func (s *applicationStateSuite) TestConstraintFull(c *tc.C) {
 func (s *applicationStateSuite) TestConstraintPartial(c *tc.C) {
 	id := s.createIAASApplication(c, "foo", life.Alive)
 
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		addConstraintStmt := `INSERT INTO "constraint" (uuid, arch, cpu_cores, allocate_public_ip, image_id) VALUES (?, ?, ?, ?, ?)`
-		_, err := tx.ExecContext(ctx, addConstraintStmt, "constraint-uuid", "amd64", 2, true, "image-id")
-		if err != nil {
-			return err
-		}
-		addAppConstraintStmt := `INSERT INTO application_constraint (application_uuid, constraint_uuid) VALUES (?, ?)`
-		_, err = tx.ExecContext(ctx, addAppConstraintStmt, id, "constraint-uuid")
-		return err
+	err := s.state.SetApplicationConstraints(c.Context(), id, constraints.Constraints{
+		AllocatePublicIP: ptr(true),
+		Arch:             ptr("amd64"),
+		CpuCores:         ptr(uint64(2)),
+		ImageID:          ptr("image-id"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -2948,15 +2981,8 @@ func (s *applicationStateSuite) TestConstraintPartial(c *tc.C) {
 func (s *applicationStateSuite) TestConstraintSingleValue(c *tc.C) {
 	id := s.createIAASApplication(c, "foo", life.Alive)
 
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		addConstraintStmt := `INSERT INTO "constraint" (uuid, cpu_cores) VALUES (?, ?)`
-		_, err := tx.ExecContext(ctx, addConstraintStmt, "constraint-uuid", 2)
-		if err != nil {
-			return err
-		}
-		addAppConstraintStmt := `INSERT INTO application_constraint (application_uuid, constraint_uuid) VALUES (?, ?)`
-		_, err = tx.ExecContext(ctx, addAppConstraintStmt, id, "constraint-uuid")
-		return err
+	err := s.state.SetApplicationConstraints(c.Context(), id, constraints.Constraints{
+		CpuCores: ptr(uint64(2)),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -36,6 +36,8 @@ type BaseAddApplicationArg struct {
 	// This information is used to download the charm from the charm store if
 	// required.
 	CharmDownloadInfo *domaincharm.DownloadInfo
+	// Constraints contains the application constraints.
+	Constraints constraints.Constraints
 	// Platform contains the platform information for the application. The
 	// operating system and architecture.
 	Platform deployment.Platform


### PR DESCRIPTION
This patch adds the missing insert to the join table application_constraints when creating an application. This was missing although we already had the correct methods in state.

The patch makes sure the constraints are created in the "insertApplication()" state method.


## QA steps

Creating an application with constraints and retrieving them must work:

```
$ juju bootstrap lxc c
$ juju add-model m
$ juju deploy "juju-qa-test" --revision 22 --channel stable "juju-qa-test" --constraints mem=3G
$ juju constraints juju-qa-test
arch=amd64 mem=3072M
```
Make sure the db contents are correct:
```
$ juju ssh -m controller 0
ubuntu@juju-2b1898-0:~$ juju_db_repl
repl (controller)> .switch model-m
repl (model-m)> select * from "constraint"
uuid                                    arch    cpu_cores       cpu_power       mem     root_disk       root_disk_source        instance_role   instance_type   container_type_id       virt_type      allocate_public_ip      image_id
89532324-993c-462c-844b-d3d2638f7e7f    amd64   <nil>           <nil>           3072    <nil>           <nil>                   <nil>           <nil>           <nil>                   <nil> <nil>                    <nil>
a9eb32eb-9a6c-4fd9-8d54-75be2e3bf714    amd64   <nil>           <nil>           3072    <nil>           <nil>                   <nil>           <nil>           <nil>                   <nil> <nil>                    <nil>
818d313c-2304-43ce-8bb7-af04e3fe8961    amd64   <nil>           <nil>           3072    <nil>           <nil>                   <nil>           <nil>           <nil>                   <nil> <nil>                    <nil>

repl (model-m)> select * from application_constraint
application_uuid                        constraint_uuid
164c259c-debf-47df-8f21-a021113910f4    89532324-993c-462c-844b-d3d2638f7e7f
```

