### PR TITLE
fix: delete `application_controller` when deleting app

### DIFF
--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -346,6 +346,7 @@ func (st *State) deleteSimpleApplicationReferences(ctx context.Context, tx *sqla
 		"DELETE FROM application_config WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM application_config_hash WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM application_constraint WHERE application_uuid = $entityUUID.uuid",
+		"DELETE FROM application_controller WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM application_setting WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM application_exposed_endpoint_space WHERE application_uuid = $entityUUID.uuid",
 		"DELETE FROM application_exposed_endpoint_cidr WHERE application_uuid = $entityUUID.uuid",


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
Delete from `application_controller` before attempting to delete `application`, to avoid FK violation in its absence.

There wasn't anywhere else where deletes from this table happen and it doesn't reference anything else (https://github.com/juju/juju/blob/main/domain/schema/model/sql/0019-application.sql#L24)

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
BOOTSTRAP_PROVIDER=k8s B./main.sh deploy_caas test_deploy_charm
```
When it finishes, it'll destroy the controller. With this fix, that *won't* fill controller logs with repeated failures to delete because of a FK. The test still doesn't succeed, but that's a different bug.