### PR TITLE
feat: add application consumer method on the service layer 

### DIFF
--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -221,6 +221,44 @@ func (m *MockModelState) EXPECT() *MockModelStateMockRecorder {
 	return m.recorder
 }
 
+// AddRemoteApplicationConsumer mocks base method.
+func (m *MockModelState) AddRemoteApplicationConsumer(arg0 context.Context, arg1 string, arg2 crossmodelrelation.AddRemoteApplicationConsumerArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddRemoteApplicationConsumer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddRemoteApplicationConsumer indicates an expected call of AddRemoteApplicationConsumer.
+func (mr *MockModelStateMockRecorder) AddRemoteApplicationConsumer(arg0, arg1, arg2 any) *MockModelStateAddRemoteApplicationConsumerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteApplicationConsumer", reflect.TypeOf((*MockModelState)(nil).AddRemoteApplicationConsumer), arg0, arg1, arg2)
+	return &MockModelStateAddRemoteApplicationConsumerCall{Call: call}
+}
+
+// MockModelStateAddRemoteApplicationConsumerCall wrap *gomock.Call
+type MockModelStateAddRemoteApplicationConsumerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateAddRemoteApplicationConsumerCall) Return(arg0 error) *MockModelStateAddRemoteApplicationConsumerCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateAddRemoteApplicationConsumerCall) Do(f func(context.Context, string, crossmodelrelation.AddRemoteApplicationConsumerArgs) error) *MockModelStateAddRemoteApplicationConsumerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateAddRemoteApplicationConsumerCall) DoAndReturn(f func(context.Context, string, crossmodelrelation.AddRemoteApplicationConsumerArgs) error) *MockModelStateAddRemoteApplicationConsumerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // AddRemoteApplicationOfferer mocks base method.
 func (m *MockModelState) AddRemoteApplicationOfferer(arg0 context.Context, arg1 string, arg2 crossmodelrelation.AddRemoteApplicationOffererArgs) error {
 	m.ctrl.T.Helper()

--- a/domain/crossmodelrelation/service/types.go
+++ b/domain/crossmodelrelation/service/types.go
@@ -35,10 +35,10 @@ type AddRemoteApplicationOffererArgs struct {
 // AddRemoteApplicationConsumerArgs contains the parameters required to add a
 // new remote application consumer.
 type AddRemoteApplicationConsumerArgs struct {
-	// RemoteApplicationName is the application named as as it exists in the
+	// RemoteApplicationUUID is the application UUID as as it exists in the
 	// remote (consuming) model. It contains the value from the RPC param
 	// ApplicationToken.
-	RemoteApplicationName string
+	RemoteApplicationUUID string
 
 	// OfferUUID is the UUID of the offer that the remote application is
 	// consuming.

--- a/domain/crossmodelrelation/service/types.go
+++ b/domain/crossmodelrelation/service/types.go
@@ -31,3 +31,23 @@ type AddRemoteApplicationOffererArgs struct {
 	// authenticate with the offerer model.
 	Macaroon *macaroon.Macaroon
 }
+
+// AddRemoteApplicationConsumerArgs contains the parameters required to add a
+// new remote application consumer.
+type AddRemoteApplicationConsumerArgs struct {
+	// RemoteApplicationName is the application named as as it exists in the
+	// remote (consuming) model. It contains the value from the RPC param
+	// ApplicationToken.
+	RemoteApplicationName string
+
+	// OfferUUID is the UUID of the offer that the remote application is
+	// consuming.
+	OfferUUID string
+
+	// RelationUUID is the UUID of the relation created to connect the remote
+	// application to a local application, on the consuming model.
+	RelationUUID string
+
+	// Endpoints is the collection of endpoint relations offered.
+	Endpoints []charm.Relation
+}


### PR DESCRIPTION
This pull request introduces support for adding a remote application consumer to the cross-model relation service. It adds a new method to handle the creation of synthetic applications representing remote relations on the consuming model, ensures proper validation, and provides comprehensive test coverage for the new functionality. Additionally, input validation logic is refactored for better code reuse.

**New functionality:**

* Added the `AddRemoteApplicationConsumer` method to the `Service` and `ModelRemoteApplicationState` interfaces, enabling the creation of synthetic applications that represent remote relations on the consuming model. This includes input validation, synthetic charm construction, and error handling. [[1]](diffhunk://#diff-48511545fb22a79305588229b8054da940e75c42f3cf5e6c85b2998f7c729d2fR39-R46) [[2]](diffhunk://#diff-48511545fb22a79305588229b8054da940e75c42f3cf5e6c85b2998f7c729d2fR126-R184)

* Introduced the `AddRemoteApplicationConsumerArgs` struct to encapsulate the parameters required for adding a remote application consumer.

**Testing:**

* Added comprehensive unit tests for the `AddRemoteApplicationConsumer` method, covering valid cases, input validation errors, endpoint scope validation, and error propagation from state.

* Updated the mock implementation of `ModelRemoteApplicationState` to support the new `AddRemoteApplicationConsumer` method for testing purposes.

**Refactoring and validation improvements:**

* Moved endpoint validation logic into the shared `constructSyntheticCharm` function, ensuring both offerer and consumer creation validate endpoints consistently. [[1]](diffhunk://#diff-48511545fb22a79305588229b8054da940e75c42f3cf5e6c85b2998f7c729d2fL69-L80) [[2]](diffhunk://#diff-48511545fb22a79305588229b8054da940e75c42f3cf5e6c85b2998f7c729d2fR260-R272)

* Minor import update to include `fmt` for string formatting in the new functionality.
## QA steps

N/A, nothing wired. Unit tests should pass though.

## Links


**Jira card:** https://warthogs.atlassian.net/browse/JUJU-8472
