### PR TITLE
ci: fix for authorized keys suite

### DIFF
--- a/tests/suites/authorized_keys/bootstrap.sh
+++ b/tests/suites/authorized_keys/bootstrap.sh
@@ -29,7 +29,9 @@ run_bootstrap_authorized_keys_loaded() {
 
 	(
 		export HOME="${SUB_TEST_DIR}"
-		export JUJU_DATA="${JUJU_DATA:=$juju_home_dir}"
+		# Always isolate JUJU_DATA to the subtest directory to avoid leaking/using
+		# any CI-provided or globally configured Juju client store.
+		export JUJU_DATA="${juju_home_dir}"
 
 		bootstrap_additional_args=(--config "'authorized-keys=$(cat ${extra_key_file_pub})'")
 		BOOTSTRAP_ADDITIONAL_ARGS="${bootstrap_additional_args[*]}" \
@@ -78,7 +80,9 @@ run_bootstrap_authorized_keys_default() {
 
 	(
 		export HOME="${SUB_TEST_DIR}"
-		export JUJU_DATA="${JUJU_DATA:=$juju_home_dir}"
+		# Always isolate JUJU_DATA to the subtest directory to avoid leaking/using
+		# any CI-provided or globally configured Juju client store.
+		export JUJU_DATA="${juju_home_dir}"
 
 		BOOTSTRAP_REUSE=false \
 			bootstrap "authorized-keys-default" "$log_file"


### PR DESCRIPTION
This PR attempts to fix the CI failure in the authorized_keys suite. The test runs successfully but fails at the final cleanup with,
```
ERROR No selected controller.

Use "juju switch" to select from the following controllers:

  - ctrl-fitqcuy3
jq: error (at <stdin>:1): Cannot iterate over null (null)
====> ERROR Destroy controller/model. Unable to locate authorizedkeys
```

Running the test locally it passes.

A short explanation on what the test is doing:
- The test runner starts by creating a controller.
- The subtest starts, creates a new JUJU_DATA dir, bootstraps a controller, runs its logic, then removes the controller.
- The test runner then attempts to destroy the original controller and fails because we have no controller selected.

It seems the reason why it fails in CI but not locally is because in CI we set `JUJU_DATA=$CLOUD_CITY` before we start the test. If we look at the changes in this PR, the deleted line would only change `JUJU_DATA` if it was not set. So, ultimately, we were using the wrong `JUJU_DATA` dir in the subtest, deleting a controller, and then returning to the test runner with an "invalid" setup because the test runner assumes we are always switched to a controller.

The fix is hopefully simple then, just set the `JUJU_DATA` directory unconditionally.

Fixes [JUJU-8575](https://warthogs.atlassian.net/browse/JUJU-8575)

[JUJU-8575]: https://warthogs.atlassian.net/browse/JUJU-8575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ