### PR TITLE
fix(remove-unit): fix remove-unit by deleting foreign key references for unit_resolved

### DIFF
--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -646,6 +646,7 @@ func (st *State) deleteForeignKeyUnitReferences(ctx context.Context, tx *sqlair.
 		"DELETE FROM unit_workload_status WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_workload_version WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_principal WHERE unit_uuid = $entityUUID.uuid",
+		"DELETE FROM unit_resolved WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_resource WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM k8s_pod_status WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM port_range WHERE unit_uuid = $entityUUID.uuid",


### PR DESCRIPTION
# Description

While QA other stuff i've noticed creating and destroying a controller was returning some 
```
2025-09-26T09:12:47.989Z [jujud] 2025-09-26 09:12:47 ERROR juju.database transaction.go:277 constraint error deleting unit for unit "4bce5177-7428-4120-8100-a631bd4d404e": FOREIGN KEY constraint failed - running queries:
```

After further inspection we were not cleaning up the unit_resolved table.

# QA

`juju bootstrap microk8s test`

`juju destroy-controller test`

SQL error is gone.