### PR TITLE
fix: secret collection indexes

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -588,37 +588,38 @@ func allCollections() CollectionSchema {
 
 		secretMetadataC: {
 			indexes: []mgo.Index{{
-				Key: []string{"owner-tag", "label", "model-uuid"},
+				Key: []string{"model-uuid", "owner-tag", "label"},
 			}},
 		},
 
 		secretRevisionsC: {
-			indexes: []mgo.Index{{
-				Key: []string{"revision", "_id", "model-uuid"},
-			}},
+			indexes: []mgo.Index{
+				{Key: []string{"model-uuid", "_id", "revision"}},
+				{Key: []string{"model-uuid", "_id"}},
+			},
 		},
 
 		secretConsumersC: {
 			indexes: []mgo.Index{{
-				Key: []string{"consumer-tag", "label", "model-uuid"},
+				Key: []string{"model-uuid", "consumer-tag", "label"},
 			}},
 		},
 
 		secretRemoteConsumersC: {
 			indexes: []mgo.Index{{
-				Key: []string{"consumer-tag", "model-uuid"},
+				Key: []string{"model-uuid", "consumer-tag"},
 			}},
 		},
 
 		secretPermissionsC: {
 			indexes: []mgo.Index{{
-				Key: []string{"subject-tag", "scope-tag", "model-uuid"},
+				Key: []string{"model-uuid", "subject-tag", "scope-tag"},
 			}},
 		},
 
 		secretRotateC: {
 			indexes: []mgo.Index{{
-				Key: []string{"owner-tag", "model-uuid"},
+				Key: []string{"model-uuid", "owner-tag"},
 			}},
 		},
 


### PR DESCRIPTION
Indexes that include `model-uuid` should have it listed first because it is always an equality comparison, which limits before applying any range based argumentation such as regular expressions to subsequent fields. This is fixed for all the secrets collections, which were the only outliers in this regard.

A new index is added to `secretRevisions` for the exact query observed in production as a repeating in the slow logs.

## QA steps

Secrets CI tests will cover it.