### PR TITLE
fix(ci-test): refresh suite basic

### DIFF
--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -736,7 +736,6 @@ WHERE object_store_uuid = $entityAssociationCount.uuid
 		return errors.Capture(err)
 	}
 
-	st.logger.Errorf(ctx, "running charm usage query for object store %q", objectStoreUUID)
 	// It is also possible for an underlying object store item to be used by a charm.
 	// Only delete the object store entry if it is not used by any charms.
 	var charmCount entityAssociationCount
@@ -746,7 +745,6 @@ WHERE object_store_uuid = $entityAssociationCount.uuid
 		st.logger.Infof(ctx, "object store %q is still used by %d charm(s), not deleting", objectStoreUUID, charmCount.Count)
 		return nil
 	}
-	st.logger.Errorf(ctx, "object store %q is still used by %d charm(s), not deleting", objectStoreUUID, charmCount.Count)
 
 	return st.deleteFromObjectStore(ctx, tx, objectStoreUUID)
 }

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -13,7 +13,7 @@ run_refresh_local() {
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
 	OUT=$(juju refresh ubuntu --path "${charm_name}" 2>&1 || true)
-	if echo "${OUT}" | grep -E -vq "Added local charm"; then
+	if echo "${OUT}" | grep -v "no change" | grep -E -vq "Added local charm"; then
 		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
 		exit 5

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -16,7 +16,7 @@ run_refresh_switch_local_to_ch_channel() {
 	wait_for "refresher" "$(idle_condition "refresher")"
 
 	OUT=$(juju refresh refresher --switch ch:juju-qa-refresher --channel edge 2>&1 || true)
-	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
+	if echo "${OUT}" | grep -v "no change" | grep -E -vq "Added charm-hub charm"; then
 		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
 		exit 5


### PR DESCRIPTION
# Description 
This pr fixes the refresh suite basic and starts the fix for refresh suite switch.
It has two commits:
- first one: making sure we delete store obj if unused. This is to avoid constraint errors when deleting object storage referenced by dangling charms. As discussed with Simon, deleting dangling charms and object stores will be part of other prs and effort. 
- second one: in juju 4 we log to stdout addition lines when refreshing a charm, and with this fix we make sure we don't fail just because of that. So the new grep condition will return `true` if at least one line contains the expected output.



# QA
The suite passes.