### PR TITLE
fix(refresh): fix panic in juju refresh when the channel is nil

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -494,11 +494,15 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	// 2. There is a resource change to process.
 	if errors.Is(runErr, refresher.ErrAlreadyUpToDate) {
 		ctx.Infof("%s", runErr.Error())
-		if len(resourceIDs) == 0 && c.Channel.String() == oldOrigin.CoreCharmOrigin().Channel.String() {
+		oldCoreCharmOriginChannel := oldOrigin.CoreCharmOrigin().Channel
+		if oldCoreCharmOriginChannel == nil {
 			return nil
 		}
-		if c.Channel.String() != oldOrigin.CoreCharmOrigin().Channel.String() {
-			ctx.Infof("Note: all future refreshes will now use channel %q", charmID.Origin.Channel.String())
+		if len(resourceIDs) == 0 && c.Channel.String() == oldCoreCharmOriginChannel.String() {
+			return nil
+		}
+		if c.Channel.String() != oldCoreCharmOriginChannel.String() {
+			ctx.Infof("Note: all future refreshes will now use channel %q", oldCoreCharmOriginChannel.String())
 		}
 		if len(resourceIDs) > 0 {
 			ctx.Infof("resources to be upgraded")


### PR DESCRIPTION
# Description

`juju refresh` panics when a local charm is refreshed and it's already up-to-date.

# QA

download a charm
`juju download juju-qa-refresher --no-progress - > ubuntu.charm` 

deploy the charm
`juju deploy ./ubuntu.charm` 

refresh it two times
` juju refresh refresher --switch ch:juju-qa-refresher --channel edge`

The second time:
before the patch -> panics
after the patch -> `charm "deployer": already up-to-date`