### PR TITLE
feat: add support for multi lines in dqlite cmd tool

### DIFF
--- a/scripts/dqlite/cmd/main.go
+++ b/scripts/dqlite/cmd/main.go
@@ -147,6 +147,7 @@ func main() {
 			}
 		}
 
+		var lineBuildUp strings.Builder
 		for {
 			select {
 			case <-ctx.Done():
@@ -171,23 +172,32 @@ func main() {
 				return
 			}
 
-			// Process the input query.
-			result, err := processQuery(ctx, db, input)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "Error: ", err)
-			} else {
-				line.AppendHistory(input)
-				if result != "" {
-					fmt.Println()
-					fmt.Println(result)
-				}
-
-				// This can fail, so we don't care if it errors out.
-				if file != nil {
-					fmt.Fprintln(file, input)
-					_ = file.Sync()
-				}
+			lineBuildUp.WriteString(input + " ")
+			if !strings.HasSuffix(strings.TrimSpace(input), ";") {
+				continue
 			}
+
+			func() {
+				defer lineBuildUp.Reset()
+
+				// Process the input query.
+				result, err := processQuery(ctx, db, lineBuildUp.String())
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "Error: ", err)
+				} else {
+					line.AppendHistory(lineBuildUp.String())
+					if result != "" {
+						fmt.Println()
+						fmt.Println(result)
+					}
+
+					// This can fail, so we don't care if it errors out.
+					if file != nil {
+						fmt.Fprintln(file, lineBuildUp.String())
+						_ = file.Sync()
+					}
+				}
+			}()
 		}
 	}()
 


### PR DESCRIPTION
Adds support for multi lines in the dqlite cmd tool. Allows copying and pasting of formatted queries.

Simple quality of life hack.