### PR TITLE
feat(cmr): implement set remote app offerer status

### DIFF
--- a/apiserver/facades/agent/uniter/status.go
+++ b/apiserver/facades/agent/uniter/status.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/unit"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	statuserrors "github.com/juju/juju/domain/status/errors"
 	"github.com/juju/juju/rpc/params"
 )
@@ -181,7 +182,7 @@ func (s *StatusAPI) ApplicationStatus(ctx context.Context, args params.Entities)
 		}
 
 		appStatus, unitStatuses, err := s.statusService.GetApplicationAndUnitStatusesForUnitWithLeader(ctx, unitName)
-		if errors.Is(err, statuserrors.ApplicationNotFound) {
+		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			result.Results[i].Error = apiservererrors.ServerError(errors.NotFoundf("application %q", unitName.Application()))
 			continue
 		} else if errors.Is(err, statuserrors.UnitNotLeader) {

--- a/apiserver/facades/agent/uniter/status_test.go
+++ b/apiserver/facades/agent/uniter/status_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	statuserrors "github.com/juju/juju/domain/status/errors"
 	"github.com/juju/juju/rpc/params"
 )
@@ -212,7 +213,7 @@ func (s *ApplicationStatusAPISuite) TesApplicationStatustNotATag(c *tc.C) {
 func (s *ApplicationStatusAPISuite) TesApplicationStatustNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.statusService.EXPECT().GetApplicationAndUnitStatusesForUnitWithLeader(gomock.Any(), coreunit.Name("foo/0")).Return(status.StatusInfo{}, nil, statuserrors.ApplicationNotFound)
+	s.statusService.EXPECT().GetApplicationAndUnitStatusesForUnitWithLeader(gomock.Any(), coreunit.Name("foo/0")).Return(status.StatusInfo{}, nil, applicationerrors.ApplicationNotFound)
 
 	result, err := s.api.ApplicationStatus(c.Context(), params.Entities{Entities: []params.Entity{{
 		Tag: names.NewUnitTag("foo/0").String(),

--- a/core/remoteapplication/testing/testing.go
+++ b/core/remoteapplication/testing/testing.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/tc"
+
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
+)
+
+// GenRemoteApplicationUUID can be used in testing for generating a remote
+// application uuid that is checked for subsequent errors using the test suits
+// go check instance.
+func GenRemoteApplicationUUID(c *tc.C) coreremoteapplication.UUID {
+	uuid, err := coreremoteapplication.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+	return uuid
+}

--- a/core/remoteapplication/uuid.go
+++ b/core/remoteapplication/uuid.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoteapplication
+
+import (
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// UUID represents a remoteapplication unique identifier.
+type UUID string
+
+// NewUUID is a convenience function for generating a new remoteapplication uuid.
+func NewUUID() (UUID, error) {
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return UUID(""), err
+	}
+	return UUID(uuid.String()), nil
+}
+
+// ParseUUID returns a new UUID from the given string. If the string is not a valid
+// uuid an error satisfying [errors.NotValid] will be returned.
+func ParseUUID(value string) (UUID, error) {
+	if !uuid.IsValidUUIDString(value) {
+		return "", errors.Errorf("id %q %w", value, coreerrors.NotValid)
+	}
+	return UUID(value), nil
+}
+
+// String implements the stringer interface for UUID.
+func (u UUID) String() string {
+	return string(u)
+}
+
+// Validate ensures the consistency of the UUID. If the uuid is invalid an error
+// satisfying [errors.NotValid] will be returned.
+func (u UUID) Validate() error {
+	if u == "" {
+		return errors.Errorf("id cannot be empty").Add(coreerrors.NotValid)
+	}
+	if !uuid.IsValidUUIDString(string(u)) {
+		return errors.Errorf("id %q %w", u, coreerrors.NotValid)
+	}
+	return nil
+}

--- a/core/remoteapplication/uuid_test.go
+++ b/core/remoteapplication/uuid_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package remoteapplication
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/testhelpers"
+	"github.com/juju/juju/internal/uuid"
+)
+
+type remoteApplicationSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestRemoteApplicationSuite(t *testing.T) {
+	tc.Run(t, &remoteApplicationSuite{})
+}
+
+func (*remoteApplicationSuite) TestUUIDValidate(c *tc.C) {
+	tests := []struct {
+		uuid string
+		err  error
+	}{
+		{
+			uuid: "",
+			err:  coreerrors.NotValid,
+		},
+		{
+			uuid: "invalid",
+			err:  coreerrors.NotValid,
+		},
+		{
+			uuid: uuid.MustNewUUID().String(),
+		},
+	}
+
+	for i, test := range tests {
+		c.Logf("test %d: %q", i, test.uuid)
+		err := UUID(test.uuid).Validate()
+
+		if test.err == nil {
+			c.Check(err, tc.IsNil)
+			continue
+		}
+
+		c.Check(err, tc.ErrorIs, test.err)
+	}
+}
+
+func (*remoteApplicationSuite) TestParseUUID(c *tc.C) {
+	tests := []struct {
+		uuid string
+		err  error
+	}{
+		{
+			uuid: "",
+			err:  coreerrors.NotValid,
+		},
+		{
+			uuid: "invalid",
+			err:  coreerrors.NotValid,
+		},
+		{
+			uuid: uuid.MustNewUUID().String(),
+		},
+	}
+
+	for i, test := range tests {
+		c.Logf("test %d: %q", i, test.uuid)
+		id, err := ParseUUID(test.uuid)
+
+		if test.err == nil {
+			if c.Check(err, tc.IsNil) {
+				c.Check(id.String(), tc.Equals, test.uuid)
+			}
+			continue
+		}
+
+		c.Check(err, tc.ErrorIs, test.err)
+	}
+}

--- a/domain/crossmodelrelation/errors/errors.go
+++ b/domain/crossmodelrelation/errors/errors.go
@@ -6,6 +6,18 @@ package errors
 import "github.com/juju/juju/internal/errors"
 
 const (
+	// RemoteApplicationNotFound describes an error that occurs when the remote
+	// application being operated on does not exist.
+	RemoteApplicationNotFound = errors.ConstError("remote application not found")
+
+	// RemoteApplicationIsDead describes an error that occurs when the remote
+	// application being operated on is dead.
+	RemoteApplicationIsDead = errors.ConstError("remote application is dead")
+
+	// ApplicationNotRemote describes an error that occurs when the application
+	// being operated on is not a remote application.
+	ApplicationNotRemote = errors.ConstError("application not remote")
+
 	// MissingEndpoints describes an error that occurs when not all of the
 	// endpoints for the offer are found.
 	MissingEndpoints = errors.ConstError("missing endpoints")

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -10,7 +10,9 @@ import (
 	"gopkg.in/macaroon.v2"
 
 	coreapplication "github.com/juju/juju/core/application"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/errors"
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
 	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/domain/application"
@@ -85,17 +87,17 @@ func (s *Service) AddRemoteApplicationOfferer(ctx context.Context, applicationNa
 		return internalerrors.Errorf("marshalling macaroon: %w", err)
 	}
 
-	remoteApplicationUUID, err := uuid.NewUUID()
+	remoteApplicationUUID, err := coreremoteapplication.NewUUID()
 	if err != nil {
 		return internalerrors.Errorf("creating remote application uuid: %w", err)
 	}
 
-	applicationUUID, err := uuid.NewUUID()
+	applicationUUID, err := coreapplication.NewID()
 	if err != nil {
 		return internalerrors.Errorf("creating application uuid: %w", err)
 	}
 
-	charmUUID, err := uuid.NewUUID()
+	charmUUID, err := corecharm.NewID()
 	if err != nil {
 		return internalerrors.Errorf("creating charm uuid: %w", err)
 	}

--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -392,23 +392,23 @@ WHERE offer_uuid = $uuid.uuid
 	return nil
 }
 
-func (s *State) addCharm(ctx context.Context, tx *sqlair.TX, uuid string, ch charm.Charm) error {
-	if err := s.addCharmState(ctx, tx, uuid, ch); err != nil {
+func (st *State) addCharm(ctx context.Context, tx *sqlair.TX, uuid string, ch charm.Charm) error {
+	if err := st.addCharmState(ctx, tx, uuid, ch); err != nil {
 		return errors.Capture(err)
 	}
 
-	if err := s.addCharmMetadata(ctx, tx, uuid, ch.Metadata); err != nil {
+	if err := st.addCharmMetadata(ctx, tx, uuid, ch.Metadata); err != nil {
 		return errors.Capture(err)
 	}
 
-	if err := s.addCharmRelations(ctx, tx, uuid, ch.Metadata); err != nil {
+	if err := st.addCharmRelations(ctx, tx, uuid, ch.Metadata); err != nil {
 		return errors.Capture(err)
 	}
 
 	return nil
 }
 
-func (s *State) addCharmState(
+func (st *State) addCharmState(
 	ctx context.Context,
 	tx *sqlair.TX,
 	uuid string,
@@ -426,7 +426,7 @@ func (s *State) addCharmState(
 	}
 
 	charmQuery := `INSERT INTO charm (*) VALUES ($setCharmState.*);`
-	charmStmt, err := s.Prepare(charmQuery, chState)
+	charmStmt, err := st.Prepare(charmQuery, chState)
 	if err != nil {
 		return errors.Errorf("preparing query: %w", err)
 	}
@@ -438,7 +438,7 @@ func (s *State) addCharmState(
 	return nil
 }
 
-func (s *State) addCharmMetadata(
+func (st *State) addCharmMetadata(
 	ctx context.Context,
 	tx *sqlair.TX,
 	uuid string,
@@ -450,7 +450,7 @@ func (s *State) addCharmMetadata(
 	}
 
 	query := `INSERT INTO charm_metadata (*) VALUES ($setCharmMetadata.*);`
-	stmt, err := s.Prepare(query, encodedMetadata)
+	stmt, err := st.Prepare(query, encodedMetadata)
 	if err != nil {
 		return errors.Errorf("preparing query: %w", err)
 	}
@@ -462,7 +462,7 @@ func (s *State) addCharmMetadata(
 	return nil
 }
 
-func (s *State) addCharmRelations(ctx context.Context, tx *sqlair.TX, uuid string, metadata charm.Metadata) error {
+func (st *State) addCharmRelations(ctx context.Context, tx *sqlair.TX, uuid string, metadata charm.Metadata) error {
 	encodedRelations, err := encodeRelations(uuid, metadata)
 	if err != nil {
 		return errors.Errorf("encoding charm relations: %w", err)
@@ -484,7 +484,7 @@ func (s *State) addCharmRelations(ctx context.Context, tx *sqlair.TX, uuid strin
 	}
 
 	query := `INSERT INTO charm_relation (*) VALUES ($setCharmRelation.*);`
-	stmt, err := s.Prepare(query, setCharmRelation{})
+	stmt, err := st.Prepare(query, setCharmRelation{})
 	if err != nil {
 		return errors.Errorf("preparing query: %w", err)
 	}

--- a/domain/status/errors/errors.go
+++ b/domain/status/errors/errors.go
@@ -10,14 +10,6 @@ const (
 	// valid.
 	InvalidStatus = errors.ConstError("invalid status")
 
-	// ApplicationNotFound describes an error that occurs when the application
-	// being operated on does not exist.
-	ApplicationNotFound = errors.ConstError("application not found")
-
-	// ApplicationIsDead describes an error that occurs when trying to access
-	// an application that is dead.
-	ApplicationIsDead = errors.ConstError("application is dead")
-
 	// RelationNotFound describes an error that occurs when the relation
 	// being operated on does not exist.
 	RelationNotFound = errors.ConstError("relation not found")
@@ -53,4 +45,6 @@ const (
 	// VolumeStatusTransitionNotValid describes an error that occurs when the
 	// current volume status cannot transition to the new volume status.
 	VolumeStatusTransitionNotValid = errors.ConstError("volume status transition not valid")
+
+	RemoteApplicationStatusNotFound = errors.ConstError("remote application status not found")
 )

--- a/domain/status/service/crossmodelrelation.go
+++ b/domain/status/service/crossmodelrelation.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
+	corestatus "github.com/juju/juju/core/status"
+	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/domain/status"
+	"github.com/juju/juju/internal/errors"
+)
+
+// CrossModelRelationState provides access to CMR related state methods.
+type CrossModelRelationState interface {
+	// GetRemoteApplicationOffererUUIDByName returns the UUID for the named for the remote
+	// application wrapping the named application
+	GetRemoteApplicationOffererUUIDByName(ctx context.Context, name string) (coreremoteapplication.UUID, error)
+
+	// SetRemoteApplicationOffererStatus sets the status of the specified remote
+	// application in the local model.
+	SetRemoteApplicationOffererStatus(
+		ctx context.Context,
+		remoteApplicationUUID string,
+		statusInfo status.StatusInfo[status.WorkloadStatusType],
+	) error
+}
+
+// SetRemoteApplicationOffererStatus sets the status of the specified remote
+// application in the local model.
+func (s *Service) SetRemoteApplicationOffererStatus(
+	ctx context.Context,
+	appName string,
+	statusInfo corestatus.StatusInfo,
+) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	// This will also verify that the status is valid.
+	encodedStatus, err := encodeWorkloadStatus(statusInfo)
+	if err != nil {
+		return errors.Errorf("encoding workload status: %w", err)
+	}
+
+	remoteAppUUID, err := s.modelState.GetRemoteApplicationOffererUUIDByName(ctx, appName)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if err := s.modelState.SetRemoteApplicationOffererStatus(ctx, remoteAppUUID.String(), encodedStatus); err != nil {
+		return errors.Capture(err)
+	}
+
+	if err := s.statusHistory.RecordStatus(ctx, status.RemoteApplication.WithID(appName), statusInfo); err != nil {
+		s.logger.Warningf(ctx, "recording setting remote application status history: %v", err)
+	}
+
+	return nil
+}

--- a/domain/status/service/crossmodelrelation_test.go
+++ b/domain/status/service/crossmodelrelation_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"time"
+
+	"github.com/juju/tc"
+	gomock "go.uber.org/mock/gomock"
+	"gopkg.in/check.v1"
+
+	remoteapplicationtesting "github.com/juju/juju/core/remoteapplication/testing"
+	corestatus "github.com/juju/juju/core/status"
+	"github.com/juju/juju/domain/status"
+	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/statushistory"
+)
+
+func (s *serviceSuite) TestSetRemoteApplicationOffererStatus(c *check.C) {
+	defer s.setupMocks(c).Finish()
+
+	now := time.Now().UTC()
+
+	remoteAppUUID := remoteapplicationtesting.GenRemoteApplicationUUID(c)
+	s.modelState.EXPECT().GetRemoteApplicationOffererUUIDByName(gomock.Any(), "foo").Return(remoteAppUUID, nil)
+	s.modelState.EXPECT().SetRemoteApplicationOffererStatus(gomock.Any(), remoteAppUUID.String(), status.StatusInfo[status.WorkloadStatusType]{
+		Status:  status.WorkloadStatusActive,
+		Message: "message",
+		Data:    []byte(`{"foo":"bar"}`),
+		Since:   &now,
+	})
+
+	err := s.modelService.SetRemoteApplicationOffererStatus(c.Context(), "foo", corestatus.StatusInfo{
+		Status:  corestatus.Active,
+		Message: "message",
+		Data:    map[string]any{"foo": "bar"},
+		Since:   &now,
+	})
+
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(s.statusHistory.records, tc.DeepEquals, []statusHistoryRecord{{
+		ns: statushistory.Namespace{Kind: corestatus.KindSAAS, ID: "foo"},
+		s: corestatus.StatusInfo{
+			Status:  corestatus.Active,
+			Message: "message",
+			Data:    map[string]any{"foo": "bar"},
+			Since:   &now,
+		},
+	}})
+}
+
+func (s *serviceSuite) TestSetRemoteApplicationOffererStatusError(c *check.C) {
+	defer s.setupMocks(c).Finish()
+
+	now := time.Now().UTC()
+
+	s.modelState.EXPECT().GetRemoteApplicationOffererUUIDByName(gomock.Any(), "foo").Return("", errors.Errorf("boom"))
+
+	err := s.modelService.SetRemoteApplicationOffererStatus(c.Context(), "foo", corestatus.StatusInfo{
+		Status:  corestatus.Active,
+		Message: "message",
+		Data:    map[string]any{"foo": "bar"},
+		Since:   &now,
+	})
+
+	c.Assert(err, tc.ErrorMatches, `.*boom`)
+}

--- a/domain/status/service/leaderservice_test.go
+++ b/domain/status/service/leaderservice_test.go
@@ -19,6 +19,7 @@ import (
 	corestatus "github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
 	unittesting "github.com/juju/juju/core/unit/testing"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/status"
 	statuserrors "github.com/juju/juju/domain/status/errors"
 	"github.com/juju/juju/internal/errors"
@@ -217,9 +218,9 @@ func (s *leaderServiceSuite) TestGetApplicationAndUnitStatusesForUnitWithLeaderN
 
 	unitName := coreunit.Name("foo/0")
 
-	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", statuserrors.ApplicationNotFound)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return("", applicationerrors.ApplicationNotFound)
 	_, _, err := s.service.GetApplicationAndUnitStatusesForUnitWithLeader(c.Context(), unitName)
-	c.Assert(err, tc.ErrorIs, statuserrors.ApplicationNotFound)
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
 func (s *leaderServiceSuite) TestGetApplicationAndUnitStatusesForUnitWithLeaderApplicationStatusSet(c *tc.C) {

--- a/domain/status/service/package_mock_test.go
+++ b/domain/status/service/package_mock_test.go
@@ -16,6 +16,7 @@ import (
 	application "github.com/juju/juju/core/application"
 	machine "github.com/juju/juju/core/machine"
 	relation "github.com/juju/juju/core/relation"
+	remoteapplication "github.com/juju/juju/core/remoteapplication"
 	unit "github.com/juju/juju/core/unit"
 	status "github.com/juju/juju/domain/status"
 	storageprovisioning "github.com/juju/juju/domain/storageprovisioning"
@@ -825,6 +826,45 @@ func (c *MockModelStateGetRelationUUIDByIDCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
+// GetRemoteApplicationOffererUUIDByName mocks base method.
+func (m *MockModelState) GetRemoteApplicationOffererUUIDByName(ctx context.Context, name string) (remoteapplication.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRemoteApplicationOffererUUIDByName", ctx, name)
+	ret0, _ := ret[0].(remoteapplication.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteApplicationOffererUUIDByName indicates an expected call of GetRemoteApplicationOffererUUIDByName.
+func (mr *MockModelStateMockRecorder) GetRemoteApplicationOffererUUIDByName(ctx, name any) *MockModelStateGetRemoteApplicationOffererUUIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteApplicationOffererUUIDByName", reflect.TypeOf((*MockModelState)(nil).GetRemoteApplicationOffererUUIDByName), ctx, name)
+	return &MockModelStateGetRemoteApplicationOffererUUIDByNameCall{Call: call}
+}
+
+// MockModelStateGetRemoteApplicationOffererUUIDByNameCall wrap *gomock.Call
+type MockModelStateGetRemoteApplicationOffererUUIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetRemoteApplicationOffererUUIDByNameCall) Return(arg0 remoteapplication.UUID, arg1 error) *MockModelStateGetRemoteApplicationOffererUUIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetRemoteApplicationOffererUUIDByNameCall) Do(f func(context.Context, string) (remoteapplication.UUID, error)) *MockModelStateGetRemoteApplicationOffererUUIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetRemoteApplicationOffererUUIDByNameCall) DoAndReturn(f func(context.Context, string) (remoteapplication.UUID, error)) *MockModelStateGetRemoteApplicationOffererUUIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetStorageInstanceAttachments mocks base method.
 func (m *MockModelState) GetStorageInstanceAttachments(ctx context.Context) ([]status.StorageAttachment, error) {
 	m.ctrl.T.Helper()
@@ -1478,6 +1518,44 @@ func (c *MockModelStateSetRelationStatusCall) Do(f func(context.Context, relatio
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelStateSetRelationStatusCall) DoAndReturn(f func(context.Context, relation.UUID, status.StatusInfo[status.RelationStatusType]) error) *MockModelStateSetRelationStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetRemoteApplicationOffererStatus mocks base method.
+func (m *MockModelState) SetRemoteApplicationOffererStatus(ctx context.Context, remoteApplicationUUID string, statusInfo status.StatusInfo[status.WorkloadStatusType]) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRemoteApplicationOffererStatus", ctx, remoteApplicationUUID, statusInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRemoteApplicationOffererStatus indicates an expected call of SetRemoteApplicationOffererStatus.
+func (mr *MockModelStateMockRecorder) SetRemoteApplicationOffererStatus(ctx, remoteApplicationUUID, statusInfo any) *MockModelStateSetRemoteApplicationOffererStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteApplicationOffererStatus", reflect.TypeOf((*MockModelState)(nil).SetRemoteApplicationOffererStatus), ctx, remoteApplicationUUID, statusInfo)
+	return &MockModelStateSetRemoteApplicationOffererStatusCall{Call: call}
+}
+
+// MockModelStateSetRemoteApplicationOffererStatusCall wrap *gomock.Call
+type MockModelStateSetRemoteApplicationOffererStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateSetRemoteApplicationOffererStatusCall) Return(arg0 error) *MockModelStateSetRemoteApplicationOffererStatusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, string, status.StatusInfo[status.WorkloadStatusType]) error) *MockModelStateSetRemoteApplicationOffererStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, string, status.StatusInfo[status.WorkloadStatusType]) error) *MockModelStateSetRemoteApplicationOffererStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/status/service/service.go
+++ b/domain/status/service/service.go
@@ -28,7 +28,9 @@ import (
 // ModelState describes retrieval and persistence methods for the statuses of
 // applications and units.
 type ModelState interface {
+	CrossModelRelationState
 	StorageState
+
 	// GetAllRelationStatuses returns all the relation statuses of the given model.
 	GetAllRelationStatuses(ctx context.Context) ([]status.RelationStatusInfo, error)
 

--- a/domain/status/service/service_test.go
+++ b/domain/status/service/service_test.go
@@ -22,6 +22,7 @@ import (
 	unittesting "github.com/juju/juju/core/unit/testing"
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/life"
 	modelerrors "github.com/juju/juju/domain/model/errors"
@@ -173,12 +174,12 @@ func (s *serviceSuite) TestSetApplicationStatus(c *tc.C) {
 func (s *serviceSuite) TestSetApplicationStatusNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return("", statuserrors.ApplicationNotFound)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return("", applicationerrors.ApplicationNotFound)
 
 	err := s.modelService.SetApplicationStatus(c.Context(), "gitlab", corestatus.StatusInfo{
 		Status: corestatus.Active,
 	})
-	c.Assert(err, tc.ErrorIs, statuserrors.ApplicationNotFound)
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
 func (s *serviceSuite) TestSetApplicationStatusInvalidStatus(c *tc.C) {
@@ -198,10 +199,10 @@ func (s *serviceSuite) TestSetApplicationStatusInvalidStatus(c *tc.C) {
 func (s *serviceSuite) TestGetApplicationDisplayStatusNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return("", statuserrors.ApplicationNotFound)
+	s.modelState.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return("", applicationerrors.ApplicationNotFound)
 
 	_, err := s.modelService.GetApplicationDisplayStatus(c.Context(), "gitlab")
-	c.Assert(err, tc.ErrorIs, statuserrors.ApplicationNotFound)
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
 func (s *serviceSuite) TestGetApplicationDisplayStatusApplicationStatusSet(c *tc.C) {

--- a/domain/status/state/crossmodelrelation.go
+++ b/domain/status/state/crossmodelrelation.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/canonical/sqlair"
+
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
+	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
+	domainlife "github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/status"
+	statuserrors "github.com/juju/juju/domain/status/errors"
+	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
+)
+
+// GetRemoteApplicationOffererUUIDByName returns the UUID for the named for the remote
+// application wrapping the named application
+func (st *ModelState) GetRemoteApplicationOffererUUIDByName(
+	ctx context.Context,
+	name string,
+) (coreremoteapplication.UUID, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	var uuid coreremoteapplication.UUID
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		uuid, err = st.lookupRemoteApplicationOfferer(ctx, tx, name)
+		return err
+	}); err != nil {
+		return "", errors.Capture(err)
+	}
+
+	return uuid, nil
+}
+
+// GetRemoteApplicationOffererStatus returns the status of the specified remote
+// application in the local model.
+func (st *ModelState) GetRemoteApplicationOffererStatus(
+	ctx context.Context,
+	uuid string,
+) (status.StatusInfo[status.WorkloadStatusType], error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return status.StatusInfo[status.WorkloadStatusType]{}, errors.Capture(err)
+	}
+
+	ident := remoteApplicationUUID{RemoteApplicationUUID: uuid}
+
+	query, err := st.Prepare(`
+SELECT &statusInfo.*
+FROM application_remote_offerer_status
+WHERE application_remote_offerer_uuid = $remoteApplicationUUID.uuid
+`, statusInfo{}, ident)
+	if err != nil {
+		return status.StatusInfo[status.WorkloadStatusType]{}, errors.Capture(err)
+	}
+
+	var statusInfo statusInfo
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := st.checkRemoteApplicationNotDead(ctx, tx, ident); err != nil {
+			return errors.Capture(err)
+		}
+		err := tx.Query(ctx, query, ident).Get(&statusInfo)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("remote application %q status not set", uuid).
+				Add(statuserrors.RemoteApplicationStatusNotFound)
+		} else if err != nil {
+			return errors.Capture(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return status.StatusInfo[status.WorkloadStatusType]{}, errors.Capture(err)
+	}
+
+	statusType, err := status.DecodeWorkloadStatus(statusInfo.StatusID)
+	if err != nil {
+		return status.StatusInfo[status.WorkloadStatusType]{}, errors.Capture(err)
+	}
+
+	return status.StatusInfo[status.WorkloadStatusType]{
+		Status:  statusType,
+		Message: statusInfo.Message,
+		Data:    statusInfo.Data,
+		Since:   statusInfo.UpdatedAt,
+	}, nil
+}
+
+// SetRemoteApplicationOffererStatus sets the status of the specified remote
+// application in the local model.
+func (st *ModelState) SetRemoteApplicationOffererStatus(
+	ctx context.Context,
+	remoteApplicationUUID string,
+	sts status.StatusInfo[status.WorkloadStatusType],
+) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	statusID, err := status.EncodeWorkloadStatus(sts.Status)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	statusInfo := remoteApplicationStatus{
+		RemoteApplicationUUID: remoteApplicationUUID,
+		StatusID:              statusID,
+		Message:               sts.Message,
+		Data:                  sts.Data,
+		UpdatedAt:             sts.Since,
+	}
+
+	stmt, err := st.Prepare(`
+INSERT INTO application_remote_offerer_status (*) VALUES ($remoteApplicationStatus.*)
+ON CONFLICT(application_remote_offerer_uuid) DO UPDATE SET
+    status_id = excluded.status_id,
+    message = excluded.message,
+    updated_at = excluded.updated_at,
+    data = excluded.data;
+`, statusInfo)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, stmt, statusInfo).Run(); internaldatabase.IsErrConstraintForeignKey(err) {
+			return errors.Errorf("%w: %q", crossmodelrelationerrors.RemoteApplicationNotFound, remoteApplicationUUID)
+		} else if err != nil {
+			return errors.Capture(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return nil
+}
+
+func (st *ModelState) lookupRemoteApplicationOfferer(ctx context.Context, tx *sqlair.TX, name string) (coreremoteapplication.UUID, error) {
+	type remoteApplicationUUID struct {
+		RemoteApplicationUUID sql.Null[string] `db:"uuid"`
+	}
+	appIdent := applicationName{Name: name}
+
+	queryRemoteAppStmt, err := st.Prepare(`
+SELECT    aro.uuid AS &remoteApplicationUUID.uuid
+FROM      application AS a
+-- left join ensures we can distinguish between an application that doesn't
+-- exist and one that is not remote
+LEFT JOIN application_remote_offerer AS aro
+WHERE     a.name = $applicationName.name `,
+		remoteApplicationUUID{}, appIdent)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	var result remoteApplicationUUID
+
+	err = tx.Query(ctx, queryRemoteAppStmt, appIdent).Get(&result)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return "", errors.Errorf("application %q not found", name).Add(applicationerrors.ApplicationNotFound)
+	} else if err != nil {
+		return "", errors.Errorf("looking up UUID for remote application %q: %w", name, err)
+	} else if !result.RemoteApplicationUUID.Valid {
+		return "", errors.Errorf("application %q is not remote", name).Add(crossmodelrelationerrors.ApplicationNotRemote)
+	}
+
+	return coreremoteapplication.UUID(result.RemoteApplicationUUID.V), nil
+}
+
+func (st *ModelState) checkRemoteApplicationNotDead(ctx context.Context, tx *sqlair.TX, ident remoteApplicationUUID) error {
+	type life struct {
+		LifeID domainlife.Life `db:"life_id"`
+	}
+
+	query := `
+SELECT &life.*
+FROM application_remote_offerer
+WHERE uuid = $remoteApplicationUUID.uuid;
+`
+	stmt, err := st.Prepare(query, ident, life{})
+	if err != nil {
+		return errors.Errorf("preparing query for remote application %q: %w", ident.RemoteApplicationUUID, err)
+	}
+
+	var result life
+	err = tx.Query(ctx, stmt, ident).Get(&result)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return crossmodelrelationerrors.RemoteApplicationNotFound
+	} else if err != nil {
+		return errors.Errorf("checking if remote application %q exists: %w", ident.RemoteApplicationUUID, err)
+	}
+
+	switch result.LifeID {
+	case domainlife.Dead:
+		return crossmodelrelationerrors.RemoteApplicationIsDead
+	default:
+		return nil
+	}
+}

--- a/domain/status/state/crossmodelrelation_test.go
+++ b/domain/status/state/crossmodelrelation_test.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/tc"
+
+	remoteapplicationtesting "github.com/juju/juju/core/remoteapplication/testing"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
+	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/status"
+	statuserrors "github.com/juju/juju/domain/status/errors"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type crossModelRelationSuite struct {
+	baseSuite
+
+	state *ModelState
+}
+
+func TestCrossModelRelationSuite(t *testing.T) {
+	tc.Run(t, &crossModelRelationSuite{})
+}
+
+func (s *crossModelRelationSuite) SetUpTest(c *tc.C) {
+	s.ModelSuite.SetUpTest(c)
+
+	s.state = NewModelState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+}
+
+func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererUUIDByName(c *tc.C) {
+	appUUID, _ := s.createIAASApplication(c, "foo", life.Alive, false, s.workloadStatus(time.Now()))
+	remoteAppUUID := remoteapplicationtesting.GenRemoteApplicationUUID(c)
+	s.insertRemoteApplication(c, appUUID.String(), remoteAppUUID.String())
+
+	gotUUID, err := s.state.GetRemoteApplicationOffererUUIDByName(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotUUID, tc.Equals, remoteAppUUID)
+}
+
+func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererUUIDByNameNotRemote(c *tc.C) {
+	s.createIAASApplication(c, "foo", life.Alive, false, s.workloadStatus(time.Now()))
+
+	_, err := s.state.GetRemoteApplicationOffererUUIDByName(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.ApplicationNotRemote)
+}
+
+func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererUUIDByNameNotFound(c *tc.C) {
+	_, err := s.state.GetRemoteApplicationOffererUUIDByName(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
+func (s *crossModelRelationSuite) TestSetRemoteApplicationOffererStatus(c *tc.C) {
+	appUUID, _ := s.createIAASApplication(c, "foo", life.Alive, false, s.workloadStatus(time.Now()))
+	remoteAppUUID := remoteapplicationtesting.GenRemoteApplicationUUID(c)
+	s.insertRemoteApplication(c, appUUID.String(), remoteAppUUID.String())
+
+	now := time.Now().UTC()
+	expected := status.StatusInfo[status.WorkloadStatusType]{
+		Status:  status.WorkloadStatusActive,
+		Message: "message",
+		Data:    []byte("data"),
+		Since:   ptr(now),
+	}
+
+	err := s.state.SetRemoteApplicationOffererStatus(c.Context(), remoteAppUUID.String(), expected)
+	c.Assert(err, tc.ErrorIsNil)
+
+	status, err := s.state.GetRemoteApplicationOffererStatus(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(status.Status, tc.Equals, expected.Status)
+	c.Check(status.Message, tc.Equals, expected.Message)
+	c.Check(status.Data, tc.DeepEquals, expected.Data)
+	c.Check(status.Since, tc.DeepEquals, expected.Since)
+}
+
+func (s *crossModelRelationSuite) TestSetRemoteApplicationOffererStatusMultipleTimes(c *tc.C) {
+	appUUID, _ := s.createIAASApplication(c, "foo", life.Alive, false, s.workloadStatus(time.Now()))
+	remoteAppUUID := remoteapplicationtesting.GenRemoteApplicationUUID(c)
+	s.insertRemoteApplication(c, appUUID.String(), remoteAppUUID.String())
+
+	err := s.state.SetRemoteApplicationOffererStatus(c.Context(), remoteAppUUID.String(), status.StatusInfo[status.WorkloadStatusType]{
+		Status:  status.WorkloadStatusBlocked,
+		Message: "blocked",
+		Since:   ptr(time.Now().UTC()),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	now := time.Now().UTC()
+	expected := status.StatusInfo[status.WorkloadStatusType]{
+		Status:  status.WorkloadStatusActive,
+		Message: "message",
+		Data:    []byte("data"),
+		Since:   ptr(now),
+	}
+
+	err = s.state.SetRemoteApplicationOffererStatus(c.Context(), remoteAppUUID.String(), expected)
+	c.Assert(err, tc.ErrorIsNil)
+
+	status, err := s.state.GetRemoteApplicationOffererStatus(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(status.Status, tc.Equals, expected.Status)
+	c.Check(status.Message, tc.Equals, expected.Message)
+	c.Check(status.Data, tc.DeepEquals, expected.Data)
+	c.Check(status.Since, tc.DeepEquals, expected.Since)
+}
+
+func (s *crossModelRelationSuite) TestSetRemoteApplicationOffererStatusNotFound(c *tc.C) {
+	err := s.state.SetRemoteApplicationOffererStatus(c.Context(), "missing-uuid", status.StatusInfo[status.WorkloadStatusType]{
+		Status: status.WorkloadStatusActive,
+	})
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.RemoteApplicationNotFound)
+}
+
+func (s *crossModelRelationSuite) TestSetRemoteApplicationOffererStatusInvalidStatus(c *tc.C) {
+	appUUID, _ := s.createIAASApplication(c, "foo", life.Alive, false, s.workloadStatus(time.Now()))
+	remoteAppUUID := remoteapplicationtesting.GenRemoteApplicationUUID(c)
+	s.insertRemoteApplication(c, appUUID.String(), remoteAppUUID.String())
+
+	expected := status.StatusInfo[status.WorkloadStatusType]{
+		Status: status.WorkloadStatusType(99),
+	}
+
+	err := s.state.SetRemoteApplicationOffererStatus(c.Context(), remoteAppUUID.String(), expected)
+	c.Assert(err, tc.ErrorMatches, `unknown status.*`)
+}
+
+func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererStatusNotFound(c *tc.C) {
+	_, err := s.state.GetRemoteApplicationOffererStatus(c.Context(), "missing-uuid")
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.RemoteApplicationNotFound)
+}
+
+func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererStatusNotSet(c *tc.C) {
+	appUUID, _ := s.createIAASApplication(c, "foo", life.Alive, false, s.workloadStatus(time.Now()))
+	remoteAppUUID := remoteapplicationtesting.GenRemoteApplicationUUID(c)
+	s.insertRemoteApplication(c, appUUID.String(), remoteAppUUID.String())
+
+	_, err := s.state.GetRemoteApplicationOffererStatus(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIs, statuserrors.RemoteApplicationStatusNotFound)
+}

--- a/domain/status/state/package_test.go
+++ b/domain/status/state/package_test.go
@@ -1,0 +1,317 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/tc"
+
+	coreapplication "github.com/juju/juju/core/application"
+	coremachine "github.com/juju/juju/core/machine"
+	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/application/architecture"
+	"github.com/juju/juju/domain/application/charm"
+	applicationstate "github.com/juju/juju/domain/application/state"
+	"github.com/juju/juju/domain/deployment"
+	"github.com/juju/juju/domain/life"
+	domainnetwork "github.com/juju/juju/domain/network"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/domain/status"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type baseSuite struct {
+	schematesting.ModelSuite
+}
+
+func (s *baseSuite) workloadStatus(now time.Time) *status.StatusInfo[status.WorkloadStatusType] {
+	return &status.StatusInfo[status.WorkloadStatusType]{
+		Status:  status.WorkloadStatusActive,
+		Message: "it's active!",
+		Data:    []byte(`{"foo": "bar"}`),
+		Since:   ptr(now),
+	}
+}
+
+func (s *baseSuite) createCAASUnitArg(c *tc.C) application.AddCAASUnitArg {
+	return application.AddCAASUnitArg{
+		AddUnitArg: application.AddUnitArg{
+			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
+		},
+	}
+}
+
+func (s *baseSuite) createIAASUnitArg(c *tc.C) application.AddIAASUnitArg {
+	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
+	return application.AddIAASUnitArg{
+		MachineNetNodeUUID: netNodeUUID,
+		MachineUUID:        tc.Must(c, coremachine.NewUUID),
+		AddUnitArg: application.AddUnitArg{
+			NetNodeUUID: netNodeUUID,
+		},
+	}
+}
+
+func (s *baseSuite) createIAASApplicationWithNUnits(
+	c *tc.C,
+	name string,
+	nUnits int,
+) (coreapplication.UUID, []coreunit.UUID) {
+	units := make([]application.AddIAASUnitArg, nUnits)
+	for i := range units {
+		netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
+		units[i].MachineUUID = tc.Must(c, coremachine.NewUUID)
+		units[i].MachineNetNodeUUID = netNodeUUID
+		units[i].NetNodeUUID = netNodeUUID
+	}
+
+	return s.createIAASApplication(
+		c, name, life.Alive, false, s.workloadStatus(time.Now()), units...,
+	)
+}
+
+func (s *baseSuite) createIAASApplication(
+	c *tc.C,
+	name string,
+	l life.Life,
+	subordinate bool,
+	appStatus *status.StatusInfo[status.WorkloadStatusType],
+	units ...application.AddIAASUnitArg,
+) (coreapplication.UUID, []coreunit.UUID) {
+	appState := applicationstate.NewState(
+		s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c),
+	)
+
+	platform := deployment.Platform{
+		Channel:      "22.04/stable",
+		OSType:       deployment.Ubuntu,
+		Architecture: architecture.ARM64,
+	}
+	channel := &deployment.Channel{
+		Track:  "track",
+		Risk:   "stable",
+		Branch: "branch",
+	}
+	ctx := c.Context()
+
+	appID, _, err := appState.CreateIAASApplication(ctx, name, application.AddIAASApplicationArg{
+		BaseAddApplicationArg: application.BaseAddApplicationArg{
+			Platform: platform,
+			Channel:  channel,
+			Charm: charm.Charm{
+				Metadata: charm.Metadata{
+					Name:        name,
+					Subordinate: subordinate,
+					Provides: map[string]charm.Relation{
+						"endpoint": {
+							Name:  "endpoint",
+							Role:  charm.RoleProvider,
+							Scope: charm.ScopeGlobal,
+						},
+						"misc": {
+							Name:  "misc",
+							Role:  charm.RoleProvider,
+							Scope: charm.ScopeGlobal,
+						},
+					},
+				},
+				Manifest:      s.minimalManifest(c),
+				ReferenceName: name,
+				Source:        charm.CharmHubSource,
+				Revision:      42,
+				Hash:          "hash",
+				Architecture:  architecture.ARM64,
+			},
+			CharmDownloadInfo: &charm.DownloadInfo{
+				Provenance:         charm.ProvenanceDownload,
+				CharmhubIdentifier: "ident",
+				DownloadURL:        "https://example.com",
+				DownloadSize:       42,
+			},
+			Status: appStatus,
+		},
+	}, units)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var unitUUIDs = make([]coreunit.UUID, 0, len(units))
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "UPDATE application SET life_id = ? WHERE name = ?", l, name)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, "UPDATE unit SET life_id = ? WHERE application_uuid = ?", l, appID)
+		if err != nil {
+			return err
+		}
+
+		rows, err := tx.QueryContext(
+			ctx,
+			"SELECT uuid FROM unit WHERE application_uuid = ?",
+			appID.String(),
+		)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			var unitUUID string
+			c.Assert(rows.Scan(&unitUUID), tc.ErrorIsNil)
+			unitUUIDs = append(unitUUIDs, coreunit.UUID(unitUUID))
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	return appID, unitUUIDs
+}
+
+func (s *baseSuite) createCAASApplication(
+	c *tc.C,
+	name string,
+	l life.Life,
+	subordinate bool,
+	appStatus *status.StatusInfo[status.WorkloadStatusType],
+	units ...application.AddCAASUnitArg,
+) (coreapplication.UUID, []coreunit.UUID) {
+	appState := applicationstate.NewState(
+		s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c),
+	)
+
+	platform := deployment.Platform{
+		Channel:      "22.04/stable",
+		OSType:       deployment.Ubuntu,
+		Architecture: architecture.ARM64,
+	}
+	channel := &deployment.Channel{
+		Track:  "track",
+		Risk:   "stable",
+		Branch: "branch",
+	}
+	ctx := c.Context()
+
+	appID, err := appState.CreateCAASApplication(ctx, name, application.AddCAASApplicationArg{
+		Scale: len(units),
+		BaseAddApplicationArg: application.BaseAddApplicationArg{
+			Platform: platform,
+			Channel:  channel,
+			Charm: charm.Charm{
+				Metadata: charm.Metadata{
+					Name:        name,
+					Subordinate: subordinate,
+					Provides: map[string]charm.Relation{
+						"endpoint": {
+							Name:  "endpoint",
+							Role:  charm.RoleProvider,
+							Scope: charm.ScopeGlobal,
+						},
+						"misc": {
+							Name:  "misc",
+							Role:  charm.RoleProvider,
+							Scope: charm.ScopeGlobal,
+						},
+					},
+				},
+				Manifest:      s.minimalManifest(c),
+				ReferenceName: name,
+				Source:        charm.CharmHubSource,
+				Revision:      42,
+				Hash:          "hash",
+				Architecture:  architecture.ARM64,
+			},
+			CharmDownloadInfo: &charm.DownloadInfo{
+				Provenance:         charm.ProvenanceDownload,
+				CharmhubIdentifier: "ident",
+				DownloadURL:        "https://example.com",
+				DownloadSize:       42,
+			},
+			Status: appStatus,
+		},
+	}, units)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var unitUUIDs = make([]coreunit.UUID, 0, len(units))
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "UPDATE application SET life_id = ? WHERE name = ?", l, name)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, "UPDATE unit SET life_id = ? WHERE application_uuid = ?", l, appID)
+		if err != nil {
+			return err
+		}
+
+		rows, err := tx.QueryContext(
+			ctx,
+			"SELECT uuid FROM unit WHERE application_uuid = ?",
+			appID.String(),
+		)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			var unitUUID string
+			c.Assert(rows.Scan(&unitUUID), tc.ErrorIsNil)
+			unitUUIDs = append(unitUUIDs, coreunit.UUID(unitUUID))
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	return appID, unitUUIDs
+}
+
+func (s *baseSuite) insertRemoteApplication(c *tc.C, appUUID, remoteAppUUID string) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO application_remote_offerer (uuid, life_id, application_uuid, offer_uuid, version, offerer_model_uuid, macaroon)
+VALUES (?, 0, ?, "1", "2", "3", "4")
+`, remoteAppUUID, appUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *baseSuite) setApplicationLXDProfile(c *tc.C, appUUID coreapplication.UUID, profile string) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE charm SET lxd_profile = ? WHERE uuid = (SELECT charm_uuid FROM application WHERE uuid = ?)
+`, profile, appUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *baseSuite) setApplicationSubordinate(c *tc.C, principal coreunit.UUID, subordinate coreunit.UUID) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO unit_principal (unit_uuid, principal_uuid)
+VALUES (?, ?);`, subordinate, principal)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *baseSuite) minimalManifest(c *tc.C) charm.Manifest {
+	return charm.Manifest{
+		Bases: []charm.Base{
+			{
+				Name: "ubuntu",
+				Channel: charm.Channel{
+					Risk: charm.RiskStable,
+				},
+				Architectures: []string{"amd64"},
+			},
+		},
+	}
+}

--- a/domain/status/state/types.go
+++ b/domain/status/state/types.go
@@ -21,6 +21,10 @@ type applicationUUID struct {
 	ID coreapplication.UUID `db:"uuid"`
 }
 
+type applicationName struct {
+	Name string `db:"name"`
+}
+
 type applicationUUIDAndName struct {
 	ID   coreapplication.UUID `db:"uuid"`
 	Name string               `db:"name"`
@@ -41,6 +45,10 @@ type unitName struct {
 type unitPresence struct {
 	UnitUUID coreunit.UUID `db:"unit_uuid"`
 	LastSeen time.Time     `db:"last_seen"`
+}
+
+type remoteApplicationUUID struct {
+	RemoteApplicationUUID string `db:"uuid"`
 }
 
 type statusInfo struct {
@@ -441,6 +449,14 @@ type machineSpaceAddress struct {
 	Scope       string         `db:"scope_name"`
 	SpaceUUID   sql.NullString `db:"space_uuid"`
 	SubnetCIDR  sql.NullString `db:"cidr"`
+}
+
+type remoteApplicationStatus struct {
+	RemoteApplicationUUID string     `db:"application_remote_offerer_uuid"`
+	StatusID              int        `db:"status_id"`
+	Message               string     `db:"message"`
+	Data                  []byte     `db:"data"`
+	UpdatedAt             *time.Time `db:"updated_at"`
 }
 
 func decodeHardwareCharacteristics(

--- a/internal/worker/remoterelationconsumer/applicationworker.go
+++ b/internal/worker/remoterelationconsumer/applicationworker.go
@@ -351,7 +351,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 		case changes := <-offerStatusChanges:
 			w.logger.Debugf(ctx, "offer status changed: %#v", changes)
 			for _, change := range changes {
-				if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationUUID, change.Status); err != nil {
+				if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationName, change.Status); err != nil {
 					return errors.Annotatef(err, "updating remote application %v status from remote model %v", w.applicationName, w.remoteModelUUID)
 				}
 
@@ -388,7 +388,7 @@ func (w *remoteApplicationWorker) setupRemoteModelClient(ctx context.Context) (R
 	// we cannot connect to the remote model. If this fails, log the error,
 	// as we don't want the worker to bounce on this error. Instead, we want
 	// to bounce on the original error.
-	if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationUUID, status.StatusInfo{
+	if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationName, status.StatusInfo{
 		Status:  status.Error,
 		Message: fmt.Sprintf("cannot connect to external controller: %v", err.Error()),
 	}); err != nil {
@@ -425,7 +425,7 @@ func (w *remoteApplicationWorker) checkOfferPermissionDenied(ctx context.Context
 		return
 	}
 
-	if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationUUID, status.StatusInfo{
+	if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationName, status.StatusInfo{
 		Status:  status.Error,
 		Message: err.Error(),
 	}); err != nil {
@@ -461,7 +461,7 @@ func (w *remoteApplicationWorker) remoteOfferRemoved(ctx context.Context) error 
 	// and not removing any additional workers? If the offer has been removed,
 	// surely we want to some how trigger a cleanup of the remote application
 	// and data associated with it?
-	if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationUUID, status.StatusInfo{
+	if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationName, status.StatusInfo{
 		Status:  status.Terminated,
 		Message: "offer has been removed",
 	}); err != nil {

--- a/internal/worker/remoterelationconsumer/applicationworker_test.go
+++ b/internal/worker/remoterelationconsumer/applicationworker_test.go
@@ -37,6 +37,7 @@ func TestApplicationWorker(t *stdtesting.T) {
 type applicationWorkerSuite struct {
 	baseSuite
 
+	applicationName string
 	applicationUUID application.UUID
 	remoteModelUUID string
 	offerUUID       string
@@ -46,6 +47,7 @@ type applicationWorkerSuite struct {
 func (s *applicationWorkerSuite) SetUpTest(c *tc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
+	s.applicationName = "foo"
 	s.applicationUUID = tc.Must(c, application.NewID)
 	s.remoteModelUUID = tc.Must(c, model.NewUUID).String()
 	s.offerUUID = tc.Must(c, uuid.NewUUID).String()
@@ -197,11 +199,11 @@ func (s *applicationWorkerSuite) TestStartNoRemoteClient(c *tc.C) {
 		Return(s.remoteModelRelationClient, errors.NotFound)
 
 	s.crossModelService.EXPECT().
-		SetRemoteApplicationOffererStatus(gomock.Any(), s.applicationUUID, status.StatusInfo{
+		SetRemoteApplicationOffererStatus(gomock.Any(), s.applicationName, status.StatusInfo{
 			Status:  status.Error,
 			Message: "cannot connect to external controller: not found",
 		}).
-		DoAndReturn(func(ctx context.Context, i application.UUID, si status.StatusInfo) error {
+		DoAndReturn(func(context.Context, string, status.StatusInfo) error {
 			defer close(done)
 			return nil
 		})
@@ -266,7 +268,7 @@ func (s *applicationWorkerSuite) newApplicationConfig(c *tc.C) RemoteApplication
 		CrossModelService:          s.crossModelService,
 		RemoteRelationClientGetter: s.remoteRelationClientGetter,
 		OfferUUID:                  s.offerUUID,
-		ApplicationName:            "foo",
+		ApplicationName:            s.applicationName,
 		ApplicationUUID:            s.applicationUUID,
 		LocalModelUUID:             tc.Must(c, model.NewUUID),
 		RemoteModelUUID:            s.remoteModelUUID,

--- a/internal/worker/remoterelationconsumer/manifold.go
+++ b/internal/worker/remoterelationconsumer/manifold.go
@@ -174,9 +174,11 @@ func GetCrossModelService(getter dependency.Getter, domainServicesName string) (
 	return struct {
 		RelationService
 		CrossModelRelationService
+		StatusService
 	}{
 		RelationService:           services.Relation(),
 		CrossModelRelationService: services.CrossModelRelation(),
+		StatusService:             services.Status(),
 	}, nil
 }
 

--- a/internal/worker/remoterelationconsumer/service_mock_test.go
+++ b/internal/worker/remoterelationconsumer/service_mock_test.go
@@ -816,17 +816,17 @@ func (c *MockCrossModelServiceSaveMacaroonForRelationCall) DoAndReturn(f func(co
 }
 
 // SetRemoteApplicationOffererStatus mocks base method.
-func (m *MockCrossModelService) SetRemoteApplicationOffererStatus(arg0 context.Context, arg1 application.UUID, arg2 status.StatusInfo) error {
+func (m *MockCrossModelService) SetRemoteApplicationOffererStatus(ctx context.Context, appName string, sts status.StatusInfo) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRemoteApplicationOffererStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetRemoteApplicationOffererStatus", ctx, appName, sts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetRemoteApplicationOffererStatus indicates an expected call of SetRemoteApplicationOffererStatus.
-func (mr *MockCrossModelServiceMockRecorder) SetRemoteApplicationOffererStatus(arg0, arg1, arg2 any) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
+func (mr *MockCrossModelServiceMockRecorder) SetRemoteApplicationOffererStatus(ctx, appName, sts any) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteApplicationOffererStatus", reflect.TypeOf((*MockCrossModelService)(nil).SetRemoteApplicationOffererStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteApplicationOffererStatus", reflect.TypeOf((*MockCrossModelService)(nil).SetRemoteApplicationOffererStatus), ctx, appName, sts)
 	return &MockCrossModelServiceSetRemoteApplicationOffererStatusCall{Call: call}
 }
 
@@ -842,13 +842,13 @@ func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, application.UUID, status.StatusInfo) error) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
+func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, string, status.StatusInfo) error) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, application.UUID, status.StatusInfo) error) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
+func (c *MockCrossModelServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, string, status.StatusInfo) error) *MockCrossModelServiceSetRemoteApplicationOffererStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1403,44 +1403,6 @@ func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) DoAndReturn(f
 	return c
 }
 
-// SetRemoteApplicationOffererStatus mocks base method.
-func (m *MockCrossModelRelationService) SetRemoteApplicationOffererStatus(arg0 context.Context, arg1 application.UUID, arg2 status.StatusInfo) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRemoteApplicationOffererStatus", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetRemoteApplicationOffererStatus indicates an expected call of SetRemoteApplicationOffererStatus.
-func (mr *MockCrossModelRelationServiceMockRecorder) SetRemoteApplicationOffererStatus(arg0, arg1, arg2 any) *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteApplicationOffererStatus", reflect.TypeOf((*MockCrossModelRelationService)(nil).SetRemoteApplicationOffererStatus), arg0, arg1, arg2)
-	return &MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall{Call: call}
-}
-
-// MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall wrap *gomock.Call
-type MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall) Return(arg0 error) *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, application.UUID, status.StatusInfo) error) *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, application.UUID, status.StatusInfo) error) *MockCrossModelRelationServiceSetRemoteApplicationOffererStatusCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // WatchRemoteApplicationOfferers mocks base method.
 func (m *MockCrossModelRelationService) WatchRemoteApplicationOfferers(ctx context.Context) (watcher0.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
@@ -1476,6 +1438,67 @@ func (c *MockCrossModelRelationServiceWatchRemoteApplicationOfferersCall) Do(f f
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelRelationServiceWatchRemoteApplicationOfferersCall) DoAndReturn(f func(context.Context) (watcher0.NotifyWatcher, error)) *MockCrossModelRelationServiceWatchRemoteApplicationOfferersCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// MockStatusService is a mock of StatusService interface.
+type MockStatusService struct {
+	ctrl     *gomock.Controller
+	recorder *MockStatusServiceMockRecorder
+}
+
+// MockStatusServiceMockRecorder is the mock recorder for MockStatusService.
+type MockStatusServiceMockRecorder struct {
+	mock *MockStatusService
+}
+
+// NewMockStatusService creates a new mock instance.
+func NewMockStatusService(ctrl *gomock.Controller) *MockStatusService {
+	mock := &MockStatusService{ctrl: ctrl}
+	mock.recorder = &MockStatusServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStatusService) EXPECT() *MockStatusServiceMockRecorder {
+	return m.recorder
+}
+
+// SetRemoteApplicationOffererStatus mocks base method.
+func (m *MockStatusService) SetRemoteApplicationOffererStatus(ctx context.Context, appName string, sts status.StatusInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRemoteApplicationOffererStatus", ctx, appName, sts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRemoteApplicationOffererStatus indicates an expected call of SetRemoteApplicationOffererStatus.
+func (mr *MockStatusServiceMockRecorder) SetRemoteApplicationOffererStatus(ctx, appName, sts any) *MockStatusServiceSetRemoteApplicationOffererStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteApplicationOffererStatus", reflect.TypeOf((*MockStatusService)(nil).SetRemoteApplicationOffererStatus), ctx, appName, sts)
+	return &MockStatusServiceSetRemoteApplicationOffererStatusCall{Call: call}
+}
+
+// MockStatusServiceSetRemoteApplicationOffererStatusCall wrap *gomock.Call
+type MockStatusServiceSetRemoteApplicationOffererStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStatusServiceSetRemoteApplicationOffererStatusCall) Return(arg0 error) *MockStatusServiceSetRemoteApplicationOffererStatusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStatusServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, string, status.StatusInfo) error) *MockStatusServiceSetRemoteApplicationOffererStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStatusServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, string, status.StatusInfo) error) *MockStatusServiceSetRemoteApplicationOffererStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/remoterelationconsumer/worker.go
+++ b/internal/worker/remoterelationconsumer/worker.go
@@ -80,6 +80,7 @@ type RemoteModelRelationsClient interface {
 type CrossModelService interface {
 	RelationService
 	CrossModelRelationService
+	StatusService
 }
 
 // RelationService is an interface that defines the methods for
@@ -112,10 +113,6 @@ type CrossModelRelationService interface {
 	// application consumers in the local model.
 	GetRemoteApplicationOfferers(context.Context) ([]crossmodelrelation.RemoteApplicationOfferer, error)
 
-	// SetRemoteApplicationOffererStatus sets the status of the specified remote
-	// application in the local model.
-	SetRemoteApplicationOffererStatus(context.Context, application.UUID, status.StatusInfo) error
-
 	// ConsumeRemoteRelationChange applies a relation change event received
 	// from a remote model to the local model.
 	ConsumeRemoteRelationChange(context.Context) error
@@ -135,6 +132,14 @@ type CrossModelRelationService interface {
 	// ImportRemoteApplicationToken imports a remote application token
 	// into the local model.
 	ImportRemoteApplicationToken(context.Context, names.Tag, string) error
+}
+
+// StatusService is an interface that defines the methods for
+// managing status directly on the local model database.
+type StatusService interface {
+	// SetRemoteApplicationOffererStatus sets the status of the specified remote
+	// application in the local model.
+	SetRemoteApplicationOffererStatus(ctx context.Context, appName string, sts status.StatusInfo) error
 }
 
 // Config defines the operation of a Worker.


### PR DESCRIPTION
Remote application offerers have a status. Add and implement a method to the status service to set this status

## QA steps

passing unit tests

The implementation isn't fully wired up yet, so passing unit tests is the best we can do