### PR TITLE
fix: offer access for users when creating an offer

### DIFF
--- a/domain/removal/state/controller/offer_test.go
+++ b/domain/removal/state/controller/offer_test.go
@@ -40,7 +40,7 @@ func (s *offerSuite) TestDeleteOfferAccess(c *tc.C) {
 
 	var ownerUUID string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		return tx.QueryRowContext(ctx, "SELECT uuid FROM user").Scan(&ownerUUID)
+		return tx.QueryRowContext(ctx, `SELECT uuid FROM user WHERE name != 'everyone@external'`).Scan(&ownerUUID)
 	})
 	c.Assert(err, tc.ErrorIsNil)
 

--- a/domain/removal/state/controller/state_test.go
+++ b/domain/removal/state/controller/state_test.go
@@ -84,7 +84,7 @@ func (m *baseSuite) SetUpTest(c *tc.C) {
 		false,
 		everyoneExternalUUID,
 	)
-	c.Check(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorIsNil)
 
 	// We need to generate a cloud in the database so that we can set the model
 	// cloud.


### PR DESCRIPTION
You can't pick *any* user, it must not be the everyone@external user, otherwise it will be the same user that you're granting it to.
