### PR TITLE
feat: add obliterate_on_cleanup flag to volume and filesystem ddl

### DIFF
--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -267,7 +267,7 @@ CREATE TABLE storage_volume (
     persistent BOOLEAN,
     obliterate_on_cleanup BOOLEAN,
     CONSTRAINT chk_storage_volume_obliterate_on_cleanup_set_when_not_alive
-    CHECK (obliterate_on_cleanup IS NULL OR life_id != 0),
+    CHECK (obliterate_on_cleanup IS NULL OR life_id <> 0),
     CONSTRAINT fk_storage_instance_life
     FOREIGN KEY (life_id)
     REFERENCES life (id),
@@ -379,7 +379,7 @@ CREATE TABLE storage_filesystem (
     size_mib INT,
     obliterate_on_cleanup BOOLEAN,
     CONSTRAINT chk_storage_filesystem_obliterate_on_cleanup_set_when_not_alive
-    CHECK (obliterate_on_cleanup IS NULL OR life_id != 0),
+    CHECK (obliterate_on_cleanup IS NULL OR life_id <> 0),
     CONSTRAINT fk_storage_filesystem_life
     FOREIGN KEY (life_id)
     REFERENCES life (id),


### PR DESCRIPTION
When a Volume or Filesystem is marked dead, the storage provisioner
must know if it can obliterate the underlying volume or filesystem
that is referred to by the provider_id. This setting of obliterate
flag must always come from intent to destroy a volume or filesystem.

It is better to ensure this is a column of the volume and filesystem
than to be in the JSON argument of a cleanup job. Otherwise, the
state layer for the storageprovisioning domain needs to, within the
same txn, find a cleanup job, get its JSON, return it to the service layer
which then needs to interpret the JSON to get the obliterate flag from
there. It is better for the cleanup job to instead, using the arguments
set on it, interpret it's own values, then set the life and obliterate flag
of the volume/filesystem itself.  

## QA steps

Test via db repl:
```sql
dqlite> INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id) VALUES("vuuid", "vid", 0, 0);
dqlite> UPDATE storage_volume SET obliterate_on_cleanup = true;
Error:  rows: CHECK constraint failed: chk_storage_volume_obliterate_on_cleanup_set_when_not_alive
dqlite> UPDATE storage_volume SET obliterate_on_cleanup = true, life_id=1;
```

## Links

**Jira card:** [JUJU-8619](https://warthogs.atlassian.net/browse/JUJU-8619) [JUJU-8620](https://warthogs.atlassian.net/browse/JUJU-8620)


[JUJU-8619]: https://warthogs.atlassian.net/browse/JUJU-8619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ