### PR TITLE
fix: uniter must report error status for invalid actions

### DIFF
--- a/internal/worker/uniter/op_callbacks.go
+++ b/internal/worker/uniter/op_callbacks.go
@@ -118,6 +118,19 @@ func (opc *operationCallbacks) FailAction(ctx stdcontext.Context, actionId, mess
 	return err
 }
 
+// ErrorAction is part of the operation.Callbacks interface.
+func (opc *operationCallbacks) ErrorAction(ctx stdcontext.Context, actionId, message string) error {
+	if !names.IsValidAction(actionId) {
+		return errors.Errorf("invalid action id %q", actionId)
+	}
+	tag := names.NewActionTag(actionId)
+	err := opc.u.client.ActionFinish(ctx, tag, params.ActionError, nil, message)
+	if params.IsCodeNotFoundOrCodeUnauthorized(err) || params.IsCodeAlreadyExists(err) {
+		err = nil
+	}
+	return err
+}
+
 func (opc *operationCallbacks) ActionStatus(ctx stdcontext.Context, actionId string) (string, error) {
 	if !names.IsValidAction(actionId) {
 		return "", errors.NotValidf("invalid action id %q", actionId)

--- a/internal/worker/uniter/operation/failaction_test.go
+++ b/internal/worker/uniter/operation/failaction_test.go
@@ -76,6 +76,7 @@ func (s *FailActionSuite) TestExecuteSuccess(c *tc.C) {
 		c.Assert(newState, tc.DeepEquals, &test.after)
 		c.Assert(*callbacks.MockFailAction.gotMessage, tc.Equals, "action terminated")
 		c.Assert(*callbacks.MockFailAction.gotActionId, tc.Equals, someActionId)
+		c.Assert(callbacks.MockFailAction.status, tc.Equals, "failed")
 	}
 }
 

--- a/internal/worker/uniter/operation/interface.go
+++ b/internal/worker/uniter/operation/interface.go
@@ -195,9 +195,13 @@ type Callbacks interface {
 	// The following methods exist primarily to allow us to test operation code
 	// without using a live api connection.
 
-	// FailAction marks the supplied action failed. It's only used by
-	// RunActions operations.
+	// FailAction marks the supplied action status as "failed". It's only used
+	// by RunActions operations.
 	FailAction(ctx stdcontext.Context, actionId, message string) error
+
+	// ErrorAction marks the supplied action status as "error". It's only used
+	// by RunActions operations.
+	ErrorAction(ctx stdcontext.Context, actionId, message string) error
 
 	// ActionStatus returns the status of the action required by the action operation for
 	// cancelation.

--- a/internal/worker/uniter/operation/mocks/interface_mock.go
+++ b/internal/worker/uniter/operation/mocks/interface_mock.go
@@ -902,6 +902,44 @@ func (c *MockCallbacksCommitHookCall) DoAndReturn(f func(context.Context, hook.I
 	return c
 }
 
+// ErrorAction mocks base method.
+func (m *MockCallbacks) ErrorAction(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ErrorAction", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ErrorAction indicates an expected call of ErrorAction.
+func (mr *MockCallbacksMockRecorder) ErrorAction(arg0, arg1, arg2 any) *MockCallbacksErrorActionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorAction", reflect.TypeOf((*MockCallbacks)(nil).ErrorAction), arg0, arg1, arg2)
+	return &MockCallbacksErrorActionCall{Call: call}
+}
+
+// MockCallbacksErrorActionCall wrap *gomock.Call
+type MockCallbacksErrorActionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCallbacksErrorActionCall) Return(arg0 error) *MockCallbacksErrorActionCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCallbacksErrorActionCall) Do(f func(context.Context, string, string) error) *MockCallbacksErrorActionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCallbacksErrorActionCall) DoAndReturn(f func(context.Context, string, string) error) *MockCallbacksErrorActionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // FailAction mocks base method.
 func (m *MockCallbacks) FailAction(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/internal/worker/uniter/operation/runaction.go
+++ b/internal/worker/uniter/operation/runaction.go
@@ -56,7 +56,7 @@ func (ra *runAction) Prepare(ctx context.Context, state State) (*State, error) {
 	actionID := ra.action.ID()
 	rnr, err := ra.runnerFactory.NewActionRunner(ctx, ra.action, ra.cancel)
 	if cause := errors.Cause(err); charmrunner.IsBadActionError(cause) {
-		if err := ra.callbacks.FailAction(ctx, actionID, err.Error()); err != nil {
+		if err := ra.callbacks.ErrorAction(ctx, actionID, err.Error()); err != nil {
 			return nil, err
 		}
 		return nil, ErrSkipExecute

--- a/internal/worker/uniter/operation/runaction_test.go
+++ b/internal/worker/uniter/operation/runaction_test.go
@@ -75,6 +75,7 @@ func (s *RunActionSuite) TestPrepareErrorBadActionAndFailSucceeds(c *tc.C) {
 	c.Assert(runnerFactory.MockNewActionRunner.gotCancel, tc.NotNil)
 	c.Assert(*callbacks.MockFailAction.gotActionId, tc.Equals, someActionId)
 	c.Assert(*callbacks.MockFailAction.gotMessage, tc.Equals, errBadAction.Error())
+	c.Assert(callbacks.MockFailAction.status, tc.Equals, "error")
 }
 
 func (s *RunActionSuite) TestPrepareErrorBadActionAndFailErrors(c *tc.C) {
@@ -96,6 +97,7 @@ func (s *RunActionSuite) TestPrepareErrorBadActionAndFailErrors(c *tc.C) {
 	c.Assert(runnerFactory.MockNewActionRunner.gotCancel, tc.NotNil)
 	c.Assert(*callbacks.MockFailAction.gotActionId, tc.Equals, someActionId)
 	c.Assert(*callbacks.MockFailAction.gotMessage, tc.Equals, errBadAction.Error())
+	c.Assert(callbacks.MockFailAction.status, tc.Equals, "error")
 }
 
 func (s *RunActionSuite) TestPrepareErrorActionNotAvailable(c *tc.C) {

--- a/internal/worker/uniter/operation/util_test.go
+++ b/internal/worker/uniter/operation/util_test.go
@@ -106,12 +106,14 @@ func (d *MockDeployer) Deploy() error {
 type MockFailAction struct {
 	gotActionId *string
 	gotMessage  *string
+	status      string
 	err         error
 }
 
-func (mock *MockFailAction) Call(actionId, message string) error {
+func (mock *MockFailAction) Call(actionId, status, message string) error {
 	mock.gotActionId = &actionId
 	mock.gotMessage = &message
+	mock.status = status
 	return mock.err
 }
 
@@ -125,7 +127,11 @@ type RunActionCallbacks struct {
 }
 
 func (cb *RunActionCallbacks) FailAction(_ context.Context, actionId, message string) error {
-	return cb.MockFailAction.Call(actionId, message)
+	return cb.MockFailAction.Call(actionId, "failed", message)
+}
+
+func (cb *RunActionCallbacks) ErrorAction(_ context.Context, actionId, message string) error {
+	return cb.MockFailAction.Call(actionId, "error", message)
 }
 
 func (cb *RunActionCallbacks) SetExecutingStatus(_ context.Context, message string) error {


### PR DESCRIPTION
When the uniter reports that an action did not run, it must report that as
the action having "error" status. This indicates that the action did not run
and had an error before running. When an action fails, that should be
reported as a "failed" status.

This fixes the actions shell test for "error" status when passed the wrong
parameters and incorrectly getting the "failed" status. The reason this
worked in 3.x is unknown, but it might be due to the client checking if the
action is nil (?) then reporting "error".

## QA steps

`cd tests && ./main.sh actions`
