### PR TITLE
feat: use same relation UUID on offering and consuming sides of CMR

### DIFF
--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -149,7 +149,7 @@ func (st *State) GetOfferUUIDByRelationUUID(ctx context.Context, relationUUID st
 	stmt, err := st.Prepare(`
 SELECT &offerConnection.*
 FROM   offer_connection oc
-WHERE  oc.application_remote_relation_uuid = $remoteRelationUUID.uuid
+WHERE  oc.remote_relation_uuid = $remoteRelationUUID.uuid
 `, remoteRelationUUID, offerConnection{})
 	if err != nil {
 		return "", errors.Capture(err)

--- a/domain/crossmodelrelation/state/model/package_test.go
+++ b/domain/crossmodelrelation/state/model/package_test.go
@@ -179,14 +179,10 @@ INSERT INTO offer_endpoint (offer_uuid, endpoint_uuid) VALUES (?, ?)`, offerUUID
 
 func (s *baseSuite) addOfferConnection(c *tc.C, offerUUID offer.UUID, statusID status.RelationStatusType) string {
 	relUUID := s.addRelation(c)
-	consumerRelUUID := tc.Must(c, internaluuid.NewUUID).String()
-	s.query(c, `
-INSERT INTO application_remote_relation (relation_uuid, consumer_relation_uuid)
-VALUES (?, ?)`, relUUID, consumerRelUUID)
 
 	connUUID := tc.Must(c, internaluuid.NewUUID).String()
 	s.query(c, `
-INSERT INTO offer_connection (uuid, offer_uuid, application_remote_relation_uuid, username)
+INSERT INTO offer_connection (uuid, offer_uuid, remote_relation_uuid, username)
 VALUES (?, ?, ?, "bob")`, connUUID, offerUUID, relUUID)
 
 	s.query(c, `

--- a/domain/crossmodelrelation/state/model/remoteapplication_test.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication_test.go
@@ -570,20 +570,9 @@ func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationConsumer(c *tc.C) 
 	c.Check(endpoints[1].charmRelationName, tc.Equals, "db")
 	c.Check(endpoints[2].charmRelationName, tc.Equals, "juju-info")
 
-	// Fetch the synthetic relation from the application_remote_relation table:
-	var syntheticRelationUUID string
-	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		return tx.QueryRowContext(ctx, `
-SELECT r.uuid
-FROM   relation AS r
-JOIN   application_remote_relation AS arr ON r.uuid = arr.relation_uuid
-WHERE  arr.consumer_relation_uuid = ?`, relationUUID).
-			Scan(&syntheticRelationUUID)
-	})
-	c.Assert(err, tc.ErrorIsNil)
 	// Check that the synthetic relation has been created with the expected
 	// UUID and ID 0 (the first relation created in the model).
-	s.assertRelation(c, syntheticRelationUUID, 0)
+	s.assertRelation(c, relationUUID, 0)
 }
 
 func (s *modelRemoteApplicationSuite) TestAddRemoteApplicationConsumerTwiceSameApp(c *tc.C) {
@@ -1086,10 +1075,10 @@ SELECT uuid FROM application_remote_consumer WHERE consumer_application_uuid = ?
 	var offererRelationUUID string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		return tx.QueryRowContext(ctx, `
-SELECT arr.relation_uuid
+SELECT r.uuid
 FROM   application_remote_consumer AS arc
 JOIN   offer_connection AS oc ON oc.uuid = arc.offer_connection_uuid
-JOIN   application_remote_relation AS arr ON arr.relation_uuid = oc.application_remote_relation_uuid
+JOIN   relation AS r ON r.uuid = oc.remote_relation_uuid
 WHERE  arc.uuid = ?`, consumerUUID).Scan(&offererRelationUUID)
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -1239,18 +1228,18 @@ SELECT uuid FROM application_remote_consumer WHERE consumer_application_uuid = ?
 			return err
 		}
 		if err := tx.QueryRowContext(ctx, `
-SELECT arr.relation_uuid
+SELECT r.uuid
 FROM   application_remote_consumer AS arc
 JOIN   offer_connection AS oc ON oc.uuid = arc.offer_connection_uuid
-JOIN   application_remote_relation AS arr ON arr.relation_uuid = oc.application_remote_relation_uuid
+JOIN   relation AS r ON r.uuid = oc.remote_relation_uuid
 WHERE  arc.uuid = ?`, consumerUUID1).Scan(&offererRelationUUID1); err != nil {
 			return err
 		}
 		return tx.QueryRowContext(ctx, `
-SELECT arr.relation_uuid
+SELECT r.uuid
 FROM   application_remote_consumer AS arc
 JOIN   offer_connection AS oc ON oc.uuid = arc.offer_connection_uuid
-JOIN   application_remote_relation AS arr ON arr.relation_uuid = oc.application_remote_relation_uuid
+JOIN   relation AS r ON r.uuid = oc.remote_relation_uuid
 WHERE  arc.uuid = ?`, consumerUUID2).Scan(&offererRelationUUID2)
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -1367,18 +1356,18 @@ SELECT uuid FROM application_remote_consumer WHERE consumer_application_uuid = ?
 			return err
 		}
 		if err := tx.QueryRowContext(ctx, `
-SELECT arr.relation_uuid
+SELECT r.uuid
 FROM   application_remote_consumer AS arc
 JOIN   offer_connection AS oc ON oc.uuid = arc.offer_connection_uuid
-JOIN   application_remote_relation AS arr ON arr.relation_uuid = oc.application_remote_relation_uuid
+JOIN   relation AS r ON r.uuid = oc.remote_relation_uuid
 WHERE  arc.uuid = ?`, consumerUUID1).Scan(&offererRelationUUID1); err != nil {
 			return err
 		}
 		return tx.QueryRowContext(ctx, `
-SELECT arr.relation_uuid
+SELECT r.uuid
 FROM   application_remote_consumer AS arc
 JOIN   offer_connection AS oc ON oc.uuid = arc.offer_connection_uuid
-JOIN   application_remote_relation AS arr ON arr.relation_uuid = oc.application_remote_relation_uuid
+JOIN   relation AS r ON r.uuid = oc.remote_relation_uuid
 WHERE  arc.uuid = ?`, consumerUUID2).Scan(&offererRelationUUID2)
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -1456,10 +1445,10 @@ SELECT uuid FROM application_remote_consumer WHERE consumer_application_uuid = ?
 			return err
 		}
 		return tx.QueryRowContext(ctx, `
-SELECT arr.relation_uuid
+SELECT r.uuid
 FROM   application_remote_consumer AS arc
 JOIN   offer_connection AS oc ON oc.uuid = arc.offer_connection_uuid
-JOIN   application_remote_relation AS arr ON arr.relation_uuid = oc.application_remote_relation_uuid
+JOIN   relation AS r ON r.uuid = oc.remote_relation_uuid
 WHERE  arc.uuid = ?`, consumerUUID).Scan(&offererRelationUUID)
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -1518,10 +1507,10 @@ SELECT uuid FROM application_remote_consumer WHERE consumer_application_uuid = ?
 			return err
 		}
 		return tx.QueryRowContext(ctx, `
-SELECT arr.relation_uuid
+SELECT r.uuid
 FROM   application_remote_consumer AS arc
 JOIN   offer_connection AS oc ON oc.uuid = arc.offer_connection_uuid
-JOIN   application_remote_relation AS arr ON arr.relation_uuid = oc.application_remote_relation_uuid
+JOIN   relation AS r ON r.uuid = oc.remote_relation_uuid
 WHERE  arc.uuid = ?`, consumerUUID).Scan(&offererRelationUUID)
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -231,10 +231,10 @@ type remoteApplicationConsumer struct {
 }
 
 type offerConnection struct {
-	UUID                          string `db:"uuid"`
-	OfferUUID                     string `db:"offer_uuid"`
-	ApplicationRemoteRelationUUID string `db:"application_remote_relation_uuid"`
-	Username                      string `db:"username"`
+	UUID               string `db:"uuid"`
+	OfferUUID          string `db:"offer_uuid"`
+	RemoteRelationUUID string `db:"remote_relation_uuid"`
+	Username           string `db:"username"`
 }
 
 type remoteRelationUUID struct {
@@ -249,15 +249,6 @@ type relation struct {
 	UUID       string `db:"uuid"`
 	LifeID     int    `db:"life_id"`
 	RelationID uint64 `db:"relation_id"`
-}
-
-type applicationRemoteRelation struct {
-	RelationUUID         string `db:"relation_uuid"`
-	ConsumerRelationUUID string `db:"consumer_relation_uuid"`
-}
-
-type consumerRelationUUID struct {
-	ConsumerRelationUUID string `db:"consumer_relation_uuid"`
 }
 
 type consumerApplicationUUID struct {

--- a/domain/schema/model/sql/0032-offer.sql
+++ b/domain/schema/model/sql/0032-offer.sql
@@ -27,7 +27,7 @@ WITH conn AS (
 
 active_conn AS (
     SELECT oc.offer_uuid FROM offer_connection AS oc
-    JOIN relation_status AS rs ON oc.application_remote_relation_uuid = rs.relation_uuid
+    JOIN relation_status AS rs ON oc.remote_relation_uuid = rs.relation_uuid
     WHERE rs.relation_status_type_id = 1
 )
 

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -105,38 +105,15 @@ CREATE TABLE application_remote_consumer (
 CREATE UNIQUE INDEX idx_application_remote_consumer_consumed_application_uuid
 ON application_remote_consumer (consumer_application_uuid);
 
--- application_remote_relation represents a look up table to find the consumer
--- relation UUID for a given (synthetic) relation in the offerer model.
-CREATE TABLE application_remote_relation (
-    -- relation_uuid is the relation UUID as created in the offerer model. This
-    -- is effectively a synthetic relation.
-    relation_uuid TEXT NOT NULL PRIMARY KEY,
-    -- consumer_relation_uuid is the relation UUID in the consumer model.
-    -- There is no FK constraint on it, because we don't have the relation
-    -- locally in the model.
-    -- NOTE: In terms of the cross model relation API, this is the 
-    -- relation-token.
-    consumer_relation_uuid TEXT NOT NULL,
-    CONSTRAINT fk_relation_uuid
-    FOREIGN KEY (relation_uuid)
-    REFERENCES relation (uuid)
-);
-
--- Offering model relations (synthetic) are 1:1 with consumer model relations.
-CREATE UNIQUE INDEX idx_application_remote_relation_consumer_relation_uuid
-ON application_remote_relation (consumer_relation_uuid);
-
 -- offer connection links the application remote consumer to the offer.
 CREATE TABLE offer_connection (
     uuid TEXT NOT NULL PRIMARY KEY,
     -- offer_uuid is the offer that the remote application is using.
     offer_uuid TEXT NOT NULL,
-    -- application_remote_relation_uuid is the relation uuid in the offerer
-    -- model that is being used for this offer connection. It is effectively a
-    -- synthetic relation.
-    -- It is foreign keyed to application_remote_relation, which allows us to
-    -- find the relation uuid of the relation in the consumer model.
-    application_remote_relation_uuid TEXT NOT NULL,
+    -- remote_relation_uuid is the relation for which the offer connection
+    -- is made. It uses the relation, as we can identify both the
+    -- relation id and the relation key from it.
+    remote_relation_uuid TEXT NOT NULL,
     -- username is the user in the consumer model that created the offer
     -- connection. This is not a user, but an offer user for which offers are
     -- granted permissions on.
@@ -145,6 +122,6 @@ CREATE TABLE offer_connection (
     FOREIGN KEY (offer_uuid)
     REFERENCES offer (uuid),
     CONSTRAINT fk_remote_relation_uuid
-    FOREIGN KEY (application_remote_relation_uuid)
-    REFERENCES application_remote_relation (relation_uuid)
+    FOREIGN KEY (remote_relation_uuid)
+    REFERENCES relation (uuid)
 );

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -311,7 +311,6 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"application_remote_offerer",
 		"application_remote_offerer_status",
 		"application_remote_offerer_relation_macaroon",
-		"application_remote_relation",
 		"offer_connection",
 
 		// Operations


### PR DESCRIPTION
This patch removes the application_remote_relation table, and makes sure that the created synthetic relation on the offering side has the same UUID as the one on the consuming side.
This is possible because when registering, the consuming side passes its relation UUID.

This changes are needed to facilitate how the firewaller publishes network changes from the consuming to the offering side: we now don't need to wait for the offering side to notify when it's ready.

## QA steps

Nothing wired yet, firewaller changes will be landing in future PRs.

## Links

**Jira card:** [JUJU-8489](https://warthogs.atlassian.net/browse/JUJU-8489)


[JUJU-8489]: https://warthogs.atlassian.net/browse/JUJU-8489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ