### PR TITLE
fix(destroy-model): fix nil pointer dereference for cascaded.MachineUUID

### DIFF
--- a/domain/removal/service/unit.go
+++ b/domain/removal/service/unit.go
@@ -125,9 +125,8 @@ func (s *Service) RemoveUnit(
 		return unitJobUUID, nil
 	}
 
-	s.logger.Infof(ctx, "unit was the last one on machine %q, scheduling removal", *cascaded.MachineUUID)
-
 	if cascaded.MachineUUID != nil {
+		s.logger.Infof(ctx, "unit was the last one on machine %q, scheduling removal", *cascaded.MachineUUID)
 		if _, err := s.machineScheduleRemoval(ctx, machine.UUID(*cascaded.MachineUUID), force, wait); err != nil {
 			return "", errors.Capture(err)
 		}


### PR DESCRIPTION
# Description

`cascaded.MachineUUID` is referenced before is checked not nil.

This should partially fix: [test-deploy_caas-test-deploy-charm-microk8s](https://jenkins.juju.canonical.com/job/test-deploy_caas-test-deploy-charm-microk8s/2818/)