### PR TITLE
fix: wire up refresh charm args

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -707,7 +707,11 @@ func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetChar
 		return errors.Trace(err)
 	}
 
-	err = api.applicationService.SetApplicationCharm(ctx, args.ApplicationName, newCharmLocator, application.SetCharmParams{})
+	err = api.applicationService.SetApplicationCharm(ctx, args.ApplicationName, newCharmLocator, application.SetCharmParams{
+		// Storage: args.StorageDirectives,
+		CharmUpgradeOnError: args.Force,
+		EndpointBindings:    transform.Map(args.EndpointBindings, func(k, v string) (string, network.SpaceName) { return k, network.SpaceName(v) }),
+	})
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return errors.NotFoundf("application %q", args.ApplicationName)
 	} else if errors.Is(err, applicationerrors.CharmNotFound) {

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -763,6 +763,49 @@ func (s *applicationSuite) TestCharmConfig(c *tc.C) {
 	})
 }
 
+func (s *applicationSuite) TestSetCharm(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.setupAPI(c)
+
+	s.applicationService.EXPECT().SetApplicationCharm(gomock.Any(), "foo", applicationcharm.CharmLocator{
+		Name:         "foo",
+		Revision:     42,
+		Source:       applicationcharm.CharmHubSource,
+		Architecture: architecture.ARM64,
+	}, domainapplication.SetCharmParams{
+		CharmUpgradeOnError: true,
+		EndpointBindings: map[string]network.SpaceName{
+			"binding-1": "endpoint-1",
+			"binding-2": "endpoint-2",
+		},
+	}).Return(nil)
+
+	err := s.api.SetCharm(c.Context(), params.ApplicationSetCharmV2{
+		ApplicationName: "foo",
+		CharmURL:        "ch:arm64/foo-42",
+		CharmOrigin: &params.CharmOrigin{
+			Type:   "charm",
+			Source: "charm-hub",
+			Base: params.Base{
+				Name:    "ubuntu",
+				Channel: "24.04",
+			},
+			Architecture: "arm64",
+			Revision:     ptr(42),
+			Track:        ptr("1.0"),
+			Risk:         "stable",
+		},
+		Force: true,
+		EndpointBindings: map[string]string{
+			"binding-1": "endpoint-1",
+			"binding-2": "endpoint-2",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+}
+
 func (s *applicationSuite) TestSetConfigsYAMLNotImplemented(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 


### PR DESCRIPTION
This PR wires up args in the `SetCharm` API method. They were not being passed to the service layer.

The only difficulty here is that there are still many arguments that `SetCharms`'s RPC method accepts but are not options in the application domain, these include:
```go
type ApplicationSetCharmV2 struct {
	// Generation is the generation version that this
	// request will set the application charm for.
	Generation string `json:"generation"`

	// Channel is the charm store channel from which the charm came.
	Channel string `json:"channel"`

	// ConfigSettings is the charm settings to set during the upgrade.
	// This field is only understood by Application facade version 2
	// and greater.
	ConfigSettings map[string]string `json:"config-settings,omitempty"`

	// ConfigSettingsYAML is the charm settings in YAML format to set
	// during the upgrade. If this is non-empty, it will take precedence
	// over ConfigSettings. This field is only understood by Application
	// facade version 2
	ConfigSettingsYAML string `json:"config-settings-yaml,omitempty"`

	// ForceUnits forces the upgrade on units in an error state.
	ForceUnits bool `json:"force-units"`

	// ForceBase forces the use of the charm even if it doesn't match the
	// series of the unit.
	ForceBase bool `json:"force-base"`

	// ResourceIDs is a map of resource names to resource IDs to activate during
	// the upgrade.
	ResourceIDs map[string]string `json:"resource-ids,omitempty"`
}
```

Some of the fields are not needed, like `Channel` whose information is encoded in the charm URL and the multiple force flags are intended to be coalesced into one based on a TODO elsewhere, while others like `Generation` seem old and unused.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages


## Links

**Jira card:** [JUJU-8556](https://warthogs.atlassian.net/browse/JUJU-8556)


[JUJU-8556]: https://warthogs.atlassian.net/browse/JUJU-8556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ