### PR TITLE
feat: add consumer model uuid for remote app consumer

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -91,6 +91,10 @@ func (api *CrossModelRelationsAPIv3) registerOneRemoteRelation(
 	if err != nil {
 		return nil, err
 	}
+	sourceModelTag, err := names.ParseModelTag(relation.SourceModelTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	appName, appUUID, err := api.crossModelRelationService.GetApplicationNameAndUUIDByOfferUUID(ctx, offerUUID)
 	if err != nil {
@@ -115,6 +119,7 @@ func (api *CrossModelRelationsAPIv3) registerOneRemoteRelation(
 			RemoteApplicationUUID: relation.ApplicationToken,
 			OfferUUID:             offerUUID,
 			RelationUUID:          relation.RelationToken,
+			ConsumerModelUUID:     sourceModelTag.Id(),
 			// We only have the actual consumed endpoint.
 			Endpoints: []charm.Relation{
 				{

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -161,6 +161,9 @@ func (s *Service) AddRemoteApplicationConsumer(ctx context.Context, args AddRemo
 	if !uuid.IsValidUUIDString(args.RelationUUID) {
 		return internalerrors.Errorf("relation UUID %q is not a valid UUID", args.RelationUUID).Add(errors.NotValid)
 	}
+	if !uuid.IsValidUUIDString(args.ConsumerModelUUID) {
+		return internalerrors.Errorf("consumer model UUID %q is not a valid UUID", args.ConsumerModelUUID).Add(errors.NotValid)
+	}
 
 	// Construct a synthetic charm to represent the remote application charm,
 	// so we can track the endpoints it offers.
@@ -185,10 +188,11 @@ func (s *Service) AddRemoteApplicationConsumer(ctx context.Context, args AddRemo
 			// NOTE: We use the same UUID as in the remote (consuming) model for
 			// the synthetic application we are creating in the offering model.
 			// We can do that because we know it's a valid UUID at this point.
-			ApplicationUUID: remoteApplicationUUID.String(),
-			CharmUUID:       charmUUID.String(),
-			Charm:           syntheticCharm,
-			OfferUUID:       args.OfferUUID.String(),
+			ApplicationUUID:   remoteApplicationUUID.String(),
+			CharmUUID:         charmUUID.String(),
+			Charm:             syntheticCharm,
+			OfferUUID:         args.OfferUUID.String(),
+			ConsumerModelUUID: args.ConsumerModelUUID,
 		},
 		RelationUUID: args.RelationUUID,
 	}); internalerrors.Is(err, crossmodelrelationerrors.RemoteRelationAlreadyRegistered) {

--- a/domain/crossmodelrelation/service/types.go
+++ b/domain/crossmodelrelation/service/types.go
@@ -49,6 +49,10 @@ type AddRemoteApplicationConsumerArgs struct {
 	// application to a local application, on the consuming model.
 	RelationUUID string
 
+	// ConsumerModelUUID is the UUID of the model that is consuming the
+	// application.
+	ConsumerModelUUID string
+
 	// Endpoints is the collection of endpoint relations offered.
 	Endpoints []charm.Relation
 }

--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -131,7 +131,7 @@ func (st *State) AddRemoteApplicationConsumer(
 
 		// Insert the remote application consumer record, this allows us to find
 		// the synthetic application later.
-		if err := st.insertRemoteApplicationConsumer(ctx, tx, offerConnectionUUID, localApplicationUUID, args.ApplicationUUID, args.OfferUUID); err != nil {
+		if err := st.insertRemoteApplicationConsumer(ctx, tx, offerConnectionUUID, localApplicationUUID, args.ApplicationUUID, args.ConsumerModelUUID, args.OfferUUID); err != nil {
 			return errors.Capture(err)
 		}
 
@@ -349,6 +349,7 @@ func (st *State) insertRemoteApplicationConsumer(
 	offerConnectionUUID string,
 	localApplicationUUID string,
 	consumerApplicationUUID string,
+	consumerModelUUID string,
 	offerUUID string,
 ) error {
 
@@ -368,6 +369,7 @@ func (st *State) insertRemoteApplicationConsumer(
 		OffererApplicationUUID:  localApplicationUUID,
 		ConsumerApplicationUUID: consumerApplicationUUID,
 		OfferConnectionUUID:     offerConnectionUUID,
+		ConsumerModelUUID:       consumerModelUUID,
 		Version:                 version,
 		LifeID:                  life.Alive,
 	}

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -218,6 +218,7 @@ type remoteApplicationConsumer struct {
 	OffererApplicationUUID  string    `db:"offerer_application_uuid"`
 	ConsumerApplicationUUID string    `db:"consumer_application_uuid"`
 	OfferConnectionUUID     string    `db:"offer_connection_uuid"`
+	ConsumerModelUUID       string    `db:"consumer_model_uuid"`
 	Version                 uint64    `db:"version"`
 	LifeID                  life.Life `db:"life_id"`
 }

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -242,6 +242,10 @@ type AddRemoteApplicationArgs struct {
 	// OfferUUID is the UUID of the offer that the remote application is
 	// consuming. The offer is in this model, the offering model.
 	OfferUUID string
+
+	// ConsumerModelUUID is the UUID of the model that is consuming the
+	// application.
+	ConsumerModelUUID string
 }
 
 // RemoteRelationChangedArgs contains the parameters required to process a

--- a/domain/crossmodelrelation/watcher_test.go
+++ b/domain/crossmodelrelation/watcher_test.go
@@ -108,7 +108,9 @@ func (s *watcherSuite) TestWatchRemoteApplicationConsumers(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relationUUID := uuid.MustNewUUID().String()
+	relationUUID := tc.Must(c, uuid.NewUUID).String()
+	consumerModelUUID := tc.Must(c, uuid.NewUUID).String()
+
 	s.createLocalOfferForConsumer(c, db, offerUUID)
 
 	watcher, err := svc.WatchRemoteApplicationConsumers(c.Context())
@@ -121,6 +123,7 @@ func (s *watcherSuite) TestWatchRemoteApplicationConsumers(c *tc.C) {
 			RemoteApplicationUUID: uuid.MustNewUUID().String(),
 			OfferUUID:             offerUUID,
 			RelationUUID:          relationUUID,
+			ConsumerModelUUID:     consumerModelUUID,
 			Endpoints: []charm.Relation{{
 				Name:  "db",
 				Role:  charm.RoleProvider,

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -77,6 +77,10 @@ CREATE TABLE application_remote_consumer (
     -- offer_connection_uuid is the offer connection that links the remote
     -- consumer to the offer.
     offer_connection_uuid TEXT NOT NULL,
+    -- consumer_model_uuid is the model in the consuming controller where
+    -- the consumer application is located. There is no FK constraint on it,
+    -- because we don't have the model locally.
+    consumer_model_uuid TEXT NOT NULL,
     -- version is the unique version number that is incremented when the
     -- consumer model changes the consumer application.
     version INT NOT NULL,

--- a/domain/schema/model/triggers/crossmodelrelation-triggers.gen.go
+++ b/domain/schema/model/triggers/crossmodelrelation-triggers.gen.go
@@ -33,6 +33,7 @@ WHEN
 	NEW.offerer_application_uuid != OLD.offerer_application_uuid OR
 	NEW.consumer_application_uuid != OLD.consumer_application_uuid OR
 	NEW.offer_connection_uuid != OLD.offer_connection_uuid OR
+	NEW.consumer_model_uuid != OLD.consumer_model_uuid OR
 	NEW.version != OLD.version OR
 	NEW.life_id != OLD.life_id 
 BEGIN


### PR DESCRIPTION
The source model uuid (consuming model uuid when the remote app is added on the offering side) was missing on the DDL although it was passed in the API args.
This small patch adds it, since the model uuid is needed for the firewaller work.


## QA steps

Nothing wired on the firewaller side, so no changes expected. Unit tests should pass though.

## Links

**Jira card:** [JUJU-8489](https://warthogs.atlassian.net/browse/JUJU-8489)


[JUJU-8489]: https://warthogs.atlassian.net/browse/JUJU-8489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ