### PR TITLE
fix: check all machine targets exist when exec

### DIFF
--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -343,6 +343,12 @@ func toOperationResult(op operation.OperationInfo) params.OperationResult {
 
 // toActionResult converts an operation.TaskInfo to a params.ActionResult.
 func toActionResult(receiver names.Tag, info operation.TaskInfo) params.ActionResult {
+	if info.Error != nil {
+		return params.ActionResult{
+			Error: apiservererrors.ServerError(info.Error),
+		}
+	}
+
 	var logs []params.ActionMessage
 	if len(info.Log) > 0 {
 		logs = transform.Slice(info.Log, func(l operation.TaskLog) params.ActionMessage {

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -371,7 +371,6 @@ func toActionResult(receiver names.Tag, info operation.TaskInfo) params.ActionRe
 		Message:   info.Message,
 		Log:       logs,
 		Output:    info.Output,
-		Error:     apiservererrors.ServerError(info.Error),
 	}
 }
 

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -283,14 +283,6 @@ func toEnqueuedActions(result operation.RunResult) params.EnqueuedActions {
 		return result
 	})
 
-	// Since no machines nor units were finally valid, no task has been
-	// enqueued and therefore we haven't got any operation ID from the
-	// service.
-	// However, we must return a valid operation ID for the client to get
-	// the tag from. We therefore return an empty operation with the 0 ID.
-	if result.OperationID == "" {
-		result.OperationID = "0"
-	}
 	return params.EnqueuedActions{
 		OperationTag: names.NewOperationTag(result.OperationID).String(),
 		Actions:      append(machineResult, unitResults...),

--- a/apiserver/facades/client/action/operationget_test.go
+++ b/apiserver/facades/client/action/operationget_test.go
@@ -329,12 +329,6 @@ func (s *getOperationSuite) TestListOperationsActionFieldMapping(c *tc.C) {
 	acts := res.Results[0].Actions
 	c.Assert(acts, tc.HasLen, 1)
 	ar := acts[0]
-	c.Check(ar.Status, tc.Equals, "running")
-	c.Check(ar.Message, tc.Equals, "in progress")
-	c.Check(ar.Log, tc.HasLen, 1)
-	c.Check(ar.Log[0].Timestamp.Equal(when), tc.Equals, true)
-	c.Check(ar.Log[0].Message, tc.Equals, "log1")
-	c.Check(ar.Output["k"], tc.Equals, "v")
 	c.Assert(ar.Error, tc.NotNil)
 	c.Check(ar.Error.Message, tc.Matches, ".*task-fail.*")
 }

--- a/apiserver/facades/client/action/operationstart_test.go
+++ b/apiserver/facades/client/action/operationstart_test.go
@@ -628,6 +628,7 @@ func (s *runSuite) TestRunNoValidTarget(c *tc.C) {
 			c.Check(target.Machines, tc.HasLen, 1)
 			c.Check(target.Units, tc.HasLen, 0)
 			return operation.RunResult{
+				OperationID: "1",
 				Machines: []operation.MachineTaskResult{
 					{
 						TaskInfo: operation.TaskInfo{
@@ -647,7 +648,9 @@ func (s *runSuite) TestRunNoValidTarget(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.IsNil)
-	c.Check(res.OperationTag, tc.Equals, "operation-0") // zero ID when no operation created
+	c.Check(res.OperationTag, tc.Equals, "operation-1")
+	c.Assert(res.Actions, tc.HasLen, 1)
+	c.Check(res.Actions[0].Error, tc.ErrorMatches, ".*machine \"42\" not found.*")
 }
 
 // TestRunBlockServiceError ensures a non-NotFound block service error

--- a/domain/operation/service/package_mock_test.go
+++ b/domain/operation/service/package_mock_test.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 	time "time"
 
-	set "github.com/juju/collections/set"
 	machine "github.com/juju/juju/core/machine"
 	unit "github.com/juju/juju/core/unit"
 	operation "github.com/juju/juju/domain/operation"
@@ -198,44 +197,6 @@ func (c *MockStateCancelTaskCall) Do(f func(context.Context, string) (operation.
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateCancelTaskCall) DoAndReturn(f func(context.Context, string) (operation.Task, error)) *MockStateCancelTaskCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// CheckMachinesByNameExist mocks base method.
-func (m *MockState) CheckMachinesByNameExist(arg0 context.Context, arg1 set.Strings) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckMachinesByNameExist", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckMachinesByNameExist indicates an expected call of CheckMachinesByNameExist.
-func (mr *MockStateMockRecorder) CheckMachinesByNameExist(arg0, arg1 any) *MockStateCheckMachinesByNameExistCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckMachinesByNameExist", reflect.TypeOf((*MockState)(nil).CheckMachinesByNameExist), arg0, arg1)
-	return &MockStateCheckMachinesByNameExistCall{Call: call}
-}
-
-// MockStateCheckMachinesByNameExistCall wrap *gomock.Call
-type MockStateCheckMachinesByNameExistCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateCheckMachinesByNameExistCall) Return(arg0 error) *MockStateCheckMachinesByNameExistCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateCheckMachinesByNameExistCall) Do(f func(context.Context, set.Strings) error) *MockStateCheckMachinesByNameExistCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCheckMachinesByNameExistCall) DoAndReturn(f func(context.Context, set.Strings) error) *MockStateCheckMachinesByNameExistCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -509,6 +470,45 @@ func (c *MockStateGetMachineUUIDByNameCall) Do(f func(context.Context, machine.N
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetMachineUUIDByNameCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateGetMachineUUIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetMachines mocks base method.
+func (m *MockState) GetMachines(arg0 context.Context, arg1 []machine.Name) ([]machine.Name, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachines", arg0, arg1)
+	ret0, _ := ret[0].([]machine.Name)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachines indicates an expected call of GetMachines.
+func (mr *MockStateMockRecorder) GetMachines(arg0, arg1 any) *MockStateGetMachinesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachines", reflect.TypeOf((*MockState)(nil).GetMachines), arg0, arg1)
+	return &MockStateGetMachinesCall{Call: call}
+}
+
+// MockStateGetMachinesCall wrap *gomock.Call
+type MockStateGetMachinesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetMachinesCall) Return(arg0 []machine.Name, arg1 error) *MockStateGetMachinesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetMachinesCall) Do(f func(context.Context, []machine.Name) ([]machine.Name, error)) *MockStateGetMachinesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetMachinesCall) DoAndReturn(f func(context.Context, []machine.Name) ([]machine.Name, error)) *MockStateGetMachinesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/operation/service/package_mock_test.go
+++ b/domain/operation/service/package_mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	set "github.com/juju/collections/set"
 	machine "github.com/juju/juju/core/machine"
 	unit "github.com/juju/juju/core/unit"
 	operation "github.com/juju/juju/domain/operation"
@@ -197,6 +198,44 @@ func (c *MockStateCancelTaskCall) Do(f func(context.Context, string) (operation.
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateCancelTaskCall) DoAndReturn(f func(context.Context, string) (operation.Task, error)) *MockStateCancelTaskCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// CheckMachinesByNameExist mocks base method.
+func (m *MockState) CheckMachinesByNameExist(arg0 context.Context, arg1 set.Strings) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckMachinesByNameExist", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckMachinesByNameExist indicates an expected call of CheckMachinesByNameExist.
+func (mr *MockStateMockRecorder) CheckMachinesByNameExist(arg0, arg1 any) *MockStateCheckMachinesByNameExistCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckMachinesByNameExist", reflect.TypeOf((*MockState)(nil).CheckMachinesByNameExist), arg0, arg1)
+	return &MockStateCheckMachinesByNameExistCall{Call: call}
+}
+
+// MockStateCheckMachinesByNameExistCall wrap *gomock.Call
+type MockStateCheckMachinesByNameExistCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateCheckMachinesByNameExistCall) Return(arg0 error) *MockStateCheckMachinesByNameExistCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateCheckMachinesByNameExistCall) Do(f func(context.Context, set.Strings) error) *MockStateCheckMachinesByNameExistCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateCheckMachinesByNameExistCall) DoAndReturn(f func(context.Context, set.Strings) error) *MockStateCheckMachinesByNameExistCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/operation/service/service.go
+++ b/domain/operation/service/service.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/clock"
-	"github.com/juju/collections/set"
 
 	"github.com/juju/juju/core/logger"
 	coremachine "github.com/juju/juju/core/machine"
@@ -40,12 +39,9 @@ type State interface {
 	// ID.
 	CancelTask(ctx context.Context, taskID string) (operation.Task, error)
 
-	// CheckMachinesByNameExist checks if all given machine names exist in the
-	// database.
-	//
-	// The following errors may be returned:
-	// - [machineerrors.MachineNotFound]: if one or more machines are not found.
-	CheckMachinesByNameExist(ctx context.Context, machineNames set.Strings) error
+	// GetMachines returns the list of machine names from the input list that exist
+	// in the database.
+	GetMachines(ctx context.Context, machineNames []coremachine.Name) ([]coremachine.Name, error)
 
 	// FilterTaskUUIDsForMachine returns a list of task IDs that corresponds to the
 	// filtered list of task UUIDs from the provided list that target the given

--- a/domain/operation/service/start.go
+++ b/domain/operation/service/start.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
+
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/trace"
 	coreunit "github.com/juju/juju/core/unit"

--- a/domain/operation/service/start.go
+++ b/domain/operation/service/start.go
@@ -29,14 +29,6 @@ func (s *Service) AddExecOperation(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	// Return early if no targets were provided.
-	if len(target.Applications) == 0 &&
-		len(target.Machines) == 0 &&
-		len(target.Units) == 0 &&
-		len(target.LeaderUnit) == 0 {
-		return operation.RunResult{}, nil
-	}
-
 	operationUUID, err := internaluuid.NewUUID()
 	if err != nil {
 		return operation.RunResult{}, errors.Errorf("generating operation UUID: %w", err)

--- a/domain/operation/service/start_test.go
+++ b/domain/operation/service/start_test.go
@@ -494,20 +494,6 @@ func (s *startSuite) TestStartExecOperationOnlyLeaderUnits(c *tc.C) {
 	c.Check(result.Units[0].TaskInfo.ID, tc.Equals, "43")
 }
 
-func (s *startSuite) TestStartExecOperationEmptyTarget(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	target := operation.Receivers{}
-	args := operation.ExecArgs{Command: "echo hello"}
-
-	// Return early without calling state layer.
-	result, err := s.service().AddExecOperation(c.Context(), target, args)
-	c.Assert(err, tc.IsNil)
-	c.Check(result.OperationID, tc.Equals, "")
-	c.Assert(result.Units, tc.HasLen, 0)
-	c.Check(result.Machines, tc.HasLen, 0)
-}
-
 func (s *startSuite) TestStartExecOperationOnAllMachinesSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/operation/service/start_test.go
+++ b/domain/operation/service/start_test.go
@@ -107,10 +107,14 @@ func (s *startSuite) TestAddExecOperationMachineTargetsNoneExist(c *tc.C) {
 
 	// Simulate no machines exist.
 	s.state.EXPECT().GetMachines(gomock.Any(), target.Machines).Return(nil, nil)
+	s.state.EXPECT().AddExecOperation(gomock.Any(), gomock.Any(), gomock.Any(), args).Return(
+		operation.RunResult{
+			OperationID: "1",
+		}, nil)
 
 	result, err := s.service().AddExecOperation(c.Context(), target, args)
 	c.Assert(err, tc.IsNil)
-	c.Check(result.OperationID, tc.Equals, "")
+	c.Check(result.OperationID, tc.Equals, "1")
 	c.Check(result.Machines, tc.HasLen, 2)
 	c.Check(result.Machines[0].Error, tc.ErrorMatches, ".*machine \"0\" not found.*")
 	c.Check(result.Machines[1].Error, tc.ErrorMatches, ".*machine \"1\" not found.*")
@@ -322,11 +326,15 @@ func (s *startSuite) TestStartExecOperationLeaderResolutionError(c *tc.C) {
 	}
 
 	s.mockLeadershipService.EXPECT().ApplicationLeader("test-app").Return("", errors.New("leadership error"))
+	s.state.EXPECT().AddExecOperation(gomock.Any(), gomock.Any(), gomock.Any(), args).Return(
+		operation.RunResult{
+			OperationID: "1",
+		}, nil)
 
 	// Return early since there are no valid targets to pass to state layer.
 	result, err := s.service().AddExecOperation(c.Context(), target, args)
 	c.Assert(err, tc.IsNil)
-	c.Check(result.OperationID, tc.Equals, "")
+	c.Check(result.OperationID, tc.Equals, "1")
 	c.Assert(result.Units, tc.HasLen, 1)
 	c.Check(result.Units[0].ReceiverName, tc.Equals, unit.Name("test-app/0"))
 	c.Check(result.Units[0].IsLeader, tc.Equals, true)
@@ -344,11 +352,15 @@ func (s *startSuite) TestStartExecOperationLeaderUnitNameParsingError(c *tc.C) {
 	}
 
 	s.mockLeadershipService.EXPECT().ApplicationLeader("test-app").Return("invalid-unit-name", nil)
+	s.state.EXPECT().AddExecOperation(gomock.Any(), gomock.Any(), gomock.Any(), args).Return(
+		operation.RunResult{
+			OperationID: "1",
+		}, nil)
 
 	// Return early since there are no valid targets to pass to state layer.
 	result, err := s.service().AddExecOperation(c.Context(), target, args)
 	c.Assert(err, tc.IsNil)
-	c.Check(result.OperationID, tc.Equals, "")
+	c.Check(result.OperationID, tc.Equals, "1")
 	c.Assert(result.Units, tc.HasLen, 1)
 	c.Check(result.Units[0].ReceiverName, tc.Equals, unit.Name("test-app/0"))
 	c.Check(result.Units[0].IsLeader, tc.Equals, true)

--- a/domain/operation/state/start.go
+++ b/domain/operation/state/start.go
@@ -183,34 +183,6 @@ func (st *State) AddActionOperation(ctx context.Context,
 	return result, nil
 }
 
-// // addMachineExecTargets inserts a list of machine tasks for the provided target
-// // and operation UUID.
-// func (st *State) addMachineExecTargets(
-// 	ctx context.Context,
-// 	tx *sqlair.TX,
-// 	operationUUID string,
-// 	machineTargets []machine.UUID,
-// ) []operation.MachineTaskResult {
-// 	for _, machineTask := range machineTargets {
-// 		// Create the task UUID.
-// 		taskUUID, err := internaluuid.NewUUID()
-// 		if err != nil {
-// 			taskResult := operation.MachineTaskResult{
-// 				ReceiverName: machineTask,
-// 				TaskInfo: operation.TaskInfo{
-// 					Error: errors.Errorf("generating task UUID: %w", err),
-// 				},
-// 			}
-// 			result.Machines = append(result.Machines, taskResult)
-// 			continue
-// 		}
-// 		taskResult := st.addMachineTask(ctx, tx, operationUUID, taskUUID.String(), machineTask)
-// 		taskResult.IsParallel = args.Parallel
-// 		taskResult.ExecutionGroup = &args.ExecutionGroup
-// 		result.Machines = append(result.Machines, taskResult)
-// 	}
-// }
-
 // addExecOperation creates the exec operation for the provided receivers.
 func (st *State) addExecOperation(
 	ctx context.Context,

--- a/domain/operation/state/state.go
+++ b/domain/operation/state/state.go
@@ -16,7 +16,6 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
-	"github.com/juju/juju/core/machine"
 	coremachine "github.com/juju/juju/core/machine"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain"
@@ -368,7 +367,7 @@ WHERE  name = $nameArg.name`
 
 // GetMachines returns the list of machine names from the input list that exist
 // in the database.
-func (st *State) GetMachines(ctx context.Context, machineNames []machine.Name) ([]machine.Name, error) {
+func (st *State) GetMachines(ctx context.Context, machineNames []coremachine.Name) ([]coremachine.Name, error) {
 	if len(machineNames) == 0 {
 		return nil, nil
 	}
@@ -378,7 +377,7 @@ func (st *State) GetMachines(ctx context.Context, machineNames []machine.Name) (
 	}
 
 	type names []string
-	nameStrs := transform.Slice(machineNames, func(n machine.Name) string {
+	nameStrs := transform.Slice(machineNames, func(n coremachine.Name) string {
 		return n.String()
 	})
 
@@ -403,8 +402,8 @@ WHERE name IN ($names[:])`, nameArg{}, names(nameStrs))
 		return nil, errors.Capture(err)
 	}
 
-	return transform.Slice(res, func(r nameArg) machine.Name {
-		return machine.Name(r.Name)
+	return transform.Slice(res, func(r nameArg) coremachine.Name {
+		return coremachine.Name(r.Name)
 	}), nil
 }
 

--- a/domain/operation/state/types.go
+++ b/domain/operation/state/types.go
@@ -136,3 +136,7 @@ type insertMachineTask struct {
 type charmUUIDResult struct {
 	CharmUUID string `db:"charm_uuid"`
 }
+
+type countResult struct {
+	Count int `db:"count"`
+}

--- a/domain/operation/state/types.go
+++ b/domain/operation/state/types.go
@@ -136,7 +136,3 @@ type insertMachineTask struct {
 type charmUUIDResult struct {
 	CharmUUID string `db:"charm_uuid"`
 }
-
-type countResult struct {
-	Count int `db:"count"`
-}


### PR DESCRIPTION
This patch fixes an issue when running an exec with machine targets that don't actually exist (panics).
The fix is to validate the input target before enqueueing anything.

As a flyby I had to fix another issue in the facades, in the toEnqueuedActions method, because when no valid target is passed to the service, the operation tag was empty and this breaks the api client. I therefore had to add an artificial ("0") operation tag. Again, a separate commit.
This behavior is shown in the QA steps when trying to run an exec on a machine that doesn't exist.


## QA steps

Try running an exec on a machine that doesn't exist (even if some of the passed list do exist):

```
$ juju add-machine # adds machine 0
$ juju exec --machine 0,1 juju-engine-report
Some actions could not be scheduled:
machine "1" not found
$ juju exec --machine 1 juju-engine-report
Operation 0 failed to schedule any tasks:
machine "1" not found
```
The last command hangs because another issue (in the uniter/machineaction being addressed separately.

## Links

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-8358
