### PR TITLE
chore: rename application ID to UUID

### DIFF
--- a/apiserver/common/unitcommon/accessor.go
+++ b/apiserver/common/unitcommon/accessor.go
@@ -20,7 +20,7 @@ import (
 type ApplicationService interface {
 	// GetApplicationIDByName returns nil if the application exists.
 	// Otherwise, it returns an error.
-	GetApplicationIDByName(ctx context.Context, name string) (application.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (application.UUID, error)
 }
 
 // UnitAccessor returns an auth function which determines if the

--- a/apiserver/common/unitcommon/accessor.go
+++ b/apiserver/common/unitcommon/accessor.go
@@ -18,9 +18,9 @@ import (
 // ApplicationService describes the ability to check if an
 // application exists in the model.
 type ApplicationService interface {
-	// GetApplicationIDByName returns nil if the application exists.
+	// GetApplicationUUIDByName returns nil if the application exists.
 	// Otherwise, it returns an error.
-	GetApplicationIDByName(ctx context.Context, name string) (application.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (application.UUID, error)
 }
 
 // UnitAccessor returns an auth function which determines if the
@@ -32,7 +32,7 @@ func UnitAccessor(authorizer facade.Authorizer, applicationService ApplicationSe
 			// If called by an application agent, any of the units
 			// belonging to that application can be accessed.
 			appName := authTag.Name
-			if _, err := applicationService.GetApplicationIDByName(ctx, appName); errors.Is(err, applicationerrors.ApplicationNotFound) {
+			if _, err := applicationService.GetApplicationUUIDByName(ctx, appName); errors.Is(err, applicationerrors.ApplicationNotFound) {
 				return nil, errors.NotFoundf("application %q", appName)
 			} else if err != nil {
 				return nil, errors.Trace(err)

--- a/apiserver/common/unitcommon/accessor_test.go
+++ b/apiserver/common/unitcommon/accessor_test.go
@@ -32,7 +32,7 @@ func (s *UnitAccessorSuite) TestApplicationAgent(c *tc.C) {
 
 	s.applicationService.EXPECT().
 		GetApplicationIDByName(gomock.Any(), "gitlab").
-		Return(application.ID("1"), nil)
+		Return(application.UUID("1"), nil)
 
 	auth := apiservertesting.FakeAuthorizer{
 		Tag: names.NewApplicationTag("gitlab"),
@@ -52,7 +52,7 @@ func (s *UnitAccessorSuite) TestApplicationNotFound(c *tc.C) {
 
 	s.applicationService.EXPECT().
 		GetApplicationIDByName(gomock.Any(), "gitlab").
-		Return(application.ID("1"), applicationerrors.ApplicationNotFound)
+		Return(application.UUID("1"), applicationerrors.ApplicationNotFound)
 
 	auth := apiservertesting.FakeAuthorizer{
 		Tag: names.NewApplicationTag("gitlab"),

--- a/apiserver/common/unitcommon/accessor_test.go
+++ b/apiserver/common/unitcommon/accessor_test.go
@@ -31,7 +31,7 @@ func (s *UnitAccessorSuite) TestApplicationAgent(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.applicationService.EXPECT().
-		GetApplicationIDByName(gomock.Any(), "gitlab").
+		GetApplicationUUIDByName(gomock.Any(), "gitlab").
 		Return(application.UUID("1"), nil)
 
 	auth := apiservertesting.FakeAuthorizer{
@@ -51,7 +51,7 @@ func (s *UnitAccessorSuite) TestApplicationNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.applicationService.EXPECT().
-		GetApplicationIDByName(gomock.Any(), "gitlab").
+		GetApplicationUUIDByName(gomock.Any(), "gitlab").
 		Return(application.UUID("1"), applicationerrors.ApplicationNotFound)
 
 	auth := apiservertesting.FakeAuthorizer{

--- a/apiserver/common/unitcommon/service_mock_test.go
+++ b/apiserver/common/unitcommon/service_mock_test.go
@@ -40,41 +40,41 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/common/unitcommon/service_mock_test.go
+++ b/apiserver/common/unitcommon/service_mock_test.go
@@ -41,10 +41,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -62,19 +62,19 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/resourceshookcontext/package_mock_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/package_mock_test.go
@@ -42,80 +42,80 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// GetApplicationIDByUnitName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
+// GetApplicationUUIDByUnitName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByUnitName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByUnitName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByUnitName indicates an expected call of GetApplicationIDByUnitName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByUnitName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+// GetApplicationUUIDByUnitName indicates an expected call of GetApplicationUUIDByUnitName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByUnitName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByUnitName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByUnitName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByUnitNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByUnitName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByUnitName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByUnitNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByUnitNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByUnitNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByUnitNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByUnitNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/resourceshookcontext/package_mock_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/package_mock_test.go
@@ -43,10 +43,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -64,28 +64,28 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByUnitName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByUnitName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -103,19 +103,19 @@ type MockApplicationServiceGetApplicationIDByUnitNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.ID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.ID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -144,7 +144,7 @@ func (m *MockResourceService) EXPECT() *MockResourceServiceMockRecorder {
 }
 
 // GetResourcesByApplicationID mocks base method.
-func (m *MockResourceService) GetResourcesByApplicationID(arg0 context.Context, arg1 application.ID) ([]resource.Resource, error) {
+func (m *MockResourceService) GetResourcesByApplicationID(arg0 context.Context, arg1 application.UUID) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesByApplicationID", arg0, arg1)
 	ret0, _ := ret[0].([]resource.Resource)
@@ -171,13 +171,13 @@ func (c *MockResourceServiceGetResourcesByApplicationIDCall) Return(arg0 []resou
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockResourceServiceGetResourcesByApplicationIDCall) Do(f func(context.Context, application.ID) ([]resource.Resource, error)) *MockResourceServiceGetResourcesByApplicationIDCall {
+func (c *MockResourceServiceGetResourcesByApplicationIDCall) Do(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockResourceServiceGetResourcesByApplicationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockResourceServiceGetResourcesByApplicationIDCall) DoAndReturn(f func(context.Context, application.ID) ([]resource.Resource, error)) *MockResourceServiceGetResourcesByApplicationIDCall {
+func (c *MockResourceServiceGetResourcesByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockResourceServiceGetResourcesByApplicationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/resourceshookcontext/package_mock_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/package_mock_test.go
@@ -143,41 +143,41 @@ func (m *MockResourceService) EXPECT() *MockResourceServiceMockRecorder {
 	return m.recorder
 }
 
-// GetResourcesByApplicationID mocks base method.
-func (m *MockResourceService) GetResourcesByApplicationID(arg0 context.Context, arg1 application.UUID) ([]resource.Resource, error) {
+// GetResourcesByApplicationUUID mocks base method.
+func (m *MockResourceService) GetResourcesByApplicationUUID(arg0 context.Context, arg1 application.UUID) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResourcesByApplicationID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetResourcesByApplicationUUID", arg0, arg1)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetResourcesByApplicationID indicates an expected call of GetResourcesByApplicationID.
-func (mr *MockResourceServiceMockRecorder) GetResourcesByApplicationID(arg0, arg1 any) *MockResourceServiceGetResourcesByApplicationIDCall {
+// GetResourcesByApplicationUUID indicates an expected call of GetResourcesByApplicationUUID.
+func (mr *MockResourceServiceMockRecorder) GetResourcesByApplicationUUID(arg0, arg1 any) *MockResourceServiceGetResourcesByApplicationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByApplicationID", reflect.TypeOf((*MockResourceService)(nil).GetResourcesByApplicationID), arg0, arg1)
-	return &MockResourceServiceGetResourcesByApplicationIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByApplicationUUID", reflect.TypeOf((*MockResourceService)(nil).GetResourcesByApplicationUUID), arg0, arg1)
+	return &MockResourceServiceGetResourcesByApplicationUUIDCall{Call: call}
 }
 
-// MockResourceServiceGetResourcesByApplicationIDCall wrap *gomock.Call
-type MockResourceServiceGetResourcesByApplicationIDCall struct {
+// MockResourceServiceGetResourcesByApplicationUUIDCall wrap *gomock.Call
+type MockResourceServiceGetResourcesByApplicationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockResourceServiceGetResourcesByApplicationIDCall) Return(arg0 []resource.Resource, arg1 error) *MockResourceServiceGetResourcesByApplicationIDCall {
+func (c *MockResourceServiceGetResourcesByApplicationUUIDCall) Return(arg0 []resource.Resource, arg1 error) *MockResourceServiceGetResourcesByApplicationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockResourceServiceGetResourcesByApplicationIDCall) Do(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockResourceServiceGetResourcesByApplicationIDCall {
+func (c *MockResourceServiceGetResourcesByApplicationUUIDCall) Do(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockResourceServiceGetResourcesByApplicationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockResourceServiceGetResourcesByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockResourceServiceGetResourcesByApplicationIDCall {
+func (c *MockResourceServiceGetResourcesByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockResourceServiceGetResourcesByApplicationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/resourceshookcontext/service.go
+++ b/apiserver/facades/agent/resourceshookcontext/service.go
@@ -16,7 +16,7 @@ import (
 type ResourceService interface {
 
 	// GetResourcesByApplicationID retrieves all resources associated with a given application ID in the specified context.
-	GetResourcesByApplicationID(ctx context.Context, applicationID coreapplication.ID) ([]coreresource.Resource,
+	GetResourcesByApplicationID(ctx context.Context, applicationID coreapplication.UUID) ([]coreresource.Resource,
 		error)
 }
 
@@ -25,9 +25,9 @@ type ResourceService interface {
 type ApplicationService interface {
 	// GetApplicationIDByName returns an application ID by application name. It
 	// returns an error if the application can not be found by the name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationIDByUnitName returns the application ID for the named unit. It
 	// returns an error if the unit is not found by the name
-	GetApplicationIDByUnitName(ctx context.Context, unitName coreunit.Name) (coreapplication.ID, error)
+	GetApplicationIDByUnitName(ctx context.Context, unitName coreunit.Name) (coreapplication.UUID, error)
 }

--- a/apiserver/facades/agent/resourceshookcontext/service.go
+++ b/apiserver/facades/agent/resourceshookcontext/service.go
@@ -23,11 +23,11 @@ type ResourceService interface {
 // ApplicationService defines operations to retrieve application IDs based
 // on application or unit names.
 type ApplicationService interface {
-	// GetApplicationIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application ID by application name. It
 	// returns an error if the application can not be found by the name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
-	// GetApplicationIDByUnitName returns the application ID for the named unit. It
+	// GetApplicationUUIDByUnitName returns the application ID for the named unit. It
 	// returns an error if the unit is not found by the name
-	GetApplicationIDByUnitName(ctx context.Context, unitName coreunit.Name) (coreapplication.UUID, error)
+	GetApplicationUUIDByUnitName(ctx context.Context, unitName coreunit.Name) (coreapplication.UUID, error)
 }

--- a/apiserver/facades/agent/resourceshookcontext/service.go
+++ b/apiserver/facades/agent/resourceshookcontext/service.go
@@ -15,19 +15,20 @@ import (
 // to applications.
 type ResourceService interface {
 
-	// GetResourcesByApplicationID retrieves all resources associated with a given application ID in the specified context.
-	GetResourcesByApplicationID(ctx context.Context, applicationID coreapplication.UUID) ([]coreresource.Resource,
+	// GetResourcesByApplicationUUID retrieves all resources associated with a
+	// given application UUID in the specified context.
+	GetResourcesByApplicationUUID(ctx context.Context, applicationID coreapplication.UUID) ([]coreresource.Resource,
 		error)
 }
 
-// ApplicationService defines operations to retrieve application IDs based
+// ApplicationService defines operations to retrieve application UUIDs based
 // on application or unit names.
 type ApplicationService interface {
-	// GetApplicationUUIDByName returns an application ID by application name. It
-	// returns an error if the application can not be found by the name.
+	// GetApplicationUUIDByName returns an application UUID by application name.
+	// It returns an error if the application can not be found by the name.
 	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
-	// GetApplicationUUIDByUnitName returns the application ID for the named unit. It
-	// returns an error if the unit is not found by the name
+	// GetApplicationUUIDByUnitName returns the application UUID for the named
+	// unit. It returns an error if the unit is not found by the name
 	GetApplicationUUIDByUnitName(ctx context.Context, unitName coreunit.Name) (coreapplication.UUID, error)
 }

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade.go
@@ -21,7 +21,7 @@ import (
 // applicationIDGetter is a function type used to retrieve a coreapplication.ID
 // based on the given context (from application name or unit name)
 // It returns an error if the ID retrieval fails.
-type applicationIDGetter func(ctx context.Context) (coreapplication.ID, error)
+type applicationIDGetter func(ctx context.Context) (coreapplication.UUID, error)
 
 // NewUnitFacade returns the resources portion of the uniter's API facade.
 func NewUnitFacade(
@@ -36,11 +36,11 @@ func NewUnitFacade(
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
-		applicationIDGetter = func(ctx context.Context) (coreapplication.ID, error) {
+		applicationIDGetter = func(ctx context.Context) (coreapplication.UUID, error) {
 			return applicationService.GetApplicationIDByUnitName(ctx, unitName)
 		}
 	case names.ApplicationTag:
-		applicationIDGetter = func(ctx context.Context) (coreapplication.ID, error) {
+		applicationIDGetter = func(ctx context.Context) (coreapplication.UUID, error) {
 			return applicationService.GetApplicationIDByName(ctx, tag.Id())
 		}
 	default:
@@ -57,12 +57,12 @@ func NewUnitFacade(
 type UnitFacade struct {
 	resourceService         ResourceService
 	getApplicationIDFromAPI applicationIDGetter
-	applicationID           coreapplication.ID
+	applicationID           coreapplication.UUID
 }
 
 // getApplicationID retrieves and caches the application ID for the unit.
 // It fetches from the API if not already cached.
-func (uf *UnitFacade) getApplicationID(ctx context.Context) (coreapplication.ID, error) {
+func (uf *UnitFacade) getApplicationID(ctx context.Context) (coreapplication.UUID, error) {
 	if uf.applicationID == "" {
 		applicationID, err := uf.getApplicationIDFromAPI(ctx)
 		if err != nil {

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade.go
@@ -37,11 +37,11 @@ func NewUnitFacade(
 			return nil, errors.Capture(err)
 		}
 		applicationIDGetter = func(ctx context.Context) (coreapplication.UUID, error) {
-			return applicationService.GetApplicationIDByUnitName(ctx, unitName)
+			return applicationService.GetApplicationUUIDByUnitName(ctx, unitName)
 		}
 	case names.ApplicationTag:
 		applicationIDGetter = func(ctx context.Context) (coreapplication.UUID, error) {
-			return applicationService.GetApplicationIDByName(ctx, tag.Id())
+			return applicationService.GetApplicationUUIDByName(ctx, tag.Id())
 		}
 	default:
 		return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
@@ -54,12 +54,12 @@ func (s *unitFacadeSuite) TestNewUnitFacadeApplicationTag(c *tc.C) {
 		s.resourceService)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", err))
 	c.Assert(facade, tc.NotNil, tc.Commentf("(Act) facade is nil"))
-	appID, err := facade.getApplicationID(c.Context())
+	appID, err := facade.getApplicationUUID(c.Context())
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) unexpected error: %v", err))
 	c.Check(appID, tc.Equals, coreapplication.UUID("expected-application-id"),
-		tc.Commentf("(Assert) application ID doesn't match: %v", appID))
+		tc.Commentf("(Assert) application UUID doesn't match: %v", appID))
 }
 
 // TestNewUnitFacadeApplicationTagError verifies error handling during
@@ -77,7 +77,7 @@ func (s *unitFacadeSuite) TestNewUnitFacadeApplicationTagError(c *tc.C) {
 		s.resourceService)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", err))
 	c.Assert(facade, tc.NotNil, tc.Commentf("(Act) facade is nil"))
-	_, err = facade.getApplicationID(c.Context())
+	_, err = facade.getApplicationUUID(c.Context())
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, expectedError, tc.Commentf("(Assert) unexpected error: %v", err))
@@ -99,12 +99,12 @@ func (s *unitFacadeSuite) TestNewUnitFacadeUnitTag(c *tc.C) {
 		s.resourceService)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", err))
 	c.Assert(facade, tc.NotNil, tc.Commentf("(Act) facade is nil"))
-	appID, err := facade.getApplicationID(c.Context())
+	appID, err := facade.getApplicationUUID(c.Context())
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) unexpected error: %v", err))
 	c.Check(appID, tc.Equals, coreapplication.UUID("expected-application-id"),
-		tc.Commentf("(Assert) application ID doesn't match: %v", appID))
+		tc.Commentf("(Assert) application UUID doesn't match: %v", appID))
 }
 
 // TestNewUnitFacadeUnitTagError verifies error handling during UnitFacade
@@ -122,7 +122,7 @@ func (s *unitFacadeSuite) TestNewUnitFacadeUnitTagError(c *tc.C) {
 		s.resourceService)
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", err))
 	c.Assert(facade, tc.NotNil, tc.Commentf("(Act) facade is nil"))
-	_, err = facade.getApplicationID(c.Context())
+	_, err = facade.getApplicationUUID(c.Context())
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, expectedError, tc.Commentf("(Assert) unexpected error: %v", err))
@@ -144,14 +144,14 @@ func (s *unitFacadeSuite) TestNewUnitUnexpectedTag(c *tc.C) {
 		tc.Commentf("(Assert) error doesn't match or no error: %v", err))
 }
 
-// TestGetResourceInfoGetApplicationIDError verifies the behavior of
-// GetResourceInfo when getApplicationID returns an error.
-func (s *unitFacadeSuite) TestGetResourceInfoGetApplicationIDError(c *tc.C) {
+// TestGetResourceInfoGetApplicationUUIDError verifies the behavior of
+// GetResourceInfo when getApplicationUUID returns an error.
+func (s *unitFacadeSuite) TestGetResourceInfoGetApplicationUUIDError(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 	expectedError := errors.New("expected error")
 	facade := UnitFacade{
-		getApplicationIDFromAPI: func(ctx context.Context) (coreapplication.UUID, error) { return "", expectedError },
+		getApplicationUUIDFromAPI: func(ctx context.Context) (coreapplication.UUID, error) { return "", expectedError },
 	}
 
 	// Act
@@ -163,25 +163,26 @@ func (s *unitFacadeSuite) TestGetResourceInfoGetApplicationIDError(c *tc.C) {
 		result.Error))
 }
 
-// TestGetApplicationIDCache verifies that the application ID is correctly retrieved and cached to avoid redundant API calls.
-func (s *unitFacadeSuite) TestGetApplicationIDCache(c *tc.C) {
+// TestGetApplicationUUIDCache verifies that the application UUID is correctly
+// retrieved and cached to avoid redundant API calls.
+func (s *unitFacadeSuite) TestGetApplicationUUIDCache(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 	facade := UnitFacade{
-		getApplicationIDFromAPI: func(ctx context.Context) (coreapplication.UUID, error) { return "cached-id", nil },
+		getApplicationUUIDFromAPI: func(ctx context.Context) (coreapplication.UUID, error) { return "cached-id", nil },
 	}
 
 	// Act & Assert: first retrieval (non cached)
-	id, err := facade.getApplicationID(c.Context())
+	id, err := facade.getApplicationUUID(c.Context())
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", err))
-	c.Check(id, tc.Equals, coreapplication.UUID("cached-id"), tc.Commentf("(Assert) unexpected application ID: %v", id))
+	c.Check(id, tc.Equals, coreapplication.UUID("cached-id"), tc.Commentf("(Assert) unexpected application UUID: %v", id))
 	c.Check(facade.applicationID, tc.Equals, coreapplication.UUID("cached-id"),
-		tc.Commentf("(Assert)application ID should be cached: %v", id))
+		tc.Commentf("(Assert)application UUID should be cached: %v", id))
 
 	// Act & Assert: first retrieval (cached)
-	id, err = facade.getApplicationID(c.Context())
+	id, err = facade.getApplicationUUID(c.Context())
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", err))
-	c.Check(id, tc.Equals, coreapplication.UUID("cached-id"), tc.Commentf("(Assert) unexpected application ID: %v", id))
+	c.Check(id, tc.Equals, coreapplication.UUID("cached-id"), tc.Commentf("(Assert) unexpected application UUID: %v", id))
 
 }
 
@@ -213,7 +214,7 @@ func (s *unitFacadeSuite) TestGetResourceInfoListResourceError(c *tc.C) {
 	expectedError := errors.New("expected error")
 	tag := names.NewApplicationTag("a-application")
 	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), gomock.Any()).Return("expected-application-id", nil)
-	s.resourceService.EXPECT().GetResourcesByApplicationID(gomock.Any(), gomock.Any()).Return(nil, expectedError)
+	s.resourceService.EXPECT().GetResourcesByApplicationUUID(gomock.Any(), gomock.Any()).Return(nil, expectedError)
 	facade, err := NewUnitFacade(tag,
 		s.applicationService,
 		s.resourceService)
@@ -249,7 +250,7 @@ func (s *unitFacadeSuite) TestGetResourceInfo(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	tag := names.NewApplicationTag("a-application")
 	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), gomock.Any()).Return("expected-application-id", nil)
-	s.resourceService.EXPECT().GetResourcesByApplicationID(gomock.Any(), gomock.Any()).Return([]coreresource.Resource{
+	s.resourceService.EXPECT().GetResourcesByApplicationUUID(gomock.Any(), gomock.Any()).Return([]coreresource.Resource{
 		minimalResourceInfo("fetched-resource-1"),
 		minimalResourceInfo("not-fetched-resource"),
 		minimalResourceInfo("fetched-resource-2"),

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
@@ -58,7 +58,7 @@ func (s *unitFacadeSuite) TestNewUnitFacadeApplicationTag(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) unexpected error: %v", err))
-	c.Check(appID, tc.Equals, coreapplication.ID("expected-application-id"),
+	c.Check(appID, tc.Equals, coreapplication.UUID("expected-application-id"),
 		tc.Commentf("(Assert) application ID doesn't match: %v", appID))
 }
 
@@ -103,7 +103,7 @@ func (s *unitFacadeSuite) TestNewUnitFacadeUnitTag(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) unexpected error: %v", err))
-	c.Check(appID, tc.Equals, coreapplication.ID("expected-application-id"),
+	c.Check(appID, tc.Equals, coreapplication.UUID("expected-application-id"),
 		tc.Commentf("(Assert) application ID doesn't match: %v", appID))
 }
 
@@ -151,7 +151,7 @@ func (s *unitFacadeSuite) TestGetResourceInfoGetApplicationIDError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	expectedError := errors.New("expected error")
 	facade := UnitFacade{
-		getApplicationIDFromAPI: func(ctx context.Context) (coreapplication.ID, error) { return "", expectedError },
+		getApplicationIDFromAPI: func(ctx context.Context) (coreapplication.UUID, error) { return "", expectedError },
 	}
 
 	// Act
@@ -168,20 +168,20 @@ func (s *unitFacadeSuite) TestGetApplicationIDCache(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 	facade := UnitFacade{
-		getApplicationIDFromAPI: func(ctx context.Context) (coreapplication.ID, error) { return "cached-id", nil },
+		getApplicationIDFromAPI: func(ctx context.Context) (coreapplication.UUID, error) { return "cached-id", nil },
 	}
 
 	// Act & Assert: first retrieval (non cached)
 	id, err := facade.getApplicationID(c.Context())
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", err))
-	c.Check(id, tc.Equals, coreapplication.ID("cached-id"), tc.Commentf("(Assert) unexpected application ID: %v", id))
-	c.Check(facade.applicationID, tc.Equals, coreapplication.ID("cached-id"),
+	c.Check(id, tc.Equals, coreapplication.UUID("cached-id"), tc.Commentf("(Assert) unexpected application ID: %v", id))
+	c.Check(facade.applicationID, tc.Equals, coreapplication.UUID("cached-id"),
 		tc.Commentf("(Assert)application ID should be cached: %v", id))
 
 	// Act & Assert: first retrieval (cached)
 	id, err = facade.getApplicationID(c.Context())
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", err))
-	c.Check(id, tc.Equals, coreapplication.ID("cached-id"), tc.Commentf("(Assert) unexpected application ID: %v", id))
+	c.Check(id, tc.Equals, coreapplication.UUID("cached-id"), tc.Commentf("(Assert) unexpected application ID: %v", id))
 
 }
 

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
@@ -46,7 +46,7 @@ func (s *unitFacadeSuite) TestNewUnitFacadeApplicationTag(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 	tag := names.NewApplicationTag("a-application")
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), tag.Id()).Return("expected-application-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), tag.Id()).Return("expected-application-id", nil)
 
 	// Act
 	facade, err := NewUnitFacade(tag,
@@ -69,7 +69,7 @@ func (s *unitFacadeSuite) TestNewUnitFacadeApplicationTagError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	tag := names.NewApplicationTag("a-application")
 	expectedError := errors.New("expected error")
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), gomock.Any()).Return("", expectedError)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), gomock.Any()).Return("", expectedError)
 
 	// Act
 	facade, err := NewUnitFacade(tag,
@@ -90,7 +90,7 @@ func (s *unitFacadeSuite) TestNewUnitFacadeUnitTag(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 	tag := names.NewUnitTag("a-application/0")
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(),
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(),
 		coreunit.Name(tag.Id())).Return("expected-application-id", nil)
 
 	// Act
@@ -114,7 +114,7 @@ func (s *unitFacadeSuite) TestNewUnitFacadeUnitTagError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	tag := names.NewUnitTag("a-application/0")
 	expectedError := errors.New("expected error")
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), gomock.Any()).Return("", expectedError)
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), gomock.Any()).Return("", expectedError)
 
 	// Act
 	facade, err := NewUnitFacade(tag,
@@ -212,7 +212,7 @@ func (s *unitFacadeSuite) TestGetResourceInfoListResourceError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	expectedError := errors.New("expected error")
 	tag := names.NewApplicationTag("a-application")
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), gomock.Any()).Return("expected-application-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), gomock.Any()).Return("expected-application-id", nil)
 	s.resourceService.EXPECT().GetResourcesByApplicationID(gomock.Any(), gomock.Any()).Return(nil, expectedError)
 	facade, err := NewUnitFacade(tag,
 		s.applicationService,
@@ -248,7 +248,7 @@ func (s *unitFacadeSuite) TestGetResourceInfo(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 	tag := names.NewApplicationTag("a-application")
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), gomock.Any()).Return("expected-application-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), gomock.Any()).Return("expected-application-id", nil)
 	s.resourceService.EXPECT().GetResourcesByApplicationID(gomock.Any(), gomock.Any()).Return([]coreresource.Resource{
 		minimalResourceInfo("fetched-resource-1"),
 		minimalResourceInfo("not-fetched-resource"),

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -66,7 +66,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesNoRelation(c *tc.C) {
 	unitName := coreunit.Name("wordpress/0")
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
 	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
 		Return(map[coreunit.Name]corestatus.StatusInfo{
 			unitName: {
@@ -117,7 +117,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesPeerUnitsNotRelation(c *tc.C) {
 	otherUnitName := coreunit.Name("wordpress/1")
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
 	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
 		Return(map[coreunit.Name]corestatus.StatusInfo{
 			unitName: {
@@ -191,9 +191,9 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelation(c *tc.C) {
 	appID := applicationtesting.GenApplicationUUID(c)
 	otherAppID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "wordpress").Return(otherAppID, nil)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "mysql").Return(otherAppID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "wordpress").Return(otherAppID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "mysql").Return(otherAppID, nil)
 	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
 		Return(map[coreunit.Name]corestatus.StatusInfo{
 			unitName: {
@@ -283,7 +283,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *tc.C) {
 	deadUnitName := coreunit.Name("wordpress/1")
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
 	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
 		Return(map[coreunit.Name]corestatus.StatusInfo{
 			unitName: {
@@ -352,7 +352,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *tc.C) {
 	dyingUnitName := coreunit.Name("wordpress/1")
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), unitName).Return(appID, nil)
 	s.statusService.EXPECT().GetUnitWorkloadStatusesForApplication(gomock.Any(), appID).
 		Return(map[coreunit.Name]corestatus.StatusInfo{
 			unitName: {
@@ -429,8 +429,8 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *tc.C) {
 	wpUnit := coreunit.Name("wordpress/0")
 	otherWpUnit := coreunit.Name("wordpress/1")
 	wpAppID := applicationtesting.GenApplicationUUID(c)
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), wpUnit).Return(wpAppID, nil)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "wordpress").Return(wpAppID, nil).MinTimes(1)
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), wpUnit).Return(wpAppID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "wordpress").Return(wpAppID, nil).MinTimes(1)
 	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "wordpress").
 		Return([]coreunit.Name{wpUnit, otherWpUnit}, nil)
 	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), wpUnit).Return("", false, nil)
@@ -443,8 +443,8 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *tc.C) {
 	mysqlAppID := applicationtesting.GenApplicationUUID(c)
 	otherAppMysqlUnit := coreunit.Name("other-mysql/0")
 	otherMysqlAppID := applicationtesting.GenApplicationUUID(c)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "mysql").Return(mysqlAppID, nil)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "other-mysql").Return(otherMysqlAppID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "mysql").Return(mysqlAppID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "other-mysql").Return(otherMysqlAppID, nil)
 	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "mysql").
 		Return([]coreunit.Name{mysqlUnit, otherMysqlUnit}, nil)
 	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "other-mysql").
@@ -458,7 +458,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *tc.C) {
 
 	loggingUnit := coreunit.Name("logging/0")
 	loggingAppID := applicationtesting.GenApplicationUUID(c)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "logging").Return(loggingAppID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "logging").Return(loggingAppID, nil)
 	s.applicationService.EXPECT().GetUnitNamesForApplication(gomock.Any(), "logging").
 		Return([]coreunit.Name{loggingUnit}, nil)
 	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), loggingUnit).Return("", false, nil)

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -148,16 +148,16 @@ type ApplicationService interface {
 	// will be returned.
 	WatchUnitForLegacyUniter(context.Context, coreunit.Name) (watcher.NotifyWatcher, error)
 
-	// GetApplicationIDByUnitName returns the application ID for the named unit.
+	// GetApplicationUUIDByUnitName returns the application UUID for the named unit.
 	//
 	// Returns [applicationerrors.UnitNotFound] if the unit is not found.
-	GetApplicationIDByUnitName(context.Context, coreunit.Name) (coreapplication.UUID, error)
+	GetApplicationUUIDByUnitName(context.Context, coreunit.Name) (coreapplication.UUID, error)
 
-	// GetApplicationIDByName returns an application ID by application name.
+	// GetApplicationUUIDByName returns an application UUID by application name.
 	//
 	// Returns [applicationerrors.ApplicationNotFound] if the application is not
 	// found.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetCharmModifiedVersion looks up the charm modified version of the given
 	// application.

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -151,17 +151,17 @@ type ApplicationService interface {
 	// GetApplicationIDByUnitName returns the application ID for the named unit.
 	//
 	// Returns [applicationerrors.UnitNotFound] if the unit is not found.
-	GetApplicationIDByUnitName(context.Context, coreunit.Name) (coreapplication.ID, error)
+	GetApplicationIDByUnitName(context.Context, coreunit.Name) (coreapplication.UUID, error)
 
 	// GetApplicationIDByName returns an application ID by application name.
 	//
 	// Returns [applicationerrors.ApplicationNotFound] if the application is not
 	// found.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetCharmModifiedVersion looks up the charm modified version of the given
 	// application.
-	GetCharmModifiedVersion(context.Context, coreapplication.ID) (int, error)
+	GetCharmModifiedVersion(context.Context, coreapplication.UUID) (int, error)
 
 	// GetAvailableCharmArchiveSHA256 returns the SHA256 hash of the charm
 	// archive for the given charm name, source and revision. If the charm is
@@ -181,7 +181,7 @@ type ApplicationService interface {
 	// AddIAASSubordinateUnit adds a IAAS unit to the specified subordinate
 	// application to the application on the same machine as the given principal
 	// unit and records the principal-subordinate relationship.
-	AddIAASSubordinateUnit(ctx context.Context, subordinateAppID coreapplication.ID, principalUnitName coreunit.Name) error
+	AddIAASSubordinateUnit(ctx context.Context, subordinateAppID coreapplication.UUID, principalUnitName coreunit.Name) error
 
 	// SetUnitWorkloadVersion sets the workload version for the given unit.
 	SetUnitWorkloadVersion(ctx context.Context, unitName coreunit.Name, version string) error
@@ -195,7 +195,7 @@ type ApplicationService interface {
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationConfigWithDefaults(context.Context, coreapplication.ID) (internalcharm.Config, error)
+	GetApplicationConfigWithDefaults(context.Context, coreapplication.UUID) (internalcharm.Config, error)
 
 	// WatchApplicationConfigHash watches for changes to the specified application's
 	// config hash.
@@ -313,7 +313,7 @@ type StatusService interface {
 
 	// GetUnitWorkloadStatusesForApplication returns the workload statuses of
 	// all units in the specified application, indexed by unit name
-	GetUnitWorkloadStatusesForApplication(ctx context.Context, appID coreapplication.ID) (map[coreunit.Name]corestatus.StatusInfo, error)
+	GetUnitWorkloadStatusesForApplication(ctx context.Context, appID coreapplication.UUID) (map[coreunit.Name]corestatus.StatusInfo, error)
 
 	// SetRelationStatus sets the status of the relation to the status provided.
 	// Status may only be set by the application leader.
@@ -459,7 +459,7 @@ type RelationService interface {
 	// all relations the given application is in, modulo peer relations.
 	GetGoalStateRelationDataForApplication(
 		ctx context.Context,
-		applicationID coreapplication.ID,
+		applicationID coreapplication.UUID,
 	) ([]relation.GoalStateRelationData, error)
 
 	// GetRelationApplicationSettingsWithLeader returns the application settings
@@ -471,7 +471,7 @@ type RelationService interface {
 		ctx context.Context,
 		unitName coreunit.Name,
 		relationUUID corerelation.UUID,
-		applicationID coreapplication.ID,
+		applicationID coreapplication.UUID,
 	) (map[string]string, error)
 
 	// GetRelationDetails returns the relation details requested by the uniter
@@ -493,7 +493,7 @@ type RelationService interface {
 	GetRelationUnitChanges(
 		ctx context.Context,
 		unitUUIDs []coreunit.UUID,
-		appUUIDs []coreapplication.ID,
+		appUUIDs []coreapplication.UUID,
 	) (relation.RelationUnitsChange, error)
 
 	// GetRelationUnitSettings returns the unit settings for the
@@ -524,7 +524,7 @@ type RelationService interface {
 	GetRelationApplicationSettings(
 		ctx context.Context,
 		relationUUID corerelation.UUID,
-		applicationID coreapplication.ID,
+		applicationID coreapplication.UUID,
 	) (map[string]string, error)
 
 	// LeaveScope updates the given relation to indicate it is not in scope.

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -62,7 +62,7 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // AddIAASSubordinateUnit mocks base method.
-func (m *MockApplicationService) AddIAASSubordinateUnit(arg0 context.Context, arg1 application.ID, arg2 unit.Name) error {
+func (m *MockApplicationService) AddIAASSubordinateUnit(arg0 context.Context, arg1 application.UUID, arg2 unit.Name) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddIAASSubordinateUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -88,19 +88,19 @@ func (c *MockApplicationServiceAddIAASSubordinateUnitCall) Return(arg0 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceAddIAASSubordinateUnitCall) Do(f func(context.Context, application.ID, unit.Name) error) *MockApplicationServiceAddIAASSubordinateUnitCall {
+func (c *MockApplicationServiceAddIAASSubordinateUnitCall) Do(f func(context.Context, application.UUID, unit.Name) error) *MockApplicationServiceAddIAASSubordinateUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceAddIAASSubordinateUnitCall) DoAndReturn(f func(context.Context, application.ID, unit.Name) error) *MockApplicationServiceAddIAASSubordinateUnitCall {
+func (c *MockApplicationServiceAddIAASSubordinateUnitCall) DoAndReturn(f func(context.Context, application.UUID, unit.Name) error) *MockApplicationServiceAddIAASSubordinateUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationConfigWithDefaults mocks base method.
-func (m *MockApplicationService) GetApplicationConfigWithDefaults(arg0 context.Context, arg1 application.ID) (charm0.Config, error) {
+func (m *MockApplicationService) GetApplicationConfigWithDefaults(arg0 context.Context, arg1 application.UUID) (charm0.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationConfigWithDefaults", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Config)
@@ -127,22 +127,22 @@ func (c *MockApplicationServiceGetApplicationConfigWithDefaultsCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationConfigWithDefaultsCall) Do(f func(context.Context, application.ID) (charm0.Config, error)) *MockApplicationServiceGetApplicationConfigWithDefaultsCall {
+func (c *MockApplicationServiceGetApplicationConfigWithDefaultsCall) Do(f func(context.Context, application.UUID) (charm0.Config, error)) *MockApplicationServiceGetApplicationConfigWithDefaultsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationConfigWithDefaultsCall) DoAndReturn(f func(context.Context, application.ID) (charm0.Config, error)) *MockApplicationServiceGetApplicationConfigWithDefaultsCall {
+func (c *MockApplicationServiceGetApplicationConfigWithDefaultsCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Config, error)) *MockApplicationServiceGetApplicationConfigWithDefaultsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -160,28 +160,28 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByUnitName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByUnitName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -199,19 +199,19 @@ type MockApplicationServiceGetApplicationIDByUnitNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.ID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.ID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -413,7 +413,7 @@ func (c *MockApplicationServiceGetCharmLocatorByApplicationNameCall) DoAndReturn
 }
 
 // GetCharmModifiedVersion mocks base method.
-func (m *MockApplicationService) GetCharmModifiedVersion(arg0 context.Context, arg1 application.ID) (int, error) {
+func (m *MockApplicationService) GetCharmModifiedVersion(arg0 context.Context, arg1 application.UUID) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmModifiedVersion", arg0, arg1)
 	ret0, _ := ret[0].(int)
@@ -440,13 +440,13 @@ func (c *MockApplicationServiceGetCharmModifiedVersionCall) Return(arg0 int, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetCharmModifiedVersionCall) Do(f func(context.Context, application.ID) (int, error)) *MockApplicationServiceGetCharmModifiedVersionCall {
+func (c *MockApplicationServiceGetCharmModifiedVersionCall) Do(f func(context.Context, application.UUID) (int, error)) *MockApplicationServiceGetCharmModifiedVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetCharmModifiedVersionCall) DoAndReturn(f func(context.Context, application.ID) (int, error)) *MockApplicationServiceGetCharmModifiedVersionCall {
+func (c *MockApplicationServiceGetCharmModifiedVersionCall) DoAndReturn(f func(context.Context, application.UUID) (int, error)) *MockApplicationServiceGetCharmModifiedVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1316,7 +1316,7 @@ func (c *MockStatusServiceGetUnitWorkloadStatusCall) DoAndReturn(f func(context.
 }
 
 // GetUnitWorkloadStatusesForApplication mocks base method.
-func (m *MockStatusService) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.ID) (map[unit.Name]status.StatusInfo, error) {
+func (m *MockStatusService) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]status.StatusInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitWorkloadStatusesForApplication", arg0, arg1)
 	ret0, _ := ret[0].(map[unit.Name]status.StatusInfo)
@@ -1343,13 +1343,13 @@ func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.UUID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1568,7 +1568,7 @@ func (c *MockRelationServiceEnterScopeCall) DoAndReturn(f func(context.Context, 
 }
 
 // GetGoalStateRelationDataForApplication mocks base method.
-func (m *MockRelationService) GetGoalStateRelationDataForApplication(arg0 context.Context, arg1 application.ID) ([]relation0.GoalStateRelationData, error) {
+func (m *MockRelationService) GetGoalStateRelationDataForApplication(arg0 context.Context, arg1 application.UUID) ([]relation0.GoalStateRelationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGoalStateRelationDataForApplication", arg0, arg1)
 	ret0, _ := ret[0].([]relation0.GoalStateRelationData)
@@ -1595,19 +1595,19 @@ func (c *MockRelationServiceGetGoalStateRelationDataForApplicationCall) Return(a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetGoalStateRelationDataForApplicationCall) Do(f func(context.Context, application.ID) ([]relation0.GoalStateRelationData, error)) *MockRelationServiceGetGoalStateRelationDataForApplicationCall {
+func (c *MockRelationServiceGetGoalStateRelationDataForApplicationCall) Do(f func(context.Context, application.UUID) ([]relation0.GoalStateRelationData, error)) *MockRelationServiceGetGoalStateRelationDataForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetGoalStateRelationDataForApplicationCall) DoAndReturn(f func(context.Context, application.ID) ([]relation0.GoalStateRelationData, error)) *MockRelationServiceGetGoalStateRelationDataForApplicationCall {
+func (c *MockRelationServiceGetGoalStateRelationDataForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) ([]relation0.GoalStateRelationData, error)) *MockRelationServiceGetGoalStateRelationDataForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetRelationApplicationSettings mocks base method.
-func (m *MockRelationService) GetRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.ID) (map[string]string, error) {
+func (m *MockRelationService) GetRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationApplicationSettings", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]string)
@@ -1634,19 +1634,19 @@ func (c *MockRelationServiceGetRelationApplicationSettingsCall) Return(arg0 map[
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.ID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsCall {
+func (c *MockRelationServiceGetRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.UUID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.ID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsCall {
+func (c *MockRelationServiceGetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetRelationApplicationSettingsWithLeader mocks base method.
-func (m *MockRelationService) GetRelationApplicationSettingsWithLeader(arg0 context.Context, arg1 unit.Name, arg2 relation.UUID, arg3 application.ID) (map[string]string, error) {
+func (m *MockRelationService) GetRelationApplicationSettingsWithLeader(arg0 context.Context, arg1 unit.Name, arg2 relation.UUID, arg3 application.UUID) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationApplicationSettingsWithLeader", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(map[string]string)
@@ -1673,13 +1673,13 @@ func (c *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall) Return
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall) Do(f func(context.Context, unit.Name, relation.UUID, application.ID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall {
+func (c *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall) Do(f func(context.Context, unit.Name, relation.UUID, application.UUID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall) DoAndReturn(f func(context.Context, unit.Name, relation.UUID, application.ID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall {
+func (c *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall) DoAndReturn(f func(context.Context, unit.Name, relation.UUID, application.UUID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsWithLeaderCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1841,7 +1841,7 @@ func (c *MockRelationServiceGetRelationUnitCall) DoAndReturn(f func(context.Cont
 }
 
 // GetRelationUnitChanges mocks base method.
-func (m *MockRelationService) GetRelationUnitChanges(arg0 context.Context, arg1 []unit.UUID, arg2 []application.ID) (relation0.RelationUnitsChange, error) {
+func (m *MockRelationService) GetRelationUnitChanges(arg0 context.Context, arg1 []unit.UUID, arg2 []application.UUID) (relation0.RelationUnitsChange, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationUnitChanges", arg0, arg1, arg2)
 	ret0, _ := ret[0].(relation0.RelationUnitsChange)
@@ -1868,13 +1868,13 @@ func (c *MockRelationServiceGetRelationUnitChangesCall) Return(arg0 relation0.Re
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationUnitChangesCall) Do(f func(context.Context, []unit.UUID, []application.ID) (relation0.RelationUnitsChange, error)) *MockRelationServiceGetRelationUnitChangesCall {
+func (c *MockRelationServiceGetRelationUnitChangesCall) Do(f func(context.Context, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockRelationServiceGetRelationUnitChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationUnitChangesCall) DoAndReturn(f func(context.Context, []unit.UUID, []application.ID) (relation0.RelationUnitsChange, error)) *MockRelationServiceGetRelationUnitChangesCall {
+func (c *MockRelationServiceGetRelationUnitChangesCall) DoAndReturn(f func(context.Context, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockRelationServiceGetRelationUnitChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -138,84 +138,6 @@ func (c *MockApplicationServiceGetApplicationConfigWithDefaultsCall) DoAndReturn
 	return c
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
-}
-
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetApplicationIDByUnitName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByUnitName", arg0, arg1)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetApplicationIDByUnitName indicates an expected call of GetApplicationIDByUnitName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByUnitName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByUnitNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByUnitName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByUnitName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByUnitNameCall{Call: call}
-}
-
-// MockApplicationServiceGetApplicationIDByUnitNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByUnitNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetApplicationLifeByName mocks base method.
 func (m *MockApplicationService) GetApplicationLifeByName(arg0 context.Context, arg1 string) (life.Value, error) {
 	m.ctrl.T.Helper()
@@ -290,6 +212,84 @@ func (c *MockApplicationServiceGetApplicationTrustSettingCall) Do(f func(context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetApplicationTrustSettingCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockApplicationServiceGetApplicationTrustSettingCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDByUnitName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByUnitName", arg0, arg1)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationUUIDByUnitName indicates an expected call of GetApplicationUUIDByUnitName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByUnitName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByUnitName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByUnitName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByUnitNameCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationUUIDByUnitNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByUnitNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -748,7 +748,7 @@ func (u *UniterAPI) charmModifiedVersion(
 		return -1, apiservererrors.ErrPerm
 	}
 
-	var id application.ID
+	var id application.UUID
 	switch tag.(type) {
 	case names.ApplicationTag:
 		id, err = u.applicationService.GetApplicationIDByName(ctx, tag.Id())
@@ -1626,10 +1626,10 @@ func (u *UniterAPI) EnterScope(ctx context.Context, args params.RelationUnits) (
 	return result, nil
 }
 
-type subordinateCreator func(ctx context.Context, subordinateAppID application.ID, principalUnitName coreunit.Name) error
+type subordinateCreator func(ctx context.Context, subordinateAppID application.UUID, principalUnitName coreunit.Name) error
 
 // CreateSubordinate creates units on a subordinate application.
-func (c subordinateCreator) CreateSubordinate(ctx context.Context, subordinateAppID application.ID, principalUnitName coreunit.Name) error {
+func (c subordinateCreator) CreateSubordinate(ctx context.Context, subordinateAppID application.UUID, principalUnitName coreunit.Name) error {
 	return c(ctx, subordinateAppID, principalUnitName)
 }
 
@@ -2600,7 +2600,7 @@ func (u *UniterAPI) goalStateRelations(
 
 // goalStateUnits loops through all application units related to principalName,
 // and stores the goal state status in UnitsGoalState.
-func (u *UniterAPI) goalStateUnits(ctx context.Context, appName string, appID application.ID, principalName coreunit.Name) (params.UnitsGoalState, error) {
+func (u *UniterAPI) goalStateUnits(ctx context.Context, appName string, appID application.UUID, principalName coreunit.Name) (params.UnitsGoalState, error) {
 
 	allUnitNames, err := u.applicationService.GetUnitNamesForApplication(ctx, appName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -751,7 +751,7 @@ func (u *UniterAPI) charmModifiedVersion(
 	var id application.UUID
 	switch tag.(type) {
 	case names.ApplicationTag:
-		id, err = u.applicationService.GetApplicationIDByName(ctx, tag.Id())
+		id, err = u.applicationService.GetApplicationUUIDByName(ctx, tag.Id())
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			// Return an error that also matches a generic not found error.
 			return -1, internalerrors.Join(err, errors.Hide(errors.NotFound))
@@ -763,7 +763,7 @@ func (u *UniterAPI) charmModifiedVersion(
 		if err != nil {
 			return -1, err
 		}
-		id, err = u.applicationService.GetApplicationIDByUnitName(ctx, name)
+		id, err = u.applicationService.GetApplicationUUIDByUnitName(ctx, name)
 		if errors.Is(err, applicationerrors.UnitNotFound) {
 			// Return an error that also matches a generic not found error.
 			return -1, internalerrors.Join(err, errors.Hide(errors.NotFound))
@@ -1063,7 +1063,7 @@ func (u *UniterAPI) ConfigSettings(ctx context.Context, args params.Entities) (p
 			continue
 		}
 
-		appID, err := u.applicationService.GetApplicationIDByUnitName(ctx, unitName)
+		appID, err := u.applicationService.GetApplicationUUIDByUnitName(ctx, unitName)
 		if errors.Is(err, applicationerrors.UnitNotFound) {
 			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
@@ -1918,7 +1918,7 @@ func (u *UniterAPI) readLocalApplicationSettings(
 		return nil, apiservererrors.ErrPerm
 	}
 
-	appID, err := u.applicationService.GetApplicationIDByName(ctx, appTag.Id())
+	appID, err := u.applicationService.GetApplicationUUIDByName(ctx, appTag.Id())
 	if errors.Is(err, errors.NotFound) {
 		return nil, apiservererrors.ErrPerm
 	} else if err != nil {
@@ -1994,7 +1994,7 @@ func (u *UniterAPI) readOneRemoteSettings(ctx context.Context, canAccess common.
 			return nil, internalerrors.Capture(err)
 		}
 	case names.ApplicationTag:
-		remoteAppID, err := u.applicationService.GetApplicationIDByName(ctx, remoteTag.Id())
+		remoteAppID, err := u.applicationService.GetApplicationUUIDByName(ctx, remoteTag.Id())
 		if err != nil {
 			return nil, internalerrors.Capture(err)
 		}
@@ -2492,7 +2492,7 @@ func (u *UniterAPI) GoalStates(ctx context.Context, args params.Entities) (param
 func (u *UniterAPI) oneGoalState(ctx context.Context, unitName coreunit.Name) (*params.GoalState, error) {
 	appName := unitName.Application()
 
-	appID, err := u.applicationService.GetApplicationIDByUnitName(ctx, unitName)
+	appID, err := u.applicationService.GetApplicationUUIDByUnitName(ctx, unitName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return nil, errors.NotFoundf("application %q", appName)
 	} else if err != nil {
@@ -2549,7 +2549,7 @@ func (u *UniterAPI) goalStateRelations(
 		// Now gather the goal state.
 		for _, e := range endPoints {
 			var appName string
-			appID, err := u.applicationService.GetApplicationIDByName(ctx, e.ApplicationName)
+			appID, err := u.applicationService.GetApplicationUUIDByName(ctx, e.ApplicationName)
 			if err == nil {
 				appName = e.ApplicationName
 			} else if errors.Is(err, applicationerrors.ApplicationNotFound) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1351,7 +1351,7 @@ func (s *uniterSuite) TestLogActionsMessages(c *tc.C) {
 }
 
 func (s *uniterSuite) expectedGetConfigSettings(unitName coreunit.Name, settings map[string]any, err error) {
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(coreapplication.UUID(unitName.Application()), err)
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), unitName).Return(coreapplication.UUID(unitName.Application()), err)
 	if err == nil {
 		s.applicationService.EXPECT().GetApplicationConfigWithDefaults(
 			gomock.Any(), coreapplication.UUID(unitName.Application()),
@@ -1737,7 +1737,7 @@ func (s *uniterRelationSuite) TestReadSettingsApplication(c *tc.C) {
 	settings := map[string]string{"wanda": "firebaugh"}
 
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
-	s.expectGetApplicationIDByName(s.wordpressAppTag.Id(), appID)
+	s.expectGetApplicationUUIDByName(s.wordpressAppTag.Id(), appID)
 	s.expectGetRelationApplicationSettingsWithLeader(coreunit.Name(s.wordpressUnitTag.Id()), relUUID, appID, settings)
 
 	// act
@@ -1842,7 +1842,7 @@ func (s *uniterRelationSuite) TestReadSettingsForLocalApplication(c *tc.C) {
 	settings := map[string]string{"wanda": "firebaugh"}
 
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
-	s.expectGetApplicationIDByName(s.wordpressAppTag.Id(), appID)
+	s.expectGetApplicationUUIDByName(s.wordpressAppTag.Id(), appID)
 	s.expectGetRelationApplicationSettingsWithLeader(coreunit.Name(s.wordpressUnitTag.Id()), relUUID, appID, settings)
 
 	// act
@@ -1959,7 +1959,7 @@ func (s *uniterRelationSuite) TestReadRemoteSettingsForApplication(c *tc.C) {
 	settings := map[string]string{"wanda": "firebaugh"}
 
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
-	s.expectGetApplicationIDByName(remoteAppTag.Id(), appID)
+	s.expectGetApplicationUUIDByName(remoteAppTag.Id(), appID)
 	s.expectGetRelationApplicationSettings(relUUID, appID, settings)
 
 	// act
@@ -1992,7 +1992,7 @@ func (s *uniterRelationSuite) TestReadRemoteApplicationSettingsWithLocalApplicat
 	settings := map[string]string{"wanda": "firebaugh"}
 
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
-	s.expectGetApplicationIDByName(s.wordpressAppTag.Id(), appID)
+	s.expectGetApplicationUUIDByName(s.wordpressAppTag.Id(), appID)
 	s.expectGetRelationApplicationSettings(relUUID, appID, settings)
 
 	// act
@@ -2521,8 +2521,8 @@ func (s *uniterRelationSuite) expectGetRelationDetailsUnexpectedAppName(c *tc.C,
 	}, nil)
 }
 
-func (s *uniterRelationSuite) expectGetApplicationIDByName(appName string, id coreapplication.UUID) {
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(id, nil)
+func (s *uniterRelationSuite) expectGetApplicationUUIDByName(appName string, id coreapplication.UUID) {
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(id, nil)
 }
 
 func (s *uniterRelationSuite) expectGetRelationApplicationSettingsWithLeader(unitName coreunit.Name, uuid corerelation.UUID, id coreapplication.UUID, settings map[string]string) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1351,10 +1351,10 @@ func (s *uniterSuite) TestLogActionsMessages(c *tc.C) {
 }
 
 func (s *uniterSuite) expectedGetConfigSettings(unitName coreunit.Name, settings map[string]any, err error) {
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(coreapplication.ID(unitName.Application()), err)
+	s.applicationService.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(coreapplication.UUID(unitName.Application()), err)
 	if err == nil {
 		s.applicationService.EXPECT().GetApplicationConfigWithDefaults(
-			gomock.Any(), coreapplication.ID(unitName.Application()),
+			gomock.Any(), coreapplication.UUID(unitName.Application()),
 		).Return(settings, nil)
 	}
 }
@@ -2270,7 +2270,7 @@ func (s *uniterRelationSuite) TestWatchRelationUnits(c *tc.C) {
 		unittesting.GenUnitUUID(c),
 		unittesting.GenUnitUUID(c),
 	}
-	appUUIDs := []coreapplication.ID{
+	appUUIDs := []coreapplication.UUID{
 		applicationtesting.GenApplicationUUID(c),
 	}
 
@@ -2521,15 +2521,15 @@ func (s *uniterRelationSuite) expectGetRelationDetailsUnexpectedAppName(c *tc.C,
 	}, nil)
 }
 
-func (s *uniterRelationSuite) expectGetApplicationIDByName(appName string, id coreapplication.ID) {
+func (s *uniterRelationSuite) expectGetApplicationIDByName(appName string, id coreapplication.UUID) {
 	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(id, nil)
 }
 
-func (s *uniterRelationSuite) expectGetRelationApplicationSettingsWithLeader(unitName coreunit.Name, uuid corerelation.UUID, id coreapplication.ID, settings map[string]string) {
+func (s *uniterRelationSuite) expectGetRelationApplicationSettingsWithLeader(unitName coreunit.Name, uuid corerelation.UUID, id coreapplication.UUID, settings map[string]string) {
 	s.relationService.EXPECT().GetRelationApplicationSettingsWithLeader(gomock.Any(), unitName, uuid, id).Return(settings, nil)
 }
 
-func (s *uniterRelationSuite) expectGetRelationApplicationSettings(uuid corerelation.UUID, id coreapplication.ID, settings map[string]string) {
+func (s *uniterRelationSuite) expectGetRelationApplicationSettings(uuid corerelation.UUID, id coreapplication.UUID, settings map[string]string) {
 	s.relationService.EXPECT().GetRelationApplicationSettings(gomock.Any(), uuid, id).Return(settings, nil)
 }
 
@@ -2584,7 +2584,7 @@ func (s *uniterRelationSuite) expectWatchRelatedUnitsChange(
 	watchedUnitUUID coreunit.UUID,
 	relUUID corerelation.UUID,
 	unitUUIDs []coreunit.UUID,
-	appUUIDS []coreapplication.ID,
+	appUUIDS []coreapplication.UUID,
 	watcherID string,
 	changes relation.RelationUnitsChange,
 ) {
@@ -2602,7 +2602,7 @@ func encodeUnitFromUUID(uuid coreunit.UUID) string {
 	return relation.EncodeUnitUUID(uuid.String())
 }
 
-func encodeAppFromUUID(uuid coreapplication.ID) string {
+func encodeAppFromUUID(uuid coreapplication.UUID) string {
 	return relation.EncodeApplicationUUID(uuid.String())
 }
 

--- a/apiserver/facades/agent/uniter/watcherrelationunit.go
+++ b/apiserver/facades/agent/uniter/watcherrelationunit.go
@@ -65,7 +65,7 @@ func newRelationUnitsWatcher(
 func (w *relationUnitsWatcher) fetchRelationUnitChanges(ctx context.Context,
 	changes []string) (params.RelationUnitsChange, error) {
 	var changedUnitUUIDs []coreunit.UUID
-	var changedAppUUIDs []application.ID
+	var changedAppUUIDs []application.UUID
 
 	// sort uuid by kind
 	for _, change := range changes {
@@ -77,7 +77,7 @@ func (w *relationUnitsWatcher) fetchRelationUnitChanges(ctx context.Context,
 		case relation.UnitUUID:
 			changedUnitUUIDs = append(changedUnitUUIDs, coreunit.UUID(uuid))
 		case relation.ApplicationUUID:
-			changedAppUUIDs = append(changedAppUUIDs, application.ID(uuid))
+			changedAppUUIDs = append(changedAppUUIDs, application.UUID(uuid))
 		default:
 			return params.RelationUnitsChange{}, internalerrors.Errorf("unknown relation unit change kind: %q", kind)
 		}

--- a/apiserver/facades/agent/uniter/watcherrelationunit_test.go
+++ b/apiserver/facades/agent/uniter/watcherrelationunit_test.go
@@ -274,7 +274,7 @@ func (s *watcherRelationUnitSuite) TestRelationUnitsWatcher(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	relationUUID := corerelationtesting.GenRelationUUID(c)
 
-	appUUIDByName := map[string]coreapplication.ID{
+	appUUIDByName := map[string]coreapplication.UUID{
 		"app1": coreapplicationtesting.GenApplicationUUID(c),
 		"app2": coreapplicationtesting.GenApplicationUUID(c),
 	}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1111,7 +1111,7 @@ func (api *APIBase) DestroyApplication(ctx context.Context, args params.DestroyA
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			return &info, err
 		} else if err != nil {
-			return nil, errors.Annotatef(err, "getting application ID %q", tag.Id())
+			return nil, errors.Annotatef(err, "getting application UUID %q", tag.Id())
 		}
 		maxWait := time.Duration(0)
 		if arg.MaxWait != nil {
@@ -2120,7 +2120,7 @@ func (api *APIBase) openPortsOnUnit(ctx context.Context, unitUUID coreunit.UUID)
 func (api *APIBase) relationData(ctx context.Context, appName string) ([]params.EndpointRelationData, error) {
 	appID, err := api.applicationService.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
-		return nil, internalerrors.Errorf("getting application id for %q: %v", appName, err)
+		return nil, internalerrors.Errorf("getting application UUID for %q: %v", appName, err)
 	}
 	endpointsData, err := api.relationService.ApplicationRelationsInfo(ctx, appID)
 	if err != nil {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -797,7 +797,7 @@ func (api *APIBase) CharmRelations(ctx context.Context, p params.ApplicationChar
 		return results, errors.Trace(err)
 	}
 
-	appID, err := api.applicationService.GetApplicationIDByName(ctx, p.ApplicationName)
+	appID, err := api.applicationService.GetApplicationUUIDByName(ctx, p.ApplicationName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return results, apiservererrors.ParamsErrorf(params.CodeNotFound, "application %q not found", p.ApplicationName)
 	} else if err != nil {
@@ -1107,7 +1107,7 @@ func (api *APIBase) DestroyApplication(ctx context.Context, args params.DestroyA
 			return &info, nil
 		}
 
-		appID, err := api.applicationService.GetApplicationIDByName(ctx, tag.Id())
+		appID, err := api.applicationService.GetApplicationUUIDByName(ctx, tag.Id())
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			return &info, err
 		} else if err != nil {
@@ -1264,7 +1264,7 @@ func (api *APIBase) getConstraints(ctx context.Context, entity string) (constrai
 	}
 	switch kind := tag.Kind(); kind {
 	case names.ApplicationTagKind:
-		appID, err := api.applicationService.GetApplicationIDByName(ctx, tag.Id())
+		appID, err := api.applicationService.GetApplicationUUIDByName(ctx, tag.Id())
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			return constraints.Value{}, errors.NotFoundf("application %s", tag.Id())
 		} else if err != nil {
@@ -1291,7 +1291,7 @@ func (api *APIBase) SetConstraints(ctx context.Context, args params.SetConstrain
 		return errors.Trace(err)
 	}
 
-	appID, err := api.applicationService.GetApplicationIDByName(ctx, args.ApplicationName)
+	appID, err := api.applicationService.GetApplicationUUIDByName(ctx, args.ApplicationName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return errors.NotFoundf("application %s", args.ApplicationName)
 	} else if err != nil {
@@ -1602,7 +1602,7 @@ func (api *APIBase) setConfig(ctx context.Context, arg params.ConfigSet) params.
 		return params.ErrorResult{Error: apiservererrors.ServerError(errors.NotImplementedf("config yaml not supported"))}
 	}
 
-	appID, err := api.applicationService.GetApplicationIDByName(ctx, arg.ApplicationName)
+	appID, err := api.applicationService.GetApplicationUUIDByName(ctx, arg.ApplicationName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return params.ErrorResult{Error: apiservererrors.ServerError(errors.NotFoundf("application %q", arg.ApplicationName))}
 	} else if errors.Is(err, applicationerrors.ApplicationNameNotValid) {
@@ -1640,7 +1640,7 @@ func (api *APIBase) UnsetApplicationsConfig(ctx context.Context, args params.App
 }
 
 func (api *APIBase) unsetApplicationConfig(ctx context.Context, arg params.ApplicationUnset) error {
-	appID, err := api.applicationService.GetApplicationIDByName(ctx, arg.ApplicationName)
+	appID, err := api.applicationService.GetApplicationUUIDByName(ctx, arg.ApplicationName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return errors.NotFoundf("application %s", arg.ApplicationName)
 	} else if err != nil {
@@ -1733,7 +1733,7 @@ func (api *APIBase) ApplicationsInfo(ctx context.Context, in params.Entities) (p
 			continue
 		}
 
-		appID, err := api.applicationService.GetApplicationIDByName(ctx, tag.Name)
+		appID, err := api.applicationService.GetApplicationUUIDByName(ctx, tag.Name)
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			out[i].Error = apiservererrors.ParamsErrorf(params.CodeNotFound, "application %s not found", tag.Name)
 			continue
@@ -1922,7 +1922,7 @@ func (api *APIBase) MergeBindings(ctx context.Context, in params.ApplicationMerg
 			continue
 		}
 
-		appID, err := api.applicationService.GetApplicationIDByName(ctx, tag.Id())
+		appID, err := api.applicationService.GetApplicationUUIDByName(ctx, tag.Id())
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			res[i].Error = apiservererrors.ParamsErrorf(params.CodeNotFound, "application %s not found", tag.Id())
 			continue
@@ -2118,7 +2118,7 @@ func (api *APIBase) openPortsOnUnit(ctx context.Context, unitUUID coreunit.UUID)
 }
 
 func (api *APIBase) relationData(ctx context.Context, appName string) ([]params.EndpointRelationData, error) {
-	appID, err := api.applicationService.GetApplicationIDByName(ctx, appName)
+	appID, err := api.applicationService.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, internalerrors.Errorf("getting application id for %q: %v", appName, err)
 	}

--- a/apiserver/facades/client/application/application_get.go
+++ b/apiserver/facades/client/application/application_get.go
@@ -31,7 +31,7 @@ func (api *APIBase) getConfig(
 	// Once application service is refactored to return the merged config, this
 	// should be a single call.
 
-	appID, err := api.applicationService.GetApplicationIDByName(ctx, args.ApplicationName)
+	appID, err := api.applicationService.GetApplicationUUIDByName(ctx, args.ApplicationName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return params.ApplicationGetResults{}, errors.NotFoundf("application %s", args.ApplicationName)
 	} else if err != nil {
@@ -173,7 +173,7 @@ func (api *APIBase) getMergedAppAndCharmConfig(ctx context.Context, appName stri
 	// TODO (stickupkid): This should be one call to the application service.
 	// Thee application service should return the merged config, this should
 	// not happen at the API server level.
-	appID, err := api.applicationService.GetApplicationIDByName(ctx, appName)
+	appID, err := api.applicationService.GetApplicationUUIDByName(ctx, appName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return nil, errors.NotFoundf("application %s", appName)
 	} else if err != nil {

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -496,7 +496,7 @@ func (s *applicationSuite) TestGetApplicationConstraintsAppNotFound(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.ID(""), applicationerrors.ApplicationNotFound)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID(""), applicationerrors.ApplicationNotFound)
 
 	res, err := s.api.GetConstraints(c.Context(), params.Entities{
 		Entities: []params.Entity{{Tag: "application-foo"}},
@@ -510,8 +510,8 @@ func (s *applicationSuite) TestGetApplicationConstraintsError(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.ID("app-foo"), nil)
-	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), application.ID("app-foo")).Return(constraints.Value{}, errors.New("boom"))
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
+	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), application.UUID("app-foo")).Return(constraints.Value{}, errors.New("boom"))
 
 	res, err := s.api.GetConstraints(c.Context(), params.Entities{
 		Entities: []params.Entity{{Tag: "application-foo"}},
@@ -525,8 +525,8 @@ func (s *applicationSuite) TestGetApplicationConstraints(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.ID("app-foo"), nil)
-	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), application.ID("app-foo")).Return(constraints.Value{Mem: ptr(uint64(42))}, nil)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
+	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), application.UUID("app-foo")).Return(constraints.Value{Mem: ptr(uint64(42))}, nil)
 
 	res, err := s.api.GetConstraints(c.Context(), params.Entities{
 		Entities: []params.Entity{{Tag: "application-foo"}},
@@ -540,7 +540,7 @@ func (s *applicationSuite) TestSetApplicationConstraintsAppNotFound(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.ID(""), applicationerrors.ApplicationNotFound)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID(""), applicationerrors.ApplicationNotFound)
 
 	err := s.api.SetConstraints(c.Context(), params.SetConstraints{
 		ApplicationName: "foo",
@@ -554,8 +554,8 @@ func (s *applicationSuite) TestSetApplicationConstraintsError(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.ID("app-foo"), nil)
-	s.applicationService.EXPECT().SetApplicationConstraints(gomock.Any(), application.ID("app-foo"), constraints.Value{Mem: ptr(uint64(42))}).Return(errors.New("boom"))
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
+	s.applicationService.EXPECT().SetApplicationConstraints(gomock.Any(), application.UUID("app-foo"), constraints.Value{Mem: ptr(uint64(42))}).Return(errors.New("boom"))
 
 	err := s.api.SetConstraints(c.Context(), params.SetConstraints{
 		ApplicationName: "foo",
@@ -569,8 +569,8 @@ func (s *applicationSuite) TestSetApplicationConstraints(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.ID("app-foo"), nil)
-	s.applicationService.EXPECT().SetApplicationConstraints(gomock.Any(), application.ID("app-foo"), constraints.Value{Mem: ptr(uint64(42))}).Return(nil)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
+	s.applicationService.EXPECT().SetApplicationConstraints(gomock.Any(), application.UUID("app-foo"), constraints.Value{Mem: ptr(uint64(42))}).Return(nil)
 
 	err := s.api.SetConstraints(c.Context(), params.SetConstraints{
 		ApplicationName: "foo",
@@ -1563,7 +1563,7 @@ func (s *applicationSuite) expectCreateApplicationForDeploy(name string, retErr 
 		gomock.Any(),
 		gomock.Any(),
 		gomock.AssignableToTypeOf(applicationservice.AddApplicationArgs{}),
-	).Return(application.ID("app-"+name), retErr)
+	).Return(application.UUID("app-"+name), retErr)
 }
 
 // expectCreateApplicationForDeploy should only be used when calling
@@ -1575,9 +1575,9 @@ func (s *applicationSuite) expectCreateApplicationForDeployWithConfig(c *tc.C, n
 		gomock.Any(),
 		gomock.Any(),
 		gomock.AssignableToTypeOf(applicationservice.AddApplicationArgs{}),
-	).DoAndReturn(func(ctx context.Context, s string, charm internalcharm.Charm, origin corecharm.Origin, args applicationservice.AddApplicationArgs, arg ...applicationservice.AddIAASUnitArg) (application.ID, error) {
+	).DoAndReturn(func(ctx context.Context, s string, charm internalcharm.Charm, origin corecharm.Origin, args applicationservice.AddApplicationArgs, arg ...applicationservice.AddIAASUnitArg) (application.UUID, error) {
 		c.Check(args.ApplicationConfig, tc.DeepEquals, appConfig)
-		return application.ID("app-" + name), retErr
+		return application.UUID("app-" + name), retErr
 	})
 }
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -392,7 +392,7 @@ func (s *applicationSuite) TestCharmRelations(c *tc.C) {
 	appID := applicationtesting.GenApplicationUUID(c)
 	rels := []string{"foo", "bar"}
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "doink").Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "doink").Return(appID, nil)
 	s.applicationService.EXPECT().GetApplicationEndpointNames(gomock.Any(), appID).Return(rels, nil)
 
 	res, err := s.api.CharmRelations(c.Context(), params.ApplicationCharmRelations{
@@ -407,7 +407,7 @@ func (s *applicationSuite) TestCharmRelationsAppNotFound(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "doink").Return("", applicationerrors.ApplicationNotFound)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "doink").Return("", applicationerrors.ApplicationNotFound)
 
 	_, err := s.api.CharmRelations(c.Context(), params.ApplicationCharmRelations{
 		ApplicationName: "doink",
@@ -496,7 +496,7 @@ func (s *applicationSuite) TestGetApplicationConstraintsAppNotFound(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID(""), applicationerrors.ApplicationNotFound)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(application.UUID(""), applicationerrors.ApplicationNotFound)
 
 	res, err := s.api.GetConstraints(c.Context(), params.Entities{
 		Entities: []params.Entity{{Tag: "application-foo"}},
@@ -510,7 +510,7 @@ func (s *applicationSuite) TestGetApplicationConstraintsError(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
 	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), application.UUID("app-foo")).Return(constraints.Value{}, errors.New("boom"))
 
 	res, err := s.api.GetConstraints(c.Context(), params.Entities{
@@ -525,7 +525,7 @@ func (s *applicationSuite) TestGetApplicationConstraints(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
 	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), application.UUID("app-foo")).Return(constraints.Value{Mem: ptr(uint64(42))}, nil)
 
 	res, err := s.api.GetConstraints(c.Context(), params.Entities{
@@ -540,7 +540,7 @@ func (s *applicationSuite) TestSetApplicationConstraintsAppNotFound(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID(""), applicationerrors.ApplicationNotFound)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(application.UUID(""), applicationerrors.ApplicationNotFound)
 
 	err := s.api.SetConstraints(c.Context(), params.SetConstraints{
 		ApplicationName: "foo",
@@ -554,7 +554,7 @@ func (s *applicationSuite) TestSetApplicationConstraintsError(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
 	s.applicationService.EXPECT().SetApplicationConstraints(gomock.Any(), application.UUID("app-foo"), constraints.Value{Mem: ptr(uint64(42))}).Return(errors.New("boom"))
 
 	err := s.api.SetConstraints(c.Context(), params.SetConstraints{
@@ -569,7 +569,7 @@ func (s *applicationSuite) TestSetApplicationConstraints(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(application.UUID("app-foo"), nil)
 	s.applicationService.EXPECT().SetApplicationConstraints(gomock.Any(), application.UUID("app-foo"), constraints.Value{Mem: ptr(uint64(42))}).Return(nil)
 
 	err := s.api.SetConstraints(c.Context(), params.SetConstraints{
@@ -697,7 +697,7 @@ func (s *applicationSuite) TestCharmConfigApplicationNotFound(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
 
 	res, err := s.api.CharmConfig(c.Context(), params.ApplicationGetArgs{
 		Args: []params.ApplicationGet{{
@@ -715,7 +715,7 @@ func (s *applicationSuite) TestCharmConfig(c *tc.C) {
 	s.setupAPI(c)
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appID, nil)
 	s.applicationService.EXPECT().GetApplicationAndCharmConfig(gomock.Any(), appID).Return(applicationservice.ApplicationConfig{
 		CharmName: "ch",
 		ApplicationConfig: internalcharm.Config{
@@ -784,7 +784,7 @@ func (s *applicationSuite) TestSetConfigsApplicationNotFound(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
 
 	res, err := s.api.SetConfigs(c.Context(), params.ConfigSetArgs{
 		Args: []params.ConfigSet{{
@@ -802,7 +802,7 @@ func (s *applicationSuite) TestSetConfigsNotValidApplicationName(c *tc.C) {
 
 	s.setupAPI(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNameNotValid)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNameNotValid)
 
 	res, err := s.api.SetConfigs(c.Context(), params.ConfigSetArgs{
 		Args: []params.ConfigSet{{
@@ -821,7 +821,7 @@ func (s *applicationSuite) TestSetConfigsInvalidConfig(c *tc.C) {
 	s.setupAPI(c)
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appID, nil)
 	s.applicationService.EXPECT().UpdateApplicationConfig(gomock.Any(), appID, gomock.Any()).Return(applicationerrors.InvalidApplicationConfig)
 
 	res, err := s.api.SetConfigs(c.Context(), params.ConfigSetArgs{
@@ -841,7 +841,7 @@ func (s *applicationSuite) TestSetConfigs(c *tc.C) {
 	s.setupAPI(c)
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appID, nil)
 	s.applicationService.EXPECT().UpdateApplicationConfig(gomock.Any(), appID, map[string]string{"foo": "bar"}).Return(nil)
 
 	res, err := s.api.SetConfigs(c.Context(), params.ConfigSetArgs{
@@ -961,7 +961,7 @@ func (s *applicationSuite) TestMergeBindings(c *tc.C) {
 	appName := "doink"
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appID, nil)
 	s.applicationService.EXPECT().MergeApplicationEndpointBindings(gomock.Any(), appID, map[string]network.SpaceName{
 		"foo": "alpha",
 		"bar": "beta",
@@ -990,7 +990,7 @@ func (s *applicationSuite) TestMergeBindingsForce(c *tc.C) {
 	appName := "doink"
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(appID, nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appID, nil)
 	s.applicationService.EXPECT().MergeApplicationEndpointBindings(gomock.Any(), appID, map[string]network.SpaceName{
 		"foo": "alpha",
 		"bar": "beta",
@@ -1018,7 +1018,7 @@ func (s *applicationSuite) TestMergeBindingsNotFound(c *tc.C) {
 
 	appName := "doink"
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return("", applicationerrors.ApplicationNotFound)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return("", applicationerrors.ApplicationNotFound)
 
 	ret, err := s.api.MergeBindings(c.Context(), params.ApplicationMergeBindingsArgs{
 		Args: []params.ApplicationMergeBindings{{
@@ -1148,7 +1148,7 @@ func (s *applicationSuite) testUnitsInfoCAAS(c *tc.C, inputTag names.Tag, result
 	}, nil)
 
 	appID := applicationtesting.GenApplicationUUID(c)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appID, nil).AnyTimes()
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appID, nil).AnyTimes()
 
 	s.applicationService.EXPECT().GetUnitLife(gomock.Any(), resultingUnitName).Return(life.Alive, nil)
 	s.applicationService.EXPECT().GetUnitWorkloadVersion(gomock.Any(), resultingUnitName).Return("1.0.0", nil)

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -245,7 +245,7 @@ type ApplicationService interface {
 	// This will return true if the charm is available, and false otherwise.
 	IsCharmAvailable(ctx context.Context, locator applicationcharm.CharmLocator) (bool, error)
 
-	// GetApplicationUUIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application UUID by application name. It
 	// returns an error if the application can not be found by the name.
 	//
 	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not
@@ -254,9 +254,9 @@ type ApplicationService interface {
 	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationConstraints returns the application constraints for the
-	// specified application ID.
+	// specified application UUID.
 	// Empty constraints are returned if no constraints exist for the given
-	// application ID.
+	// application UUID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (constraints.Value, error)
@@ -267,11 +267,11 @@ type ApplicationService interface {
 	GetApplicationCharmOrigin(ctx context.Context, name string) (corecharm.Origin, error)
 
 	// GetApplicationAndCharmConfig returns the application and charm config for the
-	// specified application ID.
+	// specified application UUID.
 	GetApplicationAndCharmConfig(context.Context, coreapplication.UUID) (applicationservice.ApplicationConfig, error)
 
 	// SetApplicationConstraints sets the application constraints for the
-	// specified application ID.
+	// specified application UUID.
 	// This method overwrites the full constraints on every call.
 	// If invalid constraints are provided (e.g. invalid container type or
 	// non-existing space), a [applicationerrors.InvalidApplicationConstraints]

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -245,13 +245,13 @@ type ApplicationService interface {
 	// This will return true if the charm is available, and false otherwise.
 	IsCharmAvailable(ctx context.Context, locator applicationcharm.CharmLocator) (bool, error)
 
-	// GetApplicationIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application ID by application name. It
 	// returns an error if the application can not be found by the name.
 	//
 	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not
 	// valid, and [applicationerrors.ApplicationNotFound] if the application is
 	// not found.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationConstraints returns the application constraints for the
 	// specified application ID.

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -155,11 +155,11 @@ type MachineService interface {
 type ApplicationService interface {
 	// CreateIAASApplication creates the specified IAAS application and
 	// subsequent units if supplied.
-	CreateIAASApplication(context.Context, string, internalcharm.Charm, corecharm.Origin, applicationservice.AddApplicationArgs, ...applicationservice.AddIAASUnitArg) (coreapplication.ID, error)
+	CreateIAASApplication(context.Context, string, internalcharm.Charm, corecharm.Origin, applicationservice.AddApplicationArgs, ...applicationservice.AddIAASUnitArg) (coreapplication.UUID, error)
 
 	// CreateCAASApplication creates the specified CAAS application and
 	// subsequent units if supplied.
-	CreateCAASApplication(context.Context, string, internalcharm.Charm, corecharm.Origin, applicationservice.AddApplicationArgs, ...applicationservice.AddUnitArg) (coreapplication.ID, error)
+	CreateCAASApplication(context.Context, string, internalcharm.Charm, corecharm.Origin, applicationservice.AddApplicationArgs, ...applicationservice.AddUnitArg) (coreapplication.UUID, error)
 
 	// AddIAASUnits adds IAAS units to the application.
 	AddIAASUnits(ctx context.Context, name string, units ...applicationservice.AddIAASUnitArg) ([]unit.Name, []machine.Name, error)
@@ -180,7 +180,7 @@ type ApplicationService interface {
 	ChangeApplicationScale(ctx context.Context, name string, scaleChange int) (int, error)
 
 	// GetApplicationLife looks up the life of the specified application.
-	GetApplicationLife(context.Context, coreapplication.ID) (life.Value, error)
+	GetApplicationLife(context.Context, coreapplication.UUID) (life.Value, error)
 
 	// GetUnitLife looks up the life of the specified unit.
 	GetUnitLife(context.Context, unit.Name) (life.Value, error)
@@ -251,7 +251,7 @@ type ApplicationService interface {
 	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not
 	// valid, and [applicationerrors.ApplicationNotFound] if the application is
 	// not found.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationConstraints returns the application constraints for the
 	// specified application ID.
@@ -259,7 +259,7 @@ type ApplicationService interface {
 	// application ID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationConstraints(ctx context.Context, appID coreapplication.ID) (constraints.Value, error)
+	GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (constraints.Value, error)
 
 	// GetApplicationCharmOrigin returns the charm origin for the specified
 	// application name. If the application does not exist, an error satisfying
@@ -268,7 +268,7 @@ type ApplicationService interface {
 
 	// GetApplicationAndCharmConfig returns the application and charm config for the
 	// specified application ID.
-	GetApplicationAndCharmConfig(context.Context, coreapplication.ID) (applicationservice.ApplicationConfig, error)
+	GetApplicationAndCharmConfig(context.Context, coreapplication.UUID) (applicationservice.ApplicationConfig, error)
 
 	// SetApplicationConstraints sets the application constraints for the
 	// specified application ID.
@@ -278,13 +278,13 @@ type ApplicationService interface {
 	// error is returned.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	SetApplicationConstraints(context.Context, coreapplication.ID, constraints.Value) error
+	SetApplicationConstraints(context.Context, coreapplication.UUID, constraints.Value) error
 
 	// UnsetApplicationConfigKeys removes the specified keys from the application
 	// config. If the key does not exist, it is ignored.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	UnsetApplicationConfigKeys(context.Context, coreapplication.ID, []string) error
+	UnsetApplicationConfigKeys(context.Context, coreapplication.UUID, []string) error
 
 	// UpdateApplicationConfig updates the application config with the specified
 	// values. If the key does not exist, it is created. If the key already exists,
@@ -294,7 +294,7 @@ type ApplicationService interface {
 	// [applicationerrors.ApplicationNotFound] is returned.
 	// If the charm config is not valid, an error satisfying
 	// [applicationerrors.InvalidApplicationConfig] is returned.
-	UpdateApplicationConfig(context.Context, coreapplication.ID, map[string]string) error
+	UpdateApplicationConfig(context.Context, coreapplication.UUID, map[string]string) error
 
 	// IsApplicationExposed returns whether the provided application is exposed or not.
 	//
@@ -306,7 +306,7 @@ type ApplicationService interface {
 	// application.
 	// The following errors may be returned:
 	// - [appliationerrors.ApplicationNotFound] if the application does not exist
-	IsSubordinateApplication(context.Context, coreapplication.ID) (bool, error)
+	IsSubordinateApplication(context.Context, coreapplication.UUID) (bool, error)
 
 	// IsSubordinateApplicationByName returns true if the application is a
 	// subordinate application.
@@ -327,13 +327,13 @@ type ApplicationService interface {
 	// The following errors may be returned:
 	//   - [applicationerrors.ApplicationNotFound] is returned if the application
 	//     doesn't exist.
-	GetApplicationEndpointNames(context.Context, coreapplication.ID) ([]string, error)
+	GetApplicationEndpointNames(context.Context, coreapplication.UUID) ([]string, error)
 
 	// MergeApplicationEndpointBindings merge the provided bindings into the bindings
 	// for the specified application.
 	// The following errors may be returned:
 	// - [applicationerrors.ApplicationNotFound] if the application does not exist
-	MergeApplicationEndpointBindings(ctx context.Context, appID coreapplication.ID, bindings map[string]network.SpaceName, force bool) error
+	MergeApplicationEndpointBindings(ctx context.Context, appID coreapplication.UUID, bindings map[string]network.SpaceName, force bool) error
 
 	// GetExposedEndpoints returns map where keys are endpoint names (or the ""
 	// value which represents all endpoints) and values are ExposedEndpoint
@@ -433,7 +433,7 @@ type RelationService interface {
 	AddRelation(ctx context.Context, ep1, ep2 string) (relation.Endpoint, relation.Endpoint, error)
 
 	// ApplicationRelationsInfo returns all EndpointRelationData for an application.
-	ApplicationRelationsInfo(ctx context.Context, applicationID coreapplication.ID) ([]relation.EndpointRelationData, error)
+	ApplicationRelationsInfo(ctx context.Context, applicationID coreapplication.UUID) ([]relation.EndpointRelationData, error)
 
 	// GetRelationUUIDForRemoval returns the relation UUID, of the relation
 	// represented in GetRelationUUIDForRemovalArgs, with the understanding
@@ -466,7 +466,7 @@ type RemovalService interface {
 	// The UUID for the scheduled removal job is returned.
 	RemoveApplication(
 		ctx context.Context,
-		appUUID coreapplication.ID,
+		appUUID coreapplication.UUID,
 		destroyStorage bool,
 		force bool,
 		wait time.Duration,

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -659,14 +659,14 @@ func (c *MockApplicationServiceChangeApplicationScaleCall) DoAndReturn(f func(co
 }
 
 // CreateCAASApplication mocks base method.
-func (m *MockApplicationService) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 charm1.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 charm1.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddUnitArg) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2, arg3, arg4}
 	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateCAASApplication", varargs...)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -685,32 +685,32 @@ type MockApplicationServiceCreateCAASApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceCreateCAASApplicationCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceCreateCAASApplicationCall {
+func (c *MockApplicationServiceCreateCAASApplicationCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateCAASApplicationCall) Do(f func(context.Context, string, charm1.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateCAASApplicationCall {
+func (c *MockApplicationServiceCreateCAASApplicationCall) Do(f func(context.Context, string, charm1.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.UUID, error)) *MockApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateCAASApplicationCall) DoAndReturn(f func(context.Context, string, charm1.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateCAASApplicationCall {
+func (c *MockApplicationServiceCreateCAASApplicationCall) DoAndReturn(f func(context.Context, string, charm1.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.UUID, error)) *MockApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateIAASApplication mocks base method.
-func (m *MockApplicationService) CreateIAASApplication(arg0 context.Context, arg1 string, arg2 charm1.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddIAASUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateIAASApplication(arg0 context.Context, arg1 string, arg2 charm1.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddIAASUnitArg) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2, arg3, arg4}
 	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateIAASApplication", varargs...)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -729,25 +729,25 @@ type MockApplicationServiceCreateIAASApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceCreateIAASApplicationCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceCreateIAASApplicationCall {
+func (c *MockApplicationServiceCreateIAASApplicationCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateIAASApplicationCall) Do(f func(context.Context, string, charm1.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddIAASUnitArg) (application.ID, error)) *MockApplicationServiceCreateIAASApplicationCall {
+func (c *MockApplicationServiceCreateIAASApplicationCall) Do(f func(context.Context, string, charm1.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddIAASUnitArg) (application.UUID, error)) *MockApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateIAASApplicationCall) DoAndReturn(f func(context.Context, string, charm1.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddIAASUnitArg) (application.ID, error)) *MockApplicationServiceCreateIAASApplicationCall {
+func (c *MockApplicationServiceCreateIAASApplicationCall) DoAndReturn(f func(context.Context, string, charm1.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddIAASUnitArg) (application.UUID, error)) *MockApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationAndCharmConfig mocks base method.
-func (m *MockApplicationService) GetApplicationAndCharmConfig(arg0 context.Context, arg1 application.ID) (service.ApplicationConfig, error) {
+func (m *MockApplicationService) GetApplicationAndCharmConfig(arg0 context.Context, arg1 application.UUID) (service.ApplicationConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationAndCharmConfig", arg0, arg1)
 	ret0, _ := ret[0].(service.ApplicationConfig)
@@ -774,13 +774,13 @@ func (c *MockApplicationServiceGetApplicationAndCharmConfigCall) Return(arg0 ser
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationAndCharmConfigCall) Do(f func(context.Context, application.ID) (service.ApplicationConfig, error)) *MockApplicationServiceGetApplicationAndCharmConfigCall {
+func (c *MockApplicationServiceGetApplicationAndCharmConfigCall) Do(f func(context.Context, application.UUID) (service.ApplicationConfig, error)) *MockApplicationServiceGetApplicationAndCharmConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationAndCharmConfigCall) DoAndReturn(f func(context.Context, application.ID) (service.ApplicationConfig, error)) *MockApplicationServiceGetApplicationAndCharmConfigCall {
+func (c *MockApplicationServiceGetApplicationAndCharmConfigCall) DoAndReturn(f func(context.Context, application.UUID) (service.ApplicationConfig, error)) *MockApplicationServiceGetApplicationAndCharmConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -825,7 +825,7 @@ func (c *MockApplicationServiceGetApplicationCharmOriginCall) DoAndReturn(f func
 }
 
 // GetApplicationConstraints mocks base method.
-func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.ID) (constraints.Value, error) {
+func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.UUID) (constraints.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationConstraints", arg0, arg1)
 	ret0, _ := ret[0].(constraints.Value)
@@ -852,13 +852,13 @@ func (c *MockApplicationServiceGetApplicationConstraintsCall) Return(arg0 constr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationConstraintsCall) Do(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+func (c *MockApplicationServiceGetApplicationConstraintsCall) Do(f func(context.Context, application.UUID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.UUID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -903,7 +903,7 @@ func (c *MockApplicationServiceGetApplicationEndpointBindingsCall) DoAndReturn(f
 }
 
 // GetApplicationEndpointNames mocks base method.
-func (m *MockApplicationService) GetApplicationEndpointNames(arg0 context.Context, arg1 application.ID) ([]string, error) {
+func (m *MockApplicationService) GetApplicationEndpointNames(arg0 context.Context, arg1 application.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationEndpointNames", arg0, arg1)
 	ret0, _ := ret[0].([]string)
@@ -930,22 +930,22 @@ func (c *MockApplicationServiceGetApplicationEndpointNamesCall) Return(arg0 []st
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationEndpointNamesCall) Do(f func(context.Context, application.ID) ([]string, error)) *MockApplicationServiceGetApplicationEndpointNamesCall {
+func (c *MockApplicationServiceGetApplicationEndpointNamesCall) Do(f func(context.Context, application.UUID) ([]string, error)) *MockApplicationServiceGetApplicationEndpointNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationEndpointNamesCall) DoAndReturn(f func(context.Context, application.ID) ([]string, error)) *MockApplicationServiceGetApplicationEndpointNamesCall {
+func (c *MockApplicationServiceGetApplicationEndpointNamesCall) DoAndReturn(f func(context.Context, application.UUID) ([]string, error)) *MockApplicationServiceGetApplicationEndpointNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -963,25 +963,25 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationLife mocks base method.
-func (m *MockApplicationService) GetApplicationLife(arg0 context.Context, arg1 application.ID) (life.Value, error) {
+func (m *MockApplicationService) GetApplicationLife(arg0 context.Context, arg1 application.UUID) (life.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationLife", arg0, arg1)
 	ret0, _ := ret[0].(life.Value)
@@ -1008,13 +1008,13 @@ func (c *MockApplicationServiceGetApplicationLifeCall) Return(arg0 life.Value, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context, application.ID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context, application.UUID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.ID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.UUID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1607,7 +1607,7 @@ func (c *MockApplicationServiceIsCharmAvailableCall) DoAndReturn(f func(context.
 }
 
 // IsSubordinateApplication mocks base method.
-func (m *MockApplicationService) IsSubordinateApplication(arg0 context.Context, arg1 application.ID) (bool, error) {
+func (m *MockApplicationService) IsSubordinateApplication(arg0 context.Context, arg1 application.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSubordinateApplication", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -1634,13 +1634,13 @@ func (c *MockApplicationServiceIsSubordinateApplicationCall) Return(arg0 bool, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceIsSubordinateApplicationCall) Do(f func(context.Context, application.ID) (bool, error)) *MockApplicationServiceIsSubordinateApplicationCall {
+func (c *MockApplicationServiceIsSubordinateApplicationCall) Do(f func(context.Context, application.UUID) (bool, error)) *MockApplicationServiceIsSubordinateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceIsSubordinateApplicationCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockApplicationServiceIsSubordinateApplicationCall {
+func (c *MockApplicationServiceIsSubordinateApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (bool, error)) *MockApplicationServiceIsSubordinateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1685,7 +1685,7 @@ func (c *MockApplicationServiceIsSubordinateApplicationByNameCall) DoAndReturn(f
 }
 
 // MergeApplicationEndpointBindings mocks base method.
-func (m *MockApplicationService) MergeApplicationEndpointBindings(arg0 context.Context, arg1 application.ID, arg2 map[string]network.SpaceName, arg3 bool) error {
+func (m *MockApplicationService) MergeApplicationEndpointBindings(arg0 context.Context, arg1 application.UUID, arg2 map[string]network.SpaceName, arg3 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MergeApplicationEndpointBindings", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -1711,13 +1711,13 @@ func (c *MockApplicationServiceMergeApplicationEndpointBindingsCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceMergeApplicationEndpointBindingsCall) Do(f func(context.Context, application.ID, map[string]network.SpaceName, bool) error) *MockApplicationServiceMergeApplicationEndpointBindingsCall {
+func (c *MockApplicationServiceMergeApplicationEndpointBindingsCall) Do(f func(context.Context, application.UUID, map[string]network.SpaceName, bool) error) *MockApplicationServiceMergeApplicationEndpointBindingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceMergeApplicationEndpointBindingsCall) DoAndReturn(f func(context.Context, application.ID, map[string]network.SpaceName, bool) error) *MockApplicationServiceMergeApplicationEndpointBindingsCall {
+func (c *MockApplicationServiceMergeApplicationEndpointBindingsCall) DoAndReturn(f func(context.Context, application.UUID, map[string]network.SpaceName, bool) error) *MockApplicationServiceMergeApplicationEndpointBindingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1838,7 +1838,7 @@ func (c *MockApplicationServiceSetApplicationCharmCall) DoAndReturn(f func(conte
 }
 
 // SetApplicationConstraints mocks base method.
-func (m *MockApplicationService) SetApplicationConstraints(arg0 context.Context, arg1 application.ID, arg2 constraints.Value) error {
+func (m *MockApplicationService) SetApplicationConstraints(arg0 context.Context, arg1 application.UUID, arg2 constraints.Value) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetApplicationConstraints", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1864,13 +1864,13 @@ func (c *MockApplicationServiceSetApplicationConstraintsCall) Return(arg0 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceSetApplicationConstraintsCall) Do(f func(context.Context, application.ID, constraints.Value) error) *MockApplicationServiceSetApplicationConstraintsCall {
+func (c *MockApplicationServiceSetApplicationConstraintsCall) Do(f func(context.Context, application.UUID, constraints.Value) error) *MockApplicationServiceSetApplicationConstraintsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceSetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID, constraints.Value) error) *MockApplicationServiceSetApplicationConstraintsCall {
+func (c *MockApplicationServiceSetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.UUID, constraints.Value) error) *MockApplicationServiceSetApplicationConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1914,7 +1914,7 @@ func (c *MockApplicationServiceSetApplicationScaleCall) DoAndReturn(f func(conte
 }
 
 // UnsetApplicationConfigKeys mocks base method.
-func (m *MockApplicationService) UnsetApplicationConfigKeys(arg0 context.Context, arg1 application.ID, arg2 []string) error {
+func (m *MockApplicationService) UnsetApplicationConfigKeys(arg0 context.Context, arg1 application.UUID, arg2 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnsetApplicationConfigKeys", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1940,13 +1940,13 @@ func (c *MockApplicationServiceUnsetApplicationConfigKeysCall) Return(arg0 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceUnsetApplicationConfigKeysCall) Do(f func(context.Context, application.ID, []string) error) *MockApplicationServiceUnsetApplicationConfigKeysCall {
+func (c *MockApplicationServiceUnsetApplicationConfigKeysCall) Do(f func(context.Context, application.UUID, []string) error) *MockApplicationServiceUnsetApplicationConfigKeysCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceUnsetApplicationConfigKeysCall) DoAndReturn(f func(context.Context, application.ID, []string) error) *MockApplicationServiceUnsetApplicationConfigKeysCall {
+func (c *MockApplicationServiceUnsetApplicationConfigKeysCall) DoAndReturn(f func(context.Context, application.UUID, []string) error) *MockApplicationServiceUnsetApplicationConfigKeysCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1990,7 +1990,7 @@ func (c *MockApplicationServiceUnsetExposeSettingsCall) DoAndReturn(f func(conte
 }
 
 // UpdateApplicationConfig mocks base method.
-func (m *MockApplicationService) UpdateApplicationConfig(arg0 context.Context, arg1 application.ID, arg2 map[string]string) error {
+func (m *MockApplicationService) UpdateApplicationConfig(arg0 context.Context, arg1 application.UUID, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateApplicationConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -2016,13 +2016,13 @@ func (c *MockApplicationServiceUpdateApplicationConfigCall) Return(arg0 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceUpdateApplicationConfigCall) Do(f func(context.Context, application.ID, map[string]string) error) *MockApplicationServiceUpdateApplicationConfigCall {
+func (c *MockApplicationServiceUpdateApplicationConfigCall) Do(f func(context.Context, application.UUID, map[string]string) error) *MockApplicationServiceUpdateApplicationConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceUpdateApplicationConfigCall) DoAndReturn(f func(context.Context, application.ID, map[string]string) error) *MockApplicationServiceUpdateApplicationConfigCall {
+func (c *MockApplicationServiceUpdateApplicationConfigCall) DoAndReturn(f func(context.Context, application.UUID, map[string]string) error) *MockApplicationServiceUpdateApplicationConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2376,7 +2376,7 @@ func (c *MockRelationServiceAddRelationCall) DoAndReturn(f func(context.Context,
 }
 
 // ApplicationRelationsInfo mocks base method.
-func (m *MockRelationService) ApplicationRelationsInfo(arg0 context.Context, arg1 application.ID) ([]relation0.EndpointRelationData, error) {
+func (m *MockRelationService) ApplicationRelationsInfo(arg0 context.Context, arg1 application.UUID) ([]relation0.EndpointRelationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationRelationsInfo", arg0, arg1)
 	ret0, _ := ret[0].([]relation0.EndpointRelationData)
@@ -2403,13 +2403,13 @@ func (c *MockRelationServiceApplicationRelationsInfoCall) Return(arg0 []relation
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceApplicationRelationsInfoCall) Do(f func(context.Context, application.ID) ([]relation0.EndpointRelationData, error)) *MockRelationServiceApplicationRelationsInfoCall {
+func (c *MockRelationServiceApplicationRelationsInfoCall) Do(f func(context.Context, application.UUID) ([]relation0.EndpointRelationData, error)) *MockRelationServiceApplicationRelationsInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceApplicationRelationsInfoCall) DoAndReturn(f func(context.Context, application.ID) ([]relation0.EndpointRelationData, error)) *MockRelationServiceApplicationRelationsInfoCall {
+func (c *MockRelationServiceApplicationRelationsInfoCall) DoAndReturn(f func(context.Context, application.UUID) ([]relation0.EndpointRelationData, error)) *MockRelationServiceApplicationRelationsInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2538,7 +2538,7 @@ func (m *MockRemovalService) EXPECT() *MockRemovalServiceMockRecorder {
 }
 
 // RemoveApplication mocks base method.
-func (m *MockRemovalService) RemoveApplication(arg0 context.Context, arg1 application.ID, arg2, arg3 bool, arg4 time.Duration) (removal.UUID, error) {
+func (m *MockRemovalService) RemoveApplication(arg0 context.Context, arg1 application.UUID, arg2, arg3 bool, arg4 time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveApplication", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(removal.UUID)
@@ -2565,13 +2565,13 @@ func (c *MockRemovalServiceRemoveApplicationCall) Return(arg0 removal.UUID, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRemovalServiceRemoveApplicationCall) Do(f func(context.Context, application.ID, bool, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveApplicationCall {
+func (c *MockRemovalServiceRemoveApplicationCall) Do(f func(context.Context, application.UUID, bool, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRemovalServiceRemoveApplicationCall) DoAndReturn(f func(context.Context, application.ID, bool, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveApplicationCall {
+func (c *MockRemovalServiceRemoveApplicationCall) DoAndReturn(f func(context.Context, application.UUID, bool, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -941,45 +941,6 @@ func (c *MockApplicationServiceGetApplicationEndpointNamesCall) DoAndReturn(f fu
 	return c
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
-}
-
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetApplicationLife mocks base method.
 func (m *MockApplicationService) GetApplicationLife(arg0 context.Context, arg1 application.UUID) (life.Value, error) {
 	m.ctrl.T.Helper()
@@ -1015,6 +976,45 @@ func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.UUID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/charms/service.go
+++ b/apiserver/facades/client/charms/service.go
@@ -32,12 +32,12 @@ type ApplicationService interface {
 	// locator by the name. If no names are provided, all charms are returned.
 	ListCharmLocators(ctx context.Context, names ...string) ([]charm.CharmLocator, error)
 
-	// GetApplicationIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application ID by application name. It
 	// returns an error if the application can not be found by the name.
 	//
 	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
 	// and [applicationerrors.ApplicationNotFound] if the application is not found.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// IsSubordinateApplication returns true if the application is a subordinate
 	// application.

--- a/apiserver/facades/client/charms/service.go
+++ b/apiserver/facades/client/charms/service.go
@@ -32,7 +32,7 @@ type ApplicationService interface {
 	// locator by the name. If no names are provided, all charms are returned.
 	ListCharmLocators(ctx context.Context, names ...string) ([]charm.CharmLocator, error)
 
-	// GetApplicationUUIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application UUID by application name. It
 	// returns an error if the application can not be found by the name.
 	//
 	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
@@ -46,9 +46,9 @@ type ApplicationService interface {
 	IsSubordinateApplication(context.Context, coreapplication.UUID) (bool, error)
 
 	// GetApplicationConstraints returns the application constraints for the
-	// specified application ID.
+	// specified application UUID.
 	// Empty constraints are returned if no constraints exist for the given
-	// application ID.
+	// application UUID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationConstraints(context.Context, coreapplication.UUID) (constraints.Value, error)

--- a/apiserver/facades/client/charms/service.go
+++ b/apiserver/facades/client/charms/service.go
@@ -37,13 +37,13 @@ type ApplicationService interface {
 	//
 	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
 	// and [applicationerrors.ApplicationNotFound] if the application is not found.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// IsSubordinateApplication returns true if the application is a subordinate
 	// application.
 	// The following errors may be returned:
 	// - [appliationerrors.ApplicationNotFound] if the application does not exist
-	IsSubordinateApplication(context.Context, coreapplication.ID) (bool, error)
+	IsSubordinateApplication(context.Context, coreapplication.UUID) (bool, error)
 
 	// GetApplicationConstraints returns the application constraints for the
 	// specified application ID.
@@ -51,5 +51,5 @@ type ApplicationService interface {
 	// application ID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationConstraints(context.Context, coreapplication.ID) (constraints.Value, error)
+	GetApplicationConstraints(context.Context, coreapplication.UUID) (constraints.Value, error)
 }

--- a/apiserver/facades/client/charms/service_mock_test.go
+++ b/apiserver/facades/client/charms/service_mock_test.go
@@ -147,7 +147,7 @@ func (c *MockApplicationServiceAddCharmCall) DoAndReturn(f func(context.Context,
 }
 
 // GetApplicationConstraints mocks base method.
-func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.ID) (constraints.Value, error) {
+func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.UUID) (constraints.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationConstraints", arg0, arg1)
 	ret0, _ := ret[0].(constraints.Value)
@@ -174,22 +174,22 @@ func (c *MockApplicationServiceGetApplicationConstraintsCall) Return(arg0 constr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationConstraintsCall) Do(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+func (c *MockApplicationServiceGetApplicationConstraintsCall) Do(f func(context.Context, application.UUID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.UUID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -207,25 +207,25 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // IsSubordinateApplication mocks base method.
-func (m *MockApplicationService) IsSubordinateApplication(arg0 context.Context, arg1 application.ID) (bool, error) {
+func (m *MockApplicationService) IsSubordinateApplication(arg0 context.Context, arg1 application.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSubordinateApplication", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -252,13 +252,13 @@ func (c *MockApplicationServiceIsSubordinateApplicationCall) Return(arg0 bool, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceIsSubordinateApplicationCall) Do(f func(context.Context, application.ID) (bool, error)) *MockApplicationServiceIsSubordinateApplicationCall {
+func (c *MockApplicationServiceIsSubordinateApplicationCall) Do(f func(context.Context, application.UUID) (bool, error)) *MockApplicationServiceIsSubordinateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceIsSubordinateApplicationCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockApplicationServiceIsSubordinateApplicationCall {
+func (c *MockApplicationServiceIsSubordinateApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (bool, error)) *MockApplicationServiceIsSubordinateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/charms/service_mock_test.go
+++ b/apiserver/facades/client/charms/service_mock_test.go
@@ -185,41 +185,41 @@ func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func
 	return c
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -138,7 +138,7 @@ func (a *API) ListResources(ctx context.Context, args params.ListResourcesArgs) 
 			continue
 		}
 
-		appID, err := a.applicationService.GetApplicationIDByName(ctx, tag.Id())
+		appID, err := a.applicationService.GetApplicationUUIDByName(ctx, tag.Id())
 		if err != nil {
 			r.Results[i] = errorResult(err)
 			continue
@@ -205,7 +205,7 @@ func (a *API) AddPendingResources(
 		return result, nil
 	}
 
-	applicationID, err := a.applicationService.GetApplicationIDByName(ctx, appName)
+	applicationID, err := a.applicationService.GetApplicationUUIDByName(ctx, appName)
 	if err == nil {
 		// The application does exist, therefore the intent is to
 		// update a resource.

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -298,7 +298,7 @@ func (a *API) addPendingResources(
 // updateResources handles updates of all provided resources.
 func (a *API) updateResources(
 	ctx context.Context,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	resources []charmresource.Resource,
 ) ([]string, error) {
 	newUUIDs := make([]string, len(resources))
@@ -326,7 +326,7 @@ func (a *API) updateResources(
 // updateResource updates the resource based on origin.
 func (a *API) updateResource(
 	ctx context.Context,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	res charmresource.Resource,
 ) (coreresource.UUID, error) {
 	resourceID, err := a.resourceService.GetApplicationResourceID(ctx,

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -331,8 +331,8 @@ func (a *API) updateResource(
 ) (coreresource.UUID, error) {
 	resourceID, err := a.resourceService.GetApplicationResourceID(ctx,
 		resource.GetApplicationResourceIDArgs{
-			ApplicationID: appID,
-			Name:          res.Name,
+			ApplicationUUID: appID,
+			Name:            res.Name,
 		},
 	)
 	if errors.Is(err, resourceerrors.ResourceNameNotValid) || errors.Is(err, resourceerrors.ResourceNotFound) {

--- a/apiserver/facades/client/resources/facade_test.go
+++ b/apiserver/facades/client/resources/facade_test.go
@@ -55,7 +55,7 @@ func (s *resourcesSuite) TestListResourcesOkay(c *tc.C) {
 	appTag := names.NewApplicationTag("a-application")
 	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(),
 		appTag.Id()).Return("a-application-id", nil)
-	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.ID("a-application-id")).Return(
+	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.UUID("a-application-id")).Return(
 		resource.ApplicationResources{
 			Resources: []resource.Resource{
 				res1,
@@ -122,7 +122,7 @@ func (s *resourcesSuite) TestListResourcesEmpty(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	tag := names.NewApplicationTag("a-application")
 	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "a-application").Return("a-application-id", nil)
-	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.ID("a-application-id")).Return(resource.ApplicationResources{}, nil)
+	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.UUID("a-application-id")).Return(resource.ApplicationResources{}, nil)
 
 	results, err := s.newFacade(c).ListResources(c.Context(), params.ListResourcesArgs{
 		Entities: []params.Entity{{
@@ -163,7 +163,7 @@ func (s *resourcesSuite) TestListResourcesError(c *tc.C) {
 	failure := errors.New("<failure>")
 	tag := names.NewApplicationTag("a-application")
 	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "a-application").Return("a-application-id", nil)
-	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.ID("a-application-id")).Return(resource.ApplicationResources{}, failure)
+	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.UUID("a-application-id")).Return(resource.ApplicationResources{}, failure)
 
 	results, err := s.newFacade(c).ListResources(c.Context(), params.ListResourcesArgs{
 		Entities: []params.Entity{{
@@ -261,7 +261,7 @@ type addPendingResourceSuite struct {
 	BaseSuite
 
 	appTag               names.ApplicationTag
-	appUUID              coreapplication.ID
+	appUUID              coreapplication.UUID
 	curl                 *charm.URL
 	charmLoc             applicationcharm.CharmLocator
 	pendingResourceIDOne resource.UUID
@@ -410,7 +410,7 @@ func (s *addPendingResourceSuite) expectResolveResourcesStoreContainer(resName s
 }
 
 func (s *addPendingResourceSuite) expectGetApplicationIDByName(err error) {
-	var id coreapplication.ID
+	var id coreapplication.UUID
 	if err == nil {
 		id = s.appUUID
 	}

--- a/apiserver/facades/client/resources/facade_test.go
+++ b/apiserver/facades/client/resources/facade_test.go
@@ -53,7 +53,7 @@ func (s *resourcesSuite) TestListResourcesOkay(c *tc.C) {
 	apiChRes2.Revision++
 
 	appTag := names.NewApplicationTag("a-application")
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(),
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(),
 		appTag.Id()).Return("a-application-id", nil)
 	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.UUID("a-application-id")).Return(
 		resource.ApplicationResources{
@@ -121,7 +121,7 @@ func (s *resourcesSuite) TestListResourcesOkay(c *tc.C) {
 func (s *resourcesSuite) TestListResourcesEmpty(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	tag := names.NewApplicationTag("a-application")
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "a-application").Return("a-application-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "a-application").Return("a-application-id", nil)
 	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.UUID("a-application-id")).Return(resource.ApplicationResources{}, nil)
 
 	results, err := s.newFacade(c).ListResources(c.Context(), params.ListResourcesArgs{
@@ -140,7 +140,7 @@ func (s *resourcesSuite) TestListResourcesErrorGetAppID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	failure := errors.New("<failure>")
 	tag := names.NewApplicationTag("a-application")
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "a-application").Return("", failure)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "a-application").Return("", failure)
 
 	results, err := s.newFacade(c).ListResources(c.Context(), params.ListResourcesArgs{
 		Entities: []params.Entity{{
@@ -162,7 +162,7 @@ func (s *resourcesSuite) TestListResourcesError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	failure := errors.New("<failure>")
 	tag := names.NewApplicationTag("a-application")
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "a-application").Return("a-application-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "a-application").Return("a-application-id", nil)
 	s.resourceService.EXPECT().ListResources(gomock.Any(), coreapplication.UUID("a-application-id")).Return(resource.ApplicationResources{}, failure)
 
 	results, err := s.newFacade(c).ListResources(c.Context(), params.ListResourcesArgs{
@@ -290,7 +290,7 @@ func (s *addPendingResourceSuite) TestAddPendingResourcesBeforeApplication(c *tc
 	defer s.setupMocks(c).Finish()
 
 	resourceRevision := 42
-	s.expectGetApplicationIDByName(applicationerrors.ApplicationNotFound)
+	s.expectGetApplicationUUIDByName(applicationerrors.ApplicationNotFound)
 	s.expectResolveResourceForBeforeApplication(resourceRevision)
 	s.expectAddResourcesBeforeApplication(resourceRevision)
 
@@ -329,7 +329,7 @@ func (s *addPendingResourceSuite) TestAddPendingResourcesUpdateStoreResource(c *
 	defer s.setupMocks(c).Finish()
 
 	resourceRevision := 42
-	s.expectGetApplicationIDByName(nil)
+	s.expectGetApplicationUUIDByName(nil)
 	s.expectResolveResourcesStoreContainer(s.resourceNameTwo, resourceRevision)
 	s.expectGetApplicationResourceIDTwo()
 	newUUIDTwo := s.expectUpdateResourceRevisionTwo(c, resourceRevision)
@@ -362,7 +362,7 @@ func (s *addPendingResourceSuite) TestAddPendingResourcesUpdateStoreResource(c *
 func (s *addPendingResourceSuite) TestAddPendingResourcesUpdateUploadResource(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectGetApplicationIDByName(nil)
+	s.expectGetApplicationUUIDByName(nil)
 	s.expectResolveResourcesUploadContainer(c)
 	s.expectGetApplicationResourceIDTwo()
 	newUUIDTwo := s.expectUpdateUploadResourceTwo(c)
@@ -409,12 +409,12 @@ func (s *addPendingResourceSuite) expectResolveResourcesStoreContainer(resName s
 	s.repository.EXPECT().ResolveResources(gomock.Any(), resolveArgs, gomock.Any()).Return(resolveArgs, nil)
 }
 
-func (s *addPendingResourceSuite) expectGetApplicationIDByName(err error) {
+func (s *addPendingResourceSuite) expectGetApplicationUUIDByName(err error) {
 	var id coreapplication.UUID
 	if err == nil {
 		id = s.appUUID
 	}
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), s.appTag.Name).Return(id, err)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), s.appTag.Name).Return(id, err)
 }
 
 func (s *addPendingResourceSuite) expectGetApplicationResourceIDTwo() {

--- a/apiserver/facades/client/resources/facade_test.go
+++ b/apiserver/facades/client/resources/facade_test.go
@@ -419,8 +419,8 @@ func (s *addPendingResourceSuite) expectGetApplicationUUIDByName(err error) {
 
 func (s *addPendingResourceSuite) expectGetApplicationResourceIDTwo() {
 	getResIDArgs := domainresource.GetApplicationResourceIDArgs{
-		ApplicationID: s.appUUID,
-		Name:          s.resourceNameTwo,
+		ApplicationUUID: s.appUUID,
+		Name:            s.resourceNameTwo,
 	}
 	s.resourceService.EXPECT().GetApplicationResourceID(gomock.Any(), getResIDArgs).Return(s.pendingResourceIDTwo, nil)
 }

--- a/apiserver/facades/client/resources/service.go
+++ b/apiserver/facades/client/resources/service.go
@@ -42,6 +42,6 @@ type ResourceService interface {
 
 // ApplicationService defines methods to manage application.
 type ApplicationService interface {
-	// GetApplicationIDByName returns an application ID by application name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	// GetApplicationUUIDByName returns an application ID by application name.
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 }

--- a/apiserver/facades/client/resources/service.go
+++ b/apiserver/facades/client/resources/service.go
@@ -27,7 +27,7 @@ type ResourceService interface {
 	) (coreresource.UUID, error)
 
 	// ListResources returns the resources for the given application.
-	ListResources(ctx context.Context, applicationID coreapplication.ID) (coreresource.ApplicationResources, error)
+	ListResources(ctx context.Context, applicationID coreapplication.UUID) (coreresource.ApplicationResources, error)
 
 	// UpdateResourceRevision adds a new entry for the revision in the resource
 	// table with the desired parameters and sets it on the application. Any
@@ -43,5 +43,5 @@ type ResourceService interface {
 // ApplicationService defines methods to manage application.
 type ApplicationService interface {
 	// GetApplicationIDByName returns an application ID by application name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 }

--- a/apiserver/facades/client/resources/service.go
+++ b/apiserver/facades/client/resources/service.go
@@ -42,6 +42,6 @@ type ResourceService interface {
 
 // ApplicationService defines methods to manage application.
 type ApplicationService interface {
-	// GetApplicationUUIDByName returns an application ID by application name.
+	// GetApplicationUUIDByName returns an application UUID by application name.
 	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 }

--- a/apiserver/facades/client/resources/service_mock_test.go
+++ b/apiserver/facades/client/resources/service_mock_test.go
@@ -45,10 +45,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -66,19 +66,19 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -185,7 +185,7 @@ func (c *MockResourceServiceGetApplicationResourceIDCall) DoAndReturn(f func(con
 }
 
 // ListResources mocks base method.
-func (m *MockResourceService) ListResources(arg0 context.Context, arg1 application.ID) (resource.ApplicationResources, error) {
+func (m *MockResourceService) ListResources(arg0 context.Context, arg1 application.UUID) (resource.ApplicationResources, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResources", arg0, arg1)
 	ret0, _ := ret[0].(resource.ApplicationResources)
@@ -212,13 +212,13 @@ func (c *MockResourceServiceListResourcesCall) Return(arg0 resource.ApplicationR
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockResourceServiceListResourcesCall) Do(f func(context.Context, application.ID) (resource.ApplicationResources, error)) *MockResourceServiceListResourcesCall {
+func (c *MockResourceServiceListResourcesCall) Do(f func(context.Context, application.UUID) (resource.ApplicationResources, error)) *MockResourceServiceListResourcesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockResourceServiceListResourcesCall) DoAndReturn(f func(context.Context, application.ID) (resource.ApplicationResources, error)) *MockResourceServiceListResourcesCall {
+func (c *MockResourceServiceListResourcesCall) DoAndReturn(f func(context.Context, application.UUID) (resource.ApplicationResources, error)) *MockResourceServiceListResourcesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/resources/service_mock_test.go
+++ b/apiserver/facades/client/resources/service_mock_test.go
@@ -44,41 +44,41 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -422,7 +422,7 @@ func (a *API) provisioningInfo(ctx context.Context, appTag names.ApplicationTag)
 		return nil, errors.Trace(err)
 	}
 
-	appID, err := a.applicationService.GetApplicationIDByName(ctx, appName)
+	appID, err := a.applicationService.GetApplicationUUIDByName(ctx, appName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return nil, errors.NotFoundf("application %s", appName)
 	} else if err != nil {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -147,8 +147,8 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *tc.C) {
 	s.modelInfoService.EXPECT().ResolveConstraints(gomock.Any(), constraints.Value{}).Return(constraints.Value{}, nil)
 
 	s.applicationService.EXPECT().GetApplicationScale(gomock.Any(), "gitlab").Return(3, nil)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "gitlab").Return(coreapplication.ID("deadbeef"), nil)
-	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), coreapplication.ID("deadbeef")).Return(constraints.Value{}, nil)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "gitlab").Return(coreapplication.UUID("deadbeef"), nil)
+	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), coreapplication.UUID("deadbeef")).Return(constraints.Value{}, nil)
 	s.applicationService.EXPECT().GetDeviceConstraints(gomock.Any(), "gitlab").Return(map[string]devices.Constraints{}, nil)
 	s.applicationService.EXPECT().GetApplicationCharmOrigin(gomock.Any(), "gitlab").Return(charm.Origin{
 		Platform: charm.Platform{
@@ -156,7 +156,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *tc.C) {
 			OS:      ostype.Ubuntu.String(),
 		},
 	}, nil)
-	s.applicationService.EXPECT().GetCharmModifiedVersion(gomock.Any(), coreapplication.ID("deadbeef")).Return(10, nil)
+	s.applicationService.EXPECT().GetCharmModifiedVersion(gomock.Any(), coreapplication.UUID("deadbeef")).Return(10, nil)
 	s.applicationService.EXPECT().GetApplicationTrustSetting(gomock.Any(), "gitlab").Return(true, nil)
 
 	result, err := s.api.ProvisioningInfo(c.Context(), params.Entities{Entities: []params.Entity{{Tag: "application-gitlab"}}})

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -147,7 +147,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *tc.C) {
 	s.modelInfoService.EXPECT().ResolveConstraints(gomock.Any(), constraints.Value{}).Return(constraints.Value{}, nil)
 
 	s.applicationService.EXPECT().GetApplicationScale(gomock.Any(), "gitlab").Return(3, nil)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "gitlab").Return(coreapplication.UUID("deadbeef"), nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return(coreapplication.UUID("deadbeef"), nil)
 	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), coreapplication.UUID("deadbeef")).Return(constraints.Value{}, nil)
 	s.applicationService.EXPECT().GetDeviceConstraints(gomock.Any(), "gitlab").Return(map[string]devices.Constraints{}, nil)
 	s.applicationService.EXPECT().GetApplicationCharmOrigin(gomock.Any(), "gitlab").Return(charm.Origin{

--- a/apiserver/facades/controller/caasapplicationprovisioner/service.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service.go
@@ -104,9 +104,9 @@ type ApplicationService interface {
 	// UpdateCAASUnit updates the specified CAAS unit
 	UpdateCAASUnit(context.Context, unit.Name, service.UpdateCAASUnitParams) error
 
-	// GetApplicationIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application ID by application name. It
 	// returns an error if the application can not be found by the name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationConstraints returns the application constraints for the
 	// specified application ID.

--- a/apiserver/facades/controller/caasapplicationprovisioner/service.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service.go
@@ -106,13 +106,13 @@ type ApplicationService interface {
 
 	// GetApplicationIDByName returns an application ID by application name. It
 	// returns an error if the application can not be found by the name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationConstraints returns the application constraints for the
 	// specified application ID.
 	// Empty constraints are returned if no constraints exist for the given
 	// application ID.
-	GetApplicationConstraints(ctx context.Context, appID coreapplication.ID) (constraints.Value, error)
+	GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (constraints.Value, error)
 
 	// WatchApplication returns a NotifyWatcher for changes to the application.
 	WatchApplication(ctx context.Context, name string) (watcher.NotifyWatcher, error)
@@ -128,7 +128,7 @@ type ApplicationService interface {
 
 	// GetCharmModifiedVersion looks up the charm modified version of the given
 	// application.
-	GetCharmModifiedVersion(ctx context.Context, id coreapplication.ID) (int, error)
+	GetCharmModifiedVersion(ctx context.Context, id coreapplication.UUID) (int, error)
 
 	// GetUnitNamesForApplication returns a slice of the unit names for the
 	// given application
@@ -170,7 +170,7 @@ type RemovalService interface {
 type StatusService interface {
 	// GetUnitWorkloadStatusesForApplication returns the workload statuses of
 	// all units in the specified application, indexed by unit name.
-	GetUnitWorkloadStatusesForApplication(context.Context, coreapplication.ID) (map[unit.Name]status.StatusInfo, error)
+	GetUnitWorkloadStatusesForApplication(context.Context, coreapplication.UUID) (map[unit.Name]status.StatusInfo, error)
 
 	// SetApplicationStatus saves the given application status, overwriting any
 	// current status data.

--- a/apiserver/facades/controller/caasapplicationprovisioner/service.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service.go
@@ -104,14 +104,14 @@ type ApplicationService interface {
 	// UpdateCAASUnit updates the specified CAAS unit
 	UpdateCAASUnit(context.Context, unit.Name, service.UpdateCAASUnitParams) error
 
-	// GetApplicationUUIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application UUID by application name. It
 	// returns an error if the application can not be found by the name.
 	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationConstraints returns the application constraints for the
-	// specified application ID.
+	// specified application UUID.
 	// Empty constraints are returned if no constraints exist for the given
-	// application ID.
+	// application UUID.
 	GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (constraints.Value, error)
 
 	// WatchApplication returns a NotifyWatcher for changes to the application.

--- a/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
@@ -399,7 +399,7 @@ func (c *MockApplicationServiceGetApplicationCharmOriginCall) DoAndReturn(f func
 }
 
 // GetApplicationConstraints mocks base method.
-func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.ID) (constraints.Value, error) {
+func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.UUID) (constraints.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationConstraints", arg0, arg1)
 	ret0, _ := ret[0].(constraints.Value)
@@ -426,22 +426,22 @@ func (c *MockApplicationServiceGetApplicationConstraintsCall) Return(arg0 constr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationConstraintsCall) Do(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+func (c *MockApplicationServiceGetApplicationConstraintsCall) Do(f func(context.Context, application.UUID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.UUID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -459,19 +459,19 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -711,7 +711,7 @@ func (c *MockApplicationServiceGetCharmMetadataStorageCall) DoAndReturn(f func(c
 }
 
 // GetCharmModifiedVersion mocks base method.
-func (m *MockApplicationService) GetCharmModifiedVersion(arg0 context.Context, arg1 application.ID) (int, error) {
+func (m *MockApplicationService) GetCharmModifiedVersion(arg0 context.Context, arg1 application.UUID) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmModifiedVersion", arg0, arg1)
 	ret0, _ := ret[0].(int)
@@ -738,13 +738,13 @@ func (c *MockApplicationServiceGetCharmModifiedVersionCall) Return(arg0 int, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetCharmModifiedVersionCall) Do(f func(context.Context, application.ID) (int, error)) *MockApplicationServiceGetCharmModifiedVersionCall {
+func (c *MockApplicationServiceGetCharmModifiedVersionCall) Do(f func(context.Context, application.UUID) (int, error)) *MockApplicationServiceGetCharmModifiedVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetCharmModifiedVersionCall) DoAndReturn(f func(context.Context, application.ID) (int, error)) *MockApplicationServiceGetCharmModifiedVersionCall {
+func (c *MockApplicationServiceGetCharmModifiedVersionCall) DoAndReturn(f func(context.Context, application.UUID) (int, error)) *MockApplicationServiceGetCharmModifiedVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1006,7 +1006,7 @@ func (m *MockStatusService) EXPECT() *MockStatusServiceMockRecorder {
 }
 
 // GetUnitWorkloadStatusesForApplication mocks base method.
-func (m *MockStatusService) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.ID) (map[unit.Name]status.StatusInfo, error) {
+func (m *MockStatusService) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]status.StatusInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitWorkloadStatusesForApplication", arg0, arg1)
 	ret0, _ := ret[0].(map[unit.Name]status.StatusInfo)
@@ -1033,13 +1033,13 @@ func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.UUID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
@@ -437,45 +437,6 @@ func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func
 	return c
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
-}
-
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetApplicationLifeByName mocks base method.
 func (m *MockApplicationService) GetApplicationLifeByName(arg0 context.Context, arg1 string) (life.Value, error) {
 	m.ctrl.T.Helper()
@@ -589,6 +550,45 @@ func (c *MockApplicationServiceGetApplicationTrustSettingCall) Do(f func(context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetApplicationTrustSettingCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockApplicationServiceGetApplicationTrustSettingCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/internal/charms/appcharminfo_test.go
+++ b/apiserver/internal/charms/appcharminfo_test.go
@@ -61,8 +61,8 @@ func (s *appCharmInfoSuite) TestApplicationCharmInfo(c *tc.C) {
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	s.appService.EXPECT().GetApplicationIDByName(gomock.Any(), "fuu").Return(id, nil)
-	s.appService.EXPECT().GetCharmByApplicationID(gomock.Any(), id).Return(charmBase, locator, nil)
+	s.appService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "fuu").Return(id, nil)
+	s.appService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), id).Return(charmBase, locator, nil)
 
 	// Make the ApplicationCharmInfo call
 	api, err := charms.NewApplicationCharmInfoAPI(internaltesting.ModelTag, s.appService, s.authorizer)
@@ -94,8 +94,8 @@ func (s *appCharmInfoSuite) TestApplicationCharmInfoMinimal(c *tc.C) {
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	s.appService.EXPECT().GetApplicationIDByName(gomock.Any(), "fuu").Return(id, nil)
-	s.appService.EXPECT().GetCharmByApplicationID(gomock.Any(), id).Return(charmBase, locator, nil)
+	s.appService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "fuu").Return(id, nil)
+	s.appService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), id).Return(charmBase, locator, nil)
 
 	// Make the ApplicationCharmInfo call
 	api, err := charms.NewApplicationCharmInfoAPI(internaltesting.ModelTag, s.appService, s.authorizer)

--- a/apiserver/internal/charms/common.go
+++ b/apiserver/internal/charms/common.go
@@ -81,12 +81,12 @@ func (a *CharmInfoAPI) CharmInfo(ctx context.Context, args params.CharmURL) (par
 // ApplicationService is the interface that the ApplicationCharmInfoAPI
 // requires to fetch charm information for an application.
 type ApplicationService interface {
-	// GetApplicationIDByName returns a application ID by application name. It
-	// returns an error if the application can not be found by the name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
-	// GetCharmByApplicationID returns the charm for the specified application
-	// ID.
-	GetCharmByApplicationID(context.Context, coreapplication.UUID) (charm.Charm, applicationcharm.CharmLocator, error)
+	// GetApplicationUUIDByName returns a application UUID by application name.
+	// It returns an error if the application can not be found by the name.
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	// GetCharmByApplicationUUID returns the charm for the specified application
+	// UUID.
+	GetCharmByApplicationUUID(context.Context, coreapplication.UUID) (charm.Charm, applicationcharm.CharmLocator, error)
 }
 
 // ApplicationCharmInfoAPI implements the ApplicationCharmInfo endpoint.
@@ -119,14 +119,14 @@ func (a *ApplicationCharmInfoAPI) ApplicationCharmInfo(ctx context.Context, args
 	// Application name is used to fetch the charm information.
 	appName := appTag.Id()
 
-	appID, err := a.service.GetApplicationIDByName(ctx, appName)
+	appID, err := a.service.GetApplicationUUIDByName(ctx, appName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return params.Charm{}, errors.NotFoundf("application %q", appName)
 	} else if err != nil {
 		return params.Charm{}, errors.Trace(err)
 	}
 
-	ch, locator, err := a.service.GetCharmByApplicationID(ctx, appID)
+	ch, locator, err := a.service.GetCharmByApplicationUUID(ctx, appID)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return params.Charm{}, errors.NotFoundf("application %q", appName)
 	} else if err != nil {

--- a/apiserver/internal/charms/common.go
+++ b/apiserver/internal/charms/common.go
@@ -83,10 +83,10 @@ func (a *CharmInfoAPI) CharmInfo(ctx context.Context, args params.CharmURL) (par
 type ApplicationService interface {
 	// GetApplicationIDByName returns a application ID by application name. It
 	// returns an error if the application can not be found by the name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 	// GetCharmByApplicationID returns the charm for the specified application
 	// ID.
-	GetCharmByApplicationID(context.Context, coreapplication.ID) (charm.Charm, applicationcharm.CharmLocator, error)
+	GetCharmByApplicationID(context.Context, coreapplication.UUID) (charm.Charm, applicationcharm.CharmLocator, error)
 }
 
 // ApplicationCharmInfoAPI implements the ApplicationCharmInfo endpoint.

--- a/apiserver/internal/charms/mocks/mocks.go
+++ b/apiserver/internal/charms/mocks/mocks.go
@@ -107,10 +107,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -128,25 +128,25 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetCharmByApplicationID mocks base method.
-func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.ID) (charm0.Charm, charm.CharmLocator, error) {
+func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmByApplicationID", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Charm)
@@ -174,13 +174,13 @@ func (c *MockApplicationServiceGetCharmByApplicationIDCall) Return(arg0 charm0.C
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.ID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.ID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/internal/charms/mocks/mocks.go
+++ b/apiserver/internal/charms/mocks/mocks.go
@@ -106,81 +106,81 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// GetCharmByApplicationID mocks base method.
-func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
+// GetCharmByApplicationUUID mocks base method.
+func (m *MockApplicationService) GetCharmByApplicationUUID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmByApplicationID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetCharmByApplicationUUID", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Charm)
 	ret1, _ := ret[1].(charm.CharmLocator)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetCharmByApplicationID indicates an expected call of GetCharmByApplicationID.
-func (mr *MockApplicationServiceMockRecorder) GetCharmByApplicationID(arg0, arg1 any) *MockApplicationServiceGetCharmByApplicationIDCall {
+// GetCharmByApplicationUUID indicates an expected call of GetCharmByApplicationUUID.
+func (mr *MockApplicationServiceMockRecorder) GetCharmByApplicationUUID(arg0, arg1 any) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationID", reflect.TypeOf((*MockApplicationService)(nil).GetCharmByApplicationID), arg0, arg1)
-	return &MockApplicationServiceGetCharmByApplicationIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationUUID", reflect.TypeOf((*MockApplicationService)(nil).GetCharmByApplicationUUID), arg0, arg1)
+	return &MockApplicationServiceGetCharmByApplicationUUIDCall{Call: call}
 }
 
-// MockApplicationServiceGetCharmByApplicationIDCall wrap *gomock.Call
-type MockApplicationServiceGetCharmByApplicationIDCall struct {
+// MockApplicationServiceGetCharmByApplicationUUIDCall wrap *gomock.Call
+type MockApplicationServiceGetCharmByApplicationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Return(arg0 charm0.Charm, arg1 charm.CharmLocator, arg2 error) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) Return(arg0 charm0.Charm, arg1 charm.CharmLocator, arg2 error) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/core/application/id.go
+++ b/core/application/id.go
@@ -48,6 +48,6 @@ func (u UUID) Validate() error {
 }
 
 // IsEmpty returns true if the ID is empty.
-func (u ID) IsEmpty() bool {
+func (u UUID) IsEmpty() bool {
 	return u == ""
 }

--- a/core/application/id.go
+++ b/core/application/id.go
@@ -9,35 +9,35 @@ import (
 	"github.com/juju/juju/internal/uuid"
 )
 
-// ID represents a application unique identifier.
-type ID string
+// UUID represents a application unique identifier.
+type UUID string
 
 // NewID is a convenience function for generating a new application uuid.
-func NewID() (ID, error) {
+func NewID() (UUID, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return ID(""), err
+		return UUID(""), err
 	}
-	return ID(uuid.String()), nil
+	return UUID(uuid.String()), nil
 }
 
 // ParseID returns a new ID from the given string. If the string is not a valid
 // uuid an error satisfying [errors.NotValid] will be returned.
-func ParseID(value string) (ID, error) {
+func ParseID(value string) (UUID, error) {
 	if !uuid.IsValidUUIDString(value) {
 		return "", errors.Errorf("id %q %w", value, coreerrors.NotValid)
 	}
-	return ID(value), nil
+	return UUID(value), nil
 }
 
 // String implements the stringer interface for ID.
-func (u ID) String() string {
+func (u UUID) String() string {
 	return string(u)
 }
 
 // Validate ensures the consistency of the ID. If the uuid is invalid an error
 // satisfying [errors.NotValid] will be returned.
-func (u ID) Validate() error {
+func (u UUID) Validate() error {
 	if u == "" {
 		return errors.Errorf("id cannot be empty").Add(coreerrors.NotValid)
 	}

--- a/core/application/id_test.go
+++ b/core/application/id_test.go
@@ -41,7 +41,7 @@ func (*ApplicationSuite) TestIDValidate(c *tc.C) {
 
 	for i, test := range tests {
 		c.Logf("test %d: %q", i, test.uuid)
-		err := ID(test.uuid).Validate()
+		err := UUID(test.uuid).Validate()
 
 		if test.err == nil {
 			c.Check(err, tc.IsNil)

--- a/core/application/testing/testing.go
+++ b/core/application/testing/testing.go
@@ -11,7 +11,7 @@ import (
 
 // GenApplicationUUID can be used in testing for generating a application id
 // that is checked for subsequent errors using the test suits go check instance.
-func GenApplicationUUID(c *tc.C) coreapplication.ID {
+func GenApplicationUUID(c *tc.C) coreapplication.UUID {
 	uuid, err := coreapplication.NewID()
 	c.Assert(err, tc.ErrorIsNil)
 	return uuid

--- a/core/application/testing/testing.go
+++ b/core/application/testing/testing.go
@@ -9,7 +9,7 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 )
 
-// GenApplicationUUID can be used in testing for generating a application id
+// GenApplicationUUID can be used in testing for generating a application UUID
 // that is checked for subsequent errors using the test suits go check instance.
 func GenApplicationUUID(c *tc.C) coreapplication.UUID {
 	uuid, err := coreapplication.NewID()

--- a/core/network/testing/testing.go
+++ b/core/network/testing/testing.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/juju/core/network"
 )
 
-// GenApplicationUUID can be used in testing for generating a application id
+// GenApplicationUUID can be used in testing for generating a application UUID
 // that is checked for subsequent errors using the test suits go check instance.
 func GenSpaceUUID(c *tc.C) network.SpaceUUID {
 	uuid, err := network.NewSpaceUUID()

--- a/domain/agentpassword/service/service.go
+++ b/domain/agentpassword/service/service.go
@@ -50,10 +50,10 @@ type ModelState interface {
 	// password hash stored in the database.
 	MatchesApplicationPasswordHash(context.Context, application.UUID, agentpassword.PasswordHash) (bool, error)
 
-	// GetApplicationIDByName returns the application ID for the named application.
+	// GetApplicationUUIDByName returns the application ID for the named application.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationIDByName(ctx context.Context, name string) (application.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (application.UUID, error)
 
 	// SetModelPasswordHash sets the password hash for the model overriding any
 	// previously set value.
@@ -286,7 +286,7 @@ func (s *Service) MatchesApplicationPasswordHash(ctx context.Context, appName st
 		return false, errors.Errorf("password is only %d bytes long, and is not a valid Agent password: %w", len(password), passworderrors.InvalidPassword)
 	}
 
-	appID, err := s.modelState.GetApplicationIDByName(ctx, appName)
+	appID, err := s.modelState.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return false, errors.Capture(err)
 	}

--- a/domain/agentpassword/service/service.go
+++ b/domain/agentpassword/service/service.go
@@ -50,7 +50,7 @@ type ModelState interface {
 	// password hash stored in the database.
 	MatchesApplicationPasswordHash(context.Context, application.UUID, agentpassword.PasswordHash) (bool, error)
 
-	// GetApplicationUUIDByName returns the application ID for the named application.
+	// GetApplicationUUIDByName returns the application UUID for the named application.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationUUIDByName(ctx context.Context, name string) (application.UUID, error)

--- a/domain/agentpassword/service/service.go
+++ b/domain/agentpassword/service/service.go
@@ -44,16 +44,16 @@ type ModelState interface {
 	IsMachineController(context.Context, machine.Name) (bool, error)
 
 	// SetApplicationPasswordHash sets the password hash for the given application.
-	SetApplicationPasswordHash(context.Context, application.ID, agentpassword.PasswordHash) error
+	SetApplicationPasswordHash(context.Context, application.UUID, agentpassword.PasswordHash) error
 
 	// MatchesApplicationPasswordHash checks if the password is valid or not against the
 	// password hash stored in the database.
-	MatchesApplicationPasswordHash(context.Context, application.ID, agentpassword.PasswordHash) (bool, error)
+	MatchesApplicationPasswordHash(context.Context, application.UUID, agentpassword.PasswordHash) (bool, error)
 
 	// GetApplicationIDByName returns the application ID for the named application.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationIDByName(ctx context.Context, name string) (application.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (application.UUID, error)
 
 	// SetModelPasswordHash sets the password hash for the model overriding any
 	// previously set value.
@@ -262,7 +262,7 @@ func (s *Service) MatchesControllerNodePasswordHash(ctx context.Context, id, pas
 // SetApplicationPassword sets the password for the given application. If the
 // app does not exist, an error satisfying [applicationerrors.ApplicationNotFound]
 // is returned.
-func (s *Service) SetApplicationPassword(ctx context.Context, appID application.ID, password string) error {
+func (s *Service) SetApplicationPassword(ctx context.Context, appID application.UUID, password string) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/agentpassword/service/service_test.go
+++ b/domain/agentpassword/service/service_test.go
@@ -444,7 +444,7 @@ func (s *serviceSuite) TestMatchesApplicationPasswordHash(c *tc.C) {
 	password, err := internalpassword.RandomPassword()
 	c.Assert(err, tc.ErrorIsNil)
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(appID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appID, nil)
 	s.modelState.EXPECT().MatchesApplicationPasswordHash(gomock.Any(), appID, hashPassword(password)).Return(true, nil)
 
 	service := NewService(s.modelState, s.controllerState)
@@ -463,7 +463,7 @@ func (s *serviceSuite) TestMatchesApplicationPasswordHashNotFound(c *tc.C) {
 	password, err := internalpassword.RandomPassword()
 	c.Assert(err, tc.ErrorIsNil)
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(appID, applicationerrors.ApplicationNotFound)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appID, applicationerrors.ApplicationNotFound)
 
 	service := NewService(s.modelState, s.controllerState)
 	valid, err := service.MatchesApplicationPasswordHash(c.Context(), appName, password)
@@ -481,7 +481,7 @@ func (s *serviceSuite) TestMatchesApplicationPasswordHashNotMatch(c *tc.C) {
 	password, err := internalpassword.RandomPassword()
 	c.Assert(err, tc.ErrorIsNil)
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(appID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appID, nil)
 	s.modelState.EXPECT().MatchesApplicationPasswordHash(gomock.Any(), appID, hashPassword(password)).Return(false, nil)
 
 	service := NewService(s.modelState, s.controllerState)

--- a/domain/agentpassword/service/state_mock_test.go
+++ b/domain/agentpassword/service/state_mock_test.go
@@ -44,10 +44,10 @@ func (m *MockModelState) EXPECT() *MockModelStateMockRecorder {
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockModelState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockModelState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -65,19 +65,19 @@ type MockModelStateGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockModelStateGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -200,7 +200,7 @@ func (c *MockModelStateIsMachineControllerCall) DoAndReturn(f func(context.Conte
 }
 
 // MatchesApplicationPasswordHash mocks base method.
-func (m *MockModelState) MatchesApplicationPasswordHash(arg0 context.Context, arg1 application.ID, arg2 agentpassword.PasswordHash) (bool, error) {
+func (m *MockModelState) MatchesApplicationPasswordHash(arg0 context.Context, arg1 application.UUID, arg2 agentpassword.PasswordHash) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MatchesApplicationPasswordHash", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -227,13 +227,13 @@ func (c *MockModelStateMatchesApplicationPasswordHashCall) Return(arg0 bool, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateMatchesApplicationPasswordHashCall) Do(f func(context.Context, application.ID, agentpassword.PasswordHash) (bool, error)) *MockModelStateMatchesApplicationPasswordHashCall {
+func (c *MockModelStateMatchesApplicationPasswordHashCall) Do(f func(context.Context, application.UUID, agentpassword.PasswordHash) (bool, error)) *MockModelStateMatchesApplicationPasswordHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateMatchesApplicationPasswordHashCall) DoAndReturn(f func(context.Context, application.ID, agentpassword.PasswordHash) (bool, error)) *MockModelStateMatchesApplicationPasswordHashCall {
+func (c *MockModelStateMatchesApplicationPasswordHashCall) DoAndReturn(f func(context.Context, application.UUID, agentpassword.PasswordHash) (bool, error)) *MockModelStateMatchesApplicationPasswordHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -356,7 +356,7 @@ func (c *MockModelStateMatchesUnitPasswordHashCall) DoAndReturn(f func(context.C
 }
 
 // SetApplicationPasswordHash mocks base method.
-func (m *MockModelState) SetApplicationPasswordHash(arg0 context.Context, arg1 application.ID, arg2 agentpassword.PasswordHash) error {
+func (m *MockModelState) SetApplicationPasswordHash(arg0 context.Context, arg1 application.UUID, arg2 agentpassword.PasswordHash) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetApplicationPasswordHash", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -382,13 +382,13 @@ func (c *MockModelStateSetApplicationPasswordHashCall) Return(arg0 error) *MockM
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateSetApplicationPasswordHashCall) Do(f func(context.Context, application.ID, agentpassword.PasswordHash) error) *MockModelStateSetApplicationPasswordHashCall {
+func (c *MockModelStateSetApplicationPasswordHashCall) Do(f func(context.Context, application.UUID, agentpassword.PasswordHash) error) *MockModelStateSetApplicationPasswordHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateSetApplicationPasswordHashCall) DoAndReturn(f func(context.Context, application.ID, agentpassword.PasswordHash) error) *MockModelStateSetApplicationPasswordHashCall {
+func (c *MockModelStateSetApplicationPasswordHashCall) DoAndReturn(f func(context.Context, application.UUID, agentpassword.PasswordHash) error) *MockModelStateSetApplicationPasswordHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/agentpassword/service/state_mock_test.go
+++ b/domain/agentpassword/service/state_mock_test.go
@@ -43,41 +43,41 @@ func (m *MockModelState) EXPECT() *MockModelStateMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockModelState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockModelState) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockModelStateMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockModelStateGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockModelStateMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockModelStateGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockModelState)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockModelStateGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockModelState)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockModelStateGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockModelStateGetApplicationIDByNameCall wrap *gomock.Call
-type MockModelStateGetApplicationIDByNameCall struct {
+// MockModelStateGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockModelStateGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockModelStateGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/agentpassword/state/modelstate.go
+++ b/domain/agentpassword/state/modelstate.go
@@ -482,7 +482,7 @@ func (s *ModelState) getMachineUUIDFromName(ctx context.Context, tx *sqlair.TX, 
 
 // SetApplicationPasswordHash sets the password hash for the given application.
 func (s *ModelState) SetApplicationPasswordHash(
-	ctx context.Context, appID application.ID, passwordHash agentpassword.PasswordHash,
+	ctx context.Context, appID application.UUID, passwordHash agentpassword.PasswordHash,
 ) error {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -537,7 +537,7 @@ UPDATE SET  password_hash = $entityPasswordHash.password_hash,
 // MatchesApplicationPasswordHash checks if the password is valid or not against the
 // password hash stored in the database.
 func (s *ModelState) MatchesApplicationPasswordHash(
-	ctx context.Context, appID application.ID, passwordHash agentpassword.PasswordHash,
+	ctx context.Context, appID application.UUID, passwordHash agentpassword.PasswordHash,
 ) (bool, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -573,7 +573,7 @@ AND    password_hash = $validatePasswordHash.password_hash;
 // GetApplicationIDByName returns the application ID for the named application.
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
-func (s *ModelState) GetApplicationIDByName(ctx context.Context, name string) (application.ID, error) {
+func (s *ModelState) GetApplicationIDByName(ctx context.Context, name string) (application.UUID, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)

--- a/domain/agentpassword/state/modelstate.go
+++ b/domain/agentpassword/state/modelstate.go
@@ -570,10 +570,10 @@ AND    password_hash = $validatePasswordHash.password_hash;
 	return count > 0, errors.Capture(err)
 }
 
-// GetApplicationIDByName returns the application ID for the named application.
+// GetApplicationUUIDByName returns the application ID for the named application.
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
-func (s *ModelState) GetApplicationIDByName(ctx context.Context, name string) (application.UUID, error) {
+func (s *ModelState) GetApplicationUUIDByName(ctx context.Context, name string) (application.UUID, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)

--- a/domain/agentpassword/state/modelstate.go
+++ b/domain/agentpassword/state/modelstate.go
@@ -570,7 +570,7 @@ AND    password_hash = $validatePasswordHash.password_hash;
 	return count > 0, errors.Capture(err)
 }
 
-// GetApplicationUUIDByName returns the application ID for the named application.
+// GetApplicationUUIDByName returns the application UUID for the named application.
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
 func (s *ModelState) GetApplicationUUIDByName(ctx context.Context, name string) (application.UUID, error) {

--- a/domain/agentpassword/state/modelstate_test.go
+++ b/domain/agentpassword/state/modelstate_test.go
@@ -583,7 +583,7 @@ func (s *modelStateSuite) genPasswordHash(c *tc.C) agentpassword.PasswordHash {
 	return agentpassword.PasswordHash(internalpassword.AgentPasswordHash(rand))
 }
 
-func (s *modelStateSuite) createApplication(c *tc.C, controller bool) coreapplication.ID {
+func (s *modelStateSuite) createApplication(c *tc.C, controller bool) coreapplication.UUID {
 	applicationSt := applicationstate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 	appID, _, err := applicationSt.CreateIAASApplication(c.Context(), "foo", application.AddIAASApplicationArg{
 		BaseAddApplicationArg: application.BaseAddApplicationArg{

--- a/domain/agentpassword/state/modelstate_test.go
+++ b/domain/agentpassword/state/modelstate_test.go
@@ -491,23 +491,23 @@ func (s *modelStateSuite) TestSetApplicationPassword(c *tc.C) {
 	c.Assert(hash, tc.Equals, string(passwordHash))
 }
 
-// TestGetApplicationIDByName asserts that an application ID can be found by name.
-func (s *modelStateSuite) TestGetApplicationIDByName(c *tc.C) {
+// TestGetApplicationUUIDByName asserts that an application ID can be found by name.
+func (s *modelStateSuite) TestGetApplicationUUIDByName(c *tc.C) {
 	st := NewModelState(s.TxnRunnerFactory())
 
 	appID := s.createApplication(c, false)
 
-	gotAppID, err := st.GetApplicationIDByName(c.Context(), "foo")
+	gotAppID, err := st.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(gotAppID, tc.Equals, appID)
 }
 
-// TestGetApplicationIDByNameNotFound asserts that an application not found error
+// TestGetApplicationUUIDByNameNotFound asserts that an application not found error
 // is returned when the named application cannot be found.
-func (s *modelStateSuite) TestGetApplicationIDByNameNotFound(c *tc.C) {
+func (s *modelStateSuite) TestGetApplicationUUIDByNameNotFound(c *tc.C) {
 	st := NewModelState(s.TxnRunnerFactory())
 
-	_, err := st.GetApplicationIDByName(c.Context(), "foo")
+	_, err := st.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
@@ -642,7 +642,7 @@ func (s *modelStateSuite) createUnit(c *tc.C) unit.Name {
 	ctx := c.Context()
 	applicationSt := applicationstate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
-	appID, err := applicationSt.GetApplicationIDByName(ctx, "foo")
+	appID, err := applicationSt.GetApplicationUUIDByName(ctx, "foo")
 	c.Assert(err, tc.ErrorIsNil)
 
 	netNodeUUID := tc.Must(c, network.NewNetNodeUUID)

--- a/domain/agentpassword/state/modelstate_test.go
+++ b/domain/agentpassword/state/modelstate_test.go
@@ -491,7 +491,7 @@ func (s *modelStateSuite) TestSetApplicationPassword(c *tc.C) {
 	c.Assert(hash, tc.Equals, string(passwordHash))
 }
 
-// TestGetApplicationUUIDByName asserts that an application ID can be found by name.
+// TestGetApplicationUUIDByName asserts that an application UUID can be found by name.
 func (s *modelStateSuite) TestGetApplicationUUIDByName(c *tc.C) {
 	st := NewModelState(s.TxnRunnerFactory())
 

--- a/domain/agentpassword/state/types.go
+++ b/domain/agentpassword/state/types.go
@@ -77,5 +77,5 @@ type applicationID struct {
 
 type applicationIDAndName struct {
 	ID   application.UUID `db:"uuid"`
-	Name string         `db:"name"`
+	Name string           `db:"name"`
 }

--- a/domain/agentpassword/state/types.go
+++ b/domain/agentpassword/state/types.go
@@ -72,10 +72,10 @@ type modelPasswordHash struct {
 }
 
 type applicationID struct {
-	ID application.ID `db:"uuid"`
+	ID application.UUID `db:"uuid"`
 }
 
 type applicationIDAndName struct {
-	ID   application.ID `db:"uuid"`
+	ID   application.UUID `db:"uuid"`
 	Name string         `db:"name"`
 }

--- a/domain/annotation/state/state_test.go
+++ b/domain/annotation/state/state_test.go
@@ -147,7 +147,7 @@ func (s *stateSuite) TestSetAnnotationsUpdateMachine(c *tc.C) {
 }
 
 // TestSetAnnotationsUpdateApplication asserts the happy path, updates some
-// annotations in the DB for an Application ID.
+// annotations in the DB for an Application UUID.
 func (s *stateSuite) TestSetAnnotationsUpdateApplication(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -50,9 +50,9 @@ const (
 	// not valid.
 	ApplicationNameNotValid = errors.ConstError("application name not valid")
 
-	// ApplicationIDNotValid describes an error when the application ID is
+	// ApplicationUUIDNotValid describes an error when the application UUID is
 	// not valid.
-	ApplicationIDNotValid = errors.ConstError("application ID not valid")
+	ApplicationUUIDNotValid = errors.ConstError("application UUID not valid")
 
 	// UnitNotFound describes an error that occurs when the unit being operated
 	// on does not exist.

--- a/domain/application/modelmigration/export.go
+++ b/domain/application/modelmigration/export.go
@@ -78,7 +78,7 @@ type ExportService interface {
 	// GetApplicationConstraints returns the application constraints for the
 	// specified application name.
 	// Empty constraints are returned if no constraints exist for the given
-	// application ID.
+	// application UUID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationConstraints(ctx context.Context, name string) (constraints.Value, error)

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -55,10 +55,11 @@ type ApplicationState interface {
 	// - [applicationerrors.ApplicationNotFound] if the application does not exist
 	GetApplicationName(context.Context, coreapplication.UUID) (string, error)
 
-	// GetApplicationIDByName returns the application ID for the named application.
+	// GetApplicationUUIDByName returns the application UUID for the named
+	// application.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// CreateIAASApplication creates an application. Returns the application ID,
 	// along with any machine names created.
@@ -130,12 +131,12 @@ type ApplicationState interface {
 	// [applicationerrors.ScaleChangeInvalid] is returned.
 	UpdateApplicationScale(ctx context.Context, appUUID coreapplication.UUID, delta int) (int, error)
 
-	// GetCharmByApplicationID returns the charm, charm origin and charm
-	// platform for the specified application ID.
+	// GetCharmByApplicationUUID returns the charm, charm origin and charm
+	// platform for the specified application UUID.
 	//
 	// If the application does not exist, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetCharmByApplicationID(context.Context, coreapplication.UUID) (charm.Charm, error)
+	GetCharmByApplicationUUID(context.Context, coreapplication.UUID) (charm.Charm, error)
 
 	// GetCharmIDByApplicationName returns a charm ID by application name. It
 	// returns an error if the charm can not be found by the name. This can also
@@ -147,15 +148,15 @@ type ApplicationState interface {
 	// the provided parameters and validates changes.
 	SetApplicationCharm(ctx context.Context, appID coreapplication.UUID, charmID corecharm.ID, params application.SetCharmParams) error
 
-	// GetApplicationIDByUnitName returns the application ID for the named unit,
+	// GetApplicationUUIDByUnitName returns the application UUID for the named unit,
 	// returning an error satisfying [applicationerrors.UnitNotFound] if the
 	// unit doesn't exist.
-	GetApplicationIDByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, error)
+	GetApplicationUUIDByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, error)
 
-	// GetApplicationIDAndNameByUnitName returns the application ID and name for
+	// GetApplicationUUIDAndNameByUnitName returns the application UUID and name for
 	// the named unit, returning an error satisfying
 	// [applicationerrors.UnitNotFound] if the unit doesn't exist.
-	GetApplicationIDAndNameByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, string, error)
+	GetApplicationUUIDAndNameByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, string, error)
 
 	// GetCharmModifiedVersion looks up the charm modified version of the given
 	// application. Returns [applicationerrors.ApplicationNotFound] if the
@@ -183,13 +184,13 @@ type ApplicationState interface {
 	// This will return an empty slice if there are no applications.
 	GetApplicationsForRevisionUpdater(ctx context.Context) ([]application.RevisionUpdaterApplication, error)
 
-	// GetCharmConfigByApplicationID returns the charm config for the specified
-	// application ID.
+	// GetCharmConfigByApplicationUUID returns the charm config for the
+	// specified application UUID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	// If the charm for the application does not exist, an error satisfying
 	// [applicationerrors.CharmNotFoundError] is returned.
-	GetCharmConfigByApplicationID(ctx context.Context, appID coreapplication.UUID) (corecharm.ID, charm.Config, error)
+	GetCharmConfigByApplicationUUID(ctx context.Context, appID coreapplication.UUID) (corecharm.ID, charm.Config, error)
 
 	// GetApplicationConfigAndSettings returns the application config and
 	// settings attributes for the application ID.
@@ -834,17 +835,17 @@ func validateApplicationStorageDirective(
 	return nil
 }
 
-// GetApplicationIDByUnitName returns the application ID for the named unit,
+// GetApplicationUUIDByUnitName returns the application UUID for the named unit,
 // returning an error satisfying [applicationerrors.UnitNotFound] if the unit
 // doesn't exist.
-func (s *Service) GetApplicationIDByUnitName(
+func (s *Service) GetApplicationUUIDByUnitName(
 	ctx context.Context,
 	unitName coreunit.Name,
 ) (coreapplication.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	id, err := s.st.GetApplicationIDByUnitName(ctx, unitName)
+	id, err := s.st.GetApplicationUUIDByUnitName(ctx, unitName)
 	if err != nil {
 		return "", errors.Errorf("getting application id: %w", err)
 	}
@@ -960,7 +961,7 @@ func (s *Service) SetApplicationCharm(ctx context.Context, appName string, charm
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return errors.Errorf("getting application ID: %w", err)
 	}
@@ -993,12 +994,12 @@ func (s *Service) GetApplicationName(ctx context.Context, appID coreapplication.
 	return name, nil
 }
 
-// GetApplicationIDByName returns an application ID by application name. It
+// GetApplicationUUIDByName returns an application UUID by application name. It
 // returns an error if the application can not be found by the name.
 //
 // Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
 // and [applicationerrors.ApplicationNotFound] if the application is not found.
-func (s *Service) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
+func (s *Service) GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1006,7 +1007,7 @@ func (s *Service) GetApplicationIDByName(ctx context.Context, name string) (core
 		return "", applicationerrors.ApplicationNameNotValid
 	}
 
-	appID, err := s.st.GetApplicationIDByName(ctx, name)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return "", errors.Capture(err)
 	}
@@ -1053,14 +1054,14 @@ func (s *Service) GetCharmModifiedVersion(ctx context.Context, id coreapplicatio
 	return charmModifiedVersion, nil
 }
 
-// GetCharmByApplicationID returns the charm for the specified application
-// ID.
+// GetCharmByApplicationUUID returns the charm for the specified application
+// UUID.
 //
 // If the application does not exist, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned. If the application name
 // is not valid, an error satisfying [applicationerrors.ApplicationNameNotValid]
 // is returned.
-func (s *Service) GetCharmByApplicationID(ctx context.Context, id coreapplication.UUID) (
+func (s *Service) GetCharmByApplicationUUID(ctx context.Context, id coreapplication.UUID) (
 	internalcharm.Charm,
 	charm.CharmLocator,
 	error,
@@ -1072,7 +1073,7 @@ func (s *Service) GetCharmByApplicationID(ctx context.Context, id coreapplicatio
 		return nil, charm.CharmLocator{}, errors.Errorf("application ID: %w", err).Add(applicationerrors.ApplicationIDNotValid)
 	}
 
-	ch, err := s.st.GetCharmByApplicationID(ctx, id)
+	ch, err := s.st.GetCharmByApplicationUUID(ctx, id)
 	if err != nil {
 		return nil, charm.CharmLocator{}, errors.Capture(err)
 	}
@@ -1193,7 +1194,7 @@ func (s *Service) IsSubordinateApplication(ctx context.Context, appUUID coreappl
 // The following errors may be returned:
 // - [appliationerrors.ApplicationNotFound] if the application does not exist
 func (s *Service) IsSubordinateApplicationByName(ctx context.Context, appName string) (bool, error) {
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return false, errors.Capture(err)
 	}
@@ -1210,7 +1211,7 @@ func (s *Service) SetApplicationScale(ctx context.Context, appName string, scale
 	if scale < 0 {
 		return errors.Errorf("application scale %d not valid", scale).Add(applicationerrors.ScaleChangeInvalid)
 	}
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -1235,7 +1236,7 @@ func (s *Service) GetApplicationScale(ctx context.Context, appName string) (int,
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return -1, errors.Capture(err)
 	}
@@ -1269,7 +1270,7 @@ func (s *Service) ChangeApplicationScale(ctx context.Context, appName string, sc
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return -1, errors.Capture(err)
 	}
@@ -1301,7 +1302,7 @@ func (s *Service) GetApplicationScalingState(ctx context.Context, appName string
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return ScalingState{}, errors.Capture(err)
 	}
@@ -1515,7 +1516,7 @@ func (s *Service) GetApplicationTrustSetting(ctx context.Context, appName string
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return false, errors.Capture(err)
 	}
@@ -1531,7 +1532,7 @@ func (s *Service) GetApplicationCharmOrigin(ctx context.Context, name string) (c
 		return corecharm.Origin{}, applicationerrors.ApplicationNameNotValid
 	}
 
-	appID, err := s.st.GetApplicationIDByName(ctx, name)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return corecharm.Origin{}, errors.Capture(err)
 	}
@@ -1564,7 +1565,7 @@ func (s *Service) GetApplicationAndCharmConfig(ctx context.Context, appID coreap
 		return ApplicationConfig{}, errors.Errorf("decoding application config: %w", err)
 	}
 
-	charmID, charmConfig, err := s.st.GetCharmConfigByApplicationID(ctx, appID)
+	charmID, charmConfig, err := s.st.GetCharmConfigByApplicationUUID(ctx, appID)
 	if err != nil {
 		return ApplicationConfig{}, errors.Capture(err)
 	}
@@ -1642,7 +1643,7 @@ func (s *Service) UpdateApplicationConfig(ctx context.Context, appID coreapplica
 	// Return back the charm UUID, so that we can verify that the charm
 	// hasn't changed between this call and the transaction to set it.
 
-	_, cfg, err := s.st.GetCharmConfigByApplicationID(ctx, appID)
+	_, cfg, err := s.st.GetCharmConfigByApplicationUUID(ctx, appID)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -1729,7 +1730,7 @@ func (s *Service) GetApplicationEndpointBindings(ctx context.Context, appName st
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -1790,7 +1791,7 @@ func (s *Service) GetDeviceConstraints(ctx context.Context, name string) (map[st
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, name)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -1815,7 +1816,7 @@ func (s *Service) GetMachinesForApplication(ctx context.Context, appName string)
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appUUID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, errors.Errorf("getting application ID for application %q: %w", appName, err)
 	}

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -61,7 +61,7 @@ type ApplicationState interface {
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
-	// CreateIAASApplication creates an application. Returns the application ID,
+	// CreateIAASApplication creates an application. Returns the application UUID,
 	// along with any machine names created.
 	CreateIAASApplication(
 		context.Context,
@@ -193,7 +193,7 @@ type ApplicationState interface {
 	GetCharmConfigByApplicationUUID(ctx context.Context, appID coreapplication.UUID) (corecharm.ID, charm.Config, error)
 
 	// GetApplicationConfigAndSettings returns the application config and
-	// settings attributes for the application ID.
+	// settings attributes for the application UUID.
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
@@ -238,7 +238,7 @@ type ApplicationState interface {
 	UnsetApplicationConfigKeys(ctx context.Context, appID coreapplication.UUID, keys []string) error
 
 	// GetApplicationConfigHash returns the SHA256 hash of the application config
-	// for the specified application ID.
+	// for the specified application UUID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationConfigHash(ctx context.Context, appID coreapplication.UUID) (string, error)
@@ -283,15 +283,15 @@ type ApplicationState interface {
 	GetNetNodeUUIDByUnitName(ctx context.Context, name coreunit.Name) (string, error)
 
 	// GetApplicationConstraints returns the application constraints for the
-	// specified application ID.
+	// specified application UUID.
 	// Empty constraints are returned if no constraints exist for the given
-	// application ID.
+	// application UUID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (constraints.Constraints, error)
 
 	// SetApplicationConstraints sets the application constraints for the
-	// specified application ID.
+	// specified application UUID.
 	// This method overwrites the full constraints on every call.
 	// If invalid constraints are provided (e.g. invalid container type or
 	// non-existing space), a [applicationerrors.InvalidApplicationConstraints]
@@ -301,7 +301,7 @@ type ApplicationState interface {
 	SetApplicationConstraints(ctx context.Context, appID coreapplication.UUID, cons constraints.Constraints) error
 
 	// GetApplicationCharmOrigin returns the platform and channel for the
-	// specified application ID.
+	// specified application UUID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationCharmOrigin(ctx context.Context, appID coreapplication.UUID) (application.CharmOrigin, error)
@@ -847,7 +847,7 @@ func (s *Service) GetApplicationUUIDByUnitName(
 
 	id, err := s.st.GetApplicationUUIDByUnitName(ctx, unitName)
 	if err != nil {
-		return "", errors.Errorf("getting application id: %w", err)
+		return "", errors.Errorf("getting application UUID: %w", err)
 	}
 	return id, nil
 }
@@ -963,7 +963,7 @@ func (s *Service) SetApplicationCharm(ctx context.Context, appName string, charm
 
 	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
-		return errors.Errorf("getting application ID: %w", err)
+		return errors.Errorf("getting application UUID: %w", err)
 	}
 	charmID, err := s.st.GetCharmID(ctx, charmLocator.Name, charmLocator.Revision, charmLocator.Source)
 	if err != nil {
@@ -984,7 +984,7 @@ func (s *Service) GetApplicationName(ctx context.Context, appID coreapplication.
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return "", errors.Errorf("application ID: %w", err)
+		return "", errors.Errorf("application UUID: %w", err)
 	}
 
 	name, err := s.st.GetApplicationName(ctx, appID)
@@ -1070,7 +1070,7 @@ func (s *Service) GetCharmByApplicationUUID(ctx context.Context, id coreapplicat
 	defer span.End()
 
 	if err := id.Validate(); err != nil {
-		return nil, charm.CharmLocator{}, errors.Errorf("application ID: %w", err).Add(applicationerrors.ApplicationIDNotValid)
+		return nil, charm.CharmLocator{}, errors.Errorf("application UUID: %w", err).Add(applicationerrors.ApplicationUUIDNotValid)
 	}
 
 	ch, err := s.st.GetCharmByApplicationUUID(ctx, id)
@@ -1339,7 +1339,7 @@ func (s *Service) GetAsyncCharmDownloadInfo(ctx context.Context, appID coreappli
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return application.CharmDownloadInfo{}, errors.Errorf("application ID: %w", err)
+		return application.CharmDownloadInfo{}, errors.Errorf("application UUID: %w", err)
 	}
 
 	return s.st.GetAsyncCharmDownloadInfo(ctx, appID)
@@ -1355,7 +1355,7 @@ func (s *Service) ResolveCharmDownload(ctx context.Context, appID coreapplicatio
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return errors.Errorf("application ID: %w", err)
+		return errors.Errorf("application UUID: %w", err)
 	}
 
 	// Although, we're resolving the charm download, we're calling the
@@ -1494,7 +1494,7 @@ func (s *Service) GetApplicationConfigWithDefaults(ctx context.Context, appID co
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return nil, errors.Errorf("application ID: %w", err)
+		return nil, errors.Errorf("application UUID: %w", err)
 	}
 
 	cfg, err := s.st.GetApplicationConfigWithDefaults(ctx, appID)
@@ -1546,13 +1546,13 @@ func (s *Service) GetApplicationCharmOrigin(ctx context.Context, name string) (c
 }
 
 // GetApplicationAndCharmConfig returns the application and charm config for the
-// specified application ID.
+// specified application UUID.
 func (s *Service) GetApplicationAndCharmConfig(ctx context.Context, appID coreapplication.UUID) (ApplicationConfig, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return ApplicationConfig{}, errors.Errorf("application ID: %w", err)
+		return ApplicationConfig{}, errors.Errorf("application UUID: %w", err)
 	}
 
 	appConfig, settings, err := s.st.GetApplicationConfigAndSettings(ctx, appID)
@@ -1609,7 +1609,7 @@ func (s *Service) UnsetApplicationConfigKeys(ctx context.Context, appID coreappl
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return errors.Errorf("application ID: %w", err)
+		return errors.Errorf("application UUID: %w", err)
 	}
 	if len(keys) == 0 {
 		return nil
@@ -1630,7 +1630,7 @@ func (s *Service) UpdateApplicationConfig(ctx context.Context, appID coreapplica
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return errors.Errorf("application ID: %w", err)
+		return errors.Errorf("application UUID: %w", err)
 	}
 
 	// Get the charm config. This should be safe to do outside of a singular
@@ -1684,9 +1684,9 @@ func (s *Service) UpdateApplicationConfig(ctx context.Context, appID coreapplica
 }
 
 // GetApplicationConstraints returns the application constraints for the
-// specified application ID.
+// specified application UUID.
 // Empty constraints are returned if no constraints exist for the given
-// application ID.
+// application UUID.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
 func (s *Service) GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (coreconstraints.Value, error) {
@@ -1694,7 +1694,7 @@ func (s *Service) GetApplicationConstraints(ctx context.Context, appID coreappli
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return coreconstraints.Value{}, errors.Errorf("application ID: %w", err)
+		return coreconstraints.Value{}, errors.Errorf("application UUID: %w", err)
 	}
 
 	cons, err := s.st.GetApplicationConstraints(ctx, appID)
@@ -1804,7 +1804,7 @@ func (s *Service) IsControllerApplication(ctx context.Context, appID coreapplica
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return false, errors.Errorf("validating application ID: %w", err)
+		return false, errors.Errorf("validating application UUID: %w", err)
 	}
 
 	return s.st.IsControllerApplication(ctx, appID)
@@ -1818,7 +1818,7 @@ func (s *Service) GetMachinesForApplication(ctx context.Context, appName string)
 
 	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
-		return nil, errors.Errorf("getting application ID for application %q: %w", appName, err)
+		return nil, errors.Errorf("getting application UUID for application %q: %w", appName, err)
 	}
 
 	machineNames, err := s.st.GetMachinesForApplication(ctx, appUUID.String())

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -53,12 +53,12 @@ type ApplicationState interface {
 	// GetApplicationName returns the name of the specified application.
 	// The following errors may be returned:
 	// - [applicationerrors.ApplicationNotFound] if the application does not exist
-	GetApplicationName(context.Context, coreapplication.ID) (string, error)
+	GetApplicationName(context.Context, coreapplication.UUID) (string, error)
 
 	// GetApplicationIDByName returns the application ID for the named application.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// CreateIAASApplication creates an application. Returns the application ID,
 	// along with any machine names created.
@@ -67,14 +67,14 @@ type ApplicationState interface {
 		string,
 		application.AddIAASApplicationArg,
 		[]application.AddIAASUnitArg,
-	) (coreapplication.ID, []coremachine.Name, error)
+	) (coreapplication.UUID, []coremachine.Name, error)
 
 	// CreateCAASApplication creates an application, returning an error
 	// satisfying [applicationerrors.ApplicationAlreadyExists] if the
 	// application already exists. If returns as error satisfying
 	// [applicationerrors.CharmNotFound] if the charm for the application is not
 	// found.
-	CreateCAASApplication(context.Context, string, application.AddCAASApplicationArg, []application.AddCAASUnitArg) (coreapplication.ID, error)
+	CreateCAASApplication(context.Context, string, application.AddCAASApplicationArg, []application.AddCAASUnitArg) (coreapplication.UUID, error)
 
 	// UpsertCloudService updates the cloud service for the specified application.
 	// The following errors may be returned:
@@ -85,12 +85,12 @@ type ApplicationState interface {
 	// application.
 	// The following errors may be returned:
 	// - [appliationerrors.ApplicationNotFound] if the application does not exist
-	IsSubordinateApplication(context.Context, coreapplication.ID) (bool, error)
+	IsSubordinateApplication(context.Context, coreapplication.UUID) (bool, error)
 
 	// GetApplicationScaleState looks up the scale state of the specified
 	// application, returning an error satisfying
 	// [applicationerrors.ApplicationNotFound] if the application is not found.
-	GetApplicationScaleState(context.Context, coreapplication.ID) (application.ScaleState, error)
+	GetApplicationScaleState(context.Context, coreapplication.UUID) (application.ScaleState, error)
 
 	// GetApplicationUnitLife returns the life values for the specified units of
 	// the given application. The supplied ids may belong to a different
@@ -101,13 +101,13 @@ type ApplicationState interface {
 	// returning an error satisfying
 	// [applicationerrors.ApplicationNotFoundError] if the application is not
 	// found.
-	GetApplicationLife(ctx context.Context, appID coreapplication.ID) (life.Life, error)
+	GetApplicationLife(ctx context.Context, appID coreapplication.UUID) (life.Life, error)
 
 	// GetApplicationLifeByName looks up the life of the specified application,
 	// returning an error satisfying
 	// [applicationerrors.ApplicationNotFoundError] if the application is not
 	// found.
-	GetApplicationLifeByName(ctx context.Context, appName string) (coreapplication.ID, life.Life, error)
+	GetApplicationLifeByName(ctx context.Context, appName string) (coreapplication.UUID, life.Life, error)
 
 	// CheckAllApplicationsAndUnitsAreAlive checks that all applications and units
 	// in the model are alive, returning an error if any are not.
@@ -122,20 +122,20 @@ type ApplicationState interface {
 
 	// SetDesiredApplicationScale updates the desired scale of the specified
 	// application.
-	SetDesiredApplicationScale(context.Context, coreapplication.ID, int) error
+	SetDesiredApplicationScale(context.Context, coreapplication.UUID, int) error
 
 	// UpdateApplicationScale updates the desired scale of an application by a
 	// delta.
 	// If the resulting scale is less than zero, an error satisfying
 	// [applicationerrors.ScaleChangeInvalid] is returned.
-	UpdateApplicationScale(ctx context.Context, appUUID coreapplication.ID, delta int) (int, error)
+	UpdateApplicationScale(ctx context.Context, appUUID coreapplication.UUID, delta int) (int, error)
 
 	// GetCharmByApplicationID returns the charm, charm origin and charm
 	// platform for the specified application ID.
 	//
 	// If the application does not exist, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetCharmByApplicationID(context.Context, coreapplication.ID) (charm.Charm, error)
+	GetCharmByApplicationID(context.Context, coreapplication.UUID) (charm.Charm, error)
 
 	// GetCharmIDByApplicationName returns a charm ID by application name. It
 	// returns an error if the charm can not be found by the name. This can also
@@ -145,33 +145,33 @@ type ApplicationState interface {
 
 	// SetApplicationCharm sets a new charm for the specified application using
 	// the provided parameters and validates changes.
-	SetApplicationCharm(ctx context.Context, appID coreapplication.ID, charmID corecharm.ID, params application.SetCharmParams) error
+	SetApplicationCharm(ctx context.Context, appID coreapplication.UUID, charmID corecharm.ID, params application.SetCharmParams) error
 
 	// GetApplicationIDByUnitName returns the application ID for the named unit,
 	// returning an error satisfying [applicationerrors.UnitNotFound] if the
 	// unit doesn't exist.
-	GetApplicationIDByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.ID, error)
+	GetApplicationIDByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, error)
 
 	// GetApplicationIDAndNameByUnitName returns the application ID and name for
 	// the named unit, returning an error satisfying
 	// [applicationerrors.UnitNotFound] if the unit doesn't exist.
-	GetApplicationIDAndNameByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.ID, string, error)
+	GetApplicationIDAndNameByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, string, error)
 
 	// GetCharmModifiedVersion looks up the charm modified version of the given
 	// application. Returns [applicationerrors.ApplicationNotFound] if the
 	// application is not found.
-	GetCharmModifiedVersion(ctx context.Context, id coreapplication.ID) (int, error)
+	GetCharmModifiedVersion(ctx context.Context, id coreapplication.UUID) (int, error)
 
 	// GetApplicationsWithPendingCharmsFromUUIDs returns the applications
 	// with pending charms for the specified UUIDs. If the application has a
 	// different status, it's ignored.
-	GetApplicationsWithPendingCharmsFromUUIDs(ctx context.Context, uuids []coreapplication.ID) ([]coreapplication.ID, error)
+	GetApplicationsWithPendingCharmsFromUUIDs(ctx context.Context, uuids []coreapplication.UUID) ([]coreapplication.UUID, error)
 
 	// GetAsyncCharmDownloadInfo reserves the charm download for the specified
 	// application, returning an error satisfying
 	// [applicationerrors.AlreadyDownloadingCharm] if the application is already
 	// downloading a charm.
-	GetAsyncCharmDownloadInfo(ctx context.Context, appID coreapplication.ID) (application.CharmDownloadInfo, error)
+	GetAsyncCharmDownloadInfo(ctx context.Context, appID coreapplication.UUID) (application.CharmDownloadInfo, error)
 
 	// ResolveCharmDownload resolves the charm download for the specified
 	// application, updating the charm with the specified charm information.
@@ -189,14 +189,14 @@ type ApplicationState interface {
 	// [applicationerrors.ApplicationNotFound] is returned.
 	// If the charm for the application does not exist, an error satisfying
 	// [applicationerrors.CharmNotFoundError] is returned.
-	GetCharmConfigByApplicationID(ctx context.Context, appID coreapplication.ID) (corecharm.ID, charm.Config, error)
+	GetCharmConfigByApplicationID(ctx context.Context, appID coreapplication.UUID) (corecharm.ID, charm.Config, error)
 
 	// GetApplicationConfigAndSettings returns the application config and
 	// settings attributes for the application ID.
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationConfigAndSettings(ctx context.Context, appID coreapplication.ID) (
+	GetApplicationConfigAndSettings(ctx context.Context, appID coreapplication.UUID) (
 		map[string]application.ApplicationConfig,
 		application.ApplicationSettings,
 		error,
@@ -208,7 +208,7 @@ type ApplicationState interface {
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationConfigWithDefaults(ctx context.Context, appID coreapplication.ID) (
+	GetApplicationConfigWithDefaults(ctx context.Context, appID coreapplication.UUID) (
 		map[string]application.ApplicationConfig,
 		error,
 	)
@@ -216,7 +216,7 @@ type ApplicationState interface {
 	// GetApplicationTrustSetting returns the application trust setting.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationTrustSetting(ctx context.Context, appID coreapplication.ID) (bool, error)
+	GetApplicationTrustSetting(ctx context.Context, appID coreapplication.UUID) (bool, error)
 
 	// UpdateApplicationConfigAndSettings sets the application config attributes
 	// using the configuration, and sets the trust setting as part of the
@@ -225,7 +225,7 @@ type ApplicationState interface {
 	// [applicationerrors.ApplicationNotFound] is returned.
 	UpdateApplicationConfigAndSettings(
 		ctx context.Context,
-		appID coreapplication.ID,
+		appID coreapplication.UUID,
 		config map[string]application.AddApplicationConfig,
 		settings application.UpdateApplicationSettingsArg,
 	) error
@@ -234,13 +234,13 @@ type ApplicationState interface {
 	// config. If the key does not exist, it is ignored.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	UnsetApplicationConfigKeys(ctx context.Context, appID coreapplication.ID, keys []string) error
+	UnsetApplicationConfigKeys(ctx context.Context, appID coreapplication.UUID, keys []string) error
 
 	// GetApplicationConfigHash returns the SHA256 hash of the application config
 	// for the specified application ID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationConfigHash(ctx context.Context, appID coreapplication.ID) (string, error)
+	GetApplicationConfigHash(ctx context.Context, appID coreapplication.UUID) (string, error)
 
 	// InitialWatchStatementUnitLife returns the initial namespace query for the
 	// application unit life watcher.
@@ -257,7 +257,7 @@ type ApplicationState interface {
 	// InitialWatchStatementUnitAddressesHash returns the initial namespace query
 	// for the unit addresses hash watcher as well as the tables to be watched
 	// (ip_address and application_endpoint)
-	InitialWatchStatementUnitAddressesHash(appUUID coreapplication.ID, netNodeUUID string) (string, string, eventsource.NamespaceQuery)
+	InitialWatchStatementUnitAddressesHash(appUUID coreapplication.UUID, netNodeUUID string) (string, string, eventsource.NamespaceQuery)
 
 	// InitialWatchStatementUnitInsertDeleteOnNetNode returns the initial namespace
 	// query for unit insert and delete events on a specific net node, as well as
@@ -270,7 +270,7 @@ type ApplicationState interface {
 
 	// GetAddressesHash returns the sha256 hash of the application unit and cloud
 	// service (if any) addresses along with the associated endpoint bindings.
-	GetAddressesHash(ctx context.Context, appUUID coreapplication.ID, netNodeUUID string) (string, error)
+	GetAddressesHash(ctx context.Context, appUUID coreapplication.UUID, netNodeUUID string) (string, error)
 
 	// GetNetNodeUUIDByUnitName returns the net node UUID for the named unit or the
 	// cloud service associated with the unit's application. This method is meant
@@ -287,7 +287,7 @@ type ApplicationState interface {
 	// application ID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationConstraints(ctx context.Context, appID coreapplication.ID) (constraints.Constraints, error)
+	GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (constraints.Constraints, error)
 
 	// SetApplicationConstraints sets the application constraints for the
 	// specified application ID.
@@ -297,13 +297,13 @@ type ApplicationState interface {
 	// error is returned.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	SetApplicationConstraints(ctx context.Context, appID coreapplication.ID, cons constraints.Constraints) error
+	SetApplicationConstraints(ctx context.Context, appID coreapplication.UUID, cons constraints.Constraints) error
 
 	// GetApplicationCharmOrigin returns the platform and channel for the
 	// specified application ID.
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationCharmOrigin(ctx context.Context, appID coreapplication.ID) (application.CharmOrigin, error)
+	GetApplicationCharmOrigin(ctx context.Context, appID coreapplication.UUID) (application.CharmOrigin, error)
 
 	// NamespaceForWatchApplication returns the namespace identifier
 	// for application watchers.
@@ -326,7 +326,7 @@ type ApplicationState interface {
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	IsApplicationExposed(ctx context.Context, appID coreapplication.ID) (bool, error)
+	IsApplicationExposed(ctx context.Context, appID coreapplication.UUID) (bool, error)
 
 	// NamespaceForWatchApplicationExposed returns the namespace identifier
 	// for application exposed endpoints changes. The first return value is the
@@ -353,7 +353,7 @@ type ApplicationState interface {
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationEndpointBindings(context.Context, coreapplication.ID) (map[string]string, error)
+	GetApplicationEndpointBindings(context.Context, coreapplication.UUID) (map[string]string, error)
 
 	// GetApplicationsBoundToSpace returns the names of the applications bound to
 	// the given space.
@@ -364,7 +364,7 @@ type ApplicationState interface {
 	// The following errors may be returned:
 	//   - [applicationerrors.ApplicationNotFound] is returned if the application
 	//     doesn't exist.
-	GetApplicationEndpointNames(context.Context, coreapplication.ID) ([]string, error)
+	GetApplicationEndpointNames(context.Context, coreapplication.UUID) ([]string, error)
 
 	// MergeApplicationEndpointBindings merge the provided bindings into the bindings
 	// for the specified application.
@@ -383,7 +383,7 @@ type ApplicationState interface {
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetExposedEndpoints(ctx context.Context, appID coreapplication.ID) (map[string]application.ExposedEndpoint, error)
+	GetExposedEndpoints(ctx context.Context, appID coreapplication.UUID) (map[string]application.ExposedEndpoint, error)
 
 	// UnsetExposeSettings removes the expose settings for the provided list of
 	// endpoint names. If the resulting exposed endpoints map for the application
@@ -394,7 +394,7 @@ type ApplicationState interface {
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	UnsetExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints set.Strings) error
+	UnsetExposeSettings(ctx context.Context, appID coreapplication.UUID, exposedEndpoints set.Strings) error
 
 	// MergeExposeSettings marks the application as exposed and merges the provided
 	// ExposedEndpoint details into the current set of expose settings. The merge
@@ -402,19 +402,19 @@ type ApplicationState interface {
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	MergeExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints map[string]application.ExposedEndpoint) error
+	MergeExposeSettings(ctx context.Context, appID coreapplication.UUID, exposedEndpoints map[string]application.ExposedEndpoint) error
 
 	// EndpointsExist returns an error satisfying
 	// [applicationerrors.EndpointNotFound] if any of the provided endpoints do not
 	// exist.
-	EndpointsExist(ctx context.Context, appID coreapplication.ID, endpoints set.Strings) error
+	EndpointsExist(ctx context.Context, appID coreapplication.UUID, endpoints set.Strings) error
 
 	// SpacesExist returns an error satisfying [networkerrors.SpaceNotFound] if any
 	// of the provided spaces do not exist.
 	SpacesExist(ctx context.Context, spaceUUIDs set.Strings) error
 
 	// GetDeviceConstraints returns the device constraints for an application.
-	GetDeviceConstraints(ctx context.Context, appID coreapplication.ID) (map[string]devices.Constraints, error)
+	GetDeviceConstraints(ctx context.Context, appID coreapplication.UUID) (map[string]devices.Constraints, error)
 
 	// ShouldAllowCharmUpgradeOnError indicates if the units of an application
 	// should upgrade to the latest version of the application charm even if
@@ -425,7 +425,7 @@ type ApplicationState interface {
 	ShouldAllowCharmUpgradeOnError(ctx context.Context, appName string) (bool, error)
 
 	// IsControllerApplication returns true when the application is the controller.
-	IsControllerApplication(ctx context.Context, appID coreapplication.ID) (bool, error)
+	IsControllerApplication(ctx context.Context, appID coreapplication.UUID) (bool, error)
 
 	// GetMachinesForApplication returns the names of the machines which have a unit.
 	// of the specified application deployed to it.
@@ -840,7 +840,7 @@ func validateApplicationStorageDirective(
 func (s *Service) GetApplicationIDByUnitName(
 	ctx context.Context,
 	unitName coreunit.Name,
-) (coreapplication.ID, error) {
+) (coreapplication.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -978,7 +978,7 @@ func (s *Service) SetApplicationCharm(ctx context.Context, appName string, charm
 // GetApplicationName returns the name of the specified application.
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
-func (s *Service) GetApplicationName(ctx context.Context, appID coreapplication.ID) (string, error) {
+func (s *Service) GetApplicationName(ctx context.Context, appID coreapplication.UUID) (string, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -998,7 +998,7 @@ func (s *Service) GetApplicationName(ctx context.Context, appID coreapplication.
 //
 // Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
 // and [applicationerrors.ApplicationNotFound] if the application is not found.
-func (s *Service) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error) {
+func (s *Service) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1042,7 +1042,7 @@ func (s *Service) GetCharmLocatorByApplicationName(ctx context.Context, name str
 // application.
 //
 // Returns [applicationerrors.ApplicationNotFound] if the application is not found.
-func (s *Service) GetCharmModifiedVersion(ctx context.Context, id coreapplication.ID) (int, error) {
+func (s *Service) GetCharmModifiedVersion(ctx context.Context, id coreapplication.UUID) (int, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1060,7 +1060,7 @@ func (s *Service) GetCharmModifiedVersion(ctx context.Context, id coreapplicatio
 // [applicationerrors.ApplicationNotFound] is returned. If the application name
 // is not valid, an error satisfying [applicationerrors.ApplicationNameNotValid]
 // is returned.
-func (s *Service) GetCharmByApplicationID(ctx context.Context, id coreapplication.ID) (
+func (s *Service) GetCharmByApplicationID(ctx context.Context, id coreapplication.UUID) (
 	internalcharm.Charm,
 	charm.CharmLocator,
 	error,
@@ -1136,7 +1136,7 @@ func (s *Service) UpdateCloudService(ctx context.Context, appName, providerID st
 // GetApplicationLifelooks up the life of the specified application, returning
 // an error satisfying [applicationerrors.ApplicationNotFoundError] if the
 // application is not found.
-func (s *Service) GetApplicationLife(ctx context.Context, appID coreapplication.ID) (corelife.Value, error) {
+func (s *Service) GetApplicationLife(ctx context.Context, appID coreapplication.UUID) (corelife.Value, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1177,7 +1177,7 @@ func (s *Service) CheckAllApplicationsAndUnitsAreAlive(ctx context.Context) erro
 // application.
 // The following errors may be returned:
 // - [appliationerrors.ApplicationNotFound] if the application does not exist
-func (s *Service) IsSubordinateApplication(ctx context.Context, appUUID coreapplication.ID) (bool, error) {
+func (s *Service) IsSubordinateApplication(ctx context.Context, appUUID coreapplication.UUID) (bool, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1318,7 +1318,7 @@ func (s *Service) GetApplicationScalingState(ctx context.Context, appName string
 // GetApplicationsWithPendingCharmsFromUUIDs returns the application UUIDs that
 // have pending charms from the provided UUIDs. If there are no applications
 // with pending status charms, then those applications are ignored.
-func (s *Service) GetApplicationsWithPendingCharmsFromUUIDs(ctx context.Context, uuids []coreapplication.ID) ([]coreapplication.ID, error) {
+func (s *Service) GetApplicationsWithPendingCharmsFromUUIDs(ctx context.Context, uuids []coreapplication.UUID) ([]coreapplication.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1333,7 +1333,7 @@ func (s *Service) GetApplicationsWithPendingCharmsFromUUIDs(ctx context.Context,
 // return [applicationerrors.CharmAlreadyAvailable]. The charm download
 // information is returned which includes the charm name, origin and the
 // digest.
-func (s *Service) GetAsyncCharmDownloadInfo(ctx context.Context, appID coreapplication.ID) (application.CharmDownloadInfo, error) {
+func (s *Service) GetAsyncCharmDownloadInfo(ctx context.Context, appID coreapplication.UUID) (application.CharmDownloadInfo, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1349,7 +1349,7 @@ func (s *Service) GetAsyncCharmDownloadInfo(ctx context.Context, appID coreappli
 // information.
 // This returns [applicationerrors.CharmNotResolved] if the charm UUID isn't
 // the same as the one that was reserved.
-func (s *Service) ResolveCharmDownload(ctx context.Context, appID coreapplication.ID, resolve application.ResolveCharmDownload) error {
+func (s *Service) ResolveCharmDownload(ctx context.Context, appID coreapplication.UUID, resolve application.ResolveCharmDownload) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1488,7 +1488,7 @@ func (s *Service) GetApplicationsForRevisionUpdater(ctx context.Context) ([]appl
 //
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (s *Service) GetApplicationConfigWithDefaults(ctx context.Context, appID coreapplication.ID) (internalcharm.Config, error) {
+func (s *Service) GetApplicationConfigWithDefaults(ctx context.Context, appID coreapplication.UUID) (internalcharm.Config, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1546,7 +1546,7 @@ func (s *Service) GetApplicationCharmOrigin(ctx context.Context, name string) (c
 
 // GetApplicationAndCharmConfig returns the application and charm config for the
 // specified application ID.
-func (s *Service) GetApplicationAndCharmConfig(ctx context.Context, appID coreapplication.ID) (ApplicationConfig, error) {
+func (s *Service) GetApplicationAndCharmConfig(ctx context.Context, appID coreapplication.UUID) (ApplicationConfig, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1603,7 +1603,7 @@ func (s *Service) GetApplicationAndCharmConfig(ctx context.Context, appID coreap
 // config. If the key does not exist, it is ignored.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (s *Service) UnsetApplicationConfigKeys(ctx context.Context, appID coreapplication.ID, keys []string) error {
+func (s *Service) UnsetApplicationConfigKeys(ctx context.Context, appID coreapplication.UUID, keys []string) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1624,7 +1624,7 @@ func (s *Service) UnsetApplicationConfigKeys(ctx context.Context, appID coreappl
 // [applicationerrors.ApplicationNotFound] is returned.
 // If the application config is not valid, an error satisfying
 // [applicationerrors.InvalidApplicationConfig] is returned.
-func (s *Service) UpdateApplicationConfig(ctx context.Context, appID coreapplication.ID, newConfig map[string]string) error {
+func (s *Service) UpdateApplicationConfig(ctx context.Context, appID coreapplication.UUID, newConfig map[string]string) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1688,7 +1688,7 @@ func (s *Service) UpdateApplicationConfig(ctx context.Context, appID coreapplica
 // application ID.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (s *Service) GetApplicationConstraints(ctx context.Context, appID coreapplication.ID) (coreconstraints.Value, error) {
+func (s *Service) GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (coreconstraints.Value, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1760,7 +1760,7 @@ func (s *Service) GetApplicationsBoundToSpace(ctx context.Context, uuid network.
 // The following errors may be returned:
 //   - [applicationerrors.ApplicationNotFound] is returned if the application
 //     doesn't exist.
-func (s *Service) GetApplicationEndpointNames(ctx context.Context, appUUID coreapplication.ID) ([]string, error) {
+func (s *Service) GetApplicationEndpointNames(ctx context.Context, appUUID coreapplication.UUID) ([]string, error) {
 	if err := appUUID.Validate(); err != nil {
 		return nil, errors.Errorf("validating application UUID: %w", err)
 	}
@@ -1771,7 +1771,7 @@ func (s *Service) GetApplicationEndpointNames(ctx context.Context, appUUID corea
 
 // MergeApplicationEndpointBindings merge the provided bindings into the bindings
 // for the specified application.
-func (s *Service) MergeApplicationEndpointBindings(ctx context.Context, appID coreapplication.ID, bindings map[string]network.SpaceName, force bool) error {
+func (s *Service) MergeApplicationEndpointBindings(ctx context.Context, appID coreapplication.UUID, bindings map[string]network.SpaceName, force bool) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1798,7 +1798,7 @@ func (s *Service) GetDeviceConstraints(ctx context.Context, name string) (map[st
 }
 
 // IsControllerApplication returns true when the application is the controller.
-func (s *Service) IsControllerApplication(ctx context.Context, appID coreapplication.ID) (bool, error) {
+func (s *Service) IsControllerApplication(ctx context.Context, appID coreapplication.UUID) (bool, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -1263,8 +1263,8 @@ func (s *applicationServiceSuite) TestGetDeviceConstraintsAppNotFound(c *tc.C) {
 func (s *applicationServiceSuite) TestGetDeviceConstraintsDeadApp(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "dead-app").Return(coreapplication.ID("foo"), nil)
-	s.state.EXPECT().GetDeviceConstraints(gomock.Any(), coreapplication.ID("foo")).Return(nil, errors.Errorf("%w", applicationerrors.ApplicationIsDead))
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "dead-app").Return(coreapplication.UUID("foo"), nil)
+	s.state.EXPECT().GetDeviceConstraints(gomock.Any(), coreapplication.UUID("foo")).Return(nil, errors.Errorf("%w", applicationerrors.ApplicationIsDead))
 
 	_, err := s.service.GetDeviceConstraints(c.Context(), "dead-app")
 	c.Assert(err, tc.ErrorMatches, applicationerrors.ApplicationIsDead.Error())
@@ -1273,8 +1273,8 @@ func (s *applicationServiceSuite) TestGetDeviceConstraintsDeadApp(c *tc.C) {
 func (s *applicationServiceSuite) TestGetDeviceConstraints(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID("foo-uuid"), nil)
-	s.state.EXPECT().GetDeviceConstraints(gomock.Any(), coreapplication.ID("foo-uuid")).Return(map[string]devices.Constraints{
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID("foo-uuid"), nil)
+	s.state.EXPECT().GetDeviceConstraints(gomock.Any(), coreapplication.UUID("foo-uuid")).Return(map[string]devices.Constraints{
 		"dev0": {
 			Type:  "type0",
 			Count: 42,
@@ -1345,7 +1345,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationsWithPendingCharmsFromUUIDs(gomock.Any(), []coreapplication.ID{appID}).Return([]coreapplication.ID{
+	s.state.EXPECT().GetApplicationsWithPendingCharmsFromUUIDs(gomock.Any(), []coreapplication.UUID{appID}).Return([]coreapplication.UUID{
 		appID,
 	}, nil)
 
@@ -1384,7 +1384,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 	// that the mapper correctly orders the results based on changes emitted by
 	// the watcher.
 
-	appIDs := make([]coreapplication.ID, 4)
+	appIDs := make([]coreapplication.UUID, 4)
 	for i := range appIDs {
 		appIDs[i] = applicationtesting.GenApplicationUUID(c)
 	}
@@ -1402,7 +1402,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 	// order. This is because we can't guarantee the order if there are holes in
 	// the pending sequence.
 
-	shuffle := make([]coreapplication.ID, len(appIDs))
+	shuffle := make([]coreapplication.UUID, len(appIDs))
 	copy(shuffle, appIDs)
 	rand.Shuffle(len(shuffle), func(i, j int) {
 		shuffle[i], shuffle[j] = shuffle[j], shuffle[i]
@@ -1424,7 +1424,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 	// that the mapper correctly orders the results based on changes emitted by
 	// the watcher.
 
-	appIDs := make([]coreapplication.ID, 10)
+	appIDs := make([]coreapplication.UUID, 10)
 	for i := range appIDs {
 		appIDs[i] = applicationtesting.GenApplicationUUID(c)
 	}
@@ -1442,7 +1442,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 	// order. This is because we can't guarantee the order if there are holes in
 	// the pending sequence.
 
-	var dropped []coreapplication.ID
+	var dropped []coreapplication.UUID
 	var expected []string
 	for i, appID := range appIDs {
 		if rand.IntN(2) == 0 {
@@ -1466,7 +1466,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 	// that the mapper correctly orders the results based on changes emitted by
 	// the watcher.
 
-	appIDs := make([]coreapplication.ID, 10)
+	appIDs := make([]coreapplication.UUID, 10)
 	for i := range appIDs {
 		appIDs[i] = applicationtesting.GenApplicationUUID(c)
 	}
@@ -1484,7 +1484,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 	// order. This is because we can't guarantee the order if there are holes in
 	// the pending sequence.
 
-	var dropped []coreapplication.ID
+	var dropped []coreapplication.UUID
 	var expected []string
 	for i, appID := range appIDs {
 		if rand.IntN(2) == 0 {
@@ -1496,7 +1496,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 
 	// Shuffle them to replicate out of order return.
 
-	shuffle := make([]coreapplication.ID, len(dropped))
+	shuffle := make([]coreapplication.UUID, len(dropped))
 	copy(shuffle, dropped)
 	rand.Shuffle(len(shuffle), func(i, j int) {
 		shuffle[i], shuffle[j] = shuffle[j], shuffle[i]

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -68,7 +68,7 @@ func (s *applicationServiceSuite) TestGetCharmByApplicationID(c *tc.C) {
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmByApplicationID(gomock.Any(), id).Return(applicationcharm.Charm{
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), id).Return(applicationcharm.Charm{
 		Metadata: applicationcharm.Metadata{
 			Name: "foo",
 
@@ -82,7 +82,7 @@ func (s *applicationServiceSuite) TestGetCharmByApplicationID(c *tc.C) {
 		Architecture:  architecture.AMD64,
 	}, nil)
 
-	ch, locator, err := s.service.GetCharmByApplicationID(c.Context(), id)
+	ch, locator, err := s.service.GetCharmByApplicationUUID(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(ch.Meta(), tc.DeepEquals, &internalcharm.Meta{
 		Name: "foo",
@@ -120,24 +120,24 @@ func (s *applicationServiceSuite) TestGetApplicationNameNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
-func (s *applicationServiceSuite) TestGetApplicationIDByName(c *tc.C) {
+func (s *applicationServiceSuite) TestGetApplicationUUIDByName(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(id, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(id, nil)
 
-	obtainedID, err := s.service.GetApplicationIDByName(c.Context(), "foo")
+	obtainedID, err := s.service.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtainedID, tc.Equals, id)
 }
 
-func (s *applicationServiceSuite) TestGetApplicationIDByNameNotFound(c *tc.C) {
+func (s *applicationServiceSuite) TestGetApplicationUUIDByNameNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
 
-	_, err := s.service.GetApplicationIDByName(c.Context(), "foo")
+	_, err := s.service.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
@@ -165,14 +165,14 @@ func (s *applicationServiceSuite) TestGetCharmLocatorByApplicationName(c *tc.C) 
 	c.Check(locator, tc.DeepEquals, expectedLocator)
 }
 
-func (s *applicationServiceSuite) TestGetApplicationIDByUnitName(c *tc.C) {
+func (s *applicationServiceSuite) TestGetApplicationUUIDByUnitName(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	expectedAppID := applicationtesting.GenApplicationUUID(c)
 	unitName := coreunit.Name("foo")
-	s.state.EXPECT().GetApplicationIDByUnitName(gomock.Any(), unitName).Return(expectedAppID, nil)
+	s.state.EXPECT().GetApplicationUUIDByUnitName(gomock.Any(), unitName).Return(expectedAppID, nil)
 
-	obtainedAppID, err := s.service.GetApplicationIDByUnitName(c.Context(), unitName)
+	obtainedAppID, err := s.service.GetApplicationUUIDByUnitName(c.Context(), unitName)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtainedAppID, tc.DeepEquals, expectedAppID)
 }
@@ -535,7 +535,7 @@ func (s *applicationServiceSuite) TestGetApplicationTrustSetting(c *tc.C) {
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationTrustSetting(gomock.Any(), appUUID).Return(true, nil)
 
 	results, err := s.service.GetApplicationTrustSetting(c.Context(), "foo")
@@ -546,7 +546,7 @@ func (s *applicationServiceSuite) TestGetApplicationTrustSetting(c *tc.C) {
 func (s *applicationServiceSuite) TestGetApplicationTrustSettingNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
 
 	_, err := s.service.GetApplicationTrustSetting(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
@@ -557,7 +557,7 @@ func (s *applicationServiceSuite) TestGetApplicationCharmOrigin(c *tc.C) {
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(id, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), id).Return(application.CharmOrigin{
 		Name:   "foo",
 		Source: applicationcharm.CharmHubSource,
@@ -599,7 +599,7 @@ func (s *applicationServiceSuite) TestGetApplicationCharmOriginGetApplicationErr
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(id, errors.Errorf("boom"))
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(id, errors.Errorf("boom"))
 
 	_, err := s.service.GetApplicationCharmOrigin(c.Context(), "foo")
 	c.Assert(err, tc.ErrorMatches, "boom")
@@ -644,7 +644,7 @@ func (s *applicationServiceSuite) TestUpdateApplicationConfig(c *tc.C) {
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
 		Options: map[string]applicationcharm.Option{
 			"foo": {
 				Type:    applicationcharm.OptionString,
@@ -673,7 +673,7 @@ func (s *applicationServiceSuite) TestUpdateApplicationConfigRemoveTrust(c *tc.C
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
 		Options: map[string]applicationcharm.Option{
 			"foo": {
 				Type:    applicationcharm.OptionString,
@@ -702,7 +702,7 @@ func (s *applicationServiceSuite) TestUpdateApplicationConfigNoTrust(c *tc.C) {
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
 		Options: map[string]applicationcharm.Option{
 			"foo": {
 				Type:    applicationcharm.OptionString,
@@ -728,7 +728,7 @@ func (s *applicationServiceSuite) TestUpdateApplicationConfigNoCharmConfig(c *tc
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return(
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return(
 		"",
 		applicationcharm.Config{},
 		applicationerrors.CharmNotFound,
@@ -746,7 +746,7 @@ func (s *applicationServiceSuite) TestUpdateApplicationConfigWithNoCharmConfig(c
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
 		Options: map[string]applicationcharm.Option{},
 	}, nil)
 
@@ -762,7 +762,7 @@ func (s *applicationServiceSuite) TestUpdateApplicationConfigInvalidOptionType(c
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
 		Options: map[string]applicationcharm.Option{
 			"foo": {
 				Type:    "blah",
@@ -783,7 +783,7 @@ func (s *applicationServiceSuite) TestUpdateApplicationConfigInvalidTrustType(c 
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return("", applicationcharm.Config{
 		Options: map[string]applicationcharm.Option{
 			"foo": {
 				Type:    "string",
@@ -804,7 +804,7 @@ func (s *applicationServiceSuite) TestUpdateApplicationConfigNoConfig(c *tc.C) {
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return("", applicationcharm.Config{}, nil)
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return("", applicationcharm.Config{}, nil)
 	s.state.EXPECT().UpdateApplicationConfigAndSettings(
 		gomock.Any(), appUUID,
 		nil,
@@ -860,7 +860,7 @@ func (s *applicationServiceSuite) TestGetApplicationAndCharmConfig(c *tc.C) {
 	}
 
 	s.state.EXPECT().GetApplicationConfigAndSettings(gomock.Any(), appUUID).Return(appConfig, settings, nil)
-	s.state.EXPECT().GetCharmConfigByApplicationID(gomock.Any(), appUUID).Return(charmUUID, charmConfig, nil)
+	s.state.EXPECT().GetCharmConfigByApplicationUUID(gomock.Any(), appUUID).Return(charmUUID, charmConfig, nil)
 	s.state.EXPECT().IsSubordinateCharm(gomock.Any(), charmUUID).Return(false, nil)
 	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), appUUID).Return(charmOrigin, nil)
 
@@ -1132,7 +1132,7 @@ func (s *applicationServiceSuite) TestGetAllEndpointBindingsErrors(c *tc.C) {
 func (s *applicationServiceSuite) TestGetApplicationEndpointBindingsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
 
 	_, err := s.service.GetApplicationEndpointBindings(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
@@ -1143,7 +1143,7 @@ func (s *applicationServiceSuite) TestGetApplicationEndpointBindings(c *tc.C) {
 
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appID, nil)
 	s.state.EXPECT().GetApplicationEndpointBindings(gomock.Any(), appID).Return(map[string]string{
 		"foo": "bar",
 	}, nil)
@@ -1254,7 +1254,7 @@ func (s *applicationServiceSuite) TestMergeApplicationEndpointBindingsInvalid(c 
 func (s *applicationServiceSuite) TestGetDeviceConstraintsAppNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "unknown-app").Return("", errors.Errorf("%w", applicationerrors.ApplicationNotFound))
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "unknown-app").Return("", errors.Errorf("%w", applicationerrors.ApplicationNotFound))
 
 	_, err := s.service.GetDeviceConstraints(c.Context(), "unknown-app")
 	c.Assert(err, tc.ErrorMatches, applicationerrors.ApplicationNotFound.Error())
@@ -1263,7 +1263,7 @@ func (s *applicationServiceSuite) TestGetDeviceConstraintsAppNotFound(c *tc.C) {
 func (s *applicationServiceSuite) TestGetDeviceConstraintsDeadApp(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "dead-app").Return(coreapplication.UUID("foo"), nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "dead-app").Return(coreapplication.UUID("foo"), nil)
 	s.state.EXPECT().GetDeviceConstraints(gomock.Any(), coreapplication.UUID("foo")).Return(nil, errors.Errorf("%w", applicationerrors.ApplicationIsDead))
 
 	_, err := s.service.GetDeviceConstraints(c.Context(), "dead-app")
@@ -1273,7 +1273,7 @@ func (s *applicationServiceSuite) TestGetDeviceConstraintsDeadApp(c *tc.C) {
 func (s *applicationServiceSuite) TestGetDeviceConstraints(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID("foo-uuid"), nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(coreapplication.UUID("foo-uuid"), nil)
 	s.state.EXPECT().GetDeviceConstraints(gomock.Any(), coreapplication.UUID("foo-uuid")).Return(map[string]devices.Constraints{
 		"dev0": {
 			Type:  "type0",
@@ -1312,7 +1312,7 @@ func (s *applicationWatcherServiceSuite) TestGetMachinesForApplication(c *tc.C) 
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
 	s.state.EXPECT().GetMachinesForApplication(gomock.Any(), appUUID.String()).Return([]string{"0", "1"}, nil)
 
 	results, err := s.service.GetMachinesForApplication(c.Context(), "foo")

--- a/domain/application/service/exposed.go
+++ b/domain/application/service/exposed.go
@@ -23,7 +23,7 @@ func (s *Service) IsApplicationExposed(ctx context.Context, appName string) (boo
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return false, errors.Capture(err)
 	}
@@ -42,7 +42,7 @@ func (s *Service) GetExposedEndpoints(ctx context.Context, appName string) (map[
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -61,7 +61,7 @@ func (s *Service) UnsetExposeSettings(ctx context.Context, appName string, expos
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -79,7 +79,7 @@ func (s *Service) MergeExposeSettings(ctx context.Context, appName string, expos
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/application/service/exposed_test.go
+++ b/domain/application/service/exposed_test.go
@@ -29,7 +29,7 @@ func TestExposedServiceSuite(t *testing.T) {
 func (s *exposedServiceSuite) TestApplicationExposedNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
 
 	_, err := s.service.IsApplicationExposed(c.Context(), "foo")
 	c.Assert(err, tc.ErrorMatches, "application not found")
@@ -39,7 +39,7 @@ func (s *exposedServiceSuite) TestApplicationExposed(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.state.EXPECT().IsApplicationExposed(gomock.Any(), applicationUUID).Return(true, nil)
 
 	exposed, err := s.service.IsApplicationExposed(c.Context(), "foo")
@@ -50,7 +50,7 @@ func (s *exposedServiceSuite) TestApplicationExposed(c *tc.C) {
 func (s *exposedServiceSuite) TestExposedEndpointsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
 
 	_, err := s.service.GetExposedEndpoints(c.Context(), "foo")
 	c.Assert(err, tc.ErrorMatches, "application not found")
@@ -60,7 +60,7 @@ func (s *exposedServiceSuite) TestExposedEndpoints(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	expected := map[string]application.ExposedEndpoint{
 		"endpoint0": {
 			ExposeToSpaceIDs: set.NewStrings("space0", "space1"),
@@ -79,7 +79,7 @@ func (s *exposedServiceSuite) TestExposedEndpoints(c *tc.C) {
 func (s *exposedServiceSuite) TestUnsetExposeSettingsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
 
 	err := s.service.UnsetExposeSettings(c.Context(), "foo", set.NewStrings("endpoint0"))
 	c.Assert(err, tc.ErrorMatches, "application not found")
@@ -89,7 +89,7 @@ func (s *exposedServiceSuite) TestUnsetExposeSettings(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	exposedEndpoints := set.NewStrings("endpoint0", "endpoint1")
 	s.state.EXPECT().UnsetExposeSettings(gomock.Any(), applicationUUID, exposedEndpoints).Return(nil)
 
@@ -100,7 +100,7 @@ func (s *exposedServiceSuite) TestUnsetExposeSettings(c *tc.C) {
 func (s *exposedServiceSuite) TestMergeExposeSettingsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
 
 	err := s.service.MergeExposeSettings(c.Context(), "foo", map[string]application.ExposedEndpoint{
 		"endpoint0": {
@@ -117,7 +117,7 @@ func (s *exposedServiceSuite) TestMergeExposeSettingsEndpointsExistError(c *tc.C
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings("endpoint0", "endpoint1")).Return(errors.New("boom"))
 
 	err := s.service.MergeExposeSettings(c.Context(), "foo", map[string]application.ExposedEndpoint{
@@ -135,7 +135,7 @@ func (s *exposedServiceSuite) TestMergeExposeSettingsSpacesNotExist(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings("endpoint0", "endpoint1")).Return(nil)
 	s.state.EXPECT().SpacesExist(gomock.Any(), set.NewStrings("space0", "space1")).Return(errors.New("one or more of the provided spaces \\[space0 space1\\] do not exist"))
 
@@ -154,7 +154,7 @@ func (s *exposedServiceSuite) TestMergeExposeSettingsEmptyEndpointsList(c *tc.C)
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings()).Return(nil)
 	s.state.EXPECT().SpacesExist(gomock.Any(), set.NewStrings()).Return(nil)
 	s.state.EXPECT().MergeExposeSettings(gomock.Any(), applicationUUID, map[string]application.ExposedEndpoint{
@@ -171,7 +171,7 @@ func (s *exposedServiceSuite) TestMergeExposeSettingsWildcard(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings("endpoint1")).Return(nil)
 	s.state.EXPECT().SpacesExist(gomock.Any(), set.NewStrings("space0", "space1")).Return(nil)
 	s.state.EXPECT().MergeExposeSettings(gomock.Any(), applicationUUID, map[string]application.ExposedEndpoint{
@@ -198,7 +198,7 @@ func (s *exposedServiceSuite) TestMergeExposeSettings(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings("endpoint0", "endpoint1")).Return(nil)
 	s.state.EXPECT().SpacesExist(gomock.Any(), set.NewStrings("space0", "space1")).Return(nil)
 	s.state.EXPECT().MergeExposeSettings(gomock.Any(), applicationUUID, map[string]application.ExposedEndpoint{

--- a/domain/application/service/exposed_test.go
+++ b/domain/application/service/exposed_test.go
@@ -29,7 +29,7 @@ func TestExposedServiceSuite(t *testing.T) {
 func (s *exposedServiceSuite) TestApplicationExposedNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
 
 	_, err := s.service.IsApplicationExposed(c.Context(), "foo")
 	c.Assert(err, tc.ErrorMatches, "application not found")
@@ -50,7 +50,7 @@ func (s *exposedServiceSuite) TestApplicationExposed(c *tc.C) {
 func (s *exposedServiceSuite) TestExposedEndpointsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
 
 	_, err := s.service.GetExposedEndpoints(c.Context(), "foo")
 	c.Assert(err, tc.ErrorMatches, "application not found")
@@ -79,7 +79,7 @@ func (s *exposedServiceSuite) TestExposedEndpoints(c *tc.C) {
 func (s *exposedServiceSuite) TestUnsetExposeSettingsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
 
 	err := s.service.UnsetExposeSettings(c.Context(), "foo", set.NewStrings("endpoint0"))
 	c.Assert(err, tc.ErrorMatches, "application not found")
@@ -100,7 +100,7 @@ func (s *exposedServiceSuite) TestUnsetExposeSettings(c *tc.C) {
 func (s *exposedServiceSuite) TestMergeExposeSettingsNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.UUID(""), applicationerrors.ApplicationNotFound)
 
 	err := s.service.MergeExposeSettings(c.Context(), "foo", map[string]application.ExposedEndpoint{
 		"endpoint0": {

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -186,7 +186,7 @@ func (s *MigrationService) GetApplicationUnits(ctx context.Context, name string)
 		return nil, applicationerrors.ApplicationNameNotValid
 	}
 
-	appID, err := s.st.GetApplicationIDByName(ctx, name)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -205,7 +205,7 @@ func (s *MigrationService) GetApplicationCharmOrigin(ctx context.Context, name s
 		return application.CharmOrigin{}, applicationerrors.ApplicationNameNotValid
 	}
 
-	appID, err := s.st.GetApplicationIDByName(ctx, name)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return application.CharmOrigin{}, errors.Capture(err)
 	}
@@ -228,7 +228,7 @@ func (s *MigrationService) GetApplicationConfigAndSettings(ctx context.Context, 
 		return nil, application.ApplicationSettings{}, applicationerrors.ApplicationNameNotValid
 	}
 
-	appID, err := s.st.GetApplicationIDByName(ctx, name)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return nil, application.ApplicationSettings{}, errors.Capture(err)
 	}
@@ -260,7 +260,7 @@ func (s *MigrationService) GetApplicationConstraints(ctx context.Context, name s
 		return coreconstraints.Value{}, applicationerrors.ApplicationNameNotValid
 	}
 
-	appID, err := s.st.GetApplicationIDByName(ctx, name)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return coreconstraints.Value{}, errors.Capture(err)
 	}
@@ -294,7 +294,7 @@ func (s *MigrationService) GetApplicationScaleState(ctx context.Context, name st
 		return application.ScaleState{}, applicationerrors.ApplicationNameNotValid
 	}
 
-	appID, err := s.st.GetApplicationIDByName(ctx, name)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return application.ScaleState{}, errors.Capture(err)
 	}
@@ -448,7 +448,7 @@ func (s *MigrationService) IsApplicationExposed(ctx context.Context, appName str
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return false, errors.Capture(err)
 	}
@@ -467,7 +467,7 @@ func (s *MigrationService) GetExposedEndpoints(ctx context.Context, appName stri
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -249,7 +249,7 @@ func (s *MigrationService) GetApplicationConfigAndSettings(ctx context.Context, 
 // GetApplicationConstraints returns the application constraints for the
 // specified application name.
 // Empty constraints are returned if no constraints exist for the given
-// application ID.
+// application UUID.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
 func (s *MigrationService) GetApplicationConstraints(ctx context.Context, name string) (coreconstraints.Value, error) {

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -35,7 +35,7 @@ type MigrationState interface {
 	// application in the model.
 	// If the application does not exist, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	GetApplicationUnitsForExport(ctx context.Context, appID coreapplication.ID) ([]application.ExportUnit, error)
+	GetApplicationUnitsForExport(ctx context.Context, appID coreapplication.UUID) ([]application.ExportUnit, error)
 
 	// GetSpaceUUIDByName returns the UUID of the space with the given name.
 	// It returns an error satisfying [networkerrors.SpaceNotFound] if the provided
@@ -48,7 +48,7 @@ type MigrationState interface {
 	// application already exists. If returns as error satisfying
 	// [applicationerrors.CharmNotFound] if the charm for the application is
 	// not found.
-	InsertMigratingApplication(context.Context, string, application.InsertApplicationArgs) (coreapplication.ID, error)
+	InsertMigratingApplication(context.Context, string, application.InsertApplicationArgs) (coreapplication.UUID, error)
 }
 
 // MigrationService provides the API for migrating applications.
@@ -359,7 +359,7 @@ func (s *MigrationService) importApplication(
 	ctx context.Context,
 	name string,
 	args ImportApplicationArgs,
-) (coreapplication.ID, corecharm.ID, error) {
+) (coreapplication.UUID, corecharm.ID, error) {
 	if err := validateCharmAndApplicationParams(name, args.ReferenceName, args.Charm, args.CharmOrigin); err != nil {
 		return "", "", errors.Errorf("invalid application args: %w", err)
 	}

--- a/domain/application/service/migration_test.go
+++ b/domain/application/service/migration_test.go
@@ -448,14 +448,14 @@ func (s *migrationServiceSuite) assertImportApplication(c *tc.C, modelType corem
 
 	var receivedUnitArgs []application.ImportUnitArg
 	if modelType == coremodel.IAAS {
-		s.state.EXPECT().InsertMigratingIAASUnits(gomock.Any(), id, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.ID, args ...application.ImportUnitArg) error {
+		s.state.EXPECT().InsertMigratingIAASUnits(gomock.Any(), id, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.UUID, args ...application.ImportUnitArg) error {
 			receivedUnitArgs = args
 			return nil
 		})
 	} else {
 		s.state.EXPECT().SetDesiredApplicationScale(gomock.Any(), id, 1).Return(nil)
 		s.state.EXPECT().SetApplicationScalingState(gomock.Any(), "ubuntu", 42, true).Return(nil)
-		s.state.EXPECT().InsertMigratingCAASUnits(gomock.Any(), id, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.ID, args ...application.ImportUnitArg) error {
+		s.state.EXPECT().InsertMigratingCAASUnits(gomock.Any(), id, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.UUID, args ...application.ImportUnitArg) error {
 			receivedUnitArgs = args
 			return nil
 		})

--- a/domain/application/service/migration_test.go
+++ b/domain/application/service/migration_test.go
@@ -278,7 +278,7 @@ func (s *migrationServiceSuite) TestGetApplicationCharmOrigin(c *tc.C) {
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(id, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), id).Return(application.CharmOrigin{
 		Name:   "foo",
 		Source: domaincharm.CharmHubSource,
@@ -297,7 +297,7 @@ func (s *migrationServiceSuite) TestGetApplicationCharmOriginGetApplicationError
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(id, errors.Errorf("boom"))
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(id, errors.Errorf("boom"))
 
 	_, err := s.service.GetApplicationCharmOrigin(c.Context(), "foo")
 	c.Assert(err, tc.ErrorMatches, "boom")
@@ -315,7 +315,7 @@ func (s *migrationServiceSuite) TestGetApplicationConfigAndSettings(c *tc.C) {
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationConfigAndSettings(gomock.Any(), appUUID).Return(map[string]application.ApplicationConfig{
 		"foo": {
 			Type:  domaincharm.OptionString,
@@ -345,7 +345,7 @@ func (s *migrationServiceSuite) TestGetApplicationConfigWithNameError(c *tc.C) {
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appUUID, errors.Errorf("boom"))
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, errors.Errorf("boom"))
 
 	_, _, err := s.service.GetApplicationConfigAndSettings(c.Context(), "foo")
 	c.Assert(err, tc.ErrorMatches, "boom")
@@ -357,7 +357,7 @@ func (s *migrationServiceSuite) TestGetApplicationConfigWithConfigError(c *tc.C)
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationConfigAndSettings(gomock.Any(), appUUID).
 		Return(map[string]application.ApplicationConfig{}, application.ApplicationSettings{}, errors.Errorf("boom"))
 
@@ -371,7 +371,7 @@ func (s *migrationServiceSuite) TestGetApplicationConfigNoConfig(c *tc.C) {
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationConfigAndSettings(gomock.Any(), appUUID).
 		Return(map[string]application.ApplicationConfig{}, application.ApplicationSettings{}, nil)
 
@@ -386,7 +386,7 @@ func (s *migrationServiceSuite) TestGetApplicationConfigNoConfigWithTrust(c *tc.
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationConfigAndSettings(gomock.Any(), appUUID).
 		Return(map[string]application.ApplicationConfig{}, application.ApplicationSettings{
 			Trust: true,
@@ -648,7 +648,7 @@ func (s *migrationServiceSuite) TestGetApplicationUnits(c *tc.C) {
 		},
 	}
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appID, nil)
 	s.state.EXPECT().GetApplicationUnitsForExport(gomock.Any(), appID).Return(units, nil)
 
 	res, err := s.service.GetApplicationUnits(c.Context(), "foo")
@@ -661,7 +661,7 @@ func (s *migrationServiceSuite) TestGetApplicationUnitsNotFound(c *tc.C) {
 
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appID, applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appID, applicationerrors.ApplicationNotFound)
 
 	_, err := s.service.GetApplicationUnits(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
@@ -674,7 +674,7 @@ func (s *migrationServiceSuite) TestGetApplicationUnitsNoUnits(c *tc.C) {
 
 	units := []application.ExportUnit{}
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(appID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appID, nil)
 	s.state.EXPECT().GetApplicationUnitsForExport(gomock.Any(), appID).Return(units, nil)
 
 	res, err := s.service.GetApplicationUnits(c.Context(), "foo")

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -510,7 +510,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AddCAASUnits mocks base method.
-func (m *MockState) AddCAASUnits(arg0 context.Context, arg1 application.ID, arg2 ...application0.AddCAASUnitArg) ([]unit.Name, error) {
+func (m *MockState) AddCAASUnits(arg0 context.Context, arg1 application.UUID, arg2 ...application0.AddCAASUnitArg) ([]unit.Name, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -542,13 +542,13 @@ func (c *MockStateAddCAASUnitsCall) Return(arg0 []unit.Name, arg1 error) *MockSt
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAddCAASUnitsCall) Do(f func(context.Context, application.ID, ...application0.AddCAASUnitArg) ([]unit.Name, error)) *MockStateAddCAASUnitsCall {
+func (c *MockStateAddCAASUnitsCall) Do(f func(context.Context, application.UUID, ...application0.AddCAASUnitArg) ([]unit.Name, error)) *MockStateAddCAASUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAddCAASUnitsCall) DoAndReturn(f func(context.Context, application.ID, ...application0.AddCAASUnitArg) ([]unit.Name, error)) *MockStateAddCAASUnitsCall {
+func (c *MockStateAddCAASUnitsCall) DoAndReturn(f func(context.Context, application.UUID, ...application0.AddCAASUnitArg) ([]unit.Name, error)) *MockStateAddCAASUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -634,7 +634,7 @@ func (c *MockStateAddIAASSubordinateUnitCall) DoAndReturn(f func(context.Context
 }
 
 // AddIAASUnits mocks base method.
-func (m *MockState) AddIAASUnits(arg0 context.Context, arg1 application.ID, arg2 ...application0.AddIAASUnitArg) ([]unit.Name, []machine.Name, error) {
+func (m *MockState) AddIAASUnits(arg0 context.Context, arg1 application.UUID, arg2 ...application0.AddIAASUnitArg) ([]unit.Name, []machine.Name, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -667,13 +667,13 @@ func (c *MockStateAddIAASUnitsCall) Return(arg0 []unit.Name, arg1 []machine.Name
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAddIAASUnitsCall) Do(f func(context.Context, application.ID, ...application0.AddIAASUnitArg) ([]unit.Name, []machine.Name, error)) *MockStateAddIAASUnitsCall {
+func (c *MockStateAddIAASUnitsCall) Do(f func(context.Context, application.UUID, ...application0.AddIAASUnitArg) ([]unit.Name, []machine.Name, error)) *MockStateAddIAASUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAddIAASUnitsCall) DoAndReturn(f func(context.Context, application.ID, ...application0.AddIAASUnitArg) ([]unit.Name, []machine.Name, error)) *MockStateAddIAASUnitsCall {
+func (c *MockStateAddIAASUnitsCall) DoAndReturn(f func(context.Context, application.UUID, ...application0.AddIAASUnitArg) ([]unit.Name, []machine.Name, error)) *MockStateAddIAASUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -794,10 +794,10 @@ func (c *MockStateCheckAllApplicationsAndUnitsAreAliveCall) DoAndReturn(f func(c
 }
 
 // CreateCAASApplication mocks base method.
-func (m *MockState) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 application0.AddCAASApplicationArg, arg3 []application0.AddCAASUnitArg) (application.ID, error) {
+func (m *MockState) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 application0.AddCAASApplicationArg, arg3 []application0.AddCAASUnitArg) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCAASApplication", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -815,28 +815,28 @@ type MockStateCreateCAASApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateCreateCAASApplicationCall) Return(arg0 application.ID, arg1 error) *MockStateCreateCAASApplicationCall {
+func (c *MockStateCreateCAASApplicationCall) Return(arg0 application.UUID, arg1 error) *MockStateCreateCAASApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateCreateCAASApplicationCall) Do(f func(context.Context, string, application0.AddCAASApplicationArg, []application0.AddCAASUnitArg) (application.ID, error)) *MockStateCreateCAASApplicationCall {
+func (c *MockStateCreateCAASApplicationCall) Do(f func(context.Context, string, application0.AddCAASApplicationArg, []application0.AddCAASUnitArg) (application.UUID, error)) *MockStateCreateCAASApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateCAASApplicationCall) DoAndReturn(f func(context.Context, string, application0.AddCAASApplicationArg, []application0.AddCAASUnitArg) (application.ID, error)) *MockStateCreateCAASApplicationCall {
+func (c *MockStateCreateCAASApplicationCall) DoAndReturn(f func(context.Context, string, application0.AddCAASApplicationArg, []application0.AddCAASUnitArg) (application.UUID, error)) *MockStateCreateCAASApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateIAASApplication mocks base method.
-func (m *MockState) CreateIAASApplication(arg0 context.Context, arg1 string, arg2 application0.AddIAASApplicationArg, arg3 []application0.AddIAASUnitArg) (application.ID, []machine.Name, error) {
+func (m *MockState) CreateIAASApplication(arg0 context.Context, arg1 string, arg2 application0.AddIAASApplicationArg, arg3 []application0.AddIAASUnitArg) (application.UUID, []machine.Name, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateIAASApplication", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].([]machine.Name)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -855,19 +855,19 @@ type MockStateCreateIAASApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateCreateIAASApplicationCall) Return(arg0 application.ID, arg1 []machine.Name, arg2 error) *MockStateCreateIAASApplicationCall {
+func (c *MockStateCreateIAASApplicationCall) Return(arg0 application.UUID, arg1 []machine.Name, arg2 error) *MockStateCreateIAASApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateCreateIAASApplicationCall) Do(f func(context.Context, string, application0.AddIAASApplicationArg, []application0.AddIAASUnitArg) (application.ID, []machine.Name, error)) *MockStateCreateIAASApplicationCall {
+func (c *MockStateCreateIAASApplicationCall) Do(f func(context.Context, string, application0.AddIAASApplicationArg, []application0.AddIAASUnitArg) (application.UUID, []machine.Name, error)) *MockStateCreateIAASApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateIAASApplicationCall) DoAndReturn(f func(context.Context, string, application0.AddIAASApplicationArg, []application0.AddIAASUnitArg) (application.ID, []machine.Name, error)) *MockStateCreateIAASApplicationCall {
+func (c *MockStateCreateIAASApplicationCall) DoAndReturn(f func(context.Context, string, application0.AddIAASApplicationArg, []application0.AddIAASUnitArg) (application.UUID, []machine.Name, error)) *MockStateCreateIAASApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -949,7 +949,7 @@ func (c *MockStateDetachStorageForUnitCall) DoAndReturn(f func(context.Context, 
 }
 
 // EndpointsExist mocks base method.
-func (m *MockState) EndpointsExist(arg0 context.Context, arg1 application.ID, arg2 set.Strings) error {
+func (m *MockState) EndpointsExist(arg0 context.Context, arg1 application.UUID, arg2 set.Strings) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EndpointsExist", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -975,19 +975,19 @@ func (c *MockStateEndpointsExistCall) Return(arg0 error) *MockStateEndpointsExis
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateEndpointsExistCall) Do(f func(context.Context, application.ID, set.Strings) error) *MockStateEndpointsExistCall {
+func (c *MockStateEndpointsExistCall) Do(f func(context.Context, application.UUID, set.Strings) error) *MockStateEndpointsExistCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateEndpointsExistCall) DoAndReturn(f func(context.Context, application.ID, set.Strings) error) *MockStateEndpointsExistCall {
+func (c *MockStateEndpointsExistCall) DoAndReturn(f func(context.Context, application.UUID, set.Strings) error) *MockStateEndpointsExistCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetAddressesHash mocks base method.
-func (m *MockState) GetAddressesHash(arg0 context.Context, arg1 application.ID, arg2 string) (string, error) {
+func (m *MockState) GetAddressesHash(arg0 context.Context, arg1 application.UUID, arg2 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAddressesHash", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
@@ -1014,13 +1014,13 @@ func (c *MockStateGetAddressesHashCall) Return(arg0 string, arg1 error) *MockSta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetAddressesHashCall) Do(f func(context.Context, application.ID, string) (string, error)) *MockStateGetAddressesHashCall {
+func (c *MockStateGetAddressesHashCall) Do(f func(context.Context, application.UUID, string) (string, error)) *MockStateGetAddressesHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetAddressesHashCall) DoAndReturn(f func(context.Context, application.ID, string) (string, error)) *MockStateGetAddressesHashCall {
+func (c *MockStateGetAddressesHashCall) DoAndReturn(f func(context.Context, application.UUID, string) (string, error)) *MockStateGetAddressesHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1065,7 +1065,7 @@ func (c *MockStateGetAllEndpointBindingsCall) DoAndReturn(f func(context.Context
 }
 
 // GetAllUnitCloudContainerIDsForApplication mocks base method.
-func (m *MockState) GetAllUnitCloudContainerIDsForApplication(arg0 context.Context, arg1 application.ID) (map[unit.Name]string, error) {
+func (m *MockState) GetAllUnitCloudContainerIDsForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllUnitCloudContainerIDsForApplication", arg0, arg1)
 	ret0, _ := ret[0].(map[unit.Name]string)
@@ -1092,19 +1092,19 @@ func (c *MockStateGetAllUnitCloudContainerIDsForApplicationCall) Return(arg0 map
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetAllUnitCloudContainerIDsForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.Name]string, error)) *MockStateGetAllUnitCloudContainerIDsForApplicationCall {
+func (c *MockStateGetAllUnitCloudContainerIDsForApplicationCall) Do(f func(context.Context, application.UUID) (map[unit.Name]string, error)) *MockStateGetAllUnitCloudContainerIDsForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetAllUnitCloudContainerIDsForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.Name]string, error)) *MockStateGetAllUnitCloudContainerIDsForApplicationCall {
+func (c *MockStateGetAllUnitCloudContainerIDsForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[unit.Name]string, error)) *MockStateGetAllUnitCloudContainerIDsForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetAllUnitLifeForApplication mocks base method.
-func (m *MockState) GetAllUnitLifeForApplication(arg0 context.Context, arg1 application.ID) (map[string]int, error) {
+func (m *MockState) GetAllUnitLifeForApplication(arg0 context.Context, arg1 application.UUID) (map[string]int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllUnitLifeForApplication", arg0, arg1)
 	ret0, _ := ret[0].(map[string]int)
@@ -1131,13 +1131,13 @@ func (c *MockStateGetAllUnitLifeForApplicationCall) Return(arg0 map[string]int, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetAllUnitLifeForApplicationCall) Do(f func(context.Context, application.ID) (map[string]int, error)) *MockStateGetAllUnitLifeForApplicationCall {
+func (c *MockStateGetAllUnitLifeForApplicationCall) Do(f func(context.Context, application.UUID) (map[string]int, error)) *MockStateGetAllUnitLifeForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetAllUnitLifeForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[string]int, error)) *MockStateGetAllUnitLifeForApplicationCall {
+func (c *MockStateGetAllUnitLifeForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[string]int, error)) *MockStateGetAllUnitLifeForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1182,7 +1182,7 @@ func (c *MockStateGetAllUnitNamesCall) DoAndReturn(f func(context.Context) ([]un
 }
 
 // GetApplicationCharmOrigin mocks base method.
-func (m *MockState) GetApplicationCharmOrigin(arg0 context.Context, arg1 application.ID) (application0.CharmOrigin, error) {
+func (m *MockState) GetApplicationCharmOrigin(arg0 context.Context, arg1 application.UUID) (application0.CharmOrigin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationCharmOrigin", arg0, arg1)
 	ret0, _ := ret[0].(application0.CharmOrigin)
@@ -1209,19 +1209,19 @@ func (c *MockStateGetApplicationCharmOriginCall) Return(arg0 application0.CharmO
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationCharmOriginCall) Do(f func(context.Context, application.ID) (application0.CharmOrigin, error)) *MockStateGetApplicationCharmOriginCall {
+func (c *MockStateGetApplicationCharmOriginCall) Do(f func(context.Context, application.UUID) (application0.CharmOrigin, error)) *MockStateGetApplicationCharmOriginCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationCharmOriginCall) DoAndReturn(f func(context.Context, application.ID) (application0.CharmOrigin, error)) *MockStateGetApplicationCharmOriginCall {
+func (c *MockStateGetApplicationCharmOriginCall) DoAndReturn(f func(context.Context, application.UUID) (application0.CharmOrigin, error)) *MockStateGetApplicationCharmOriginCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationConfigAndSettings mocks base method.
-func (m *MockState) GetApplicationConfigAndSettings(arg0 context.Context, arg1 application.ID) (map[string]application0.ApplicationConfig, application0.ApplicationSettings, error) {
+func (m *MockState) GetApplicationConfigAndSettings(arg0 context.Context, arg1 application.UUID) (map[string]application0.ApplicationConfig, application0.ApplicationSettings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationConfigAndSettings", arg0, arg1)
 	ret0, _ := ret[0].(map[string]application0.ApplicationConfig)
@@ -1249,19 +1249,19 @@ func (c *MockStateGetApplicationConfigAndSettingsCall) Return(arg0 map[string]ap
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationConfigAndSettingsCall) Do(f func(context.Context, application.ID) (map[string]application0.ApplicationConfig, application0.ApplicationSettings, error)) *MockStateGetApplicationConfigAndSettingsCall {
+func (c *MockStateGetApplicationConfigAndSettingsCall) Do(f func(context.Context, application.UUID) (map[string]application0.ApplicationConfig, application0.ApplicationSettings, error)) *MockStateGetApplicationConfigAndSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationConfigAndSettingsCall) DoAndReturn(f func(context.Context, application.ID) (map[string]application0.ApplicationConfig, application0.ApplicationSettings, error)) *MockStateGetApplicationConfigAndSettingsCall {
+func (c *MockStateGetApplicationConfigAndSettingsCall) DoAndReturn(f func(context.Context, application.UUID) (map[string]application0.ApplicationConfig, application0.ApplicationSettings, error)) *MockStateGetApplicationConfigAndSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationConfigHash mocks base method.
-func (m *MockState) GetApplicationConfigHash(arg0 context.Context, arg1 application.ID) (string, error) {
+func (m *MockState) GetApplicationConfigHash(arg0 context.Context, arg1 application.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationConfigHash", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -1288,19 +1288,19 @@ func (c *MockStateGetApplicationConfigHashCall) Return(arg0 string, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationConfigHashCall) Do(f func(context.Context, application.ID) (string, error)) *MockStateGetApplicationConfigHashCall {
+func (c *MockStateGetApplicationConfigHashCall) Do(f func(context.Context, application.UUID) (string, error)) *MockStateGetApplicationConfigHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationConfigHashCall) DoAndReturn(f func(context.Context, application.ID) (string, error)) *MockStateGetApplicationConfigHashCall {
+func (c *MockStateGetApplicationConfigHashCall) DoAndReturn(f func(context.Context, application.UUID) (string, error)) *MockStateGetApplicationConfigHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationConfigWithDefaults mocks base method.
-func (m *MockState) GetApplicationConfigWithDefaults(arg0 context.Context, arg1 application.ID) (map[string]application0.ApplicationConfig, error) {
+func (m *MockState) GetApplicationConfigWithDefaults(arg0 context.Context, arg1 application.UUID) (map[string]application0.ApplicationConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationConfigWithDefaults", arg0, arg1)
 	ret0, _ := ret[0].(map[string]application0.ApplicationConfig)
@@ -1327,19 +1327,19 @@ func (c *MockStateGetApplicationConfigWithDefaultsCall) Return(arg0 map[string]a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationConfigWithDefaultsCall) Do(f func(context.Context, application.ID) (map[string]application0.ApplicationConfig, error)) *MockStateGetApplicationConfigWithDefaultsCall {
+func (c *MockStateGetApplicationConfigWithDefaultsCall) Do(f func(context.Context, application.UUID) (map[string]application0.ApplicationConfig, error)) *MockStateGetApplicationConfigWithDefaultsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationConfigWithDefaultsCall) DoAndReturn(f func(context.Context, application.ID) (map[string]application0.ApplicationConfig, error)) *MockStateGetApplicationConfigWithDefaultsCall {
+func (c *MockStateGetApplicationConfigWithDefaultsCall) DoAndReturn(f func(context.Context, application.UUID) (map[string]application0.ApplicationConfig, error)) *MockStateGetApplicationConfigWithDefaultsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationConstraints mocks base method.
-func (m *MockState) GetApplicationConstraints(arg0 context.Context, arg1 application.ID) (constraints0.Constraints, error) {
+func (m *MockState) GetApplicationConstraints(arg0 context.Context, arg1 application.UUID) (constraints0.Constraints, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationConstraints", arg0, arg1)
 	ret0, _ := ret[0].(constraints0.Constraints)
@@ -1366,19 +1366,19 @@ func (c *MockStateGetApplicationConstraintsCall) Return(arg0 constraints0.Constr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationConstraintsCall) Do(f func(context.Context, application.ID) (constraints0.Constraints, error)) *MockStateGetApplicationConstraintsCall {
+func (c *MockStateGetApplicationConstraintsCall) Do(f func(context.Context, application.UUID) (constraints0.Constraints, error)) *MockStateGetApplicationConstraintsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID) (constraints0.Constraints, error)) *MockStateGetApplicationConstraintsCall {
+func (c *MockStateGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.UUID) (constraints0.Constraints, error)) *MockStateGetApplicationConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationEndpointBindings mocks base method.
-func (m *MockState) GetApplicationEndpointBindings(arg0 context.Context, arg1 application.ID) (map[string]string, error) {
+func (m *MockState) GetApplicationEndpointBindings(arg0 context.Context, arg1 application.UUID) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationEndpointBindings", arg0, arg1)
 	ret0, _ := ret[0].(map[string]string)
@@ -1405,19 +1405,19 @@ func (c *MockStateGetApplicationEndpointBindingsCall) Return(arg0 map[string]str
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationEndpointBindingsCall) Do(f func(context.Context, application.ID) (map[string]string, error)) *MockStateGetApplicationEndpointBindingsCall {
+func (c *MockStateGetApplicationEndpointBindingsCall) Do(f func(context.Context, application.UUID) (map[string]string, error)) *MockStateGetApplicationEndpointBindingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationEndpointBindingsCall) DoAndReturn(f func(context.Context, application.ID) (map[string]string, error)) *MockStateGetApplicationEndpointBindingsCall {
+func (c *MockStateGetApplicationEndpointBindingsCall) DoAndReturn(f func(context.Context, application.UUID) (map[string]string, error)) *MockStateGetApplicationEndpointBindingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationEndpointNames mocks base method.
-func (m *MockState) GetApplicationEndpointNames(arg0 context.Context, arg1 application.ID) ([]string, error) {
+func (m *MockState) GetApplicationEndpointNames(arg0 context.Context, arg1 application.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationEndpointNames", arg0, arg1)
 	ret0, _ := ret[0].([]string)
@@ -1444,22 +1444,22 @@ func (c *MockStateGetApplicationEndpointNamesCall) Return(arg0 []string, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationEndpointNamesCall) Do(f func(context.Context, application.ID) ([]string, error)) *MockStateGetApplicationEndpointNamesCall {
+func (c *MockStateGetApplicationEndpointNamesCall) Do(f func(context.Context, application.UUID) ([]string, error)) *MockStateGetApplicationEndpointNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationEndpointNamesCall) DoAndReturn(f func(context.Context, application.ID) ([]string, error)) *MockStateGetApplicationEndpointNamesCall {
+func (c *MockStateGetApplicationEndpointNamesCall) DoAndReturn(f func(context.Context, application.UUID) ([]string, error)) *MockStateGetApplicationEndpointNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDAndNameByUnitName mocks base method.
-func (m *MockState) GetApplicationIDAndNameByUnitName(arg0 context.Context, arg1 unit.Name) (application.ID, string, error) {
+func (m *MockState) GetApplicationIDAndNameByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDAndNameByUnitName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -1478,28 +1478,28 @@ type MockStateGetApplicationIDAndNameByUnitNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationIDAndNameByUnitNameCall) Return(arg0 application.ID, arg1 string, arg2 error) *MockStateGetApplicationIDAndNameByUnitNameCall {
+func (c *MockStateGetApplicationIDAndNameByUnitNameCall) Return(arg0 application.UUID, arg1 string, arg2 error) *MockStateGetApplicationIDAndNameByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationIDAndNameByUnitNameCall) Do(f func(context.Context, unit.Name) (application.ID, string, error)) *MockStateGetApplicationIDAndNameByUnitNameCall {
+func (c *MockStateGetApplicationIDAndNameByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockStateGetApplicationIDAndNameByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationIDAndNameByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.ID, string, error)) *MockStateGetApplicationIDAndNameByUnitNameCall {
+func (c *MockStateGetApplicationIDAndNameByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockStateGetApplicationIDAndNameByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1517,28 +1517,28 @@ type MockStateGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockStateGetApplicationIDByNameCall {
+func (c *MockStateGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockStateGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockStateGetApplicationIDByNameCall {
+func (c *MockStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockStateGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockStateGetApplicationIDByNameCall {
+func (c *MockStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockStateGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByUnitName mocks base method.
-func (m *MockState) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.ID, error) {
+func (m *MockState) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByUnitName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1556,25 +1556,25 @@ type MockStateGetApplicationIDByUnitNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationIDByUnitNameCall) Return(arg0 application.ID, arg1 error) *MockStateGetApplicationIDByUnitNameCall {
+func (c *MockStateGetApplicationIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockStateGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.ID, error)) *MockStateGetApplicationIDByUnitNameCall {
+func (c *MockStateGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockStateGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.ID, error)) *MockStateGetApplicationIDByUnitNameCall {
+func (c *MockStateGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockStateGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationLife mocks base method.
-func (m *MockState) GetApplicationLife(arg0 context.Context, arg1 application.ID) (life.Life, error) {
+func (m *MockState) GetApplicationLife(arg0 context.Context, arg1 application.UUID) (life.Life, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationLife", arg0, arg1)
 	ret0, _ := ret[0].(life.Life)
@@ -1601,22 +1601,22 @@ func (c *MockStateGetApplicationLifeCall) Return(arg0 life.Life, arg1 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationLifeCall) Do(f func(context.Context, application.ID) (life.Life, error)) *MockStateGetApplicationLifeCall {
+func (c *MockStateGetApplicationLifeCall) Do(f func(context.Context, application.UUID) (life.Life, error)) *MockStateGetApplicationLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.ID) (life.Life, error)) *MockStateGetApplicationLifeCall {
+func (c *MockStateGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.UUID) (life.Life, error)) *MockStateGetApplicationLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationLifeByName mocks base method.
-func (m *MockState) GetApplicationLifeByName(arg0 context.Context, arg1 string) (application.ID, life.Life, error) {
+func (m *MockState) GetApplicationLifeByName(arg0 context.Context, arg1 string) (application.UUID, life.Life, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationLifeByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(life.Life)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -1635,25 +1635,25 @@ type MockStateGetApplicationLifeByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationLifeByNameCall) Return(arg0 application.ID, arg1 life.Life, arg2 error) *MockStateGetApplicationLifeByNameCall {
+func (c *MockStateGetApplicationLifeByNameCall) Return(arg0 application.UUID, arg1 life.Life, arg2 error) *MockStateGetApplicationLifeByNameCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationLifeByNameCall) Do(f func(context.Context, string) (application.ID, life.Life, error)) *MockStateGetApplicationLifeByNameCall {
+func (c *MockStateGetApplicationLifeByNameCall) Do(f func(context.Context, string) (application.UUID, life.Life, error)) *MockStateGetApplicationLifeByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationLifeByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, life.Life, error)) *MockStateGetApplicationLifeByNameCall {
+func (c *MockStateGetApplicationLifeByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, life.Life, error)) *MockStateGetApplicationLifeByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationName mocks base method.
-func (m *MockState) GetApplicationName(arg0 context.Context, arg1 application.ID) (string, error) {
+func (m *MockState) GetApplicationName(arg0 context.Context, arg1 application.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationName", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -1680,19 +1680,19 @@ func (c *MockStateGetApplicationNameCall) Return(arg0 string, arg1 error) *MockS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationNameCall) Do(f func(context.Context, application.ID) (string, error)) *MockStateGetApplicationNameCall {
+func (c *MockStateGetApplicationNameCall) Do(f func(context.Context, application.UUID) (string, error)) *MockStateGetApplicationNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationNameCall) DoAndReturn(f func(context.Context, application.ID) (string, error)) *MockStateGetApplicationNameCall {
+func (c *MockStateGetApplicationNameCall) DoAndReturn(f func(context.Context, application.UUID) (string, error)) *MockStateGetApplicationNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationScaleState mocks base method.
-func (m *MockState) GetApplicationScaleState(arg0 context.Context, arg1 application.ID) (application0.ScaleState, error) {
+func (m *MockState) GetApplicationScaleState(arg0 context.Context, arg1 application.UUID) (application0.ScaleState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationScaleState", arg0, arg1)
 	ret0, _ := ret[0].(application0.ScaleState)
@@ -1719,19 +1719,19 @@ func (c *MockStateGetApplicationScaleStateCall) Return(arg0 application0.ScaleSt
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationScaleStateCall) Do(f func(context.Context, application.ID) (application0.ScaleState, error)) *MockStateGetApplicationScaleStateCall {
+func (c *MockStateGetApplicationScaleStateCall) Do(f func(context.Context, application.UUID) (application0.ScaleState, error)) *MockStateGetApplicationScaleStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationScaleStateCall) DoAndReturn(f func(context.Context, application.ID) (application0.ScaleState, error)) *MockStateGetApplicationScaleStateCall {
+func (c *MockStateGetApplicationScaleStateCall) DoAndReturn(f func(context.Context, application.UUID) (application0.ScaleState, error)) *MockStateGetApplicationScaleStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationStorageDirectives mocks base method.
-func (m *MockState) GetApplicationStorageDirectives(arg0 context.Context, arg1 application.ID) ([]application0.StorageDirective, error) {
+func (m *MockState) GetApplicationStorageDirectives(arg0 context.Context, arg1 application.UUID) ([]application0.StorageDirective, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationStorageDirectives", arg0, arg1)
 	ret0, _ := ret[0].([]application0.StorageDirective)
@@ -1758,19 +1758,19 @@ func (c *MockStateGetApplicationStorageDirectivesCall) Return(arg0 []application
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationStorageDirectivesCall) Do(f func(context.Context, application.ID) ([]application0.StorageDirective, error)) *MockStateGetApplicationStorageDirectivesCall {
+func (c *MockStateGetApplicationStorageDirectivesCall) Do(f func(context.Context, application.UUID) ([]application0.StorageDirective, error)) *MockStateGetApplicationStorageDirectivesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationStorageDirectivesCall) DoAndReturn(f func(context.Context, application.ID) ([]application0.StorageDirective, error)) *MockStateGetApplicationStorageDirectivesCall {
+func (c *MockStateGetApplicationStorageDirectivesCall) DoAndReturn(f func(context.Context, application.UUID) ([]application0.StorageDirective, error)) *MockStateGetApplicationStorageDirectivesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationTrustSetting mocks base method.
-func (m *MockState) GetApplicationTrustSetting(arg0 context.Context, arg1 application.ID) (bool, error) {
+func (m *MockState) GetApplicationTrustSetting(arg0 context.Context, arg1 application.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationTrustSetting", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -1797,13 +1797,13 @@ func (c *MockStateGetApplicationTrustSettingCall) Return(arg0 bool, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationTrustSettingCall) Do(f func(context.Context, application.ID) (bool, error)) *MockStateGetApplicationTrustSettingCall {
+func (c *MockStateGetApplicationTrustSettingCall) Do(f func(context.Context, application.UUID) (bool, error)) *MockStateGetApplicationTrustSettingCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationTrustSettingCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockStateGetApplicationTrustSettingCall {
+func (c *MockStateGetApplicationTrustSettingCall) DoAndReturn(f func(context.Context, application.UUID) (bool, error)) *MockStateGetApplicationTrustSettingCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1853,7 +1853,7 @@ func (c *MockStateGetApplicationUnitLifeCall) DoAndReturn(f func(context.Context
 }
 
 // GetApplicationUnitsForExport mocks base method.
-func (m *MockState) GetApplicationUnitsForExport(arg0 context.Context, arg1 application.ID) ([]application0.ExportUnit, error) {
+func (m *MockState) GetApplicationUnitsForExport(arg0 context.Context, arg1 application.UUID) ([]application0.ExportUnit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationUnitsForExport", arg0, arg1)
 	ret0, _ := ret[0].([]application0.ExportUnit)
@@ -1880,13 +1880,13 @@ func (c *MockStateGetApplicationUnitsForExportCall) Return(arg0 []application0.E
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationUnitsForExportCall) Do(f func(context.Context, application.ID) ([]application0.ExportUnit, error)) *MockStateGetApplicationUnitsForExportCall {
+func (c *MockStateGetApplicationUnitsForExportCall) Do(f func(context.Context, application.UUID) ([]application0.ExportUnit, error)) *MockStateGetApplicationUnitsForExportCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationUnitsForExportCall) DoAndReturn(f func(context.Context, application.ID) ([]application0.ExportUnit, error)) *MockStateGetApplicationUnitsForExportCall {
+func (c *MockStateGetApplicationUnitsForExportCall) DoAndReturn(f func(context.Context, application.UUID) ([]application0.ExportUnit, error)) *MockStateGetApplicationUnitsForExportCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2009,10 +2009,10 @@ func (c *MockStateGetApplicationsForRevisionUpdaterCall) DoAndReturn(f func(cont
 }
 
 // GetApplicationsWithPendingCharmsFromUUIDs mocks base method.
-func (m *MockState) GetApplicationsWithPendingCharmsFromUUIDs(arg0 context.Context, arg1 []application.ID) ([]application.ID, error) {
+func (m *MockState) GetApplicationsWithPendingCharmsFromUUIDs(arg0 context.Context, arg1 []application.UUID) ([]application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationsWithPendingCharmsFromUUIDs", arg0, arg1)
-	ret0, _ := ret[0].([]application.ID)
+	ret0, _ := ret[0].([]application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2030,25 +2030,25 @@ type MockStateGetApplicationsWithPendingCharmsFromUUIDsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall) Return(arg0 []application.ID, arg1 error) *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall {
+func (c *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall) Return(arg0 []application.UUID, arg1 error) *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall) Do(f func(context.Context, []application.ID) ([]application.ID, error)) *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall {
+func (c *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall) Do(f func(context.Context, []application.UUID) ([]application.UUID, error)) *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall) DoAndReturn(f func(context.Context, []application.ID) ([]application.ID, error)) *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall {
+func (c *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall) DoAndReturn(f func(context.Context, []application.UUID) ([]application.UUID, error)) *MockStateGetApplicationsWithPendingCharmsFromUUIDsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetAsyncCharmDownloadInfo mocks base method.
-func (m *MockState) GetAsyncCharmDownloadInfo(arg0 context.Context, arg1 application.ID) (application0.CharmDownloadInfo, error) {
+func (m *MockState) GetAsyncCharmDownloadInfo(arg0 context.Context, arg1 application.UUID) (application0.CharmDownloadInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAsyncCharmDownloadInfo", arg0, arg1)
 	ret0, _ := ret[0].(application0.CharmDownloadInfo)
@@ -2075,13 +2075,13 @@ func (c *MockStateGetAsyncCharmDownloadInfoCall) Return(arg0 application0.CharmD
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetAsyncCharmDownloadInfoCall) Do(f func(context.Context, application.ID) (application0.CharmDownloadInfo, error)) *MockStateGetAsyncCharmDownloadInfoCall {
+func (c *MockStateGetAsyncCharmDownloadInfoCall) Do(f func(context.Context, application.UUID) (application0.CharmDownloadInfo, error)) *MockStateGetAsyncCharmDownloadInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetAsyncCharmDownloadInfoCall) DoAndReturn(f func(context.Context, application.ID) (application0.CharmDownloadInfo, error)) *MockStateGetAsyncCharmDownloadInfoCall {
+func (c *MockStateGetAsyncCharmDownloadInfoCall) DoAndReturn(f func(context.Context, application.UUID) (application0.CharmDownloadInfo, error)) *MockStateGetAsyncCharmDownloadInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2284,7 +2284,7 @@ func (c *MockStateGetCharmArchivePathCall) DoAndReturn(f func(context.Context, c
 }
 
 // GetCharmByApplicationID mocks base method.
-func (m *MockState) GetCharmByApplicationID(arg0 context.Context, arg1 application.ID) (charm0.Charm, error) {
+func (m *MockState) GetCharmByApplicationID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmByApplicationID", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Charm)
@@ -2311,13 +2311,13 @@ func (c *MockStateGetCharmByApplicationIDCall) Return(arg0 charm0.Charm, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetCharmByApplicationIDCall) Do(f func(context.Context, application.ID) (charm0.Charm, error)) *MockStateGetCharmByApplicationIDCall {
+func (c *MockStateGetCharmByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, error)) *MockStateGetCharmByApplicationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.ID) (charm0.Charm, error)) *MockStateGetCharmByApplicationIDCall {
+func (c *MockStateGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, error)) *MockStateGetCharmByApplicationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2362,7 +2362,7 @@ func (c *MockStateGetCharmConfigCall) DoAndReturn(f func(context.Context, charm.
 }
 
 // GetCharmConfigByApplicationID mocks base method.
-func (m *MockState) GetCharmConfigByApplicationID(arg0 context.Context, arg1 application.ID) (charm.ID, charm0.Config, error) {
+func (m *MockState) GetCharmConfigByApplicationID(arg0 context.Context, arg1 application.UUID) (charm.ID, charm0.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmConfigByApplicationID", arg0, arg1)
 	ret0, _ := ret[0].(charm.ID)
@@ -2390,13 +2390,13 @@ func (c *MockStateGetCharmConfigByApplicationIDCall) Return(arg0 charm.ID, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetCharmConfigByApplicationIDCall) Do(f func(context.Context, application.ID) (charm.ID, charm0.Config, error)) *MockStateGetCharmConfigByApplicationIDCall {
+func (c *MockStateGetCharmConfigByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm.ID, charm0.Config, error)) *MockStateGetCharmConfigByApplicationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCharmConfigByApplicationIDCall) DoAndReturn(f func(context.Context, application.ID) (charm.ID, charm0.Config, error)) *MockStateGetCharmConfigByApplicationIDCall {
+func (c *MockStateGetCharmConfigByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm.ID, charm0.Config, error)) *MockStateGetCharmConfigByApplicationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2832,7 +2832,7 @@ func (c *MockStateGetCharmMetadataStorageCall) DoAndReturn(f func(context.Contex
 }
 
 // GetCharmModifiedVersion mocks base method.
-func (m *MockState) GetCharmModifiedVersion(arg0 context.Context, arg1 application.ID) (int, error) {
+func (m *MockState) GetCharmModifiedVersion(arg0 context.Context, arg1 application.UUID) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmModifiedVersion", arg0, arg1)
 	ret0, _ := ret[0].(int)
@@ -2859,13 +2859,13 @@ func (c *MockStateGetCharmModifiedVersionCall) Return(arg0 int, arg1 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetCharmModifiedVersionCall) Do(f func(context.Context, application.ID) (int, error)) *MockStateGetCharmModifiedVersionCall {
+func (c *MockStateGetCharmModifiedVersionCall) Do(f func(context.Context, application.UUID) (int, error)) *MockStateGetCharmModifiedVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCharmModifiedVersionCall) DoAndReturn(f func(context.Context, application.ID) (int, error)) *MockStateGetCharmModifiedVersionCall {
+func (c *MockStateGetCharmModifiedVersionCall) DoAndReturn(f func(context.Context, application.UUID) (int, error)) *MockStateGetCharmModifiedVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2910,7 +2910,7 @@ func (c *MockStateGetDefaultStorageProvisionersCall) DoAndReturn(f func(context.
 }
 
 // GetDeviceConstraints mocks base method.
-func (m *MockState) GetDeviceConstraints(arg0 context.Context, arg1 application.ID) (map[string]devices.Constraints, error) {
+func (m *MockState) GetDeviceConstraints(arg0 context.Context, arg1 application.UUID) (map[string]devices.Constraints, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeviceConstraints", arg0, arg1)
 	ret0, _ := ret[0].(map[string]devices.Constraints)
@@ -2937,19 +2937,19 @@ func (c *MockStateGetDeviceConstraintsCall) Return(arg0 map[string]devices.Const
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetDeviceConstraintsCall) Do(f func(context.Context, application.ID) (map[string]devices.Constraints, error)) *MockStateGetDeviceConstraintsCall {
+func (c *MockStateGetDeviceConstraintsCall) Do(f func(context.Context, application.UUID) (map[string]devices.Constraints, error)) *MockStateGetDeviceConstraintsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetDeviceConstraintsCall) DoAndReturn(f func(context.Context, application.ID) (map[string]devices.Constraints, error)) *MockStateGetDeviceConstraintsCall {
+func (c *MockStateGetDeviceConstraintsCall) DoAndReturn(f func(context.Context, application.UUID) (map[string]devices.Constraints, error)) *MockStateGetDeviceConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetExposedEndpoints mocks base method.
-func (m *MockState) GetExposedEndpoints(arg0 context.Context, arg1 application.ID) (map[string]application0.ExposedEndpoint, error) {
+func (m *MockState) GetExposedEndpoints(arg0 context.Context, arg1 application.UUID) (map[string]application0.ExposedEndpoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExposedEndpoints", arg0, arg1)
 	ret0, _ := ret[0].(map[string]application0.ExposedEndpoint)
@@ -2976,13 +2976,13 @@ func (c *MockStateGetExposedEndpointsCall) Return(arg0 map[string]application0.E
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetExposedEndpointsCall) Do(f func(context.Context, application.ID) (map[string]application0.ExposedEndpoint, error)) *MockStateGetExposedEndpointsCall {
+func (c *MockStateGetExposedEndpointsCall) Do(f func(context.Context, application.UUID) (map[string]application0.ExposedEndpoint, error)) *MockStateGetExposedEndpointsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetExposedEndpointsCall) DoAndReturn(f func(context.Context, application.ID) (map[string]application0.ExposedEndpoint, error)) *MockStateGetExposedEndpointsCall {
+func (c *MockStateGetExposedEndpointsCall) DoAndReturn(f func(context.Context, application.UUID) (map[string]application0.ExposedEndpoint, error)) *MockStateGetExposedEndpointsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -3262,7 +3262,7 @@ func (c *MockStateGetSpaceUUIDByNameCall) DoAndReturn(f func(context.Context, st
 }
 
 // GetStorageInstancesForProviderIDs mocks base method.
-func (m *MockState) GetStorageInstancesForProviderIDs(arg0 context.Context, arg1 application.ID, arg2 []string) (map[string]storage0.StorageInstanceUUID, error) {
+func (m *MockState) GetStorageInstancesForProviderIDs(arg0 context.Context, arg1 application.UUID, arg2 []string) (map[string]storage0.StorageInstanceUUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStorageInstancesForProviderIDs", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]storage0.StorageInstanceUUID)
@@ -3289,13 +3289,13 @@ func (c *MockStateGetStorageInstancesForProviderIDsCall) Return(arg0 map[string]
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetStorageInstancesForProviderIDsCall) Do(f func(context.Context, application.ID, []string) (map[string]storage0.StorageInstanceUUID, error)) *MockStateGetStorageInstancesForProviderIDsCall {
+func (c *MockStateGetStorageInstancesForProviderIDsCall) Do(f func(context.Context, application.UUID, []string) (map[string]storage0.StorageInstanceUUID, error)) *MockStateGetStorageInstancesForProviderIDsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetStorageInstancesForProviderIDsCall) DoAndReturn(f func(context.Context, application.ID, []string) (map[string]storage0.StorageInstanceUUID, error)) *MockStateGetStorageInstancesForProviderIDsCall {
+func (c *MockStateGetStorageInstancesForProviderIDsCall) DoAndReturn(f func(context.Context, application.UUID, []string) (map[string]storage0.StorageInstanceUUID, error)) *MockStateGetStorageInstancesForProviderIDsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -3496,7 +3496,7 @@ func (c *MockStateGetUnitMachineUUIDCall) DoAndReturn(f func(context.Context, un
 }
 
 // GetUnitNamesForApplication mocks base method.
-func (m *MockState) GetUnitNamesForApplication(arg0 context.Context, arg1 application.ID) ([]unit.Name, error) {
+func (m *MockState) GetUnitNamesForApplication(arg0 context.Context, arg1 application.UUID) ([]unit.Name, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitNamesForApplication", arg0, arg1)
 	ret0, _ := ret[0].([]unit.Name)
@@ -3523,13 +3523,13 @@ func (c *MockStateGetUnitNamesForApplicationCall) Return(arg0 []unit.Name, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitNamesForApplicationCall) Do(f func(context.Context, application.ID) ([]unit.Name, error)) *MockStateGetUnitNamesForApplicationCall {
+func (c *MockStateGetUnitNamesForApplicationCall) Do(f func(context.Context, application.UUID) ([]unit.Name, error)) *MockStateGetUnitNamesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitNamesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) ([]unit.Name, error)) *MockStateGetUnitNamesForApplicationCall {
+func (c *MockStateGetUnitNamesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) ([]unit.Name, error)) *MockStateGetUnitNamesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -4083,7 +4083,7 @@ func (c *MockStateInitialWatchStatementApplicationsWithPendingCharmsCall) DoAndR
 }
 
 // InitialWatchStatementUnitAddressesHash mocks base method.
-func (m *MockState) InitialWatchStatementUnitAddressesHash(arg0 application.ID, arg1 string) (string, string, eventsource.NamespaceQuery) {
+func (m *MockState) InitialWatchStatementUnitAddressesHash(arg0 application.UUID, arg1 string) (string, string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitialWatchStatementUnitAddressesHash", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -4111,13 +4111,13 @@ func (c *MockStateInitialWatchStatementUnitAddressesHashCall) Return(arg0, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInitialWatchStatementUnitAddressesHashCall) Do(f func(application.ID, string) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementUnitAddressesHashCall {
+func (c *MockStateInitialWatchStatementUnitAddressesHashCall) Do(f func(application.UUID, string) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementUnitAddressesHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInitialWatchStatementUnitAddressesHashCall) DoAndReturn(f func(application.ID, string) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementUnitAddressesHashCall {
+func (c *MockStateInitialWatchStatementUnitAddressesHashCall) DoAndReturn(f func(application.UUID, string) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementUnitAddressesHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -4201,10 +4201,10 @@ func (c *MockStateInitialWatchStatementUnitLifeCall) DoAndReturn(f func(string) 
 }
 
 // InsertMigratingApplication mocks base method.
-func (m *MockState) InsertMigratingApplication(arg0 context.Context, arg1 string, arg2 application0.InsertApplicationArgs) (application.ID, error) {
+func (m *MockState) InsertMigratingApplication(arg0 context.Context, arg1 string, arg2 application0.InsertApplicationArgs) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertMigratingApplication", arg0, arg1, arg2)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4222,25 +4222,25 @@ type MockStateInsertMigratingApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateInsertMigratingApplicationCall) Return(arg0 application.ID, arg1 error) *MockStateInsertMigratingApplicationCall {
+func (c *MockStateInsertMigratingApplicationCall) Return(arg0 application.UUID, arg1 error) *MockStateInsertMigratingApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInsertMigratingApplicationCall) Do(f func(context.Context, string, application0.InsertApplicationArgs) (application.ID, error)) *MockStateInsertMigratingApplicationCall {
+func (c *MockStateInsertMigratingApplicationCall) Do(f func(context.Context, string, application0.InsertApplicationArgs) (application.UUID, error)) *MockStateInsertMigratingApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInsertMigratingApplicationCall) DoAndReturn(f func(context.Context, string, application0.InsertApplicationArgs) (application.ID, error)) *MockStateInsertMigratingApplicationCall {
+func (c *MockStateInsertMigratingApplicationCall) DoAndReturn(f func(context.Context, string, application0.InsertApplicationArgs) (application.UUID, error)) *MockStateInsertMigratingApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InsertMigratingCAASUnits mocks base method.
-func (m *MockState) InsertMigratingCAASUnits(arg0 context.Context, arg1 application.ID, arg2 ...application0.ImportUnitArg) error {
+func (m *MockState) InsertMigratingCAASUnits(arg0 context.Context, arg1 application.UUID, arg2 ...application0.ImportUnitArg) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -4271,19 +4271,19 @@ func (c *MockStateInsertMigratingCAASUnitsCall) Return(arg0 error) *MockStateIns
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInsertMigratingCAASUnitsCall) Do(f func(context.Context, application.ID, ...application0.ImportUnitArg) error) *MockStateInsertMigratingCAASUnitsCall {
+func (c *MockStateInsertMigratingCAASUnitsCall) Do(f func(context.Context, application.UUID, ...application0.ImportUnitArg) error) *MockStateInsertMigratingCAASUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInsertMigratingCAASUnitsCall) DoAndReturn(f func(context.Context, application.ID, ...application0.ImportUnitArg) error) *MockStateInsertMigratingCAASUnitsCall {
+func (c *MockStateInsertMigratingCAASUnitsCall) DoAndReturn(f func(context.Context, application.UUID, ...application0.ImportUnitArg) error) *MockStateInsertMigratingCAASUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InsertMigratingIAASUnits mocks base method.
-func (m *MockState) InsertMigratingIAASUnits(arg0 context.Context, arg1 application.ID, arg2 ...application0.ImportUnitArg) error {
+func (m *MockState) InsertMigratingIAASUnits(arg0 context.Context, arg1 application.UUID, arg2 ...application0.ImportUnitArg) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -4314,19 +4314,19 @@ func (c *MockStateInsertMigratingIAASUnitsCall) Return(arg0 error) *MockStateIns
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInsertMigratingIAASUnitsCall) Do(f func(context.Context, application.ID, ...application0.ImportUnitArg) error) *MockStateInsertMigratingIAASUnitsCall {
+func (c *MockStateInsertMigratingIAASUnitsCall) Do(f func(context.Context, application.UUID, ...application0.ImportUnitArg) error) *MockStateInsertMigratingIAASUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInsertMigratingIAASUnitsCall) DoAndReturn(f func(context.Context, application.ID, ...application0.ImportUnitArg) error) *MockStateInsertMigratingIAASUnitsCall {
+func (c *MockStateInsertMigratingIAASUnitsCall) DoAndReturn(f func(context.Context, application.UUID, ...application0.ImportUnitArg) error) *MockStateInsertMigratingIAASUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // IsApplicationExposed mocks base method.
-func (m *MockState) IsApplicationExposed(arg0 context.Context, arg1 application.ID) (bool, error) {
+func (m *MockState) IsApplicationExposed(arg0 context.Context, arg1 application.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsApplicationExposed", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -4353,13 +4353,13 @@ func (c *MockStateIsApplicationExposedCall) Return(arg0 bool, arg1 error) *MockS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateIsApplicationExposedCall) Do(f func(context.Context, application.ID) (bool, error)) *MockStateIsApplicationExposedCall {
+func (c *MockStateIsApplicationExposedCall) Do(f func(context.Context, application.UUID) (bool, error)) *MockStateIsApplicationExposedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateIsApplicationExposedCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockStateIsApplicationExposedCall {
+func (c *MockStateIsApplicationExposedCall) DoAndReturn(f func(context.Context, application.UUID) (bool, error)) *MockStateIsApplicationExposedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -4404,7 +4404,7 @@ func (c *MockStateIsCharmAvailableCall) DoAndReturn(f func(context.Context, char
 }
 
 // IsControllerApplication mocks base method.
-func (m *MockState) IsControllerApplication(arg0 context.Context, arg1 application.ID) (bool, error) {
+func (m *MockState) IsControllerApplication(arg0 context.Context, arg1 application.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsControllerApplication", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -4431,13 +4431,13 @@ func (c *MockStateIsControllerApplicationCall) Return(arg0 bool, arg1 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateIsControllerApplicationCall) Do(f func(context.Context, application.ID) (bool, error)) *MockStateIsControllerApplicationCall {
+func (c *MockStateIsControllerApplicationCall) Do(f func(context.Context, application.UUID) (bool, error)) *MockStateIsControllerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateIsControllerApplicationCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockStateIsControllerApplicationCall {
+func (c *MockStateIsControllerApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (bool, error)) *MockStateIsControllerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -4560,7 +4560,7 @@ func (c *MockStateIsMachineControllerCall) DoAndReturn(f func(context.Context, s
 }
 
 // IsSubordinateApplication mocks base method.
-func (m *MockState) IsSubordinateApplication(arg0 context.Context, arg1 application.ID) (bool, error) {
+func (m *MockState) IsSubordinateApplication(arg0 context.Context, arg1 application.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSubordinateApplication", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -4587,13 +4587,13 @@ func (c *MockStateIsSubordinateApplicationCall) Return(arg0 bool, arg1 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateIsSubordinateApplicationCall) Do(f func(context.Context, application.ID) (bool, error)) *MockStateIsSubordinateApplicationCall {
+func (c *MockStateIsSubordinateApplicationCall) Do(f func(context.Context, application.UUID) (bool, error)) *MockStateIsSubordinateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateIsSubordinateApplicationCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockStateIsSubordinateApplicationCall {
+func (c *MockStateIsSubordinateApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (bool, error)) *MockStateIsSubordinateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -4754,7 +4754,7 @@ func (c *MockStateMergeApplicationEndpointBindingsCall) DoAndReturn(f func(conte
 }
 
 // MergeExposeSettings mocks base method.
-func (m *MockState) MergeExposeSettings(arg0 context.Context, arg1 application.ID, arg2 map[string]application0.ExposedEndpoint) error {
+func (m *MockState) MergeExposeSettings(arg0 context.Context, arg1 application.UUID, arg2 map[string]application0.ExposedEndpoint) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MergeExposeSettings", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -4780,13 +4780,13 @@ func (c *MockStateMergeExposeSettingsCall) Return(arg0 error) *MockStateMergeExp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateMergeExposeSettingsCall) Do(f func(context.Context, application.ID, map[string]application0.ExposedEndpoint) error) *MockStateMergeExposeSettingsCall {
+func (c *MockStateMergeExposeSettingsCall) Do(f func(context.Context, application.UUID, map[string]application0.ExposedEndpoint) error) *MockStateMergeExposeSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateMergeExposeSettingsCall) DoAndReturn(f func(context.Context, application.ID, map[string]application0.ExposedEndpoint) error) *MockStateMergeExposeSettingsCall {
+func (c *MockStateMergeExposeSettingsCall) DoAndReturn(f func(context.Context, application.UUID, map[string]application0.ExposedEndpoint) error) *MockStateMergeExposeSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -5214,7 +5214,7 @@ func (c *MockStateResolveMigratingUploadedCharmCall) DoAndReturn(f func(context.
 }
 
 // SetApplicationCharm mocks base method.
-func (m *MockState) SetApplicationCharm(arg0 context.Context, arg1 application.ID, arg2 charm.ID, arg3 application0.SetCharmParams) error {
+func (m *MockState) SetApplicationCharm(arg0 context.Context, arg1 application.UUID, arg2 charm.ID, arg3 application0.SetCharmParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetApplicationCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -5240,19 +5240,19 @@ func (c *MockStateSetApplicationCharmCall) Return(arg0 error) *MockStateSetAppli
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetApplicationCharmCall) Do(f func(context.Context, application.ID, charm.ID, application0.SetCharmParams) error) *MockStateSetApplicationCharmCall {
+func (c *MockStateSetApplicationCharmCall) Do(f func(context.Context, application.UUID, charm.ID, application0.SetCharmParams) error) *MockStateSetApplicationCharmCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetApplicationCharmCall) DoAndReturn(f func(context.Context, application.ID, charm.ID, application0.SetCharmParams) error) *MockStateSetApplicationCharmCall {
+func (c *MockStateSetApplicationCharmCall) DoAndReturn(f func(context.Context, application.UUID, charm.ID, application0.SetCharmParams) error) *MockStateSetApplicationCharmCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetApplicationConstraints mocks base method.
-func (m *MockState) SetApplicationConstraints(arg0 context.Context, arg1 application.ID, arg2 constraints0.Constraints) error {
+func (m *MockState) SetApplicationConstraints(arg0 context.Context, arg1 application.UUID, arg2 constraints0.Constraints) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetApplicationConstraints", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -5278,13 +5278,13 @@ func (c *MockStateSetApplicationConstraintsCall) Return(arg0 error) *MockStateSe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetApplicationConstraintsCall) Do(f func(context.Context, application.ID, constraints0.Constraints) error) *MockStateSetApplicationConstraintsCall {
+func (c *MockStateSetApplicationConstraintsCall) Do(f func(context.Context, application.UUID, constraints0.Constraints) error) *MockStateSetApplicationConstraintsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID, constraints0.Constraints) error) *MockStateSetApplicationConstraintsCall {
+func (c *MockStateSetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.UUID, constraints0.Constraints) error) *MockStateSetApplicationConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -5366,7 +5366,7 @@ func (c *MockStateSetCharmAvailableCall) DoAndReturn(f func(context.Context, cha
 }
 
 // SetDesiredApplicationScale mocks base method.
-func (m *MockState) SetDesiredApplicationScale(arg0 context.Context, arg1 application.ID, arg2 int) error {
+func (m *MockState) SetDesiredApplicationScale(arg0 context.Context, arg1 application.UUID, arg2 int) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDesiredApplicationScale", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -5392,13 +5392,13 @@ func (c *MockStateSetDesiredApplicationScaleCall) Return(arg0 error) *MockStateS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetDesiredApplicationScaleCall) Do(f func(context.Context, application.ID, int) error) *MockStateSetDesiredApplicationScaleCall {
+func (c *MockStateSetDesiredApplicationScaleCall) Do(f func(context.Context, application.UUID, int) error) *MockStateSetDesiredApplicationScaleCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetDesiredApplicationScaleCall) DoAndReturn(f func(context.Context, application.ID, int) error) *MockStateSetDesiredApplicationScaleCall {
+func (c *MockStateSetDesiredApplicationScaleCall) DoAndReturn(f func(context.Context, application.UUID, int) error) *MockStateSetDesiredApplicationScaleCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -5596,7 +5596,7 @@ func (c *MockStateSupportsContainersCall) DoAndReturn(f func(context.Context, ch
 }
 
 // UnsetApplicationConfigKeys mocks base method.
-func (m *MockState) UnsetApplicationConfigKeys(arg0 context.Context, arg1 application.ID, arg2 []string) error {
+func (m *MockState) UnsetApplicationConfigKeys(arg0 context.Context, arg1 application.UUID, arg2 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnsetApplicationConfigKeys", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -5622,19 +5622,19 @@ func (c *MockStateUnsetApplicationConfigKeysCall) Return(arg0 error) *MockStateU
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUnsetApplicationConfigKeysCall) Do(f func(context.Context, application.ID, []string) error) *MockStateUnsetApplicationConfigKeysCall {
+func (c *MockStateUnsetApplicationConfigKeysCall) Do(f func(context.Context, application.UUID, []string) error) *MockStateUnsetApplicationConfigKeysCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUnsetApplicationConfigKeysCall) DoAndReturn(f func(context.Context, application.ID, []string) error) *MockStateUnsetApplicationConfigKeysCall {
+func (c *MockStateUnsetApplicationConfigKeysCall) DoAndReturn(f func(context.Context, application.UUID, []string) error) *MockStateUnsetApplicationConfigKeysCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UnsetExposeSettings mocks base method.
-func (m *MockState) UnsetExposeSettings(arg0 context.Context, arg1 application.ID, arg2 set.Strings) error {
+func (m *MockState) UnsetExposeSettings(arg0 context.Context, arg1 application.UUID, arg2 set.Strings) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnsetExposeSettings", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -5660,19 +5660,19 @@ func (c *MockStateUnsetExposeSettingsCall) Return(arg0 error) *MockStateUnsetExp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUnsetExposeSettingsCall) Do(f func(context.Context, application.ID, set.Strings) error) *MockStateUnsetExposeSettingsCall {
+func (c *MockStateUnsetExposeSettingsCall) Do(f func(context.Context, application.UUID, set.Strings) error) *MockStateUnsetExposeSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUnsetExposeSettingsCall) DoAndReturn(f func(context.Context, application.ID, set.Strings) error) *MockStateUnsetExposeSettingsCall {
+func (c *MockStateUnsetExposeSettingsCall) DoAndReturn(f func(context.Context, application.UUID, set.Strings) error) *MockStateUnsetExposeSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdateApplicationConfigAndSettings mocks base method.
-func (m *MockState) UpdateApplicationConfigAndSettings(arg0 context.Context, arg1 application.ID, arg2 map[string]application0.AddApplicationConfig, arg3 application0.UpdateApplicationSettingsArg) error {
+func (m *MockState) UpdateApplicationConfigAndSettings(arg0 context.Context, arg1 application.UUID, arg2 map[string]application0.AddApplicationConfig, arg3 application0.UpdateApplicationSettingsArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateApplicationConfigAndSettings", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -5698,19 +5698,19 @@ func (c *MockStateUpdateApplicationConfigAndSettingsCall) Return(arg0 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpdateApplicationConfigAndSettingsCall) Do(f func(context.Context, application.ID, map[string]application0.AddApplicationConfig, application0.UpdateApplicationSettingsArg) error) *MockStateUpdateApplicationConfigAndSettingsCall {
+func (c *MockStateUpdateApplicationConfigAndSettingsCall) Do(f func(context.Context, application.UUID, map[string]application0.AddApplicationConfig, application0.UpdateApplicationSettingsArg) error) *MockStateUpdateApplicationConfigAndSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpdateApplicationConfigAndSettingsCall) DoAndReturn(f func(context.Context, application.ID, map[string]application0.AddApplicationConfig, application0.UpdateApplicationSettingsArg) error) *MockStateUpdateApplicationConfigAndSettingsCall {
+func (c *MockStateUpdateApplicationConfigAndSettingsCall) DoAndReturn(f func(context.Context, application.UUID, map[string]application0.AddApplicationConfig, application0.UpdateApplicationSettingsArg) error) *MockStateUpdateApplicationConfigAndSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdateApplicationScale mocks base method.
-func (m *MockState) UpdateApplicationScale(arg0 context.Context, arg1 application.ID, arg2 int) (int, error) {
+func (m *MockState) UpdateApplicationScale(arg0 context.Context, arg1 application.UUID, arg2 int) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateApplicationScale", arg0, arg1, arg2)
 	ret0, _ := ret[0].(int)
@@ -5737,13 +5737,13 @@ func (c *MockStateUpdateApplicationScaleCall) Return(arg0 int, arg1 error) *Mock
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpdateApplicationScaleCall) Do(f func(context.Context, application.ID, int) (int, error)) *MockStateUpdateApplicationScaleCall {
+func (c *MockStateUpdateApplicationScaleCall) Do(f func(context.Context, application.UUID, int) (int, error)) *MockStateUpdateApplicationScaleCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpdateApplicationScaleCall) DoAndReturn(f func(context.Context, application.ID, int) (int, error)) *MockStateUpdateApplicationScaleCall {
+func (c *MockStateUpdateApplicationScaleCall) DoAndReturn(f func(context.Context, application.UUID, int) (int, error)) *MockStateUpdateApplicationScaleCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -1455,124 +1455,6 @@ func (c *MockStateGetApplicationEndpointNamesCall) DoAndReturn(f func(context.Co
 	return c
 }
 
-// GetApplicationIDAndNameByUnitName mocks base method.
-func (m *MockState) GetApplicationIDAndNameByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDAndNameByUnitName", arg0, arg1)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetApplicationIDAndNameByUnitName indicates an expected call of GetApplicationIDAndNameByUnitName.
-func (mr *MockStateMockRecorder) GetApplicationIDAndNameByUnitName(arg0, arg1 any) *MockStateGetApplicationIDAndNameByUnitNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDAndNameByUnitName", reflect.TypeOf((*MockState)(nil).GetApplicationIDAndNameByUnitName), arg0, arg1)
-	return &MockStateGetApplicationIDAndNameByUnitNameCall{Call: call}
-}
-
-// MockStateGetApplicationIDAndNameByUnitNameCall wrap *gomock.Call
-type MockStateGetApplicationIDAndNameByUnitNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationIDAndNameByUnitNameCall) Return(arg0 application.UUID, arg1 string, arg2 error) *MockStateGetApplicationIDAndNameByUnitNameCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationIDAndNameByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockStateGetApplicationIDAndNameByUnitNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationIDAndNameByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockStateGetApplicationIDAndNameByUnitNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetApplicationIDByName mocks base method.
-func (m *MockState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockStateMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockStateGetApplicationIDByNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockState)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockStateGetApplicationIDByNameCall{Call: call}
-}
-
-// MockStateGetApplicationIDByNameCall wrap *gomock.Call
-type MockStateGetApplicationIDByNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockStateGetApplicationIDByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockStateGetApplicationIDByNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockStateGetApplicationIDByNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetApplicationIDByUnitName mocks base method.
-func (m *MockState) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByUnitName", arg0, arg1)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetApplicationIDByUnitName indicates an expected call of GetApplicationIDByUnitName.
-func (mr *MockStateMockRecorder) GetApplicationIDByUnitName(arg0, arg1 any) *MockStateGetApplicationIDByUnitNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByUnitName", reflect.TypeOf((*MockState)(nil).GetApplicationIDByUnitName), arg0, arg1)
-	return &MockStateGetApplicationIDByUnitNameCall{Call: call}
-}
-
-// MockStateGetApplicationIDByUnitNameCall wrap *gomock.Call
-type MockStateGetApplicationIDByUnitNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockStateGetApplicationIDByUnitNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockStateGetApplicationIDByUnitNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockStateGetApplicationIDByUnitNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetApplicationLife mocks base method.
 func (m *MockState) GetApplicationLife(arg0 context.Context, arg1 application.UUID) (life.Life, error) {
 	m.ctrl.T.Helper()
@@ -1804,6 +1686,124 @@ func (c *MockStateGetApplicationTrustSettingCall) Do(f func(context.Context, app
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetApplicationTrustSettingCall) DoAndReturn(f func(context.Context, application.UUID) (bool, error)) *MockStateGetApplicationTrustSettingCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDAndNameByUnitName mocks base method.
+func (m *MockState) GetApplicationUUIDAndNameByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDAndNameByUnitName", arg0, arg1)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetApplicationUUIDAndNameByUnitName indicates an expected call of GetApplicationUUIDAndNameByUnitName.
+func (mr *MockStateMockRecorder) GetApplicationUUIDAndNameByUnitName(arg0, arg1 any) *MockStateGetApplicationUUIDAndNameByUnitNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDAndNameByUnitName", reflect.TypeOf((*MockState)(nil).GetApplicationUUIDAndNameByUnitName), arg0, arg1)
+	return &MockStateGetApplicationUUIDAndNameByUnitNameCall{Call: call}
+}
+
+// MockStateGetApplicationUUIDAndNameByUnitNameCall wrap *gomock.Call
+type MockStateGetApplicationUUIDAndNameByUnitNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetApplicationUUIDAndNameByUnitNameCall) Return(arg0 application.UUID, arg1 string, arg2 error) *MockStateGetApplicationUUIDAndNameByUnitNameCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetApplicationUUIDAndNameByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockStateGetApplicationUUIDAndNameByUnitNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetApplicationUUIDAndNameByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockStateGetApplicationUUIDAndNameByUnitNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDByName mocks base method.
+func (m *MockState) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockStateMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockStateGetApplicationUUIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockState)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockStateGetApplicationUUIDByNameCall{Call: call}
+}
+
+// MockStateGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockStateGetApplicationUUIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockStateGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockStateGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockStateGetApplicationUUIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDByUnitName mocks base method.
+func (m *MockState) GetApplicationUUIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByUnitName", arg0, arg1)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationUUIDByUnitName indicates an expected call of GetApplicationUUIDByUnitName.
+func (mr *MockStateMockRecorder) GetApplicationUUIDByUnitName(arg0, arg1 any) *MockStateGetApplicationUUIDByUnitNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByUnitName", reflect.TypeOf((*MockState)(nil).GetApplicationUUIDByUnitName), arg0, arg1)
+	return &MockStateGetApplicationUUIDByUnitNameCall{Call: call}
+}
+
+// MockStateGetApplicationUUIDByUnitNameCall wrap *gomock.Call
+type MockStateGetApplicationUUIDByUnitNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetApplicationUUIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockStateGetApplicationUUIDByUnitNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetApplicationUUIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockStateGetApplicationUUIDByUnitNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetApplicationUUIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockStateGetApplicationUUIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2283,41 +2283,41 @@ func (c *MockStateGetCharmArchivePathCall) DoAndReturn(f func(context.Context, c
 	return c
 }
 
-// GetCharmByApplicationID mocks base method.
-func (m *MockState) GetCharmByApplicationID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, error) {
+// GetCharmByApplicationUUID mocks base method.
+func (m *MockState) GetCharmByApplicationUUID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmByApplicationID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetCharmByApplicationUUID", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Charm)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetCharmByApplicationID indicates an expected call of GetCharmByApplicationID.
-func (mr *MockStateMockRecorder) GetCharmByApplicationID(arg0, arg1 any) *MockStateGetCharmByApplicationIDCall {
+// GetCharmByApplicationUUID indicates an expected call of GetCharmByApplicationUUID.
+func (mr *MockStateMockRecorder) GetCharmByApplicationUUID(arg0, arg1 any) *MockStateGetCharmByApplicationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationID", reflect.TypeOf((*MockState)(nil).GetCharmByApplicationID), arg0, arg1)
-	return &MockStateGetCharmByApplicationIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationUUID", reflect.TypeOf((*MockState)(nil).GetCharmByApplicationUUID), arg0, arg1)
+	return &MockStateGetCharmByApplicationUUIDCall{Call: call}
 }
 
-// MockStateGetCharmByApplicationIDCall wrap *gomock.Call
-type MockStateGetCharmByApplicationIDCall struct {
+// MockStateGetCharmByApplicationUUIDCall wrap *gomock.Call
+type MockStateGetCharmByApplicationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetCharmByApplicationIDCall) Return(arg0 charm0.Charm, arg1 error) *MockStateGetCharmByApplicationIDCall {
+func (c *MockStateGetCharmByApplicationUUIDCall) Return(arg0 charm0.Charm, arg1 error) *MockStateGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetCharmByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, error)) *MockStateGetCharmByApplicationIDCall {
+func (c *MockStateGetCharmByApplicationUUIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, error)) *MockStateGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, error)) *MockStateGetCharmByApplicationIDCall {
+func (c *MockStateGetCharmByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, error)) *MockStateGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2361,42 +2361,42 @@ func (c *MockStateGetCharmConfigCall) DoAndReturn(f func(context.Context, charm.
 	return c
 }
 
-// GetCharmConfigByApplicationID mocks base method.
-func (m *MockState) GetCharmConfigByApplicationID(arg0 context.Context, arg1 application.UUID) (charm.ID, charm0.Config, error) {
+// GetCharmConfigByApplicationUUID mocks base method.
+func (m *MockState) GetCharmConfigByApplicationUUID(arg0 context.Context, arg1 application.UUID) (charm.ID, charm0.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmConfigByApplicationID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetCharmConfigByApplicationUUID", arg0, arg1)
 	ret0, _ := ret[0].(charm.ID)
 	ret1, _ := ret[1].(charm0.Config)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetCharmConfigByApplicationID indicates an expected call of GetCharmConfigByApplicationID.
-func (mr *MockStateMockRecorder) GetCharmConfigByApplicationID(arg0, arg1 any) *MockStateGetCharmConfigByApplicationIDCall {
+// GetCharmConfigByApplicationUUID indicates an expected call of GetCharmConfigByApplicationUUID.
+func (mr *MockStateMockRecorder) GetCharmConfigByApplicationUUID(arg0, arg1 any) *MockStateGetCharmConfigByApplicationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmConfigByApplicationID", reflect.TypeOf((*MockState)(nil).GetCharmConfigByApplicationID), arg0, arg1)
-	return &MockStateGetCharmConfigByApplicationIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmConfigByApplicationUUID", reflect.TypeOf((*MockState)(nil).GetCharmConfigByApplicationUUID), arg0, arg1)
+	return &MockStateGetCharmConfigByApplicationUUIDCall{Call: call}
 }
 
-// MockStateGetCharmConfigByApplicationIDCall wrap *gomock.Call
-type MockStateGetCharmConfigByApplicationIDCall struct {
+// MockStateGetCharmConfigByApplicationUUIDCall wrap *gomock.Call
+type MockStateGetCharmConfigByApplicationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetCharmConfigByApplicationIDCall) Return(arg0 charm.ID, arg1 charm0.Config, arg2 error) *MockStateGetCharmConfigByApplicationIDCall {
+func (c *MockStateGetCharmConfigByApplicationUUIDCall) Return(arg0 charm.ID, arg1 charm0.Config, arg2 error) *MockStateGetCharmConfigByApplicationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetCharmConfigByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm.ID, charm0.Config, error)) *MockStateGetCharmConfigByApplicationIDCall {
+func (c *MockStateGetCharmConfigByApplicationUUIDCall) Do(f func(context.Context, application.UUID) (charm.ID, charm0.Config, error)) *MockStateGetCharmConfigByApplicationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCharmConfigByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm.ID, charm0.Config, error)) *MockStateGetCharmConfigByApplicationIDCall {
+func (c *MockStateGetCharmConfigByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm.ID, charm0.Config, error)) *MockStateGetCharmConfigByApplicationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -265,7 +265,7 @@ type ImportApplicationArgs struct {
 }
 
 // ApplicationConfig represents the application config for the specified
-// application ID.
+// application UUID.
 type ApplicationConfig struct {
 	CharmOrigin       corecharm.Origin
 	CharmConfig       internalcharm.ConfigSpec

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -228,7 +228,7 @@ func (s *ProviderService) GetSupportedFeatures(ctx context.Context) (assumes.Fea
 }
 
 // SetApplicationConstraints sets the application constraints for the
-// specified application ID.
+// specified application UUID.
 // This method overwrites the full constraints on every call.
 // If invalid constraints are provided (e.g. invalid container type or
 // non-existing space), a [applicationerrors.InvalidApplicationConstraints]
@@ -242,7 +242,7 @@ func (s *ProviderService) SetApplicationConstraints(
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return errors.Errorf("application ID: %w", err)
+		return errors.Errorf("application UUID: %w", err)
 	}
 	if err := s.validateConstraints(ctx, cons); err != nil {
 		return err

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -108,7 +108,7 @@ func (s *ProviderService) CreateIAASApplication(
 	origin corecharm.Origin,
 	args AddApplicationArgs,
 	units ...AddIAASUnitArg,
-) (coreapplication.ID, error) {
+) (coreapplication.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -155,7 +155,7 @@ func (s *ProviderService) CreateCAASApplication(
 	origin corecharm.Origin,
 	args AddApplicationArgs,
 	units ...AddUnitArg,
-) (coreapplication.ID, error) {
+) (coreapplication.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -236,7 +236,7 @@ func (s *ProviderService) GetSupportedFeatures(ctx context.Context) (assumes.Fea
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
 func (s *ProviderService) SetApplicationConstraints(
-	ctx context.Context, appID coreapplication.ID, cons coreconstraints.Value,
+	ctx context.Context, appID coreapplication.UUID, cons coreconstraints.Value,
 ) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -577,7 +577,7 @@ func (s *ProviderService) ResolveApplicationConstraints(
 // exists.
 func (s *ProviderService) getRegisterCAASUnitStorageArgs(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	unitName coreunit.Name,
 	providerFilesystemInfo []caas.FilesystemInfo,
 ) (application.RegisterUnitStorageArg, error) {
@@ -953,7 +953,7 @@ func (s *ProviderService) precheckInstances(
 }
 
 func (s *ProviderService) makeApplicationConstraints(
-	ctx context.Context, appUUID coreapplication.ID,
+	ctx context.Context, appUUID coreapplication.UUID,
 ) (coreconstraints.Value, error) {
 	appCons, err := s.st.GetApplicationConstraints(ctx, appUUID)
 	if err != nil {

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -268,7 +268,7 @@ func (s *ProviderService) AddIAASUnits(
 		return nil, nil, applicationerrors.ApplicationNameNotValid
 	}
 
-	appUUID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, nil, errors.Errorf("getting application %q id: %w", appName, err)
 	}
@@ -339,7 +339,7 @@ func (s *ProviderService) AddCAASUnits(
 		return nil, applicationerrors.ApplicationNameNotValid
 	}
 
-	appUUID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, errors.Errorf("getting application %q id: %w", appName, err)
 	}
@@ -428,7 +428,7 @@ func (s *ProviderService) CAASUnitTerminating(ctx context.Context, unitNameStr s
 	if err != nil {
 		return false, errors.Capture(err)
 	}
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return false, errors.Capture(err)
 	}
@@ -459,7 +459,7 @@ func (s *ProviderService) RegisterCAASUnit(
 		return "", "", errors.Errorf("provider id %w", coreerrors.NotValid)
 	}
 
-	appUUID, err := s.st.GetApplicationIDByName(ctx, params.ApplicationName)
+	appUUID, err := s.st.GetApplicationUUIDByName(ctx, params.ApplicationName)
 	if err != nil {
 		return "", "", errors.Capture(err)
 	}

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -2349,14 +2349,14 @@ func (s *providerServiceSuite) TestGetApplicationConstraintsInvalidAppID(c *tc.C
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.GetApplicationConstraints(c.Context(), "bad-app-id")
-	c.Assert(err, tc.ErrorMatches, "application ID: id \"bad-app-id\" not valid")
+	c.Assert(err, tc.ErrorMatches, "application UUID: id \"bad-app-id\" not valid")
 }
 
 func (s *providerServiceSuite) TestSetApplicationConstraintsInvalidAppID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	err := s.service.SetApplicationConstraints(c.Context(), "bad-app-id", coreconstraints.Value{})
-	c.Assert(err, tc.ErrorMatches, "application ID: id \"bad-app-id\" not valid")
+	c.Assert(err, tc.ErrorMatches, "application UUID: id \"bad-app-id\" not valid")
 }
 
 func (s *providerServiceSuite) TestSetConstraintsProviderNotSupported(c *tc.C) {

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -157,7 +157,7 @@ func (s *providerServiceSuite) TestCreateCAASApplication(c *tc.C) {
 	}).Return(nil)
 
 	var receivedArgs []application.AddCAASUnitArg
-	s.state.EXPECT().CreateCAASApplication(gomock.Any(), "ubuntu", gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, a application.AddCAASApplicationArg, args []application.AddCAASUnitArg) (coreapplication.ID, error) {
+	s.state.EXPECT().CreateCAASApplication(gomock.Any(), "ubuntu", gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, a application.AddCAASApplicationArg, args []application.AddCAASUnitArg) (coreapplication.UUID, error) {
 		c.Assert(a, tc.DeepEquals, app)
 		receivedArgs = args
 		return id, nil
@@ -245,7 +245,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationWithApplicationStatus(c 
 	)
 
 	var receivedArgs application.AddIAASApplicationArg
-	s.state.EXPECT().CreateIAASApplication(gomock.Any(), "ubuntu", gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, appArgs application.AddIAASApplicationArg, _ []application.AddIAASUnitArg) (coreapplication.ID, []coremachine.Name, error) {
+	s.state.EXPECT().CreateIAASApplication(gomock.Any(), "ubuntu", gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, appArgs application.AddIAASApplicationArg, _ []application.AddIAASUnitArg) (coreapplication.UUID, []coremachine.Name, error) {
 		receivedArgs = appArgs
 		return id, nil, nil
 	})
@@ -463,7 +463,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationMachineScope(c *tc.C) {
 		_ string,
 		_ application.AddIAASApplicationArg,
 		args []application.AddIAASUnitArg,
-	) (coreapplication.ID, []coremachine.Name, error) {
+	) (coreapplication.UUID, []coremachine.Name, error) {
 		recievedUnitArgs = args
 		return id, nil, nil
 	})
@@ -951,7 +951,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationPendingResources(c *tc.C
 		},
 	}).Return(nil)
 
-	s.state.EXPECT().CreateIAASApplication(gomock.Any(), "ubuntu", gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, a application.AddIAASApplicationArg, _ []application.AddIAASUnitArg) (coreapplication.ID, []coremachine.Name, error) {
+	s.state.EXPECT().CreateIAASApplication(gomock.Any(), "ubuntu", gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, a application.AddIAASApplicationArg, _ []application.AddIAASUnitArg) (coreapplication.UUID, []coremachine.Name, error) {
 		c.Assert(a, tc.DeepEquals, app)
 		return id, nil, nil
 	})
@@ -2461,7 +2461,7 @@ func (s *providerServiceSuite) TestAddCAASUnitsEmptyConstraints(c *tc.C) {
 	s.expectEmptyUnitConstraints(c, appUUID)
 
 	var received []application.AddCAASUnitArg
-	s.state.EXPECT().AddCAASUnits(gomock.Any(), appUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.ID, args ...application.AddCAASUnitArg) ([]coreunit.Name, error) {
+	s.state.EXPECT().AddCAASUnits(gomock.Any(), appUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.UUID, args ...application.AddCAASUnitArg) ([]coreunit.Name, error) {
 		received = args
 		return []coreunit.Name{"foo/0"}, nil
 	})
@@ -2529,7 +2529,7 @@ func (s *providerServiceSuite) TestAddCAASUnitsAppConstraints(c *tc.C) {
 	s.expectAppConstraints(c, unitUUID, appUUID)
 
 	var received []application.AddCAASUnitArg
-	s.state.EXPECT().AddCAASUnits(gomock.Any(), appUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.ID, args ...application.AddCAASUnitArg) ([]coreunit.Name, error) {
+	s.state.EXPECT().AddCAASUnits(gomock.Any(), appUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.UUID, args ...application.AddCAASUnitArg) ([]coreunit.Name, error) {
 		received = args
 		return []coreunit.Name{"foo/0"}, nil
 	})
@@ -2595,7 +2595,7 @@ func (s *providerServiceSuite) TestAddCAASUnitsModelConstraints(c *tc.C) {
 	s.expectModelConstraints(appUUID)
 
 	var received []application.AddCAASUnitArg
-	s.state.EXPECT().AddCAASUnits(gomock.Any(), appUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.ID, args ...application.AddCAASUnitArg) ([]coreunit.Name, error) {
+	s.state.EXPECT().AddCAASUnits(gomock.Any(), appUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.UUID, args ...application.AddCAASUnitArg) ([]coreunit.Name, error) {
 		received = args
 		return []coreunit.Name{"foo/0"}, nil
 	})
@@ -2646,7 +2646,7 @@ func (s *providerServiceSuite) TestAddCAASUnitsFullConstraints(c *tc.C) {
 	s.expectFullConstraints(c, unitUUID, appUUID)
 
 	var received []application.AddCAASUnitArg
-	s.state.EXPECT().AddCAASUnits(gomock.Any(), appUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.ID, args ...application.AddCAASUnitArg) ([]coreunit.Name, error) {
+	s.state.EXPECT().AddCAASUnits(gomock.Any(), appUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.UUID, args ...application.AddCAASUnitArg) ([]coreunit.Name, error) {
 		received = args
 		return []coreunit.Name{"foo/0"}, nil
 	})
@@ -2755,7 +2755,7 @@ func (s *providerServiceSuite) TestAddIAASUnitsMachinePlacement(c *tc.C) {
 	s.state.EXPECT().AddIAASUnits(
 		gomock.Any(), appUUID, gomock.Any(),
 	).DoAndReturn(func(
-		_ context.Context, _ coreapplication.ID, args ...application.AddIAASUnitArg,
+		_ context.Context, _ coreapplication.UUID, args ...application.AddIAASUnitArg,
 	) ([]coreunit.Name, []coremachine.Name, error) {
 		recievedArgs = args
 		return []coreunit.Name{"foo/0"}, nil, nil
@@ -2838,7 +2838,7 @@ func (s *providerServiceSuite) TestResolveApplicationConstraintsWithArch(c *tc.C
 	c.Check(*merged.Arch, tc.Equals, arch.AMD64)
 }
 
-func (s *providerServiceSuite) expectEmptyUnitConstraints(c *tc.C, appUUID coreapplication.ID) {
+func (s *providerServiceSuite) expectEmptyUnitConstraints(c *tc.C, appUUID coreapplication.UUID) {
 	appConstraints := constraints.Constraints{}
 	modelConstraints := constraints.Constraints{}
 
@@ -2850,7 +2850,7 @@ func (s *providerServiceSuite) expectEmptyUnitConstraints(c *tc.C, appUUID corea
 	s.validator.EXPECT().Merge(constraints.EncodeConstraints(appConstraints), constraints.EncodeConstraints(modelConstraints)).Return(coreconstraints.Value{}, nil)
 }
 
-func (s *providerServiceSuite) expectAppConstraints(c *tc.C, unitUUID coreunit.UUID, appUUID coreapplication.ID) {
+func (s *providerServiceSuite) expectAppConstraints(c *tc.C, unitUUID coreunit.UUID, appUUID coreapplication.UUID) {
 	appConstraints := constraints.Constraints{
 		Arch:           ptr("amd64"),
 		Container:      ptr(instance.LXD),
@@ -2880,7 +2880,7 @@ func (s *providerServiceSuite) expectAppConstraints(c *tc.C, unitUUID coreunit.U
 	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(modelConstraints, nil)
 }
 
-func (s *providerServiceSuite) expectModelConstraints(appUUID coreapplication.ID) {
+func (s *providerServiceSuite) expectModelConstraints(appUUID coreapplication.UUID) {
 	modelConstraints := constraints.Constraints{
 		Arch:           ptr("amd64"),
 		Container:      ptr(instance.LXD),
@@ -2909,7 +2909,7 @@ func (s *providerServiceSuite) expectModelConstraints(appUUID coreapplication.ID
 	s.validator.EXPECT().Merge(constraints.EncodeConstraints(modelConstraints), constraints.EncodeConstraints(appConstraints)).Return(constraints.EncodeConstraints(unitConstraints), nil)
 }
 
-func (s *providerServiceSuite) expectFullConstraints(c *tc.C, unitUUID coreunit.UUID, appUUID coreapplication.ID) {
+func (s *providerServiceSuite) expectFullConstraints(c *tc.C, unitUUID coreunit.UUID, appUUID coreapplication.UUID) {
 	modelConstraints := constraints.Constraints{
 		CpuCores: ptr(uint64(4)),
 	}

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -2450,7 +2450,7 @@ func (s *providerServiceSuite) TestAddCAASUnitsEmptyConstraints(c *tc.C) {
 			},
 		},
 	}}
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(nil, nil)
 	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), appUUID).Return(application.CharmOrigin{}, nil)
 	s.provider.EXPECT().PrecheckInstance(gomock.Any(), environs.PrecheckInstanceParams{
@@ -2517,7 +2517,7 @@ func (s *providerServiceSuite) TestAddCAASUnitsAppConstraints(c *tc.C) {
 			},
 		},
 	}}
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(nil, nil)
 	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), appUUID).Return(application.CharmOrigin{}, nil)
 	s.provider.EXPECT().PrecheckInstance(gomock.Any(), environs.PrecheckInstanceParams{
@@ -2583,7 +2583,7 @@ func (s *providerServiceSuite) TestAddCAASUnitsModelConstraints(c *tc.C) {
 			},
 		},
 	}}
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(nil, nil)
 	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), appUUID).Return(application.CharmOrigin{}, nil)
 	s.provider.EXPECT().PrecheckInstance(gomock.Any(), environs.PrecheckInstanceParams{
@@ -2634,7 +2634,7 @@ func (s *providerServiceSuite) TestAddCAASUnitsFullConstraints(c *tc.C) {
 			},
 		},
 	}}
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(nil, nil)
 	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), appUUID).Return(application.CharmOrigin{}, nil)
 	s.provider.EXPECT().PrecheckInstance(gomock.Any(), environs.PrecheckInstanceParams{
@@ -2681,7 +2681,7 @@ func (s *providerServiceSuite) TestAddIAASUnitsApplicationNotFound(c *tc.C) {
 
 	appUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "ubuntu").Return(appUUID, applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "ubuntu").Return(appUUID, applicationerrors.ApplicationNotFound)
 
 	_, _, err := s.service.AddIAASUnits(c.Context(), "ubuntu", AddIAASUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
@@ -2696,7 +2696,7 @@ func (s *providerServiceSuite) TestAddIAASUnitsInvalidPlacement(c *tc.C) {
 
 	s.state.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(nil, nil)
 	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), appUUID).Return(application.CharmOrigin{}, nil)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
 	s.expectFullConstraints(c, unitUUID, appUUID)
 
 	placement := &instance.Placement{
@@ -2748,7 +2748,7 @@ func (s *providerServiceSuite) TestAddIAASUnitsMachinePlacement(c *tc.C) {
 	s.state.EXPECT().GetMachineUUIDAndNetNodeForName(gomock.Any(), "0").Return(
 		machineUUID, netNodeUUID, nil,
 	)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "ubuntu").Return(appUUID, nil)
 	s.expectFullConstraints(c, unitUUID, appUUID)
 
 	var recievedArgs []application.AddIAASUnitArg

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -308,7 +308,7 @@ func (s *WatchableService) WatchUnitLife(ctx context.Context, unitName coreunit.
 func (s *WatchableService) WatchApplicationScale(ctx context.Context, appName string) (watcher.NotifyWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
-	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -439,7 +439,7 @@ func (s *WatchableService) WatchApplication(ctx context.Context, name string) (w
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	uuid, err := s.GetApplicationIDByName(ctx, name)
+	uuid, err := s.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return nil, errors.Errorf("getting ID of application %s: %w", name, err)
 	}
@@ -466,7 +466,7 @@ func (s *WatchableService) WatchApplicationConfig(ctx context.Context, name stri
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	uuid, err := s.GetApplicationIDByName(ctx, name)
+	uuid, err := s.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return nil, errors.Errorf("getting ID of application %s: %w", name, err)
 	}
@@ -496,7 +496,7 @@ func (s *WatchableService) WatchApplicationConfigHash(ctx context.Context, name 
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.GetApplicationIDByName(ctx, name)
+	appID, err := s.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return nil, errors.Errorf("getting ID of application %s: %w", name, err)
 	}
@@ -563,7 +563,7 @@ func (s *WatchableService) WatchApplicationSettings(ctx context.Context, appName
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	uuid, err := s.GetApplicationIDByName(ctx, appName)
+	uuid, err := s.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, errors.Errorf("getting ID of application %s: %w", appName, err)
 	}
@@ -589,7 +589,7 @@ func (s *WatchableService) WatchUnitAddressesHash(ctx context.Context, unitName 
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appUUID, err := s.st.GetApplicationIDByUnitName(ctx, unitName)
+	appUUID, err := s.st.GetApplicationUUIDByUnitName(ctx, unitName)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -745,7 +745,7 @@ func (s *WatchableService) WatchApplicationExposed(ctx context.Context, name str
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	uuid, err := s.GetApplicationIDByName(ctx, name)
+	uuid, err := s.GetApplicationUUIDByName(ctx, name)
 	if err != nil {
 		return nil, errors.Errorf("getting ID of application %s: %w", name, err)
 	}

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -373,8 +373,8 @@ func (s *WatchableService) watchApplicationsWithPendingCharmsMapper(ctx context.
 	// Preserve the ordering of the changes, as this is a strings watcher
 	// and we want to return the changes in the order they were received.
 
-	appChanges := make(map[coreapplication.ID][]indexedChanged)
-	uuids := make([]coreapplication.ID, 0)
+	appChanges := make(map[coreapplication.UUID][]indexedChanged)
+	uuids := make([]coreapplication.UUID, 0)
 	for i, change := range changes {
 		appID, err := coreapplication.ParseID(change.Changed())
 		if err != nil {

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -152,7 +152,7 @@ type StorageState interface {
 	// - [github.com/juju/juju/domain/application/errors.ApplicationNotFound]
 	// when the application no longer exists.
 	GetApplicationStorageDirectives(
-		context.Context, coreapplication.ID,
+		context.Context, coreapplication.UUID,
 	) ([]application.StorageDirective, error)
 
 	// GetDefaultStorageProvisioners returns the default storage provisioners
@@ -172,7 +172,7 @@ type StorageState interface {
 	// The caller should expect that a zero length result can be supplied.
 	GetStorageInstancesForProviderIDs(
 		ctx context.Context,
-		applicationUUID coreapplication.ID,
+		applicationUUID coreapplication.UUID,
 		ids []string,
 	) (map[string]domainstorage.StorageInstanceUUID, error)
 

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -617,7 +617,7 @@ func (s *Service) GetUnitNamesForApplication(ctx context.Context, appName string
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appUUID, err := s.st.GetApplicationIDByName(ctx, appName)
+	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -126,7 +126,7 @@ type UnitState interface {
 	GetModelConstraints(context.Context) (constraints.Constraints, error)
 
 	// SetUnitConstraints sets the unit constraints for the
-	// specified application ID.
+	// specified application UUID.
 	// This method overwrites the full constraints on every call.
 	// If invalid constraints are provided (e.g. invalid container type or
 	// non-existing space), a [applicationerrors.InvalidUnitConstraints]

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -29,11 +29,11 @@ import (
 type UnitState interface {
 	// AddIAASUnits adds the specified units to the application, returning their
 	// names.
-	AddIAASUnits(context.Context, coreapplication.ID, ...application.AddIAASUnitArg) ([]coreunit.Name, []coremachine.Name, error)
+	AddIAASUnits(context.Context, coreapplication.UUID, ...application.AddIAASUnitArg) ([]coreunit.Name, []coremachine.Name, error)
 
 	// AddCAASUnits adds the specified units to the application, returning their
 	// names.
-	AddCAASUnits(context.Context, coreapplication.ID, ...application.AddCAASUnitArg) ([]coreunit.Name, error)
+	AddCAASUnits(context.Context, coreapplication.UUID, ...application.AddCAASUnitArg) ([]coreunit.Name, error)
 
 	// InsertMigratingIAASUnits inserts the fully formed units for the specified
 	// IAAS application. This is only used when inserting units during model
@@ -41,7 +41,7 @@ type UnitState interface {
 	// [applicationerrors.ApplicationNotFound] is returned. If any of the units
 	// already exists, an error satisfying [applicationerrors.UnitAlreadyExists]
 	// is returned.
-	InsertMigratingIAASUnits(context.Context, coreapplication.ID, ...application.ImportUnitArg) error
+	InsertMigratingIAASUnits(context.Context, coreapplication.UUID, ...application.ImportUnitArg) error
 
 	// InsertMigratingCAASUnits inserts the fully formed units for the specified
 	// CAAS application. This is only used when inserting units during model
@@ -49,7 +49,7 @@ type UnitState interface {
 	// [applicationerrors.ApplicationNotFound] is returned. If any of the units
 	// already exists, an error satisfying [applicationerrors.UnitAlreadyExists]
 	// is returned.
-	InsertMigratingCAASUnits(context.Context, coreapplication.ID, ...application.ImportUnitArg) error
+	InsertMigratingCAASUnits(context.Context, coreapplication.UUID, ...application.ImportUnitArg) error
 
 	// RegisterCAASUnit registers the specified CAAS application unit. The
 	// following errors can be expected:
@@ -105,7 +105,7 @@ type UnitState interface {
 	// for the given application.
 	//   - If the application is not found, [applicationerrors.ApplicationNotFound]
 	//     is returned.
-	GetAllUnitLifeForApplication(context.Context, coreapplication.ID) (map[string]int, error)
+	GetAllUnitLifeForApplication(context.Context, coreapplication.UUID) (map[string]int, error)
 
 	// GetMachineUUIDAndNetNodeForName is responsible for identifying the uuid
 	// and net node for a machine by it's name.
@@ -158,7 +158,7 @@ type UnitState interface {
 	// The following errors may be returned:
 	// - [applicationerrors.ApplicationIsDead] if the application is dead
 	// - [applicationerrors.ApplicationNotFound] if the application does not exist
-	GetUnitNamesForApplication(context.Context, coreapplication.ID) ([]coreunit.Name, error)
+	GetUnitNamesForApplication(context.Context, coreapplication.UUID) ([]coreunit.Name, error)
 
 	// GetUnitNamesForNetNode returns a slice of the unit names for the given net node
 	GetUnitNamesForNetNode(context.Context, string) ([]coreunit.Name, error)
@@ -197,7 +197,7 @@ type UnitState interface {
 	//   - If the application is dead, [applicationerrors.ApplicationIsDead] is returned.
 	//   - If the application is not found, [applicationerrors.ApplicationNotFound]
 	//     is returned.
-	GetAllUnitCloudContainerIDsForApplication(context.Context, coreapplication.ID) (map[coreunit.Name]string, error)
+	GetAllUnitCloudContainerIDsForApplication(context.Context, coreapplication.UUID) (map[coreunit.Name]string, error)
 }
 
 func (s *ProviderService) makeIAASUnitArgs(
@@ -360,7 +360,7 @@ func (s *Service) makeUnitStatusArgs(workloadMessage string) application.UnitSta
 // - [applicationerrors.UnitNotFound] when the principal unit does not exist.
 func (s *Service) AddIAASSubordinateUnit(
 	ctx context.Context,
-	subordinateAppID coreapplication.ID,
+	subordinateAppID coreapplication.UUID,
 	principalUnitName coreunit.Name,
 ) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
@@ -718,7 +718,7 @@ func (s *Service) GetUnitSubordinates(ctx context.Context, unitName coreunit.Nam
 // for the given application.
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
-func (s *Service) GetAllUnitLifeForApplication(ctx context.Context, appID coreapplication.ID) (map[coreunit.Name]corelife.Value, error) {
+func (s *Service) GetAllUnitLifeForApplication(ctx context.Context, appID coreapplication.UUID) (map[coreunit.Name]corelife.Value, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -750,7 +750,7 @@ func (s *Service) GetAllUnitLifeForApplication(ctx context.Context, appID coreap
 //   - If the application is not found, [applicationerrors.ApplicationNotFound]
 //     is returned.
 //   - If the application UUID is not valid, [coreerrors.NotValid] is returned.
-func (s *Service) GetAllUnitCloudContainerIDsForApplication(ctx context.Context, appUUID coreapplication.ID) (map[coreunit.Name]string, error) {
+func (s *Service) GetAllUnitCloudContainerIDsForApplication(ctx context.Context, appUUID coreapplication.UUID) (map[coreunit.Name]string, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -794,7 +794,7 @@ func (s *unitServiceSuite) TestGetAllUnitCloudContainerIDsForApplicationErrors(c
 func (s *unitServiceSuite) TestGetAllUnitCloudContainerIDsForApplicationInvalidApplicationUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appID := coreapplication.ID("$")
+	appID := coreapplication.UUID("$")
 	_, err := s.service.GetAllUnitCloudContainerIDsForApplication(c.Context(), appID)
 	c.Assert(err, tc.NotNil)
 }

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -132,7 +132,7 @@ func (s *unitServiceSuite) TestRegisterCAASUnit(c *tc.C) {
 	}}, nil)
 	s.caasProvider.EXPECT().Application("foo", caas.DeploymentStateful).Return(app)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").
 		Return(appUUID, nil)
 	s.state.EXPECT().GetStorageInstancesForProviderIDs(gomock.Any(), appUUID,
 		gomock.Any()).Return(nil, nil)
@@ -192,7 +192,7 @@ func (s *unitServiceSuite) TestRegisterCAASUnitApplicationNoPods(c *tc.C) {
 	app.EXPECT().Units().Return([]caas.Unit{}, nil)
 	s.caasProvider.EXPECT().Application("foo", caas.DeploymentStateful).Return(app)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").
 		Return(appUUID, nil)
 
 	p := application.RegisterCAASUnitParams{
@@ -345,7 +345,7 @@ func (s *unitServiceSuite) TestGetUnitNamesForApplication(c *tc.C) {
 	appID := applicationtesting.GenApplicationUUID(c)
 	unitNames := []coreunit.Name{"foo/666", "foo/667"}
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(appID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appID, nil)
 	s.state.EXPECT().GetUnitNamesForApplication(gomock.Any(), appID).Return(unitNames, nil)
 
 	names, err := s.service.GetUnitNamesForApplication(c.Context(), appName)
@@ -356,7 +356,7 @@ func (s *unitServiceSuite) TestGetUnitNamesForApplication(c *tc.C) {
 func (s *unitServiceSuite) TestGetUnitNamesForApplicationNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
 
 	_, err := s.service.GetUnitNamesForApplication(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
@@ -368,7 +368,7 @@ func (s *unitServiceSuite) TestGetUnitNamesForApplicationDead(c *tc.C) {
 	appName := "foo"
 	appID := applicationtesting.GenApplicationUUID(c)
 
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), appName).Return(appID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appID, nil)
 	s.state.EXPECT().GetUnitNamesForApplication(gomock.Any(), appID).Return(nil, applicationerrors.ApplicationIsDead)
 
 	_, err := s.service.GetUnitNamesForApplication(c.Context(), appName)

--- a/domain/application/service_test.go
+++ b/domain/application/service_test.go
@@ -420,15 +420,15 @@ func (s *serviceSuite) setupMocks(c *tc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *serviceSuite) createApplication(c *tc.C, name string, units ...service.AddUnitArg) coreapplication.ID {
+func (s *serviceSuite) createApplication(c *tc.C, name string, units ...service.AddUnitArg) coreapplication.UUID {
 	return s.createApplicationWithCharm(c, name, &stubCharm{}, units...)
 }
 
-func (s *serviceSuite) createSubordinateApplication(c *tc.C, name string, units ...service.AddUnitArg) coreapplication.ID {
+func (s *serviceSuite) createSubordinateApplication(c *tc.C, name string, units ...service.AddUnitArg) coreapplication.UUID {
 	return s.createApplicationWithCharm(c, name, &stubCharm{subordinate: true}, units...)
 }
 
-func (s *serviceSuite) createApplicationWithCharm(c *tc.C, name string, ch internalcharm.Charm, units ...service.AddUnitArg) coreapplication.ID {
+func (s *serviceSuite) createApplicationWithCharm(c *tc.C, name string, ch internalcharm.Charm, units ...service.AddUnitArg) coreapplication.UUID {
 	appID, err := s.svc.CreateCAASApplication(c.Context(), name, ch, corecharm.Origin{
 		Source: corecharm.CharmHub,
 		Platform: corecharm.Platform{

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -52,7 +52,7 @@ import (
 func (st *State) checkApplicationExists(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 ) (bool, error) {
 	uuidInput := entityUUID{UUID: appUUID.String()}
 
@@ -86,7 +86,7 @@ func (st *State) CreateIAASApplication(
 	name string,
 	args application.AddIAASApplicationArg,
 	units []application.AddIAASUnitArg,
-) (coreapplication.ID, []coremachine.Name, error) {
+) (coreapplication.UUID, []coremachine.Name, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", nil, errors.Capture(err)
@@ -138,7 +138,7 @@ func (st *State) CreateCAASApplication(
 	name string,
 	args application.AddCAASApplicationArg,
 	units []application.AddCAASUnitArg,
-) (coreapplication.ID, error) {
+) (coreapplication.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
@@ -195,7 +195,7 @@ func (st *State) insertApplication(
 	ctx context.Context,
 	tx *sqlair.TX,
 	name string,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	args application.BaseAddApplicationArg,
 ) error {
 	charmID, err := corecharm.NewID()
@@ -388,7 +388,7 @@ VALUES ($applicationDetails.uuid)
 
 func (st *State) insertIAASApplicationUnits(
 	ctx context.Context, tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	charmUUID corecharm.ID,
 	units []application.AddIAASUnitArg,
 ) ([]coremachine.Name, error) {
@@ -406,7 +406,7 @@ func (st *State) insertIAASApplicationUnits(
 
 func (st *State) insertCAASApplicationUnits(
 	ctx context.Context, tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	charmUUID corecharm.ID,
 	units []application.AddCAASUnitArg,
 ) error {
@@ -465,7 +465,7 @@ WHERE name = $unitNameLife.name
 
 // GetApplicationScaleState looks up the scale state of the specified application, returning an error
 // satisfying [applicationerrors.ApplicationNotFound] if the application is not found.
-func (st *State) GetApplicationScaleState(ctx context.Context, appUUID coreapplication.ID) (application.ScaleState, error) {
+func (st *State) GetApplicationScaleState(ctx context.Context, appUUID coreapplication.UUID) (application.ScaleState, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return application.ScaleState{}, errors.Capture(err)
@@ -483,7 +483,7 @@ func (st *State) GetApplicationScaleState(ctx context.Context, appUUID coreappli
 	return appScale, nil
 }
 
-func (st *State) getApplicationScaleState(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.ID) (application.ScaleState, error) {
+func (st *State) getApplicationScaleState(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID) (application.ScaleState, error) {
 	appScale := applicationScale{ApplicationID: appUUID}
 	queryScale := `
 SELECT &applicationScale.*
@@ -511,7 +511,7 @@ WHERE application_uuid = $applicationScale.application_uuid
 // GetApplicationLife looks up the life of the specified application, returning
 // an error satisfying [applicationerrors.ApplicationNotFoundError] if the
 // application is not found.
-func (st *State) GetApplicationLife(ctx context.Context, appUUID coreapplication.ID) (life.Life, error) {
+func (st *State) GetApplicationLife(ctx context.Context, appUUID coreapplication.UUID) (life.Life, error) {
 	ident := applicationID{ID: appUUID}
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -543,7 +543,7 @@ WHERE a.uuid = $applicationID.uuid AND c.source_id < 2;
 }
 
 // IsControllerApplication returns true when the application is the controller.
-func (st *State) IsControllerApplication(ctx context.Context, appID coreapplication.ID) (bool, error) {
+func (st *State) IsControllerApplication(ctx context.Context, appID coreapplication.UUID) (bool, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return false, errors.Capture(err)
@@ -591,7 +591,7 @@ WHERE application_uuid = $controllerApplication.application_uuid
 // GetApplicationLifeByName looks up the life of the specified application, returning
 // an error satisfying [applicationerrors.ApplicationNotFoundError] if the
 // application is not found.
-func (st *State) GetApplicationLifeByName(ctx context.Context, appName string) (coreapplication.ID, life.Life, error) {
+func (st *State) GetApplicationLifeByName(ctx context.Context, appName string) (coreapplication.UUID, life.Life, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", -1, errors.Capture(err)
@@ -693,7 +693,7 @@ WHERE a.name = $applicationDetails.name AND c.source_id < 2;
 
 // SetDesiredApplicationScale updates the desired scale of the specified
 // application.
-func (st *State) SetDesiredApplicationScale(ctx context.Context, appUUID coreapplication.ID, scale int) error {
+func (st *State) SetDesiredApplicationScale(ctx context.Context, appUUID coreapplication.UUID, scale int) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -722,7 +722,7 @@ WHERE application_uuid = $applicationScale.application_uuid
 // delta.
 // If the resulting scale is less than zero, an error satisfying
 // [applicationerrors.ScaleChangeInvalid] is returned.
-func (st *State) UpdateApplicationScale(ctx context.Context, appUUID coreapplication.ID, delta int) (int, error) {
+func (st *State) UpdateApplicationScale(ctx context.Context, appUUID coreapplication.UUID, delta int) (int, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return -1, errors.Capture(err)
@@ -998,7 +998,7 @@ INSERT INTO link_layer_device (*) VALUES ($cloudServiceDevice.*)
 	return devUUID, nil
 }
 
-func (st *State) deleteCloudServiceAddresses(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.ID, providerID string) error {
+func (st *State) deleteCloudServiceAddresses(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID, providerID string) error {
 	cloudService := cloudService{
 		ApplicationUUID: appUUID,
 		ProviderID:      providerID,
@@ -1286,7 +1286,7 @@ WHERE  name = $unitName.name
 // of interest for the unit is low.
 // A possible future improvement would be to accumulate the change events and
 // check whether the unit of interest has been affaceted, before hitting the db.
-func (st *State) GetAddressesHash(ctx context.Context, appUUID coreapplication.ID, netNodeUUID string) (string, error) {
+func (st *State) GetAddressesHash(ctx context.Context, appUUID coreapplication.UUID, netNodeUUID string) (string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
@@ -1410,13 +1410,13 @@ func (st *State) hashAddress(writer io.Writer, address spaceAddress) error {
 
 // GetApplicationsWithPendingCharmsFromUUIDs returns the application IDs for the
 // applications with pending charms from the specified UUIDs.
-func (st *State) GetApplicationsWithPendingCharmsFromUUIDs(ctx context.Context, uuids []coreapplication.ID) ([]coreapplication.ID, error) {
+func (st *State) GetApplicationsWithPendingCharmsFromUUIDs(ctx context.Context, uuids []coreapplication.UUID) ([]coreapplication.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	type applicationIDs []coreapplication.ID
+	type applicationIDs []coreapplication.UUID
 
 	stmt, err := st.Prepare(`
 SELECT a.uuid AS &applicationID.uuid
@@ -1440,7 +1440,7 @@ WHERE a.uuid IN ($applicationIDs[:]) AND c.available = FALSE
 		return nil, errors.Errorf("querying requested applications that have pending charms: %w", err)
 	}
 
-	return transform.Slice(results, func(r applicationID) coreapplication.ID {
+	return transform.Slice(results, func(r applicationID) coreapplication.UUID {
 		return r.ID
 	}), nil
 }
@@ -1487,7 +1487,7 @@ func (st *State) GetCharmIDByApplicationName(ctx context.Context, name string) (
 //
 // If the application does not exist, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetCharmByApplicationID(ctx context.Context, appUUID coreapplication.ID) (charm.Charm, error) {
+func (st *State) GetCharmByApplicationID(ctx context.Context, appUUID coreapplication.UUID) (charm.Charm, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return charm.Charm{}, errors.Capture(err)
@@ -1522,7 +1522,7 @@ func (st *State) GetCharmByApplicationID(ctx context.Context, appUUID coreapplic
 // relation can change the validation result.
 func (st *State) SetApplicationCharm(
 	ctx context.Context,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	chID corecharm.ID,
 	params application.SetCharmParams,
 ) error {
@@ -1613,7 +1613,7 @@ WHERE  uuid = $applicationID.uuid
 func (st *State) GetApplicationIDByUnitName(
 	ctx context.Context,
 	name coreunit.Name,
-) (coreapplication.ID, error) {
+) (coreapplication.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
@@ -1652,7 +1652,7 @@ WHERE name = $unitName.name;
 func (st *State) GetApplicationIDAndNameByUnitName(
 	ctx context.Context,
 	name coreunit.Name,
-) (coreapplication.ID, string, error) {
+) (coreapplication.UUID, string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", "", errors.Capture(err)
@@ -1690,7 +1690,7 @@ WHERE u.name = $unitName.name;
 //
 // Returns [applicationerrors.ApplicationNotFound] if the
 // application is not found.
-func (st *State) GetCharmModifiedVersion(ctx context.Context, id coreapplication.ID) (int, error) {
+func (st *State) GetCharmModifiedVersion(ctx context.Context, id coreapplication.UUID) (int, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return -1, errors.Capture(err)
@@ -1730,7 +1730,7 @@ WHERE uuid = $applicationID.uuid
 // [applicationerrors.CharmAlreadyAvailable] if the application is already
 // downloading a charm, or [applicationerrors.ApplicationNotFound] if the
 // application is not found.
-func (st *State) GetAsyncCharmDownloadInfo(ctx context.Context, appID coreapplication.ID) (application.CharmDownloadInfo, error) {
+func (st *State) GetAsyncCharmDownloadInfo(ctx context.Context, appID coreapplication.UUID) (application.CharmDownloadInfo, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return application.CharmDownloadInfo{}, errors.Capture(err)
@@ -1979,7 +1979,7 @@ FROM v_revision_updater_application_unit
 //
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetApplicationConfigAndSettings(ctx context.Context, appID coreapplication.ID) (map[string]application.ApplicationConfig, application.ApplicationSettings, error) {
+func (st *State) GetApplicationConfigAndSettings(ctx context.Context, appID coreapplication.UUID) (map[string]application.ApplicationConfig, application.ApplicationSettings, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, application.ApplicationSettings{}, errors.Capture(err)
@@ -2041,7 +2041,7 @@ func (st *State) GetApplicationConfigAndSettings(ctx context.Context, appID core
 //
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetApplicationConfigWithDefaults(ctx context.Context, appID coreapplication.ID) (map[string]application.ApplicationConfig, error) {
+func (st *State) GetApplicationConfigWithDefaults(ctx context.Context, appID coreapplication.UUID) (map[string]application.ApplicationConfig, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -2091,7 +2091,7 @@ func (st *State) GetApplicationConfigWithDefaults(ctx context.Context, appID cor
 // GetApplicationTrustSetting returns the application trust setting.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetApplicationTrustSetting(ctx context.Context, appID coreapplication.ID) (bool, error) {
+func (st *State) GetApplicationTrustSetting(ctx context.Context, appID coreapplication.UUID) (bool, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return false, errors.Capture(err)
@@ -2134,7 +2134,7 @@ WHERE application_uuid = $applicationID.uuid;`
 // using the configuration.
 func (st *State) UpdateApplicationConfigAndSettings(
 	ctx context.Context,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	config map[string]application.AddApplicationConfig,
 	settings application.UpdateApplicationSettingsArg,
 ) error {
@@ -2216,7 +2216,7 @@ ON CONFLICT(application_uuid) DO UPDATE SET
 // config. If the key does not exist, it is ignored.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) UnsetApplicationConfigKeys(ctx context.Context, appID coreapplication.ID, keys []string) error {
+func (st *State) UnsetApplicationConfigKeys(ctx context.Context, appID coreapplication.UUID, keys []string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -2301,7 +2301,7 @@ ON CONFLICT(application_uuid) DO UPDATE SET
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
 // If the charm for the application does not exist.
-func (st *State) GetCharmConfigByApplicationID(ctx context.Context, appID coreapplication.ID) (corecharm.ID, charm.Config, error) {
+func (st *State) GetCharmConfigByApplicationID(ctx context.Context, appID coreapplication.UUID) (corecharm.ID, charm.Config, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", charm.Config{}, errors.Capture(err)
@@ -2348,7 +2348,7 @@ WHERE uuid = $applicationID.uuid;
 // GetApplicationName returns the name of the specified application.
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
-func (st *State) GetApplicationName(ctx context.Context, appID coreapplication.ID) (string, error) {
+func (st *State) GetApplicationName(ctx context.Context, appID coreapplication.UUID) (string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
@@ -2369,13 +2369,13 @@ func (st *State) GetApplicationName(ctx context.Context, appID coreapplication.I
 // GetApplicationIDByName returns the application ID for the named application.
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
-func (st *State) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error) {
+func (st *State) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	var id coreapplication.ID
+	var id coreapplication.UUID
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		id, err = st.lookupApplication(ctx, tx, name)
 		return err
@@ -2429,7 +2429,7 @@ WHERE  name = $getCharmUpgradeOnError.name AND c.source_id < 2;
 func (st *State) getApplicationName(
 	ctx context.Context,
 	tx *sqlair.TX,
-	id coreapplication.ID) (string, error) {
+	id coreapplication.UUID) (string, error) {
 	arg := applicationIDAndName{
 		ID: id,
 	}
@@ -2457,7 +2457,7 @@ WHERE  a.uuid = $applicationIDAndName.uuid AND c.source_id < 2;
 // for the specified application ID.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetApplicationConfigHash(ctx context.Context, appID coreapplication.ID) (string, error) {
+func (st *State) GetApplicationConfigHash(ctx context.Context, appID coreapplication.UUID) (string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
@@ -2500,7 +2500,7 @@ WHERE application_uuid = $applicationID.uuid;
 // specified application ID.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetApplicationCharmOrigin(ctx context.Context, appID coreapplication.ID) (application.CharmOrigin, error) {
+func (st *State) GetApplicationCharmOrigin(ctx context.Context, appID coreapplication.UUID) (application.CharmOrigin, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return application.CharmOrigin{}, errors.Capture(err)
@@ -2599,7 +2599,7 @@ WHERE application_uuid = $applicationID.uuid;
 // application ID.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetApplicationConstraints(ctx context.Context, appID coreapplication.ID) (constraints.Constraints, error) {
+func (st *State) GetApplicationConstraints(ctx context.Context, appID coreapplication.UUID) (constraints.Constraints, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return constraints.Constraints{}, errors.Capture(err)
@@ -2645,7 +2645,7 @@ WHERE application_uuid = $applicationID.uuid;
 // error is returned.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) SetApplicationConstraints(ctx context.Context, appID coreapplication.ID, cons constraints.Constraints) error {
+func (st *State) SetApplicationConstraints(ctx context.Context, appID coreapplication.UUID, cons constraints.Constraints) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -2663,7 +2663,7 @@ func (st *State) SetApplicationConstraints(ctx context.Context, appID coreapplic
 func (st *State) setApplicationConstraints(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	cons constraints.Constraints,
 ) error {
 
@@ -2853,7 +2853,7 @@ ON CONFLICT (application_uuid) DO NOTHING
 // If the application is dead, [applicationerrors.ApplicationIsDead] is returned.
 // If the application is not found, [applicationerrors.ApplicationNotFound]
 // is returned.
-func (st *State) GetDeviceConstraints(ctx context.Context, appID coreapplication.ID) (map[string]devices.Constraints, error) {
+func (st *State) GetDeviceConstraints(ctx context.Context, appID coreapplication.UUID) (map[string]devices.Constraints, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -2912,7 +2912,7 @@ func (st *State) decodeDeviceConstraints(cons []deviceConstraint) map[string]dev
 	return res
 }
 
-func (st *State) insertDeviceConstraints(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, cons map[string]devices.Constraints) error {
+func (st *State) insertDeviceConstraints(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID, cons map[string]devices.Constraints) error {
 	if len(cons) == 0 {
 		return nil
 	}
@@ -3138,7 +3138,7 @@ func encodeConstraints(constraintUUID string, cons constraints.Constraints, cont
 // application.ID.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) lookupApplication(ctx context.Context, tx *sqlair.TX, name string) (coreapplication.ID, error) {
+func (st *State) lookupApplication(ctx context.Context, tx *sqlair.TX, name string) (coreapplication.UUID, error) {
 	app := applicationIDAndName{Name: name}
 	queryApplicationStmt, err := st.Prepare(`
 SELECT a.uuid AS &applicationIDAndName.uuid
@@ -3220,7 +3220,7 @@ WHERE application_uuid = $applicationID.uuid;
 func (st *State) insertApplicationConfig(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	config map[string]application.AddApplicationConfig,
 ) error {
 	if len(config) == 0 {
@@ -3261,7 +3261,7 @@ VALUES ($setApplicationConfig.*);
 func (st *State) insertApplicationSettings(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	settings application.ApplicationSettings,
 ) error {
 	insertQuery := `
@@ -3286,7 +3286,7 @@ VALUES ($setApplicationSettings.*);
 func (st *State) insertApplicationStatus(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	sts *status.StatusInfo[status.WorkloadStatusType],
 ) error {
 	if sts == nil {
@@ -3446,7 +3446,7 @@ func decodeChannel(track string, risk sql.NullString, branch string) (*deploymen
 // It returns a slice of relationInfo containing all relevant information from
 // charm_relation and the count of applications linked through this relation to
 // the current one.
-func (st *State) getAllRelationInfo(ctx context.Context, tx *sqlair.TX, id coreapplication.ID) ([]relationInfo, error) {
+func (st *State) getAllRelationInfo(ctx context.Context, tx *sqlair.TX, id coreapplication.UUID) ([]relationInfo, error) {
 	type application dbUUID
 	app := application{UUID: id.String()}
 

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -107,7 +107,7 @@ func (st *State) CreateIAASApplication(
 			return nil
 		}
 
-		charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, appUUID)
+		charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 		if err != nil {
 			return errors.Errorf(
 				"getting charm uuid for new application %q: %w",
@@ -172,7 +172,7 @@ func (st *State) CreateCAASApplication(
 			return nil
 		}
 
-		charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, appUUID)
+		charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 		if err != nil {
 			return errors.Errorf(
 				"getting charm uuid for new application %q: %w",
@@ -1466,7 +1466,7 @@ func (st *State) GetCharmIDByApplicationName(ctx context.Context, name string) (
 			return errors.Errorf("looking up application %q: %w", name, err)
 		}
 
-		result, err = st.getCharmIDByApplicationID(ctx, tx, appUUID)
+		result, err = st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 		if err != nil {
 			return errors.Errorf("getting charm for application %q: %w", name, err)
 		}
@@ -1479,15 +1479,15 @@ func (st *State) GetCharmIDByApplicationName(ctx context.Context, name string) (
 	return result, nil
 }
 
-// GetCharmByApplicationID returns the charm for the specified application
-// ID.
+// GetCharmByApplicationUUID returns the charm for the specified application
+// UUID.
 // This method should be used sparingly, as it is not efficient. It should
 // be only used when you need the whole charm, otherwise use the more specific
 // methods.
 //
 // If the application does not exist, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetCharmByApplicationID(ctx context.Context, appUUID coreapplication.UUID) (charm.Charm, error) {
+func (st *State) GetCharmByApplicationUUID(ctx context.Context, appUUID coreapplication.UUID) (charm.Charm, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return charm.Charm{}, errors.Capture(err)
@@ -1495,7 +1495,7 @@ func (st *State) GetCharmByApplicationID(ctx context.Context, appUUID coreapplic
 
 	var ch charm.Charm
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, appUUID)
+		charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 		if err != nil {
 			return errors.Errorf("getting charm ID from application ID %q: %w", appUUID, err)
 		}
@@ -1606,11 +1606,11 @@ WHERE  uuid = $applicationID.uuid
 	return nil
 }
 
-// GetApplicationIDByUnitName returns the application ID for the named unit.
+// GetApplicationUUIDByUnitName returns the application UUID for the named unit.
 //
 // Returns an error satisfying [applicationerrors.UnitNotFound] if the unit
 // doesn't exist.
-func (st *State) GetApplicationIDByUnitName(
+func (st *State) GetApplicationUUIDByUnitName(
 	ctx context.Context,
 	name coreunit.Name,
 ) (coreapplication.UUID, error) {
@@ -1644,12 +1644,12 @@ WHERE name = $unitName.name;
 	return app.ID, nil
 }
 
-// GetApplicationIDAndNameByUnitName returns the application ID and name for the
-// named unit.
+// GetApplicationUUIDAndNameByUnitName returns the application UUID and name
+// for the named unit.
 //
 // Returns an error satisfying [applicationerrors.UnitNotFound] if the unit
 // doesn't exist.
-func (st *State) GetApplicationIDAndNameByUnitName(
+func (st *State) GetApplicationUUIDAndNameByUnitName(
 	ctx context.Context,
 	name coreunit.Name,
 ) (coreapplication.UUID, string, error) {
@@ -2296,12 +2296,12 @@ ON CONFLICT(application_uuid) DO UPDATE SET
 	return nil
 }
 
-// GetCharmConfigByApplicationID returns the charm config for the specified
-// application ID.
+// GetCharmConfigByApplicationUUID returns the charm config for the specified
+// application UUID.
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
 // If the charm for the application does not exist.
-func (st *State) GetCharmConfigByApplicationID(ctx context.Context, appID coreapplication.UUID) (corecharm.ID, charm.Config, error) {
+func (st *State) GetCharmConfigByApplicationUUID(ctx context.Context, appID coreapplication.UUID) (corecharm.ID, charm.Config, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", charm.Config{}, errors.Capture(err)
@@ -2366,10 +2366,11 @@ func (st *State) GetApplicationName(ctx context.Context, appID coreapplication.U
 	return name, nil
 }
 
-// GetApplicationIDByName returns the application ID for the named application.
+// GetApplicationUUIDByName returns the application UUID for the named
+// application.
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
-func (st *State) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
+func (st *State) GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)

--- a/domain/application/state/application_endpoint.go
+++ b/domain/application/state/application_endpoint.go
@@ -217,7 +217,7 @@ func (st *State) GetApplicationEndpointNames(ctx context.Context, appUUID coreap
 
 	var eps []charmRelationName
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, appUUID)
+		charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 		if err != nil {
 			return errors.Errorf("getting charm for application %q: %w", appUUID, err)
 		}
@@ -307,7 +307,7 @@ type insertApplicationEndpointsParams struct {
 // the application default space may have been updated if a binding without endpoint
 // was present in params.
 func (st *State) insertApplicationEndpointBindings(ctx context.Context, tx *sqlair.TX, params insertApplicationEndpointsParams) error {
-	charm, err := st.getCharmIDByApplicationID(ctx, tx, params.appID)
+	charm, err := st.getCharmIDByApplicationUUID(ctx, tx, params.appID)
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/application/state/application_endpoint.go
+++ b/domain/application/state/application_endpoint.go
@@ -140,7 +140,7 @@ JOIN   application a ON a.uuid = aee.application_uuid
 //
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetApplicationEndpointBindings(ctx context.Context, appUUID coreapplication.ID) (map[string]string, error) {
+func (st *State) GetApplicationEndpointBindings(ctx context.Context, appUUID coreapplication.UUID) (map[string]string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -209,7 +209,7 @@ SELECT name AS &applicationName.name FROM (
 // The following errors may be returned:
 //   - [applicationerrors.ApplicationNotFound] is returned if the application
 //     doesn't exist.
-func (st *State) GetApplicationEndpointNames(ctx context.Context, appUUID coreapplication.ID) ([]string, error) {
+func (st *State) GetApplicationEndpointNames(ctx context.Context, appUUID coreapplication.UUID) ([]string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -286,7 +286,7 @@ func (st *State) mergeApplicationEndpointBindings(ctx context.Context, tx *sqlai
 // insertApplicationEndpointsParams contains parameters required to insert
 // application endpoints into the database.
 type insertApplicationEndpointsParams struct {
-	appID coreapplication.ID
+	appID coreapplication.UUID
 
 	// EndpointBindings is a map to bind application endpoint by name to a
 	// specific space. The default space is referenced by an empty key, if any.
@@ -354,7 +354,7 @@ func (st *State) insertApplicationEndpointBindings(ctx context.Context, tx *sqla
 func (st *State) insertApplicationRelationEndpointBindings(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	relations []charmRelationName,
 	spaceNamesToUUID map[network.SpaceName]string,
 	bindings map[string]network.SpaceName,
@@ -406,7 +406,7 @@ VALUES ($setApplicationEndpointBinding.*)
 func (st *State) insertApplicationExtraBindings(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	extraBindings []charmExtraBinding,
 	spaceNamesToUUID map[network.SpaceName]string,
 	bindings map[string]network.SpaceName,
@@ -718,7 +718,7 @@ WHERE uuid =  $setDefaultSpace.uuid`, app)
 // getEndpointBindings gets a map of endpoint names to space UUIDs. This
 // includes the application endpoints, and the application extra endpoints. An
 // endpoint name of "" is used to record the default application space.
-func (st *State) getEndpointBindings(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.ID) (map[string]string, error) {
+func (st *State) getEndpointBindings(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID) (map[string]string, error) {
 	appIdent := applicationID{ID: appUUID}
 
 	relationEndpoints, err := st.getRelationEndpointBindings(ctx, tx, appIdent)
@@ -860,7 +860,7 @@ AND    application_uuid = $applicationID.uuid
 		return nil, errors.Errorf("preparing charm endpoint count query: %w", err)
 	}
 
-	applicationID := applicationID{ID: coreapplication.ID(appID)}
+	applicationID := applicationID{ID: coreapplication.UUID(appID)}
 	eps := endpointNames(names)
 
 	var result []bindingToTable

--- a/domain/application/state/application_endpoint.go
+++ b/domain/application/state/application_endpoint.go
@@ -719,7 +719,7 @@ WHERE uuid =  $setDefaultSpace.uuid`, app)
 // includes the application endpoints, and the application extra endpoints. An
 // endpoint name of "" is used to record the default application space.
 func (st *State) getEndpointBindings(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID) (map[string]string, error) {
-	appIdent := applicationUUDID{ID: appUUID}
+	appIdent := entityUUID{UUID: appUUID.String()}
 
 	relationEndpoints, err := st.getRelationEndpointBindings(ctx, tx, appIdent)
 	if err != nil {
@@ -736,7 +736,7 @@ func (st *State) getEndpointBindings(ctx context.Context, tx *sqlair.TX, appUUID
 	defaultEndpointStmt, err := st.Prepare(`
 SELECT space_uuid AS &spaceUUID.uuid
 FROM   application 
-WHERE  uuid = $applicationID.uuid
+WHERE  uuid = $entityUUID.uuid
 `, defaultSpaceUUID, appIdent)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -770,12 +770,12 @@ WHERE  uuid = $applicationID.uuid
 	return endpoints, nil
 }
 
-func (st *State) getRelationEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent applicationUUDID) ([]endpointBinding, error) {
+func (st *State) getRelationEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent entityUUID) ([]endpointBinding, error) {
 	stmt, err := st.Prepare(`
 SELECT (ae.space_uuid, cr.name) AS (&endpointBinding.*)
 FROM   application_endpoint ae
 JOIN   charm_relation cr ON cr.uuid = ae.charm_relation_uuid
-WHERE  ae.application_uuid = $applicationID.uuid
+WHERE  ae.application_uuid = $entityUUID.uuid
 `, endpointBinding{}, appIdent)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -790,12 +790,12 @@ WHERE  ae.application_uuid = $applicationID.uuid
 	return endpoints, nil
 }
 
-func (st *State) getExtraEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent applicationUUDID) ([]endpointBinding, error) {
+func (st *State) getExtraEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent entityUUID) ([]endpointBinding, error) {
 	stmt, err := st.Prepare(`
 SELECT (aee.space_uuid, ceb.name) AS (&endpointBinding.*)
 FROM   application_extra_endpoint aee
 JOIN   charm_extra_binding ceb ON ceb.uuid = aee.charm_extra_binding_uuid
-WHERE  aee.application_uuid = $applicationID.uuid
+WHERE  aee.application_uuid = $entityUUID.uuid
 `, endpointBinding{}, appIdent)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -853,14 +853,14 @@ charm_bindings AS (
 SELECT &bindingToTable.*
 FROM   charm_bindings
 WHERE  name IN ($endpointNames[:])
-AND    application_uuid = $applicationID.uuid
+AND    application_uuid = $entityUUID.uuid
 `
-	relationEndpointStmt, err := st.Prepare(query, bindingToTable{}, applicationUUDID{}, endpointNames{})
+	relationEndpointStmt, err := st.Prepare(query, bindingToTable{}, entityUUID{}, endpointNames{})
 	if err != nil {
 		return nil, errors.Errorf("preparing charm endpoint count query: %w", err)
 	}
 
-	applicationID := applicationUUDID{ID: coreapplication.UUID(appID)}
+	applicationID := entityUUID{UUID: appID}
 	eps := endpointNames(names)
 
 	var result []bindingToTable
@@ -948,7 +948,7 @@ FROM   requested_spaces
 		Add(networkerrors.SpaceNotFound)
 }
 
-func (st *State) refreshApplicationEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent applicationUUDID, charmIdent charmID) error {
+func (st *State) refreshApplicationEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent entityUUID, charmIdent charmID) error {
 	if err := st.refreshApplicationRelationEndpointBindings(ctx, tx, appIdent, charmIdent); err != nil {
 		return errors.Errorf("refreshing application relation endpoint bindings: %w", err)
 	}
@@ -958,7 +958,7 @@ func (st *State) refreshApplicationEndpointBindings(ctx context.Context, tx *sql
 	return nil
 }
 
-func (st *State) refreshApplicationRelationEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent applicationUUDID, charmIdent charmID) error {
+func (st *State) refreshApplicationRelationEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent entityUUID, charmIdent charmID) error {
 	mapCharmRelationStmt, err := st.Prepare(`
 WITH given_charm_relations AS (
     SELECT uuid, name FROM charm_relation
@@ -969,17 +969,22 @@ SELECT    cr1.uuid AS &mapCharmRelation.source_charm_relation_uuid,
 FROM      application_endpoint AS ae
 JOIN      charm_relation AS cr1 ON ae.charm_relation_uuid = cr1.uuid
 LEFT JOIN given_charm_relations AS cr2 ON cr1.name = cr2.name
-WHERE     ae.application_uuid = $applicationID.uuid
+WHERE     ae.application_uuid = $entityUUID.uuid
 	`, mapCharmRelation{}, appIdent, charmIdent)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
+	// This type is only needed inlined here because we have a query with two
+	// entityUUIDs, so we need to differentiate them.
+	type charmRelationUUID struct {
+		UUID string `db:"uuid"`
+	}
 	removeApplicationEndpointStmt, err := st.Prepare(`
 DELETE FROM application_endpoint
-WHERE application_uuid = $applicationID.uuid
-AND charm_relation_uuid = $entityUUID.uuid
-	`, appIdent, entityUUID{})
+WHERE application_uuid = $entityUUID.uuid
+AND charm_relation_uuid = $charmRelationUUID.uuid
+	`, appIdent, charmRelationUUID{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -999,13 +1004,13 @@ WITH ep_names AS (
     SELECT cr.name
     FROM application_endpoint AS ae
     JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
-    WHERE ae.application_uuid = $applicationID.uuid
+    WHERE ae.application_uuid = $entityUUID.uuid
 )
-SELECT &entityUUID.*
+SELECT &charmRelationUUID.*
 FROM charm_relation
 WHERE charm_uuid = $charmID.uuid
 AND name NOT IN ep_names
-	`, entityUUID{}, appIdent, charmIdent)
+	`, charmRelationUUID{}, appIdent, charmIdent)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -1028,13 +1033,13 @@ VALUES ($setApplicationEndpointBinding.*)
 		if !pair.DestinationCharmRelationUUID.Valid {
 			// We don't need to verify these can be removed, since we have already pre-checked relations
 			// in this transaction.
-			err := tx.Query(ctx, removeApplicationEndpointStmt, appIdent, entityUUID{UUID: pair.SourceCharmRelationUUID}).Run()
+			err := tx.Query(ctx, removeApplicationEndpointStmt, appIdent, charmRelationUUID{UUID: pair.SourceCharmRelationUUID}).Run()
 			if err != nil {
 				return errors.Errorf("removing application endpoint: %w", err)
 			}
 		} else {
 			err := tx.Query(ctx, refreshApplicationEndpointStmt, refreshBinding{
-				ApplicationID:                appIdent.ID.String(),
+				ApplicationID:                appIdent.UUID,
 				SourceCharmRelationUUID:      pair.SourceCharmRelationUUID,
 				DestinationCharmRelationUUID: pair.DestinationCharmRelationUUID.V,
 			}).Run()
@@ -1044,7 +1049,7 @@ VALUES ($setApplicationEndpointBinding.*)
 		}
 	}
 
-	additionalRelations := []entityUUID{}
+	additionalRelations := []charmRelationUUID{}
 	err = tx.Query(ctx, additionalRelationsStmt, appIdent, charmIdent).GetAll(&additionalRelations)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 		return errors.Capture(err)
@@ -1057,7 +1062,7 @@ VALUES ($setApplicationEndpointBinding.*)
 		}
 		inserts[i] = setApplicationEndpointBinding{
 			UUID:          uuid,
-			ApplicationID: appIdent.ID,
+			ApplicationID: coreapplication.UUID(appIdent.UUID),
 			RelationUUID:  relation.UUID,
 			// New relations should inherit the default space. If a binding is
 			// specified, it will be set later
@@ -1081,7 +1086,7 @@ VALUES ($setApplicationEndpointBinding.*)
 // application_extra_endpoint is not the target of any foreign key constraints,
 // it does not have a uuid primary key column. So we can achieve this be clearing
 // the table and inserting the new bindings.
-func (st *State) refreshApplicationExtraEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent applicationUUDID, charmIdent charmID) error {
+func (st *State) refreshApplicationExtraEndpointBindings(ctx context.Context, tx *sqlair.TX, appIdent entityUUID, charmIdent charmID) error {
 	extraEndpointBindings, err := st.getExtraEndpointBindings(ctx, tx, appIdent)
 	if err != nil {
 		return errors.Errorf("getting existing extra endpoint bindings: %w", err)
@@ -1097,7 +1102,7 @@ func (st *State) refreshApplicationExtraEndpointBindings(ctx context.Context, tx
 
 	clearExtraBindingsStmt, err := st.Prepare(`
 DELETE FROM application_extra_endpoint
-WHERE application_uuid = $applicationID.uuid
+WHERE application_uuid = $entityUUID.uuid
 	`, appIdent)
 	if err != nil {
 		return errors.Capture(err)
@@ -1120,7 +1125,7 @@ VALUES ($setApplicationExtraEndpointBinding.*)
 		originalboundSpaceUUID, _ := extraBindingsMap[charmExtraBinding.Name]
 
 		refreshedExtraBindings = append(refreshedExtraBindings, setApplicationExtraEndpointBinding{
-			ApplicationID: appIdent.ID,
+			ApplicationID: coreapplication.UUID(appIdent.UUID),
 			RelationUUID:  charmExtraBinding.UUID,
 			Space:         originalboundSpaceUUID,
 		})

--- a/domain/application/state/application_endpoint_test.go
+++ b/domain/application/state/application_endpoint_test.go
@@ -32,7 +32,7 @@ import (
 type applicationEndpointStateSuite struct {
 	baseSuite
 
-	appID     coreapplication.ID
+	appID     coreapplication.UUID
 	charmUUID corecharm.ID
 
 	state *State

--- a/domain/application/state/application_refresh_test.go
+++ b/domain/application/state/application_refresh_test.go
@@ -800,7 +800,7 @@ func (s *applicationRefreshSuite) TestSetApplicationCharmTrustIsMaintained(c *tc
 }
 
 // createApplication creates a new application in the state with the provided arguments and returns its unique ID.
-func (s *applicationRefreshSuite) createApplication(c *tc.C, args createApplicationArgs) coreapplication.ID {
+func (s *applicationRefreshSuite) createApplication(c *tc.C, args createApplicationArgs) coreapplication.UUID {
 	appName := args.appName
 	if appName == "" {
 		appName = "some-app"
@@ -874,7 +874,7 @@ func (s *applicationRefreshSuite) createCharm(c *tc.C, args createCharmArgs) cor
 
 // establishRelationWith creates a new relation between the current application
 // and another, created on the fly, based on the given parameters.
-func (s *applicationRefreshSuite) establishRelationWith(c *tc.C, currentAppID coreapplication.ID, relationName string,
+func (s *applicationRefreshSuite) establishRelationWith(c *tc.C, currentAppID coreapplication.UUID, relationName string,
 	role charm.RelationRole) {
 	s.counter++
 	// Create relation metadata based on the role.
@@ -953,7 +953,7 @@ func (s *applicationRefreshSuite) establishRelationWith(c *tc.C, currentAppID co
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *applicationRefreshSuite) establishPeerRelation(c *tc.C, appID coreapplication.ID, relationName string) {
+func (s *applicationRefreshSuite) establishPeerRelation(c *tc.C, appID coreapplication.UUID, relationName string) {
 	s.counter++
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		// Get the application endpoint for the application

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1326,7 +1326,7 @@ func (s *applicationStateSuite) TestGetApplicationUUIDByUnitNameUnitUnitNotFound
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *applicationStateSuite) TestGetApplicationIDAndNameByUnitName(c *tc.C) {
+func (s *applicationStateSuite) TestGetApplicationUUIDAndNameByUnitName(c *tc.C) {
 	expectedAppUUID, _ := s.createIAASApplicationWithNUnits(c, "foo", life.Alive, 1)
 
 	appUUID, appName, err := s.state.GetApplicationUUIDAndNameByUnitName(c.Context(), "foo/0")
@@ -1335,7 +1335,7 @@ func (s *applicationStateSuite) TestGetApplicationIDAndNameByUnitName(c *tc.C) {
 	c.Check(appName, tc.Equals, "foo")
 }
 
-func (s *applicationStateSuite) TestGetApplicationIDAndNameByUnitNameNotFound(c *tc.C) {
+func (s *applicationStateSuite) TestGetApplicationUUIDAndNameByUnitNameNotFound(c *tc.C) {
 	_, _, err := s.state.GetApplicationUUIDAndNameByUnitName(c.Context(), "failme")
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
@@ -2843,7 +2843,7 @@ func (s *applicationStateSuite) TestCheckApplicationCharm(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return s.checkApplicationCharm(c.Context(), tx, applicationID{ID: id}, charmID{UUID: cid})
+		return s.checkApplicationCharm(c.Context(), tx, applicationUUDID{ID: id}, charmID{UUID: cid})
 	})
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -2852,7 +2852,7 @@ func (s *applicationStateSuite) TestCheckApplicationCharmDifferentCharm(c *tc.C)
 	id := s.createIAASApplication(c, "foo", life.Alive)
 
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return s.checkApplicationCharm(c.Context(), tx, applicationID{ID: id}, charmID{UUID: "other"})
+		return s.checkApplicationCharm(c.Context(), tx, applicationUUDID{ID: id}, charmID{UUID: "other"})
 	})
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationHasDifferentCharm)
 }
@@ -4059,7 +4059,7 @@ ORDER BY r.relation_id
 	c.Check(peerRelations, tc.SameContents, expected)
 }
 
-func (s *applicationStateSuite) checkApplicationCharm(ctx context.Context, tx *sqlair.TX, ident applicationID, charmID charmID) error {
+func (s *applicationStateSuite) checkApplicationCharm(ctx context.Context, tx *sqlair.TX, ident applicationUUDID, charmID charmID) error {
 	query := `
 SELECT COUNT(*) AS &countResult.count
 FROM application

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1313,30 +1313,30 @@ func (s *applicationStateSuite) TestUpsertCloudServiceNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
-func (s *applicationStateSuite) TestGetApplicationIDByUnitName(c *tc.C) {
+func (s *applicationStateSuite) TestGetApplicationUUIDByUnitName(c *tc.C) {
 	expectedAppUUID, _ := s.createIAASApplicationWithNUnits(c, "foo", life.Alive, 1)
 
-	obtainedAppUUID, err := s.state.GetApplicationIDByUnitName(c.Context(), "foo/0")
+	obtainedAppUUID, err := s.state.GetApplicationUUIDByUnitName(c.Context(), "foo/0")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtainedAppUUID, tc.Equals, expectedAppUUID)
 }
 
-func (s *applicationStateSuite) TestGetApplicationIDByUnitNameUnitUnitNotFound(c *tc.C) {
-	_, err := s.state.GetApplicationIDByUnitName(c.Context(), "failme")
+func (s *applicationStateSuite) TestGetApplicationUUIDByUnitNameUnitUnitNotFound(c *tc.C) {
+	_, err := s.state.GetApplicationUUIDByUnitName(c.Context(), "failme")
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
 func (s *applicationStateSuite) TestGetApplicationIDAndNameByUnitName(c *tc.C) {
 	expectedAppUUID, _ := s.createIAASApplicationWithNUnits(c, "foo", life.Alive, 1)
 
-	appUUID, appName, err := s.state.GetApplicationIDAndNameByUnitName(c.Context(), "foo/0")
+	appUUID, appName, err := s.state.GetApplicationUUIDAndNameByUnitName(c.Context(), "foo/0")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(appUUID, tc.Equals, expectedAppUUID)
 	c.Check(appName, tc.Equals, "foo")
 }
 
 func (s *applicationStateSuite) TestGetApplicationIDAndNameByUnitNameNotFound(c *tc.C) {
-	_, _, err := s.state.GetApplicationIDAndNameByUnitName(c.Context(), "failme")
+	_, _, err := s.state.GetApplicationUUIDAndNameByUnitName(c.Context(), "failme")
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
@@ -1752,7 +1752,7 @@ func (s *applicationStateSuite) TestGetCharmByApplicationID(c *tc.C) {
 	// Add the implicit juju-info relation inserted with the charm.
 	expectedMetadata.Provides = jujuInfoRelation()
 
-	ch, err := s.state.GetCharmByApplicationID(c.Context(), appID)
+	ch, err := s.state.GetCharmByApplicationUUID(c.Context(), appID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(ch, tc.DeepEquals, charm.Charm{
 		Metadata:      expectedMetadata,
@@ -1849,7 +1849,7 @@ func (s *applicationStateSuite) TestCreateApplicationDefaultSourceIsCharmhub(c *
 	// Add the implicit juju-info relation inserted with the charm.
 	expectedMetadata.Provides = jujuInfoRelation()
 
-	ch, err := s.state.GetCharmByApplicationID(c.Context(), appID)
+	ch, err := s.state.GetCharmByApplicationUUID(c.Context(), appID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(ch, tc.DeepEquals, charm.Charm{
 		Metadata:      expectedMetadata,
@@ -1889,7 +1889,7 @@ func (s *applicationStateSuite) TestSetCharmThenGetCharmByApplicationNameInvalid
 
 	id := applicationtesting.GenApplicationUUID(c)
 
-	_, err = s.state.GetCharmByApplicationID(c.Context(), id)
+	_, err = s.state.GetCharmByApplicationUUID(c.Context(), id)
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
@@ -2083,7 +2083,7 @@ func (s *applicationStateSuite) TestResolveCharmDownload(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(available, tc.Equals, true)
 
-	ch, err := s.state.GetCharmByApplicationID(c.Context(), id)
+	ch, err := s.state.GetCharmByApplicationUUID(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(ch.Actions, tc.DeepEquals, actions)
@@ -2799,7 +2799,7 @@ func (s *applicationStateSuite) TestGetCharmConfigByApplicationID(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	charmID, config, err := s.state.GetCharmConfigByApplicationID(c.Context(), id)
+	charmID, config, err := s.state.GetCharmConfigByApplicationUUID(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(charmID, tc.Equals, cid)
 	c.Check(config, tc.DeepEquals, charm.Config{
@@ -2832,7 +2832,7 @@ SELECT charm_uuid FROM application WHERE uuid = ?
 func (s *applicationStateSuite) TestGetCharmConfigByApplicationIDApplicationNotFound(c *tc.C) {
 	// If the application is not found, it should return application not found.
 	id := applicationtesting.GenApplicationUUID(c)
-	_, _, err := s.state.GetCharmConfigByApplicationID(c.Context(), id)
+	_, _, err := s.state.GetCharmConfigByApplicationUUID(c.Context(), id)
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
@@ -2870,16 +2870,16 @@ func (s *applicationStateSuite) TestGetApplicationNameNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
-func (s *applicationStateSuite) TestGetApplicationIDByName(c *tc.C) {
+func (s *applicationStateSuite) TestGetApplicationUUIDByName(c *tc.C) {
 	id := s.createIAASApplication(c, "foo", life.Alive)
 
-	gotID, err := s.state.GetApplicationIDByName(c.Context(), "foo")
+	gotID, err := s.state.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(gotID, tc.Equals, id)
 }
 
-func (s *applicationStateSuite) TestGetApplicationIDByNameNotFound(c *tc.C) {
-	_, err := s.state.GetApplicationIDByName(c.Context(), "foo")
+func (s *applicationStateSuite) TestGetApplicationUUIDByNameNotFound(c *tc.C) {
+	_, err := s.state.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1373,7 +1373,7 @@ func (s *applicationStateSuite) TestGetApplicationScaleState(c *tc.C) {
 }
 
 func (s *applicationStateSuite) TestGetApplicationScaleStateNotFound(c *tc.C) {
-	_, err := s.state.GetApplicationScaleState(c.Context(), coreapplication.ID(uuid.MustNewUUID().String()))
+	_, err := s.state.GetApplicationScaleState(c.Context(), coreapplication.UUID(uuid.MustNewUUID().String()))
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
@@ -1953,9 +1953,9 @@ func (s *applicationStateSuite) TestInitialWatchStatementApplicationsWithPending
 func (s *applicationStateSuite) TestGetApplicationsWithPendingCharmsFromUUIDsIfPending(c *tc.C) {
 	id := s.createIAASApplication(c, "foo", life.Alive)
 
-	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.ID{id})
+	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.UUID{id})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(expected, tc.DeepEquals, []coreapplication.ID{id})
+	c.Check(expected, tc.DeepEquals, []coreapplication.UUID{id})
 }
 
 func (s *applicationStateSuite) TestGetApplicationsWithPendingCharmsFromUUIDsIfAvailable(c *tc.C) {
@@ -1973,13 +1973,13 @@ WHERE a.uuid=?`, id.String())
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.ID{id})
+	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.UUID{id})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(expected, tc.HasLen, 0)
 }
 
 func (s *applicationStateSuite) TestGetApplicationsWithPendingCharmsFromUUIDsNotFound(c *tc.C) {
-	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.ID{"foo"})
+	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.UUID{"foo"})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(expected, tc.HasLen, 0)
 }
@@ -2003,7 +2003,7 @@ WHERE a.uuid=?`, id1.String())
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.ID{id0, id1})
+	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.UUID{id0, id1})
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(expected, tc.HasLen, 0)
@@ -3465,7 +3465,7 @@ func (s *applicationStateSuite) TestGetApplicationCharmOriginNoCharmhubIdentifie
 }
 
 func (s *applicationStateSuite) TestGetDeviceConstraintsAppNotFound(c *tc.C) {
-	_, err := s.state.GetDeviceConstraints(c.Context(), coreapplication.ID("foo"))
+	_, err := s.state.GetDeviceConstraints(c.Context(), coreapplication.UUID("foo"))
 	c.Assert(err, tc.ErrorMatches, applicationerrors.ApplicationNotFound.Error())
 }
 
@@ -3849,7 +3849,7 @@ func (s *applicationStateSuite) TestShouldAllowCharmUpgradeOnErrorNotFound(c *tc
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
-func (s *applicationStateSuite) setCharmUpgradeOnError(c *tc.C, appUUID coreapplication.ID, v bool) {
+func (s *applicationStateSuite) setCharmUpgradeOnError(c *tc.C, appUUID coreapplication.UUID, v bool) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.Exec(`
 UPDATE application
@@ -3971,7 +3971,7 @@ func (s *applicationStateSuite) assertCAASApplication(
 	}
 }
 
-func (s *applicationStateSuite) addCharmModifiedVersion(c *tc.C, appID coreapplication.ID, charmModifiedVersion int) {
+func (s *applicationStateSuite) addCharmModifiedVersion(c *tc.C, appID coreapplication.UUID, charmModifiedVersion int) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "UPDATE application SET charm_modified_version = ? WHERE uuid = ?", charmModifiedVersion, appID)
 		return err
@@ -3979,7 +3979,7 @@ func (s *applicationStateSuite) addCharmModifiedVersion(c *tc.C, appID coreappli
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *applicationStateSuite) insertApplicationConfigWithDefault(c *tc.C, appID coreapplication.ID, key, value, defaultValue string, optionType charm.OptionType) {
+func (s *applicationStateSuite) insertApplicationConfigWithDefault(c *tc.C, appID coreapplication.UUID, key, value, defaultValue string, optionType charm.OptionType) {
 	t, err := encodeConfigType(optionType)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -3993,7 +3993,7 @@ INSERT INTO application_config (application_uuid, key, value, type_id) VALUES (?
 	s.insertCharmConfig(c, appID, key, defaultValue, optionType)
 }
 
-func (s *applicationStateSuite) insertCharmConfig(c *tc.C, appID coreapplication.ID, key, defaultValue string, optionType charm.OptionType) {
+func (s *applicationStateSuite) insertCharmConfig(c *tc.C, appID coreapplication.UUID, key, defaultValue string, optionType charm.OptionType) {
 	t, err := encodeConfigType(optionType)
 	c.Assert(err, tc.ErrorIsNil)
 

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -1075,7 +1075,7 @@ SELECT charm_uuid AS &charmUUID.*
 FROM application
 WHERE uuid = $applicationID.uuid;
 `
-	ident := applicationID{ID: appID}
+	ident := applicationUUDID{ID: appID}
 	stmt, err := s.Prepare(query, charmUUID{}, ident)
 	if err != nil {
 		return "", errors.Errorf("preparing query: %w", err)
@@ -1084,7 +1084,7 @@ WHERE uuid = $applicationID.uuid;
 	if err := tx.Query(ctx, stmt, ident).Get(&charmUUID); errors.Is(err, sqlair.ErrNoRows) {
 		return "", applicationerrors.ApplicationNotFound
 	} else if err != nil {
-		return "", errors.Errorf("getting charm ID by application ID: %w", err)
+		return "", errors.Errorf("getting charm ID by application UUID: %w", err)
 	}
 	return charmUUID.UUID, nil
 }

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -1069,7 +1069,7 @@ func (s *State) NamespaceForWatchCharm() string {
 	return "charm"
 }
 
-func (s *State) getCharmIDByApplicationID(ctx context.Context, tx *sqlair.TX, appID application.UUID) (corecharm.ID, error) {
+func (s *State) getCharmIDByApplicationUUID(ctx context.Context, tx *sqlair.TX, appID application.UUID) (corecharm.ID, error) {
 	query := `
 SELECT charm_uuid AS &charmUUID.*
 FROM application

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -1069,7 +1069,7 @@ func (s *State) NamespaceForWatchCharm() string {
 	return "charm"
 }
 
-func (s *State) getCharmIDByApplicationID(ctx context.Context, tx *sqlair.TX, appID application.ID) (corecharm.ID, error) {
+func (s *State) getCharmIDByApplicationID(ctx context.Context, tx *sqlair.TX, appID application.UUID) (corecharm.ID, error) {
 	query := `
 SELECT charm_uuid AS &charmUUID.*
 FROM application

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -1073,9 +1073,9 @@ func (s *State) getCharmIDByApplicationUUID(ctx context.Context, tx *sqlair.TX, 
 	query := `
 SELECT charm_uuid AS &charmUUID.*
 FROM application
-WHERE uuid = $applicationID.uuid;
+WHERE uuid = $entityUUID.uuid;
 `
-	ident := applicationUUDID{ID: appID}
+	ident := entityUUID{UUID: appID.String()}
 	stmt, err := s.Prepare(query, charmUUID{}, ident)
 	if err != nil {
 		return "", errors.Errorf("preparing query: %w", err)

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -3521,7 +3521,7 @@ func (s *charmStateSuite) TestGetCharmIDByApplicationIDNotFound(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		_, err := st.getCharmIDByApplicationID(c.Context(), tx, applicationtesting.GenApplicationUUID(c))
+		_, err := st.getCharmIDByApplicationUUID(c.Context(), tx, applicationtesting.GenApplicationUUID(c))
 		return err
 	})
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
@@ -3538,7 +3538,7 @@ func (s *charmStateSuite) TestGetCharmIDByApplicationID(c *tc.C) {
 	var result corecharm.ID
 	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		result, err = st.getCharmIDByApplicationID(c.Context(), tx, uuid)
+		result, err = st.getCharmIDByApplicationUUID(c.Context(), tx, uuid)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/application/state/exposed.go
+++ b/domain/application/state/exposed.go
@@ -26,7 +26,7 @@ func (st *State) IsApplicationExposed(ctx context.Context, appID coreapplication
 		return false, errors.Capture(err)
 	}
 
-	ident := applicationID{ID: appID}
+	ident := applicationUUDID{ID: appID}
 	query := `
 SELECT COUNT(*) AS &countResult.count
 FROM v_application_exposed_endpoint
@@ -61,7 +61,7 @@ func (st *State) GetExposedEndpoints(ctx context.Context, appID coreapplication.
 		return nil, errors.Capture(err)
 	}
 
-	ident := applicationID{ID: appID}
+	ident := applicationUUDID{ID: appID}
 	query := `
 SELECT 
     cr.name AS &endpointCIDRsSpaces.name,
@@ -194,7 +194,7 @@ func (st *State) MergeExposeSettings(ctx context.Context, appID coreapplication.
 }
 
 func (st *State) unsetAllExposedEndpoints(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID) error {
-	applicationID := applicationID{ID: appID}
+	applicationID := applicationUUDID{ID: appID}
 
 	unsetExposedCIDRQuery := `
 DELETE FROM application_exposed_endpoint_cidr
@@ -235,7 +235,7 @@ func (st *State) unsetExposedEndpoints(ctx context.Context, tx *sqlair.TX, appID
 }
 
 func (st *State) unsetExposedEndpointCIDRs(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID, endpoint ...string) error {
-	applicationID := applicationID{ID: appID}
+	applicationID := applicationUUDID{ID: appID}
 	endpointNames := endpointNames(endpoint)
 
 	unsetExposedCIDRQuery := `
@@ -279,7 +279,7 @@ AND application_endpoint_uuid IS NULL;
 }
 
 func (st *State) unsetExposedEndpointSpaces(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID, endpoint ...string) error {
-	applicationID := applicationID{ID: appID}
+	applicationID := applicationUUDID{ID: appID}
 	endpointNames := endpointNames(endpoint)
 
 	unsetExposedSpaceQuery := `
@@ -426,7 +426,7 @@ LEFT JOIN charm_relation ON application_endpoint.charm_relation_uuid = charm_rel
 WHERE application_endpoint.application_uuid = $applicationID.uuid 
 AND charm_relation.name IN ($endpointNames[:]);
 	`
-	applicationID := applicationID{ID: appID}
+	applicationID := applicationUUDID{ID: appID}
 	stmt, err := st.Prepare(query, countResult{}, applicationID, eps)
 	if err != nil {
 		return errors.Errorf("preparing endpoint exists query: %w", err)

--- a/domain/application/state/exposed.go
+++ b/domain/application/state/exposed.go
@@ -20,7 +20,7 @@ import (
 
 // IsApplicationExposed returns whether the provided application is exposed or
 // not.
-func (st *State) IsApplicationExposed(ctx context.Context, appID coreapplication.ID) (bool, error) {
+func (st *State) IsApplicationExposed(ctx context.Context, appID coreapplication.UUID) (bool, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return false, errors.Capture(err)
@@ -55,7 +55,7 @@ WHERE application_uuid = $applicationID.uuid;
 // value which represents all endpoints) and values are ExposedEndpoint
 // instances that specify which sources (spaces or CIDRs) can access the
 // opened ports for each endpoint once the application is exposed.
-func (st *State) GetExposedEndpoints(ctx context.Context, appID coreapplication.ID) (map[string]application.ExposedEndpoint, error) {
+func (st *State) GetExposedEndpoints(ctx context.Context, appID coreapplication.UUID) (map[string]application.ExposedEndpoint, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -144,7 +144,7 @@ func encodeExposedEndpoints(endpoints []endpointCIDRsSpaces) map[string]applicat
 // automatically unexposed.
 // If the provided set of endpoints is empty, all exposed endpoints of the
 // application will be removed.
-func (st *State) UnsetExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints set.Strings) error {
+func (st *State) UnsetExposeSettings(ctx context.Context, appID coreapplication.UUID, exposedEndpoints set.Strings) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -163,7 +163,7 @@ func (st *State) UnsetExposeSettings(ctx context.Context, appID coreapplication.
 // MergeExposeSettings marks the application as exposed and merges the provided
 // ExposedEndpoint details into the current set of expose settings. The merge
 // operation will overwrite expose settings for each existing endpoint name.
-func (st *State) MergeExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints map[string]application.ExposedEndpoint) error {
+func (st *State) MergeExposeSettings(ctx context.Context, appID coreapplication.UUID, exposedEndpoints map[string]application.ExposedEndpoint) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -193,7 +193,7 @@ func (st *State) MergeExposeSettings(ctx context.Context, appID coreapplication.
 	return errors.Capture(err)
 }
 
-func (st *State) unsetAllExposedEndpoints(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID) error {
+func (st *State) unsetAllExposedEndpoints(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID) error {
 	applicationID := applicationID{ID: appID}
 
 	unsetExposedCIDRQuery := `
@@ -224,7 +224,7 @@ WHERE application_uuid = $applicationID.uuid;
 	return nil
 }
 
-func (st *State) unsetExposedEndpoints(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint ...string) error {
+func (st *State) unsetExposedEndpoints(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID, endpoint ...string) error {
 	if err := st.unsetExposedEndpointCIDRs(ctx, tx, appID, endpoint...); err != nil {
 		return errors.Capture(err)
 	}
@@ -234,7 +234,7 @@ func (st *State) unsetExposedEndpoints(ctx context.Context, tx *sqlair.TX, appID
 	return nil
 }
 
-func (st *State) unsetExposedEndpointCIDRs(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint ...string) error {
+func (st *State) unsetExposedEndpointCIDRs(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID, endpoint ...string) error {
 	applicationID := applicationID{ID: appID}
 	endpointNames := endpointNames(endpoint)
 
@@ -278,7 +278,7 @@ AND application_endpoint_uuid IS NULL;
 	return nil
 }
 
-func (st *State) unsetExposedEndpointSpaces(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint ...string) error {
+func (st *State) unsetExposedEndpointSpaces(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID, endpoint ...string) error {
 	applicationID := applicationID{ID: appID}
 	endpointNames := endpointNames(endpoint)
 
@@ -322,7 +322,7 @@ AND application_endpoint_uuid IS NULL;
 	return nil
 }
 
-func (st *State) upsertExposedSpaces(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint string, exposeToSpaceIDs set.Strings) error {
+func (st *State) upsertExposedSpaces(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID, endpoint string, exposeToSpaceIDs set.Strings) error {
 	if exposeToSpaceIDs.Size() == 0 {
 		return nil
 	}
@@ -363,7 +363,7 @@ INSERT INTO application_exposed_endpoint_space(application_uuid, application_end
 	return nil
 }
 
-func (st *State) upsertExposedCIDRs(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint string, exposeToCIDRs set.Strings) error {
+func (st *State) upsertExposedCIDRs(ctx context.Context, tx *sqlair.TX, appID coreapplication.UUID, endpoint string, exposeToCIDRs set.Strings) error {
 	if exposeToCIDRs.Size() == 0 {
 		return nil
 	}
@@ -411,7 +411,7 @@ INSERT INTO application_exposed_endpoint_cidr(application_uuid, application_endp
 // EndpointsExist returns an error satisfying
 // [applicationerrors.EndpointNotFound] if any of the provided endpoints do not
 // exist.
-func (st *State) EndpointsExist(ctx context.Context, appID coreapplication.ID, endpoints set.Strings) error {
+func (st *State) EndpointsExist(ctx context.Context, appID coreapplication.UUID, endpoints set.Strings) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/application/state/exposed_test.go
+++ b/domain/application/state/exposed_test.go
@@ -37,7 +37,7 @@ func (s *exposedStateSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *exposedStateSuite) TestApplicationNotExposed(c *tc.C) {
-	appUUID := coreapplication.ID(uuid.MustNewUUID().String())
+	appUUID := coreapplication.UUID(uuid.MustNewUUID().String())
 
 	isExposed, err := s.state.IsApplicationExposed(c.Context(), appUUID)
 	c.Assert(err, tc.ErrorIsNil)
@@ -534,7 +534,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsDifferentEndpointsNotOverwrit
 	c.Check(exposedEndpoints["endpoint1"].ExposeToSpaceIDs.IsEmpty(), tc.IsTrue)
 }
 
-func (s *exposedStateSuite) setUpEndpoint(c *tc.C, appID coreapplication.ID) {
+func (s *exposedStateSuite) setUpEndpoint(c *tc.C, appID coreapplication.UUID) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		insertSpace := `INSERT INTO space (uuid, name) VALUES (?, ?)`
 		_, err := tx.ExecContext(ctx, insertSpace, "space0-uuid", "space0")
@@ -561,7 +561,7 @@ func (s *exposedStateSuite) setUpEndpoint(c *tc.C, appID coreapplication.ID) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *exposedStateSuite) createExposedEndpointSpace(c *tc.C, appID coreapplication.ID) {
+func (s *exposedStateSuite) createExposedEndpointSpace(c *tc.C, appID coreapplication.UUID) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		insertExposedSpace := `
 INSERT INTO application_exposed_endpoint_space
@@ -576,7 +576,7 @@ VALUES (?, ?, ?)`
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *exposedStateSuite) createExposedEndpointCIDR(c *tc.C, appID coreapplication.ID, cidr string) {
+func (s *exposedStateSuite) createExposedEndpointCIDR(c *tc.C, appID coreapplication.UUID, cidr string) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		insertExposedCIDR := `
 INSERT INTO application_exposed_endpoint_cidr

--- a/domain/application/state/machine_placement_test.go
+++ b/domain/application/state/machine_placement_test.go
@@ -119,7 +119,7 @@ func (s *machinePlacementSuite) TestGetMachinesForApplicationNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
-func (s *machinePlacementSuite) createApplication(c *tc.C, controller bool) coreapplication.ID {
+func (s *machinePlacementSuite) createApplication(c *tc.C, controller bool) coreapplication.UUID {
 	appID, _, err := s.state.CreateIAASApplication(c.Context(), "foo", application.AddIAASApplicationArg{
 		BaseAddApplicationArg: application.BaseAddApplicationArg{
 			Charm: charm.Charm{

--- a/domain/application/state/machine_placement_test.go
+++ b/domain/application/state/machine_placement_test.go
@@ -146,7 +146,7 @@ func (s *machinePlacementSuite) createApplication(c *tc.C, controller bool) core
 }
 
 func (s *machinePlacementSuite) createUnit(c *tc.C) unit.Name {
-	appID, err := s.state.GetApplicationIDByName(c.Context(), "foo")
+	appID, err := s.state.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
 
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -101,7 +101,7 @@ func (st *State) GetApplicationsForExport(ctx context.Context) ([]application.Ex
 // application in the model.
 // If the application does not exist, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (st *State) GetApplicationUnitsForExport(ctx context.Context, appID coreapplication.ID) ([]application.ExportUnit, error) {
+func (st *State) GetApplicationUnitsForExport(ctx context.Context, appID coreapplication.UUID) ([]application.ExportUnit, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ WHERE application_uuid = $applicationID.uuid
 // application already exists. If returns as error satisfying
 // [applicationerrors.CharmNotFound] if the charm for the application is
 // not found.
-func (st *State) InsertMigratingApplication(ctx context.Context, name string, args application.InsertApplicationArgs) (coreapplication.ID, error) {
+func (st *State) InsertMigratingApplication(ctx context.Context, name string, args application.InsertApplicationArgs) (coreapplication.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
@@ -329,7 +329,7 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 
 // InsertIAASUnits imports the fully formed units for the specified IAAS
 // application. This is only used when importing units during model migration.
-func (st *State) InsertMigratingIAASUnits(ctx context.Context, appUUID coreapplication.ID, units ...application.ImportUnitArg) error {
+func (st *State) InsertMigratingIAASUnits(ctx context.Context, appUUID coreapplication.UUID, units ...application.ImportUnitArg) error {
 	if len(units) == 0 {
 		return nil
 	}
@@ -349,7 +349,7 @@ func (st *State) InsertMigratingIAASUnits(ctx context.Context, appUUID coreappli
 
 // InsertCAASUnits imports the fully formed units for the specified CAAS
 // application. This is only used when importing units during model migration.
-func (st *State) InsertMigratingCAASUnits(ctx context.Context, appUUID coreapplication.ID, units ...application.ImportUnitArg) error {
+func (st *State) InsertMigratingCAASUnits(ctx context.Context, appUUID coreapplication.UUID, units ...application.ImportUnitArg) error {
 	if len(units) == 0 {
 		return nil
 	}
@@ -370,7 +370,7 @@ func (st *State) InsertMigratingCAASUnits(ctx context.Context, appUUID coreappli
 func (st *State) importCAASUnit(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	args application.ImportUnitArg,
 ) error {
 	err := st.checkUnitExistsByName(ctx, tx, args.UnitName)
@@ -439,7 +439,7 @@ func (st *State) importCAASUnit(
 func (st *State) importIAASUnit(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	args application.ImportUnitArg,
 ) error {
 	err := st.checkUnitExistsByName(ctx, tx, args.UnitName)

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -108,7 +108,7 @@ func (st *State) GetApplicationUnitsForExport(ctx context.Context, appID coreapp
 	}
 
 	var unit exportUnit
-	id := applicationID{
+	id := applicationUUDID{
 		ID: appID,
 	}
 	query := `
@@ -296,7 +296,7 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 		if err := st.insertApplicationSettings(ctx, tx, appDetails.UUID, args.Settings); err != nil {
 			return errors.Errorf("inserting settings for application %q: %w", name, err)
 		}
-		if err := st.updateConfigHash(ctx, tx, applicationID{ID: appUUID}); err != nil {
+		if err := st.updateConfigHash(ctx, tx, applicationUUDID{ID: appUUID}); err != nil {
 			return errors.Errorf("refreshing config hash for application %q: %w", name, err)
 		}
 		if err := st.updateDefaultSpace(ctx, tx, appDetails.UUID.String(), args.EndpointBindings); err != nil {

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -390,7 +390,7 @@ func (st *State) importCAASUnit(
 		return errors.Capture(err)
 	}
 
-	charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, appUUID)
+	charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 	if err != nil {
 		return errors.Errorf("getting charm for application %q: %w", appUUID, err)
 	}
@@ -459,7 +459,7 @@ func (st *State) importIAASUnit(
 		return errors.Capture(err)
 	}
 
-	charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, appUUID)
+	charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 	if err != nil {
 		return errors.Errorf("getting charm for application %q: %w", appUUID, err)
 	}

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -108,12 +108,12 @@ func (st *State) GetApplicationUnitsForExport(ctx context.Context, appID coreapp
 	}
 
 	var unit exportUnit
-	id := applicationUUDID{
-		ID: appID,
+	id := entityUUID{
+		UUID: appID.String(),
 	}
 	query := `
 SELECT &exportUnit.* FROM v_unit_export
-WHERE application_uuid = $applicationID.uuid
+WHERE application_uuid = $entityUUID.uuid
 `
 	stmt, err := st.Prepare(query, unit, id)
 	if err != nil {
@@ -296,7 +296,7 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 		if err := st.insertApplicationSettings(ctx, tx, appDetails.UUID, args.Settings); err != nil {
 			return errors.Errorf("inserting settings for application %q: %w", name, err)
 		}
-		if err := st.updateConfigHash(ctx, tx, applicationUUDID{ID: appUUID}); err != nil {
+		if err := st.updateConfigHash(ctx, tx, entityUUID{UUID: appUUID.String()}); err != nil {
 			return errors.Errorf("refreshing config hash for application %q: %w", name, err)
 		}
 		if err := st.updateDefaultSpace(ctx, tx, appDetails.UUID.String(), args.EndpointBindings); err != nil {

--- a/domain/application/state/migration_test.go
+++ b/domain/application/state/migration_test.go
@@ -505,7 +505,7 @@ WHERE  charm_relation_uuid = ?
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *migrationStateSuite) assertDownloadProvenance(c *tc.C, appID coreapplication.ID, expectedProvenance charm.Provenance) {
+func (s *migrationStateSuite) assertDownloadProvenance(c *tc.C, appID coreapplication.UUID, expectedProvenance charm.Provenance) {
 	var obtainedProvenance string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, `
@@ -595,7 +595,7 @@ func (s *unitStateSuite) TestInsertMigratingIAASUnitsSubordinate(c *tc.C) {
 	s.assertUnitPrincipal(c, unitUUIDs[0], sub)
 }
 
-func (s *unitStateSuite) assertInsertMigratingUnits(c *tc.C, appID coreapplication.ID) {
+func (s *unitStateSuite) assertInsertMigratingUnits(c *tc.C, appID coreapplication.UUID) {
 	var unitName string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT name FROM unit WHERE application_uuid=?", appID).Scan(&unitName)

--- a/domain/application/state/package_test.go
+++ b/domain/application/state/package_test.go
@@ -203,7 +203,7 @@ func (s *baseSuite) createNamedCAASUnit(c *tc.C) (coreunit.Name, coreunit.UUID) 
 	return name, unitUUIDS[0]
 }
 
-func (s *baseSuite) createIAASApplication(c *tc.C, name string, l life.Life, units ...application.AddIAASUnitArg) coreapplication.ID {
+func (s *baseSuite) createIAASApplication(c *tc.C, name string, l life.Life, units ...application.AddIAASUnitArg) coreapplication.UUID {
 	return s.createIAASApplicationWithEndpointBindings(c, name, l, nil, units...)
 }
 
@@ -212,7 +212,7 @@ func (s *baseSuite) createIAASApplicationWithNUnits(
 	name string,
 	l life.Life,
 	unitCount int,
-) (coreapplication.ID, []coreunit.UUID) {
+) (coreapplication.UUID, []coreunit.UUID) {
 	state := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 	platform := deployment.Platform{
 		Channel:      "22.04/stable",
@@ -314,7 +314,7 @@ func (s *baseSuite) createIAASApplicationWithEndpointBindings(
 	l life.Life,
 	bindings map[string]network.SpaceName,
 	units ...application.AddIAASUnitArg,
-) coreapplication.ID {
+) coreapplication.UUID {
 	state := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 	platform := deployment.Platform{
 		Channel:      "22.04/stable",
@@ -425,7 +425,7 @@ func (s *baseSuite) createSubnetForCAASModel(c *tc.C) {
 
 func (s *baseSuite) createCAASApplicationWithNUnits(
 	c *tc.C, name string, l life.Life, unitCount int,
-) (coreapplication.ID, []coreunit.UUID) {
+) (coreapplication.UUID, []coreunit.UUID) {
 	appUUID := s.createCAASApplication(
 		c, name, l, make([]application.AddCAASUnitArg, unitCount)...,
 	)
@@ -435,7 +435,7 @@ func (s *baseSuite) createCAASApplicationWithNUnits(
 	return appUUID, uuids
 }
 
-func (s *baseSuite) createCAASApplication(c *tc.C, name string, l life.Life, units ...application.AddCAASUnitArg) coreapplication.ID {
+func (s *baseSuite) createCAASApplication(c *tc.C, name string, l life.Life, units ...application.AddCAASUnitArg) coreapplication.UUID {
 	s.createSubnetForCAASModel(c)
 	state := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
@@ -523,7 +523,7 @@ func (s *baseSuite) createCAASApplication(c *tc.C, name string, l life.Life, uni
 	return appID
 }
 
-func (s *baseSuite) createCAASScalingApplication(c *tc.C, name string, l life.Life, scale int) coreapplication.ID {
+func (s *baseSuite) createCAASScalingApplication(c *tc.C, name string, l life.Life, scale int) coreapplication.UUID {
 	s.createSubnetForCAASModel(c)
 	state := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
@@ -644,11 +644,11 @@ func (s *baseSuite) assertApplication(
 	}
 }
 
-func (s *baseSuite) addUnit(c *tc.C, unitName coreunit.Name, appUUID coreapplication.ID) coreunit.UUID {
+func (s *baseSuite) addUnit(c *tc.C, unitName coreunit.Name, appUUID coreapplication.UUID) coreunit.UUID {
 	return s.addUnitWithLife(c, unitName, appUUID, life.Alive)
 }
 
-func (s *baseSuite) addUnitWithLife(c *tc.C, unitName coreunit.Name, appUUID coreapplication.ID, l life.Life) coreunit.UUID {
+func (s *baseSuite) addUnitWithLife(c *tc.C, unitName coreunit.Name, appUUID coreapplication.UUID, l life.Life) coreunit.UUID {
 	unitUUID := coreunittesting.GenUnitUUID(c)
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		netNodeUUID := uuid.MustNewUUID().String()

--- a/domain/application/state/peer_relation.go
+++ b/domain/application/state/peer_relation.go
@@ -21,7 +21,7 @@ import (
 
 // getPeerEndpoints retrieves a list of peer endpoint for the given
 // application UUID from the database.
-func (st *State) getPeerEndpoints(ctx context.Context, tx *sqlair.TX, uuid coreapplication.ID) ([]peerEndpoint, error) {
+func (st *State) getPeerEndpoints(ctx context.Context, tx *sqlair.TX, uuid coreapplication.UUID) ([]peerEndpoint, error) {
 	type application dbUUID
 	app := application{UUID: uuid.String()}
 
@@ -53,7 +53,7 @@ ORDER BY cr.name -- ensure that peer endpoints relation id are always generated 
 // within a transactional context.
 // It retrieves peer endpoints, creates new relations for them,
 // and inserts their statuses and endpoints. Returns an error if any step fails.
-func (st *State) insertPeerRelations(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.ID) error {
+func (st *State) insertPeerRelations(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID) error {
 	peerEndpoints, err := st.getPeerEndpoints(ctx, tx, appUUID)
 	if err != nil {
 		return errors.Errorf("getting peer endpoints: %w", err)
@@ -77,7 +77,7 @@ func (st *State) insertPeerRelations(ctx context.Context, tx *sqlair.TX, appUUID
 // within a transactional context, using the relation ID provided during migration.
 // It retrieves peer endpoints, creates new relations for them,
 // and inserts their statuses and endpoints. Returns an error if any step fails.
-func (st *State) insertMigratingPeerRelations(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.ID, relations map[string]int) error {
+func (st *State) insertMigratingPeerRelations(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID, relations map[string]int) error {
 	peerEndpoints, err := st.getPeerEndpoints(ctx, tx, appUUID)
 	if err != nil {
 		return errors.Errorf("getting peer endpoints: %w", err)

--- a/domain/application/state/resource.go
+++ b/domain/application/state/resource.go
@@ -167,7 +167,7 @@ type uuids []string
 
 // resolvePendingResources finds pending resources for the application and
 // makes links them in the application resource link table now that an
-// application ID is available. Duplicated those resources for charmhub
+// application UUID is available. Duplicated those resources for charmhub
 // sourced charms as potential.
 func (st *State) resolvePendingResources(
 	ctx context.Context,

--- a/domain/application/state/resource.go
+++ b/domain/application/state/resource.go
@@ -99,7 +99,7 @@ func (st *State) buildResourcesToAdd(
 }
 
 type insertResourcesArgs struct {
-	appID        coreapplication.ID
+	appID        coreapplication.UUID
 	charmUUID    corecharm.ID
 	charmSource  charm.CharmSource
 	appResources []application.AddApplicationResourceArg
@@ -172,7 +172,7 @@ type uuids []string
 func (st *State) resolvePendingResources(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	charmSource charm.CharmSource,
 	resources []coreresource.UUID,
 ) error {

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -1367,7 +1367,7 @@ WHERE name = $applicationDetails.name
 //   - If the application is not alive, [applicationerrors.ApplicationNotAlive] is returned.
 //   - If the application is not found, [applicationerrors.ApplicationNotFound]
 //     is returned.
-func (st *State) checkApplicationAlive(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.ID) error {
+func (st *State) checkApplicationAlive(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID) error {
 	return st.checkApplicationLife(ctx, tx, appUUID, domainlife.Alive)
 }
 
@@ -1376,7 +1376,7 @@ func (st *State) checkApplicationAlive(ctx context.Context, tx *sqlair.TX, appUU
 //   - If the application is dead, [applicationerrors.ApplicationIsDead] is returned.
 //   - If the application is not found, [applicationerrors.ApplicationNotFound]
 //     is returned.
-func (st *State) checkApplicationNotDead(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.ID) error {
+func (st *State) checkApplicationNotDead(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID) error {
 	return st.checkApplicationLife(ctx, tx, appUUID, domainlife.Dying)
 }
 
@@ -1386,7 +1386,7 @@ func (st *State) checkApplicationNotDead(ctx context.Context, tx *sqlair.TX, app
 // Instead use one of:
 //   - checkApplicationAlive
 //   - checkApplicationNotDead
-func (st *State) checkApplicationLife(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.ID, allowed domainlife.Life) error {
+func (st *State) checkApplicationLife(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID, allowed domainlife.Life) error {
 	type life struct {
 		LifeID domainlife.Life `db:"life_id"`
 	}

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -1391,7 +1391,7 @@ func (st *State) checkApplicationLife(ctx context.Context, tx *sqlair.TX, appUUI
 		LifeID domainlife.Life `db:"life_id"`
 	}
 
-	ident := applicationID{ID: appUUID}
+	ident := applicationUUDID{ID: appUUID}
 	query := `
 SELECT &life.*
 FROM application AS a

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -1391,16 +1391,16 @@ func (st *State) checkApplicationLife(ctx context.Context, tx *sqlair.TX, appUUI
 		LifeID domainlife.Life `db:"life_id"`
 	}
 
-	ident := applicationUUDID{ID: appUUID}
+	ident := entityUUID{UUID: appUUID.String()}
 	query := `
 SELECT &life.*
 FROM application AS a
 JOIN charm AS c ON a.charm_uuid = c.uuid
-WHERE a.uuid = $applicationID.uuid AND c.source_id < 2;
+WHERE a.uuid = $entityUUID.uuid AND c.source_id < 2;
 `
 	stmt, err := st.Prepare(query, ident, life{})
 	if err != nil {
-		return errors.Errorf("preparing query for application %q: %w", ident.ID, err)
+		return errors.Errorf("preparing query for application %q: %w", ident.UUID, err)
 	}
 
 	var result life
@@ -1408,7 +1408,7 @@ WHERE a.uuid = $applicationID.uuid AND c.source_id < 2;
 	if errors.Is(err, sql.ErrNoRows) {
 		return applicationerrors.ApplicationNotFound
 	} else if err != nil {
-		return errors.Errorf("checking application %q exists: %w", ident.ID, err)
+		return errors.Errorf("checking application %q exists: %w", ident.UUID, err)
 	}
 
 	switch result.LifeID {

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -47,7 +47,7 @@ const (
 // when the application no longer exists.
 func (st *State) GetApplicationStorageDirectives(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 ) ([]application.StorageDirective, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -109,7 +109,7 @@ WHERE  application_uuid = $entityUUID.uuid
 
 func (st *State) GetStorageInstancesForProviderIDs(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	ids []string,
 ) (map[string]domainstorage.StorageInstanceUUID, error) {
 	return nil, nil
@@ -237,7 +237,7 @@ WHERE  unit_uuid = $entityUUID.uuid
 func (st *State) insertApplicationStorageDirectives(
 	ctx context.Context,
 	tx *sqlair.TX,
-	uuid coreapplication.ID,
+	uuid coreapplication.UUID,
 	charmUUID corecharm.ID,
 	directives []application.CreateApplicationStorageDirectiveArg,
 ) error {

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -47,24 +47,24 @@ type KeyValue struct {
 
 // applicationID is used to get the ID of an application.
 type applicationID struct {
-	ID coreapplication.ID `db:"uuid"`
+	ID coreapplication.UUID `db:"uuid"`
 }
 
 // applicationIDAndName is used to get the ID and name of an application.
 type applicationIDAndName struct {
-	ID   coreapplication.ID `db:"uuid"`
+	ID   coreapplication.UUID `db:"uuid"`
 	Name string             `db:"name"`
 }
 
 type applicationChannel struct {
-	ApplicationID coreapplication.ID `db:"application_uuid"`
+	ApplicationID coreapplication.UUID `db:"application_uuid"`
 	Track         string             `db:"track"`
 	Risk          string             `db:"risk"`
 	Branch        string             `db:"branch"`
 }
 
 type applicationPlatform struct {
-	ApplicationID  coreapplication.ID `db:"application_uuid"`
+	ApplicationID  coreapplication.UUID `db:"application_uuid"`
 	OSTypeID       int                `db:"os_id"`
 	Channel        string             `db:"channel"`
 	ArchitectureID int                `db:"architecture_id"`
@@ -76,7 +76,7 @@ type applicationName struct {
 }
 
 type applicationDetails struct {
-	UUID      coreapplication.ID `db:"uuid"`
+	UUID      coreapplication.UUID `db:"uuid"`
 	Name      string             `db:"name"`
 	CharmUUID corecharm.ID       `db:"charm_uuid"`
 	LifeID    life.Life          `db:"life_id"`
@@ -84,7 +84,7 @@ type applicationDetails struct {
 }
 
 type applicationScale struct {
-	ApplicationID coreapplication.ID `db:"application_uuid"`
+	ApplicationID coreapplication.UUID `db:"application_uuid"`
 	Scaling       bool               `db:"scaling"`
 	Scale         int                `db:"scale"`
 	ScaleTarget   int                `db:"scale_target"`
@@ -123,7 +123,7 @@ type unitRow struct {
 	UnitUUID                coreunit.UUID      `db:"uuid"`
 	Name                    coreunit.Name      `db:"name"`
 	LifeID                  life.Life          `db:"life_id"`
-	ApplicationID           coreapplication.ID `db:"application_uuid"`
+	ApplicationID           coreapplication.UUID `db:"application_uuid"`
 	NetNodeID               string             `db:"net_node_uuid"`
 	CharmUUID               corecharm.ID       `db:"charm_uuid"`
 	PasswordHash            sql.NullString     `db:"password_hash"`
@@ -185,7 +185,7 @@ type unitNameCloudContainer struct {
 
 type cloudService struct {
 	UUID            string             `db:"uuid"`
-	ApplicationUUID coreapplication.ID `db:"application_uuid"`
+	ApplicationUUID coreapplication.UUID `db:"application_uuid"`
 	NetNodeUUID     string             `db:"net_node_uuid"`
 	ProviderID      string             `db:"provider_id"`
 }
@@ -766,7 +766,7 @@ type applicationConfig struct {
 }
 
 type setApplicationConfig struct {
-	ApplicationUUID coreapplication.ID `db:"application_uuid"`
+	ApplicationUUID coreapplication.UUID `db:"application_uuid"`
 	Key             string             `db:"key"`
 	Value           any                `db:"value"`
 	TypeID          int                `db:"type_id"`
@@ -777,12 +777,12 @@ type applicationSettings struct {
 }
 
 type setApplicationSettings struct {
-	ApplicationUUID coreapplication.ID `db:"application_uuid"`
+	ApplicationUUID coreapplication.UUID `db:"application_uuid"`
 	Trust           bool               `db:"trust"`
 }
 
 type applicationConfigHash struct {
-	ApplicationUUID coreapplication.ID `db:"application_uuid"`
+	ApplicationUUID coreapplication.UUID `db:"application_uuid"`
 	SHA256          string             `db:"sha256"`
 }
 
@@ -826,13 +826,13 @@ type setApplicationConstraint struct {
 
 type setApplicationEndpointBinding struct {
 	UUID          corerelation.EndpointUUID `db:"uuid"`
-	ApplicationID coreapplication.ID        `db:"application_uuid"`
+	ApplicationID coreapplication.UUID        `db:"application_uuid"`
 	RelationUUID  string                    `db:"charm_relation_uuid"`
 	Space         sql.Null[string]          `db:"space_uuid"`
 }
 
 type setApplicationExtraEndpointBinding struct {
-	ApplicationID coreapplication.ID `db:"application_uuid"`
+	ApplicationID coreapplication.UUID `db:"application_uuid"`
 	RelationUUID  string             `db:"charm_extra_binding_uuid"`
 	Space         sql.Null[string]   `db:"space_uuid"`
 }
@@ -1085,7 +1085,7 @@ type applicationOrigin struct {
 }
 
 type exportApplication struct {
-	UUID                 coreapplication.ID `db:"uuid"`
+	UUID                 coreapplication.UUID `db:"uuid"`
 	Name                 string             `db:"name"`
 	CharmUUID            corecharm.ID       `db:"charm_uuid"`
 	Life                 life.Life          `db:"life_id"`
@@ -1248,7 +1248,7 @@ type getCharmUpgradeOnError struct {
 }
 
 type controllerApplication struct {
-	ApplicationID coreapplication.ID `db:"application_uuid"`
+	ApplicationID coreapplication.UUID `db:"application_uuid"`
 	IsController  bool               `db:"is_controller"`
 }
 

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -45,13 +45,13 @@ type KeyValue struct {
 	Value string `db:"value"`
 }
 
-// applicationID is used to get the ID of an application.
-type applicationID struct {
+// applicationUUDID is used to get the ID of an application.
+type applicationUUDID struct {
 	ID coreapplication.UUID `db:"uuid"`
 }
 
-// applicationIDAndName is used to get the ID and name of an application.
-type applicationIDAndName struct {
+// applicationUUIDAndName is used to get the ID and name of an application.
+type applicationUUIDAndName struct {
 	ID   coreapplication.UUID `db:"uuid"`
 	Name string               `db:"name"`
 }

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -45,11 +45,6 @@ type KeyValue struct {
 	Value string `db:"value"`
 }
 
-// applicationUUDID is used to get the ID of an application.
-type applicationUUDID struct {
-	ID coreapplication.UUID `db:"uuid"`
-}
-
 // applicationUUIDAndName is used to get the ID and name of an application.
 type applicationUUIDAndName struct {
 	ID   coreapplication.UUID `db:"uuid"`

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -53,21 +53,21 @@ type applicationID struct {
 // applicationIDAndName is used to get the ID and name of an application.
 type applicationIDAndName struct {
 	ID   coreapplication.UUID `db:"uuid"`
-	Name string             `db:"name"`
+	Name string               `db:"name"`
 }
 
 type applicationChannel struct {
 	ApplicationID coreapplication.UUID `db:"application_uuid"`
-	Track         string             `db:"track"`
-	Risk          string             `db:"risk"`
-	Branch        string             `db:"branch"`
+	Track         string               `db:"track"`
+	Risk          string               `db:"risk"`
+	Branch        string               `db:"branch"`
 }
 
 type applicationPlatform struct {
 	ApplicationID  coreapplication.UUID `db:"application_uuid"`
-	OSTypeID       int                `db:"os_id"`
-	Channel        string             `db:"channel"`
-	ArchitectureID int                `db:"architecture_id"`
+	OSTypeID       int                  `db:"os_id"`
+	Channel        string               `db:"channel"`
+	ArchitectureID int                  `db:"architecture_id"`
 }
 
 // applicationName is used to get the name of an application.
@@ -77,17 +77,17 @@ type applicationName struct {
 
 type applicationDetails struct {
 	UUID      coreapplication.UUID `db:"uuid"`
-	Name      string             `db:"name"`
-	CharmUUID corecharm.ID       `db:"charm_uuid"`
-	LifeID    life.Life          `db:"life_id"`
-	SpaceUUID network.SpaceUUID  `db:"space_uuid"`
+	Name      string               `db:"name"`
+	CharmUUID corecharm.ID         `db:"charm_uuid"`
+	LifeID    life.Life            `db:"life_id"`
+	SpaceUUID network.SpaceUUID    `db:"space_uuid"`
 }
 
 type applicationScale struct {
 	ApplicationID coreapplication.UUID `db:"application_uuid"`
-	Scaling       bool               `db:"scaling"`
-	Scale         int                `db:"scale"`
-	ScaleTarget   int                `db:"scale_target"`
+	Scaling       bool                 `db:"scaling"`
+	Scale         int                  `db:"scale"`
+	ScaleTarget   int                  `db:"scale_target"`
 }
 
 type architectureMap struct {
@@ -120,14 +120,14 @@ type unitNameLife struct {
 }
 
 type unitRow struct {
-	UnitUUID                coreunit.UUID      `db:"uuid"`
-	Name                    coreunit.Name      `db:"name"`
-	LifeID                  life.Life          `db:"life_id"`
+	UnitUUID                coreunit.UUID        `db:"uuid"`
+	Name                    coreunit.Name        `db:"name"`
+	LifeID                  life.Life            `db:"life_id"`
 	ApplicationID           coreapplication.UUID `db:"application_uuid"`
-	NetNodeID               string             `db:"net_node_uuid"`
-	CharmUUID               corecharm.ID       `db:"charm_uuid"`
-	PasswordHash            sql.NullString     `db:"password_hash"`
-	PasswordHashAlgorithmID sql.NullInt16      `db:"password_hash_algorithm_id"`
+	NetNodeID               string               `db:"net_node_uuid"`
+	CharmUUID               corecharm.ID         `db:"charm_uuid"`
+	PasswordHash            sql.NullString       `db:"password_hash"`
+	PasswordHashAlgorithmID sql.NullInt16        `db:"password_hash_algorithm_id"`
 }
 
 type unitDetails struct {
@@ -184,10 +184,10 @@ type unitNameCloudContainer struct {
 }
 
 type cloudService struct {
-	UUID            string             `db:"uuid"`
+	UUID            string               `db:"uuid"`
 	ApplicationUUID coreapplication.UUID `db:"application_uuid"`
-	NetNodeUUID     string             `db:"net_node_uuid"`
-	ProviderID      string             `db:"provider_id"`
+	NetNodeUUID     string               `db:"net_node_uuid"`
+	ProviderID      string               `db:"provider_id"`
 }
 
 type cloudServiceDevice struct {
@@ -767,9 +767,9 @@ type applicationConfig struct {
 
 type setApplicationConfig struct {
 	ApplicationUUID coreapplication.UUID `db:"application_uuid"`
-	Key             string             `db:"key"`
-	Value           any                `db:"value"`
-	TypeID          int                `db:"type_id"`
+	Key             string               `db:"key"`
+	Value           any                  `db:"value"`
+	TypeID          int                  `db:"type_id"`
 }
 
 type applicationSettings struct {
@@ -778,12 +778,12 @@ type applicationSettings struct {
 
 type setApplicationSettings struct {
 	ApplicationUUID coreapplication.UUID `db:"application_uuid"`
-	Trust           bool               `db:"trust"`
+	Trust           bool                 `db:"trust"`
 }
 
 type applicationConfigHash struct {
 	ApplicationUUID coreapplication.UUID `db:"application_uuid"`
-	SHA256          string             `db:"sha256"`
+	SHA256          string               `db:"sha256"`
 }
 
 type applicationStatus struct {
@@ -826,15 +826,15 @@ type setApplicationConstraint struct {
 
 type setApplicationEndpointBinding struct {
 	UUID          corerelation.EndpointUUID `db:"uuid"`
-	ApplicationID coreapplication.UUID        `db:"application_uuid"`
+	ApplicationID coreapplication.UUID      `db:"application_uuid"`
 	RelationUUID  string                    `db:"charm_relation_uuid"`
 	Space         sql.Null[string]          `db:"space_uuid"`
 }
 
 type setApplicationExtraEndpointBinding struct {
 	ApplicationID coreapplication.UUID `db:"application_uuid"`
-	RelationUUID  string             `db:"charm_extra_binding_uuid"`
-	Space         sql.Null[string]   `db:"space_uuid"`
+	RelationUUID  string               `db:"charm_extra_binding_uuid"`
+	Space         sql.Null[string]     `db:"space_uuid"`
 }
 
 type setConstraint struct {
@@ -1086,17 +1086,17 @@ type applicationOrigin struct {
 
 type exportApplication struct {
 	UUID                 coreapplication.UUID `db:"uuid"`
-	Name                 string             `db:"name"`
-	CharmUUID            corecharm.ID       `db:"charm_uuid"`
-	Life                 life.Life          `db:"life_id"`
-	Subordinate          bool               `db:"subordinate"`
-	CharmModifiedVersion int                `db:"charm_modified_version"`
-	CharmUpgradeOnError  bool               `db:"charm_upgrade_on_error"`
-	CharmReferenceName   string             `db:"reference_name"`
-	CharmSourceID        int                `db:"source_id"`
-	CharmRevision        int                `db:"revision"`
-	CharmArchitectureID  sql.Null[int64]    `db:"architecture_id"`
-	K8sServiceProviderID sql.NullString     `db:"k8s_provider_id"`
+	Name                 string               `db:"name"`
+	CharmUUID            corecharm.ID         `db:"charm_uuid"`
+	Life                 life.Life            `db:"life_id"`
+	Subordinate          bool                 `db:"subordinate"`
+	CharmModifiedVersion int                  `db:"charm_modified_version"`
+	CharmUpgradeOnError  bool                 `db:"charm_upgrade_on_error"`
+	CharmReferenceName   string               `db:"reference_name"`
+	CharmSourceID        int                  `db:"source_id"`
+	CharmRevision        int                  `db:"revision"`
+	CharmArchitectureID  sql.Null[int64]      `db:"architecture_id"`
+	K8sServiceProviderID sql.NullString       `db:"k8s_provider_id"`
 	EndpointBindings     map[string]string
 }
 
@@ -1249,7 +1249,7 @@ type getCharmUpgradeOnError struct {
 
 type controllerApplication struct {
 	ApplicationID coreapplication.UUID `db:"application_uuid"`
-	IsController  bool               `db:"is_controller"`
+	IsController  bool                 `db:"is_controller"`
 }
 
 // insertApplicationStorageDirective represents the set of values required for

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -187,7 +187,7 @@ ON CONFLICT(unit_uuid) DO UPDATE SET
 // InitialWatchStatementUnitAddressesHash returns the initial namespace query
 // for the unit addresses hash watcher as well as the tables to be watched
 // (ip_address and application_endpoint)
-func (st *State) InitialWatchStatementUnitAddressesHash(appUUID coreapplication.ID, netNodeUUID string) (string, string, eventsource.NamespaceQuery) {
+func (st *State) InitialWatchStatementUnitAddressesHash(appUUID coreapplication.UUID, netNodeUUID string) (string, string, eventsource.NamespaceQuery) {
 	queryFunc := func(ctx context.Context, runner database.TxnRunner) ([]string, error) {
 
 		var (
@@ -318,7 +318,7 @@ AND a.name = $applicationName.name
 // check is performed to make sure the application for the supplied uuid exists.
 func (st *State) getApplicationUnits(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 ) ([]coreunit.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -363,7 +363,7 @@ WHERE application_uuid = $applicationUUID.application_uuid
 // for the given application.
 //   - If the application is not found, [applicationerrors.ApplicationNotFound]
 //     is returned.
-func (st *State) GetAllUnitLifeForApplication(ctx context.Context, appID coreapplication.ID) (map[string]int, error) {
+func (st *State) GetAllUnitLifeForApplication(ctx context.Context, appID coreapplication.UUID) (map[string]int, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -573,7 +573,7 @@ WHERE  u.uuid = $entityUUID.uuid
 //     is returned.
 func (st *State) AddIAASUnits(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	args ...application.AddIAASUnitArg,
 ) ([]coreunit.Name, []coremachine.Name, error) {
 	if len(args) == 0 {
@@ -618,7 +618,7 @@ func (st *State) AddIAASUnits(
 //   - If the application is not found, [applicationerrors.ApplicationNotFound] is returned.
 func (st *State) AddCAASUnits(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	args ...application.AddCAASUnitArg,
 ) ([]coreunit.Name, error) {
 	if len(args) == 0 {
@@ -786,7 +786,7 @@ WHERE  sub.name = $getPrincipal.subordinate_unit_name
 func (st *State) checkNoSubordinateExists(
 	ctx context.Context,
 	tx *sqlair.TX,
-	subordinateAppUUID coreapplication.ID,
+	subordinateAppUUID coreapplication.UUID,
 	principalUnitUUID coreunit.UUID,
 ) error {
 	var (
@@ -824,7 +824,7 @@ AND    su.application_uuid = $applicationUUID.application_uuid
 // - [appliationerrors.ApplicationNotFound] if the application does not exist
 func (st *State) IsSubordinateApplication(
 	ctx context.Context,
-	applicationUUID coreapplication.ID,
+	applicationUUID coreapplication.UUID,
 ) (bool, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -832,7 +832,7 @@ func (st *State) IsSubordinateApplication(
 	}
 
 	type getSubordinate struct {
-		ApplicationUUID coreapplication.ID `db:"application_uuid"`
+		ApplicationUUID coreapplication.UUID `db:"application_uuid"`
 		Subordinate     bool               `db:"subordinate"`
 	}
 	subordinate := getSubordinate{
@@ -1303,7 +1303,7 @@ WHERE uuid = $unitPassword.uuid
 func (st *State) insertCAASUnit(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	charmUUID corecharm.ID,
 	args application.AddCAASUnitArg,
 ) (coreunit.Name, error) {
@@ -1325,7 +1325,7 @@ func (st *State) insertCAASUnit(
 func (st *State) insertCAASUnitWithName(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	charmUUID corecharm.ID,
 	unitName coreunit.Name,
 	args application.AddCAASUnitArg,
@@ -1433,7 +1433,7 @@ func (st *State) placeIAASUnitMachine(
 func (st *State) insertIAASUnit(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	charmUUID corecharm.ID,
 	args application.AddIAASUnitArg,
 ) (coreunit.Name, coreunit.UUID, []coremachine.Name, error) {
@@ -1519,7 +1519,7 @@ type insertUnitArg struct {
 
 func (st *State) insertUnit(
 	ctx context.Context, tx *sqlair.TX,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	unitUUID coreunit.UUID,
 	netNodeUUID string,
 	args insertUnitArg,
@@ -1890,7 +1890,7 @@ func (st *State) GetAllUnitNames(ctx context.Context) ([]coreunit.Name, error) {
 // The following errors may be returned:
 // - [applicationerrors.ApplicationIsDead] if the application is dead
 // - [applicationerrors.ApplicationNotFound] if the application does not exist
-func (st *State) GetUnitNamesForApplication(ctx context.Context, uuid coreapplication.ID) ([]coreunit.Name, error) {
+func (st *State) GetUnitNamesForApplication(ctx context.Context, uuid coreapplication.UUID) ([]coreunit.Name, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -2143,7 +2143,7 @@ WHERE  unit_uuid = $unitWorkloadVersion.unit_uuid
 //     is returned.
 func (st *State) GetAllUnitCloudContainerIDsForApplication(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 ) (map[coreunit.Name]string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -2190,7 +2190,7 @@ WHERE u.application_uuid = $applicationID.uuid
 func (st *State) newUnitName(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 ) (coreunit.Name, error) {
 
 	var nextUnitNum uint64

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -594,7 +594,7 @@ func (st *State) AddIAASUnits(
 			return errors.Capture(err)
 		}
 
-		charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, appUUID)
+		charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 		if err != nil {
 			return errors.Errorf("getting application %q charm uuid: %w", appUUID, err)
 		}
@@ -632,7 +632,7 @@ func (st *State) AddCAASUnits(
 
 	var unitNames []coreunit.Name
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, appUUID)
+		charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID)
 		if err != nil {
 			return errors.Errorf("getting application %q charm uuid: %w", appUUID, err)
 		}
@@ -690,7 +690,7 @@ func (st *State) AddIAASSubordinateUnit(
 		if err != nil {
 			return errors.Errorf("checking if subordinate already exists: %w", err)
 		}
-		charmUUID, err := st.getCharmIDByApplicationID(ctx, tx, arg.SubordinateAppID)
+		charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, arg.SubordinateAppID)
 		if err != nil {
 			return errors.Errorf(
 				"getting subordinate application %q charm uuid: %w",
@@ -833,7 +833,7 @@ func (st *State) IsSubordinateApplication(
 
 	type getSubordinate struct {
 		ApplicationUUID coreapplication.UUID `db:"application_uuid"`
-		Subordinate     bool               `db:"subordinate"`
+		Subordinate     bool                 `db:"subordinate"`
 	}
 	subordinate := getSubordinate{
 		ApplicationUUID: applicationUUID,
@@ -1101,7 +1101,7 @@ func (st *State) getUnitDetails(ctx context.Context, tx *sqlair.TX, unitName cor
 	return &unit, nil
 }
 
-func (st *State) getUnitApplicationID(ctx context.Context, tx *sqlair.TX, uuid coreunit.UUID) (string, error) {
+func (st *State) getUnitApplicationUUID(ctx context.Context, tx *sqlair.TX, uuid coreunit.UUID) (string, error) {
 	unitUUID := unitUUID{UnitUUID: uuid}
 
 	query, err := st.Prepare(`
@@ -2077,7 +2077,7 @@ ON CONFLICT (application_uuid) DO UPDATE SET
 		return errors.Capture(err)
 	}
 
-	appID, err := st.getUnitApplicationID(ctx, tx, unitUUID)
+	appID, err := st.getUnitApplicationUUID(ctx, tx, unitUUID)
 	if err != nil {
 		return errors.Errorf("getting application id for unit %q: %w", unitUUID, err)
 	}

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -369,7 +369,7 @@ func (st *State) GetAllUnitLifeForApplication(ctx context.Context, appID coreapp
 		return nil, errors.Capture(err)
 	}
 
-	ident := applicationID{ID: appID}
+	ident := applicationUUDID{ID: appID}
 	appExistsQuery := `
 SELECT &applicationID.*
 FROM application
@@ -386,7 +386,7 @@ FROM unit u
 WHERE u.application_uuid = $applicationID.uuid
 `
 
-	app := applicationID{ID: appID}
+	app := applicationUUDID{ID: appID}
 	lifeStmt, err := st.Prepare(lifeQuery, app, unitNameLife{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -1109,12 +1109,12 @@ SELECT a.uuid AS &applicationID.uuid
 FROM application AS a
 JOIN unit AS u ON u.application_uuid = a.uuid
 WHERE u.uuid = $unitUUID.uuid
-	`, applicationID{}, unitUUID)
+	`, applicationUUDID{}, unitUUID)
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	var appID applicationID
+	var appID applicationUUDID
 	err = tx.Query(ctx, query, unitUUID).Get(&appID)
 	if errors.Is(err, sqlair.ErrNoRows) {
 		return "", errors.Errorf("unit %q not found", uuid).Add(applicationerrors.UnitNotFound)
@@ -1896,7 +1896,7 @@ func (st *State) GetUnitNamesForApplication(ctx context.Context, uuid coreapplic
 		return nil, errors.Capture(err)
 	}
 
-	appUUID := applicationID{ID: uuid}
+	appUUID := applicationUUDID{ID: uuid}
 	query := ` SELECT &unitName.* FROM unit WHERE application_uuid = $applicationID.uuid`
 	stmt, err := st.Prepare(query, unitName{}, appUUID)
 	if err != nil {
@@ -2079,7 +2079,7 @@ ON CONFLICT (application_uuid) DO UPDATE SET
 
 	appID, err := st.getUnitApplicationUUID(ctx, tx, unitUUID)
 	if err != nil {
-		return errors.Errorf("getting application id for unit %q: %w", unitUUID, err)
+		return errors.Errorf("getting application UUID for unit %q: %w", unitUUID, err)
 	}
 
 	if err := tx.Query(ctx, unitQuery, unitWorkloadVersion{
@@ -2150,7 +2150,7 @@ func (st *State) GetAllUnitCloudContainerIDsForApplication(
 		return nil, errors.Capture(err)
 	}
 
-	input := applicationID{ID: appUUID}
+	input := applicationUUDID{ID: appUUID}
 	query := `
 SELECT (u.name, kp.provider_id) AS (&unitNameCloudContainer.*)
 FROM unit u

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -1227,7 +1227,7 @@ func (s *unitStateSuite) TestGetUnitMachineNameIsDead(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitIsDead)
 }
 
-func (s *unitStateSuite) assertApplicationWorkloadVersion(c *tc.C, appID coreapplication.ID, expected string) {
+func (s *unitStateSuite) assertApplicationWorkloadVersion(c *tc.C, appID coreapplication.UUID, expected string) {
 	var version string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT version FROM application_workload_version WHERE application_uuid=?", appID).Scan(&version)
@@ -2009,7 +2009,7 @@ VALUES (?, ?)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *unitStateSubordinateSuite) createSubordinateApplication(c *tc.C, name string, l life.Life) coreapplication.ID {
+func (s *unitStateSubordinateSuite) createSubordinateApplication(c *tc.C, name string, l life.Life) coreapplication.UUID {
 	state := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
 	appID, machineNames, err := state.CreateIAASApplication(c.Context(), name, application.AddIAASApplicationArg{

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -258,7 +258,7 @@ type UnitStatusArg struct {
 type SubordinateUnitArg struct {
 	CreateUnitStorageArg
 	UnitStatusArg
-	SubordinateAppID application.ID
+	SubordinateAppID application.UUID
 	// NetNodeUUID describes the network node uuid for this subordinate unit.
 	NetNodeUUID domainnetwork.NetNodeUUID
 
@@ -385,7 +385,7 @@ type ExposedEndpoint struct {
 
 // ExportApplication contains parameters for exporting an application.
 type ExportApplication struct {
-	UUID                 application.ID
+	UUID                 application.UUID
 	Name                 string
 	CharmUUID            charm.ID
 	Life                 life.Life

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -110,7 +110,7 @@ func (s *watcherSuite) TestWatchCharm(c *tc.C) {
 
 	// Ensure that we get the charm created event when an application is created.
 
-	var appID coreapplication.ID
+	var appID coreapplication.UUID
 	harness.AddTest(c, func(c *tc.C) {
 		appID = s.createIAASApplication(c, svc, "foo")
 		id, err = st.GetCharmIDByApplicationName(c.Context(), "foo")
@@ -506,7 +506,7 @@ func (s *watcherSuite) TestWatchApplicationsWithPendingCharms(c *tc.C) {
 
 	harness := watchertest.NewHarness[[]string](s, watchertest.NewWatcherC[[]string](c, watcher))
 
-	var id0, id1 coreapplication.ID
+	var id0, id1 coreapplication.UUID
 	harness.AddTest(c, func(c *tc.C) {
 		id0 = s.createIAASApplication(c, svc, "foo")
 		id1 = s.createIAASApplication(c, svc, "bar")
@@ -552,7 +552,7 @@ WHERE uuid=?`, id0.String())
 	})
 
 	// Add another application with a pending charm.
-	var id2 coreapplication.ID
+	var id2 coreapplication.UUID
 	harness.AddTest(c, func(c *tc.C) {
 		id2 = s.createIAASApplication(c, svc, "baz")
 	}, func(w watchertest.WatcherC[[]string]) {
@@ -1214,7 +1214,7 @@ func (s *watcherSuite) TestWatchUnitAddRemoveOnMachineSubordinates(c *tc.C) {
 		w.Check(watchertest.SliceAssert([]string{"foo/0"}))
 	})
 
-	var subordinateAppID coreapplication.ID
+	var subordinateAppID coreapplication.UUID
 	harness.AddTest(c, func(c *tc.C) {
 		subordinateAppID = s.createIAASApplicationWithCharmAndStoragePath(c, svc, "bar", &stubCharm{subordinate: true}, "deadbeef")
 	}, func(w watchertest.WatcherC[[]string]) {
@@ -1306,7 +1306,7 @@ func (s *watcherSuite) TestWatchApplications(c *tc.C) {
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
 
-	var appID coreapplication.ID
+	var appID coreapplication.UUID
 	harness.AddTest(c, func(c *tc.C) {
 		appID = s.createCAASApplication(c, svc, "foo")
 	}, func(w watchertest.WatcherC[[]string]) {
@@ -1674,7 +1674,7 @@ func (s *watcherSuite) TestWatchUnitAddresses(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
-func (s *watcherSuite) getApplicationConfigHash(c *tc.C, db changestream.WatchableDB, appUUID coreapplication.ID) string {
+func (s *watcherSuite) getApplicationConfigHash(c *tc.C, db changestream.WatchableDB, appUUID coreapplication.UUID) string {
 	var hash string
 	err := db.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `SELECT sha256 FROM application_config_hash WHERE application_uuid=?`, appUUID.String())
@@ -1741,11 +1741,11 @@ func (s *watcherSuite) createMachine(
 	return res1.MachineName
 }
 
-func (s *watcherSuite) createIAASApplication(c *tc.C, svc *service.WatchableService, name string, units ...service.AddIAASUnitArg) coreapplication.ID {
+func (s *watcherSuite) createIAASApplication(c *tc.C, svc *service.WatchableService, name string, units ...service.AddIAASUnitArg) coreapplication.UUID {
 	return s.createIAASApplicationWithCharmAndStoragePath(c, svc, name, &stubCharm{}, "", units...)
 }
 
-func (s *watcherSuite) createIAASApplicationWithCharmAndStoragePath(c *tc.C, svc *service.WatchableService, name string, ch internalcharm.Charm, storagePath string, units ...service.AddIAASUnitArg) coreapplication.ID {
+func (s *watcherSuite) createIAASApplicationWithCharmAndStoragePath(c *tc.C, svc *service.WatchableService, name string, ch internalcharm.Charm, storagePath string, units ...service.AddIAASUnitArg) coreapplication.UUID {
 	ctx := c.Context()
 	appID, err := svc.CreateIAASApplication(ctx, name, ch, corecharm.Origin{
 		Source: corecharm.CharmHub,
@@ -1766,7 +1766,7 @@ func (s *watcherSuite) createIAASApplicationWithCharmAndStoragePath(c *tc.C, svc
 	return appID
 }
 
-func (s *watcherSuite) createCAASApplication(c *tc.C, svc *service.WatchableService, name string, units ...service.AddUnitArg) coreapplication.ID {
+func (s *watcherSuite) createCAASApplication(c *tc.C, svc *service.WatchableService, name string, units ...service.AddUnitArg) coreapplication.UUID {
 	ctx := c.Context()
 	s.createSubnetForCAASModel(c)
 	appID, err := svc.CreateCAASApplication(ctx, name, &stubCharm{}, corecharm.Origin{

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -155,7 +155,7 @@ func (s *Service) GetRemoteApplicationConsumers(ctx context.Context) ([]crossmod
 
 // SetRemoteApplicationOffererStatus sets the status of the specified remote
 // application in the local model.
-func (s *Service) SetRemoteApplicationOffererStatus(context.Context, coreapplication.ID, corestatus.StatusInfo) error {
+func (s *Service) SetRemoteApplicationOffererStatus(context.Context, coreapplication.UUID, corestatus.StatusInfo) error {
 	return nil
 }
 

--- a/domain/crossmodelrelation/state/model/package_test.go
+++ b/domain/crossmodelrelation/state/model/package_test.go
@@ -81,7 +81,7 @@ func (s *baseSuite) query(c *tc.C, query string, args ...any) {
 
 // addApplication adds a new application to the database with the specified
 // charm UUID and application name. It returns the application UUID.
-func (s *baseSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appName string) coreapplication.ID {
+func (s *baseSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appName string) coreapplication.UUID {
 	appUUID := coreapplicationtesting.GenApplicationUUID(c)
 	s.query(c, `
 INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid)
@@ -92,7 +92,7 @@ VALUES (?, ?, ?, ?, ?)
 
 // addApplicationEndpoint inserts a new application endpoint into the database
 // with the specified UUIDs. Returns the endpoint uuid.
-func (s *baseSuite) addApplicationEndpoint(c *tc.C, applicationUUID coreapplication.ID,
+func (s *baseSuite) addApplicationEndpoint(c *tc.C, applicationUUID coreapplication.UUID,
 	charmRelationUUID string) string {
 	applicationEndpointUUID := internaluuid.MustNewUUID().String()
 	s.query(c, `

--- a/domain/modelagent/state/modelstate_test.go
+++ b/domain/modelagent/state/modelstate_test.go
@@ -301,7 +301,7 @@ func (s *modelStateSuite) createTestingUnitForApplication(
 func (s *modelStateSuite) createTestingApplicationWithName(
 	c *tc.C,
 	appName string,
-) coreapplication.ID {
+) coreapplication.UUID {
 	appState := applicationstate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
 	platform := deployment.Platform{

--- a/domain/modelagent/state/modelstate_test.go
+++ b/domain/modelagent/state/modelstate_test.go
@@ -277,7 +277,7 @@ func (s *modelStateSuite) createTestingUnitForApplication(
 	appName string,
 ) coreunit.UUID {
 	appState := applicationstate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-	appID, err := appState.GetApplicationIDByName(c.Context(), appName)
+	appID, err := appState.GetApplicationUUIDByName(c.Context(), appName)
 	c.Assert(err, tc.ErrorIsNil)
 
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)

--- a/domain/network/state/container_test.go
+++ b/domain/network/state/container_test.go
@@ -311,7 +311,7 @@ func (s *containerSuite) addCharm(c *tc.C, subordinate bool) corecharm.ID {
 
 // addApplication adds a new application to the database with the specified
 // charm UUID and application name. It returns the application UUID.
-func (s *containerSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appName string) coreapplication.ID {
+func (s *containerSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appName string) coreapplication.UUID {
 	appUUID := coreapplicationtesting.GenApplicationUUID(c)
 	s.query(c, `
 INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) 
@@ -323,7 +323,7 @@ VALUES (?, ?, ?, ?, ?)
 // addUnit adds a new unit to the specified application in the database with
 // the given UUID and name. Returns the unit uuid.
 func (s *containerSuite) addUnit(
-	c *tc.C, unitName coreunit.Name, appUUID coreapplication.ID, charmUUID corecharm.ID, nodeUUID string,
+	c *tc.C, unitName coreunit.Name, appUUID coreapplication.UUID, charmUUID corecharm.ID, nodeUUID string,
 ) coreunit.UUID {
 	unitUUID := coreunittesting.GenUnitUUID(c)
 	s.query(c, `

--- a/domain/network/state/movesubnets_test.go
+++ b/domain/network/state/movesubnets_test.go
@@ -149,7 +149,7 @@ func (s *spaceMachineSuite) TestValidateSubnetsLeavingSpacesAppEndpointBindingSu
 	charmRelationUUID := s.addCharmRelation(c, corecharm.ID(charmUUID), charm.Relation{Name: "db",
 		Role:      charm.RoleProvider,
 		Interface: "mysql", Optional: false, Limit: 1, Scope: charm.ScopeGlobal})
-	s.addApplicationEndpoint(c, coreapplication.ID(appUUID), charmRelationUUID, fromSpaceUUID)
+	s.addApplicationEndpoint(c, coreapplication.UUID(appUUID), charmRelationUUID, fromSpaceUUID)
 	s.addUnit(c, appUUID, charmUUID, nodeUUID)
 
 	db, err := s.state.DB(c.Context())
@@ -279,7 +279,7 @@ func (s *spaceMachineSuite) TestValidateSubnetsLeavingSpacesAppEndpointBindingFa
 	charmRelationUUID := s.addCharmRelation(c, corecharm.ID(charmUUID), charm.Relation{Name: "db",
 		Role:      charm.RoleProvider,
 		Interface: "mysql", Optional: false, Limit: 1, Scope: charm.ScopeGlobal})
-	s.addApplicationEndpoint(c, coreapplication.ID(appUUID), charmRelationUUID, fromSpaceUUID)
+	s.addApplicationEndpoint(c, coreapplication.UUID(appUUID), charmRelationUUID, fromSpaceUUID)
 	s.addUnit(c, appUUID, charmUUID, nodeUUID)
 	s.addMachine(c, "machine-1", nodeUUID)
 
@@ -392,7 +392,7 @@ func (s *spaceMachineSuite) TestValidateSubnetsLeavingSpacesMultipleFailure(c *t
 	charmRelationUUID := s.addCharmRelation(c, corecharm.ID(charmUUID), charm.Relation{Name: "db",
 		Role:      charm.RoleProvider,
 		Interface: "mysql", Optional: false, Limit: 1, Scope: charm.ScopeGlobal})
-	s.addApplicationEndpoint(c, coreapplication.ID(appUUID), charmRelationUUID, fromSpaceUUID3)
+	s.addApplicationEndpoint(c, coreapplication.UUID(appUUID), charmRelationUUID, fromSpaceUUID3)
 	s.addUnit(c, appUUID, charmUUID, nodeUUID3)
 	s.addMachine(c, "machine-3", nodeUUID3)
 

--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -80,7 +80,7 @@ func (s *linkLayerBaseSuite) addApplicationWithName(c *tc.C, charmUUID, spaceUUI
 // addApplicationEndpoint inserts a new application endpoint into the
 // database with the specified UUIDs. Returns the endpoint uuid.
 func (s *linkLayerBaseSuite) addApplicationEndpoint(
-	c *tc.C, applicationUUID coreapplication.ID, charmRelationUUID string, boundSpaceUUID string) string {
+	c *tc.C, applicationUUID coreapplication.UUID, charmRelationUUID string, boundSpaceUUID string) string {
 	applicationEndpointUUID := uuid.MustNewUUID().String()
 	s.query(c, `
 INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid, space_uuid)
@@ -92,7 +92,7 @@ VALUES (?, ?, ?, ?)
 // addApplicationExtraEndpoint inserts a new application extra endpoint into the
 // database with the specified UUIDs. Returns the endpoint uuid.
 func (s *linkLayerBaseSuite) addApplicationExtraEndpoint(
-	c *tc.C, applicationUUID coreapplication.ID, charmRelationUUID string, boundSpaceUUID string) {
+	c *tc.C, applicationUUID coreapplication.UUID, charmRelationUUID string, boundSpaceUUID string) {
 	s.query(c, `
 INSERT INTO application_extra_endpoint (application_uuid, charm_extra_binding_uuid,space_uuid)
 VALUES (?, ?, ?)

--- a/domain/network/state/space_remove_test.go
+++ b/domain/network/state/space_remove_test.go
@@ -111,8 +111,8 @@ func (s *spaceDeleteSuite) TestDeleteSpaceRemoveEndpointBindings(c *tc.C) {
 	charmRelationUUID2 := s.addCharmRelation(c, corecharm.ID(charmUUID),
 		charm.Relation{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal})
 
-	s.addApplicationEndpoint(c, application.ID(appUUID1), charmRelationUUID1, toDeleteUUID)
-	s.addApplicationEndpoint(c, application.ID(appUUID2), charmRelationUUID2, otherUUID)
+	s.addApplicationEndpoint(c, application.UUID(appUUID1), charmRelationUUID1, toDeleteUUID)
+	s.addApplicationEndpoint(c, application.UUID(appUUID2), charmRelationUUID2, otherUUID)
 
 	// Act
 	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
@@ -139,8 +139,8 @@ func (s *spaceDeleteSuite) TestDeleteSpaceRemoveExtraBindings(c *tc.C) {
 	charmExtraUUID1 := s.addCharmExtraBinding(c, corecharm.ID(charmUUID), "extra1")
 	charmExtraUUID2 := s.addCharmExtraBinding(c, corecharm.ID(charmUUID), "extra2")
 
-	s.addApplicationExtraEndpoint(c, application.ID(appUUID1), charmExtraUUID1, toDeleteUUID)
-	s.addApplicationExtraEndpoint(c, application.ID(appUUID2), charmExtraUUID2, otherUUID)
+	s.addApplicationExtraEndpoint(c, application.UUID(appUUID1), charmExtraUUID1, toDeleteUUID)
+	s.addApplicationExtraEndpoint(c, application.UUID(appUUID2), charmExtraUUID2, otherUUID)
 
 	// Act
 	err := s.txn(c, func(ctx context.Context, tx *sqlair.TX) error {
@@ -169,8 +169,8 @@ func (s *spaceDeleteSuite) TestDeleteSpaceResetExposedEndpoints(c *tc.C) {
 	charmRelationUUID2 := s.addCharmRelation(c, corecharm.ID(charmUUID),
 		charm.Relation{Name: "ep2", Role: charm.RoleProvider, Scope: charm.ScopeGlobal})
 
-	epUUID1 := s.addApplicationEndpoint(c, application.ID(appUUID1), charmRelationUUID1, "")
-	epUUID2 := s.addApplicationEndpoint(c, application.ID(appUUID2), charmRelationUUID2, "")
+	epUUID1 := s.addApplicationEndpoint(c, application.UUID(appUUID1), charmRelationUUID1, "")
+	epUUID2 := s.addApplicationEndpoint(c, application.UUID(appUUID2), charmRelationUUID2, "")
 
 	s.addApplicationExposedEndpoint(c, appUUID1, epUUID1, toDeleteUUID)
 	s.addApplicationExposedEndpoint(c, appUUID2, epUUID2, otherUUID)
@@ -339,18 +339,18 @@ func (s *spaceDeleteSuite) TestGetApplicationBoundToSpace(c *tc.C) {
 	appUUID1 := s.addApplication(c, charmUUID, spaceUUID)
 	// endpoint binding
 	appUUID2 := s.addApplication(c, charmUUID, network.AlphaSpaceId.String())
-	s.addApplicationEndpoint(c, application.ID(appUUID2), charmRelationUUID, spaceUUID)
+	s.addApplicationEndpoint(c, application.UUID(appUUID2), charmRelationUUID, spaceUUID)
 	// extra endpoint binding
 	appUUID3 := s.addApplication(c, charmUUID, network.AlphaSpaceId.String())
-	s.addApplicationExtraEndpoint(c, application.ID(appUUID3), charmExtraUUID, spaceUUID)
+	s.addApplicationExtraEndpoint(c, application.UUID(appUUID3), charmExtraUUID, spaceUUID)
 	// exposed endpoint binding
 	appUUID4 := s.addApplication(c, charmUUID, network.AlphaSpaceId.String())
-	epUUID4 := s.addApplicationEndpoint(c, application.ID(appUUID4), charmRelationUUID, "")
+	epUUID4 := s.addApplicationEndpoint(c, application.UUID(appUUID4), charmRelationUUID, "")
 	s.addApplicationExposedEndpoint(c, appUUID4, epUUID4, spaceUUID)
 	// All bindings (shouldn't be duplicated)
 	appUUID5 := s.addApplication(c, charmUUID, spaceUUID)
-	epUUID5 := s.addApplicationEndpoint(c, application.ID(appUUID5), charmRelationUUID, spaceUUID)
-	s.addApplicationExtraEndpoint(c, application.ID(appUUID5), charmExtraUUID, spaceUUID)
+	epUUID5 := s.addApplicationEndpoint(c, application.UUID(appUUID5), charmRelationUUID, spaceUUID)
+	s.addApplicationExtraEndpoint(c, application.UUID(appUUID5), charmExtraUUID, spaceUUID)
 	s.addApplicationExposedEndpoint(c, appUUID5, epUUID5, spaceUUID)
 
 	// No binding (shouldn't be found at all)

--- a/domain/port/service/package_mock_test.go
+++ b/domain/port/service/package_mock_test.go
@@ -46,7 +46,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // FilterUnitUUIDsForApplication mocks base method.
-func (m *MockState) FilterUnitUUIDsForApplication(arg0 context.Context, arg1 []unit.UUID, arg2 application.ID) (set.Strings, error) {
+func (m *MockState) FilterUnitUUIDsForApplication(arg0 context.Context, arg1 []unit.UUID, arg2 application.UUID) (set.Strings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterUnitUUIDsForApplication", arg0, arg1, arg2)
 	ret0, _ := ret[0].(set.Strings)
@@ -73,13 +73,13 @@ func (c *MockStateFilterUnitUUIDsForApplicationCall) Return(arg0 set.Strings, ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateFilterUnitUUIDsForApplicationCall) Do(f func(context.Context, []unit.UUID, application.ID) (set.Strings, error)) *MockStateFilterUnitUUIDsForApplicationCall {
+func (c *MockStateFilterUnitUUIDsForApplicationCall) Do(f func(context.Context, []unit.UUID, application.UUID) (set.Strings, error)) *MockStateFilterUnitUUIDsForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateFilterUnitUUIDsForApplicationCall) DoAndReturn(f func(context.Context, []unit.UUID, application.ID) (set.Strings, error)) *MockStateFilterUnitUUIDsForApplicationCall {
+func (c *MockStateFilterUnitUUIDsForApplicationCall) DoAndReturn(f func(context.Context, []unit.UUID, application.UUID) (set.Strings, error)) *MockStateFilterUnitUUIDsForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -124,7 +124,7 @@ func (c *MockStateGetAllOpenedPortsCall) DoAndReturn(f func(context.Context) (po
 }
 
 // GetApplicationOpenedPorts mocks base method.
-func (m *MockState) GetApplicationOpenedPorts(arg0 context.Context, arg1 application.ID) (port.UnitEndpointPortRanges, error) {
+func (m *MockState) GetApplicationOpenedPorts(arg0 context.Context, arg1 application.UUID) (port.UnitEndpointPortRanges, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].(port.UnitEndpointPortRanges)
@@ -151,13 +151,13 @@ func (c *MockStateGetApplicationOpenedPortsCall) Return(arg0 port.UnitEndpointPo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationOpenedPortsCall) Do(f func(context.Context, application.ID) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
+func (c *MockStateGetApplicationOpenedPortsCall) Do(f func(context.Context, application.UUID) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationOpenedPortsCall) DoAndReturn(f func(context.Context, application.ID) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
+func (c *MockStateGetApplicationOpenedPortsCall) DoAndReturn(f func(context.Context, application.UUID) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/port/service/service.go
+++ b/domain/port/service/service.go
@@ -35,7 +35,7 @@ type State interface {
 	// GetApplicationOpenedPorts returns the opened ports for all the units of the
 	// given application. We return opened ports paired with the unit UUIDs, grouped
 	// by endpoint.
-	GetApplicationOpenedPorts(ctx context.Context, applicationUUID coreapplication.ID) (port.UnitEndpointPortRanges, error)
+	GetApplicationOpenedPorts(ctx context.Context, applicationUUID coreapplication.UUID) (port.UnitEndpointPortRanges, error)
 
 	// GetUnitUUID returns the UUID of the unit with the given name.
 	GetUnitUUID(ctx context.Context, unitName coreunit.Name) (coreunit.UUID, error)
@@ -93,7 +93,7 @@ func (s *Service) GetMachineOpenedPorts(ctx context.Context, machineUUID string)
 
 // GetApplicationOpenedPorts returns the opened ports for all the units of the
 // application. Opened ports are grouped first by unit name and then by endpoint.
-func (s *Service) GetApplicationOpenedPorts(ctx context.Context, applicationUUID coreapplication.ID) (map[coreunit.Name]network.GroupedPortRanges, error) {
+func (s *Service) GetApplicationOpenedPorts(ctx context.Context, applicationUUID coreapplication.UUID) (map[coreunit.Name]network.GroupedPortRanges, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -110,7 +110,7 @@ func (s *Service) GetApplicationOpenedPorts(ctx context.Context, applicationUUID
 // NOTE: The returned port ranges are atomised, meaning we guarantee that each
 // port range is of unit length. This is useful for down-stream consumers such
 // as k8s, which can only reason with unit-length port ranges.
-func (s *Service) GetApplicationOpenedPortsByEndpoint(ctx context.Context, applicationUUID coreapplication.ID) (network.GroupedPortRanges, error) {
+func (s *Service) GetApplicationOpenedPortsByEndpoint(ctx context.Context, applicationUUID coreapplication.UUID) (network.GroupedPortRanges, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/port/service/service_test.go
+++ b/domain/port/service/service_test.go
@@ -26,8 +26,8 @@ func TestServiceSuite(t *testing.T) {
 }
 
 const (
-	unitUUID    coreunit.UUID      = "unit-uuid"
-	machineUUID string             = "machine-uuid"
+	unitUUID    coreunit.UUID        = "unit-uuid"
+	machineUUID string               = "machine-uuid"
 	appUUID     coreapplication.UUID = "app-uuid"
 )
 

--- a/domain/port/service/service_test.go
+++ b/domain/port/service/service_test.go
@@ -28,7 +28,7 @@ func TestServiceSuite(t *testing.T) {
 const (
 	unitUUID    coreunit.UUID      = "unit-uuid"
 	machineUUID string             = "machine-uuid"
-	appUUID     coreapplication.ID = "app-uuid"
+	appUUID     coreapplication.UUID = "app-uuid"
 )
 
 func (s *serviceSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/domain/port/service/watcher.go
+++ b/domain/port/service/watcher.go
@@ -85,7 +85,7 @@ type WatcherState interface {
 
 	// FilterUnitUUIDsForApplication returns the subset of provided endpoint
 	// uuids that are associated with the provided application.
-	FilterUnitUUIDsForApplication(context.Context, []unit.UUID, coreapplication.ID) (set.Strings, error)
+	FilterUnitUUIDsForApplication(context.Context, []unit.UUID, coreapplication.UUID) (set.Strings, error)
 }
 
 // WatchMachineOpenedPorts returns a strings watcher for opened ports. This
@@ -109,7 +109,7 @@ func (s *WatchableService) WatchMachineOpenedPorts(ctx context.Context) (watcher
 // WatchOpenedPortsForApplication returns a notify watcher for opened ports. This
 // watcher emits events for changes to the opened ports table that are associated
 // with the given application
-func (s *WatchableService) WatchOpenedPortsForApplication(ctx context.Context, applicationUUID coreapplication.ID) (watcher.NotifyWatcher, error) {
+func (s *WatchableService) WatchOpenedPortsForApplication(ctx context.Context, applicationUUID coreapplication.UUID) (watcher.NotifyWatcher, error) {
 	_, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -177,7 +177,7 @@ type indexed struct {
 // filterForApplication returns an eventsource.Mapper that filters events
 // emitted by port range changes to only include events for port range changes
 // corresponding to the given application
-func (s *WatchableService) filterForApplication(applicationUUID coreapplication.ID) eventsource.Mapper {
+func (s *WatchableService) filterForApplication(applicationUUID coreapplication.UUID) eventsource.Mapper {
 	return func(
 		ctx context.Context, events []changestream.ChangeEvent,
 	) ([]string, error) {

--- a/domain/port/state/state.go
+++ b/domain/port/state/state.go
@@ -169,7 +169,7 @@ WHERE machine.uuid = $machineUUID.machine_uuid
 // GetApplicationOpenedPorts returns the opened ports for all the units of the
 // given application. We return opened ports paired with the unit UUIDs, grouped
 // by endpoint. This is because some consumers do not care about the unit.
-func (st *State) GetApplicationOpenedPorts(ctx context.Context, application coreapplication.ID) (port.UnitEndpointPortRanges, error) {
+func (st *State) GetApplicationOpenedPorts(ctx context.Context, application coreapplication.UUID) (port.UnitEndpointPortRanges, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/port/state/state_test.go
+++ b/domain/port/state/state_test.go
@@ -42,7 +42,7 @@ type stateSuite struct {
 	unitUUID coreunit.UUID
 	unitName coreunit.Name
 
-	appUUID coreapplication.ID
+	appUUID coreapplication.UUID
 }
 
 func TestStateSuite(t *stdtesting.T) {
@@ -96,7 +96,7 @@ func (s *stateSuite) SetUpTest(c *tc.C) {
 	s.unitUUID, s.unitName = s.createUnit(c, netNodeUUIDs[0], appNames[0])
 }
 
-func (s *baseSuite) createApplicationWithRelations(c *tc.C, appName string, relations ...string) coreapplication.ID {
+func (s *baseSuite) createApplicationWithRelations(c *tc.C, appName string, relations ...string) coreapplication.UUID {
 	relationsMap := map[string]charm.Relation{}
 	for _, relation := range relations {
 		relationsMap[relation] = charm.Relation{

--- a/domain/port/state/state_test.go
+++ b/domain/port/state/state_test.go
@@ -138,7 +138,7 @@ func (s *baseSuite) createUnit(c *tc.C, netNodeUUID, appName string) (coreunit.U
 	ctx := c.Context()
 	applicationSt := applicationstate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
-	appID, err := applicationSt.GetApplicationIDByName(ctx, appName)
+	appID, err := applicationSt.GetApplicationUUIDByName(ctx, appName)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Ensure that we place the unit on the same machine as the net node.

--- a/domain/port/state/types.go
+++ b/domain/port/state/types.go
@@ -158,7 +158,7 @@ type machineName struct {
 
 // applicationUUID represents an application's UUID.
 type applicationUUID struct {
-	UUID application.ID `db:"application_uuid"`
+	UUID application.UUID `db:"application_uuid"`
 }
 
 // unitName represents a unit's name.

--- a/domain/port/state/updateunitports_test.go
+++ b/domain/port/state/updateunitports_test.go
@@ -31,7 +31,7 @@ type updateUnitPortsSuite struct {
 	unitUUID coreunit.UUID
 	unitName coreunit.Name
 
-	appUUID coreapplication.ID
+	appUUID coreapplication.UUID
 }
 
 func TestUpdateUnitPortsSuite(t *testing.T) {

--- a/domain/port/state/watcher.go
+++ b/domain/port/state/watcher.go
@@ -67,7 +67,7 @@ WHERE unit.uuid IN ($unitUUIDs[:])
 	return transform.Slice(machineNames, func(m machineName) coremachine.Name { return m.Name }), nil
 }
 
-func (st *State) FilterUnitUUIDsForApplication(ctx context.Context, units []unit.UUID, app coreapplication.ID) (set.Strings, error) {
+func (st *State) FilterUnitUUIDsForApplication(ctx context.Context, units []unit.UUID, app coreapplication.UUID) (set.Strings, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/port/state/watcher_test.go
+++ b/domain/port/state/watcher_test.go
@@ -28,7 +28,7 @@ type watcherSuite struct {
 
 	unitUUIDs [3]coreunit.UUID
 
-	appUUIDs [2]coreapplication.ID
+	appUUIDs [2]coreapplication.UUID
 }
 
 func TestWatcherSuite(t *testing.T) {

--- a/domain/port/watcher_test.go
+++ b/domain/port/watcher_test.go
@@ -45,7 +45,7 @@ type watcherSuite struct {
 
 	unitUUIDs [3]coreunit.UUID
 
-	appUUIDs [2]coreapplication.ID
+	appUUIDs [2]coreapplication.UUID
 }
 
 func TestWatcherSuite(t *testing.T) {
@@ -111,7 +111,7 @@ func (s *watcherSuite) SetUpTest(c *tc.C) {
 	netNodeUUIDs = []string{netNodeUUID0, netNodeUUID1}
 }
 
-func (s *watcherSuite) createApplicationWithRelations(c *tc.C, appName string, relations ...string) coreapplication.ID {
+func (s *watcherSuite) createApplicationWithRelations(c *tc.C, appName string, relations ...string) coreapplication.UUID {
 	relationsMap := map[string]charm.Relation{}
 	for _, relation := range relations {
 		relationsMap[relation] = charm.Relation{

--- a/domain/port/watcher_test.go
+++ b/domain/port/watcher_test.go
@@ -153,7 +153,7 @@ func (s *watcherSuite) createUnit(c *tc.C, netNodeUUID, appName string) coreunit
 	applicationSt := applicationstate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 	ctx := c.Context()
 
-	appID, err := applicationSt.GetApplicationIDByName(ctx, appName)
+	appID, err := applicationSt.GetApplicationUUIDByName(ctx, appName)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Ensure that we place the unit on the same machine as the net node.

--- a/domain/relation/errors/errors.go
+++ b/domain/relation/errors/errors.go
@@ -10,9 +10,9 @@ const (
 	// to relate two application
 	AmbiguousRelation = errors.ConstError("ambiguous relation")
 
-	// ApplicationIDNotValid describes an error when the application ID is
+	// ApplicationUUIDNotValid describes an error when the application UUID is
 	// not valid.
-	ApplicationIDNotValid = errors.ConstError("application ID not valid")
+	ApplicationUUIDNotValid = errors.ConstError("application UUID not valid")
 
 	// ApplicationNotAlive describes an error that occurs when a relation is
 	// added between two application where at least one is not alive

--- a/domain/relation/service/migration.go
+++ b/domain/relation/service/migration.go
@@ -35,14 +35,14 @@ type MigrationState interface {
 	) (corerelation.UUID, error)
 
 	// GetApplicationIDByName returns the application ID of the given application.
-	GetApplicationIDByName(ctx context.Context, appName string) (application.ID, error)
+	GetApplicationIDByName(ctx context.Context, appName string) (application.UUID, error)
 
 	// SetRelationApplicationSettings records settings for a specific application
 	// relation combination.
 	SetRelationApplicationSettings(
 		ctx context.Context,
 		relationUUID corerelation.UUID,
-		applicationID application.ID,
+		applicationID application.UUID,
 		settings map[string]string,
 	) error
 

--- a/domain/relation/service/migration.go
+++ b/domain/relation/service/migration.go
@@ -34,7 +34,7 @@ type MigrationState interface {
 		scope charm.RelationScope,
 	) (corerelation.UUID, error)
 
-	// GetApplicationUUIDByName returns the application ID of the given application.
+	// GetApplicationUUIDByName returns the application UUID of the given application.
 	GetApplicationUUIDByName(ctx context.Context, appName string) (application.UUID, error)
 
 	// SetRelationApplicationSettings records settings for a specific application

--- a/domain/relation/service/migration.go
+++ b/domain/relation/service/migration.go
@@ -34,8 +34,8 @@ type MigrationState interface {
 		scope charm.RelationScope,
 	) (corerelation.UUID, error)
 
-	// GetApplicationIDByName returns the application ID of the given application.
-	GetApplicationIDByName(ctx context.Context, appName string) (application.UUID, error)
+	// GetApplicationUUIDByName returns the application ID of the given application.
+	GetApplicationUUIDByName(ctx context.Context, appName string) (application.UUID, error)
 
 	// SetRelationApplicationSettings records settings for a specific application
 	// relation combination.
@@ -125,7 +125,7 @@ func (s *MigrationService) importRelation(ctx context.Context, arg relation.Impo
 }
 
 func (s *MigrationService) importRelationEndpoint(ctx context.Context, relUUID corerelation.UUID, ep relation.ImportEndpoint) error {
-	appID, err := s.st.GetApplicationIDByName(ctx, ep.ApplicationName)
+	appID, err := s.st.GetApplicationUUIDByName(ctx, ep.ApplicationName)
 	if err != nil {
 		return err
 	}

--- a/domain/relation/service/migration_test.go
+++ b/domain/relation/service/migration_test.go
@@ -80,9 +80,9 @@ func (s *migrationServiceSuite) TestImportRelations(c *tc.C) {
 	}
 	peerRelUUID := s.expectGetPeerRelationUUIDByEndpointIdentifiers(c, ep1[0])
 	relUUID := s.expectImportRelation(c, ep2[0], ep2[1], uint64(8), charm.ScopeGlobal)
-	app1ID := s.expectGetApplicationIDByName(c, args[0].Endpoints[0].ApplicationName)
-	app2ID := s.expectGetApplicationIDByName(c, args[1].Endpoints[0].ApplicationName)
-	app3ID := s.expectGetApplicationIDByName(c, args[1].Endpoints[1].ApplicationName)
+	app1ID := s.expectGetApplicationUUIDByName(c, args[0].Endpoints[0].ApplicationName)
+	app2ID := s.expectGetApplicationUUIDByName(c, args[1].Endpoints[0].ApplicationName)
+	app3ID := s.expectGetApplicationUUIDByName(c, args[1].Endpoints[1].ApplicationName)
 	s.expectSetRelationApplicationSettings(peerRelUUID, app1ID, args[0].Endpoints[0].ApplicationSettings)
 	s.expectSetRelationApplicationSettings(relUUID, app2ID, args[1].Endpoints[0].ApplicationSettings)
 	s.expectSetRelationApplicationSettings(relUUID, app3ID, args[1].Endpoints[1].ApplicationSettings)
@@ -190,9 +190,9 @@ func (s *migrationServiceSuite) expectImportRelation(
 	return relUUID
 }
 
-func (s *migrationServiceSuite) expectGetApplicationIDByName(c *tc.C, name string) coreapplication.UUID {
+func (s *migrationServiceSuite) expectGetApplicationUUIDByName(c *tc.C, name string) coreapplication.UUID {
 	appID := coreapplicationtesting.GenApplicationUUID(c)
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), name).Return(appID, nil)
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), name).Return(appID, nil)
 	return appID
 }
 

--- a/domain/relation/service/migration_test.go
+++ b/domain/relation/service/migration_test.go
@@ -190,7 +190,7 @@ func (s *migrationServiceSuite) expectImportRelation(
 	return relUUID
 }
 
-func (s *migrationServiceSuite) expectGetApplicationIDByName(c *tc.C, name string) coreapplication.ID {
+func (s *migrationServiceSuite) expectGetApplicationIDByName(c *tc.C, name string) coreapplication.UUID {
 	appID := coreapplicationtesting.GenApplicationUUID(c)
 	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), name).Return(appID, nil)
 	return appID
@@ -198,7 +198,7 @@ func (s *migrationServiceSuite) expectGetApplicationIDByName(c *tc.C, name strin
 
 func (s *migrationServiceSuite) expectSetRelationApplicationSettings(
 	uuid corerelation.UUID,
-	id coreapplication.ID,
+	id coreapplication.UUID,
 	settings map[string]interface{},
 ) {
 	appSettings, _ := settingsMap(settings)

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -1314,41 +1314,41 @@ func (c *MockMigrationStateExportRelationsCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockMigrationState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockMigrationState) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockMigrationStateMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockMigrationStateGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockMigrationStateMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockMigrationStateGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockMigrationState)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockMigrationStateGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockMigrationState)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockMigrationStateGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockMigrationStateGetApplicationIDByNameCall wrap *gomock.Call
-type MockMigrationStateGetApplicationIDByNameCall struct {
+// MockMigrationStateGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockMigrationStateGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMigrationStateGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockMigrationStateGetApplicationIDByNameCall {
+func (c *MockMigrationStateGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockMigrationStateGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMigrationStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockMigrationStateGetApplicationIDByNameCall {
+func (c *MockMigrationStateGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockMigrationStateGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMigrationStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockMigrationStateGetApplicationIDByNameCall {
+func (c *MockMigrationStateGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockMigrationStateGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -396,42 +396,42 @@ func (c *MockStateGetPeerRelationUUIDByEndpointIdentifiersCall) DoAndReturn(f fu
 	return c
 }
 
-// GetPrincipalSubordinateApplicationIDs mocks base method.
-func (m *MockState) GetPrincipalSubordinateApplicationIDs(arg0 context.Context, arg1 unit.UUID) (application.UUID, application.UUID, error) {
+// GetPrincipalSubordinateApplicationUUIDs mocks base method.
+func (m *MockState) GetPrincipalSubordinateApplicationUUIDs(arg0 context.Context, arg1 unit.UUID) (application.UUID, application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPrincipalSubordinateApplicationIDs", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetPrincipalSubordinateApplicationUUIDs", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(application.UUID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetPrincipalSubordinateApplicationIDs indicates an expected call of GetPrincipalSubordinateApplicationIDs.
-func (mr *MockStateMockRecorder) GetPrincipalSubordinateApplicationIDs(arg0, arg1 any) *MockStateGetPrincipalSubordinateApplicationIDsCall {
+// GetPrincipalSubordinateApplicationUUIDs indicates an expected call of GetPrincipalSubordinateApplicationUUIDs.
+func (mr *MockStateMockRecorder) GetPrincipalSubordinateApplicationUUIDs(arg0, arg1 any) *MockStateGetPrincipalSubordinateApplicationUUIDsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrincipalSubordinateApplicationIDs", reflect.TypeOf((*MockState)(nil).GetPrincipalSubordinateApplicationIDs), arg0, arg1)
-	return &MockStateGetPrincipalSubordinateApplicationIDsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrincipalSubordinateApplicationUUIDs", reflect.TypeOf((*MockState)(nil).GetPrincipalSubordinateApplicationUUIDs), arg0, arg1)
+	return &MockStateGetPrincipalSubordinateApplicationUUIDsCall{Call: call}
 }
 
-// MockStateGetPrincipalSubordinateApplicationIDsCall wrap *gomock.Call
-type MockStateGetPrincipalSubordinateApplicationIDsCall struct {
+// MockStateGetPrincipalSubordinateApplicationUUIDsCall wrap *gomock.Call
+type MockStateGetPrincipalSubordinateApplicationUUIDsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) Return(arg0, arg1 application.UUID, arg2 error) *MockStateGetPrincipalSubordinateApplicationIDsCall {
+func (c *MockStateGetPrincipalSubordinateApplicationUUIDsCall) Return(arg0, arg1 application.UUID, arg2 error) *MockStateGetPrincipalSubordinateApplicationUUIDsCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) Do(f func(context.Context, unit.UUID) (application.UUID, application.UUID, error)) *MockStateGetPrincipalSubordinateApplicationIDsCall {
+func (c *MockStateGetPrincipalSubordinateApplicationUUIDsCall) Do(f func(context.Context, unit.UUID) (application.UUID, application.UUID, error)) *MockStateGetPrincipalSubordinateApplicationUUIDsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) DoAndReturn(f func(context.Context, unit.UUID) (application.UUID, application.UUID, error)) *MockStateGetPrincipalSubordinateApplicationIDsCall {
+func (c *MockStateGetPrincipalSubordinateApplicationUUIDsCall) DoAndReturn(f func(context.Context, unit.UUID) (application.UUID, application.UUID, error)) *MockStateGetPrincipalSubordinateApplicationUUIDsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -87,7 +87,7 @@ func (c *MockStateAddRelationCall) DoAndReturn(f func(context.Context, relation0
 }
 
 // ApplicationExists mocks base method.
-func (m *MockState) ApplicationExists(arg0 context.Context, arg1 application.ID) error {
+func (m *MockState) ApplicationExists(arg0 context.Context, arg1 application.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationExists", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -113,13 +113,13 @@ func (c *MockStateApplicationExistsCall) Return(arg0 error) *MockStateApplicatio
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateApplicationExistsCall) Do(f func(context.Context, application.ID) error) *MockStateApplicationExistsCall {
+func (c *MockStateApplicationExistsCall) Do(f func(context.Context, application.UUID) error) *MockStateApplicationExistsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateApplicationExistsCall) DoAndReturn(f func(context.Context, application.ID) error) *MockStateApplicationExistsCall {
+func (c *MockStateApplicationExistsCall) DoAndReturn(f func(context.Context, application.UUID) error) *MockStateApplicationExistsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -125,7 +125,7 @@ func (c *MockStateApplicationExistsCall) DoAndReturn(f func(context.Context, app
 }
 
 // ApplicationRelationsInfo mocks base method.
-func (m *MockState) ApplicationRelationsInfo(arg0 context.Context, arg1 application.ID) ([]relation0.EndpointRelationData, error) {
+func (m *MockState) ApplicationRelationsInfo(arg0 context.Context, arg1 application.UUID) ([]relation0.EndpointRelationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationRelationsInfo", arg0, arg1)
 	ret0, _ := ret[0].([]relation0.EndpointRelationData)
@@ -152,13 +152,13 @@ func (c *MockStateApplicationRelationsInfoCall) Return(arg0 []relation0.Endpoint
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateApplicationRelationsInfoCall) Do(f func(context.Context, application.ID) ([]relation0.EndpointRelationData, error)) *MockStateApplicationRelationsInfoCall {
+func (c *MockStateApplicationRelationsInfoCall) Do(f func(context.Context, application.UUID) ([]relation0.EndpointRelationData, error)) *MockStateApplicationRelationsInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateApplicationRelationsInfoCall) DoAndReturn(f func(context.Context, application.ID) ([]relation0.EndpointRelationData, error)) *MockStateApplicationRelationsInfoCall {
+func (c *MockStateApplicationRelationsInfoCall) DoAndReturn(f func(context.Context, application.UUID) ([]relation0.EndpointRelationData, error)) *MockStateApplicationRelationsInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -241,7 +241,7 @@ func (c *MockStateGetAllRelationDetailsCall) DoAndReturn(f func(context.Context)
 }
 
 // GetGoalStateRelationDataForApplication mocks base method.
-func (m *MockState) GetGoalStateRelationDataForApplication(arg0 context.Context, arg1 application.ID) ([]relation0.GoalStateRelationData, error) {
+func (m *MockState) GetGoalStateRelationDataForApplication(arg0 context.Context, arg1 application.UUID) ([]relation0.GoalStateRelationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGoalStateRelationDataForApplication", arg0, arg1)
 	ret0, _ := ret[0].([]relation0.GoalStateRelationData)
@@ -268,19 +268,19 @@ func (c *MockStateGetGoalStateRelationDataForApplicationCall) Return(arg0 []rela
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetGoalStateRelationDataForApplicationCall) Do(f func(context.Context, application.ID) ([]relation0.GoalStateRelationData, error)) *MockStateGetGoalStateRelationDataForApplicationCall {
+func (c *MockStateGetGoalStateRelationDataForApplicationCall) Do(f func(context.Context, application.UUID) ([]relation0.GoalStateRelationData, error)) *MockStateGetGoalStateRelationDataForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetGoalStateRelationDataForApplicationCall) DoAndReturn(f func(context.Context, application.ID) ([]relation0.GoalStateRelationData, error)) *MockStateGetGoalStateRelationDataForApplicationCall {
+func (c *MockStateGetGoalStateRelationDataForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) ([]relation0.GoalStateRelationData, error)) *MockStateGetGoalStateRelationDataForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetMapperDataForWatchLifeSuspendedStatus mocks base method.
-func (m *MockState) GetMapperDataForWatchLifeSuspendedStatus(arg0 context.Context, arg1 relation.UUID, arg2 application.ID) (relation0.RelationLifeSuspendedData, error) {
+func (m *MockState) GetMapperDataForWatchLifeSuspendedStatus(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (relation0.RelationLifeSuspendedData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMapperDataForWatchLifeSuspendedStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(relation0.RelationLifeSuspendedData)
@@ -307,19 +307,19 @@ func (c *MockStateGetMapperDataForWatchLifeSuspendedStatusCall) Return(arg0 rela
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetMapperDataForWatchLifeSuspendedStatusCall) Do(f func(context.Context, relation.UUID, application.ID) (relation0.RelationLifeSuspendedData, error)) *MockStateGetMapperDataForWatchLifeSuspendedStatusCall {
+func (c *MockStateGetMapperDataForWatchLifeSuspendedStatusCall) Do(f func(context.Context, relation.UUID, application.UUID) (relation0.RelationLifeSuspendedData, error)) *MockStateGetMapperDataForWatchLifeSuspendedStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMapperDataForWatchLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, relation.UUID, application.ID) (relation0.RelationLifeSuspendedData, error)) *MockStateGetMapperDataForWatchLifeSuspendedStatusCall {
+func (c *MockStateGetMapperDataForWatchLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID) (relation0.RelationLifeSuspendedData, error)) *MockStateGetMapperDataForWatchLifeSuspendedStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetOtherRelatedEndpointApplicationData mocks base method.
-func (m *MockState) GetOtherRelatedEndpointApplicationData(arg0 context.Context, arg1 relation.UUID, arg2 application.ID) (relation0.OtherApplicationForWatcher, error) {
+func (m *MockState) GetOtherRelatedEndpointApplicationData(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (relation0.OtherApplicationForWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOtherRelatedEndpointApplicationData", arg0, arg1, arg2)
 	ret0, _ := ret[0].(relation0.OtherApplicationForWatcher)
@@ -346,13 +346,13 @@ func (c *MockStateGetOtherRelatedEndpointApplicationDataCall) Return(arg0 relati
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetOtherRelatedEndpointApplicationDataCall) Do(f func(context.Context, relation.UUID, application.ID) (relation0.OtherApplicationForWatcher, error)) *MockStateGetOtherRelatedEndpointApplicationDataCall {
+func (c *MockStateGetOtherRelatedEndpointApplicationDataCall) Do(f func(context.Context, relation.UUID, application.UUID) (relation0.OtherApplicationForWatcher, error)) *MockStateGetOtherRelatedEndpointApplicationDataCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetOtherRelatedEndpointApplicationDataCall) DoAndReturn(f func(context.Context, relation.UUID, application.ID) (relation0.OtherApplicationForWatcher, error)) *MockStateGetOtherRelatedEndpointApplicationDataCall {
+func (c *MockStateGetOtherRelatedEndpointApplicationDataCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID) (relation0.OtherApplicationForWatcher, error)) *MockStateGetOtherRelatedEndpointApplicationDataCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -397,11 +397,11 @@ func (c *MockStateGetPeerRelationUUIDByEndpointIdentifiersCall) DoAndReturn(f fu
 }
 
 // GetPrincipalSubordinateApplicationIDs mocks base method.
-func (m *MockState) GetPrincipalSubordinateApplicationIDs(arg0 context.Context, arg1 unit.UUID) (application.ID, application.ID, error) {
+func (m *MockState) GetPrincipalSubordinateApplicationIDs(arg0 context.Context, arg1 unit.UUID) (application.UUID, application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPrincipalSubordinateApplicationIDs", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
-	ret1, _ := ret[1].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(application.UUID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -419,19 +419,19 @@ type MockStateGetPrincipalSubordinateApplicationIDsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) Return(arg0, arg1 application.ID, arg2 error) *MockStateGetPrincipalSubordinateApplicationIDsCall {
+func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) Return(arg0, arg1 application.UUID, arg2 error) *MockStateGetPrincipalSubordinateApplicationIDsCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) Do(f func(context.Context, unit.UUID) (application.ID, application.ID, error)) *MockStateGetPrincipalSubordinateApplicationIDsCall {
+func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) Do(f func(context.Context, unit.UUID) (application.UUID, application.UUID, error)) *MockStateGetPrincipalSubordinateApplicationIDsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) DoAndReturn(f func(context.Context, unit.UUID) (application.ID, application.ID, error)) *MockStateGetPrincipalSubordinateApplicationIDsCall {
+func (c *MockStateGetPrincipalSubordinateApplicationIDsCall) DoAndReturn(f func(context.Context, unit.UUID) (application.UUID, application.UUID, error)) *MockStateGetPrincipalSubordinateApplicationIDsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -476,7 +476,7 @@ func (c *MockStateGetRegularRelationUUIDByEndpointIdentifiersCall) DoAndReturn(f
 }
 
 // GetRelationApplicationSettings mocks base method.
-func (m *MockState) GetRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.ID) (map[string]string, error) {
+func (m *MockState) GetRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationApplicationSettings", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]string)
@@ -503,13 +503,13 @@ func (c *MockStateGetRelationApplicationSettingsCall) Return(arg0 map[string]str
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.ID) (map[string]string, error)) *MockStateGetRelationApplicationSettingsCall {
+func (c *MockStateGetRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.UUID) (map[string]string, error)) *MockStateGetRelationApplicationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.ID) (map[string]string, error)) *MockStateGetRelationApplicationSettingsCall {
+func (c *MockStateGetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID) (map[string]string, error)) *MockStateGetRelationApplicationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -554,7 +554,7 @@ func (c *MockStateGetRelationDetailsCall) DoAndReturn(f func(context.Context, re
 }
 
 // GetRelationEndpointScope mocks base method.
-func (m *MockState) GetRelationEndpointScope(arg0 context.Context, arg1 relation.UUID, arg2 application.ID) (charm.RelationScope, error) {
+func (m *MockState) GetRelationEndpointScope(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (charm.RelationScope, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationEndpointScope", arg0, arg1, arg2)
 	ret0, _ := ret[0].(charm.RelationScope)
@@ -581,13 +581,13 @@ func (c *MockStateGetRelationEndpointScopeCall) Return(arg0 charm.RelationScope,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetRelationEndpointScopeCall) Do(f func(context.Context, relation.UUID, application.ID) (charm.RelationScope, error)) *MockStateGetRelationEndpointScopeCall {
+func (c *MockStateGetRelationEndpointScopeCall) Do(f func(context.Context, relation.UUID, application.UUID) (charm.RelationScope, error)) *MockStateGetRelationEndpointScopeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetRelationEndpointScopeCall) DoAndReturn(f func(context.Context, relation.UUID, application.ID) (charm.RelationScope, error)) *MockStateGetRelationEndpointScopeCall {
+func (c *MockStateGetRelationEndpointScopeCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID) (charm.RelationScope, error)) *MockStateGetRelationEndpointScopeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -710,7 +710,7 @@ func (c *MockStateGetRelationUnitCall) DoAndReturn(f func(context.Context, relat
 }
 
 // GetRelationUnitChanges mocks base method.
-func (m *MockState) GetRelationUnitChanges(arg0 context.Context, arg1 []unit.UUID, arg2 []application.ID) (relation0.RelationUnitsChange, error) {
+func (m *MockState) GetRelationUnitChanges(arg0 context.Context, arg1 []unit.UUID, arg2 []application.UUID) (relation0.RelationUnitsChange, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationUnitChanges", arg0, arg1, arg2)
 	ret0, _ := ret[0].(relation0.RelationUnitsChange)
@@ -737,13 +737,13 @@ func (c *MockStateGetRelationUnitChangesCall) Return(arg0 relation0.RelationUnit
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetRelationUnitChangesCall) Do(f func(context.Context, []unit.UUID, []application.ID) (relation0.RelationUnitsChange, error)) *MockStateGetRelationUnitChangesCall {
+func (c *MockStateGetRelationUnitChangesCall) Do(f func(context.Context, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockStateGetRelationUnitChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetRelationUnitChangesCall) DoAndReturn(f func(context.Context, []unit.UUID, []application.ID) (relation0.RelationUnitsChange, error)) *MockStateGetRelationUnitChangesCall {
+func (c *MockStateGetRelationUnitChangesCall) DoAndReturn(f func(context.Context, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockStateGetRelationUnitChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -866,7 +866,7 @@ func (c *MockStateInferRelationUUIDByEndpointsCall) DoAndReturn(f func(context.C
 }
 
 // InitialWatchLifeSuspendedStatus mocks base method.
-func (m *MockState) InitialWatchLifeSuspendedStatus(arg0 application.ID) (string, string, eventsource.NamespaceQuery) {
+func (m *MockState) InitialWatchLifeSuspendedStatus(arg0 application.UUID) (string, string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitialWatchLifeSuspendedStatus", arg0)
 	ret0, _ := ret[0].(string)
@@ -894,13 +894,13 @@ func (c *MockStateInitialWatchLifeSuspendedStatusCall) Return(arg0, arg1 string,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInitialWatchLifeSuspendedStatusCall) Do(f func(application.ID) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchLifeSuspendedStatusCall {
+func (c *MockStateInitialWatchLifeSuspendedStatusCall) Do(f func(application.UUID) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchLifeSuspendedStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInitialWatchLifeSuspendedStatusCall) DoAndReturn(f func(application.ID) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchLifeSuspendedStatusCall {
+func (c *MockStateInitialWatchLifeSuspendedStatusCall) DoAndReturn(f func(application.UUID) (string, string, eventsource.NamespaceQuery)) *MockStateInitialWatchLifeSuspendedStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1024,10 +1024,10 @@ func (c *MockStateLeaveScopeCall) DoAndReturn(f func(context.Context, relation.U
 }
 
 // NeedsSubordinateUnit mocks base method.
-func (m *MockState) NeedsSubordinateUnit(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (*application.ID, error) {
+func (m *MockState) NeedsSubordinateUnit(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (*application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NeedsSubordinateUnit", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*application.ID)
+	ret0, _ := ret[0].(*application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1045,19 +1045,19 @@ type MockStateNeedsSubordinateUnitCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateNeedsSubordinateUnitCall) Return(arg0 *application.ID, arg1 error) *MockStateNeedsSubordinateUnitCall {
+func (c *MockStateNeedsSubordinateUnitCall) Return(arg0 *application.UUID, arg1 error) *MockStateNeedsSubordinateUnitCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateNeedsSubordinateUnitCall) Do(f func(context.Context, relation.UUID, unit.Name) (*application.ID, error)) *MockStateNeedsSubordinateUnitCall {
+func (c *MockStateNeedsSubordinateUnitCall) Do(f func(context.Context, relation.UUID, unit.Name) (*application.UUID, error)) *MockStateNeedsSubordinateUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateNeedsSubordinateUnitCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (*application.ID, error)) *MockStateNeedsSubordinateUnitCall {
+func (c *MockStateNeedsSubordinateUnitCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (*application.UUID, error)) *MockStateNeedsSubordinateUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1315,10 +1315,10 @@ func (c *MockMigrationStateExportRelationsCall) DoAndReturn(f func(context.Conte
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockMigrationState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockMigrationState) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1336,19 +1336,19 @@ type MockMigrationStateGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMigrationStateGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockMigrationStateGetApplicationIDByNameCall {
+func (c *MockMigrationStateGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockMigrationStateGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMigrationStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockMigrationStateGetApplicationIDByNameCall {
+func (c *MockMigrationStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockMigrationStateGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMigrationStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockMigrationStateGetApplicationIDByNameCall {
+func (c *MockMigrationStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockMigrationStateGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1432,7 +1432,7 @@ func (c *MockMigrationStateImportRelationCall) DoAndReturn(f func(context.Contex
 }
 
 // SetRelationApplicationSettings mocks base method.
-func (m *MockMigrationState) SetRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.ID, arg3 map[string]string) error {
+func (m *MockMigrationState) SetRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID, arg3 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRelationApplicationSettings", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -1458,13 +1458,13 @@ func (c *MockMigrationStateSetRelationApplicationSettingsCall) Return(arg0 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMigrationStateSetRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.ID, map[string]string) error) *MockMigrationStateSetRelationApplicationSettingsCall {
+func (c *MockMigrationStateSetRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.UUID, map[string]string) error) *MockMigrationStateSetRelationApplicationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMigrationStateSetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.ID, map[string]string) error) *MockMigrationStateSetRelationApplicationSettingsCall {
+func (c *MockMigrationStateSetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID, map[string]string) error) *MockMigrationStateSetRelationApplicationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -204,7 +204,7 @@ func (s *LeadershipService) GetRelationApplicationSettingsWithLeader(
 	}
 	if err := applicationID.Validate(); err != nil {
 		return nil, errors.Errorf(
-			"%w:%w", relationerrors.ApplicationIDNotValid, err)
+			"%w:%w", relationerrors.ApplicationUUIDNotValid, err)
 	}
 	settings := make(map[string]string)
 	if err := s.leaderEnsurer.WithLeader(ctx, unitName.Application(), unitName.String(),
@@ -304,7 +304,7 @@ func (s *Service) AddRelation(ctx context.Context, ep1, ep2 string) (relation.En
 // ApplicationRelationsInfo returns all EndpointRelationData for an application.
 //
 // The following error types can be expected to be returned:
-//   - [relationerrors.ApplicationIDNotValid] if the application id is not valid.
+//   - [relationerrors.ApplicationUUIDNotValid] if the application UUID is not valid.
 //   - [relationerrors.ApplicationNotFound] is returned if the application is
 //     not found.
 func (s *Service) ApplicationRelationsInfo(
@@ -315,7 +315,7 @@ func (s *Service) ApplicationRelationsInfo(
 	defer span.End()
 
 	if err := applicationID.Validate(); err != nil {
-		return nil, relationerrors.ApplicationIDNotValid
+		return nil, relationerrors.ApplicationUUIDNotValid
 	}
 	return s.st.ApplicationRelationsInfo(ctx, applicationID)
 }
@@ -397,7 +397,7 @@ func (s *Service) GetAllRelationDetails(ctx context.Context) ([]relation.Relatio
 // if the application is not in any relations.
 //
 // The following error types can be expected to be returned:
-//   - [relationerrors.ApplicationIDNotValid] is returned if the application
+//   - [relationerrors.ApplicationUUIDNotValid] is returned if the application
 //     UUID is not valid.
 func (s *Service) GetGoalStateRelationDataForApplication(
 	ctx context.Context,
@@ -407,7 +407,7 @@ func (s *Service) GetGoalStateRelationDataForApplication(
 	defer span.End()
 	if err := applicationID.Validate(); err != nil {
 		return nil, errors.Errorf(
-			"%w: %w", relationerrors.ApplicationIDNotValid, err)
+			"%w: %w", relationerrors.ApplicationUUIDNotValid, err)
 	}
 	return s.st.GetGoalStateRelationDataForApplication(ctx, applicationID)
 }
@@ -548,7 +548,7 @@ func (s *Service) GetRelationUnitChanges(ctx context.Context, unitUUIDs []unit.U
 	}
 	for _, uuid := range appUUIDs {
 		if err := uuid.Validate(); err != nil {
-			return relation.RelationUnitsChange{}, relationerrors.ApplicationIDNotValid
+			return relation.RelationUnitsChange{}, relationerrors.ApplicationUUIDNotValid
 		}
 	}
 
@@ -711,7 +711,7 @@ func (s *Service) GetRelationApplicationSettings(
 	}
 	if err := applicationID.Validate(); err != nil {
 		return nil, errors.Errorf(
-			"%w:%w", relationerrors.ApplicationIDNotValid, err)
+			"%w:%w", relationerrors.ApplicationUUIDNotValid, err)
 	}
 
 	settings, err := s.st.GetRelationApplicationSettings(ctx, relationUUID, applicationID)

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -150,7 +150,7 @@ type State interface {
 	) error
 
 	// ApplicationExists checks if the given application exists.
-	ApplicationExists(ctx context.Context, applicationID application.ID) error
+	ApplicationExists(ctx context.Context, applicationID application.UUID) error
 }
 
 // LeadershipService provides the API for working with the statuses of
@@ -753,7 +753,7 @@ func (s *Service) RelationUnitInScopeByID(ctx context.Context, relationID int, u
 }
 
 // GetRelationUnits returns the current state of the relation units.
-func (s *Service) GetRelationUnits(ctx context.Context, appID application.ID) (relation.RelationUnitChange, error) {
+func (s *Service) GetRelationUnits(ctx context.Context, appID application.UUID) (relation.RelationUnitChange, error) {
 	_, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -28,7 +28,7 @@ type State interface {
 	// relation endpoints.
 	ApplicationRelationsInfo(
 		ctx context.Context,
-		applicationID application.ID,
+		applicationID application.UUID,
 	) ([]relation.EndpointRelationData, error)
 
 	// AddRelation establishes a relation between two endpoints identified
@@ -41,7 +41,7 @@ type State interface {
 		ctx context.Context,
 		relationUUID corerelation.UUID,
 		principalUnitName unit.Name,
-	) (*application.ID, error)
+	) (*application.UUID, error)
 
 	// EnterScope indicates that the provided unit has joined the relation.
 	// When the unit has already entered its relation scope, EnterScope will report
@@ -62,7 +62,7 @@ type State interface {
 	// all relations the given application is in, modulo peer relations.
 	GetGoalStateRelationDataForApplication(
 		ctx context.Context,
-		applicationID application.ID,
+		applicationID application.UUID,
 	) ([]relation.GoalStateRelationData, error)
 
 	// GetPeerRelationUUIDByEndpointIdentifiers gets the UUID of a peer
@@ -77,7 +77,7 @@ type State interface {
 	GetRelationApplicationSettings(
 		ctx context.Context,
 		relationUUID corerelation.UUID,
-		applicationID application.ID,
+		applicationID application.UUID,
 	) (map[string]string, error)
 
 	// GetRelationUUIDByID returns the relation UUID based on the relation ID.
@@ -107,7 +107,7 @@ type State interface {
 	// It takes a list of unit UUIDs and application UUIDs, returning the
 	// current setting version for each one, or departed if any unit is not
 	// found
-	GetRelationUnitChanges(ctx context.Context, unitUUIDs []unit.UUID, appUUIDs []application.ID) (relation.RelationUnitsChange, error)
+	GetRelationUnitChanges(ctx context.Context, unitUUIDs []unit.UUID, appUUIDs []application.UUID) (relation.RelationUnitsChange, error)
 
 	// GetRelationUnit retrieves the UUID of a relation unit based on the given
 	// relation UUID and unit name.
@@ -190,7 +190,7 @@ func (s *LeadershipService) GetRelationApplicationSettingsWithLeader(
 	ctx context.Context,
 	unitName unit.Name,
 	relationUUID corerelation.UUID,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) (map[string]string, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -309,7 +309,7 @@ func (s *Service) AddRelation(ctx context.Context, ep1, ep2 string) (relation.En
 //     not found.
 func (s *Service) ApplicationRelationsInfo(
 	ctx context.Context,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) ([]relation.EndpointRelationData, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -401,7 +401,7 @@ func (s *Service) GetAllRelationDetails(ctx context.Context) ([]relation.Relatio
 //     UUID is not valid.
 func (s *Service) GetGoalStateRelationDataForApplication(
 	ctx context.Context,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) ([]relation.GoalStateRelationData, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -537,7 +537,7 @@ func (s *Service) getRelationUnitByID(
 // GetRelationUnitChanges validates the given unit and application UUIDs,
 // and retrieves related unit changes.
 // If any UUID is invalid, an appropriate error is returned.
-func (s *Service) GetRelationUnitChanges(ctx context.Context, unitUUIDs []unit.UUID, appUUIDs []application.ID) (relation.RelationUnitsChange, error) {
+func (s *Service) GetRelationUnitChanges(ctx context.Context, unitUUIDs []unit.UUID, appUUIDs []application.UUID) (relation.RelationUnitsChange, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -700,7 +700,7 @@ func (s *Service) inferRelationUUIDByEndpoints(ctx context.Context, ep1, ep2 str
 func (s *Service) GetRelationApplicationSettings(
 	ctx context.Context,
 	relationUUID corerelation.UUID,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) (map[string]string, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/relation/service/relation_mock_test.go
+++ b/domain/relation/service/relation_mock_test.go
@@ -42,7 +42,7 @@ func (m *MockSubordinateCreator) EXPECT() *MockSubordinateCreatorMockRecorder {
 }
 
 // CreateSubordinate mocks base method.
-func (m *MockSubordinateCreator) CreateSubordinate(arg0 context.Context, arg1 application.ID, arg2 unit.Name) error {
+func (m *MockSubordinateCreator) CreateSubordinate(arg0 context.Context, arg1 application.UUID, arg2 unit.Name) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSubordinate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -68,13 +68,13 @@ func (c *MockSubordinateCreatorCreateSubordinateCall) Return(arg0 error) *MockSu
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSubordinateCreatorCreateSubordinateCall) Do(f func(context.Context, application.ID, unit.Name) error) *MockSubordinateCreatorCreateSubordinateCall {
+func (c *MockSubordinateCreatorCreateSubordinateCall) Do(f func(context.Context, application.UUID, unit.Name) error) *MockSubordinateCreatorCreateSubordinateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSubordinateCreatorCreateSubordinateCall) DoAndReturn(f func(context.Context, application.ID, unit.Name) error) *MockSubordinateCreatorCreateSubordinateCall {
+func (c *MockSubordinateCreatorCreateSubordinateCall) DoAndReturn(f func(context.Context, application.UUID, unit.Name) error) *MockSubordinateCreatorCreateSubordinateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -446,7 +446,7 @@ func (s *relationServiceSuite) TestGetRelationUnitByIDUnitStateError(c *tc.C) {
 func (s *relationServiceSuite) TestGetRelationUnitChanges(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
-	appUUIDs := []coreapplication.ID{
+	appUUIDs := []coreapplication.UUID{
 		coreapplicationtesting.GenApplicationUUID(c),
 		coreapplicationtesting.GenApplicationUUID(c),
 	}
@@ -495,9 +495,9 @@ func (s *relationServiceSuite) TestGetRelationUnitChangesUnitUUIDNotValid(c *tc.
 func (s *relationServiceSuite) TestGetRelationUnitChangesAppUUIDNotValid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
-	appUUIDs := []coreapplication.ID{
+	appUUIDs := []coreapplication.UUID{
 		coreapplicationtesting.GenApplicationUUID(c),
-		coreapplication.ID("not-valid-uuid"),
+		coreapplication.UUID("not-valid-uuid"),
 		coreapplicationtesting.GenApplicationUUID(c),
 	}
 

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -505,7 +505,7 @@ func (s *relationServiceSuite) TestGetRelationUnitChangesAppUUIDNotValid(c *tc.C
 	_, err := s.service.GetRelationUnitChanges(c.Context(), nil, appUUIDs)
 
 	// Assert
-	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationIDNotValid)
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationUUIDNotValid)
 }
 
 func (s *relationServiceSuite) TestGetRelationUnitChangesUnitStateError(c *tc.C) {
@@ -731,7 +731,7 @@ func (s *relationServiceSuite) TestGetRelationApplicationSettingsApplicationIDNo
 	_, err := s.service.GetRelationApplicationSettings(c.Context(), relationUUID, "bad-uuid")
 
 	// Assert:
-	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationIDNotValid)
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationUUIDNotValid)
 }
 
 func (s *relationServiceSuite) TestGetRelationApplicationSettingsRelationUUIDNotValid(c *tc.C) {
@@ -754,7 +754,7 @@ func (s *relationServiceSuite) TestApplicationRelationsInfoApplicationUUIDNotVal
 	_, err := s.service.ApplicationRelationsInfo(c.Context(), "bad-uuid")
 
 	// Assert.
-	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationIDNotValid)
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationUUIDNotValid)
 }
 
 func (s *relationServiceSuite) TestGetGoalStateRelationDataForApplication(c *tc.C) {
@@ -783,7 +783,7 @@ func (s *relationServiceSuite) TestGetGoalStateRelationDataForApplicationNotVali
 	_, err := s.service.GetGoalStateRelationDataForApplication(c.Context(), "bad-uuid")
 
 	// Assert:
-	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationIDNotValid)
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationUUIDNotValid)
 }
 
 func (s *relationServiceSuite) TestGetGoalStateRelationDataForApplicationError(c *tc.C) {
@@ -1060,7 +1060,7 @@ func (s *relationLeadershipServiceSuite) TestGetRelationApplicationSettingsWithL
 	_, err := s.leadershipService.GetRelationApplicationSettingsWithLeader(c.Context(), unitName, relationUUID, "bad-uuid")
 
 	// Assert:
-	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationIDNotValid)
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationUUIDNotValid)
 }
 
 func (s *relationLeadershipServiceSuite) TestGetRelationApplicationSettingsWithLeaderRelationUUIDNotValid(c *tc.C) {

--- a/domain/relation/service/watcher.go
+++ b/domain/relation/service/watcher.go
@@ -223,7 +223,7 @@ type lifeSuspendedStatusWatcher struct {
 	// appID is the application ID of the application whose relations are
 	// being watched for life and being suspended. It is a subordinate
 	// application.
-	appID application.ID
+	appID application.UUID
 	// currentRelations holds the life and suspended status of each relation
 	// being watched, to check if the values have changed when the Mapper is
 	// triggered.
@@ -362,7 +362,7 @@ type principalLifeSuspendedStatusWatcher struct {
 	lifeSuspendedStatusWatcher
 }
 
-func newPrincipalLifeSuspendedStatusWatcher(s *WatchableService, appID application.ID) namespaceMapper {
+func newPrincipalLifeSuspendedStatusWatcher(s *WatchableService, appID application.UUID) namespaceMapper {
 	w := &principalLifeSuspendedStatusWatcher{}
 	w.lifeSuspendedStatusWatcher = lifeSuspendedStatusWatcher{
 		s:                s,
@@ -421,10 +421,10 @@ type subordinateLifeSuspendedStatusWatcher struct {
 
 	// parentAppID is the application ID of the parent or principal application
 	// of the appID.
-	parentAppID application.ID
+	parentAppID application.UUID
 }
 
-func newSubordinateLifeSuspendedStatusWatcher(s *WatchableService, subordinateID, principalID application.ID) namespaceMapper {
+func newSubordinateLifeSuspendedStatusWatcher(s *WatchableService, subordinateID, principalID application.UUID) namespaceMapper {
 	w := &subordinateLifeSuspendedStatusWatcher{
 		parentAppID: principalID,
 	}

--- a/domain/relation/service/watcher.go
+++ b/domain/relation/service/watcher.go
@@ -562,6 +562,6 @@ func (s *WatchableService) WatchRelatedUnits(
 
 // WatchRelationUnits returns a watcher for changes to the units
 // in the given relation in the local model.
-func (s *WatchableService) WatchRelationUnits(context.Context, application.ID) (watcher.NotifyWatcher, error) {
+func (s *WatchableService) WatchRelationUnits(context.Context, application.UUID) (watcher.NotifyWatcher, error) {
 	return nil, errors.Errorf("WatchRelationUnits").Add(coreerrors.NotImplemented)
 }

--- a/domain/relation/service/watcher_test.go
+++ b/domain/relation/service/watcher_test.go
@@ -273,7 +273,7 @@ func (s *watcherSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 func (s *watcherSuite) expectGetRelationEndpointScope(
 	uuid corerelation.UUID,
-	id coreapplication.ID,
+	id coreapplication.UUID,
 	scope charm.RelationScope,
 	err error,
 ) {
@@ -282,7 +282,7 @@ func (s *watcherSuite) expectGetRelationEndpointScope(
 
 func (s *watcherSuite) expectGetOtherRelatedEndpointApplicationData(
 	relUUID corerelation.UUID,
-	id coreapplication.ID,
+	id coreapplication.UUID,
 	data relation.OtherApplicationForWatcher,
 	err error,
 ) {
@@ -298,14 +298,14 @@ func (s *watcherSuite) expectChanged(ctrl *gomock.Controller, uuid corerelation.
 
 func (s *watcherSuite) expectGetMapperDataForWatchLifeSuspendedStatus(
 	relUUID corerelation.UUID,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	data relation.RelationLifeSuspendedData,
 	err error,
 ) {
 	s.state.EXPECT().GetMapperDataForWatchLifeSuspendedStatus(gomock.Any(), relUUID, appID).Return(data, err)
 }
 
-func (s *watcherSuite) getSubordinateWatcher(principalID coreapplication.ID, subordinateID coreapplication.ID) *subordinateLifeSuspendedStatusWatcher {
+func (s *watcherSuite) getSubordinateWatcher(principalID coreapplication.UUID, subordinateID coreapplication.UUID) *subordinateLifeSuspendedStatusWatcher {
 	w := &subordinateLifeSuspendedStatusWatcher{
 		parentAppID: principalID,
 	}

--- a/domain/relation/state/migration.go
+++ b/domain/relation/state/migration.go
@@ -73,13 +73,13 @@ func (st *State) ImportRelation(
 // The following error types can be expected to be returned:
 //   - [applicationerrors.ApplicationNotFound] is returned if application ID
 //     doesn't refer an existing application.
-func (st *State) GetApplicationIDByName(ctx context.Context, appName string) (application.ID, error) {
+func (st *State) GetApplicationIDByName(ctx context.Context, appName string) (application.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	var id application.ID
+	var id application.UUID
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		app := applicationIDAndName{Name: appName}
 		queryApplicationStmt, err := st.Prepare(`
@@ -115,7 +115,7 @@ WHERE name = $applicationIDAndName.name
 func (st *State) SetRelationApplicationSettings(
 	ctx context.Context,
 	relationUUID corerelation.UUID,
-	applicationID application.ID,
+	applicationID application.UUID,
 	settings map[string]string,
 ) error {
 	db, err := st.DB(ctx)

--- a/domain/relation/state/migration.go
+++ b/domain/relation/state/migration.go
@@ -68,12 +68,12 @@ func (st *State) ImportRelation(
 	return relUUID, errors.Capture(err)
 }
 
-// GetApplicationIDByName returns the application ID of the given application.
+// GetApplicationUUIDByName returns the application ID of the given application.
 //
 // The following error types can be expected to be returned:
 //   - [applicationerrors.ApplicationNotFound] is returned if application ID
 //     doesn't refer an existing application.
-func (st *State) GetApplicationIDByName(ctx context.Context, appName string) (application.UUID, error) {
+func (st *State) GetApplicationUUIDByName(ctx context.Context, appName string) (application.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)

--- a/domain/relation/state/migration.go
+++ b/domain/relation/state/migration.go
@@ -68,10 +68,10 @@ func (st *State) ImportRelation(
 	return relUUID, errors.Capture(err)
 }
 
-// GetApplicationUUIDByName returns the application ID of the given application.
+// GetApplicationUUIDByName returns the application UUID of the given application.
 //
 // The following error types can be expected to be returned:
-//   - [applicationerrors.ApplicationNotFound] is returned if application ID
+//   - [applicationerrors.ApplicationNotFound] is returned if application UUID
 //     doesn't refer an existing application.
 func (st *State) GetApplicationUUIDByName(ctx context.Context, appName string) (application.UUID, error) {
 	db, err := st.DB(ctx)
@@ -81,11 +81,11 @@ func (st *State) GetApplicationUUIDByName(ctx context.Context, appName string) (
 
 	var id application.UUID
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		app := applicationIDAndName{Name: appName}
+		app := applicationUUIDAndName{Name: appName}
 		queryApplicationStmt, err := st.Prepare(`
-SELECT uuid AS &applicationIDAndName.uuid
+SELECT uuid AS &applicationUUIDAndName.uuid
 FROM application
-WHERE name = $applicationIDAndName.name
+WHERE name = $applicationUUIDAndName.name
 `, app)
 		if err != nil {
 			return errors.Capture(err)

--- a/domain/relation/state/migration_test.go
+++ b/domain/relation/state/migration_test.go
@@ -93,14 +93,14 @@ func (s *migrationSuite) TestImportRelation(c *tc.C) {
 	c.Assert(obtainedRelUUID, tc.Equals, foundRelUUID)
 }
 
-func (s *migrationSuite) TestGetApplicationIDByName(c *tc.C) {
-	obtainedID, err := s.state.GetApplicationIDByName(c.Context(), s.fakeApplicationName1)
+func (s *migrationSuite) TestGetApplicationUUIDByName(c *tc.C) {
+	obtainedID, err := s.state.GetApplicationUUIDByName(c.Context(), s.fakeApplicationName1)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtainedID, tc.Equals, s.fakeApplicationUUID1)
 }
 
-func (s *migrationSuite) TestGetApplicationIDByNameNotFound(c *tc.C) {
-	_, err := s.state.GetApplicationIDByName(c.Context(), "foo")
+func (s *migrationSuite) TestGetApplicationUUIDByNameNotFound(c *tc.C) {
+	_, err := s.state.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 

--- a/domain/relation/state/migration_test.go
+++ b/domain/relation/state/migration_test.go
@@ -31,8 +31,8 @@ type migrationSuite struct {
 
 	fakeCharmUUID1       corecharm.ID
 	fakeCharmUUID2       corecharm.ID
-	fakeApplicationUUID1 coreapplication.ID
-	fakeApplicationUUID2 coreapplication.ID
+	fakeApplicationUUID1 coreapplication.UUID
+	fakeApplicationUUID2 coreapplication.UUID
 	fakeApplicationName1 string
 	fakeApplicationName2 string
 }
@@ -582,7 +582,7 @@ func (s *migrationSuite) TestExportRelations(c *tc.C) {
 // endpoint based on the provided relation.
 func (s *migrationSuite) addApplicationEndpointFromRelation(c *tc.C,
 	charmUUID corecharm.ID,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	relation charm.Relation) corerelation.EndpointUUID {
 
 	// todo(gfouillet) introduce proper generation for this uuid

--- a/domain/relation/state/package_test.go
+++ b/domain/relation/state/package_test.go
@@ -308,7 +308,7 @@ VALUES (?,?,?)
 }
 
 // addRelationApplicationSetting inserts a relation application setting into the database
-// using the provided relation and application ID.
+// using the provided relation and application UUID.
 func (s *baseRelationSuite) addRelationApplicationSetting(c *tc.C, relationEndpointUUID, key, value string) {
 	s.query(c, `
 INSERT INTO relation_application_setting (relation_endpoint_uuid, key, value)

--- a/domain/relation/state/package_test.go
+++ b/domain/relation/state/package_test.go
@@ -74,7 +74,7 @@ func (s *baseRelationSuite) query(c *tc.C, query string, args ...any) {
 
 // addApplication adds a new application to the database with the specified
 // charm UUID and application name. It returns the application UUID.
-func (s *baseRelationSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appName string) coreapplication.ID {
+func (s *baseRelationSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appName string) coreapplication.UUID {
 	appUUID := coreapplicationtesting.GenApplicationUUID(c)
 	s.query(c, `
 INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) 
@@ -85,7 +85,7 @@ VALUES (?, ?, ?, ?, ?)
 
 // addApplicationEndpoint inserts a new application endpoint into the database
 // with the specified UUIDs. Returns the endpoint uuid.
-func (s *baseRelationSuite) addApplicationEndpoint(c *tc.C, applicationUUID coreapplication.ID,
+func (s *baseRelationSuite) addApplicationEndpoint(c *tc.C, applicationUUID coreapplication.UUID,
 	charmRelationUUID string) string {
 	// TODO(gfouillet): introduce proper UUID for this one, from corerelation & corerelationtesting
 	applicationEndpointUUID := uuid.MustNewUUID().String()
@@ -318,7 +318,7 @@ VALUES (?,?,?)
 
 // addUnit adds a new unit to the specified application in the database with
 // the given UUID and name. Returns the unit uuid.
-func (s *baseRelationSuite) addUnit(c *tc.C, unitName coreunit.Name, appUUID coreapplication.ID, charmUUID corecharm.ID) coreunit.UUID {
+func (s *baseRelationSuite) addUnit(c *tc.C, unitName coreunit.Name, appUUID coreapplication.UUID, charmUUID corecharm.ID) coreunit.UUID {
 	unitUUID := coreunittesting.GenUnitUUID(c)
 	netNodeUUID := uuid.MustNewUUID().String()
 	s.query(c, `
@@ -336,7 +336,7 @@ VALUES (?, ?, ?, ?, ?, ?)
 
 // addUnitWithLife adds a new unit to the specified application in the database with
 // the given UUID, name and life. Returns the unit uuid.
-func (s *baseRelationSuite) addUnitWithLife(c *tc.C, unitName coreunit.Name, appUUID coreapplication.ID,
+func (s *baseRelationSuite) addUnitWithLife(c *tc.C, unitName coreunit.Name, appUUID coreapplication.UUID,
 	charmUUID corecharm.ID, life corelife.Value) coreunit.UUID {
 	unitUUID := coreunittesting.GenUnitUUID(c)
 	netNodeUUID := uuid.MustNewUUID().String()

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -40,7 +40,7 @@ import (
 type addRelationSuite struct {
 	baseRelationSuite
 
-	// charmByApp maps application IDs to their associated charm IDs for quick
+	// charmByApp maps application UUIDs to their associated charm IDs for quick
 	// lookup during tests.
 	charmByApp map[coreapplication.UUID]corecharm.ID
 }
@@ -809,7 +809,7 @@ func (s *relationSuite) TestGetRelationEndpointUUID(c *tc.C) {
 
 	// Act: get the relation endpoint UUID.
 	uuid, err := s.state.GetRelationEndpointUUID(c.Context(), domainrelation.GetRelationEndpointUUIDArgs{
-		ApplicationID: s.fakeApplicationUUID1,
+		ApplicationUUID: s.fakeApplicationUUID1,
 		RelationUUID:  relationUUID,
 	})
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", errors.ErrorStack(err)))
@@ -826,7 +826,7 @@ func (s *relationSuite) TestGetRelationEndpointUUIDRelationNotFound(c *tc.C) {
 
 	// Act: get a relation.
 	_, err := s.state.GetRelationEndpointUUID(c.Context(), domainrelation.GetRelationEndpointUUIDArgs{
-		ApplicationID: s.fakeApplicationUUID1,
+		ApplicationUUID: s.fakeApplicationUUID1,
 		RelationUUID:  "not-found-relation-uuid",
 	})
 
@@ -835,14 +835,14 @@ func (s *relationSuite) TestGetRelationEndpointUUIDRelationNotFound(c *tc.C) {
 }
 
 // TestGetRelationEndpointUUIDApplicationNotFound verifies that attempting to
-// fetch a relation endpoint UUID with a non-existent application ID returns
+// fetch a relation endpoint UUID with a non-existent application UUID returns
 // the ApplicationNotFound error.
 func (s *relationSuite) TestGetRelationEndpointUUIDApplicationNotFound(c *tc.C) {
 	// Arrange: nothing to do, will fail on application fetch anyway.
 
 	// Act: get a relation.
 	_, err := s.state.GetRelationEndpointUUID(c.Context(), domainrelation.GetRelationEndpointUUIDArgs{
-		ApplicationID: "not-found-application-uuid ",
+		ApplicationUUID: "not-found-application-uuid ",
 		RelationUUID:  "not-used-uuid",
 	})
 
@@ -860,7 +860,7 @@ func (s *relationSuite) TestGetRelationEndpointUUIDRelationEndPointNotFound(c *t
 
 	// Act: get a relation.
 	_, err := s.state.GetRelationEndpointUUID(c.Context(), domainrelation.GetRelationEndpointUUIDArgs{
-		ApplicationID: s.fakeApplicationUUID1,
+		ApplicationUUID: s.fakeApplicationUUID1,
 		RelationUUID:  relationUUID,
 	})
 
@@ -2212,7 +2212,7 @@ func (s *relationSuite) TestGetRelationUnitChangesEmptyArgs(c *tc.C) {
 	})
 }
 
-func (s *relationSuite) TestGetPrincipalSubordinateApplicationIDs(c *tc.C) {
+func (s *relationSuite) TestGetPrincipalSubordinateApplicationUUIDs(c *tc.C) {
 	// Arrange: Populate charm metadata with subordinate data.
 	subordinateCharm := s.fakeCharmUUID1
 	subordinateAppUUID := s.fakeApplicationUUID1
@@ -2229,7 +2229,7 @@ func (s *relationSuite) TestGetPrincipalSubordinateApplicationIDs(c *tc.C) {
 	s.setUnitSubordinate(c, subordinateUnitUUID, principalUnitUUID)
 
 	// Act
-	obtainedPrincipal, obtainedSubordinate, err := s.state.GetPrincipalSubordinateApplicationIDs(
+	obtainedPrincipal, obtainedSubordinate, err := s.state.GetPrincipalSubordinateApplicationUUIDs(
 		c.Context(), subordinateUnitUUID)
 
 	// Assert
@@ -2238,7 +2238,7 @@ func (s *relationSuite) TestGetPrincipalSubordinateApplicationIDs(c *tc.C) {
 	c.Check(obtainedSubordinate, tc.Equals, subordinateAppUUID)
 }
 
-func (s *relationSuite) TestGetPrincipalSubordinateApplicationIDsPrincipalOnly(c *tc.C) {
+func (s *relationSuite) TestGetPrincipalSubordinateApplicationUUIDsPrincipalOnly(c *tc.C) {
 	// Arrange: Populate charm metadata with subordinate data.
 	principalCharm := s.fakeCharmUUID1
 	principalAppUUID := s.fakeApplicationUUID2
@@ -2249,7 +2249,7 @@ func (s *relationSuite) TestGetPrincipalSubordinateApplicationIDsPrincipalOnly(c
 	principalUnitUUID := s.addUnit(c, principalUnitName, principalAppUUID, principalCharm)
 
 	// Act
-	obtainedPrincipal, obtainedSubordinate, err := s.state.GetPrincipalSubordinateApplicationIDs(
+	obtainedPrincipal, obtainedSubordinate, err := s.state.GetPrincipalSubordinateApplicationUUIDs(
 		c.Context(), principalUnitUUID)
 
 	// Assert

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -810,7 +810,7 @@ func (s *relationSuite) TestGetRelationEndpointUUID(c *tc.C) {
 	// Act: get the relation endpoint UUID.
 	uuid, err := s.state.GetRelationEndpointUUID(c.Context(), domainrelation.GetRelationEndpointUUIDArgs{
 		ApplicationUUID: s.fakeApplicationUUID1,
-		RelationUUID:  relationUUID,
+		RelationUUID:    relationUUID,
 	})
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) unexpected error: %v", errors.ErrorStack(err)))
 
@@ -827,7 +827,7 @@ func (s *relationSuite) TestGetRelationEndpointUUIDRelationNotFound(c *tc.C) {
 	// Act: get a relation.
 	_, err := s.state.GetRelationEndpointUUID(c.Context(), domainrelation.GetRelationEndpointUUIDArgs{
 		ApplicationUUID: s.fakeApplicationUUID1,
-		RelationUUID:  "not-found-relation-uuid",
+		RelationUUID:    "not-found-relation-uuid",
 	})
 
 	// Assert: check that RelationNotFound is returned.
@@ -843,7 +843,7 @@ func (s *relationSuite) TestGetRelationEndpointUUIDApplicationNotFound(c *tc.C) 
 	// Act: get a relation.
 	_, err := s.state.GetRelationEndpointUUID(c.Context(), domainrelation.GetRelationEndpointUUIDArgs{
 		ApplicationUUID: "not-found-application-uuid ",
-		RelationUUID:  "not-used-uuid",
+		RelationUUID:    "not-used-uuid",
 	})
 
 	// Assert: check that ApplicationNotFound is returned.
@@ -861,7 +861,7 @@ func (s *relationSuite) TestGetRelationEndpointUUIDRelationEndPointNotFound(c *t
 	// Act: get a relation.
 	_, err := s.state.GetRelationEndpointUUID(c.Context(), domainrelation.GetRelationEndpointUUIDArgs{
 		ApplicationUUID: s.fakeApplicationUUID1,
-		RelationUUID:  relationUUID,
+		RelationUUID:    relationUUID,
 	})
 
 	// Assert: check that ApplicationNotFound is returned.

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -42,7 +42,7 @@ type addRelationSuite struct {
 
 	// charmByApp maps application IDs to their associated charm IDs for quick
 	// lookup during tests.
-	charmByApp map[coreapplication.ID]corecharm.ID
+	charmByApp map[coreapplication.UUID]corecharm.ID
 }
 
 func TestAddRelationSuite(t *testing.T) {
@@ -51,7 +51,7 @@ func TestAddRelationSuite(t *testing.T) {
 
 func (s *addRelationSuite) SetUpTest(c *tc.C) {
 	s.baseRelationSuite.SetUpTest(c)
-	s.charmByApp = make(map[coreapplication.ID]corecharm.ID)
+	s.charmByApp = make(map[coreapplication.UUID]corecharm.ID)
 }
 
 func (s *addRelationSuite) TestAddRelation(c *tc.C) {
@@ -664,7 +664,7 @@ func (s *addRelationSuite) TestInferEndpointsError(c *tc.C) {
 func (s *addRelationSuite) addApplication(
 	c *tc.C,
 	applicationName string,
-) coreapplication.ID {
+) coreapplication.UUID {
 	charmUUID := s.addCharm(c)
 	s.addCharmMetadata(c, charmUUID, false)
 	appUUID := s.baseRelationSuite.addApplication(c, charmUUID, applicationName)
@@ -677,7 +677,7 @@ func (s *addRelationSuite) addApplication(
 // Os is defaulted to ubuntu and architecture to AMD64 (db zero-values)
 func (s *addRelationSuite) addApplicationPlatform(
 	c *tc.C,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	channel corebase.Channel,
 ) {
 	s.query(c, `
@@ -691,7 +691,7 @@ VALUES (?, 0, ?, 0)`, appUUID, channel.String())
 func (s *addRelationSuite) addSubordinateApplication(
 	c *tc.C,
 	applicationName string,
-) coreapplication.ID {
+) coreapplication.UUID {
 	charmUUID := s.addCharm(c)
 	s.addCharmMetadata(c, charmUUID, true)
 	appUUID := s.baseRelationSuite.addApplication(c, charmUUID, applicationName)
@@ -703,7 +703,7 @@ func (s *addRelationSuite) addSubordinateApplication(
 // attributes and returns its unique identifier.
 func (s *addRelationSuite) addApplicationEndpoint(
 	c *tc.C,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	name string,
 	role charm.RelationRole,
 	relInterface string) corerelation.EndpointUUID {
@@ -719,7 +719,7 @@ func (s *addRelationSuite) addApplicationEndpoint(
 // addApplicationEndpointFromRelation creates and associates a new application
 // endpoint based on the provided relation.
 func (s *addRelationSuite) addApplicationEndpointFromRelation(c *tc.C,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	relation charm.Relation) corerelation.EndpointUUID {
 
 	// Generate and get required UUIDs
@@ -752,8 +752,8 @@ type relationSuite struct {
 
 	fakeCharmUUID1                corecharm.ID
 	fakeCharmUUID2                corecharm.ID
-	fakeApplicationUUID1          coreapplication.ID
-	fakeApplicationUUID2          coreapplication.ID
+	fakeApplicationUUID1          coreapplication.UUID
+	fakeApplicationUUID2          coreapplication.UUID
 	fakeApplicationName1          string
 	fakeApplicationName2          string
 	fakeCharmRelationProvidesUUID string
@@ -2172,7 +2172,7 @@ func (s *relationSuite) TestGetRelationUnitChanges(c *tc.C) {
 	err = db.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		changes, err = s.state.GetRelationUnitChanges(ctx,
 			[]coreunit.UUID{noSettingUnitUUID, withSettingUnitUUID, departedUnitUUID},
-			[]coreapplication.ID{noSettingAppUUID, withSettingAppUUID},
+			[]coreapplication.UUID{noSettingAppUUID, withSettingAppUUID},
 		)
 		return err
 	})
@@ -3707,7 +3707,7 @@ func (s *relationSuite) doesRelationUnitExist(c *tc.C, relationUnitUUID string) 
 	return s.doesUUIDExist(c, "relation_unit", relationUnitUUID)
 }
 
-func (s *relationSuite) addContainerScopedRelation(c *tc.C, app1ID, app2ID coreapplication.ID) (corerelation.UUID, string, string) {
+func (s *relationSuite) addContainerScopedRelation(c *tc.C, app1ID, app2ID coreapplication.UUID) (corerelation.UUID, string, string) {
 	// Arrange: Add two endpoints
 	endpoint1 := charm.Relation{
 		Name:      "fake-endpoint-name-1",
@@ -3732,7 +3732,7 @@ func (s *relationSuite) addContainerScopedRelation(c *tc.C, app1ID, app2ID corea
 	return relationUUID, relationEndpointUUID1, relationEndpointUUID2
 }
 
-func (s *relationSuite) addGlobalScopedRelation(c *tc.C, app1ID, app2ID coreapplication.ID) (corerelation.UUID, string, string) {
+func (s *relationSuite) addGlobalScopedRelation(c *tc.C, app1ID, app2ID coreapplication.UUID) (corerelation.UUID, string, string) {
 	// Arrange: Add two endpoints
 	endpoint1 := charm.Relation{
 		Name:      "fake-endpoint-name-1",
@@ -3757,7 +3757,7 @@ func (s *relationSuite) addGlobalScopedRelation(c *tc.C, app1ID, app2ID coreappl
 	return relationUUID, relationEndpointUUID1, relationEndpointUUID2
 }
 
-func (s *relationSuite) addPeerRelation(c *tc.C, charmUUID corecharm.ID, appUUID coreapplication.ID) (corerelation.UUID, string) {
+func (s *relationSuite) addPeerRelation(c *tc.C, charmUUID corecharm.ID, appUUID coreapplication.UUID) (corerelation.UUID, string) {
 	endpoint1 := charm.Relation{
 		Name:      "fake-endpoint-name-1",
 		Role:      charm.RoleProvider,

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -29,7 +29,7 @@ type entityUUID struct {
 
 // applicationID is used to get the ID of an application.
 type applicationID struct {
-	ID application.ID `db:"uuid"`
+	ID application.UUID `db:"uuid"`
 }
 
 type relationUUID struct {
@@ -37,7 +37,7 @@ type relationUUID struct {
 }
 
 type applicationUUID struct {
-	UUID application.ID `db:"application_uuid"`
+	UUID application.UUID `db:"application_uuid"`
 }
 
 type relation struct {
@@ -115,12 +115,12 @@ type getLife struct {
 }
 
 type getUnitApp struct {
-	ApplicationUUID application.ID `db:"application_uuid"`
-	UnitUUID        string         `db:"uuid"`
+	ApplicationUUID application.UUID `db:"application_uuid"`
+	UnitUUID        string           `db:"uuid"`
 }
 
 type getUnitRelAndApp struct {
-	ApplicationUUID  application.ID        `db:"application_uuid"`
+	ApplicationUUID  application.UUID      `db:"application_uuid"`
 	RelationUnitUUID corerelation.UnitUUID `db:"uuid"`
 	RelationUUID     corerelation.UUID     `db:"relation_uuid"`
 }
@@ -130,19 +130,19 @@ type scope struct {
 }
 
 type getSubordinate struct {
-	ApplicationUUID application.ID `db:"application_uuid"`
-	Subordinate     bool           `db:"subordinate"`
+	ApplicationUUID application.UUID `db:"application_uuid"`
+	Subordinate     bool             `db:"subordinate"`
 }
 
 // getPrincipal is used to get the principal application of a unit.
 type getPrincipal struct {
-	UnitUUID        string         `db:"unit_uuid"`
-	ApplicationUUID application.ID `db:"application_uuid"`
+	UnitUUID        string           `db:"unit_uuid"`
+	ApplicationUUID application.UUID `db:"application_uuid"`
 }
 
 type relationAndApplicationUUID struct {
 	RelationUUID  corerelation.UUID `db:"relation_uuid"`
-	ApplicationID application.ID    `db:"application_uuid"`
+	ApplicationID application.UUID  `db:"application_uuid"`
 }
 
 type relationSetting struct {
@@ -250,7 +250,7 @@ type Endpoint struct {
 	ApplicationName string `db:"application_name"`
 	// ApplicationUUID is a unique identifier for the application associated
 	// with the endpoint.
-	ApplicationUUID application.ID `db:"application_uuid"`
+	ApplicationUUID application.UUID `db:"application_uuid"`
 }
 
 // String returns a formatted string representation combining
@@ -305,8 +305,8 @@ type setRelationStatus struct {
 // otherApplicationsForWatcher contains data required by
 // WatchLifeSuspendedStatus watchers.
 type otherApplicationsForWatcher struct {
-	AppID       application.ID `db:"application_uuid"`
-	Subordinate bool           `db:"subordinate"`
+	AppID       application.UUID `db:"application_uuid"`
+	Subordinate bool             `db:"subordinate"`
 }
 
 type watcherMapperData struct {
@@ -318,8 +318,8 @@ type watcherMapperData struct {
 
 // applicationIDAndName is used to get the ID and name of an application.
 type applicationIDAndName struct {
-	ID   application.ID `db:"uuid"`
-	Name string         `db:"name"`
+	ID   application.UUID `db:"uuid"`
+	Name string           `db:"name"`
 }
 
 // rows is used to count the number of rows found.

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -27,11 +27,6 @@ type entityUUID struct {
 	UUID string `db:"uuid"`
 }
 
-// applicationID is used to get the ID of an application.
-type applicationID struct {
-	ID application.UUID `db:"uuid"`
-}
-
 type relationUUID struct {
 	UUID corerelation.UUID `db:"uuid"`
 }
@@ -316,8 +311,8 @@ type watcherMapperData struct {
 	Suspended    string `db:"name"`
 }
 
-// applicationIDAndName is used to get the ID and name of an application.
-type applicationIDAndName struct {
+// applicationUUIDAndName is used to get the UUID and name of an application.
+type applicationUUIDAndName struct {
 	ID   application.UUID `db:"uuid"`
 	Name string           `db:"name"`
 }

--- a/domain/relation/types.go
+++ b/domain/relation/types.go
@@ -30,7 +30,7 @@ const SequenceNamespace = sequence.StaticNamespace("relation")
 type GetRelationEndpointUUIDArgs struct {
 	// ApplicationID identifies the unique identifier of the application
 	// associated with the expected endpoint.
-	ApplicationID application.ID
+	ApplicationID application.UUID
 
 	// RelationUUID represents the unique identifier for the relation associated
 	// with the expected endpoint.
@@ -225,7 +225,7 @@ func (ep Endpoint) EndpointIdentifier() corerelation.EndpointIdentifier {
 // the PrincipalLifeSuspendedStatus watcher on other endpoints in a
 // relation.
 type OtherApplicationForWatcher struct {
-	ApplicationID application.ID
+	ApplicationID application.UUID
 	Subordinate   bool
 }
 
@@ -258,7 +258,7 @@ type RelationUnitsChange struct {
 type SubordinateCreator interface {
 	// CreateSubordinate is the signature of the function used to create units on a
 	// subordinate application.
-	CreateSubordinate(ctx context.Context, subordinateAppID application.ID, principalUnitName unit.Name) error
+	CreateSubordinate(ctx context.Context, subordinateAppID application.UUID, principalUnitName unit.Name) error
 }
 
 // GoalStateRelationData contains the necessary data from the relation

--- a/domain/relation/types.go
+++ b/domain/relation/types.go
@@ -28,9 +28,9 @@ const SequenceNamespace = sequence.StaticNamespace("relation")
 // GetRelationEndpointUUIDArgs represents the arguments required to retrieve
 // the UUID of a relation endpoint.
 type GetRelationEndpointUUIDArgs struct {
-	// ApplicationID identifies the unique identifier of the application
+	// ApplicationUUID identifies the unique identifier of the application
 	// associated with the expected endpoint.
-	ApplicationID application.UUID
+	ApplicationUUID application.UUID
 
 	// RelationUUID represents the unique identifier for the relation associated
 	// with the expected endpoint.

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -43,7 +43,7 @@ type watcherSuite struct {
 
 	charmUUID         corecharm.ID
 	charmRelationUUID uuid.UUID
-	appUUID           coreapplication.ID
+	appUUID           coreapplication.UUID
 	appEndpointUUID   uuid.UUID
 	appName           string
 	// helps generation of consecutive relation_id
@@ -386,7 +386,7 @@ func (s *watcherSuite) TestWatchApplicationLifeSuspendedStatusPrincipal(c *tc.C)
 
 func (s *watcherSuite) setupSecondAppAndRelate(
 	c *tc.C, appNameTwo string,
-) (relation.UUID, coreapplication.ID, corecharm.ID) {
+) (relation.UUID, coreapplication.UUID, corecharm.ID) {
 	relationUUID := relationtesting.GenRelationUUID(c)
 	relationEndpointUUID := relationtesting.GenEndpointUUID(c)
 
@@ -656,7 +656,7 @@ type testWatchRelationUnit struct {
 	relationUUID                           relation.UUID
 	other0UUID, watched0UUID, watched1UUID coreunit.UUID
 	otherRelationUUID, watchedRelationUUID relation.EndpointUUID
-	otherUUID                              coreapplication.ID
+	otherUUID                              coreapplication.UUID
 	initialEvents                          []coreunit.UUID
 }
 
@@ -708,7 +708,7 @@ type testWatchPeerRelationUnit struct {
 	relationUUID               relation.UUID
 	watched0UUID, watched1UUID coreunit.UUID
 	watchedRelationUUID        relation.EndpointUUID
-	watchedUUID                coreapplication.ID
+	watchedUUID                coreapplication.UUID
 	initialEvents              []coreunit.UUID
 }
 
@@ -776,7 +776,7 @@ VALUES (?,?)
 
 // addApplication adds a new application to the database with the specified UUID
 // and name.
-func (s *watcherSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appUUID coreapplication.ID, appName string) {
+func (s *watcherSuite) addApplication(c *tc.C, charmUUID corecharm.ID, appUUID coreapplication.UUID, appName string) {
 	s.arrange(c, `
 INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) 
 VALUES (?, ?, ?, ?, ?)
@@ -785,7 +785,7 @@ VALUES (?, ?, ?, ?, ?)
 
 // addApplicationEndpoint inserts a new application endpoint into the database
 // with the specified UUIDs and relation data.
-func (s *watcherSuite) addApplicationEndpoint(c *tc.C, applicationEndpointUUID uuid.UUID, applicationUUID coreapplication.ID, charmRelationUUID uuid.UUID) {
+func (s *watcherSuite) addApplicationEndpoint(c *tc.C, applicationEndpointUUID uuid.UUID, applicationUUID coreapplication.UUID, charmRelationUUID uuid.UUID) {
 	s.arrange(c, `
 INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid,space_uuid)
 VALUES (?, ?, ?, ?)
@@ -847,7 +847,7 @@ func (s *watcherSuite) addUnit(
 	c *tc.C,
 	unitUUID coreunit.UUID,
 	unitName coreunit.Name,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	charmUUID corecharm.ID,
 ) {
 	fakeNetNodeUUID := "fake-net-node-uuid"

--- a/domain/removal/service/application.go
+++ b/domain/removal/service/application.go
@@ -59,7 +59,7 @@ type ApplicationState interface {
 // The UUID for the scheduled removal job is returned.
 func (s *Service) RemoveApplication(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 	destroyStorage bool,
 	force bool,
 	wait time.Duration,
@@ -132,7 +132,7 @@ func (s *Service) RemoveApplication(
 }
 
 func (s *Service) applicationScheduleRemoval(
-	ctx context.Context, appUUID coreapplication.ID, force bool, wait time.Duration,
+	ctx context.Context, appUUID coreapplication.UUID, force bool, wait time.Duration,
 ) (removal.UUID, error) {
 	jobUUID, err := removal.NewUUID()
 	if err != nil {

--- a/domain/removal/service/service.go
+++ b/domain/removal/service/service.go
@@ -223,7 +223,7 @@ func (s *Service) removeApplications(
 ) {
 	for _, applicationUUID := range uuids {
 		if _, err := s.RemoveApplication(
-			ctx, application.ID(applicationUUID), destroyStorage, force, wait,
+			ctx, application.UUID(applicationUUID), destroyStorage, force, wait,
 		); errors.Is(err, applicationerrors.ApplicationNotFound) {
 			// There could be a chance that the application has already been
 			// removed by another process. We can safely ignore this error and

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -746,7 +746,7 @@ func (s *applicationSuite) TestDeleteApplicationWithSharedObjectstoreResource(c 
 	c.Check(exists, tc.Equals, false)
 }
 
-func (s *applicationSuite) getAppResourceUUID(c *tc.C, appUUID coreapplication.ID) string {
+func (s *applicationSuite) getAppResourceUUID(c *tc.C, appUUID coreapplication.UUID) string {
 	row := s.DB().QueryRow(`
 SELECT uuid
 FROM application_resource ar
@@ -770,7 +770,7 @@ func (s *applicationSuite) checkMachineContents(c *tc.C, actual []string, expect
 	}))
 }
 
-func (s *applicationSuite) checkApplicationDyingState(c *tc.C, appUUID coreapplication.ID) {
+func (s *applicationSuite) checkApplicationDyingState(c *tc.C, appUUID coreapplication.UUID) {
 	row := s.DB().QueryRow("SELECT life_id FROM application where uuid = ?", appUUID.String())
 	var lifeID int
 	err := row.Scan(&lifeID)

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -222,7 +222,7 @@ func (s *baseSuite) setupRelationService(c *tc.C) *relationservice.Service {
 	)
 }
 
-func (s *baseSuite) createIAASApplication(c *tc.C, svc *applicationservice.ProviderService, name string, units ...applicationservice.AddIAASUnitArg) coreapplication.ID {
+func (s *baseSuite) createIAASApplication(c *tc.C, svc *applicationservice.ProviderService, name string, units ...applicationservice.AddIAASUnitArg) coreapplication.UUID {
 	ch := &stubCharm{name: "test-charm"}
 	appID, err := svc.CreateIAASApplication(c.Context(), name, ch, corecharm.Origin{
 		Source: corecharm.CharmHub,
@@ -250,7 +250,7 @@ func (s *baseSuite) createIAASApplication(c *tc.C, svc *applicationservice.Provi
 	return appID
 }
 
-func (s *baseSuite) createIAASSubordinateApplication(c *tc.C, svc *applicationservice.ProviderService, name string, units ...applicationservice.AddIAASUnitArg) coreapplication.ID {
+func (s *baseSuite) createIAASSubordinateApplication(c *tc.C, svc *applicationservice.ProviderService, name string, units ...applicationservice.AddIAASUnitArg) coreapplication.UUID {
 	ch := &stubCharm{name: "test-charm", subordinate: true}
 	appID, err := svc.CreateIAASApplication(c.Context(), name, ch, corecharm.Origin{
 		Source: corecharm.CharmHub,
@@ -278,7 +278,7 @@ func (s *baseSuite) createIAASSubordinateApplication(c *tc.C, svc *applicationse
 	return appID
 }
 
-func (s *baseSuite) createCAASApplication(c *tc.C, svc *applicationservice.ProviderService, name string, units ...applicationservice.AddUnitArg) coreapplication.ID {
+func (s *baseSuite) createCAASApplication(c *tc.C, svc *applicationservice.ProviderService, name string, units ...applicationservice.AddUnitArg) coreapplication.UUID {
 	ch := &stubCharm{name: "test-charm"}
 	s.createSubnetForCAASModel(c)
 	appID, err := svc.CreateCAASApplication(c.Context(), name, ch, corecharm.Origin{
@@ -341,7 +341,7 @@ func (s *baseSuite) createSubnetForCAASModel(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *baseSuite) setCharmObjectStoreMetadata(c *tc.C, appID coreapplication.ID) {
+func (s *baseSuite) setCharmObjectStoreMetadata(c *tc.C, appID coreapplication.UUID) {
 	modelDB := func(ctx context.Context) (database.TxnRunner, error) {
 		return s.ModelTxnRunner(), nil
 	}
@@ -368,7 +368,7 @@ WHERE uuid IN (
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *baseSuite) getAllUnitUUIDs(c *tc.C, appID coreapplication.ID) []unit.UUID {
+func (s *baseSuite) getAllUnitUUIDs(c *tc.C, appID coreapplication.UUID) []unit.UUID {
 	var unitUUIDs []unit.UUID
 	err := s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, `SELECT uuid FROM unit WHERE application_uuid = ? ORDER BY name`, appID)
@@ -462,7 +462,7 @@ WHERE u.uuid = ?
 	return machineUUIDs[0]
 }
 
-func (s *baseSuite) getMachineUUIDFromApp(c *tc.C, appUUID coreapplication.ID) machine.UUID {
+func (s *baseSuite) getMachineUUIDFromApp(c *tc.C, appUUID coreapplication.UUID) machine.UUID {
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
 	c.Assert(len(unitUUIDs), tc.Equals, 1)
 	unitUUID := unitUUIDs[0]
@@ -488,7 +488,7 @@ func (s *baseSuite) checkCharmsCount(c *tc.C, expectedCount int) {
 	c.Check(count, tc.Equals, expectedCount)
 }
 
-func (s *baseSuite) advanceApplicationLife(c *tc.C, appUUID coreapplication.ID, newLife life.Life) {
+func (s *baseSuite) advanceApplicationLife(c *tc.C, appUUID coreapplication.UUID, newLife life.Life) {
 	_, err := s.DB().Exec("UPDATE application SET life_id = ? WHERE uuid = ?", newLife, appUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 }

--- a/domain/resource/errors/errors.go
+++ b/domain/resource/errors/errors.go
@@ -6,9 +6,9 @@ package errors
 import "github.com/juju/juju/internal/errors"
 
 const (
-	// ApplicationIDNotValid describes an error when the application ID is
+	// ApplicationUUIDNotValid describes an error when the application UUID is
 	// not valid.
-	ApplicationIDNotValid = errors.ConstError("application ID not valid")
+	ApplicationUUIDNotValid = errors.ConstError("application UUID not valid")
 
 	// ApplicationNotFound describes an error that occurs when the application
 	// being operated on does not exist.

--- a/domain/resource/service/package_mock_test.go
+++ b/domain/resource/service/package_mock_test.go
@@ -431,41 +431,41 @@ func (c *MockStateGetResourceUUIDByApplicationAndResourceNameCall) DoAndReturn(f
 	return c
 }
 
-// GetResourcesByApplicationID mocks base method.
-func (m *MockState) GetResourcesByApplicationID(arg0 context.Context, arg1 application.UUID) ([]resource.Resource, error) {
+// GetResourcesByApplicationUUID mocks base method.
+func (m *MockState) GetResourcesByApplicationUUID(arg0 context.Context, arg1 application.UUID) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResourcesByApplicationID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetResourcesByApplicationUUID", arg0, arg1)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetResourcesByApplicationID indicates an expected call of GetResourcesByApplicationID.
-func (mr *MockStateMockRecorder) GetResourcesByApplicationID(arg0, arg1 any) *MockStateGetResourcesByApplicationIDCall {
+// GetResourcesByApplicationUUID indicates an expected call of GetResourcesByApplicationUUID.
+func (mr *MockStateMockRecorder) GetResourcesByApplicationUUID(arg0, arg1 any) *MockStateGetResourcesByApplicationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByApplicationID", reflect.TypeOf((*MockState)(nil).GetResourcesByApplicationID), arg0, arg1)
-	return &MockStateGetResourcesByApplicationIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByApplicationUUID", reflect.TypeOf((*MockState)(nil).GetResourcesByApplicationUUID), arg0, arg1)
+	return &MockStateGetResourcesByApplicationUUIDCall{Call: call}
 }
 
-// MockStateGetResourcesByApplicationIDCall wrap *gomock.Call
-type MockStateGetResourcesByApplicationIDCall struct {
+// MockStateGetResourcesByApplicationUUIDCall wrap *gomock.Call
+type MockStateGetResourcesByApplicationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetResourcesByApplicationIDCall) Return(arg0 []resource.Resource, arg1 error) *MockStateGetResourcesByApplicationIDCall {
+func (c *MockStateGetResourcesByApplicationUUIDCall) Return(arg0 []resource.Resource, arg1 error) *MockStateGetResourcesByApplicationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetResourcesByApplicationIDCall) Do(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockStateGetResourcesByApplicationIDCall {
+func (c *MockStateGetResourcesByApplicationUUIDCall) Do(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockStateGetResourcesByApplicationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetResourcesByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockStateGetResourcesByApplicationIDCall {
+func (c *MockStateGetResourcesByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockStateGetResourcesByApplicationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/resource/service/package_mock_test.go
+++ b/domain/resource/service/package_mock_test.go
@@ -85,7 +85,7 @@ func (c *MockStateAddResourcesBeforeApplicationCall) DoAndReturn(f func(context.
 }
 
 // DeleteApplicationResources mocks base method.
-func (m *MockState) DeleteApplicationResources(arg0 context.Context, arg1 application.ID) error {
+func (m *MockState) DeleteApplicationResources(arg0 context.Context, arg1 application.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteApplicationResources", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -111,13 +111,13 @@ func (c *MockStateDeleteApplicationResourcesCall) Return(arg0 error) *MockStateD
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateDeleteApplicationResourcesCall) Do(f func(context.Context, application.ID) error) *MockStateDeleteApplicationResourcesCall {
+func (c *MockStateDeleteApplicationResourcesCall) Do(f func(context.Context, application.UUID) error) *MockStateDeleteApplicationResourcesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateDeleteApplicationResourcesCall) DoAndReturn(f func(context.Context, application.ID) error) *MockStateDeleteApplicationResourcesCall {
+func (c *MockStateDeleteApplicationResourcesCall) DoAndReturn(f func(context.Context, application.UUID) error) *MockStateDeleteApplicationResourcesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -432,7 +432,7 @@ func (c *MockStateGetResourceUUIDByApplicationAndResourceNameCall) DoAndReturn(f
 }
 
 // GetResourcesByApplicationID mocks base method.
-func (m *MockState) GetResourcesByApplicationID(arg0 context.Context, arg1 application.ID) ([]resource.Resource, error) {
+func (m *MockState) GetResourcesByApplicationID(arg0 context.Context, arg1 application.UUID) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesByApplicationID", arg0, arg1)
 	ret0, _ := ret[0].([]resource.Resource)
@@ -459,13 +459,13 @@ func (c *MockStateGetResourcesByApplicationIDCall) Return(arg0 []resource.Resour
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetResourcesByApplicationIDCall) Do(f func(context.Context, application.ID) ([]resource.Resource, error)) *MockStateGetResourcesByApplicationIDCall {
+func (c *MockStateGetResourcesByApplicationIDCall) Do(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockStateGetResourcesByApplicationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetResourcesByApplicationIDCall) DoAndReturn(f func(context.Context, application.ID) ([]resource.Resource, error)) *MockStateGetResourcesByApplicationIDCall {
+func (c *MockStateGetResourcesByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) ([]resource.Resource, error)) *MockStateGetResourcesByApplicationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -509,7 +509,7 @@ func (c *MockStateImportResourcesCall) DoAndReturn(f func(context.Context, resou
 }
 
 // ListResources mocks base method.
-func (m *MockState) ListResources(arg0 context.Context, arg1 application.ID) (resource.ApplicationResources, error) {
+func (m *MockState) ListResources(arg0 context.Context, arg1 application.UUID) (resource.ApplicationResources, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResources", arg0, arg1)
 	ret0, _ := ret[0].(resource.ApplicationResources)
@@ -536,13 +536,13 @@ func (c *MockStateListResourcesCall) Return(arg0 resource.ApplicationResources, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateListResourcesCall) Do(f func(context.Context, application.ID) (resource.ApplicationResources, error)) *MockStateListResourcesCall {
+func (c *MockStateListResourcesCall) Do(f func(context.Context, application.UUID) (resource.ApplicationResources, error)) *MockStateListResourcesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateListResourcesCall) DoAndReturn(f func(context.Context, application.ID) (resource.ApplicationResources, error)) *MockStateListResourcesCall {
+func (c *MockStateListResourcesCall) DoAndReturn(f func(context.Context, application.UUID) (resource.ApplicationResources, error)) *MockStateListResourcesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/resource/service/resource.go
+++ b/domain/resource/service/resource.go
@@ -30,7 +30,7 @@ type State interface {
 
 	// DeleteApplicationResources removes all associated resources of a given
 	// application identified by applicationID.
-	DeleteApplicationResources(ctx context.Context, applicationID coreapplication.ID) error
+	DeleteApplicationResources(ctx context.Context, applicationID coreapplication.UUID) error
 
 	// DeleteResourcesAddedBeforeApplication removes all resources for the
 	// given resource UUIDs. These resource UUIDs must have been returned
@@ -57,7 +57,7 @@ type State interface {
 	GetResourceUUIDByApplicationAndResourceName(ctx context.Context, appName, resName string) (coreresource.UUID, error)
 
 	// ListResources returns the list of resource for the given application.
-	ListResources(ctx context.Context, applicationID coreapplication.ID) (coreresource.ApplicationResources, error)
+	ListResources(ctx context.Context, applicationID coreapplication.UUID) (coreresource.ApplicationResources, error)
 
 	// GetResource returns the identified resource.
 	GetResource(ctx context.Context, resourceUUID coreresource.UUID) (coreresource.Resource, error)
@@ -70,7 +70,7 @@ type State interface {
 	//
 	// If the application exists but doesn't have any resources, no error are
 	// returned, the result just contains an empty list.
-	GetResourcesByApplicationID(ctx context.Context, applicationID coreapplication.ID) ([]coreresource.Resource, error)
+	GetResourcesByApplicationID(ctx context.Context, applicationID coreapplication.UUID) ([]coreresource.Resource, error)
 
 	// ExportResources returns the list of application and unit resources to
 	// export for the given application.
@@ -207,7 +207,7 @@ func NewService(
 //     application resources.
 func (s *Service) DeleteApplicationResources(
 	ctx context.Context,
-	applicationID coreapplication.ID,
+	applicationID coreapplication.UUID,
 ) error {
 	if err := applicationID.Validate(); err != nil {
 		return resourceerrors.ApplicationIDNotValid
@@ -290,7 +290,7 @@ func (s *Service) GetResourceUUIDByApplicationAndResourceName(
 // No error is returned if the provided application has no resource.
 func (s *Service) ListResources(
 	ctx context.Context,
-	applicationID coreapplication.ID,
+	applicationID coreapplication.UUID,
 ) (coreresource.ApplicationResources, error) {
 	if err := applicationID.Validate(); err != nil {
 		return coreresource.ApplicationResources{}, errors.Errorf("%w: %w", err, resourceerrors.ApplicationIDNotValid)
@@ -309,7 +309,7 @@ func (s *Service) ListResources(
 //
 // If the application doesn't have any resources, no error are
 // returned, the result just contain an empty list.
-func (s *Service) GetResourcesByApplicationID(ctx context.Context, applicationID coreapplication.ID) ([]coreresource.Resource,
+func (s *Service) GetResourcesByApplicationID(ctx context.Context, applicationID coreapplication.UUID) ([]coreresource.Resource,
 	error) {
 	if err := applicationID.Validate(); err != nil {
 		return nil, errors.Errorf("%w: %w", err, resourceerrors.ApplicationIDNotValid)

--- a/domain/resource/service/resource_test.go
+++ b/domain/resource/service/resource_test.go
@@ -63,9 +63,9 @@ func (s *resourceServiceSuite) TestDeleteApplicationResourcesBadArgs(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	err := s.service.DeleteApplicationResources(c.Context(),
-		"not an application ID")
-	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationIDNotValid,
-		tc.Commentf("Application ID should be stated as not valid"))
+		"not an application UUID")
+	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationUUIDNotValid,
+		tc.Commentf("Application UUID should be stated as not valid"))
 }
 
 func (s *resourceServiceSuite) TestDeleteApplicationResourcesUnexpectedError(c *tc.C) {
@@ -126,8 +126,8 @@ func (s *resourceServiceSuite) TestGetApplicationResourceID(c *tc.C) {
 
 	retID := resourcetesting.GenResourceUUID(c)
 	args := resource.GetApplicationResourceIDArgs{
-		ApplicationID: applicationtesting.GenApplicationUUID(c),
-		Name:          "test-resource",
+		ApplicationUUID: applicationtesting.GenApplicationUUID(c),
+		Name:            "test-resource",
 	}
 	s.state.EXPECT().GetApplicationResourceID(gomock.Any(), args).Return(retID, nil)
 
@@ -140,8 +140,8 @@ func (s *resourceServiceSuite) TestGetApplicationResourceIDBadID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	args := resource.GetApplicationResourceIDArgs{
-		ApplicationID: "",
-		Name:          "test-resource",
+		ApplicationUUID: "",
+		Name:            "test-resource",
 	}
 	_, err := s.service.GetApplicationResourceID(c.Context(), args)
 	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
@@ -151,8 +151,8 @@ func (s *resourceServiceSuite) TestGetApplicationResourceIDBadName(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	args := resource.GetApplicationResourceIDArgs{
-		ApplicationID: applicationtesting.GenApplicationUUID(c),
-		Name:          "",
+		ApplicationUUID: applicationtesting.GenApplicationUUID(c),
+		Name:            "",
 	}
 	_, err := s.service.GetApplicationResourceID(c.Context(), args)
 	c.Assert(err, tc.ErrorIs, resourceerrors.ResourceNameNotValid)
@@ -225,22 +225,22 @@ func (s *resourceServiceSuite) TestListResources(c *tc.C) {
 	c.Assert(obtainedList, tc.DeepEquals, expectedList)
 }
 
-func (s *resourceServiceSuite) TestGetResourcesByApplicationIDBadID(c *tc.C) {
+func (s *resourceServiceSuite) TestGetResourcesByApplicationUUIDBadID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	_, err := s.service.GetResourcesByApplicationID(c.Context(), "")
-	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationIDNotValid)
+	_, err := s.service.GetResourcesByApplicationUUID(c.Context(), "")
+	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationUUIDNotValid)
 }
 
-func (s *resourceServiceSuite) TestGetResourcesByApplicationID(c *tc.C) {
+func (s *resourceServiceSuite) TestGetResourcesByApplicationUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	id := applicationtesting.GenApplicationUUID(c)
 	expectedList := []coreresource.Resource{{
 		RetrievedBy: "admin",
 	}}
-	s.state.EXPECT().GetResourcesByApplicationID(gomock.Any(), id).Return(expectedList, nil)
+	s.state.EXPECT().GetResourcesByApplicationUUID(gomock.Any(), id).Return(expectedList, nil)
 
-	obtainedList, err := s.service.GetResourcesByApplicationID(c.Context(), id)
+	obtainedList, err := s.service.GetResourcesByApplicationUUID(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(obtainedList, tc.DeepEquals, expectedList)
 }
@@ -248,7 +248,7 @@ func (s *resourceServiceSuite) TestGetResourcesByApplicationID(c *tc.C) {
 func (s *resourceServiceSuite) TestListResourcesBadID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	_, err := s.service.ListResources(c.Context(), "")
-	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationIDNotValid)
+	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationUUIDNotValid)
 }
 
 func (s *resourceServiceSuite) TestGetResource(c *tc.C) {
@@ -889,8 +889,8 @@ func (s *resourceServiceSuite) TestSetRepositoryResources(c *tc.C) {
 	fp, err := charmresource.NewFingerprint(fingerprint)
 	c.Assert(err, tc.ErrorIsNil)
 	args := resource.SetRepositoryResourcesArgs{
-		ApplicationID: applicationtesting.GenApplicationUUID(c),
-		CharmID:       charmtesting.GenCharmID(c),
+		ApplicationUUID: applicationtesting.GenApplicationUUID(c),
+		CharmID:         charmtesting.GenCharmID(c),
 		Info: []charmresource.Resource{{
 
 			Meta: charmresource.Meta{
@@ -923,8 +923,8 @@ func (s *resourceServiceSuite) TestSetRepositoryResourcesApplicationError(c *tc.
 
 	// Act
 	err = s.service.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: applicationtesting.GenApplicationUUID(c),
-		CharmID:       charmtesting.GenCharmID(c),
+		ApplicationUUID: applicationtesting.GenApplicationUUID(c),
+		CharmID:         charmtesting.GenCharmID(c),
 		Info: []charmresource.Resource{{
 			Meta: charmresource.Meta{
 				Name:        "my-resource",
@@ -949,11 +949,11 @@ func (s *resourceServiceSuite) TestSetRepositoryResourcesApplicationIDNotValid(c
 
 	// Act
 	err := s.service.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: "Not-valid",
+		ApplicationUUID: "Not-valid",
 	})
 
 	// Assert
-	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationIDNotValid)
+	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationUUIDNotValid)
 }
 
 func (s *resourceServiceSuite) TestSetRepositoryResourcesCharmIDNotValid(c *tc.C) {
@@ -961,8 +961,8 @@ func (s *resourceServiceSuite) TestSetRepositoryResourcesCharmIDNotValid(c *tc.C
 
 	// Act
 	err := s.service.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: applicationtesting.GenApplicationUUID(c),
-		CharmID:       "Not-valid",
+		ApplicationUUID: applicationtesting.GenApplicationUUID(c),
+		CharmID:         "Not-valid",
 	})
 
 	// Assert
@@ -978,8 +978,8 @@ func (s *resourceServiceSuite) TestSetRepositoryResourcesApplicationNoLastPolled
 
 	// Act
 	err = s.service.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: applicationtesting.GenApplicationUUID(c),
-		CharmID:       charmtesting.GenCharmID(c),
+		ApplicationUUID: applicationtesting.GenApplicationUUID(c),
+		CharmID:         charmtesting.GenCharmID(c),
 		Info: []charmresource.Resource{{
 			Meta: charmresource.Meta{
 				Name:        "my-resource",
@@ -1004,10 +1004,10 @@ func (s *resourceServiceSuite) TestSetRepositoryResourcesApplicationNoInfo(c *tc
 
 	// Act
 	err := s.service.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: applicationtesting.GenApplicationUUID(c),
-		CharmID:       charmtesting.GenCharmID(c),
-		Info:          nil,
-		LastPolled:    time.Now(),
+		ApplicationUUID: applicationtesting.GenApplicationUUID(c),
+		CharmID:         charmtesting.GenCharmID(c),
+		Info:            nil,
+		LastPolled:      time.Now(),
 	})
 
 	// Assert
@@ -1019,10 +1019,10 @@ func (s *resourceServiceSuite) TestSetRepositoryResourcesApplicationInvalidInfo(
 
 	// Act
 	err := s.service.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: applicationtesting.GenApplicationUUID(c),
-		CharmID:       charmtesting.GenCharmID(c),
-		Info:          []charmresource.Resource{{}, {}}, // Invalid resources
-		LastPolled:    time.Now(),
+		ApplicationUUID: applicationtesting.GenApplicationUUID(c),
+		CharmID:         charmtesting.GenCharmID(c),
+		Info:            []charmresource.Resource{{}, {}}, // Invalid resources
+		LastPolled:      time.Now(),
 	})
 
 	// Assert

--- a/domain/resource/state/resource.go
+++ b/domain/resource/state/resource.go
@@ -54,7 +54,7 @@ func NewState(factory database.TxnRunnerFactory, clock clock.Clock, logger logge
 // can led to inconsistent state due to foreign key constraints.
 func (st *State) DeleteApplicationResources(
 	ctx context.Context,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -185,7 +185,7 @@ func (st *State) DeleteUnitResources(
 	})
 }
 
-func (st *State) getAppResources(ctx context.Context, tx *sqlair.TX, appID application.ID) (uuids, error) {
+func (st *State) getAppResources(ctx context.Context, tx *sqlair.TX, appID application.UUID) (uuids, error) {
 	id := applicationID{ID: appID}
 	var resources []localUUID
 	// SQL statement to list all resources for an application.
@@ -409,7 +409,7 @@ AND    r.state_id = 0 -- Only check available resources, not potential.
 // given application.
 func (st *State) ListResources(
 	ctx context.Context,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) (coreresource.ApplicationResources, error) {
 	potential, available, err := st.listApplicationResources(ctx, applicationID)
 	if err != nil {
@@ -432,7 +432,7 @@ func (st *State) ListResources(
 // an application.
 func (st *State) listApplicationResources(
 	ctx context.Context,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) ([]charmresource.Resource, []coreresource.Resource, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -504,7 +504,7 @@ WHERE application_uuid = $resourceIdentity.application_uuid`
 // application.
 func (st *State) listUnitResources(
 	ctx context.Context,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) ([]coreresource.UnitResources, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -586,7 +586,7 @@ func (st *State) listUnitResources(
 // returned, the result just contains an empty list.
 func (st *State) GetResourcesByApplicationID(
 	ctx context.Context,
-	applicationID application.ID,
+	applicationID application.UUID,
 ) ([]coreresource.Resource, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -2079,7 +2079,7 @@ func (st *State) getResourcesToSet(
 	tx *sqlair.TX,
 	typeIDs typeIDs,
 	charmID corecharm.ID,
-	appID application.ID,
+	appID application.UUID,
 	resources []resource.ImportResourceInfo,
 ) (resourcesToSet, map[string]uuidOriginAndRevision, error) {
 	var toSet resourcesToSet
@@ -2159,7 +2159,7 @@ func (st *State) getResourceToSet(typeIDs typeIDs, charmID corecharm.ID, res res
 func (st *State) getPotentialResourcePlaceholdersToSet(
 	typeIDs typeIDs,
 	charmID corecharm.ID,
-	appID application.ID,
+	appID application.UUID,
 	resources []resource.ImportResourceInfo,
 ) ([]setResource, []applicationResource, error) {
 	// All repository resources have origin store.
@@ -2385,7 +2385,7 @@ func (st *State) ExportResources(ctx context.Context, appName string) (resource.
 		return resource.ExportedResources{}, errors.Capture(err)
 	}
 
-	var appID application.ID
+	var appID application.UUID
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		appID, err = st.getApplicationUUID(ctx, tx, appName)
 		if err != nil {
@@ -2424,7 +2424,7 @@ func (st *State) getApplicationAndCharmUUID(
 	ctx context.Context,
 	tx *sqlair.TX,
 	applicationName string,
-) (application.ID, corecharm.ID, error) {
+) (application.UUID, corecharm.ID, error) {
 	app := getApplicationAndCharmID{Name: applicationName}
 	queryApplicationStmt, err := st.Prepare(`
 SELECT (charm_uuid, uuid) AS (&getApplicationAndCharmID.*)
@@ -2523,7 +2523,7 @@ WHERE  name = $unitUUIDAndName.name
 }
 
 // checkApplicationIDExists checks if an application exists in the database by its UUID.
-func (st *State) checkApplicationIDExists(ctx context.Context, tx *sqlair.TX, appID application.ID) (bool, error) {
+func (st *State) checkApplicationIDExists(ctx context.Context, tx *sqlair.TX, appID application.UUID) (bool, error) {
 	application := applicationNameAndID{ApplicationID: appID}
 	checkApplicationExistsStmt, err := st.Prepare(`
 SELECT &applicationNameAndID.*
@@ -2567,7 +2567,7 @@ WHERE  name = $applicationNameAndID.name
 
 // getApplicationUUID gets the application ID from the name. It returns
 // [resourceerrors.ApplicationNotFound] if the application cannot be found.
-func (st *State) getApplicationUUID(ctx context.Context, tx *sqlair.TX, appName string) (application.ID, error) {
+func (st *State) getApplicationUUID(ctx context.Context, tx *sqlair.TX, appName string) (application.UUID, error) {
 	appID := applicationNameAndID{
 		Name: appName,
 	}

--- a/domain/resource/state/resource_test.go
+++ b/domain/resource/state/resource_test.go
@@ -182,7 +182,7 @@ func (s *resourceSuite) TestDeleteApplicationResources(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act: delete resources from application 1
-	err = s.state.DeleteApplicationResources(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	err = s.state.DeleteApplicationResources(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert: check that resources have been deleted in expected tables
 	// without errors
@@ -247,7 +247,7 @@ func (s *resourceSuite) TestDeleteApplicationResourcesErrorRemainingUnits(c *tc.
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act: delete resources from application 1
-	err = s.state.DeleteApplicationResources(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	err = s.state.DeleteApplicationResources(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert: check an error is returned and no resource deleted
 	c.Check(err, tc.ErrorIs, resourceerrors.CleanUpStateNotValid,
@@ -296,7 +296,7 @@ VALUES (?,'store-uuid')`, input.UUID); err != nil {
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act: delete resources from application 1
-	err = s.state.DeleteApplicationResources(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	err = s.state.DeleteApplicationResources(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert: check an error is returned and no resource deleted
 	c.Check(err, tc.ErrorIs, resourceerrors.CleanUpStateNotValid,
@@ -345,7 +345,7 @@ VALUES (?,'store-uuid')`, input.UUID); err != nil {
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act: delete resources from application 1
-	err = s.state.DeleteApplicationResources(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	err = s.state.DeleteApplicationResources(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert: check an error is returned and no resource deleted
 	c.Check(err, tc.ErrorIs, resourceerrors.CleanUpStateNotValid,
@@ -456,7 +456,7 @@ func (s *resourceSuite) TestGetApplicationResourceID(c *tc.C) {
 
 	// Act: Get application resource ID
 	id, err := s.state.GetApplicationResourceID(c.Context(), resource.GetApplicationResourceIDArgs{
-		ApplicationID: application.ID(s.constants.fakeApplicationUUID1),
+		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
 		Name:          found.Name,
 	})
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) failed to get application resource ID: %v", errors.ErrorStack(err)))
@@ -471,7 +471,7 @@ func (s *resourceSuite) TestGetApplicationResourceIDNotFound(c *tc.C) {
 	// Arrange: No resources
 	// Act: Get application resource ID
 	_, err := s.state.GetApplicationResourceID(c.Context(), resource.GetApplicationResourceIDArgs{
-		ApplicationID: application.ID(s.constants.fakeApplicationUUID1),
+		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
 		Name:          "resource-name-not-found",
 	})
 	c.Assert(err, tc.ErrorIs, resourceerrors.ResourceNotFound, tc.Commentf("(Act) unexpected error"))
@@ -502,7 +502,7 @@ func (s *resourceSuite) TestGetApplicationResourceIDCannotGetPotentialResource(c
 
 	// Act: Get application resource ID.
 	_, err = s.state.GetApplicationResourceID(c.Context(), resource.GetApplicationResourceIDArgs{
-		ApplicationID: application.ID(s.constants.fakeApplicationUUID1),
+		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
 		Name:          "potential-resource-name",
 	})
 
@@ -861,7 +861,7 @@ VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING`,
 
 	// Act: update resource 1 and 2 (not 3)
 	err = s.state.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: application.ID(s.constants.fakeApplicationUUID1),
+		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
 		CharmID:       charm.ID(newCharmUUID),
 		Info: []charmresource.Resource{{
 			Meta: charmresource.Meta{
@@ -938,7 +938,7 @@ VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING`,
 func (s *resourceSuite) TestSetRepositoryResourceUnknownResource(c *tc.C) {
 	// Act: update non-existent resources
 	err := s.state.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: application.ID(s.constants.fakeApplicationUUID1),
+		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
 		Info: []charmresource.Resource{{
 			Meta: charmresource.Meta{
 				Name: "not-a-resource-1",
@@ -1734,7 +1734,7 @@ func (s *resourceSuite) TestGetResourceTypeNotFound(c *tc.C) {
 func (s *resourceSuite) TestListResourcesNoResources(c *tc.C) {
 	// Arrange: No resources
 	// Act
-	results, err := s.state.ListResources(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	results, err := s.state.ListResources(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) failed to list resources: %v", errors.ErrorStack(err)))
 	c.Check(results.UnitResources, tc.DeepEquals, []coreresource.UnitResources{
@@ -1844,7 +1844,7 @@ func (s *resourceSuite) TestListResources(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act
-	results, err := s.state.ListResources(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	results, err := s.state.ListResources(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert
 	// the application, even if not directly linked to this unit resource, should be properly retrieved
@@ -1901,7 +1901,7 @@ func (s *resourceSuite) TestGetResourcesByApplicationIDWrongApplicationID(c *tc.
 func (s *resourceSuite) TestGetResourcesByApplicationIDNoResources(c *tc.C) {
 	// Arrange: No resources
 	// Act
-	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) failed to list resources: %v", errors.ErrorStack(err)))
 	c.Assert(results, tc.HasLen, 0)
@@ -1966,7 +1966,7 @@ func (s *resourceSuite) TestGetResourcesByApplicationID(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act
-	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) failed to list resources: %v", errors.ErrorStack(err)))
@@ -2015,7 +2015,7 @@ func (s *resourceSuite) TestGetResourcesByApplicationIDWithStatePotential(c *tc.
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act
-	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.ID(s.constants.fakeApplicationUUID1))
+	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) failed to list resources: %v", errors.ErrorStack(err)))

--- a/domain/resource/state/resource_test.go
+++ b/domain/resource/state/resource_test.go
@@ -456,8 +456,8 @@ func (s *resourceSuite) TestGetApplicationResourceID(c *tc.C) {
 
 	// Act: Get application resource ID
 	id, err := s.state.GetApplicationResourceID(c.Context(), resource.GetApplicationResourceIDArgs{
-		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
-		Name:          found.Name,
+		ApplicationUUID: application.UUID(s.constants.fakeApplicationUUID1),
+		Name:            found.Name,
 	})
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Act) failed to get application resource ID: %v", errors.ErrorStack(err)))
 	c.Assert(id, tc.Equals, coreresource.UUID(found.UUID),
@@ -471,8 +471,8 @@ func (s *resourceSuite) TestGetApplicationResourceIDNotFound(c *tc.C) {
 	// Arrange: No resources
 	// Act: Get application resource ID
 	_, err := s.state.GetApplicationResourceID(c.Context(), resource.GetApplicationResourceIDArgs{
-		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
-		Name:          "resource-name-not-found",
+		ApplicationUUID: application.UUID(s.constants.fakeApplicationUUID1),
+		Name:            "resource-name-not-found",
 	})
 	c.Assert(err, tc.ErrorIs, resourceerrors.ResourceNotFound, tc.Commentf("(Act) unexpected error"))
 }
@@ -502,8 +502,8 @@ func (s *resourceSuite) TestGetApplicationResourceIDCannotGetPotentialResource(c
 
 	// Act: Get application resource ID.
 	_, err = s.state.GetApplicationResourceID(c.Context(), resource.GetApplicationResourceIDArgs{
-		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
-		Name:          "potential-resource-name",
+		ApplicationUUID: application.UUID(s.constants.fakeApplicationUUID1),
+		Name:            "potential-resource-name",
 	})
 
 	// Assert: No resource can be found.
@@ -861,8 +861,8 @@ VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING`,
 
 	// Act: update resource 1 and 2 (not 3)
 	err = s.state.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
-		CharmID:       charm.ID(newCharmUUID),
+		ApplicationUUID: application.UUID(s.constants.fakeApplicationUUID1),
+		CharmID:         charm.ID(newCharmUUID),
 		Info: []charmresource.Resource{{
 			Meta: charmresource.Meta{
 				Name: "not-polled-1",
@@ -938,7 +938,7 @@ VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING`,
 func (s *resourceSuite) TestSetRepositoryResourceUnknownResource(c *tc.C) {
 	// Act: update non-existent resources
 	err := s.state.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: application.UUID(s.constants.fakeApplicationUUID1),
+		ApplicationUUID: application.UUID(s.constants.fakeApplicationUUID1),
 		Info: []charmresource.Resource{{
 			Meta: charmresource.Meta{
 				Name: "not-a-resource-1",
@@ -964,9 +964,9 @@ func (s *resourceSuite) TestSetRepositoryResourceUnknownResource(c *tc.C) {
 func (s *resourceSuite) TestSetRepositoryResourceApplicationNotFound(c *tc.C) {
 	// Act: request a non-existent application.
 	err := s.state.SetRepositoryResources(c.Context(), resource.SetRepositoryResourcesArgs{
-		ApplicationID: "not-an-application",
-		Info:          []charmresource.Resource{{}}, // Non empty info
-		LastPolled:    time.Now(),                   // not used
+		ApplicationUUID: "not-an-application",
+		Info:            []charmresource.Resource{{}}, // Non empty info
+		LastPolled:      time.Now(),                   // not used
 	})
 
 	// Assert: check expected error
@@ -1881,35 +1881,35 @@ func (s *resourceSuite) TestListResources(c *tc.C) {
 	})
 }
 
-// TestGetResourcesByApplicationIDWrongApplicationID verifies the behavior
-// when querying non-existing application ID.
+// TestGetResourcesByApplicationUUIDWrongApplicationUUID verifies the behavior
+// when querying non-existing application UUID.
 // Ensures the method returns the correct `ApplicationNotFound` error for an
-// invalid application ID.
-func (s *resourceSuite) TestGetResourcesByApplicationIDWrongApplicationID(c *tc.C) {
+// invalid application UUID.
+func (s *resourceSuite) TestGetResourcesByApplicationUUIDWrongApplicationUUID(c *tc.C) {
 	// Arrange: No resources
 	// Act
-	_, err := s.state.GetResourcesByApplicationID(c.Context(), "not-an-application-id")
+	_, err := s.state.GetResourcesByApplicationUUID(c.Context(), "not-an-application-id")
 	// Assert
 	c.Assert(err, tc.ErrorIs, resourceerrors.ApplicationNotFound,
 		tc.Commentf("(Assert) should fails with specific error: %v",
 			errors.ErrorStack(err)))
 }
 
-// TestGetResourcesByApplicationIDNoResources verifies that no resources are listed for an
+// TestGetResourcesByApplicationUUIDNoResources verifies that no resources are listed for an
 // application when no resources exist. It checks that the resulting lists
 // is empty.
-func (s *resourceSuite) TestGetResourcesByApplicationIDNoResources(c *tc.C) {
+func (s *resourceSuite) TestGetResourcesByApplicationUUIDNoResources(c *tc.C) {
 	// Arrange: No resources
 	// Act
-	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
+	results, err := s.state.GetResourcesByApplicationUUID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) failed to list resources: %v", errors.ErrorStack(err)))
 	c.Assert(results, tc.HasLen, 0)
 }
 
-// TestGetResourcesByApplicationID tests the retrieval and organization of resources from the
-// database.
-func (s *resourceSuite) TestGetResourcesByApplicationID(c *tc.C) {
+// TestGetResourcesByApplicationUUID tests the retrieval and organization of
+// resources from the database.
+func (s *resourceSuite) TestGetResourcesByApplicationUUID(c *tc.C) {
 	// Arrange
 	now := time.Now().Truncate(time.Second).UTC()
 	// Arrange : Insert several resources
@@ -1966,7 +1966,7 @@ func (s *resourceSuite) TestGetResourcesByApplicationID(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act
-	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
+	results, err := s.state.GetResourcesByApplicationUUID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) failed to list resources: %v", errors.ErrorStack(err)))
@@ -1979,11 +1979,11 @@ func (s *resourceSuite) TestGetResourcesByApplicationID(c *tc.C) {
 	})
 }
 
-// TestGetResourcesByApplicationIDWithStatePotential tests retrieving resources
-// by application ID where state filters are applied. It ensures that only
+// TestGetResourcesByApplicationUUIDWithStatePotential tests retrieving resources
+// by application UUID where state filters are applied. It ensures that only
 // resources with the "available" state are returned, excluding any with the
 // "potential" state.
-func (s *resourceSuite) TestGetResourcesByApplicationIDWithStatePotential(c *tc.C) {
+func (s *resourceSuite) TestGetResourcesByApplicationUUIDWithStatePotential(c *tc.C) {
 	// Arrange
 	now := time.Now().Truncate(time.Second).UTC()
 	// Arrange : Insert several resources
@@ -2015,7 +2015,7 @@ func (s *resourceSuite) TestGetResourcesByApplicationIDWithStatePotential(c *tc.
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) failed to populate DB: %v", errors.ErrorStack(err)))
 
 	// Act
-	results, err := s.state.GetResourcesByApplicationID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
+	results, err := s.state.GetResourcesByApplicationUUID(c.Context(), application.UUID(s.constants.fakeApplicationUUID1))
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) failed to list resources: %v", errors.ErrorStack(err)))

--- a/domain/resource/state/types.go
+++ b/domain/resource/state/types.go
@@ -138,12 +138,12 @@ type unitResource struct {
 }
 
 type applicationNameAndID struct {
-	ApplicationID coreapplication.ID `db:"uuid"`
+	ApplicationID coreapplication.UUID `db:"uuid"`
 	Name          string             `db:"name"`
 }
 
 type applicationID struct {
-	ID coreapplication.ID `db:"uuid"`
+	ID coreapplication.UUID `db:"uuid"`
 }
 
 // charmResource contains the identifiers of the charm resource in the
@@ -157,7 +157,7 @@ type charmResource struct {
 // getApplicationAndCharmID gets the application and charm ID from the
 // application table using the application name.
 type getApplicationAndCharmID struct {
-	ApplicationID coreapplication.ID `db:"uuid"`
+	ApplicationID coreapplication.UUID `db:"uuid"`
 	CharmID       charm.ID           `db:"charm_uuid"`
 	Name          string             `db:"name"`
 }

--- a/domain/resource/state/types.go
+++ b/domain/resource/state/types.go
@@ -139,7 +139,7 @@ type unitResource struct {
 
 type applicationNameAndID struct {
 	ApplicationID coreapplication.UUID `db:"uuid"`
-	Name          string             `db:"name"`
+	Name          string               `db:"name"`
 }
 
 type applicationID struct {
@@ -158,8 +158,8 @@ type charmResource struct {
 // application table using the application name.
 type getApplicationAndCharmID struct {
 	ApplicationID coreapplication.UUID `db:"uuid"`
-	CharmID       charm.ID           `db:"charm_uuid"`
-	Name          string             `db:"name"`
+	CharmID       charm.ID             `db:"charm_uuid"`
+	Name          string               `db:"name"`
 }
 
 // kubernetesApplicationResource represents the mapping of a resource to a unit.

--- a/domain/resource/types.go
+++ b/domain/resource/types.go
@@ -36,15 +36,15 @@ const (
 // GetApplicationResourceIDArgs holds the arguments for the
 // GetApplicationResourceID method.
 type GetApplicationResourceIDArgs struct {
-	ApplicationID application.UUID
-	Name          string
+	ApplicationUUID application.UUID
+	Name            string
 }
 
 // SetRepositoryResourcesArgs holds the arguments for the
 // SetRepositoryResources method.
 type SetRepositoryResourcesArgs struct {
-	// ApplicationID is the id of the application having these resources.
-	ApplicationID application.UUID
+	// ApplicationUUID is the id of the application having these resources.
+	ApplicationUUID application.UUID
 	// CharmID is the unique identifier for a charm to update resources.
 	CharmID corecharm.ID
 	// Info is a slice of resource data received from the repository.
@@ -120,8 +120,8 @@ type AddResourceDetails struct {
 // UpdateUploadResourceArgs holds arguments to update the resource to
 // expect a new blob to be uploaded.
 type UpdateUploadResourceArgs struct {
-	// ApplicationID is the ID of the application this resource belongs to.
-	ApplicationID application.UUID
+	// ApplicationUUID is the UUID of the application this resource belongs to.
+	ApplicationUUID application.UUID
 	// Name is the resource name.
 	Name string
 }

--- a/domain/resource/types.go
+++ b/domain/resource/types.go
@@ -36,7 +36,7 @@ const (
 // GetApplicationResourceIDArgs holds the arguments for the
 // GetApplicationResourceID method.
 type GetApplicationResourceIDArgs struct {
-	ApplicationID application.ID
+	ApplicationID application.UUID
 	Name          string
 }
 
@@ -44,7 +44,7 @@ type GetApplicationResourceIDArgs struct {
 // SetRepositoryResources method.
 type SetRepositoryResourcesArgs struct {
 	// ApplicationID is the id of the application having these resources.
-	ApplicationID application.ID
+	ApplicationID application.UUID
 	// CharmID is the unique identifier for a charm to update resources.
 	CharmID corecharm.ID
 	// Info is a slice of resource data received from the repository.
@@ -121,7 +121,7 @@ type AddResourceDetails struct {
 // expect a new blob to be uploaded.
 type UpdateUploadResourceArgs struct {
 	// ApplicationID is the ID of the application this resource belongs to.
-	ApplicationID application.ID
+	ApplicationID application.UUID
 	// Name is the resource name.
 	Name string
 }

--- a/domain/secret/service/interface.go
+++ b/domain/secret/service/interface.go
@@ -25,18 +25,18 @@ type AtomicState interface {
 	domain.AtomicStateBase
 
 	DeleteSecret(ctx domain.AtomicContext, uri *secrets.URI, revs []int) error
-	GetApplicationUUID(ctx domain.AtomicContext, appName string) (coreapplication.ID, error)
+	GetApplicationUUID(ctx domain.AtomicContext, appName string) (coreapplication.UUID, error)
 	GetUnitUUID(ctx domain.AtomicContext, name coreunit.Name) (coreunit.UUID, error)
 	GetSecretOwner(ctx domain.AtomicContext, uri *secrets.URI) (domainsecret.Owner, error)
 
 	CheckUserSecretLabelExists(ctx domain.AtomicContext, label string) (bool, error)
-	CheckApplicationSecretLabelExists(ctx domain.AtomicContext, appUUID coreapplication.ID, label string) (bool, error)
+	CheckApplicationSecretLabelExists(ctx domain.AtomicContext, appUUID coreapplication.UUID, label string) (bool, error)
 	CheckUnitSecretLabelExists(ctx domain.AtomicContext, unitUUID coreunit.UUID, label string) (bool, error)
 	CreateUserSecret(
 		ctx domain.AtomicContext, version int, uri *secrets.URI, secret domainsecret.UpsertSecretParams,
 	) error
 	CreateCharmApplicationSecret(
-		ctx domain.AtomicContext, version int, uri *secrets.URI, appUUID coreapplication.ID, secret domainsecret.UpsertSecretParams,
+		ctx domain.AtomicContext, version int, uri *secrets.URI, appUUID coreapplication.UUID, secret domainsecret.UpsertSecretParams,
 	) error
 	CreateCharmUnitSecret(
 		ctx domain.AtomicContext, version int, uri *secrets.URI, unitUUID coreunit.UUID, secret domainsecret.UpsertSecretParams,

--- a/domain/secret/service/package_mock_test.go
+++ b/domain/secret/service/package_mock_test.go
@@ -246,7 +246,7 @@ func (c *MockStateChangeSecretBackendCall) DoAndReturn(f func(context.Context, u
 }
 
 // CheckApplicationSecretLabelExists mocks base method.
-func (m *MockState) CheckApplicationSecretLabelExists(arg0 domain.AtomicContext, arg1 application.ID, arg2 string) (bool, error) {
+func (m *MockState) CheckApplicationSecretLabelExists(arg0 domain.AtomicContext, arg1 application.UUID, arg2 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckApplicationSecretLabelExists", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -273,13 +273,13 @@ func (c *MockStateCheckApplicationSecretLabelExistsCall) Return(arg0 bool, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateCheckApplicationSecretLabelExistsCall) Do(f func(domain.AtomicContext, application.ID, string) (bool, error)) *MockStateCheckApplicationSecretLabelExistsCall {
+func (c *MockStateCheckApplicationSecretLabelExistsCall) Do(f func(domain.AtomicContext, application.UUID, string) (bool, error)) *MockStateCheckApplicationSecretLabelExistsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCheckApplicationSecretLabelExistsCall) DoAndReturn(f func(domain.AtomicContext, application.ID, string) (bool, error)) *MockStateCheckApplicationSecretLabelExistsCall {
+func (c *MockStateCheckApplicationSecretLabelExistsCall) DoAndReturn(f func(domain.AtomicContext, application.UUID, string) (bool, error)) *MockStateCheckApplicationSecretLabelExistsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -363,7 +363,7 @@ func (c *MockStateCheckUserSecretLabelExistsCall) DoAndReturn(f func(domain.Atom
 }
 
 // CreateCharmApplicationSecret mocks base method.
-func (m *MockState) CreateCharmApplicationSecret(arg0 domain.AtomicContext, arg1 int, arg2 *secrets.URI, arg3 application.ID, arg4 secret.UpsertSecretParams) error {
+func (m *MockState) CreateCharmApplicationSecret(arg0 domain.AtomicContext, arg1 int, arg2 *secrets.URI, arg3 application.UUID, arg4 secret.UpsertSecretParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCharmApplicationSecret", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -389,13 +389,13 @@ func (c *MockStateCreateCharmApplicationSecretCall) Return(arg0 error) *MockStat
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateCreateCharmApplicationSecretCall) Do(f func(domain.AtomicContext, int, *secrets.URI, application.ID, secret.UpsertSecretParams) error) *MockStateCreateCharmApplicationSecretCall {
+func (c *MockStateCreateCharmApplicationSecretCall) Do(f func(domain.AtomicContext, int, *secrets.URI, application.UUID, secret.UpsertSecretParams) error) *MockStateCreateCharmApplicationSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateCharmApplicationSecretCall) DoAndReturn(f func(domain.AtomicContext, int, *secrets.URI, application.ID, secret.UpsertSecretParams) error) *MockStateCreateCharmApplicationSecretCall {
+func (c *MockStateCreateCharmApplicationSecretCall) DoAndReturn(f func(domain.AtomicContext, int, *secrets.URI, application.UUID, secret.UpsertSecretParams) error) *MockStateCreateCharmApplicationSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -554,10 +554,10 @@ func (c *MockStateDeleteSecretCall) DoAndReturn(f func(domain.AtomicContext, *se
 }
 
 // GetApplicationUUID mocks base method.
-func (m *MockState) GetApplicationUUID(arg0 domain.AtomicContext, arg1 string) (application.ID, error) {
+func (m *MockState) GetApplicationUUID(arg0 domain.AtomicContext, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationUUID", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -575,19 +575,19 @@ type MockStateGetApplicationUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetApplicationUUIDCall) Return(arg0 application.ID, arg1 error) *MockStateGetApplicationUUIDCall {
+func (c *MockStateGetApplicationUUIDCall) Return(arg0 application.UUID, arg1 error) *MockStateGetApplicationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationUUIDCall) Do(f func(domain.AtomicContext, string) (application.ID, error)) *MockStateGetApplicationUUIDCall {
+func (c *MockStateGetApplicationUUIDCall) Do(f func(domain.AtomicContext, string) (application.UUID, error)) *MockStateGetApplicationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationUUIDCall) DoAndReturn(f func(domain.AtomicContext, string) (application.ID, error)) *MockStateGetApplicationUUIDCall {
+func (c *MockStateGetApplicationUUIDCall) DoAndReturn(f func(domain.AtomicContext, string) (application.UUID, error)) *MockStateGetApplicationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -617,7 +617,7 @@ func (s *SecretService) updateSecret(ctx domain.AtomicContext, uri *secrets.URI,
 		var labelExists bool
 		switch kind := owner.Kind; kind {
 		case domainsecret.ApplicationOwner:
-			labelExists, err = s.secretState.CheckApplicationSecretLabelExists(ctx, coreapplication.ID(owner.UUID), *params.Label)
+			labelExists, err = s.secretState.CheckApplicationSecretLabelExists(ctx, coreapplication.UUID(owner.UUID), *params.Label)
 		case domainsecret.UnitOwner:
 			labelExists, err = s.secretState.CheckUnitSecretLabelExists(ctx, coreunit.UUID(owner.UUID), *params.Label)
 		case domainsecret.ModelOwner:

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -527,7 +527,7 @@ func (s *serviceSuite) TestCreateCharmApplicationSecret(c *tc.C) {
 	s.state.EXPECT().GetApplicationUUID(domaintesting.IsAtomicContextChecker, "mariadb").Return(appUUID, nil)
 	s.state.EXPECT().CheckApplicationSecretLabelExists(domaintesting.IsAtomicContextChecker, appUUID, "my secret").Return(false, nil)
 	s.state.EXPECT().CreateCharmApplicationSecret(domaintesting.IsAtomicContextChecker, 1, uri, appUUID, gomock.AssignableToTypeOf(p)).
-		DoAndReturn(func(_ domain.AtomicContext, _ int, _ *coresecrets.URI, _ coreapplication.ID, got domainsecret.UpsertSecretParams) error {
+		DoAndReturn(func(_ domain.AtomicContext, _ int, _ *coresecrets.URI, _ coreapplication.UUID, got domainsecret.UpsertSecretParams) error {
 			c.Assert(got.NextRotateTime, tc.NotNil)
 			c.Assert(*got.NextRotateTime, tc.Almost, rotateTime)
 			got.NextRotateTime = nil

--- a/domain/secret/state/package_test.go
+++ b/domain/secret/state/package_test.go
@@ -13,8 +13,8 @@ import (
 	domainsecret "github.com/juju/juju/domain/secret"
 )
 
-func getApplicationUUID(ctx context.Context, st *State, appName string) (coreapplication.ID, error) {
-	var uuid coreapplication.ID
+func getApplicationUUID(ctx context.Context, st *State, appName string) (coreapplication.UUID, error) {
+	var uuid coreapplication.UUID
 	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		var err error
 		uuid, err = st.GetApplicationUUID(ctx, appName)
@@ -53,7 +53,7 @@ func checkUserSecretLabelExists(ctx context.Context, st *State, label string) (b
 	return exists, err
 }
 
-func checkApplicationSecretLabelExists(ctx context.Context, st *State, appUUID coreapplication.ID, label string) (bool, error) {
+func checkApplicationSecretLabelExists(ctx context.Context, st *State, appUUID coreapplication.UUID, label string) (bool, error) {
 	var exists bool
 	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		var err error

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -81,7 +81,7 @@ func (st State) getModelUUID(ctx context.Context, tx *sqlair.TX) (coremodel.UUID
 
 // GetApplicationUUID returns the UUID of the application with the given name, returning an error satisfying
 // [applicationerrors.ApplicationNotFound] if the application does not exist.
-func (st State) GetApplicationUUID(ctx domain.AtomicContext, appName string) (coreapplication.ID, error) {
+func (st State) GetApplicationUUID(ctx domain.AtomicContext, appName string) (coreapplication.UUID, error) {
 	app := application{Name: appName}
 
 	selectApplicationUUIDStmt, err := st.Prepare(`
@@ -138,7 +138,7 @@ WHERE name=$unit.name`, u)
 }
 
 // CheckApplicationSecretLabelExists checks if a charm application secret with the given label already exists.
-func (st State) CheckApplicationSecretLabelExists(ctx domain.AtomicContext, appUUID coreapplication.ID, label string) (bool, error) {
+func (st State) CheckApplicationSecretLabelExists(ctx domain.AtomicContext, appUUID coreapplication.UUID, label string) (bool, error) {
 	if label == "" {
 		return false, nil
 	}
@@ -285,7 +285,7 @@ func (st State) CreateUserSecret(
 // It also returns an error satisfying [applicationerrors.ApplicationNotFound]
 // ifthe application does not exist.
 func (st State) CreateCharmApplicationSecret(
-	ctx domain.AtomicContext, version int, uri *coresecrets.URI, appUUID coreapplication.ID, secret domainsecret.UpsertSecretParams,
+	ctx domain.AtomicContext, version int, uri *coresecrets.URI, appUUID coreapplication.UUID, secret domainsecret.UpsertSecretParams,
 ) error {
 	if secret.AutoPrune != nil && *secret.AutoPrune {
 		return secreterrors.AutoPruneNotSupported

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -46,7 +46,7 @@ type unit struct {
 
 type application struct {
 	UUID coreapplication.UUID `db:"uuid"`
-	Name string             `db:"name"`
+	Name string               `db:"name"`
 }
 
 type secretRef struct {

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -45,7 +45,7 @@ type unit struct {
 }
 
 type application struct {
-	UUID coreapplication.ID `db:"uuid"`
+	UUID coreapplication.UUID `db:"uuid"`
 	Name string             `db:"name"`
 }
 

--- a/domain/status/leadership_test.go
+++ b/domain/status/leadership_test.go
@@ -184,7 +184,7 @@ func (s *leadershipSuite) setupMocks(c *tc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *leadershipSuite) createApplication(c *tc.C, name string, units ...application.AddIAASUnitArg) coreapplication.ID {
+func (s *leadershipSuite) createApplication(c *tc.C, name string, units ...application.AddIAASUnitArg) coreapplication.UUID {
 	appState := applicationstate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
 	platform := deployment.Platform{

--- a/domain/status/service/leaderservice.go
+++ b/domain/status/service/leaderservice.go
@@ -80,7 +80,7 @@ func (s *LeadershipService) SetApplicationStatusForUnitLeader(
 	// is because we're doing a reverse lookup from the unit to the application.
 	// We can't return the application not found, as we're not looking up the
 	// application directly.
-	appID, appName, err := s.modelState.GetApplicationIDAndNameByUnitName(ctx, unitName)
+	appID, appName, err := s.modelState.GetApplicationUUIDAndNameByUnitName(ctx, unitName)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -120,7 +120,7 @@ func (s *LeadershipService) GetApplicationAndUnitStatusesForUnitWithLeader(
 	appName := unitName.Application()
 	appID, err := s.modelState.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
-		return corestatus.StatusInfo{}, nil, errors.Errorf("getting application id: %w", err)
+		return corestatus.StatusInfo{}, nil, errors.Errorf("getting application UUID: %w", err)
 	}
 
 	var applicationStatus status.StatusInfo[status.WorkloadStatusType]

--- a/domain/status/service/leaderservice.go
+++ b/domain/status/service/leaderservice.go
@@ -118,7 +118,7 @@ func (s *LeadershipService) GetApplicationAndUnitStatusesForUnitWithLeader(
 	}
 
 	appName := unitName.Application()
-	appID, err := s.modelState.GetApplicationIDByName(ctx, appName)
+	appID, err := s.modelState.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return corestatus.StatusInfo{}, nil, errors.Errorf("getting application id: %w", err)
 	}

--- a/domain/status/service/leaderservice_test.go
+++ b/domain/status/service/leaderservice_test.go
@@ -112,7 +112,7 @@ func (s *leaderServiceSuite) TestSetApplicationStatusForUnitLeader(c *tc.C) {
 			return fn(ctx)
 		})
 
-	s.modelState.EXPECT().GetApplicationIDAndNameByUnitName(gomock.Any(), unitName).Return(applicationUUID, "foo", nil)
+	s.modelState.EXPECT().GetApplicationUUIDAndNameByUnitName(gomock.Any(), unitName).Return(applicationUUID, "foo", nil)
 	s.modelState.EXPECT().SetApplicationStatus(gomock.Any(), applicationUUID, status.StatusInfo[status.WorkloadStatusType]{
 		Status:  status.WorkloadStatusActive,
 		Message: "doink",
@@ -142,7 +142,7 @@ func (s *leaderServiceSuite) TestSetApplicationStatusForUnitLeaderNotLeader(c *t
 			return lease.ErrNotHeld
 		})
 
-	s.modelState.EXPECT().GetApplicationIDAndNameByUnitName(gomock.Any(), unitName).Return(applicationUUID, "foo", nil)
+	s.modelState.EXPECT().GetApplicationUUIDAndNameByUnitName(gomock.Any(), unitName).Return(applicationUUID, "foo", nil)
 
 	err := s.service.SetApplicationStatusForUnitLeader(c.Context(), unitName, corestatus.StatusInfo{
 		Status:  corestatus.Active,
@@ -176,7 +176,7 @@ func (s *leaderServiceSuite) TestSetApplicationStatusForUnitLeaderNoUnitFound(c 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
 	unitName := coreunit.Name("foo/666")
 
-	s.modelState.EXPECT().GetApplicationIDAndNameByUnitName(gomock.Any(), unitName).
+	s.modelState.EXPECT().GetApplicationUUIDAndNameByUnitName(gomock.Any(), unitName).
 		Return(applicationUUID, "foo", statuserrors.UnitNotFound)
 
 	err := s.service.SetApplicationStatusForUnitLeader(c.Context(), unitName, corestatus.StatusInfo{

--- a/domain/status/service/leaderservice_test.go
+++ b/domain/status/service/leaderservice_test.go
@@ -194,7 +194,7 @@ func (s *leaderServiceSuite) TestGetApplicationAndUnitStatusesForUnitWithLeaderN
 	unitName := coreunit.Name("foo/0")
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 
 	s.leadership.EXPECT().WithLeader(gomock.Any(), "foo", unitName.String(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, _, _ string, fn func(context.Context) error) error {
@@ -217,7 +217,7 @@ func (s *leaderServiceSuite) TestGetApplicationAndUnitStatusesForUnitWithLeaderN
 
 	unitName := coreunit.Name("foo/0")
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("", statuserrors.ApplicationNotFound)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", statuserrors.ApplicationNotFound)
 	_, _, err := s.service.GetApplicationAndUnitStatusesForUnitWithLeader(c.Context(), unitName)
 	c.Assert(err, tc.ErrorIs, statuserrors.ApplicationNotFound)
 }
@@ -234,7 +234,7 @@ func (s *leaderServiceSuite) TestGetApplicationAndUnitStatusesForUnitWithLeaderA
 			return fn(ctx)
 		})
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 
 	s.modelState.EXPECT().GetApplicationStatus(gomock.Any(), applicationUUID).Return(
 		status.StatusInfo[status.WorkloadStatusType]{
@@ -308,7 +308,7 @@ func (s *leaderServiceSuite) TestGetApplicationAndUnitStatusesForUnitWithLeaderA
 			return fn(ctx)
 		})
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 
 	s.modelState.EXPECT().GetApplicationStatus(gomock.Any(), applicationUUID).Return(
 		status.StatusInfo[status.WorkloadStatusType]{

--- a/domain/status/service/package_mock_test.go
+++ b/domain/status/service/package_mock_test.go
@@ -123,7 +123,7 @@ func (c *MockModelStateGetAllApplicationStatusesCall) DoAndReturn(f func(context
 }
 
 // GetAllFullUnitStatusesForApplication mocks base method.
-func (m *MockModelState) GetAllFullUnitStatusesForApplication(arg0 context.Context, arg1 application.ID) (status.FullUnitStatuses, error) {
+func (m *MockModelState) GetAllFullUnitStatusesForApplication(arg0 context.Context, arg1 application.UUID) (status.FullUnitStatuses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllFullUnitStatusesForApplication", arg0, arg1)
 	ret0, _ := ret[0].(status.FullUnitStatuses)
@@ -150,13 +150,13 @@ func (c *MockModelStateGetAllFullUnitStatusesForApplicationCall) Return(arg0 sta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetAllFullUnitStatusesForApplicationCall) Do(f func(context.Context, application.ID) (status.FullUnitStatuses, error)) *MockModelStateGetAllFullUnitStatusesForApplicationCall {
+func (c *MockModelStateGetAllFullUnitStatusesForApplicationCall) Do(f func(context.Context, application.UUID) (status.FullUnitStatuses, error)) *MockModelStateGetAllFullUnitStatusesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetAllFullUnitStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (status.FullUnitStatuses, error)) *MockModelStateGetAllFullUnitStatusesForApplicationCall {
+func (c *MockModelStateGetAllFullUnitStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (status.FullUnitStatuses, error)) *MockModelStateGetAllFullUnitStatusesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -396,10 +396,10 @@ func (c *MockModelStateGetApplicationAndUnitStatusesCall) DoAndReturn(f func(con
 }
 
 // GetApplicationIDAndNameByUnitName mocks base method.
-func (m *MockModelState) GetApplicationIDAndNameByUnitName(ctx context.Context, name unit.Name) (application.ID, string, error) {
+func (m *MockModelState) GetApplicationIDAndNameByUnitName(ctx context.Context, name unit.Name) (application.UUID, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDAndNameByUnitName", ctx, name)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -418,28 +418,28 @@ type MockModelStateGetApplicationIDAndNameByUnitNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) Return(arg0 application.ID, arg1 string, arg2 error) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
+func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) Return(arg0 application.UUID, arg1 string, arg2 error) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) Do(f func(context.Context, unit.Name) (application.ID, string, error)) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
+func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.ID, string, error)) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
+func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockModelState) GetApplicationIDByName(ctx context.Context, name string) (application.ID, error) {
+func (m *MockModelState) GetApplicationIDByName(ctx context.Context, name string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", ctx, name)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -457,25 +457,25 @@ type MockModelStateGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockModelStateGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockModelStateGetApplicationIDByNameCall {
+func (c *MockModelStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationStatus mocks base method.
-func (m *MockModelState) GetApplicationStatus(ctx context.Context, appID application.ID) (status.StatusInfo[status.WorkloadStatusType], error) {
+func (m *MockModelState) GetApplicationStatus(ctx context.Context, appID application.UUID) (status.StatusInfo[status.WorkloadStatusType], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationStatus", ctx, appID)
 	ret0, _ := ret[0].(status.StatusInfo[status.WorkloadStatusType])
@@ -502,13 +502,13 @@ func (c *MockModelStateGetApplicationStatusCall) Return(arg0 status.StatusInfo[s
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetApplicationStatusCall) Do(f func(context.Context, application.ID) (status.StatusInfo[status.WorkloadStatusType], error)) *MockModelStateGetApplicationStatusCall {
+func (c *MockModelStateGetApplicationStatusCall) Do(f func(context.Context, application.UUID) (status.StatusInfo[status.WorkloadStatusType], error)) *MockModelStateGetApplicationStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetApplicationStatusCall) DoAndReturn(f func(context.Context, application.ID) (status.StatusInfo[status.WorkloadStatusType], error)) *MockModelStateGetApplicationStatusCall {
+func (c *MockModelStateGetApplicationStatusCall) DoAndReturn(f func(context.Context, application.UUID) (status.StatusInfo[status.WorkloadStatusType], error)) *MockModelStateGetApplicationStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -943,7 +943,7 @@ func (c *MockModelStateGetUnitAgentStatusCall) DoAndReturn(f func(context.Contex
 }
 
 // GetUnitAgentStatusesForApplication mocks base method.
-func (m *MockModelState) GetUnitAgentStatusesForApplication(arg0 context.Context, arg1 application.ID) (status.UnitAgentStatuses, error) {
+func (m *MockModelState) GetUnitAgentStatusesForApplication(arg0 context.Context, arg1 application.UUID) (status.UnitAgentStatuses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitAgentStatusesForApplication", arg0, arg1)
 	ret0, _ := ret[0].(status.UnitAgentStatuses)
@@ -970,13 +970,13 @@ func (c *MockModelStateGetUnitAgentStatusesForApplicationCall) Return(arg0 statu
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetUnitAgentStatusesForApplicationCall) Do(f func(context.Context, application.ID) (status.UnitAgentStatuses, error)) *MockModelStateGetUnitAgentStatusesForApplicationCall {
+func (c *MockModelStateGetUnitAgentStatusesForApplicationCall) Do(f func(context.Context, application.UUID) (status.UnitAgentStatuses, error)) *MockModelStateGetUnitAgentStatusesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetUnitAgentStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (status.UnitAgentStatuses, error)) *MockModelStateGetUnitAgentStatusesForApplicationCall {
+func (c *MockModelStateGetUnitAgentStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (status.UnitAgentStatuses, error)) *MockModelStateGetUnitAgentStatusesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1099,7 +1099,7 @@ func (c *MockModelStateGetUnitWorkloadStatusCall) DoAndReturn(f func(context.Con
 }
 
 // GetUnitWorkloadStatusesForApplication mocks base method.
-func (m *MockModelState) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.ID) (status.UnitWorkloadStatuses, error) {
+func (m *MockModelState) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.UUID) (status.UnitWorkloadStatuses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitWorkloadStatusesForApplication", arg0, arg1)
 	ret0, _ := ret[0].(status.UnitWorkloadStatuses)
@@ -1126,13 +1126,13 @@ func (c *MockModelStateGetUnitWorkloadStatusesForApplicationCall) Return(arg0 st
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.ID) (status.UnitWorkloadStatuses, error)) *MockModelStateGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockModelStateGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.UUID) (status.UnitWorkloadStatuses, error)) *MockModelStateGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (status.UnitWorkloadStatuses, error)) *MockModelStateGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockModelStateGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (status.UnitWorkloadStatuses, error)) *MockModelStateGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1293,7 +1293,7 @@ func (c *MockModelStateImportRelationStatusCall) DoAndReturn(f func(context.Cont
 }
 
 // SetApplicationStatus mocks base method.
-func (m *MockModelState) SetApplicationStatus(ctx context.Context, applicationID application.ID, status status.StatusInfo[status.WorkloadStatusType]) error {
+func (m *MockModelState) SetApplicationStatus(ctx context.Context, applicationID application.UUID, status status.StatusInfo[status.WorkloadStatusType]) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetApplicationStatus", ctx, applicationID, status)
 	ret0, _ := ret[0].(error)
@@ -1319,13 +1319,13 @@ func (c *MockModelStateSetApplicationStatusCall) Return(arg0 error) *MockModelSt
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateSetApplicationStatusCall) Do(f func(context.Context, application.ID, status.StatusInfo[status.WorkloadStatusType]) error) *MockModelStateSetApplicationStatusCall {
+func (c *MockModelStateSetApplicationStatusCall) Do(f func(context.Context, application.UUID, status.StatusInfo[status.WorkloadStatusType]) error) *MockModelStateSetApplicationStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateSetApplicationStatusCall) DoAndReturn(f func(context.Context, application.ID, status.StatusInfo[status.WorkloadStatusType]) error) *MockModelStateSetApplicationStatusCall {
+func (c *MockModelStateSetApplicationStatusCall) DoAndReturn(f func(context.Context, application.UUID, status.StatusInfo[status.WorkloadStatusType]) error) *MockModelStateSetApplicationStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/status/service/package_mock_test.go
+++ b/domain/status/service/package_mock_test.go
@@ -435,45 +435,6 @@ func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) DoAndReturn(f func
 	return c
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockModelState) GetApplicationIDByName(ctx context.Context, name string) (application.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", ctx, name)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockModelStateMockRecorder) GetApplicationIDByName(ctx, name any) *MockModelStateGetApplicationIDByNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockModelState)(nil).GetApplicationIDByName), ctx, name)
-	return &MockModelStateGetApplicationIDByNameCall{Call: call}
-}
-
-// MockModelStateGetApplicationIDByNameCall wrap *gomock.Call
-type MockModelStateGetApplicationIDByNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockModelStateGetApplicationIDByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationIDByNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationIDByNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetApplicationStatus mocks base method.
 func (m *MockModelState) GetApplicationStatus(ctx context.Context, appID application.UUID) (status.StatusInfo[status.WorkloadStatusType], error) {
 	m.ctrl.T.Helper()
@@ -509,6 +470,45 @@ func (c *MockModelStateGetApplicationStatusCall) Do(f func(context.Context, appl
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelStateGetApplicationStatusCall) DoAndReturn(f func(context.Context, application.UUID) (status.StatusInfo[status.WorkloadStatusType], error)) *MockModelStateGetApplicationStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDByName mocks base method.
+func (m *MockModelState) GetApplicationUUIDByName(ctx context.Context, name string) (application.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", ctx, name)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockModelStateMockRecorder) GetApplicationUUIDByName(ctx, name any) *MockModelStateGetApplicationUUIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockModelState)(nil).GetApplicationUUIDByName), ctx, name)
+	return &MockModelStateGetApplicationUUIDByNameCall{Call: call}
+}
+
+// MockModelStateGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockModelStateGetApplicationUUIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockModelStateGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationUUIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockModelStateGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/status/service/package_mock_test.go
+++ b/domain/status/service/package_mock_test.go
@@ -395,46 +395,6 @@ func (c *MockModelStateGetApplicationAndUnitStatusesCall) DoAndReturn(f func(con
 	return c
 }
 
-// GetApplicationIDAndNameByUnitName mocks base method.
-func (m *MockModelState) GetApplicationIDAndNameByUnitName(ctx context.Context, name unit.Name) (application.UUID, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDAndNameByUnitName", ctx, name)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetApplicationIDAndNameByUnitName indicates an expected call of GetApplicationIDAndNameByUnitName.
-func (mr *MockModelStateMockRecorder) GetApplicationIDAndNameByUnitName(ctx, name any) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDAndNameByUnitName", reflect.TypeOf((*MockModelState)(nil).GetApplicationIDAndNameByUnitName), ctx, name)
-	return &MockModelStateGetApplicationIDAndNameByUnitNameCall{Call: call}
-}
-
-// MockModelStateGetApplicationIDAndNameByUnitNameCall wrap *gomock.Call
-type MockModelStateGetApplicationIDAndNameByUnitNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) Return(arg0 application.UUID, arg1 string, arg2 error) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetApplicationIDAndNameByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockModelStateGetApplicationIDAndNameByUnitNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetApplicationStatus mocks base method.
 func (m *MockModelState) GetApplicationStatus(ctx context.Context, appID application.UUID) (status.StatusInfo[status.WorkloadStatusType], error) {
 	m.ctrl.T.Helper()
@@ -470,6 +430,46 @@ func (c *MockModelStateGetApplicationStatusCall) Do(f func(context.Context, appl
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelStateGetApplicationStatusCall) DoAndReturn(f func(context.Context, application.UUID) (status.StatusInfo[status.WorkloadStatusType], error)) *MockModelStateGetApplicationStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationUUIDAndNameByUnitName mocks base method.
+func (m *MockModelState) GetApplicationUUIDAndNameByUnitName(ctx context.Context, name unit.Name) (application.UUID, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationUUIDAndNameByUnitName", ctx, name)
+	ret0, _ := ret[0].(application.UUID)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetApplicationUUIDAndNameByUnitName indicates an expected call of GetApplicationUUIDAndNameByUnitName.
+func (mr *MockModelStateMockRecorder) GetApplicationUUIDAndNameByUnitName(ctx, name any) *MockModelStateGetApplicationUUIDAndNameByUnitNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDAndNameByUnitName", reflect.TypeOf((*MockModelState)(nil).GetApplicationUUIDAndNameByUnitName), ctx, name)
+	return &MockModelStateGetApplicationUUIDAndNameByUnitNameCall{Call: call}
+}
+
+// MockModelStateGetApplicationUUIDAndNameByUnitNameCall wrap *gomock.Call
+type MockModelStateGetApplicationUUIDAndNameByUnitNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetApplicationUUIDAndNameByUnitNameCall) Return(arg0 application.UUID, arg1 string, arg2 error) *MockModelStateGetApplicationUUIDAndNameByUnitNameCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetApplicationUUIDAndNameByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockModelStateGetApplicationUUIDAndNameByUnitNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetApplicationUUIDAndNameByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, string, error)) *MockModelStateGetApplicationUUIDAndNameByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/status/service/service.go
+++ b/domain/status/service/service.go
@@ -35,24 +35,24 @@ type ModelState interface {
 	// GetApplicationIDByName returns the application ID for the named
 	// application. If no application is found, an error satisfying
 	// [statuserrors.ApplicationNotFound] is returned.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationIDAndNameByUnitName returns the application ID and name for
 	// the named unit, returning an error satisfying
 	// [statuserrors.UnitNotFound] if the unit doesn't exist.
-	GetApplicationIDAndNameByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.ID, string, error)
+	GetApplicationIDAndNameByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, string, error)
 
 	// GetApplicationStatus looks up the status of the specified application,
 	// returning an error satisfying [statuserrors.ApplicationNotFound] if the
 	// application is not found.
-	GetApplicationStatus(ctx context.Context, appID coreapplication.ID) (status.StatusInfo[status.WorkloadStatusType], error)
+	GetApplicationStatus(ctx context.Context, appID coreapplication.UUID) (status.StatusInfo[status.WorkloadStatusType], error)
 
 	// SetApplicationStatus sets the given application status, overwriting any
 	// current status data. If returns an error satisfying
 	// [statuserrors.ApplicationNotFound] if the application doesn't exist.
 	SetApplicationStatus(
 		ctx context.Context,
-		applicationID coreapplication.ID,
+		applicationID coreapplication.UUID,
 		status status.StatusInfo[status.WorkloadStatusType],
 	) error
 
@@ -116,7 +116,7 @@ type ModelState interface {
 	//     application doesn't exist or;
 	//   - error satisfying [statuserrors.ApplicationIsDead] if the
 	//     application is dead.
-	GetUnitWorkloadStatusesForApplication(context.Context, coreapplication.ID) (status.UnitWorkloadStatuses, error)
+	GetUnitWorkloadStatusesForApplication(context.Context, coreapplication.UUID) (status.UnitWorkloadStatuses, error)
 
 	// GetUnitAgentStatusesForApplication returns the agent statuses for
 	// all units of the specified application, returning:
@@ -124,7 +124,7 @@ type ModelState interface {
 	//     application doesn't exist or;
 	//   - error satisfying [statuserrors.ApplicationIsDead] if the
 	//     application is dead.
-	GetUnitAgentStatusesForApplication(context.Context, coreapplication.ID) (status.UnitAgentStatuses, error)
+	GetUnitAgentStatusesForApplication(context.Context, coreapplication.UUID) (status.UnitAgentStatuses, error)
 
 	// GetAllFullUnitStatusesForApplication returns the workload statuses and
 	// the cloud container statuses for all units of the specified application,
@@ -134,7 +134,7 @@ type ModelState interface {
 	//   - an error satisfying [statuserrors.ApplicationIsDead] if the
 	//     application is dead.
 	GetAllFullUnitStatusesForApplication(
-		context.Context, coreapplication.ID,
+		context.Context, coreapplication.UUID,
 	) (status.FullUnitStatuses, error)
 
 	// GetUnitAgentStatus returns the workload status of the specified unit,
@@ -427,7 +427,7 @@ func (s *Service) SetUnitAgentStatus(ctx context.Context, unitName coreunit.Name
 // units in the specified application, indexed by unit name, returning an error
 // satisfying [statuserrors.ApplicationNotFound] if the application doesn't
 // exist.
-func (s *Service) GetUnitWorkloadStatusesForApplication(ctx context.Context, appID coreapplication.ID) (map[coreunit.Name]corestatus.StatusInfo, error) {
+func (s *Service) GetUnitWorkloadStatusesForApplication(ctx context.Context, appID coreapplication.UUID) (map[coreunit.Name]corestatus.StatusInfo, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -451,7 +451,7 @@ func (s *Service) GetUnitWorkloadStatusesForApplication(ctx context.Context, app
 // units in the specified application, indexed by unit name, returning an error
 // satisfying [statuserrors.ApplicationNotFound] if the application doesn't
 // exist.
-func (s *Service) GetUnitAgentStatusesForApplication(ctx context.Context, appID coreapplication.ID) (map[coreunit.Name]corestatus.StatusInfo, error) {
+func (s *Service) GetUnitAgentStatusesForApplication(ctx context.Context, appID coreapplication.UUID) (map[coreunit.Name]corestatus.StatusInfo, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1036,7 +1036,7 @@ func (s *Service) decodeApplicationStatusDetails(ctx context.Context, app status
 
 func (s *Service) decodeApplicationDisplayStatus(
 	ctx context.Context,
-	appID coreapplication.ID,
+	appID coreapplication.UUID,
 	statusInfo status.StatusInfo[status.WorkloadStatusType],
 ) (corestatus.StatusInfo, error) {
 	if statusInfo.Status != status.WorkloadStatusUnset {

--- a/domain/status/service/service.go
+++ b/domain/status/service/service.go
@@ -32,15 +32,15 @@ type ModelState interface {
 	// GetAllRelationStatuses returns all the relation statuses of the given model.
 	GetAllRelationStatuses(ctx context.Context) ([]status.RelationStatusInfo, error)
 
-	// GetApplicationUUIDByName returns the application ID for the named
+	// GetApplicationUUIDByName returns the application UUID for the named
 	// application. If no application is found, an error satisfying
 	// [statuserrors.ApplicationNotFound] is returned.
 	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
-	// GetApplicationIDAndNameByUnitName returns the application ID and name for
+	// GetApplicationUUIDAndNameByUnitName returns the application UUID and name for
 	// the named unit, returning an error satisfying
 	// [statuserrors.UnitNotFound] if the unit doesn't exist.
-	GetApplicationIDAndNameByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, string, error)
+	GetApplicationUUIDAndNameByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, string, error)
 
 	// GetApplicationStatus looks up the status of the specified application,
 	// returning an error satisfying [statuserrors.ApplicationNotFound] if the
@@ -432,7 +432,7 @@ func (s *Service) GetUnitWorkloadStatusesForApplication(ctx context.Context, app
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return nil, errors.Errorf("application ID: %w", err)
+		return nil, errors.Errorf("application UUID: %w", err)
 	}
 
 	statuses, err := s.modelState.GetUnitWorkloadStatusesForApplication(ctx, appID)
@@ -456,7 +456,7 @@ func (s *Service) GetUnitAgentStatusesForApplication(ctx context.Context, appID 
 	defer span.End()
 
 	if err := appID.Validate(); err != nil {
-		return nil, errors.Errorf("application ID: %w", err)
+		return nil, errors.Errorf("application UUID: %w", err)
 	}
 
 	statuses, err := s.modelState.GetUnitAgentStatusesForApplication(ctx, appID)

--- a/domain/status/service/service.go
+++ b/domain/status/service/service.go
@@ -32,10 +32,10 @@ type ModelState interface {
 	// GetAllRelationStatuses returns all the relation statuses of the given model.
 	GetAllRelationStatuses(ctx context.Context) ([]status.RelationStatusInfo, error)
 
-	// GetApplicationIDByName returns the application ID for the named
+	// GetApplicationUUIDByName returns the application ID for the named
 	// application. If no application is found, an error satisfying
 	// [statuserrors.ApplicationNotFound] is returned.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationIDAndNameByUnitName returns the application ID and name for
 	// the named unit, returning an error satisfying
@@ -298,7 +298,7 @@ func (s *Service) SetApplicationStatus(
 		return errors.Errorf("encoding workload status: %w", err)
 	}
 
-	applicationID, err := s.modelState.GetApplicationIDByName(ctx, applicationName)
+	applicationID, err := s.modelState.GetApplicationUUIDByName(ctx, applicationName)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -323,7 +323,7 @@ func (s *Service) GetApplicationDisplayStatus(ctx context.Context, appName strin
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	appID, err := s.modelState.GetApplicationIDByName(ctx, appName)
+	appID, err := s.modelState.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return corestatus.StatusInfo{}, errors.Capture(err)
 	}

--- a/domain/status/service/service_test.go
+++ b/domain/status/service/service_test.go
@@ -143,7 +143,7 @@ func (s *serviceSuite) TestSetApplicationStatus(c *tc.C) {
 	now := time.Now()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "gitlab").Return(applicationUUID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return(applicationUUID, nil)
 	s.modelState.EXPECT().SetApplicationStatus(gomock.Any(), applicationUUID, status.StatusInfo[status.WorkloadStatusType]{
 		Status:  status.WorkloadStatusActive,
 		Message: "doink",
@@ -173,7 +173,7 @@ func (s *serviceSuite) TestSetApplicationStatus(c *tc.C) {
 func (s *serviceSuite) TestSetApplicationStatusNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "gitlab").Return("", statuserrors.ApplicationNotFound)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return("", statuserrors.ApplicationNotFound)
 
 	err := s.modelService.SetApplicationStatus(c.Context(), "gitlab", corestatus.StatusInfo{
 		Status: corestatus.Active,
@@ -198,7 +198,7 @@ func (s *serviceSuite) TestSetApplicationStatusInvalidStatus(c *tc.C) {
 func (s *serviceSuite) TestGetApplicationDisplayStatusNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "gitlab").Return("", statuserrors.ApplicationNotFound)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return("", statuserrors.ApplicationNotFound)
 
 	_, err := s.modelService.GetApplicationDisplayStatus(c.Context(), "gitlab")
 	c.Assert(err, tc.ErrorIs, statuserrors.ApplicationNotFound)
@@ -210,7 +210,7 @@ func (s *serviceSuite) TestGetApplicationDisplayStatusApplicationStatusSet(c *tc
 	now := time.Now()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.modelState.EXPECT().GetApplicationStatus(gomock.Any(), applicationUUID).Return(
 		status.StatusInfo[status.WorkloadStatusType]{
 			Status:  status.WorkloadStatusActive,
@@ -233,7 +233,7 @@ func (s *serviceSuite) TestGetApplicationDisplayStatusFallbackToUnitsNoUnits(c *
 	defer s.setupMocks(c).Finish()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.modelState.EXPECT().GetApplicationStatus(gomock.Any(), applicationUUID).Return(
 		status.StatusInfo[status.WorkloadStatusType]{
 			Status: status.WorkloadStatusUnset,
@@ -254,7 +254,7 @@ func (s *serviceSuite) TestGetApplicationDisplayStatusFallbackToUnitsNoContainer
 	now := time.Now()
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
-	s.modelState.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
 	s.modelState.EXPECT().GetApplicationStatus(gomock.Any(), applicationUUID).Return(
 		status.StatusInfo[status.WorkloadStatusType]{
 			Status: status.WorkloadStatusUnset,

--- a/domain/status/state/modelstate.go
+++ b/domain/status/state/modelstate.go
@@ -134,10 +134,10 @@ JOIN   relation r ON r.uuid = rs.relation_uuid
 	return relationStatuses, errors.Capture(err)
 }
 
-// GetApplicationIDByName returns the application ID for the named application.
+// GetApplicationUUIDByName returns the application ID for the named application.
 // If no application is found, an error satisfying
 // [statuserrors.ApplicationNotFound] is returned.
-func (st *ModelState) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
+func (st *ModelState) GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)

--- a/domain/status/state/modelstate.go
+++ b/domain/status/state/modelstate.go
@@ -137,13 +137,13 @@ JOIN   relation r ON r.uuid = rs.relation_uuid
 // GetApplicationIDByName returns the application ID for the named application.
 // If no application is found, an error satisfying
 // [statuserrors.ApplicationNotFound] is returned.
-func (st *ModelState) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error) {
+func (st *ModelState) GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	var id coreapplication.ID
+	var id coreapplication.UUID
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		id, err = st.lookupApplication(ctx, tx, name)
 		return err
@@ -161,7 +161,7 @@ func (st *ModelState) GetApplicationIDByName(ctx context.Context, name string) (
 func (st *ModelState) GetApplicationIDAndNameByUnitName(
 	ctx context.Context,
 	name coreunit.Name,
-) (coreapplication.ID, string, error) {
+) (coreapplication.UUID, string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", "", errors.Capture(err)
@@ -197,7 +197,7 @@ WHERE u.name = $unitName.name;
 // GetApplicationStatus looks up the status of the specified application,
 // returning an error satisfying [statuserrors.ApplicationNotFound] if the
 // application is not found.
-func (st *ModelState) GetApplicationStatus(ctx context.Context, appID coreapplication.ID) (status.StatusInfo[status.WorkloadStatusType], error) {
+func (st *ModelState) GetApplicationStatus(ctx context.Context, appID coreapplication.UUID) (status.StatusInfo[status.WorkloadStatusType], error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return status.StatusInfo[status.WorkloadStatusType]{}, errors.Capture(err)
@@ -249,7 +249,7 @@ WHERE application_uuid = $applicationID.uuid;
 // [statuserrors.ApplicationNotFound] if the application doesn't exist.
 func (st *ModelState) SetApplicationStatus(
 	ctx context.Context,
-	applicationID coreapplication.ID,
+	applicationID coreapplication.UUID,
 	sts status.StatusInfo[status.WorkloadStatusType],
 ) error {
 	db, err := st.DB(ctx)
@@ -710,7 +710,7 @@ WHERE  unit_uuid = $unitUUID.uuid
 //   - error satisfying [statuserrors.ApplicationIsDead] if the application
 //     is dead.
 func (st *ModelState) GetUnitWorkloadStatusesForApplication(
-	ctx context.Context, appID coreapplication.ID,
+	ctx context.Context, appID coreapplication.UUID,
 ) (status.UnitWorkloadStatuses, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -737,7 +737,7 @@ func (st *ModelState) GetUnitWorkloadStatusesForApplication(
 //   - error satisfying [statuserrors.ApplicationIsDead] if the application
 //     is dead.
 func (st *ModelState) GetUnitAgentStatusesForApplication(
-	ctx context.Context, appID coreapplication.ID,
+	ctx context.Context, appID coreapplication.UUID,
 ) (status.UnitAgentStatuses, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -764,7 +764,7 @@ func (st *ModelState) GetUnitAgentStatusesForApplication(
 //   - an error satisfying [statuserrors.ApplicationIsDead] if the application
 //     is dead.
 func (st *ModelState) GetAllFullUnitStatusesForApplication(
-	ctx context.Context, appID coreapplication.ID,
+	ctx context.Context, appID coreapplication.UUID,
 ) (
 	status.FullUnitStatuses, error,
 ) {
@@ -1047,7 +1047,7 @@ WHERE unit_uuid = (
 // application.ID.
 // If no application is found, an error satisfying
 // [statuserrors.ApplicationNotFound] is returned.
-func (st *ModelState) lookupApplication(ctx context.Context, tx *sqlair.TX, name string) (coreapplication.ID, error) {
+func (st *ModelState) lookupApplication(ctx context.Context, tx *sqlair.TX, name string) (coreapplication.UUID, error) {
 	app := applicationIDAndName{Name: name}
 	queryApplicationStmt, err := st.Prepare(`
 SELECT uuid AS &applicationIDAndName.uuid

--- a/domain/status/state/modelstate.go
+++ b/domain/status/state/modelstate.go
@@ -134,7 +134,7 @@ JOIN   relation r ON r.uuid = rs.relation_uuid
 	return relationStatuses, errors.Capture(err)
 }
 
-// GetApplicationUUIDByName returns the application ID for the named application.
+// GetApplicationUUIDByName returns the application UUID for the named application.
 // If no application is found, an error satisfying
 // [statuserrors.ApplicationNotFound] is returned.
 func (st *ModelState) GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
@@ -153,12 +153,12 @@ func (st *ModelState) GetApplicationUUIDByName(ctx context.Context, name string)
 	return id, nil
 }
 
-// GetApplicationIDAndNameByUnitName returns the application ID and name for the
+// GetApplicationUUIDAndNameByUnitName returns the application UUID and name for the
 // named unit.
 //
 // Returns an error satisfying [statuserrors.UnitNotFound] if the unit
 // doesn't exist.
-func (st *ModelState) GetApplicationIDAndNameByUnitName(
+func (st *ModelState) GetApplicationUUIDAndNameByUnitName(
 	ctx context.Context,
 	name coreunit.Name,
 ) (coreapplication.UUID, string, error) {
@@ -169,18 +169,18 @@ func (st *ModelState) GetApplicationIDAndNameByUnitName(
 
 	unit := unitName{Name: name}
 	queryUnit := `
-SELECT a.uuid AS &applicationIDAndName.uuid,
-       a.name AS &applicationIDAndName.name
+SELECT a.uuid AS &applicationUUIDAndName.uuid,
+       a.name AS &applicationUUIDAndName.name
 FROM unit u
 JOIN application a ON a.uuid = u.application_uuid
 WHERE u.name = $unitName.name;
 `
-	query, err := st.Prepare(queryUnit, applicationIDAndName{}, unit)
+	query, err := st.Prepare(queryUnit, applicationUUIDAndName{}, unit)
 	if err != nil {
 		return "", "", errors.Errorf("preparing query for unit %q: %w", name, err)
 	}
 
-	var app applicationIDAndName
+	var app applicationUUIDAndName
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, query, unit).Get(&app)
 		if errors.Is(err, sqlair.ErrNoRows) {
@@ -189,7 +189,7 @@ WHERE u.name = $unitName.name;
 		return err
 	})
 	if err != nil {
-		return "", "", errors.Errorf("querying unit %q application id: %w", name, err)
+		return "", "", errors.Errorf("querying unit %q application UUID: %w", name, err)
 	}
 	return app.ID, app.Name, nil
 }
@@ -203,11 +203,11 @@ func (st *ModelState) GetApplicationStatus(ctx context.Context, appID coreapplic
 		return status.StatusInfo[status.WorkloadStatusType]{}, errors.Capture(err)
 	}
 
-	identID := applicationID{ID: appID}
+	identID := applicationUUID{ID: appID}
 	query, err := st.Prepare(`
 SELECT &statusInfo.*
 FROM application_status
-WHERE application_uuid = $applicationID.uuid;
+WHERE application_uuid = $applicationUUID.uuid;
 `, identID, statusInfo{})
 	if err != nil {
 		return status.StatusInfo[status.WorkloadStatusType]{}, errors.Capture(err)
@@ -716,7 +716,7 @@ func (st *ModelState) GetUnitWorkloadStatusesForApplication(
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	ident := applicationID{ID: appID}
+	ident := applicationUUID{ID: appID}
 
 	var unitStatuses status.UnitWorkloadStatuses
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -743,7 +743,7 @@ func (st *ModelState) GetUnitAgentStatusesForApplication(
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	ident := applicationID{ID: appID}
+	ident := applicationUUID{ID: appID}
 
 	var unitAgentStatuses status.UnitAgentStatuses
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -772,12 +772,12 @@ func (st *ModelState) GetAllFullUnitStatusesForApplication(
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	ident := applicationID{ID: appID}
+	ident := applicationUUID{ID: appID}
 
 	stmt, err := st.Prepare(`
 SELECT &fullUnitStatus.*
 FROM v_full_unit_status
-WHERE application_uuid = $applicationID.uuid
+WHERE application_uuid = $applicationUUID.uuid
 `, fullUnitStatus{}, ident)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -1048,11 +1048,11 @@ WHERE unit_uuid = (
 // If no application is found, an error satisfying
 // [statuserrors.ApplicationNotFound] is returned.
 func (st *ModelState) lookupApplication(ctx context.Context, tx *sqlair.TX, name string) (coreapplication.UUID, error) {
-	app := applicationIDAndName{Name: name}
+	app := applicationUUIDAndName{Name: name}
 	queryApplicationStmt, err := st.Prepare(`
-SELECT uuid AS &applicationIDAndName.uuid
+SELECT uuid AS &applicationUUIDAndName.uuid
 FROM application
-WHERE name = $applicationIDAndName.name
+WHERE name = $applicationUUIDAndName.name
 `, app)
 	if err != nil {
 		return "", errors.Capture(err)
@@ -1071,7 +1071,7 @@ WHERE name = $applicationIDAndName.name
 //   - If the application is dead, [statuserrors.ApplicationIsDead] is returned.
 //   - If the application is not found, [statuserrors.ApplicationNotFound]
 //     is returned.
-func (st *ModelState) checkApplicationNotDead(ctx context.Context, tx *sqlair.TX, ident applicationID) error {
+func (st *ModelState) checkApplicationNotDead(ctx context.Context, tx *sqlair.TX, ident applicationUUID) error {
 	type life struct {
 		LifeID domainlife.Life `db:"life_id"`
 	}
@@ -1079,7 +1079,7 @@ func (st *ModelState) checkApplicationNotDead(ctx context.Context, tx *sqlair.TX
 	query := `
 SELECT &life.*
 FROM application
-WHERE uuid = $applicationID.uuid;
+WHERE uuid = $applicationUUID.uuid;
 `
 	stmt, err := st.Prepare(query, ident, life{})
 	if err != nil {
@@ -1138,14 +1138,14 @@ WHERE uuid = $unitUUID.uuid;
 }
 
 func (st *ModelState) getUnitWorkloadStatusesForApplication(
-	ctx context.Context, tx *sqlair.TX, ident applicationID,
+	ctx context.Context, tx *sqlair.TX, ident applicationUUID,
 ) (
 	status.UnitWorkloadStatuses, error,
 ) {
 	getUnitStatusesStmt, err := st.Prepare(`
 SELECT &statusInfoAndUnitNameAndPresence.*
 FROM   v_unit_workload_status
-WHERE  application_uuid = $applicationID.uuid
+WHERE  application_uuid = $applicationUUID.uuid
 `, statusInfoAndUnitNameAndPresence{}, ident)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -1184,14 +1184,14 @@ WHERE  application_uuid = $applicationID.uuid
 }
 
 func (st *ModelState) getUnitAgentStatusesForApplication(
-	ctx context.Context, tx *sqlair.TX, ident applicationID,
+	ctx context.Context, tx *sqlair.TX, ident applicationUUID,
 ) (
 	status.UnitAgentStatuses, error,
 ) {
 	getUnitAgentStatusesStmt, err := st.Prepare(`
 SELECT &statusInfoAndUnitName.*
 FROM   v_unit_agent_status
-WHERE  application_uuid = $applicationID.uuid
+WHERE  application_uuid = $applicationUUID.uuid
 `, statusInfoAndUnitName{}, ident)
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/status/state/modelstate_test.go
+++ b/domain/status/state/modelstate_test.go
@@ -140,17 +140,17 @@ func (s *modelStateSuite) TestGetApplicationUUIDByNameNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, statuserrors.ApplicationNotFound)
 }
 
-func (s *modelStateSuite) TestGetApplicationIDAndNameByUnitName(c *tc.C) {
+func (s *modelStateSuite) TestGetApplicationUUIDAndNameByUnitName(c *tc.C) {
 	expectedAppUUID, _ := s.createIAASApplicationWithNUnits(c, "foo", 1)
 
-	appUUID, appName, err := s.state.GetApplicationIDAndNameByUnitName(c.Context(), coreunit.Name("foo/0"))
+	appUUID, appName, err := s.state.GetApplicationUUIDAndNameByUnitName(c.Context(), coreunit.Name("foo/0"))
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(appUUID, tc.Equals, expectedAppUUID)
 	c.Check(appName, tc.Equals, "foo")
 }
 
-func (s *modelStateSuite) TestGetApplicationIDAndNameByUnitNameNotFound(c *tc.C) {
-	_, _, err := s.state.GetApplicationIDAndNameByUnitName(c.Context(), "failme")
+func (s *modelStateSuite) TestGetApplicationUUIDAndNameByUnitNameNotFound(c *tc.C) {
+	_, _, err := s.state.GetApplicationUUIDAndNameByUnitName(c.Context(), "failme")
 	c.Assert(err, tc.ErrorIs, statuserrors.UnitNotFound)
 }
 

--- a/domain/status/state/modelstate_test.go
+++ b/domain/status/state/modelstate_test.go
@@ -127,16 +127,16 @@ func (s *modelStateSuite) TestGetAllRelationStatusesNone(c *tc.C) {
 	c.Assert(result, tc.HasLen, 0)
 }
 
-func (s *modelStateSuite) TestGetApplicationIDByName(c *tc.C) {
+func (s *modelStateSuite) TestGetApplicationUUIDByName(c *tc.C) {
 	id, _ := s.createIAASApplication(c, "foo", life.Alive, false, s.appStatus(time.Now()))
 
-	gotID, err := s.state.GetApplicationIDByName(c.Context(), "foo")
+	gotID, err := s.state.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(gotID, tc.Equals, id)
 }
 
-func (s *modelStateSuite) TestGetApplicationIDByNameNotFound(c *tc.C) {
-	_, err := s.state.GetApplicationIDByName(c.Context(), "foo")
+func (s *modelStateSuite) TestGetApplicationUUIDByNameNotFound(c *tc.C) {
+	_, err := s.state.GetApplicationUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, statuserrors.ApplicationNotFound)
 }
 

--- a/domain/status/state/modelstate_test.go
+++ b/domain/status/state/modelstate_test.go
@@ -1749,7 +1749,7 @@ func (s *modelStateSuite) TestGetApplicationAndUnitStatusesWorkloadVersion(c *tc
 	})
 }
 
-func (s *modelStateSuite) setWorkloadVersion(c *tc.C, appUUID coreapplication.ID, unitUUID coreunit.UUID, version string) {
+func (s *modelStateSuite) setWorkloadVersion(c *tc.C, appUUID coreapplication.UUID, unitUUID coreunit.UUID, version string) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, `UPDATE application_workload_version SET version=? WHERE application_uuid=?`, version, appUUID); err != nil {
 			return err
@@ -2523,7 +2523,7 @@ WHERE rst.name = ?
 		relationUUID, status, message))
 }
 
-func (s *modelStateSuite) addRelationToApplication(c *tc.C, appUUID coreapplication.ID, relationUUID corerelation.UUID) {
+func (s *modelStateSuite) addRelationToApplication(c *tc.C, appUUID coreapplication.UUID, relationUUID corerelation.UUID) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		var charmRelationUUID string
 		err := tx.QueryRowContext(ctx, `SELECT uuid FROM charm_relation WHERE name = 'endpoint'`).Scan(&charmRelationUUID)
@@ -2613,7 +2613,7 @@ func (s *modelStateSuite) createIAASApplicationWithNUnits(
 	c *tc.C,
 	name string,
 	nUnits int,
-) (coreapplication.ID, []coreunit.UUID) {
+) (coreapplication.UUID, []coreunit.UUID) {
 	units := make([]application.AddIAASUnitArg, nUnits)
 	for i := range units {
 		netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
@@ -2634,7 +2634,7 @@ func (s *modelStateSuite) createIAASApplication(
 	subordinate bool,
 	appStatus *status.StatusInfo[status.WorkloadStatusType],
 	units ...application.AddIAASUnitArg,
-) (coreapplication.ID, []coreunit.UUID) {
+) (coreapplication.UUID, []coreunit.UUID) {
 	appState := applicationstate.NewState(
 		s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c),
 	)
@@ -2731,7 +2731,7 @@ func (s *modelStateSuite) createCAASApplication(
 	subordinate bool,
 	appStatus *status.StatusInfo[status.WorkloadStatusType],
 	units ...application.AddCAASUnitArg,
-) (coreapplication.ID, []coreunit.UUID) {
+) (coreapplication.UUID, []coreunit.UUID) {
 	appState := applicationstate.NewState(
 		s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c),
 	)
@@ -2822,7 +2822,7 @@ func (s *modelStateSuite) createCAASApplication(
 	return appID, unitUUIDs
 }
 
-func (s *modelStateSuite) setApplicationLXDProfile(c *tc.C, appUUID coreapplication.ID, profile string) {
+func (s *modelStateSuite) setApplicationLXDProfile(c *tc.C, appUUID coreapplication.UUID, profile string) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
 UPDATE charm SET lxd_profile = ? WHERE uuid = (SELECT charm_uuid FROM application WHERE uuid = ?)

--- a/domain/status/state/types.go
+++ b/domain/status/state/types.go
@@ -18,11 +18,11 @@ import (
 )
 
 type applicationID struct {
-	ID coreapplication.ID `db:"uuid"`
+	ID coreapplication.UUID `db:"uuid"`
 }
 
 type applicationIDAndName struct {
-	ID   coreapplication.ID `db:"uuid"`
+	ID   coreapplication.UUID `db:"uuid"`
 	Name string             `db:"name"`
 }
 
@@ -51,7 +51,7 @@ type statusInfo struct {
 }
 
 type applicationStatusInfo struct {
-	ApplicationID coreapplication.ID `db:"application_uuid"`
+	ApplicationID coreapplication.UUID `db:"application_uuid"`
 	StatusID      int                `db:"status_id"`
 	Message       string             `db:"message"`
 	Data          []byte             `db:"data"`
@@ -149,7 +149,7 @@ type CharmLocatorDetails struct {
 
 type applicationStatusDetails struct {
 	CharmLocatorDetails
-	UUID                   coreapplication.ID `db:"uuid"`
+	UUID                   coreapplication.UUID `db:"uuid"`
 	Name                   string             `db:"name"`
 	PlatformOSID           sql.Null[int64]    `db:"platform_os_id"`
 	PlatformChannel        string             `db:"platform_channel"`

--- a/domain/status/state/types.go
+++ b/domain/status/state/types.go
@@ -17,11 +17,11 @@ import (
 	"github.com/juju/juju/domain/status"
 )
 
-type applicationID struct {
+type applicationUUID struct {
 	ID coreapplication.UUID `db:"uuid"`
 }
 
-type applicationIDAndName struct {
+type applicationUUIDAndName struct {
 	ID   coreapplication.UUID `db:"uuid"`
 	Name string               `db:"name"`
 }

--- a/domain/status/state/types.go
+++ b/domain/status/state/types.go
@@ -23,7 +23,7 @@ type applicationID struct {
 
 type applicationIDAndName struct {
 	ID   coreapplication.UUID `db:"uuid"`
-	Name string             `db:"name"`
+	Name string               `db:"name"`
 }
 
 type relationUUID struct {
@@ -52,10 +52,10 @@ type statusInfo struct {
 
 type applicationStatusInfo struct {
 	ApplicationID coreapplication.UUID `db:"application_uuid"`
-	StatusID      int                `db:"status_id"`
-	Message       string             `db:"message"`
-	Data          []byte             `db:"data"`
-	UpdatedAt     *time.Time         `db:"updated_at"`
+	StatusID      int                  `db:"status_id"`
+	Message       string               `db:"message"`
+	Data          []byte               `db:"data"`
+	UpdatedAt     *time.Time           `db:"updated_at"`
 }
 
 type applicationNameStatusInfo struct {
@@ -150,26 +150,26 @@ type CharmLocatorDetails struct {
 type applicationStatusDetails struct {
 	CharmLocatorDetails
 	UUID                   coreapplication.UUID `db:"uuid"`
-	Name                   string             `db:"name"`
-	PlatformOSID           sql.Null[int64]    `db:"platform_os_id"`
-	PlatformChannel        string             `db:"platform_channel"`
-	PlatformArchitectureID sql.Null[int64]    `db:"platform_architecture_id"`
-	ChannelTrack           string             `db:"channel_track"`
-	ChannelRisk            sql.Null[string]   `db:"channel_risk"`
-	ChannelBranch          string             `db:"channel_branch"`
-	LifeID                 domainlife.Life    `db:"life_id"`
-	Subordinate            bool               `db:"subordinate"`
-	StatusID               int                `db:"status_id"`
-	Message                string             `db:"message"`
-	Data                   []byte             `db:"data"`
-	UpdatedAt              *time.Time         `db:"updated_at"`
-	RelationUUID           sql.Null[string]   `db:"relation_uuid"`
-	CharmVersion           string             `db:"charm_version"`
-	LXDProfile             sql.Null[[]byte]   `db:"lxd_profile"`
-	Exposed                bool               `db:"exposed"`
-	Scale                  sql.Null[int]      `db:"scale"`
-	WorkloadVersion        sql.Null[string]   `db:"workload_version"`
-	K8sProviderID          sql.Null[string]   `db:"k8s_provider_id"`
+	Name                   string               `db:"name"`
+	PlatformOSID           sql.Null[int64]      `db:"platform_os_id"`
+	PlatformChannel        string               `db:"platform_channel"`
+	PlatformArchitectureID sql.Null[int64]      `db:"platform_architecture_id"`
+	ChannelTrack           string               `db:"channel_track"`
+	ChannelRisk            sql.Null[string]     `db:"channel_risk"`
+	ChannelBranch          string               `db:"channel_branch"`
+	LifeID                 domainlife.Life      `db:"life_id"`
+	Subordinate            bool                 `db:"subordinate"`
+	StatusID               int                  `db:"status_id"`
+	Message                string               `db:"message"`
+	Data                   []byte               `db:"data"`
+	UpdatedAt              *time.Time           `db:"updated_at"`
+	RelationUUID           sql.Null[string]     `db:"relation_uuid"`
+	CharmVersion           string               `db:"charm_version"`
+	LXDProfile             sql.Null[[]byte]     `db:"lxd_profile"`
+	Exposed                bool                 `db:"exposed"`
+	Scale                  sql.Null[int]        `db:"scale"`
+	WorkloadVersion        sql.Null[string]     `db:"workload_version"`
+	K8sProviderID          sql.Null[string]     `db:"k8s_provider_id"`
 }
 
 type unitStatusDetails struct {

--- a/domain/status/types.go
+++ b/domain/status/types.go
@@ -19,7 +19,7 @@ import (
 
 // Application represents the status of an application.
 type Application struct {
-	ID              application.ID
+	ID              application.UUID
 	Life            life.Life
 	Status          StatusInfo[WorkloadStatusType]
 	Units           map[unit.Name]Unit

--- a/domain/storageprovisioning/service/filesystem.go
+++ b/domain/storageprovisioning/service/filesystem.go
@@ -182,7 +182,7 @@ type FilesystemState interface {
 
 	// GetFilesystemTemplatesForApplication returns all the filesystem templates
 	// for a given application.
-	GetFilesystemTemplatesForApplication(context.Context, coreapplication.ID) ([]storageprovisioning.FilesystemTemplate, error)
+	GetFilesystemTemplatesForApplication(context.Context, coreapplication.UUID) ([]storageprovisioning.FilesystemTemplate, error)
 
 	// SetFilesystemProvisionedInfo sets on the provided filesystem the information
 	// about the provisioned filesystem.
@@ -669,7 +669,7 @@ func (s *Service) WatchMachineProvisionedFilesystemAttachments(
 // GetFilesystemTemplatesForApplication returns all the filesystem templates for
 // a given application.
 func (s *Service) GetFilesystemTemplatesForApplication(
-	ctx context.Context, appUUID coreapplication.ID,
+	ctx context.Context, appUUID coreapplication.UUID,
 ) ([]storageprovisioning.FilesystemTemplate, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/storageprovisioning/service/filesystem_test.go
+++ b/domain/storageprovisioning/service/filesystem_test.go
@@ -491,7 +491,7 @@ func (s *filesystemSuite) TestGetFilesystemsTemplateForApplicationErrors(c *tc.C
 func (s *filesystemSuite) TestGetFilesystemsTemplateForApplicationInvalidApplicationUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appID := coreapplication.ID("$")
+	appID := coreapplication.UUID("$")
 	svc := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c))
 	_, err := svc.GetFilesystemTemplatesForApplication(c.Context(), appID)
 	c.Assert(err, tc.NotNil)

--- a/domain/storageprovisioning/service/package_mock_test.go
+++ b/domain/storageprovisioning/service/package_mock_test.go
@@ -633,7 +633,7 @@ func (c *MockStateGetFilesystemParamsCall) DoAndReturn(f func(context.Context, s
 }
 
 // GetFilesystemTemplatesForApplication mocks base method.
-func (m *MockState) GetFilesystemTemplatesForApplication(arg0 context.Context, arg1 application.ID) ([]storageprovisioning.FilesystemTemplate, error) {
+func (m *MockState) GetFilesystemTemplatesForApplication(arg0 context.Context, arg1 application.UUID) ([]storageprovisioning.FilesystemTemplate, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFilesystemTemplatesForApplication", arg0, arg1)
 	ret0, _ := ret[0].([]storageprovisioning.FilesystemTemplate)
@@ -660,13 +660,13 @@ func (c *MockStateGetFilesystemTemplatesForApplicationCall) Return(arg0 []storag
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetFilesystemTemplatesForApplicationCall) Do(f func(context.Context, application.ID) ([]storageprovisioning.FilesystemTemplate, error)) *MockStateGetFilesystemTemplatesForApplicationCall {
+func (c *MockStateGetFilesystemTemplatesForApplicationCall) Do(f func(context.Context, application.UUID) ([]storageprovisioning.FilesystemTemplate, error)) *MockStateGetFilesystemTemplatesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetFilesystemTemplatesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) ([]storageprovisioning.FilesystemTemplate, error)) *MockStateGetFilesystemTemplatesForApplicationCall {
+func (c *MockStateGetFilesystemTemplatesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) ([]storageprovisioning.FilesystemTemplate, error)) *MockStateGetFilesystemTemplatesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -945,7 +945,7 @@ func (c *MockStateGetStorageInstanceUUIDByIDCall) DoAndReturn(f func(context.Con
 }
 
 // GetStorageResourceTagInfoForApplication mocks base method.
-func (m *MockState) GetStorageResourceTagInfoForApplication(arg0 context.Context, arg1 application.ID, arg2 string) (storageprovisioning.ApplicationResourceTagInfo, error) {
+func (m *MockState) GetStorageResourceTagInfoForApplication(arg0 context.Context, arg1 application.UUID, arg2 string) (storageprovisioning.ApplicationResourceTagInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStorageResourceTagInfoForApplication", arg0, arg1, arg2)
 	ret0, _ := ret[0].(storageprovisioning.ApplicationResourceTagInfo)
@@ -972,13 +972,13 @@ func (c *MockStateGetStorageResourceTagInfoForApplicationCall) Return(arg0 stora
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetStorageResourceTagInfoForApplicationCall) Do(f func(context.Context, application.ID, string) (storageprovisioning.ApplicationResourceTagInfo, error)) *MockStateGetStorageResourceTagInfoForApplicationCall {
+func (c *MockStateGetStorageResourceTagInfoForApplicationCall) Do(f func(context.Context, application.UUID, string) (storageprovisioning.ApplicationResourceTagInfo, error)) *MockStateGetStorageResourceTagInfoForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetStorageResourceTagInfoForApplicationCall) DoAndReturn(f func(context.Context, application.ID, string) (storageprovisioning.ApplicationResourceTagInfo, error)) *MockStateGetStorageResourceTagInfoForApplicationCall {
+func (c *MockStateGetStorageResourceTagInfoForApplicationCall) DoAndReturn(f func(context.Context, application.UUID, string) (storageprovisioning.ApplicationResourceTagInfo, error)) *MockStateGetStorageResourceTagInfoForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/storageprovisioning/service/service.go
+++ b/domain/storageprovisioning/service/service.go
@@ -75,7 +75,7 @@ type State interface {
 
 	// GetStorageResourceTagInfoForApplication returns information required to
 	// build resource tags for storage created for the given application.
-	GetStorageResourceTagInfoForApplication(context.Context, application.ID, string) (storageprovisioning.ApplicationResourceTagInfo, error)
+	GetStorageResourceTagInfoForApplication(context.Context, application.UUID, string) (storageprovisioning.ApplicationResourceTagInfo, error)
 
 	// GetStorageAttachmentIDsForUnit returns the storage attachment IDs for the given unit UUID.
 	//
@@ -226,7 +226,7 @@ func (s *Service) WatchMachineCloudInstance(
 // the given application. These tags are used when creating a resource in an
 // environ.
 func (s *Service) GetStorageResourceTagsForApplication(
-	ctx context.Context, appUUID application.ID,
+	ctx context.Context, appUUID application.UUID,
 ) (map[string]string, error) {
 	if err := appUUID.Validate(); err != nil {
 		return nil, errors.Capture(err)

--- a/domain/storageprovisioning/service/service_test.go
+++ b/domain/storageprovisioning/service/service_test.go
@@ -165,7 +165,7 @@ func (s *serviceSuite) TestGetStorageResourceTagsForApplicationErrors(c *tc.C) {
 func (s *serviceSuite) TestGetStorageResourceTagsForApplicationInvalidApplicationUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appUUID := coreapplication.ID("$")
+	appUUID := coreapplication.UUID("$")
 	svc := NewService(s.state, s.watcherFactory, loggertesting.WrapCheckLog(c))
 	_, err := svc.GetStorageResourceTagsForApplication(c.Context(), appUUID)
 	c.Assert(err, tc.NotNil)

--- a/domain/storageprovisioning/state/filesystem.go
+++ b/domain/storageprovisioning/state/filesystem.go
@@ -28,7 +28,7 @@ import (
 // a given application.
 func (st *State) GetFilesystemTemplatesForApplication(
 	ctx context.Context,
-	appUUID coreapplication.ID,
+	appUUID coreapplication.UUID,
 ) ([]storageprovisioning.FilesystemTemplate, error) {
 	db, err := st.DB(ctx)
 	if err != nil {

--- a/domain/storageprovisioning/state/filesystem_test.go
+++ b/domain/storageprovisioning/state/filesystem_test.go
@@ -176,7 +176,7 @@ func (s *filesystemSuite) TestGetFilesystemTemplatesForApplication(c *tc.C) {
 	s.newApplicationStorageDirective(c, appUUID, charmUUID, "y", spUUID2, 456, 1)
 
 	st := NewState(s.TxnRunnerFactory())
-	result, err := st.GetFilesystemTemplatesForApplication(c.Context(), application.ID(appUUID))
+	result, err := st.GetFilesystemTemplatesForApplication(c.Context(), application.UUID(appUUID))
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(result, tc.DeepEquals, []storageprovisioning.FilesystemTemplate{{
 		StorageName:  "x",

--- a/domain/storageprovisioning/state/state.go
+++ b/domain/storageprovisioning/state/state.go
@@ -179,7 +179,7 @@ func (st *State) NamespaceForWatchMachineCloudInstance() string {
 // supplied uuid.
 func (st *State) GetStorageResourceTagInfoForApplication(
 	ctx context.Context,
-	appUUID application.ID,
+	appUUID application.UUID,
 	resourceTagModelConfigKey string,
 ) (storageprovisioning.ApplicationResourceTagInfo, error) {
 	db, err := st.DB(ctx)
@@ -431,7 +431,7 @@ WHERE  uuid = $entityUUID.uuid`, input)
 func (st *State) checkApplicationExists(
 	ctx context.Context,
 	tx *sqlair.TX,
-	appUUID application.ID,
+	appUUID application.UUID,
 ) (bool, error) {
 	input := entityUUID{UUID: appUUID.String()}
 

--- a/domain/storageprovisioning/state/state_test.go
+++ b/domain/storageprovisioning/state/state_test.go
@@ -229,7 +229,7 @@ func (s *stateSuite) TestGetStorageResourceTagInfoForApplication(c *tc.C) {
 
 	st := NewState(s.TxnRunnerFactory())
 	resourceTags, err := st.GetStorageResourceTagInfoForApplication(
-		c.Context(), coreapplication.ID(appUUID), "resource_tags",
+		c.Context(), coreapplication.UUID(appUUID), "resource_tags",
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(resourceTags, tc.DeepEquals, storageprovisioning.ApplicationResourceTagInfo{

--- a/internal/bootstrap/bootstrap_mock_test.go
+++ b/internal/bootstrap/bootstrap_mock_test.go
@@ -570,14 +570,14 @@ func (m *MockIAASApplicationService) EXPECT() *MockIAASApplicationServiceMockRec
 }
 
 // CreateIAASApplication mocks base method.
-func (m *MockIAASApplicationService) CreateIAASApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddIAASUnitArg) (application.ID, error) {
+func (m *MockIAASApplicationService) CreateIAASApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddIAASUnitArg) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2, arg3, arg4}
 	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateIAASApplication", varargs...)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -596,19 +596,19 @@ type MockIAASApplicationServiceCreateIAASApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockIAASApplicationServiceCreateIAASApplicationCall) Return(arg0 application.ID, arg1 error) *MockIAASApplicationServiceCreateIAASApplicationCall {
+func (c *MockIAASApplicationServiceCreateIAASApplicationCall) Return(arg0 application.UUID, arg1 error) *MockIAASApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockIAASApplicationServiceCreateIAASApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddIAASUnitArg) (application.ID, error)) *MockIAASApplicationServiceCreateIAASApplicationCall {
+func (c *MockIAASApplicationServiceCreateIAASApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddIAASUnitArg) (application.UUID, error)) *MockIAASApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockIAASApplicationServiceCreateIAASApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddIAASUnitArg) (application.ID, error)) *MockIAASApplicationServiceCreateIAASApplicationCall {
+func (c *MockIAASApplicationServiceCreateIAASApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddIAASUnitArg) (application.UUID, error)) *MockIAASApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -637,14 +637,14 @@ func (m *MockCAASApplicationService) EXPECT() *MockCAASApplicationServiceMockRec
 }
 
 // CreateCAASApplication mocks base method.
-func (m *MockCAASApplicationService) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddUnitArg) (application.ID, error) {
+func (m *MockCAASApplicationService) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddUnitArg) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2, arg3, arg4}
 	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateCAASApplication", varargs...)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -663,19 +663,19 @@ type MockCAASApplicationServiceCreateCAASApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockCAASApplicationServiceCreateCAASApplicationCall) Return(arg0 application.ID, arg1 error) *MockCAASApplicationServiceCreateCAASApplicationCall {
+func (c *MockCAASApplicationServiceCreateCAASApplicationCall) Return(arg0 application.UUID, arg1 error) *MockCAASApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASApplicationServiceCreateCAASApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockCAASApplicationServiceCreateCAASApplicationCall {
+func (c *MockCAASApplicationServiceCreateCAASApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.UUID, error)) *MockCAASApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASApplicationServiceCreateCAASApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockCAASApplicationServiceCreateCAASApplicationCall {
+func (c *MockCAASApplicationServiceCreateCAASApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.UUID, error)) *MockCAASApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -44,7 +44,7 @@ type IAASApplicationService interface {
 	CreateIAASApplication(
 		context.Context, string, charm.Charm, corecharm.Origin,
 		applicationservice.AddApplicationArgs, ...applicationservice.AddIAASUnitArg,
-	) (coreapplication.ID, error)
+	) (coreapplication.UUID, error)
 }
 
 // CAASApplicationService instances create an IAAS application.
@@ -54,7 +54,7 @@ type CAASApplicationService interface {
 	CreateCAASApplication(
 		context.Context, string, charm.Charm, corecharm.Origin,
 		applicationservice.AddApplicationArgs, ...applicationservice.AddUnitArg,
-	) (coreapplication.ID, error)
+	) (coreapplication.UUID, error)
 
 	// UpdateApplication updates the application with the given name.
 	UpdateCAASUnit(ctx context.Context, unitName unit.Name, params applicationservice.UpdateCAASUnitParams) error

--- a/internal/provider/azure/credentials.go
+++ b/internal/provider/azure/credentials.go
@@ -90,7 +90,7 @@ func (c environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud
 		// password.
 		clientCredentialsAuthType: {
 			{
-				credAttrAppId, cloud.CredentialAttr{Description: "Azure Active Directory application ID"},
+				credAttrAppId, cloud.CredentialAttr{Description: "Azure Active Directory application UUID"},
 			}, {
 				credAttrApplicationObjectId, cloud.CredentialAttr{
 					Description: "Azure Active Directory application Object ID",

--- a/internal/provider/azure/credentials.go
+++ b/internal/provider/azure/credentials.go
@@ -90,7 +90,7 @@ func (c environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud
 		// password.
 		clientCredentialsAuthType: {
 			{
-				credAttrAppId, cloud.CredentialAttr{Description: "Azure Active Directory application UUID"},
+				credAttrAppId, cloud.CredentialAttr{Description: "Azure Active Directory application ID"},
 			}, {
 				credAttrApplicationObjectId, cloud.CredentialAttr{
 					Description: "Azure Active Directory application Object ID",

--- a/internal/provider/azure/internal/azureauth/serviceprincipal.go
+++ b/internal/provider/azure/internal/azureauth/serviceprincipal.go
@@ -58,14 +58,14 @@ var JujuActions = []string{
 }
 
 // MaybeJujuApplicationObjectID returns the Juju Application Object ID
-// if the passed in application UUID is the Juju Enterprise App.
+// if the passed in application ID is the Juju Enterprise App.
 // This is only needed for very old credentials. At some point we
 // should be able to delete it.
 func MaybeJujuApplicationObjectID(appID string) (string, error) {
 	if appID == "60a04dc9-1857-425f-8076-5ba81ca53d66" {
 		return "8b744cea-179d-4a73-9dff-20d52126030a", nil
 	}
-	return "", errors.Errorf("unexpected application UUID %q", appID)
+	return "", errors.Errorf("unexpected application ID %q", appID)
 }
 
 // ServicePrincipalParams are used when creating Juju service principal.
@@ -278,7 +278,7 @@ func (c *ServicePrincipalCreator) ensureEnterpriseApplication(
 
 	appUUID, err := c.newUUID()
 	if err != nil {
-		return "", errors.Annotate(err, "generating application UUID")
+		return "", errors.Annotate(err, "generating application ID")
 	}
 
 	parts := strings.Split(roleDefinitionId, "/")
@@ -350,7 +350,7 @@ func (c *ServicePrincipalCreator) createOrUpdateJujuServicePrincipal(
 }
 
 func (c *ServicePrincipalCreator) createOrUpdateServicePrincipal(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, appId, label string) (models.ServicePrincipalable, error) {
-	// The service principal might already exist, so we need to query its application UUID.
+	// The service principal might already exist, so we need to query its application ID.
 	servicePrincipal, err := client.ServicePrincipalsWithAppId(to.Ptr(appId)).Get(ctx, nil)
 	if err == nil {
 		return servicePrincipal, nil

--- a/internal/provider/azure/internal/azureauth/serviceprincipal.go
+++ b/internal/provider/azure/internal/azureauth/serviceprincipal.go
@@ -58,14 +58,14 @@ var JujuActions = []string{
 }
 
 // MaybeJujuApplicationObjectID returns the Juju Application Object ID
-// if the passed in application ID is the Juju Enterprise App.
+// if the passed in application UUID is the Juju Enterprise App.
 // This is only needed for very old credentials. At some point we
 // should be able to delete it.
 func MaybeJujuApplicationObjectID(appID string) (string, error) {
 	if appID == "60a04dc9-1857-425f-8076-5ba81ca53d66" {
 		return "8b744cea-179d-4a73-9dff-20d52126030a", nil
 	}
-	return "", errors.Errorf("unexpected application ID %q", appID)
+	return "", errors.Errorf("unexpected application UUID %q", appID)
 }
 
 // ServicePrincipalParams are used when creating Juju service principal.
@@ -278,7 +278,7 @@ func (c *ServicePrincipalCreator) ensureEnterpriseApplication(
 
 	appUUID, err := c.newUUID()
 	if err != nil {
-		return "", errors.Annotate(err, "generating application ID")
+		return "", errors.Annotate(err, "generating application UUID")
 	}
 
 	parts := strings.Split(roleDefinitionId, "/")
@@ -350,7 +350,7 @@ func (c *ServicePrincipalCreator) createOrUpdateJujuServicePrincipal(
 }
 
 func (c *ServicePrincipalCreator) createOrUpdateServicePrincipal(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, appId, label string) (models.ServicePrincipalable, error) {
-	// The service principal might already exist, so we need to query its application ID.
+	// The service principal might already exist, so we need to query its application UUID.
 	servicePrincipal, err := client.ServicePrincipalsWithAppId(to.Ptr(appId)).Get(ctx, nil)
 	if err == nil {
 		return servicePrincipal, nil

--- a/internal/resource/interfaces.go
+++ b/internal/resource/interfaces.go
@@ -36,11 +36,11 @@ type ApplicationService interface {
 	GetUnitUUID(ctx context.Context, unitName coreunit.Name) (coreunit.UUID, error)
 
 	// GetApplicationIDByUnitName returns the application ID for the named unit.
-	GetApplicationIDByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.ID, error)
+	GetApplicationIDByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, error)
 
 	// GetApplicationIDByName returns an application ID by application name. It
 	// returns an error if the application can not be found by the name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationCharmOrigin returns the charm origin for the specified
 	// application name.

--- a/internal/resource/interfaces.go
+++ b/internal/resource/interfaces.go
@@ -35,12 +35,12 @@ type ApplicationService interface {
 	// GetUnitUUID returns the UUID for the named unit.
 	GetUnitUUID(ctx context.Context, unitName coreunit.Name) (coreunit.UUID, error)
 
-	// GetApplicationIDByUnitName returns the application ID for the named unit.
-	GetApplicationIDByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, error)
+	// GetApplicationUUIDByUnitName returns the application UUID for the named unit.
+	GetApplicationUUIDByUnitName(ctx context.Context, name coreunit.Name) (coreapplication.UUID, error)
 
-	// GetApplicationIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application UUID by application name. It
 	// returns an error if the application can not be found by the name.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationCharmOrigin returns the charm origin for the specified
 	// application name.

--- a/internal/resource/opener.go
+++ b/internal/resource/opener.go
@@ -76,7 +76,7 @@ func NewResourceOpenerForApplication(
 	ctx context.Context,
 	args ResourceOpenerArgs,
 	applicationName string,
-	applicationID coreapplication.ID,
+	applicationID coreapplication.UUID,
 ) (opener coreresource.Opener, err error) {
 	charmOrigin, err := args.ApplicationService.GetApplicationCharmOrigin(ctx, applicationName)
 	if err != nil {
@@ -121,7 +121,7 @@ type ResourceOpener struct {
 	retrievedByType coreresource.RetrievedByType
 	setResourceFunc func(ctx context.Context, resourceUUID coreresource.UUID) error
 	charmOrigin     charm.Origin
-	appID           coreapplication.ID
+	appID           coreapplication.UUID
 
 	resourceClientGetter        ResourceClientGetter
 	resourceDownloadLimiterFunc func() ResourceDownloadLock

--- a/internal/resource/opener.go
+++ b/internal/resource/opener.go
@@ -41,7 +41,7 @@ func NewResourceOpenerForUnit(
 	resourceDownloadLimiterFunc func() ResourceDownloadLock,
 	unitName coreunit.Name,
 ) (opener coreresource.Opener, err error) {
-	applicationID, err := args.ApplicationService.GetApplicationIDByUnitName(ctx, unitName)
+	applicationID, err := args.ApplicationService.GetApplicationUUIDByUnitName(ctx, unitName)
 	if err != nil {
 		return nil, errors.Errorf("loading application ID for unit %s: %w", unitName, err)
 	}

--- a/internal/resource/opener.go
+++ b/internal/resource/opener.go
@@ -43,12 +43,12 @@ func NewResourceOpenerForUnit(
 ) (opener coreresource.Opener, err error) {
 	applicationID, err := args.ApplicationService.GetApplicationUUIDByUnitName(ctx, unitName)
 	if err != nil {
-		return nil, errors.Errorf("loading application ID for unit %s: %w", unitName, err)
+		return nil, errors.Errorf("loading application UUID for unit %s: %w", unitName, err)
 	}
 
 	unitUUID, err := args.ApplicationService.GetUnitUUID(ctx, unitName)
 	if err != nil {
-		return nil, errors.Errorf("loading application ID for unit %s: %w", unitName, err)
+		return nil, errors.Errorf("loading application UUID for unit %s: %w", unitName, err)
 	}
 
 	applicationName := unitName.Application()
@@ -167,8 +167,8 @@ func (ro ResourceOpener) getResource(
 	defer locker.Unlock()
 
 	resourceUUID, err := ro.resourceService.GetApplicationResourceID(ctx, resource.GetApplicationResourceIDArgs{
-		ApplicationID: ro.appID,
-		Name:          resName,
+		ApplicationUUID: ro.appID,
+		Name:            resName,
 	})
 	if err != nil {
 		return coreresource.Opened{}, errors.Errorf("getting UUID of resource %s for application %s: %w", resName, ro.appID, err)

--- a/internal/resource/opener_test.go
+++ b/internal/resource/opener_test.go
@@ -430,7 +430,7 @@ func (s *OpenerSuite) TestSetResourceUsedUnitError(c *tc.C) {
 
 func (s *OpenerSuite) expectNewUnitResourceOpener(c *tc.C) {
 	// Service calls in NewResourceOpenerForUnit.
-	s.applicationService.EXPECT().GetApplicationIDByUnitName(
+	s.applicationService.EXPECT().GetApplicationUUIDByUnitName(
 		gomock.Any(),
 		s.unitName,
 	).Return(s.appID, nil)

--- a/internal/resource/opener_test.go
+++ b/internal/resource/opener_test.go
@@ -264,8 +264,8 @@ func (s *OpenerSuite) expectServiceMethods(
 ) {
 	s.resourceService.EXPECT().GetApplicationResourceID(
 		gomock.Any(), domainresource.GetApplicationResourceIDArgs{
-			ApplicationID: s.appID,
-			Name:          "wal-e",
+			ApplicationUUID: s.appID,
+			Name:            "wal-e",
 		},
 	).Return(s.resourceUUID, nil).AnyTimes()
 	var retrievedBy string
@@ -350,8 +350,8 @@ func (s *OpenerSuite) TestGetResourceErrorReleasesLock(c *tc.C) {
 	}
 	s.resourceService.EXPECT().GetApplicationResourceID(
 		gomock.Any(), domainresource.GetApplicationResourceIDArgs{
-			ApplicationID: s.appID,
-			Name:          "wal-e",
+			ApplicationUUID: s.appID,
+			Name:            "wal-e",
 		},
 	).Return(s.resourceUUID, nil)
 	s.resourceService.EXPECT().OpenResource(

--- a/internal/resource/opener_test.go
+++ b/internal/resource/opener_test.go
@@ -36,7 +36,7 @@ import (
 
 type OpenerSuite struct {
 	appName              string
-	appID                coreapplication.ID
+	appID                coreapplication.UUID
 	unitName             coreunit.Name
 	unitUUID             coreunit.UUID
 	resourceUUID         coreresource.UUID

--- a/internal/resource/resource_mock_test.go
+++ b/internal/resource/resource_mock_test.go
@@ -304,10 +304,10 @@ func (c *MockApplicationServiceGetApplicationCharmOriginCall) DoAndReturn(f func
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -325,28 +325,28 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationIDByUnitName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByUnitName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -364,19 +364,19 @@ type MockApplicationServiceGetApplicationIDByUnitNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.ID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.ID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/resource/resource_mock_test.go
+++ b/internal/resource/resource_mock_test.go
@@ -303,80 +303,80 @@ func (c *MockApplicationServiceGetApplicationCharmOriginCall) DoAndReturn(f func
 	return c
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// GetApplicationIDByUnitName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
+// GetApplicationUUIDByUnitName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByUnitName(arg0 context.Context, arg1 unit.Name) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByUnitName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByUnitName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByUnitName indicates an expected call of GetApplicationIDByUnitName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByUnitName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+// GetApplicationUUIDByUnitName indicates an expected call of GetApplicationUUIDByUnitName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByUnitName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByUnitName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByUnitName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByUnitNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByUnitName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByUnitName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByUnitNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByUnitNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByUnitNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByUnitNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByUnitNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) Do(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByUnitNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByUnitNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/asynccharmdownloader/downloader.go
+++ b/internal/worker/asynccharmdownloader/downloader.go
@@ -30,7 +30,7 @@ const (
 type asyncDownloadWorker struct {
 	tomb tomb.Tomb
 
-	appID              application.ID
+	appID              application.UUID
 	applicationService ApplicationService
 	downloader         Downloader
 
@@ -41,7 +41,7 @@ type asyncDownloadWorker struct {
 // NewAsyncDownloadWorker creates a new async worker that downloads charms for
 // the specified application.
 func NewAsyncDownloadWorker(
-	appID application.ID,
+	appID application.UUID,
 	applicationService ApplicationService,
 	downloader Downloader,
 	clock clock.Clock,

--- a/internal/worker/asynccharmdownloader/downloader_test.go
+++ b/internal/worker/asynccharmdownloader/downloader_test.go
@@ -69,7 +69,7 @@ func (s *asyncWorkerSuite) TestDownloadWorker(c *tc.C) {
 		CharmUUID: charmID,
 		Path:      "path",
 		Size:      int64(123),
-	}).DoAndReturn(func(ctx context.Context, i application.ID, rcd domainapplication.ResolveCharmDownload) error {
+	}).DoAndReturn(func(ctx context.Context, i application.UUID, rcd domainapplication.ResolveCharmDownload) error {
 		close(done)
 		return nil
 	})
@@ -126,7 +126,7 @@ func (s *asyncWorkerSuite) TestDownloadWorkerRetriesDownload(c *tc.C) {
 		CharmUUID: charmID,
 		Path:      "path",
 		Size:      int64(123),
-	}).DoAndReturn(func(ctx context.Context, i application.ID, rcd domainapplication.ResolveCharmDownload) error {
+	}).DoAndReturn(func(ctx context.Context, i application.UUID, rcd domainapplication.ResolveCharmDownload) error {
 		close(done)
 		return nil
 	})
@@ -213,7 +213,7 @@ func (s *asyncWorkerSuite) TestDownloadWorkerAlreadyDownloaded(c *tc.C) {
 		},
 	}
 
-	s.applicationService.EXPECT().GetAsyncCharmDownloadInfo(gomock.Any(), appID).DoAndReturn(func(ctx context.Context, i application.ID) (domainapplication.CharmDownloadInfo, error) {
+	s.applicationService.EXPECT().GetAsyncCharmDownloadInfo(gomock.Any(), appID).DoAndReturn(func(ctx context.Context, i application.UUID) (domainapplication.CharmDownloadInfo, error) {
 		close(done)
 		return reserveInfo, applicationerrors.CharmAlreadyAvailable
 	})
@@ -263,7 +263,7 @@ func (s *asyncWorkerSuite) TestDownloadWorkerAlreadyResolved(c *tc.C) {
 		CharmUUID: charmID,
 		Path:      "path",
 		Size:      int64(123),
-	}).DoAndReturn(func(ctx context.Context, i application.ID, rcd domainapplication.ResolveCharmDownload) error {
+	}).DoAndReturn(func(ctx context.Context, i application.UUID, rcd domainapplication.ResolveCharmDownload) error {
 		close(done)
 		return applicationerrors.CharmAlreadyResolved
 	})
@@ -280,7 +280,7 @@ func (s *asyncWorkerSuite) TestDownloadWorkerAlreadyResolved(c *tc.C) {
 	workertest.CleanKill(c, w)
 }
 
-func (s *asyncWorkerSuite) newWorker(c *tc.C, appID application.ID) worker.Worker {
+func (s *asyncWorkerSuite) newWorker(c *tc.C, appID application.UUID) worker.Worker {
 	return NewAsyncDownloadWorker(
 		appID,
 		s.applicationService,

--- a/internal/worker/asynccharmdownloader/downloadworker.go
+++ b/internal/worker/asynccharmdownloader/downloadworker.go
@@ -31,8 +31,8 @@ type ApplicationService interface {
 	// WatchApplicationsWithPendingCharms returns a watcher that notifies of
 	// changes to applications that reference charms that have not yet been
 	// downloaded.
-	// Each string will be an individual application ID. It's possible to
-	// have the same application ID multiple times in the list.
+	// Each string will be an individual application UUID. It's possible to
+	// have the same application UUID multiple times in the list.
 	WatchApplicationsWithPendingCharms(ctx context.Context) (watcher.StringsWatcher, error)
 
 	// GetAsyncCharmDownloadInfo reserves a charm download slot for the specified
@@ -201,7 +201,7 @@ func (w *Worker) loop() error {
 			for _, change := range changes {
 				appID, err := application.ParseID(change)
 				if err != nil {
-					logger.Errorf(ctx, "failed to parse application ID %q: %v", change, err)
+					logger.Errorf(ctx, "failed to parse application UUID %q: %v", change, err)
 					continue
 				}
 

--- a/internal/worker/asynccharmdownloader/downloadworker.go
+++ b/internal/worker/asynccharmdownloader/downloadworker.go
@@ -40,12 +40,12 @@ type ApplicationService interface {
 	// return [applicationerrors.AlreadyDownloadingCharm]. The charm download
 	// information is returned which includes the charm name, origin and the
 	// digest.
-	GetAsyncCharmDownloadInfo(ctx context.Context, appID application.ID) (domainapplication.CharmDownloadInfo, error)
+	GetAsyncCharmDownloadInfo(ctx context.Context, appID application.UUID) (domainapplication.CharmDownloadInfo, error)
 
 	// ResolveCharmDownload resolves the charm download slot for the specified
 	// application. The method will update the charm with the specified charm
 	// information.
-	ResolveCharmDownload(ctx context.Context, appID application.ID, resolve domainapplication.ResolveCharmDownload) error
+	ResolveCharmDownload(ctx context.Context, appID application.UUID, resolve domainapplication.ResolveCharmDownload) error
 }
 
 // Config defines the operation of a Worker.
@@ -221,7 +221,7 @@ func (w *Worker) loop() error {
 	}
 }
 
-func (w *Worker) workerFromCache(appID application.ID) (bool, error) {
+func (w *Worker) workerFromCache(appID application.UUID) (bool, error) {
 	// If the worker already exists, return the existing worker early.
 	if _, err := w.runner.Worker(appID.String(), w.catacomb.Dying()); err == nil {
 		return true, nil
@@ -243,7 +243,7 @@ func (w *Worker) workerFromCache(appID application.ID) (bool, error) {
 	return false, nil
 }
 
-func (w *Worker) initAsyncDownloadWorker(ctx context.Context, appID application.ID, downloader Downloader) error {
+func (w *Worker) initAsyncDownloadWorker(ctx context.Context, appID application.UUID, downloader Downloader) error {
 	err := w.runner.StartWorker(ctx, appID.String(), func(ctx context.Context) (worker.Worker, error) {
 		wrk := w.config.NewAsyncDownloadWorker(
 			appID,

--- a/internal/worker/asynccharmdownloader/downloadworker_test.go
+++ b/internal/worker/asynccharmdownloader/downloadworker_test.go
@@ -267,7 +267,7 @@ func (s *workerSuite) TestWorkerCreatesAsyncWorkerWithDifferentAppID(c *tc.C) {
 
 	// Using the same App ID should not cause a new worker to be created.
 
-	var apps [3]application.ID
+	var apps [3]application.UUID
 	for i := range apps {
 		apps[i] = applicationtesting.GenApplicationUUID(c)
 	}
@@ -349,7 +349,7 @@ func (s *workerSuite) newConfig(c *tc.C) Config {
 		NewDownloader: func(charmhub.HTTPClient, logger.Logger) Downloader {
 			return s.downloader
 		},
-		NewAsyncDownloadWorker: func(appID application.ID, applicationService ApplicationService, downloader Downloader, clock clock.Clock, logger logger.Logger) worker.Worker {
+		NewAsyncDownloadWorker: func(appID application.UUID, applicationService ApplicationService, downloader Downloader, clock clock.Clock, logger logger.Logger) worker.Worker {
 			if s.newAsyncWorker == nil {
 				return workertest.NewErrorWorker(nil)
 			}

--- a/internal/worker/asynccharmdownloader/manifold.go
+++ b/internal/worker/asynccharmdownloader/manifold.go
@@ -44,7 +44,7 @@ type NewHTTPClientFunc func(context.Context, corehttp.HTTPClientGetter) (corehtt
 
 // NewAsyncDownloadWorkerFunc is a function that creates a new async worker.
 type NewAsyncDownloadWorkerFunc func(
-	appID application.ID,
+	appID application.UUID,
 	applicationService ApplicationService,
 	downloader Downloader,
 	clock clock.Clock,

--- a/internal/worker/asynccharmdownloader/package_mocks_test.go
+++ b/internal/worker/asynccharmdownloader/package_mocks_test.go
@@ -45,7 +45,7 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetAsyncCharmDownloadInfo mocks base method.
-func (m *MockApplicationService) GetAsyncCharmDownloadInfo(arg0 context.Context, arg1 application.ID) (application0.CharmDownloadInfo, error) {
+func (m *MockApplicationService) GetAsyncCharmDownloadInfo(arg0 context.Context, arg1 application.UUID) (application0.CharmDownloadInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAsyncCharmDownloadInfo", arg0, arg1)
 	ret0, _ := ret[0].(application0.CharmDownloadInfo)
@@ -72,19 +72,19 @@ func (c *MockApplicationServiceGetAsyncCharmDownloadInfoCall) Return(arg0 applic
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetAsyncCharmDownloadInfoCall) Do(f func(context.Context, application.ID) (application0.CharmDownloadInfo, error)) *MockApplicationServiceGetAsyncCharmDownloadInfoCall {
+func (c *MockApplicationServiceGetAsyncCharmDownloadInfoCall) Do(f func(context.Context, application.UUID) (application0.CharmDownloadInfo, error)) *MockApplicationServiceGetAsyncCharmDownloadInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetAsyncCharmDownloadInfoCall) DoAndReturn(f func(context.Context, application.ID) (application0.CharmDownloadInfo, error)) *MockApplicationServiceGetAsyncCharmDownloadInfoCall {
+func (c *MockApplicationServiceGetAsyncCharmDownloadInfoCall) DoAndReturn(f func(context.Context, application.UUID) (application0.CharmDownloadInfo, error)) *MockApplicationServiceGetAsyncCharmDownloadInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ResolveCharmDownload mocks base method.
-func (m *MockApplicationService) ResolveCharmDownload(arg0 context.Context, arg1 application.ID, arg2 application0.ResolveCharmDownload) error {
+func (m *MockApplicationService) ResolveCharmDownload(arg0 context.Context, arg1 application.UUID, arg2 application0.ResolveCharmDownload) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveCharmDownload", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -110,13 +110,13 @@ func (c *MockApplicationServiceResolveCharmDownloadCall) Return(arg0 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceResolveCharmDownloadCall) Do(f func(context.Context, application.ID, application0.ResolveCharmDownload) error) *MockApplicationServiceResolveCharmDownloadCall {
+func (c *MockApplicationServiceResolveCharmDownloadCall) Do(f func(context.Context, application.UUID, application0.ResolveCharmDownload) error) *MockApplicationServiceResolveCharmDownloadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceResolveCharmDownloadCall) DoAndReturn(f func(context.Context, application.ID, application0.ResolveCharmDownload) error) *MockApplicationServiceResolveCharmDownloadCall {
+func (c *MockApplicationServiceResolveCharmDownloadCall) DoAndReturn(f func(context.Context, application.UUID, application0.ResolveCharmDownload) error) *MockApplicationServiceResolveCharmDownloadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/bootstrap/bootstrap_mock_test.go
+++ b/internal/worker/bootstrap/bootstrap_mock_test.go
@@ -531,14 +531,14 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // CreateCAASApplication mocks base method.
-func (m *MockApplicationService) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service0.AddApplicationArgs, arg5 ...service0.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateCAASApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service0.AddApplicationArgs, arg5 ...service0.AddUnitArg) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2, arg3, arg4}
 	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateCAASApplication", varargs...)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -557,32 +557,32 @@ type MockApplicationServiceCreateCAASApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceCreateCAASApplicationCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceCreateCAASApplicationCall {
+func (c *MockApplicationServiceCreateCAASApplicationCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateCAASApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateCAASApplicationCall {
+func (c *MockApplicationServiceCreateCAASApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.UUID, error)) *MockApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateCAASApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateCAASApplicationCall {
+func (c *MockApplicationServiceCreateCAASApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.UUID, error)) *MockApplicationServiceCreateCAASApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateIAASApplication mocks base method.
-func (m *MockApplicationService) CreateIAASApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service0.AddApplicationArgs, arg5 ...service0.AddIAASUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateIAASApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service0.AddApplicationArgs, arg5 ...service0.AddIAASUnitArg) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2, arg3, arg4}
 	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateIAASApplication", varargs...)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -601,19 +601,19 @@ type MockApplicationServiceCreateIAASApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceCreateIAASApplicationCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceCreateIAASApplicationCall {
+func (c *MockApplicationServiceCreateIAASApplicationCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateIAASApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddIAASUnitArg) (application.ID, error)) *MockApplicationServiceCreateIAASApplicationCall {
+func (c *MockApplicationServiceCreateIAASApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddIAASUnitArg) (application.UUID, error)) *MockApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateIAASApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddIAASUnitArg) (application.ID, error)) *MockApplicationServiceCreateIAASApplicationCall {
+func (c *MockApplicationServiceCreateIAASApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddIAASUnitArg) (application.UUID, error)) *MockApplicationServiceCreateIAASApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/bootstrap/service.go
+++ b/internal/worker/bootstrap/service.go
@@ -59,14 +59,14 @@ type ApplicationService interface {
 	CreateIAASApplication(
 		context.Context, string, charm.Charm, corecharm.Origin,
 		applicationservice.AddApplicationArgs, ...applicationservice.AddIAASUnitArg,
-	) (coreapplication.ID, error)
+	) (coreapplication.UUID, error)
 
 	// CreateCAASApplication creates a new application with the given name and
 	// charm.
 	CreateCAASApplication(
 		context.Context, string, charm.Charm, corecharm.Origin,
 		applicationservice.AddApplicationArgs, ...applicationservice.AddUnitArg,
-	) (coreapplication.ID, error)
+	) (coreapplication.UUID, error)
 
 	// ResolveControllerCharmDownload resolves the controller charm download
 	// slot.

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -42,7 +42,7 @@ type appWorker struct {
 	logger logger.Logger
 	ops    ApplicationOps
 
-	appID            coreapplication.ID
+	appID            coreapplication.UUID
 	changes          chan struct{}
 	password         string
 	lastApplied      caas.ApplicationConfig
@@ -53,7 +53,7 @@ type appWorker struct {
 }
 
 type AppWorkerConfig struct {
-	AppID coreapplication.ID
+	AppID coreapplication.UUID
 
 	AgentPasswordService       AgentPasswordService
 	ApplicationService         ApplicationService

--- a/internal/worker/caasapplicationprovisioner/manifold.go
+++ b/internal/worker/caasapplicationprovisioner/manifold.go
@@ -86,7 +86,7 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		CharmhubClientGetter: charmhub.NewCharmHubOpener(domainServices.Config()),
 	}
 	var rog ResourceOpenerGetterFunc = func(
-		ctx context.Context, appID application.ID, appName string,
+		ctx context.Context, appID application.UUID, appName string,
 	) (coreresource.Opener, error) {
 		return resource.NewResourceOpenerForApplication(ctx, resourceOpenerArgs,
 			appName, appID)

--- a/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
@@ -322,42 +322,42 @@ func (c *MockApplicationServiceGetApplicationTrustSettingCall) DoAndReturn(f fun
 	return c
 }
 
-// GetCharmByApplicationID mocks base method.
-func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
+// GetCharmByApplicationUUID mocks base method.
+func (m *MockApplicationService) GetCharmByApplicationUUID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmByApplicationID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetCharmByApplicationUUID", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Charm)
 	ret1, _ := ret[1].(charm.CharmLocator)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetCharmByApplicationID indicates an expected call of GetCharmByApplicationID.
-func (mr *MockApplicationServiceMockRecorder) GetCharmByApplicationID(arg0, arg1 any) *MockApplicationServiceGetCharmByApplicationIDCall {
+// GetCharmByApplicationUUID indicates an expected call of GetCharmByApplicationUUID.
+func (mr *MockApplicationServiceMockRecorder) GetCharmByApplicationUUID(arg0, arg1 any) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationID", reflect.TypeOf((*MockApplicationService)(nil).GetCharmByApplicationID), arg0, arg1)
-	return &MockApplicationServiceGetCharmByApplicationIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationUUID", reflect.TypeOf((*MockApplicationService)(nil).GetCharmByApplicationUUID), arg0, arg1)
+	return &MockApplicationServiceGetCharmByApplicationUUIDCall{Call: call}
 }
 
-// MockApplicationServiceGetCharmByApplicationIDCall wrap *gomock.Call
-type MockApplicationServiceGetCharmByApplicationIDCall struct {
+// MockApplicationServiceGetCharmByApplicationUUIDCall wrap *gomock.Call
+type MockApplicationServiceGetCharmByApplicationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Return(arg0 charm0.Charm, arg1 charm.CharmLocator, arg2 error) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) Return(arg0 charm0.Charm, arg1 charm.CharmLocator, arg2 error) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
@@ -50,7 +50,7 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetAllUnitCloudContainerIDsForApplication mocks base method.
-func (m *MockApplicationService) GetAllUnitCloudContainerIDsForApplication(arg0 context.Context, arg1 application.ID) (map[unit.Name]string, error) {
+func (m *MockApplicationService) GetAllUnitCloudContainerIDsForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllUnitCloudContainerIDsForApplication", arg0, arg1)
 	ret0, _ := ret[0].(map[unit.Name]string)
@@ -77,19 +77,19 @@ func (c *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall) Re
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.Name]string, error)) *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall {
+func (c *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall) Do(f func(context.Context, application.UUID) (map[unit.Name]string, error)) *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.Name]string, error)) *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall {
+func (c *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[unit.Name]string, error)) *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetAllUnitLifeForApplication mocks base method.
-func (m *MockApplicationService) GetAllUnitLifeForApplication(arg0 context.Context, arg1 application.ID) (map[unit.Name]life.Value, error) {
+func (m *MockApplicationService) GetAllUnitLifeForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]life.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllUnitLifeForApplication", arg0, arg1)
 	ret0, _ := ret[0].(map[unit.Name]life.Value)
@@ -116,19 +116,19 @@ func (c *MockApplicationServiceGetAllUnitLifeForApplicationCall) Return(arg0 map
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetAllUnitLifeForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.Name]life.Value, error)) *MockApplicationServiceGetAllUnitLifeForApplicationCall {
+func (c *MockApplicationServiceGetAllUnitLifeForApplicationCall) Do(f func(context.Context, application.UUID) (map[unit.Name]life.Value, error)) *MockApplicationServiceGetAllUnitLifeForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetAllUnitLifeForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.Name]life.Value, error)) *MockApplicationServiceGetAllUnitLifeForApplicationCall {
+func (c *MockApplicationServiceGetAllUnitLifeForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[unit.Name]life.Value, error)) *MockApplicationServiceGetAllUnitLifeForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationLife mocks base method.
-func (m *MockApplicationService) GetApplicationLife(arg0 context.Context, arg1 application.ID) (life.Value, error) {
+func (m *MockApplicationService) GetApplicationLife(arg0 context.Context, arg1 application.UUID) (life.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationLife", arg0, arg1)
 	ret0, _ := ret[0].(life.Value)
@@ -155,19 +155,19 @@ func (c *MockApplicationServiceGetApplicationLifeCall) Return(arg0 life.Value, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context, application.ID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context, application.UUID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.ID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.UUID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationName mocks base method.
-func (m *MockApplicationService) GetApplicationName(arg0 context.Context, arg1 application.ID) (string, error) {
+func (m *MockApplicationService) GetApplicationName(arg0 context.Context, arg1 application.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationName", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -194,13 +194,13 @@ func (c *MockApplicationServiceGetApplicationNameCall) Return(arg0 string, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationNameCall) Do(f func(context.Context, application.ID) (string, error)) *MockApplicationServiceGetApplicationNameCall {
+func (c *MockApplicationServiceGetApplicationNameCall) Do(f func(context.Context, application.UUID) (string, error)) *MockApplicationServiceGetApplicationNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationNameCall) DoAndReturn(f func(context.Context, application.ID) (string, error)) *MockApplicationServiceGetApplicationNameCall {
+func (c *MockApplicationServiceGetApplicationNameCall) DoAndReturn(f func(context.Context, application.UUID) (string, error)) *MockApplicationServiceGetApplicationNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -323,7 +323,7 @@ func (c *MockApplicationServiceGetApplicationTrustSettingCall) DoAndReturn(f fun
 }
 
 // GetCharmByApplicationID mocks base method.
-func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.ID) (charm0.Charm, charm.CharmLocator, error) {
+func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmByApplicationID", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Charm)
@@ -351,13 +351,13 @@ func (c *MockApplicationServiceGetCharmByApplicationIDCall) Return(arg0 charm0.C
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.ID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.ID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -402,7 +402,7 @@ func (c *MockApplicationServiceGetUnitLifeCall) DoAndReturn(f func(context.Conte
 }
 
 // IsControllerApplication mocks base method.
-func (m *MockApplicationService) IsControllerApplication(arg0 context.Context, arg1 application.ID) (bool, error) {
+func (m *MockApplicationService) IsControllerApplication(arg0 context.Context, arg1 application.UUID) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsControllerApplication", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -429,13 +429,13 @@ func (c *MockApplicationServiceIsControllerApplicationCall) Return(arg0 bool, ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceIsControllerApplicationCall) Do(f func(context.Context, application.ID) (bool, error)) *MockApplicationServiceIsControllerApplicationCall {
+func (c *MockApplicationServiceIsControllerApplicationCall) Do(f func(context.Context, application.UUID) (bool, error)) *MockApplicationServiceIsControllerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceIsControllerApplicationCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockApplicationServiceIsControllerApplicationCall {
+func (c *MockApplicationServiceIsControllerApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (bool, error)) *MockApplicationServiceIsControllerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -734,7 +734,7 @@ func (m *MockStatusService) EXPECT() *MockStatusServiceMockRecorder {
 }
 
 // GetUnitAgentStatusesForApplication mocks base method.
-func (m *MockStatusService) GetUnitAgentStatusesForApplication(arg0 context.Context, arg1 application.ID) (map[unit.Name]status.StatusInfo, error) {
+func (m *MockStatusService) GetUnitAgentStatusesForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]status.StatusInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitAgentStatusesForApplication", arg0, arg1)
 	ret0, _ := ret[0].(map[unit.Name]status.StatusInfo)
@@ -761,13 +761,13 @@ func (c *MockStatusServiceGetUnitAgentStatusesForApplicationCall) Return(arg0 ma
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatusServiceGetUnitAgentStatusesForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitAgentStatusesForApplicationCall {
+func (c *MockStatusServiceGetUnitAgentStatusesForApplicationCall) Do(f func(context.Context, application.UUID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitAgentStatusesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatusServiceGetUnitAgentStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitAgentStatusesForApplicationCall {
+func (c *MockStatusServiceGetUnitAgentStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[unit.Name]status.StatusInfo, error)) *MockStatusServiceGetUnitAgentStatusesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -834,7 +834,7 @@ func (m *MockAgentPasswordService) EXPECT() *MockAgentPasswordServiceMockRecorde
 }
 
 // SetApplicationPassword mocks base method.
-func (m *MockAgentPasswordService) SetApplicationPassword(arg0 context.Context, arg1 application.ID, arg2 string) error {
+func (m *MockAgentPasswordService) SetApplicationPassword(arg0 context.Context, arg1 application.UUID, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetApplicationPassword", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -860,13 +860,13 @@ func (c *MockAgentPasswordServiceSetApplicationPasswordCall) Return(arg0 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAgentPasswordServiceSetApplicationPasswordCall) Do(f func(context.Context, application.ID, string) error) *MockAgentPasswordServiceSetApplicationPasswordCall {
+func (c *MockAgentPasswordServiceSetApplicationPasswordCall) Do(f func(context.Context, application.UUID, string) error) *MockAgentPasswordServiceSetApplicationPasswordCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAgentPasswordServiceSetApplicationPasswordCall) DoAndReturn(f func(context.Context, application.ID, string) error) *MockAgentPasswordServiceSetApplicationPasswordCall {
+func (c *MockAgentPasswordServiceSetApplicationPasswordCall) DoAndReturn(f func(context.Context, application.UUID, string) error) *MockAgentPasswordServiceSetApplicationPasswordCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -895,7 +895,7 @@ func (m *MockStorageProvisioningService) EXPECT() *MockStorageProvisioningServic
 }
 
 // GetFilesystemTemplatesForApplication mocks base method.
-func (m *MockStorageProvisioningService) GetFilesystemTemplatesForApplication(arg0 context.Context, arg1 application.ID) ([]storageprovisioning.FilesystemTemplate, error) {
+func (m *MockStorageProvisioningService) GetFilesystemTemplatesForApplication(arg0 context.Context, arg1 application.UUID) ([]storageprovisioning.FilesystemTemplate, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFilesystemTemplatesForApplication", arg0, arg1)
 	ret0, _ := ret[0].([]storageprovisioning.FilesystemTemplate)
@@ -922,19 +922,19 @@ func (c *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall) Do(f func(context.Context, application.ID) ([]storageprovisioning.FilesystemTemplate, error)) *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall {
+func (c *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall) Do(f func(context.Context, application.UUID) ([]storageprovisioning.FilesystemTemplate, error)) *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) ([]storageprovisioning.FilesystemTemplate, error)) *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall {
+func (c *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) ([]storageprovisioning.FilesystemTemplate, error)) *MockStorageProvisioningServiceGetFilesystemTemplatesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetStorageResourceTagsForApplication mocks base method.
-func (m *MockStorageProvisioningService) GetStorageResourceTagsForApplication(arg0 context.Context, arg1 application.ID) (map[string]string, error) {
+func (m *MockStorageProvisioningService) GetStorageResourceTagsForApplication(arg0 context.Context, arg1 application.UUID) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStorageResourceTagsForApplication", arg0, arg1)
 	ret0, _ := ret[0].(map[string]string)
@@ -961,13 +961,13 @@ func (c *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall) Do(f func(context.Context, application.ID) (map[string]string, error)) *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall {
+func (c *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall) Do(f func(context.Context, application.UUID) (map[string]string, error)) *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[string]string, error)) *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall {
+func (c *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[string]string, error)) *MockStorageProvisioningServiceGetStorageResourceTagsForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/mocks/ops_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/ops_mock.go
@@ -84,7 +84,7 @@ func (c *MockApplicationOpsAppAliveCall) DoAndReturn(f func(context.Context, str
 }
 
 // AppDead mocks base method.
-func (m *MockApplicationOps) AppDead(arg0 context.Context, arg1 string, arg2 application.ID, arg3 caas.Application, arg4 caasapplicationprovisioner.CAASBroker, arg5 caasapplicationprovisioner.ApplicationService, arg6 caasapplicationprovisioner.StatusService, arg7 clock.Clock, arg8 logger.Logger) error {
+func (m *MockApplicationOps) AppDead(arg0 context.Context, arg1 string, arg2 application.UUID, arg3 caas.Application, arg4 caasapplicationprovisioner.CAASBroker, arg5 caasapplicationprovisioner.ApplicationService, arg6 caasapplicationprovisioner.StatusService, arg7 clock.Clock, arg8 logger.Logger) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppDead", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].(error)
@@ -110,19 +110,19 @@ func (c *MockApplicationOpsAppDeadCall) Return(arg0 error) *MockApplicationOpsAp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsAppDeadCall) Do(f func(context.Context, string, application.ID, caas.Application, caasapplicationprovisioner.CAASBroker, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) error) *MockApplicationOpsAppDeadCall {
+func (c *MockApplicationOpsAppDeadCall) Do(f func(context.Context, string, application.UUID, caas.Application, caasapplicationprovisioner.CAASBroker, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) error) *MockApplicationOpsAppDeadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsAppDeadCall) DoAndReturn(f func(context.Context, string, application.ID, caas.Application, caasapplicationprovisioner.CAASBroker, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) error) *MockApplicationOpsAppDeadCall {
+func (c *MockApplicationOpsAppDeadCall) DoAndReturn(f func(context.Context, string, application.UUID, caas.Application, caasapplicationprovisioner.CAASBroker, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) error) *MockApplicationOpsAppDeadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // AppDying mocks base method.
-func (m *MockApplicationOps) AppDying(arg0 context.Context, arg1 string, arg2 application.ID, arg3 caas.Application, arg4 life.Value, arg5 caasapplicationprovisioner.CAASProvisionerFacade, arg6 caasapplicationprovisioner.ApplicationService, arg7 caasapplicationprovisioner.StatusService, arg8 logger.Logger) error {
+func (m *MockApplicationOps) AppDying(arg0 context.Context, arg1 string, arg2 application.UUID, arg3 caas.Application, arg4 life.Value, arg5 caasapplicationprovisioner.CAASProvisionerFacade, arg6 caasapplicationprovisioner.ApplicationService, arg7 caasapplicationprovisioner.StatusService, arg8 logger.Logger) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppDying", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].(error)
@@ -148,19 +148,19 @@ func (c *MockApplicationOpsAppDyingCall) Return(arg0 error) *MockApplicationOpsA
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsAppDyingCall) Do(f func(context.Context, string, application.ID, caas.Application, life.Value, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsAppDyingCall {
+func (c *MockApplicationOpsAppDyingCall) Do(f func(context.Context, string, application.UUID, caas.Application, life.Value, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsAppDyingCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsAppDyingCall) DoAndReturn(f func(context.Context, string, application.ID, caas.Application, life.Value, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsAppDyingCall {
+func (c *MockApplicationOpsAppDyingCall) DoAndReturn(f func(context.Context, string, application.UUID, caas.Application, life.Value, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsAppDyingCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // EnsureScale mocks base method.
-func (m *MockApplicationOps) EnsureScale(arg0 context.Context, arg1 string, arg2 application.ID, arg3 caas.Application, arg4 life.Value, arg5 caasapplicationprovisioner.CAASProvisionerFacade, arg6 caasapplicationprovisioner.ApplicationService, arg7 caasapplicationprovisioner.StatusService, arg8 logger.Logger) error {
+func (m *MockApplicationOps) EnsureScale(arg0 context.Context, arg1 string, arg2 application.UUID, arg3 caas.Application, arg4 life.Value, arg5 caasapplicationprovisioner.CAASProvisionerFacade, arg6 caasapplicationprovisioner.ApplicationService, arg7 caasapplicationprovisioner.StatusService, arg8 logger.Logger) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureScale", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].(error)
@@ -186,13 +186,13 @@ func (c *MockApplicationOpsEnsureScaleCall) Return(arg0 error) *MockApplicationO
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsEnsureScaleCall) Do(f func(context.Context, string, application.ID, caas.Application, life.Value, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsEnsureScaleCall {
+func (c *MockApplicationOpsEnsureScaleCall) Do(f func(context.Context, string, application.UUID, caas.Application, life.Value, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsEnsureScaleCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsEnsureScaleCall) DoAndReturn(f func(context.Context, string, application.ID, caas.Application, life.Value, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsEnsureScaleCall {
+func (c *MockApplicationOpsEnsureScaleCall) DoAndReturn(f func(context.Context, string, application.UUID, caas.Application, life.Value, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsEnsureScaleCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -236,7 +236,7 @@ func (c *MockApplicationOpsEnsureTrustCall) DoAndReturn(f func(context.Context, 
 }
 
 // ProvisioningInfo mocks base method.
-func (m *MockApplicationOps) ProvisioningInfo(arg0 context.Context, arg1 string, arg2 application.ID, arg3 caasapplicationprovisioner.CAASProvisionerFacade, arg4 caasapplicationprovisioner.StorageProvisioningService, arg5 caasapplicationprovisioner.ApplicationService, arg6 caasapplicationprovisioner.ResourceOpenerGetter, arg7 *caasapplicationprovisioner.ProvisioningInfo, arg8 logger.Logger) (*caasapplicationprovisioner.ProvisioningInfo, error) {
+func (m *MockApplicationOps) ProvisioningInfo(arg0 context.Context, arg1 string, arg2 application.UUID, arg3 caasapplicationprovisioner.CAASProvisionerFacade, arg4 caasapplicationprovisioner.StorageProvisioningService, arg5 caasapplicationprovisioner.ApplicationService, arg6 caasapplicationprovisioner.ResourceOpenerGetter, arg7 *caasapplicationprovisioner.ProvisioningInfo, arg8 logger.Logger) (*caasapplicationprovisioner.ProvisioningInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].(*caasapplicationprovisioner.ProvisioningInfo)
@@ -263,19 +263,19 @@ func (c *MockApplicationOpsProvisioningInfoCall) Return(arg0 *caasapplicationpro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsProvisioningInfoCall) Do(f func(context.Context, string, application.ID, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.StorageProvisioningService, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.ResourceOpenerGetter, *caasapplicationprovisioner.ProvisioningInfo, logger.Logger) (*caasapplicationprovisioner.ProvisioningInfo, error)) *MockApplicationOpsProvisioningInfoCall {
+func (c *MockApplicationOpsProvisioningInfoCall) Do(f func(context.Context, string, application.UUID, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.StorageProvisioningService, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.ResourceOpenerGetter, *caasapplicationprovisioner.ProvisioningInfo, logger.Logger) (*caasapplicationprovisioner.ProvisioningInfo, error)) *MockApplicationOpsProvisioningInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsProvisioningInfoCall) DoAndReturn(f func(context.Context, string, application.ID, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.StorageProvisioningService, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.ResourceOpenerGetter, *caasapplicationprovisioner.ProvisioningInfo, logger.Logger) (*caasapplicationprovisioner.ProvisioningInfo, error)) *MockApplicationOpsProvisioningInfoCall {
+func (c *MockApplicationOpsProvisioningInfoCall) DoAndReturn(f func(context.Context, string, application.UUID, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.StorageProvisioningService, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.ResourceOpenerGetter, *caasapplicationprovisioner.ProvisioningInfo, logger.Logger) (*caasapplicationprovisioner.ProvisioningInfo, error)) *MockApplicationOpsProvisioningInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReconcileDeadUnitScale mocks base method.
-func (m *MockApplicationOps) ReconcileDeadUnitScale(arg0 context.Context, arg1 string, arg2 application.ID, arg3 caas.Application, arg4 caasapplicationprovisioner.CAASProvisionerFacade, arg5 caasapplicationprovisioner.ApplicationService, arg6 caasapplicationprovisioner.StatusService, arg7 logger.Logger) error {
+func (m *MockApplicationOps) ReconcileDeadUnitScale(arg0 context.Context, arg1 string, arg2 application.UUID, arg3 caas.Application, arg4 caasapplicationprovisioner.CAASProvisionerFacade, arg5 caasapplicationprovisioner.ApplicationService, arg6 caasapplicationprovisioner.StatusService, arg7 logger.Logger) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReconcileDeadUnitScale", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
@@ -301,19 +301,19 @@ func (c *MockApplicationOpsReconcileDeadUnitScaleCall) Return(arg0 error) *MockA
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsReconcileDeadUnitScaleCall) Do(f func(context.Context, string, application.ID, caas.Application, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsReconcileDeadUnitScaleCall {
+func (c *MockApplicationOpsReconcileDeadUnitScaleCall) Do(f func(context.Context, string, application.UUID, caas.Application, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsReconcileDeadUnitScaleCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsReconcileDeadUnitScaleCall) DoAndReturn(f func(context.Context, string, application.ID, caas.Application, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsReconcileDeadUnitScaleCall {
+func (c *MockApplicationOpsReconcileDeadUnitScaleCall) DoAndReturn(f func(context.Context, string, application.UUID, caas.Application, caasapplicationprovisioner.CAASProvisionerFacade, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, logger.Logger) error) *MockApplicationOpsReconcileDeadUnitScaleCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RefreshApplicationStatus mocks base method.
-func (m *MockApplicationOps) RefreshApplicationStatus(arg0 context.Context, arg1 string, arg2 application.ID, arg3 caas.Application, arg4 life.Value, arg5 caasapplicationprovisioner.StatusService, arg6 clock.Clock, arg7 logger.Logger) error {
+func (m *MockApplicationOps) RefreshApplicationStatus(arg0 context.Context, arg1 string, arg2 application.UUID, arg3 caas.Application, arg4 life.Value, arg5 caasapplicationprovisioner.StatusService, arg6 clock.Clock, arg7 logger.Logger) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshApplicationStatus", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
@@ -339,19 +339,19 @@ func (c *MockApplicationOpsRefreshApplicationStatusCall) Return(arg0 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsRefreshApplicationStatusCall) Do(f func(context.Context, string, application.ID, caas.Application, life.Value, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) error) *MockApplicationOpsRefreshApplicationStatusCall {
+func (c *MockApplicationOpsRefreshApplicationStatusCall) Do(f func(context.Context, string, application.UUID, caas.Application, life.Value, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) error) *MockApplicationOpsRefreshApplicationStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsRefreshApplicationStatusCall) DoAndReturn(f func(context.Context, string, application.ID, caas.Application, life.Value, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) error) *MockApplicationOpsRefreshApplicationStatusCall {
+func (c *MockApplicationOpsRefreshApplicationStatusCall) DoAndReturn(f func(context.Context, string, application.UUID, caas.Application, life.Value, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) error) *MockApplicationOpsRefreshApplicationStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdateState mocks base method.
-func (m *MockApplicationOps) UpdateState(arg0 context.Context, arg1 string, arg2 application.ID, arg3 caas.Application, arg4 caasapplicationprovisioner.UpdateStatusState, arg5 caasapplicationprovisioner.CAASBroker, arg6 caasapplicationprovisioner.ApplicationService, arg7 caasapplicationprovisioner.StatusService, arg8 clock.Clock, arg9 logger.Logger) (caasapplicationprovisioner.UpdateStatusState, error) {
+func (m *MockApplicationOps) UpdateState(arg0 context.Context, arg1 string, arg2 application.UUID, arg3 caas.Application, arg4 caasapplicationprovisioner.UpdateStatusState, arg5 caasapplicationprovisioner.CAASBroker, arg6 caasapplicationprovisioner.ApplicationService, arg7 caasapplicationprovisioner.StatusService, arg8 clock.Clock, arg9 logger.Logger) (caasapplicationprovisioner.UpdateStatusState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateState", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 	ret0, _ := ret[0].(caasapplicationprovisioner.UpdateStatusState)
@@ -378,13 +378,13 @@ func (c *MockApplicationOpsUpdateStateCall) Return(arg0 caasapplicationprovision
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsUpdateStateCall) Do(f func(context.Context, string, application.ID, caas.Application, caasapplicationprovisioner.UpdateStatusState, caasapplicationprovisioner.CAASBroker, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) (caasapplicationprovisioner.UpdateStatusState, error)) *MockApplicationOpsUpdateStateCall {
+func (c *MockApplicationOpsUpdateStateCall) Do(f func(context.Context, string, application.UUID, caas.Application, caasapplicationprovisioner.UpdateStatusState, caasapplicationprovisioner.CAASBroker, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) (caasapplicationprovisioner.UpdateStatusState, error)) *MockApplicationOpsUpdateStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsUpdateStateCall) DoAndReturn(f func(context.Context, string, application.ID, caas.Application, caasapplicationprovisioner.UpdateStatusState, caasapplicationprovisioner.CAASBroker, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) (caasapplicationprovisioner.UpdateStatusState, error)) *MockApplicationOpsUpdateStateCall {
+func (c *MockApplicationOpsUpdateStateCall) DoAndReturn(f func(context.Context, string, application.UUID, caas.Application, caasapplicationprovisioner.UpdateStatusState, caasapplicationprovisioner.CAASBroker, caasapplicationprovisioner.ApplicationService, caasapplicationprovisioner.StatusService, clock.Clock, logger.Logger) (caasapplicationprovisioner.UpdateStatusState, error)) *MockApplicationOpsUpdateStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/mocks/worker_mocks.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/worker_mocks.go
@@ -293,7 +293,7 @@ func (m *MockResourceOpenerGetter) EXPECT() *MockResourceOpenerGetterMockRecorde
 }
 
 // ResourceOpenerForApplication mocks base method.
-func (m *MockResourceOpenerGetter) ResourceOpenerForApplication(arg0 context.Context, arg1 application.ID, arg2 string) (resource.Opener, error) {
+func (m *MockResourceOpenerGetter) ResourceOpenerForApplication(arg0 context.Context, arg1 application.UUID, arg2 string) (resource.Opener, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResourceOpenerForApplication", arg0, arg1, arg2)
 	ret0, _ := ret[0].(resource.Opener)
@@ -320,13 +320,13 @@ func (c *MockResourceOpenerGetterResourceOpenerForApplicationCall) Return(arg0 r
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockResourceOpenerGetterResourceOpenerForApplicationCall) Do(f func(context.Context, application.ID, string) (resource.Opener, error)) *MockResourceOpenerGetterResourceOpenerForApplicationCall {
+func (c *MockResourceOpenerGetterResourceOpenerForApplicationCall) Do(f func(context.Context, application.UUID, string) (resource.Opener, error)) *MockResourceOpenerGetterResourceOpenerForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockResourceOpenerGetterResourceOpenerForApplicationCall) DoAndReturn(f func(context.Context, application.ID, string) (resource.Opener, error)) *MockResourceOpenerGetterResourceOpenerForApplicationCall {
+func (c *MockResourceOpenerGetterResourceOpenerForApplicationCall) DoAndReturn(f func(context.Context, application.UUID, string) (resource.Opener, error)) *MockResourceOpenerGetterResourceOpenerForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -69,7 +69,7 @@ type ProvisioningInfo struct {
 // This is exported for testing only.
 type ApplicationOps interface {
 	ProvisioningInfo(
-		ctx context.Context, appName string, appID coreapplication.ID,
+		ctx context.Context, appName string, appID coreapplication.UUID,
 		facade CAASProvisionerFacade,
 		storageProvisioningService StorageProvisioningService,
 		applicationService ApplicationService,
@@ -83,35 +83,35 @@ type ApplicationOps interface {
 		statusService StatusService,
 		clk clock.Clock, logger logger.Logger) error
 
-	AppDying(ctx context.Context, appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	AppDying(ctx context.Context, appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 		facade CAASProvisionerFacade,
 		applicationService ApplicationService, statusService StatusService,
 		logger logger.Logger) error
 
-	AppDead(ctx context.Context, appName string, appID coreapplication.ID, app caas.Application,
+	AppDead(ctx context.Context, appName string, appID coreapplication.UUID, app caas.Application,
 		broker CAASBroker, applicationService ApplicationService, statusService StatusService,
 		clk clock.Clock, logger logger.Logger) error
 
 	EnsureTrust(ctx context.Context, appName string, app caas.Application,
 		applicationService ApplicationService, logger logger.Logger) error
 
-	UpdateState(ctx context.Context, appName string, appID coreapplication.ID, app caas.Application,
+	UpdateState(ctx context.Context, appName string, appID coreapplication.UUID, app caas.Application,
 		lastReportedStatus UpdateStatusState,
 		broker CAASBroker, applicationService ApplicationService, statusService StatusService,
 		clk clock.Clock, logger logger.Logger) (UpdateStatusState, error)
 
-	RefreshApplicationStatus(ctx context.Context, appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	RefreshApplicationStatus(ctx context.Context, appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 		statusService StatusService, clk clock.Clock, logger logger.Logger) error
 
 	WaitForTerminated(appName string, app caas.Application,
 		clk clock.Clock) error
 
-	ReconcileDeadUnitScale(ctx context.Context, appName string, appID coreapplication.ID, app caas.Application,
+	ReconcileDeadUnitScale(ctx context.Context, appName string, appID coreapplication.UUID, app caas.Application,
 		facade CAASProvisionerFacade,
 		applicationService ApplicationService, statusService StatusService,
 		logger logger.Logger) error
 
-	EnsureScale(ctx context.Context, appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	EnsureScale(ctx context.Context, appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 		facade CAASProvisionerFacade,
 		applicationService ApplicationService, statusService StatusService,
 		logger logger.Logger) error
@@ -122,7 +122,7 @@ type applicationOps struct{}
 var _ ApplicationOps = &applicationOps{}
 
 func (applicationOps) ProvisioningInfo(
-	ctx context.Context, appName string, appID coreapplication.ID,
+	ctx context.Context, appName string, appID coreapplication.UUID,
 	facade CAASProvisionerFacade,
 	storageProvisioningService StorageProvisioningService,
 	applicationService ApplicationService,
@@ -145,7 +145,7 @@ func (applicationOps) AppAlive(
 
 func (applicationOps) AppDying(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 	facade CAASProvisionerFacade,
 	applicationService ApplicationService, statusService StatusService,
 	logger logger.Logger,
@@ -154,7 +154,7 @@ func (applicationOps) AppDying(
 }
 
 func (applicationOps) AppDead(ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, broker CAASBroker,
+	appName string, appID coreapplication.UUID, app caas.Application, broker CAASBroker,
 	applicationService ApplicationService, statusService StatusService,
 	clk clock.Clock, logger logger.Logger,
 ) error {
@@ -172,7 +172,7 @@ func (applicationOps) EnsureTrust(
 
 func (applicationOps) UpdateState(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, lastReportedStatus UpdateStatusState,
+	appName string, appID coreapplication.UUID, app caas.Application, lastReportedStatus UpdateStatusState,
 	broker CAASBroker, applicationService ApplicationService, statusService StatusService,
 	clk clock.Clock, logger logger.Logger,
 ) (UpdateStatusState, error) {
@@ -181,7 +181,7 @@ func (applicationOps) UpdateState(
 
 func (applicationOps) RefreshApplicationStatus(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 	statusService StatusService,
 	clk clock.Clock, logger logger.Logger,
 ) error {
@@ -197,7 +197,7 @@ func (applicationOps) WaitForTerminated(
 
 func (applicationOps) ReconcileDeadUnitScale(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application,
+	appName string, appID coreapplication.UUID, app caas.Application,
 	facade CAASProvisionerFacade,
 	applicationService ApplicationService, statusService StatusService,
 	logger logger.Logger,
@@ -207,7 +207,7 @@ func (applicationOps) ReconcileDeadUnitScale(
 
 func (applicationOps) EnsureScale(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 	facade CAASProvisionerFacade,
 	applicationService ApplicationService, statusService StatusService,
 	logger logger.Logger,
@@ -356,7 +356,7 @@ func appAlive(ctx context.Context, appName string, app caas.Application,
 // the application and removing units.
 func appDying(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 	facade CAASProvisionerFacade,
 	applicationService ApplicationService, statusService StatusService,
 	logger logger.Logger,
@@ -377,7 +377,7 @@ func appDying(
 // is removed from the k8s cluster and unblocks the cleanup of the application in state.
 func appDead(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, broker CAASBroker,
+	appName string, appID coreapplication.UUID, app caas.Application, broker CAASBroker,
 	applicationService ApplicationService, statusService StatusService,
 	clk clock.Clock, logger logger.Logger,
 ) error {
@@ -431,7 +431,7 @@ func ensureTrust(
 // status, IP addresses and volume info.
 func updateState(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application,
+	appName string, appID coreapplication.UUID, app caas.Application,
 	lastReportedStatus UpdateStatusState,
 	broker CAASBroker, applicationService ApplicationService, statusService StatusService,
 	clk clock.Clock, logger logger.Logger,
@@ -523,7 +523,7 @@ func updateState(
 
 func refreshApplicationStatus(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 	statusService StatusService,
 	clk clock.Clock, logger logger.Logger,
 ) error {
@@ -596,7 +596,7 @@ func waitForTerminated(appName string, app caas.Application,
 // can go ahead and remove the units from CAAS provider.
 func reconcileDeadUnitScale(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application,
+	appName string, appID coreapplication.UUID, app caas.Application,
 	facade CAASProvisionerFacade,
 	applicationService ApplicationService,
 	statusService StatusService,
@@ -668,7 +668,7 @@ func reconcileDeadUnitScale(
 // current scale targets that have yet to be met.
 func ensureScale(
 	ctx context.Context,
-	appName string, appID coreapplication.ID, app caas.Application, appLife life.Value,
+	appName string, appID coreapplication.UUID, app caas.Application, appLife life.Value,
 	facade CAASProvisionerFacade,
 	applicationService ApplicationService, statusService StatusService,
 	logger logger.Logger,
@@ -817,7 +817,7 @@ func ensureScaleWithFsAttachments(ctx context.Context, appName string, app caas.
 
 func provisioningInfo(
 	ctx context.Context,
-	appName string, appID coreapplication.ID,
+	appName string, appID coreapplication.UUID,
 	facade CAASProvisionerFacade,
 	storageProvisioningService StorageProvisioningService,
 	applicationService ApplicationService,

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -865,7 +865,7 @@ func provisioningInfo(
 		}
 	}
 
-	charm, _, err := applicationService.GetCharmByApplicationID(ctx, appID)
+	charm, _, err := applicationService.GetCharmByApplicationUUID(ctx, appID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -823,7 +823,7 @@ func (s *OpsSuite) TestProvisioningInfo(c *tc.C) {
 		},
 	}
 	ch := charm.NewCharmBase(chMeta, nil, nil, nil, nil)
-	applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), appId).Return(ch, applicationcharm.CharmLocator{}, nil)
+	applicationService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appId).Return(ch, applicationcharm.CharmLocator{}, nil)
 
 	mysqlImageResource := coreresource.Opened{
 		ReadCloser: io.NopCloser(bytes.NewBufferString("registrypath: mysql/ubuntu:latest-22.04")),

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -75,12 +75,12 @@ type ApplicationService interface {
 
 	SetApplicationScalingState(ctx context.Context, name string, scaleTarget int, scaling bool) error
 	GetApplicationScalingState(ctx context.Context, name string) (applicationservice.ScalingState, error)
-	GetApplicationLife(ctx context.Context, id application.ID) (life.Value, error)
+	GetApplicationLife(ctx context.Context, id application.UUID) (life.Value, error)
 	GetUnitLife(context.Context, unit.Name) (life.Value, error)
-	GetAllUnitLifeForApplication(context.Context, application.ID) (map[unit.Name]life.Value, error)
+	GetAllUnitLifeForApplication(context.Context, application.UUID) (map[unit.Name]life.Value, error)
 
 	// GetApplicationName returns the application name for the given application ID.
-	GetApplicationName(ctx context.Context, id application.ID) (string, error)
+	GetApplicationName(ctx context.Context, id application.UUID) (string, error)
 
 	// WatchApplications returns a watcher that observes changes to applications.
 	WatchApplications(ctx context.Context) (watcher.StringsWatcher, error)
@@ -89,18 +89,18 @@ type ApplicationService interface {
 	UpdateCloudService(ctx context.Context, appName, providerID string, sAddrs network.ProviderAddresses) error
 
 	// IsControllerApplication returns true when the application is the controller.
-	IsControllerApplication(ctx context.Context, id application.ID) (bool, error)
+	IsControllerApplication(ctx context.Context, id application.UUID) (bool, error)
 
 	// UpdateCAASUnit updates the specified CAAS unit
 	UpdateCAASUnit(context.Context, unit.Name, applicationservice.UpdateCAASUnitParams) error
 
 	// GetAllUnitCloudContainerIDsForApplication returns a map of the unit names
 	// and their cloud container provider IDs for the given application.
-	GetAllUnitCloudContainerIDsForApplication(ctx context.Context, id application.ID) (map[unit.Name]string, error)
+	GetAllUnitCloudContainerIDsForApplication(ctx context.Context, id application.UUID) (map[unit.Name]string, error)
 
 	// GetCharmByApplicationID returns the charm for the specified application
 	// ID.
-	GetCharmByApplicationID(context.Context, application.ID) (internalcharm.Charm, applicationcharm.CharmLocator, error)
+	GetCharmByApplicationID(context.Context, application.UUID) (internalcharm.Charm, applicationcharm.CharmLocator, error)
 }
 
 // CAASBroker exposes CAAS broker functionality to a worker.
@@ -124,7 +124,7 @@ type StatusService interface {
 	// units in the specified application, indexed by unit name, returning an error
 	// satisfying [statuserrors.ApplicationNotFound] if the application doesn't
 	// exist.
-	GetUnitAgentStatusesForApplication(ctx context.Context, appID application.ID) (map[unit.Name]status.StatusInfo, error)
+	GetUnitAgentStatusesForApplication(ctx context.Context, appID application.UUID) (map[unit.Name]status.StatusInfo, error)
 
 	// SetApplicationStatus saves the given application status, overwriting any
 	// current status data. If returns an error satisfying
@@ -136,26 +136,26 @@ type AgentPasswordService interface {
 	// SetApplicationPassword sets the password for the given application. If the
 	// app does not exist, an error satisfying [applicationerrors.ApplicationNotFound]
 	// is returned.
-	SetApplicationPassword(ctx context.Context, appID application.ID, password string) error
+	SetApplicationPassword(ctx context.Context, appID application.UUID, password string) error
 }
 
 type StorageProvisioningService interface {
 	// GetFilesystemTemplatesForApplication returns all the filesystem templates for
 	// a given application.
-	GetFilesystemTemplatesForApplication(ctx context.Context, appID application.ID) ([]storageprovisioning.FilesystemTemplate, error)
+	GetFilesystemTemplatesForApplication(ctx context.Context, appID application.UUID) ([]storageprovisioning.FilesystemTemplate, error)
 	// GetStorageResourceTagsForApplication returns the storage resource tags for
 	// the given application. These tags are used when creating a resource in an
 	// environ.
-	GetStorageResourceTagsForApplication(ctx context.Context, appID application.ID) (map[string]string, error)
+	GetStorageResourceTagsForApplication(ctx context.Context, appID application.UUID) (map[string]string, error)
 }
 
 type ResourceOpenerGetter interface {
-	ResourceOpenerForApplication(ctx context.Context, appID application.ID, appName string) (coreresource.Opener, error)
+	ResourceOpenerForApplication(ctx context.Context, appID application.UUID, appName string) (coreresource.Opener, error)
 }
 
-type ResourceOpenerGetterFunc func(context.Context, application.ID, string) (coreresource.Opener, error)
+type ResourceOpenerGetterFunc func(context.Context, application.UUID, string) (coreresource.Opener, error)
 
-func (f ResourceOpenerGetterFunc) ResourceOpenerForApplication(ctx context.Context, appID application.ID, appName string) (coreresource.Opener, error) {
+func (f ResourceOpenerGetterFunc) ResourceOpenerForApplication(ctx context.Context, appID application.UUID, appName string) (coreresource.Opener, error) {
 	return f(ctx, appID, appName)
 }
 

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -98,9 +98,9 @@ type ApplicationService interface {
 	// and their cloud container provider IDs for the given application.
 	GetAllUnitCloudContainerIDsForApplication(ctx context.Context, id application.UUID) (map[unit.Name]string, error)
 
-	// GetCharmByApplicationID returns the charm for the specified application
-	// ID.
-	GetCharmByApplicationID(context.Context, application.UUID) (internalcharm.Charm, applicationcharm.CharmLocator, error)
+	// GetCharmByApplicationUUID returns the charm for the specified application
+	// UUID.
+	GetCharmByApplicationUUID(context.Context, application.UUID) (internalcharm.Charm, applicationcharm.CharmLocator, error)
 }
 
 // CAASBroker exposes CAAS broker functionality to a worker.

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -79,7 +79,7 @@ type ApplicationService interface {
 	GetUnitLife(context.Context, unit.Name) (life.Value, error)
 	GetAllUnitLifeForApplication(context.Context, application.UUID) (map[unit.Name]life.Value, error)
 
-	// GetApplicationName returns the application name for the given application ID.
+	// GetApplicationName returns the application name for the given application UUID.
 	GetApplicationName(ctx context.Context, id application.UUID) (string, error)
 
 	// WatchApplications returns a watcher that observes changes to applications.

--- a/internal/worker/caasfirewaller/applicationworker.go
+++ b/internal/worker/caasfirewaller/applicationworker.go
@@ -24,7 +24,7 @@ type applicationWorker struct {
 	controllerUUID string
 	modelUUID      string
 	appName        string
-	appUUID        application.ID
+	appUUID        application.UUID
 
 	portService        PortService
 	applicationService ApplicationService
@@ -47,7 +47,7 @@ type applicationWorker struct {
 func newApplicationWorker(
 	controllerUUID string,
 	modelUUID string,
-	appUUID application.ID,
+	appUUID application.UUID,
 	portService PortService,
 	applicationSewrvice ApplicationService,
 	broker CAASBroker,

--- a/internal/worker/caasfirewaller/applicationworker_test.go
+++ b/internal/worker/caasfirewaller/applicationworker_test.go
@@ -31,7 +31,7 @@ type appWorkerSuite struct {
 	testing.BaseSuite
 
 	appName string
-	appUUID coreapplication.ID
+	appUUID coreapplication.UUID
 
 	portService        *mocks.MockPortService
 	applicationService *mocks.MockApplicationService

--- a/internal/worker/caasfirewaller/interface.go
+++ b/internal/worker/caasfirewaller/interface.go
@@ -47,8 +47,8 @@ type ApplicationService interface {
 	// [applicationerrors.ApplicationNotFound] is returned.
 	IsApplicationExposed(ctx context.Context, name string) (bool, error)
 
-	// GetCharmByApplicationID returns the charm for the specified application
-	// ID.
+	// GetCharmByApplicationUUID returns the charm for the specified application
+	// UUID.
 	//
 	// If the application does not exist, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned. If the charm for the
@@ -56,7 +56,7 @@ type ApplicationService interface {
 	// [applicationerrors.CharmNotFound is returned. If the application name is not
 	// valid, an error satisfying [applicationerrors.ApplicationNameNotValid] is
 	// returned.
-	GetCharmByApplicationID(context.Context, application.UUID) (internalcharm.Charm, charm.CharmLocator, error)
+	GetCharmByApplicationUUID(context.Context, application.UUID) (internalcharm.Charm, charm.CharmLocator, error)
 
 	// WatchApplicationExposed watches for changes to the specified application's
 	// exposed endpoints.

--- a/internal/worker/caasfirewaller/interface.go
+++ b/internal/worker/caasfirewaller/interface.go
@@ -19,14 +19,14 @@ type PortService interface {
 	// WatchOpenedPortsForApplication returns a notify watcher for opened ports. This
 	// watcher emits events for changes to the opened ports table that are associated
 	// with the given application
-	WatchOpenedPortsForApplication(context.Context, application.ID) (watcher.NotifyWatcher, error)
+	WatchOpenedPortsForApplication(context.Context, application.UUID) (watcher.NotifyWatcher, error)
 
 	// GetApplicationOpenedPortsByEndpoint returns all the opened ports for the given
 	// application, across all units, grouped by endpoint.
 	//
 	// NOTE: The returned port ranges are atomised, meaning we guarantee that each
 	// port range is of unit length.
-	GetApplicationOpenedPortsByEndpoint(context.Context, application.ID) (network.GroupedPortRanges, error)
+	GetApplicationOpenedPortsByEndpoint(context.Context, application.UUID) (network.GroupedPortRanges, error)
 }
 
 // ApplicationService provides access to the application service.
@@ -34,12 +34,12 @@ type ApplicationService interface {
 	// GetApplicationName returns the name of the specified application.
 	// The following errors may be returned:
 	// - [applicationerrors.ApplicationNotFound] if the application does not exist
-	GetApplicationName(context.Context, application.ID) (string, error)
+	GetApplicationName(context.Context, application.UUID) (string, error)
 
 	// GetApplicationLifelooks up the life of the specified application, returning
 	// an error satisfying [applicationerrors.ApplicationNotFoundError] if the
 	// application is not found.
-	GetApplicationLife(context.Context, application.ID) (life.Value, error)
+	GetApplicationLife(context.Context, application.UUID) (life.Value, error)
 
 	// IsApplicationExposed returns whether the provided application is exposed or not.
 	//
@@ -56,7 +56,7 @@ type ApplicationService interface {
 	// [applicationerrors.CharmNotFound is returned. If the application name is not
 	// valid, an error satisfying [applicationerrors.ApplicationNameNotValid] is
 	// returned.
-	GetCharmByApplicationID(context.Context, application.ID) (internalcharm.Charm, charm.CharmLocator, error)
+	GetCharmByApplicationID(context.Context, application.UUID) (internalcharm.Charm, charm.CharmLocator, error)
 
 	// WatchApplicationExposed watches for changes to the specified application's
 	// exposed endpoints.

--- a/internal/worker/caasfirewaller/mocks/domain_mocks.go
+++ b/internal/worker/caasfirewaller/mocks/domain_mocks.go
@@ -46,7 +46,7 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetApplicationLife mocks base method.
-func (m *MockApplicationService) GetApplicationLife(arg0 context.Context, arg1 application.ID) (life.Value, error) {
+func (m *MockApplicationService) GetApplicationLife(arg0 context.Context, arg1 application.UUID) (life.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationLife", arg0, arg1)
 	ret0, _ := ret[0].(life.Value)
@@ -73,19 +73,19 @@ func (c *MockApplicationServiceGetApplicationLifeCall) Return(arg0 life.Value, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context, application.ID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context, application.UUID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.ID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, application.UUID) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationName mocks base method.
-func (m *MockApplicationService) GetApplicationName(arg0 context.Context, arg1 application.ID) (string, error) {
+func (m *MockApplicationService) GetApplicationName(arg0 context.Context, arg1 application.UUID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationName", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -112,19 +112,19 @@ func (c *MockApplicationServiceGetApplicationNameCall) Return(arg0 string, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationNameCall) Do(f func(context.Context, application.ID) (string, error)) *MockApplicationServiceGetApplicationNameCall {
+func (c *MockApplicationServiceGetApplicationNameCall) Do(f func(context.Context, application.UUID) (string, error)) *MockApplicationServiceGetApplicationNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationNameCall) DoAndReturn(f func(context.Context, application.ID) (string, error)) *MockApplicationServiceGetApplicationNameCall {
+func (c *MockApplicationServiceGetApplicationNameCall) DoAndReturn(f func(context.Context, application.UUID) (string, error)) *MockApplicationServiceGetApplicationNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetCharmByApplicationID mocks base method.
-func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.ID) (charm0.Charm, charm.CharmLocator, error) {
+func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmByApplicationID", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Charm)
@@ -152,13 +152,13 @@ func (c *MockApplicationServiceGetCharmByApplicationIDCall) Return(arg0 charm0.C
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.ID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.ID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -304,7 +304,7 @@ func (m *MockPortService) EXPECT() *MockPortServiceMockRecorder {
 }
 
 // GetApplicationOpenedPortsByEndpoint mocks base method.
-func (m *MockPortService) GetApplicationOpenedPortsByEndpoint(arg0 context.Context, arg1 application.ID) (network.GroupedPortRanges, error) {
+func (m *MockPortService) GetApplicationOpenedPortsByEndpoint(arg0 context.Context, arg1 application.UUID) (network.GroupedPortRanges, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationOpenedPortsByEndpoint", arg0, arg1)
 	ret0, _ := ret[0].(network.GroupedPortRanges)
@@ -331,19 +331,19 @@ func (c *MockPortServiceGetApplicationOpenedPortsByEndpointCall) Return(arg0 net
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPortServiceGetApplicationOpenedPortsByEndpointCall) Do(f func(context.Context, application.ID) (network.GroupedPortRanges, error)) *MockPortServiceGetApplicationOpenedPortsByEndpointCall {
+func (c *MockPortServiceGetApplicationOpenedPortsByEndpointCall) Do(f func(context.Context, application.UUID) (network.GroupedPortRanges, error)) *MockPortServiceGetApplicationOpenedPortsByEndpointCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPortServiceGetApplicationOpenedPortsByEndpointCall) DoAndReturn(f func(context.Context, application.ID) (network.GroupedPortRanges, error)) *MockPortServiceGetApplicationOpenedPortsByEndpointCall {
+func (c *MockPortServiceGetApplicationOpenedPortsByEndpointCall) DoAndReturn(f func(context.Context, application.UUID) (network.GroupedPortRanges, error)) *MockPortServiceGetApplicationOpenedPortsByEndpointCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchOpenedPortsForApplication mocks base method.
-func (m *MockPortService) WatchOpenedPortsForApplication(arg0 context.Context, arg1 application.ID) (watcher.Watcher[struct{}], error) {
+func (m *MockPortService) WatchOpenedPortsForApplication(arg0 context.Context, arg1 application.UUID) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchOpenedPortsForApplication", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
@@ -370,13 +370,13 @@ func (c *MockPortServiceWatchOpenedPortsForApplicationCall) Return(arg0 watcher.
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPortServiceWatchOpenedPortsForApplicationCall) Do(f func(context.Context, application.ID) (watcher.Watcher[struct{}], error)) *MockPortServiceWatchOpenedPortsForApplicationCall {
+func (c *MockPortServiceWatchOpenedPortsForApplicationCall) Do(f func(context.Context, application.UUID) (watcher.Watcher[struct{}], error)) *MockPortServiceWatchOpenedPortsForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPortServiceWatchOpenedPortsForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (watcher.Watcher[struct{}], error)) *MockPortServiceWatchOpenedPortsForApplicationCall {
+func (c *MockPortServiceWatchOpenedPortsForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (watcher.Watcher[struct{}], error)) *MockPortServiceWatchOpenedPortsForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasfirewaller/mocks/domain_mocks.go
+++ b/internal/worker/caasfirewaller/mocks/domain_mocks.go
@@ -123,42 +123,42 @@ func (c *MockApplicationServiceGetApplicationNameCall) DoAndReturn(f func(contex
 	return c
 }
 
-// GetCharmByApplicationID mocks base method.
-func (m *MockApplicationService) GetCharmByApplicationID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
+// GetCharmByApplicationUUID mocks base method.
+func (m *MockApplicationService) GetCharmByApplicationUUID(arg0 context.Context, arg1 application.UUID) (charm0.Charm, charm.CharmLocator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmByApplicationID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetCharmByApplicationUUID", arg0, arg1)
 	ret0, _ := ret[0].(charm0.Charm)
 	ret1, _ := ret[1].(charm.CharmLocator)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetCharmByApplicationID indicates an expected call of GetCharmByApplicationID.
-func (mr *MockApplicationServiceMockRecorder) GetCharmByApplicationID(arg0, arg1 any) *MockApplicationServiceGetCharmByApplicationIDCall {
+// GetCharmByApplicationUUID indicates an expected call of GetCharmByApplicationUUID.
+func (mr *MockApplicationServiceMockRecorder) GetCharmByApplicationUUID(arg0, arg1 any) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationID", reflect.TypeOf((*MockApplicationService)(nil).GetCharmByApplicationID), arg0, arg1)
-	return &MockApplicationServiceGetCharmByApplicationIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationUUID", reflect.TypeOf((*MockApplicationService)(nil).GetCharmByApplicationUUID), arg0, arg1)
+	return &MockApplicationServiceGetCharmByApplicationUUIDCall{Call: call}
 }
 
-// MockApplicationServiceGetCharmByApplicationIDCall wrap *gomock.Call
-type MockApplicationServiceGetCharmByApplicationIDCall struct {
+// MockApplicationServiceGetCharmByApplicationUUIDCall wrap *gomock.Call
+type MockApplicationServiceGetCharmByApplicationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Return(arg0 charm0.Charm, arg1 charm.CharmLocator, arg2 error) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) Return(arg0 charm0.Charm, arg1 charm.CharmLocator, arg2 error) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) Do(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetCharmByApplicationIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationIDCall {
+func (c *MockApplicationServiceGetCharmByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID) (charm0.Charm, charm.CharmLocator, error)) *MockApplicationServiceGetCharmByApplicationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasfirewaller/worker.go
+++ b/internal/worker/caasfirewaller/worker.go
@@ -184,7 +184,7 @@ func (p *firewaller) loop() error {
 }
 
 func (p *firewaller) charmFormat(ctx context.Context, appUUID application.UUID) (charm.Format, error) {
-	ch, _, err := p.config.ApplicationService.GetCharmByApplicationID(ctx, appUUID)
+	ch, _, err := p.config.ApplicationService.GetCharmByApplicationUUID(ctx, appUUID)
 	if err != nil {
 		return charm.FormatUnknown, errors.Annotatef(err, "getting charm for application %q", appUUID)
 	}

--- a/internal/worker/caasfirewaller/worker.go
+++ b/internal/worker/caasfirewaller/worker.go
@@ -68,14 +68,14 @@ type firewaller struct {
 	catacomb catacomb.Catacomb
 	config   Config
 
-	appWorkers           map[application.ID]worker.Worker
+	appWorkers           map[application.UUID]worker.Worker
 	newApplicationWorker applicationWorkerCreator
 }
 
 type applicationWorkerCreator func(
 	controllerUUID string,
 	modelUUID string,
-	appUUID application.ID,
+	appUUID application.UUID,
 	portService PortService,
 	applicationService ApplicationService,
 	broker CAASBroker,
@@ -85,7 +85,7 @@ type applicationWorkerCreator func(
 func newFirewaller(config Config, f applicationWorkerCreator) *firewaller {
 	return &firewaller{
 		config:               config,
-		appWorkers:           make(map[application.ID]worker.Worker),
+		appWorkers:           make(map[application.UUID]worker.Worker),
 		newApplicationWorker: f,
 	}
 }
@@ -183,7 +183,7 @@ func (p *firewaller) loop() error {
 	}
 }
 
-func (p *firewaller) charmFormat(ctx context.Context, appUUID application.ID) (charm.Format, error) {
+func (p *firewaller) charmFormat(ctx context.Context, appUUID application.UUID) (charm.Format, error) {
 	ch, _, err := p.config.ApplicationService.GetCharmByApplicationID(ctx, appUUID)
 	if err != nil {
 		return charm.FormatUnknown, errors.Annotatef(err, "getting charm for application %q", appUUID)

--- a/internal/worker/caasfirewaller/worker_test.go
+++ b/internal/worker/caasfirewaller/worker_test.go
@@ -106,7 +106,7 @@ func (s *workerSuite) TestStartStop(c *tc.C) {
 	workerCreator := func(
 		controllerUUID string,
 		modelUUID string,
-		appUUID coreapplication.ID,
+		appUUID coreapplication.UUID,
 		portService caasfirewaller.PortService,
 		applicationService caasfirewaller.ApplicationService,
 		broker caasfirewaller.CAASBroker,
@@ -192,7 +192,7 @@ func (s *workerSuite) TestV1CharmSkipsProcessing(c *tc.C) {
 
 	var done = make(chan struct{})
 	s.applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), app1UUID).DoAndReturn(
-		func(ctx context.Context, id coreapplication.ID) (internalcharm.Charm, charm.CharmLocator, error) {
+		func(ctx context.Context, id coreapplication.UUID) (internalcharm.Charm, charm.CharmLocator, error) {
 			close(done)
 			charmInfo := &charms.CharmInfo{ // v1 charm
 				Meta:     &internalcharm.Meta{},
@@ -241,7 +241,7 @@ func (s *workerSuite) TestNotFoundCharmSkipsProcessing(c *tc.C) {
 
 	var done = make(chan struct{})
 	s.applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), app1UUID).DoAndReturn(
-		func(ctx context.Context, id coreapplication.ID) (internalcharm.Charm, charm.CharmLocator, error) {
+		func(ctx context.Context, id coreapplication.UUID) (internalcharm.Charm, charm.CharmLocator, error) {
 			close(done)
 			return nil, charm.CharmLocator{}, errors.NotFoundf("app1")
 		},

--- a/internal/worker/caasfirewaller/worker_test.go
+++ b/internal/worker/caasfirewaller/worker_test.go
@@ -127,23 +127,23 @@ func (s *workerSuite) TestStartStop(c *tc.C) {
 		Manifest: &internalcharm.Manifest{Bases: []internalcharm.Base{{}}}, // bases make it a v2 charm
 	}
 
-	s.applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), app1UUID).Return(charmInfo.Charm(), charm.CharmLocator{}, nil)
+	s.applicationService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), app1UUID).Return(charmInfo.Charm(), charm.CharmLocator{}, nil)
 	s.applicationService.EXPECT().GetApplicationLife(gomock.Any(), app1UUID).Return(life.Alive, nil)
 	// Added app1's worker to catacomb.
 	app1Worker.EXPECT().Wait().Return(nil)
 
-	s.applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), app2UUID).Return(charmInfo.Charm(), charm.CharmLocator{}, nil)
+	s.applicationService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), app2UUID).Return(charmInfo.Charm(), charm.CharmLocator{}, nil)
 	s.applicationService.EXPECT().GetApplicationLife(gomock.Any(), app2UUID).Return(life.Alive, nil)
 	// Added app2's worker to catacomb.
 	app2Worker.EXPECT().Wait().Return(nil)
 
-	s.applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), app1UUID).Return(charmInfo.Charm(), charm.CharmLocator{}, nil)
+	s.applicationService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), app1UUID).Return(charmInfo.Charm(), charm.CharmLocator{}, nil)
 	s.applicationService.EXPECT().GetApplicationLife(gomock.Any(), app1UUID).Return(life.Value(""), applicationerrors.ApplicationNotFound)
 	// Stopped app1's worker because it's removed.
 	app1Worker.EXPECT().Kill()
 	app1Worker.EXPECT().Wait().Return(nil)
 
-	s.applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), app2UUID).Return(charmInfo.Charm(), charm.CharmLocator{}, nil)
+	s.applicationService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), app2UUID).Return(charmInfo.Charm(), charm.CharmLocator{}, nil)
 	s.applicationService.EXPECT().GetApplicationLife(gomock.Any(), app2UUID).Return(life.Dead, nil)
 	// Stopped app2's worker because it's dead.
 	app2Worker.EXPECT().Kill()
@@ -191,7 +191,7 @@ func (s *workerSuite) TestV1CharmSkipsProcessing(c *tc.C) {
 	}()
 
 	var done = make(chan struct{})
-	s.applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), app1UUID).DoAndReturn(
+	s.applicationService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), app1UUID).DoAndReturn(
 		func(ctx context.Context, id coreapplication.UUID) (internalcharm.Charm, charm.CharmLocator, error) {
 			close(done)
 			charmInfo := &charms.CharmInfo{ // v1 charm
@@ -240,7 +240,7 @@ func (s *workerSuite) TestNotFoundCharmSkipsProcessing(c *tc.C) {
 	}()
 
 	var done = make(chan struct{})
-	s.applicationService.EXPECT().GetCharmByApplicationID(gomock.Any(), app1UUID).DoAndReturn(
+	s.applicationService.EXPECT().GetCharmByApplicationUUID(gomock.Any(), app1UUID).DoAndReturn(
 		func(ctx context.Context, id coreapplication.UUID) (internalcharm.Charm, charm.CharmLocator, error) {
 			close(done)
 			return nil, charm.CharmLocator{}, errors.NotFoundf("app1")

--- a/internal/worker/charmrevisioner/package_mocks_test.go
+++ b/internal/worker/charmrevisioner/package_mocks_test.go
@@ -251,10 +251,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.ID)
+	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -272,19 +272,19 @@ type MockApplicationServiceGetApplicationIDByNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/charmrevisioner/package_mocks_test.go
+++ b/internal/worker/charmrevisioner/package_mocks_test.go
@@ -250,41 +250,41 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
-// GetApplicationIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
+// GetApplicationUUIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
 }
 
-// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationIDByNameCall struct {
+// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationUUIDByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/charmrevisioner/worker.go
+++ b/internal/worker/charmrevisioner/worker.go
@@ -64,7 +64,7 @@ type ModelConfigService interface {
 // ApplicationService provides access to applications.
 type ApplicationService interface {
 
-	// GetApplicationUUIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application UUID by application name. It
 	// returns an error if the application can not be found by the name.
 	//
 	// Returns [applicationerrors.ApplicationNotFound] if the application is not found.
@@ -556,16 +556,16 @@ func (w *revisionUpdateWorker) storeNewResourcesRevision(ctx context.Context,
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		// Maybe the application has been removed in the meantime. In this case,
 		// that's not a real issue. Log it as a warning and continue.
-		w.config.Logger.Warningf(ctx, "failed to get application ID for %q: %v", info.appName, err)
+		w.config.Logger.Warningf(ctx, "failed to get application UUID for %q: %v", info.appName, err)
 		return nil
 	} else if err != nil {
 		return errors.Trace(err)
 	}
 	return w.config.ResourceService.SetRepositoryResources(ctx, domainresource.SetRepositoryResourcesArgs{
-		ApplicationID: appID,
-		CharmID:       charmID,
-		Info:          info.resources,
-		LastPolled:    w.config.Clock.Now(),
+		ApplicationUUID: appID,
+		CharmID:         charmID,
+		Info:            info.resources,
+		LastPolled:      w.config.Clock.Now(),
 	})
 }
 

--- a/internal/worker/charmrevisioner/worker.go
+++ b/internal/worker/charmrevisioner/worker.go
@@ -68,7 +68,7 @@ type ApplicationService interface {
 	// returns an error if the application can not be found by the name.
 	//
 	// Returns [applicationerrors.ApplicationNotFound] if the application is not found.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationsForRevisionUpdater returns the applications that should be
 	// used by the revision updater.

--- a/internal/worker/charmrevisioner/worker.go
+++ b/internal/worker/charmrevisioner/worker.go
@@ -64,11 +64,11 @@ type ModelConfigService interface {
 // ApplicationService provides access to applications.
 type ApplicationService interface {
 
-	// GetApplicationIDByName returns an application ID by application name. It
+	// GetApplicationUUIDByName returns an application ID by application name. It
 	// returns an error if the application can not be found by the name.
 	//
 	// Returns [applicationerrors.ApplicationNotFound] if the application is not found.
-	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
+	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationsForRevisionUpdater returns the applications that should be
 	// used by the revision updater.
@@ -552,7 +552,7 @@ func (w *revisionUpdateWorker) storeNewResourcesRevision(ctx context.Context,
 	}
 
 	// Store resources revision.
-	appID, err := w.config.ApplicationService.GetApplicationIDByName(ctx, info.appName)
+	appID, err := w.config.ApplicationService.GetApplicationUUIDByName(ctx, info.appName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		// Maybe the application has been removed in the meantime. In this case,
 		// that's not a real issue. Log it as a warning and continue.

--- a/internal/worker/charmrevisioner/worker_test.go
+++ b/internal/worker/charmrevisioner/worker_test.go
@@ -852,8 +852,8 @@ func (s *WorkerSuite) TestStoreNewResourceRevisions(c *tc.C) {
 	// This function is called but won't contribute to the revisions storage
 	s.applicationService.EXPECT().ReserveCharmRevision(gomock.Any(), gomock.Any()).Return("foo-charm-id", nil, nil).AnyTimes()
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("foo-id", nil)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "bar").Return("bar-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("foo-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "bar").Return("bar-id", nil)
 	s.resourceService.EXPECT().SetRepositoryResources(gomock.Any(), domainresource.SetRepositoryResourcesArgs{
 		ApplicationID: "foo-id",
 		CharmID:       "foo-charm-id",
@@ -906,9 +906,9 @@ func (s *WorkerSuite) TestStoreNewResourceRevisionsWithApplicationNotFound(c *tc
 	s.applicationService.EXPECT().ReserveCharmRevision(gomock.Any(), gomock.Any()).Return("foo-charm-id", nil,
 		nil).AnyTimes()
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "not-found").Return("",
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "not-found").Return("",
 		applicationerrors.ApplicationNotFound)
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("foo-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("foo-id", nil)
 	s.resourceService.EXPECT().SetRepositoryResources(gomock.Any(), domainresource.SetRepositoryResourcesArgs{
 		ApplicationID: "foo-id",
 		CharmID:       "foo-charm-id",
@@ -949,7 +949,7 @@ func (s *WorkerSuite) TestStoreNewResourceRevisionsErrorGetApplicationID(c *tc.C
 	// This function is called but won't contribute to the revisions storage
 	s.applicationService.EXPECT().ReserveCharmRevision(gomock.Any(), gomock.Any()).Return("foo", nil, nil).AnyTimes()
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("",
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("",
 		expectedError)
 
 	w := s.newWorker(c)
@@ -983,7 +983,7 @@ func (s *WorkerSuite) TestStoreNewResourceRevisionsErrorStoreRepositoryResources
 	// This function is called but won't contribute to the revisions storage
 	s.applicationService.EXPECT().ReserveCharmRevision(gomock.Any(), gomock.Any()).Return("foo", nil, nil).AnyTimes()
 
-	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return("foo-id", nil)
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("foo-id", nil)
 	s.resourceService.EXPECT().SetRepositoryResources(gomock.Any(), gomock.Any()).Return(expectedError)
 
 	w := s.newWorker(c)

--- a/internal/worker/charmrevisioner/worker_test.go
+++ b/internal/worker/charmrevisioner/worker_test.go
@@ -855,16 +855,16 @@ func (s *WorkerSuite) TestStoreNewResourceRevisions(c *tc.C) {
 	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("foo-id", nil)
 	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "bar").Return("bar-id", nil)
 	s.resourceService.EXPECT().SetRepositoryResources(gomock.Any(), domainresource.SetRepositoryResourcesArgs{
-		ApplicationID: "foo-id",
-		CharmID:       "foo-charm-id",
-		Info:          latestCharmInfos[0].resources,
-		LastPolled:    s.now,
+		ApplicationUUID: "foo-id",
+		CharmID:         "foo-charm-id",
+		Info:            latestCharmInfos[0].resources,
+		LastPolled:      s.now,
 	}).Return(nil)
 	s.resourceService.EXPECT().SetRepositoryResources(gomock.Any(), domainresource.SetRepositoryResourcesArgs{
-		ApplicationID: "bar-id",
-		CharmID:       "foo-charm-id",
-		Info:          latestCharmInfos[1].resources,
-		LastPolled:    s.now,
+		ApplicationUUID: "bar-id",
+		CharmID:         "foo-charm-id",
+		Info:            latestCharmInfos[1].resources,
+		LastPolled:      s.now,
 	}).Return(nil)
 
 	w := s.newWorker(c)
@@ -910,10 +910,10 @@ func (s *WorkerSuite) TestStoreNewResourceRevisionsWithApplicationNotFound(c *tc
 		applicationerrors.ApplicationNotFound)
 	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("foo-id", nil)
 	s.resourceService.EXPECT().SetRepositoryResources(gomock.Any(), domainresource.SetRepositoryResourcesArgs{
-		ApplicationID: "foo-id",
-		CharmID:       "foo-charm-id",
-		Info:          latestCharmInfos[1].resources,
-		LastPolled:    s.now,
+		ApplicationUUID: "foo-id",
+		CharmID:         "foo-charm-id",
+		Info:            latestCharmInfos[1].resources,
+		LastPolled:      s.now,
 	}).Return(nil)
 
 	w := s.newWorker(c)
@@ -927,7 +927,7 @@ func (s *WorkerSuite) TestStoreNewResourceRevisionsWithApplicationNotFound(c *tc
 	// Assert: check everything ok through mocks, but also that a log as been
 	// generated for the unknown application.
 	c.Assert(err, tc.ErrorIsNil)
-	//c.Check(c.GetTestLog(), tc.Contains, `failed to get application ID for "not-found"`)
+	//c.Check(c.GetTestLog(), tc.Contains, `failed to get application UUID for "not-found"`)
 }
 
 func (s *WorkerSuite) TestStoreNewResourceRevisionsErrorGetApplicationID(c *tc.C) {

--- a/internal/worker/remoterelationconsumer/applicationworker.go
+++ b/internal/worker/remoterelationconsumer/applicationworker.go
@@ -834,7 +834,7 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 	if err := remoteRelation[0].Error; err != nil {
 		return fail(errors.Annotatef(err, "registering relation %v", relationTag))
 	}
-	// Import the application id from the offering model.
+	// Import the application UUID from the offering model.
 	registerResult := *remoteRelation[0].Result
 	offeringAppToken = registerResult.Token
 

--- a/internal/worker/remoterelationconsumer/applicationworker.go
+++ b/internal/worker/remoterelationconsumer/applicationworker.go
@@ -38,7 +38,7 @@ type RemoteApplicationConfig struct {
 
 	OfferUUID       string
 	ApplicationName string
-	ApplicationUUID application.ID
+	ApplicationUUID application.UUID
 	LocalModelUUID  model.UUID
 	RemoteModelUUID string
 	ConsumeVersion  int
@@ -117,7 +117,7 @@ type remoteApplicationWorker struct {
 	// remote application proxy.
 	offerUUID       string
 	applicationName string
-	applicationUUID application.ID
+	applicationUUID application.UUID
 	localModelUUID  model.UUID // uuid of the model hosting the local application
 	remoteModelUUID string     // uuid of the model hosting the remote offer
 	consumeVersion  int

--- a/internal/worker/remoterelationconsumer/applicationworker_test.go
+++ b/internal/worker/remoterelationconsumer/applicationworker_test.go
@@ -37,7 +37,7 @@ func TestApplicationWorker(t *stdtesting.T) {
 type applicationWorkerSuite struct {
 	baseSuite
 
-	applicationUUID application.ID
+	applicationUUID application.UUID
 	remoteModelUUID string
 	offerUUID       string
 	macaroon        *macaroon.Macaroon
@@ -119,7 +119,7 @@ func (s *applicationWorkerSuite) TestStart(c *tc.C) {
 
 	s.crossModelService.EXPECT().
 		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
-		DoAndReturn(func(ctx context.Context, i application.ID) (watcher.StringsWatcher, error) {
+		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			ch := make(chan []string)
 			return watchertest.NewMockStringsWatcher(ch), nil
 		})
@@ -161,7 +161,7 @@ func (s *applicationWorkerSuite) TestStartFailedWatchApplicationLife(c *tc.C) {
 
 	s.crossModelService.EXPECT().
 		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
-		DoAndReturn(func(ctx context.Context, i application.ID) (watcher.StringsWatcher, error) {
+		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			defer close(done)
 			return nil, applicationerrors.ApplicationNotFound
 		})
@@ -187,7 +187,7 @@ func (s *applicationWorkerSuite) TestStartNoRemoteClient(c *tc.C) {
 
 	s.crossModelService.EXPECT().
 		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
-		DoAndReturn(func(ctx context.Context, i application.ID) (watcher.StringsWatcher, error) {
+		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			ch := make(chan []string)
 			return watchertest.NewMockStringsWatcher(ch), nil
 		})
@@ -201,7 +201,7 @@ func (s *applicationWorkerSuite) TestStartNoRemoteClient(c *tc.C) {
 			Status:  status.Error,
 			Message: "cannot connect to external controller: not found",
 		}).
-		DoAndReturn(func(ctx context.Context, i application.ID, si status.StatusInfo) error {
+		DoAndReturn(func(ctx context.Context, i application.UUID, si status.StatusInfo) error {
 			defer close(done)
 			return nil
 		})
@@ -227,7 +227,7 @@ func (s *applicationWorkerSuite) TestStartWatchOfferStatusFailed(c *tc.C) {
 
 	s.crossModelService.EXPECT().
 		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
-		DoAndReturn(func(ctx context.Context, i application.ID) (watcher.StringsWatcher, error) {
+		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			ch := make(chan []string)
 			return watchertest.NewMockStringsWatcher(ch), nil
 		})

--- a/internal/worker/remoterelationconsumer/localunitrelations/worker.go
+++ b/internal/worker/remoterelationconsumer/localunitrelations/worker.go
@@ -23,10 +23,10 @@ import (
 type Service interface {
 	// WatchRelationUnits returns a watcher for changes to the units
 	// in the given relation in the local model.
-	WatchRelationUnits(context.Context, application.ID) (watcher.NotifyWatcher, error)
+	WatchRelationUnits(context.Context, application.UUID) (watcher.NotifyWatcher, error)
 
 	// GetRelationUnits returns the current state of the relation units.
-	GetRelationUnits(context.Context, application.ID) (relation.RelationUnitChange, error)
+	GetRelationUnits(context.Context, application.UUID) (relation.RelationUnitChange, error)
 }
 
 // ReportableWorker is an interface that allows a worker to be reported
@@ -40,7 +40,7 @@ type ReportableWorker interface {
 // worker.
 type Config struct {
 	Service         Service
-	ApplicationUUID application.ID
+	ApplicationUUID application.UUID
 	RelationTag     names.RelationTag
 	Macaroon        *macaroon.Macaroon
 
@@ -81,7 +81,7 @@ type localWorker struct {
 
 	service Service
 
-	applicationUUID application.ID
+	applicationUUID application.UUID
 	relationTag     names.RelationTag
 	changes         chan<- relation.RelationUnitChange
 

--- a/internal/worker/remoterelationconsumer/service_mock_test.go
+++ b/internal/worker/remoterelationconsumer/service_mock_test.go
@@ -662,7 +662,7 @@ func (c *MockCrossModelServiceGetRelationDetailsCall) DoAndReturn(f func(context
 }
 
 // GetRelationUnits mocks base method.
-func (m *MockCrossModelService) GetRelationUnits(arg0 context.Context, arg1 application.ID) (relation0.RelationUnitChange, error) {
+func (m *MockCrossModelService) GetRelationUnits(arg0 context.Context, arg1 application.UUID) (relation0.RelationUnitChange, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationUnits", arg0, arg1)
 	ret0, _ := ret[0].(relation0.RelationUnitChange)
@@ -689,13 +689,13 @@ func (c *MockCrossModelServiceGetRelationUnitsCall) Return(arg0 relation0.Relati
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceGetRelationUnitsCall) Do(f func(context.Context, application.ID) (relation0.RelationUnitChange, error)) *MockCrossModelServiceGetRelationUnitsCall {
+func (c *MockCrossModelServiceGetRelationUnitsCall) Do(f func(context.Context, application.UUID) (relation0.RelationUnitChange, error)) *MockCrossModelServiceGetRelationUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceGetRelationUnitsCall) DoAndReturn(f func(context.Context, application.ID) (relation0.RelationUnitChange, error)) *MockCrossModelServiceGetRelationUnitsCall {
+func (c *MockCrossModelServiceGetRelationUnitsCall) DoAndReturn(f func(context.Context, application.UUID) (relation0.RelationUnitChange, error)) *MockCrossModelServiceGetRelationUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -816,7 +816,7 @@ func (c *MockCrossModelServiceSaveMacaroonForRelationCall) DoAndReturn(f func(co
 }
 
 // SetRemoteApplicationOffererStatus mocks base method.
-func (m *MockCrossModelService) SetRemoteApplicationOffererStatus(arg0 context.Context, arg1 application.ID, arg2 status.StatusInfo) error {
+func (m *MockCrossModelService) SetRemoteApplicationOffererStatus(arg0 context.Context, arg1 application.UUID, arg2 status.StatusInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRemoteApplicationOffererStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -842,19 +842,19 @@ func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, application.ID, status.StatusInfo) error) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
+func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, application.UUID, status.StatusInfo) error) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, application.ID, status.StatusInfo) error) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
+func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, application.UUID, status.StatusInfo) error) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchApplicationLifeSuspendedStatus mocks base method.
-func (m *MockCrossModelService) WatchApplicationLifeSuspendedStatus(arg0 context.Context, arg1 application.ID) (watcher0.StringsWatcher, error) {
+func (m *MockCrossModelService) WatchApplicationLifeSuspendedStatus(arg0 context.Context, arg1 application.UUID) (watcher0.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplicationLifeSuspendedStatus", arg0, arg1)
 	ret0, _ := ret[0].(watcher0.StringsWatcher)
@@ -881,19 +881,19 @@ func (c *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall) Return(ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall) Do(f func(context.Context, application.ID) (watcher0.StringsWatcher, error)) *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall {
+func (c *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall) Do(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, application.ID) (watcher0.StringsWatcher, error)) *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall {
+func (c *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchRelationUnits mocks base method.
-func (m *MockCrossModelService) WatchRelationUnits(arg0 context.Context, arg1 application.ID) (watcher0.NotifyWatcher, error) {
+func (m *MockCrossModelService) WatchRelationUnits(arg0 context.Context, arg1 application.UUID) (watcher0.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchRelationUnits", arg0, arg1)
 	ret0, _ := ret[0].(watcher0.NotifyWatcher)
@@ -920,13 +920,13 @@ func (c *MockCrossModelServiceWatchRelationUnitsCall) Return(arg0 watcher0.Notif
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceWatchRelationUnitsCall) Do(f func(context.Context, application.ID) (watcher0.NotifyWatcher, error)) *MockCrossModelServiceWatchRelationUnitsCall {
+func (c *MockCrossModelServiceWatchRelationUnitsCall) Do(f func(context.Context, application.UUID) (watcher0.NotifyWatcher, error)) *MockCrossModelServiceWatchRelationUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceWatchRelationUnitsCall) DoAndReturn(f func(context.Context, application.ID) (watcher0.NotifyWatcher, error)) *MockCrossModelServiceWatchRelationUnitsCall {
+func (c *MockCrossModelServiceWatchRelationUnitsCall) DoAndReturn(f func(context.Context, application.UUID) (watcher0.NotifyWatcher, error)) *MockCrossModelServiceWatchRelationUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1033,7 +1033,7 @@ func (c *MockRelationServiceGetRelationDetailsCall) DoAndReturn(f func(context.C
 }
 
 // GetRelationUnits mocks base method.
-func (m *MockRelationService) GetRelationUnits(arg0 context.Context, arg1 application.ID) (relation0.RelationUnitChange, error) {
+func (m *MockRelationService) GetRelationUnits(arg0 context.Context, arg1 application.UUID) (relation0.RelationUnitChange, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationUnits", arg0, arg1)
 	ret0, _ := ret[0].(relation0.RelationUnitChange)
@@ -1060,19 +1060,19 @@ func (c *MockRelationServiceGetRelationUnitsCall) Return(arg0 relation0.Relation
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationUnitsCall) Do(f func(context.Context, application.ID) (relation0.RelationUnitChange, error)) *MockRelationServiceGetRelationUnitsCall {
+func (c *MockRelationServiceGetRelationUnitsCall) Do(f func(context.Context, application.UUID) (relation0.RelationUnitChange, error)) *MockRelationServiceGetRelationUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationUnitsCall) DoAndReturn(f func(context.Context, application.ID) (relation0.RelationUnitChange, error)) *MockRelationServiceGetRelationUnitsCall {
+func (c *MockRelationServiceGetRelationUnitsCall) DoAndReturn(f func(context.Context, application.UUID) (relation0.RelationUnitChange, error)) *MockRelationServiceGetRelationUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchApplicationLifeSuspendedStatus mocks base method.
-func (m *MockRelationService) WatchApplicationLifeSuspendedStatus(arg0 context.Context, arg1 application.ID) (watcher0.StringsWatcher, error) {
+func (m *MockRelationService) WatchApplicationLifeSuspendedStatus(arg0 context.Context, arg1 application.UUID) (watcher0.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplicationLifeSuspendedStatus", arg0, arg1)
 	ret0, _ := ret[0].(watcher0.StringsWatcher)
@@ -1099,19 +1099,19 @@ func (c *MockRelationServiceWatchApplicationLifeSuspendedStatusCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceWatchApplicationLifeSuspendedStatusCall) Do(f func(context.Context, application.ID) (watcher0.StringsWatcher, error)) *MockRelationServiceWatchApplicationLifeSuspendedStatusCall {
+func (c *MockRelationServiceWatchApplicationLifeSuspendedStatusCall) Do(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockRelationServiceWatchApplicationLifeSuspendedStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceWatchApplicationLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, application.ID) (watcher0.StringsWatcher, error)) *MockRelationServiceWatchApplicationLifeSuspendedStatusCall {
+func (c *MockRelationServiceWatchApplicationLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockRelationServiceWatchApplicationLifeSuspendedStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchRelationUnits mocks base method.
-func (m *MockRelationService) WatchRelationUnits(arg0 context.Context, arg1 application.ID) (watcher0.NotifyWatcher, error) {
+func (m *MockRelationService) WatchRelationUnits(arg0 context.Context, arg1 application.UUID) (watcher0.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchRelationUnits", arg0, arg1)
 	ret0, _ := ret[0].(watcher0.NotifyWatcher)
@@ -1138,13 +1138,13 @@ func (c *MockRelationServiceWatchRelationUnitsCall) Return(arg0 watcher0.NotifyW
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceWatchRelationUnitsCall) Do(f func(context.Context, application.ID) (watcher0.NotifyWatcher, error)) *MockRelationServiceWatchRelationUnitsCall {
+func (c *MockRelationServiceWatchRelationUnitsCall) Do(f func(context.Context, application.UUID) (watcher0.NotifyWatcher, error)) *MockRelationServiceWatchRelationUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceWatchRelationUnitsCall) DoAndReturn(f func(context.Context, application.ID) (watcher0.NotifyWatcher, error)) *MockRelationServiceWatchRelationUnitsCall {
+func (c *MockRelationServiceWatchRelationUnitsCall) DoAndReturn(f func(context.Context, application.UUID) (watcher0.NotifyWatcher, error)) *MockRelationServiceWatchRelationUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1404,7 +1404,7 @@ func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) DoAndReturn(f
 }
 
 // SetRemoteApplicationOffererStatus mocks base method.
-func (m *MockCrossModelRelationService) SetRemoteApplicationOffererStatus(arg0 context.Context, arg1 application.ID, arg2 status.StatusInfo) error {
+func (m *MockCrossModelRelationService) SetRemoteApplicationOffererStatus(arg0 context.Context, arg1 application.UUID, arg2 status.StatusInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRemoteApplicationOffererStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1430,13 +1430,13 @@ func (c *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall) Ret
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, application.ID, status.StatusInfo) error) *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall {
+func (c *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, application.UUID, status.StatusInfo) error) *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, application.ID, status.StatusInfo) error) *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall {
+func (c *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, application.UUID, status.StatusInfo) error) *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/remoterelationconsumer/worker.go
+++ b/internal/worker/remoterelationconsumer/worker.go
@@ -88,17 +88,17 @@ type RelationService interface {
 	// WatchApplicationLifeSuspendedStatus watches the changes to the
 	// life suspended status of the specified application and notifies
 	// the worker of any changes.
-	WatchApplicationLifeSuspendedStatus(context.Context, application.ID) (watcher.StringsWatcher, error)
+	WatchApplicationLifeSuspendedStatus(context.Context, application.UUID) (watcher.StringsWatcher, error)
 
 	// GetRelationDetails returns RelationDetails for the given relationID.
 	GetRelationDetails(context.Context, corerelation.UUID) (relation.RelationDetails, error)
 
 	// WatchRelationUnits returns a watcher for changes to the units
 	// in the given relation in the local model.
-	WatchRelationUnits(context.Context, application.ID) (watcher.NotifyWatcher, error)
+	WatchRelationUnits(context.Context, application.UUID) (watcher.NotifyWatcher, error)
 
 	// GetRelationUnits returns the current state of the relation units.
-	GetRelationUnits(context.Context, application.ID) (relation.RelationUnitChange, error)
+	GetRelationUnits(context.Context, application.UUID) (relation.RelationUnitChange, error)
 }
 
 // CrossModelRelationService is an interface that defines the methods for
@@ -114,7 +114,7 @@ type CrossModelRelationService interface {
 
 	// SetRemoteApplicationOffererStatus sets the status of the specified remote
 	// application in the local model.
-	SetRemoteApplicationOffererStatus(context.Context, application.ID, status.StatusInfo) error
+	SetRemoteApplicationOffererStatus(context.Context, application.UUID, status.StatusInfo) error
 
 	// ConsumeRemoteRelationChange applies a relation change event received
 	// from a remote model to the local model.
@@ -311,7 +311,7 @@ func (w *Worker) handleApplicationChanges(ctx context.Context) error {
 			return w.config.NewRemoteApplicationWorker(RemoteApplicationConfig{
 				OfferUUID:                    remoteApp.OfferUUID,
 				ApplicationName:              remoteApp.ApplicationName,
-				ApplicationUUID:              application.ID(remoteApp.ApplicationUUID),
+				ApplicationUUID:              application.UUID(remoteApp.ApplicationUUID),
 				LocalModelUUID:               w.config.ModelUUID,
 				RemoteModelUUID:              remoteApp.OffererModelUUID,
 				ConsumeVersion:               remoteApp.ConsumeVersion,

--- a/internal/worker/remoterelationconsumer/worker_test.go
+++ b/internal/worker/remoterelationconsumer/worker_test.go
@@ -90,7 +90,7 @@ func (s *workerSuite) TestRemoteApplications(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {
@@ -142,7 +142,7 @@ func (s *workerSuite) TestRemoteApplicationsGone(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {
@@ -155,7 +155,7 @@ func (s *workerSuite) TestRemoteApplicationsGone(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	waitForEmptyRunner(c, w.runner)
@@ -206,7 +206,7 @@ func (s *workerSuite) TestRemoteApplicationsOfferChanged(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {
@@ -221,7 +221,7 @@ func (s *workerSuite) TestRemoteApplicationsOfferChanged(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {

--- a/internal/worker/remoterelationofferer/worker_test.go
+++ b/internal/worker/remoterelationofferer/worker_test.go
@@ -81,7 +81,7 @@ func (s *workerSuite) TestRemoteApplications(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {
@@ -135,7 +135,7 @@ func (s *workerSuite) TestRemoteApplicationsDead(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {
@@ -148,7 +148,7 @@ func (s *workerSuite) TestRemoteApplicationsDead(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	waitForEmptyRunner(c, w.runner)
@@ -190,7 +190,7 @@ func (s *workerSuite) TestRemoteApplicationsGone(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {
@@ -203,7 +203,7 @@ func (s *workerSuite) TestRemoteApplicationsGone(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	waitForEmptyRunner(c, w.runner)
@@ -250,7 +250,7 @@ func (s *workerSuite) TestRemoteApplicationsOfferChanged(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {
@@ -265,7 +265,7 @@ func (s *workerSuite) TestRemoteApplicationsOfferChanged(c *tc.C) {
 	select {
 	case ch <- struct{}{}:
 	case <-c.Context().Done():
-		c.Fatalf("timed out pushing application IDs to WatchRemoteApplications")
+		c.Fatalf("timed out pushing application UUIDs to WatchRemoteApplications")
 	}
 
 	select {


### PR DESCRIPTION
Small patch that renames the (wrongly named) application ID into UUID.

This work also renames the methods on the application domain that included ID -> UUID (e.g. `GetApplicationIDByName` -> `GetApplicationUUIDByName`).
Variable names, arguments, state types, etc have not been renamed, that work would be too big and little valuable wrt this one.

Error strings and comments/godoc have as well been renamed.

## QA steps

N/A
