### PR TITLE
feat: add offer connection counts to status

### DIFF
--- a/apiserver/facades/client/client/fullstatus_test.go
+++ b/apiserver/facades/client/client/fullstatus_test.go
@@ -201,6 +201,8 @@ func (s *fullStatusSuite) TestFullStatusOffersIncluded(c *tc.C) {
 		Endpoints: []crossmodelrelation.OfferEndpoint{
 			{Name: "db"},
 		},
+		TotalActiveConnections: 1,
+		TotalConnections:       2,
 	}
 
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), gomock.Any()).Return(
@@ -220,7 +222,9 @@ func (s *fullStatusSuite) TestFullStatusOffersIncluded(c *tc.C) {
 						Name: "db",
 					},
 				},
-				CharmURL: "ch:amd64/app-42",
+				CharmURL:             "ch:amd64/app-42",
+				ActiveConnectedCount: 1,
+				TotalConnectedCount:  2,
 			},
 		})
 }

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -276,12 +276,10 @@ func fetchOffers(ctx context.Context, service CrossModelRelationService) (map[st
 				ApplicationDescription: in.ApplicationDescription,
 				Endpoints:              endpoints,
 			},
-			err:      err,
-			charmURL: charmURL,
-			// TODO: cmr
-			// Fill in data during the cmr epic.
-			activeConnectedCount: 0,
-			totalConnectedCount:  0,
+			err:                  err,
+			charmURL:             charmURL,
+			activeConnectedCount: in.TotalActiveConnections,
+			totalConnectedCount:  in.TotalConnections,
 		}
 		return in.OfferName, out
 	}), nil

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -183,6 +183,8 @@ func (s *offerServiceSuite) TestGetOffersEmptyFilters(c *tc.C) {
 					Role:      charm.RoleProvider,
 				},
 			},
+			TotalConnections:       2,
+			TotalActiveConnections: 1,
 		},
 	}
 	s.modelState.EXPECT().GetOfferDetails(gomock.Any(), inputFilter).Return(offerDetails, nil)
@@ -223,6 +225,8 @@ func (s *offerServiceSuite) TestGetOffersEmptyFilters(c *tc.C) {
 					Access: permission.ConsumeAccess,
 				},
 			},
+			TotalConnections:       2,
+			TotalActiveConnections: 1,
 		},
 	})
 }
@@ -247,6 +251,8 @@ func (s *offerServiceSuite) TestGetOffers(c *tc.C) {
 					Role:      charm.RoleProvider,
 				},
 			},
+			TotalConnections:       2,
+			TotalActiveConnections: 1,
 		},
 	}
 	s.modelState.EXPECT().GetOfferDetails(gomock.Any(), inputFilter).Return(offerDetails, nil)
@@ -289,6 +295,8 @@ func (s *offerServiceSuite) TestGetOffers(c *tc.C) {
 					Access: permission.ConsumeAccess,
 				},
 			},
+			TotalConnections:       2,
+			TotalActiveConnections: 1,
 		},
 	})
 }

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -50,6 +50,8 @@ type offerDetail struct {
 	OfferName              string `db:"offer_name"`
 	ApplicationName        string `db:"application_name"`
 	ApplicationDescription string `db:"application_description"`
+	TotalConnections       int    `db:"total_connections"`
+	TotalActiveConnections int    `db:"total_active_connections"`
 
 	// CharmLocator parts
 	CharmName         string                    `db:"charm_name"`
@@ -108,6 +110,8 @@ func (o offerDetails) TransformToOfferDetails() []*crossmodelrelation.OfferDetai
 					Interface: details.EndpointInterface,
 				},
 			},
+			TotalConnections:       details.TotalConnections,
+			TotalActiveConnections: details.TotalActiveConnections,
 		}
 		converted[details.OfferUUID] = found
 	}

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -108,8 +108,13 @@ type OfferDetail struct {
 	// to the offer.
 	OfferUsers []OfferUser
 
-	// TODO (cmr)
-	// Add []OfferConnections.
+	// TotalConnections is the total number of remote connections connected to
+	// the offer.
+	TotalConnections int
+
+	// TotalActiveConnections is the total number of remote connections
+	// connected to the offer that are currently active.
+	TotalActiveConnections int
 }
 
 // OfferEndpoint contains details of charm endpoints as needed for offer

--- a/domain/schema/model/sql/0032-offer.sql
+++ b/domain/schema/model/sql/0032-offer.sql
@@ -21,6 +21,16 @@ CREATE TABLE offer_endpoint (
 );
 
 CREATE VIEW v_offer_detail AS
+WITH conn AS (
+    SELECT offer_uuid FROM offer_connection
+),
+
+active_conn AS (
+    SELECT oc.offer_uuid FROM offer_connection AS oc
+    JOIN relation_status AS rs ON oc.application_remote_relation_uuid = rs.relation_uuid
+    WHERE rs.relation_status_type_id = 1
+)
+
 SELECT
     o.uuid AS offer_uuid,
     o.name AS offer_name,
@@ -32,7 +42,9 @@ SELECT
     c.architecture_id AS charm_architecture,
     cr.name AS endpoint_name,
     crr.name AS endpoint_role,
-    cr.interface AS endpoint_interface
+    cr.interface AS endpoint_interface,
+    (SELECT COUNT(*) FROM conn AS c WHERE o.uuid = c.offer_uuid) AS total_connections,
+    (SELECT COUNT(*) FROM active_conn AS ac WHERE o.uuid = ac.offer_uuid) AS total_active_connections
 FROM offer AS o
 JOIN offer_endpoint AS oe ON o.uuid = oe.offer_uuid
 JOIN application_endpoint AS ae ON oe.endpoint_uuid = ae.uuid


### PR DESCRIPTION
Retrieve the total number of connections, and the number of active connections for each offer. Include this in the status response

## QA steps

Unfortunately CMR connections can't be established yet, so the best we can do is passing unit tests