### PR TITLE
refactor: machine service hardware characteristics and availability zone

### DIFF
--- a/apiserver/common/model/machine.go
+++ b/apiserver/common/model/machine.go
@@ -86,7 +86,7 @@ func ModelMachineInfo(ctx context.Context, machineService MachineService, status
 		} else if err != nil && !errors.Is(err, machineerrors.NotProvisioned) {
 			return nil, errors.Trace(err)
 		}
-		if hw != nil && hw.String() != "" {
+		if hw.String() != "" {
 			hwParams := &params.MachineHardware{
 				Cores:            hw.CpuCores,
 				Arch:             hw.Arch,

--- a/apiserver/common/model/machine_test.go
+++ b/apiserver/common/model/machine_test.go
@@ -79,7 +79,7 @@ func (s *machineSuite) TestMachineHardwareInfo(c *tc.C) {
 	one := uint64(1)
 	amd64 := "amd64"
 	gig := uint64(1024)
-	hw := &instance.HardwareCharacteristics{
+	hw := instance.HardwareCharacteristics{
 		Arch:     &amd64,
 		Mem:      &gig,
 		CpuCores: &one,

--- a/apiserver/common/model/modelmanagerinterface.go
+++ b/apiserver/common/model/modelmanagerinterface.go
@@ -32,7 +32,7 @@ type MachineService interface {
 
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	GetHardwareCharacteristics(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)
 
 	// GetSupportedContainersTypes returns the supported container types for the
 	// provider.

--- a/apiserver/common/model/service_mock_test.go
+++ b/apiserver/common/model/service_mock_test.go
@@ -88,10 +88,10 @@ func (c *MockMachineServiceAllMachineNamesCall) DoAndReturn(f func(context.Conte
 }
 
 // GetHardwareCharacteristics mocks base method.
-func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret0, _ := ret[0].(instance.HardwareCharacteristics)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -109,19 +109,19 @@ type MockMachineServiceGetHardwareCharacteristicsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -541,20 +541,21 @@ func (api *ProvisionerAPI) AvailabilityZone(ctx context.Context, args params.Ent
 			result.Results[i].Error = apiservererrors.ServerError(fmt.Errorf("%w: %w", err, errors.NotFound))
 			continue
 		}
-		hc, err := api.machineService.GetHardwareCharacteristics(ctx, machineUUID)
-		if errors.Is(err, machineerrors.NotProvisioned) {
+
+		az, err := api.machineService.AvailabilityZone(ctx, machineUUID)
+		switch {
+		case errors.Is(err, machineerrors.AvailabilityZoneNotFound):
+			result.Results[i].Result = ""
+			continue
+		case errors.Is(err, machineerrors.MachineNotFound):
 			result.Results[i].Error = apiservererrors.ServerError(errors.NotFound)
 			continue
-		}
-		if err != nil {
+		case err != nil:
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		if hc.AvailabilityZone != nil {
-			result.Results[i].Result = *hc.AvailabilityZone
-		} else {
-			result.Results[i].Result = ""
-		}
+
+		result.Results[i].Result = az
 	}
 	return result, nil
 }

--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -107,9 +107,14 @@ type MachineService interface {
 	// list of profiles for the given machine without any checks.
 	SetAppliedLXDProfileNames(ctx context.Context, mUUID coremachine.UUID, profileNames []string) error
 
-	// GetHardwareCharacteristics returns the hardware characteristics of the
-	// specified machine.
-	GetHardwareCharacteristics(ctx context.Context, machineUUID coremachine.UUID) (*instance.HardwareCharacteristics, error)
+	// AvailabilityZone returns the availability zone for the specified machine.
+	//
+	// The following errors may be returned:
+	// - [github.com/juju/juju/domain/machine/errors.MachineNotFound] if the machine
+	// does not exist in the model.
+	// - [github.com/juju/juju/domain/machine/errors.AvailabilityZoneNotFound] when
+	// no availability zone has been set for the machine.
+	AvailabilityZone(ctx context.Context, machineUUID coremachine.UUID) (string, error)
 
 	// GetInstanceID returns the cloud specific instance id for this machine.
 	GetInstanceID(ctx context.Context, mUUID coremachine.UUID) (instance.Id, error)

--- a/apiserver/facades/agent/provisioner/service_mock_test.go
+++ b/apiserver/facades/agent/provisioner/service_mock_test.go
@@ -618,6 +618,45 @@ func (c *MockMachineServiceAllMachineNamesCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
+// AvailabilityZone mocks base method.
+func (m *MockMachineService) AvailabilityZone(arg0 context.Context, arg1 machine.UUID) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilityZone", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AvailabilityZone indicates an expected call of AvailabilityZone.
+func (mr *MockMachineServiceMockRecorder) AvailabilityZone(arg0, arg1 any) *MockMachineServiceAvailabilityZoneCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineService)(nil).AvailabilityZone), arg0, arg1)
+	return &MockMachineServiceAvailabilityZoneCall{Call: call}
+}
+
+// MockMachineServiceAvailabilityZoneCall wrap *gomock.Call
+type MockMachineServiceAvailabilityZoneCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceAvailabilityZoneCall) Return(arg0 string, arg1 error) *MockMachineServiceAvailabilityZoneCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceAvailabilityZoneCall) Do(f func(context.Context, machine.UUID) (string, error)) *MockMachineServiceAvailabilityZoneCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceAvailabilityZoneCall) DoAndReturn(f func(context.Context, machine.UUID) (string, error)) *MockMachineServiceAvailabilityZoneCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetBootstrapEnviron mocks base method.
 func (m *MockMachineService) GetBootstrapEnviron(arg0 context.Context) (environs.BootstrapEnviron, error) {
 	m.ctrl.T.Helper()
@@ -653,45 +692,6 @@ func (c *MockMachineServiceGetBootstrapEnvironCall) Do(f func(context.Context) (
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceGetBootstrapEnvironCall) DoAndReturn(f func(context.Context) (environs.BootstrapEnviron, error)) *MockMachineServiceGetBootstrapEnvironCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetHardwareCharacteristics mocks base method.
-func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHardwareCharacteristics indicates an expected call of GetHardwareCharacteristics.
-func (mr *MockMachineServiceMockRecorder) GetHardwareCharacteristics(arg0, arg1 any) *MockMachineServiceGetHardwareCharacteristicsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHardwareCharacteristics", reflect.TypeOf((*MockMachineService)(nil).GetHardwareCharacteristics), arg0, arg1)
-	return &MockMachineServiceGetHardwareCharacteristicsCall{Call: call}
-}
-
-// MockMachineServiceGetHardwareCharacteristicsCall wrap *gomock.Call
-type MockMachineServiceGetHardwareCharacteristicsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/storageprovisioner/register.go
+++ b/apiserver/facades/agent/storageprovisioner/register.go
@@ -37,7 +37,6 @@ func Register(registry facade.FacadeRegistry) {
 // newFacadeV4 provides the signature required for facade registration.
 func newFacadeV4(stdCtx context.Context, ctx facade.ModelContext) (*StorageProvisionerAPIv4, error) {
 	domainServices := ctx.DomainServices()
-	storageService := domainServices.Storage()
 
 	return NewStorageProvisionerAPIv4(
 		stdCtx,
@@ -48,7 +47,6 @@ func newFacadeV4(stdCtx context.Context, ctx facade.ModelContext) (*StorageProvi
 		domainServices.Application(),
 		domainServices.Removal(),
 		ctx.Auth(),
-		storageService,
 		domainServices.Status(),
 		domainServices.StorageProvisioning(),
 		ctx.Logger().Child("storageprovisioner"),

--- a/apiserver/facades/agent/storageprovisioner/service.go
+++ b/apiserver/facades/agent/storageprovisioner/service.go
@@ -39,17 +39,13 @@ type ModelConfigService interface {
 type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	GetMachineUUID(ctx context.Context, machineName machine.Name) (machine.UUID, error)
+
 	// GetInstanceID returns the cloud specific instance id for this machine.
 	GetInstanceID(ctx context.Context, machineUUID machine.UUID) (instance.Id, error)
-	// GetInstanceIDAndName returns the cloud specific instance ID and display
-	// name for this machine.
-	GetInstanceIDAndName(ctx context.Context, machineUUID machine.UUID) (instance.Id, string, error)
-	// GetHardwareCharacteristics returns the hardware characteristics of the
-	// specified machine.
-	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
-	// GetMachineLife returns the lifecycle state of the machine with the
-	// specified UUID.
-	GetMachineLife(ctx context.Context, machineName machine.Name) (life.Value, error)
+
+	// GetMachineLife returns the lifecycle of the machine.
+	GetMachineLife(ctx context.Context, name machine.Name) (life.Value, error)
+
 	// WatchMachineCloudInstances returns a NotifyWatcher that is subscribed to
 	// the changes in the machine_cloud_instance table in the model, for the given
 	// machine UUID.

--- a/apiserver/facades/agent/storageprovisioner/service_mock_test.go
+++ b/apiserver/facades/agent/storageprovisioner/service_mock_test.go
@@ -188,45 +188,6 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 	return m.recorder
 }
 
-// GetHardwareCharacteristics mocks base method.
-func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHardwareCharacteristics indicates an expected call of GetHardwareCharacteristics.
-func (mr *MockMachineServiceMockRecorder) GetHardwareCharacteristics(arg0, arg1 any) *MockMachineServiceGetHardwareCharacteristicsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHardwareCharacteristics", reflect.TypeOf((*MockMachineService)(nil).GetHardwareCharacteristics), arg0, arg1)
-	return &MockMachineServiceGetHardwareCharacteristicsCall{Call: call}
-}
-
-// MockMachineServiceGetHardwareCharacteristicsCall wrap *gomock.Call
-type MockMachineServiceGetHardwareCharacteristicsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetInstanceID mocks base method.
 func (m *MockMachineService) GetInstanceID(arg0 context.Context, arg1 machine.UUID) (instance.Id, error) {
 	m.ctrl.T.Helper()
@@ -262,46 +223,6 @@ func (c *MockMachineServiceGetInstanceIDCall) Do(f func(context.Context, machine
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceGetInstanceIDCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, error)) *MockMachineServiceGetInstanceIDCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetInstanceIDAndName mocks base method.
-func (m *MockMachineService) GetInstanceIDAndName(arg0 context.Context, arg1 machine.UUID) (instance.Id, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInstanceIDAndName", arg0, arg1)
-	ret0, _ := ret[0].(instance.Id)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetInstanceIDAndName indicates an expected call of GetInstanceIDAndName.
-func (mr *MockMachineServiceMockRecorder) GetInstanceIDAndName(arg0, arg1 any) *MockMachineServiceGetInstanceIDAndNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceIDAndName", reflect.TypeOf((*MockMachineService)(nil).GetInstanceIDAndName), arg0, arg1)
-	return &MockMachineServiceGetInstanceIDAndNameCall{Call: call}
-}
-
-// MockMachineServiceGetInstanceIDAndNameCall wrap *gomock.Call
-type MockMachineServiceGetInstanceIDAndNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetInstanceIDAndNameCall) Return(arg0 instance.Id, arg1 string, arg2 error) *MockMachineServiceGetInstanceIDAndNameCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetInstanceIDAndNameCall) Do(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceGetInstanceIDAndNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetInstanceIDAndNameCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.Id, string, error)) *MockMachineServiceGetInstanceIDAndNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -44,7 +44,6 @@ type StorageProvisionerAPIv4 struct {
 
 	blockDeviceService         BlockDeviceService
 	authorizer                 facade.Authorizer
-	storagePoolGetter          StoragePoolGetter
 	storageStatusService       StorageStatusService
 	storageProvisioningService StorageProvisioningService
 	machineService             MachineService
@@ -73,7 +72,6 @@ func NewStorageProvisionerAPIv4(
 	applicationService ApplicationService,
 	removalService RemovalService,
 	authorizer facade.Authorizer,
-	storagePoolGetter StoragePoolGetter,
 	storageStatusService StorageStatusService,
 	storageProvisioningService StorageProvisioningService,
 	logger logger.Logger,
@@ -194,7 +192,6 @@ func NewStorageProvisionerAPIv4(
 		watcherRegistry: watcherRegistry,
 
 		authorizer:                 authorizer,
-		storagePoolGetter:          storagePoolGetter,
 		storageStatusService:       storageStatusService,
 		storageProvisioningService: storageProvisioningService,
 		machineService:             machineService,

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -89,7 +89,6 @@ func (s *provisionerSuite) setupAPI(c *tc.C) *gomock.Controller {
 		s.applicationService,
 		s.removalService,
 		s.authorizer,
-		nil, // storageService
 		nil, // statusService
 		s.storageProvisioningService,
 		loggertesting.WrapCheckLog(c),

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -155,7 +155,7 @@ type MachineService interface {
 
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (instance.HardwareCharacteristics, error)
 
 	// GetMachineBase returns the base for the given machine.
 	GetMachineBase(ctx context.Context, mName machine.Name) (base.Base, error)

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -393,10 +393,10 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // GetHardwareCharacteristics mocks base method.
-func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret0, _ := ret[0].(instance.HardwareCharacteristics)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -414,19 +414,19 @@ type MockMachineServiceGetHardwareCharacteristicsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/controller/service.go
+++ b/apiserver/facades/client/controller/service.go
@@ -169,7 +169,7 @@ type MachineService interface {
 
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (instance.HardwareCharacteristics, error)
 
 	// GetSupportedContainersTypes returns the supported container types for the
 	// provider.

--- a/apiserver/facades/client/machinemanager/instanceconfig_test.go
+++ b/apiserver/facades/client/machinemanager/instanceconfig_test.go
@@ -91,7 +91,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *tc.C) {
 	hc := instance.MustParseHardware("mem=4G arch=amd64")
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), coremachine.Name("0")).Return("deadbeef", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(&hc, nil)
+	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(hc, nil)
 	s.agentPasswordService.EXPECT().SetMachinePassword(gomock.Any(), coremachine.Name("0"), gomock.Any()).Return(nil)
 
 	metadata := []agentbinary.Metadata{{

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -175,7 +175,7 @@ func TestDestroyMachineManagerSuite(t *testing.T) {
 
 func (s *DestroyMachineManagerSuite) TestStub(c *tc.C) {
 	c.Skip(`This suite is missing the following tests:
-- TestForceDestroyMachineFailedSomeStorageRetrievalManyMachines 
+- TestForceDestroyMachineFailedSomeStorageRetrievalManyMachines
 - TestDestroyMachineFailedAllStorageRetrieval
 - TestDestroyMachineFailedSomeUnitStorageRetrieval
 - TestDestroyMachineFailedSomeStorageRetrievalManyMachines
@@ -511,7 +511,7 @@ func (s *ProvisioningMachineManagerSuite) setupMocks(c *tc.C) *gomock.Controller
 
 func (s *ProvisioningMachineManagerSuite) expectProvisioningMachine(arch *string) {
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), coremachine.Name("0")).Return("deadbeef", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(&instance.HardwareCharacteristics{Arch: arch}, nil)
+	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(instance.HardwareCharacteristics{Arch: arch}, nil)
 	s.machineService.EXPECT().GetMachineBase(gomock.Any(), coremachine.Name("0")).Return(corebase.MustParseBaseFromString("ubuntu@20.04/stable"), nil)
 	if arch != nil {
 		s.agentPasswordService.EXPECT().SetMachinePassword(gomock.Any(), coremachine.Name("0"), gomock.Any()).Return(nil).AnyTimes()
@@ -580,7 +580,7 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScriptNoArch(c *tc.C) 
 	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil)
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), coremachine.Name("0")).Return("deadbeef", nil)
-	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(&instance.HardwareCharacteristics{}, nil)
+	s.machineService.EXPECT().GetHardwareCharacteristics(gomock.Any(), coremachine.UUID("deadbeef")).Return(instance.HardwareCharacteristics{}, nil)
 
 	_, err = s.api.ProvisioningScript(c.Context(), params.ProvisioningScriptParams{
 		MachineId: "0",

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -397,10 +397,10 @@ func (c *MockMachineServiceAllMachineNamesCall) DoAndReturn(f func(context.Conte
 }
 
 // GetHardwareCharacteristics mocks base method.
-func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret0, _ := ret[0].(instance.HardwareCharacteristics)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -418,19 +418,19 @@ type MockMachineServiceGetHardwareCharacteristicsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/services.go
+++ b/apiserver/facades/client/machinemanager/services.go
@@ -113,7 +113,7 @@ type MachineService interface {
 
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	GetHardwareCharacteristics(context.Context, coremachine.UUID) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(context.Context, coremachine.UUID) (instance.HardwareCharacteristics, error)
 
 	// GetMachineContainers returns the names of the machines which have as parent
 	// the specified machine.

--- a/apiserver/facades/client/modelmanager/service_mock_test.go
+++ b/apiserver/facades/client/modelmanager/service_mock_test.go
@@ -1870,10 +1870,10 @@ func (c *MockMachineServiceAllMachineNamesCall) DoAndReturn(f func(context.Conte
 }
 
 // GetHardwareCharacteristics mocks base method.
-func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret0, _ := ret[0].(instance.HardwareCharacteristics)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1891,19 +1891,19 @@ type MockMachineServiceGetHardwareCharacteristicsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -243,7 +243,7 @@ type MachineService interface {
 
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	GetHardwareCharacteristics(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)
 
 	// GetSupportedContainersTypes returns the supported container types for the
 	// provider.

--- a/apiserver/facades/controller/firewaller/interface.go
+++ b/apiserver/facades/controller/firewaller/interface.go
@@ -48,7 +48,7 @@ type MachineService interface {
 
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(ctx context.Context, machineUUID machine.UUID) (instance.HardwareCharacteristics, error)
 
 	// GetSupportedContainersTypes returns the supported container types for the
 	// provider.

--- a/apiserver/facades/controller/firewaller/service_mock_test.go
+++ b/apiserver/facades/controller/firewaller/service_mock_test.go
@@ -532,10 +532,10 @@ func (c *MockMachineServiceAllMachineNamesCall) DoAndReturn(f func(context.Conte
 }
 
 // GetHardwareCharacteristics mocks base method.
-func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
+func (m *MockMachineService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret0, _ := ret[0].(instance.HardwareCharacteristics)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -553,19 +553,19 @@ type MockMachineServiceGetHardwareCharacteristicsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Return(arg0 instance.HardwareCharacteristics, arg1 error) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
+func (c *MockMachineServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockMachineServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/modelmigration/export.go
+++ b/domain/machine/modelmigration/export.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/machine"
-	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/domain/machine/state"
 	"github.com/juju/juju/internal/errors"
@@ -40,7 +39,7 @@ type ExportService interface {
 	GetInstanceID(ctx context.Context, machineUUID coremachine.UUID) (instance.Id, error)
 	// GetHardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
-	GetHardwareCharacteristics(ctx context.Context, machineUUID coremachine.UUID) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(ctx context.Context, machineUUID coremachine.UUID) (instance.HardwareCharacteristics, error)
 }
 
 // exportOperation describes a way to execute a migration for
@@ -123,9 +122,6 @@ func (e *exportOperation) exportMachine(ctx context.Context, m machine.ExportMac
 		InstanceId: m.InstanceID,
 	}
 	hardwareCharacteristics, err := e.service.GetHardwareCharacteristics(ctx, m.UUID)
-	if errors.Is(err, machineerrors.NotProvisioned) {
-		return nil
-	}
 	if err != nil {
 		return errors.Errorf("retrieving hardware characteristics for machine %q: %w", m.Name, err)
 	}

--- a/domain/machine/modelmigration/export_test.go
+++ b/domain/machine/modelmigration/export_test.go
@@ -65,7 +65,7 @@ func (s *exportSuite) TestFailGetHardwareCharacteristicsForExport(c *tc.C) {
 		},
 	}, nil)
 	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), machineUUIDs[0]).
-		Return(nil, errors.New("boom"))
+		Return(instance.HardwareCharacteristics{}, errors.New("boom"))
 
 	op := s.newExportOperation(c)
 	err := op.Execute(c.Context(), dst)
@@ -104,7 +104,7 @@ func (s *exportSuite) TestExport(c *tc.C) {
 		VirtType:         ptr("vm"),
 	}
 	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), machineUUID).
-		Return(&hc, nil)
+		Return(hc, nil)
 
 	op := s.newExportOperation(c)
 	err := op.Execute(c.Context(), dst)
@@ -177,9 +177,9 @@ func (s *exportSuite) TestExportContainer(c *tc.C) {
 		VirtType:         ptr("vm"),
 	}
 	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), machineUUID).
-		Return(&hc, nil)
+		Return(hc, nil)
 	s.service.EXPECT().GetHardwareCharacteristics(gomock.Any(), containerUUID).
-		Return(&hc, nil)
+		Return(hc, nil)
 
 	op := s.newExportOperation(c)
 	err := op.Execute(c.Context(), dst)

--- a/domain/machine/modelmigration/migrations_mock_test.go
+++ b/domain/machine/modelmigration/migrations_mock_test.go
@@ -203,10 +203,10 @@ func (m *MockExportService) EXPECT() *MockExportServiceMockRecorder {
 }
 
 // GetHardwareCharacteristics mocks base method.
-func (m *MockExportService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (*instance.HardwareCharacteristics, error) {
+func (m *MockExportService) GetHardwareCharacteristics(arg0 context.Context, arg1 machine.UUID) (instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret0, _ := ret[0].(instance.HardwareCharacteristics)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -224,19 +224,19 @@ type MockExportServiceGetHardwareCharacteristicsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockExportServiceGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockExportServiceGetHardwareCharacteristicsCall {
+func (c *MockExportServiceGetHardwareCharacteristicsCall) Return(arg0 instance.HardwareCharacteristics, arg1 error) *MockExportServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockExportServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockExportServiceGetHardwareCharacteristicsCall {
+func (c *MockExportServiceGetHardwareCharacteristicsCall) Do(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockExportServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockExportServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (*instance.HardwareCharacteristics, error)) *MockExportServiceGetHardwareCharacteristicsCall {
+func (c *MockExportServiceGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, machine.UUID) (instance.HardwareCharacteristics, error)) *MockExportServiceGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/migration.go
+++ b/domain/machine/service/migration.go
@@ -27,7 +27,7 @@ type MigrationState interface {
 
 	// GetHardwareCharacteristics returns the hardware characteristics struct with
 	// data retrieved from the machine cloud instance table.
-	GetHardwareCharacteristics(context.Context, string) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(context.Context, string) (instance.HardwareCharacteristics, error)
 
 	// SetMachineCloudInstance sets an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
@@ -113,13 +113,16 @@ func (s *MigrationService) GetInstanceID(ctx context.Context, machineUUID corema
 
 // GetHardwareCharacteristics returns the hardware characteristics of the
 // of the specified machine.
-func (s *MigrationService) GetHardwareCharacteristics(ctx context.Context, machineUUID coremachine.UUID) (*instance.HardwareCharacteristics, error) {
+func (s *MigrationService) GetHardwareCharacteristics(ctx context.Context, machineUUID coremachine.UUID) (instance.HardwareCharacteristics, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	hc, err := s.st.GetHardwareCharacteristics(ctx, machineUUID.String())
 	if err != nil {
-		return hc, errors.Errorf("retrieving hardware characteristics for machine %q: %w", machineUUID, err)
+		return instance.HardwareCharacteristics{}, errors.Errorf(
+			"retrieving hardware characteristics for machine %q: %w",
+			machineUUID, err,
+		)
 	}
 	return hc, nil
 }

--- a/domain/machine/service/migration_mock_test.go
+++ b/domain/machine/service/migration_mock_test.go
@@ -42,10 +42,10 @@ func (m *MockMigrationState) EXPECT() *MockMigrationStateMockRecorder {
 }
 
 // GetHardwareCharacteristics mocks base method.
-func (m *MockMigrationState) GetHardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockMigrationState) GetHardwareCharacteristics(arg0 context.Context, arg1 string) (instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret0, _ := ret[0].(instance.HardwareCharacteristics)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -63,19 +63,19 @@ type MockMigrationStateGetHardwareCharacteristicsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockMigrationStateGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockMigrationStateGetHardwareCharacteristicsCall {
+func (c *MockMigrationStateGetHardwareCharacteristicsCall) Return(arg0 instance.HardwareCharacteristics, arg1 error) *MockMigrationStateGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMigrationStateGetHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMigrationStateGetHardwareCharacteristicsCall {
+func (c *MockMigrationStateGetHardwareCharacteristicsCall) Do(f func(context.Context, string) (instance.HardwareCharacteristics, error)) *MockMigrationStateGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMigrationStateGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockMigrationStateGetHardwareCharacteristicsCall {
+func (c *MockMigrationStateGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (instance.HardwareCharacteristics, error)) *MockMigrationStateGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/migration_test.go
+++ b/domain/machine/service/migration_test.go
@@ -88,7 +88,7 @@ func (s *migrationServiceSuite) TestGetInstanceID(c *tc.C) {
 func (s *migrationServiceSuite) TestGetHardwareCharacteristics(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	hwc := &instance.HardwareCharacteristics{
+	hwc := instance.HardwareCharacteristics{
 		Mem: ptr[uint64](1024),
 	}
 

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -65,7 +65,7 @@ type State interface {
 
 	// GetHardwareCharacteristics returns the hardware characteristics struct with
 	// data retrieved from the machine cloud instance table.
-	GetHardwareCharacteristics(context.Context, string) (*instance.HardwareCharacteristics, error)
+	GetHardwareCharacteristics(context.Context, string) (instance.HardwareCharacteristics, error)
 
 	// AvailabilityZone returns the availability zone for the specified machine.
 	AvailabilityZone(context.Context, string) (string, error)

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -323,10 +323,10 @@ func (c *MockStateGetAllProvisionedMachineInstanceIDCall) DoAndReturn(f func(con
 }
 
 // GetHardwareCharacteristics mocks base method.
-func (m *MockState) GetHardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+func (m *MockState) GetHardwareCharacteristics(arg0 context.Context, arg1 string) (instance.HardwareCharacteristics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret0, _ := ret[0].(instance.HardwareCharacteristics)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -344,19 +344,19 @@ type MockStateGetHardwareCharacteristicsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockStateGetHardwareCharacteristicsCall {
+func (c *MockStateGetHardwareCharacteristicsCall) Return(arg0 instance.HardwareCharacteristics, arg1 error) *MockStateGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateGetHardwareCharacteristicsCall {
+func (c *MockStateGetHardwareCharacteristicsCall) Do(f func(context.Context, string) (instance.HardwareCharacteristics, error)) *MockStateGetHardwareCharacteristicsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateGetHardwareCharacteristicsCall {
+func (c *MockStateGetHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (instance.HardwareCharacteristics, error)) *MockStateGetHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -10,15 +10,14 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
-	coremachinetesting "github.com/juju/juju/core/machine/testing"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 )
 
-func (s *stateSuite) TestGetHardwareCharacteristicsWithNoData(c *tc.C) {
-	machineUUID := coremachinetesting.GenUUID(c)
+func (s *stateSuite) TestGetHardwareCharacteristicsMachineNotFound(c *tc.C) {
+	machineUUID := tc.Must(c, machine.NewUUID)
 
 	_, err := s.state.GetHardwareCharacteristics(c.Context(), machineUUID.String())
-	c.Assert(err, tc.ErrorIs, machineerrors.NotProvisioned)
+	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 func (s *stateSuite) TestGetHardwareCharacteristics(c *tc.C) {
@@ -72,7 +71,14 @@ func (s *stateSuite) TestGetHardwareCharacteristicsWithoutAvailabilityZone(c *tc
 }
 
 func (s *stateSuite) TestAvailabilityZoneWithNoMachine(c *tc.C) {
-	machineUUID := coremachinetesting.GenUUID(c)
+	machineUUID := tc.Must(c, machine.NewUUID)
+
+	_, err := s.state.AvailabilityZone(c.Context(), machineUUID.String())
+	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
+}
+
+func (s *stateSuite) TestAvailabilityZoneWithNoHardwareCharacteristics(c *tc.C) {
+	machineUUID, _ := s.addMachine(c)
 
 	_, err := s.state.AvailabilityZone(c.Context(), machineUUID.String())
 	c.Assert(err, tc.ErrorIs, machineerrors.AvailabilityZoneNotFound)

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -78,8 +78,8 @@ func tagsFromHardwareCharacteristics(machineUUID string, hc *instance.HardwareCh
 	return res
 }
 
-func (d *instanceDataResult) toHardwareCharacteristics() *instance.HardwareCharacteristics {
-	return &instance.HardwareCharacteristics{
+func (d *instanceDataResult) toHardwareCharacteristics() instance.HardwareCharacteristics {
+	return instance.HardwareCharacteristics{
 		Arch:             d.Arch,
 		Mem:              d.Mem,
 		RootDisk:         d.RootDisk,


### PR DESCRIPTION
This work came out of moving the machine provisioner facade over to internal errors. It was noticed that there was a call to hardware characteristics for the availability zone.

The code was treating the not provisioned error as a machine not found error. When in actual fact a not provisioned error was never possible because we always populate the table for new machines.

All of the values for hardware characteristics are optional and it is really there lack of existence that tells us not povisioned. However the caller really didn't care about this and what it needed was the availability zone not found error.

I moved the call over to the availability zone getter that already existed.

I made the get hardware characteristics always return a struct and not a pointer. Returning the pointer was a poor implementation hack from mongo that doesn't need to exist in reality.

I also made the two functions check for the machine exists and validate the uuid. All of the associated tests were testing that we were broken in this area.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests are fine for this one.

## Documentation changes

N/A
