### PR TITLE
fix(ci): secret suites

### DIFF
--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -1,78 +1,79 @@
 check_secrets() {
-	juju --show-log deploy easyrsa
-	juju --show-log deploy etcd
-	juju --show-log integrate etcd easyrsa
+	juju --show-log deploy juju-qa-dummy-source source
+	juju --show-log deploy juju-qa-dummy-sink sink
+	juju --show-log integrate sink source
+	juju config source token=start # enable relation
 
-	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
-	wait_for "active" '.applications["etcd"] | ."application-status".current' 900
-	wait_for "easyrsa" "$(idle_condition "easyrsa" 0)"
-	wait_for "etcd" "$(idle_condition "etcd" 0)"
-	wait_for "active" "$(workload_status "etcd" 0).current"
+	wait_for "active" '.applications["source"] | ."application-status".current'
+	wait_for "active" '.applications["sink"] | ."application-status".current' 900
+	wait_for "source" "$(idle_condition "source" 0)"
+	wait_for "sink" "$(idle_condition "sink" 0)"
+	wait_for "active" "$(workload_status "sink" 0).current"
 
 	echo "Apps deployed, creating secrets"
-	secret_owned_by_easyrsa_0=$(juju exec --unit easyrsa/0 -- secret-add --owner unit owned-by=easyrsa/0)
-	secret_owned_by_easyrsa_0_id=${secret_owned_by_easyrsa_0##*/}
-	secret_owned_by_easyrsa=$(juju exec --unit easyrsa/0 -- secret-add owned-by=easyrsa-app)
-	secret_owned_by_easyrsa_id=${secret_owned_by_easyrsa##*/}
+	secret_owned_by_source_0=$(juju exec --unit source/0 -- secret-add --owner unit owned-by=source/0)
+	secret_owned_by_source_0_id=${secret_owned_by_source_0##*/}
+	secret_owned_by_source=$(juju exec --unit source/0 -- secret-add owned-by=source-app)
+	secret_owned_by_source_id=${secret_owned_by_source##*/}
 
-	echo "Set same content again for $secret_owned_by_easyrsa."
-	juju exec --unit easyrsa/0 -- secret-set "$secret_owned_by_easyrsa_id" owned-by=easyrsa-app
+	echo "Set same content again for $secret_owned_by_source."
+	juju exec --unit source/0 -- secret-set "$secret_owned_by_source_id" owned-by=source-app
 
 	echo "Checking secret ids"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-ids)" "$secret_owned_by_easyrsa_id"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-ids)" "$secret_owned_by_easyrsa_0_id"
+	check_contains "$(juju exec --unit source/0 -- secret-ids)" "$secret_owned_by_source_id"
+	check_contains "$(juju exec --unit source/0 -- secret-ids)" "$secret_owned_by_source_0_id"
 
-	echo "Set a label for the unit owned secret $secret_owned_by_easyrsa_0."
-	juju exec --unit easyrsa/0 -- secret-set "$secret_owned_by_easyrsa_0" --label=easyrsa_0
-	echo "Set a consumer label for the app owned secret $secret_owned_by_easyrsa."
-	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" --label=easyrsa-app
+	echo "Set a label for the unit owned secret $secret_owned_by_source_0."
+	juju exec --unit source/0 -- secret-set "$secret_owned_by_source_0" --label=source_0
+	echo "Set a consumer label for the app owned secret $secret_owned_by_source."
+	juju exec --unit source/0 -- secret-get "$secret_owned_by_source" --label=source-app
 
 	echo "Checking: secret-get by URI - content"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa_0")" 'owned-by: easyrsa/0'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa")" 'owned-by: easyrsa-app'
+	check_contains "$(juju exec --unit source/0 -- secret-get "$secret_owned_by_source_0")" 'owned-by: source/0'
+	check_contains "$(juju exec --unit source/0 -- secret-get "$secret_owned_by_source")" 'owned-by: source-app'
 
 	echo "Checking: secret-get by URI - metadata"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa_0" --format json | jq ".${secret_owned_by_easyrsa_0_id}.owner")" 'unit'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa_id}.owner")" 'application'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa_id}.revision")" '1'
+	check_contains "$(juju exec --unit source/0 -- secret-info-get "$secret_owned_by_source_0" --format json | jq ".${secret_owned_by_source_0_id}.owner")" 'unit'
+	check_contains "$(juju exec --unit source/0 -- secret-info-get "$secret_owned_by_source" --format json | jq ".${secret_owned_by_source_id}.owner")" 'application'
+	check_contains "$(juju exec --unit source/0 -- secret-info-get "$secret_owned_by_source" --format json | jq ".${secret_owned_by_source_id}.revision")" '1'
 
 	echo "Checking: secret-get by label or consumer label - content"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get --label=easyrsa_0)" 'owned-by: easyrsa/0'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get --label=easyrsa-app)" 'owned-by: easyrsa-app'
+	check_contains "$(juju exec --unit source/0 -- secret-get --label=source_0)" 'owned-by: source/0'
+	check_contains "$(juju exec --unit source/0 -- secret-get --label=source-app)" 'owned-by: source-app'
 
 	echo "Checking: secret-get by label - metadata"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get --label=easyrsa_0 --format json | jq ".${secret_owned_by_easyrsa_0_id}.label")" 'easyrsa_0'
+	check_contains "$(juju exec --unit source/0 -- secret-info-get --label=source_0 --format json | jq ".${secret_owned_by_source_0_id}.label")" 'source_0'
 
-	relation_id=$(juju --show-log show-unit easyrsa/0 --format json | jq '."easyrsa/0"."relation-info"[0]."relation-id"')
-	juju exec --unit easyrsa/0 -- secret-grant "$secret_owned_by_easyrsa_0" -r "$relation_id"
-	juju exec --unit easyrsa/0 -- secret-grant "$secret_owned_by_easyrsa" -r "$relation_id"
+	relation_id=$(juju --show-log show-unit source/0 --format json | jq '."source/0"."relation-info"[0]."relation-id"')
+	juju exec --unit source/0 -- secret-grant "$secret_owned_by_source_0" -r "$relation_id"
+	juju exec --unit source/0 -- secret-grant "$secret_owned_by_source" -r "$relation_id"
 
 	echo "Checking: secret-get by URI - consume content by ID"
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa_0" --label=consumer_label_secret_owned_by_easyrsa_0)" 'owned-by: easyrsa/0'
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa" --label=consumer_label_secret_owned_by_easyrsa)" 'owned-by: easyrsa-app'
+	check_contains "$(juju exec --unit sink/0 -- secret-get "$secret_owned_by_source_0" --label=consumer_label_secret_owned_by_source_0)" 'owned-by: source/0'
+	check_contains "$(juju exec --unit sink/0 -- secret-get "$secret_owned_by_source" --label=consumer_label_secret_owned_by_source)" 'owned-by: source-app'
 
 	echo "Checking: secret-get by URI - consume content by label"
-	check_contains "$(juju exec --unit etcd/0 -- secret-get --label=consumer_label_secret_owned_by_easyrsa_0)" 'owned-by: easyrsa/0'
-	check_contains "$(juju exec --unit etcd/0 -- secret-get --label=consumer_label_secret_owned_by_easyrsa)" 'owned-by: easyrsa-app'
+	check_contains "$(juju exec --unit sink/0 -- secret-get --label=consumer_label_secret_owned_by_source_0)" 'owned-by: source/0'
+	check_contains "$(juju exec --unit sink/0 -- secret-get --label=consumer_label_secret_owned_by_source)" 'owned-by: source-app'
 
-	echo "Set different content for $secret_owned_by_easyrsa."
-	juju exec --unit easyrsa/0 -- secret-set "$secret_owned_by_easyrsa_id" foo=bar
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa_id}.revision")" '2'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get --refresh "$secret_owned_by_easyrsa")" 'foo: bar'
+	echo "Set different content for $secret_owned_by_source."
+	juju exec --unit source/0 -- secret-set "$secret_owned_by_source_id" foo=bar
+	check_contains "$(juju exec --unit source/0 -- secret-info-get "$secret_owned_by_source" --format json | jq ".${secret_owned_by_source_id}.revision")" '2'
+	check_contains "$(juju exec --unit source/0 -- secret-get --refresh "$secret_owned_by_source")" 'foo: bar'
 
 	echo "Checking: secret-revoke by relation ID"
-	juju exec --unit easyrsa/0 -- secret-revoke "$secret_owned_by_easyrsa" --relation "$relation_id"
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa" 2>&1)" 'is not allowed to read this secret'
+	juju exec --unit source/0 -- secret-revoke "$secret_owned_by_source" --relation "$relation_id"
+	check_contains "$(juju exec --unit sink/0 -- secret-get "$secret_owned_by_source" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Checking: secret-revoke by app name"
-	juju exec --unit easyrsa/0 -- secret-revoke "$secret_owned_by_easyrsa_0" --app etcd
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa_0" 2>&1)" 'is not allowed to read this secret'
+	juju exec --unit source/0 -- secret-revoke "$secret_owned_by_source_0" --app sink
+	check_contains "$(juju exec --unit sink/0 -- secret-get "$secret_owned_by_source_0" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Checking: secret-remove"
-	juju exec --unit easyrsa/0 -- secret-remove "$secret_owned_by_easyrsa_0"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa_0" 2>&1)" 'not found'
-	juju exec --unit easyrsa/0 -- secret-remove "$secret_owned_by_easyrsa"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" 2>&1)" 'not found'
+	juju exec --unit source/0 -- secret-remove "$secret_owned_by_source_0"
+	check_contains "$(juju exec --unit source/0 -- secret-get "$secret_owned_by_source_0" 2>&1)" 'not found'
+	juju exec --unit source/0 -- secret-remove "$secret_owned_by_source"
+	check_contains "$(juju exec --unit source/0 -- secret-get "$secret_owned_by_source" 2>&1)" 'not found'
 }
 
 run_user_secrets() {
@@ -80,10 +81,10 @@ run_user_secrets() {
 
 	model_name=${1}
 
-	app_name='easyrsa-user-secrets'
-	juju --show-log deploy easyrsa "$app_name"
+	app_name='test-user-secrets'
+	juju --show-log deploy juju-qa-test "$app_name"
 	
-	wait_for "active" '.applications["easyrsa-user-secrets"] | ."application-status".current'
+	wait_for "active" '.applications["test-user-secrets"] | ."application-status".current'
 
 	# first test the creation of a large secret which encodes to approx 1MB in size.
 	echo "data: $(cat /dev/zero | tr '\0' A | head -c 749500)" >"${TEST_DIR}/secret.txt"


### PR DESCRIPTION
Fixes several issues in 4.0 in secret suites:

* using easyrsa and etcd causes an issue since they rely on leader-get/set deprecated hook function.
* check using yq were expecting yaml output but returns json output

Fixes:
* use juju-qa-xxx instead of easyrsa and etcd
* force yq output to be yaml through `-y` flag

## QA steps

Run the secrets suite.

You will have a issue on destroy model, the test will time out without ending because in some case destroying doesn't works in test suite. This is unrelated.

## Links

**Jira card:** [JUJU-8605](https://warthogs.atlassian.net/browse/JUJU-8605)


[JUJU-8605]: https://warthogs.atlassian.net/browse/JUJU-8605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ