### PR TITLE
fix: temp fix for 2.9 lxd and cloud init issues on series less than n…

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # TODO: add microk8s tests
         cloud: ["lxd"]
-        channel: ["2.9/stable", "3.1/stable"] # "" 2.9 deploy of application on LXD is currently broken due to a snapd issue.
+        channel: ["3.1/stable"] # "2.9/stable" deploy of application on LXD is currently broken due to a snapd issue. 
         client: ['source', 'target']
 
     steps:


### PR DESCRIPTION
CI is currently broken for 2.9 migrates due to an issue with cloud init and lxd (see https://chat.canonical.com/canonical/pl/fjz6zzspbfb8tdje5a1scn4mtw)