### PR TITLE
refactor: kubernetes unit network info

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2083,7 +2083,7 @@ func (api *APIBase) unitResultForUnit(ctx context.Context, unitName coreunit.Nam
 		} else if err != nil {
 			return nil, err
 		}
-		result.ProviderId = podInfo.ProviderID.String()
+		result.ProviderId = podInfo.ProviderID
 		result.Address = podInfo.Address
 		result.OpenedPorts = podInfo.Ports
 

--- a/domain/application/internal/unit.go
+++ b/domain/application/internal/unit.go
@@ -6,6 +6,8 @@ package internal
 // UnitK8sInformation represents the Kubernetes related information about a
 // unit.
 type UnitK8sInformation struct {
+	// Addresses provides all of the available ip addresses for the unit include
+	// the subnet mask of the address.
 	Addresses  []string
 	ProviderID string
 	Ports      []string

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -33,6 +33,7 @@ import (
 	architecture "github.com/juju/juju/domain/application/architecture"
 	charm0 "github.com/juju/juju/domain/application/charm"
 	store "github.com/juju/juju/domain/application/charm/store"
+	internal "github.com/juju/juju/domain/application/internal"
 	constraints0 "github.com/juju/juju/domain/constraints"
 	life "github.com/juju/juju/domain/life"
 	network0 "github.com/juju/juju/domain/network"
@@ -3578,10 +3579,10 @@ func (c *MockStateGetUnitWorkloadVersionCall) DoAndReturn(f func(context.Context
 }
 
 // GetUnitsK8sPodInfo mocks base method.
-func (m *MockState) GetUnitsK8sPodInfo(arg0 context.Context) (map[unit.Name]application0.K8sPodInfo, error) {
+func (m *MockState) GetUnitsK8sPodInfo(arg0 context.Context) (map[string]internal.UnitK8sInformation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitsK8sPodInfo", arg0)
-	ret0, _ := ret[0].(map[unit.Name]application0.K8sPodInfo)
+	ret0, _ := ret[0].(map[string]internal.UnitK8sInformation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3599,19 +3600,19 @@ type MockStateGetUnitsK8sPodInfoCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitsK8sPodInfoCall) Return(arg0 map[unit.Name]application0.K8sPodInfo, arg1 error) *MockStateGetUnitsK8sPodInfoCall {
+func (c *MockStateGetUnitsK8sPodInfoCall) Return(arg0 map[string]internal.UnitK8sInformation, arg1 error) *MockStateGetUnitsK8sPodInfoCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitsK8sPodInfoCall) Do(f func(context.Context) (map[unit.Name]application0.K8sPodInfo, error)) *MockStateGetUnitsK8sPodInfoCall {
+func (c *MockStateGetUnitsK8sPodInfoCall) Do(f func(context.Context) (map[string]internal.UnitK8sInformation, error)) *MockStateGetUnitsK8sPodInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitsK8sPodInfoCall) DoAndReturn(f func(context.Context) (map[unit.Name]application0.K8sPodInfo, error)) *MockStateGetUnitsK8sPodInfoCall {
+func (c *MockStateGetUnitsK8sPodInfoCall) DoAndReturn(f func(context.Context) (map[string]internal.UnitK8sInformation, error)) *MockStateGetUnitsK8sPodInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/application/internal"
 	"github.com/juju/juju/domain/constraints"
 	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/life"
@@ -145,8 +146,16 @@ type UnitState interface {
 	// - [applicationerrors.UnitIsDead] if the unit is dead
 	GetUnitK8sPodInfo(context.Context, coreunit.Name) (application.K8sPodInfo, error)
 
-	// GetUnitsK8sPodInfo returns information about the k8s pods for all alive units.
-	GetUnitsK8sPodInfo(ctx context.Context) (map[coreunit.Name]application.K8sPodInfo, error)
+	// GetUnitsK8sPodInfo returns Kubernetes related information for each unit
+	// in the model that is running inside of a Kubernetes pod. If no Kubernetes
+	// based units are found than an empty result is returned.
+	//
+	// This function WILL return ip address values for each pod in a
+	// deterministic order. IP addresses will be order based on how public they
+	// are, ipv6 addresses before ipv4 addresses and then natural sort over of
+	// value. This ordering exists so that the user always get a deterministic
+	// result.
+	GetUnitsK8sPodInfo(ctx context.Context) (map[string]internal.UnitK8sInformation, error)
 
 	// GetAllUnitNames returns a slice of all unit names in the model.
 	GetAllUnitNames(context.Context) ([]coreunit.Name, error)
@@ -705,7 +714,29 @@ func (s *Service) GetUnitsK8sPodInfo(ctx context.Context) (map[coreunit.Name]app
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return s.st.GetUnitsK8sPodInfo(ctx)
+	stateUnitsInfo, err := s.st.GetUnitsK8sPodInfo(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	rval := make(map[coreunit.Name]application.K8sPodInfo, len(stateUnitsInfo))
+	for _, info := range stateUnitsInfo {
+		var suggestedAddress string
+		if len(info.Addresses) != 0 {
+			// We take the first address because the expectation is that they
+			// have been order into a deterministic order. However we should
+			// be returning all addresses to the caller and this needs to get
+			// fixed.
+			suggestedAddress = info.Addresses[0]
+		}
+		rval[coreunit.Name(info.UnitName)] = application.K8sPodInfo{
+			Address:    suggestedAddress,
+			ProviderID: info.ProviderID,
+			Ports:      info.Ports,
+		}
+	}
+
+	return rval, nil
 }
 
 // GetUnitSubordinates returns the names of all the subordinate units of the

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -211,8 +211,8 @@ type unitK8sPodPort struct {
 }
 
 type unitK8sPodInfo struct {
-	ProviderID sql.Null[network.Id] `db:"provider_id"`
-	Address    sql.Null[string]     `db:"address"`
+	ProviderID string           `db:"provider_id"`
+	Address    sql.Null[string] `db:"address"`
 }
 
 type ipAddress struct {
@@ -1296,4 +1296,9 @@ type unitK8sPort struct {
 
 type charmModifiedVersion struct {
 	Version uint64 `db:"charm_modified_version"`
+}
+
+// ipAddressScopeID represents the scope_id column for the ip_address table.
+type ipAddressScopeID struct {
+	ScopeID int `db:"scope_id"`
 }

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -18,13 +18,11 @@ import (
 	"github.com/juju/juju/core/application/testing"
 	coremachine "github.com/juju/juju/core/machine"
 	machinetesting "github.com/juju/juju/core/machine/testing"
-	"github.com/juju/juju/core/network"
 	coreunit "github.com/juju/juju/core/unit"
 	coreunittesting "github.com/juju/juju/core/unit/testing"
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
-	"github.com/juju/juju/domain/application/internal"
 	internalapplication "github.com/juju/juju/domain/application/internal"
 	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/ipaddress"
@@ -1227,7 +1225,7 @@ func (s *unitStateSuite) TestGetUnitsK8sPodInfo(c *tc.C) {
 
 	// Assert: only the 2 alive units are returned.
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(k8sPodInfo, tc.DeepEquals, map[string]internal.UnitK8sInformation{
+	c.Check(k8sPodInfo, tc.DeepEquals, map[string]internalapplication.UnitK8sInformation{
 		app1Unit1UUID.String(): {
 			Addresses: []string{
 				"10.6.6.6/24",
@@ -1277,7 +1275,7 @@ func (s *unitStateSuite) TestGetUnitK8sPodInfo(c *tc.C) {
 
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(info.ProviderID, tc.Equals, network.Id("some-id"))
+	c.Check(info.ProviderID, tc.Equals, "some-id")
 	c.Check(info.Address, tc.Equals, "10.6.6.6/24")
 	c.Check(info.Ports, tc.DeepEquals, []string{"666", "668"})
 }
@@ -1291,7 +1289,7 @@ func (s *unitStateSuite) TestGetUnitK8sPodInfoNoInfo(c *tc.C) {
 
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(info.ProviderID, tc.Equals, network.Id(""))
+	c.Check(info.ProviderID, tc.Equals, "")
 	c.Check(info.Address, tc.Equals, "")
 	c.Check(info.Ports, tc.DeepEquals, []string{})
 }

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -428,7 +428,7 @@ type UnitAttributes struct {
 
 // K8sPodInfo contains information about a unit's k8s pod.
 type K8sPodInfo struct {
-	ProviderID network.Id
+	ProviderID string
 	Address    string
 	Ports      []string
 }


### PR DESCRIPTION
This PR tries to fix a bad implementation we got for fetching a units Kubernetes network information. There were a few possibilities that existed with the implementation and which were not tested. While this change is still not perfect the code is now much safer and more correct with the data model we have.

In an idea world we would have got the network info for a unit in one call no matter what type the model is. There is nothing kubernetes specific about this call that couldn't have just been behind a generic service func. To deal with later.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests are fine.

## Documentation changes

N/A

## Links

**Jira card:** Drive by
