### PR TITLE
fix: initial changes missing for relation network egress

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -787,12 +787,12 @@ func (api *CrossModelRelationsAPIv3) WatchEgressAddressesForRelations(ctx contex
 	}
 	for i, arg := range remoteRelationArgs.Args {
 		relationUUID := corerelation.UUID(arg.Token)
-		relationDetails, err := api.relationService.GetRelationDetails(ctx, relationUUID)
+		relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, relationUUID.String())
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		relationTag := names.NewRelationTag(relationDetails.Key.String())
+		relationTag := names.NewRelationTag(relationKey.String())
 
 		if err := api.checkMacaroonsForRelation(ctx, relationUUID, relationTag, arg.Macaroons, arg.BakeryVersion); err != nil {
 			if errors.Is(err, crossmodelrelationerrors.OfferNotFound) {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -1520,9 +1520,7 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelations(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	relationTag := names.NewRelationTag(relKey.String())
 
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID).Return(domainrelation.RelationDetails{
-		Key: relKey,
-	}, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID.String(), relationTag, gomock.Any(), bakery.LatestVersion).
@@ -1565,7 +1563,7 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	relUUID := relationtesting.GenRelationUUID(c)
 
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID).Return(domainrelation.RelationDetails{}, errors.New("relation not found"))
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(corerelation.Key{}, errors.New("relation not found"))
 
 	api := s.api(c)
 	results, err := api.WatchEgressAddressesForRelations(c.Context(), params.RemoteEntityArgs{
@@ -1591,9 +1589,7 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsOfferNotFound(c *tc.C)
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
 	c.Assert(err, tc.ErrorIsNil)
 
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID).Return(domainrelation.RelationDetails{
-		Key: relKey,
-	}, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return("", crossmodelrelationerrors.OfferNotFound)
 
 	api := s.api(c)
@@ -1622,9 +1618,7 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsAuthError(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	relationTag := names.NewRelationTag(relKey.String())
 
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID).Return(domainrelation.RelationDetails{
-		Key: relKey,
-	}, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID.String(), relationTag, gomock.Any(), bakery.LatestVersion).
@@ -1656,9 +1650,7 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsWatcherError(c *tc.C) 
 	c.Assert(err, tc.ErrorIsNil)
 	relationTag := names.NewRelationTag(relKey.String())
 
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID).Return(domainrelation.RelationDetails{
-		Key: relKey,
-	}, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID.String(), relationTag, gomock.Any(), bakery.LatestVersion).
@@ -1694,9 +1686,7 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsMultipleRelations(c *t
 	relationTag1 := names.NewRelationTag(relKey1.String())
 
 	// First relation succeeds.
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID1).Return(domainrelation.RelationDetails{
-		Key: relKey1,
-	}, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID1.String()).Return(relKey1, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID1).Return(offerUUID1, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID1.String(), relationTag1, gomock.Any(), bakery.LatestVersion).
@@ -1714,8 +1704,8 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsMultipleRelations(c *t
 			return "1", nil
 		})
 
-	// Second relation fails on GetRelationDetails.
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID2).Return(domainrelation.RelationDetails{}, errors.New("not found"))
+	// Second relation fails on GetRelationKeyByUUID.
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID2.String()).Return(corerelation.Key{}, errors.New("not found"))
 
 	api := s.api(c)
 	results, err := api.WatchEgressAddressesForRelations(c.Context(), params.RemoteEntityArgs{

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -1449,41 +1449,41 @@ func (c *MockModelStateInitialWatchStatementForRemoteConsumedSecretsChangesFromO
 	return c
 }
 
-// IsApplicationLocal mocks base method.
-func (m *MockModelState) IsApplicationLocal(arg0 context.Context, arg1 string) (bool, error) {
+// IsApplicationSynthetic mocks base method.
+func (m *MockModelState) IsApplicationSynthetic(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsApplicationLocal", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsApplicationSynthetic", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsApplicationLocal indicates an expected call of IsApplicationLocal.
-func (mr *MockModelStateMockRecorder) IsApplicationLocal(arg0, arg1 any) *MockModelStateIsApplicationLocalCall {
+// IsApplicationSynthetic indicates an expected call of IsApplicationSynthetic.
+func (mr *MockModelStateMockRecorder) IsApplicationSynthetic(arg0, arg1 any) *MockModelStateIsApplicationSyntheticCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationLocal", reflect.TypeOf((*MockModelState)(nil).IsApplicationLocal), arg0, arg1)
-	return &MockModelStateIsApplicationLocalCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationSynthetic", reflect.TypeOf((*MockModelState)(nil).IsApplicationSynthetic), arg0, arg1)
+	return &MockModelStateIsApplicationSyntheticCall{Call: call}
 }
 
-// MockModelStateIsApplicationLocalCall wrap *gomock.Call
-type MockModelStateIsApplicationLocalCall struct {
+// MockModelStateIsApplicationSyntheticCall wrap *gomock.Call
+type MockModelStateIsApplicationSyntheticCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateIsApplicationLocalCall) Return(arg0 bool, arg1 error) *MockModelStateIsApplicationLocalCall {
+func (c *MockModelStateIsApplicationSyntheticCall) Return(arg0 bool, arg1 error) *MockModelStateIsApplicationSyntheticCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateIsApplicationLocalCall) Do(f func(context.Context, string) (bool, error)) *MockModelStateIsApplicationLocalCall {
+func (c *MockModelStateIsApplicationSyntheticCall) Do(f func(context.Context, string) (bool, error)) *MockModelStateIsApplicationSyntheticCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateIsApplicationLocalCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockModelStateIsApplicationLocalCall {
+func (c *MockModelStateIsApplicationSyntheticCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockModelStateIsApplicationSyntheticCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -1449,41 +1449,41 @@ func (c *MockModelStateInitialWatchStatementForRemoteConsumedSecretsChangesFromO
 	return c
 }
 
-// IsApplicationConsumer mocks base method.
-func (m *MockModelState) IsApplicationConsumer(arg0 context.Context, arg1 string) (bool, error) {
+// IsApplicationLocal mocks base method.
+func (m *MockModelState) IsApplicationLocal(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsApplicationConsumer", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsApplicationLocal", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsApplicationConsumer indicates an expected call of IsApplicationConsumer.
-func (mr *MockModelStateMockRecorder) IsApplicationConsumer(arg0, arg1 any) *MockModelStateIsApplicationConsumerCall {
+// IsApplicationLocal indicates an expected call of IsApplicationLocal.
+func (mr *MockModelStateMockRecorder) IsApplicationLocal(arg0, arg1 any) *MockModelStateIsApplicationLocalCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationConsumer", reflect.TypeOf((*MockModelState)(nil).IsApplicationConsumer), arg0, arg1)
-	return &MockModelStateIsApplicationConsumerCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationLocal", reflect.TypeOf((*MockModelState)(nil).IsApplicationLocal), arg0, arg1)
+	return &MockModelStateIsApplicationLocalCall{Call: call}
 }
 
-// MockModelStateIsApplicationConsumerCall wrap *gomock.Call
-type MockModelStateIsApplicationConsumerCall struct {
+// MockModelStateIsApplicationLocalCall wrap *gomock.Call
+type MockModelStateIsApplicationLocalCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateIsApplicationConsumerCall) Return(arg0 bool, arg1 error) *MockModelStateIsApplicationConsumerCall {
+func (c *MockModelStateIsApplicationLocalCall) Return(arg0 bool, arg1 error) *MockModelStateIsApplicationLocalCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateIsApplicationConsumerCall) Do(f func(context.Context, string) (bool, error)) *MockModelStateIsApplicationConsumerCall {
+func (c *MockModelStateIsApplicationLocalCall) Do(f func(context.Context, string) (bool, error)) *MockModelStateIsApplicationLocalCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateIsApplicationConsumerCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockModelStateIsApplicationConsumerCall {
+func (c *MockModelStateIsApplicationLocalCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockModelStateIsApplicationLocalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -139,9 +139,9 @@ type ModelRemoteApplicationState interface {
 	//     is not a remote offerer application.
 	GetOffererModelUUID(ctx context.Context, appName string) (coremodel.UUID, error)
 
-	// IsApplicationConsumer checks if the given application exists in the model and
-	// is a non-synthetic application, in the consumer model.
-	IsApplicationConsumer(ctx context.Context, appName string) (bool, error)
+	// IsApplicationLocal checks if the given application exists in the model and
+	// is a non-synthetic application.
+	IsApplicationLocal(ctx context.Context, appName string) (bool, error)
 }
 
 // AddRemoteApplicationOfferer adds a new synthetic application representing
@@ -540,13 +540,13 @@ func splitRelationsByType(relations []charm.Relation) (map[string]charm.Relation
 	return provides, requires, nil
 }
 
-// IsApplicationConsumer checks if the given application exists in the model and
-// is a non-synthetic application, in the consumer model.
-func (s *Service) IsApplicationConsumer(ctx context.Context, appName string) (bool, error) {
+// IsApplicationLocal checks if the given application exists in the model and
+// is a non-synthetic application.
+func (s *Service) IsApplicationLocal(ctx context.Context, appName string) (bool, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return s.modelState.IsApplicationConsumer(ctx, appName)
+	return s.modelState.IsApplicationLocal(ctx, appName)
 }
 
 // GetOffererModelUUID returns the offering model UUID, based on a given

--- a/domain/crossmodelrelation/service/remoteapplication.go
+++ b/domain/crossmodelrelation/service/remoteapplication.go
@@ -139,9 +139,9 @@ type ModelRemoteApplicationState interface {
 	//     is not a remote offerer application.
 	GetOffererModelUUID(ctx context.Context, appName string) (coremodel.UUID, error)
 
-	// IsApplicationLocal checks if the given application exists in the model and
-	// is a non-synthetic application.
-	IsApplicationLocal(ctx context.Context, appName string) (bool, error)
+	// IsApplicationSynthetic checks if the given application exists in the model
+	// and is a synthetic application, based on the charm source being 'cmr'.
+	IsApplicationSynthetic(ctx context.Context, appName string) (bool, error)
 }
 
 // AddRemoteApplicationOfferer adds a new synthetic application representing
@@ -540,13 +540,13 @@ func splitRelationsByType(relations []charm.Relation) (map[string]charm.Relation
 	return provides, requires, nil
 }
 
-// IsApplicationLocal checks if the given application exists in the model and
-// is a non-synthetic application.
-func (s *Service) IsApplicationLocal(ctx context.Context, appName string) (bool, error) {
+// IsApplicationSynthetic checks if the given application exists in the model
+// and is a synthetic application.
+func (s *Service) IsApplicationSynthetic(ctx context.Context, appName string) (bool, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return s.modelState.IsApplicationLocal(ctx, appName)
+	return s.modelState.IsApplicationSynthetic(ctx, appName)
 }
 
 // GetOffererModelUUID returns the offering model UUID, based on a given

--- a/domain/crossmodelrelation/service/remoteapplication_test.go
+++ b/domain/crossmodelrelation/service/remoteapplication_test.go
@@ -819,38 +819,38 @@ func (s *remoteApplicationServiceSuite) TestGetOffererModelUUIDNotFound(c *tc.C)
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.RemoteApplicationNotFound)
 }
 
-func (s *remoteApplicationServiceSuite) TestCheckIsApplicationConsumer(c *tc.C) {
+func (s *remoteApplicationServiceSuite) TestCheckIsApplicationSynthetic(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsApplicationLocal(gomock.Any(), "wordpress").Return(true, nil)
+	s.modelState.EXPECT().IsApplicationSynthetic(gomock.Any(), "wordpress").Return(true, nil)
 
 	service := s.service(c)
 
-	isLocal, err := service.IsApplicationLocal(c.Context(), "wordpress")
+	isLocal, err := service.IsApplicationSynthetic(c.Context(), "wordpress")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(isLocal, tc.IsTrue)
 }
 
-func (s *remoteApplicationServiceSuite) TestCheckIsApplicationConsumerNotFound(c *tc.C) {
+func (s *remoteApplicationServiceSuite) TestCheckIsApplicationSyntheticNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsApplicationLocal(gomock.Any(), "non-existent").Return(false, nil)
+	s.modelState.EXPECT().IsApplicationSynthetic(gomock.Any(), "non-existent").Return(false, nil)
 
 	service := s.service(c)
 
-	isLocal, err := service.IsApplicationLocal(c.Context(), "non-existent")
+	isLocal, err := service.IsApplicationSynthetic(c.Context(), "non-existent")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(isLocal, tc.IsFalse)
 }
 
-func (s *remoteApplicationServiceSuite) TestCheckIsApplicationConsumerError(c *tc.C) {
+func (s *remoteApplicationServiceSuite) TestCheckIsApplicationSyntheticError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsApplicationLocal(gomock.Any(), "remote-app").Return(false, internalerrors.Errorf("boom"))
+	s.modelState.EXPECT().IsApplicationSynthetic(gomock.Any(), "remote-app").Return(false, internalerrors.Errorf("boom"))
 
 	service := s.service(c)
 
-	isLocal, err := service.IsApplicationLocal(c.Context(), "remote-app")
+	isLocal, err := service.IsApplicationSynthetic(c.Context(), "remote-app")
 	c.Assert(err, tc.ErrorMatches, "boom")
 	c.Check(isLocal, tc.IsFalse)
 }

--- a/domain/crossmodelrelation/service/remoteapplication_test.go
+++ b/domain/crossmodelrelation/service/remoteapplication_test.go
@@ -822,35 +822,35 @@ func (s *remoteApplicationServiceSuite) TestGetOffererModelUUIDNotFound(c *tc.C)
 func (s *remoteApplicationServiceSuite) TestCheckIsApplicationConsumer(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsApplicationConsumer(gomock.Any(), "wordpress").Return(true, nil)
+	s.modelState.EXPECT().IsApplicationLocal(gomock.Any(), "wordpress").Return(true, nil)
 
 	service := s.service(c)
 
-	isConsumer, err := service.IsApplicationConsumer(c.Context(), "wordpress")
+	isLocal, err := service.IsApplicationLocal(c.Context(), "wordpress")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(isConsumer, tc.IsTrue)
+	c.Check(isLocal, tc.IsTrue)
 }
 
 func (s *remoteApplicationServiceSuite) TestCheckIsApplicationConsumerNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsApplicationConsumer(gomock.Any(), "non-existent").Return(false, nil)
+	s.modelState.EXPECT().IsApplicationLocal(gomock.Any(), "non-existent").Return(false, nil)
 
 	service := s.service(c)
 
-	isConsumer, err := service.IsApplicationConsumer(c.Context(), "non-existent")
+	isLocal, err := service.IsApplicationLocal(c.Context(), "non-existent")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(isConsumer, tc.IsFalse)
+	c.Check(isLocal, tc.IsFalse)
 }
 
 func (s *remoteApplicationServiceSuite) TestCheckIsApplicationConsumerError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsApplicationConsumer(gomock.Any(), "remote-app").Return(false, internalerrors.Errorf("boom"))
+	s.modelState.EXPECT().IsApplicationLocal(gomock.Any(), "remote-app").Return(false, internalerrors.Errorf("boom"))
 
 	service := s.service(c)
 
-	isConsumer, err := service.IsApplicationConsumer(c.Context(), "remote-app")
+	isLocal, err := service.IsApplicationLocal(c.Context(), "remote-app")
 	c.Assert(err, tc.ErrorMatches, "boom")
-	c.Check(isConsumer, tc.IsFalse)
+	c.Check(isLocal, tc.IsFalse)
 }

--- a/domain/crossmodelrelation/state/model/relation_network.go
+++ b/domain/crossmodelrelation/state/model/relation_network.go
@@ -6,6 +6,7 @@ package state
 import (
 	"context"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/canonical/sqlair"
@@ -173,8 +174,10 @@ func (st *State) NamespacesForRelationEgressNetworksWatcher() (string, string, s
 
 // InitialWatchStatementForRelationEgressNetworks returns the initial query
 // for watching relation egress networks. It returns the actual egress CIDRs
-// if the relation exists, or an empty slice if no egress networks are
-// configured.
+// following the same priority logic as the watcher mapper:
+// 1. Relation-specific egress CIDRs from relation_network_egress
+// 2. Model config egress-subnets
+// 3. Unit public addresses converted to CIDRs
 func (st *State) InitialWatchStatementForRelationEgressNetworks(relationUUID string) eventsource.NamespaceQuery {
 	return func(ctx context.Context, runner database.TxnRunner) ([]string, error) {
 		db, err := st.DB(ctx)
@@ -182,16 +185,29 @@ func (st *State) InitialWatchStatementForRelationEgressNetworks(relationUUID str
 			return nil, errors.Capture(err)
 		}
 
-		checkStmt, err := st.Prepare(`
-SELECT &uuid.*
-FROM   relation
-WHERE  uuid = $uuid.uuid
-`, uuid{})
+		// Step 1: Get unit addresses for this relation
+		// If there are no units, return empty regardless of configured CIDRs
+		unitAddressStmt, err := st.Prepare(`
+SELECT u.uuid AS &unitAddress.unit_uuid,
+       ua.address_value AS &unitAddress.address_value,
+       ua.config_type_name AS &unitAddress.config_type_name,
+       ua.type_name AS &unitAddress.type_name,
+       ua.origin_name AS &unitAddress.origin_name,
+       ua.scope_name AS &unitAddress.scope_name,
+       ua.space_uuid AS &unitAddress.space_uuid,
+       ua.cidr AS &unitAddress.cidr
+FROM   relation_unit ru
+JOIN   relation_endpoint re ON ru.relation_endpoint_uuid = re.uuid
+JOIN   unit u ON ru.unit_uuid = u.uuid
+JOIN   v_all_unit_address AS ua ON u.uuid = ua.unit_uuid
+WHERE  re.relation_uuid = $uuid.uuid
+`, unitAddress{}, uuid{})
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
 
-		selectStmt, err := st.Prepare(`
+		// Step 2: Check relation-specific egress CIDRs
+		relationEgressStmt, err := st.Prepare(`
 SELECT &cidr.*
 FROM   relation_network_egress
 WHERE  relation_uuid = $uuid.uuid
@@ -200,10 +216,33 @@ WHERE  relation_uuid = $uuid.uuid
 			return nil, errors.Capture(err)
 		}
 
+		// Step 3: Check model config egress-subnets
+		egressSubnetsConfigKey := modelConfigKey{
+			Key: config.EgressSubnets,
+		}
+		modelConfigStmt, err := st.Prepare(`
+SELECT &modelConfigValue.value
+FROM   model_config
+WHERE  key = $modelConfigKey.key
+`, modelConfigValue{}, egressSubnetsConfigKey)
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+
 		var cidrs []string
 		err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			// Check if relation exists
 			var result uuid
-			err := tx.Query(ctx, checkStmt, uuid{UUID: relationUUID}).Get(&result)
+			checkStmt, err := st.Prepare(`
+SELECT &uuid.*
+FROM   relation
+WHERE  uuid = $uuid.uuid
+`, uuid{})
+			if err != nil {
+				return errors.Capture(err)
+			}
+
+			err = tx.Query(ctx, checkStmt, uuid{UUID: relationUUID}).Get(&result)
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return relationerrors.RelationNotFound
 			}
@@ -211,15 +250,79 @@ WHERE  relation_uuid = $uuid.uuid
 				return err
 			}
 
-			var results []cidr
-			if err := tx.Query(ctx, selectStmt, uuid{UUID: relationUUID}).GetAll(&results); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			// Get unit addresses
+			var addresses []unitAddress
+			err = tx.Query(ctx, unitAddressStmt, uuid{UUID: relationUUID}).GetAll(&addresses)
+			if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+				return errors.Capture(err)
+			}
+
+			// If no units, return empty
+			if len(addresses) == 0 {
+				cidrs = []string{}
+				return nil
+			}
+
+			// Priority 1: Check relation-specific egress CIDRs
+			var relationCIDRs []cidr
+			err = tx.Query(ctx, relationEgressStmt, uuid{UUID: relationUUID}).GetAll(&relationCIDRs)
+			if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 				return errors.Errorf("retrieving relation network egress for relation %q: %w", relationUUID, err)
 			}
 
-			cidrs = make([]string, len(results))
-			for i, result := range results {
-				cidrs[i] = result.CIDR
+			if len(relationCIDRs) > 0 {
+				cidrs = make([]string, len(relationCIDRs))
+				for i, c := range relationCIDRs {
+					cidrs[i] = c.CIDR
+				}
+				return nil
 			}
+
+			// Priority 2: Check model config for egress-subnets
+			var configValue modelConfigValue
+			err = tx.Query(ctx, modelConfigStmt, egressSubnetsConfigKey).Get(&configValue)
+			if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+				return errors.Capture(err)
+			}
+
+			if configValue.Value != "" {
+				configCIDRs := strings.Split(configValue.Value, ",")
+				cidrs = make([]string, 0, len(configCIDRs))
+				for _, c := range configCIDRs {
+					trimmed := strings.TrimSpace(c)
+					if trimmed != "" {
+						cidrs = append(cidrs, trimmed)
+					}
+				}
+				if len(cidrs) > 0 {
+					return nil
+				}
+			}
+
+			// Priority 3: Use unit public addresses
+			// Group addresses by unit UUID
+			unitAddressesMap := make(map[string]network.SpaceAddresses)
+			for _, addr := range addresses {
+				spaceAddr, err := encodeIPAddress(addr)
+				if err != nil {
+					return errors.Capture(err)
+				}
+				unitAddressesMap[addr.UnitUUID] = append(unitAddressesMap[addr.UnitUUID], spaceAddr)
+			}
+
+			// Filter for public addresses
+			var allPublicAddresses []string
+			for _, addrs := range unitAddressesMap {
+				matchedAddrs := addrs.AllMatchingScope(network.ScopeMatchPublic)
+				if len(matchedAddrs) == 0 {
+					continue
+				}
+				sort.Sort(matchedAddrs)
+				allPublicAddresses = append(allPublicAddresses, matchedAddrs[0].Value)
+			}
+
+			// Convert to /32 or /128 CIDRs
+			cidrs = network.SubnetsForAddresses(allPublicAddresses)
 			return nil
 		})
 		if err != nil {

--- a/domain/crossmodelrelation/state/model/relation_network.go
+++ b/domain/crossmodelrelation/state/model/relation_network.go
@@ -185,122 +185,46 @@ func (st *State) InitialWatchStatementForRelationEgressNetworks(relationUUID str
 			return nil, errors.Capture(err)
 		}
 
-		// Step 1: Get unit addresses for this relation
-		// If there are no units, return empty regardless of configured CIDRs
-		unitAddressStmt, err := st.Prepare(`
-SELECT u.uuid AS &unitAddress.unit_uuid,
-       ua.address_value AS &unitAddress.address_value,
-       ua.config_type_name AS &unitAddress.config_type_name,
-       ua.type_name AS &unitAddress.type_name,
-       ua.origin_name AS &unitAddress.origin_name,
-       ua.scope_name AS &unitAddress.scope_name,
-       ua.space_uuid AS &unitAddress.space_uuid,
-       ua.cidr AS &unitAddress.cidr
-FROM   relation_unit ru
-JOIN   relation_endpoint re ON ru.relation_endpoint_uuid = re.uuid
-JOIN   unit u ON ru.unit_uuid = u.uuid
-JOIN   v_all_unit_address AS ua ON u.uuid = ua.unit_uuid
-WHERE  re.relation_uuid = $uuid.uuid
-`, unitAddress{}, uuid{})
-		if err != nil {
-			return nil, errors.Capture(err)
-		}
-
-		// Step 2: Check relation-specific egress CIDRs
-		relationEgressStmt, err := st.Prepare(`
-SELECT &cidr.*
-FROM   relation_network_egress
-WHERE  relation_uuid = $uuid.uuid
-`, cidr{}, uuid{})
-		if err != nil {
-			return nil, errors.Capture(err)
-		}
-
-		// Step 3: Check model config egress-subnets
-		egressSubnetsConfigKey := modelConfigKey{
-			Key: config.EgressSubnets,
-		}
-		modelConfigStmt, err := st.Prepare(`
-SELECT &modelConfigValue.value
-FROM   model_config
-WHERE  key = $modelConfigKey.key
-`, modelConfigValue{}, egressSubnetsConfigKey)
-		if err != nil {
-			return nil, errors.Capture(err)
-		}
-
 		var cidrs []string
 		err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			// Check if relation exists
-			var result uuid
-			checkStmt, err := st.Prepare(`
-SELECT &uuid.*
-FROM   relation
-WHERE  uuid = $uuid.uuid
-`, uuid{})
+			// Check that the relation exists.
+			_, err := st.getRelationLife(ctx, tx, relationUUID)
 			if err != nil {
 				return errors.Capture(err)
 			}
 
-			err = tx.Query(ctx, checkStmt, uuid{UUID: relationUUID}).Get(&result)
-			if errors.Is(err, sqlair.ErrNoRows) {
-				return relationerrors.RelationNotFound
-			}
+			// Get unit addresses for units in the relation.
+			addresses, err := st.getUnitAddresses(ctx, tx, relationUUID)
 			if err != nil {
-				return err
-			}
-
-			// Get unit addresses
-			var addresses []unitAddress
-			err = tx.Query(ctx, unitAddressStmt, uuid{UUID: relationUUID}).GetAll(&addresses)
-			if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 				return errors.Capture(err)
 			}
-
-			// If no units, return empty
 			if len(addresses) == 0 {
+				// No units found, return empty CIDR list.
 				cidrs = []string{}
 				return nil
 			}
 
-			// Priority 1: Check relation-specific egress CIDRs
-			var relationCIDRs []cidr
-			err = tx.Query(ctx, relationEgressStmt, uuid{UUID: relationUUID}).GetAll(&relationCIDRs)
-			if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Errorf("retrieving relation network egress for relation %q: %w", relationUUID, err)
+			// Priority 1: Check relation-specific egress CIDRs.
+			egressSubnets, err := st.getRelationEgressSubnets(ctx, tx, relationUUID)
+			if err != nil {
+				return errors.Capture(err)
 			}
-
-			if len(relationCIDRs) > 0 {
-				cidrs = make([]string, len(relationCIDRs))
-				for i, c := range relationCIDRs {
-					cidrs[i] = c.CIDR
-				}
+			if len(egressSubnets) > 0 {
+				cidrs = egressSubnets
 				return nil
 			}
 
-			// Priority 2: Check model config for egress-subnets
-			var configValue modelConfigValue
-			err = tx.Query(ctx, modelConfigStmt, egressSubnetsConfigKey).Get(&configValue)
-			if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			// Priority 2: Check model config for egress-subnets.
+			modelConfigCIDRs, err := st.getEgressSubnetModelConfig(ctx, tx)
+			if err != nil {
 				return errors.Capture(err)
 			}
-
-			if configValue.Value != "" {
-				configCIDRs := strings.Split(configValue.Value, ",")
-				cidrs = make([]string, 0, len(configCIDRs))
-				for _, c := range configCIDRs {
-					trimmed := strings.TrimSpace(c)
-					if trimmed != "" {
-						cidrs = append(cidrs, trimmed)
-					}
-				}
-				if len(cidrs) > 0 {
-					return nil
-				}
+			if len(modelConfigCIDRs) > 0 {
+				cidrs = modelConfigCIDRs
+				return nil
 			}
 
-			// Priority 3: Use unit public addresses
-			// Group addresses by unit UUID
+			// Priority 3: Use unit public addresses grouped by unit UUID.
 			unitAddressesMap := make(map[string]network.SpaceAddresses)
 			for _, addr := range addresses {
 				spaceAddr, err := encodeIPAddress(addr)
@@ -310,7 +234,7 @@ WHERE  uuid = $uuid.uuid
 				unitAddressesMap[addr.UnitUUID] = append(unitAddressesMap[addr.UnitUUID], spaceAddr)
 			}
 
-			// Filter for public addresses
+			// Filter for public addresses.
 			var allPublicAddresses []string
 			for _, addrs := range unitAddressesMap {
 				matchedAddrs := addrs.AllMatchingScope(network.ScopeMatchPublic)
@@ -321,7 +245,7 @@ WHERE  uuid = $uuid.uuid
 				allPublicAddresses = append(allPublicAddresses, matchedAddrs[0].Value)
 			}
 
-			// Convert to /32 or /128 CIDRs
+			// Convert to /32 or /128 CIDRs.
 			cidrs = network.SubnetsForAddresses(allPublicAddresses)
 			return nil
 		})
@@ -331,6 +255,96 @@ WHERE  uuid = $uuid.uuid
 
 		return cidrs, nil
 	}
+}
+
+func (st *State) getUnitAddresses(ctx context.Context, tx *sqlair.TX, relationUUID string) ([]unitAddress, error) {
+	unitAddressStmt, err := st.Prepare(`
+SELECT u.uuid AS &unitAddress.unit_uuid,
+       (ua.address_value,
+       ua.config_type_name,
+       ua.type_name,
+       ua.origin_name,
+       ua.scope_name,
+       ua.space_uuid,
+       ua.cidr) AS (&unitAddress.*)
+FROM   relation_unit AS ru
+JOIN   relation_endpoint AS re ON ru.relation_endpoint_uuid = re.uuid
+JOIN   unit AS u ON ru.unit_uuid = u.uuid
+JOIN   v_all_unit_address AS ua ON u.uuid = ua.unit_uuid
+WHERE  re.relation_uuid = $uuid.uuid
+`, unitAddress{}, uuid{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	// Get unit addresses.
+	var addresses []unitAddress
+	err = tx.Query(ctx, unitAddressStmt, uuid{UUID: relationUUID}).GetAll(&addresses)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return nil, errors.Capture(err)
+	}
+
+	return addresses, nil
+}
+
+func (st *State) getRelationEgressSubnets(ctx context.Context, tx *sqlair.TX, relationUUID string) ([]string, error) {
+	relationEgressStmt, err := st.Prepare(`
+SELECT &cidr.*
+FROM   relation_network_egress
+WHERE  relation_uuid = $uuid.uuid
+`, cidr{}, uuid{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var relationCIDRs []cidr
+	err = tx.Query(ctx, relationEgressStmt, uuid{UUID: relationUUID}).GetAll(&relationCIDRs)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return nil, errors.Errorf("retrieving relation network egress for relation %q: %w", relationUUID, err)
+	}
+
+	cidrs := make([]string, len(relationCIDRs))
+	for i, c := range relationCIDRs {
+		cidrs[i] = c.CIDR
+	}
+
+	return cidrs, nil
+}
+
+func (st *State) getEgressSubnetModelConfig(ctx context.Context, tx *sqlair.TX) ([]string, error) {
+	egressSubnetsConfigKey := modelConfigKey{
+		Key: config.EgressSubnets,
+	}
+	modelConfigStmt, err := st.Prepare(`
+SELECT &modelConfigValue.value
+FROM   model_config
+WHERE  key = $modelConfigKey.key
+`, modelConfigValue{}, egressSubnetsConfigKey)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var configValue modelConfigValue
+	err = tx.Query(ctx, modelConfigStmt, egressSubnetsConfigKey).Get(&configValue)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return nil, errors.Capture(err)
+	}
+
+	if configValue.Value == "" {
+		// No config set, return early.
+		return nil, nil
+	}
+
+	configCIDRs := strings.Split(configValue.Value, ",")
+	cidrs := make([]string, 0, len(configCIDRs))
+	for _, c := range configCIDRs {
+		trimmed := strings.TrimSpace(c)
+		if trimmed != "" {
+			cidrs = append(cidrs, trimmed)
+		}
+	}
+
+	return cidrs, nil
 }
 
 // GetUnitAddressesForRelation returns all unit addresses for units that are
@@ -343,13 +357,13 @@ func (st *State) GetUnitAddressesForRelation(ctx context.Context, relationUUID s
 
 	stmt, err := st.Prepare(`
 SELECT u.uuid AS &unitAddress.unit_uuid,
-       ua.address_value AS &unitAddress.address_value,
-       ua.config_type_name AS &unitAddress.config_type_name,
-       ua.type_name AS &unitAddress.type_name,
-       ua.origin_name AS &unitAddress.origin_name,
-       ua.scope_name AS &unitAddress.scope_name,
-       ua.space_uuid AS &unitAddress.space_uuid,
-       ua.cidr AS &unitAddress.cidr
+       (ua.address_value,
+       ua.config_type_name,
+       ua.type_name,
+       ua.origin_name,
+       ua.scope_name,
+       ua.space_uuid,
+       ua.cidr) AS (&unitAddress.*)
 FROM   relation_unit ru
 JOIN   relation_endpoint re ON ru.relation_endpoint_uuid = re.uuid
 JOIN   unit u ON ru.unit_uuid = u.uuid

--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -1627,9 +1627,9 @@ WHERE a.name = $name.name`, modelUUID{}, name{})
 	return coremodel.UUID(result.UUID), nil
 }
 
-// IsApplicationConsumer checks if the given application exists in the model and
-// is a non-synthetic application, in the consumer model.
-func (st *State) IsApplicationConsumer(ctx context.Context, appName string) (bool, error) {
+// IsApplicationLocal checks if the given application exists in the model and
+// is a non-synthetic application, based on the charm source not being 'cmr'.
+func (st *State) IsApplicationLocal(ctx context.Context, appName string) (bool, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return false, errors.Capture(err)

--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -1627,9 +1627,9 @@ WHERE a.name = $name.name`, modelUUID{}, name{})
 	return coremodel.UUID(result.UUID), nil
 }
 
-// IsApplicationLocal checks if the given application exists in the model and
-// is a non-synthetic application, based on the charm source not being 'cmr'.
-func (st *State) IsApplicationLocal(ctx context.Context, appName string) (bool, error) {
+// IsApplicationSynthetic checks if the given application exists in the model
+// and is a synthetic application, based on the charm source being 'cmr'.
+func (st *State) IsApplicationSynthetic(ctx context.Context, appName string) (bool, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return false, errors.Capture(err)
@@ -1641,7 +1641,7 @@ FROM   application AS a
 JOIN   charm AS c ON c.uuid = a.charm_uuid
 JOIN   charm_source AS cs ON cs.id = c.source_id
 WHERE  a.name = $name.name 
-AND    cs.name != 'cmr'`, countResult{}, name{})
+AND    cs.name = 'cmr'`, countResult{}, name{})
 	if err != nil {
 		return false, errors.Capture(err)
 	}

--- a/domain/crossmodelrelation/state/model/remoteapplication_test.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication_test.go
@@ -2382,7 +2382,7 @@ func (s *modelRemoteApplicationSuite) TestGetOffererModelUUIDNotRemoteOfferer(c 
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.RemoteApplicationNotFound)
 }
 
-func (s *modelRemoteApplicationSuite) TestCheckIsApplicationConsumer(c *tc.C) {
+func (s *modelRemoteApplicationSuite) TestCheckIsApplicationLocal(c *tc.C) {
 	applicationUUID := tc.Must(c, coreapplication.NewUUID)
 	charmUUID := tc.Must(c, corecharm.NewID).String()
 	offerUUID := tc.Must(c, coreoffer.NewUUID).String()
@@ -2391,15 +2391,15 @@ func (s *modelRemoteApplicationSuite) TestCheckIsApplicationConsumer(c *tc.C) {
 	s.createCharm(c, charmUUID)
 	s.createApplication(c, applicationUUID, charmUUID, offerUUID)
 
-	isConsumer, err := s.state.IsApplicationConsumer(c.Context(), applicationUUID.String())
+	isLocal, err := s.state.IsApplicationLocal(c.Context(), applicationUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(isConsumer, tc.IsTrue)
+	c.Check(isLocal, tc.IsTrue)
 }
 
 func (s *modelRemoteApplicationSuite) TestCheckIsApplicationConsumerNotFound(c *tc.C) {
-	isConsumer, err := s.state.IsApplicationConsumer(c.Context(), "non-existent-app")
+	isLocal, err := s.state.IsApplicationLocal(c.Context(), "non-existent-app")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(isConsumer, tc.IsFalse)
+	c.Check(isLocal, tc.IsFalse)
 }
 
 func (s *modelRemoteApplicationSuite) TestCheckIsApplicationConsumerSynthetic(c *tc.C) {
@@ -2439,7 +2439,7 @@ func (s *modelRemoteApplicationSuite) TestCheckIsApplicationConsumerSynthetic(c 
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	isConsumer, err := s.state.IsApplicationConsumer(c.Context(), "remote-app")
+	isLocal, err := s.state.IsApplicationLocal(c.Context(), "remote-app")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(isConsumer, tc.IsFalse)
+	c.Check(isLocal, tc.IsFalse)
 }

--- a/domain/crossmodelrelation/state/model/remoteapplication_test.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication_test.go
@@ -2382,7 +2382,7 @@ func (s *modelRemoteApplicationSuite) TestGetOffererModelUUIDNotRemoteOfferer(c 
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.RemoteApplicationNotFound)
 }
 
-func (s *modelRemoteApplicationSuite) TestCheckIsApplicationLocal(c *tc.C) {
+func (s *modelRemoteApplicationSuite) TestCheckIsApplicationSyntheticNot(c *tc.C) {
 	applicationUUID := tc.Must(c, coreapplication.NewUUID)
 	charmUUID := tc.Must(c, corecharm.NewID).String()
 	offerUUID := tc.Must(c, coreoffer.NewUUID).String()
@@ -2391,18 +2391,18 @@ func (s *modelRemoteApplicationSuite) TestCheckIsApplicationLocal(c *tc.C) {
 	s.createCharm(c, charmUUID)
 	s.createApplication(c, applicationUUID, charmUUID, offerUUID)
 
-	isLocal, err := s.state.IsApplicationLocal(c.Context(), applicationUUID.String())
+	isSynthetic, err := s.state.IsApplicationSynthetic(c.Context(), applicationUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(isLocal, tc.IsTrue)
+	c.Check(isSynthetic, tc.IsFalse)
 }
 
 func (s *modelRemoteApplicationSuite) TestCheckIsApplicationConsumerNotFound(c *tc.C) {
-	isLocal, err := s.state.IsApplicationLocal(c.Context(), "non-existent-app")
+	isSynthetic, err := s.state.IsApplicationSynthetic(c.Context(), "non-existent-app")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(isLocal, tc.IsFalse)
+	c.Check(isSynthetic, tc.IsFalse)
 }
 
-func (s *modelRemoteApplicationSuite) TestCheckIsApplicationConsumerSynthetic(c *tc.C) {
+func (s *modelRemoteApplicationSuite) TestCheckIsApplicationSynthetic(c *tc.C) {
 	applicationUUID := tc.Must(c, coreapplication.NewUUID).String()
 	charmUUID := tc.Must(c, corecharm.NewID).String()
 	remoteAppUUID := tc.Must(c, coreapplication.NewUUID).String()
@@ -2439,7 +2439,7 @@ func (s *modelRemoteApplicationSuite) TestCheckIsApplicationConsumerSynthetic(c 
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	isLocal, err := s.state.IsApplicationLocal(c.Context(), "remote-app")
+	isSynthetic, err := s.state.IsApplicationSynthetic(c.Context(), "remote-app")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(isLocal, tc.IsFalse)
+	c.Check(isSynthetic, tc.IsTrue)
 }

--- a/domain/crossmodelrelation/watcher_test.go
+++ b/domain/crossmodelrelation/watcher_test.go
@@ -1055,8 +1055,10 @@ func (s *watcherSuite) TestWatchRelationEgressNetworks(c *tc.C) {
 		w.AssertNoChange()
 	})
 
-	// Initial event should be empty (no egress networks configured initially).
-	harness.Run(c, []string{})
+	// Initial event should contain the unit address converted to CIDR.
+	// The setupRemoteOffererLocalAndRelation creates a unit with address
+	// 198.51.100.1 (public scope), which should be returned as 198.51.100.1/32.
+	harness.Run(c, []string{"198.51.100.1/32"})
 }
 
 func (s *watcherSuite) TestWatchRelationEgressNetworksEmptyRelationUUID(c *tc.C) {

--- a/internal/worker/firewaller/firewaller.go
+++ b/internal/worker/firewaller/firewaller.go
@@ -477,18 +477,23 @@ func (fw *Firewaller) subnetsChanged(ctx context.Context) error {
 }
 
 func (fw *Firewaller) relationIngressChanged(ctx context.Context, change *remoteRelationNetworkChange) error {
-	fw.logger.Debugf(ctx, "process remote relation ingress change for %v", change.relationTag)
+	fw.logger.Debugf(ctx, "process remote relation ingress change: %v", change)
 	relData, ok := fw.relationIngress[change.relationTag]
 	if !ok {
 		relData = &remoteRelationData{
 			fw:                  fw,
 			tag:                 change.relationTag,
 			localApplicationTag: change.localApplicationTag,
+			workerID:            change.workerID,
 		}
 		fw.relationIngress[change.relationTag] = relData
 	}
 	relData.networks = change.networks
 	relData.ingressRequired = change.ingressRequired
+	// Update workerID in case it wasn't set before
+	if relData.workerID == "" && change.workerID != "" {
+		relData.workerID = change.workerID
+	}
 	appData, ok := fw.applicationids[change.localApplicationTag]
 	if !ok {
 		fw.logger.Debugf(ctx, "ignoring unknown application: %v", change.localApplicationTag)
@@ -978,6 +983,7 @@ func (fw *Firewaller) ingressRulesForNonExposedMachineUnit(ctx context.Context,
 	if err != nil || len(srcCIDRs) == 0 {
 		return nil, errors.Trace(err)
 	}
+	fw.logger.Debugf(ctx, "adding remote relation ingress CIDRs %v for non-exposed application %q", srcCIDRs, appTag)
 
 	var rules firewall.IngressRules
 	for _, portRange := range openUnitPortRanges.UniquePortRanges() {
@@ -1576,6 +1582,7 @@ func (fw *Firewaller) handleRelationLifeChange(
 	relationUUID relation.UUID,
 	relationType RelationType,
 ) (bool, domainrelation.RelationDetails, error) {
+	fw.logger.Debugf(ctx, "handling %s relation life change for %q", relationType, relationUUID)
 	var (
 		gone bool
 		rel  domainrelation.RelationDetails
@@ -1588,6 +1595,7 @@ func (fw *Firewaller) handleRelationLifeChange(
 	} else if err != nil {
 		return false, rel, errors.Trace(err)
 	}
+	fw.logger.Debugf(ctx, "retrieved (%s) relation %q details: %+v", relationType, relationUUID, rel)
 
 	gone = gone || rel.Life == life.Dead || rel.Suspended
 
@@ -1601,6 +1609,7 @@ func (fw *Firewaller) handleRelationLifeChange(
 				relationTag:         tag,
 				localApplicationTag: data.localApplicationTag,
 				ingressRequired:     false,
+				workerID:            data.workerID,
 			}
 			if err := fw.relationIngressChanged(ctx, change); err != nil {
 				return false, rel, errors.Trace(err)
@@ -1619,6 +1628,7 @@ func (fw *Firewaller) handleRelationLifeChange(
 // - If requirer: watch local egress and publish to remote.
 // - If provider: watch remote egress and apply ingress locally.
 func (fw *Firewaller) startConsumerRelation(ctx context.Context, rel domainrelation.RelationDetails) error {
+	fw.logger.Debugf(ctx, "starting consumer relation watcher for %q", rel.Key.String())
 	// For consuming side, we need to identify which endpoint is local and which
 	// is remote.
 	if len(rel.Endpoints) != 2 {
@@ -1631,16 +1641,16 @@ func (fw *Firewaller) startConsumerRelation(ctx context.Context, rel domainrelat
 
 	// We only have to check one of the endpoints to see if it's local.
 	// If it's not local, the other one must be.
-	isConsumer, err := fw.crossModelRelationService.IsApplicationConsumer(ctx, rel.Endpoints[0].ApplicationName)
+	isLocal, err := fw.crossModelRelationService.IsApplicationLocal(ctx, rel.Endpoints[0].ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if !isConsumer {
-		localEndpoint = rel.Endpoints[1]
-		remoteEndpoint = rel.Endpoints[0]
-	} else {
+	if isLocal {
 		localEndpoint = rel.Endpoints[0]
 		remoteEndpoint = rel.Endpoints[1]
+	} else {
+		localEndpoint = rel.Endpoints[1]
+		remoteEndpoint = rel.Endpoints[0]
 	}
 
 	// Get the remote model UUID for the remote application.
@@ -1668,13 +1678,15 @@ func (fw *Firewaller) startConsumerRelationRequirer(
 	remoteModelUUID coremodel.UUID,
 ) error {
 	tag := names.NewRelationTag(rel.Key.String())
-	fw.logger.Debugf(ctx, "starting consumer relation requirer watcher for %v", tag.Id())
+	fw.logger.Debugf(ctx, "starting consumer relation requirer watcher for %q", tag.Id())
 
-	if err := fw.relationWorkerRunner.StartWorker(ctx, tag.Id(), func(ctx context.Context) (worker.Worker, error) {
+	workerID := "consumer-requirer " + tag.Id()
+	if err := fw.relationWorkerRunner.StartWorker(ctx, workerID, func(ctx context.Context) (worker.Worker, error) {
 		data := &remoteRelationData{
 			fw:                  fw,
 			tag:                 tag,
 			localApplicationTag: localApplicationTag,
+			workerID:            workerID,
 			relationUUID:        rel.UUID,
 			remoteModelUUID:     remoteModelUUID,
 		}
@@ -1703,13 +1715,15 @@ func (fw *Firewaller) startConsumerRelationProvider(
 	remoteModelUUID coremodel.UUID,
 ) error {
 	tag := names.NewRelationTag(rel.Key.String())
-	fw.logger.Debugf(ctx, "starting consumer relation provider watcher for %v", tag.Id())
+	fw.logger.Debugf(ctx, "starting consumer relation provider watcher for %q", tag.Id())
 
-	if err := fw.relationWorkerRunner.StartWorker(ctx, tag.Id(), func(ctx context.Context) (worker.Worker, error) {
+	workerID := "consumer-provider " + tag.Id()
+	if err := fw.relationWorkerRunner.StartWorker(ctx, workerID, func(ctx context.Context) (worker.Worker, error) {
 		data := &remoteRelationData{
 			fw:                  fw,
 			tag:                 tag,
 			localApplicationTag: localApplicationTag,
+			workerID:            workerID,
 			relationUUID:        rel.UUID,
 			remoteModelUUID:     remoteModelUUID,
 		}
@@ -1734,15 +1748,24 @@ func (fw *Firewaller) startConsumerRelationProvider(
 // have been published from the consuming model.
 // We only watch if the local endpoint role is provider.
 func (fw *Firewaller) startOffererRelation(ctx context.Context, rel domainrelation.RelationDetails) error {
+	fw.logger.Debugf(ctx, "starting offerer relation watcher for %q", rel.Key.String())
 	tag := names.NewRelationTag(rel.Key.String())
-	fw.logger.Debugf(ctx, "starting offerer relation watcher for %v", tag.Id())
 
-	// For offering side, get the local application name from the first
-	// endpoint.
 	if len(rel.Endpoints) == 0 {
 		return errors.Errorf("relation %v has no endpoints", tag.Id())
 	}
-	localEndpoint := rel.Endpoints[0]
+	// We only have to check one of the endpoints to see if it's local.
+	// If it's not local, the other one must be.
+	var localEndpoint domainrelation.Endpoint
+	isLocal, err := fw.crossModelRelationService.IsApplicationLocal(ctx, rel.Endpoints[0].ApplicationName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if isLocal {
+		localEndpoint = rel.Endpoints[0]
+	} else {
+		localEndpoint = rel.Endpoints[1]
+	}
 
 	// On the offering side, only watch for ingress changes if the endpoint is a
 	// provider.
@@ -1754,12 +1777,14 @@ func (fw *Firewaller) startOffererRelation(ctx context.Context, rel domainrelati
 	localApplicationName := localEndpoint.ApplicationName
 
 	// Start the worker which watches for ingress address changes
-	if err := fw.relationWorkerRunner.StartWorker(ctx, tag.Id(), func(ctx context.Context) (worker.Worker, error) {
+	workerID := "offerer " + tag.Id()
+	if err := fw.relationWorkerRunner.StartWorker(ctx, workerID, func(ctx context.Context) (worker.Worker, error) {
 		// Create a fresh relation worker instance for each (re)start to avoid reusing catacombs.
 		data := &remoteRelationData{
 			fw:                  fw,
 			tag:                 tag,
 			localApplicationTag: names.NewApplicationTag(localApplicationName),
+			workerID:            workerID,
 			relationUUID:        rel.UUID,
 		}
 		if err := catacomb.Invoke(catacomb.Plan{
@@ -1816,6 +1841,7 @@ func (rd *remoteRelationData) watchLocalIngress() error {
 				localApplicationTag: rd.localApplicationTag,
 				networks:            set.NewStrings(cidrs...),
 				ingressRequired:     len(cidrs) > 0,
+				workerID:            rd.workerID,
 			}
 			select {
 			case <-rd.catacomb.Dying():
@@ -1832,7 +1858,7 @@ func (rd *remoteRelationData) watchLocalEgressPublishRemote() error {
 	ctx, cancel := rd.scopedContext()
 	defer cancel()
 
-	rd.fw.logger.Debugf(ctx, "watching local egress for %v to publish to remote", rd.tag.Id())
+	rd.fw.logger.Debugf(ctx, "watching local egress for %q to publish to remote", rd.tag.Id())
 
 	defer func() {
 		if rd.crossModelFirewallerFacade != nil {
@@ -1876,7 +1902,7 @@ func (rd *remoteRelationData) watchRemoteEgressApplyLocal() error {
 	ctx, cancel := rd.scopedContext()
 	defer cancel()
 
-	rd.fw.logger.Debugf(ctx, "watching remote egress for %v to apply local ingress", rd.tag.Id())
+	rd.fw.logger.Debugf(ctx, "watching remote egress for %q to apply local ingress", rd.tag.Id())
 
 	apiInfo, err := rd.fw.firewallerApi.ControllerAPIInfoForModel(ctx, rd.remoteModelUUID.String())
 	if err != nil {
@@ -1922,7 +1948,7 @@ func (rd *remoteRelationData) watchRemoteEgressApplyLocal() error {
 		case <-rd.catacomb.Dying():
 			return rd.catacomb.ErrDying()
 		case cidrs := <-egressAddressWatcher.Changes():
-			rd.fw.logger.Debugf(ctx, "remote egress addresses for %v changed: %v", rd.tag, cidrs)
+			rd.fw.logger.Debugf(ctx, "remote egress addresses for %q changed: %v", rd.tag, cidrs)
 			if err := rd.updateIngressNetworks(ctx, cidrs); err != nil {
 				return errors.Trace(err)
 			}
@@ -1994,6 +2020,7 @@ type remoteRelationData struct {
 
 	tag                 names.RelationTag
 	localApplicationTag names.ApplicationTag
+	workerID            string
 	// relationUUID is the relation UUID both in the consuming and offering
 	// model. It's used as relationToken when communicating with the remote
 	// model.
@@ -2017,16 +2044,18 @@ type remoteRelationNetworkChange struct {
 	localApplicationTag names.ApplicationTag
 	networks            set.Strings
 	ingressRequired     bool
+	workerID            string
 }
 
 // updateIngressNetworks processes the changed ingress networks on the relation.
 func (rd *remoteRelationData) updateIngressNetworks(ctx context.Context, cidrs []string) error {
-	rd.fw.logger.Debugf(ctx, "ingress cidrs for %v: %+v", rd.tag, cidrs)
+	rd.fw.logger.Debugf(ctx, "ingress cidrs for %q: %v", rd.tag, cidrs)
 	change := &remoteRelationNetworkChange{
 		relationTag:         rd.tag,
 		localApplicationTag: rd.localApplicationTag,
 		networks:            set.NewStrings(cidrs...),
 		ingressRequired:     len(cidrs) > 0,
+		workerID:            rd.workerID,
 	}
 	select {
 	case <-rd.catacomb.Dying():
@@ -2052,7 +2081,7 @@ func (fw *Firewaller) forgetRelation(ctx context.Context, data *remoteRelationDa
 	delete(fw.relationIngress, data.tag)
 	// There's not much we can do if there's an error stopping the remote
 	// relation worker, so just log it.
-	if err := fw.relationWorkerRunner.StopAndRemoveWorker(data.tag.Id(), fw.catacomb.Dying()); err != nil {
+	if err := fw.relationWorkerRunner.StopAndRemoveWorker(data.workerID, fw.catacomb.Dying()); err != nil {
 		fw.logger.Errorf(ctx, "error stopping remote relation worker for %s: %v", data.tag, err)
 	}
 	fw.logger.Debugf(ctx, "stopped watching %q", data.tag)

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -1415,7 +1415,7 @@ func (s *InstanceModeSuite) setupRemoteRelationRequirerRoleConsumingSide(c *tc.C
 
 	offererModelUUID := tc.Must(c, coremodel.NewUUID)
 
-	s.crossModelRelationService.EXPECT().IsApplicationConsumer(gomock.Any(), "wordpress").Return(true, nil).MinTimes(1)
+	s.crossModelRelationService.EXPECT().IsApplicationLocal(gomock.Any(), "wordpress").Return(true, nil).MinTimes(1)
 	s.crossModelRelationService.EXPECT().GetOffererModelUUID(gomock.Any(), "remote-mysql").Return(offererModelUUID, nil).MinTimes(1)
 	relTag := names.NewRelationTag("wordpress:db remote-mysql:server")
 	relKey, err := relation.NewKeyFromString(relTag.Id())
@@ -1591,7 +1591,7 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *tc.C)
 
 	offererModelUUID := tc.Must(c, coremodel.NewUUID)
 
-	s.crossModelRelationService.EXPECT().IsApplicationConsumer(gomock.Any(), "remote-wordpress").Return(false, nil).MinTimes(1)
+	s.crossModelRelationService.EXPECT().IsApplicationLocal(gomock.Any(), "remote-wordpress").Return(false, nil).MinTimes(1)
 	s.crossModelRelationService.EXPECT().GetOffererModelUUID(gomock.Any(), "remote-wordpress").Return(offererModelUUID, nil).MinTimes(1)
 
 	relTag := names.NewRelationTag("remote-wordpress:db mysql:server")
@@ -1677,7 +1677,7 @@ func (s *InstanceModeSuite) TestRemoteRelationIngressRejected(c *tc.C) {
 
 	offererModelUUID := tc.Must(c, coremodel.NewUUID)
 
-	s.crossModelRelationService.EXPECT().IsApplicationConsumer(gomock.Any(), "wordpress").Return(true, nil).MinTimes(1)
+	s.crossModelRelationService.EXPECT().IsApplicationLocal(gomock.Any(), "wordpress").Return(true, nil).MinTimes(1)
 	s.crossModelRelationService.EXPECT().GetOffererModelUUID(gomock.Any(), "remote-mysql").Return(offererModelUUID, nil).MinTimes(1)
 
 	relTag := names.NewRelationTag("wordpress:db remote-mysql:server")
@@ -1841,6 +1841,8 @@ func (s *InstanceModeSuite) assertIngressCidrs(c *tc.C, ctrl *gomock.Controller,
 				},
 			}, nil
 		}).AnyTimes()
+
+	s.crossModelRelationService.EXPECT().IsApplicationLocal(gomock.Any(), "mysql").Return(true, nil).AnyTimes()
 
 	localIngressCh := make(chan []string, 1)
 	notifyCh := make(chan struct{}, 1)

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -1415,7 +1415,7 @@ func (s *InstanceModeSuite) setupRemoteRelationRequirerRoleConsumingSide(c *tc.C
 
 	offererModelUUID := tc.Must(c, coremodel.NewUUID)
 
-	s.crossModelRelationService.EXPECT().IsApplicationLocal(gomock.Any(), "wordpress").Return(true, nil).MinTimes(1)
+	s.crossModelRelationService.EXPECT().IsApplicationSynthetic(gomock.Any(), "wordpress").Return(false, nil).MinTimes(1)
 	s.crossModelRelationService.EXPECT().GetOffererModelUUID(gomock.Any(), "remote-mysql").Return(offererModelUUID, nil).MinTimes(1)
 	relTag := names.NewRelationTag("wordpress:db remote-mysql:server")
 	relKey, err := relation.NewKeyFromString(relTag.Id())
@@ -1591,7 +1591,7 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *tc.C)
 
 	offererModelUUID := tc.Must(c, coremodel.NewUUID)
 
-	s.crossModelRelationService.EXPECT().IsApplicationLocal(gomock.Any(), "remote-wordpress").Return(false, nil).MinTimes(1)
+	s.crossModelRelationService.EXPECT().IsApplicationSynthetic(gomock.Any(), "remote-wordpress").Return(true, nil).MinTimes(1)
 	s.crossModelRelationService.EXPECT().GetOffererModelUUID(gomock.Any(), "remote-wordpress").Return(offererModelUUID, nil).MinTimes(1)
 
 	relTag := names.NewRelationTag("remote-wordpress:db mysql:server")
@@ -1677,7 +1677,7 @@ func (s *InstanceModeSuite) TestRemoteRelationIngressRejected(c *tc.C) {
 
 	offererModelUUID := tc.Must(c, coremodel.NewUUID)
 
-	s.crossModelRelationService.EXPECT().IsApplicationLocal(gomock.Any(), "wordpress").Return(true, nil).MinTimes(1)
+	s.crossModelRelationService.EXPECT().IsApplicationSynthetic(gomock.Any(), "wordpress").Return(false, nil).MinTimes(1)
 	s.crossModelRelationService.EXPECT().GetOffererModelUUID(gomock.Any(), "remote-mysql").Return(offererModelUUID, nil).MinTimes(1)
 
 	relTag := names.NewRelationTag("wordpress:db remote-mysql:server")
@@ -1842,7 +1842,7 @@ func (s *InstanceModeSuite) assertIngressCidrs(c *tc.C, ctrl *gomock.Controller,
 			}, nil
 		}).AnyTimes()
 
-	s.crossModelRelationService.EXPECT().IsApplicationLocal(gomock.Any(), "mysql").Return(true, nil).AnyTimes()
+	s.crossModelRelationService.EXPECT().IsApplicationSynthetic(gomock.Any(), "mysql").Return(false, nil).AnyTimes()
 
 	localIngressCh := make(chan []string, 1)
 	notifyCh := make(chan struct{}, 1)

--- a/internal/worker/firewaller/interface.go
+++ b/internal/worker/firewaller/interface.go
@@ -82,9 +82,9 @@ type CrossModelRelationService interface {
 	// specified relation.
 	GetRelationNetworkIngress(ctx context.Context, relationUUID relation.UUID) ([]string, error)
 
-	// IsApplicationConsumer checks if the given application exists in the model and
-	// is a non-synthetic application, in the consumer model.
-	IsApplicationConsumer(ctx context.Context, appName string) (bool, error)
+	// IsApplicationLocal checks if the given application exists in the model and
+	// is a non-synthetic application.
+	IsApplicationLocal(ctx context.Context, appName string) (bool, error)
 
 	// WatchConsumerRelations watches the changes to (remote) relations on the
 	// consuming model and notifies the worker of any changes.

--- a/internal/worker/firewaller/interface.go
+++ b/internal/worker/firewaller/interface.go
@@ -82,9 +82,9 @@ type CrossModelRelationService interface {
 	// specified relation.
 	GetRelationNetworkIngress(ctx context.Context, relationUUID relation.UUID) ([]string, error)
 
-	// IsApplicationLocal checks if the given application exists in the model and
-	// is a non-synthetic application.
-	IsApplicationLocal(ctx context.Context, appName string) (bool, error)
+	// IsApplicationSynthetic checks if the given application exists in the model
+	// and is a synthetic application.
+	IsApplicationSynthetic(ctx context.Context, appName string) (bool, error)
 
 	// WatchConsumerRelations watches the changes to (remote) relations on the
 	// consuming model and notifies the worker of any changes.

--- a/internal/worker/firewaller/mocks/domain_mocks.go
+++ b/internal/worker/firewaller/mocks/domain_mocks.go
@@ -546,41 +546,41 @@ func (c *MockCrossModelRelationServiceGetRelationNetworkIngressCall) DoAndReturn
 	return c
 }
 
-// IsApplicationLocal mocks base method.
-func (m *MockCrossModelRelationService) IsApplicationLocal(arg0 context.Context, arg1 string) (bool, error) {
+// IsApplicationSynthetic mocks base method.
+func (m *MockCrossModelRelationService) IsApplicationSynthetic(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsApplicationLocal", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsApplicationSynthetic", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsApplicationLocal indicates an expected call of IsApplicationLocal.
-func (mr *MockCrossModelRelationServiceMockRecorder) IsApplicationLocal(arg0, arg1 any) *MockCrossModelRelationServiceIsApplicationLocalCall {
+// IsApplicationSynthetic indicates an expected call of IsApplicationSynthetic.
+func (mr *MockCrossModelRelationServiceMockRecorder) IsApplicationSynthetic(arg0, arg1 any) *MockCrossModelRelationServiceIsApplicationSyntheticCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationLocal", reflect.TypeOf((*MockCrossModelRelationService)(nil).IsApplicationLocal), arg0, arg1)
-	return &MockCrossModelRelationServiceIsApplicationLocalCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationSynthetic", reflect.TypeOf((*MockCrossModelRelationService)(nil).IsApplicationSynthetic), arg0, arg1)
+	return &MockCrossModelRelationServiceIsApplicationSyntheticCall{Call: call}
 }
 
-// MockCrossModelRelationServiceIsApplicationLocalCall wrap *gomock.Call
-type MockCrossModelRelationServiceIsApplicationLocalCall struct {
+// MockCrossModelRelationServiceIsApplicationSyntheticCall wrap *gomock.Call
+type MockCrossModelRelationServiceIsApplicationSyntheticCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockCrossModelRelationServiceIsApplicationLocalCall) Return(arg0 bool, arg1 error) *MockCrossModelRelationServiceIsApplicationLocalCall {
+func (c *MockCrossModelRelationServiceIsApplicationSyntheticCall) Return(arg0 bool, arg1 error) *MockCrossModelRelationServiceIsApplicationSyntheticCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceIsApplicationLocalCall) Do(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationLocalCall {
+func (c *MockCrossModelRelationServiceIsApplicationSyntheticCall) Do(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationSyntheticCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceIsApplicationLocalCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationLocalCall {
+func (c *MockCrossModelRelationServiceIsApplicationSyntheticCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationSyntheticCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/firewaller/mocks/domain_mocks.go
+++ b/internal/worker/firewaller/mocks/domain_mocks.go
@@ -546,41 +546,41 @@ func (c *MockCrossModelRelationServiceGetRelationNetworkIngressCall) DoAndReturn
 	return c
 }
 
-// IsApplicationConsumer mocks base method.
-func (m *MockCrossModelRelationService) IsApplicationConsumer(arg0 context.Context, arg1 string) (bool, error) {
+// IsApplicationLocal mocks base method.
+func (m *MockCrossModelRelationService) IsApplicationLocal(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsApplicationConsumer", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsApplicationLocal", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsApplicationConsumer indicates an expected call of IsApplicationConsumer.
-func (mr *MockCrossModelRelationServiceMockRecorder) IsApplicationConsumer(arg0, arg1 any) *MockCrossModelRelationServiceIsApplicationConsumerCall {
+// IsApplicationLocal indicates an expected call of IsApplicationLocal.
+func (mr *MockCrossModelRelationServiceMockRecorder) IsApplicationLocal(arg0, arg1 any) *MockCrossModelRelationServiceIsApplicationLocalCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationConsumer", reflect.TypeOf((*MockCrossModelRelationService)(nil).IsApplicationConsumer), arg0, arg1)
-	return &MockCrossModelRelationServiceIsApplicationConsumerCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationLocal", reflect.TypeOf((*MockCrossModelRelationService)(nil).IsApplicationLocal), arg0, arg1)
+	return &MockCrossModelRelationServiceIsApplicationLocalCall{Call: call}
 }
 
-// MockCrossModelRelationServiceIsApplicationConsumerCall wrap *gomock.Call
-type MockCrossModelRelationServiceIsApplicationConsumerCall struct {
+// MockCrossModelRelationServiceIsApplicationLocalCall wrap *gomock.Call
+type MockCrossModelRelationServiceIsApplicationLocalCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockCrossModelRelationServiceIsApplicationConsumerCall) Return(arg0 bool, arg1 error) *MockCrossModelRelationServiceIsApplicationConsumerCall {
+func (c *MockCrossModelRelationServiceIsApplicationLocalCall) Return(arg0 bool, arg1 error) *MockCrossModelRelationServiceIsApplicationLocalCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceIsApplicationConsumerCall) Do(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationConsumerCall {
+func (c *MockCrossModelRelationServiceIsApplicationLocalCall) Do(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationLocalCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceIsApplicationConsumerCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationConsumerCall {
+func (c *MockCrossModelRelationServiceIsApplicationLocalCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationLocalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
This commit fixes the relation network egress watcher which had partially correct initial events. It was missing from the model config and unit addresses sources.

Also, it renames the method `IsApplicationConsumer` into `IsApplicationLocal`, which makes more sense since we're only looking at the charm source to identify if the application is non-synthetic. This makes the firewaller code more readable where it's used.

Another fix was done on the multiple workers started for the remote relations in the firewaller: the watcher IDs were improved and added to the structs that hold the workers, before they were simply the relation tag.

Finally, some logs were added for future debugging to the firewaller.

## QA steps

Although there are still some bugs on CMRs, we can at least fully QA the firewaller (ingress/egress) changes now.
The way to flex this is to have cross-controller relations between non-exposed apps that do need to open some port. And it has to be done on a provider that supports security rules.
Let's try this on aws.

Offer controller and model:
```
$ juju bootstrap aws offer 
$ juju add-model offer --config "logging-config=<root>=INFO;juju.worker.firewaller=TRACE"
$ juju deploy postgresql --channel 16/stable
$ juju offer postgresql:replication-offer replication
```
Consumer controller and model:
```
$ juju bootstrap aws consume 
$ juju add-model consume --config "logging-config=<root>=INFO;juju.worker.firewaller=TRACE"
$ juju deploy postgresql --channel 16/stable
$ juju consume offer:admin/offer.replication
# Wait until everything is idle
$ juju relate postgresql:replication replication
 ```


In the consumer logs you should see the line that publishes the ingress changes to the offering model:
```
machine-0: 11:16:15 DEBUG juju.worker.firewaller publishing ingress cidrs for relation-postgresql.replication#replication.replication-offer: [35.180.15.95/32]
```
And on the offering model you should see the actual change trigger from the (local) ingress db and flush of rules:
```
machine-0: 11:16:17 DEBUG juju.worker.firewaller offerer relation ingress addresses for relation-remote-68f03f524fd54eb889eff304d7469dd5.replication#postgresql.replication-offer changed: [35.180.15.95/32]
machine-0: 11:16:17 DEBUG juju.worker.firewaller process remote relation ingress change: &{{remote-68f03f524fd54eb889eff304d7469dd5.replication#postgresql.replication-offer} {postgresql} map[35.180.15.95/32:true] true offerer remote-68f03f524fd54eb889eff304d7469dd5:replication postgresql:replication-offer}
machine-0: 11:16:17 DEBUG juju.worker.firewaller finding egress rules for application-postgresql
machine-0: 11:16:17 DEBUG juju.worker.firewaller adding remote relation ingress CIDRs map[35.180.15.95/32:true] for non-exposed application "application-postgresql"
machine-0: 11:16:17 DEBUG juju.worker.firewaller ingress rules for "postgresql/0": [5432/tcp from 35.180.15.95/32]
machine-0: 11:16:17 DEBUG juju.worker.firewaller flush instance ports for 0: to open [5432/tcp from 35.180.15.95/32], to close []
machine-0: 11:16:18 INFO juju.worker.firewaller opened port ranges [5432/tcp from 35.180.15.95/32] on "0"
```

In the offering model, if you open the repl you should see the newly added ingress CIDR:
```
repl (controller)> .switch model-offer
repl (model-offer)> select * from relation_network_ingress
relation_uuid                           cidr
1de2fc67-8443-46fb-850f-f95145acd8dc    35.180.15.95/32
```

Last, you should check on the aws console that the security group for the port 5432 has only the ingress from the consumer model:

<img width="1325" height="151" alt="image" src="https://github.com/user-attachments/assets/8248269b-ded8-42ab-b8e1-4886bd6e4c36" />


## Links

**Jira card:** [JUJU-8489](https://warthogs.atlassian.net/browse/JUJU-8489)


[JUJU-8489]: https://warthogs.atlassian.net/browse/JUJU-8489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ