### PR TITLE
feat: do not save store uuid if nothing stored

### DIFF
--- a/domain/operation/service/task.go
+++ b/domain/operation/service/task.go
@@ -68,7 +68,7 @@ func (s *Service) FinishTask(ctx context.Context, result operation.CompletedTask
 }
 
 func (s *Service) storeTaskResults(ctx context.Context, taskUUID string, results map[string]interface{}) (string, func(), error) {
-	if results == nil {
+	if len(results) == 0 {
 		return "", nil, nil
 	}
 

--- a/domain/operation/service/task_test.go
+++ b/domain/operation/service/task_test.go
@@ -300,6 +300,33 @@ func (s *serviceSuite) TestFinishTask(c *tc.C) {
 	c.Assert(err, tc.IsNil)
 }
 
+func (s *serviceSuite) TestFinishTaskTaskFailed(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	taskID := "42"
+	taskUUID := uuid.MustNewUUID().String()
+	s.state.EXPECT().GetTaskUUIDByID(gomock.Any(), taskID).Return(taskUUID, nil)
+
+	input := internal.CompletedTask{
+		TaskUUID: taskUUID,
+		Status:   corestatus.Failed.String(),
+		Message:  "done",
+	}
+	s.state.EXPECT().FinishTask(gomock.Any(), input).Return(nil)
+
+	arg := operation.CompletedTaskResult{
+		TaskID:  taskID,
+		Message: "done",
+		Status:  corestatus.Failed.String(),
+	}
+
+	// Act
+	err := s.service().FinishTask(c.Context(), arg)
+	// Assert
+	c.Assert(err, tc.IsNil)
+}
+
 func (s *serviceSuite) TestLogTaskMessage(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/operation/state/task.go
+++ b/domain/operation/state/task.go
@@ -242,7 +242,7 @@ func (st *State) FinishTask(ctx context.Context, task internal.CompletedTask) er
 			return errors.Capture(err)
 		}
 
-		if err := st.insertOperationTaskOutput(ctx, tx, task.TaskUUID, task.StoreUUID); err != nil {
+		if err := st.insertOperationTaskOutputIfAny(ctx, tx, task.TaskUUID, task.StoreUUID); err != nil {
 			return errors.Capture(err)
 		}
 
@@ -296,11 +296,15 @@ WHERE task_uuid = $taskStatus.task_uuid
 	return nil
 }
 
-func (st *State) insertOperationTaskOutput(
+func (st *State) insertOperationTaskOutputIfAny(
 	ctx context.Context,
 	tx *sqlair.TX,
 	taskUUID, storeUUID string,
 ) error {
+	// If the task failed, there may not be output saved.
+	if storeUUID == "" {
+		return nil
+	}
 
 	store := outputStore{
 		TaskUUID:  taskUUID,

--- a/domain/operation/state/task_test.go
+++ b/domain/operation/state/task_test.go
@@ -342,6 +342,29 @@ func (s *taskSuite) TestFinishTaskNotOperation(c *tc.C) {
 	s.checkOperationCompleted(c, operationUUID, false)
 }
 
+func (s *taskSuite) TestFinishTaskNotOperationNoStoredOutput(c *tc.C) {
+	// Arrange
+	// Add an operation and two tasks, neither have been completed.
+	operationUUID := s.addOperation(c)
+	s.addOperationTaskStatus(c, s.addOperationTask(c, operationUUID), corestatus.Aborting.String())
+	taskUUID := s.addOperationTask(c, operationUUID)
+	s.addOperationTaskStatus(c, taskUUID, corestatus.Aborting.String())
+
+	arg := internal.CompletedTask{
+		TaskUUID: taskUUID,
+		Status:   corestatus.Aborted.String(),
+		Message:  "done",
+	}
+
+	// Act
+	err := s.state.FinishTask(c.Context(), arg)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	s.checkTaskStatus(c, taskUUID, arg.Status)
+	s.checkOperationCompleted(c, operationUUID, false)
+}
+
 func (s *taskSuite) TestFinishTaskAndOperation(c *tc.C) {
 	// Arrange
 	// Add an operation and two tasks, one is finished with


### PR DESCRIPTION
There is no guarantee that a finished task as output to store. Especially when it fails. Do not attempt to store it, nor save an empty store uuid.

This was causing a FOREIGN KEY failed error.
```
machine-0: 20:13:44 ERROR juju.database constraint error inserting task "c505aa57-76d9-42f2-8b99-6ac321c92abb" output "": FOREIGN KEY constraint failed - running queries:
 BEGIN

UPDATE operation_task_status
SET    message = @sqlair_0,
       updated_at = @sqlair_1,
       status_id = (
           SELECT id FROM operation_task_status_value WHERE status = @sqlair_2
       )
WHERE task_uuid = @sqlair_3


INSERT INTO operation_task_output (store_uuid, task_uuid) VALUES (@sqlair_0, @sqlair_1)
```

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju bootstrap localhost test  ; juju add-model six ; juju add-machine -n 3
# wait for the machines to become idle active
$ juju exec --machine 0,1 -- juju-engine-report
$ juju show-operation 0
# it'll show failed results, juju_engine_report is not in the path

# verify the controller log shows no FOREIGN KEY constraint failures as described above.
juju debug-log -m controller --replay --level error
```

## Links

**Jira card:** JUJU-6924
