### PR TITLE
refactor: rename relation watchers

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -545,11 +545,11 @@ type RelationService interface {
 		applicationSettings, unitSettings map[string]string,
 	) error
 
-	// WatchUnitApplicationLifeSuspendedStatus returns a watcher that notifies
+	// WatchRelationUnitApplicationLifeSuspendedStatus returns a watcher that notifies
 	// of changes to the life or suspended status any relation the unit's
 	// application is part of. If the unit is a subordinate, its principal
 	// application is watched.
-	WatchUnitApplicationLifeSuspendedStatus(
+	WatchRelationUnitApplicationLifeSuspendedStatus(
 		ctx context.Context,
 		unitID coreunit.UUID,
 	) (watcher.StringsWatcher, error)

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -2072,41 +2072,41 @@ func (c *MockRelationServiceWatchRelatedUnitsCall) DoAndReturn(f func(context.Co
 	return c
 }
 
-// WatchUnitApplicationLifeSuspendedStatus mocks base method.
-func (m *MockRelationService) WatchUnitApplicationLifeSuspendedStatus(arg0 context.Context, arg1 unit.UUID) (watcher.Watcher[[]string], error) {
+// WatchRelationUnitApplicationLifeSuspendedStatus mocks base method.
+func (m *MockRelationService) WatchRelationUnitApplicationLifeSuspendedStatus(arg0 context.Context, arg1 unit.UUID) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchUnitApplicationLifeSuspendedStatus", arg0, arg1)
+	ret := m.ctrl.Call(m, "WatchRelationUnitApplicationLifeSuspendedStatus", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchUnitApplicationLifeSuspendedStatus indicates an expected call of WatchUnitApplicationLifeSuspendedStatus.
-func (mr *MockRelationServiceMockRecorder) WatchUnitApplicationLifeSuspendedStatus(arg0, arg1 any) *MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall {
+// WatchRelationUnitApplicationLifeSuspendedStatus indicates an expected call of WatchRelationUnitApplicationLifeSuspendedStatus.
+func (mr *MockRelationServiceMockRecorder) WatchRelationUnitApplicationLifeSuspendedStatus(arg0, arg1 any) *MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnitApplicationLifeSuspendedStatus", reflect.TypeOf((*MockRelationService)(nil).WatchUnitApplicationLifeSuspendedStatus), arg0, arg1)
-	return &MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRelationUnitApplicationLifeSuspendedStatus", reflect.TypeOf((*MockRelationService)(nil).WatchRelationUnitApplicationLifeSuspendedStatus), arg0, arg1)
+	return &MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall{Call: call}
 }
 
-// MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall wrap *gomock.Call
-type MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall struct {
+// MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall wrap *gomock.Call
+type MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall {
+func (c *MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall) Do(f func(context.Context, unit.UUID) (watcher.Watcher[[]string], error)) *MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall {
+func (c *MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall) Do(f func(context.Context, unit.UUID) (watcher.Watcher[[]string], error)) *MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, unit.UUID) (watcher.Watcher[[]string], error)) *MockRelationServiceWatchUnitApplicationLifeSuspendedStatusCall {
+func (c *MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, unit.UUID) (watcher.Watcher[[]string], error)) *MockRelationServiceWatchRelationUnitApplicationLifeSuspendedStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2391,7 +2391,7 @@ func (u *UniterAPI) watchOneUnitRelations(ctx context.Context, tag names.UnitTag
 		return nothing, err
 	}
 
-	watch, err := u.relationService.WatchUnitApplicationLifeSuspendedStatus(ctx, unitUUID)
+	watch, err := u.relationService.WatchRelationUnitApplicationLifeSuspendedStatus(ctx, unitUUID)
 	if err != nil {
 		updatedError := internalerrors.Errorf("WatchUnitRelations for %q: %w",
 			unitName, err)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2444,7 +2444,7 @@ func (s *uniterRelationSuite) TestWatchUnitRelations(c *tc.C) {
 	relationChanges <- change
 	watch := watchertest.NewMockStringsWatcher(relationChanges)
 	s.expectGetUnitUUID(s.wordpressUnitTag.Id(), unitUUID, nil)
-	s.expectWatchUnitApplicationLifeSuspendedStatus(unitUUID, watch, nil)
+	s.expectWatchRelationUnitApplicationLifeSuspendedStatus(unitUUID, watch, nil)
 	s.expectWatcherRegistry(watcherID, watch, nil)
 
 	// Act
@@ -2652,8 +2652,8 @@ func (s *uniterRelationSuite) expectEnterScope(uuid corerelation.UUID, name core
 	s.relationService.EXPECT().EnterScope(gomock.Any(), uuid, name, settings, gomock.Any()).Return(err)
 }
 
-func (s *uniterRelationSuite) expectWatchUnitApplicationLifeSuspendedStatus(unitUUID coreunit.UUID, watch watcher.StringsWatcher, err error) {
-	s.relationService.EXPECT().WatchUnitApplicationLifeSuspendedStatus(gomock.Any(), unitUUID).Return(watch, err)
+func (s *uniterRelationSuite) expectWatchRelationUnitApplicationLifeSuspendedStatus(unitUUID coreunit.UUID, watch watcher.StringsWatcher, err error) {
+	s.relationService.EXPECT().WatchRelationUnitApplicationLifeSuspendedStatus(gomock.Any(), unitUUID).Return(watch, err)
 }
 
 func (s *uniterRelationSuite) expectWatcherRegistry(watchID string, watch *watchertest.MockStringsWatcher, err error) {

--- a/domain/relation/service/watcher.go
+++ b/domain/relation/service/watcher.go
@@ -134,11 +134,11 @@ func NewWatchableService(
 	}
 }
 
-// WatchUnitApplicationLifeSuspendedStatus returns a watcher that notifies of
+// WatchRelationUnitApplicationLifeSuspendedStatus returns a watcher that notifies of
 // changes to the life or suspended status any relation the unit's application
 // is part of. If the unit is a subordinate, its principal application is
 // watched. The watcher notifies with the relation keys.
-func (s *WatchableService) WatchUnitApplicationLifeSuspendedStatus(
+func (s *WatchableService) WatchRelationUnitApplicationLifeSuspendedStatus(
 	ctx context.Context,
 	unitUUID unit.UUID,
 ) (watcher.StringsWatcher, error) {
@@ -170,10 +170,10 @@ func (s *WatchableService) WatchUnitApplicationLifeSuspendedStatus(
 	)
 }
 
-// WatchApplicationLifeSuspendedStatus returns a watcher that notifies of
-// changes to the life or suspended status for any relation the application
-// is part of. The watcher notifies with the relation UUIDs.
-func (s *WatchableService) WatchApplicationLifeSuspendedStatus(
+// WatchRelationsLifeSuspendedStatusForApplication returns a watcher that
+// notifies of changes to the life or suspended status for any relation the
+// application is part of. The watcher notifies with the relation UUIDs.
+func (s *WatchableService) WatchRelationsLifeSuspendedStatusForApplication(
 	ctx context.Context,
 	applicationUUID application.UUID,
 ) (watcher.StringsWatcher, error) {

--- a/domain/relation/service/watcher_test.go
+++ b/domain/relation/service/watcher_test.go
@@ -246,12 +246,12 @@ func (s *watcherSuite) TestChangeEventsForSubordinateLifeSuspendedStatusMapper(c
 	c.Check(relationsIgnored.Contains(unrelatedRelUUID.String()), tc.IsTrue)
 }
 
-func (s *watcherSuite) TestWatchApplicationLifeSuspendedStatusApplicationNotFound(c *tc.C) {
+func (s *watcherSuite) TestWatchRelationsLifeSuspendedStatusForApplicationApplicationNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.state.EXPECT().ApplicationExists(gomock.Any(), gomock.Any()).Return(applicationerrors.ApplicationNotFound)
 
-	_, err := s.service.WatchApplicationLifeSuspendedStatus(c.Context(), tc.Must(c, coreapplication.NewUUID))
+	_, err := s.service.WatchRelationsLifeSuspendedStatusForApplication(c.Context(), tc.Must(c, coreapplication.NewUUID))
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -70,7 +70,7 @@ func (s *watcherSuite) SetUpTest(c *tc.C) {
 	s.addApplicationEndpoint(c, s.appEndpointUUID, s.appUUID, s.charmRelationUUID)
 }
 
-func (s *watcherSuite) TestWatchUnitApplicationLifeSuspendedStatusPrincipal(c *tc.C) {
+func (s *watcherSuite) TestWatchRelationUnitApplicationLifeSuspendedStatusPrincipal(c *tc.C) {
 	// Arrange: create the required state, with one relation and its status.
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, s.ModelUUID())
 
@@ -79,7 +79,7 @@ func (s *watcherSuite) TestWatchUnitApplicationLifeSuspendedStatusPrincipal(c *t
 	s.addUnit(c, unitUUID, "my-application/0", s.appUUID, s.charmUUID)
 
 	svc := s.setupService(c, factory)
-	watcher, err := svc.WatchUnitApplicationLifeSuspendedStatus(c.Context(), unitUUID)
+	watcher, err := svc.WatchRelationUnitApplicationLifeSuspendedStatus(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	relationKey := relationtesting.GenNewKey(c, "two:fake-1 my-application:fake-0").String()
@@ -170,7 +170,7 @@ func (s *watcherSuite) TestWatchUnitApplicationLifeSuspendedStatusPrincipal(c *t
 	harness.Run(c, []string{relationKey})
 }
 
-func (s *watcherSuite) TestWatchUnitApplicationLifeSuspendedStatusSubordinate(c *tc.C) {
+func (s *watcherSuite) TestWatchRelationUnitApplicationLifeSuspendedStatusSubordinate(c *tc.C) {
 	// Arrange: create the required state, with one relation and its status.
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, s.ModelUUID())
 
@@ -184,7 +184,7 @@ func (s *watcherSuite) TestWatchUnitApplicationLifeSuspendedStatusSubordinate(c 
 	s.setUnitSubordinate(c, subordinateUnitUUID, principalUnitUUID)
 
 	svc := s.setupService(c, factory)
-	watcher, err := svc.WatchUnitApplicationLifeSuspendedStatus(c.Context(), subordinateUnitUUID)
+	watcher, err := svc.WatchRelationUnitApplicationLifeSuspendedStatus(c.Context(), subordinateUnitUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	relationKey := relationtesting.GenNewKey(c, "two:fake-1 my-application:fake-0").String()
@@ -283,7 +283,7 @@ func (s *watcherSuite) TestWatchUnitApplicationLifeSuspendedStatusSubordinate(c 
 	harness.Run(c, []string{relationKey})
 }
 
-func (s *watcherSuite) TestWatchApplicationLifeSuspendedStatus(c *tc.C) {
+func (s *watcherSuite) TestWatchRelationsLifeSuspendedStatusForApplication(c *tc.C) {
 	// Arrange: create the required state, with one relation and its status.
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, s.ModelUUID())
 
@@ -292,7 +292,7 @@ func (s *watcherSuite) TestWatchApplicationLifeSuspendedStatus(c *tc.C) {
 	s.addUnit(c, unitUUID, "my-application/0", s.appUUID, s.charmUUID)
 
 	svc := s.setupService(c, factory)
-	watcher, err := svc.WatchApplicationLifeSuspendedStatus(c.Context(), applicationUUID)
+	watcher, err := svc.WatchRelationsLifeSuspendedStatusForApplication(c.Context(), applicationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))

--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -251,7 +251,7 @@ func (w *localConsumerWorker) loop() (err error) {
 	ctx := w.catacomb.Context(context.Background())
 
 	// Watch for changes to any local relations to the remote application.
-	relationsWatcher, err := w.crossModelService.WatchApplicationLifeSuspendedStatus(ctx, w.applicationUUID)
+	relationsWatcher, err := w.crossModelService.WatchRelationsLifeSuspendedStatusForApplication(ctx, w.applicationUUID)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return nil
 	} else if err != nil {

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -137,7 +137,7 @@ func (s *localConsumerWorkerSuite) TestStart(c *tc.C) {
 	done := make(chan struct{})
 
 	s.crossModelService.EXPECT().
-		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
 		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			ch := make(chan []string)
 			return watchertest.NewMockStringsWatcher(ch), nil
@@ -179,7 +179,7 @@ func (s *localConsumerWorkerSuite) TestStartFailedWatchApplicationLife(c *tc.C) 
 	done := make(chan struct{})
 
 	s.crossModelService.EXPECT().
-		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
 		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			defer close(done)
 			return nil, applicationerrors.ApplicationNotFound
@@ -205,7 +205,7 @@ func (s *localConsumerWorkerSuite) TestStartNoRemoteClient(c *tc.C) {
 	done := make(chan struct{})
 
 	s.crossModelService.EXPECT().
-		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
 		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			ch := make(chan []string)
 			return watchertest.NewMockStringsWatcher(ch), nil
@@ -245,7 +245,7 @@ func (s *localConsumerWorkerSuite) TestStartWatchOfferStatusFailed(c *tc.C) {
 	done := make(chan struct{})
 
 	s.crossModelService.EXPECT().
-		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
 		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			ch := make(chan []string)
 			return watchertest.NewMockStringsWatcher(ch), nil
@@ -289,7 +289,7 @@ func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChanged(c *tc.C) {
 
 	ch := make(chan []string)
 	s.crossModelService.EXPECT().
-		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
 		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 
 			return watchertest.NewMockStringsWatcher(ch), nil
@@ -352,7 +352,7 @@ func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChangedNotFound(c *
 
 	ch := make(chan []string)
 	s.crossModelService.EXPECT().
-		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
 		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			return watchertest.NewMockStringsWatcher(ch), nil
 		})
@@ -430,7 +430,7 @@ func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChangedError(c *tc.
 
 	ch := make(chan []string)
 	s.crossModelService.EXPECT().
-		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
 		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			return watchertest.NewMockStringsWatcher(ch), nil
 		})
@@ -2583,7 +2583,7 @@ func (s *localConsumerWorkerSuite) expectWorkerStartup() <-chan struct{} {
 
 	ch := make(chan []string)
 	s.crossModelService.EXPECT().
-		WatchApplicationLifeSuspendedStatus(gomock.Any(), s.applicationUUID).
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
 		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
 			return watchertest.NewMockStringsWatcher(ch), nil
 		})

--- a/internal/worker/remoterelationconsumer/service_mock_test.go
+++ b/internal/worker/remoterelationconsumer/service_mock_test.go
@@ -1007,45 +1007,6 @@ func (c *MockCrossModelServiceSetRemoteRelationSuspendedStateCall) DoAndReturn(f
 	return c
 }
 
-// WatchApplicationLifeSuspendedStatus mocks base method.
-func (m *MockCrossModelService) WatchApplicationLifeSuspendedStatus(arg0 context.Context, arg1 application.UUID) (watcher0.StringsWatcher, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchApplicationLifeSuspendedStatus", arg0, arg1)
-	ret0, _ := ret[0].(watcher0.StringsWatcher)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchApplicationLifeSuspendedStatus indicates an expected call of WatchApplicationLifeSuspendedStatus.
-func (mr *MockCrossModelServiceMockRecorder) WatchApplicationLifeSuspendedStatus(arg0, arg1 any) *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationLifeSuspendedStatus", reflect.TypeOf((*MockCrossModelService)(nil).WatchApplicationLifeSuspendedStatus), arg0, arg1)
-	return &MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall{Call: call}
-}
-
-// MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall wrap *gomock.Call
-type MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall) Return(arg0 watcher0.StringsWatcher, arg1 error) *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall) Do(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockCrossModelServiceWatchApplicationLifeSuspendedStatusCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // WatchRelationUnits mocks base method.
 func (m *MockCrossModelService) WatchRelationUnits(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (watcher0.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
@@ -1081,6 +1042,45 @@ func (c *MockCrossModelServiceWatchRelationUnitsCall) Do(f func(context.Context,
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelServiceWatchRelationUnitsCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID) (watcher0.NotifyWatcher, error)) *MockCrossModelServiceWatchRelationUnitsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// WatchRelationsLifeSuspendedStatusForApplication mocks base method.
+func (m *MockCrossModelService) WatchRelationsLifeSuspendedStatusForApplication(arg0 context.Context, arg1 application.UUID) (watcher0.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchRelationsLifeSuspendedStatusForApplication", arg0, arg1)
+	ret0, _ := ret[0].(watcher0.StringsWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchRelationsLifeSuspendedStatusForApplication indicates an expected call of WatchRelationsLifeSuspendedStatusForApplication.
+func (mr *MockCrossModelServiceMockRecorder) WatchRelationsLifeSuspendedStatusForApplication(arg0, arg1 any) *MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRelationsLifeSuspendedStatusForApplication", reflect.TypeOf((*MockCrossModelService)(nil).WatchRelationsLifeSuspendedStatusForApplication), arg0, arg1)
+	return &MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall{Call: call}
+}
+
+// MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall wrap *gomock.Call
+type MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall) Return(arg0 watcher0.StringsWatcher, arg1 error) *MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall) Do(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockCrossModelServiceWatchRelationsLifeSuspendedStatusForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1340,45 +1340,6 @@ func (c *MockRelationServiceSetRemoteRelationSuspendedStateCall) DoAndReturn(f f
 	return c
 }
 
-// WatchApplicationLifeSuspendedStatus mocks base method.
-func (m *MockRelationService) WatchApplicationLifeSuspendedStatus(arg0 context.Context, arg1 application.UUID) (watcher0.StringsWatcher, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchApplicationLifeSuspendedStatus", arg0, arg1)
-	ret0, _ := ret[0].(watcher0.StringsWatcher)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchApplicationLifeSuspendedStatus indicates an expected call of WatchApplicationLifeSuspendedStatus.
-func (mr *MockRelationServiceMockRecorder) WatchApplicationLifeSuspendedStatus(arg0, arg1 any) *MockRelationServiceWatchApplicationLifeSuspendedStatusCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationLifeSuspendedStatus", reflect.TypeOf((*MockRelationService)(nil).WatchApplicationLifeSuspendedStatus), arg0, arg1)
-	return &MockRelationServiceWatchApplicationLifeSuspendedStatusCall{Call: call}
-}
-
-// MockRelationServiceWatchApplicationLifeSuspendedStatusCall wrap *gomock.Call
-type MockRelationServiceWatchApplicationLifeSuspendedStatusCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceWatchApplicationLifeSuspendedStatusCall) Return(arg0 watcher0.StringsWatcher, arg1 error) *MockRelationServiceWatchApplicationLifeSuspendedStatusCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceWatchApplicationLifeSuspendedStatusCall) Do(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockRelationServiceWatchApplicationLifeSuspendedStatusCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceWatchApplicationLifeSuspendedStatusCall) DoAndReturn(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockRelationServiceWatchApplicationLifeSuspendedStatusCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // WatchRelationUnits mocks base method.
 func (m *MockRelationService) WatchRelationUnits(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (watcher0.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
@@ -1414,6 +1375,45 @@ func (c *MockRelationServiceWatchRelationUnitsCall) Do(f func(context.Context, r
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockRelationServiceWatchRelationUnitsCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID) (watcher0.NotifyWatcher, error)) *MockRelationServiceWatchRelationUnitsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// WatchRelationsLifeSuspendedStatusForApplication mocks base method.
+func (m *MockRelationService) WatchRelationsLifeSuspendedStatusForApplication(arg0 context.Context, arg1 application.UUID) (watcher0.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchRelationsLifeSuspendedStatusForApplication", arg0, arg1)
+	ret0, _ := ret[0].(watcher0.StringsWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchRelationsLifeSuspendedStatusForApplication indicates an expected call of WatchRelationsLifeSuspendedStatusForApplication.
+func (mr *MockRelationServiceMockRecorder) WatchRelationsLifeSuspendedStatusForApplication(arg0, arg1 any) *MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRelationsLifeSuspendedStatusForApplication", reflect.TypeOf((*MockRelationService)(nil).WatchRelationsLifeSuspendedStatusForApplication), arg0, arg1)
+	return &MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall{Call: call}
+}
+
+// MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall wrap *gomock.Call
+type MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall) Return(arg0 watcher0.StringsWatcher, arg1 error) *MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall) Do(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (watcher0.StringsWatcher, error)) *MockRelationServiceWatchRelationsLifeSuspendedStatusForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/remoterelationconsumer/worker.go
+++ b/internal/worker/remoterelationconsumer/worker.go
@@ -92,10 +92,10 @@ type CrossModelService interface {
 // RelationService is an interface that defines the methods for
 // managing relations directly on the local model database.
 type RelationService interface {
-	// WatchApplicationLifeSuspendedStatus watches the changes to the
+	// WatchRelationsLifeSuspendedStatusForApplication watches the changes to the
 	// life suspended status of the specified application and notifies
 	// the worker of any changes.
-	WatchApplicationLifeSuspendedStatus(context.Context, application.UUID) (watcher.StringsWatcher, error)
+	WatchRelationsLifeSuspendedStatusForApplication(context.Context, application.UUID) (watcher.StringsWatcher, error)
 
 	// GetRelationDetails returns RelationDetails for the given relationID.
 	GetRelationDetails(context.Context, corerelation.UUID) (relation.RelationDetails, error)


### PR DESCRIPTION
The watchers names only told half the story, as in, you needed to know that you where dealing with a relation in the first place. We've long said that we're not doing the repository pattern, and that the name of the entity needs to be represented in the name i.e. using GetRelation instead of Get. Thus the watcher method name should include the word relation.

## QA steps

Simple regression test should suffice.

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy juju-qa-dummy-sink
$ juju deploy juju-qa-dummy-source
$ juju integration dummy-sink dummy-source
```
