### PR TITLE
feat: ensure we can set empty settings

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -478,9 +478,9 @@ type RelationService interface {
 	// for a relation.
 	GetRelationDetails(ctx context.Context, relationUUID corerelation.UUID) (relation.RelationDetails, error)
 
-	// GetRelationUnit returns the relation unit UUID for the given unit within
-	// the given relation.
-	GetRelationUnit(
+	// GetRelationUnitUUID returns the relation unit UUID for the given unit
+	// within the given relation.
+	GetRelationUnitUUID(
 		ctx context.Context,
 		relationUUID corerelation.UUID,
 		unitName coreunit.Name,
@@ -528,12 +528,20 @@ type RelationService interface {
 		applicationID coreapplication.UUID,
 	) (map[string]string, error)
 
+	// SetRelationUnitSettings records settings for a unit in a relation.
+	SetRelationUnitSettings(
+		ctx context.Context,
+		unitName coreunit.Name,
+		relationUUID corerelation.UUID,
+		unitSettings map[string]string,
+	) error
+
 	// SetRelationApplicationAndUnitSettings records settings for a unit and
 	// an application in a relation.
 	SetRelationApplicationAndUnitSettings(
 		ctx context.Context,
 		unitName coreunit.Name,
-		relationUnitUUID corerelation.UnitUUID,
+		relationUnitUUID corerelation.UUID,
 		applicationSettings, unitSettings map[string]string,
 	) error
 

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -1801,45 +1801,6 @@ func (c *MockRelationServiceGetRelationUUIDByKeyCall) DoAndReturn(f func(context
 	return c
 }
 
-// GetRelationUnit mocks base method.
-func (m *MockRelationService) GetRelationUnit(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (relation.UnitUUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelationUnit", arg0, arg1, arg2)
-	ret0, _ := ret[0].(relation.UnitUUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRelationUnit indicates an expected call of GetRelationUnit.
-func (mr *MockRelationServiceMockRecorder) GetRelationUnit(arg0, arg1, arg2 any) *MockRelationServiceGetRelationUnitCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnit", reflect.TypeOf((*MockRelationService)(nil).GetRelationUnit), arg0, arg1, arg2)
-	return &MockRelationServiceGetRelationUnitCall{Call: call}
-}
-
-// MockRelationServiceGetRelationUnitCall wrap *gomock.Call
-type MockRelationServiceGetRelationUnitCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceGetRelationUnitCall) Return(arg0 relation.UnitUUID, arg1 error) *MockRelationServiceGetRelationUnitCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationUnitCall) Do(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockRelationServiceGetRelationUnitCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationUnitCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockRelationServiceGetRelationUnitCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetRelationUnitChanges mocks base method.
 func (m *MockRelationService) GetRelationUnitChanges(arg0 context.Context, arg1 []unit.UUID, arg2 []application.UUID) (relation0.RelationUnitsChange, error) {
 	m.ctrl.T.Helper()
@@ -1918,6 +1879,45 @@ func (c *MockRelationServiceGetRelationUnitSettingsCall) DoAndReturn(f func(cont
 	return c
 }
 
+// GetRelationUnitUUID mocks base method.
+func (m *MockRelationService) GetRelationUnitUUID(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (relation.UnitUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRelationUnitUUID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(relation.UnitUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelationUnitUUID indicates an expected call of GetRelationUnitUUID.
+func (mr *MockRelationServiceMockRecorder) GetRelationUnitUUID(arg0, arg1, arg2 any) *MockRelationServiceGetRelationUnitUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitUUID", reflect.TypeOf((*MockRelationService)(nil).GetRelationUnitUUID), arg0, arg1, arg2)
+	return &MockRelationServiceGetRelationUnitUUIDCall{Call: call}
+}
+
+// MockRelationServiceGetRelationUnitUUIDCall wrap *gomock.Call
+type MockRelationServiceGetRelationUnitUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRelationServiceGetRelationUnitUUIDCall) Return(arg0 relation.UnitUUID, arg1 error) *MockRelationServiceGetRelationUnitUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRelationServiceGetRelationUnitUUIDCall) Do(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockRelationServiceGetRelationUnitUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRelationServiceGetRelationUnitUUIDCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockRelationServiceGetRelationUnitUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationsStatusForUnit mocks base method.
 func (m *MockRelationService) GetRelationsStatusForUnit(arg0 context.Context, arg1 unit.UUID) ([]relation0.RelationUnitStatus, error) {
 	m.ctrl.T.Helper()
@@ -1958,7 +1958,7 @@ func (c *MockRelationServiceGetRelationsStatusForUnitCall) DoAndReturn(f func(co
 }
 
 // SetRelationApplicationAndUnitSettings mocks base method.
-func (m *MockRelationService) SetRelationApplicationAndUnitSettings(arg0 context.Context, arg1 unit.Name, arg2 relation.UnitUUID, arg3, arg4 map[string]string) error {
+func (m *MockRelationService) SetRelationApplicationAndUnitSettings(arg0 context.Context, arg1 unit.Name, arg2 relation.UUID, arg3, arg4 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRelationApplicationAndUnitSettings", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -1984,13 +1984,51 @@ func (c *MockRelationServiceSetRelationApplicationAndUnitSettingsCall) Return(ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceSetRelationApplicationAndUnitSettingsCall) Do(f func(context.Context, unit.Name, relation.UnitUUID, map[string]string, map[string]string) error) *MockRelationServiceSetRelationApplicationAndUnitSettingsCall {
+func (c *MockRelationServiceSetRelationApplicationAndUnitSettingsCall) Do(f func(context.Context, unit.Name, relation.UUID, map[string]string, map[string]string) error) *MockRelationServiceSetRelationApplicationAndUnitSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceSetRelationApplicationAndUnitSettingsCall) DoAndReturn(f func(context.Context, unit.Name, relation.UnitUUID, map[string]string, map[string]string) error) *MockRelationServiceSetRelationApplicationAndUnitSettingsCall {
+func (c *MockRelationServiceSetRelationApplicationAndUnitSettingsCall) DoAndReturn(f func(context.Context, unit.Name, relation.UUID, map[string]string, map[string]string) error) *MockRelationServiceSetRelationApplicationAndUnitSettingsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetRelationUnitSettings mocks base method.
+func (m *MockRelationService) SetRelationUnitSettings(arg0 context.Context, arg1 unit.Name, arg2 relation.UUID, arg3 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRelationUnitSettings", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRelationUnitSettings indicates an expected call of SetRelationUnitSettings.
+func (mr *MockRelationServiceMockRecorder) SetRelationUnitSettings(arg0, arg1, arg2, arg3 any) *MockRelationServiceSetRelationUnitSettingsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRelationUnitSettings", reflect.TypeOf((*MockRelationService)(nil).SetRelationUnitSettings), arg0, arg1, arg2, arg3)
+	return &MockRelationServiceSetRelationUnitSettingsCall{Call: call}
+}
+
+// MockRelationServiceSetRelationUnitSettingsCall wrap *gomock.Call
+type MockRelationServiceSetRelationUnitSettingsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRelationServiceSetRelationUnitSettingsCall) Return(arg0 error) *MockRelationServiceSetRelationUnitSettingsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRelationServiceSetRelationUnitSettingsCall) Do(f func(context.Context, unit.Name, relation.UUID, map[string]string) error) *MockRelationServiceSetRelationUnitSettingsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRelationServiceSetRelationUnitSettingsCall) DoAndReturn(f func(context.Context, unit.Name, relation.UUID, map[string]string) error) *MockRelationServiceSetRelationUnitSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -670,45 +670,6 @@ func (c *MockStateGetRelationUUIDByIDCall) DoAndReturn(f func(context.Context, i
 	return c
 }
 
-// GetRelationUnit mocks base method.
-func (m *MockState) GetRelationUnit(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (relation.UnitUUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelationUnit", arg0, arg1, arg2)
-	ret0, _ := ret[0].(relation.UnitUUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRelationUnit indicates an expected call of GetRelationUnit.
-func (mr *MockStateMockRecorder) GetRelationUnit(arg0, arg1, arg2 any) *MockStateGetRelationUnitCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnit", reflect.TypeOf((*MockState)(nil).GetRelationUnit), arg0, arg1, arg2)
-	return &MockStateGetRelationUnitCall{Call: call}
-}
-
-// MockStateGetRelationUnitCall wrap *gomock.Call
-type MockStateGetRelationUnitCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetRelationUnitCall) Return(arg0 relation.UnitUUID, arg1 error) *MockStateGetRelationUnitCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetRelationUnitCall) Do(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockStateGetRelationUnitCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetRelationUnitCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockStateGetRelationUnitCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetRelationUnitChanges mocks base method.
 func (m *MockState) GetRelationUnitChanges(arg0 context.Context, arg1 []unit.UUID, arg2 []application.UUID) (relation0.RelationUnitsChange, error) {
 	m.ctrl.T.Helper()
@@ -822,6 +783,45 @@ func (c *MockStateGetRelationUnitSettingsArchiveCall) Do(f func(context.Context,
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetRelationUnitSettingsArchiveCall) DoAndReturn(f func(context.Context, string, string) (map[string]string, error)) *MockStateGetRelationUnitSettingsArchiveCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetRelationUnitUUID mocks base method.
+func (m *MockState) GetRelationUnitUUID(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (relation.UnitUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRelationUnitUUID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(relation.UnitUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelationUnitUUID indicates an expected call of GetRelationUnitUUID.
+func (mr *MockStateMockRecorder) GetRelationUnitUUID(arg0, arg1, arg2 any) *MockStateGetRelationUnitUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitUUID", reflect.TypeOf((*MockState)(nil).GetRelationUnitUUID), arg0, arg1, arg2)
+	return &MockStateGetRelationUnitUUIDCall{Call: call}
+}
+
+// MockStateGetRelationUnitUUIDCall wrap *gomock.Call
+type MockStateGetRelationUnitUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetRelationUnitUUIDCall) Return(arg0 relation.UnitUUID, arg1 error) *MockStateGetRelationUnitUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetRelationUnitUUIDCall) Do(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockStateGetRelationUnitUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetRelationUnitUUIDCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockStateGetRelationUnitUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -319,16 +319,16 @@ func (s *relationServiceSuite) TestGetRelationsStatusForUnitStateError(c *tc.C) 
 	c.Assert(err, tc.ErrorIs, boom)
 }
 
-func (s *relationServiceSuite) TestGetRelationUnit(c *tc.C) {
+func (s *relationServiceSuite) TestGetRelationUnitUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
 	relationUUID := corerelationtesting.GenRelationUUID(c)
 	unitName := coreunittesting.GenNewName(c, "app1/0")
 	unitUUID := corerelationtesting.GenRelationUnitUUID(c)
-	s.state.EXPECT().GetRelationUnit(gomock.Any(), relationUUID, unitName).Return(unitUUID, nil)
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return(unitUUID, nil)
 
 	// Act
-	uuid, err := s.service.GetRelationUnit(c.Context(), relationUUID, unitName)
+	uuid, err := s.service.GetRelationUnitUUID(c.Context(), relationUUID, unitName)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -342,35 +342,35 @@ func (s *relationServiceSuite) TestGetRelationUnitRelationUUIDNotValid(c *tc.C) 
 	unitName := coreunittesting.GenNewName(c, "app1/0")
 
 	// Act
-	_, err := s.service.GetRelationUnit(c.Context(), relationUUID, unitName)
+	_, err := s.service.GetRelationUnitUUID(c.Context(), relationUUID, unitName)
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationUUIDNotValid)
 }
 
-func (s *relationServiceSuite) TestGetRelationUnitUnitNameNotValid(c *tc.C) {
+func (s *relationServiceSuite) TestGetRelationUnitUUIDUnitNameNotValid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
 	relationUUID := corerelationtesting.GenRelationUUID(c)
 	unitName := coreunit.Name("not-valid-name")
 
 	// Act
-	_, err := s.service.GetRelationUnit(c.Context(), relationUUID, unitName)
+	_, err := s.service.GetRelationUnitUUID(c.Context(), relationUUID, unitName)
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, coreunit.InvalidUnitName)
 }
 
-func (s *relationServiceSuite) TestGetRelationUnitUnitStateError(c *tc.C) {
+func (s *relationServiceSuite) TestGetRelationUnitUUIDUnitStateError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
 	relationUUID := corerelationtesting.GenRelationUUID(c)
 	unitName := coreunittesting.GenNewName(c, "app1/0")
 	boom := errors.Errorf("boom")
-	s.state.EXPECT().GetRelationUnit(gomock.Any(), relationUUID, unitName).Return("", boom)
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return("", boom)
 
 	// Act
-	_, err := s.service.GetRelationUnit(c.Context(), relationUUID, unitName)
+	_, err := s.service.GetRelationUnitUUID(c.Context(), relationUUID, unitName)
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, boom)
@@ -384,7 +384,7 @@ func (s *relationServiceSuite) TestGetRelationUnitByID(c *tc.C) {
 	unitName := coreunittesting.GenNewName(c, "app1/0")
 	unitUUID := corerelationtesting.GenRelationUnitUUID(c)
 	s.state.EXPECT().GetRelationUUIDByID(gomock.Any(), relationID).Return(relationUUID, nil)
-	s.state.EXPECT().GetRelationUnit(gomock.Any(), relationUUID, unitName).Return(unitUUID, nil)
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return(unitUUID, nil)
 
 	// Act
 	uuid, err := s.service.getRelationUnitByID(c.Context(), relationID, unitName)
@@ -428,7 +428,7 @@ func (s *relationServiceSuite) TestGetRelationUnitByIDUnitStateError(c *tc.C) {
 	unitName := coreunittesting.GenNewName(c, "app1/0")
 	boom := errors.Errorf("boom")
 	s.state.EXPECT().GetRelationUUIDByID(gomock.Any(), relationID).Return(relationUUID, nil)
-	s.state.EXPECT().GetRelationUnit(gomock.Any(), relationUUID, unitName).Return("", boom)
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return("", boom)
 
 	// Act
 	_, err := s.service.getRelationUnitByID(c.Context(), relationID, unitName)
@@ -655,7 +655,7 @@ func (s *relationServiceSuite) TestGetRelationUnitSettings(c *tc.C) {
 		"key": "value",
 	}
 
-	s.state.EXPECT().GetRelationUnit(gomock.Any(), relationUUID, unitName).Return(relationUnitUUID, nil)
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return(relationUnitUUID, nil)
 	s.state.EXPECT().GetRelationUnitSettings(gomock.Any(), relationUnitUUID).Return(expectedSettings, nil)
 
 	// Act:
@@ -691,7 +691,7 @@ func (s *relationServiceSuite) TestGetRelationUnitSettingsFallback(c *tc.C) {
 	}
 
 	exp := s.state.EXPECT()
-	exp.GetRelationUnit(gomock.Any(), relationUUID, unitName).Return("", relationerrors.RelationUnitNotFound)
+	exp.GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return("", relationerrors.RelationUnitNotFound)
 	exp.GetRelationUnitSettingsArchive(gomock.Any(), relationUUID.String(), unitName.String()).Return(expectedSettings, nil)
 
 	// Act:
@@ -1003,6 +1003,7 @@ type relationLeadershipServiceSuite struct {
 func TestRelationLeadershipServiceSuite(t *testing.T) {
 	tc.Run(t, &relationLeadershipServiceSuite{})
 }
+
 func (s *relationLeadershipServiceSuite) TestGetRelationApplicationSettingsWithLeader(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -1066,6 +1067,61 @@ func (s *relationLeadershipServiceSuite) TestGetRelationApplicationSettingsWithL
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationUUIDNotValid)
 }
 
+func (s *relationLeadershipServiceSuite) TestSetRelationUnitSettings(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	unitName := coreunittesting.GenNewName(c, "app/0")
+
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+	unitSettings := map[string]string{
+		"unitKey": "unitValue",
+	}
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return(relationUnitUUID, nil)
+	s.state.EXPECT().SetRelationUnitSettings(gomock.Any(), relationUnitUUID, unitSettings).Return(nil)
+
+	// Act:
+	err := s.leadershipService.SetRelationUnitSettings(c.Context(), unitName, relationUUID, unitSettings)
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *relationLeadershipServiceSuite) TestSetRelationUnitSettingsEmpty(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	unitName := coreunittesting.GenNewName(c, "app/0")
+
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+	unitSettings := make(map[string]string)
+
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return(relationUnitUUID, nil)
+	s.state.EXPECT().SetRelationUnitSettings(gomock.Any(), relationUnitUUID, unitSettings).Return(nil)
+
+	// Act:
+	err := s.leadershipService.SetRelationUnitSettings(c.Context(), unitName, relationUUID, unitSettings)
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *relationLeadershipServiceSuite) TestSetRelationUnitSettingsNil(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+
+	// Act:
+	err := s.leadershipService.SetRelationUnitSettings(c.Context(), unitName, relationUUID, nil)
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettings(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -1073,6 +1129,7 @@ func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettin
 	unitName := coreunittesting.GenNewName(c, "app/0")
 	s.expectWithLeader(c, unitName)
 
+	relationUUID := corerelationtesting.GenRelationUUID(c)
 	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
 	appSettings := map[string]string{
 		"appKey": "appValue",
@@ -1080,44 +1137,11 @@ func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettin
 	unitSettings := map[string]string{
 		"unitKey": "unitValue",
 	}
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return(relationUnitUUID, nil)
 	s.state.EXPECT().SetRelationApplicationAndUnitSettings(gomock.Any(), relationUnitUUID, appSettings, unitSettings).Return(nil)
 
 	// Act:
-	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, relationUnitUUID, appSettings, unitSettings)
-
-	// Assert:
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-// TestSetRelationApplicationAndUnitSettingsOnlyUnit checks that if only the
-// unit settings are changed, leadership is not checked.
-func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettingsOnlyUnit(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	// Arrange:
-	unitName := coreunittesting.GenNewName(c, "app/0")
-	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
-	unitSettings := map[string]string{
-		"unitKey": "unitValue",
-	}
-	s.state.EXPECT().SetRelationUnitSettings(gomock.Any(), relationUnitUUID, unitSettings).Return(nil)
-
-	// Act:
-	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, relationUnitUUID, nil, unitSettings)
-
-	// Assert:
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettingsNil(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	// Arrange:
-	unitName := coreunittesting.GenNewName(c, "app/0")
-	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
-
-	// Act:
-	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, relationUnitUUID, nil, nil)
+	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, relationUUID, appSettings, unitSettings)
 
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
@@ -1128,9 +1152,32 @@ func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettin
 
 	// Arrange:
 	unitName := coreunittesting.GenNewName(c, "app/0")
+	s.expectWithLeader(c, unitName)
+
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+	applicationSettings := make(map[string]string)
+	unitSettings := make(map[string]string)
+
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return(relationUnitUUID, nil)
+	s.state.EXPECT().SetRelationApplicationAndUnitSettings(gomock.Any(), relationUnitUUID, applicationSettings, unitSettings).Return(nil)
 
 	// Act:
-	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, "bad-uuid", make(map[string]string), make(map[string]string))
+	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, relationUUID, applicationSettings, unitSettings)
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettingsNil(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+
+	// Act:
+	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, relationUUID, nil, nil)
 
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
@@ -1141,14 +1188,18 @@ func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettin
 
 	// Arrange:
 	unitName := coreunittesting.GenNewName(c, "app/0")
+	relationUUID := corerelationtesting.GenRelationUUID(c)
 	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+
+	s.state.EXPECT().GetRelationUnitUUID(gomock.Any(), relationUUID, unitName).Return(relationUnitUUID, nil)
+
 	s.leaderEnsurer.EXPECT().WithLeader(gomock.Any(), unitName.Application(), unitName.String(), gomock.Any()).Return(corelease.ErrNotHeld)
 	settings := map[string]string{
 		"key": "value",
 	}
 
 	// Act:
-	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, relationUnitUUID, settings, settings)
+	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), unitName, relationUUID, settings, settings)
 
 	// Assert:
 	c.Assert(err, tc.ErrorIs, corelease.ErrNotHeld)
@@ -1158,13 +1209,13 @@ func (s *relationLeadershipServiceSuite) TestSetRelationApplicationAndUnitSettin
 	defer s.setupMocks(c).Finish()
 
 	// Arrange:
-	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+	relationUUID := corerelationtesting.GenRelationUUID(c)
 	settings := map[string]string{
 		"key": "value",
 	}
 
 	// Act:
-	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), "", relationUnitUUID, settings, nil)
+	err := s.leadershipService.SetRelationApplicationAndUnitSettings(c.Context(), "", relationUUID, settings, nil)
 
 	// Assert:
 	c.Assert(err, tc.ErrorIs, coreunit.InvalidUnitName)

--- a/domain/relation/state/migration_test.go
+++ b/domain/relation/state/migration_test.go
@@ -387,7 +387,7 @@ func (s *migrationSuite) TestSetRelationApplicationSettingsApplicationNotFoundIn
 		c.Context(),
 		relationUUID,
 		s.fakeApplicationUUID1,
-		nil,
+		map[string]string{"key": "value"},
 	)
 
 	// Assert:
@@ -400,7 +400,7 @@ func (s *migrationSuite) TestSetRelationApplicationSettingsRelationNotFound(c *t
 		c.Context(),
 		"bad-uuid",
 		s.fakeApplicationUUID1,
-		nil,
+		map[string]string{"key": "value"},
 	)
 
 	// Assert:

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -1096,13 +1096,13 @@ WHERE u.uuid IN ($uuids[:])`, getUnit{}, uuids{})
 	}, nil
 }
 
-// GetRelationUnit retrieves the UUID of a relation unit based on the given
+// GetRelationUnitUUID retrieves the UUID of a relation unit based on the given
 // relation UUID and unit name.
 //
 // The following error types can be expected to be returned:
 //   - [relationerrors.RelationUnitNotFound] if the relation unit cannot be
 //     found.
-func (st *State) GetRelationUnit(
+func (st *State) GetRelationUnitUUID(
 	ctx context.Context,
 	relationUUID corerelation.UUID,
 	unitName unit.Name,
@@ -2144,6 +2144,11 @@ func (st *State) setRelationUnitSettings(
 	relationUnitUUID string,
 	settings map[string]string,
 ) error {
+	// If the settings are nil then there is nothing to do. Do not check for
+	// length of 0, as that is valid for deleting all settings.
+	if settings == nil {
+		return nil
+	}
 
 	// Get the relation endpoint UUID.
 	exists, err := st.checkExistsByUUID(ctx, tx, "relation_unit", relationUnitUUID)
@@ -3404,6 +3409,12 @@ func (st *State) setRelationApplicationSettings(
 	applicationID application.UUID,
 	settings map[string]string,
 ) error {
+	// If the settings are nil then there is nothing to do. Do not check for
+	// length of 0, as that is valid for deleting all settings.
+	if settings == nil {
+		return nil
+	}
+
 	// Get the relation endpoint UUID.
 	endpointUUID, err := st.getRelationEndpointUUID(ctx, tx, relationUUID, applicationID)
 	if err != nil {

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -1376,7 +1376,7 @@ func (s *relationSuite) TestGetRelationDetailsNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
-func (s *relationSuite) TestGetRelationUnit(c *tc.C) {
+func (s *relationSuite) TestGetRelationUnitUUID(c *tc.C) {
 	// Arrange: one relation unit
 	charmUUID := s.addCharm(c)
 	appUUID := s.addApplication(c, charmUUID, "my-app")
@@ -1388,16 +1388,16 @@ func (s *relationSuite) TestGetRelationUnit(c *tc.C) {
 	relUnitUUID := s.addRelationUnit(c, unitUUID, relEndpointUUID)
 
 	// Act
-	uuid, err := s.state.GetRelationUnit(c.Context(), relUUID, "my-app/0")
+	uuid, err := s.state.GetRelationUnitUUID(c.Context(), relUUID, "my-app/0")
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil, tc.Commentf(errors.ErrorStack(err)))
 	c.Check(uuid, tc.Equals, relUnitUUID)
 }
 
-func (s *relationSuite) TestGetRelationUnitNotFound(c *tc.C) {
+func (s *relationSuite) TestGetRelationUnitUUIDNotFound(c *tc.C) {
 	// Act
-	_, err := s.state.GetRelationUnit(c.Context(), "unknown-relation-uuid", "some-unit-name")
+	_, err := s.state.GetRelationUnitUUID(c.Context(), "unknown-relation-uuid", "some-unit-name")
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationUnitNotFound)
@@ -2595,6 +2595,7 @@ func (s *relationSuite) TestSetRelationUnitSettingsHashUpdated(c *tc.C) {
 		relationUnitUUID,
 		initialSettings,
 	)
+
 	c.Assert(err, tc.ErrorIsNil)
 
 	initialHash := s.getRelationUnitSettingsHash(c, relationUnitUUID)
@@ -2672,7 +2673,7 @@ func (s *relationSuite) TestSetRelationUnitSettingsRelationUnitNotFound(c *tc.C)
 	err := s.state.SetRelationUnitSettings(
 		c.Context(),
 		"bad-uuid",
-		nil,
+		map[string]string{"key": "value"},
 	)
 
 	// Assert:
@@ -2795,8 +2796,8 @@ func (s *relationSuite) TestSetRelationApplicationAndUnitSettingsRelationUnitNot
 	err := s.state.SetRelationApplicationAndUnitSettings(
 		c.Context(),
 		"bad-uuid",
-		nil,
-		nil,
+		map[string]string{"key": "value"},
+		map[string]string{"key": "value"},
 	)
 
 	// Assert:


### PR DESCRIPTION
This is step 1 in a series of changes for implementing writing application and unit settings to the local database. This is broken off from https://github.com/juju/juju/pull/20890

-----

Empty settings for both the units and applications are allowed to clear the settings of a relation. If the maps are nil, then updating them should be skipped.

Lastly, the setting of application and unit settings was overloaded to support nil application settings. This could cause issues if you didn't know what nil vs empty was. Just split the methods up and have a better clean API.


## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model m
$ juju deploy juju-qa-dummy-sink sink
$ juju deploy juju-qa-dummy-source src
$ juju relate src sink
$ juju config src token="hey"
```
## Links

**Jira card:** [JUJU-8492](https://warthogs.atlassian.net/browse/JUJU-8492)


[JUJU-8492]: https://warthogs.atlassian.net/browse/JUJU-8492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ