### PR TITLE
fix(operation): handle correctly the Command parameters

### DIFF
--- a/domain/operation/state/state.go
+++ b/domain/operation/state/state.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/canonical/sqlair"
@@ -571,5 +570,10 @@ func decodeParameterValue(storedStr string) any {
 		return value
 	}
 	// If the value is not a number, then it's a string.
-	return strings.Trim(storedStr, "\"")
+	// Remove the quotes from the string, if any
+	if unquoted, err := strconv.Unquote(storedStr); err == nil {
+		return unquoted
+	}
+	// If no quotes were found, then return the string value as is.
+	return storedStr
 }

--- a/domain/operation/state/task_test.go
+++ b/domain/operation/state/task_test.go
@@ -122,6 +122,7 @@ func (s *taskSuite) TestGetTaskWithTypedParameters(c *tc.C) {
 	// Values that should remain as strings
 	s.addOperationParameter(c, operationUUID, "str", "hello")
 	s.addOperationParameter(c, operationUUID, "quoted-num", `"42"`)
+	s.addOperationParameter(c, operationUUID, "string-with-quote", "state-get | grep \"{}\"")
 
 	// Act
 	task, _, err := s.state.GetTask(c.Context(), taskID)
@@ -154,6 +155,9 @@ func (s *taskSuite) TestGetTaskWithTypedParameters(c *tc.C) {
 	vQte, ok := task.Parameters["quoted-num"].(string)
 	c.Assert(ok, tc.Equals, true)
 	c.Check(vQte, tc.Equals, "42")
+	vStrWithQuote, ok := task.Parameters["string-with-quote"].(string)
+	c.Assert(ok, tc.Equals, true)
+	c.Check(vStrWithQuote, tc.Equals, "state-get | grep \"{}\"")
 }
 
 func (s *taskSuite) TestGetTaskWithLogs(c *tc.C) {


### PR DESCRIPTION
The `command` parameter isn't correctly parsed by the task. a command containing a string parameter with a space will be incorrectly handled: the parameter will be parsed as two params.

This PR fixes the encoding/decoding of task parameters which causes this behavior whenever a parameter has a string containing quotes.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

run the beginning of the test `run_state_delete_get_set`: in `tests/suites/hooktools/state_tools.sh`

```sh
juju deploy ubuntu-lite
# wait ubuntu being up
juju exec --unit ubuntu-lite/0 'state-get | grep -q "{}"'
juju exec --unit ubuntu-lite/0 'state-set one=two'
juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
```

This should not cause any error.

## Links

**Jira card:** [JUJU-8608](https://warthogs.atlassian.net/browse/JUJU-8608)


[JUJU-8608]: https://warthogs.atlassian.net/browse/JUJU-8608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ