### PR TITLE
feat: simplify report channel

### DIFF
--- a/internal/worker/remoterelationconsumer/consumerunitrelations/worker_test.go
+++ b/internal/worker/remoterelationconsumer/consumerunitrelations/worker_test.go
@@ -298,12 +298,12 @@ func (s *localUnitRelationsWorker) TestReport(c *tc.C) {
 	}
 
 	c.Assert(w.Report(), tc.DeepEquals, map[string]any{
-		"application-uuid": s.consumerApplicationUUID.String(),
-		"relation-uuid":    s.consumerRelationUUID.String(),
-		"changed-units":    []relation.UnitChange(nil),
-		"available-units":  []int(nil),
-		"settings":         map[string]any(nil),
-		"departed-units":   []int(nil),
+		"consumer-application-uuid": s.consumerApplicationUUID.String(),
+		"consumer-relation-uuid":    s.consumerRelationUUID.String(),
+		"changed-units":             []relation.UnitChange(nil),
+		"available-units":           []int(nil),
+		"settings":                  map[string]any(nil),
+		"departed-units":            []int(nil),
 	})
 
 	select {
@@ -319,8 +319,8 @@ func (s *localUnitRelationsWorker) TestReport(c *tc.C) {
 	}
 
 	c.Assert(w.Report(), tc.DeepEquals, map[string]any{
-		"application-uuid": s.consumerApplicationUUID.String(),
-		"relation-uuid":    s.consumerRelationUUID.String(),
+		"consumer-application-uuid": s.consumerApplicationUUID.String(),
+		"consumer-relation-uuid":    s.consumerRelationUUID.String(),
 		"changed-units": []relation.UnitChange{{
 			UnitID: 0,
 			Settings: map[string]any{

--- a/internal/worker/remoterelationconsumer/offererunitrelations/worker_test.go
+++ b/internal/worker/remoterelationconsumer/offererunitrelations/worker_test.go
@@ -247,15 +247,14 @@ func (s *offererUnitRelationsWorker) TestReport(c *tc.C) {
 	}
 
 	c.Assert(w.Report(), tc.DeepEquals, map[string]any{
-		"application-uuid": s.offererApplicationUUID.String(),
-		"relation-uuid":    s.consumerRelationUUID.String(),
-		"changed-units":    []map[string]any(nil),
-		"settings":         map[string]any(nil),
-		"unit-count":       0,
-		"departed-units":   []int(nil),
-		"life":             life.Value(""),
-		"suspended":        false,
-		"suspended-reason": "",
+		"offerer-application-uuid": s.offererApplicationUUID.String(),
+		"consumer-relation-uuid":   s.consumerRelationUUID.String(),
+		"changed-units":            []map[string]any(nil),
+		"settings":                 map[string]any(nil),
+		"departed-units":           []int(nil),
+		"life":                     life.Value(""),
+		"suspended":                false,
+		"suspended-reason":         "",
 	})
 
 	select {
@@ -283,8 +282,8 @@ func (s *offererUnitRelationsWorker) TestReport(c *tc.C) {
 	}
 
 	c.Assert(w.Report(), tc.DeepEquals, map[string]any{
-		"application-uuid": s.offererApplicationUUID.String(),
-		"relation-uuid":    s.consumerRelationUUID.String(),
+		"offerer-application-uuid": s.offererApplicationUUID.String(),
+		"consumer-relation-uuid":   s.consumerRelationUUID.String(),
 		"changed-units": []map[string]any{{
 			"unit-id": 0,
 			"settings": map[string]any{
@@ -294,7 +293,6 @@ func (s *offererUnitRelationsWorker) TestReport(c *tc.C) {
 		"settings": map[string]any{
 			"foo": "bar",
 		},
-		"unit-count": 3,
 		"departed-units": []int{
 			4,
 		},


### PR DESCRIPTION
The report channel didn't need to be so complicated, as we can just wait for the consumer to read the channel without the need to pass a channel to pass back.

We can expect the sub workers to disapear without notice, so check for a timeout and if the catacomb is dying. Thus we can return back quickly without waiting for the timeout - which might seem like a lifetime.


## QA steps

Tests should pass.
