### PR TITLE
fix: child logger for aws s3 client

### DIFF
--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -84,7 +84,7 @@ func NewS3Client(endpoint string, httpClient HTTPClient, credentials Credentials
 	}
 
 	awsLogger := &awsLogger{
-		logger: logger,
+		logger: logger.Child("aws.s3"),
 	}
 
 	cfg, err := config.LoadDefaultConfig(


### PR DESCRIPTION
The AWS s3 client gets a juju logger and because the library has some small format bugs in log messages it makes the Juju uniter code look like it has an error when in reality it is coming from aws.

This change creates a child logger for the aws s3 client so we can see easily from logs that is not a direct Juju source of the problem.

`unit-controller-0: 04:24:28 WARNING juju.worker.units3caller Response has no supported checksum. Not validating response payload.%!(EXTRA []interface {}=[])`

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A
