### PR TITLE
fix(arch): arch is no longer required for charmhub

### DIFF
--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -648,12 +648,6 @@ func (v *deployFromRepositoryValidator) deducePlatform(ctx context.Context, arg 
 		platform.Channel = base.Channel.String()
 	}
 
-	// Initial validation of platform from known data.
-	_, err = corecharm.ParsePlatform(platform.String())
-	if err != nil && !errors.Is(err, errors.BadRequest) {
-		return corecharm.Platform{}, usedModelDefaultBase, err
-	}
-
 	placementPlatform, placementsMatch, err := v.platformFromPlacement(ctx, arg.Placement)
 	if err != nil {
 		return corecharm.Platform{}, usedModelDefaultBase, err
@@ -677,7 +671,9 @@ func (v *deployFromRepositoryValidator) deducePlatform(ctx context.Context, arg 
 	// Check that the placement platform and the derived platform match
 	// when a base is supplied. There is no guarantee that all placement
 	// directives are machine scoped.
-	if placementPlatform.String() == platform.String() {
+	if (platform.OS == "" || platform.OS == placementPlatform.OS) &&
+		(platform.Channel == "" || platform.Channel == placementPlatform.Channel) &&
+		(platform.Architecture == "" || platform.Architecture == placementPlatform.Architecture) {
 		return *placementPlatform, usedModelDefaultBase, nil
 	}
 

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -309,12 +309,6 @@ func (a *API) resolveOneCharm(ctx context.Context, arg params.ResolveCharmWithCh
 		return result
 	}
 
-	// Validate the origin passed in.
-	if err := validateOrigin(requestedOrigin, curl, arg.SwitchCharm); err != nil {
-		result.Error = apiservererrors.ServerError(err)
-		return result
-	}
-
 	repo, err := a.getCharmRepository(ctx)
 	if err != nil {
 		result.Error = apiservererrors.ServerError(err)
@@ -359,23 +353,6 @@ func convertCharmBase(in corecharm.Platform) params.Base {
 		Name:    in.OS,
 		Channel: in.Channel,
 	}
-}
-
-func validateOrigin(origin corecharm.Origin, curl *charm.URL, switchCharm bool) error {
-	if !charm.CharmHub.Matches(curl.Schema) {
-		return errors.Errorf("unknown schema for charm URL %q", curl.String())
-	}
-	// If we are switching to a different charm we can skip the following
-	// origin check; doing so allows us to switch from a charmstore charm
-	// to the equivalent charmhub charm.
-	if !switchCharm {
-		schema := curl.Schema
-		if (corecharm.Local.Matches(origin.Source.String()) && !charm.Local.Matches(schema)) ||
-			(corecharm.CharmHub.Matches(origin.Source.String()) && !charm.CharmHub.Matches(schema)) {
-			return errors.NotValidf("origin source %q with schema", origin.Source)
-		}
-	}
-	return origin.Validate()
 }
 
 func (a *API) getCharmRepository(ctx context.Context) (corecharm.Repository, error) {

--- a/apiserver/facades/client/charms/clientnormalize_test.go
+++ b/apiserver/facades/client/charms/clientnormalize_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/juju/tc"
 
-	corecharm "github.com/juju/juju/core/charm"
-	"github.com/juju/juju/internal/charm"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/rpc/params"
@@ -54,30 +52,4 @@ func (s *clientNormalizeOriginSuite) TestNormalizeCharmOriginWithEmpty(c *tc.C) 
 	origin.Architecture = "amd64"
 	origin.Base.Channel = ""
 	c.Assert(obtained, tc.DeepEquals, origin)
-}
-
-type clientValidateOriginSuite struct {
-	testhelpers.IsolationSuite
-}
-
-func TestClientValidateOriginSuite(t *testing.T) {
-	tc.Run(t, &clientValidateOriginSuite{})
-}
-func (s *clientValidateOriginSuite) TestValidateOrigin(c *tc.C) {
-	origin := corecharm.Origin{
-		Source:   "charm-hub",
-		Platform: corecharm.Platform{Architecture: "all"},
-	}
-
-	err := validateOrigin(origin, charm.MustParseURL("ch:ubuntu"), false)
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *clientValidateOriginSuite) TestValidateOriginWithEmptyArch(c *tc.C) {
-	origin := corecharm.Origin{
-		Source: "charm-hub",
-	}
-
-	err := validateOrigin(origin, charm.MustParseURL("ch:ubuntu"), false)
-	c.Assert(err, tc.ErrorMatches, "empty architecture not valid")
 }

--- a/internal/charm/repository/charmhub.go
+++ b/internal/charm/repository/charmhub.go
@@ -337,16 +337,11 @@ func (c *CharmHubRepository) resolveWithPreferredChannel(ctx context.Context, ch
 
 // validateOrigin, validate the origin and maybe fix as follows:
 //
-//	Platform must have an architecture.
 //	Platform can have both an empty Channel AND os.
 //	Platform must have channel if os defined.
 //	Platform must have os if channel defined.
 func (c *CharmHubRepository) validateOrigin(origin corecharm.Origin) (corecharm.Origin, error) {
 	p := origin.Platform
-
-	if p.Architecture == "" {
-		return corecharm.Origin{}, errors.BadRequestf("origin.Platform requires an Architecture")
-	}
 
 	if p.OS != "" && p.Channel == "" {
 		return corecharm.Origin{}, errors.BadRequestf("origin.Platform requires a Channel, if OS set")


### PR DESCRIPTION
We recently made some slight chanegs to how arch was handled. An arch used to be requried to call the charmhub API code. This cause problems, since we lost whether the arch was a set constraint, or just a default value which could be overriden by the return of charmhub.

However, a number of checks were still in place that asserted an arch was provided when it was no longer needed.

This commit drops these checks where they are no longer needed.

## QA steps

### Bundles

Create a bundle
```
applications:
  juju-qa-test:
    charm: juju-qa-test
    revision: 23
    channel: latest/stable
    num_units: 1
```
& deploy
```
$ juju deploy ./bundle
Located charm "juju-qa-test" in charm-hub, channel latest/stable
Executing changes:
- upload charm juju-qa-test from charm-hub with revision 23
- deploy application juju-qa-test from charm-hub with latest/stable
  added resource foo-file
- add unit juju-qa-test/0 to new machine 0
Deploy of bundle completed.
```
amend the bundle to:
```
applications:
  juju-qa-test:
    charm: juju-qa-test
    revision: 25
    channel: latest/stable
    num_units: 1
```
and re-deploy
```
Executing changes:
- upload charm juju-qa-test from charm-hub with revision 25
- upgrade juju-qa-test from charm-hub using charm juju-qa-test from channel latest/stable
- set constraints for juju-qa-test to ""
Deploy of bundle completed.
```
and check the revision:
```
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m3     lxd         lxd/localhost  4.0-beta7.1  14:04:40+01:00

App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  no       hello

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0*  active    idle   0        10.51.45.189           hello

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.189  juju-a99c44-0  ubuntu@20.04  jack  Running
```

### Deploy to base

```
$ juju deploy juju-qa-test --base ubuntu@20.04
Deployed "juju-qa-test" from charm-hub charm "juju-qa-test", revision 26 in channel latest/stable on ubuntu@20.04/stable
$ juju deploy juju-qa-test jam --base ubuntu@22.04
Deployed "jam" from charm-hub charm "juju-qa-test", revision 25 in channel latest/stable on ubuntu@22.04/stable
```

## Deploy to arm
```
$ juju deploy juju-qa-test --constraints arch=arm64
Deployed "juju-qa-test" from charm-hub charm "juju-qa-test", revision 25 in channel latest/stable on ubuntu@20.04/stable
```

And verify this attempts to deploy to arm (a `no matching agent binaries available` error should occur).