### PR TITLE
ci: update microk8s version in CI tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.cloud == 'microk8s'
         uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9
         with:
-          channel: "1.30-strict/stable"
+          channel: "1.34-strict/stable"
           addons: '["dns", "hostpath-storage", "rbac"]'
           launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -107,7 +107,7 @@ jobs:
         if: matrix.cloud == 'microk8s'
         uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9
         with:
-          channel: "1.30-strict/stable"
+          channel: "1.34-strict/stable"
           addons: '["dns", "hostpath-storage"]'
           launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 


### PR DESCRIPTION
This PR updates the version of the Microk8s snap that is installed in our CI tests. Ubuntu 24.04 and higher have introduced a change in apparmor rules that broke the strict microk8s snap. See [here](https://github.com/canonical/microk8s/issues/5190).

The fix is [here](https://github.com/canonical/microk8s/pull/5218). It seems the fix was backported to Microk8s 1.32 and 1.33 based on the labels in that PR but testing 1.32 still fails so I've bumped up to 1.34 and I haven't tested 1.33. This change should fix failing Microk8s smoke tests.
