### PR TITLE
fix: flaky storage watcher tests

### DIFF
--- a/domain/storageprovisioning/watcher_test.go
+++ b/domain/storageprovisioning/watcher_test.go
@@ -674,7 +674,6 @@ func (s *watcherSuite) TestWatchStorageAttachmentsForUnit(c *tc.C) {
 			storageInstanceUUID2,
 			storageInstanceUUID3,
 		)
-		fmt.Println(attachmenUUIDs)
 
 		storageAttachmentUUID1 = attachmenUUIDs[0]
 		storageAttachmentUUID2 = attachmenUUIDs[1]


### PR DESCRIPTION
This PR provides two solutions to fix the same problem. We have been noticing intermittent test failures of `TestWatcherSuite/TestWatchStorageAttachmentsForUnit` (https://github.com/juju/juju/blob/b9dd273d4a907dd2f30636085b6d2b767a972d6d/domain/storageprovisioning/watcher_test.go#L642) that have been almost impossible to reproduce locally.

Example of a failure is:
```
13:54:29 --- FAIL: TestWatcherSuite (45.10s)
13:54:29     transaction.go:175: WARNING juju.database failed to rollback transaction: sql: transaction has already been committed or rolled back
13:54:29     transaction.go:175: WARNING juju.database failed to rollback transaction: sql: transaction has already been committed or rolled back
13:54:29     --- FAIL: TestWatcherSuite/TestWatchStorageAttachmentsForUnit (11.74s)
13:54:29         /home/jenkins/workspace/unit-tests-race-amd64/src/github.com/juju/juju/domain/storageprovisioning/watcher_test.go:642
13:54:29         stream.go:320: TRACE: read 0 changes
13:54:29         stream.go:336: TRACE: no changes, with attempt 1
13:54:29         watcher.go:137: WatcherC Watcher.Changes() => []string(nil)
13:54:29         stream.go:320: TRACE: read 7 changes
13:54:29         stream.go:364: TRACE: change event: {1 1 test foo 2025-10-10T11:53:59.992Z}
13:54:29         stream.go:364: TRACE: change event: {2 1 charm 7b6f84c2-788b-4f3d-8fd8-0bc1aac67b1b 2025-10-10T11:54:00Z}
13:54:29         stream.go:364: TRACE: change event: {3 1 custom_application_uuid_lifecycle 1a86a344-30b3-49c3-881c-cf3f10f7bba2 2025-10-10T11:54:00Z}
13:54:29         stream.go:364: TRACE: change event: {4 1 application 1a86a344-30b3-49c3-881c-cf3f10f7bba2 2025-10-10T11:54:00Z}
13:54:29         stream.go:364: TRACE: change event: {5 1 custom_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:00Z}
13:54:29         stream.go:364: TRACE: change event: {6 1 custom_unit_name_lifecycle foo/0 2025-10-10T11:54:00Z}
13:54:29         stream.go:364: TRACE: change event: {7 1 unit a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:00Z}
13:54:29         stream.go:388: TRACE: term start: processing changes 7
13:54:29         stream.go:437: TRACE: empty term, with attempt 2
13:54:29         stream.go:320: TRACE: read 0 changes
13:54:29         stream.go:336: TRACE: no changes, with attempt 3
13:54:29         stream.go:715: TRACE: no changes, backing off after 3 attempt
13:54:29         harness.go:109: running test 0
13:54:29         stream.go:320: TRACE: read 0 changes
13:54:29         stream.go:336: TRACE: no changes, with attempt 4
13:54:29         stream.go:320: TRACE: read 1 changes
13:54:29         stream.go:364: TRACE: change event: {10 1 custom_storage_attachment_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:00Z}
13:54:29         stream.go:388: TRACE: term start: processing changes 1
13:54:29         eventmultiplexer.go:345: TRACE: dispatching change: {10 1 custom_storage_attachment_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:00Z}
13:54:29         stream.go:453: TRACE: term done: processed changes 1
13:54:29         stream.go:320: TRACE: read 0 changes
13:54:29         stream.go:336: TRACE: no changes, with attempt 1
13:54:29         stream.go:715: TRACE: no changes, backing off after 1 attempt
13:54:29         watcher.go:166: WatcherC Watcher.Changes() => []string{"mystorage/0", "mystorage/1", "mystorage/2"}
13:54:29         watcher.go:181: received [[mystorage/0 mystorage/1 mystorage/2]]
13:54:29         harness.go:109: running test 1
13:54:29         stream.go:320: TRACE: read 0 changes
13:54:29         stream.go:336: TRACE: no changes, with attempt 2
13:54:29         stream.go:320: TRACE: read 3 changes
13:54:29         stream.go:364: TRACE: change event: {11 2 custom_storage_attachment_entities_storage_attachment_uuid bfa72578-8d47-4178-8662-6b924c94ea41 2025-10-10T11:54:01Z}
13:54:29         stream.go:364: TRACE: change event: {13 2 custom_storage_attachment_entities_storage_attachment_uuid 66810f27-8a52-456d-8c93-7ea2058eb8ff 2025-10-10T11:54:01Z}
13:54:29         stream.go:364: TRACE: change event: {14 2 custom_storage_attachment_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:01Z}
13:54:29         stream.go:388: TRACE: term start: processing changes 3
13:54:29         eventmultiplexer.go:345: TRACE: dispatching change: {14 2 custom_storage_attachment_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:01Z}
13:54:29         stream.go:453: TRACE: term done: processed changes 3
13:54:29         stream.go:320: TRACE: read 0 changes
13:54:29         stream.go:336: TRACE: no changes, with attempt 1
13:54:29         stream.go:715: TRACE: no changes, backing off after 1 attempt
13:54:29         watcher.go:166: WatcherC Watcher.Changes() => []string{"mystorage/0", "mystorage/1"}
13:54:29         watcher.go:181: received [[mystorage/0 mystorage/1]]
13:54:29         harness.go:109: running test 2
13:54:29         stream.go:320: TRACE: read 2 changes
13:54:29         stream.go:364: TRACE: change event: {15 2 custom_storage_attachment_entities_storage_attachment_uuid bfa72578-8d47-4178-8662-6b924c94ea41 2025-10-10T11:54:01Z}
13:54:29         stream.go:364: TRACE: change event: {16 2 custom_storage_attachment_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:01Z}
13:54:29         stream.go:388: TRACE: term start: processing changes 2
13:54:29         eventmultiplexer.go:345: TRACE: dispatching change: {16 2 custom_storage_attachment_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:01Z}
13:54:29         stream.go:453: TRACE: term done: processed changes 2
13:54:29         stream.go:320: TRACE: read 2 changes
13:54:29         stream.go:364: TRACE: change event: {17 2 custom_storage_attachment_entities_storage_attachment_uuid 8ea7f2fc-9195-4c74-8de1-70254548158d 2025-10-10T11:54:01Z}
13:54:29         stream.go:364: TRACE: change event: {18 2 custom_storage_attachment_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:01Z}
13:54:29         stream.go:388: TRACE: term start: processing changes 2
13:54:29         eventmultiplexer.go:345: TRACE: dispatching change: {18 2 custom_storage_attachment_unit_uuid_lifecycle a813e880-7bec-45fd-8937-55d0cbe82163 2025-10-10T11:54:01Z}
13:54:29         modelsuite.go:74: timed out waiting for idle state
13:54:29 FAIL
13:54:29 FAIL	github.com/juju/juju/domain/storageprovisioning	45.356s
```

The reason for the failure is because the change set available in the change stream sometimes gets broken up over multiple terms. When this happens the subscription dispatcher gets dead locked as it needs the first change set to have been consumed. Because of the way the test harness is structured watcher changes cannot be consumed until the change stream becomes idle. The idle change stream can't happen until all the dispatch operations have happened.

This PR has two fixes for the same problem in it to float the idea of which one we think should be the answer to this problem.

The first change updates the test to make all of the changes in a single transaction guaranteeing no term splitting just based on the knowledge of how the terms are constructed. While here I fixed up the test to include some documentation as it was not exactly clear what was under test. We were also using a different entity id to affect change on the test entity which makes the test even more confusing.

The second change proposed updates the subscription implementation to append subsequent changesets to the changeset that is already blocked. This allows the previously blocked caller to be released.

This is a very contrived situation that will only ever occur in testing. I wouldn't expect this to exist in the controller. To force the problem and see the unit tests solving the issue I applied the following sql patch to force exactly one change per term.

```git
diff --git a/internal/changestream/stream/stream.go b/internal/changestream/stream/stream.go
index 43a5f91b0ef..fb85818ffec 100644
--- a/internal/changestream/stream/stream.go
+++ b/internal/changestream/stream/stream.go
@@ -469,7 +469,8 @@ SELECT MAX(c.id), c.edit_type_id, n.namespace, changed, created_at
                JOIN change_log_namespace n ON c.namespace_id = n.id
        WHERE c.id > ?
        GROUP BY c.namespace_id, c.changed
-       ORDER BY c.id;
+       ORDER BY c.id
+       LIMIT 1;
 `
 )
 ```

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run the units tests with the above patch.

## Documentation changes

N/A
