### PR TITLE
fix(modelmanager): finds valid credentials when creating a model

### DIFF
--- a/apiserver/facades/client/modelmanager/service_mock_test.go
+++ b/apiserver/facades/client/modelmanager/service_mock_test.go
@@ -360,6 +360,45 @@ func (c *MockModelServiceCreateModelCall) DoAndReturn(f func(context.Context, mo
 	return c
 }
 
+// DefaultCloudCredentialKeyForOwner mocks base method.
+func (m *MockModelService) DefaultCloudCredentialKeyForOwner(arg0 context.Context, arg1 user.Name, arg2 string) (credential.Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DefaultCloudCredentialKeyForOwner", arg0, arg1, arg2)
+	ret0, _ := ret[0].(credential.Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DefaultCloudCredentialKeyForOwner indicates an expected call of DefaultCloudCredentialKeyForOwner.
+func (mr *MockModelServiceMockRecorder) DefaultCloudCredentialKeyForOwner(arg0, arg1, arg2 any) *MockModelServiceDefaultCloudCredentialKeyForOwnerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultCloudCredentialKeyForOwner", reflect.TypeOf((*MockModelService)(nil).DefaultCloudCredentialKeyForOwner), arg0, arg1, arg2)
+	return &MockModelServiceDefaultCloudCredentialKeyForOwnerCall{Call: call}
+}
+
+// MockModelServiceDefaultCloudCredentialKeyForOwnerCall wrap *gomock.Call
+type MockModelServiceDefaultCloudCredentialKeyForOwnerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelServiceDefaultCloudCredentialKeyForOwnerCall) Return(arg0 credential.Key, arg1 error) *MockModelServiceDefaultCloudCredentialKeyForOwnerCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelServiceDefaultCloudCredentialKeyForOwnerCall) Do(f func(context.Context, user.Name, string) (credential.Key, error)) *MockModelServiceDefaultCloudCredentialKeyForOwnerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelServiceDefaultCloudCredentialKeyForOwnerCall) DoAndReturn(f func(context.Context, user.Name, string) (credential.Key, error)) *MockModelServiceDefaultCloudCredentialKeyForOwnerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DefaultModelCloudInfo mocks base method.
 func (m *MockModelService) DefaultModelCloudInfo(arg0 context.Context) (string, string, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/juju/apiserver/facade"
-	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/agentbinary"
 	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/core/credential"
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
 	corestatus "github.com/juju/juju/core/status"
-	coreuser "github.com/juju/juju/core/user"
+	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/access"
 	"github.com/juju/juju/domain/blockcommand"
@@ -87,6 +87,11 @@ type ModelService interface {
 	// as that of the model.
 	UpdateCredential(ctx context.Context, uuid coremodel.UUID, key credential.Key) error
 
+	// DefaultCloudCredentialKeyForOwner returns the owner's valid (and non-revoked) credential key for a given cloud
+	// if only one credential exists. If owner has multiple valid cloud credentials a NotFound error is returned as
+	// we cannot determine the default credential.
+	DefaultCloudCredentialKeyForOwner(ctx context.Context, owner user.Name, cloudName string) (credential.Key, error)
+
 	// Model returns the model associated with the provided uuid.
 	Model(ctx context.Context, uuid coremodel.UUID) (coremodel.Model, error)
 
@@ -99,7 +104,7 @@ type ModelService interface {
 	ListAllModels(context.Context) ([]coremodel.Model, error)
 
 	// ListModelsForUser returns a list of models for the given user.
-	ListModelsForUser(context.Context, coreuser.UUID) ([]coremodel.Model, error)
+	ListModelsForUser(context.Context, user.UUID) ([]coremodel.Model, error)
 
 	// ListModelUUIDs returns a list of all model UUIDs in the controller that
 	// are active.
@@ -108,7 +113,7 @@ type ModelService interface {
 	// ListModelUUIDsForUser returns a list of model UUIDs that the supplied
 	// user has access to. If the user supplied does not have access to any
 	// models then an empty slice is returned.
-	ListModelUUIDsForUser(context.Context, coreuser.UUID) ([]coremodel.UUID, error)
+	ListModelUUIDsForUser(context.Context, user.UUID) ([]coremodel.UUID, error)
 
 	// GetModelUsers will retrieve basic information about users with
 	// permissions on the given model UUID.
@@ -116,7 +121,7 @@ type ModelService interface {
 
 	// GetModelUser will retrieve basic information about the specified model
 	// user.
-	GetModelUser(ctx context.Context, modelUUID coremodel.UUID, name coreuser.Name) (coremodel.ModelUserInfo, error)
+	GetModelUser(ctx context.Context, modelUUID coremodel.UUID, name user.Name) (coremodel.ModelUserInfo, error)
 }
 
 // ModelDefaultsService defines a interface for interacting with the model
@@ -175,7 +180,7 @@ type ModelInfoService interface {
 
 	// GetUserModelSummary returns a summary of the current model from the
 	// provided user's perspective.
-	GetUserModelSummary(ctx context.Context, userUUID coreuser.UUID) (coremodel.UserModelSummary, error)
+	GetUserModelSummary(ctx context.Context, userUUID user.UUID) (coremodel.UserModelSummary, error)
 
 	// IsControllerModel returns true if the model is the controller model.
 	IsControllerModel(ctx context.Context) (bool, error)
@@ -189,19 +194,19 @@ type ModelInfoService interface {
 // CredentialService exposes State methods needed by credential manager.
 type CredentialService interface {
 	// CloudCredential returns the cloud credential for the given key.
-	CloudCredential(ctx context.Context, id credential.Key) (jujucloud.Credential, error)
+	CloudCredential(ctx context.Context, id credential.Key) (cloud.Credential, error)
 }
 
 // AccessService defines a interface for interacting the users and permissions
 // of a controller.
 type AccessService interface {
 	// GetUserUUIDByName returns the UUID of the user with the given name.
-	GetUserUUIDByName(context.Context, coreuser.Name) (coreuser.UUID, error)
+	GetUserUUIDByName(context.Context, user.Name) (user.UUID, error)
 	// UpdatePermission updates the access level for a user of the model.
 	UpdatePermission(ctx context.Context, args access.UpdatePermissionArgs) error
 	// LastModelLogin will return the last login time of the specified
 	// user.
-	LastModelLogin(context.Context, coreuser.Name, coremodel.UUID) (time.Time, error)
+	LastModelLogin(context.Context, user.Name, coremodel.UUID) (time.Time, error)
 }
 
 // ModelAgentService provides access to the Juju agent version for the model.

--- a/domain/model/service/package_mock_test.go
+++ b/domain/model/service/package_mock_test.go
@@ -1375,6 +1375,45 @@ func (c *MockStateCreateCall) DoAndReturn(f func(context.Context, model.UUID, mo
 	return c
 }
 
+// DefaultCloudCredentialNameForOwner mocks base method.
+func (m *MockState) DefaultCloudCredentialNameForOwner(arg0 context.Context, arg1 user.Name, arg2 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DefaultCloudCredentialNameForOwner", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DefaultCloudCredentialNameForOwner indicates an expected call of DefaultCloudCredentialNameForOwner.
+func (mr *MockStateMockRecorder) DefaultCloudCredentialNameForOwner(arg0, arg1, arg2 any) *MockStateDefaultCloudCredentialNameForOwnerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultCloudCredentialNameForOwner", reflect.TypeOf((*MockState)(nil).DefaultCloudCredentialNameForOwner), arg0, arg1, arg2)
+	return &MockStateDefaultCloudCredentialNameForOwnerCall{Call: call}
+}
+
+// MockStateDefaultCloudCredentialNameForOwnerCall wrap *gomock.Call
+type MockStateDefaultCloudCredentialNameForOwnerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateDefaultCloudCredentialNameForOwnerCall) Return(arg0 string, arg1 error) *MockStateDefaultCloudCredentialNameForOwnerCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateDefaultCloudCredentialNameForOwnerCall) Do(f func(context.Context, user.Name, string) (string, error)) *MockStateDefaultCloudCredentialNameForOwnerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateDefaultCloudCredentialNameForOwnerCall) DoAndReturn(f func(context.Context, user.Name, string) (string, error)) *MockStateDefaultCloudCredentialNameForOwnerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Delete mocks base method.
 func (m *MockState) Delete(arg0 context.Context, arg1 model.UUID) error {
 	m.ctrl.T.Helper()

--- a/domain/model/service/state_test.go
+++ b/domain/model/service/state_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/core/version"
 	usererrors "github.com/juju/juju/domain/access/errors"
 	clouderrors "github.com/juju/juju/domain/cloud/errors"
+	credentialerrors "github.com/juju/juju/domain/credential/errors"
 	domainlife "github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
@@ -38,6 +39,7 @@ type dummyState struct {
 	users               map[user.UUID]user.Name
 	secretBackends      []string
 	controllerModelUUID coremodel.UUID
+	credentialName      string
 }
 
 func (d *dummyState) CheckModelExists(ctx context.Context, uuid coremodel.UUID) (bool, error) {
@@ -305,6 +307,13 @@ func (d *dummyState) UpdateCredential(
 	}
 
 	return nil
+}
+
+func (d *dummyState) DefaultCloudCredentialNameForOwner(ctx context.Context, owner user.Name, cloudName string) (string, error) {
+	if d.credentialName != "" {
+		return "", credentialerrors.NotFound
+	}
+	return d.credentialName, nil
 }
 
 func (d *dummyState) GetModelUsers(_ context.Context, _ coremodel.UUID) ([]coremodel.ModelUserInfo, error) {

--- a/domain/model/state/controller/types.go
+++ b/domain/model/state/controller/types.go
@@ -347,3 +347,8 @@ type dbModelCredentialInvalidStatus struct {
 type modelUUID struct {
 	UUID coremodel.UUID `db:"uuid"`
 }
+
+type ownerAndCloudName struct {
+	OwnerName string `db:"owner_name"`
+	CloudName string `db:"cloud_name"`
+}


### PR DESCRIPTION
In case user did not specify cloud credentials this code will use the first valid credential to create a model.

fix #20881


## QA steps

 1. Bootstrap a 4 controller
 2. create the following main.tf 
```terraform
terraform {
  required_providers {
    juju = {
      version = "0.23.1"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
 <fill in configuration>
}

resource "juju_model" "test" {
  name = "test"
}

```
3. run `terraform apply -auto-approve`
4. observe the model was created

