### PR TITLE
fix: use 1-21 as per the original bug

### DIFF
--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -3440,7 +3440,7 @@ func (s *SecretsSuite) TestDeleteRevisionsMultiple(c *gc.C) {
 	_, err = s.store.CreateSecret(uri, cp)
 	c.Assert(err, jc.ErrorIsNil)
 
-	for i := 0; i < 15; i++ {
+	for i := 0; i < 21; i++ {
 		_, err = s.store.UpdateSecret(uri, state.UpdateSecretParams{
 			LeaderToken: &fakeToken{},
 			Data:        map[string]string{"foo": fmt.Sprintf("bar%d", i)},
@@ -3452,6 +3452,8 @@ func (s *SecretsSuite) TestDeleteRevisionsMultiple(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(external, gc.HasLen, 0)
 
-	_, _, err = s.store.GetSecretValue(uri, 11)
+	// If you use an unterminated regex prefix search, you end up removing all of the 10,11,12 etc.
+	// We want to make sure that we have only removed the first one.
+	_, _, err = s.store.GetSecretValue(uri, 18)
 	c.Check(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
Tom had requested this change, and I thought I had pushed it when I asked to merge my PR, but I discovered that I had not pushed the tweak.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Just a unittest tweak.

## Documentation changes

None

## Links

None