### PR TITLE
feat: delete secret consumer reference with unit

### DIFF
--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -653,6 +653,7 @@ func (st *State) deleteForeignKeyUnitReferences(ctx context.Context, tx *sqlair.
 		"DELETE FROM port_range WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_storage_directive WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_agent_presence WHERE unit_uuid = $entityUUID.uuid",
+		"DELETE FROM secret_unit_consumer WHERE unit_uuid = $entityUUID.uuid",
 	} {
 		deleteUnitReferenceStmt, err := st.Prepare(table, unitUUIDRec)
 		if err != nil {


### PR DESCRIPTION
We need to delete secret consumer references when we delete units.

## QA steps

A definitive QA procedure will be possible when we have storage removals working.

Unit tests verify this change.
