### PR TITLE
feat: add github actions for running unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [main, "[0-9].[0-9]+", "[0-9].[0-9]+.[0-9]+"]
+    branches: [main, "[4-9].[0-9]+", "[4-9].[0-9]+.[0-9]+"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,41 @@
+name: Unit tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main, "[0-9].[0-9]+", "[0-9].[0-9]+.[0-9]+"]
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    name: Unit (race) tests on ${{ matrix.host_arch }}
+    runs-on:
+      [self-hosted, linux, "${{ matrix.host_arch }}", aws, "${{ matrix.size }}"]
+    timeout-minutes: 120
+    if: github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host_arch: x64
+            size: quad-xlarge
+          - host_arch: arm64
+            size: xxlarge
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Run race tests
+        env:
+          TEST_TIMEOUT: "5400s"
+        shell: bash
+        run: |
+          set -euxo pipefail
+          make race-test VERBOSE_CHECK=1 TEST_TIMEOUT="${TEST_TIMEOUT}"


### PR DESCRIPTION
Add GitHub Actions workflow for running Go unit tests on PRs.

This creates one more github workflow, with a matrix for 2 targets (amd, arm). The run is basically `make race-test ...`.

Test coverage results are omitted for the moment, this should be part of a follow-up patch(es).

_Note: This workflow will run only on main and 4.0+ branches._



## QA steps

The GH actions (unit tests) should pass.

_Note: Unit tests will be failing until https://github.com/juju/juju/pull/20751 lands._

