### PR TITLE
fix: revoke unit leadership only upon successful deletion

### DIFF
--- a/domain/removal/service/unit_test.go
+++ b/domain/removal/service/unit_test.go
@@ -200,10 +200,7 @@ func (s *unitSuite) TestExecuteJobForUnitDyingDeleteUnitError(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.DeleteUnit(gomock.Any(), j.EntityUUID).Return(errors.Errorf("the front fell off"))
-
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
@@ -216,6 +213,7 @@ func (s *unitSuite) TestExecuteJobForUnitRevokingUnitError(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
+	exp.DeleteUnit(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 
 	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(errors.Errorf("the front fell off"))


### PR DESCRIPTION
Removing (without force) a unit of the postgresql charm was immediately sending the unit into an error state, which prevented it from taking its _dying_ actions.

This turned out to be due to the fact that it accesses application relation settings, but was getting a permission error caused by not being the leader.

What was happening is that upon dying, a removal job was scheduled immediately and got its first processing attempt. It was returning without successful completion, but only _after_ it had revoked the unit's leadership.

Here, we just move leadership revocation until after successful deletion. This behaviour is perfectly fine. The revocation will expedite the election of a new leader if removal is successful, but otherwise the unit remains the leader if it can still renew its lease. If it can't renew _and_ the removal job is not complete, the lease will still expire normally.

## QA steps

- Bootstrap, add a model and deploy postgresql.
- Once settled, `juju remove-unit postgresql --no-prompt`.
- The unit should advance to the `terminated` state without errors reported by the charm.