### PR TITLE
fix(remove-application): remove application fails with FOREIGN KEY reference

### DIFF
--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -489,19 +489,8 @@ WHERE  uuid = $entityUUID.uuid;`, unitUUIDRec)
 			return errors.Errorf("deleting unit references for unit %q: %w", unitUUID, err)
 		}
 
-		// Get the charm UUID before we delete the unit.
-		charmUUID, err := st.getCharmUUIDForUnit(ctx, tx, unitUUID)
-		if err != nil {
-			return errors.Errorf("getting charm UUID for application: %w", err)
-		}
-
 		if err := tx.Query(ctx, deleteUnitStmt, unitUUIDRec).Run(); err != nil {
 			return errors.Errorf("deleting unit for unit %q: %w", unitUUID, err)
-		}
-
-		// See if it's possible to delete the charm any more.
-		if err := st.deleteCharmIfUnusedByUUID(ctx, tx, charmUUID); err != nil {
-			return errors.Errorf("deleting charm if unused: %w", err)
 		}
 
 		return nil
@@ -665,25 +654,4 @@ func (st *State) deleteForeignKeyUnitReferences(ctx context.Context, tx *sqlair.
 		}
 	}
 	return nil
-}
-
-func (st *State) getCharmUUIDForUnit(ctx context.Context, tx *sqlair.TX, uUUID string) (string, error) {
-	appID := entityUUID{UUID: uUUID}
-
-	stmt, err := st.Prepare(`
-SELECT charm_uuid AS &entityUUID.uuid
-FROM   unit
-WHERE  uuid = $entityUUID.uuid`, appID)
-	if err != nil {
-		return "", errors.Errorf("preparing charm UUID query: %w", err)
-	}
-
-	var result entityUUID
-	if err := tx.Query(ctx, stmt, appID).Get(&result); errors.Is(err, sqlair.ErrNoRows) {
-		// No charm associated with the unit, so we can skip this.
-		return "", nil
-	} else if err != nil {
-		return "", errors.Errorf("running charm UUID query: %w", err)
-	}
-	return result.UUID, nil
 }


### PR DESCRIPTION
# Description

Remove applications doesn't work because it tries to delete charm if they are unused, charms reference resources, but resources are deleted in application removal. So, trying to remove resources during unit's deletion is a circular dependency.
I'm not sure how to test it, resources are already deleted during removal of application. It seems this is unnecessary.

# QA

The easiest way is to run:
`./main.sh deploy run_deploy_revision_refresh` -> because it creates an application with resources.

Before:
`deleting charm if unused: deleting reference to charm in DELETE FROM charm_resource WHERE charm_uuid = $entityUUID.uuid: FOREIGN KEY constraint failed` and the tests hangs.
After:
no error and the test returns successful.