### PR TITLE
fix(status-log): make status-log in ascending order to match juju 3.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/vault/api v1.10.0
 	github.com/hpcloud/tail v1.0.0
-	github.com/icza/backscanner v0.0.0-20241124160932-dff01ac50250
 	github.com/im7mortal/kmutex v1.0.1
 	github.com/juju/ansiterm v1.0.0
 	github.com/juju/clock v1.1.1
@@ -206,6 +205,7 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/icza/backscanner v0.0.0-20241124160932-dff01ac50250 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -350,7 +350,6 @@ github.com/hpidcock/gc-compat-tc v0.0.0-20250523041742-c3a83c867edf h1:sFwkVpTbk
 github.com/hpidcock/gc-compat-tc v0.0.0-20250523041742-c3a83c867edf/go.mod h1:lyEaDukSWSGyb/L0YGDaS1hU2p40qb5s/Ck6qm4CneU=
 github.com/icza/backscanner v0.0.0-20241124160932-dff01ac50250 h1:BNmTcPx0VddsU1pIgq3GoXtO8ek6tygVtj+l37Dcqo0=
 github.com/icza/backscanner v0.0.0-20241124160932-dff01ac50250/go.mod h1:GYeBD1CF7AqnKZK+UCytLcY3G+UKo0ByXX/3xfdNyqQ=
-github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6 h1:8UsGZ2rr2ksmEru6lToqnXgA8Mz1DP11X4zSJ159C3k=
 github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=
 github.com/im7mortal/kmutex v1.0.1 h1:zAACzjwD+OEknDqnLdvRa/BhzFM872EBwKijviGLc9Q=
 github.com/im7mortal/kmutex v1.0.1/go.mod h1:f71c/Ugk/+58OHRAgvgzPP3QEiWGUjK13fd8ozfKWdo=

--- a/internal/statushistory/statushistory_test.go
+++ b/internal/statushistory/statushistory_test.go
@@ -11,7 +11,6 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -246,12 +245,6 @@ func (s *statusHistoryReaderSuite) TestWalk(c *tc.C) {
 				},
 			})
 		}
-
-		sort.Slice(expected, func(i, j int) bool {
-			tag1, _ := strconv.Atoi(expected[i].Tag)
-			tag2, _ := strconv.Atoi(expected[j].Tag)
-			return tag1 >= tag2
-		})
 	})
 
 	history, err := ModelStatusHistoryReaderFromFile(model.UUID(modelUUID), path)
@@ -319,12 +312,6 @@ func (s *statusHistoryReaderSuite) TestWalkWhilstAdding(c *tc.C) {
 				},
 			})
 		}
-
-		sort.Slice(expected, func(i, j int) bool {
-			tag1, _ := strconv.Atoi(expected[i].Tag)
-			tag2, _ := strconv.Atoi(expected[j].Tag)
-			return tag1 >= tag2
-		})
 	})
 
 	history, err := ModelStatusHistoryReaderFromFile(model.UUID(modelUUID), path)
@@ -505,10 +492,6 @@ func (s *statusHistoryReaderSuite) TestWalkCorruptLine(c *tc.C) {
 				},
 			})
 		}
-
-		sort.Slice(expected, func(i, j int) bool {
-			return expected[i].Tag > expected[j].Tag
-		})
 	})
 
 	history, err := ModelStatusHistoryReaderFromFile(model.UUID(modelUUID), path)


### PR DESCRIPTION
# Description

`juju show-status-log` was yielding results in descending order. To
match Juju 3.6 behavior I've swapped the implementation of the
scanner from a backscanner to a regular bufio.scanner.

# QA

`juju deploy juju-qa-test test`

`juju show-status-log test/0`

Before the patch:

```
29 Sep 2025 11:56:24+02:00  workload   active       it is now: 09/29/2025, 09:56:24
29 Sep 2025 11:51:18+02:00  workload   active       it is now: 09/29/2025, 09:51:18
29 Sep 2025 11:46:38+02:00  juju-unit  idle         
29 Sep 2025 11:46:37+02:00  juju-unit  executing    running start hook
29 Sep 2025 11:46:37+02:00  workload   active       hello
29 Sep 2025 11:46:37+02:00  workload   active       resource line one: testing one.
29 Sep 2025 11:46:36+02:00  juju-unit  executing    running config-changed hook
```

After the patch:

```
Time                        Type       Status       Message
29 Sep 2025 12:37:52+02:00  workload   waiting      agent initialising
29 Sep 2025 12:37:58+02:00  workload   maintenance  installing charm software
29 Sep 2025 12:37:58+02:00  juju-unit  executing    running install hook
29 Sep 2025 12:37:59+02:00  juju-unit  executing    running leader-elected hook
29 Sep 2025 12:37:59+02:00  juju-unit  executing    running config-changed hook
29 Sep 2025 12:38:00+02:00  workload   active       resource line one: testing one.
29 Sep 2025 12:38:00+02:00  workload   active       hello
29 Sep 2025 12:38:00+02:00  juju-unit  executing    running start hook
29 Sep 2025 12:38:01+02:00  juju-unit  idle   
```