### PR TITLE
fix(uniter): add support for peer relations in Uniter API

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -45,6 +45,7 @@ import (
 	relationerrors "github.com/juju/juju/domain/relation/errors"
 	resolveerrors "github.com/juju/juju/domain/resolve/errors"
 	"github.com/juju/juju/domain/unitstate"
+	"github.com/juju/juju/internal/charm"
 	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/rpc/params"
 )
@@ -2208,6 +2209,14 @@ func (u *UniterAPI) prepareRelationResult(
 		} else {
 			otherAppName = v.ApplicationName
 		}
+	}
+	// In case of peer relation, the other application name is the current one
+	if len(rel.Endpoints) == 1 && rel.Endpoints[0].Role == charm.RolePeer {
+		otherAppName = applicationName
+	}
+	// At this point we should have a valid otherAppName
+	if otherAppName == "" {
+		return params.RelationResultV2{}, errors.New("no other application found")
 	}
 	// Only an application in the relation can request this data.
 	if unitEp.ApplicationName != applicationName {


### PR DESCRIPTION
This patch fixes #20590 which prevents peer relation from being created. This was because the Uniter API doesn't return the "otherApplicationName" in case of peer relation, which causes various side effects, especially in `relation-get` and `relation-list` hook commands.

This fix simply returns the current application name as otherApplicationName for peer relation, since this type of relation is one self.

- Updated `Relation` in `apiserver/facades/agent/uniter/uniter.go` to handle scenarios where the `otherAppName` for peer relations defaults to the current application name when only one endpoint is present.
- Added a new test, `TestPeerRelation`, in `apiserver/facades/agent/uniter/uniter_test.go` to verify correct handling of peer relations. The test validates that the relation details, life, and endpoints are accurately processed and returned.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Follow reproduce step from #20590 

## Links

**Jira card:** [JUJU-8517](https://warthogs.atlassian.net/browse/JUJU-8517)


[JUJU-8517]: https://warthogs.atlassian.net/browse/JUJU-8517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ