### PR TITLE
fix: remove additional wait

### DIFF
--- a/tests/suites/dashboard/dashboard.sh
+++ b/tests/suites/dashboard/dashboard.sh
@@ -7,8 +7,6 @@ run_dashboard_deploy() {
 	juju relate dashboard controller
 
 	wait_for "controller" "$(active_condition "dashboard")"
-	juju wait-for application dashboard
-	sleep 10 # short wait for relation data to update
 
 	# verify juju dashboard fails as expected
 	#open_dashboard


### PR DESCRIPTION
The issue for this test is wait-for isn't implemented in main yet, and even if it was, we were running wait-for twice (one via the bashsuites wait_for func and the supercommand wait-for.

I also removed the sleep as it run fine locally without it.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Simply run the test.