### PR TITLE
fix: plugin hardware characteristics for manually provided machines

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -176,7 +176,8 @@ func (mm *MachineManagerAPI) addOneMachine(ctx context.Context, p params.AddMach
 			Channel: base.Channel.String(),
 			OSType:  osType,
 		},
-		Directive: parsedPlacement,
+		Directive:               parsedPlacement,
+		HardwareCharacteristics: p.HardwareCharacteristics,
 	})
 
 	return addedMachine.MachineName, err

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -79,12 +79,13 @@ func (st *State) AddMachine(ctx context.Context, args domainmachine.AddMachineAr
 	}
 
 	placeArgs := domainmachine.PlaceMachineArgs{
-		Constraints: args.Constraints,
-		Directive:   args.Directive,
-		Platform:    args.Platform,
-		MachineUUID: machineUUID,
-		NetNodeUUID: netNodeUUID,
-		Nonce:       args.Nonce,
+		Constraints:             args.Constraints,
+		Directive:               args.Directive,
+		Platform:                args.Platform,
+		MachineUUID:             machineUUID,
+		NetNodeUUID:             netNodeUUID,
+		Nonce:                   args.Nonce,
+		HardwareCharacteristics: args.HardwareCharacteristics,
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		machineNames, err = PlaceMachine(ctx, tx, st, st.clock, placeArgs)

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -23,6 +23,8 @@ type CreateMachineArgs struct {
 	NetNodeUUID string
 	Platform    deployment.Platform
 	Nonce       *string
+	// HardwareCharacteristics contains the hardware characteristics for a manually provisioned machine.
+	HardwareCharacteristics instance.HardwareCharacteristics
 }
 
 // instanceData represents the struct to be inserted into the instance_data

--- a/domain/machine/types.go
+++ b/domain/machine/types.go
@@ -40,6 +40,9 @@ type AddMachineArgs struct {
 	Directive   deployment.Placement
 	Platform    deployment.Platform
 	Nonce       *string
+
+	// HardwareCharacteristics contains the hardware characteristics for a manually provisioned machine.
+	HardwareCharacteristics instance.HardwareCharacteristics
 }
 
 type PlaceMachineArgs struct {
@@ -59,6 +62,9 @@ type PlaceMachineArgs struct {
 	NetNodeUUID network.NetNodeUUID
 
 	Nonce *string
+
+	// HardwareCharacteristics contains the hardware characteristics for a manually provisioned machine.
+	HardwareCharacteristics instance.HardwareCharacteristics
 }
 
 // PollingInfo contains information about a machine that is being polled.


### PR DESCRIPTION
I was working on the CI broken test:
manual suite
https://jenkins.juju.canonical.com/job/test-manual-multijob/4061/
fails with ERROR cannot obtain provisioning script ERROR getting instance config: arch is not set for "1"

The arch issue was because the characteristics were missing in the machine cloud instance table. I wasn't sure if I should do another insert or just plumb them through into instanceData, so I just plumbed them through. Ty @SimonRichardson  for suggesting putting them in this way.

There's a few more issues though. The constraints for the platform info aren't populated (so if you're scaling an app and you're not on AMD64 it is broken). And secondly it begins to try to call StartInstance against the manual provider and I'm not sure what the correct behaviour is to go and fix it. 

Perhaps this PR isn't right and it needs implementing properly, but thought I'd put it up anyways to show the issue better & give us a reference-able link on the CI issue.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Run test_deploy_manual:
`BOOTSTRAP_ARCH=arm64 MODEL_ARCH=arm64 BOOTSTRAP_REUSE=true TEST_INSPECT=true ./main.sh -v manual test_deploy_manual`


