### PR TITLE
feat: save relation macaroon

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -439,6 +439,10 @@ func (api *CrossModelRelationsAPIv3) registerOneRemoteRelation(
 	if err != nil {
 		return nil, errors.Annotate(err, "creating relation macaroon")
 	}
+	// Save the macaroon, many different calls try to find it.
+	if err := api.crossModelRelationService.SaveMacaroonForRelation(ctx, corerelation.UUID(relation.RelationToken), relationMacaroon.M()); err != nil {
+		return nil, internalerrors.Errorf("saving macaroon for %q: %w", relation.RelationToken, err)
+	}
 	return &params.ConsumingRelationDetails{
 		// The offering model application UUID is used as the token for the
 		// remote model.

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -584,8 +584,11 @@ func (s *facadeSuite) TestRegisterRemoteRelationsSuccess(c *tc.C) {
 
 	offererRemoteRelationTag := names.NewRelationTag(relKey.String())
 
+	mac := &bakery.Macaroon{}
 	s.crossModelAuthContext.EXPECT().CreateRemoteRelationMacaroon(gomock.Any(), s.modelUUID, offerUUID.String(), "bob", offererRemoteRelationTag, bakery.LatestVersion).
-		Return(&bakery.Macaroon{}, nil)
+		Return(mac, nil)
+
+	s.crossModelRelationService.EXPECT().SaveMacaroonForRelation(gomock.Any(), corerelation.UUID(relationUUID), mac.M())
 
 	api := s.api(c)
 	arg := s.relationArg(c, remoteAppToken, offerUUID, relationUUID, "remoteapp:db", "db", macaroon.Slice{testMac})

--- a/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
@@ -27,6 +27,7 @@ import (
 	removal "github.com/juju/juju/domain/removal"
 	config "github.com/juju/juju/environs/config"
 	gomock "go.uber.org/mock/gomock"
+	macaroon "gopkg.in/macaroon.v2"
 )
 
 // MockCrossModelRelationService is a mock of CrossModelRelationService interface.
@@ -280,6 +281,44 @@ func (c *MockCrossModelRelationServiceGetOfferingApplicationTokenCall) Do(f func
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelRelationServiceGetOfferingApplicationTokenCall) DoAndReturn(f func(context.Context, relation.UUID) (application.UUID, error)) *MockCrossModelRelationServiceGetOfferingApplicationTokenCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SaveMacaroonForRelation mocks base method.
+func (m *MockCrossModelRelationService) SaveMacaroonForRelation(arg0 context.Context, arg1 relation.UUID, arg2 *macaroon.Macaroon) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveMacaroonForRelation", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveMacaroonForRelation indicates an expected call of SaveMacaroonForRelation.
+func (mr *MockCrossModelRelationServiceMockRecorder) SaveMacaroonForRelation(arg0, arg1, arg2 any) *MockCrossModelRelationServiceSaveMacaroonForRelationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveMacaroonForRelation", reflect.TypeOf((*MockCrossModelRelationService)(nil).SaveMacaroonForRelation), arg0, arg1, arg2)
+	return &MockCrossModelRelationServiceSaveMacaroonForRelationCall{Call: call}
+}
+
+// MockCrossModelRelationServiceSaveMacaroonForRelationCall wrap *gomock.Call
+type MockCrossModelRelationServiceSaveMacaroonForRelationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) Return(arg0 error) *MockCrossModelRelationServiceSaveMacaroonForRelationCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) Do(f func(context.Context, relation.UUID, *macaroon.Macaroon) error) *MockCrossModelRelationServiceSaveMacaroonForRelationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) DoAndReturn(f func(context.Context, relation.UUID, *macaroon.Macaroon) error) *MockCrossModelRelationServiceSaveMacaroonForRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelrelations/service.go
+++ b/apiserver/facades/controller/crossmodelrelations/service.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"time"
 
+	"gopkg.in/macaroon.v2"
+
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/offer"
 	corerelation "github.com/juju/juju/core/relation"
@@ -52,6 +54,10 @@ type CrossModelRelationService interface {
 	// EnsureUnitsExist ensures that the given synthetic units exist in the local
 	// model.
 	EnsureUnitsExist(ctx context.Context, appUUID coreapplication.UUID, units []unit.Name) error
+
+	// SaveMacaroonForRelation saves the given macaroon for the specified remote
+	// application.
+	SaveMacaroonForRelation(context.Context, corerelation.UUID, *macaroon.Macaroon) error
 
 	// WatchRemoteConsumedSecretsChanges watches secrets remotely consumed by any
 	// unit of the specified app and returns a watcher which notifies of secret URIs


### PR DESCRIPTION
When registering a CMR, save the macaroon. It's required by various callers including the firewaller and some watchers.

Fixes the error message:
```
watching remote relation c9bbabe1-aa36-48ef-8b73-73f2af103c71: getting initial change: getting relation macaroon: macaroon for relation "c9bbabe1-aa36-48ef-8b73-73f2af103c71" not found
```

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju add-model offer ; juju deploy juju-qa-dummy-sink sink ;  juju offer sink:source; juju add-model consume ; juju deploy juju-qa-dummy-source source; juju integrate source admin/offer.sink
```

Check the logs, the above error should not occur.