### PR TITLE
fix(machine/state): resolve query clash with `sqlair.Prepare`

### DIFF
--- a/domain/machine/state/placement.go
+++ b/domain/machine/state/placement.go
@@ -518,8 +518,13 @@ VALUES ($setConstraint.*)
 		return errors.Capture(err)
 	}
 
+	// note(gfouillet): this Prepare statement use directly sqlair to avoid
+	// a clash with the same query in the application state.
+	// Both prepare uses a setConstraintTag struct from different packages,
+	// which causes a clash in sqlair.Query below.
+	// See https://github.com/juju/juju/pull/20882 for more details.
 	insertConstraintTagsQuery := `INSERT INTO constraint_tag(*) VALUES ($setConstraintTag.*)`
-	insertConstraintTagsStmt, err := preparer.Prepare(insertConstraintTagsQuery, setConstraintTag{})
+	insertConstraintTagsStmt, err := sqlair.Prepare(insertConstraintTagsQuery, setConstraintTag{})
 	if err != nil {
 		return errors.Capture(err)
 	}


### PR DESCRIPTION
This patch fixes a clash through the `Prepare` method in `domain/state.go` to while inserting constraint tags.

The bug is due to the fact that we have two query with the same text: `INSERT INTO constraint_tag(*) VALUES ($setConstraintTag.*)` used in two different package, ie `domain/machine/state/placement.go#L522` and `domain/application/state/application.go#L2740`. Both use cases use a different type for `state.setConstraintTag`.

However, during bootstrap, both functions use the same state instance to prepare the query, and thus, sqlair uses the first prepared statement to run the second one and fails on sqlair .Query because for sqlair check that the provided type is exactly the same and in this case types are different.

- Updated `Prepare` to use `sqlair.Prepare` instead of `preparer.Prepare` for `insertConstraintTagsQuery` in `placement.go`.
- Added a comment explaining the reasoning and linked relevant context from the associated pull request.

> [!NOTE]
> Since this is a very edgy case, implying several layers, I didn't wrap my head around to find a way to Unit test it.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

bootstrap on lxd with tag constraints:

```sh
 juju bootstrap --bootstrap-constraints 'tags=juju,sqa-dh1_j9_2' lxd lxd-debug
 ```
 
 It should works (ignore the warning, it is normal)

## Links

**Jira card:** [JUJU-8635](https://warthogs.atlassian.net/browse/JUJU-8635)

[JUJU-8635]: https://warthogs.atlassian.net/browse/JUJU-8635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ