### PR TITLE
feat: add watcher for remote application consumers

### DIFF
--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -492,6 +492,45 @@ func (c *MockModelStateGetOfferUUIDCall) DoAndReturn(f func(context.Context, str
 	return c
 }
 
+// GetRemoteApplicationConsumers mocks base method.
+func (m *MockModelState) GetRemoteApplicationConsumers(arg0 context.Context) ([]crossmodelrelation.RemoteApplicationConsumer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRemoteApplicationConsumers", arg0)
+	ret0, _ := ret[0].([]crossmodelrelation.RemoteApplicationConsumer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteApplicationConsumers indicates an expected call of GetRemoteApplicationConsumers.
+func (mr *MockModelStateMockRecorder) GetRemoteApplicationConsumers(arg0 any) *MockModelStateGetRemoteApplicationConsumersCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteApplicationConsumers", reflect.TypeOf((*MockModelState)(nil).GetRemoteApplicationConsumers), arg0)
+	return &MockModelStateGetRemoteApplicationConsumersCall{Call: call}
+}
+
+// MockModelStateGetRemoteApplicationConsumersCall wrap *gomock.Call
+type MockModelStateGetRemoteApplicationConsumersCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetRemoteApplicationConsumersCall) Return(arg0 []crossmodelrelation.RemoteApplicationConsumer, arg1 error) *MockModelStateGetRemoteApplicationConsumersCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetRemoteApplicationConsumersCall) Do(f func(context.Context) ([]crossmodelrelation.RemoteApplicationConsumer, error)) *MockModelStateGetRemoteApplicationConsumersCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetRemoteApplicationConsumersCall) DoAndReturn(f func(context.Context) ([]crossmodelrelation.RemoteApplicationConsumer, error)) *MockModelStateGetRemoteApplicationConsumersCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRemoteApplicationOfferers mocks base method.
 func (m *MockModelState) GetRemoteApplicationOfferers(arg0 context.Context) ([]crossmodelrelation.RemoteApplicationOfferer, error) {
 	m.ctrl.T.Helper()
@@ -527,6 +566,44 @@ func (c *MockModelStateGetRemoteApplicationOfferersCall) Do(f func(context.Conte
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelStateGetRemoteApplicationOfferersCall) DoAndReturn(f func(context.Context) ([]crossmodelrelation.RemoteApplicationOfferer, error)) *MockModelStateGetRemoteApplicationOfferersCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// NamespaceRemoteApplicationConsumers mocks base method.
+func (m *MockModelState) NamespaceRemoteApplicationConsumers() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NamespaceRemoteApplicationConsumers")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// NamespaceRemoteApplicationConsumers indicates an expected call of NamespaceRemoteApplicationConsumers.
+func (mr *MockModelStateMockRecorder) NamespaceRemoteApplicationConsumers() *MockModelStateNamespaceRemoteApplicationConsumersCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceRemoteApplicationConsumers", reflect.TypeOf((*MockModelState)(nil).NamespaceRemoteApplicationConsumers))
+	return &MockModelStateNamespaceRemoteApplicationConsumersCall{Call: call}
+}
+
+// MockModelStateNamespaceRemoteApplicationConsumersCall wrap *gomock.Call
+type MockModelStateNamespaceRemoteApplicationConsumersCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateNamespaceRemoteApplicationConsumersCall) Return(arg0 string) *MockModelStateNamespaceRemoteApplicationConsumersCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateNamespaceRemoteApplicationConsumersCall) Do(f func() string) *MockModelStateNamespaceRemoteApplicationConsumersCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateNamespaceRemoteApplicationConsumersCall) DoAndReturn(f func() string) *MockModelStateNamespaceRemoteApplicationConsumersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -49,9 +49,17 @@ type ModelRemoteApplicationState interface {
 	// application offerers in the local model.
 	GetRemoteApplicationOfferers(context.Context) ([]crossmodelrelation.RemoteApplicationOfferer, error)
 
+	// GetRemoteApplicationConsumers returns all the current non-dead remote
+	// application consumers in the local model.
+	GetRemoteApplicationConsumers(context.Context) ([]crossmodelrelation.RemoteApplicationConsumer, error)
+
 	// NamespaceRemoteApplicationOfferers returns the database namespace
 	// for remote application offerers.
 	NamespaceRemoteApplicationOfferers() string
+
+	// NamespaceRemoteApplicationConsumers returns the database namespace
+	// for remote application consumers.
+	NamespaceRemoteApplicationConsumers() string
 
 	// SaveMacaroonForRelation saves the given macaroon for the specified
 	// remote application.
@@ -225,10 +233,10 @@ func (s *Service) GetRemoteApplicationOfferers(ctx context.Context) ([]crossmode
 // GetRemoteApplicationConsumers returns the current state of all remote
 // application consumers in the local model.
 func (s *Service) GetRemoteApplicationConsumers(ctx context.Context) ([]crossmodelrelation.RemoteApplicationConsumer, error) {
-	_, span := trace.Start(ctx, trace.NameFromFunc())
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return nil, errors.NotImplemented
+	return s.modelState.GetRemoteApplicationConsumers(ctx)
 }
 
 // SetRemoteApplicationOffererStatus sets the status of the specified remote

--- a/domain/crossmodelrelation/service/remoteapplication_test.go
+++ b/domain/crossmodelrelation/service/remoteapplication_test.go
@@ -582,3 +582,52 @@ func (s *remoteApplicationServiceSuite) TestGetApplicationNameAndUUIDByOfferUUID
 	_, _, err := service.GetApplicationNameAndUUIDByOfferUUID(c.Context(), offerUUID)
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
+
+func (s *remoteApplicationServiceSuite) TestGetRemoteApplicationConsumers(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	expected := []crossmodelrelation.RemoteApplicationConsumer{{
+		ApplicationName: "remote-app-1",
+		Life:            life.Alive,
+		OfferUUID:       "offer-uuid-1",
+		ConsumeVersion:  0,
+	}, {
+		ApplicationName: "remote-app-2",
+		Life:            life.Dying,
+		OfferUUID:       "offer-uuid-2",
+		ConsumeVersion:  3,
+	}}
+
+	s.modelState.EXPECT().GetRemoteApplicationConsumers(gomock.Any()).Return(expected, nil)
+
+	service := s.service(c)
+
+	actual, err := service.GetRemoteApplicationConsumers(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(actual, tc.DeepEquals, expected)
+}
+
+func (s *remoteApplicationServiceSuite) TestGetRemoteApplicationConsumersEmpty(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	expected := []crossmodelrelation.RemoteApplicationConsumer{}
+
+	s.modelState.EXPECT().GetRemoteApplicationConsumers(gomock.Any()).Return(expected, nil)
+
+	service := s.service(c)
+
+	actual, err := service.GetRemoteApplicationConsumers(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(actual, tc.DeepEquals, expected)
+}
+
+func (s *remoteApplicationServiceSuite) TestGetRemoteApplicationConsumersError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelState.EXPECT().GetRemoteApplicationConsumers(gomock.Any()).Return(nil, internalerrors.Errorf("front fell off"))
+
+	service := s.service(c)
+
+	_, err := service.GetRemoteApplicationConsumers(c.Context())
+	c.Assert(err, tc.ErrorMatches, "front fell off")
+}

--- a/domain/crossmodelrelation/service/service.go
+++ b/domain/crossmodelrelation/service/service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/clock"
 
 	"github.com/juju/juju/core/changestream"
-	"github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/trace"
@@ -132,7 +131,16 @@ func NewWatchableService(
 // WatchRemoteApplicationConsumers watches the changes to remote
 // application consumers and notifies the worker of any changes.
 func (w *WatchableService) WatchRemoteApplicationConsumers(ctx context.Context) (watcher.NotifyWatcher, error) {
-	return nil, errors.NotImplemented
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	table := w.modelState.NamespaceRemoteApplicationConsumers()
+
+	return w.watcherFactory.NewNotifyWatcher(
+		ctx,
+		"watch remote application consumer",
+		eventsource.NamespaceFilter(table, changestream.All),
+	)
 }
 
 // WatchRemoteApplicationOfferers watches the changes to remote application

--- a/domain/crossmodelrelation/watcher_test.go
+++ b/domain/crossmodelrelation/watcher_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/application/charm"
@@ -98,6 +99,64 @@ SELECT uuid FROM application_remote_offerer WHERE application_uuid = ?)`, applic
 	harness.Run(c, struct{}{})
 }
 
+func (s *watcherSuite) TestWatchRemoteApplicationConsumers(c *tc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, s.modelUUID)
+	svc := s.setupService(c, factory)
+
+	db, err := s.GetWatchableDB(c.Context(), s.modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	offerUUID := uuid.MustNewUUID().String()
+	relationUUID := uuid.MustNewUUID().String()
+	s.createLocalOfferForConsumer(c, db, offerUUID)
+
+	watcher, err := svc.WatchRemoteApplicationConsumers(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s.modelIdler, watchertest.NewWatcherC(c, watcher))
+
+	harness.AddTest(c, func(c *tc.C) {
+		err := svc.AddRemoteApplicationConsumer(c.Context(), service.AddRemoteApplicationConsumerArgs{
+			RemoteApplicationUUID: uuid.MustNewUUID().String(),
+			OfferUUID:             offerUUID,
+			RelationUUID:          relationUUID,
+			Endpoints: []charm.Relation{{
+				Name:  "db",
+				Role:  charm.RoleProvider,
+				Scope: charm.ScopeGlobal,
+			}},
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	harness.AddTest(c, func(c *tc.C) {
+		err = db.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			var consumerUUID, offerConnUUID string
+			if err := tx.QueryRowContext(ctx, `
+	SELECT arc.uuid, arc.offer_connection_uuid
+	FROM application_remote_consumer arc
+	JOIN offer_connection oc ON oc.uuid = arc.offer_connection_uuid
+	WHERE oc.offer_uuid = ?`, offerUUID).Scan(&consumerUUID, &offerConnUUID); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM application_remote_consumer WHERE uuid=?`, consumerUUID); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM offer_connection WHERE uuid=?`, offerConnUUID); err != nil {
+				return err
+			}
+			return nil
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	harness.Run(c, struct{}{})
+}
+
 func (s *watcherSuite) setupService(c *tc.C, factory domain.WatchableDBFactory) *service.WatchableService {
 	controllerDB := func(ctx context.Context) (database.TxnRunner, error) {
 		return s.ControllerTxnRunner(), nil
@@ -123,4 +182,69 @@ func newMacaroon(c *tc.C, id string) *macaroon.Macaroon {
 	mac, err := macaroon.New(nil, []byte(id), "", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	return mac
+}
+
+func (s *watcherSuite) createLocalOfferForConsumer(c *tc.C, db database.TxnRunner, offerUUID string) {
+	err := db.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		// Create charm.
+		charmUUID := uuid.MustNewUUID().String()
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, reference_name, architecture_id, revision)
+VALUES (?, ?, 0, 1)`, charmUUID, charmUUID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO charm_metadata (charm_uuid, name, subordinate, description)
+VALUES (?, ?, false, 'test app')`, charmUUID, "local-app"); err != nil {
+			return err
+		}
+
+		// Get provider role and global scope IDs.
+		var providerRoleID, globalScopeID int
+		if err := tx.QueryRowContext(ctx, `SELECT id FROM charm_relation_role WHERE name='provider'`).Scan(&providerRoleID); err != nil {
+			return err
+		}
+		if err := tx.QueryRowContext(ctx, `SELECT id FROM charm_relation_scope WHERE name='global'`).Scan(&globalScopeID); err != nil {
+			return err
+		}
+
+		// Create charm relation referenced by endpoint/offer.
+		charmRelationUUID := uuid.MustNewUUID().String()
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, interface, capacity, scope_id)
+VALUES (?, ?, 'db', ?, 'db', 0, ?)`, charmRelationUUID, charmUUID, providerRoleID, globalScopeID); err != nil {
+			return err
+		}
+
+		// Create application.
+		appUUID := uuid.MustNewUUID().String()
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid)
+VALUES (?, 'local-app', 0, ?, ?)`, appUUID, charmUUID, network.AlphaSpaceId); err != nil {
+			return err
+		}
+
+		// Application endpoint.
+		appEndpointUUID := uuid.MustNewUUID().String()
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid, space_uuid)
+VALUES (?, ?, ?, ?)`, appEndpointUUID, appUUID, charmRelationUUID, network.AlphaSpaceId); err != nil {
+			return err
+		}
+
+		// Offer + endpoint mapping.
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO offer (uuid, name)
+VALUES (?, 'local-offer')`, offerUUID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO offer_endpoint (offer_uuid, endpoint_uuid)
+VALUES (?, ?)`, offerUUID, appEndpointUUID); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
 }

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -25,7 +25,7 @@ import (
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/relation-triggers.gen.go -package=triggers -tables=relation_application_settings_hash,relation_unit_settings_hash,relation_unit,relation,relation_status,application_endpoint
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/cleanup-triggers.gen.go -package=triggers -tables=removal
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/operation-triggers.gen.go -package=triggers -tables=operation_task_log
-//go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/crossmodelrelation-triggers.gen.go -package=triggers -tables=application_remote_offerer
+//go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/crossmodelrelation-triggers.gen.go -package=triggers -tables=application_remote_offerer,application_remote_consumer
 
 //go:embed model/sql/*.sql
 var modelSchemaDir embed.FS
@@ -93,6 +93,7 @@ const (
 	tableApplicationEndpoint
 	tableOperationTaskLog
 	tableCrossModelRelationApplicationRemoteOfferers
+	tableCrossModelRelationApplicationRemoteConsumers
 )
 
 // ModelDDL is used to create model databases.
@@ -173,6 +174,8 @@ func ModelDDL() *schema.Schema {
 		triggers.ChangeLogTriggersForOperationTaskLog("task_uuid", tableOperationTaskLog),
 		triggers.ChangeLogTriggersForApplicationRemoteOfferer("uuid",
 			tableCrossModelRelationApplicationRemoteOfferers),
+		triggers.ChangeLogTriggersForApplicationRemoteConsumer("uuid",
+			tableCrossModelRelationApplicationRemoteConsumers),
 	)
 
 	// Generic triggers.

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -649,6 +649,10 @@ func (s *modelSchemaSuite) TestModelTriggers(c *tc.C) {
 		"trg_log_application_remote_offerer_delete",
 		"trg_log_application_remote_offerer_insert",
 		"trg_log_application_remote_offerer_update",
+
+		"trg_log_application_remote_consumer_delete",
+		"trg_log_application_remote_consumer_insert",
+		"trg_log_application_remote_consumer_update",
 	)
 
 	// These are additional triggers that are not change log triggers, but


### PR DESCRIPTION
Also as a fly-by, implement GetRemoteApplicationConsumers in the service and state layers. This method is needed when we get the notification from the watcher on the worker.

- Add database triggers and schema changes for consumers.
- Add tests for consumer retrieval and watching.
- Enable WatchRemoteApplicationConsumers in service layer.


## QA steps

Remote relation registration is not fully wired yet (another patch), so this full scenario is not QAable yet. Unit/watcher tests should pass though.

## Links


**Jira card:** [JUJU-8467
](https://warthogs.atlassian.net/browse/JUJU-8467)