### PR TITLE
fix: action result with wrong error

### DIFF
--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -343,6 +343,12 @@ func toOperationResult(op operation.OperationInfo) params.OperationResult {
 
 // toActionResult converts an operation.TaskInfo to a params.ActionResult.
 func toActionResult(receiver names.Tag, info operation.TaskInfo) params.ActionResult {
+	if info.Error != nil {
+		return params.ActionResult{
+			Error: apiservererrors.ServerError(info.Error),
+		}
+	}
+
 	var logs []params.ActionMessage
 	if len(info.Log) > 0 {
 		logs = transform.Slice(info.Log, func(l operation.TaskLog) params.ActionMessage {
@@ -365,7 +371,6 @@ func toActionResult(receiver names.Tag, info operation.TaskInfo) params.ActionRe
 		Message:   info.Message,
 		Log:       logs,
 		Output:    info.Output,
-		Error:     apiservererrors.ServerError(info.Error),
 	}
 }
 

--- a/apiserver/facades/client/action/operationget_test.go
+++ b/apiserver/facades/client/action/operationget_test.go
@@ -329,12 +329,6 @@ func (s *getOperationSuite) TestListOperationsActionFieldMapping(c *tc.C) {
 	acts := res.Results[0].Actions
 	c.Assert(acts, tc.HasLen, 1)
 	ar := acts[0]
-	c.Check(ar.Status, tc.Equals, "running")
-	c.Check(ar.Message, tc.Equals, "in progress")
-	c.Check(ar.Log, tc.HasLen, 1)
-	c.Check(ar.Log[0].Timestamp.Equal(when), tc.Equals, true)
-	c.Check(ar.Log[0].Message, tc.Equals, "log1")
-	c.Check(ar.Output["k"], tc.Equals, "v")
 	c.Assert(ar.Error, tc.NotNil)
 	c.Check(ar.Error.Message, tc.Matches, ".*task-fail.*")
 }


### PR DESCRIPTION
This patch fixes an issue when running an exec with machine targets that don't actually exist (panics).
It is due to a wrong behavior in the `toActionResult` method which tries to fill the full result even when the TaskInfo contains an error. In that case, the rest of the fields of TaskInfo are not guaranteed to be non-nil, so this resulted in panics or empty fields. 

The fix is to check whether we have an error in the task, and return early in that case.

_Note: This PR was created in replacement of https://github.com/juju/juju/pull/20735, more specifically the comment https://github.com/juju/juju/pull/20735#pullrequestreview-3273110551._

## QA steps

Try running an exec on a machine that doesn't exist (even if some of the passed list do exist):

```
$ juju add-machine # adds machine 0
$ juju exec --machine 0,1 juju-engine-report
Some actions could not be scheduled:
getting machine UUID for "1": machine "1" not found
$ juju exec --machine 1 juju-engine-report
Some actions could not be scheduled:
getting machine UUID for "1": machine "1" not found
```

## Links


**Jira card:** [JUJU-8358
](https://warthogs.atlassian.net/browse/JUJU-8358)