### PR TITLE
feat(status): add remote application (SAAS) to status

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1509,8 +1509,14 @@ func (api *APIBase) saveRemoteApplicationOfferer(
 		return internalerrors.Errorf("parsing offer UUID: %w", err)
 	}
 
+	offerURL, err := crossmodel.ParseOfferURL(offer.OfferURL)
+	if err != nil {
+		return internalerrors.Errorf("parsing offer URL: %w", err)
+	}
+
 	if err := api.crossModelRelationService.AddRemoteApplicationOfferer(ctx, applicationName, crossmodelrelationservice.AddRemoteApplicationOffererArgs{
 		OfferUUID:             offerUUID,
+		OfferURL:              offerURL,
 		OffererControllerUUID: offererControllerUUID,
 		OffererModelUUID:      offererModelUUID,
 		Endpoints:             remoteEps,

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1358,6 +1358,7 @@ func (s *applicationSuite) TestConsume(c *tc.C) {
 	s.externalControllerService.EXPECT().UpdateExternalController(gomock.Any(), controllerInfo).Return(nil)
 	s.crossModelRelationService.EXPECT().AddRemoteApplicationOfferer(gomock.Any(), "my-offer", crossmodelrelationservice.AddRemoteApplicationOffererArgs{
 		OfferUUID:             offerUUID,
+		OfferURL:              tc.Must1(c, crossmodel.ParseOfferURL, "controller:qualifier/model.my-offer"),
 		OffererControllerUUID: ptr(controllerUUID),
 		OffererModelUUID:      modelUUID,
 		Endpoints: []applicationcharm.Relation{{
@@ -1376,6 +1377,7 @@ func (s *applicationSuite) TestConsume(c *tc.C) {
 			ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
 				OfferUUID:      offerUUID.String(),
 				OfferName:      "my-offer",
+				OfferURL:       "controller:qualifier/model.my-offer",
 				SourceModelTag: names.NewModelTag(modelUUID).String(),
 				Endpoints: []params.RemoteEndpoint{{
 					Name:      "db",
@@ -1408,6 +1410,7 @@ func (s *applicationSuite) TestConsumeNoExternalController(c *tc.C) {
 
 	s.crossModelRelationService.EXPECT().AddRemoteApplicationOfferer(gomock.Any(), "my-offer", crossmodelrelationservice.AddRemoteApplicationOffererArgs{
 		OfferUUID:        offerUUID,
+		OfferURL:         tc.Must1(c, crossmodel.ParseOfferURL, "controller:qualifier/model.my-offer"),
 		OffererModelUUID: modelUUID,
 		Endpoints: []applicationcharm.Relation{{
 			Name:      "db",
@@ -1425,6 +1428,7 @@ func (s *applicationSuite) TestConsumeNoExternalController(c *tc.C) {
 			ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
 				OfferUUID:      offerUUID.String(),
 				OfferName:      "my-offer",
+				OfferURL:       "controller:qualifier/model.my-offer",
 				SourceModelTag: names.NewModelTag(modelUUID).String(),
 				Endpoints: []params.RemoteEndpoint{{
 					Name:      "db",
@@ -1454,6 +1458,7 @@ func (s *applicationSuite) TestConsumeSameController(c *tc.C) {
 
 	s.crossModelRelationService.EXPECT().AddRemoteApplicationOfferer(gomock.Any(), "my-offer", crossmodelrelationservice.AddRemoteApplicationOffererArgs{
 		OfferUUID:        offerUUID,
+		OfferURL:         tc.Must1(c, crossmodel.ParseOfferURL, "controller:qualifier/model.my-offer"),
 		OffererModelUUID: modelUUID,
 		Endpoints: []applicationcharm.Relation{{
 			Name:      "db",
@@ -1471,6 +1476,7 @@ func (s *applicationSuite) TestConsumeSameController(c *tc.C) {
 			ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
 				OfferUUID:      offerUUID.String(),
 				OfferName:      "my-offer",
+				OfferURL:       "controller:qualifier/model.my-offer",
 				SourceModelTag: names.NewModelTag(modelUUID).String(),
 				Endpoints: []params.RemoteEndpoint{{
 					Name:      "db",
@@ -1497,6 +1503,7 @@ func (s *applicationSuite) TestConsumeSameControllerSameOfferUUID(c *tc.C) {
 
 	s.crossModelRelationService.EXPECT().AddRemoteApplicationOfferer(gomock.Any(), "my-offer", crossmodelrelationservice.AddRemoteApplicationOffererArgs{
 		OfferUUID:        offerUUID,
+		OfferURL:         tc.Must1(c, crossmodel.ParseOfferURL, "controller:qualifier/model.my-offer"),
 		OffererModelUUID: modelUUID,
 		Endpoints: []applicationcharm.Relation{{
 			Name:      "db",
@@ -1514,6 +1521,7 @@ func (s *applicationSuite) TestConsumeSameControllerSameOfferUUID(c *tc.C) {
 			ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
 				OfferUUID:      offerUUID.String(),
 				OfferName:      "my-offer",
+				OfferURL:       "controller:qualifier/model.my-offer",
 				SourceModelTag: names.NewModelTag(modelUUID).String(),
 				Endpoints: []params.RemoteEndpoint{{
 					Name:      "db",
@@ -1569,6 +1577,7 @@ func (s *applicationSuite) TestConsumeInvalidEndpointRole(c *tc.C) {
 			ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
 				OfferUUID:      offerUUID.String(),
 				OfferName:      "my-offer",
+				OfferURL:       "controller:qualifier/model.my-offer",
 				SourceModelTag: names.NewModelTag(modelUUID).String(),
 				Endpoints: []params.RemoteEndpoint{{
 					Name:      "db",

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -565,7 +565,7 @@ func (api *OffersAPI) ModifyOfferAccess(ctx context.Context, args params.ModifyO
 func (api *OffersAPI) modifyOneOfferAccess(
 	ctx context.Context,
 	apiUserTag names.UserTag,
-	offerURL *corecrossmodel.OfferURL,
+	offerURL corecrossmodel.OfferURL,
 	modelUUID string,
 	arg params.ModifyOfferAccess,
 ) error {
@@ -636,7 +636,7 @@ func (api *OffersAPI) changeOfferAccess(
 }
 
 type offerModel struct {
-	url   *corecrossmodel.OfferURL
+	url   corecrossmodel.OfferURL
 	model model.Model
 	err   error
 }
@@ -646,10 +646,10 @@ type offerModel struct {
 func (api *OffersAPI) getModelsFromOffers(ctx context.Context, user names.UserTag, offerURLs ...string) ([]offerModel, error) {
 	// Cache the models found so far so we don't look them up more than once.
 	modelsCache := make(map[string]model.Model)
-	oneModel := func(offerURL string) (*corecrossmodel.OfferURL, model.Model, error) {
+	oneModel := func(offerURL string) (corecrossmodel.OfferURL, model.Model, error) {
 		url, err := corecrossmodel.ParseOfferURL(offerURL)
 		if err != nil {
-			return nil, model.Model{}, errors.Capture(err)
+			return corecrossmodel.OfferURL{}, model.Model{}, errors.Capture(err)
 		}
 
 		url.ModelQualifier = constructModelQualifier(url.ModelQualifier, user).String()
@@ -660,7 +660,7 @@ func (api *OffersAPI) getModelsFromOffers(ctx context.Context, user names.UserTa
 
 		m, err := api.modelForName(ctx, url.ModelName, url.ModelQualifier)
 		if err != nil {
-			return nil, model.Model{}, errors.Capture(err)
+			return corecrossmodel.OfferURL{}, model.Model{}, errors.Capture(err)
 		}
 		return url, m, nil
 	}
@@ -792,7 +792,7 @@ func applicationOfferURLAndFilter(in string, apiUserTag names.UserTag) (string, 
 	return url.String(), filterFromURL(url), nil
 }
 
-func filterFromURL(url *corecrossmodel.OfferURL) params.OfferFilter {
+func filterFromURL(url corecrossmodel.OfferURL) params.OfferFilter {
 	f := params.OfferFilter{
 		ModelQualifier: url.ModelQualifier,
 		ModelName:      url.ModelName,

--- a/apiserver/facades/client/applicationoffers/package_mock_test.go
+++ b/apiserver/facades/client/applicationoffers/package_mock_test.go
@@ -250,7 +250,7 @@ func (m *MockCrossModelRelationService) EXPECT() *MockCrossModelRelationServiceM
 }
 
 // GetOfferUUID mocks base method.
-func (m *MockCrossModelRelationService) GetOfferUUID(arg0 context.Context, arg1 *crossmodel.OfferURL) (offer.UUID, error) {
+func (m *MockCrossModelRelationService) GetOfferUUID(arg0 context.Context, arg1 crossmodel.OfferURL) (offer.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOfferUUID", arg0, arg1)
 	ret0, _ := ret[0].(offer.UUID)
@@ -277,13 +277,13 @@ func (c *MockCrossModelRelationServiceGetOfferUUIDCall) Return(arg0 offer.UUID, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceGetOfferUUIDCall) Do(f func(context.Context, *crossmodel.OfferURL) (offer.UUID, error)) *MockCrossModelRelationServiceGetOfferUUIDCall {
+func (c *MockCrossModelRelationServiceGetOfferUUIDCall) Do(f func(context.Context, crossmodel.OfferURL) (offer.UUID, error)) *MockCrossModelRelationServiceGetOfferUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceGetOfferUUIDCall) DoAndReturn(f func(context.Context, *crossmodel.OfferURL) (offer.UUID, error)) *MockCrossModelRelationServiceGetOfferUUIDCall {
+func (c *MockCrossModelRelationServiceGetOfferUUIDCall) DoAndReturn(f func(context.Context, crossmodel.OfferURL) (offer.UUID, error)) *MockCrossModelRelationServiceGetOfferUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/applicationoffers/service.go
+++ b/apiserver/facades/client/applicationoffers/service.go
@@ -49,7 +49,7 @@ type ModelService interface {
 // CrossModelRelationService defines the interface for interacting with the crossmodelrelation domain.
 type CrossModelRelationService interface {
 	// GetOfferUUID returns the uuid for the provided offer URL.
-	GetOfferUUID(ctx context.Context, offerURL *crossmodel.OfferURL) (offer.UUID, error)
+	GetOfferUUID(ctx context.Context, offerURL crossmodel.OfferURL) (offer.UUID, error)
 
 	// GetOffers returns offer details for all offers satisfying any of the
 	// provided filters.

--- a/apiserver/facades/client/client/fullstatus_test.go
+++ b/apiserver/facades/client/client/fullstatus_test.go
@@ -128,6 +128,7 @@ func (s *fullStatusSuite) TestFullStatusNetworkInterfaces(c *tc.C) {
 
 	s.applicationService.EXPECT().GetAllEndpointBindings(gomock.Any()).Return(nil, nil)
 	s.statusService.EXPECT().GetApplicationAndUnitStatuses(gomock.Any()).Return(nil, nil)
+	s.statusService.EXPECT().GetRemoteApplicationOffererStatuses(gomock.Any()).Return(nil, nil)
 	s.portService.EXPECT().GetAllOpenedPorts(gomock.Any()).Return(nil, nil)
 	s.networkService.EXPECT().GetAllSpaces(gomock.Any()).Return(nil, nil)
 	s.relationService.EXPECT().GetAllRelationDetails(gomock.Any()).Return(nil, nil)
@@ -330,6 +331,7 @@ func (s *fullStatusSuite) expectCheckIsAdmin(client *Client, read bool) {
 
 func (s *fullStatusSuite) expectEmptyModelModuloOffers(c *tc.C) {
 	s.statusService.EXPECT().GetApplicationAndUnitStatuses(gomock.Any()).Return(nil, nil)
+	s.statusService.EXPECT().GetRemoteApplicationOffererStatuses(gomock.Any()).Return(nil, nil)
 	s.applicationService.EXPECT().GetAllEndpointBindings(gomock.Any()).Return(nil, nil)
 
 	s.portService.EXPECT().GetAllOpenedPorts(gomock.Any()).Return(nil, nil)

--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -63,6 +63,10 @@ type StatusService interface {
 	// applications in the model, indexed by application name.
 	GetApplicationAndUnitStatuses(context.Context) (map[string]statusservice.Application, error)
 
+	// GetRemoteApplicationOffererStatuses returns the statuses of all remote
+	// application offerers in the model, indexed by application name.
+	GetRemoteApplicationOffererStatuses(ctx context.Context) (map[string]statusservice.RemoteApplicationOfferer, error)
+
 	// GetStatusHistory returns the status history based on the request.
 	GetStatusHistory(context.Context, statusservice.StatusHistoryRequest) ([]status.DetailedStatus, error)
 

--- a/apiserver/facades/client/client/service_mock_test.go
+++ b/apiserver/facades/client/client/service_mock_test.go
@@ -1018,6 +1018,45 @@ func (c *MockStatusServiceGetModelStatusCall) DoAndReturn(f func(context.Context
 	return c
 }
 
+// GetRemoteApplicationOffererStatuses mocks base method.
+func (m *MockStatusService) GetRemoteApplicationOffererStatuses(arg0 context.Context) (map[string]service.RemoteApplicationOfferer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRemoteApplicationOffererStatuses", arg0)
+	ret0, _ := ret[0].(map[string]service.RemoteApplicationOfferer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteApplicationOffererStatuses indicates an expected call of GetRemoteApplicationOffererStatuses.
+func (mr *MockStatusServiceMockRecorder) GetRemoteApplicationOffererStatuses(arg0 any) *MockStatusServiceGetRemoteApplicationOffererStatusesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteApplicationOffererStatuses", reflect.TypeOf((*MockStatusService)(nil).GetRemoteApplicationOffererStatuses), arg0)
+	return &MockStatusServiceGetRemoteApplicationOffererStatusesCall{Call: call}
+}
+
+// MockStatusServiceGetRemoteApplicationOffererStatusesCall wrap *gomock.Call
+type MockStatusServiceGetRemoteApplicationOffererStatusesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStatusServiceGetRemoteApplicationOffererStatusesCall) Return(arg0 map[string]service.RemoteApplicationOfferer, arg1 error) *MockStatusServiceGetRemoteApplicationOffererStatusesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStatusServiceGetRemoteApplicationOffererStatusesCall) Do(f func(context.Context) (map[string]service.RemoteApplicationOfferer, error)) *MockStatusServiceGetRemoteApplicationOffererStatusesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStatusServiceGetRemoteApplicationOffererStatusesCall) DoAndReturn(f func(context.Context) (map[string]service.RemoteApplicationOfferer, error)) *MockStatusServiceGetRemoteApplicationOffererStatusesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetStatusHistory mocks base method.
 func (m *MockStatusService) GetStatusHistory(arg0 context.Context, arg1 service.StatusHistoryRequest) ([]status.DetailedStatus, error) {
 	m.ctrl.T.Helper()

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -99,7 +99,7 @@ func (c *consumeCommand) getTargetAPI(ctx context.Context) (applicationConsumeAP
 	return application.NewClient(root), nil
 }
 
-func (c *consumeCommand) getSourceAPI(ctx context.Context, url *crossmodel.OfferURL) (applicationConsumeDetailsAPI, error) {
+func (c *consumeCommand) getSourceAPI(ctx context.Context, url crossmodel.OfferURL) (applicationConsumeDetailsAPI, error) {
 	if c.sourceAPI != nil {
 		return c.sourceAPI, nil
 	}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -197,7 +197,7 @@ func newDeployCommand() *DeployCommand {
 			spacesClient:         spaces.NewAPI(apiRoot),
 		}, nil
 	}
-	deployCmd.NewConsumeDetailsAPI = func(ctx context.Context, url *crossmodel.OfferURL) (deployer.ConsumeDetails, error) {
+	deployCmd.NewConsumeDetailsAPI = func(ctx context.Context, url crossmodel.OfferURL) (deployer.ConsumeDetails, error) {
 		root, err := deployCmd.CommandBase.NewAPIRoot(ctx, deployCmd.ClientStore(), url.Source, "")
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -324,7 +324,7 @@ type DeployCommand struct {
 
 	// NewConsumeDetailsAPI stores a function which will return a new API
 	// for consume details API using the url as the source.
-	NewConsumeDetailsAPI func(ctx context.Context, url *crossmodel.OfferURL) (deployer.ConsumeDetails, error)
+	NewConsumeDetailsAPI func(ctx context.Context, url crossmodel.OfferURL) (deployer.ConsumeDetails, error)
 
 	// DeployResources stores a function which deploys charm resources.
 	DeployResources deployer.DeployResourcesFunc

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1195,7 +1195,7 @@ func newDeployCommandForTest(fakeAPI *fakeDeployAPI) modelcmd.ModelCommand {
 	deployCmd.NewCharmsAPI = func(api base.APICallCloser) CharmsAPI {
 		return apicharms.NewClient(fakeAPI)
 	}
-	deployCmd.NewConsumeDetailsAPI = func(ctx context.Context, url *crossmodel.OfferURL) (deployer.ConsumeDetails, error) {
+	deployCmd.NewConsumeDetailsAPI = func(ctx context.Context, url crossmodel.OfferURL) (deployer.ConsumeDetails, error) {
 		return fakeAPI, nil
 	}
 	return cmd

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -41,7 +41,7 @@ type deployBundle struct {
 	defaultCharmSchema charm.Schema
 
 	resolver             Resolver
-	newConsumeDetailsAPI func(ctx context.Context, url *crossmodel.OfferURL) (ConsumeDetails, error)
+	newConsumeDetailsAPI func(ctx context.Context, url crossmodel.OfferURL) (ConsumeDetails, error)
 	deployResources      DeployResourcesFunc
 	charmReader          CharmReader
 
@@ -196,7 +196,7 @@ func (d *deployBundle) makeBundleDeploySpec(ctx *cmd.Context, apiRoot DeployerAP
 	// the local cache.
 	// If no controller is found within the local cache, an error will be raised
 	// which should ask the user to login.
-	getConsumeDetails := func(url *crossmodel.OfferURL) (ConsumeDetails, error) {
+	getConsumeDetails := func(url crossmodel.OfferURL) (ConsumeDetails, error) {
 		// Ensure that we have a url source when querying the controller.
 		if url.Source == "" {
 			url.Source = d.controllerName

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -64,7 +64,7 @@ type bundleDeploySpec struct {
 
 	deployAPI            DeployerAPI
 	bundleResolver       Resolver
-	getConsumeDetailsAPI func(*crossmodel.OfferURL) (ConsumeDetails, error)
+	getConsumeDetailsAPI func(crossmodel.OfferURL) (ConsumeDetails, error)
 	deployResources      DeployResourcesFunc
 	charmReader          CharmReader
 
@@ -143,7 +143,7 @@ type bundleHandler struct {
 	// deployAPI is used to interact with the environment.
 	deployAPI            DeployerAPI
 	bundleResolver       Resolver
-	getConsumeDetailsAPI func(*crossmodel.OfferURL) (ConsumeDetails, error)
+	getConsumeDetailsAPI func(crossmodel.OfferURL) (ConsumeDetails, error)
 	deployResources      DeployResourcesFunc
 	charmReader          CharmReader
 

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -2252,8 +2252,8 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusWordpressBundle() {
 				},
 			},
 		},
-		RemoteApplications: nil,
-		Offers:             nil,
+		RemoteApplicationOfferers: nil,
+		Offers:                    nil,
 		Relations: []params.RelationStatus{
 			{
 				Endpoints: []params.EndpointStatus{
@@ -2283,10 +2283,10 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjangoBundle() {
 				},
 			},
 		},
-		RemoteApplications:  nil,
-		Offers:              nil,
-		Relations:           nil,
-		ControllerTimestamp: nil,
+		RemoteApplicationOfferers: nil,
+		Offers:                    nil,
+		Relations:                 nil,
+		ControllerTimestamp:       nil,
 	}
 	s.deployerAPI.EXPECT().Status(gomock.Any(), gomock.Any()).Return(status, nil)
 }
@@ -2318,10 +2318,10 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjangoMemBundle() {
 				},
 			},
 		},
-		RemoteApplications:  nil,
-		Offers:              nil,
-		Relations:           nil,
-		ControllerTimestamp: nil,
+		RemoteApplicationOfferers: nil,
+		Offers:                    nil,
+		Relations:                 nil,
+		ControllerTimestamp:       nil,
 	}
 	s.deployerAPI.EXPECT().Status(gomock.Any(), gomock.Any()).Return(status, nil)
 }
@@ -2345,10 +2345,10 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjango2Units() {
 				},
 			},
 		},
-		RemoteApplications:  nil,
-		Offers:              nil,
-		Relations:           nil,
-		ControllerTimestamp: nil,
+		RemoteApplicationOfferers: nil,
+		Offers:                    nil,
+		Relations:                 nil,
+		ControllerTimestamp:       nil,
 	}
 	s.deployerAPI.EXPECT().Status(gomock.Any(), gomock.Any()).Return(status, nil)
 }
@@ -2798,8 +2798,8 @@ func (s *BundleHandlerMakeModelSuite) expectDeployerAPIStatusWordpressBundle() {
 				},
 			},
 		},
-		RemoteApplications: nil,
-		Offers:             nil,
+		RemoteApplicationOfferers: nil,
+		Offers:                    nil,
 		Relations: []params.RelationStatus{
 			{
 				Endpoints: []params.EndpointStatus{

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -388,7 +388,7 @@ type DeployerDependencies struct {
 	Model                ModelCommand
 	FileSystem           modelcmd.Filesystem
 	CharmReader          CharmReader
-	NewConsumeDetailsAPI func(ctx context.Context, url *crossmodel.OfferURL) (ConsumeDetails, error)
+	NewConsumeDetailsAPI func(ctx context.Context, url crossmodel.OfferURL) (ConsumeDetails, error)
 	DeployKind           DeployerFactory
 }
 
@@ -434,7 +434,7 @@ type factory struct {
 	// DeployerDependencies
 	model                ModelCommand
 	deployResources      DeployResourcesFunc
-	newConsumeDetailsAPI func(ctx context.Context, url *crossmodel.OfferURL) (ConsumeDetails, error)
+	newConsumeDetailsAPI func(ctx context.Context, url crossmodel.OfferURL) (ConsumeDetails, error)
 	fileSystem           modelcmd.Filesystem
 	charmReader          CharmReader
 

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -403,7 +403,7 @@ func (s *deployerSuite) newDeployerFactory() DeployerFactory {
 			return s.deployResourceIDs, nil
 		},
 		Model: s.modelCommand,
-		NewConsumeDetailsAPI: func(ctx context.Context, url *crossmodel.OfferURL) (ConsumeDetails, error) {
+		NewConsumeDetailsAPI: func(ctx context.Context, url crossmodel.OfferURL) (ConsumeDetails, error) {
 			return s.consumeDetails, nil
 		},
 		FileSystem:  s.filesystem,

--- a/cmd/juju/application/integrate.go
+++ b/cmd/juju/application/integrate.go
@@ -365,7 +365,7 @@ func (c *addRelationCommand) validateEndpoints(all []string) error {
 			if c.remoteEndpoint != nil {
 				return errors.NotSupportedf("providing more than one remote endpoints")
 			}
-			c.remoteEndpoint = url
+			c.remoteEndpoint = &url
 			c.endpoints = append(c.endpoints, url.Name)
 			continue
 		}

--- a/cmd/juju/crossmodel/list.go
+++ b/cmd/juju/crossmodel/list.go
@@ -268,7 +268,7 @@ func formatApplicationOfferDetails(store string, all []*crossmodel.ApplicationOf
 	return result, nil
 }
 
-func convertOfferToListItem(url *crossmodel.OfferURL, offer *crossmodel.ApplicationOfferDetails) ListOfferItem {
+func convertOfferToListItem(url crossmodel.OfferURL, offer *crossmodel.ApplicationOfferDetails) ListOfferItem {
 	item := ListOfferItem{
 		OfferName:       offer.OfferName,
 		ApplicationName: offer.ApplicationName,

--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -167,13 +167,13 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	return block.ProcessBlockedError(err, block.BlockRemove)
 }
 
-func (c *removeCommand) parseOfferURL(controllerName, currentModel, urlStr string) (*crossmodel.OfferURL, error) {
+func (c *removeCommand) parseOfferURL(controllerName, currentModel, urlStr string) (crossmodel.OfferURL, error) {
 	url, err := crossmodel.ParseOfferURL(urlStr)
 	if err == nil {
 		return url, nil
 	}
 	if !names.IsValidApplication(urlStr) {
-		return nil, errors.Trace(err)
+		return crossmodel.OfferURL{}, errors.Trace(err)
 	}
 	store := c.ClientStore()
 	return makeURLFromCurrentModel(store, controllerName, c.offerSource, currentModel, urlStr)
@@ -181,10 +181,10 @@ func (c *removeCommand) parseOfferURL(controllerName, currentModel, urlStr strin
 
 func makeURLFromCurrentModel(
 	store jujuclient.ClientStore, controllerName, offerSource, modelName, offerName string,
-) (*crossmodel.OfferURL, error) {
+) (crossmodel.OfferURL, error) {
 	// We may have just been given an offer name.
 	// Try again with the current model as the host model.
-	url := &crossmodel.OfferURL{
+	url := crossmodel.OfferURL{
 		Source: offerSource,
 		Name:   offerName,
 	}
@@ -192,7 +192,7 @@ func makeURLFromCurrentModel(
 		if jujuclient.IsQualifiedModelName(modelName) {
 			modelName, qualifier, err := jujuclient.SplitFullyQualifiedModelName(modelName)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return crossmodel.OfferURL{}, errors.Trace(err)
 			}
 			url.ModelQualifier = qualifier
 			url.ModelName = modelName
@@ -204,7 +204,7 @@ func makeURLFromCurrentModel(
 	if url.ModelQualifier == "" {
 		accountDetails, err := store.AccountDetails(controllerName)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return crossmodel.OfferURL{}, errors.Trace(err)
 		}
 		qualifier := model.QualifierFromUserTag(names.NewUserTag(accountDetails.User))
 		url.ModelQualifier = qualifier.String()

--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -106,7 +106,7 @@ func (c *showCommand) Run(ctx *cmd.Context) (err error) {
 		if !names.IsValidApplication(c.url) {
 			return errors.Trace(err)
 		}
-		url = &crossmodel.OfferURL{
+		url = crossmodel.OfferURL{
 			Name: c.url,
 		}
 	}

--- a/cmd/juju/model/grantrevoke.go
+++ b/cmd/juju/model/grantrevoke.go
@@ -114,7 +114,7 @@ type accessCommand struct {
 
 	User       string
 	ModelNames []string
-	OfferURLs  []*crossmodel.OfferURL
+	OfferURLs  []crossmodel.OfferURL
 	Access     string
 }
 
@@ -406,9 +406,9 @@ type accountDetailsGetter interface {
 
 // setUnsetQualifiers sets any empty qualifier entries in the given offer URLs
 // to the currently logged in user.
-func setUnsetQualifiers(c accountDetailsGetter, offerURLs []*crossmodel.OfferURL) error {
+func setUnsetQualifiers(c accountDetailsGetter, offerURLs []crossmodel.OfferURL) error {
 	var currentAccountDetails *jujuclient.AccountDetails
-	for _, url := range offerURLs {
+	for i, url := range offerURLs {
 		if url.ModelQualifier != "" {
 			continue
 		}
@@ -421,6 +421,7 @@ func setUnsetQualifiers(c accountDetailsGetter, offerURLs []*crossmodel.OfferURL
 		}
 		// The qualifier is derived from the username.
 		url.ModelQualifier = model.QualifierFromUserTag(names.NewUserTag(currentAccountDetails.User)).String()
+		offerURLs[i] = url
 	}
 	return nil
 }

--- a/cmd/juju/model/grantrevoke_test.go
+++ b/cmd/juju/model/grantrevoke_test.go
@@ -155,7 +155,7 @@ func (s *grantSuite) TestInitOffers(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	url2, err := crossmodel.ParseOfferURL("mary/model.offer2")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(grantCmd.OfferURLs, tc.DeepEquals, []*crossmodel.OfferURL{url1, url2})
+	c.Assert(grantCmd.OfferURLs, tc.DeepEquals, []crossmodel.OfferURL{url1, url2})
 	c.Assert(grantCmd.ModelNames, tc.HasLen, 0)
 }
 

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -95,7 +95,7 @@ func (sf *statusFormatter) Format() (formattedStatus, error) {
 	for name, app := range sf.status.Applications {
 		out.Applications[name] = sf.formatApplication(name, app)
 	}
-	for name, app := range sf.status.RemoteApplications {
+	for name, app := range sf.status.RemoteApplicationOfferers {
 		out.RemoteApplications[name] = sf.formatRemoteApplication(name, app)
 	}
 	for name, offer := range sf.status.Offers {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -152,10 +152,10 @@ func (s *StatusSuite) newContext() *ctx {
 						Since:  &now,
 					},
 				},
-				Machines:           make(map[string]params.MachineStatus),
-				Applications:       make(map[string]params.ApplicationStatus),
-				Offers:             make(map[string]params.ApplicationOfferStatus),
-				RemoteApplications: make(map[string]params.RemoteApplicationStatus),
+				Machines:                  make(map[string]params.MachineStatus),
+				Applications:              make(map[string]params.ApplicationStatus),
+				Offers:                    make(map[string]params.ApplicationOfferStatus),
+				RemoteApplicationOfferers: make(map[string]params.RemoteApplicationStatus),
 			},
 		},
 	}
@@ -3535,7 +3535,7 @@ func (as addRemoteApplication) step(c *tc.C, ctx *ctx) {
 			Relations: make(map[string][]string),
 		}
 	} else {
-		ctx.api.result.RemoteApplications[as.name] = params.RemoteApplicationStatus{
+		ctx.api.result.RemoteApplicationOfferers[as.name] = params.RemoteApplicationStatus{
 			OfferName: as.name,
 			OfferURL:  as.url,
 			Endpoints: endpoints,
@@ -4010,7 +4010,7 @@ func canRelateTo(ep1, ep2 charm.Relation) bool {
 }
 
 func appEndpoints(c *tc.C, ctx *ctx, appName string) ([]charm.Relation, bool) {
-	remoteApp, ok := ctx.api.result.RemoteApplications[appName]
+	remoteApp, ok := ctx.api.result.RemoteApplicationOfferers[appName]
 	if !ok {
 		remoteApp, ok = ctx.remoteProxies[appName]
 	}
@@ -4129,11 +4129,11 @@ func (rs relateApplications) step(c *tc.C, ctx *ctx) {
 	if app2ok {
 		rels2 = app2.Relations
 	}
-	rapp1, rapp1ok := ctx.api.result.RemoteApplications[rs.app1]
+	rapp1, rapp1ok := ctx.api.result.RemoteApplicationOfferers[rs.app1]
 	if rapp1ok {
 		rels1 = rapp1.Relations
 	}
-	rapp2, rapp2ok := ctx.api.result.RemoteApplications[rs.app2]
+	rapp2, rapp2ok := ctx.api.result.RemoteApplicationOfferers[rs.app2]
 	if rapp2ok {
 		rels2 = rapp2.Relations
 	}

--- a/core/crossmodel/offerurl.go
+++ b/core/crossmodel/offerurl.go
@@ -39,7 +39,7 @@ type OfferURL struct {
 }
 
 // Path returns the path component of the URL.
-func (u *OfferURL) Path() string {
+func (u OfferURL) Path() string {
 	var parts []string
 	if u.ModelQualifier != "" {
 		parts = append(parts, u.ModelQualifier)
@@ -55,15 +55,15 @@ func (u *OfferURL) Path() string {
 	return fmt.Sprintf("%s:%s", u.Source, path)
 }
 
-func (u *OfferURL) String() string {
+func (u OfferURL) String() string {
 	return u.Path()
 }
 
 // AsLocal returns a copy of the URL with an empty (local) source.
-func (u *OfferURL) AsLocal() *OfferURL {
-	localURL := *u
+func (u OfferURL) AsLocal() OfferURL {
+	localURL := u
 	localURL.Source = ""
-	return &localURL
+	return localURL
 }
 
 // HasEndpoint returns whether this offer URL includes an
@@ -86,18 +86,18 @@ var modelApplicationRegexp = regexp.MustCompile(`(/?((?P<qualifier>[^/]+)/)?(?P<
 //	<source>:<model-name>.<offer-name>:<relation-name>
 //	<source>:<qualifier>/<model-name>.<offer-name>
 //	<source>:<qualifier>/<model-name>.<offer-name>:<relation-name>
-func ParseOfferURL(urlStr string) (*OfferURL, error) {
+func ParseOfferURL(urlStr string) (OfferURL, error) {
 	return parseOfferURL(urlStr)
 }
 
 // parseOfferURL parses the specified URL string into an OfferURL.
-func parseOfferURL(urlStr string) (*OfferURL, error) {
+func parseOfferURL(urlStr string) (OfferURL, error) {
 	urlParts, err := parseOfferURLParts(urlStr, false)
 	if err != nil {
-		return nil, err
+		return OfferURL{}, err
 	}
 	url := OfferURL(*urlParts)
-	return &url, nil
+	return url, nil
 }
 
 // OfferURLParts contains various attributes of a URL.

--- a/core/crossmodel/offerurl_test.go
+++ b/core/crossmodel/offerurl_test.go
@@ -23,33 +23,33 @@ func TestOfferURLSuite(t *testing.T) {
 var urlTests = []struct {
 	s, err string
 	exact  string
-	url    *crossmodel.OfferURL
+	url    crossmodel.OfferURL
 }{{
 	s:   "controller:qualifier/modelname.offername",
-	url: &crossmodel.OfferURL{"controller", "qualifier", "modelname", "offername"},
+	url: crossmodel.OfferURL{"controller", "qualifier", "modelname", "offername"},
 }, {
 	s:   "controller:qualifier/modelname.offername:rel",
-	url: &crossmodel.OfferURL{"controller", "qualifier", "modelname", "offername:rel"},
+	url: crossmodel.OfferURL{"controller", "qualifier", "modelname", "offername:rel"},
 }, {
 	s:   "modelname.offername",
-	url: &crossmodel.OfferURL{"", "", "modelname", "offername"},
+	url: crossmodel.OfferURL{"", "", "modelname", "offername"},
 }, {
 	s:   "modelname.offername:rel",
-	url: &crossmodel.OfferURL{"", "", "modelname", "offername:rel"},
+	url: crossmodel.OfferURL{"", "", "modelname", "offername:rel"},
 }, {
 	s:   "qualifier/modelname.offername:rel",
-	url: &crossmodel.OfferURL{"", "qualifier", "modelname", "offername:rel"},
+	url: crossmodel.OfferURL{"", "qualifier", "modelname", "offername:rel"},
 }, {
 	s:     "/modelname.offername",
-	url:   &crossmodel.OfferURL{"", "", "modelname", "offername"},
+	url:   crossmodel.OfferURL{"", "", "modelname", "offername"},
 	exact: "modelname.offername",
 }, {
 	s:     "/modelname.offername:rel",
-	url:   &crossmodel.OfferURL{"", "", "modelname", "offername:rel"},
+	url:   crossmodel.OfferURL{"", "", "modelname", "offername:rel"},
 	exact: "modelname.offername:rel",
 }, {
 	s:   "qualifier/modelname.offername",
-	url: &crossmodel.OfferURL{"", "qualifier", "modelname", "offername"},
+	url: crossmodel.OfferURL{"", "qualifier", "modelname", "offername"},
 }, {
 	s:   "controller:modelname",
 	err: `offer URL is missing the name`,
@@ -79,15 +79,13 @@ func (s *OfferURLSuite) TestParseURL(c *tc.C) {
 		if t.exact != "" {
 			match = t.exact
 		}
-		if t.url != nil {
-			c.Assert(err, tc.IsNil)
-			c.Check(url, tc.DeepEquals, t.url)
-			c.Check(url.String(), tc.Equals, match)
-		}
 		if t.err != "" {
 			t.err = strings.Replace(t.err, "$URL", regexp.QuoteMeta(fmt.Sprintf("%q", t.s)), -1)
 			c.Check(err, tc.ErrorMatches, t.err)
-			c.Check(url, tc.IsNil)
+		} else {
+			c.Assert(err, tc.IsNil)
+			c.Check(url, tc.DeepEquals, t.url)
+			c.Check(url.String(), tc.Equals, match)
 		}
 	}
 }
@@ -171,7 +169,7 @@ func (s *OfferURLSuite) TestAsLocal(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	expected, err := crossmodel.ParseOfferURL("model.application:endpoint")
 	c.Assert(err, tc.ErrorIsNil)
-	original := *url
+	original := url
 	c.Assert(url.AsLocal(), tc.DeepEquals, expected)
-	c.Assert(*url, tc.DeepEquals, original)
+	c.Assert(url, tc.DeepEquals, original)
 }

--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -53,7 +53,7 @@ type ModelOfferState interface {
 
 // GetOfferUUID returns the uuid for the provided offer URL.
 // Returns crossmodelrelationerrors.OfferNotFound of the offer is not found.
-func (s *Service) GetOfferUUID(ctx context.Context, offerURL *crossmodel.OfferURL) (offer.UUID, error) {
+func (s *Service) GetOfferUUID(ctx context.Context, offerURL crossmodel.OfferURL) (offer.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -127,6 +127,7 @@ func (s *Service) AddRemoteApplicationOfferer(ctx context.Context, applicationNa
 			Charm:                 syntheticCharm,
 			OfferUUID:             args.OfferUUID.String(),
 		},
+		OfferURL:              args.OfferURL.String(),
 		OffererControllerUUID: args.OffererControllerUUID,
 		OffererModelUUID:      args.OffererModelUUID,
 		EncodedMacaroon:       encodedMacaroon,

--- a/domain/crossmodelrelation/service/remoteapplication_test.go
+++ b/domain/crossmodelrelation/service/remoteapplication_test.go
@@ -11,6 +11,7 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	coreapplicationtesting "github.com/juju/juju/core/application/testing"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/offer"
 	corerelation "github.com/juju/juju/core/relation"
@@ -77,6 +78,7 @@ func (s *remoteApplicationServiceSuite) TestAddRemoteApplicationOfferer(c *tc.C)
 		OfferUUID:             offerUUID,
 		OffererControllerUUID: offererControllerUUID,
 		OffererModelUUID:      offererModelUUID,
+		OfferURL:              tc.Must1(c, crossmodel.ParseOfferURL, "controller:qualifier/model.offername"),
 		Endpoints: []charm.Relation{{
 			Name:      "db",
 			Role:      charm.RoleProvider,
@@ -106,6 +108,7 @@ func (s *remoteApplicationServiceSuite) TestAddRemoteApplicationOfferer(c *tc.C)
 			Charm:     syntheticCharm,
 			OfferUUID: offerUUID.String(),
 		},
+		OfferURL:              "controller:qualifier/model.offername",
 		OffererControllerUUID: offererControllerUUID,
 		OffererModelUUID:      offererModelUUID,
 		EncodedMacaroon:       tc.Must(c, macaroon.MarshalJSON),

--- a/domain/crossmodelrelation/service/types.go
+++ b/domain/crossmodelrelation/service/types.go
@@ -6,6 +6,7 @@ package service
 import (
 	"gopkg.in/macaroon.v2"
 
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/offer"
 	"github.com/juju/juju/domain/application/charm"
 )
@@ -16,6 +17,10 @@ type AddRemoteApplicationOffererArgs struct {
 	// OfferUUID is the UUID of the offer that the remote application is
 	// consuming.
 	OfferUUID offer.UUID
+
+	// OfferURL is the URL of this offer, used to located an offered appliction
+	// and it's exported endpoints
+	OfferURL crossmodel.OfferURL
 
 	// OffererControllerUUID is the UUID of the controller that the remote
 	// application is in.

--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -158,6 +158,7 @@ SELECT  a.name AS &remoteApplicationOffererInfo.application_name,
         aro.offer_uuid AS &remoteApplicationOffererInfo.offer_uuid,
         aro.version AS &remoteApplicationOffererInfo.version,
         aro.offerer_model_uuid AS &remoteApplicationOffererInfo.offerer_model_uuid,
+		aro.offer_url AS &remoteApplicationOffererInfo.offer_url,
         aro.macaroon AS &remoteApplicationOffererInfo.macaroon
 FROM    application_remote_offerer AS aro
 JOIN    application AS a ON a.uuid = aro.application_uuid
@@ -189,6 +190,7 @@ WHERE   aro.life_id < 2;`
 			ApplicationUUID:  offerer.ApplicationUUID,
 			ApplicationName:  offerer.ApplicationName,
 			OfferUUID:        offerer.OfferUUID,
+			OfferURL:         offerer.OfferURL,
 			ConsumeVersion:   int(offerer.Version),
 			OffererModelUUID: offerer.OffererModelUUID,
 			Macaroon:         macaroon,
@@ -314,6 +316,7 @@ func (st *State) insertRemoteApplicationOfferer(
 		LifeID:                life.Alive,
 		ApplicationUUID:       args.ApplicationUUID,
 		OfferUUID:             args.OfferUUID,
+		OfferURL:              args.OfferURL,
 		Version:               version,
 		OffererControllerUUID: offererControllerUUID,
 		OffererModelUUID:      args.OffererModelUUID,

--- a/domain/crossmodelrelation/state/model/remoteapplication_test.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication_test.go
@@ -418,6 +418,7 @@ func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationOfferers(c *tc.C) 
 			Charm:                 charm,
 		},
 		OffererModelUUID: offererModelUUID,
+		OfferURL:         "controller:qualifier/model.offername",
 		EncodedMacaroon:  macBytes,
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -429,6 +430,7 @@ func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationOfferers(c *tc.C) 
 		ApplicationName:  "foo",
 		Life:             life.Alive,
 		OfferUUID:        offerUUID,
+		OfferURL:         "controller:qualifier/model.offername",
 		ConsumeVersion:   0,
 		OffererModelUUID: offererModelUUID,
 		Macaroon:         mac,

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -169,6 +169,9 @@ type remoteApplicationOfferer struct {
 	// OfferUUID is the offer uuid that ties both the offerer and consumer
 	// together.
 	OfferUUID string `db:"offer_uuid"`
+	// OfferURL is the URL of the offer that the remote application is
+	// consuming.
+	OfferURL string `db:"offer_url"`
 	// Version is the version of the remote application offerer.
 	Version uint64 `db:"version"`
 	// OffererControllerUUID is the unique identifier for the controller
@@ -193,6 +196,9 @@ type remoteApplicationOffererInfo struct {
 	// OfferUUID is the offer uuid that ties both the offerer and consumer
 	// together.
 	OfferUUID string `db:"offer_uuid"`
+	// OfferURL is the URL of the offer that the remote application is
+	// consuming.
+	OfferURL string `db:"offer_url"`
 	// Version is the version of the remote application offerer.
 	Version uint64 `db:"version"`
 	// OffererControllerUUID is the unique identifier for the controller

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -179,6 +179,10 @@ type RemoteApplicationOfferer struct {
 	// consuming.
 	OfferUUID string
 
+	// OfferURL is the URL of this offer, used to located an offered appliction
+	// and it's exported endpoints
+	OfferURL string
+
 	// ConsumeVersion is the version of the offer that the remote application is
 	// consuming.
 	ConsumeVersion int
@@ -196,6 +200,10 @@ type RemoteApplicationOfferer struct {
 // remote application offerer.
 type AddRemoteApplicationOffererArgs struct {
 	AddRemoteApplicationArgs
+
+	// OfferURL is the URL of this offer, the natural key for the offer to
+	// identify the in offer in the offering model.
+	OfferURL string
 
 	// OffererControllerUUID is the UUID of the controller that the remote
 	// application is in.

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -387,7 +387,9 @@ func (s *Service) EnterScope(
 	return nil
 }
 
-// GetAllRelationDetails return RelationDetailResults of all relation for the current model.
+// GetAllRelationDetails return RelationDetailResults of all relation for the
+// current model. This includes relations with synthetic applications (i.e.
+// CMRs)
 func (s *Service) GetAllRelationDetails(ctx context.Context) ([]relation.RelationDetailsResult, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -360,8 +360,9 @@ AND    ae.application_uuid = $relationAndApplicationUUID.application_uuid
 }
 
 // GetAllRelationDetails retrieves the details of all relations from the
-// database. It returns the list of endpoints, the life status and
-// identification data (UUID and ID) for each relation.
+// database. This includes relations with synthetic applications (i.e. CMRs).
+// It returns the list of endpoints, the life status and identification data
+// (UUID and ID) for each relation.
 func (st *State) GetAllRelationDetails(ctx context.Context) ([]domainrelation.RelationDetailsResult, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -370,6 +371,7 @@ func (st *State) GetAllRelationDetails(ctx context.Context) ([]domainrelation.Re
 
 	var relationsDetails []domainrelation.RelationDetailsResult
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// TODO: Do this all in one query
 		relations, err := st.getAllRelations(ctx, tx)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("getting all relations: %w", err)

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -9,6 +9,9 @@ CREATE TABLE application_remote_offerer (
     -- offer_uuid is the offer uuid that ties both the offerer and the consumer
     -- together.
     offer_uuid TEXT NOT NULL,
+    -- offer_url is the URL of the offer that the remote application is
+    -- consuming.
+    offer_url TEXT NOT NULL,
     -- version is the unique version number that is incremented when the 
     -- consumer model changes the offerer application.
     version INT NOT NULL,

--- a/domain/schema/model/triggers/crossmodelrelation-triggers.gen.go
+++ b/domain/schema/model/triggers/crossmodelrelation-triggers.gen.go
@@ -74,6 +74,7 @@ WHEN
 	NEW.life_id != OLD.life_id OR
 	NEW.application_uuid != OLD.application_uuid OR
 	NEW.offer_uuid != OLD.offer_uuid OR
+	NEW.offer_url != OLD.offer_url OR
 	NEW.version != OLD.version OR
 	(NEW.offerer_controller_uuid != OLD.offerer_controller_uuid OR (NEW.offerer_controller_uuid IS NOT NULL AND OLD.offerer_controller_uuid IS NULL) OR (NEW.offerer_controller_uuid IS NULL AND OLD.offerer_controller_uuid IS NOT NULL)) OR
 	NEW.offerer_model_uuid != OLD.offerer_model_uuid OR

--- a/domain/status/service/crossmodelrelation_test.go
+++ b/domain/status/service/crossmodelrelation_test.go
@@ -10,11 +10,16 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	coreapplicationtesting "github.com/juju/juju/core/application/testing"
+	"github.com/juju/juju/core/crossmodel"
+	corelife "github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/offer"
+	corerelation "github.com/juju/juju/core/relation"
 	remoteapplicationtesting "github.com/juju/juju/core/remoteapplication/testing"
 	corestatus "github.com/juju/juju/core/status"
 	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
+	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/status"
+	internalcharm "github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/statushistory"
 )
@@ -59,6 +64,93 @@ func (s *serviceSuite) TestGetOfferStatus(c *tc.C) {
 		Data:    map[string]any{"foo": "bar"},
 		Since:   &now,
 	})
+}
+
+func (s *serviceSuite) TestGetRemoteApplicationOffererStatuses(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	now := s.clock.Now().UTC()
+
+	relUUID1 := tc.Must(c, corerelation.NewUUID)
+	relUUID2 := tc.Must(c, corerelation.NewUUID)
+	relUUID3 := tc.Must(c, corerelation.NewUUID)
+
+	s.modelState.EXPECT().GetRemoteApplicationOffererStatuses(gomock.Any()).Return(map[string]status.RemoteApplicationOfferer{
+		"foo": {
+			Status: status.StatusInfo[status.WorkloadStatusType]{
+				Status:  status.WorkloadStatusActive,
+				Message: "it's active",
+				Data:    []byte(`{"foo":"bar"}`),
+				Since:   &now,
+			},
+			Life:     life.Alive,
+			OfferURL: "controller:qualifier/model.offername",
+			Endpoints: []status.Endpoint{
+				{Name: "endpoint-1", Role: "provider", Interface: "interface-1", Limit: 10},
+				{Name: "endpoint-2", Role: "requirer", Interface: "interface-2", Limit: 20},
+			},
+			Relations: []string{relUUID1.String(), relUUID2.String()},
+		},
+		"bar": {
+			Status: status.StatusInfo[status.WorkloadStatusType]{
+				Status:  status.WorkloadStatusError,
+				Message: "it's error",
+				Data:    []byte(`{"bar":"foo"}`),
+				Since:   &now,
+			},
+			Life:     life.Dying,
+			OfferURL: "controller:qualifier/model.offername",
+			Endpoints: []status.Endpoint{
+				{Name: "endpoint-3", Role: "peer", Interface: "interface-3", Limit: 30},
+				{Name: "endpoint-4", Role: "peer", Interface: "interface-4", Limit: 40},
+			},
+			Relations: []string{relUUID3.String()},
+		},
+	}, nil)
+
+	res, err := s.modelService.GetRemoteApplicationOffererStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res, tc.DeepEquals, map[string]RemoteApplicationOfferer{
+		"foo": {
+			Status: corestatus.StatusInfo{
+				Status:  corestatus.Active,
+				Message: "it's active",
+				Data:    map[string]interface{}{"foo": "bar"},
+				Since:   &now,
+			},
+			Life:     corelife.Alive,
+			OfferURL: tc.Must1(c, crossmodel.ParseOfferURL, "controller:qualifier/model.offername"),
+			Endpoints: []Endpoint{
+				{Name: "endpoint-1", Role: internalcharm.RoleProvider, Interface: "interface-1", Limit: 10},
+				{Name: "endpoint-2", Role: internalcharm.RoleRequirer, Interface: "interface-2", Limit: 20},
+			},
+			Relations: []corerelation.UUID{relUUID1, relUUID2},
+		},
+		"bar": {
+			Status: corestatus.StatusInfo{
+				Status:  corestatus.Error,
+				Message: "it's error",
+				Data:    map[string]interface{}{"bar": "foo"},
+				Since:   &now,
+			},
+			Life:     corelife.Dying,
+			OfferURL: tc.Must1(c, crossmodel.ParseOfferURL, "controller:qualifier/model.offername"),
+			Endpoints: []Endpoint{
+				{Name: "endpoint-3", Role: internalcharm.RolePeer, Interface: "interface-3", Limit: 30},
+				{Name: "endpoint-4", Role: internalcharm.RolePeer, Interface: "interface-4", Limit: 40},
+			},
+			Relations: []corerelation.UUID{relUUID3},
+		},
+	})
+}
+
+func (s *serviceSuite) TestGetRemoteApplicationOffererStatusesError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelState.EXPECT().GetRemoteApplicationOffererStatuses(gomock.Any()).Return(nil, errors.Errorf("boom"))
+
+	_, err := s.modelService.GetRemoteApplicationOffererStatuses(c.Context())
+	c.Assert(err, tc.ErrorMatches, ".*boom")
 }
 
 func (s *serviceSuite) TestSetRemoteApplicationOffererStatus(c *tc.C) {

--- a/domain/status/service/package_mock_test.go
+++ b/domain/status/service/package_mock_test.go
@@ -865,6 +865,45 @@ func (c *MockModelStateGetRelationUUIDByIDCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
+// GetRemoteApplicationOffererStatuses mocks base method.
+func (m *MockModelState) GetRemoteApplicationOffererStatuses(ctx context.Context) (map[string]status.RemoteApplicationOfferer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRemoteApplicationOffererStatuses", ctx)
+	ret0, _ := ret[0].(map[string]status.RemoteApplicationOfferer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteApplicationOffererStatuses indicates an expected call of GetRemoteApplicationOffererStatuses.
+func (mr *MockModelStateMockRecorder) GetRemoteApplicationOffererStatuses(ctx any) *MockModelStateGetRemoteApplicationOffererStatusesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteApplicationOffererStatuses", reflect.TypeOf((*MockModelState)(nil).GetRemoteApplicationOffererStatuses), ctx)
+	return &MockModelStateGetRemoteApplicationOffererStatusesCall{Call: call}
+}
+
+// MockModelStateGetRemoteApplicationOffererStatusesCall wrap *gomock.Call
+type MockModelStateGetRemoteApplicationOffererStatusesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetRemoteApplicationOffererStatusesCall) Return(arg0 map[string]status.RemoteApplicationOfferer, arg1 error) *MockModelStateGetRemoteApplicationOffererStatusesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetRemoteApplicationOffererStatusesCall) Do(f func(context.Context) (map[string]status.RemoteApplicationOfferer, error)) *MockModelStateGetRemoteApplicationOffererStatusesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetRemoteApplicationOffererStatusesCall) DoAndReturn(f func(context.Context) (map[string]status.RemoteApplicationOfferer, error)) *MockModelStateGetRemoteApplicationOffererStatusesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRemoteApplicationOffererUUIDByName mocks base method.
 func (m *MockModelState) GetRemoteApplicationOffererUUIDByName(ctx context.Context, name string) (remoteapplication.UUID, error) {
 	m.ctrl.T.Helper()

--- a/domain/status/service/types.go
+++ b/domain/status/service/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machine"
@@ -152,4 +153,19 @@ type VolumeAttachment struct {
 type VolumeAttachmentPlan struct {
 	DeviceType       storageprovisioning.PlanDeviceType
 	DeviceAttributes map[string]string
+}
+
+type RemoteApplicationOfferer struct {
+	Status    status.StatusInfo
+	OfferURL  crossmodel.OfferURL
+	Life      life.Value
+	Endpoints []Endpoint
+	Relations []relation.UUID
+}
+
+type Endpoint struct {
+	Name      string
+	Role      internalcharm.RelationRole
+	Interface string
+	Limit     int
 }

--- a/domain/status/state/package_test.go
+++ b/domain/status/state/package_test.go
@@ -6,28 +6,46 @@ package state
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
-	"github.com/juju/clock"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/tc"
 
 	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/crossmodel"
+	corelife "github.com/juju/juju/core/life"
 	coremachine "github.com/juju/juju/core/machine"
+	coremodel "github.com/juju/juju/core/model"
+	corerelation "github.com/juju/juju/core/relation"
+	corerelationtesting "github.com/juju/juju/core/relation/testing"
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
+	remoteapplicationtesting "github.com/juju/juju/core/remoteapplication/testing"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
 	applicationstate "github.com/juju/juju/domain/application/state"
+	"github.com/juju/juju/domain/crossmodelrelation"
+	crossmodelrelationstate "github.com/juju/juju/domain/crossmodelrelation/state/model"
 	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/domain/status"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/uuid"
 )
 
 type baseSuite struct {
 	schematesting.ModelSuite
+
+	now time.Time
+}
+
+func (s *baseSuite) SetUpTest(c *tc.C) {
+	s.ModelSuite.SetUpTest(c)
+	s.now = time.Now().UTC()
 }
 
 func (s *baseSuite) workloadStatus(now time.Time) *status.StatusInfo[status.WorkloadStatusType] {
@@ -72,20 +90,140 @@ func (s *baseSuite) createIAASApplicationWithNUnits(
 	}
 
 	return s.createIAASApplication(
-		c, name, life.Alive, false, s.workloadStatus(time.Now()), units...,
+		c, name, life.Alive, s.workloadStatus(time.Now()), units...,
 	)
+}
+
+func (s *baseSuite) createSubordinateIAASApplication(
+	c *tc.C,
+	name string,
+	l life.Life,
+	appStatus *status.StatusInfo[status.WorkloadStatusType],
+	units ...application.AddIAASUnitArg,
+) (coreapplication.UUID, []coreunit.UUID) {
+	ch := charm.Charm{
+		Metadata: charm.Metadata{
+			Name:        name,
+			Subordinate: true,
+			Provides: map[string]charm.Relation{
+				"endpoint": {
+					Name:  "endpoint",
+					Role:  charm.RoleProvider,
+					Scope: charm.ScopeGlobal,
+				},
+				"misc": {
+					Name:  "misc",
+					Role:  charm.RoleProvider,
+					Scope: charm.ScopeGlobal,
+				},
+			},
+		},
+		Manifest:      s.minimalManifest(c),
+		ReferenceName: name,
+		Source:        charm.CharmHubSource,
+		Revision:      42,
+		Hash:          "hash",
+		Architecture:  architecture.ARM64,
+	}
+	return s.createIAASApplicationWithCharm(c, name, l, ch, appStatus, units...)
 }
 
 func (s *baseSuite) createIAASApplication(
 	c *tc.C,
 	name string,
 	l life.Life,
-	subordinate bool,
+	appStatus *status.StatusInfo[status.WorkloadStatusType],
+	units ...application.AddIAASUnitArg,
+) (coreapplication.UUID, []coreunit.UUID) {
+	ch := charm.Charm{
+		Metadata: charm.Metadata{
+			Name: name,
+			Provides: map[string]charm.Relation{
+				"endpoint": {
+					Name:  "endpoint",
+					Role:  charm.RoleProvider,
+					Scope: charm.ScopeGlobal,
+				},
+				"misc": {
+					Name:  "misc",
+					Role:  charm.RoleProvider,
+					Scope: charm.ScopeGlobal,
+				},
+			},
+		},
+		Manifest:      s.minimalManifest(c),
+		ReferenceName: name,
+		Source:        charm.CharmHubSource,
+		Revision:      42,
+		Hash:          "hash",
+		Architecture:  architecture.ARM64,
+	}
+	return s.createIAASApplicationWithCharm(c, name, l, ch, appStatus, units...)
+}
+
+func (s *baseSuite) createIAASRemoteApplicationOfferer(
+	c *tc.C,
+	name string,
+) (coreapplication.UUID, coreremoteapplication.UUID) {
+	cmrState := crossmodelrelationstate.NewState(
+		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
+	)
+
+	ch := charm.Charm{
+		Metadata: charm.Metadata{
+			Name: name,
+			Provides: map[string]charm.Relation{
+				"endpoint": {
+					Name:      "endpoint",
+					Interface: "interf",
+					Role:      charm.RoleProvider,
+					Scope:     charm.ScopeGlobal,
+				},
+				"misc": {
+					Name:      "misc",
+					Interface: "interf",
+					Role:      charm.RoleProvider,
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+		},
+		Manifest:      s.minimalManifest(c),
+		ReferenceName: name,
+		Source:        charm.CMRSource,
+		Revision:      42,
+		Hash:          "hash",
+		Architecture:  architecture.ARM64,
+	}
+
+	remoteAppUUID := remoteapplicationtesting.GenRemoteApplicationUUID(c)
+	appUUID := tc.Must(c, coreapplication.NewID)
+	err := cmrState.AddRemoteApplicationOfferer(c.Context(), name, crossmodelrelation.AddRemoteApplicationOffererArgs{
+		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
+			RemoteApplicationUUID: remoteAppUUID.String(),
+			ApplicationUUID:       appUUID.String(),
+			CharmUUID:             tc.Must(c, uuid.NewUUID).String(),
+			Charm:                 ch,
+			OfferUUID:             tc.Must(c, uuid.NewUUID).String(),
+		},
+		OfferURL:         tc.Must1(c, crossmodel.ParseOfferURL, fmt.Sprintf("controller:qualifier/model.%s", name)).String(),
+		OffererModelUUID: tc.Must(c, uuid.NewUUID).String(),
+		EncodedMacaroon:  []byte("macaroon"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	return appUUID, remoteAppUUID
+}
+
+func (s *baseSuite) createIAASApplicationWithCharm(
+	c *tc.C,
+	name string,
+	l life.Life,
+	ch charm.Charm,
 	appStatus *status.StatusInfo[status.WorkloadStatusType],
 	units ...application.AddIAASUnitArg,
 ) (coreapplication.UUID, []coreunit.UUID) {
 	appState := applicationstate.NewState(
-		s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c),
+		s.TxnRunnerFactory(), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
 	)
 
 	platform := deployment.Platform{
@@ -104,30 +242,7 @@ func (s *baseSuite) createIAASApplication(
 		BaseAddApplicationArg: application.BaseAddApplicationArg{
 			Platform: platform,
 			Channel:  channel,
-			Charm: charm.Charm{
-				Metadata: charm.Metadata{
-					Name:        name,
-					Subordinate: subordinate,
-					Provides: map[string]charm.Relation{
-						"endpoint": {
-							Name:  "endpoint",
-							Role:  charm.RoleProvider,
-							Scope: charm.ScopeGlobal,
-						},
-						"misc": {
-							Name:  "misc",
-							Role:  charm.RoleProvider,
-							Scope: charm.ScopeGlobal,
-						},
-					},
-				},
-				Manifest:      s.minimalManifest(c),
-				ReferenceName: name,
-				Source:        charm.CharmHubSource,
-				Revision:      42,
-				Hash:          "hash",
-				Architecture:  architecture.ARM64,
-			},
+			Charm:    ch,
 			CharmDownloadInfo: &charm.DownloadInfo{
 				Provenance:         charm.ProvenanceDownload,
 				CharmhubIdentifier: "ident",
@@ -177,12 +292,11 @@ func (s *baseSuite) createCAASApplication(
 	c *tc.C,
 	name string,
 	l life.Life,
-	subordinate bool,
 	appStatus *status.StatusInfo[status.WorkloadStatusType],
 	units ...application.AddCAASUnitArg,
 ) (coreapplication.UUID, []coreunit.UUID) {
 	appState := applicationstate.NewState(
-		s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c),
+		s.TxnRunnerFactory(), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
 	)
 
 	platform := deployment.Platform{
@@ -204,8 +318,7 @@ func (s *baseSuite) createCAASApplication(
 			Channel:  channel,
 			Charm: charm.Charm{
 				Metadata: charm.Metadata{
-					Name:        name,
-					Subordinate: subordinate,
+					Name: name,
 					Provides: map[string]charm.Relation{
 						"endpoint": {
 							Name:  "endpoint",
@@ -271,17 +384,6 @@ func (s *baseSuite) createCAASApplication(
 	return appID, unitUUIDs
 }
 
-func (s *baseSuite) insertRemoteApplication(c *tc.C, appUUID, remoteAppUUID string) {
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-INSERT INTO application_remote_offerer (uuid, life_id, application_uuid, offer_uuid, version, offerer_model_uuid, macaroon)
-VALUES (?, 0, ?, "1", "2", "3", "4")
-`, remoteAppUUID, appUUID)
-		return err
-	})
-	c.Assert(err, tc.ErrorIsNil)
-}
-
 func (s *baseSuite) setApplicationLXDProfile(c *tc.C, appUUID coreapplication.UUID, profile string) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
@@ -314,4 +416,51 @@ func (s *baseSuite) minimalManifest(c *tc.C) charm.Manifest {
 			},
 		},
 	}
+}
+
+// addRelationWithLifeAndID inserts a new relation into the database with the
+// given details.
+func (s *baseSuite) addRelationWithLifeAndID(c *tc.C, life corelife.Value, relationID int) corerelation.UUID {
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec(`
+INSERT INTO relation (uuid, relation_id, life_id, scope_id)
+SELECT ?, ?, id, 0
+FROM life
+WHERE value = ?
+`, relationUUID, relationID, life)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) Failed to insert relation %s, id %d", relationUUID, relationID))
+	return relationUUID
+}
+
+func (s *baseSuite) addRelationToApplication(c *tc.C, appUUID coreapplication.UUID, relationUUID corerelation.UUID) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		var charmRelationUUID string
+		err := tx.QueryRowContext(ctx, `SELECT uuid FROM charm_relation WHERE name = 'endpoint'`).Scan(&charmRelationUUID)
+		if err != nil {
+			return err
+		}
+
+		var endpointUUID string
+		err = tx.QueryRowContext(ctx, `SELECT uuid FROM application_endpoint WHERE application_uuid = ? AND charm_relation_uuid = ?`, appUUID, charmRelationUUID).Scan(&endpointUUID)
+		if err != nil {
+			return err
+		}
+
+		relationEndpointUUID := uuid.MustNewUUID().String()
+		_, err = tx.ExecContext(ctx, `INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?);`, relationEndpointUUID, relationUUID, endpointUUID)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO application_exposed_endpoint_cidr (application_uuid, application_endpoint_uuid, cidr) VALUES (?, ?, "10.0.0.0/24") ON CONFLICT DO NOTHING;`, appUUID, endpointUUID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
 }

--- a/domain/status/state/types.go
+++ b/domain/status/state/types.go
@@ -467,6 +467,21 @@ type remoteApplicationStatus struct {
 	UpdatedAt             *time.Time `db:"updated_at"`
 }
 
+type fullRemoteApplicationStatus struct {
+	Name              string           `db:"name"`
+	LifeID            domainlife.Life  `db:"life_id"`
+	StatusID          int              `db:"status_id"`
+	Message           string           `db:"message"`
+	Data              []byte           `db:"data"`
+	UpdatedAt         *time.Time       `db:"updated_at"`
+	OfferURL          string           `db:"offer_url"`
+	EndpointName      string           `db:"endpoint_name"`
+	EndpointRole      string           `db:"endpoint_role"`
+	EndpointInterface string           `db:"endpoint_interface"`
+	EndpointLimit     int              `db:"endpoint_limit"`
+	RelationUUID      sql.Null[string] `db:"relation_uuid"`
+}
+
 func decodeHardwareCharacteristics(
 	arch sql.Null[string],
 	cpuCores sql.Null[uint64],

--- a/domain/status/types.go
+++ b/domain/status/types.go
@@ -7,9 +7,7 @@ import (
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
-	"github.com/juju/juju/core/offer"
 	"github.com/juju/juju/core/relation"
-	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/constraints"
@@ -145,7 +143,18 @@ type VolumeAttachmentPlan struct {
 	DeviceAttributes map[string]string
 }
 
-type Offer struct {
-	UUID   offer.UUID
-	Status corestatus.StatusInfo
+type RemoteApplicationOfferer struct {
+	Status    StatusInfo[WorkloadStatusType]
+	OfferName string
+	OfferURL  string
+	Life      life.Life
+	Endpoints []Endpoint
+	Relations []string
+}
+
+type Endpoint struct {
+	Name      string
+	Role      string
+	Interface string
+	Limit     int
 }

--- a/rpc/params/status.go
+++ b/rpc/params/status.go
@@ -22,17 +22,17 @@ type StatusParams struct {
 
 // FullStatus holds information about the status of a juju model.
 type FullStatus struct {
-	Model               ModelStatusInfo                    `json:"model"`
-	Machines            map[string]MachineStatus           `json:"machines"`
-	Applications        map[string]ApplicationStatus       `json:"applications"`
-	RemoteApplications  map[string]RemoteApplicationStatus `json:"remote-applications"`
-	Offers              map[string]ApplicationOfferStatus  `json:"offers"`
-	Relations           []RelationStatus                   `json:"relations"`
-	ControllerTimestamp *time.Time                         `json:"controller-timestamp"`
-	Branches            map[string]BranchStatus            `json:"branches"`
-	Storage             []StorageDetails                   `json:"storage,omitempty"`
-	Filesystems         []FilesystemDetails                `json:"filesystems,omitempty"`
-	Volumes             []VolumeDetails                    `json:"volumes,omitempty"`
+	Model                     ModelStatusInfo                    `json:"model"`
+	Machines                  map[string]MachineStatus           `json:"machines"`
+	Applications              map[string]ApplicationStatus       `json:"applications"`
+	RemoteApplicationOfferers map[string]RemoteApplicationStatus `json:"remote-applications"`
+	Offers                    map[string]ApplicationOfferStatus  `json:"offers"`
+	Relations                 []RelationStatus                   `json:"relations"`
+	ControllerTimestamp       *time.Time                         `json:"controller-timestamp"`
+	Branches                  map[string]BranchStatus            `json:"branches"`
+	Storage                   []StorageDetails                   `json:"storage,omitempty"`
+	Filesystems               []FilesystemDetails                `json:"filesystems,omitempty"`
+	Volumes                   []VolumeDetails                    `json:"volumes,omitempty"`
 }
 
 // IsEmpty checks all collections on FullStatus to determine if the status is empty.
@@ -41,7 +41,7 @@ func (fs *FullStatus) IsEmpty() bool {
 	return len(fs.Applications) == 0 &&
 		len(fs.Machines) == 0 &&
 		len(fs.Offers) == 0 &&
-		len(fs.RemoteApplications) == 0 &&
+		len(fs.RemoteApplicationOfferers) == 0 &&
 		len(fs.Relations) == 0
 }
 


### PR DESCRIPTION
This required a new service method to bulk get the statuses of remote application offerers.

For this, I needed to include offer urls in the db. Refactor "AddRemoteApplicationOfferer" to store this piece of data as well.

Wire this up to the FullStatus facade.

As a flyby:
- refactor usage of offer url to use a concrete type instead of a pointer
- refactor our testing infra for status slightly, to simplify arrange steps

## QA steps

```
$ juju add-model offerer
$ juju deploy juj-qa-test
$ juju offer juju-qa-test:info
Application "juju-qa-test" endpoints [info] available at "admin/offerer.juju-qa-test"
$ juju add-model consumer
$ juju consume admin/offerer.juju-qa-test
$ juju status
Model     Controller  Cloud/Region   Version      Timestamp
consumer  lxd         lxd/localhost  4.0-beta8.1  11:31:01+01:00

SAAS          Status  Store  URL
juju-qa-test  active  local  admin/offerer.juju-qa-test

$ juju status --format yaml
model: 
  name: consumer
  type: iaas
  controller: lxd
  cloud: lxd
  region: localhost
  version: 4.0-beta8.1
  model-status: 
    current: available
    since: 15 Oct 2025 11:31:08+01:00
machines: {}
applications: {}
application-endpoints: 
  juju-qa-test: 
    url: admin/offerer.juju-qa-test
    endpoints: 
      info: 
        interface: juju-info
        role: requirer
      juju-info: 
        interface: juju-info
        role: provider
    life: alive
    application-status: 
      current: active
      message: hello
      since: 15 Oct 2025 11:30:19+01:00
storage: {}
controller: 
  timestamp: 11:31:08+01:00
```