### PR TITLE
feat: add relation network tables

### DIFF
--- a/domain/schema/model/sql/0024-relation.sql
+++ b/domain/schema/model/sql/0024-relation.sql
@@ -202,6 +202,27 @@ INSERT INTO relation_status_type VALUES
 (4, 'suspended'),
 (5, 'error');
 
+-- relation_network_ingress holds information about ingress CIDRs for a 
+-- relation.
+CREATE TABLE relation_network_ingress (
+    relation_uuid TEXT NOT NULL,
+    cidr TEXT NOT NULL,
+    CONSTRAINT fk_relation_uuid
+    FOREIGN KEY (relation_uuid)
+    REFERENCES relation (uuid),
+    PRIMARY KEY (relation_uuid, cidr)
+);
+
+-- relation_network_egress holds information about egress CIDRs for a relation.
+CREATE TABLE relation_network_egress (
+    relation_uuid TEXT NOT NULL,
+    cidr TEXT NOT NULL,
+    CONSTRAINT fk_relation_uuid
+    FOREIGN KEY (relation_uuid)
+    REFERENCES relation (uuid),
+    PRIMARY KEY (relation_uuid, cidr)
+);
+
 -- The relation_status maps a relation to its status
 -- as defined in the relation_status_type table.
 CREATE TABLE relation_status (

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -291,6 +291,8 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"relation_unit_setting_archive",
 		"relation_unit",
 		"relation",
+		"relation_network_ingress",
+		"relation_network_egress",
 
 		// Cleanup
 		"removal_type",


### PR DESCRIPTION
This patch adds two tables `relation_network_ingress` and `relation_network_egress`, needed for the relations added with `--via` in CMR scenarios.

> [!NOTE]
> In 3.6, this was only one collection with CIDRs and a direction (ingress/egress). I find it more explicit if we store them in separate tables, because these two tables are written and read on different sides of the CMR.


## QA steps

Nothing wired yet.

## Links


**Jira card:** [JUJU-8489](https://warthogs.atlassian.net/browse/JUJU-8489)


[JUJU-8489]: https://warthogs.atlassian.net/browse/JUJU-8489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ