### PR TITLE
feat(domain/operation): add machine task query by status

### DIFF
--- a/apiserver/facades/agent/machineactions/machineactions.go
+++ b/apiserver/facades/agent/machineactions/machineactions.go
@@ -7,6 +7,7 @@ package machineactions
 import (
 	"context"
 
+	"github.com/juju/collections/transform"
 	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/apiserver/common"
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/internal"
 	coremachine "github.com/juju/juju/core/machine"
+	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/domain/operation"
@@ -45,6 +47,9 @@ type OperationService interface {
 	// NOTE: This watcher will emit events for tasks changing their statuses to
 	// PENDING only.
 	WatchMachineTaskNotifications(ctx context.Context, machineName coremachine.Name) (watcher.StringsWatcher, error)
+
+	// GetMachineTaskIDsWithStatus retrieves all task IDs for a machine with the specified status.
+	GetMachineTaskIDsWithStatus(ctx context.Context, name coremachine.Name, running corestatus.Status) ([]string, error)
 }
 
 // Facade implements the machineactions interface and is the concrete
@@ -214,10 +219,51 @@ func (f *Facade) WatchActionNotifications(ctx context.Context, args params.Entit
 // RunningActions lists the actions running for the entities passed in.
 // If we end up needing more than ListRunning at some point we could follow/abstract
 // what's done in the client actions package.
+//
+// Note(gfouillet): this implementation is minimal to fulfill requirements for
+// the client method RunningActions in `api/agent/machineactions/machineactions.go`
+// and its only user in the machineactions worker
+// in the SetUp method in `internal/worker/machineactions/worker.go` which
+// only query for machine as entities and only use the action ID (eg TaskID in 4.x)
 func (f *Facade) RunningActions(ctx context.Context, args params.Entities) params.ActionsByReceivers {
-	return params.ActionsByReceivers{
+	canAccess := f.accessMachine
+
+	response := params.ActionsByReceivers{
 		Actions: make([]params.ActionsByReceiver, len(args.Entities)),
 	}
+
+	for i, entity := range args.Entities {
+		currentResult := &response.Actions[i]
+		receiverTag, err := names.ParseMachineTag(entity.Tag)
+		if err != nil {
+			currentResult.Error = apiservererrors.ServerError(apiservererrors.ErrBadId)
+			continue
+		}
+		currentResult.Receiver = receiverTag.String()
+
+		if !canAccess(receiverTag) {
+			currentResult.Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
+			continue
+		}
+		taskIDs, err := f.operationService.GetMachineTaskIDsWithStatus(
+			ctx,
+			coremachine.Name(receiverTag.Id()),
+			corestatus.Running,
+		)
+		if err != nil {
+			currentResult.Error = apiservererrors.ServerError(err)
+			continue
+		}
+		currentResult.Actions = transform.Slice(taskIDs, func(id string) params.ActionResult {
+			return params.ActionResult{
+				Action: &params.Action{
+					Tag: names.NewActionTag(id).String(),
+				},
+			}
+		})
+	}
+
+	return response
 }
 
 func ptr[T any](v T) *T {

--- a/apiserver/facades/agent/machineactions/package_mock_test.go
+++ b/apiserver/facades/agent/machineactions/package_mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	machine "github.com/juju/juju/core/machine"
+	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	operation "github.com/juju/juju/domain/operation"
 	gomock "go.uber.org/mock/gomock"
@@ -76,6 +77,45 @@ func (c *MockOperationServiceFinishTaskCall) Do(f func(context.Context, operatio
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockOperationServiceFinishTaskCall) DoAndReturn(f func(context.Context, operation.CompletedTaskResult) error) *MockOperationServiceFinishTaskCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetMachineTaskIDsWithStatus mocks base method.
+func (m *MockOperationService) GetMachineTaskIDsWithStatus(arg0 context.Context, arg1 machine.Name, arg2 status.Status) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineTaskIDsWithStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineTaskIDsWithStatus indicates an expected call of GetMachineTaskIDsWithStatus.
+func (mr *MockOperationServiceMockRecorder) GetMachineTaskIDsWithStatus(arg0, arg1, arg2 any) *MockOperationServiceGetMachineTaskIDsWithStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineTaskIDsWithStatus", reflect.TypeOf((*MockOperationService)(nil).GetMachineTaskIDsWithStatus), arg0, arg1, arg2)
+	return &MockOperationServiceGetMachineTaskIDsWithStatusCall{Call: call}
+}
+
+// MockOperationServiceGetMachineTaskIDsWithStatusCall wrap *gomock.Call
+type MockOperationServiceGetMachineTaskIDsWithStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOperationServiceGetMachineTaskIDsWithStatusCall) Return(arg0 []string, arg1 error) *MockOperationServiceGetMachineTaskIDsWithStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOperationServiceGetMachineTaskIDsWithStatusCall) Do(f func(context.Context, machine.Name, status.Status) ([]string, error)) *MockOperationServiceGetMachineTaskIDsWithStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOperationServiceGetMachineTaskIDsWithStatusCall) DoAndReturn(f func(context.Context, machine.Name, status.Status) ([]string, error)) *MockOperationServiceGetMachineTaskIDsWithStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/operation/service/package_mock_test.go
+++ b/domain/operation/service/package_mock_test.go
@@ -396,6 +396,45 @@ func (c *MockStateGetLatestTaskLogsByUUIDCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
+// GetMachineTaskIDsWithStatus mocks base method.
+func (m *MockState) GetMachineTaskIDsWithStatus(arg0 context.Context, arg1, arg2 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineTaskIDsWithStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineTaskIDsWithStatus indicates an expected call of GetMachineTaskIDsWithStatus.
+func (mr *MockStateMockRecorder) GetMachineTaskIDsWithStatus(arg0, arg1, arg2 any) *MockStateGetMachineTaskIDsWithStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineTaskIDsWithStatus", reflect.TypeOf((*MockState)(nil).GetMachineTaskIDsWithStatus), arg0, arg1, arg2)
+	return &MockStateGetMachineTaskIDsWithStatusCall{Call: call}
+}
+
+// MockStateGetMachineTaskIDsWithStatusCall wrap *gomock.Call
+type MockStateGetMachineTaskIDsWithStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetMachineTaskIDsWithStatusCall) Return(arg0 []string, arg1 error) *MockStateGetMachineTaskIDsWithStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetMachineTaskIDsWithStatusCall) Do(f func(context.Context, string, string) ([]string, error)) *MockStateGetMachineTaskIDsWithStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetMachineTaskIDsWithStatusCall) DoAndReturn(f func(context.Context, string, string) ([]string, error)) *MockStateGetMachineTaskIDsWithStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetMachineUUIDByName mocks base method.
 func (m *MockState) GetMachineUUIDByName(arg0 context.Context, arg1 machine.Name) (string, error) {
 	m.ctrl.T.Helper()

--- a/domain/operation/service/query.go
+++ b/domain/operation/service/query.go
@@ -6,6 +6,9 @@ package service
 import (
 	"context"
 
+	coreerrors "github.com/juju/juju/core/errors"
+	coremachine "github.com/juju/juju/core/machine"
+	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/domain/operation"
 	"github.com/juju/juju/internal/errors"
 )
@@ -19,4 +22,24 @@ func (s *Service) GetOperations(ctx context.Context, params operation.QueryArgs)
 // GetOperationByID returns an operation by its ID.
 func (s *Service) GetOperationByID(ctx context.Context, operationID string) (operation.OperationInfo, error) {
 	return operation.OperationInfo{}, errors.New("actions in Dqlite not supported")
+}
+
+// GetMachineTaskIDsWithStatus retrieves the task IDs for a specific machine name and status.
+func (s *Service) GetMachineTaskIDsWithStatus(ctx context.Context,
+	name coremachine.Name, wantedStatus corestatus.Status) ([]string, error) {
+
+	if !wantedStatus.KnownTaskStatus() {
+		return nil, errors.Errorf("unknown task status %q", wantedStatus).Add(coreerrors.NotValid)
+	}
+
+	if err := name.Validate(); err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	ids, err := s.st.GetMachineTaskIDsWithStatus(ctx, name.String(), wantedStatus.String())
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return ids, nil
 }

--- a/domain/operation/service/query_test.go
+++ b/domain/operation/service/query_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+	"go.uber.org/mock/gomock"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	coremachine "github.com/juju/juju/core/machine"
+	corestatus "github.com/juju/juju/core/status"
+	"github.com/juju/juju/internal/errors"
+)
+
+// querySuite provides tests for query-related service methods.
+//
+// It embeds serviceSuite to reuse its setup helpers and mocks.
+type querySuite struct {
+	serviceSuite
+}
+
+func TestQuerySuite(t *testing.T) {
+	tc.Run(t, &querySuite{})
+}
+
+// TestGetMachineTaskIDsWithStatusHappyPath verifies that a valid machine name
+// and status filter result in delegating to state and returning the IDs.
+func (s *querySuite) TestGetMachineTaskIDsWithStatusHappyPath(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	mName := coremachine.Name("0")
+	status := corestatus.Running
+	expected := []string{"t-1", "t-2"}
+	s.state.EXPECT().GetMachineTaskIDsWithStatus(gomock.Any(), mName.String(), status.String()).Return(expected, nil)
+
+	// Act
+	ids, err := s.service().GetMachineTaskIDsWithStatus(c.Context(), mName, status)
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+	c.Check(ids, tc.DeepEquals, expected)
+}
+
+// TestGetMachineTaskIDsWithStatusNameValidationError ensures that an invalid machine
+// name triggers a validation error before any state interaction.
+func (s *querySuite) TestGetMachineTaskIDsWithStatusNameValidationError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	// Invalid machine name (empty) should fail validation via coremachine.Name.Validate.
+	var mName coremachine.Name
+
+	// No expectation set on state: should not be called on validation error.
+
+	// Act
+	_, err := s.service().GetMachineTaskIDsWithStatus(c.Context(), mName, corestatus.Running)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestGetMachineTaskIDsWithStatusStatusValidationError ensures that an invalid
+// status triggers a validation error before any state interaction.
+func (s *querySuite) TestGetMachineTaskIDsWithStatusStatusValidationError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	mName := coremachine.Name("0")
+	status := corestatus.Allocating // invalid status
+
+	// No expectation set on state: should not be called on validation error.
+
+	// Act
+	_, err := s.service().GetMachineTaskIDsWithStatus(c.Context(), mName, status)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestGetMachineTaskIDsWithStatusStateError validates that state errors are
+// captured and returned by the service method.
+func (s *querySuite) TestGetMachineTaskIDsWithStatusStateError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	mName := coremachine.Name("1")
+	status := corestatus.Running
+	stateErr := errors.New("boom")
+	s.state.EXPECT().GetMachineTaskIDsWithStatus(gomock.Any(), mName.String(), status.String()).Return(nil, stateErr)
+
+	// Act
+	_, err := s.service().GetMachineTaskIDsWithStatus(c.Context(), mName, status)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, stateErr)
+}

--- a/domain/operation/service/service.go
+++ b/domain/operation/service/service.go
@@ -56,6 +56,11 @@ type State interface {
 	// store.
 	GetTask(ctx context.Context, taskID string) (operation.Task, *string, error)
 
+	// GetMachineTaskIDsWithStatus retrieves all task IDs associated with a specific
+	//machine and filtered by a given status.
+	GetMachineTaskIDsWithStatus(ctx context.Context, machineName string, statusFilter string) ([]string,
+		error)
+
 	// GetTaskIDsByUUIDsFilteredByReceiverUUID returns task IDs of the tasks
 	// provided having the given receiverUUID.
 	GetTaskIDsByUUIDsFilteredByReceiverUUID(


### PR DESCRIPTION
Introduce a new service method `GetMachineTaskIDsWithStatus` in `domain/operation/service/query.go` to retrieve task IDs filtered by machine name and status.

This is the minimal required implementation: despite the facade provides a complete task result, the only usage of this facade only fetches for TaskID. So this implementation doesn't return full-fledged TaskInfo, but only the required TaskID.

- Implemented `GetMachineTaskIDsWithStatus` in `service.go` and `query.go` to delegate state query operations to `State`. Validation of a machine name is performed via `coremachine.Name.Validate`.
- Added a state-level method `GetMachineTaskIDsWithStatus` in `state/task.go`, leveraging database queries to retrieve task IDs filtered by machine and status.
- Enhanced testing with multiple scenarios:
  - `query_test.go`: Unit tests for service behavior, validation errors, and state error propagation.
  - `task_test.go`: Database-level tests covering task ID retrieval, filtering by machine and status, and edge cases with no results.
- Updated mock generation for state and service components in `state_mock_test.go` and `package_mock_test.go`.

Additionally, integrated this capability into the API layer, specifically in `apiserver/facades/agent/machineactions/machineactions.go`. New functionality in `RunningActions` now uses this query to retrieve running actions for machines. Corresponding tests added in `machineactions_test.go` for API-level verification.


## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

 Can't QA yet, Unit Test should pass

## Links

**Jira card:** JUJU-8544
