### PR TITLE
fix: gce by adding service-account auth type

### DIFF
--- a/domain/schema/controller/sql/0005-cloud.sql
+++ b/domain/schema/controller/sql/0005-cloud.sql
@@ -47,7 +47,8 @@ INSERT INTO auth_type VALUES
 (10, 'certificate'),
 (11, 'oauth2withcert'),
 (12, 'service-principal-secret'),
-(13, 'managed-identity');
+(13, 'managed-identity'),
+(14, 'service-account');
 
 CREATE TABLE cloud (
     uuid TEXT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
#20585 added support for service account auth types but was not
introduced into 4.0. This adds that auth type.

`ERROR running bootstrap operation at index 3: creating bootstrap cloud: updating cloud 606a31e4-8e9a-478e-8dc9-2f0c3787f551: updating cloud 606a31e4-8e9a-478e-8dc9-2f0c3787f551 auth types: auth type "service-account" not valid`

## QA steps

`juju bootstrap google`

## Links

https://jenkins.juju.canonical.com/job/test-constraints-test-constraints-model-google/1188/console