### PR TITLE
feat(removal): cascade offer removal

### DIFF
--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -129,7 +129,7 @@ func (s *watcherSuite) TestWatchCharm(c *tc.C) {
 
 	removalSt := removalstatemodel.NewState(modelDB, loggertesting.WrapCheckLog(c))
 	harness.AddTest(c, func(c *tc.C) {
-		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false)
+		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false, false)
 		c.Assert(err, tc.ErrorIsNil)
 		err = removalSt.DeleteApplication(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)
@@ -1319,7 +1319,7 @@ WHERE uuid=?
 	})
 
 	harness.AddTest(c, func(c *tc.C) {
-		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false)
+		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false, false)
 		c.Assert(err, tc.ErrorIsNil)
 		err = removalSt.DeleteApplication(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)

--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -131,6 +131,10 @@ func (st *State) AddConsumedRelation(
 			return errors.Capture(err)
 		}
 
+		if err := st.checkApplicationAlive(ctx, tx, offerApplicationUUID); err != nil {
+			return errors.Capture(err)
+		}
+
 		// If the relation already exists, return an error. All relations are
 		// immutable, so we can only consume it once.
 		if err := st.checkConsumerRelationExists(ctx, tx, args.RelationUUID); err != nil {

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -407,6 +407,10 @@ type cidr struct {
 	CIDR string `db:"cidr"`
 }
 
+type lifeID struct {
+	Life int `db:"life_id"`
+}
+
 type queryLife struct {
 	Value corelife.Value `db:"value"`
 }

--- a/domain/removal/errors/errors.go
+++ b/domain/removal/errors/errors.go
@@ -52,6 +52,10 @@ const (
 	// still has relations
 	OfferHasRelations = errors.ConstError("offer has relations")
 
+	// ApplicationHasOfferConnections indicates that an application cannot be
+	// deleted because it still has offer connections
+	ApplicationHasOfferConnections = errors.ConstError("application has offer connections")
+
 	// ForceRequired indicates that a removal job requires the force flag to
 	// be set to true in order to proceed.
 	ForceRequired = errors.ConstError("force required for removal job")

--- a/domain/removal/service/application.go
+++ b/domain/removal/service/application.go
@@ -35,7 +35,7 @@ type ApplicationState interface {
 	// the last ones on their machines, it will cascade and the machines are
 	// also set to dying. The affected machine UUIDs are returned.
 	EnsureApplicationNotAliveCascade(
-		ctx context.Context, appUUID string, destroyStorage bool,
+		ctx context.Context, appUUID string, destroyStorage, force bool,
 	) (internal.CascadedApplicationLives, error)
 
 	// ApplicationScheduleRemoval schedules a removal job for the application
@@ -92,7 +92,7 @@ func (s *Service) RemoveApplication(
 		return "", errors.Errorf("application %q does not exist", appUUID).Add(applicationerrors.ApplicationNotFound)
 	}
 
-	cascaded, err := s.modelState.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), destroyStorage)
+	cascaded, err := s.modelState.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), destroyStorage, force)
 	if err != nil {
 		return "", errors.Errorf("application %q: %w", appUUID, err)
 	}

--- a/domain/removal/service/application_test.go
+++ b/domain/removal/service/application_test.go
@@ -37,7 +37,7 @@ func (s *applicationSuite) TestRemoveApplicationDestroyStorageNoForceSuccess(c *
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), true).Return(internal.CascadedApplicationLives{}, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), true, false).Return(internal.CascadedApplicationLives{}, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveApplication(c.Context(), appUUID, true, false, 0)
@@ -55,7 +55,7 @@ func (s *applicationSuite) TestRemoveApplicationForceNoWaitSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{}, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, true).Return(internal.CascadedApplicationLives{}, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), true, when.UTC()).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveApplication(c.Context(), appUUID, false, true, 0)
@@ -73,7 +73,7 @@ func (s *applicationSuite) TestRemoveApplicationForceWaitSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{}, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, true).Return(internal.CascadedApplicationLives{}, nil)
 
 	// The first normal removal scheduled immediately.
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
@@ -107,7 +107,7 @@ func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithUnitsAndStorag
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(internal.CascadedApplicationLives{
 		UnitUUIDs: []string{"unit-1", "unit-2"},
 		CascadedStorageLives: internal.CascadedStorageLives{
 			StorageAttachmentUUIDs: []string{"st-att-unit-1", "st-att-unit-2"},
@@ -135,7 +135,7 @@ func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithMachines(c *tc
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(internal.CascadedApplicationLives{
 		MachineUUIDs: []string{"machine-1", "machine-2"},
 	}, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
@@ -158,7 +158,7 @@ func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithRelations(c *t
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(internal.CascadedApplicationLives{
 		RelationUUIDs: []string{"relation-1", "relation-2"},
 	}, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -984,18 +984,18 @@ func (c *MockModelDBStateDeleteVolumeCall) DoAndReturn(f func(context.Context, s
 }
 
 // EnsureApplicationNotAliveCascade mocks base method.
-func (m *MockModelDBState) EnsureApplicationNotAliveCascade(arg0 context.Context, arg1 string, arg2 bool) (internal.CascadedApplicationLives, error) {
+func (m *MockModelDBState) EnsureApplicationNotAliveCascade(arg0 context.Context, arg1 string, arg2, arg3 bool) (internal.CascadedApplicationLives, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureApplicationNotAliveCascade", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureApplicationNotAliveCascade", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(internal.CascadedApplicationLives)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureApplicationNotAliveCascade indicates an expected call of EnsureApplicationNotAliveCascade.
-func (mr *MockModelDBStateMockRecorder) EnsureApplicationNotAliveCascade(arg0, arg1, arg2 any) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
+func (mr *MockModelDBStateMockRecorder) EnsureApplicationNotAliveCascade(arg0, arg1, arg2, arg3 any) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureApplicationNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureApplicationNotAliveCascade), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureApplicationNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureApplicationNotAliveCascade), arg0, arg1, arg2, arg3)
 	return &MockModelDBStateEnsureApplicationNotAliveCascadeCall{Call: call}
 }
 
@@ -1011,13 +1011,13 @@ func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) Return(arg0 inter
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) Do(f func(context.Context, string, bool) (internal.CascadedApplicationLives, error)) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) Do(f func(context.Context, string, bool, bool) (internal.CascadedApplicationLives, error)) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) DoAndReturn(f func(context.Context, string, bool) (internal.CascadedApplicationLives, error)) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) DoAndReturn(f func(context.Context, string, bool, bool) (internal.CascadedApplicationLives, error)) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/service/remoterelation.go
+++ b/domain/removal/service/remoterelation.go
@@ -37,7 +37,7 @@ type RemoteRelationState interface {
 	DeleteRemoteRelation(ctx context.Context, rUUID string) error
 }
 
-// RemoveRelation checks if a relation with the input UUID exists.
+// RemoveRemoteRelation checks if a relation with the input UUID exists.
 // If it does, the relation is guaranteed after this call to be:
 // - No longer alive.
 // - Removed or scheduled to be removed with the input force qualification.

--- a/domain/removal/state/model/model.go
+++ b/domain/removal/state/model/model.go
@@ -353,8 +353,8 @@ WHERE uuid = $entityUUID.uuid;
 // IsControllerModel returns true if the model is the controller model.
 // The following errors may be returned:
 // - [modelerrors.NotFound] when the model does not exist.
-func (s *State) IsControllerModel(ctx context.Context, mUUID string) (bool, error) {
-	db, err := s.DB(ctx)
+func (st *State) IsControllerModel(ctx context.Context, mUUID string) (bool, error) {
+	db, err := st.DB(ctx)
 	if err != nil {
 		return false, errors.Capture(err)
 	}
@@ -366,7 +366,7 @@ func (s *State) IsControllerModel(ctx context.Context, mUUID string) (bool, erro
 	uuid := entityUUID{UUID: mUUID}
 	var m model
 
-	stmt, err := s.Prepare(`
+	stmt, err := st.Prepare(`
 SELECT &model.is_controller_model
 FROM model
 WHERE uuid = $entityUUID.uuid

--- a/domain/removal/state/model/offer_test.go
+++ b/domain/removal/state/model/offer_test.go
@@ -8,13 +8,8 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/juju/clock/testclock"
 	"github.com/juju/tc"
 
-	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/offer"
-	"github.com/juju/juju/domain/crossmodelrelation"
-	crossmodelrelationstate "github.com/juju/juju/domain/crossmodelrelation/state/model"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
@@ -115,22 +110,4 @@ func (s *offerSuite) TestDeleteOfferForceWithRelations(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(relCount, tc.Equals, 0)
 	c.Check(remoteAppCount, tc.Equals, 0)
-}
-
-func (s *offerSuite) createOffer(c *tc.C, appName string) offer.UUID {
-	cmrState := crossmodelrelationstate.NewState(
-		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
-	)
-	s.createIAASApplication(c, s.setupApplicationService(c), appName)
-	offerUUID := tc.Must(c, offer.NewUUID)
-
-	err := cmrState.CreateOffer(c.Context(), crossmodelrelation.CreateOfferArgs{
-		UUID:            offerUUID,
-		ApplicationName: "foo",
-		Endpoints:       []string{"foo", "bar"},
-		OfferName:       "foo",
-	})
-	c.Assert(err, tc.ErrorIsNil)
-
-	return offerUUID
 }

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -343,6 +343,41 @@ func (s *baseSuite) createCAASApplication(c *tc.C, svc *applicationservice.Provi
 	return appID
 }
 
+func (s *baseSuite) createOffer(c *tc.C, offerName string) offer.UUID {
+	cmrState := crossmodelrelationstate.NewState(
+		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
+	)
+	s.createIAASApplication(c, s.setupApplicationService(c), offerName)
+	offerUUID := tc.Must(c, offer.NewUUID)
+
+	err := cmrState.CreateOffer(c.Context(), crossmodelrelation.CreateOfferArgs{
+		UUID:            offerUUID,
+		ApplicationName: offerName,
+		Endpoints:       []string{"foo", "bar"},
+		OfferName:       offerName,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	return offerUUID
+}
+
+func (s *baseSuite) createOfferForApplication(c *tc.C, appName string, offerName string) offer.UUID {
+	cmrState := crossmodelrelationstate.NewState(
+		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
+	)
+	offerUUID := tc.Must(c, offer.NewUUID)
+
+	err := cmrState.CreateOffer(c.Context(), crossmodelrelation.CreateOfferArgs{
+		UUID:            offerUUID,
+		ApplicationName: appName,
+		Endpoints:       []string{"foo", "bar"},
+		OfferName:       offerName,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	return offerUUID
+}
+
 func (s *baseSuite) createRemoteApplicationOfferer(
 	c *tc.C,
 	name string,


### PR DESCRIPTION
Offers are entities subordinate to applications. An offer 'offers' an endpoint for an application.

So to remove an application, we need to remove all it's offers. Refactor the removal domain for applications to remove these offers.

This required a small change to the cmr domain. To protect against races, we need to ensure that we cannot establish new connections offers of dying applications.

## QA steps

### Without connections

```
$ juju add-model m
$ juju deploy juju-qa-dummy-source
$ juju offer dummy-source:sink
$ juju remove-application dummy-source
(wait)
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      lxd         lxd/localhost  4.0-beta8.1  21:07:36Z

Model "admin/m" is empty.
```

### With connections
```
$ juju add-model offerer
$ juju deploy juju-qa-dummy-source
$ juju offer dummy-source:sink
$ juju add-model consumer
$ juju consume admin/offerer.dummy-source
$ juju relate dummy-source dummy-sink
$ juju switch -
$ juju remove-application dummy-source
ERROR removing application dummy-source failed: removing application "dummy-source": application "dcdac048-f0df-427f-863b-a69de4db9edf": cannot remove application "dcdac048-f0df-427f-863b-a69de4db9edf", it has 1 offer(s)

$ juju remove-application dummy-source --force
(wait)
$ juju status
Model    Controller  Cloud/Region   Version      Timestamp
offerer  lxd         lxd/localhost  4.0-beta8.1  21:22:10Z

Model "admin/offerer" is empty.
```