### PR TITLE
feat: fall back to archive for unit relation settings

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -496,11 +496,12 @@ type RelationService interface {
 		appUUIDs []coreapplication.UUID,
 	) (relation.RelationUnitsChange, error)
 
-	// GetRelationUnitSettings returns the unit settings for the
-	// given relation unit identifier.
+	// GetRelationUnitSettings returns the relation settings for the input unit
+	// in the input relation.
 	GetRelationUnitSettings(
 		ctx context.Context,
-		relationUnitUUID corerelation.UnitUUID,
+		relationUUID corerelation.UUID,
+		unitName coreunit.Name,
 	) (map[string]string, error)
 
 	// GetRelationUUIDByKey returns a relation UUID for the given relation Key.

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -1880,18 +1880,18 @@ func (c *MockRelationServiceGetRelationUnitChangesCall) DoAndReturn(f func(conte
 }
 
 // GetRelationUnitSettings mocks base method.
-func (m *MockRelationService) GetRelationUnitSettings(arg0 context.Context, arg1 relation.UnitUUID) (map[string]string, error) {
+func (m *MockRelationService) GetRelationUnitSettings(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelationUnitSettings", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetRelationUnitSettings", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRelationUnitSettings indicates an expected call of GetRelationUnitSettings.
-func (mr *MockRelationServiceMockRecorder) GetRelationUnitSettings(arg0, arg1 any) *MockRelationServiceGetRelationUnitSettingsCall {
+func (mr *MockRelationServiceMockRecorder) GetRelationUnitSettings(arg0, arg1, arg2 any) *MockRelationServiceGetRelationUnitSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitSettings", reflect.TypeOf((*MockRelationService)(nil).GetRelationUnitSettings), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitSettings", reflect.TypeOf((*MockRelationService)(nil).GetRelationUnitSettings), arg0, arg1, arg2)
 	return &MockRelationServiceGetRelationUnitSettingsCall{Call: call}
 }
 
@@ -1907,13 +1907,13 @@ func (c *MockRelationServiceGetRelationUnitSettingsCall) Return(arg0 map[string]
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationUnitSettingsCall) Do(f func(context.Context, relation.UnitUUID) (map[string]string, error)) *MockRelationServiceGetRelationUnitSettingsCall {
+func (c *MockRelationServiceGetRelationUnitSettingsCall) Do(f func(context.Context, relation.UUID, unit.Name) (map[string]string, error)) *MockRelationServiceGetRelationUnitSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationUnitSettingsCall) DoAndReturn(f func(context.Context, relation.UnitUUID) (map[string]string, error)) *MockRelationServiceGetRelationUnitSettingsCall {
+func (c *MockRelationServiceGetRelationUnitSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (map[string]string, error)) *MockRelationServiceGetRelationUnitSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1829,12 +1829,8 @@ func (u *UniterAPI) readLocalUnitSettings(
 	if err != nil {
 		return nil, internalerrors.Capture(err)
 	}
-	relUnitUUID, err := u.relationService.GetRelationUnit(ctx, relUUID, unitName)
-	if err != nil {
-		return nil, internalerrors.Capture(err)
-	}
 
-	return u.relationService.GetRelationUnitSettings(ctx, relUnitUUID)
+	return u.relationService.GetRelationUnitSettings(ctx, relUUID, unitName)
 }
 
 // ReadLocalApplicationSettings returns the local application settings for a
@@ -1985,11 +1981,7 @@ func (u *UniterAPI) readOneRemoteSettings(ctx context.Context, canAccess common.
 		if err != nil {
 			return nil, internalerrors.Capture(err)
 		}
-		relUnitUUID, err := u.relationService.GetRelationUnit(ctx, relUUID, remoteUnitName)
-		if err != nil {
-			return nil, internalerrors.Capture(err)
-		}
-		settings, err = u.relationService.GetRelationUnitSettings(ctx, relUnitUUID)
+		settings, err = u.relationService.GetRelationUnitSettings(ctx, relUUID, remoteUnitName)
 		if err != nil {
 			return nil, internalerrors.Capture(err)
 		}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1762,12 +1762,11 @@ func (s *uniterRelationSuite) TestReadSettingsUnit(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	relTag := names.NewRelationTag("mysql:database wordpress:mysql")
 	relUUID := relationtesting.GenRelationUUID(c)
-	relUnitUUID := relationtesting.GenRelationUnitUUID(c)
 	settings := map[string]string{"wanda": "firebaugh"}
 
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
-	s.expectGetRelationUnit(relUUID, relUnitUUID, s.wordpressUnitTag.Id())
-	s.expectGetRelationUnitSettings(relUnitUUID, settings)
+	s.relationService.EXPECT().GetRelationUnitSettings(
+		gomock.Any(), relUUID, coreunit.Name(s.wordpressUnitTag.Id())).Return(settings, nil)
 
 	// act
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
@@ -1921,12 +1920,11 @@ func (s *uniterRelationSuite) TestReadRemoteSettingsForUnit(c *tc.C) {
 	relTag := names.NewRelationTag("mysql:database wordpress:mysql")
 	remoteUnitTag := names.NewUnitTag("mysql/2")
 	relUUID := relationtesting.GenRelationUUID(c)
-	relUnitUUID := relationtesting.GenRelationUnitUUID(c)
 	settings := map[string]string{"wanda": "firebaugh"}
 
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID, nil)
-	s.expectGetRelationUnit(relUUID, relUnitUUID, remoteUnitTag.Id())
-	s.expectGetRelationUnitSettings(relUnitUUID, settings)
+	s.relationService.EXPECT().GetRelationUnitSettings(
+		gomock.Any(), relUUID, coreunit.Name(remoteUnitTag.Id())).Return(settings, nil)
 
 	// act
 	args := params.RelationUnitPairs{RelationUnitPairs: []params.RelationUnitPair{
@@ -2531,14 +2529,6 @@ func (s *uniterRelationSuite) expectGetRelationApplicationSettingsWithLeader(uni
 
 func (s *uniterRelationSuite) expectGetRelationApplicationSettings(uuid corerelation.UUID, id coreapplication.UUID, settings map[string]string) {
 	s.relationService.EXPECT().GetRelationApplicationSettings(gomock.Any(), uuid, id).Return(settings, nil)
-}
-
-func (s *uniterRelationSuite) expectGetRelationUnit(relUUID corerelation.UUID, uuid corerelation.UnitUUID, unitTagID string) {
-	s.relationService.EXPECT().GetRelationUnit(gomock.Any(), relUUID, coreunit.Name(unitTagID)).Return(uuid, nil)
-}
-
-func (s *uniterRelationSuite) expectGetRelationUnitSettings(uuid corerelation.UnitUUID, settings map[string]string) {
-	s.relationService.EXPECT().GetRelationUnitSettings(gomock.Any(), uuid).Return(settings, nil)
 }
 
 func (s *uniterRelationSuite) expectGetUnitUUID(name string, unitUUID coreunit.UUID, err error) {

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -787,6 +787,45 @@ func (c *MockStateGetRelationUnitSettingsCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
+// GetRelationUnitSettingsArchive mocks base method.
+func (m *MockState) GetRelationUnitSettingsArchive(arg0 context.Context, arg1, arg2 string) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRelationUnitSettingsArchive", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelationUnitSettingsArchive indicates an expected call of GetRelationUnitSettingsArchive.
+func (mr *MockStateMockRecorder) GetRelationUnitSettingsArchive(arg0, arg1, arg2 any) *MockStateGetRelationUnitSettingsArchiveCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitSettingsArchive", reflect.TypeOf((*MockState)(nil).GetRelationUnitSettingsArchive), arg0, arg1, arg2)
+	return &MockStateGetRelationUnitSettingsArchiveCall{Call: call}
+}
+
+// MockStateGetRelationUnitSettingsArchiveCall wrap *gomock.Call
+type MockStateGetRelationUnitSettingsArchiveCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetRelationUnitSettingsArchiveCall) Return(arg0 map[string]string, arg1 error) *MockStateGetRelationUnitSettingsArchiveCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetRelationUnitSettingsArchiveCall) Do(f func(context.Context, string, string) (map[string]string, error)) *MockStateGetRelationUnitSettingsArchiveCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetRelationUnitSettingsArchiveCall) DoAndReturn(f func(context.Context, string, string) (map[string]string, error)) *MockStateGetRelationUnitSettingsArchiveCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationsStatusForUnit mocks base method.
 func (m *MockState) GetRelationsStatusForUnit(arg0 context.Context, arg1 unit.UUID) ([]relation0.RelationUnitStatusResult, error) {
 	m.ctrl.T.Helper()

--- a/domain/relation/service/package_test.go
+++ b/domain/relation/service/package_test.go
@@ -3,6 +3,34 @@
 
 package service
 
+import (
+	"github.com/juju/tc"
+	gomock "go.uber.org/mock/gomock"
+
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
+)
+
 //go:generate go run go.uber.org/mock/mockgen -typed -package service -destination leader_mock_test.go github.com/juju/juju/core/leadership Ensurer
 //go:generate go run go.uber.org/mock/mockgen -typed -package service -destination package_mock_test.go github.com/juju/juju/domain/relation/service State,MigrationState,WatcherFactory
 //go:generate go run go.uber.org/mock/mockgen -typed -package service -destination relation_mock_test.go github.com/juju/juju/domain/relation SubordinateCreator
+
+type baseServiceSuite struct {
+	testhelpers.IsolationSuite
+
+	state              *MockState
+	subordinateCreator *MockSubordinateCreator
+
+	service *Service
+}
+
+func (s *baseServiceSuite) setupMocks(c *tc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+
+	s.state = NewMockState(ctrl)
+	s.subordinateCreator = NewMockSubordinateCreator(ctrl)
+
+	s.service = NewService(s.state, loggertesting.WrapCheckLog(c))
+
+	return ctrl
+}

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -678,14 +678,18 @@ func (s *relationServiceSuite) TestGetRelationUnitSettings(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange:
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+	unitName := coreunittesting.GenNewName(c, "app/0")
 	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
 	expectedSettings := map[string]string{
 		"key": "value",
 	}
+
+	s.state.EXPECT().GetRelationUnit(gomock.Any(), relationUUID, unitName).Return(relationUnitUUID, nil)
 	s.state.EXPECT().GetRelationUnitSettings(gomock.Any(), relationUnitUUID).Return(expectedSettings, nil)
 
 	// Act:
-	settings, err := s.service.GetRelationUnitSettings(c.Context(), relationUnitUUID)
+	settings, err := s.service.GetRelationUnitSettings(c.Context(), relationUUID, unitName)
 
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
@@ -695,11 +699,37 @@ func (s *relationServiceSuite) TestGetRelationUnitSettings(c *tc.C) {
 func (s *relationServiceSuite) TestGetRelationUnitSettingsUnitIDNotValid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	_, err := s.service.GetRelationUnitSettings(c.Context(), corerelationtesting.GenRelationUUID(c), "bad-uuid")
+	c.Check(err, tc.ErrorMatches, "invalid unit name.*")
+}
+
+func (s *relationServiceSuite) TestGetRelationUnitSettingsRelationIDNotValid(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	_, err := s.service.GetRelationUnitSettings(c.Context(), "nah", coreunittesting.GenNewName(c, "app/0"))
+	c.Check(err, tc.ErrorIs, relationerrors.RelationUUIDNotValid)
+}
+
+func (s *relationServiceSuite) TestGetRelationUnitSettingsFallback(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	expectedSettings := map[string]string{
+		"key": "value",
+	}
+
+	exp := s.state.EXPECT()
+	exp.GetRelationUnit(gomock.Any(), relationUUID, unitName).Return("", relationerrors.RelationUnitNotFound)
+	exp.GetRelationUnitSettingsArchive(gomock.Any(), relationUUID.String(), unitName.String()).Return(expectedSettings, nil)
+
 	// Act:
-	_, err := s.service.GetRelationUnitSettings(c.Context(), "bad-uuid")
+	settings, err := s.service.GetRelationUnitSettings(c.Context(), relationUUID, unitName)
 
 	// Assert:
-	c.Assert(err, tc.ErrorIs, relationerrors.RelationUUIDNotValid)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(settings, tc.DeepEquals, expectedSettings)
 }
 
 func (s *relationServiceSuite) TestGetRelationApplicationSettings(c *tc.C) {

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -24,16 +24,10 @@ import (
 	internalcharm "github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
-	"github.com/juju/juju/internal/testhelpers"
 )
 
 type relationServiceSuite struct {
-	testhelpers.IsolationSuite
-
-	state              *MockState
-	subordinateCreator *MockSubordinateCreator
-
-	service *Service
+	baseServiceSuite
 }
 
 func TestRelationServiceSuite(t *testing.T) {
@@ -1023,19 +1017,8 @@ func (s *relationServiceSuite) TestGetRelationUUIDForRemovalIDIsPeerFail(c *tc.C
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
-func (s *relationServiceSuite) setupMocks(c *tc.C) *gomock.Controller {
-	ctrl := gomock.NewController(c)
-
-	s.state = NewMockState(ctrl)
-	s.subordinateCreator = NewMockSubordinateCreator(ctrl)
-
-	s.service = NewService(s.state, loggertesting.WrapCheckLog(c))
-
-	return ctrl
-}
-
 type relationLeadershipServiceSuite struct {
-	relationServiceSuite
+	baseServiceSuite
 
 	leadershipService *LeadershipService
 	leaderEnsurer     *MockEnsurer
@@ -1228,7 +1211,7 @@ func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettin
 }
 
 func (s *relationLeadershipServiceSuite) setupMocks(c *tc.C) *gomock.Controller {
-	ctrl := s.relationServiceSuite.setupMocks(c)
+	ctrl := s.baseServiceSuite.setupMocks(c)
 
 	s.leaderEnsurer = NewMockEnsurer(ctrl)
 	s.leadershipService = NewLeadershipService(s.state, s.leaderEnsurer, loggertesting.WrapCheckLog(c))


### PR DESCRIPTION
We will now fall back to checking the archive when requesting unit relation settings.

The method signature is changed to accept a relation UUID and unit name instead of a relation-unit UUID. We check for the existence if settings under the relation-unit, and if none is found, we check the archive. 

## QA steps

This test is for regression. A patch to follow will include the `LeaveScope` logic as part of unit removal whereupon we can QA properly.

I tested on MAAS, but the same test could run on LXD without the need to deploy into space-constrained containers.
- Bootstrap and add a model
- `juju add-machine`.
- I had to pack the dummy-[source|sink] charms, as deploying from a directory is not supported.
- `juju deploy ./testcharms/charms/dummy-source/dummy-source_amd64.charm --to lxd:0 --bind primary --config token=INITIAL`.
- `juju deploy ./testcharms/charms/dummy-sink/dummy-sink_amd64.charm --to lxd:0 --bind primary`.
- `juju relate dummy-source dummy-sink`.
- Everything works as expected:
```
Model  Controller  Cloud/Region  Version      Timestamp
work   officemaas  officemaas    4.0-beta7.1  12:07:59+02:00

App           Version  Status  Scale  Charm         Channel  Rev  Exposed  Message
dummy-sink             active      1  dummy-sink               0  no       Token is INITIAL
dummy-source           active      1  dummy-source             0  no       Token is INITIAL

Unit             Workload  Agent  Machine  Public address  Ports  Message
dummy-sink/0*    active    idle   0/lxd/1  192.168.30.83          Token is INITIAL
dummy-source/0*  active    idle   0/lxd/0  192.168.30.84          Token is INITIAL

Machine  State    Address        Inst id              Base          AZ       Message
0        started  192.168.30.82  nuc-2                ubuntu@24.04  default  Deployed
0/lxd/0  started  192.168.30.84  juju-68ddda-0-lxd-0  ubuntu@24.04  default  Container started
0/lxd/1  started  192.168.30.83  juju-68ddda-0-lxd-1  ubuntu@24.04  default  Container started
```
