### PR TITLE
feat: allow an offer to be consumed more than once

### DIFF
--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -61,13 +61,16 @@ func (st *State) AddRemoteApplicationOfferer(
 	}
 
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// Check the offer doesn't already exist. This must be done first
+		// as the api caller should check for AleadyExists errors and
+		// continue.
+		if err := st.checkApplicationRemoteOffererDoesNotExist(ctx, tx, args.OfferUUID); err != nil {
+			return errors.Capture(err)
+		}
+
 		// Check if the application already exists.
 		if err := st.checkApplicationNameAvailable(ctx, tx, applicationName); err != nil {
 			return errors.Errorf("checking if application %q exists: %w", applicationName, err)
-		}
-		// Check the offer doesn't already exist.
-		if err := st.checkApplicationRemoteOffererDoesNotExist(ctx, tx, args.OfferUUID); err != nil {
-			return errors.Capture(err)
 		}
 
 		// Insert the application, along with the associated charm.


### PR DESCRIPTION
Check to see if an offer has been consumed already before checking if the application name is available. Order of error is important for the clients, offer AlreadyExists takes precedence over the application existing.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
# setup two ones with one cmr
$ juju add-model offer ; juju deploy juju-qa-dummy-sink sink ;  juju offer sink:source; juju add-model consume ; juju deploy juju-qa-dummy-source source; juju integrate source admin/offer.sink

# add a second application to the consume model and integrate it.
$ juju deploy juju-qa-dummy-source second
$ juju relate admin/offer.sink second

# should succeed
$ juju status --relations
...
Integration provider       Requirer                   Interface          Type     Message
...
sink:source                second:sink                dummy-token        regular
sink:source                source:sink                dummy-token        regular
```
