### PR TITLE
fix: `deploy_caas` integration test

### DIFF
--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -131,7 +131,7 @@ func (s *watcherSuite) TestWatchCharm(c *tc.C) {
 	harness.AddTest(c, func(c *tc.C) {
 		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)
-		err = removalSt.DeleteApplication(c.Context(), appID.String())
+		err = removalSt.DeleteApplication(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.Check(
@@ -1319,7 +1319,7 @@ WHERE uuid=?
 	harness.AddTest(c, func(c *tc.C) {
 		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)
-		err = removalSt.DeleteApplication(c.Context(), appID.String())
+		err = removalSt.DeleteApplication(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.Check(watchertest.SliceAssert([]string{appID.String()}))

--- a/domain/removal/service/application.go
+++ b/domain/removal/service/application.go
@@ -47,7 +47,7 @@ type ApplicationState interface {
 	GetApplicationLife(ctx context.Context, appUUID string) (life.Life, error)
 
 	// DeleteApplication removes a application from the database completely.
-	DeleteApplication(ctx context.Context, appUUID string) error
+	DeleteApplication(ctx context.Context, appUUID string, force bool) error
 }
 
 // RemoveApplication checks if a application with the input application UUID
@@ -179,7 +179,7 @@ func (s *Service) processApplicationRemovalJob(ctx context.Context, job removal.
 		return errors.Errorf("application %q is alive", job.EntityUUID).Add(removalerrors.EntityStillAlive)
 	}
 
-	if err := s.modelState.DeleteApplication(ctx, job.EntityUUID); errors.Is(err, applicationerrors.ApplicationNotFound) {
+	if err := s.modelState.DeleteApplication(ctx, job.EntityUUID, job.Force); errors.Is(err, applicationerrors.ApplicationNotFound) {
 		// The application has already been removed.
 		// Indicate success so that this job will be deleted.
 		return nil

--- a/domain/removal/service/application_test.go
+++ b/domain/removal/service/application_test.go
@@ -226,7 +226,7 @@ func (s *applicationSuite) TestExecuteJobForApplicationDyingDeleteApplication(c 
 
 	exp := s.modelState.EXPECT()
 	exp.GetApplicationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
-	exp.DeleteApplication(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteApplication(gomock.Any(), j.EntityUUID, false).Return(nil)
 	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
@@ -240,7 +240,7 @@ func (s *applicationSuite) TestExecuteJobForApplicationDyingDeleteApplicationErr
 
 	exp := s.modelState.EXPECT()
 	exp.GetApplicationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
-	exp.DeleteApplication(gomock.Any(), j.EntityUUID).Return(errors.Errorf("the front fell off"))
+	exp.DeleteApplication(gomock.Any(), j.EntityUUID, false).Return(errors.Errorf("the front fell off"))
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorMatches, ".*the front fell off")

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -376,17 +376,17 @@ func (c *MockModelDBStateApplicationScheduleRemovalCall) DoAndReturn(f func(cont
 }
 
 // DeleteApplication mocks base method.
-func (m *MockModelDBState) DeleteApplication(arg0 context.Context, arg1 string) error {
+func (m *MockModelDBState) DeleteApplication(arg0 context.Context, arg1 string, arg2 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteApplication", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeleteApplication", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteApplication indicates an expected call of DeleteApplication.
-func (mr *MockModelDBStateMockRecorder) DeleteApplication(arg0, arg1 any) *MockModelDBStateDeleteApplicationCall {
+func (mr *MockModelDBStateMockRecorder) DeleteApplication(arg0, arg1, arg2 any) *MockModelDBStateDeleteApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteApplication", reflect.TypeOf((*MockModelDBState)(nil).DeleteApplication), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteApplication", reflect.TypeOf((*MockModelDBState)(nil).DeleteApplication), arg0, arg1, arg2)
 	return &MockModelDBStateDeleteApplicationCall{Call: call}
 }
 
@@ -402,13 +402,13 @@ func (c *MockModelDBStateDeleteApplicationCall) Return(arg0 error) *MockModelDBS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateDeleteApplicationCall) Do(f func(context.Context, string) error) *MockModelDBStateDeleteApplicationCall {
+func (c *MockModelDBStateDeleteApplicationCall) Do(f func(context.Context, string, bool) error) *MockModelDBStateDeleteApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateDeleteApplicationCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateDeleteApplicationCall {
+func (c *MockModelDBStateDeleteApplicationCall) DoAndReturn(f func(context.Context, string, bool) error) *MockModelDBStateDeleteApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -431,7 +431,7 @@ func (s *applicationSuite) TestDeleteIAASApplication(c *tc.C) {
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err := st.DeleteApplication(c.Context(), appUUID.String())
+	err := st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// The application should be gone.
@@ -455,7 +455,7 @@ func (s *applicationSuite) TestDeleteIAASApplicationWithUnits(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	// This should fail because the application has units.
-	err := st.DeleteApplication(c.Context(), appUUID.String())
+	err := st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
 	c.Check(err, tc.ErrorIs, applicationerrors.ApplicationHasUnits)
 
@@ -464,7 +464,7 @@ func (s *applicationSuite) TestDeleteIAASApplicationWithUnits(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Now we can delete the application.
-	err = st.DeleteApplication(c.Context(), appUUID.String())
+	err = st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// The application should be gone.
@@ -494,7 +494,7 @@ func (s *applicationSuite) TestDeleteIAASApplicationWithRelations(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	// This should fail because the application has units.
-	err = st.DeleteApplication(c.Context(), appUUID.String())
+	err = st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
 	c.Check(err, tc.ErrorIs, applicationerrors.ApplicationHasRelations)
 
@@ -503,7 +503,7 @@ func (s *applicationSuite) TestDeleteIAASApplicationWithRelations(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Now we can delete the application.
-	err = st.DeleteApplication(c.Context(), appUUID.String())
+	err = st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// The application should be gone.
@@ -533,14 +533,14 @@ func (s *applicationSuite) TestDeleteIAASApplicationMultipleRemovesCharm(c *tc.C
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Now we can delete the application.
-	err = st.DeleteApplication(c.Context(), appUUID1.String())
+	err = st.DeleteApplication(c.Context(), appUUID1.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	s.checkCharmsCount(c, 1)
 
 	// Now we can delete the application and the charm should be removed as
 	// well.
-	err = st.DeleteApplication(c.Context(), appUUID2.String())
+	err = st.DeleteApplication(c.Context(), appUUID2.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	s.checkNoCharmsExist(c)
@@ -562,7 +562,7 @@ func (s *applicationSuite) TestDeleteCAASApplication(c *tc.C) {
 	err := st.DeleteUnit(c.Context(), unitUUIDs[0].String())
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.DeleteApplication(c.Context(), appUUID.String())
+	err = st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// The application should be gone.
@@ -581,7 +581,7 @@ func (s *applicationSuite) TestDeleteCAASApplicationWithUnit(c *tc.C) {
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err := st.DeleteApplication(c.Context(), appUUID.String())
+	err := st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorMatches, `.*still has 1 unit.*`)
 }
 
@@ -650,7 +650,7 @@ func (s *applicationSuite) TestDeleteApplicationNotWipingDeviceConstraints(c *tc
 
 	s.advanceApplicationLife(c, app1ID, life.Dead)
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err = st.DeleteApplication(c.Context(), app1ID.String())
+	err = st.DeleteApplication(c.Context(), app1ID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = st.GetApplicationLife(c.Context(), "app1")
@@ -685,7 +685,7 @@ func (s *applicationSuite) TestDeleteApplicationWithObjectstoreResource(c *tc.C)
 
 	// Act: Delete the application
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err = st.DeleteApplication(c.Context(), appUUID.String())
+	err = st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Assert: The application is deleted
@@ -730,7 +730,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)`, "1", charmUUID, "buzz", 1, 0, 0, time.Now())
 
 	// Act: Delete the application
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err = st.DeleteApplication(c.Context(), appUUID.String())
+	err = st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Assert: The application is deleted
@@ -776,7 +776,7 @@ func (s *applicationSuite) TestDeleteApplicationWithSharedObjectstoreResource(c 
 
 	// Act: Delete an application
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err = st.DeleteApplication(c.Context(), appUUID1.String())
+	err = st.DeleteApplication(c.Context(), appUUID1.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Assert: The application is deleted

--- a/domain/removal/state/model/model_test.go
+++ b/domain/removal/state/model/model_test.go
@@ -199,7 +199,7 @@ func (s *modelSuite) TestDeleteModel(c *tc.C) {
 	err = st.DeleteMachine(c.Context(), machineUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.DeleteApplication(c.Context(), appUUID.String())
+	err = st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = st.DeleteModelArtifacts(c.Context(), modelUUID)


### PR DESCRIPTION
When running the `deploy_caas` integration test, it currently doesn't terminate gracefully. On teardown, the controller gets stuck failing to delete the model due to failing to delete the application. It'll keep looping and filling the logs with FK violation errors.

This PR fixes two bugs causing this sympton:
- Delete from `application_controller` before attempting to delete application (replacing https://github.com/juju/juju/pull/20969)
- Delete from `secret_application_owner` if `force=true` (set in CI)

Note that secrets are still not being cleaned up gracefully on model destruction. The same FK constraint violation will happen when `force=false`. @manadart mentioned coming up with a plan to address this.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run this integration test:
```sh
BOOTSTRAP_PROVIDER=k8s B./main.sh deploy_caas test_deploy_charm
```

It'll terminate gracefully after a while.

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8613](https://warthogs.atlassian.net/browse/JUJU-8613)


[JUJU-8613]: https://warthogs.atlassian.net/browse/JUJU-8613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ