### PR TITLE
fix: use numerical test equality for copyright check

### DIFF
--- a/tests/suites/static_analysis/copyright.sh
+++ b/tests/suites/static_analysis/copyright.sh
@@ -1,7 +1,7 @@
 run_copyright() {
 	OUT=$(find . -name '*.go' | grep -v -E "(./vendor|./provider/azure/internal|./cloudconfig|./core/output/progress|./_deps|./generate/schemagen/jsonschema-gen)" | sort | xargs grep -L -E '// (Copyright|Code generated)' || true)
-	LINES=$(echo "${OUT}" | wc -w)
-	if [ "$LINES" != 0 ]; then
+	LINES=$(echo "${OUT}" | wc -w | tr -d '[:space:]')
+	if [ "$LINES" -ne 0 ]; then
 		echo ""
 		echo "$(red 'Found some issues:')"
 		echo -e '\nThe following files are missing copyright headers'


### PR DESCRIPTION
Our copyright check bash script would fail for some versions of wc. wc would insert padding before the count resulting in a tab character that would be string compared to 0.

This changes the wc command to trim white space and change the test check to be numerical based.
