### PR TITLE
feat: start to wire up relation worker

### DIFF
--- a/internal/worker/remoterelationconsumer/applicationworker.go
+++ b/internal/worker/remoterelationconsumer/applicationworker.go
@@ -349,10 +349,11 @@ func (w *remoteApplicationWorker) watchRemoteOfferStatus(ctx context.Context) (w
 		BakeryVersion: bakery.LatestVersion,
 	})
 	if isNotFound(err) {
-		w.checkOfferPermissionDenied(ctx, err, "", "")
 		return nil, w.remoteOfferRemoved(ctx)
 	} else if err != nil {
-		w.checkOfferPermissionDenied(ctx, err, "", "")
+		if statusErr := w.setApplicationOffererStatusMacaroonError(ctx, err); statusErr != nil {
+			w.logger.Errorf(ctx, "failed updating remote application %v status from remote model %v: %v", w.applicationName, w.offererModelUUID, statusErr)
+		}
 		return nil, errors.Annotate(err, "watching status for offer")
 	}
 
@@ -363,39 +364,18 @@ func (w *remoteApplicationWorker) watchRemoteOfferStatus(ctx context.Context) (w
 	return offerStatusWatcher, nil
 }
 
-func (w *remoteApplicationWorker) checkOfferPermissionDenied(ctx context.Context, err error, appToken, localRelationToken string) {
-	// If consume permission has been revoked for the offer, set the
-	// status of the local remote application entity.
+func (w *remoteApplicationWorker) setApplicationOffererStatusMacaroonError(ctx context.Context, err error) error {
 	if params.ErrCode(err) != params.CodeDischargeRequired {
-		return
+		return nil
 	}
 
 	if err := w.crossModelService.SetRemoteApplicationOffererStatus(ctx, w.applicationName, status.StatusInfo{
 		Status:  status.Error,
 		Message: err.Error(),
 	}); err != nil {
-		w.logger.Errorf(ctx,
-			"updating remote application %v status from remote model %v: %v",
-			w.applicationName, w.offererModelUUID, err)
+		return err
 	}
-
-	// If we don't have the tokens, we can't do anything more.
-	if localRelationToken == "" {
-		return
-	}
-
-	w.logger.Debugf(ctx, "discharge required error: app token: %v rel token: %v", appToken, localRelationToken)
-
-	event := params.RemoteRelationChangeEvent{
-		RelationToken:           localRelationToken,
-		ApplicationOrOfferToken: appToken,
-		Suspended:               ptr(true),
-		SuspendedReason:         "offer permission revoked",
-	}
-	_ = event
-	if err := w.crossModelService.ConsumeRemoteRelationChange(ctx); err != nil {
-		w.logger.Errorf(ctx, "updating relation status: %v", err)
-	}
+	return nil
 }
 
 func (w *remoteApplicationWorker) remoteOfferRemoved(ctx context.Context) error {
@@ -469,27 +449,57 @@ func (w *remoteApplicationWorker) handleRelationConsumption(
 
 	// We have not seen the relation before, or the relation was suspended, make
 	// sure it is registered (ack'd) on the offering side.
-	remoteRelation, err := w.registerRemoteRelation(
+	result, err := w.registerConsumerRelation(
 		ctx,
 		details.UUID, w.offerUUID, w.consumeVersion,
 		synthEndpoint, otherEndpointName,
 	)
 	if err != nil {
-		w.checkOfferPermissionDenied(ctx, err, "", "")
+		if statusErr := w.setApplicationOffererStatusMacaroonError(ctx, err); statusErr != nil {
+			w.logger.Errorf(ctx, "failed updating remote application %v status from remote model %v: %v", w.applicationName, w.offererModelUUID, statusErr)
+		}
 		return errors.Annotatef(err, "registering application %q and relation %q", w.applicationName, details.UUID)
 	}
-	w.logger.Debugf(ctx, "consumer relation registered for %q: %v", details.UUID, remoteRelation)
 
-	_ = remoteRelation
+	w.logger.Debugf(ctx, "consumer relation registered for %q: %v", details.UUID, result)
+
+	// Start the remote relation worker to watch for offerer relation changes.
+	// The aim is to ensure that we can track the suspended status of the
+	// relation so we can correctly react to that.
+	if err := w.createOffererRelationWorker(ctx, details.UUID, result.macaroon); err != nil {
+		return errors.Annotatef(err, "creating offerer relation worker for %q", details.UUID)
+	}
 
 	return nil
 }
 
-func (w *remoteApplicationWorker) registerRemoteRelation(
+// Create a new worker to watch for changes to the relation in the offering
+// model.
+func (w *remoteApplicationWorker) createOffererRelationWorker(ctx context.Context, relationUUID corerelation.UUID, mac *macaroon.Macaroon) error {
+	if err := w.runner.StartWorker(ctx, relationUUID.String(), func(ctx context.Context) (worker.Worker, error) {
+		return w.newRemoteRelationsWorker(remoterelations.Config{
+			Client:   w.remoteModelClient,
+			Macaroon: mac,
+			Changes:  w.remoteRelationChanges,
+			Clock:    w.clock,
+			Logger:   w.logger,
+		})
+
+	}); err != nil && !errors.Is(err, errors.AlreadyExists) {
+		return errors.Annotatef(err, "starting offerer relation worker for %q", relationUUID)
+	}
+
+	return nil
+}
+
+// registerConsumerRelation registers the relation in the offering model,
+// and returns the offering application UUID and macaroon for the relation.
+// The relation has been created in the consumer model.
+func (w *remoteApplicationWorker) registerConsumerRelation(
 	ctx context.Context,
 	relationUUID corerelation.UUID, offerUUID string, consumeVersion int,
 	applicationEndpointIdent relation.Endpoint, remoteEndpointName string,
-) (remoteRelationResult, error) {
+) (consumerRelationResult, error) {
 	w.logger.Debugf(ctx, "register consumer relation %q to synthetic offerer application %q", relationUUID, w.applicationName)
 
 	// This data goes to the remote model so we map local info
@@ -510,24 +520,24 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 		Macaroons:         macaroon.Slice{w.offerMacaroon},
 		BakeryVersion:     bakery.LatestVersion,
 	}
-	remoteRelations, err := w.remoteModelClient.RegisterRemoteRelations(ctx, arg)
+	offererRelations, err := w.remoteModelClient.RegisterRemoteRelations(ctx, arg)
 	if err != nil {
-		return remoteRelationResult{}, errors.Trace(err)
-	} else if len(remoteRelations) == 0 {
-		return remoteRelationResult{}, errors.New("no result from registering remote relation")
-	} else if len(remoteRelations) > 1 {
-		w.logger.Infof(ctx, "expected one result from registering remote relation, got %d", len(remoteRelations))
+		return consumerRelationResult{}, errors.Trace(err)
+	} else if len(offererRelations) == 0 {
+		return consumerRelationResult{}, errors.New("no result from registering remote relation")
+	} else if len(offererRelations) > 1 {
+		w.logger.Infof(ctx, "expected one result from registering remote relation, got %d", len(offererRelations))
 	}
 
 	// We've guarded against this from being out of bounds, so it's safe to do
 	// a raw access.
-	remoteRelation := remoteRelations[0]
-	if err := remoteRelation.Error; err != nil {
-		return remoteRelationResult{}, errors.Annotatef(err, "registering relation %q", relationUUID)
+	offererRelation := offererRelations[0]
+	if err := offererRelation.Error; err != nil {
+		return consumerRelationResult{}, errors.Annotatef(err, "registering relation %q", relationUUID)
 	}
 
 	// Import the application UUID from the offering model.
-	registerResult := *remoteRelation.Result
+	registerResult := *offererRelation.Result
 
 	// The register result token is always a UUID. This is the case for 3.x
 	// and onwards. This should ensure that we're backwards compatible with
@@ -536,22 +546,22 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 	// See: https://github.com/juju/juju/blob/43e381811d9e330ee2d095c1e0562300bd78b68a/state/remoteentities.go#L110-L115
 	offeringAppUUID, err := application.ParseID(registerResult.Token)
 	if err != nil {
-		return remoteRelationResult{}, errors.Annotatef(err, "parsing offering application token %q", registerResult.Token)
+		return consumerRelationResult{}, errors.Annotatef(err, "parsing offering application token %q", registerResult.Token)
 	}
 
 	// We have a new macaroon attenuated to the relation.
 	// Save for the firewaller.
 	if err := w.crossModelService.SaveMacaroonForRelation(ctx, relationUUID, registerResult.Macaroon); err != nil {
-		return remoteRelationResult{}, errors.Annotatef(err, "saving macaroon for %q", relationUUID)
+		return consumerRelationResult{}, errors.Annotatef(err, "saving macaroon for %q", relationUUID)
 	}
 
-	return remoteRelationResult{
+	return consumerRelationResult{
 		offeringApplicationUUID: offeringAppUUID,
 		macaroon:                registerResult.Macaroon,
 	}, nil
 }
 
-type remoteRelationResult struct {
+type consumerRelationResult struct {
 	offeringApplicationUUID application.UUID
 	macaroon                *macaroon.Macaroon
 }
@@ -564,8 +574,4 @@ func isNotFound(err error) bool {
 		return false
 	}
 	return errors.Is(err, errors.NotFound) || params.IsCodeNotFound(err)
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/internal/worker/remoterelationconsumer/applicationworker_test.go
+++ b/internal/worker/remoterelationconsumer/applicationworker_test.go
@@ -632,7 +632,7 @@ func (s *applicationWorkerSuite) TestHandleRelationChangePeerRelation(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, errors.NotValid)
 }
 
-func (s *applicationWorkerSuite) TestRegisterRemoteRelation(c *tc.C) {
+func (s *applicationWorkerSuite) TestRegisterConsumerRelation(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	token := tc.Must(c, application.NewID)
@@ -679,7 +679,7 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelation(c *tc.C) {
 		c.Fatalf("timed out waiting for worker to be started")
 	}
 
-	result, err := w.registerRemoteRelation(c.Context(),
+	result, err := w.registerConsumerRelation(c.Context(),
 		relationUUID,
 		s.offerUUID,
 		1,
@@ -694,13 +694,13 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelation(c *tc.C) {
 		"blog",
 	)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(result, tc.DeepEquals, remoteRelationResult{
+	c.Check(result, tc.DeepEquals, consumerRelationResult{
 		offeringApplicationUUID: token,
 		macaroon:                mac,
 	})
 }
 
-func (s *applicationWorkerSuite) TestRegisterRemoteRelationFailedRequest(c *tc.C) {
+func (s *applicationWorkerSuite) TestRegisterConsumerRelationFailedRequest(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relationUUID := tc.Must(c, relation.NewUUID)
@@ -736,7 +736,7 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelationFailedRequest(c *tc.C
 		c.Fatalf("timed out waiting for worker to be started")
 	}
 
-	_, err := w.registerRemoteRelation(c.Context(),
+	_, err := w.registerConsumerRelation(c.Context(),
 		relationUUID,
 		s.offerUUID,
 		1,
@@ -753,7 +753,7 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelationFailedRequest(c *tc.C
 	c.Assert(err, tc.ErrorMatches, `.*front fell off.*`)
 }
 
-func (s *applicationWorkerSuite) TestRegisterRemoteRelationInvalidResultLength(c *tc.C) {
+func (s *applicationWorkerSuite) TestRegisterConsumerRelationInvalidResultLength(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relationUUID := tc.Must(c, relation.NewUUID)
@@ -789,7 +789,7 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelationInvalidResultLength(c
 		c.Fatalf("timed out waiting for worker to be started")
 	}
 
-	_, err := w.registerRemoteRelation(c.Context(),
+	_, err := w.registerConsumerRelation(c.Context(),
 		relationUUID,
 		s.offerUUID,
 		1,
@@ -806,7 +806,7 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelationInvalidResultLength(c
 	c.Assert(err, tc.ErrorMatches, `.*no result from registering remote relation.*`)
 }
 
-func (s *applicationWorkerSuite) TestRegisterRemoteRelationFailedRequestError(c *tc.C) {
+func (s *applicationWorkerSuite) TestRegisterConsumerRelationFailedRequestError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relationUUID := tc.Must(c, relation.NewUUID)
@@ -847,7 +847,7 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelationFailedRequestError(c 
 		c.Fatalf("timed out waiting for worker to be started")
 	}
 
-	_, err := w.registerRemoteRelation(c.Context(),
+	_, err := w.registerConsumerRelation(c.Context(),
 		relationUUID,
 		s.offerUUID,
 		1,
@@ -864,7 +864,7 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelationFailedRequestError(c 
 	c.Assert(err, tc.ErrorMatches, `.*registering relation.*`)
 }
 
-func (s *applicationWorkerSuite) TestRegisterRemoteRelationFailedToSaveMacaroon(c *tc.C) {
+func (s *applicationWorkerSuite) TestRegisterConsumerRelationFailedToSaveMacaroon(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	token := tc.Must(c, application.NewID)
@@ -911,7 +911,7 @@ func (s *applicationWorkerSuite) TestRegisterRemoteRelationFailedToSaveMacaroon(
 		c.Fatalf("timed out waiting for worker to be started")
 	}
 
-	_, err := w.registerRemoteRelation(c.Context(),
+	_, err := w.registerConsumerRelation(c.Context(),
 		relationUUID,
 		s.offerUUID,
 		1,


### PR DESCRIPTION
The relation worker monitors the relation suspended status of the offerer model. This will require some thought as to which relation UUID is actually being watched.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
