### PR TITLE
fix: logging for waiting on dead entities

### DIFF
--- a/domain/removal/state/controller/model.go
+++ b/domain/removal/state/controller/model.go
@@ -179,7 +179,7 @@ WHERE grant_on = $entityUUID.uuid;
 			return errors.Errorf("cannot delete model %q, model is still alive", modelUUIDParam.UUID).
 				Add(removalerrors.EntityStillAlive)
 		} else if mLife == life.Dying {
-			return errors.Errorf("waiting for model to be removed before deletion").
+			return errors.Errorf("waiting for model to be dead before deletion").
 				Add(removalerrors.RemovalJobIncomplete)
 		}
 

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -458,7 +458,7 @@ WHERE uuid = $machine.uuid;
 			return errors.Errorf("cannot delete machine %q, machine is still alive", machineUUIDParam.UUID).
 				Add(removalerrors.EntityStillAlive)
 		} else if mLife == life.Dying {
-			return errors.Errorf("waiting for machine to be removed before deletion").
+			return errors.Errorf("waiting for machine to be dead before deletion").
 				Add(removalerrors.RemovalJobIncomplete)
 		}
 
@@ -478,7 +478,7 @@ WHERE uuid = $machine.uuid;
 		} else if iLife == life.Alive {
 			return errors.Errorf("cannot delete machine %q, instance is still alive", machineUUIDParam.UUID)
 		} else if iLife == life.Dying {
-			return errors.Errorf("waiting for instance to be removed before deletion").Add(removalerrors.RemovalJobIncomplete)
+			return errors.Errorf("waiting for instance to be dead before deletion").Add(removalerrors.RemovalJobIncomplete)
 		}
 
 		err = st.checkNoMachineDependents(ctx, tx, machineUUIDParam)

--- a/domain/removal/state/model/model.go
+++ b/domain/removal/state/model/model.go
@@ -320,7 +320,7 @@ WHERE uuid = $entityUUID.uuid;
 			return errors.Errorf("cannot delete model %q, model is still alive", modelUUIDParam.UUID).
 				Add(removalerrors.EntityStillAlive)
 		} else if mLife == life.Dying {
-			return errors.Errorf("waiting for model to be removed before deletion").
+			return errors.Errorf("waiting for model to be dead before deletion").
 				Add(removalerrors.RemovalJobIncomplete)
 		}
 

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -489,7 +489,7 @@ WHERE  uuid = $entityUUID.uuid;`, unitUUIDRec)
 				Add(removalerrors.EntityStillAlive)
 		} else if uLife == life.Dying {
 			// The unit is dying, we cannot delete it yet.
-			return errors.Errorf("waiting for unit %q to be removed before deletion", unitUUID).
+			return errors.Errorf("waiting for unit %q to be dead before deletion", unitUUID).
 				Add(removalerrors.RemovalJobIncomplete)
 		}
 


### PR DESCRIPTION
We're not waiting on things to be _removed_ before deletion (these are synonyms).

We are waiting for them to be declared dead.