### PR TITLE
fix: check for correct default base in test

### DIFF
--- a/tests/suites/deploy/deploy_default_base.sh
+++ b/tests/suites/deploy/deploy_default_base.sh
@@ -13,7 +13,7 @@ run_deploy_default_series() {
 	ubuntu_base_name=$(juju status --format=json | jq ".applications.ubuntu.base.name")
 	ubuntu_base_ch=$(juju status --format=json | jq ".applications.ubuntu.base.channel")
 	echo "$ubuntu_base_name" | check "ubuntu"
-	echo "$ubuntu_base_ch" | check "22.04"
+	echo "$ubuntu_base_ch" | check "24.04"
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
This PR fixes the "deploy_default_base" test that was failing with,
```
    | "Expected": 22.04
    | "Received": "24.04"
```

We simply need to correct a typo and expect the correct string.

When this file was previously updated we can see where the typo was made https://github.com/juju/juju/commit/76ddbec398727f7ea5f72770fd7b4ea639c53cd7#diff-5c9e696065686eea47d02fa225c39932e9793e2f331e0db5b825b4affea72e01R9-R16 (see file `tests/suites/deploy/deploy_default_base.sh` if you don't get sent there automatically).
