### PR TITLE
ci(ssdlc): add workflow to generate SBOM and run security scans via sbomber

### DIFF
--- a/.github/workflows/sbom-secscan.yaml
+++ b/.github/workflows/sbom-secscan.yaml
@@ -1,0 +1,54 @@
+name: SBOM and secscan
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scan:
+    name: SBOM generation
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libapt-pkg-dev
+          sudo apt install -y python3-apt
+      - name: Checkout security scanner
+        uses: actions/checkout@v5
+        with:
+          repository: canonical/sbomber
+          path: scanner
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6  # v6.6.1
+      - name: Install secscan cli
+        run: |
+          sudo snap install canonical-secscan-client
+          sudo snap connect canonical-secscan-client:home system:home
+      - name: Prepare the artifacts
+        run: |
+          cd scanner
+          ./sbomber prepare ../.sbomber-manifest.yaml
+      - name: Submit the artifacts
+        run: |
+          cd scanner
+          ./sbomber submit
+      - name: Wait for the scans to finish
+        run: |
+          cd scanner
+          ./sbomber poll --wait --timeout 30
+      - name: Download the reports
+        run: |
+          cd scanner && ./sbomber download
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: secscan-report-upload
+          path: ./scanner/reports/

--- a/.github/workflows/sbom-secscan.yaml
+++ b/.github/workflows/sbom-secscan.yaml
@@ -1,8 +1,9 @@
 name: SBOM and secscan
 
-on:
-  workflow_call:
-  workflow_dispatch:
+on: [pull_request, workflow_dispatch]
+#on:
+#  workflow_call:
+#  workflow_dispatch:
 
 permissions: {}
 

--- a/.sbomber-manifest.yaml
+++ b/.sbomber-manifest.yaml
@@ -1,0 +1,20 @@
+# this manifest is used in `.github/workflows/sbom-secscan.yaml` workflow
+# to generate SBOM and run security scans on the specified artifacts.
+
+clients:
+  sbom:
+    service_url: https://sbom-request.canonical.com
+    department: charm_engineering
+    email: vitaly.antonenko@canonical.com
+    team: juju
+  secscan: {}
+
+
+artifacts:
+  - name: 'juju'
+    type: 'snap'
+    ssdlc_params:
+      name: 'juju'
+      version: ''
+      channel: 'stable'
+      cycle: '25.10'


### PR DESCRIPTION
This PR adds GitHub Actions workflow sbom-secscan that:
- Generates SBOM and submits artifacts for security scanning using canonical/sbomber and canonical-secscan-client.
- Supports workflow_call and manual dispatch triggers.
- Runs on self-hosted runner and uploads generated reports as artifacts.

Introduces .sbomber-manifest.yaml defining sbom and secscan clients plus juju snap artifact metadata for SBOM and scan submission.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# just passes checks
```

## Links
- [sbomber](https://github.com/canonical/sbomber)