### PR TITLE
feat: use the consumer application uuid

### DIFF
--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -208,7 +208,7 @@ func (s *Service) AddRemoteApplicationConsumer(ctx context.Context, args AddRemo
 
 	// The synthetic application name is prefixed with "remote-" to avoid
 	// name clashes with local applications.
-	synthApplicationName := "remote-" + strings.Replace(args.RemoteApplicationUUID, "-", "", -1)
+	synthApplicationName := "remote-" + strings.ReplaceAll(args.RemoteApplicationUUID, "-", "")
 	if !application.IsValidApplicationName(synthApplicationName) {
 		return applicationerrors.ApplicationNameNotValid
 	}
@@ -229,11 +229,6 @@ func (s *Service) AddRemoteApplicationConsumer(ctx context.Context, args AddRemo
 		return internalerrors.Capture(err)
 	}
 
-	remoteApplicationUUID, err := coreremoteapplication.NewUUID()
-	if err != nil {
-		return internalerrors.Errorf("creating remote application uuid: %w", err)
-	}
-
 	charmUUID, err := corecharm.NewID()
 	if err != nil {
 		return internalerrors.Errorf("creating charm uuid: %w", err)
@@ -241,11 +236,10 @@ func (s *Service) AddRemoteApplicationConsumer(ctx context.Context, args AddRemo
 
 	if err := s.modelState.AddRemoteApplicationConsumer(ctx, synthApplicationName, crossmodelrelation.AddRemoteApplicationConsumerArgs{
 		AddRemoteApplicationArgs: crossmodelrelation.AddRemoteApplicationArgs{
-			RemoteApplicationUUID: remoteApplicationUUID.String(),
+			RemoteApplicationUUID: args.RemoteApplicationUUID,
 			// NOTE: We use the same UUID as in the remote (consuming) model for
 			// the synthetic application we are creating in the offering model.
-			// We can do that because we know it's a valid UUID at this point.
-			ApplicationUUID:   remoteApplicationUUID.String(),
+			ApplicationUUID:   args.RemoteApplicationUUID,
 			CharmUUID:         charmUUID.String(),
 			Charm:             syntheticCharm,
 			OfferUUID:         args.OfferUUID.String(),


### PR DESCRIPTION
When creating the consumer synthetic application in the offerer side, we need to use the passed in application uuid. This ensures that we can find the application again just by the token. It will be the remote application and application uuid.

## QA steps

```sh
$ juju bootstrap lxd src
$ juju add-model source
$ juju deploy juju-qa-test
$ juju offer juju-qa-test:info
$ juju offers
```

```sh
$ juju bootstrap lxd dst
$ juju add-model dest
$ juju consume src:admin/source.juju-qa-test
```

```sh
$ juju deploy juju-qa-test test
$ juju integrate juju-qa-test test
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8490](https://warthogs.atlassian.net/browse/JUJU-8490)


[JUJU-8490]: https://warthogs.atlassian.net/browse/JUJU-8490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ