### PR TITLE
fix(sidecar-suite): fix sidecar rootless integration test

### DIFF
--- a/domain/application/state/metadata.go
+++ b/domain/application/state/metadata.go
@@ -91,7 +91,7 @@ func decodeRunAs(runAs string) (charm.RunAs, error) {
 		return charm.RunAsRoot, nil
 	case "sudoer":
 		return charm.RunAsSudoer, nil
-	case "user":
+	case "non-root":
 		return charm.RunAsNonRoot, nil
 	default:
 		return "", errors.Errorf("unknown run as value %q", runAs)

--- a/domain/application/state/metadata_test.go
+++ b/domain/application/state/metadata_test.go
@@ -61,6 +61,28 @@ var metadataDecodeTestCases = [...]struct {
 		},
 	},
 	{
+		name: "non-root user",
+		input: charmMetadata{
+			Name:           "foo",
+			Summary:        "summary",
+			Description:    "description",
+			MinJujuVersion: "2.0.0",
+			RunAs:          "non-root",
+			Subordinate:    true,
+			Assumes:        []byte("null"),
+		},
+		inputArgs: decodeMetadataArgs{},
+		output: charm.Metadata{
+			Name:           "foo",
+			Summary:        "summary",
+			Description:    "description",
+			MinJujuVersion: semversion.MustParse("2.0.0"),
+			RunAs:          charm.RunAsNonRoot,
+			Subordinate:    true,
+			Assumes:        []byte("null"),
+		},
+	},
+	{
 		name:  "tags",
 		input: charmMetadata{},
 		inputArgs: decodeMetadataArgs{


### PR DESCRIPTION
# Description

decodeRunAs had a typo, instead of `non-root` it was searching for `user`. Searching through the code and juju 3 as well. It seems the `user` is just the wrong string. https://github.com/juju/juju/blob/3.6/caas/application.go#L191

# QA

`cd testcharms/charms/sidecar-non-root/metadata.yaml`
`charmcraft pack`
`juju deploy <charm-file> --resource ubuntu=public.ecr.aws/ubuntu/ubuntu:22.04`
Before the patch:
"ERROR getting charm: cannot decode run as "non-root": unknown run as value "non-root"

After the patch:
it works.