### PR TITLE
ci: simplify configure_multi_nic_netplan function

### DIFF
--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -19,7 +19,6 @@ run_juju_bind() {
 	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("en") or startswith("eth"))')
 	primary_iface=$(echo $ifaces | cut -d " " -f1)
 	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
-	expect_multi_nic_machine "$juju_machine_id"
 
 	# Deploy test charm to dual-nic machine
 	# shellcheck disable=SC2046

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -19,7 +19,6 @@ run_upgrade_charm_with_bind() {
 	ifaces=$(juju ssh ${juju_machine_id} 'ip -j link' | jq -r '.[].ifname | select(. | startswith("en") or startswith("eth"))')
 	primary_iface=$(echo $ifaces | cut -d " " -f1)
 	hotplug_iface=$(echo $ifaces | cut -d " " -f2)
-	expect_multi_nic_machine "$juju_machine_id"
 
 	# Deploy test charm to dual-nic machine
 	charm=$(pack_charm ./testcharms/charms/space-defender)

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -2,6 +2,13 @@
 #
 # Create a new machine, wait for it to boot and hotplug a pre-allocated
 # network interface which has been tagged: "nic-type: hotpluggable".
+# Then restart the machine agent and wait for juju to detect 2 network
+# interfaces before returning.
+#
+# NICs are automatically setup on Ubuntu 24.04+ by cloud-init's hotplug module.
+# See https://repost.aws/knowledge-center/ec2-ubuntu-secondary-network-interface
+# as a reference. If provisioning older Ubuntu releases, additional steps
+# with netplan are required.
 add_multi_nic_machine() {
 	local hotplug_nic_id
 	hotplug_nic_id=$1
@@ -38,19 +45,6 @@ add_multi_nic_machine() {
 
 		sleep 1
 	done
-}
-
-# expect_multi_nic_machine()
-#
-# Restart the machine agent and wait for juju to detect 2
-# network interfaces before returning.
-# NICs are automatically setup on Ubuntu 24.04+ by cloud-init's hotplug module.
-# See https://repost.aws/knowledge-center/ec2-ubuntu-secondary-network-interface
-# as a reference. If provisioning older Ubuntu releases, additional steps
-# with netplan are required.
-expect_multi_nic_machine() {
-	local juju_machine_id
-	juju_machine_id=$1
 
 	echo "[+] restarting machine agent on ${juju_machine_id}..."
 	juju ssh "${juju_machine_id}" 'sudo systemctl restart jujud-machine-*'


### PR DESCRIPTION
This PR simplifies the ec2_spaces test suite, removing the netplan configuration steps. 

The ec2_spaces tests create a machine with 2 network interfaces and use netplan to configure the second interface. Since Ubuntu 24.04 and cloud-init's hotplug module, the network interface is automatically provisioned. Considering that these tests don't require an older Ubuntu release for testing spaces we can simplify the test code.

[AWS docs reference ](https://repost.aws/knowledge-center/ec2-ubuntu-secondary-network-interface)
[Cloud-init docs](https://docs.cloud-init.io/en/22.1/topics/modules.html?highlight=hotplug#module-cloudinit.config.cc_install_hotplug)

## Links

**Jira card:** [JUJU-8556](https://warthogs.atlassian.net/browse/JUJU-8556)


[JUJU-8556]: https://warthogs.atlassian.net/browse/JUJU-8556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ