### PR TITLE
docs: refactor scale docs

### DIFF
--- a/cmd/juju/application/scaleapplication.go
+++ b/cmd/juju/application/scaleapplication.go
@@ -43,7 +43,7 @@ type scaleApplicationCommand struct {
 const scaleApplicationDoc = `
 Scale a Kubernetes application by specifying how many units there should be.
 The new number of units can be greater or less than the current number, thus
-allowing both scale up and scale down.
+allowing both scale out and scale in.
 `
 
 const scaleApplicationExamples = `

--- a/docs/howto/manage-applications.md
+++ b/docs/howto/manage-applications.md
@@ -233,7 +233,7 @@ See also: {ref}`high-availability`
 See more: [Charmhub > `<your charm of interest`](https://charmhub.io/)
 ```
 
-2. Scale up horizontally as usual.
+2. Scale out as usual.
 
 ```{ibnote}
 See more: {ref}`scale-an-application-horizontally`

--- a/docs/reference/high-availability.md
+++ b/docs/reference/high-availability.md
@@ -8,7 +8,7 @@ See also:
 - {ref}`make-an-application-highly-available`
 ```
 
-In the context of a cloud deployment in general, **high availability (HA)** is the concept of making software resilient to failures by means of running multiple replicas with shared and synchronised software context -- something usually achieved through coordinated {ref}`scaling (horizontally and up) <scaling>`. In Juju, it is supported for controllers on machine clouds and for regular applications on both machine and Kubernetes clouds
+In the context of a cloud deployment in general, **high availability (HA)** is the concept of making software resilient to failures by means of running multiple replicas with shared and synchronised software context -- something usually achieved through coordinated {ref}`scaling (out and up) <scaling>`. In Juju, it is supported for controllers on machine clouds and for regular applications on both machine and Kubernetes clouds
 
 
 ![Juju - Controller high availability (machines)](high-availability.png)

--- a/docs/reference/scaling.md
+++ b/docs/reference/scaling.md
@@ -5,7 +5,7 @@
 See also: {ref}`scale-an-application`
 ```
 
-In the context of a cloud deployment in general, **scaling**  means modifying the amount of resources thrown at an application, which can be done *vertically* (modifying the memory, CPU, or disk for a cloud resource) or *horizontally* (modifying the number of resources), where each can be *up* (more) or down (*less*). In the context of Juju, scaling means exactly the same, with the mention that
+In the context of a cloud deployment in general, **scaling**  means modifying the amount of resources allocated to an application, which can be done *vertically* (modifying the memory, CPU, or disk for a cloud resource) or *horizontally* (modifying the number of resource instances), where each can be *more* (up or out) or less (*down or in*). In the context of Juju, scaling means exactly the same, with the mention that
 
 - Vertical scaling is handled through {ref}`constraints <constraint>` and horizontal scaling through {ref}`units <unit>`.
 - Horizontal scaling up can be used to achieve {ref}`high availability (HA) <high-availability>` -- though, depending on whether the charm delivering the application supports HA natively or not, you may also have to perform additional steps.


### PR DESCRIPTION
This PR updates the scaling documentation to use the correct terminology:
- "scale out/in" instead of "scale up/down" for horizontal scaling.

## Links
**Github issue:** https://github.com/juju/juju/issues/20879