### PR TITLE
feat: save relation macaroon

### DIFF
--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -490,6 +490,44 @@ func (c *MockModelStateNamespaceRemoteApplicationOfferersCall) DoAndReturn(f fun
 	return c
 }
 
+// SaveMacaroonForRelation mocks base method.
+func (m *MockModelState) SaveMacaroonForRelation(arg0 context.Context, arg1 string, arg2 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveMacaroonForRelation", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveMacaroonForRelation indicates an expected call of SaveMacaroonForRelation.
+func (mr *MockModelStateMockRecorder) SaveMacaroonForRelation(arg0, arg1, arg2 any) *MockModelStateSaveMacaroonForRelationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveMacaroonForRelation", reflect.TypeOf((*MockModelState)(nil).SaveMacaroonForRelation), arg0, arg1, arg2)
+	return &MockModelStateSaveMacaroonForRelationCall{Call: call}
+}
+
+// MockModelStateSaveMacaroonForRelationCall wrap *gomock.Call
+type MockModelStateSaveMacaroonForRelationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateSaveMacaroonForRelationCall) Return(arg0 error) *MockModelStateSaveMacaroonForRelationCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateSaveMacaroonForRelationCall) Do(f func(context.Context, string, []byte) error) *MockModelStateSaveMacaroonForRelationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateSaveMacaroonForRelationCall) DoAndReturn(f func(context.Context, string, []byte) error) *MockModelStateSaveMacaroonForRelationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpdateOffer mocks base method.
 func (m *MockModelState) UpdateOffer(arg0 context.Context, arg1 string, arg2 []string) error {
 	m.ctrl.T.Helper()

--- a/domain/crossmodelrelation/service/remoteapplication_test.go
+++ b/domain/crossmodelrelation/service/remoteapplication_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/core/errors"
+	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/crossmodelrelation"
@@ -229,4 +230,39 @@ func (s *remoteApplicationServiceSuite) TestGetRemoteApplicationOfferersError(c 
 
 	_, err := service.GetRemoteApplicationOfferers(c.Context())
 	c.Assert(err, tc.ErrorMatches, "front fell off")
+}
+
+func (s *remoteApplicationServiceSuite) TestSaveMacaroonForRelation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relationUUID := tc.Must(c, corerelation.NewUUID)
+	mac := newMacaroon(c, "test")
+	encodedMac := tc.Must(c, mac.MarshalJSON)
+
+	s.modelState.EXPECT().SaveMacaroonForRelation(gomock.Any(), relationUUID.String(), encodedMac).Return(nil)
+
+	service := s.service(c)
+
+	err := service.SaveMacaroonForRelation(c.Context(), relationUUID, mac)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteApplicationServiceSuite) TestSaveMacaroonForRelationInvalidRelationUUID(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	service := s.service(c)
+
+	err := service.SaveMacaroonForRelation(c.Context(), "foo", nil)
+	c.Assert(err, tc.ErrorIs, errors.NotValid)
+}
+
+func (s *remoteApplicationServiceSuite) TestSaveMacaroonForRelationInvalidMacaroon(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relationUUID := tc.Must(c, corerelation.NewUUID)
+
+	service := s.service(c)
+
+	err := service.SaveMacaroonForRelation(c.Context(), relationUUID, nil)
+	c.Assert(err, tc.ErrorIs, errors.NotValid)
 }

--- a/domain/crossmodelrelation/state/model/macaroon.go
+++ b/domain/crossmodelrelation/state/model/macaroon.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+
+	"github.com/juju/juju/internal/errors"
+)
+
+// SaveMacaroonForRelation saves the given macaroon for the specified relation.
+func (st *State) SaveMacaroonForRelation(ctx context.Context, relationUUID string, mac []byte) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	type relationMacaroon struct {
+		RelationUUID string `db:"relation_uuid"`
+		Macaroon     []byte `db:"macaroon"`
+	}
+
+	arg := relationMacaroon{
+		RelationUUID: relationUUID,
+		Macaroon:     mac,
+	}
+
+	stmt, err := st.Prepare(`
+INSERT INTO application_remote_offerer_relation_macaroon (relation_uuid, macaroon)
+VALUES ($relationMacaroon.relation_uuid, $relationMacaroon.macaroon)
+ON CONFLICT (relation_uuid) DO UPDATE SET macaroon = EXCLUDED.macaroon
+`, arg)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, arg).Run()
+		return errors.Capture(err)
+	}); err != nil {
+		return errors.Capture(err)
+	}
+
+	return nil
+}

--- a/domain/crossmodelrelation/state/model/macaroon_test.go
+++ b/domain/crossmodelrelation/state/model/macaroon_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/juju/tc"
+)
+
+type macaroonSuite struct {
+	baseSuite
+}
+
+func TestMacaroonSuite(t *testing.T) {
+	tc.Run(t, &macaroonSuite{})
+}
+
+func (s *macaroonSuite) TestSaveMacaroonForRelation(c *tc.C) {
+	relationUUID := s.addRelation(c)
+
+	s.DumpTable(c, "relation")
+
+	err := s.state.SaveMacaroonForRelation(c.Context(), relationUUID.String(), []byte("macaroon"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	var bytes []byte
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+SELECT macaroon FROM application_remote_offerer_relation_macaroon WHERE relation_uuid = ?`, relationUUID,
+		).Scan(&bytes)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(bytes, tc.DeepEquals, []byte("macaroon"))
+}
+
+func (s *macaroonSuite) TestSaveMacaroonForRelationCalledMultipleTimes(c *tc.C) {
+	relationUUID := s.addRelation(c)
+
+	s.DumpTable(c, "relation")
+
+	err := s.state.SaveMacaroonForRelation(c.Context(), relationUUID.String(), []byte("macaroon"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.SaveMacaroonForRelation(c.Context(), relationUUID.String(), []byte("meshuggah"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	var bytes []byte
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+SELECT macaroon FROM application_remote_offerer_relation_macaroon WHERE relation_uuid = ?`, relationUUID,
+		).Scan(&bytes)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(bytes, tc.DeepEquals, []byte("meshuggah"))
+}

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -54,6 +54,16 @@ CREATE TABLE application_remote_offerer_status (
     REFERENCES workload_status_value (id)
 );
 
+-- application_remote_offerer_relation_macaroon represents the macaroon
+-- used to authenticate against the offering model for a given relation.
+CREATE TABLE application_remote_offerer_relation_macaroon (
+    relation_uuid TEXT NOT NULL PRIMARY KEY,
+    macaroon TEXT NOT NULL,
+    CONSTRAINT fk_relation_uuid
+    FOREIGN KEY (relation_uuid)
+    REFERENCES relation (uuid)
+);
+
 -- application_remote_consumer represents a remote consumer application
 -- inside of the offering model.
 CREATE TABLE application_remote_consumer (

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -309,6 +309,7 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"application_remote_consumer",
 		"application_remote_offerer",
 		"application_remote_offerer_status",
+		"application_remote_offerer_relation_macaroon",
 		"application_remote_relation",
 		"offer_connection",
 


### PR DESCRIPTION
Saves the relation macaroon, which is what we can use for the firewaller. This is a bit heavy handed, but we don't want to change the firewaller code right now.

----

This pull request adds support for saving and managing macaroons (authentication tokens) associated with remote application relations in the cross-model relation service. It introduces new database schema, service methods, and tests to handle storing and updating these macaroons securely and efficiently.

**Database and Persistence Layer:**

* Added a new table `application_remote_offerer_relation_macaroon` to store macaroons for each relation in the database schema.
* Implemented the `SaveMacaroonForRelation` method in the `State` struct to insert or update macaroons for a given relation in the database, ensuring idempotency on repeated saves.

**Service Layer:**

* Extended the `ModelRemoteApplicationState` interface and its mock to include the `SaveMacaroonForRelation` method, enabling the service to persist macaroons via the state layer. [[1]](diffhunk://#diff-48511545fb22a79305588229b8054da940e75c42f3cf5e6c85b2998f7c729d2fR45-R48) [[2]](diffhunk://#diff-056f968e72421870f5e2624f062154e813e3e8931b24478eec6ef488eb87adb4R493-R530)
* Implemented the `Service.SaveMacaroonForRelation` method, including input validation, error handling, and marshaling of macaroons before saving.

**Testing:**

* Added comprehensive unit tests for the new service method, covering successful saves, invalid UUIDs, and nil macaroons.
* Introduced a new test suite for the state layer, verifying correct saving and updating of macaroons in the database.
* Added utility methods in the test base suite to simplify relation creation for testing purposes.

**Test Utilities and Imports:**

* Updated test files to import the new `corerelation` package and maintain proper test state. [[1]](diffhunk://#diff-e2b0a1f837cf029fe36a3c38a068d39c338b39b5bc2d75d27423c7adde52d877R13) [[2]](diffhunk://#diff-b5bb3171eaa72ed07c53e049a8ef1ab49c83f9ae318dc704b39ad575cbab9fd9R19) [[3]](diffhunk://#diff-b5bb3171eaa72ed07c53e049a8ef1ab49c83f9ae318dc704b39ad575cbab9fd9R30-R42)

These changes collectively provide robust support for associating and persisting macaroons with remote application relations, ensuring secure authentication in cross-model scenarios.

## QA steps

This isn't wired up yet, as we need a response from register for this to work.

## Links

**Jira card:** [JUJU-8470](https://warthogs.atlassian.net/browse/JUJU-8470)


[JUJU-8470]: https://warthogs.atlassian.net/browse/JUJU-8470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ