### PR TITLE
fix(remove-application): fix remove-application because it was preventing model's destruction

### DIFF
--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -384,6 +384,7 @@ func (st *State) deleteSimpleApplicationReferences(ctx context.Context, tx *sqla
 		"DELETE FROM application_extra_endpoint WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM application_storage_directive WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM application_status WHERE application_uuid = $entityUUID.uuid",
+		"DELETE FROM application_agent WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM application_workload_version WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM device_constraint WHERE application_uuid = $entityUUID.uuid",
 	} {


### PR DESCRIPTION
# Description

Trying to investigate the failure behind https://jenkins.juju.canonical.com/job/test-smoke_k8s-multijob i've noticed locally i couldn't remove an application.

remove-application was failing with `ERROR juju.database transaction.go:277 constraint error deleting application: FOREIGN KEY constraint failed`. After inspecting the code I have noticed the table `application_agent` wasn't cleanup on application's deletion. Just adding this delete made my local qa to pass with microk8s.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

> I'm not sure how to test this one, i would have expect some tests to fail because remove-application doesn't work. Maybe the `application_agent` is populated just with microk8s and that's the reason why this failure was never caught.

## QA steps
use a microk8s controller

Before this pr:

`juju deploy snappass-test test` 

`juju remove-application test` does remove the units, but not the application. Check the logs and it should be consistent with what I've described.

After:

`juju remove-application test` works and you can `juju destroy-model` as well on microk8s.