### PR TITLE
feat: index on operation_task_log

### DIFF
--- a/domain/schema/model/sql/0033-operation.sql
+++ b/domain/schema/model/sql/0033-operation.sql
@@ -131,6 +131,9 @@ CREATE TABLE operation_task_log (
     REFERENCES operation_task (uuid)
 );
 
+CREATE INDEX idx_operation_task_log_id
+ON operation_task_log (task_uuid, created_at);
+
 -- operation_parameter holds the parameters passed to an operation.
 -- In the case of an action, these are the user-passed parameters, where the 
 -- keys should match the charm_action's parameters.


### PR DESCRIPTION
Follow on to #20565 

Create an index with the task_uuid and created_at values to faciliate retrieving the logs in a paginated fashion based on the created_at time for a task.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

GetLatestTaskLogsByUUID can't be exercised yet as #20680 hasn't landed.