### PR TITLE
fix: filter ports by server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gliderlabs/ssh v0.3.8
-	github.com/go-goose/goose/v5 v5.1.3
+	github.com/go-goose/goose/v5 v5.1.4
 	github.com/go-logr/logr v1.4.3
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1
 	github.com/google/gnostic-models v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hH
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-goose/goose/v5 v5.1.3 h1:YjWBSaqC/aNKFCyQ3jhom+ONJbEbClsqvlp38HL1FsU=
-github.com/go-goose/goose/v5 v5.1.3/go.mod h1:BxICmnmP7QlxZhKP2BHkpWQS0tbb3LrsrLtd9TQyyms=
+github.com/go-goose/goose/v5 v5.1.4 h1:L2H+sTKp9BZehpHAs9EBz65L7hUZuxj8WqQn9lt/cNg=
+github.com/go-goose/goose/v5 v5.1.4/go.mod h1:wm2H9/ef6rvcIrvqv9WumylTUczf8m/f103RkZwYNdA=
 github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
 github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=

--- a/internal/provider/openstack/export_test.go
+++ b/internal/provider/openstack/export_test.go
@@ -176,3 +176,7 @@ func GetFirewaller(e environs.Environ) Firewaller {
 	env := e.(*Environ)
 	return env.firewaller
 }
+
+func SetNovaClient(env *Environ, client *nova.Client) {
+	env.novaUnlocked = client
+}

--- a/internal/provider/openstack/export_test.go
+++ b/internal/provider/openstack/export_test.go
@@ -149,6 +149,11 @@ func FindNetworks(e environs.Environ, internal bool) (set.Strings, error) {
 	return e.(*Environ).networking.FindNetworks(internal)
 }
 
+// TerminateInstanceNetworkPorts exposes environ helper function terminateInstanceNetworkPorts for testing.
+func TerminateInstanceNetworkPorts(e environs.Environ, id instance.Id) error {
+	return e.(*Environ).terminateInstanceNetworkPorts(id)
+}
+
 var PortsToRuleInfo = rulesToRuleInfo
 var SecGroupMatchesIngressRule = secGroupMatchesIngressRule
 
@@ -175,8 +180,4 @@ func GetModelGroupNames(e environs.Environ) ([]string, error) {
 func GetFirewaller(e environs.Environ) Firewaller {
 	env := e.(*Environ)
 	return env.firewaller
-}
-
-func SetNovaClient(env *Environ, client *nova.Client) {
-	env.novaUnlocked = client
 }

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -154,8 +154,6 @@ var shortAttempt = utils.AttemptStrategy{
 	Delay: 200 * time.Millisecond,
 }
 
-var novaListOSInterfacesForTest func(*nova.Client, string) ([]nova.OSInterface, error)
-
 const (
 	// provider version 1 introduces tags to security groups.
 	providerVersion1 = 1
@@ -2238,16 +2236,7 @@ func (e *Environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 
 func (e *Environ) terminateInstanceNetworkPorts(id instance.Id) error {
 	novaClient := e.nova()
-
-	var osInterfaces []nova.OSInterface
-	var err error
-
-	if novaListOSInterfacesForTest != nil {
-		osInterfaces, err = novaListOSInterfacesForTest(novaClient, string(id))
-	} else {
-		osInterfaces, err = novaClient.ListOSInterfaces(string(id))
-	}
-
+	osInterfaces, err := novaClient.ListOSInterfaces(string(id))
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/provider/openstack/provider_test.go
+++ b/internal/provider/openstack/provider_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-goose/goose/v5/identity"
 	"github.com/go-goose/goose/v5/neutron"
 	"github.com/go-goose/goose/v5/nova"
-	"github.com/juju/juju/core/instance"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
@@ -1189,61 +1188,4 @@ func envWithNetworking(net Networking, netCfg string) *Environ {
 		},
 		networking: net,
 	}
-}
-
-func (s *providerUnitTests) TestTerminateInstanceNetworkPorts(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	modelUUID := "test-model"
-	instanceID := instance.Id("test-instance-1")
-
-	testInterfaces := []nova.OSInterface{
-		{PortID: "server-1-port-1"},
-		{PortID: "server-1-port-2"},
-		{PortID: ""},
-	}
-
-	mockNeutron := NewMockNetworkingNeutron(ctrl)
-
-	// We need to ensure that the query uses the correct filter to only list ports on the test-instance-1.
-	filter := neutron.NewFilter()
-	filter.Set("device_id", "test-instance-1")
-	mockNeutron.EXPECT().ListPortsV2(filter).Return(
-		[]neutron.PortV2{
-			{
-				Id:   "server-1-port-1",
-				Name: fmt.Sprintf("juju-%s-server-1-port-1", modelUUID),
-			},
-			{
-				Id:   "server-1-port-2",
-				Name: "other-port-1",
-			},
-		}, nil)
-	mockNeutron.EXPECT().PortByIdV2("server-1-port-1").Return(neutron.PortV2{
-		Id:   "server-1-port-1",
-		Name: fmt.Sprintf("juju-%s-port-1", modelUUID),
-	}, nil)
-	mockNeutron.EXPECT().PortByIdV2("server-1-port-2").Return(neutron.PortV2{
-		Id:   "server-1-port-2",
-		Name: "other-port-1",
-	}, nil)
-	mockNeutron.EXPECT().DeletePortV2("server-1-port-1").Return(nil)
-
-	env := &Environ{
-		modelUUID:       modelUUID,
-		neutronUnlocked: mockNeutron,
-	}
-
-	s.PatchValue(&novaListOSInterfacesForTest, func(client *nova.Client, serverID string) ([]nova.OSInterface, error) {
-		c.Assert(serverID, gc.Equals, string(instanceID))
-		return testInterfaces, nil
-	})
-	err := env.terminateInstanceNetworkPorts(instanceID)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-type testNovaClient struct {
-	nova.Client
-	osInterfaces []nova.OSInterface
 }

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -52,13 +52,15 @@ join() {
 
 run_govulncheck() {
 	ignore=(
-		# false positive vulnerability in github.com/canonical/lxd. This is resolved in lxd-5.21.2.
+		# false positive vulnerability in github.com/canonical/lxd. This is resolved upstream.
 		# Anyway, it does not affect as we only use client-side lxc code, but the vulnerability is
 		# server-side.
 		# https://pkg.go.dev/vuln/GO-2024-3312
 		# https://pkg.go.dev/vuln/GO-2024-3313
+		# https://pkg.go.dev/vuln/GO-2025-4121
 		"GO-2024-3312"
 		"GO-2024-3313"
+		"GO-2025-4121"
 		# false positive vulnerabilities in github.com/canonical/lxd. These are resolved in lxd-5.21.4.
 		# https://pkg.go.dev/vuln/GO-2025-3999
 		# https://pkg.go.dev/vuln/GO-2025-4003


### PR DESCRIPTION
When terminating instance ports, the ports need to be filtered by the device_id (the server ID). Using only the port name is too broad and will result in the deletion of ports that are unrelated to the termination.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

A reproducer would do something like the following:

```console
$ juju bootstrap --config network=net1 --config network=net2
$ juju add-model ports
$ juju add-space beta net1/cidr
$ juju add-space gamma net2/cidr
$ juju deploy --num-units 2 --bind beta ubuntu server-beta
$ juju deploy --num-units 2 --bind gamma ubuntu server-gamma
$ openstack port list --column Name --column "MAC Address" --format value | grep juju-
juju-7fdb0ac2-9a6b-4743-80f2-f644ee7a9a5a-y9degn8b fa:16:3e:52:2e:06
juju-7fdb0ac2-9a6b-4743-80f2-f644ee7a9a5a-9l06zsug fa:16:3e:35:2b:14
```

Juju will create 2 named ports attached to the machines in space beta
(server-beta application). The ports in space alpha do not have a name.

When the server-beta deployment is scaled down, juju will remove all
ports:

```console
$ juju remove-unit server-beta/1
$ openstack server list --name test-2 --column Name --column Networks --format value
juju-9aead6-test-2 {}
```

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #20763.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
