### PR TITLE
feat: handle force cleanup

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -6,7 +6,6 @@ package crossmodelrelations
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
@@ -149,7 +148,8 @@ func (api *CrossModelRelationsAPIv3) publishOneRelationChange(ctx context.Contex
 	case change.Life != life.Alive:
 		// Relations only transition to dying and are removed, so we can safely
 		// just remove the relation and return early.
-		_, err := api.removalService.RemoveRemoteRelation(ctx, relationUUID, true, time.Minute)
+		forceCleanup := change.ForceCleanup != nil && *change.ForceCleanup
+		_, err := api.removalService.RemoveRemoteRelation(ctx, relationUUID, forceCleanup, 0)
 		if errors.Is(err, relationerrors.RelationNotFound) {
 			return nil
 		}

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -278,7 +278,7 @@ func (s *facadeSuite) TestPublishRelationChangesLifeDead(c *tc.C) {
 			Name: "foo",
 		}, nil)
 	s.removalService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID, true, time.Minute).
+		RemoveRemoteRelation(gomock.Any(), relationUUID, true, time.Duration(0)).
 		Return("", nil)
 
 	api := s.api(c)
@@ -289,6 +289,7 @@ func (s *facadeSuite) TestPublishRelationChangesLifeDead(c *tc.C) {
 			ApplicationOrOfferToken: applicationUUID.String(),
 			Macaroons:               s.macaroons,
 			BakeryVersion:           bakery.LatestVersion,
+			ForceCleanup:            ptr(true),
 		}},
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -1198,6 +1198,7 @@ func (s *localConsumerWorkerSuite) TestHandleRelationConsumptionRelationDying(c 
 			ApplicationOrOfferToken: s.applicationUUID.String(),
 			Macaroons:               macaroon.Slice{s.macaroon},
 			BakeryVersion:           bakery.LatestVersion,
+			ForceCleanup:            ptr(true),
 		}).
 		Return(nil)
 
@@ -1291,6 +1292,7 @@ func (s *localConsumerWorkerSuite) TestHandleRelationConsumptionRelationDyingDis
 			ApplicationOrOfferToken: s.applicationUUID.String(),
 			Macaroons:               macaroon.Slice{s.macaroon},
 			BakeryVersion:           bakery.LatestVersion,
+			ForceCleanup:            ptr(true),
 		}).
 		Return(params.Error{
 			Code:    params.CodeDischargeRequired,
@@ -1424,8 +1426,9 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChange(c *tc.C) {
 
 	// Force the offerer relation worker to be created, so that we can
 	// test the relation dead logic.
-	err := w.ensureOffererRelationWorker(c.Context(), relationUUID, w.applicationUUID, s.macaroon)
+	known, err := w.ensureOffererRelationWorker(c.Context(), relationUUID, w.applicationUUID, s.macaroon)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(known, tc.IsFalse)
 
 	select {
 	case <-s.offererRelationWorkerStarted:
@@ -1492,8 +1495,9 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeNonNilApplication
 
 	// Force the offerer relation worker to be created, so that we can
 	// test the relation dead logic.
-	err := w.ensureOffererRelationWorker(c.Context(), relationUUID, w.applicationUUID, s.macaroon)
+	known, err := w.ensureOffererRelationWorker(c.Context(), relationUUID, w.applicationUUID, s.macaroon)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(known, tc.IsFalse)
 
 	select {
 	case <-s.offererRelationWorkerStarted:
@@ -1557,8 +1561,9 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeNilUnitSettings(c
 
 	// Force the offerer relation worker to be created, so that we can
 	// test the relation dead logic.
-	err := w.ensureOffererRelationWorker(c.Context(), relationUUID, w.applicationUUID, s.macaroon)
+	known, err := w.ensureOffererRelationWorker(c.Context(), relationUUID, w.applicationUUID, s.macaroon)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(known, tc.IsFalse)
 
 	select {
 	case <-s.offererRelationWorkerStarted:


### PR DESCRIPTION
When consuming an offer for a relation, if we don't know the relation already *and* we're in the dying state, tell the offerer side to force remove everything.

This is required for publishing changes.

-----

This pull request updates the handling of remote relation cleanup in the cross-model relations subsystem. The main improvement is the addition of a `ForceCleanup` flag to ensure proper resource cleanup when a relation is dying, especially in cases where the worker restarts and the relation may have already been removed. The changes also refactor worker lifecycle management and update related tests to cover the new logic.

**Remote relation cleanup improvements:**

* Added a `ForceCleanup` flag to `RemoteRelationChangeEvent` that is set when the worker has restarted and the relation is already gone, ensuring that cleanup is properly forced in edge cases. [[1]](diffhunk://#diff-4dba9def5248b1f2b651d981f062a96422682d5cde12de03d2fa7bcd39439489L599-R612) [[2]](diffhunk://#diff-c53fd275d2d9244cdfc1a3b41debf173b3b75a5b9736910359d02bb260e8d04bL152-R152)

**Worker lifecycle management:**

* Refactored `ensureOffererRelationWorker` to return a boolean indicating whether the worker was already running, allowing downstream logic to determine if cleanup should be forced. [[1]](diffhunk://#diff-4dba9def5248b1f2b651d981f062a96422682d5cde12de03d2fa7bcd39439489R633-R641) [[2]](diffhunk://#diff-4dba9def5248b1f2b651d981f062a96422682d5cde12de03d2fa7bcd39439489L642-R658)
* Updated `handleRelationDying` to accept the `forceCleanup` parameter and pass it through to the change event. [[1]](diffhunk://#diff-4dba9def5248b1f2b651d981f062a96422682d5cde12de03d2fa7bcd39439489L582-R596) [[2]](diffhunk://#diff-4dba9def5248b1f2b651d981f062a96422682d5cde12de03d2fa7bcd39439489L599-R612)

**Test coverage updates:**

* Modified tests to set and validate the new `ForceCleanup` flag in scenarios where relations are dying and workers may have restarted. [[1]](diffhunk://#diff-d0c68056bcab2d5de14dc892b79b9460a2e56810e01b4420c711d94a302adec1R1201) [[2]](diffhunk://#diff-d0c68056bcab2d5de14dc892b79b9460a2e56810e01b4420c711d94a302adec1R1295) [[3]](diffhunk://#diff-5621f5f98742aea5cd15dd26860e6e38be2675a81313fc7c2dee9f0470032f9cR292)
* Updated worker lifecycle tests to check the new return value from `ensureOffererRelationWorker`. [[1]](diffhunk://#diff-d0c68056bcab2d5de14dc892b79b9460a2e56810e01b4420c711d94a302adec1L1427-R1431) [[2]](diffhunk://#diff-d0c68056bcab2d5de14dc892b79b9460a2e56810e01b4420c711d94a302adec1L1495-R1500) [[3]](diffhunk://#diff-d0c68056bcab2d5de14dc892b79b9460a2e56810e01b4420c711d94a302adec1L1560-R1566)
* Updated the expected parameters in removal service mocks to use the new `forceCleanup` logic and zero duration.

**Miscellaneous:**

* Removed unused `time` import from `crossmodelrelations.go`.
* Added a generic `ptr` helper function for pointer creation.

## QA steps

Unit tests pass.

## Links

**Jira card:** [JUJU-8490](https://warthogs.atlassian.net/browse/JUJU-8490)



[JUJU-8490]: https://warthogs.atlassian.net/browse/JUJU-8490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ