### PR TITLE
feat: implement log actions messages in uniter facade

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -357,6 +357,9 @@ type OperationService interface {
 	// a pending status.
 	GetPendingTaskByTaskID(ctx context.Context, id string) (operation.TaskArgs, error)
 
+	// LogTaskMessage stores the message for the given task ID.
+	LogTaskMessage(ctx context.Context, id, message string) error
+
 	// StartTask marks a task as running and logs the time it was started.
 	StartTask(ctx context.Context, id string) error
 

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -2902,6 +2902,44 @@ func (c *MockOperationServiceGetPendingTaskByTaskIDCall) DoAndReturn(f func(cont
 	return c
 }
 
+// LogTaskMessage mocks base method.
+func (m *MockOperationService) LogTaskMessage(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LogTaskMessage", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LogTaskMessage indicates an expected call of LogTaskMessage.
+func (mr *MockOperationServiceMockRecorder) LogTaskMessage(arg0, arg1, arg2 any) *MockOperationServiceLogTaskMessageCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogTaskMessage", reflect.TypeOf((*MockOperationService)(nil).LogTaskMessage), arg0, arg1, arg2)
+	return &MockOperationServiceLogTaskMessageCall{Call: call}
+}
+
+// MockOperationServiceLogTaskMessageCall wrap *gomock.Call
+type MockOperationServiceLogTaskMessageCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOperationServiceLogTaskMessageCall) Return(arg0 error) *MockOperationServiceLogTaskMessageCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOperationServiceLogTaskMessageCall) Do(f func(context.Context, string, string) error) *MockOperationServiceLogTaskMessageCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOperationServiceLogTaskMessageCall) DoAndReturn(f func(context.Context, string, string) error) *MockOperationServiceLogTaskMessageCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ReceiverFromTask mocks base method.
 func (m *MockOperationService) ReceiverFromTask(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()

--- a/domain/operation/service/service.go
+++ b/domain/operation/service/service.go
@@ -90,6 +90,9 @@ type State interface {
 	// query function which returns the list of task ids for the given machine.
 	InitialWatchStatementMachineTask() (string, string)
 
+	// LogTaskMessage stores the message for the given task ID.
+	LogTaskMessage(ctx context.Context, taskID, message string) error
+
 	// StartTask sets the task start time and updates the status to running.
 	// The following errors may be returned:
 	// - [operationerrors.TaskNotFound] if the task does not exist.

--- a/domain/operation/service/state_mock_test.go
+++ b/domain/operation/service/state_mock_test.go
@@ -555,6 +555,44 @@ func (c *MockStateInitialWatchStatementUnitTaskCall) DoAndReturn(f func() (strin
 	return c
 }
 
+// LogTaskMessage mocks base method.
+func (m *MockState) LogTaskMessage(ctx context.Context, taskID, message string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LogTaskMessage", ctx, taskID, message)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LogTaskMessage indicates an expected call of LogTaskMessage.
+func (mr *MockStateMockRecorder) LogTaskMessage(ctx, taskID, message any) *MockStateLogTaskMessageCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogTaskMessage", reflect.TypeOf((*MockState)(nil).LogTaskMessage), ctx, taskID, message)
+	return &MockStateLogTaskMessageCall{Call: call}
+}
+
+// MockStateLogTaskMessageCall wrap *gomock.Call
+type MockStateLogTaskMessageCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateLogTaskMessageCall) Return(arg0 error) *MockStateLogTaskMessageCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateLogTaskMessageCall) Do(f func(context.Context, string, string) error) *MockStateLogTaskMessageCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateLogTaskMessageCall) DoAndReturn(f func(context.Context, string, string) error) *MockStateLogTaskMessageCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // NamespaceForTaskAbortingWatcher mocks base method.
 func (m *MockState) NamespaceForTaskAbortingWatcher() string {
 	m.ctrl.T.Helper()

--- a/domain/operation/service/task.go
+++ b/domain/operation/service/task.go
@@ -187,3 +187,14 @@ func (s *Service) CancelTask(ctx context.Context, taskID string) (operation.Task
 
 	return task, nil
 }
+
+// LogTaskMessage stores the message for the given task ID.
+func (s *Service) LogTaskMessage(ctx context.Context, taskID, message string) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc(),
+		trace.WithAttributes(
+			trace.StringAttr("task.id", taskID),
+		))
+	defer span.End()
+
+	return errors.Capture(s.st.LogTaskMessage(ctx, taskID, message))
+}

--- a/domain/operation/service/task_test.go
+++ b/domain/operation/service/task_test.go
@@ -133,7 +133,7 @@ func (s *serviceSuite) TestGetTaskWithOutput(c *tc.C) {
 	c.Check(task.Output["message"], tc.Equals, "Task completed successfully")
 }
 
-func (s *serviceSuite) TestStartTaskSuccess(c *tc.C) {
+func (s *serviceSuite) TestStartTask(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
@@ -147,7 +147,7 @@ func (s *serviceSuite) TestStartTaskSuccess(c *tc.C) {
 	c.Assert(err, tc.IsNil)
 }
 
-func (s *serviceSuite) TestStartTaskSuccessFails(c *tc.C) {
+func (s *serviceSuite) TestStartTaskFails(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
@@ -162,7 +162,6 @@ func (s *serviceSuite) TestStartTaskSuccessFails(c *tc.C) {
 }
 
 func (s *serviceSuite) TestFinishTask(c *tc.C) {
-
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
@@ -193,6 +192,20 @@ func (s *serviceSuite) TestFinishTask(c *tc.C) {
 
 	// Act
 	err := s.service().FinishTask(c.Context(), arg)
+	// Assert
+	c.Assert(err, tc.IsNil)
+}
+
+func (s *serviceSuite) TestLogTaskMessage(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	taskID := "42"
+	msg := "log message"
+	s.state.EXPECT().LogTaskMessage(gomock.Any(), taskID, msg).Return(nil)
+
+	// Act
+	err := s.service().LogTaskMessage(c.Context(), taskID, msg)
 
 	// Assert
 	c.Assert(err, tc.IsNil)
@@ -333,4 +346,20 @@ func (s *serviceSuite) TestFinishTaskNoStore(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorMatches, "putting task result \"42\" in store: getting object store: boom")
+}
+
+func (s *serviceSuite) TestLogTaskMessageError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Assert
+	taskID := "42"
+	msg := "log message"
+	expectedError := errors.New("boom")
+	s.state.EXPECT().LogTaskMessage(gomock.Any(), taskID, msg).Return(expectedError)
+
+	// Act
+	err := s.service().LogTaskMessage(c.Context(), taskID, msg)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, `boom`)
 }


### PR DESCRIPTION
The facade is implemented as bulk call, however the api only uses it for a single log message at a time. Thus the domain call is a singleton. A message is written to the database for the  provided task ID.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Operations are not yet enqueued, therefore we cannot test end to end. Unit tests will pass.

## Links

**Jira card:** JUJU-6719
