### PR TITLE
feat: implement & wire up remote relation removal

### DIFF
--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -548,4 +548,19 @@ type RemovalService interface {
 		force bool,
 		wait time.Duration,
 	) (removal.UUID, error)
+
+	// RemoveRelation checks if a relation with the input UUID exists.
+	// If it does, the relation is guaranteed after this call to be:
+	// - No longer alive.
+	// - Removed or scheduled to be removed with the input force qualification.
+	// The input wait duration is the time that we will give for the normal
+	// life-cycle advancement and removal to finish before forcefully removing the
+	// remote application. This duration is ignored if the force argument is false.
+	// The UUID for the scheduled removal job is returned.
+	RemoveRemoteRelation(
+		ctx context.Context,
+		relUUID corerelation.UUID,
+		force bool,
+		wait time.Duration,
+	) (removal.UUID, error)
 }

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -2772,6 +2772,45 @@ func (c *MockRemovalServiceRemoveRemoteApplicationOffererCall) DoAndReturn(f fun
 	return c
 }
 
+// RemoveRemoteRelation mocks base method.
+func (m *MockRemovalService) RemoveRemoteRelation(arg0 context.Context, arg1 relation.UUID, arg2 bool, arg3 time.Duration) (removal.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveRemoteRelation", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(removal.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveRemoteRelation indicates an expected call of RemoveRemoteRelation.
+func (mr *MockRemovalServiceMockRecorder) RemoveRemoteRelation(arg0, arg1, arg2, arg3 any) *MockRemovalServiceRemoveRemoteRelationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteRelation), arg0, arg1, arg2, arg3)
+	return &MockRemovalServiceRemoveRemoteRelationCall{Call: call}
+}
+
+// MockRemovalServiceRemoveRemoteRelationCall wrap *gomock.Call
+type MockRemovalServiceRemoveRemoteRelationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRemovalServiceRemoveRemoteRelationCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRemoteRelationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRemovalServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRemovalServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveUnit mocks base method.
 func (m *MockRemovalService) RemoveUnit(arg0 context.Context, arg1 unit.UUID, arg2, arg3 bool, arg4 time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	time "time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/names/v6"
@@ -277,8 +278,8 @@ func (s *facadeSuite) TestPublishRelationChangesLifeDead(c *tc.C) {
 			Name: "foo",
 		}, nil)
 	s.removalService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID).
-		Return(nil)
+		RemoveRemoteRelation(gomock.Any(), relationUUID, true, time.Minute).
+		Return("", nil)
 
 	api := s.api(c)
 	results, err := api.PublishRelationChanges(c.Context(), params.RemoteRelationsChanges{

--- a/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
@@ -12,6 +12,7 @@ package crossmodelrelations
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	application "github.com/juju/juju/core/application"
 	offer "github.com/juju/juju/core/offer"
@@ -23,6 +24,7 @@ import (
 	application0 "github.com/juju/juju/domain/application"
 	service "github.com/juju/juju/domain/crossmodelrelation/service"
 	relation0 "github.com/juju/juju/domain/relation"
+	removal "github.com/juju/juju/domain/removal"
 	config "github.com/juju/juju/environs/config"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -846,17 +848,18 @@ func (c *MockRemovalServiceLeaveScopeCall) DoAndReturn(f func(context.Context, r
 }
 
 // RemoveRemoteRelation mocks base method.
-func (m *MockRemovalService) RemoveRemoteRelation(arg0 context.Context, arg1 relation.UUID) error {
+func (m *MockRemovalService) RemoveRemoteRelation(arg0 context.Context, arg1 relation.UUID, arg2 bool, arg3 time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveRemoteRelation", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "RemoveRemoteRelation", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(removal.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RemoveRemoteRelation indicates an expected call of RemoveRemoteRelation.
-func (mr *MockRemovalServiceMockRecorder) RemoveRemoteRelation(arg0, arg1 any) *MockRemovalServiceRemoveRemoteRelationCall {
+func (mr *MockRemovalServiceMockRecorder) RemoveRemoteRelation(arg0, arg1, arg2, arg3 any) *MockRemovalServiceRemoveRemoteRelationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteRelation), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteRelation), arg0, arg1, arg2, arg3)
 	return &MockRemovalServiceRemoveRemoteRelationCall{Call: call}
 }
 
@@ -866,19 +869,19 @@ type MockRemovalServiceRemoveRemoteRelationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Return(arg0 error) *MockRemovalServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockRemovalServiceRemoveRemoteRelationCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRemoteRelationCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID) error) *MockRemovalServiceRemoveRemoteRelationCall {
+func (c *MockRemovalServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRemovalServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID) error) *MockRemovalServiceRemoveRemoteRelationCall {
+func (c *MockRemovalServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelrelations/service.go
+++ b/apiserver/facades/controller/crossmodelrelations/service.go
@@ -5,6 +5,7 @@ package crossmodelrelations
 
 import (
 	"context"
+	"time"
 
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/offer"
@@ -16,6 +17,7 @@ import (
 	domainapplication "github.com/juju/juju/domain/application"
 	crossmodelrelationservice "github.com/juju/juju/domain/crossmodelrelation/service"
 	domainrelation "github.com/juju/juju/domain/relation"
+	"github.com/juju/juju/domain/removal"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -126,7 +128,8 @@ type RemovalService interface {
 	// - No longer alive.
 	// - Removed or scheduled to be removed with the input force qualification.
 	RemoveRemoteRelation(
-		ctx context.Context, relUUID corerelation.UUID) error
+		ctx context.Context, relUUID corerelation.UUID, force bool, wait time.Duration,
+	) (removal.UUID, error)
 
 	// LeaveScope updates the relation to indicate that the unit represented by
 	// the input relation unit UUID is not in the implied relation scope.

--- a/domain/removal/errors/errors.go
+++ b/domain/removal/errors/errors.go
@@ -32,6 +32,10 @@ const (
 	// later. It is not to be deleted from the removal table.
 	RemovalJobIncomplete = errors.ConstError("removal job incomplete")
 
+	// RelationIsCrossModel indicates that a relation cannot be deleted (in this
+	// manner) because it is a cross model relation.
+	RelationIsCrossModel = errors.ConstError("relation is cross model")
+
 	// UnitsStillInScope indicates that a relation can not be deleted from
 	// the database because it has associated relation_unit records.
 	UnitsStillInScope = errors.ConstError("units still in relation scope")

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -679,6 +679,44 @@ func (c *MockModelDBStateDeleteRemoteApplicationOffererCall) DoAndReturn(f func(
 	return c
 }
 
+// DeleteRemoteRelation mocks base method.
+func (m *MockModelDBState) DeleteRemoteRelation(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRemoteRelation", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRemoteRelation indicates an expected call of DeleteRemoteRelation.
+func (mr *MockModelDBStateMockRecorder) DeleteRemoteRelation(arg0, arg1 any) *MockModelDBStateDeleteRemoteRelationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRemoteRelation", reflect.TypeOf((*MockModelDBState)(nil).DeleteRemoteRelation), arg0, arg1)
+	return &MockModelDBStateDeleteRemoteRelationCall{Call: call}
+}
+
+// MockModelDBStateDeleteRemoteRelationCall wrap *gomock.Call
+type MockModelDBStateDeleteRemoteRelationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateDeleteRemoteRelationCall) Return(arg0 error) *MockModelDBStateDeleteRemoteRelationCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateDeleteRemoteRelationCall) Do(f func(context.Context, string) error) *MockModelDBStateDeleteRemoteRelationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateDeleteRemoteRelationCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateDeleteRemoteRelationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DeleteStorageAttachment mocks base method.
 func (m *MockModelDBState) DeleteStorageAttachment(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -983,6 +1021,44 @@ func (c *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall) Do(f
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) (internal.CascadedRemoteApplicationOffererLives, error)) *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// EnsureRemoteRelationNotAliveCascade mocks base method.
+func (m *MockModelDBState) EnsureRemoteRelationNotAliveCascade(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureRemoteRelationNotAliveCascade", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureRemoteRelationNotAliveCascade indicates an expected call of EnsureRemoteRelationNotAliveCascade.
+func (mr *MockModelDBStateMockRecorder) EnsureRemoteRelationNotAliveCascade(arg0, arg1 any) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureRemoteRelationNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureRemoteRelationNotAliveCascade), arg0, arg1)
+	return &MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall{Call: call}
+}
+
+// MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall wrap *gomock.Call
+type MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) Return(arg0 error) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) Do(f func(context.Context, string) error) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2375,6 +2451,83 @@ func (c *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall) Do(f func(
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RemoteRelationExists mocks base method.
+func (m *MockModelDBState) RemoteRelationExists(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoteRelationExists", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoteRelationExists indicates an expected call of RemoteRelationExists.
+func (mr *MockModelDBStateMockRecorder) RemoteRelationExists(arg0, arg1 any) *MockModelDBStateRemoteRelationExistsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteRelationExists", reflect.TypeOf((*MockModelDBState)(nil).RemoteRelationExists), arg0, arg1)
+	return &MockModelDBStateRemoteRelationExistsCall{Call: call}
+}
+
+// MockModelDBStateRemoteRelationExistsCall wrap *gomock.Call
+type MockModelDBStateRemoteRelationExistsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateRemoteRelationExistsCall) Return(arg0 bool, arg1 error) *MockModelDBStateRemoteRelationExistsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateRemoteRelationExistsCall) Do(f func(context.Context, string) (bool, error)) *MockModelDBStateRemoteRelationExistsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateRemoteRelationExistsCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockModelDBStateRemoteRelationExistsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RemoteRelationScheduleRemoval mocks base method.
+func (m *MockModelDBState) RemoteRelationScheduleRemoval(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoteRelationScheduleRemoval", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoteRelationScheduleRemoval indicates an expected call of RemoteRelationScheduleRemoval.
+func (mr *MockModelDBStateMockRecorder) RemoteRelationScheduleRemoval(arg0, arg1, arg2, arg3, arg4 any) *MockModelDBStateRemoteRelationScheduleRemovalCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteRelationScheduleRemoval", reflect.TypeOf((*MockModelDBState)(nil).RemoteRelationScheduleRemoval), arg0, arg1, arg2, arg3, arg4)
+	return &MockModelDBStateRemoteRelationScheduleRemovalCall{Call: call}
+}
+
+// MockModelDBStateRemoteRelationScheduleRemovalCall wrap *gomock.Call
+type MockModelDBStateRemoteRelationScheduleRemovalCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateRemoteRelationScheduleRemovalCall) Return(arg0 error) *MockModelDBStateRemoteRelationScheduleRemovalCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateRemoteRelationScheduleRemovalCall) Do(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRemoteRelationScheduleRemovalCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateRemoteRelationScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRemoteRelationScheduleRemovalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/service/relation_test.go
+++ b/domain/removal/service/relation_test.go
@@ -124,6 +124,17 @@ func (s *relationSuite) TestExecuteJobForRelationNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *relationSuite) TestProcessRelationRemovalJobInvalidJobType(c *tc.C) {
+	var invalidJobType removal.JobType = 500
+
+	job := removal.Job{
+		RemovalType: invalidJobType,
+	}
+
+	err := s.newService(c).processRelationRemovalJob(c.Context(), job)
+	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobTypeNotValid)
+}
+
 func (s *relationSuite) TestExecuteJobForRelationStillAlive(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/removal/service/remoterelation.go
+++ b/domain/removal/service/remoterelation.go
@@ -5,24 +5,150 @@ package service
 
 import (
 	"context"
+	"time"
 
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/domain/life"
+	relationerrors "github.com/juju/juju/domain/relation/errors"
+	"github.com/juju/juju/domain/removal"
+	removalerrors "github.com/juju/juju/domain/removal/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RemoteRelationState describes retrieval and persistence
 // methods specific to remote relation removal.
 type RemoteRelationState interface {
+	// RemoteRelationExists returns true if a relation exists with the input
+	// UUID, and relates a synthetic application
+	RemoteRelationExists(ctx context.Context, rUUID string) (bool, error)
+
+	// EnsureRemoteRelationNotAliveCascade ensures that the relation identified
+	// by the input UUID is not alive, and sets the synthetic units in scope
+	// of this relation to dead
+	EnsureRemoteRelationNotAliveCascade(ctx context.Context, rUUID string) error
+
+	// RemoteRelationScheduleRemoval schedules a removal job for the relation
+	// with the input UUID, qualified with the input force boolean.
+	RemoteRelationScheduleRemoval(ctx context.Context, removalUUID, relUUID string, force bool, when time.Time) error
+
+	// DeleteRemoteRelation deletes a remote relation record under and all it's
+	// and anything dependent upon it. This includes synthetic units.
+	DeleteRemoteRelation(ctx context.Context, rUUID string) error
 }
 
 // RemoveRelation checks if a relation with the input UUID exists.
 // If it does, the relation is guaranteed after this call to be:
 // - No longer alive.
 // - Removed or scheduled to be removed with the input force qualification.
+// The input wait duration is the time that we will give for the normal
+// life-cycle advancement and removal to finish before forcefully removing the
+// remote application. This duration is ignored if the force argument is false.
+// The UUID for the scheduled removal job is returned.
 func (s *Service) RemoveRemoteRelation(
-	ctx context.Context, relUUID corerelation.UUID) error {
-	_, span := trace.Start(ctx, trace.NameFromFunc())
+	ctx context.Context, relUUID corerelation.UUID, force bool, wait time.Duration,
+) (removal.UUID, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
+
+	exists, err := s.modelState.RemoteRelationExists(ctx, relUUID.String())
+	if err != nil {
+		return "", errors.Errorf("checking if remote relation %q exists: %w", relUUID, err)
+	}
+	if !exists {
+		return "", errors.Errorf("remote relation %q does not exist", relUUID).Add(relationerrors.RelationNotFound)
+	}
+
+	if err := s.modelState.EnsureRemoteRelationNotAliveCascade(ctx, relUUID.String()); err != nil {
+		return "", errors.Errorf("remote relation %q: %w", relUUID, err)
+	}
+
+	var jUUID removal.UUID
+	if force {
+		if wait > 0 {
+			// If we have been supplied with the force flag *and* a wait time,
+			// schedule a normal removal job immediately. This will cause the
+			// earliest removal of the relation if the normal destruction
+			// workflows complete within the wait duration.
+			if _, err := s.remoteRelationScheduleRemoval(ctx, relUUID, false, 0); err != nil {
+				return jUUID, errors.Capture(err)
+			}
+		}
+	} else {
+		if wait > 0 {
+			s.logger.Infof(ctx, "ignoring wait duration for non-forced removal of remote relation %q", relUUID.String())
+			wait = 0
+		}
+	}
+
+	jUUID, err = s.remoteRelationScheduleRemoval(ctx, relUUID, force, wait)
+	return jUUID, errors.Capture(err)
+}
+
+func (s *Service) remoteRelationScheduleRemoval(
+	ctx context.Context, relUUID corerelation.UUID, force bool, wait time.Duration,
+) (removal.UUID, error) {
+	jobUUID, err := removal.NewUUID()
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if err := s.modelState.RemoteRelationScheduleRemoval(
+		ctx, jobUUID.String(), relUUID.String(), force, s.clock.Now().UTC().Add(wait),
+	); err != nil {
+		return "", errors.Errorf("remote relation %q: %w", relUUID, err)
+	}
+
+	s.logger.Infof(ctx, "scheduled removal job %q for remote relation %q", jobUUID, relUUID)
+	return jobUUID, nil
+}
+
+func (s *Service) processRemoteRelationRemovalJob(ctx context.Context, job removal.Job) error {
+	if job.RemovalType != removal.RemoteRelationJob {
+		return errors.Errorf("job type: %q not valid for remote relation removal", job.RemovalType).Add(
+			removalerrors.RemovalJobTypeNotValid)
+	}
+
+	l, err := s.modelState.GetRelationLife(ctx, job.EntityUUID)
+	if errors.Is(err, relationerrors.RelationNotFound) {
+		// The relation has already been removed.
+		// Indicate success so that this job will be deleted.
+		return nil
+	}
+	if err != nil {
+		return errors.Errorf("getting remote relation %q life: %w", job.EntityUUID, err)
+	}
+
+	if l == life.Alive {
+		return errors.Errorf("remote relation %q is alive", job.EntityUUID).Add(removalerrors.EntityStillAlive)
+	}
+
+	inScope, err := s.modelState.UnitNamesInScope(ctx, job.EntityUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if len(inScope) > 0 {
+		// If this is a regular removal, we just exit and wait for
+		// the job to be scheduled again for a later check.
+		if !job.Force {
+			s.logger.Infof(ctx, "removal job %q for relation %q is waiting for units to leave scope: %v",
+				job.UUID, job.EntityUUID, inScope)
+
+			return removalerrors.RemovalJobIncomplete
+		}
+
+		s.logger.Infof(ctx, "removal job %q for relation %q forcefully removing units from scope",
+			job.UUID, job.EntityUUID)
+
+		if err := s.modelState.DeleteRelationUnits(ctx, job.EntityUUID); err != nil {
+			return errors.Errorf("departing units from relation %q scope: %w", job.EntityUUID, err)
+		}
+	}
+
+	if err := s.modelState.DeleteRemoteRelation(ctx, job.EntityUUID); err != nil {
+		return errors.Errorf("deleting remote relation %q: %w", job.EntityUUID, err)
+	}
 
 	return nil
 }

--- a/domain/removal/service/remoterelation_test.go
+++ b/domain/removal/service/remoterelation_test.go
@@ -1,0 +1,215 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juju/tc"
+	"go.uber.org/mock/gomock"
+
+	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/domain/life"
+	relationerrors "github.com/juju/juju/domain/relation/errors"
+	"github.com/juju/juju/domain/removal"
+	removalerrors "github.com/juju/juju/domain/removal/errors"
+	"github.com/juju/juju/internal/errors"
+)
+
+type remoteRelationSuite struct {
+	baseSuite
+}
+
+func TestRemoteRelationSuite(t *testing.T) {
+	tc.Run(t, &remoteRelationSuite{})
+}
+
+func (s *remoteRelationSuite) TestRemoveRemoteRelationNoForceSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relUUID := tc.Must(c, relation.NewUUID)
+
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when)
+
+	exp := s.modelState.EXPECT()
+	exp.RemoteRelationExists(gomock.Any(), relUUID.String()).Return(true, nil)
+	exp.EnsureRemoteRelationNotAliveCascade(gomock.Any(), relUUID.String()).Return(nil)
+	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), false, when.UTC()).Return(nil)
+
+	jobUUID, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *remoteRelationSuite) TestRemoveRemoteRelationForceNoWaitSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relUUID := tc.Must(c, relation.NewUUID)
+
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when)
+
+	exp := s.modelState.EXPECT()
+	exp.RemoteRelationExists(gomock.Any(), relUUID.String()).Return(true, nil)
+	exp.EnsureRemoteRelationNotAliveCascade(gomock.Any(), relUUID.String()).Return(nil)
+	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), true, when.UTC()).Return(nil)
+
+	jobUUID, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, true, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *remoteRelationSuite) TestRemoveRemoteRelationForceWaitSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relUUID := tc.Must(c, relation.NewUUID)
+
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).MinTimes(1)
+
+	exp := s.modelState.EXPECT()
+	exp.RemoteRelationExists(gomock.Any(), relUUID.String()).Return(true, nil)
+	exp.EnsureRemoteRelationNotAliveCascade(gomock.Any(), relUUID.String()).Return(nil)
+
+	// The first normal removal scheduled immediately.
+	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), false, when.UTC()).Return(nil)
+
+	// The forced removal scheduled after the wait duration.
+	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), true, when.UTC().Add(time.Minute)).Return(nil)
+
+	jobUUID, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, true, time.Minute)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *remoteRelationSuite) TestRemoveRemoteRelationNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relUUID := tc.Must(c, relation.NewUUID)
+
+	s.modelState.EXPECT().RemoteRelationExists(gomock.Any(), relUUID.String()).Return(false, nil)
+
+	_, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, false, 0)
+	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
+}
+
+func (s *remoteRelationSuite) TestProcessRemoteRelationRemovalJobInvalidJobType(c *tc.C) {
+	var invalidJobType removal.JobType = 500
+
+	job := removal.Job{
+		RemovalType: invalidJobType,
+	}
+
+	err := s.newService(c).processRemoteRelationRemovalJob(c.Context(), job)
+	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobTypeNotValid)
+}
+
+func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteRelationJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(-1, relationerrors.RelationNotFound)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteRelationJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(-1, errors.Errorf("the front fell off"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
+}
+
+func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationStillAlive(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteRelationJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Alive, nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIs, removalerrors.EntityStillAlive)
+}
+
+func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationUnitsInScope(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteRelationJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
+	exp.UnitNamesInScope(gomock.Any(), j.EntityUUID).Return([]string{"unit/0"}, nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationUnitsInScopeForce(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteRelationJob(c)
+	j.Force = true
+
+	exp := s.modelState.EXPECT()
+	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
+	exp.UnitNamesInScope(gomock.Any(), j.EntityUUID).Return([]string{"unit/0"}, nil)
+	exp.DeleteRelationUnits(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteRemoteRelation(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationDyingDeleteRemoteRelation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteRelationJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
+	exp.UnitNamesInScope(gomock.Any(), j.EntityUUID).Return(nil, nil)
+	exp.DeleteRemoteRelation(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationDyingDeleteRemoteRelationError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newRemoteRelationJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
+	exp.UnitNamesInScope(gomock.Any(), j.EntityUUID).Return(nil, nil)
+	exp.DeleteRemoteRelation(gomock.Any(), j.EntityUUID).Return(errors.Errorf("the front fell off"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
+}
+
+func newRemoteRelationJob(c *tc.C) removal.Job {
+	jUUID, err := removal.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+
+	return removal.Job{
+		UUID:        jUUID,
+		RemovalType: removal.RemoteRelationJob,
+		EntityUUID:  tc.Must(c, relation.NewUUID).String(),
+	}
+}

--- a/domain/removal/service/service.go
+++ b/domain/removal/service/service.go
@@ -52,6 +52,7 @@ type ModelDBState interface {
 	ModelState
 	StorageState
 	RemoteApplicationOffererState
+	RemoteRelationState
 
 	// GetAllJobs returns all removal jobs.
 	GetAllJobs(ctx context.Context) ([]removal.Job, error)
@@ -152,6 +153,9 @@ func (s *Service) ExecuteJob(ctx context.Context, job removal.Job) error {
 
 	case removal.RemoteApplicationOffererJob:
 		err = s.processRemoteApplicationOffererRemovalJob(ctx, job)
+
+	case removal.RemoteRelationJob:
+		err = s.processRemoteRelationRemovalJob(ctx, job)
 
 	default:
 		err = errors.Errorf("removal job type %q not supported", job.RemovalType).Add(

--- a/domain/removal/state/model/remoterelation.go
+++ b/domain/removal/state/model/remoterelation.go
@@ -1,0 +1,234 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/sqlair"
+
+	"github.com/juju/juju/domain/removal"
+	"github.com/juju/juju/internal/errors"
+)
+
+// RemoteRelationExists returns true if a relation exists with the input
+// UUID, and relates a synthetic application
+func (st *State) RemoteRelationExists(ctx context.Context, rUUID string) (bool, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	remoteRelationUUID := entityUUID{UUID: rUUID}
+	existsStmt, err := st.Prepare(`
+SELECT r.uuid AS &entityUUID.uuid
+FROM   relation AS r
+JOIN   relation_endpoint AS re ON r.uuid = re.relation_uuid
+JOIN   application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
+JOIN   application AS a ON ae.application_uuid = a.uuid
+JOIN   charm AS c ON a.charm_uuid = c.uuid
+JOIN   charm_source AS cs ON c.source_id = cs.id
+WHERE  r.uuid = $entityUUID.uuid
+AND    cs.name = 'cmr'`, remoteRelationUUID)
+	if err != nil {
+		return false, errors.Errorf("preparing remote relation exists query: %w", err)
+	}
+
+	var remoteRelationExists bool
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, existsStmt, remoteRelationUUID).Get(&remoteRelationUUID)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return errors.Errorf("running remote relation exists query: %w", err)
+		}
+
+		remoteRelationExists = true
+		return nil
+	})
+
+	return remoteRelationExists, errors.Capture(err)
+}
+
+// EnsureRemoteRelationNotAliveCascade ensures that the relation identified
+// by the input UUID is not alive, and sets the synthetic units in scope
+// of this relation to dead
+// NOTE: We do not return any artifacts here, as the only entities that are
+// cascaded are synthetic units, which do no need a removal job scheduled.
+func (st *State) EnsureRemoteRelationNotAliveCascade(ctx context.Context, rUUID string) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	remoteRelationUUID := entityUUID{UUID: rUUID}
+	updateRelationStmt, err := st.Prepare(`
+UPDATE relation
+SET    life_id = 1
+WHERE  uuid = $entityUUID.uuid
+AND    life_id = 0`, remoteRelationUUID)
+	if err != nil {
+		return errors.Errorf("preparing remote relation life update: %w", err)
+	}
+
+	getSyntheticAppUUIDStmt, err := st.Prepare(`
+SELECT a.uuid AS &entityUUID.uuid
+FROM   relation AS r
+JOIN   relation_endpoint AS re ON r.uuid = re.relation_uuid
+JOIN   application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
+JOIN   application AS a ON ae.application_uuid = a.uuid
+JOIN   charm AS c ON a.charm_uuid = c.uuid
+JOIN   charm_source AS cs ON c.source_id = cs.id
+WHERE  r.uuid = $entityUUID.uuid
+AND    cs.name = 'cmr'`, remoteRelationUUID)
+	if err != nil {
+		return errors.Errorf("preparing remote relation synthetic app UUID query: %w", err)
+	}
+
+	updateSyntheticUnitStmt, err := st.Prepare(`
+UPDATE unit
+SET    life_id = 2
+WHERE  life_id = 0
+AND    application_uuid = $entityUUID.uuid
+`, entityUUID{})
+	if err != nil {
+		return errors.Errorf("preparing remote relation synthetic unit update: %w", err)
+	}
+
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, updateRelationStmt, remoteRelationUUID).Run()
+		if err != nil {
+			return errors.Errorf("advancing remote relation life: %w", err)
+		}
+
+		var synthAppUUID entityUUID
+		err = tx.Query(ctx, getSyntheticAppUUIDStmt, remoteRelationUUID).Get(&synthAppUUID)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return errors.Errorf("getting synthetic app UUID: %w", err)
+		}
+
+		err = tx.Query(ctx, updateSyntheticUnitStmt, synthAppUUID).Run()
+		if err != nil {
+			return errors.Errorf("advancing remote relation synthetic unit life: %w", err)
+		}
+
+		return nil
+	}))
+}
+
+// RemoteRelationScheduleRemoval schedules a removal job for the relation
+// with the input UUID, qualified with the input force boolean.
+func (st *State) RemoteRelationScheduleRemoval(ctx context.Context, removalUUID, relUUID string, force bool, when time.Time) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	removalRec := removalJob{
+		UUID:          removalUUID,
+		RemovalTypeID: uint64(removal.RemoteRelationJob),
+		EntityUUID:    relUUID,
+		Force:         force,
+		ScheduledFor:  when,
+	}
+
+	stmt, err := st.Prepare("INSERT INTO removal (*) VALUES ($removalJob.*)", removalRec)
+	if err != nil {
+		return errors.Errorf("preparing remote relation removal: %w", err)
+	}
+
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, stmt, removalRec).Run()
+		if err != nil {
+			return errors.Errorf("scheduling remote relation removal: %w", err)
+		}
+		return nil
+	}))
+}
+
+// DeleteRemoteRelation deletes a remote relation record under and all it's
+// and anything dependent upon it. This includes synthetic units.
+func (st *State) DeleteRemoteRelation(ctx context.Context, rUUID string) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	remoteRelationUUID := entityUUID{UUID: rUUID}
+
+	getSyntheticAppUUIDStmt, err := st.Prepare(`
+SELECT a.uuid AS &entityUUID.uuid
+FROM   relation AS r
+JOIN   relation_endpoint AS re ON r.uuid = re.relation_uuid
+JOIN   application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
+JOIN   application AS a ON ae.application_uuid = a.uuid
+JOIN   charm AS c ON a.charm_uuid = c.uuid
+JOIN   charm_source AS cs ON c.source_id = cs.id
+WHERE  r.uuid = $entityUUID.uuid
+AND    cs.name = 'cmr'`, remoteRelationUUID)
+	if err != nil {
+		return errors.Errorf("preparing remote relation app UUID query: %w", err)
+	}
+
+	countSyntheticAppRelationsStmt, err := st.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM   relation_endpoint AS re
+JOIN   application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
+WHERE  ae.application_uuid = $entityUUID.uuid
+`, count{}, entityUUID{})
+	if err != nil {
+		return errors.Errorf("preparing remote relation app relation count query: %w", err)
+	}
+
+	deleteRemoteOffererRelationMacaroonStmt, err := st.Prepare(`
+DELETE FROM application_remote_offerer_relation_macaroon
+WHERE  relation_uuid = $entityUUID.uuid`, entityUUID{})
+	if err != nil {
+		return errors.Errorf("preparing remote relation macaroon deletion: %w", err)
+	}
+
+	deleteSyntheticUnitsStmt, err := st.Prepare(`
+DELETE FROM unit
+WHERE  application_uuid = $entityUUID.uuid
+`, entityUUID{})
+	if err != nil {
+		return errors.Errorf("preparing remote relation unit deletion: %w", err)
+	}
+
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var synthAppUUID entityUUID
+		err = tx.Query(ctx, getSyntheticAppUUIDStmt, remoteRelationUUID).Get(&synthAppUUID)
+		if err != nil {
+			return errors.Errorf("getting app UUID: %w", err)
+		}
+
+		err = tx.Query(ctx, deleteRemoteOffererRelationMacaroonStmt, remoteRelationUUID).Run()
+		if err != nil {
+			return errors.Errorf("running remote relation macaroon deletion: %w", err)
+		}
+
+		err := st.deleteRelation(ctx, tx, remoteRelationUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+
+		var relationCount count
+		err = tx.Query(ctx, countSyntheticAppRelationsStmt, synthAppUUID).Get(&relationCount)
+		if err != nil {
+			return errors.Errorf("getting relation count: %w", err)
+		}
+
+		if relationCount.Count == 0 {
+			err = tx.Query(ctx, deleteSyntheticUnitsStmt, synthAppUUID).Run()
+			if err != nil {
+				return errors.Errorf("running unit deletion: %w", err)
+			}
+		}
+
+		return nil
+	}))
+}

--- a/domain/removal/state/model/remoterelation_test.go
+++ b/domain/removal/state/model/remoterelation_test.go
@@ -1,0 +1,208 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juju/tc"
+
+	applicationservice "github.com/juju/juju/domain/application/service"
+	"github.com/juju/juju/domain/life"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type remoteRelationSuite struct {
+	baseSuite
+}
+
+func TestRemoteRelationSuite(t *testing.T) {
+	tc.Run(t, &remoteRelationSuite{})
+}
+
+func (s *remoteRelationSuite) TestRemoteRelationExists(c *tc.C) {
+	relUUID, _ := s.createRemoteRelation(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	exists, err := st.RemoteRelationExists(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, true)
+}
+
+func (s *remoteRelationSuite) TestRemoteRelationExistsFalseForRegularRelation(c *tc.C) {
+	relUUID := s.createRelation(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	exists, err := st.RemoteRelationExists(c.Context(), relUUID.String())
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+}
+
+func (s *remoteRelationSuite) TestRemoteRelationExistsFalseForNonExistingRelation(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	exists, err := st.RemoteRelationExists(c.Context(), "not-today-henry")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+}
+
+func (s *remoteRelationSuite) TestEnsureRemoteRelationNotAliveCascadeNormalSuccess(c *tc.C) {
+	relUUID, synthAppUUID := s.createRemoteRelation(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.EnsureRemoteRelationNotAliveCascade(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var lifeID int
+	row := s.DB().QueryRowContext(c.Context(), "SELECT life_id FROM relation where uuid = ?", relUUID.String())
+	err = row.Scan(&lifeID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 1)
+
+	// The synth app should still be alive
+	row = s.DB().QueryRowContext(c.Context(), "SELECT life_id FROM application where uuid = ?", synthAppUUID.String())
+	err = row.Scan(&lifeID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 0)
+
+	// But the synth units should all be dead
+	rows, err := s.DB().QueryContext(c.Context(), "SELECT life_id FROM unit where application_uuid = ?", synthAppUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var lifeID int
+		err := rows.Scan(&lifeID)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(lifeID, tc.Equals, 2)
+	}
+}
+
+func (s *remoteRelationSuite) TestEnsureRemoteRelationNotAliveCascadeNotExistsSuccess(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	// We don't care if it's already gone.
+	err := st.EnsureRemoteRelationNotAliveCascade(c.Context(), "some-relation-uuid")
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *remoteRelationSuite) TestRemoteRelationScheduleRemovalNormalSuccess(c *tc.C) {
+	relUUID, _ := s.createRemoteRelation(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	when := time.Now().UTC()
+	err := st.RemoteRelationScheduleRemoval(
+		c.Context(), "removal-uuid", relUUID.String(), false, when,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	row := s.DB().QueryRowContext(c.Context(), `
+SELECT t.name, r.entity_uuid, r.force, r.scheduled_for
+FROM   removal r JOIN removal_type t ON r.removal_type_id = t.id
+where  r.uuid = ?`, "removal-uuid",
+	)
+
+	var (
+		removalType  string
+		rUUID        string
+		force        bool
+		scheduledFor time.Time
+	)
+	err = row.Scan(&removalType, &rUUID, &force, &scheduledFor)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(removalType, tc.Equals, "remote relation")
+	c.Check(rUUID, tc.Equals, relUUID.String())
+	c.Check(force, tc.Equals, false)
+	c.Check(scheduledFor, tc.Equals, when)
+}
+
+func (s *remoteRelationSuite) TestRemoteRelationScheduleRemovalNotExistsSuccess(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	when := time.Now().UTC()
+	err := st.RemoteRelationScheduleRemoval(
+		c.Context(), "removal-uuid", "some-relation-uuid", true, when,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	row := s.DB().QueryRowContext(c.Context(), `
+SELECT t.name, r.entity_uuid, r.force, r.scheduled_for
+FROM   removal r JOIN removal_type t ON r.removal_type_id = t.id
+where  r.uuid = ?`, "removal-uuid",
+	)
+
+	var (
+		removalType  string
+		rUUID        string
+		force        bool
+		scheduledFor time.Time
+	)
+	err = row.Scan(&removalType, &rUUID, &force, &scheduledFor)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(removalType, tc.Equals, "remote relation")
+	c.Check(rUUID, tc.Equals, "some-relation-uuid")
+	c.Check(force, tc.Equals, true)
+	c.Check(scheduledFor, tc.Equals, when)
+}
+
+func (s *relationSuite) TestDeleteRemoteRelation(c *tc.C) {
+	relUUID, synthAppUUID := s.createRemoteRelation(c)
+
+	s.advanceRelationLife(c, relUUID, life.Dying)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.DeleteRemoteRelation(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The synth app should NOT be deleted.
+	row := s.DB().QueryRow("SELECT COUNT(*) FROM application WHERE uuid = ?", synthAppUUID.String())
+	var count int
+	err = row.Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+
+	// But the synth units should be cleaned up.
+	row = s.DB().QueryRow("SELECT COUNT(*) FROM unit WHERE application_uuid = ?", synthAppUUID.String())
+	err = row.Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+}
+
+func (s *relationSuite) TestDeleteRemoteRelationWhenRemoteAppHasMultipleRelations(c *tc.C) {
+	synthAppUUID, _ := s.createIAASRemoteApplicationOfferer(c, "foo")
+	s.createIAASApplication(c, s.setupApplicationService(c), "app1",
+		applicationservice.AddIAASUnitArg{},
+	)
+	s.createIAASApplication(c, s.setupApplicationService(c), "app2",
+		applicationservice.AddIAASUnitArg{},
+	)
+	relUUID := s.createRemoteRelationBetween(c, "foo", "app1")
+	s.createRemoteRelationBetween(c, "foo", "app2")
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.DeleteRemoteRelation(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The synth app should NOT be deleted.
+	row := s.DB().QueryRow("SELECT COUNT(*) FROM application WHERE uuid = ?", synthAppUUID.String())
+	var count int
+	err = row.Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+
+	// And the synth units should also NOT be deleted.
+	row = s.DB().QueryRow("SELECT COUNT(*) FROM unit WHERE application_uuid = ?", synthAppUUID.String())
+	err = row.Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 3)
+}

--- a/domain/removal/types.go
+++ b/domain/removal/types.go
@@ -43,6 +43,8 @@ const (
 	// RemoteApplicationOffererJob indicates a job to remove a remote
 	// application offerer.
 	RemoteApplicationOffererJob
+	// RemoteRelationJob indicates a job to remove a remote relation.
+	RemoteRelationJob
 )
 
 // String is used in logging output make job type identifiers readable.

--- a/domain/schema/model/sql/0028-cleanup.sql
+++ b/domain/schema/model/sql/0028-cleanup.sql
@@ -19,7 +19,8 @@ INSERT INTO removal_type VALUES
 (9, 'storage volume attachment'),
 (10, 'storage volume attachment plan'),
 (11, 'storage filesystem attachment'),
-(12, 'remote application offerer');
+(12, 'remote application offerer'),
+(13, 'remote relation');
 
 CREATE TABLE removal (
     uuid TEXT NOT NULL PRIMARY KEY,

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -31,6 +31,7 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	domainrelation "github.com/juju/juju/domain/relation"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
+	removal "github.com/juju/juju/domain/removal"
 	"github.com/juju/juju/internal/charm"
 	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
@@ -1950,10 +1951,10 @@ func (s *localConsumerWorkerSuite) TestHandleOffererRelationUnitChangeDyingRelat
 		GetRelationDetails(gomock.Any(), relationUUID).
 		Return(domainrelation.RelationDetails{}, nil)
 	s.crossModelService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID).
-		DoAndReturn(func(context.Context, relation.UUID) error {
+		RemoveRemoteRelation(gomock.Any(), relationUUID, false, time.Duration(0)).
+		DoAndReturn(func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error) {
 			close(sync)
-			return nil
+			return "", nil
 		})
 
 	w := s.newLocalConsumerWorker(c)
@@ -2008,10 +2009,10 @@ func (s *localConsumerWorkerSuite) TestHandleOffererRelationUnitChangeDeadRelati
 		GetRelationDetails(gomock.Any(), relationUUID).
 		Return(domainrelation.RelationDetails{}, nil)
 	s.crossModelService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID).
-		DoAndReturn(func(context.Context, relation.UUID) error {
+		RemoveRemoteRelation(gomock.Any(), relationUUID, false, time.Duration(0)).
+		DoAndReturn(func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error) {
 			close(sync)
-			return nil
+			return "", nil
 		})
 
 	w := s.newLocalConsumerWorker(c)
@@ -2450,10 +2451,10 @@ func (s *localConsumerWorkerSuite) TestHandleOffererRelationChangeDying(c *tc.C)
 
 	sync := make(chan struct{})
 	s.crossModelService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID).
-		DoAndReturn(func(ctx context.Context, rel relation.UUID) error {
+		RemoveRemoteRelation(gomock.Any(), relationUUID, false, time.Duration(0)).
+		DoAndReturn(func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error) {
 			close(sync)
-			return nil
+			return "", nil
 		})
 
 	w := s.newLocalConsumerWorker(c)

--- a/internal/worker/remoterelationconsumer/service_mock_test.go
+++ b/internal/worker/remoterelationconsumer/service_mock_test.go
@@ -818,17 +818,18 @@ func (c *MockCrossModelServiceRemoveRemoteApplicationOffererByApplicationUUIDCal
 }
 
 // RemoveRemoteRelation mocks base method.
-func (m *MockCrossModelService) RemoveRemoteRelation(ctx context.Context, relUUID relation.UUID) error {
+func (m *MockCrossModelService) RemoveRemoteRelation(ctx context.Context, relUUID relation.UUID, force bool, wait time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveRemoteRelation", ctx, relUUID)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "RemoveRemoteRelation", ctx, relUUID, force, wait)
+	ret0, _ := ret[0].(removal.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RemoveRemoteRelation indicates an expected call of RemoveRemoteRelation.
-func (mr *MockCrossModelServiceMockRecorder) RemoveRemoteRelation(ctx, relUUID any) *MockCrossModelServiceRemoveRemoteRelationCall {
+func (mr *MockCrossModelServiceMockRecorder) RemoveRemoteRelation(ctx, relUUID, force, wait any) *MockCrossModelServiceRemoveRemoteRelationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockCrossModelService)(nil).RemoveRemoteRelation), ctx, relUUID)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockCrossModelService)(nil).RemoveRemoteRelation), ctx, relUUID, force, wait)
 	return &MockCrossModelServiceRemoveRemoteRelationCall{Call: call}
 }
 
@@ -838,19 +839,19 @@ type MockCrossModelServiceRemoveRemoteRelationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockCrossModelServiceRemoveRemoteRelationCall) Return(arg0 error) *MockCrossModelServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockCrossModelServiceRemoveRemoteRelationCall) Return(arg0 removal.UUID, arg1 error) *MockCrossModelServiceRemoveRemoteRelationCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID) error) *MockCrossModelServiceRemoveRemoteRelationCall {
+func (c *MockCrossModelServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockCrossModelServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID) error) *MockCrossModelServiceRemoveRemoteRelationCall {
+func (c *MockCrossModelServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockCrossModelServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1795,17 +1796,18 @@ func (c *MockRemovalServiceRemoveRemoteApplicationOffererByApplicationUUIDCall) 
 }
 
 // RemoveRemoteRelation mocks base method.
-func (m *MockRemovalService) RemoveRemoteRelation(ctx context.Context, relUUID relation.UUID) error {
+func (m *MockRemovalService) RemoveRemoteRelation(ctx context.Context, relUUID relation.UUID, force bool, wait time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveRemoteRelation", ctx, relUUID)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "RemoveRemoteRelation", ctx, relUUID, force, wait)
+	ret0, _ := ret[0].(removal.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RemoveRemoteRelation indicates an expected call of RemoveRemoteRelation.
-func (mr *MockRemovalServiceMockRecorder) RemoveRemoteRelation(ctx, relUUID any) *MockRemovalServiceRemoveRemoteRelationCall {
+func (mr *MockRemovalServiceMockRecorder) RemoveRemoteRelation(ctx, relUUID, force, wait any) *MockRemovalServiceRemoveRemoteRelationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteRelation), ctx, relUUID)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteRelation), ctx, relUUID, force, wait)
 	return &MockRemovalServiceRemoveRemoteRelationCall{Call: call}
 }
 
@@ -1815,19 +1817,19 @@ type MockRemovalServiceRemoveRemoteRelationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Return(arg0 error) *MockRemovalServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockRemovalServiceRemoveRemoteRelationCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRemoteRelationCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID) error) *MockRemovalServiceRemoveRemoteRelationCall {
+func (c *MockRemovalServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRemovalServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID) error) *MockRemovalServiceRemoveRemoteRelationCall {
+func (c *MockRemovalServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/remoterelationconsumer/worker.go
+++ b/internal/worker/remoterelationconsumer/worker.go
@@ -172,7 +172,8 @@ type RemovalService interface {
 	// RemoveRelation sets the relation with the given relation UUID
 	// from the local model to dying.
 	RemoveRemoteRelation(
-		ctx context.Context, relUUID corerelation.UUID) error
+		ctx context.Context, relUUID corerelation.UUID, force bool, wait time.Duration,
+	) (removal.UUID, error)
 
 	// RemoveRemoteApplicationOffererByApplicationUUID sets the remote
 	// application offerer with the given application UUID from the local model


### PR DESCRIPTION
Removing a 'remote relation' (i.e. a relation between an app and a remote app) is very similar to that of regular relations.

However, there are some small optimisations/changes that are needed for this this case. This is because we create synthetic units for the relation data to flow between and such. These units do not have a uniter in this model, so cleanup needs to be handled here.

When a remote relation is removed, set the synth units to dead immediately. When removing the remote relation, delete these units. We do not need to schedule jobs or anything.

This required a few changes/fixes to the relation domain, to keep us safe from calling the wrong method.

- RelationExists will now return false (& an error) if the relation is a remote relation.
- UnitsInScope will not return synthetic units. The justification for this is that the units are not 'meaningfully' in scope in this model.

## QA steps

CMR's aren't (fully) wired up, so QA is a little incomplete. However:

```
$ juju add-model offerer
$ juju deploy juju-qa-dummy-source
$ juju offer dummy-source:sink
$ juju add-model consumer
$ juju deploy juju-qa-dummy-sink
$ juju consume admin/offerer.dummy-source
$ juju relate dummy-sink dummy-source
$ juju status --relations
Model     Controller  Cloud/Region   Version      Timestamp
consumer  lxd         lxd/localhost  4.0-beta8.1  14:15:33+01:00

SAAS          Status   Store  URL
dummy-source  waiting  local  admin/offerer.dummy-source

App         Version  Status       Scale  Charm               Channel        Rev  Exposed  Message
dummy-sink           maintenance      1  juju-qa-dummy-sink  latest/stable    7  no       Started

Unit           Workload     Agent  Machine  Public address  Ports  Message
dummy-sink/0*  maintenance  idle   0        10.51.45.231           Started

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.231  juju-24ef38-0  ubuntu@20.04  jack  Running

Integration provider  Requirer           Interface    Type     Message
dummy-sink:source     dummy-source:sink  dummy-token  regular  

$ juju remove-relation dummy-sink:source dummy-source:sink
$ juju status --relations
Model     Controller  Cloud/Region   Version      Timestamp
consumer  lxd         lxd/localhost  4.0-beta8.1  14:18:03+01:00

SAAS          Status       Store  URL
dummy-source  maintenance  local  admin/offerer.dummy-source

App         Version  Status       Scale  Charm               Channel        Rev  Exposed  Message
dummy-sink           maintenance      1  juju-qa-dummy-sink  latest/stable    7  no       Started

Unit           Workload     Agent  Machine  Public address  Ports  Message
dummy-sink/0*  maintenance  idle   0        10.51.45.231           Started

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.231  juju-24ef38-0  ubuntu@20.04  jack  Running
```