### PR TITLE
fix(provider/openstack): config hardening, validate config for GBP and PTG usage

### DIFF
--- a/internal/provider/openstack/config_test.go
+++ b/internal/provider/openstack/config_test.go
@@ -232,6 +232,34 @@ var configTests = []configTest{
 			"policy-target-group": "groundcontroltomajortom",
 		}),
 		err: "policy-target-group has invalid UUID: .*",
+	}, {
+		summary: "use gbp set through a string, ptg set",
+		config: requiredConfig.Merge(testing.Attrs{
+			"use-openstack-gbp":   "true",
+			"policy-target-group": "fb19cd79-a25c-4357-9271-b071c5cb726c",
+		}),
+	}, {
+		summary: "use gbp set through a string, ptg set, network is set",
+		config: requiredConfig.Merge(testing.Attrs{
+			"use-openstack-gbp":   "true",
+			NetworkKey:            "a-network-label",
+			"policy-target-group": "fb19cd79-a25c-4357-9271-b071c5cb726c",
+		}),
+		err: "cannot use 'network' config setting when use-openstack-gbp is set",
+	}, {
+		summary: "use gbp set through a string, ptg not set",
+		config: requiredConfig.Merge(testing.Attrs{
+			"use-openstack-gbp": "false",
+			NetworkKey:          "a-network-label",
+		}),
+		network: "a-network-label",
+	}, {
+		summary: "use gbp set through a string, ptg not set, network is set",
+		config: requiredConfig.Merge(testing.Attrs{
+			"use-openstack-gbp": "false",
+			NetworkKey:          "a-network-label",
+		}),
+		network: "a-network-label",
 	},
 }
 


### PR DESCRIPTION
This patch updates the validation logic for policy-target-group (PTG) and use-openstack-gbp (GBP) configuration in OpenStack providers.

This is an attempt to fix #20889, since after an in depth analysis of the code, this is the only code path that can trigger such panic.

This specific code didn't change between 3.6 (which doesn't trigger the issue), and 4.0 (which does). However, while the suspicious assertion is the same, the surrounding infrastructure and data flow changed:

1. Provider config schema package changes
 * 3.6 used gopkg.in/juju/environschema.v1 and github.com/juju/utils/v3.
 * Current uses github.com/juju/juju/internal/configschema and github.com/juju/utils/v4.
 * Practical impact: minimal for this panic. The provider still computes a validated/coerced map via cfg.ValidateUnknownAttrs(...) and assigns it to ecfg.attrs, but it continues to read use-openstack-gbp from cfg.AllAttrs() (the unvalidated map), which is the problem.

2. Config plumbing differences (base/config vs core/config)
 * The controller/model config implementation and schema plumbing evolved significantly from the Juju 3.x era to the current tree (4.x series).
 * In 3.6, for many bootstrap paths the provider-specific keys often didn’t show up in cfg.AllAttrs() unless explicitly set, or they appeared already in a properly typed form (bool) by the time provider Validate ran.
 * In current builds, inputs from various sources (CLI --config, --model-default, environment variables like JUJU_MODEL_CONFIG, CI wrappers) are more likely to arrive in cfg.AllAttrs() as raw strings for unknown/provider keys before coercion. This makes the unchecked .(bool) much more likely to encounter a string and panic.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Bootstrap on openstack, with a command as close as the one in linked bug:
https://github.com/juju/juju/issues/20889

> [!WARNING]
> I QAed it, but got another error
> ```sh
> 2025-10-21 08:56:41 DEBUG juju.worker.dependency engine.go:633 "bootstrap" manifold worker stopped: finalizing agent: setting machine cloud instance for machine "9d6e2473-97a4-4107-8cb5-3126395d98db": availability zone not found "availability-zone-2" for machine "9d6e2473-97a4-4107-8cb5-3126395d98db"
> stack trace:
> setting machine cloud instance for machine "9d6e2473-97a4-4107-8cb5-3126395d98db": availability zone not found "availability-zone-2" for machine "9d6e2473-97a4-4107-8cb5-3126395d98db"
> github.com/juju/juju/internal/worker/bootstrap.IAASAgentFinalizer:346: 
> github.com/juju/juju/internal/worker/bootstrap.(*bootstrapWorker).loop:280: finalizing agent
> 2025-10-21 08:56:41 ERROR juju.worker.dependency engine.go:709 "bootstrap" manifold worker returned unexpected error: finalizing agent: setting machine cloud instance for machine "9d6e2473-97a4-4107-8cb5-3126395d98db": availability zone not found "availability-zone-2" for machine "9d6e2473-97a4-4107-8cb5-3126395d98db"


## Links
**Jira card:** [JUJU-8671](https://warthogs.atlassian.net/browse/JUJU-8671)


[JUJU-8671]: https://warthogs.atlassian.net/browse/JUJU-8671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ