### PR TITLE
fix: synthetic relations should have synthetic endpoints

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -382,6 +382,10 @@ func (api *CrossModelRelationsAPIv3) registerOneRemoteRelation(
 ) (*params.ConsumingRelationDetails, error) {
 	// Retrieve the application UUID for the provided offer UUID (also validates
 	// offer exists).
+	consumingAppUUID, err := coreapplication.ParseUUID(relation.ConsumerApplicationToken)
+	if err != nil {
+		return nil, err
+	}
 	offerUUID, err := offer.ParseUUID(relation.OfferUUID)
 	if err != nil {
 		return nil, err
@@ -410,7 +414,7 @@ func (api *CrossModelRelationsAPIv3) registerOneRemoteRelation(
 	// Insert the remote relation.
 	if err := api.crossModelRelationService.AddConsumedRelation(ctx,
 		crossmodelrelationservice.AddConsumedRelationArgs{
-			ConsumerApplicationUUID: relation.ConsumerApplicationToken,
+			ConsumerApplicationUUID: consumingAppUUID,
 			OfferUUID:               offerUUID,
 			RelationUUID:            relation.RelationToken,
 			ConsumerModelUUID:       sourceModelTag.Id(),
@@ -420,7 +424,8 @@ func (api *CrossModelRelationsAPIv3) registerOneRemoteRelation(
 				Role:      charm.RelationRole(relation.ConsumerApplicationEndpoint.Role),
 				Interface: relation.ConsumerApplicationEndpoint.Interface,
 			},
-			Username: username,
+			OfferingEndpointName: relation.OfferEndpointName,
+			Username:             username,
 		},
 	); err != nil {
 		return nil, errors.Annotate(err, "adding remote application consumer")

--- a/domain/crossmodelrelation/service/types.go
+++ b/domain/crossmodelrelation/service/types.go
@@ -6,6 +6,7 @@ package service
 import (
 	"gopkg.in/macaroon.v2"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/offer"
 	"github.com/juju/juju/domain/application/charm"
@@ -44,7 +45,7 @@ type AddConsumedRelationArgs struct {
 	// ConsumerApplicationUUID is the application UUID as as it exists in the
 	// remote (consuming) model. It contains the value from the RPC param
 	// ConsumerApplicationToken.
-	ConsumerApplicationUUID string
+	ConsumerApplicationUUID coreapplication.UUID
 
 	// ConsumerApplicationEndpoint endpoint consumed.
 	ConsumerApplicationEndpoint charm.Relation
@@ -60,10 +61,6 @@ type AddConsumedRelationArgs struct {
 	// ConsumerModelUUID is the UUID of the model that is consuming the
 	// application.
 	ConsumerModelUUID string
-
-	// OfferingApplicationUUID is the UUID of the application offering
-	// the endpoint
-	OfferingApplicationUUID string
 
 	// OfferingEndpointName is the name of the endpoint on the offering
 	// application to use in the relation.

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -252,6 +252,12 @@ type relation struct {
 	RelationID uint64 `db:"relation_id"`
 }
 
+type relationEndpoint struct {
+	UUID         string `db:"uuid"`
+	RelationUUID string `db:"relation_uuid"`
+	EndpointUUID string `db:"endpoint_uuid"`
+}
+
 type charmScope struct {
 	Name string `db:"name"`
 }

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -241,6 +241,14 @@ type AddRemoteApplicationConsumerArgs struct {
 	// to represent the remote application, on the consuming model.
 	SynthApplicationUUID string
 
+	// OfferingEndpointName is the name of the endpoint on the offering (i.e
+	// the local) application to use in the relation.
+	OfferingEndpointName string
+
+	// ConsumingEndpointName is the name of the endpoint on the consuming (i.e
+	// the remote synthetic) application to use in the relation.
+	ConsumingEndpointName string
+
 	// Username is the name of the user making the request.
 	Username string
 }

--- a/domain/crossmodelrelation/watcher_test.go
+++ b/domain/crossmodelrelation/watcher_test.go
@@ -128,7 +128,7 @@ func (s *watcherSuite) TestWatchRemoteApplicationConsumers(c *tc.C) {
 
 	harness.AddTest(c, func(c *tc.C) {
 		err := svc.AddConsumedRelation(c.Context(), service.AddConsumedRelationArgs{
-			ConsumerApplicationUUID: uuid.MustNewUUID().String(),
+			ConsumerApplicationUUID: tc.Must(c, application.NewUUID),
 			OfferUUID:               offerUUID,
 			RelationUUID:            relationUUID,
 			ConsumerModelUUID:       consumerModelUUID,
@@ -564,9 +564,9 @@ func (s *watcherSuite) TestWatchOffererRelationsCaching(c *tc.C) {
 	// Add an app remote consumer - this should create a relation and trigger
 	// the watcher.
 	var consumerRelationUUID1 string
-	var remoteApplicationUUID1 string
+	var remoteApplicationUUID1 application.UUID
 	harness.AddTest(c, func(c *tc.C) {
-		remoteApplicationUUID1 = tc.Must(c, uuid.NewUUID).String()
+		remoteApplicationUUID1 = tc.Must(c, application.NewUUID)
 		consumerModelUUID := tc.Must(c, uuid.NewUUID).String()
 		consumerRelationUUID1 = tc.Must(c, uuid.NewUUID).String()
 
@@ -592,7 +592,7 @@ func (s *watcherSuite) TestWatchOffererRelationsCaching(c *tc.C) {
 	// relation too.
 	var consumerRelationUUID2 string
 	harness.AddTest(c, func(c *tc.C) {
-		remoteApplicationUUID := tc.Must(c, uuid.NewUUID).String()
+		remoteApplicationUUID := tc.Must(c, application.NewUUID)
 		consumerModelUUID := tc.Must(c, uuid.NewUUID).String()
 		consumerRelationUUID2 = tc.Must(c, uuid.NewUUID).String()
 
@@ -671,7 +671,7 @@ func (s *watcherSuite) setupLocalOfferRemoteConsumerAndRelation(c *tc.C, db data
 	s.createLocalOfferForConsumer(c, db, localOfferUUID)
 
 	// Add a remote consumer for the local offer.
-	remoteApplicationUUID := tc.Must(c, uuid.NewUUID).String()
+	remoteApplicationUUID := tc.Must(c, application.NewUUID)
 	consumerModelUUID := tc.Must(c, uuid.NewUUID).String()
 	consumerRelationUUID := tc.Must(c, uuid.NewUUID)
 

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -439,6 +439,8 @@ func (s *baseSuite) createRemoteApplicationConsumer(
 		Charm:                   ch,
 		OfferUUID:               offerUUID.String(),
 		RelationUUID:            relationUUID.String(),
+		OfferingEndpointName:    "bar",
+		ConsumingEndpointName:   "foo",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 


### PR DESCRIPTION
When we fill in a synthetic relation, we should also fill in the synthetic relation's endpoints. Otherwise, the relation is not usable.

This caused bugs in the firewaller (as reported by @nvinuesa) and caused `juju status` to break completely (however, this still needs a fix to exclude the synth relation)

Add these endpoints to the synthetic relation

## QA steps

```
$ juju add-model offerer 
$ juju deploy juju-qa-dummy-source 
$ juju offer dummy-source:sink 
$ juju add-model consumer 
$ juju deploy juju-qa-dummy-sink 
$ juju consume admin/offerer.dummy-source
$ juju relate dummy-source dummy-sink 
```
Check the db for the offering model:
```
repl (controller)> .switch model-offerer

repl (model-offerer)> SELECT * FROM relation
uuid					life_id	relation_id	suspended	suspended_reason	scope_id	
6c2ef3ae-6986-4349-8a2d-e2fb6f8afd78	0	0		false		<nil>			0		

repl (model-offerer)> SELECT * FROM relation_endpoint
uuid					relation_uuid				endpoint_uuid				
a22acfa8-5bdc-4f1b-8d04-ec3c9e877eb1	6c2ef3ae-6986-4349-8a2d-e2fb6f8afd78	e6260c53-ed61-44ee-8c0f-3869182d7d11	
803b402f-9947-46ca-8271-a46762b685aa	6c2ef3ae-6986-4349-8a2d-e2fb6f8afd78	2a2ad8da-c8e1-4d75-8566-f50ba61a3ba8	
```
Check `juju status`
```
$ juju status -m offerer --relations
Model    Controller  Cloud/Region   Version      Timestamp
offerer  lxd         lxd/localhost  4.0-beta8.1  13:06:52Z

App           Version  Status       Scale  Charm                 Channel        Rev  Exposed  Message
dummy-source           maintenance      1  juju-qa-dummy-source  latest/stable    6  no       Started

Unit             Workload     Agent  Machine  Public address  Ports  Message
dummy-source/0*  maintenance  idle   0        10.51.45.161           Started

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.161  juju-64d27d-0  ubuntu@20.04  jack  Running

Offer         Application   Charm         Rev  Connected  Endpoint  Interface    Role
dummy-source  dummy-source  dummy-source  6    0/1        sink      dummy-token  requirer

Integration provider                                Requirer           Interface    Type     Message
remote-52f8fbc5f0ff486a88d424a2c095a902:dummy-sink  dummy-source:sink  dummy-token  regular    
```
NOTE: the inclusion if the synth relation here is a bug. However, previously this call would simply error out so this is a significant improvement