### PR TITLE
fix: deploy local subordinate charms

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -107,7 +107,7 @@ func DeployApplication(
 			return errors.New("subordinate application must be deployed without units")
 		}
 		if !constraints.IsEmpty(&args.Constraints) {
-			return errors.New("subordinate application must be deployed without constraints")
+			return errors.Errorf("subordinate application must be deployed without constraints, not %q", args.Constraints)
 		}
 	}
 

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -430,7 +430,7 @@ func (v *deployFromRepositoryValidator) resolvedCharmValidation(ctx context.Cont
 			numUnits = 0
 		}
 		if !constraints.IsEmpty(&arg.Cons) {
-			errs = append(errs, fmt.Errorf("subordinate application must be deployed without constraints"))
+			errs = append(errs, fmt.Errorf("subordinate application must be deployed without constraints, not %q", arg.Cons))
 		}
 	} else {
 		cons = arg.Cons


### PR DESCRIPTION
This PR fixes an issue when deploying a local subordinate charm. The command `juju deploy ./<path-to-charm>` fails with the error `subordinate application must be deployed without constraints`.

This failure is only seen for local charms, not for store charm. This is due to the difference in logic between the `Deploy()` and `DeployFromRepository()` methods. The faulty in logic in `Deploy()` was that if no architecture constraints were set, we were populating one. This is a problem for subordinate charms because later there is a check that forbids any constraints when deploying a subordinate. The correct place, it seems, to set the architecture is on the charmOrigin object rather. This is more aligned with how `DeployFromRepository()` does it.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. `make install`
2. `juju bootstrap localhost test-subordinate`
3. `juju add-model foo`
4. `cd testcharms/charms/lxd-profile-subordinate`
5. `charmcraft pack`
6. `juju deploy ./lxd-profile-subordinate_amd64.charm`

Before the change,
```
juju deploy ./lxd-profile-subordinate_amd64.charm
Located local charm "lxd-profile-subordinate", revision 0
Deploying "lxd-profile-subordinate" from local charm "lxd-profile-subordinate", revision 0 on ubuntu@24.04/stable
ERROR cannot deploy "lxd-profile-subordinate": subordinate application must be deployed without constraints
```
After the change the error is gone.

Additionally, I tested deploying a non-subordinate local charm, e.g. `testcharms/charms/refresher` with the same steps as above and this worked as well.

## Links

**Jira card:** [JUJU-8603](https://warthogs.atlassian.net/browse/JUJU-8603)


[JUJU-8603]: https://warthogs.atlassian.net/browse/JUJU-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ