### PR TITLE
fix: add missing model-uuid index to secretRevisions

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -594,7 +594,7 @@ func allCollections() CollectionSchema {
 
 		secretRevisionsC: {
 			indexes: []mgo.Index{{
-				Key: []string{"revision", "_id"},
+				Key: []string{"revision", "_id", "model-uuid"},
 			}},
 		},
 


### PR DESCRIPTION
The warm-up period for the main ProdStack production 3.6 controller was spent under crippling load, with `secretRevisions` being the hottest collection by orders of magnitude.

The Mongo logs were full of entries like:
`{"t":{"$date":"2025-09-18T04:23:57.053+00:00"},"s":"I",  "c":"COMMAND",  "id":51803,   "ctx":"conn11436","msg":"Slow query","attr":{"type":"command","ns":"juju.secretRevisions","command":{"find":"secretRevisions","filter":{"_id":{"$regex":"d2fie4ip15bqn5pfmdd0/.*"},"model-uuid":"33f51151-9576-4c7f-81e5-60df115de23e"},"sort":{"_id":1},"skip":0,"$db":"juju"},"planSummary":"IXSCAN { _id: 1 }","keysExamined":51896,"docsExamined":1,"cursorExhausted":true,"numYields":72,"nreturned":1,"queryHash":"B2A8C74A","planCacheKey":"E2B1FE20","reslen":3822,"locks":{"FeatureCompatibilityVersion":{"acquireCount":{"r":73}},"ReplicationStateTransition":{"acquireCount":{"w":73}},"Global":{"acquireCount":{"r":73}},"Database":{"acquireCount":{"r":73}},"Collection":{"acquireCount":{"r":73}},"Mutex":{"acquireCount":{"r":1}}},"storage":{},"protocol":"op_query","durationMillis":1018}}`

Note `"keysExamined":51896` meaning every key of the index was checked.

This was due in part to the omission of `model-uuid` from the index on this non-global collection.

We add it here for future deployments. It has already been applied on PS6, with attendant reduction in load.