### PR TITLE
fix: destroy/kill-controller for CAAS environs

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -674,7 +674,7 @@ func (c *destroyCommandBase) getControllerEnvironFromStore(
 func (c *destroyCommandBase) getControllerEnvironFromAPI(
 	api destroyControllerAPI,
 	controllerModelConfigAPI modelConfigAPI,
-) (environs.Environ, error) {
+) (environs.BootstrapEnviron, error) {
 	if api == nil {
 		return nil, errors.New(
 			"unable to get bootstrap information from client store or API",
@@ -695,6 +695,13 @@ func (c *destroyCommandBase) getControllerEnvironFromAPI(
 	ctrlCfg, err := api.ControllerConfig()
 	if err != nil {
 		return nil, errors.Annotate(err, "getting controller config from API")
+	}
+	if cloud.CloudTypeIsCAAS(cloudSpec.Type) {
+		return caas.New(stdcontext.TODO(), environs.OpenParams{
+			ControllerUUID: ctrlCfg.ControllerUUID(),
+			Cloud:          cloudSpec,
+			Config:         cfg,
+		})
 	}
 	return environs.New(stdcontext.TODO(), environs.OpenParams{
 		ControllerUUID: ctrlCfg.ControllerUUID(),

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -650,3 +650,17 @@ func (m *mockCredentialAPI) Close() error {
 	m.MethodCall(m, "Close")
 	return m.NextErr()
 }
+
+func (s *DestroySuite) TestGetControllerEnvironWithCaaS(c *gc.C) {
+	s.controllerModelConfigAPI.env = createBootstrapInfo(c, "test3")
+	// The dummy provider isn't CaaS, so we pretend k8s is a dummy provider for now
+	s.api.cloud.Type = "kubernetes"
+
+	_, err := s.runDestroyCommand(c, "test3", "--no-prompt")
+	// Make sure we're *not* getting an error during `getControllerEnviron`
+	// We'll still get an error from the k8s provider since nothing is set up, but that is expected
+	c.Assert(err, gc.Not(gc.ErrorMatches),
+		"getting controller environ: cloud environ provider kubernetes.kubernetesEnvironProvider not valid",
+	)
+	checkControllerExistsInStore(c, "test3", s.store)
+}


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

Currently, attempting to call `juju destroy-controller` on a k8s controller *without* a bootstrap config return this error:
```
ERROR getting controller environ: cloud environ provider provider.kubernetesEnvironProvider not valid
```
This is due to differences between `EnvironProvider` and `CloudEnvironProvider` when attempting to create an environ from the API. I have made a change to special case the CAAS environment, just like when creating an environ from bootstrap config.

This is needed for jaas to be able to destroy controllers, including k8s ones https://github.com/canonical/jimm/pull/1714

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira cards:** [JUJU-8537](https://warthogs.atlassian.net/browse/JUJU-8537), [JUJU-8538](https://warthogs.atlassian.net/browse/JUJU-8538)


[JUJU-8537]: https://warthogs.atlassian.net/browse/JUJU-8537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ