### PR TITLE
fix: tweak deploy revision refresh test

### DIFF
--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -78,28 +78,10 @@ run_deploy_revision_refresh() {
 	# revision 23 is in channel 2.0/edge
 	juju deploy juju-qa-test --revision 23 --channel latest/edge
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 23)"
+	wait_for "juju-qa-test" "$(active_idle_condition "juju-qa-test")"
 
-	# NOTE:
-	# The following loop is specific to juju 3.0+ due to
-	# async charm download and should NOT be removed in
-	# a merge from 2.9.
-	attempt=0
-	while true; do
-		# Ensure that refresh gets the revision from the channel
-		# listed at deploy.
-		# revision 15 is in channel latest/edge
-		OUT=$(juju refresh juju-qa-test 2>&1 || true)
-		if echo "${OUT}" | grep -E -q "Added"; then
-			break
-		fi
-		attempt=$((attempt + 1))
-		if [ $attempt -eq 10 ]; then
-			# shellcheck disable=SC2046
-			echo $(red "timeout: waiting for charm download to complete 50sec")
-			exit 5
-		fi
-		sleep 5
-	done
+	# Once the application is ready, refresh is expected to immediately work.
+	juju refresh juju-qa-test
 
 	# revision 21 is in channel latest/edge
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 21)"


### PR DESCRIPTION
In the "Deploy" suite, the refresh revision test was failing because the test was running `juju refresh` and checking for the output string "Added" to indicate the command suceeded. In Juju 4 the output of `refresh` when the app is still provisioning is,
```
$ juju refresh juju-qa-test
Added charm-hub charm "juju-qa-test", revision 21 in channel latest/edge, to the model
ERROR setting application "juju-qa-test" charm: unit "juju-qa-test/0" not in space "alpha"
```
The correct thing to do is wait for the app to be ready then run the refresh.


## Checklist

- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## Links

**Jira card:** [JUJU-8603](https://warthogs.atlassian.net/browse/JUJU-8603)


[JUJU-8603]: https://warthogs.atlassian.net/browse/JUJU-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ