### PR TITLE
chore: add missing indexes on operation DDL

### DIFF
--- a/domain/operation/state/query.go
+++ b/domain/operation/state/query.go
@@ -378,6 +378,7 @@ FROM ops AS o
 	if len(whereClauses) > 0 {
 		query += "\nWHERE " + strings.Join(whereClauses, " AND ")
 	}
+	query += "\nORDER BY o.operation_id"
 
 	return query, args
 }

--- a/domain/operation/state/query_test.go
+++ b/domain/operation/state/query_test.go
@@ -1473,6 +1473,7 @@ func (s *querySuite) TestGetOperationsPaginationWithActionFilter(c *tc.C) {
 		s.addOperationTaskStatus(c, taskUUID, "running")
 	}
 
+	fmt.Printf("***************************\n")
 	// Act - get first page (limit=2) for "test-action"
 	limit := 2
 	resultPage1, err := s.state.GetOperations(c.Context(), operation.QueryArgs{
@@ -1485,6 +1486,7 @@ func (s *querySuite) TestGetOperationsPaginationWithActionFilter(c *tc.C) {
 	// should be marked truncated.
 	c.Check(resultPage1.Truncated, tc.IsTrue)
 	for _, op := range resultPage1.Operations {
+		fmt.Printf("p.1 Operation ID: %s\n", op.OperationID)
 		c.Check(op.Units[0].ActionName, tc.Equals, "test-action")
 	}
 
@@ -1502,11 +1504,14 @@ func (s *querySuite) TestGetOperationsPaginationWithActionFilter(c *tc.C) {
 	// Since fewer than limit were returned, truncated must be false.
 	c.Check(resultPage2.Truncated, tc.IsFalse)
 	c.Check(resultPage2.Operations[0].Units[0].ActionName, tc.Equals, "test-action")
+	fmt.Printf("p.2 Operation ID: %s\n", resultPage2.Operations[0].OperationID)
 
+	s.DumpTable(c, "operation")
 	// Verify that concatenating pages yields unique operation IDs and matches
 	// the expected count.
 	allOpIDs := make(map[string]bool)
 	for _, op := range append(resultPage1.Operations, resultPage2.Operations...) {
+		fmt.Printf("Operation ID: %s\n", op.OperationID)
 		c.Check(allOpIDs[op.OperationID], tc.IsFalse, tc.Commentf("Duplicate operation ID: %s", op.OperationID))
 		allOpIDs[op.OperationID] = true
 	}

--- a/domain/schema/model/sql/0033-operation.sql
+++ b/domain/schema/model/sql/0033-operation.sql
@@ -33,6 +33,9 @@ CREATE TABLE operation_action (
     REFERENCES charm_action (charm_uuid, "key")
 );
 
+CREATE INDEX idx_operation_action_charm_action_key_operation_uuid
+ON operation_action (charm_action_key, operation_uuid);
+
 -- A operation_task is the individual representation of an operation on a specific
 -- receiver. Either a machine or unit.
 CREATE TABLE operation_task (


### PR DESCRIPTION
Small patch to add two missing indexes on the operation DDL. These indexes were identified on the GetOperations query, which filters on machines, units, actions, etc.


## QA steps

__These steps should not be run on this PR code, since the indexes will be added by hand to see the difference in explain.__

Create a few operations (e.g. using the `juju-qa-action` charm):

```
juju run juju-qa-action/0 fortune length="long" fail="no"
``` 
Open up a db repl, and simulate a `list-operations` query on a specific action (`juju operations --actions "fortune"`):
This is the query we run when listing operations on an action:
```
WITH
ops AS (
    SELECT *
    FROM   operation AS o
    LIMIT 51 OFFSET 0
)
SELECT DISTINCT
       o.uuid
FROM ops AS o
JOIN operation_action AS oa ON o.uuid = oa.operation_uuid
WHERE oa.charm_action_key IN ('fortune');
```
so on the repl we can explain it:
```
explain query plan WITH ops AS (     SELECT *     FROM   operation AS o     LIMIT 51 OFFSET 0 ) SELECT DISTINCT * FROM ops AS o JOIN operation_action AS oa ON o.uuid = oa.operation_uuid WHERE oa.charm_action_key IN ('fortune');
id      parent  notused detail
2       0       0       CO-ROUTINE ops
8       2       0       SCAN o
26      0       0       SCAN oa USING INDEX sqlite_autoindex_operation_action_1
31      0       0       SCAN o
54      0       0       USE TEMP B-TREE FOR DISTINCT
```
We can quickly see that there are issues with the query, 3 scans is not good. The first `SCAN o` (id 8) is necessary because of the CTE, but we know that it's not going to be an issue because the limit is capped at 51 elements, so we cannot avoid that (scan is needed to get to the offset).

However we need to asses the other SCANs.
Create the index as proposed in this patch:
```
repl (model-m)>  create index idx_operation_action_charm_action_key_operation_uuid on operation_action (charm_action_key, operation_uuid);

repl (model-m)> explain query plan WITH ops AS (     SELECT *     FROM   operation AS o     LIMIT 51 OFFSET 0 ) SELECT DISTINCT * FROM ops AS o JOIN operation_action AS oa ON o.uuid = oa.operation_uuid WHERE oa.charm_action_key IN ('fortune');
id      parent  notused detail
2       0       0       CO-ROUTINE ops
8       2       0       SCAN o
26      0       0       SEARCH oa USING INDEX idx_operation_action_charm_action_key_operation_uuid (charm_action_key=?)
48      0       0       SEARCH o USING AUTOMATIC COVERING INDEX (uuid=?)
69      0       0       USE TEMP B-TREE FOR DISTINCT
```

Now the query looks better.

_Note: the temp b-tree is needed because of the DISTINCT results._

