### PR TITLE
feat: create state layer remote application of the consumer model

### DIFF
--- a/domain/crossmodelrelation/errors/errors.go
+++ b/domain/crossmodelrelation/errors/errors.go
@@ -18,7 +18,7 @@ const (
 	// create an offer that already exists for the same UUID.
 	OfferAlreadyConsumed = errors.ConstError("offer already consumed")
 
-	// OfferConnectionAlreadyExists describes an error that occurs when trying
-	// to connection that already exists.
-	OfferConnectionAlreadyExists = errors.ConstError("offer connection already exists")
+	// RemoteRelationAlreadyRegistered describes an error that occurs when
+	// trying to register a remote relation that already exists.
+	RemoteRelationAlreadyRegistered = errors.ConstError("remote relation already registered")
 )

--- a/domain/crossmodelrelation/errors/errors.go
+++ b/domain/crossmodelrelation/errors/errors.go
@@ -17,4 +17,8 @@ const (
 	// OfferAlreadyConsumed describes an error that occurs when trying to
 	// create an offer that already exists for the same UUID.
 	OfferAlreadyConsumed = errors.ConstError("offer already consumed")
+
+	// OfferConnectionAlreadyExists describes an error that occurs when trying
+	// to connection that already exists.
+	OfferConnectionAlreadyExists = errors.ConstError("offer connection already exists")
 )

--- a/domain/crossmodelrelation/sequences.go
+++ b/domain/crossmodelrelation/sequences.go
@@ -9,4 +9,7 @@ const (
 	// ApplicationRemoteOffererSequenceNamespace is the namespace for remote
 	// offerer application sequences.
 	ApplicationRemoteOffererSequenceNamespace = sequence.StaticNamespace("remote-offerer-application")
+	// ApplicationRemoteConsumerSequenceNamespace is the namespace for remote
+	// consumer application sequences.
+	ApplicationRemoteConsumerSequenceNamespace = sequence.StaticNamespace("remote-consumer-application")
 )

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -101,11 +101,13 @@ func (s *Service) AddRemoteApplicationOfferer(ctx context.Context, applicationNa
 	}
 
 	if err := s.modelState.AddRemoteApplicationOfferer(ctx, applicationName, crossmodelrelation.AddRemoteApplicationOffererArgs{
-		RemoteApplicationUUID: remoteApplicationUUID.String(),
-		ApplicationUUID:       applicationUUID.String(),
-		CharmUUID:             charmUUID.String(),
-		Charm:                 syntheticCharm,
-		OfferUUID:             args.OfferUUID,
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			RemoteApplicationUUID: remoteApplicationUUID.String(),
+			ApplicationUUID:       applicationUUID.String(),
+			CharmUUID:             charmUUID.String(),
+			Charm:                 syntheticCharm,
+			OfferUUID:             args.OfferUUID,
+		},
 		OffererControllerUUID: args.OffererControllerUUID,
 		OffererModelUUID:      args.OffererModelUUID,
 		EncodedMacaroon:       encodedMacaroon,

--- a/domain/crossmodelrelation/service/remoteapplication_test.go
+++ b/domain/crossmodelrelation/service/remoteapplication_test.go
@@ -97,8 +97,10 @@ func (s *remoteApplicationServiceSuite) TestAddRemoteApplicationOfferer(c *tc.C)
 	received.CharmUUID = ""
 
 	c.Check(received, tc.DeepEquals, crossmodelrelation.AddRemoteApplicationOffererArgs{
-		Charm:                 syntheticCharm,
-		OfferUUID:             offerUUID,
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			Charm:     syntheticCharm,
+			OfferUUID: offerUUID,
+		},
 		OffererControllerUUID: offererControllerUUID,
 		OffererModelUUID:      offererModelUUID,
 		EncodedMacaroon:       tc.Must(c, macaroon.MarshalJSON),

--- a/domain/crossmodelrelation/state/model/remoteapplication_test.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication_test.go
@@ -59,12 +59,14 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationOffererInsertsAppl
 		},
 	}
 	err := s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -105,12 +107,14 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationOffererInsertsAppl
 		},
 	}
 	err := s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -140,12 +144,14 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationOffererInsertsAppl
 		},
 	}
 	err := s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -193,12 +199,14 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationOffererInsertsAppl
 		},
 	}
 	err := s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -207,12 +215,14 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationOffererInsertsAppl
 	s.assertCharmMetadata(c, applicationUUID, charmUUID, charm)
 
 	err = s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationAlreadyExists)
 }
@@ -250,12 +260,14 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationOffererInsertsAppl
 	}
 
 	err := s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		OfferUUID:             offerUUID,
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -264,12 +276,14 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationOffererInsertsAppl
 	s.assertCharmMetadata(c, applicationUUID, charmUUID, charm)
 
 	err = s.state.AddRemoteApplicationOfferer(c.Context(), "bar", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		OfferUUID:             offerUUID,
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferAlreadyConsumed)
 }
@@ -288,12 +302,14 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationOffererInsertsVers
 		},
 	}
 	err := s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		OfferUUID:             offerUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			OfferUUID:             offerUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -334,12 +350,14 @@ VALUES (?, ?)
 	}
 
 	err = s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		OfferUUID:             offerUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		Charm:                 charm,
-		EncodedMacaroon:       []byte("encoded macaroon"),
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			OfferUUID:             offerUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			Charm:                 charm,
+		},
+		EncodedMacaroon: []byte("encoded macaroon"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -391,13 +409,15 @@ func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationOfferers(c *tc.C) 
 		},
 	}
 	err := s.state.AddRemoteApplicationOfferer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationOffererArgs{
-		ApplicationUUID:       applicationUUID,
-		CharmUUID:             charmUUID,
-		RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
-		OfferUUID:             offerUUID,
-		OffererModelUUID:      offererModelUUID,
-		Charm:                 charm,
-		EncodedMacaroon:       macBytes,
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm,
+		},
+		OffererModelUUID: offererModelUUID,
+		EncodedMacaroon:  macBytes,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -419,6 +439,335 @@ func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationOfferersEmpty(c *t
 	results, err := s.state.GetRemoteApplicationOfferers(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(results, tc.HasLen, 0)
+}
+
+func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationConsumer(c *tc.C) {
+	applicationUUID := tc.Must(c, internaluuid.NewUUID).String()
+	charmUUID := tc.Must(c, internaluuid.NewUUID).String()
+	offerUUID := tc.Must(c, internaluuid.NewUUID).String()
+	relationUUID := tc.Must(c, internaluuid.NewUUID).String()
+
+	// Create an offer in the database
+	s.createOffer(c, offerUUID)
+
+	charm := charm.Charm{
+		ReferenceName: "bar",
+		Source:        charm.CMRSource,
+		Metadata: charm.Metadata{
+			Name:        "foo",
+			Description: "remote consumer application",
+			Provides: map[string]charm.Relation{
+				"db": {
+					Name:      "db",
+					Role:      charm.RoleProvider,
+					Interface: "db",
+					Limit:     1,
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Requires: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      charm.RoleRequirer,
+					Interface: "cacher",
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Peers: map[string]charm.Relation{},
+		},
+	}
+	err := s.state.AddRemoteApplicationConsumer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationConsumerArgs{
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm,
+		},
+		RelationUUID: relationUUID,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.assertApplicationRemoteConsumer(c, applicationUUID)
+	s.assertApplication(c, applicationUUID)
+	s.assertCharmMetadata(c, applicationUUID, charmUUID, charm)
+
+	endpoints := s.fetchApplicationEndpoints(c, applicationUUID)
+	c.Assert(endpoints, tc.HasLen, 3)
+
+	c.Check(endpoints[0].charmRelationName, tc.Equals, "cache")
+	c.Check(endpoints[1].charmRelationName, tc.Equals, "db")
+	c.Check(endpoints[2].charmRelationName, tc.Equals, "juju-info")
+	s.assertRelation(c, relationUUID, 0)
+}
+
+func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationConsumerTwiceSameApp(c *tc.C) {
+	applicationUUID := tc.Must(c, internaluuid.NewUUID).String()
+	charmUUID := tc.Must(c, internaluuid.NewUUID).String()
+	offerUUID := tc.Must(c, internaluuid.NewUUID).String()
+	relationUUID0 := tc.Must(c, internaluuid.NewUUID).String()
+	relationUUID1 := tc.Must(c, internaluuid.NewUUID).String()
+
+	// Create an offer in the database
+	s.createOffer(c, offerUUID)
+
+	charm := charm.Charm{
+		ReferenceName: "bar",
+		Source:        charm.CMRSource,
+		Metadata: charm.Metadata{
+			Name:        "foo",
+			Description: "remote consumer application",
+			Provides: map[string]charm.Relation{
+				"db": {
+					Name:      "db",
+					Role:      charm.RoleProvider,
+					Interface: "db",
+					Limit:     1,
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Requires: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      charm.RoleRequirer,
+					Interface: "cacher",
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Peers: map[string]charm.Relation{},
+		},
+	}
+	err := s.state.AddRemoteApplicationConsumer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationConsumerArgs{
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm,
+		},
+		RelationUUID: relationUUID0,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.assertApplicationRemoteConsumer(c, applicationUUID)
+	s.assertApplication(c, applicationUUID)
+	s.assertCharmMetadata(c, applicationUUID, charmUUID, charm)
+
+	err = s.state.AddRemoteApplicationConsumer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationConsumerArgs{
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm,
+		},
+		RelationUUID: relationUUID1,
+	})
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationAlreadyExists)
+}
+
+func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationConsumerTwoApps(c *tc.C) {
+	applicationUUID := tc.Must(c, internaluuid.NewUUID).String()
+	charmUUID := tc.Must(c, internaluuid.NewUUID).String()
+	offerUUID := tc.Must(c, internaluuid.NewUUID).String()
+	relationUUID0 := tc.Must(c, internaluuid.NewUUID).String()
+	relationUUID1 := tc.Must(c, internaluuid.NewUUID).String()
+
+	// Create an offer in the database
+	s.createOffer(c, offerUUID)
+
+	charm1 := charm.Charm{
+		ReferenceName: "bar",
+		Source:        charm.CMRSource,
+		Metadata: charm.Metadata{
+			Name:        "foo",
+			Description: "remote consumer application",
+			Provides: map[string]charm.Relation{
+				"db": {
+					Name:      "db",
+					Role:      charm.RoleProvider,
+					Interface: "db",
+					Limit:     1,
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Requires: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      charm.RoleRequirer,
+					Interface: "cacher",
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Peers: map[string]charm.Relation{},
+		},
+	}
+
+	charm2 := charm.Charm{
+		ReferenceName: "baz",
+		Source:        charm.CMRSource,
+		Metadata: charm.Metadata{
+			Name:        "bar",
+			Description: "remote consumer application 2",
+			Provides: map[string]charm.Relation{
+				"db": {
+					Name:      "db",
+					Role:      charm.RoleProvider,
+					Interface: "db",
+					Limit:     1,
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Requires: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      charm.RoleRequirer,
+					Interface: "cacher",
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Peers: map[string]charm.Relation{},
+		},
+	}
+
+	err := s.state.AddRemoteApplicationConsumer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationConsumerArgs{
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID,
+			CharmUUID:             charmUUID,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm1,
+		},
+		RelationUUID: relationUUID0,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.assertApplicationRemoteConsumer(c, applicationUUID)
+	s.assertApplication(c, applicationUUID)
+	s.assertCharmMetadata(c, applicationUUID, charmUUID, charm1)
+
+	err = s.state.AddRemoteApplicationConsumer(c.Context(), "bar", crossmodelrelation.AddRemoteApplicationConsumerArgs{
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       tc.Must(c, internaluuid.NewUUID).String(),
+			CharmUUID:             tc.Must(c, internaluuid.NewUUID).String(),
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm2,
+		},
+		RelationUUID: relationUUID1,
+	})
+	c.Assert(err, tc.ErrorIsNil) // Should succeed since different applications can consume same offer
+}
+
+func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationConsumerCheckVersion(c *tc.C) {
+	applicationUUID1 := tc.Must(c, internaluuid.NewUUID).String()
+	applicationUUID2 := tc.Must(c, internaluuid.NewUUID).String()
+	charmUUID1 := tc.Must(c, internaluuid.NewUUID).String()
+	charmUUID2 := tc.Must(c, internaluuid.NewUUID).String()
+	offerUUID := tc.Must(c, internaluuid.NewUUID).String()
+	relationUUID0 := tc.Must(c, internaluuid.NewUUID).String()
+	relationUUID1 := tc.Must(c, internaluuid.NewUUID).String()
+
+	// Create an offer in the database
+	s.createOffer(c, offerUUID)
+
+	charm1 := charm.Charm{
+		ReferenceName: "bar",
+		Source:        charm.CMRSource,
+		Metadata: charm.Metadata{
+			Name:        "foo",
+			Description: "remote consumer application",
+		},
+	}
+
+	charm2 := charm.Charm{
+		ReferenceName: "baz",
+		Source:        charm.CMRSource,
+		Metadata: charm.Metadata{
+			Name:        "bar",
+			Description: "remote consumer application 2",
+		},
+	}
+
+	err := s.state.AddRemoteApplicationConsumer(c.Context(), "foo", crossmodelrelation.AddRemoteApplicationConsumerArgs{
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID1,
+			CharmUUID:             charmUUID1,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm1,
+		},
+		RelationUUID: relationUUID0,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.AddRemoteApplicationConsumer(c.Context(), "bar", crossmodelrelation.AddRemoteApplicationConsumerArgs{
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			ApplicationUUID:       applicationUUID2,
+			CharmUUID:             charmUUID2,
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             offerUUID,
+			Charm:                 charm2,
+		},
+		RelationUUID: relationUUID1,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	remoteApp1 := s.getApplicationRemoteConsumer(c, applicationUUID1)
+	c.Check(remoteApp1.Version, tc.Equals, uint64(0))
+
+	remoteApp2 := s.getApplicationRemoteConsumer(c, applicationUUID2)
+	c.Check(remoteApp2.Version, tc.Equals, uint64(1)) // Same offer, so version increments
+}
+
+func (s *modelRemoteApplicationSuite) assertApplicationRemoteConsumer(c *tc.C, applicationUUID string) {
+	var count int
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRow(`
+SELECT COUNT(*)
+FROM application_remote_consumer
+WHERE application_uuid = ?
+`, applicationUUID).Scan(&count)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+}
+
+func (s *modelRemoteApplicationSuite) getApplicationRemoteConsumer(c *tc.C, applicationUUID string) struct {
+	UUID                string
+	ApplicationUUID     string
+	OfferConnectionUUID string
+	Version             uint64
+} {
+	var result struct {
+		UUID                string
+		ApplicationUUID     string
+		OfferConnectionUUID string
+		Version             uint64
+	}
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRow(`
+SELECT uuid, application_uuid, offer_connection_uuid, version
+FROM application_remote_consumer
+WHERE application_uuid = ?
+`, applicationUUID).Scan(&result.UUID, &result.ApplicationUUID, &result.OfferConnectionUUID, &result.Version)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return result
+}
+
+func (s *modelRemoteApplicationSuite) createOffer(c *tc.C, offerUUID string) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		// Create an offer record
+		_, err := tx.Exec(`
+INSERT INTO offer (uuid, name)
+VALUES (?, 'test-offer')
+`, offerUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *modelRemoteApplicationSuite) assertApplicationRemoteOfferer(c *tc.C, uuid string) {
@@ -480,6 +829,28 @@ func (s *modelRemoteApplicationSuite) assertApplication(c *tc.C, uuid string) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(gotName, tc.Equals, "foo")
+}
+
+func (s *modelRemoteApplicationSuite) assertRelation(c *tc.C, relationUUID string, relationID int) {
+	var (
+		gotUUID    string
+		gotID      int
+		gotLifID   int
+		gotScopeID int
+	)
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT * FROM relation WHERE relation_id=?", relationID).
+			Scan(&gotUUID, &gotID, &gotLifID, &gotScopeID)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotUUID, tc.Equals, relationUUID)
+	c.Check(gotID, tc.Equals, relationID)
+	c.Check(gotLifID, tc.Equals, 0)   // life.Alive
+	c.Check(gotScopeID, tc.Equals, 0) // scope.Global
 }
 
 func (s *modelRemoteApplicationSuite) assertCharmMetadata(c *tc.C, appUUID, charmUUID string, expected charm.Charm) {

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -209,6 +209,38 @@ type remoteApplicationStatus struct {
 	UpdatedAt             *time.Time `db:"updated_at"`
 }
 
+type remoteApplicationConsumer struct {
+	// UUID is the unique identifier for this remote application consuemr.
+	UUID string `db:"uuid"`
+	// LifeID is the life state of the remote application consumer.
+	LifeID life.Life `db:"life_id"`
+	// ApplicationUUID is the unique identifier for the application
+	// that is consumed on the consuming model.
+	ApplicationUUID string `db:"application_uuid"`
+	// OfferConnectionUUID is the offer connection uuid that ties both the
+	// offerer and consumer together.
+	OfferConnectionUUID string `db:"offer_connection_uuid"`
+	// Version is the version of the remote application offerer.
+	Version uint64 `db:"version"`
+}
+
+type offerConnection struct {
+	UUID               string `db:"uuid"`
+	OfferUUID          string `db:"offer_uuid"`
+	RemoteRelationUUID string `db:"remote_relation_uuid"`
+	Username           string `db:"username"`
+}
+
+type relation struct {
+	UUID       string `db:"uuid"`
+	LifeID     int    `db:"life_id"`
+	RelationID uint64 `db:"relation_id"`
+}
+
+type charmScope struct {
+	Name string `db:"name"`
+}
+
 type setApplicationEndpointBinding struct {
 	UUID          string `db:"uuid"`
 	ApplicationID string `db:"application_uuid"`

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -210,11 +210,12 @@ type remoteApplicationStatus struct {
 }
 
 type remoteApplicationConsumer struct {
-	UUID                string    `db:"uuid"`
-	LifeID              life.Life `db:"life_id"`
-	ApplicationUUID     string    `db:"application_uuid"`
-	OfferConnectionUUID string    `db:"offer_connection_uuid"`
-	Version             uint64    `db:"version"`
+	UUID                    string    `db:"uuid"`
+	OffererApplicationUUID  string    `db:"offerer_application_uuid"`
+	ConsumerApplicationUUID string    `db:"consumer_application_uuid"`
+	OfferConnectionUUID     string    `db:"offer_connection_uuid"`
+	Version                 uint64    `db:"version"`
+	LifeID                  life.Life `db:"life_id"`
 }
 
 type offerConnection struct {
@@ -225,8 +226,7 @@ type offerConnection struct {
 }
 
 type offerConnectionQuery struct {
-	OfferUUID                     string `db:"offer_uuid"`
-	ApplicationRemoteRelationUUID string `db:"application_remote_relation_uuid"`
+	OfferUUID string `db:"offer_uuid"`
 }
 
 type relation struct {
@@ -242,6 +242,10 @@ type applicationRemoteRelation struct {
 
 type consumerRelationUUID struct {
 	ConsumerRelationUUID string `db:"consumer_relation_uuid"`
+}
+
+type consumerApplicationUUID struct {
+	ConsumerApplicationUUID string `db:"consumer_application_uuid"`
 }
 
 type charmScope struct {

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -210,31 +210,38 @@ type remoteApplicationStatus struct {
 }
 
 type remoteApplicationConsumer struct {
-	// UUID is the unique identifier for this remote application consuemr.
-	UUID string `db:"uuid"`
-	// LifeID is the life state of the remote application consumer.
-	LifeID life.Life `db:"life_id"`
-	// ApplicationUUID is the unique identifier for the application
-	// that is consumed on the consuming model.
-	ApplicationUUID string `db:"application_uuid"`
-	// OfferConnectionUUID is the offer connection uuid that ties both the
-	// offerer and consumer together.
-	OfferConnectionUUID string `db:"offer_connection_uuid"`
-	// Version is the version of the remote application offerer.
-	Version uint64 `db:"version"`
+	UUID                string    `db:"uuid"`
+	LifeID              life.Life `db:"life_id"`
+	ApplicationUUID     string    `db:"application_uuid"`
+	OfferConnectionUUID string    `db:"offer_connection_uuid"`
+	Version             uint64    `db:"version"`
 }
 
 type offerConnection struct {
-	UUID               string `db:"uuid"`
-	OfferUUID          string `db:"offer_uuid"`
-	RemoteRelationUUID string `db:"remote_relation_uuid"`
-	Username           string `db:"username"`
+	UUID                          string `db:"uuid"`
+	OfferUUID                     string `db:"offer_uuid"`
+	ApplicationRemoteRelationUUID string `db:"application_remote_relation_uuid"`
+	Username                      string `db:"username"`
+}
+
+type offerConnectionQuery struct {
+	OfferUUID                     string `db:"offer_uuid"`
+	ApplicationRemoteRelationUUID string `db:"application_remote_relation_uuid"`
 }
 
 type relation struct {
 	UUID       string `db:"uuid"`
 	LifeID     int    `db:"life_id"`
 	RelationID uint64 `db:"relation_id"`
+}
+
+type applicationRemoteRelation struct {
+	RelationUUID         string `db:"relation_uuid"`
+	ConsumerRelationUUID string `db:"consumer_relation_uuid"`
+}
+
+type consumerRelationUUID struct {
+	ConsumerRelationUUID string `db:"consumer_relation_uuid"`
 }
 
 type charmScope struct {

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -184,23 +184,7 @@ type RemoteApplicationOfferer struct {
 // AddRemoteApplicationOffererArgs contains the parameters required to add a new
 // remote application offerer.
 type AddRemoteApplicationOffererArgs struct {
-	// ApplicationUUID is the UUID to assign to the synthetic application
-	// representing the remote application.
-	ApplicationUUID string
-
-	// CharmUUID is the UUID to assign to the synthetic charm representing
-	// the remote application.
-	CharmUUID string
-
-	// RemoteApplicationUUID is the UUID of the remote application.
-	RemoteApplicationUUID string
-
-	// Charm is the charm representing the remote application.
-	Charm charm.Charm
-
-	// OfferUUID is the UUID of the offer that the remote application is
-	// consuming.
-	OfferUUID string
+	AddRemoteApplicationArgs
 
 	// OffererControllerUUID is the UUID of the controller that the remote
 	// application is in.
@@ -213,4 +197,38 @@ type AddRemoteApplicationOffererArgs struct {
 	// EncodedMacaroon is the encoded macaroon that the remote application uses
 	// to authenticate with the offerer model.
 	EncodedMacaroon []byte
+}
+
+// AddRemoteApplicationConsumerArgs contains the parameters required to add a
+// new remote application consumer.
+type AddRemoteApplicationConsumerArgs struct {
+	AddRemoteApplicationArgs
+
+	// RelationUUID is the UUID of the relation created to connect the remote
+	// application to a local application, on the consuming model.
+	RelationUUID string
+}
+
+// AddRemoteApplicationArgs contains the parameters required to add a new remote
+// application, on any of the offering or the consuming models.
+type AddRemoteApplicationArgs struct {
+	// ApplicationUUID is the UUID to assign to the synthetic application
+	// representing the remote application, on the consuming model.
+	ApplicationUUID string
+
+	// CharmUUID is the UUID to assign to the synthetic charm representing
+	// the remote application, on the consuming model.
+	CharmUUID string
+
+	// RemoteApplicationUUID is the UUID of the remote application, on the
+	// consuming model.
+	RemoteApplicationUUID string
+
+	// Charm is the charm representing the remote application, on the consuming
+	// model.
+	Charm charm.Charm
+
+	// OfferUUID is the UUID of the offer that the remote application is
+	// consuming. The offer is in this model, the offering model.
+	OfferUUID string
 }

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -80,14 +80,16 @@ CREATE TABLE application_remote_consumer (
 );
 
 -- application_remote_relation represents a look up table to find the consumer
--- relation UUID for a given local relation.
+-- relation UUID for a given (syntethic) relation in the offerer model.
 CREATE TABLE application_remote_relation (
-    uuid TEXT NOT NULL PRIMARY KEY,
-    -- relation_uuid is the local relation UUID.
-    relation_uuid TEXT NOT NULL,
+    -- relation_uuid is the relation UUID as created in the offerer model. This
+    -- is effectively a synthetic relation.
+    relation_uuid TEXT NOT NULL PRIMARY KEY,
     -- consumer_relation_uuid is the relation UUID in the consumer model.
     -- There is no FK constraint on it, because we don't have the relation
     -- locally in the model.
+    -- NOTE: In terms of the cross model relation API, this is the 
+    -- relation-token.
     consumer_relation_uuid TEXT NOT NULL,
     CONSTRAINT fk_relation_uuid
     FOREIGN KEY (relation_uuid)
@@ -99,10 +101,12 @@ CREATE TABLE offer_connection (
     uuid TEXT NOT NULL PRIMARY KEY,
     -- offer_uuid is the offer that the remote application is using.
     offer_uuid TEXT NOT NULL,
-    -- remote_relation_uuid is the relation for which the offer connection
-    -- is made. It uses the relation, as we can identify both the
-    -- relation id and the relation key from it.
-    remote_relation_uuid TEXT NOT NULL,
+    -- application_remote_relation_uuid is the relation uuid in the offerer
+    -- model that is being used for this offer connection. It is effectively a
+    -- synthetic relation.
+    -- It is foreign keyed to application_remote_relation, which allows us to
+    -- find the relation uuid of the relation in the consumer model.
+    application_remote_relation_uuid TEXT NOT NULL, 
     -- username is the user in the consumer model that created the offer
     -- connection. This is not a user, but an offer user for which offers are
     -- granted permissions on.
@@ -112,5 +116,5 @@ CREATE TABLE offer_connection (
     REFERENCES offer (uuid),
     CONSTRAINT fk_remote_relation_uuid
     FOREIGN KEY (remote_relation_uuid)
-    REFERENCES relation (uuid)
+    REFERENCES application_remote_relation (relation_uuid)
 );

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -96,6 +96,10 @@ CREATE TABLE application_remote_relation (
     REFERENCES relation (uuid)
 );
 
+-- Offering model relations (synthetic) are 1:1 with consumer model relations.
+CREATE UNIQUE INDEX idx_application_remote_relation_consumer_relation_uuid
+ON application_remote_relation (consumer_relation_uuid);
+
 -- offer connection links the application remote consumer to the offer.
 CREATE TABLE offer_connection (
     uuid TEXT NOT NULL PRIMARY KEY,
@@ -106,7 +110,7 @@ CREATE TABLE offer_connection (
     -- synthetic relation.
     -- It is foreign keyed to application_remote_relation, which allows us to
     -- find the relation uuid of the relation in the consumer model.
-    application_remote_relation_uuid TEXT NOT NULL, 
+    application_remote_relation_uuid TEXT NOT NULL,
     -- username is the user in the consumer model that created the offer
     -- connection. This is not a user, but an offer user for which offers are
     -- granted permissions on.
@@ -115,6 +119,6 @@ CREATE TABLE offer_connection (
     FOREIGN KEY (offer_uuid)
     REFERENCES offer (uuid),
     CONSTRAINT fk_remote_relation_uuid
-    FOREIGN KEY (remote_relation_uuid)
+    FOREIGN KEY (application_remote_relation_uuid)
     REFERENCES application_remote_relation (relation_uuid)
 );

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -59,6 +59,9 @@ CREATE TABLE application_remote_offerer_status (
 CREATE TABLE application_remote_consumer (
     uuid TEXT NOT NULL PRIMARY KEY,
     life_id INT NOT NULL,
+    -- application_uuid is the synthetic application in the offerer model.
+    -- Locating charm is done through the application.
+    application_uuid TEXT NOT NULL,
     -- offer_connection_uuid is the offer connection that links the remote
     -- consumer to the offer.
     offer_connection_uuid TEXT NOT NULL,
@@ -68,6 +71,9 @@ CREATE TABLE application_remote_consumer (
     CONSTRAINT fk_life_id
     FOREIGN KEY (life_id)
     REFERENCES life (id),
+    CONSTRAINT fk_application_uuid
+    FOREIGN KEY (application_uuid)
+    REFERENCES application (uuid),
     CONSTRAINT fk_offer_connection_uuid
     FOREIGN KEY (offer_connection_uuid)
     REFERENCES offer_connection (uuid)

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -58,26 +58,35 @@ CREATE TABLE application_remote_offerer_status (
 -- inside of the offering model.
 CREATE TABLE application_remote_consumer (
     uuid TEXT NOT NULL PRIMARY KEY,
-    life_id INT NOT NULL,
-    -- application_uuid is the synthetic application in the offerer model.
-    -- Locating charm is done through the application.
-    application_uuid TEXT NOT NULL,
+    -- offerer_application_uuid is application UUID of the offer in the offering
+    -- model.
+    offerer_application_uuid TEXT NOT NULL,
+    -- consumed_application_uuid is the (remote, synthetic) application UUID in 
+    -- the consumer model.
+    consumer_application_uuid TEXT NOT NULL,
     -- offer_connection_uuid is the offer connection that links the remote
     -- consumer to the offer.
     offer_connection_uuid TEXT NOT NULL,
     -- version is the unique version number that is incremented when the
     -- consumer model changes the consumer application.
     version INT NOT NULL,
+    life_id INT NOT NULL,
     CONSTRAINT fk_life_id
     FOREIGN KEY (life_id)
     REFERENCES life (id),
-    CONSTRAINT fk_application_uuid
-    FOREIGN KEY (application_uuid)
+    CONSTRAINT fk_offerer_application_uuid
+    FOREIGN KEY (offerer_application_uuid)
+    REFERENCES application (uuid),
+    CONSTRAINT fk_consumer_application_uuid
+    FOREIGN KEY (consumer_application_uuid)
     REFERENCES application (uuid),
     CONSTRAINT fk_offer_connection_uuid
     FOREIGN KEY (offer_connection_uuid)
     REFERENCES offer_connection (uuid)
 );
+
+CREATE UNIQUE INDEX idx_application_remote_consumer_consumed_application_uuid
+ON application_remote_consumer (consumer_application_uuid);
 
 -- application_remote_relation represents a look up table to find the consumer
 -- relation UUID for a given (syntethic) relation in the offerer model.


### PR DESCRIPTION
This patch adds the state layer method AddRemoteApplicationConsumer which adds the synthetic app, charm and relation on the offerer model, when called by the `RegisterRemoteRelations` endpoint.

This method is symmetrical to the already existing one (for the consumer model) `AddRemoteApplicationOfferer()`.

## QA steps

Nothing wired yet, unit tests should pass though.

## Links


**Jira card:** [JUJU-8472](https://warthogs.atlassian.net/browse/JUJU-8472)


[JUJU-8472]: https://warthogs.atlassian.net/browse/JUJU-8472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ