### PR TITLE
refactor: remove machine storage tables

### DIFF
--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -561,8 +561,6 @@ func (st *State) removeBasicMachineData(ctx context.Context, tx *sqlair.TX, mUUI
 	machineUUIDRec := entityUUID{UUID: mUUID}
 
 	tables := []string{
-		"DELETE FROM machine_volume WHERE machine_uuid = $entityUUID.uuid",
-		"DELETE FROM machine_filesystem WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_manual WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_agent_version WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM instance_tag WHERE machine_uuid = $entityUUID.uuid",

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -148,30 +148,6 @@ CREATE TABLE machine_constraint (
     REFERENCES "constraint" (uuid)
 );
 
-CREATE TABLE machine_volume (
-    machine_uuid TEXT NOT NULL,
-    volume_uuid TEXT NOT NULL,
-    CONSTRAINT fk_machine_volume_machine
-    FOREIGN KEY (machine_uuid)
-    REFERENCES machine (uuid),
-    CONSTRAINT fk_machine_volume_volume
-    FOREIGN KEY (volume_uuid)
-    REFERENCES storage_volume (uuid),
-    PRIMARY KEY (machine_uuid, volume_uuid)
-);
-
-CREATE TABLE machine_filesystem (
-    machine_uuid TEXT NOT NULL,
-    filesystem_uuid TEXT NOT NULL,
-    CONSTRAINT fk_machine_filesystem_machine
-    FOREIGN KEY (machine_uuid)
-    REFERENCES machine (uuid),
-    CONSTRAINT fk_machine_filesystem_filesystem
-    FOREIGN KEY (filesystem_uuid)
-    REFERENCES storage_filesystem (uuid),
-    PRIMARY KEY (machine_uuid, filesystem_uuid)
-);
-
 CREATE TABLE machine_requires_reboot (
     machine_uuid TEXT NOT NULL PRIMARY KEY,
     created_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -152,7 +152,6 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"machine_cloud_instance",
 		"machine_constraint",
 		"machine_container_type",
-		"machine_filesystem",
 		"machine_lxd_profile",
 		"machine_manual",
 		"machine_parent",
@@ -164,7 +163,6 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"machine_ssh_host_key",
 		"machine_status_value",
 		"machine_status",
-		"machine_volume",
 
 		// Charm
 		"architecture",


### PR DESCRIPTION
Our model DDL had tables for machine filesystem and machine volume that are not being used and will not be used. This commit removes all references to the DDL tables.

## Checklist

- ~[] Code style: imports ordered, good names, simple structure, etc~
- ~[] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A

## Documentation changes

N/A

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-8099)
