### PR TITLE
fix(application-config): application config query to avoid sharing config between apps

### DIFF
--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -3168,7 +3168,10 @@ SELECT
 FROM application AS a
 JOIN charm_config AS cc ON a.charm_uuid = cc.charm_uuid
 JOIN charm_config_type AS cct ON cc.type_id = cct.id
-LEFT JOIN application_config AS ac ON cc.key = ac.key AND cc.type_id = ac.type_id
+LEFT JOIN application_config AS ac 
+	ON  ac.application_uuid = a.uuid
+	AND ac.type_id  = cc.type_id 
+	AND ac.key = cc.key 
 WHERE a.uuid = $entityUUID.uuid;
 `, applicationConfig{}, appID)
 	if err != nil {


### PR DESCRIPTION
# Description

Before the query was problematic because since the JOIN was done based of the charm's key if two applications had the same charm uuid, they were sharing the application config. In this PR I've fixed it, and created some utils function to make it easier to add applications with the same charm's reference.

# QA
Either removing the patch and running the test i've created and let it fail.

Or:

`juju deploy juju-qa-dummy-source test`
`juju config test token=abc`

`juju show-status-log test/0` -> you should see "token is abc"

`juju deploy juju-qa-dummy-source test2`

Before the patch:
`juju show-status-log test2/0` -> "token is abc" because the config was shared between the two apps
After the patch:
You should not see it.
