### PR TITLE
fix: parsing of credentials that contain '_' in their name

### DIFF
--- a/core/credential/credential.go
+++ b/core/credential/credential.go
@@ -5,6 +5,7 @@ package credential
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/names/v6"
 
@@ -59,9 +60,20 @@ func (k Key) Tag() (names.CloudCredentialTag, error) {
 	if k.IsZero() {
 		return names.CloudCredentialTag{}, nil
 	}
-	return names.ParseCloudCredentialTag(
-		fmt.Sprintf("%s-%s_%s_%s", names.CloudCredentialTagKind, k.Cloud, k.Owner, k.Name),
+
+	// sepEscape is taken from the names package.
+	sepEscape := func(in string) string {
+		return strings.Replace(in, "_", `%5f`, -1)
+	}
+	strTag := fmt.Sprintf(
+		"%s-%s_%s_%s",
+		names.CloudCredentialTagKind,
+		sepEscape(k.Cloud),
+		sepEscape(k.Owner.String()),
+		sepEscape(k.Name),
 	)
+
+	return names.ParseCloudCredentialTag(strTag)
 }
 
 // Validate is responsible for checking all of the fields of Key are in a set

--- a/core/credential/credential_test.go
+++ b/core/credential/credential_test.go
@@ -50,6 +50,30 @@ func (s *typeSuite) TestCredentialKeyIsNotZero(c *tc.C) {
 	}
 }
 
+// TestCredentialKeyEscape is a regression test for asserting the escaping of
+// credential data before parsing to a tag. Specifically credential values that
+// contain a '_' rune need to be escaped in accordance with url patterns.
+func (s *typeSuite) TestCredentialKeyEscape(c *tc.C) {
+	k := Key{
+		Cloud: "maas_cloud",
+		Name:  "maas_cloud_credentials",
+		Owner: user.AdminUserName,
+	}
+
+	// Test to tag
+	tag, err := k.Tag()
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(
+		tag.String(),
+		tc.Equals,
+		"cloudcred-maas%5fcloud_admin_maas%5fcloud%5fcredentials",
+	)
+
+	// Test from tag
+	gotKey := KeyFromTag(tag)
+	c.Check(gotKey, tc.Equals, k)
+}
+
 func (s *typeSuite) TestCredentialKeyValidate(c *tc.C) {
 	tests := []struct {
 		Key Key


### PR DESCRIPTION
When a credential contains the '_' rune in one of their data fields it needs to be escaped when transforming to a tag.

Fixes #20916

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests are enough for this bug. However you can add a credential with an under score to the controller and deploy a model and application using it.

## Documentation changes

N/A

## Links

**Issue:** #20916
