### PR TITLE
feat: relation unit settings archive

### DIFF
--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -986,7 +986,7 @@ func (c *MockStateIsPeerRelationCall) DoAndReturn(f func(context.Context, string
 }
 
 // LeaveScope mocks base method.
-func (m *MockState) LeaveScope(arg0 context.Context, arg1 relation.UnitUUID) error {
+func (m *MockState) LeaveScope(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LeaveScope", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1012,13 +1012,13 @@ func (c *MockStateLeaveScopeCall) Return(arg0 error) *MockStateLeaveScopeCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateLeaveScopeCall) Do(f func(context.Context, relation.UnitUUID) error) *MockStateLeaveScopeCall {
+func (c *MockStateLeaveScopeCall) Do(f func(context.Context, string) error) *MockStateLeaveScopeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateLeaveScopeCall) DoAndReturn(f func(context.Context, relation.UnitUUID) error) *MockStateLeaveScopeCall {
+func (c *MockStateLeaveScopeCall) DoAndReturn(f func(context.Context, string) error) *MockStateLeaveScopeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -132,7 +132,7 @@ type State interface {
 	IsPeerRelation(ctx context.Context, relationUUID string) (bool, error)
 
 	// LeaveScope updates the given relation to indicate it is not in scope.
-	LeaveScope(ctx context.Context, relationUnitUUID corerelation.UnitUUID) error
+	LeaveScope(ctx context.Context, relationUnitUUID string) error
 
 	// SetRelationApplicationAndUnitSettings records settings for a unit and
 	// an application in a relation.
@@ -735,7 +735,7 @@ func (s *Service) LeaveScope(ctx context.Context, relationUnitUUID corerelation.
 		return errors.Errorf(
 			"%w:%w", relationerrors.RelationUUIDNotValid, err)
 	}
-	return s.st.LeaveScope(ctx, relationUnitUUID)
+	return s.st.LeaveScope(ctx, relationUnitUUID.String())
 }
 
 // RelationUnitInScopeByID returns a boolean to indicate whether the given

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -656,7 +656,7 @@ func (s *relationServiceSuite) TestLeaveScope(c *tc.C) {
 	// Arrange.
 	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
 
-	s.state.EXPECT().LeaveScope(gomock.Any(), relationUnitUUID).Return(nil)
+	s.state.EXPECT().LeaveScope(gomock.Any(), relationUnitUUID.String()).Return(nil)
 
 	// Act.
 	err := s.service.LeaveScope(c.Context(), relationUnitUUID)

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -169,10 +169,6 @@ type unitSettingsHash struct {
 
 type keys []string
 
-type relationUnitUUID struct {
-	RelationUnitUUID corerelation.UnitUUID `db:"uuid"`
-}
-
 type relationEndpointUUID struct {
 	UUID string `db:"uuid"`
 }

--- a/domain/removal/state/model/relation.go
+++ b/domain/removal/state/model/relation.go
@@ -287,6 +287,12 @@ WHERE  relation_endpoint_uuid IN (
 		return errors.Errorf("preparing relation endpoint deletion: %w", err)
 	}
 
+	archiveStmt, err := st.Prepare(
+		"DELETE FROM relation_unit_setting_archive WHERE relation_uuid = $entityUUID.uuid ", relationUUID)
+	if err != nil {
+		return errors.Errorf("preparing relation unit settings archive deletion: %w", err)
+	}
+
 	statusStmt, err := st.Prepare("DELETE FROM relation_status WHERE relation_uuid = $entityUUID.uuid ", relationUUID)
 	if err != nil {
 		return errors.Errorf("preparing relation status deletion: %w", err)
@@ -314,6 +320,11 @@ WHERE  relation_endpoint_uuid IN (
 				err = removalerrors.UnitsStillInScope
 			}
 			return errors.Errorf("running relation endpoint deletion: %w", err)
+		}
+
+		err = tx.Query(ctx, archiveStmt, relationUUID).Run()
+		if err != nil {
+			return errors.Errorf("running relation unit settings archive deletion: %w", err)
 		}
 
 		err = tx.Query(ctx, statusStmt, relationUUID).Run()

--- a/domain/removal/state/model/relation_test.go
+++ b/domain/removal/state/model/relation_test.go
@@ -303,5 +303,10 @@ VALUES (?, ?, ?, ?, ?, ?, ?)`,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
+	_, err = s.DB().Exec("INSERT INTO relation_unit_setting_archive (relation_uuid, unit_name, key, value) VALUES (?, ?, ?, ?)",
+		rel, "unit-name-does-not-matter-no-fk", "key", "value",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
 	return rel, unit
 }

--- a/domain/schema/model/sql/0024-relation.sql
+++ b/domain/schema/model/sql/0024-relation.sql
@@ -137,6 +137,27 @@ CREATE TABLE relation_unit_settings_hash (
     REFERENCES relation_unit (uuid)
 );
 
+-- relation_unit_setting_archive is used to fullfil a contract we have, whereby
+-- the settings for a relation unit are accessible for the lifetime of a
+-- relation, regardless of whether the unit has departed the relation, or even
+-- exists any longer.
+-- Upon leaving scope, we copy the unit's relation settings into this table.
+-- Accessing relation settings via the relation-get hook tool will cause Juju to
+-- check this table if the requested unit is not in scope.
+-- We need no triggers for this table, because we copy the settings before doing
+-- the relation_unit_settings deletion, and once copied they are static until
+-- the relation itself is deleted.
+CREATE TABLE relation_unit_setting_archive (
+    relation_uuid TEXT NOT NULL,
+    unit_name TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    value TEXT,
+    CONSTRAINT fk_relation_uuid
+    FOREIGN KEY (relation_uuid)
+    REFERENCES relation (uuid),
+    PRIMARY KEY (relation_uuid, unit_name, "key")
+);
+
 -- The relation_application_setting holds key value pair settings
 -- for a relation at the application level. Keys must be unique
 -- per application.

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -288,6 +288,7 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"relation_status",
 		"relation_unit_setting",
 		"relation_unit_settings_hash",
+		"relation_unit_setting_archive",
 		"relation_unit",
 		"relation",
 


### PR DESCRIPTION
We have two issues with relations:
1. We do not currently leave scope upon unit removal.
2. Our data model is such that unit relation settings are only available while a unit is in the relation scope. This directly violates our documentation, which states that they should be accessible for the life-time of the relation.

This introduces some preparatory work for exposing unit relation settings for units not in scope, including if they have been deleted altogether.

The approach, rather than watering down the strong RI that have, is to introduce an archive table for settings of units that have departed the relation. 

When a unit departs scope, its settings are copied into the table with a link to the relation and the unit _name_. When the relation is deleted, so are all the archived settings.

A future patch will ensure that If an attempt is made to access unit settings (such as via the `relation-get` hook tool), and a `relation-unit` record is not found, we fall back to looking at the archive table.

## QA steps

When this is wired up, we will be able to test properly, but there are other issues with unit removal that need fixing first.

At this time, unit tests verify correctness.