### PR TITLE
fix: calling EnsureDead does not remove the unit

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -153,15 +153,6 @@ func (u *UniterAPI) EnsureDead(ctx context.Context, args params.Entities) (param
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-
-		_, err = u.removalService.RemoveUnit(ctx, unitUUID, false, false, time.Duration(0))
-		if errors.Is(err, applicationerrors.UnitNotFound) {
-			result.Results[i].Error = apiservererrors.ParamsErrorf(params.CodeNotFound, "unit %q not found", unitName)
-			continue
-		} else if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
 	}
 	return result, nil
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -108,7 +108,6 @@ func (s *uniterSuite) TestEnsureDead(c *tc.C) {
 	unitUUID := unittesting.GenUnitUUID(c)
 	s.applicationService.EXPECT().GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
 	s.removalService.EXPECT().MarkUnitAsDead(gomock.Any(), unitUUID).Return(nil)
-	s.removalService.EXPECT().RemoveUnit(gomock.Any(), unitUUID, false, false, time.Duration(0)).Return("", nil)
 
 	// Act
 	res, err := s.uniter.EnsureDead(c.Context(), params.Entities{


### PR DESCRIPTION
The unit agent never schedules the destruction of its own unit. Rather:
- It gets notified that it is dying.
- Does the work to prepare for death.
- Marks itself dead via `EnsureDead`.
- Uninstalls itself.

The process of transitioning to dying, and scheduling the job that deletes the unit upon its death is a different responsibility, handled by client/deployer/provisioner workflows.

This removes the call to `RemoveUnit` in `EnsureDead`.

## QA steps

Deploy a couple of `tiny-bash` units, remove one, ensure it disappears.