### PR TITLE
fix: mutating web hook now attaches correct labels to k8s app resources

### DIFF
--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -134,7 +134,7 @@ func (s *applicationSuite) getApp(c *gc.C, deploymentType caas.DeploymentType, m
 	s.modelUUID = modelUUID.String()
 
 	return application.NewApplicationForTest(
-		s.appName, s.namespace, modelUUID.String(), s.namespace, 2,
+		s.appName, s.namespace, modelUUID.String(), s.namespace, constants.LabelVersion2,
 		deploymentType,
 		s.client,
 		s.extendedClient,
@@ -3055,9 +3055,7 @@ func (s *applicationSuite) TestDeleteAllCreatedResources(c *gc.C) {
 	modelUUID := s.modelUUID
 	labelVersion := constants.LabelVersion2
 
-	appLabel := k8sutils.SelectorLabelsForApp(appName, labelVersion)
-	modelLabel := k8sutils.LabelsForModel(modelName, modelUUID, controllerUUID, labelVersion)
-	resourceLabels := k8sutils.LabelsMerge(appLabel, modelLabel)
+	resourceLabels := k8sutils.LabelsForAppCreated(appName, modelName, modelUUID, controllerUUID, labelVersion)
 
 	// ServiceAccount (namespace-scoped)
 	sa := &corev1.ServiceAccount{
@@ -3387,11 +3385,9 @@ func (s *applicationSuite) TestDeleteAllCreatedResources(c *gc.C) {
 
 	// We now test the case where the resource labels do not match juju's label.
 	// We declare the names of these variables that use the wrong labels as {resource}Bad as belown.
-	wrongAppLabel := k8sutils.SelectorLabelsForApp(appName+"-other", labelVersion)
-	wrongAppResourceLabels := k8sutils.LabelsMerge(wrongAppLabel, modelLabel)
+	wrongAppResourceLabels := k8sutils.LabelsForAppCreated(appName+"-other", modelName, modelUUID, controllerUUID, labelVersion)
 
-	wrongModelLabel := k8sutils.LabelsForModel("not-model-name", modelUUID, controllerUUID, labelVersion)
-	wrongModelResourceLabels := k8sutils.LabelsMerge(appLabel, wrongModelLabel)
+	wrongModelResourceLabels := k8sutils.LabelsForAppCreated(appName, "not-model-name", modelUUID, controllerUUID, labelVersion)
 
 	// ServiceAccount (bad)
 	saBad := &corev1.ServiceAccount{

--- a/internal/provider/kubernetes/utils/labels.go
+++ b/internal/provider/kubernetes/utils/labels.go
@@ -133,6 +133,21 @@ func LabelsForApp(name string, labelVersion constants.LabelVersion) labels.Set {
 	return LabelsMerge(result, LabelsJuju)
 }
 
+// LabelsForAppCreated returns the labels that should be on a k8s object that has been
+// created directly by a given application.
+func LabelsForAppCreated(appName, modelName, modelUUID, controllerUUID string, labelVersion constants.LabelVersion) labels.Set {
+	appLabels := LabelForKeyValue(
+		constants.LabelJujuAppCreatedBy, appName,
+	)
+	if labelVersion < constants.LabelVersion2 {
+		return appLabels
+	}
+	modelLabels := LabelsForModel(
+		modelName, modelUUID, controllerUUID, labelVersion,
+	)
+	return LabelsMerge(appLabels, modelLabels, LabelsJuju)
+}
+
 // SelectorLabelsForApp returns the pod selector labels that should be on
 // a k8s object for a given application name
 func SelectorLabelsForApp(name string, labelVersion constants.LabelVersion) labels.Set {

--- a/internal/provider/kubernetes/utils/labels_test.go
+++ b/internal/provider/kubernetes/utils/labels_test.go
@@ -230,6 +230,46 @@ func (l *LabelSuite) TestLabelsForApp(c *gc.C) {
 	}
 }
 
+func (l *LabelSuite) TestLabelsForAppCreated(c *gc.C) {
+	tests := []struct {
+		AppName        string
+		ModelName      string
+		ModelUUID      string
+		ControllerUUID string
+		ExpectedLabels labels.Set
+		LabelVersion   constants.LabelVersion
+	}{
+		{
+			AppName:        "tlm-boom",
+			ModelName:      "tlm-model",
+			ModelUUID:      "d0gf00d",
+			ControllerUUID: "badf00d",
+			ExpectedLabels: labels.Set{
+				"app.juju.is/created-by": "tlm-boom",
+			},
+			LabelVersion: constants.LabelVersion1,
+		},
+		{
+			AppName:        "tlm-boom",
+			ModelName:      "tlm-model",
+			ModelUUID:      "d0gf00d",
+			ControllerUUID: "badf00d",
+			ExpectedLabels: labels.Set{
+				"app.juju.is/created-by":       "tlm-boom",
+				"app.kubernetes.io/managed-by": "juju",
+				"model.juju.is/id":             "d0gf00d",
+				"model.juju.is/name":           "tlm-model",
+			},
+			LabelVersion: constants.LabelVersion2,
+		},
+	}
+
+	for _, test := range tests {
+		rval := utils.LabelsForAppCreated(test.AppName, test.ModelName, test.ModelUUID, test.ControllerUUID, test.LabelVersion)
+		c.Assert(rval, jc.DeepEquals, test.ExpectedLabels)
+	}
+}
+
 func (l *LabelSuite) TestLabelsForStorage(c *gc.C) {
 	tests := []struct {
 		AppName        string

--- a/internal/worker/caasadmission/handler.go
+++ b/internal/worker/caasadmission/handler.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juju/juju/internal/provider/kubernetes/constants"
-	providerconst "github.com/juju/juju/internal/provider/kubernetes/constants"
 	providerutils "github.com/juju/juju/internal/provider/kubernetes/utils"
 )
 
@@ -199,17 +198,8 @@ func patchForLabels(
 	controllerUUID, modelUUID, modelName string) []patchOperation {
 	patches := []patchOperation{}
 
-	modelLabels := providerutils.LabelsForModel(
-		modelName, modelUUID, controllerUUID, labelVersion,
-	)
-
-	appLabels := providerutils.LabelsForApp(appName, labelVersion)
-
-	createdByAppLabel := providerutils.LabelForKeyValue(
-		providerconst.LabelJujuAppCreatedBy, appName,
-	)
-
-	neededLabels := providerutils.LabelsMerge(appLabels, modelLabels, createdByAppLabel)
+	neededLabels := providerutils.LabelsForAppCreated(
+		appName, modelName, modelUUID, controllerUUID, labelVersion)
 
 	if len(labels) == 0 {
 		patches = append(patches, patchOperation{

--- a/internal/worker/caasadmission/handler_test.go
+++ b/internal/worker/caasadmission/handler_test.go
@@ -210,7 +210,7 @@ func (h *HandlerSuite) TestPatchLabelsAdd(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper, constants.LabelVersion1, h.controllerUUID, h.modelUUID, h.modelName).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, constants.LabelVersion2, h.controllerUUID, h.modelUUID, h.modelName).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 
@@ -298,7 +298,7 @@ func (h *HandlerSuite) TestPatchLabelsReplace(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper, constants.LabelVersion1, h.controllerUUID, h.modelUUID, h.modelName).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, constants.LabelVersion2, h.controllerUUID, h.modelUUID, h.modelName).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 


### PR DESCRIPTION
The mutating web hook which attaches labels to k8s resources created directly by the charm was changed in this PR https://github.com/juju/juju/pull/20489 as part of the work to ensure resources are cleaned up when the app is removed. However, the wrong labels were used, and the result is that elsewhere queries for units belonging to the app would return extra (incorrect) results. The wrong labels were used because the old podspec cleanup code is a bit wrong and the implementation was more or less copied across.

For compatibility, in this PR, just the sidecar implementation is changed. The existing "podspec" specific deletion code is left untouched even though there's possibly unrelated bugs that might still be lurking. "podspec" charms have been long deprecated and there's no specific bugs relating to their deletion that we will be addressing at this time.

The fix is to ensure the `app.juju.is/created-by` label is used, not `app.kubernetes.io/name`. This matches the original implementation before the above PR.

In addition to the `app.juju.is/created-by` label, we'll also add model uuid and name labels to 100% ensure disabiguation across the cluster. This means that existing resources won't be captured in the deletion query, but this was the case anyway already. And there's no (non intrusive, non contrived) way to deal with resources with and without the extra labels. We could add a brand new label to the app's stateful set and use this as a marker, but it doesn't seem worth the trouble. So it just means that after upgrading to this version of Juju, newly created apps get their resources cleanup.


## QA steps

bootstrap on k8s
```
juju add-model test
juju deploy istio-k8s --trust --channel=2/edge
juju deploy istio-beacon-k8s --trust --channel=2/edge
juju debug-log
```

Ensure there are no errors as described in the bug.

Once juju status shows units are active, look at k8s deployment created by the istio beacon charm

```
kubectl -n test get all
...
NAME                                             READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/istiod                           1/1     1            1           86s
deployment.apps/modeloperator                    1/1     1            1           2m32s
deployment.apps/test-istio-beacon-k8s-waypoint   1/1     1            1           39s

kubectl -n test get -o yaml pod/test-istio-beacon-k8s-waypoint-77d959fb75-kztk8
apiVersion: v1
kind: Pod
metadata:
  labels:
    app.juju.is/created-by: istio-beacon-k8s
    app.kubernetes.io/instance: istio-beacon-k8s-test
    app.kubernetes.io/managed-by: juju
    charms.canonical.com/test.istio-beacon-k8s.telemetry: aggregated
    gateway.istio.io/managed: istio.io-mesh-controller
    gateway.networking.k8s.io/gateway-name: test-istio-beacon-k8s-waypoint
    istio.io/dataplane-mode: none
    istio.io/waypoint-for: service
    kubernetes-resource-handler-scope: istio-waypoint
    model.juju.is/id: 9c8717af-3e7c-45c0-8014-cffb489767f0
    model.juju.is/name: test
    pod-template-hash: 77d959fb75
    service.istio.io/canonical-name: test-istio-beacon-k8s-waypoint
    service.istio.io/canonical-revision: latest
    sidecar.istio.io/inject: "false"
...
```

Note the app labels:
```
    app.juju.is/created-by: istio-beacon-k8s
    model.juju.is/id: 9c8717af-3e7c-45c0-8014-cffb489767f0
    model.juju.is/name: test
```

Remove the istio beacon app
Note that the corresponding deployment is also removed
```
kubectl -n test get all
...
NAME                                             READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/istiod                           1/1     1            1           86s
deployment.apps/modeloperator                    1/1     1            1           2m32s
deployment.apps/test-istio-beacon-k8s-waypoint   1/1     1            1           39s
```

Also test the deployment of the dashboard
```
juju switch controller
juju deploy juju-dashboard-k8s dashboard --channel 0.15/edge
juju integrate dashboard controller
juju change-user-password
```

The point a web browser to `<ip>:8080` and log in

## Links

**Issue:** Fixes #20738 and #20704

**Jira card:** [JUJU-8579](https://warthogs.atlassian.net/browse/JUJU-8579)


[JUJU-8579]: https://warthogs.atlassian.net/browse/JUJU-8579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ