### PR TITLE
fix(provider/openstack): handle subnet availability zones

### DIFF
--- a/internal/provider/openstack/network_mock_test.go
+++ b/internal/provider/openstack/network_mock_test.go
@@ -1643,6 +1643,45 @@ func (c *MockNetworkingNovaGetServerCall) DoAndReturn(f func(string) (*nova.Serv
 	return c
 }
 
+// ListAvailabilityZones mocks base method.
+func (m *MockNetworkingNova) ListAvailabilityZones() ([]nova.AvailabilityZone, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAvailabilityZones")
+	ret0, _ := ret[0].([]nova.AvailabilityZone)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAvailabilityZones indicates an expected call of ListAvailabilityZones.
+func (mr *MockNetworkingNovaMockRecorder) ListAvailabilityZones() *MockNetworkingNovaListAvailabilityZonesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAvailabilityZones", reflect.TypeOf((*MockNetworkingNova)(nil).ListAvailabilityZones))
+	return &MockNetworkingNovaListAvailabilityZonesCall{Call: call}
+}
+
+// MockNetworkingNovaListAvailabilityZonesCall wrap *gomock.Call
+type MockNetworkingNovaListAvailabilityZonesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockNetworkingNovaListAvailabilityZonesCall) Return(arg0 []nova.AvailabilityZone, arg1 error) *MockNetworkingNovaListAvailabilityZonesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockNetworkingNovaListAvailabilityZonesCall) Do(f func() ([]nova.AvailabilityZone, error)) *MockNetworkingNovaListAvailabilityZonesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockNetworkingNovaListAvailabilityZonesCall) DoAndReturn(f func() ([]nova.AvailabilityZone, error)) *MockNetworkingNovaListAvailabilityZonesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockNetworkingEnvironConfig is a mock of NetworkingEnvironConfig interface.
 type MockNetworkingEnvironConfig struct {
 	ctrl     *gomock.Controller

--- a/internal/provider/openstack/networking_interfaces.go
+++ b/internal/provider/openstack/networking_interfaces.go
@@ -56,6 +56,7 @@ type NetworkingBase interface {
 // NetworkingNova describes the Nova methods needed for Networking.
 type NetworkingNova interface {
 	GetServer(string) (*nova.ServerDetail, error)
+	ListAvailabilityZones() ([]nova.AvailabilityZone, error)
 }
 
 // NetworkingNeutron describes the Neutron methods needed for Networking.


### PR DESCRIPTION
This patch fixes #20956, which occurs because in openstack, sometimes networks are not shipped with availability zones. This causes an issue on bootstrap since a machine is provisioned with an expected availability zone that should have been inserted in DQLITE before the provisioning. The IAASAgentFinalizer call machineService.SetMachineCloudInstance with bootstrapMachineHardwareCharacteristics which contains an availability zone. If this availability zone hasn't been populated, the bootstrap fails.

It happens when networks are not linked to the availability zone, because the openstack doesn't have any requirement one it. In this case, the openstack provider wasn't populating any AZ in database, which triggered the bug.

This patch ensures that a subnet will be inserted with at least an availability zone. It is done that way because there is no other codepath to insert AZs. So, if the associated network doesn't have any AZs, the subnet is linked with all AZs known by the project, which solve the issue.

- Added `TestSubnets_PopulatesAZsFromNetwork` and `TestSubnets_PopulatesAZsFromNovaFallback` in `internal/provider/openstack/networking_test.go` to verify subnet AZ assignments.
- Modified `makeSubnetInfo` in `internal/provider/openstack/networking.go` to accept `azNames` for AZ propagation.
- Updated `Subnets` in `internal/provider/openstack/networking.go` to gather available AZs from Nova and handle scenarios where subnets lack associated AZs.
- Enhanced mock in `internal/provider/openstack/network_mock_test.go` for `ListAvailabilityZones`.
- Extended `NetworkingNova` interface in `internal/provider/openstack/networking_interfaces.go` for AZ listing support.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

bootstrap on openstack. 

```sh
 juju bootstrap --bootstrap-constraints 'arch=amd64 root-disk=30G allocate-public-ip=false' --config caas-image-repo=ghcr.io/juju --config bootstrap-timeout=1800 ps6-dev os-test-4b8-2
```

THis should works

## Links
**Jira card:** [JUJU-8698](https://warthogs.atlassian.net/browse/JUJU-8698)


[JUJU-8698]: https://warthogs.atlassian.net/browse/JUJU-8698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ