### PR TITLE
feat(removal): implement & wire up removal of SAAS

### DIFF
--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	corerelation "github.com/juju/juju/core/relation"
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
 	coreresource "github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
@@ -112,6 +113,10 @@ type CrossModelRelationService interface {
 		applicationName string,
 		args crossmodelrelationservice.AddRemoteApplicationOffererArgs,
 	) error
+
+	// GetRemoteApplicationOffererByApplicationName returns the UUID of the remote
+	// application offerer for the given application name.
+	GetRemoteApplicationOffererByApplicationName(context.Context, string) (coreremoteapplication.UUID, error)
 }
 
 // CredentialService provides access to credentials.
@@ -504,6 +509,22 @@ type RemovalService interface {
 	RemoveRelation(
 		ctx context.Context,
 		relUUID corerelation.UUID,
+		force bool,
+		wait time.Duration,
+	) (removal.UUID, error)
+
+	// RemoveRemoteApplicationOfferer checks if a remote application with the input
+	// UUID exists. If it does, the remote application is guaranteed after this
+	// call to be:
+	// - No longer alive.
+	// - Removed or scheduled to be removed with the input force qualification.
+	// The input wait duration is the time that we will give for the normal
+	// life-cycle advancement and removal to finish before forcefully removing the
+	// remote application. This duration is ignored if the force argument is false.
+	// The UUID for the scheduled removal job is returned.
+	RemoveRemoteApplicationOfferer(
+		ctx context.Context,
+		remoteAppOffererUUID coreremoteapplication.UUID,
 		force bool,
 		wait time.Duration,
 	) (removal.UUID, error)

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -26,6 +26,7 @@ import (
 	machine "github.com/juju/juju/core/machine"
 	network "github.com/juju/juju/core/network"
 	relation "github.com/juju/juju/core/relation"
+	remoteapplication "github.com/juju/juju/core/remoteapplication"
 	resource "github.com/juju/juju/core/resource"
 	unit "github.com/juju/juju/core/unit"
 	application0 "github.com/juju/juju/domain/application"
@@ -2615,6 +2616,45 @@ func (c *MockRemovalServiceRemoveRelationCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
+// RemoveRemoteApplicationOfferer mocks base method.
+func (m *MockRemovalService) RemoveRemoteApplicationOfferer(arg0 context.Context, arg1 remoteapplication.UUID, arg2 bool, arg3 time.Duration) (removal.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveRemoteApplicationOfferer", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(removal.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveRemoteApplicationOfferer indicates an expected call of RemoveRemoteApplicationOfferer.
+func (mr *MockRemovalServiceMockRecorder) RemoveRemoteApplicationOfferer(arg0, arg1, arg2, arg3 any) *MockRemovalServiceRemoveRemoteApplicationOffererCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteApplicationOfferer", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteApplicationOfferer), arg0, arg1, arg2, arg3)
+	return &MockRemovalServiceRemoveRemoteApplicationOffererCall{Call: call}
+}
+
+// MockRemovalServiceRemoveRemoteApplicationOffererCall wrap *gomock.Call
+type MockRemovalServiceRemoveRemoteApplicationOffererCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRemovalServiceRemoveRemoteApplicationOffererCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRemoteApplicationOffererCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRemovalServiceRemoveRemoteApplicationOffererCall) Do(f func(context.Context, remoteapplication.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteApplicationOffererCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRemovalServiceRemoveRemoteApplicationOffererCall) DoAndReturn(f func(context.Context, remoteapplication.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteApplicationOffererCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveUnit mocks base method.
 func (m *MockRemovalService) RemoveUnit(arg0 context.Context, arg1 unit.UUID, arg2, arg3 bool, arg4 time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
@@ -2772,6 +2812,45 @@ func (c *MockCrossModelRelationServiceAddRemoteApplicationOffererCall) Do(f func
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelRelationServiceAddRemoteApplicationOffererCall) DoAndReturn(f func(context.Context, string, service0.AddRemoteApplicationOffererArgs) error) *MockCrossModelRelationServiceAddRemoteApplicationOffererCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetRemoteApplicationOffererByApplicationName mocks base method.
+func (m *MockCrossModelRelationService) GetRemoteApplicationOffererByApplicationName(arg0 context.Context, arg1 string) (remoteapplication.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRemoteApplicationOffererByApplicationName", arg0, arg1)
+	ret0, _ := ret[0].(remoteapplication.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteApplicationOffererByApplicationName indicates an expected call of GetRemoteApplicationOffererByApplicationName.
+func (mr *MockCrossModelRelationServiceMockRecorder) GetRemoteApplicationOffererByApplicationName(arg0, arg1 any) *MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteApplicationOffererByApplicationName", reflect.TypeOf((*MockCrossModelRelationService)(nil).GetRemoteApplicationOffererByApplicationName), arg0, arg1)
+	return &MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall{Call: call}
+}
+
+// MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall wrap *gomock.Call
+type MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall) Return(arg0 remoteapplication.UUID, arg1 error) *MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall) Do(f func(context.Context, string) (remoteapplication.UUID, error)) *MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall) DoAndReturn(f func(context.Context, string) (remoteapplication.UUID, error)) *MockCrossModelRelationServiceGetRemoteApplicationOffererByApplicationNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/crossmodelrelation/errors/errors.go
+++ b/domain/crossmodelrelation/errors/errors.go
@@ -14,6 +14,11 @@ const (
 	// application being operated on is dead.
 	RemoteApplicationIsDead = errors.ConstError("remote application is dead")
 
+	// RemoteApplicationHasRelations describes an error that occurs when an
+	// operation on a remote application can't be performed because the remote
+	// application has relations established.
+	RemoteApplicationHasRelations = errors.ConstError("remote application has relations")
+
 	// ApplicationNotRemote describes an error that occurs when the application
 	// being operated on is not a remote application.
 	ApplicationNotRemote = errors.ConstError("application not remote")

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -738,6 +738,45 @@ func (c *MockModelStateGetRemoteApplicationConsumersCall) DoAndReturn(f func(con
 	return c
 }
 
+// GetRemoteApplicationOffererByApplicationName mocks base method.
+func (m *MockModelState) GetRemoteApplicationOffererByApplicationName(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRemoteApplicationOffererByApplicationName", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteApplicationOffererByApplicationName indicates an expected call of GetRemoteApplicationOffererByApplicationName.
+func (mr *MockModelStateMockRecorder) GetRemoteApplicationOffererByApplicationName(arg0, arg1 any) *MockModelStateGetRemoteApplicationOffererByApplicationNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteApplicationOffererByApplicationName", reflect.TypeOf((*MockModelState)(nil).GetRemoteApplicationOffererByApplicationName), arg0, arg1)
+	return &MockModelStateGetRemoteApplicationOffererByApplicationNameCall{Call: call}
+}
+
+// MockModelStateGetRemoteApplicationOffererByApplicationNameCall wrap *gomock.Call
+type MockModelStateGetRemoteApplicationOffererByApplicationNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetRemoteApplicationOffererByApplicationNameCall) Return(arg0 string, arg1 error) *MockModelStateGetRemoteApplicationOffererByApplicationNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetRemoteApplicationOffererByApplicationNameCall) Do(f func(context.Context, string) (string, error)) *MockModelStateGetRemoteApplicationOffererByApplicationNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetRemoteApplicationOffererByApplicationNameCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockModelStateGetRemoteApplicationOffererByApplicationNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRemoteApplicationOfferers mocks base method.
 func (m *MockModelState) GetRemoteApplicationOfferers(arg0 context.Context) ([]crossmodelrelation.RemoteApplicationOfferer, error) {
 	m.ctrl.T.Helper()

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -52,6 +52,10 @@ type ModelRemoteApplicationState interface {
 	// application offerers in the local model.
 	GetRemoteApplicationOfferers(context.Context) ([]crossmodelrelation.RemoteApplicationOfferer, error)
 
+	// GetRemoteApplicationOffererByApplicationName returns the UUID of the remote
+	// application offerer for the given application name.
+	GetRemoteApplicationOffererByApplicationName(context.Context, string) (string, error)
+
 	// GetRemoteApplicationConsumers returns all the current non-dead remote
 	// application consumers in the local model.
 	GetRemoteApplicationConsumers(context.Context) ([]crossmodelrelation.RemoteApplicationConsumer, error)
@@ -244,6 +248,25 @@ func (s *Service) GetRemoteApplicationOfferers(ctx context.Context) ([]crossmode
 	defer span.End()
 
 	return s.modelState.GetRemoteApplicationOfferers(ctx)
+}
+
+// GetRemoteApplicationOffererByApplicationName returns the UUID of the remote
+// application offerer for the given application name.
+func (s *Service) GetRemoteApplicationOffererByApplicationName(ctx context.Context, appName string) (coreremoteapplication.UUID, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	uuid, err := s.modelState.GetRemoteApplicationOffererByApplicationName(ctx, appName)
+	if err != nil {
+		return "", internalerrors.Capture(err)
+	}
+
+	ret, err := coreremoteapplication.ParseUUID(uuid)
+	if err != nil {
+		return "", internalerrors.Errorf("parsing remote application offerer UUID: %w", err)
+	}
+
+	return ret, nil
 }
 
 // GetRemoteApplicationConsumers returns the current state of all remote

--- a/domain/removal/internal/types.go
+++ b/domain/removal/internal/types.go
@@ -28,8 +28,8 @@ func (c CascadedUnitLives) IsEmpty() bool {
 		len(c.StorageInstanceUUIDs) == 0
 }
 
-// CascadedUnitLives contains identifiers for entities that were ensured to be
-// "dying" along with a machine. It is intended to inform the service layer
+// CascadedMachineLives contains identifiers for entities that were ensured to
+// be "dying" along with a machine. It is intended to inform the service layer
 // which entities should have removal jobs scheduled for them.
 type CascadedMachineLives struct {
 	// MachineUUIDs identify containers on the machine,
@@ -88,4 +88,18 @@ func (c CascadedApplicationLives) IsEmpty() bool {
 		len(c.UnitUUIDs) == 0 &&
 		len(c.RelationUUIDs) == 0 &&
 		len(c.StorageAttachmentUUIDs) == 0
+}
+
+// CascadedRemoteApplicationOffererLives contains identifiers for entities that
+// were ensured to be "dying" along with a remote application offerer. It is
+// intended to inform the service layer which entities should have removal jobs
+// scheduled for them
+type CascadedRemoteApplicationOffererLives struct {
+	// RelationUUIDs identify relations that this application was participating
+	// in that advanced to dying along with it.
+	RelationUUIDs []string
+}
+
+func (c CascadedRemoteApplicationOffererLives) IsEmpty() bool {
+	return len(c.RelationUUIDs) == 0
 }

--- a/domain/removal/service/application_test.go
+++ b/domain/removal/service/application_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
+	coreapplication "github.com/juju/juju/core/application"
 	applicationtesting "github.com/juju/juju/core/application/testing"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
@@ -30,7 +31,7 @@ func TestApplicationSuite(t *testing.T) {
 func (s *applicationSuite) TestRemoveApplicationDestroyStorageNoForceSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appUUID := applicationtesting.GenApplicationUUID(c)
+	appUUID := tc.Must(c, coreapplication.NewID)
 
 	when := time.Now()
 	s.clock.EXPECT().Now().Return(when)
@@ -66,7 +67,7 @@ func (s *applicationSuite) TestRemoveApplicationForceNoWaitSuccess(c *tc.C) {
 func (s *applicationSuite) TestRemoveApplicationForceWaitSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appUUID := applicationtesting.GenApplicationUUID(c)
+	appUUID := tc.Must(c, coreapplication.NewID)
 
 	when := time.Now()
 	s.clock.EXPECT().Now().Return(when).MinTimes(1)
@@ -89,7 +90,7 @@ func (s *applicationSuite) TestRemoveApplicationForceWaitSuccess(c *tc.C) {
 func (s *applicationSuite) TestRemoveApplicationNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appUUID := applicationtesting.GenApplicationUUID(c)
+	appUUID := tc.Must(c, coreapplication.NewID)
 
 	s.modelState.EXPECT().ApplicationExists(gomock.Any(), appUUID.String()).Return(false, nil)
 
@@ -100,7 +101,7 @@ func (s *applicationSuite) TestRemoveApplicationNotFound(c *tc.C) {
 func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithUnitsAndStorage(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appUUID := applicationtesting.GenApplicationUUID(c)
+	appUUID := tc.Must(c, coreapplication.NewID)
 
 	when := time.Now()
 	s.clock.EXPECT().Now().Return(when).MinTimes(1)
@@ -126,7 +127,7 @@ func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithUnitsAndStorag
 func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithMachines(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appUUID := applicationtesting.GenApplicationUUID(c)
+	appUUID := tc.Must(c, coreapplication.NewID)
 
 	when := time.Now()
 	s.clock.EXPECT().Now().Return(when).MinTimes(1)
@@ -149,7 +150,7 @@ func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithMachines(c *tc
 func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithRelations(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	appUUID := applicationtesting.GenApplicationUUID(c)
+	appUUID := tc.Must(c, coreapplication.NewID)
 
 	when := time.Now()
 	s.clock.EXPECT().Now().Return(when).MinTimes(1)
@@ -251,6 +252,6 @@ func newApplicationJob(c *tc.C) removal.Job {
 	return removal.Job{
 		UUID:        jUUID,
 		RemovalType: removal.ApplicationJob,
-		EntityUUID:  applicationtesting.GenApplicationUUID(c).String(),
+		EntityUUID:  tc.Must(c, coreapplication.NewID).String(),
 	}
 }

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -603,6 +603,44 @@ func (c *MockModelDBStateDeleteRelationUnitsCall) DoAndReturn(f func(context.Con
 	return c
 }
 
+// DeleteRemoteApplicationOfferer mocks base method.
+func (m *MockModelDBState) DeleteRemoteApplicationOfferer(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRemoteApplicationOfferer", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRemoteApplicationOfferer indicates an expected call of DeleteRemoteApplicationOfferer.
+func (mr *MockModelDBStateMockRecorder) DeleteRemoteApplicationOfferer(arg0, arg1 any) *MockModelDBStateDeleteRemoteApplicationOffererCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRemoteApplicationOfferer", reflect.TypeOf((*MockModelDBState)(nil).DeleteRemoteApplicationOfferer), arg0, arg1)
+	return &MockModelDBStateDeleteRemoteApplicationOffererCall{Call: call}
+}
+
+// MockModelDBStateDeleteRemoteApplicationOffererCall wrap *gomock.Call
+type MockModelDBStateDeleteRemoteApplicationOffererCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateDeleteRemoteApplicationOffererCall) Return(arg0 error) *MockModelDBStateDeleteRemoteApplicationOffererCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateDeleteRemoteApplicationOffererCall) Do(f func(context.Context, string) error) *MockModelDBStateDeleteRemoteApplicationOffererCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateDeleteRemoteApplicationOffererCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateDeleteRemoteApplicationOffererCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DeleteStorageAttachment mocks base method.
 func (m *MockModelDBState) DeleteStorageAttachment(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -830,6 +868,45 @@ func (c *MockModelDBStateEnsureRelationNotAliveCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateEnsureRelationNotAliveCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateEnsureRelationNotAliveCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// EnsureRemoteApplicationOffererNotAliveCascade mocks base method.
+func (m *MockModelDBState) EnsureRemoteApplicationOffererNotAliveCascade(arg0 context.Context, arg1 string) (internal.CascadedRemoteApplicationOffererLives, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureRemoteApplicationOffererNotAliveCascade", arg0, arg1)
+	ret0, _ := ret[0].(internal.CascadedRemoteApplicationOffererLives)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnsureRemoteApplicationOffererNotAliveCascade indicates an expected call of EnsureRemoteApplicationOffererNotAliveCascade.
+func (mr *MockModelDBStateMockRecorder) EnsureRemoteApplicationOffererNotAliveCascade(arg0, arg1 any) *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureRemoteApplicationOffererNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureRemoteApplicationOffererNotAliveCascade), arg0, arg1)
+	return &MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall{Call: call}
+}
+
+// MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall wrap *gomock.Call
+type MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall) Return(arg0 internal.CascadedRemoteApplicationOffererLives, arg1 error) *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall) Do(f func(context.Context, string) (internal.CascadedRemoteApplicationOffererLives, error)) *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) (internal.CascadedRemoteApplicationOffererLives, error)) *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1259,6 +1336,45 @@ func (c *MockModelDBStateGetRelationUnitsForUnitCall) Do(f func(context.Context,
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateGetRelationUnitsForUnitCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockModelDBStateGetRelationUnitsForUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetRemoteApplicationOffererLife mocks base method.
+func (m *MockModelDBState) GetRemoteApplicationOffererLife(arg0 context.Context, arg1 string) (life.Life, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRemoteApplicationOffererLife", arg0, arg1)
+	ret0, _ := ret[0].(life.Life)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteApplicationOffererLife indicates an expected call of GetRemoteApplicationOffererLife.
+func (mr *MockModelDBStateMockRecorder) GetRemoteApplicationOffererLife(arg0, arg1 any) *MockModelDBStateGetRemoteApplicationOffererLifeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteApplicationOffererLife", reflect.TypeOf((*MockModelDBState)(nil).GetRemoteApplicationOffererLife), arg0, arg1)
+	return &MockModelDBStateGetRemoteApplicationOffererLifeCall{Call: call}
+}
+
+// MockModelDBStateGetRemoteApplicationOffererLifeCall wrap *gomock.Call
+type MockModelDBStateGetRemoteApplicationOffererLifeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateGetRemoteApplicationOffererLifeCall) Return(arg0 life.Life, arg1 error) *MockModelDBStateGetRemoteApplicationOffererLifeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateGetRemoteApplicationOffererLifeCall) Do(f func(context.Context, string) (life.Life, error)) *MockModelDBStateGetRemoteApplicationOffererLifeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateGetRemoteApplicationOffererLifeCall) DoAndReturn(f func(context.Context, string) (life.Life, error)) *MockModelDBStateGetRemoteApplicationOffererLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1874,6 +1990,83 @@ func (c *MockModelDBStateRelationScheduleRemovalCall) Do(f func(context.Context,
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateRelationScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRelationScheduleRemovalCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RemoteApplicationOffererExists mocks base method.
+func (m *MockModelDBState) RemoteApplicationOffererExists(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoteApplicationOffererExists", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoteApplicationOffererExists indicates an expected call of RemoteApplicationOffererExists.
+func (mr *MockModelDBStateMockRecorder) RemoteApplicationOffererExists(arg0, arg1 any) *MockModelDBStateRemoteApplicationOffererExistsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteApplicationOffererExists", reflect.TypeOf((*MockModelDBState)(nil).RemoteApplicationOffererExists), arg0, arg1)
+	return &MockModelDBStateRemoteApplicationOffererExistsCall{Call: call}
+}
+
+// MockModelDBStateRemoteApplicationOffererExistsCall wrap *gomock.Call
+type MockModelDBStateRemoteApplicationOffererExistsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateRemoteApplicationOffererExistsCall) Return(arg0 bool, arg1 error) *MockModelDBStateRemoteApplicationOffererExistsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateRemoteApplicationOffererExistsCall) Do(f func(context.Context, string) (bool, error)) *MockModelDBStateRemoteApplicationOffererExistsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateRemoteApplicationOffererExistsCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockModelDBStateRemoteApplicationOffererExistsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RemoteApplicationOffererScheduleRemoval mocks base method.
+func (m *MockModelDBState) RemoteApplicationOffererScheduleRemoval(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoteApplicationOffererScheduleRemoval", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoteApplicationOffererScheduleRemoval indicates an expected call of RemoteApplicationOffererScheduleRemoval.
+func (mr *MockModelDBStateMockRecorder) RemoteApplicationOffererScheduleRemoval(arg0, arg1, arg2, arg3, arg4 any) *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteApplicationOffererScheduleRemoval", reflect.TypeOf((*MockModelDBState)(nil).RemoteApplicationOffererScheduleRemoval), arg0, arg1, arg2, arg3, arg4)
+	return &MockModelDBStateRemoteApplicationOffererScheduleRemovalCall{Call: call}
+}
+
+// MockModelDBStateRemoteApplicationOffererScheduleRemovalCall wrap *gomock.Call
+type MockModelDBStateRemoteApplicationOffererScheduleRemovalCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall) Return(arg0 error) *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall) Do(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/service/remoteapplicationofferer.go
+++ b/domain/removal/service/remoteapplicationofferer.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/juju/core/relation"
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
+	"github.com/juju/juju/core/trace"
+	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/removal"
+	removalerrors "github.com/juju/juju/domain/removal/errors"
+	"github.com/juju/juju/domain/removal/internal"
+	"github.com/juju/juju/internal/errors"
+)
+
+// RemoteApplicationOffererState describes retrieval and persistence methods for
+// remote application offerers in the model database.
+type RemoteApplicationOffererState interface {
+	// GetRemoteApplicationOfferer returns true if a remote application exists
+	// with the input UUID.
+	RemoteApplicationOffererExists(ctx context.Context, rUUID string) (bool, error)
+
+	// EnsureRemoteApplicationOffererNotAliveCascade ensures that there is no
+	// remote application offerer identified by the input UUID, that is still
+	// alive.
+	// NOTE: We do not cascade down to (synthetic) applications or units, since
+	// they are synthetic so can be removed directly without worrying about
+	// their life
+	EnsureRemoteApplicationOffererNotAliveCascade(
+		ctx context.Context, rUUID string,
+	) (internal.CascadedRemoteApplicationOffererLives, error)
+
+	// RemoteApplicationOffererScheduleRemoval schedules a removal job for the
+	// remote application offerer with the input UUID, qualified with the input
+	// force boolean.
+	RemoteApplicationOffererScheduleRemoval(
+		ctx context.Context, removalUUID, rUUID string, force bool, when time.Time,
+	) error
+
+	// GetRemoteApplicationOffererLife returns the life of the remote application
+	// offerer with the input UUID.
+	GetRemoteApplicationOffererLife(ctx context.Context, rUUID string) (life.Life, error)
+
+	// DeleteRemoteApplicationOfferer removes a remote application offerer from
+	// the database completely. This also removes the synthetic application,
+	// unit and charm associated with the remote application offerer.
+	DeleteRemoteApplicationOfferer(ctx context.Context, rUUID string) error
+}
+
+// RemoveRemoteApplicationOfferer checks if a remote application with the input
+// UUID exists. If it does, the remote application is guaranteed after this
+// call to be:
+// - No longer alive.
+// - Removed or scheduled to be removed with the input force qualification.
+// The input wait duration is the time that we will give for the normal
+// life-cycle advancement and removal to finish before forcefully removing the
+// remote application. This duration is ignored if the force argument is false.
+// The UUID for the scheduled removal job is returned.
+func (s *Service) RemoveRemoteApplicationOfferer(
+	ctx context.Context,
+	remoteAppOffererUUID coreremoteapplication.UUID,
+	force bool,
+	wait time.Duration,
+) (removal.UUID, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	exists, err := s.modelState.RemoteApplicationOffererExists(ctx, remoteAppOffererUUID.String())
+	if err != nil {
+		return "", errors.Errorf("checking if remote application offerer %q exists: %w", remoteAppOffererUUID, err)
+	}
+	if !exists {
+		return "", errors.Errorf("remote application offerer %q does not exist", remoteAppOffererUUID).
+			Add(crossmodelrelationerrors.RemoteApplicationNotFound)
+	}
+
+	cascaded, err := s.modelState.EnsureRemoteApplicationOffererNotAliveCascade(ctx, remoteAppOffererUUID.String())
+	if err != nil {
+		return "", errors.Errorf("remote application offerer %q: %w", remoteAppOffererUUID, err)
+	}
+
+	if force {
+		if wait > 0 {
+			// If we have been supplied with the force flag *and* a wait time,
+			// schedule a normal removal job immediately. This will cause the
+			// earliest removal of the remote application offerer if the normal
+			// destruction workflows complete within the wait duration.
+			if _, err := s.remoteApplicationOffererScheduleRemoval(ctx, remoteAppOffererUUID, false, 0); err != nil {
+				return "", errors.Capture(err)
+			}
+		}
+	} else {
+		if wait > 0 {
+			s.logger.Infof(ctx, "ignoring wait duration for non-forced removal of remote application offerer %q", remoteAppOffererUUID)
+			wait = 0
+		}
+	}
+
+	appJobUUID, err := s.remoteApplicationOffererScheduleRemoval(ctx, remoteAppOffererUUID, force, wait)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if cascaded.IsEmpty() {
+		return appJobUUID, nil
+	}
+
+	for _, r := range cascaded.RelationUUIDs {
+		if _, err := s.relationScheduleRemoval(ctx, relation.UUID(r), force, wait); err != nil {
+			return "", errors.Capture(err)
+		}
+	}
+
+	return appJobUUID, nil
+}
+
+func (s *Service) remoteApplicationOffererScheduleRemoval(
+	ctx context.Context, remoteAppOffererUUID coreremoteapplication.UUID, force bool, wait time.Duration,
+) (removal.UUID, error) {
+	jobUUID, err := removal.NewUUID()
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if err := s.modelState.RemoteApplicationOffererScheduleRemoval(
+		ctx, jobUUID.String(), remoteAppOffererUUID.String(), force, s.clock.Now().UTC().Add(wait),
+	); err != nil {
+		return "", errors.Errorf("remote application offerer %q: %w", remoteAppOffererUUID, err)
+	}
+
+	s.logger.Infof(ctx, "scheduled removal job %q for remote application offerer %q", jobUUID, remoteAppOffererUUID)
+	return jobUUID, nil
+}
+
+// processRemoteApplicationOffererRemovalJob deletes a remote application offerer
+// if it is dying. Note that we do not need transactionality here:
+//   - Life can only advance - it cannot become alive if dying or dead.
+func (s *Service) processRemoteApplicationOffererRemovalJob(ctx context.Context, job removal.Job) error {
+	if job.RemovalType != removal.RemoteApplicationOffererJob {
+		return errors.Errorf("job type: %q not valid for remote application offerer removal", job.RemovalType).Add(
+			removalerrors.RemovalJobTypeNotValid)
+	}
+
+	l, err := s.modelState.GetRemoteApplicationOffererLife(ctx, job.EntityUUID)
+	if errors.Is(err, crossmodelrelationerrors.RemoteApplicationNotFound) {
+		// The remote application offerer has already been removed.
+		// Indicate success so that this job will be deleted.
+		return nil
+	} else if err != nil {
+		return errors.Errorf("getting remote application offerer %q life: %w", job.EntityUUID, err)
+	}
+
+	if l == life.Alive {
+		return errors.Errorf("remote application offerer %q is alive", job.EntityUUID).Add(removalerrors.EntityStillAlive)
+	}
+
+	if err := s.modelState.DeleteRemoteApplicationOfferer(ctx, job.EntityUUID); errors.Is(err, crossmodelrelationerrors.RemoteApplicationNotFound) {
+		// The remote application offerer has already been removed.
+		// Indicate success so that this job will be deleted.
+		return nil
+	} else if err != nil {
+		return errors.Errorf("deleting remote application offerer %q: %w", job.EntityUUID, err)
+	}
+
+	return nil
+}

--- a/domain/removal/service/remoteapplicationofferer_test.go
+++ b/domain/removal/service/remoteapplicationofferer_test.go
@@ -1,0 +1,189 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juju/tc"
+	"go.uber.org/mock/gomock"
+
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
+	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/removal"
+	removalerrors "github.com/juju/juju/domain/removal/errors"
+	"github.com/juju/juju/domain/removal/internal"
+	"github.com/juju/juju/internal/errors"
+)
+
+type remoteApplicationOffererSuite struct {
+	baseSuite
+}
+
+func TestRemoteApplicationOffererSuite(t *testing.T) {
+	tc.Run(t, &remoteApplicationOffererSuite{})
+}
+
+func (s *remoteApplicationOffererSuite) TestRemoveRemoteApplicationOffererNoWaitSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	remoteAppUUID := tc.Must(c, coreremoteapplication.NewUUID)
+
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when)
+
+	exp := s.modelState.EXPECT()
+	exp.RemoteApplicationOffererExists(gomock.Any(), remoteAppUUID.String()).Return(true, nil)
+	exp.EnsureRemoteApplicationOffererNotAliveCascade(gomock.Any(), remoteAppUUID.String()).Return(internal.CascadedRemoteApplicationOffererLives{}, nil)
+	exp.RemoteApplicationOffererScheduleRemoval(gomock.Any(), gomock.Any(), remoteAppUUID.String(), false, when.UTC()).Return(nil)
+
+	jobUUID, err := s.newService(c).RemoveRemoteApplicationOfferer(c.Context(), remoteAppUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *remoteApplicationOffererSuite) TestRemoveRemoteApplicationOffererForceWaitSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	remoteAppUUID := tc.Must(c, coreremoteapplication.NewUUID)
+
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).MinTimes(1)
+
+	exp := s.modelState.EXPECT()
+	exp.RemoteApplicationOffererExists(gomock.Any(), remoteAppUUID.String()).Return(true, nil)
+	exp.EnsureRemoteApplicationOffererNotAliveCascade(gomock.Any(), remoteAppUUID.String()).Return(internal.CascadedRemoteApplicationOffererLives{}, nil)
+
+	// The first normal removal scheduled immediately.
+	exp.RemoteApplicationOffererScheduleRemoval(gomock.Any(), gomock.Any(), remoteAppUUID.String(), false, when.UTC()).Return(nil)
+
+	// The forced removal scheduled after the wait duration.
+	exp.RemoteApplicationOffererScheduleRemoval(gomock.Any(), gomock.Any(), remoteAppUUID.String(), true, when.UTC().Add(time.Minute)).Return(nil)
+
+	jobUUID, err := s.newService(c).RemoveRemoteApplicationOfferer(c.Context(), remoteAppUUID, true, time.Minute)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *remoteApplicationOffererSuite) TestRemoveRemoteApplicationOffererNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	remoteAppUUID := tc.Must(c, coreremoteapplication.NewUUID)
+
+	s.modelState.EXPECT().RemoteApplicationOffererExists(gomock.Any(), remoteAppUUID.String()).Return(false, nil)
+
+	_, err := s.newService(c).RemoveRemoteApplicationOfferer(c.Context(), remoteAppUUID, false, 0)
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.RemoteApplicationNotFound)
+}
+
+func (s *remoteApplicationOffererSuite) TestRemoveRemoteApplicationOffererNoForceSuccessWithRelations(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	remoteAppUUID := tc.Must(c, coreremoteapplication.NewUUID)
+
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).MinTimes(1)
+
+	exp := s.modelState.EXPECT()
+	exp.RemoteApplicationOffererExists(gomock.Any(), remoteAppUUID.String()).Return(true, nil)
+	exp.EnsureRemoteApplicationOffererNotAliveCascade(gomock.Any(), remoteAppUUID.String()).Return(internal.CascadedRemoteApplicationOffererLives{
+		RelationUUIDs: []string{"relation-1", "relation-2"},
+	}, nil)
+	exp.RemoteApplicationOffererScheduleRemoval(gomock.Any(), gomock.Any(), remoteAppUUID.String(), false, when.UTC()).Return(nil)
+
+	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "relation-1", false, when.UTC()).Return(nil)
+	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "relation-2", false, when.UTC()).Return(nil)
+
+	jobUUID, err := s.newService(c).RemoveRemoteApplicationOfferer(c.Context(), remoteAppUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *remoteApplicationOffererSuite) TestProcessRemovalJobInvalidJobType(c *tc.C) {
+	var invalidJobType removal.JobType = 500
+
+	job := removal.Job{
+		RemovalType: invalidJobType,
+	}
+
+	err := s.newService(c).processRemoteApplicationOffererRemovalJob(c.Context(), job)
+	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobTypeNotValid)
+}
+
+func (s *remoteApplicationOffererSuite) TestExecuteJobForRemoteApplicationOffererNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteApplicationOffererJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRemoteApplicationOffererLife(gomock.Any(), j.EntityUUID).Return(-1, crossmodelrelationerrors.RemoteApplicationNotFound)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteApplicationOffererSuite) TestExecuteJobForRemoteApplicationOffererError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteApplicationOffererJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRemoteApplicationOffererLife(gomock.Any(), j.EntityUUID).Return(-1, errors.Errorf("the front fell off"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
+}
+
+func (s *remoteApplicationOffererSuite) TestExecuteJobForRemoteApplicationOffererStillAlive(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteApplicationOffererJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRemoteApplicationOffererLife(gomock.Any(), j.EntityUUID).Return(life.Alive, nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIs, removalerrors.EntityStillAlive)
+}
+
+func (s *remoteApplicationOffererSuite) TestExecuteJobForRemoteApplicationOffererDyingDeleteRemoteApplicationOfferer(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteApplicationOffererJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRemoteApplicationOffererLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
+	exp.DeleteRemoteApplicationOfferer(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteApplicationOffererSuite) TestExecuteJobForRemoteApplicationOffererDyingDeleteRemoteApplicationOffererError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteApplicationOffererJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRemoteApplicationOffererLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
+	exp.DeleteRemoteApplicationOfferer(gomock.Any(), j.EntityUUID).Return(errors.Errorf("the front fell off"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
+}
+
+func newRemoteApplicationOffererJob(c *tc.C) removal.Job {
+	jUUID, err := removal.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	return removal.Job{
+		UUID:        jUUID,
+		RemovalType: removal.RemoteApplicationOffererJob,
+		EntityUUID:  tc.Must(c, coreremoteapplication.NewUUID).String(),
+	}
+}

--- a/domain/removal/service/service.go
+++ b/domain/removal/service/service.go
@@ -51,6 +51,7 @@ type ModelDBState interface {
 	MachineState
 	ModelState
 	StorageState
+	RemoteApplicationOffererState
 
 	// GetAllJobs returns all removal jobs.
 	GetAllJobs(ctx context.Context) ([]removal.Job, error)
@@ -142,6 +143,9 @@ func (s *Service) ExecuteJob(ctx context.Context, job removal.Job) error {
 
 	case removal.StorageAttachmentJob:
 		err = s.processStorageAttachmentRemovalJob(ctx, job)
+
+	case removal.RemoteApplicationOffererJob:
+		err = s.processRemoteApplicationOffererRemovalJob(ctx, job)
 
 	default:
 		err = errors.Errorf("removal job type %q not supported", job.RemovalType).Add(

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -407,9 +407,7 @@ func (s *applicationSuite) TestGetApplicationLifeSuccess(c *tc.C) {
 	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
-	// Set the application to "dying" manually.
-	_, err := s.DB().Exec("UPDATE application SET life_id = 1 WHERE uuid = ?", appUUID.String())
-	c.Assert(err, tc.ErrorIsNil)
+	s.advanceApplicationLife(c, appUUID, life.Dying)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
+	"github.com/juju/juju/domain/removal"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/domain/removal/internal"
 	"github.com/juju/juju/internal/database"
@@ -233,7 +234,7 @@ func (st *State) MachineScheduleRemoval(
 
 	removalRec := removalJob{
 		UUID:          removalUUID,
-		RemovalTypeID: 3,
+		RemovalTypeID: uint64(removal.MachineJob),
 		EntityUUID:    machineUUID,
 		Force:         force,
 		ScheduledFor:  when,

--- a/domain/removal/state/model/model.go
+++ b/domain/removal/state/model/model.go
@@ -209,7 +209,7 @@ func (st *State) ModelScheduleRemoval(
 
 	removalDoc := removalJob{
 		UUID:          removalUUID,
-		RemovalTypeID: 4,
+		RemovalTypeID: uint64(removal.ModelJob),
 		EntityUUID:    modelUUID,
 		Force:         force,
 		ScheduledFor:  when,

--- a/domain/removal/state/model/relation.go
+++ b/domain/removal/state/model/relation.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/domain/life"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
+	"github.com/juju/juju/domain/removal"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
@@ -91,7 +92,7 @@ func (st *State) RelationScheduleRemoval(
 
 	removalRec := removalJob{
 		UUID:          removalUUID,
-		RemovalTypeID: 0,
+		RemovalTypeID: uint64(removal.RelationJob),
 		EntityUUID:    relUUID,
 		Force:         force,
 		ScheduledFor:  when,

--- a/domain/removal/state/model/remoteapplicationofferer.go
+++ b/domain/removal/state/model/remoteapplicationofferer.go
@@ -1,0 +1,375 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/collections/transform"
+
+	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/removal"
+	removalerrors "github.com/juju/juju/domain/removal/errors"
+	"github.com/juju/juju/domain/removal/internal"
+	"github.com/juju/juju/internal/errors"
+)
+
+// GetRemoteApplicationOfferer returns true if a remote application exists
+// with the input UUID.
+func (st *State) RemoteApplicationOffererExists(ctx context.Context, rUUID string) (bool, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	remoteAppOffererUUID := entityUUID{UUID: rUUID}
+	existsStmt, err := st.Prepare(`
+SELECT &entityUUID.uuid
+FROM   application_remote_offerer
+WHERE  uuid = $entityUUID.uuid`, remoteAppOffererUUID)
+	if err != nil {
+		return false, errors.Errorf("preparing remote application offerer exists query: %w", err)
+	}
+
+	var remoteApplicationOffererExists bool
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, existsStmt, remoteAppOffererUUID).Get(&remoteAppOffererUUID)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return errors.Errorf("running remote application offerer exists query: %w", err)
+		}
+
+		remoteApplicationOffererExists = true
+		return nil
+	})
+
+	return remoteApplicationOffererExists, errors.Capture(err)
+}
+
+// EnsureRemoteApplicationOffererNotAliveCascade ensures that there is no
+// remote application offerer identified by the input UUID, that is still
+// alive.
+func (st *State) EnsureRemoteApplicationOffererNotAliveCascade(
+	ctx context.Context, rUUID string,
+) (internal.CascadedRemoteApplicationOffererLives, error) {
+	var res internal.CascadedRemoteApplicationOffererLives
+
+	db, err := st.DB(ctx)
+	if err != nil {
+		return res, errors.Capture(err)
+	}
+
+	remoteAppOffererUUID := entityUUID{UUID: rUUID}
+	updateRemoteAppOffererStmt, err := st.Prepare(`
+UPDATE application_remote_offerer
+SET    life_id = 1
+WHERE  uuid = $entityUUID.uuid
+AND    life_id = 0`, remoteAppOffererUUID)
+	if err != nil {
+		return res, errors.Errorf("preparing remote application offerer life update: %w", err)
+	}
+
+	// Also ensure that any other entities that are associated with the
+	// remote application offerer are also set to dying. This has to be done in
+	// a single transaction because we want to ensure that the remote application
+	// offerer is not alive, and that no units are alive at the same time. Preventing
+	// any races.
+	selectRelationUUIDsStmt, err := st.Prepare(`
+SELECT r.uuid AS &entityUUID.uuid
+FROM   v_relation_endpoint AS re
+JOIN   relation AS r ON re.relation_uuid = r.uuid
+JOIN   application_remote_offerer AS aro ON re.application_uuid = aro.application_uuid
+WHERE  r.life_id = 0
+	`, entityUUID{})
+	if err != nil {
+		return res, errors.Errorf("preparing relation uuids query: %w", err)
+	}
+
+	updateRelationStmt, err := st.Prepare(`
+UPDATE relation
+SET    life_id = 1
+WHERE  uuid IN ($uuids[:])
+AND    life_id = 0`, uuids{})
+	if err != nil {
+		return res, errors.Errorf("preparing relation life update: %w", err)
+	}
+
+	if err := errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, updateRemoteAppOffererStmt, remoteAppOffererUUID).Run(); err != nil {
+			return errors.Errorf("advancing remote application offerer life: %w", err)
+		}
+
+		var relationUUIDs []entityUUID
+		err := tx.Query(ctx, selectRelationUUIDsStmt).GetAll(&relationUUIDs)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("selecting relation UUIDs: %w", err)
+		}
+		res.RelationUUIDs = transform.Slice(relationUUIDs, func(e entityUUID) string { return e.UUID })
+
+		if len(res.RelationUUIDs) > 0 {
+			if err := tx.Query(ctx, updateRelationStmt, uuids(res.RelationUUIDs)).Run(); err != nil {
+				return errors.Errorf("advancing relation life: %w", err)
+			}
+		}
+
+		return nil
+	})); err != nil {
+		return res, errors.Capture(err)
+	}
+
+	return res, nil
+}
+
+// RemoteApplicationOffererScheduleRemoval schedules a removal job for the
+// remote application offerer with the input UUID, qualified with the input
+// force boolean.
+func (st *State) RemoteApplicationOffererScheduleRemoval(
+	ctx context.Context, removalUUID, rUUID string, force bool, when time.Time,
+) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	removalRec := removalJob{
+		UUID:          removalUUID,
+		RemovalTypeID: uint64(removal.RemoteApplicationOffererJob),
+		EntityUUID:    rUUID,
+		Force:         force,
+		ScheduledFor:  when,
+	}
+
+	stmt, err := st.Prepare("INSERT INTO removal (*) VALUES ($removalJob.*)", removalRec)
+	if err != nil {
+		return errors.Errorf("preparing remote application offerer removal: %w", err)
+	}
+
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, stmt, removalRec).Run()
+		if err != nil {
+			return errors.Errorf("scheduling remote application offerer removal: %w", err)
+		}
+		return nil
+	}))
+}
+
+// GetRemoteApplicationOffererLife returns the life of the remote application
+// offerer with the input UUID.
+func (st *State) GetRemoteApplicationOffererLife(ctx context.Context, rUUID string) (life.Life, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return -1, errors.Capture(err)
+	}
+
+	var l life.Life
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		l, err = st.getRemoteApplicationOffererLife(ctx, tx, rUUID)
+		return err
+	})
+	if err != nil {
+		return -1, errors.Capture(err)
+	}
+
+	return l, nil
+}
+
+// DeleteRemoteApplicationOfferer removes a remote application offerer from
+// the database completely. This also removes the synthetic application,
+// unit and charm associated with the remote application offerer.
+func (st *State) DeleteRemoteApplicationOfferer(ctx context.Context, rUUID string) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	remoteAppOffererUUID := entityUUID{UUID: rUUID}
+
+	relationsStmt, err := st.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM v_relation_endpoint AS re
+JOIN application_remote_offerer AS aro ON re.application_uuid = aro.application_uuid
+WHERE aro.uuid = $entityUUID.uuid
+`, count{}, remoteAppOffererUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	selectSynthAppStmt, err := st.Prepare(`
+SELECT application_uuid AS &entityUUID.uuid
+FROM   application_remote_offerer
+WHERE  uuid = $entityUUID.uuid
+`, remoteAppOffererUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	deleteRemoteApplicationOffererStatusStmt, err := st.Prepare(`
+DELETE FROM application_remote_offerer_status
+WHERE  application_remote_offerer_uuid = $entityUUID.uuid`, remoteAppOffererUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	deleteRemoteApplicationOffererStmt, err := st.Prepare(`
+DELETE FROM application_remote_offerer
+WHERE  uuid = $entityUUID.uuid`, remoteAppOffererUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	deleteApplicationEndpointBindingsStmt, err := st.Prepare(`
+DELETE FROM application_endpoint
+WHERE application_uuid = $entityUUID.uuid
+`, entityUUID{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	deleteApplicationStmt, err := st.Prepare(`
+DELETE FROM application
+WHERE  uuid = $entityUUID.uuid`, entityUUID{})
+	if err != nil {
+		return errors.Errorf("preparing application delete: %w", err)
+	}
+
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		aLife, err := st.getRemoteApplicationOffererLife(ctx, tx, rUUID)
+		if err != nil {
+			return errors.Errorf("getting remote application offerer life: %w", err)
+		} else if aLife == life.Alive {
+			// The remote application offerer is still alive, we cannot delete it.
+			return errors.Errorf("cannot delete remote application offerer %q as it is still alive", rUUID).
+				Add(removalerrors.EntityStillAlive)
+		}
+
+		var numRelations count
+		err = tx.Query(ctx, relationsStmt, remoteAppOffererUUID).Get(&numRelations)
+		if err != nil {
+			return errors.Errorf("getting number of relations for remote application offerer: %w", err)
+		} else if numRelations.Count > 0 {
+			// It is required that all relations have been completely removed
+			// before the remote application offerer can be removed.
+			return errors.Errorf("cannot delete remote application offerer as it still has %d relation(s)", numRelations.Count).
+				Add(crossmodelrelationerrors.RemoteApplicationHasRelations).
+				Add(removalerrors.RemovalJobIncomplete)
+		}
+
+		var synthApp entityUUID
+		err = tx.Query(ctx, selectSynthAppStmt, remoteAppOffererUUID).Get(&synthApp)
+		if err != nil {
+			return errors.Errorf("getting application UUID for remote application offerer: %w", err)
+		}
+
+		// Get the charm UUID before we delete the application.
+		synthCharmUUID, err := st.getCharmUUIDForApplication(ctx, tx, synthApp.UUID)
+		if err != nil {
+			return errors.Errorf("getting charm UUID for application: %w", err)
+		}
+
+		if err := st.deleteRemoteApplicationOffererUnits(ctx, tx, synthApp.UUID); err != nil {
+			return errors.Errorf("deleting remote application offerer units: %w", err)
+		}
+
+		if err := tx.Query(ctx, deleteRemoteApplicationOffererStatusStmt, remoteAppOffererUUID).Run(); err != nil {
+			return errors.Errorf("deleting synthetic application remote relation status: %w", err)
+		}
+
+		if err := tx.Query(ctx, deleteRemoteApplicationOffererStmt, remoteAppOffererUUID).Run(); err != nil {
+			return errors.Errorf("deleting synthetic application remote relation: %w", err)
+		}
+
+		if err := tx.Query(ctx, deleteApplicationEndpointBindingsStmt, synthApp).Run(); err != nil {
+			return errors.Errorf("deleting synthetic application endpoint bindings: %w", err)
+		}
+
+		if err := tx.Query(ctx, deleteApplicationStmt, synthApp).Run(); err != nil {
+			return errors.Errorf("deleting synthetic application: %w", err)
+		}
+
+		// Delete the synthetic charm directly, since we know it is not shared
+		// but other applications
+		if err := st.deleteCharm(ctx, tx, synthCharmUUID); err != nil {
+			return errors.Errorf("deleting synthetic charm: %w", err)
+		}
+
+		return nil
+	}))
+}
+
+func (st *State) deleteRemoteApplicationOffererUnits(ctx context.Context, tx *sqlair.TX, appUUID string) error {
+	ident := entityUUID{UUID: appUUID}
+	selectNetNodesStmt, err := st.Prepare(`
+SELECT DISTINCT nn.uuid AS &entityUUID.uuid
+FROM   net_node AS nn
+JOIN   unit AS u ON nn.uuid = u.net_node_uuid
+JOIN   application AS a ON u.application_uuid = a.uuid
+WHERE  a.uuid = $entityUUID.uuid
+`, ident)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	deleteNetNodesStmt, err := st.Prepare(`
+DELETE FROM net_node
+WHERE uuid IN ($uuids[:])`, uuids{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	deleteUnitsStmt, err := st.Prepare(`
+DELETE FROM unit
+WHERE application_uuid = $entityUUID.uuid`, ident)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	var netNodeEntityUUIDs []entityUUID
+	err = tx.Query(ctx, selectNetNodesStmt, ident).GetAll(&netNodeEntityUUIDs)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Capture(err)
+	}
+
+	// no net nodes means no units either, so we can return early.
+	if len(netNodeEntityUUIDs) == 0 {
+		return nil
+	}
+
+	if err := tx.Query(ctx, deleteUnitsStmt, ident).Run(); err != nil {
+		return errors.Capture(err)
+	}
+
+	netNodeUUIDs := uuids(transform.Slice(netNodeEntityUUIDs, func(e entityUUID) string { return e.UUID }))
+	if err := tx.Query(ctx, deleteNetNodesStmt, netNodeUUIDs).Run(); err != nil {
+		return errors.Capture(err)
+	}
+
+	return nil
+}
+
+func (st *State) getRemoteApplicationOffererLife(ctx context.Context, tx *sqlair.TX, rUUID string) (life.Life, error) {
+	var remoteApplicationOffererLife entityLife
+	remoteAppOffererUUID := entityUUID{UUID: rUUID}
+
+	stmt, err := st.Prepare(`
+SELECT &entityLife.life_id
+FROM   application_remote_offerer
+WHERE  uuid = $entityUUID.uuid;`, remoteApplicationOffererLife, remoteAppOffererUUID)
+	if err != nil {
+		return -1, errors.Errorf("preparing remote application offerer life query: %w", err)
+	}
+
+	err = tx.Query(ctx, stmt, remoteAppOffererUUID).Get(&remoteApplicationOffererLife)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return -1, crossmodelrelationerrors.RemoteApplicationNotFound
+	} else if err != nil {
+		return -1, errors.Errorf("running remote application offerer life query: %w", err)
+	}
+
+	return life.Life(remoteApplicationOffererLife.Life), nil
+}

--- a/domain/removal/state/model/remoteapplicationofferer_test.go
+++ b/domain/removal/state/model/remoteapplicationofferer_test.go
@@ -1,0 +1,292 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/tc"
+
+	coremodel "github.com/juju/juju/core/model"
+	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
+	crossmodelrelationstate "github.com/juju/juju/domain/crossmodelrelation/state/model"
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/relation"
+	removalerrors "github.com/juju/juju/domain/removal/errors"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type remoteApplicationOffererSuite struct {
+	baseSuite
+}
+
+func TestRemoteApplicationOffererSuite(t *testing.T) {
+	tc.Run(t, &remoteApplicationOffererSuite{})
+}
+
+func (s *remoteApplicationOffererSuite) TestRemoteApplicationOffererExists(c *tc.C) {
+	_, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	exists, err := st.RemoteApplicationOffererExists(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(exists, tc.Equals, true)
+
+	exists, err = st.RemoteApplicationOffererExists(c.Context(), "not-today-henry")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(exists, tc.Equals, false)
+}
+
+func (s *remoteApplicationOffererSuite) TestEnsureRemoteApplicationOffererNotAliveCascadeNormalSuccess(c *tc.C) {
+	_, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	artifacts, err := st.EnsureRemoteApplicationOffererNotAliveCascade(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	// We don't have any units, so we expect an empty slice for both unit and
+	// machine UUIDs.
+	c.Check(artifacts.IsEmpty(), tc.Equals, true)
+	s.checkRemoteApplicationOffererLife(c, remoteAppUUID.String(), life.Dying)
+}
+
+func (s *remoteApplicationOffererSuite) TestEnsureRemoteApplicationOffererNotAliveCascadeNormalSuccessWithCascadedRelations(c *tc.C) {
+	_, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+	s.createIAASApplication(c, s.setupApplicationService(c), "bar")
+
+	relSvc := s.setupRelationService(c)
+	_, _, err := relSvc.AddRelation(c.Context(), "foo:foo", "bar:bar")
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	artifacts, err := st.EnsureRemoteApplicationOffererNotAliveCascade(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(artifacts.RelationUUIDs, tc.HasLen, 1)
+	s.checkRemoteApplicationOffererLife(c, remoteAppUUID.String(), life.Dying)
+}
+
+func (s *remoteApplicationOffererSuite) TestEnsureRemoteApplicationOffererNotAliveCascadeNotExistsSuccess(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	// We don't care if it's already gone.
+	_, err := st.EnsureRemoteApplicationOffererNotAliveCascade(c.Context(), "some-application-uuid")
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteApplicationOffererSuite) TestRemoteApplicationOffererScheduleRemovalNormalSuccess(c *tc.C) {
+	_, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	when := time.Now().UTC()
+	err := st.RemoteApplicationOffererScheduleRemoval(
+		c.Context(), "removal-uuid", remoteAppUUID.String(), false, when,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// We should have a removal job scheduled immediately.
+	row := s.DB().QueryRow(`
+SELECT t.name, r.entity_uuid, r.force, r.scheduled_for
+FROM   removal r JOIN removal_type t ON r.removal_type_id = t.id
+where  r.uuid = ?`, "removal-uuid",
+	)
+
+	var (
+		removalType  string
+		rUUID        string
+		force        bool
+		scheduledFor time.Time
+	)
+	err = row.Scan(&removalType, &rUUID, &force, &scheduledFor)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(removalType, tc.Equals, "remote application offerer")
+	c.Check(rUUID, tc.Equals, remoteAppUUID.String())
+	c.Check(force, tc.Equals, false)
+	c.Check(scheduledFor, tc.Equals, when)
+}
+
+func (s *remoteApplicationOffererSuite) TestRemoteApplicationOffererScheduleRemovalNotExistsSuccess(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	when := time.Now().UTC()
+	err := st.RemoteApplicationOffererScheduleRemoval(
+		c.Context(), "removal-uuid", "some-application-uuid", true, when,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// We should have a removal job scheduled immediately.
+	// It doesn't matter that the application does not exist.
+	// We rely on the worker to handle that fact.
+	row := s.DB().QueryRow(`
+SELECT t.name, r.entity_uuid, r.force, r.scheduled_for
+FROM   removal r JOIN removal_type t ON r.removal_type_id = t.id
+where  r.uuid = ?`, "removal-uuid",
+	)
+
+	var (
+		removalType  string
+		rUUID        string
+		force        bool
+		scheduledFor time.Time
+	)
+	err = row.Scan(&removalType, &rUUID, &force, &scheduledFor)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(removalType, tc.Equals, "remote application offerer")
+	c.Check(rUUID, tc.Equals, "some-application-uuid")
+	c.Check(force, tc.Equals, true)
+	c.Check(scheduledFor, tc.Equals, when)
+}
+
+func (s *remoteApplicationOffererSuite) TestGetRemoteApplicationOffererLifeSuccess(c *tc.C) {
+	_, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	l, err := st.GetRemoteApplicationOffererLife(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(l, tc.Equals, life.Alive)
+}
+
+func (s *remoteApplicationOffererSuite) TestGetRemoteApplicationOffererLifeDying(c *tc.C) {
+	_, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	_, err := s.DB().Exec(`UPDATE application_remote_offerer SET life_id = 1 WHERE uuid = ?`, remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	l, err := st.GetRemoteApplicationOffererLife(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(l, tc.Equals, life.Dying)
+}
+
+func (s *remoteApplicationOffererSuite) TestGetRemoteApplicationOffererLifeNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	_, err := st.GetRemoteApplicationOffererLife(c.Context(), "some-application-uuid")
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.RemoteApplicationNotFound)
+}
+
+func (s *remoteApplicationOffererSuite) TestDeleteRemoteApplicationOffererStillAlive(c *tc.C) {
+	_, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.DeleteRemoteApplicationOfferer(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIs, removalerrors.EntityStillAlive)
+}
+
+func (s *remoteApplicationOffererSuite) TestDeleteRemoteApplicationOffererSuccess(c *tc.C) {
+	appUUID, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	s.advanceRemoteApplicationOffererLife(c, remoteAppUUID.String(), life.Dying)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.DeleteRemoteApplicationOfferer(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The remote application offerer should be gone.
+	exists, err := st.RemoteApplicationOffererExists(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+
+	exists, err = st.ApplicationExists(c.Context(), appUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+
+	s.checkNoCharmsExist(c)
+}
+
+func (s *remoteApplicationOffererSuite) TestDeleteRemoteApplicationOffererWithRelations(c *tc.C) {
+	appUUID, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+	s.createIAASApplication(c, s.setupApplicationService(c), "bar")
+
+	relSvc := s.setupRelationService(c)
+	ep1, ep2, err := relSvc.AddRelation(c.Context(), "foo:foo", "bar:bar")
+	c.Assert(err, tc.ErrorIsNil)
+	relUUID, err := relSvc.GetRelationUUIDForRemoval(c.Context(), relation.GetRelationUUIDForRemovalArgs{
+		Endpoints: []string{ep1.String(), ep2.String()},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.advanceRemoteApplicationOffererLife(c, remoteAppUUID.String(), life.Dead)
+	s.advanceRelationLife(c, relUUID, life.Dead)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	// This should fail because the remote application offerer has a relation.
+	err = st.DeleteRemoteApplicationOfferer(c.Context(), remoteAppUUID.String())
+	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
+	c.Check(err, tc.ErrorIs, crossmodelrelationerrors.RemoteApplicationHasRelations)
+
+	// Delete any relations associated with the remote application offerer.
+	err = st.DeleteRelation(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Now we can delete the remote application offerer.
+	err = st.DeleteRemoteApplicationOfferer(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	exists, err := st.RemoteApplicationOffererExists(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+
+	exists, err = st.ApplicationExists(c.Context(), appUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+}
+
+func (s *remoteApplicationOffererSuite) TestDeleteRemoteApplicationOffererWithUnits(c *tc.C) {
+	appUUID, remoteAppUUID := s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	cmrState := crossmodelrelationstate.NewState(
+		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
+	)
+	// Call twice to ensure some units share a net node, but not all.
+	cmrState.EnsureUnitsExist(c.Context(), appUUID.String(), []string{"foo/0", "foo/1"})
+	cmrState.EnsureUnitsExist(c.Context(), appUUID.String(), []string{"foo/2"})
+
+	s.advanceRemoteApplicationOffererLife(c, remoteAppUUID.String(), life.Dying)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.DeleteRemoteApplicationOfferer(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	exists, err := st.RemoteApplicationOffererExists(c.Context(), remoteAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+
+	exists, err = st.ApplicationExists(c.Context(), appUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+
+	var numUnits int
+	var numNetNodes int
+	s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM unit").Scan(&numUnits)
+		if err != nil {
+			return err
+		}
+		err = tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM net_node").Scan(&numNetNodes)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	c.Check(numUnits, tc.Equals, 0)
+	c.Check(numNetNodes, tc.Equals, 0)
+}

--- a/domain/removal/state/model/storage.go
+++ b/domain/removal/state/model/storage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/sqlair"
 
 	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/removal"
 	storageprovisioningerrors "github.com/juju/juju/domain/storageprovisioning/errors"
 	"github.com/juju/juju/internal/errors"
 )
@@ -89,7 +90,7 @@ func (st *State) StorageAttachmentScheduleRemoval(
 
 	removalRec := removalJob{
 		UUID:          removalUUID,
-		RemovalTypeID: 6,
+		RemovalTypeID: uint64(removal.StorageAttachmentJob),
 		EntityUUID:    saUUID,
 		Force:         force,
 		ScheduledFor:  when,

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -12,6 +12,7 @@ import (
 
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/removal"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/domain/removal/internal"
 	"github.com/juju/juju/internal/errors"
@@ -338,7 +339,7 @@ func (st *State) UnitScheduleRemoval(
 
 	removalRec := removalJob{
 		UUID:          removalUUID,
-		RemovalTypeID: 1,
+		RemovalTypeID: uint64(removal.UnitJob),
 		EntityUUID:    unitUUID,
 		Force:         force,
 		ScheduledFor:  when,

--- a/domain/removal/types.go
+++ b/domain/removal/types.go
@@ -27,6 +27,22 @@ const (
 	// StorageAttachmentJob indicates a job to remove a unit's
 	// attachment to a storage instance.
 	StorageAttachmentJob
+	// StorageVolumeJob indicates a job to remove a storage volume.
+	StorageVolumeJob
+	// StorageFilesystemJob indicates a job to remove a storage filesystem.
+	StorageFilesystemJob
+	// StorageVolumeAttachmentJob indicates a job to remove a storage volume
+	// attachment.
+	StorageVolumeAttachmentJob
+	// StorageVolumeAttachmentPlanJob indicates a job to remove a storage volume
+	// attachment plan.
+	StorageVolumeAttachmentPlanJob
+	// StorageFilesystemAttachmentJob indicates a job to remove a storage
+	// filesystem attachment.
+	StorageFilesystemAttachmentJob
+	// RemoteApplicationOffererJob indicates a job to remove a remote
+	// application offerer.
+	RemoteApplicationOffererJob
 )
 
 // String is used in logging output make job type identifiers readable.
@@ -47,6 +63,8 @@ func (t JobType) String() string {
 		return "storage instance"
 	case StorageAttachmentJob:
 		return "storage attachment"
+	case RemoteApplicationOffererJob:
+		return "remote application offerer"
 	default:
 		return strconv.FormatInt(int64(t), 10)
 	}

--- a/domain/schema/model/sql/0028-cleanup.sql
+++ b/domain/schema/model/sql/0028-cleanup.sql
@@ -18,7 +18,8 @@ INSERT INTO removal_type VALUES
 (8, 'storage filesystem'),
 (9, 'storage volume attachment'),
 (10, 'storage volume attachment plan'),
-(11, 'storage filesystem attachment');
+(11, 'storage filesystem attachment'),
+(12, 'remote application offerer');
 
 CREATE TABLE removal (
     uuid TEXT NOT NULL PRIMARY KEY,

--- a/domain/status/state/package_test.go
+++ b/domain/status/state/package_test.go
@@ -20,7 +20,6 @@ import (
 	corerelation "github.com/juju/juju/core/relation"
 	corerelationtesting "github.com/juju/juju/core/relation/testing"
 	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
-	remoteapplicationtesting "github.com/juju/juju/core/remoteapplication/testing"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/architecture"
@@ -195,7 +194,7 @@ func (s *baseSuite) createIAASRemoteApplicationOfferer(
 		Architecture:  architecture.ARM64,
 	}
 
-	remoteAppUUID := remoteapplicationtesting.GenRemoteApplicationUUID(c)
+	remoteAppUUID := tc.Must(c, coreremoteapplication.NewUUID)
 	appUUID := tc.Must(c, coreapplication.NewID)
 	err := cmrState.AddRemoteApplicationOfferer(c.Context(), name, crossmodelrelation.AddRemoteApplicationOffererArgs{
 		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{


### PR DESCRIPTION
That is, remote application offerers.

This was surprisingly simple. The only thing we need to cascade are any relations.

Synthetic applications, since they are synthetic, are not concerned with their life, so we can simply remove them directly when removing the remote app.

## QA steps

```
$ juju add-model offerer
$ juju deploy juju-qa-dummy-source
$ juju offer dummy-source:sink
Application "dummy-source" endpoints [sink] available at "admin/offerer.dummy-source"

$ juju add-model consumer
$ juju consume admin/offerer.dummy-source
$ juju status
Model     Controller  Cloud/Region   Version      Timestamp
consumer  lxd         lxd/localhost  4.0-beta8.1  16:20:14+01:00

SAAS          Status   Store  URL
dummy-source  unknown  local  admin/offerer.dummy-source

$ juju remove-saas dummy-source
$ juju status
Model     Controller  Cloud/Region   Version      Timestamp
consumer  lxd         lxd/localhost  4.0-beta8.1  16:20:26+01:00

Model "admin/consumer" is empty.
```