### PR TITLE
fix: depart remaining unit scopes if dead or forced

### DIFF
--- a/domain/removal/errors/errors.go
+++ b/domain/removal/errors/errors.go
@@ -23,6 +23,10 @@ const (
 	// we are processing a removal job is still alive.
 	EntityStillAlive = errors.ConstError("entity still alive")
 
+	// EntityNotDead indicates that an entity for which
+	// we are processing a removal job is not dead.
+	EntityNotDead = errors.ConstError("entity not dead")
+
 	// RemovalJobIncomplete indicates that the job execution completed without
 	// errors, but that it is not complete and expected to be scheduled again
 	// later. It is not to be deleted from the removal table.


### PR DESCRIPTION
If a unit does not depart its relation scopes, but has marked itself dead, we should depart remaining scopes in the removal job.

Otherwise unit deletion is prevented by FK violations.

As before, we depart relation scopes if removal is forced, even if the unit is not dead.

## QA steps

- `juju bootstrap lxd lxd --debug; juju add-model work; juju deploy postgresql --storage pgdata=50M`.
- Once settled, `juju remove-unit postgresql/0 --no-prompt`.
- The unit should disappear.