### PR TITLE
fix(list-model-summaries): fixes the list model summaries method in the modelmanager api

### DIFF
--- a/api/client/modelmanager/legacy.go
+++ b/api/client/modelmanager/legacy.go
@@ -42,7 +42,7 @@ func (c *Client) createModelCompat(
 	}
 	info := params.ModelInfo{
 		Name:                    result.Name,
-		Qualifier:               ownerTag.Id(),
+		Qualifier:               model.QualifierFromUserTag(ownerTag).String(),
 		Type:                    result.Type,
 		UUID:                    result.UUID,
 		ControllerUUID:          result.ControllerUUID,
@@ -117,7 +117,7 @@ func (c *Client) listModelSummariesCompat(ctx context.Context, user string, all 
 			}
 			continue
 		} else {
-			qualifier = owner.Id()
+			qualifier = model.QualifierFromUserTag(owner).String()
 		}
 		results[i] = params.ModelSummaryResult{
 			Result: &params.ModelSummary{
@@ -182,7 +182,7 @@ func (c *Client) modelInfoCompat(ctx context.Context, tags []names.ModelTag) ([]
 		info[i] = params.ModelInfoResult{
 			Result: &params.ModelInfo{
 				Name:                    result.Name,
-				Qualifier:               ownerTag.Id(),
+				Qualifier:               model.QualifierFromUserTag(ownerTag).String(),
 				Type:                    result.Type,
 				UUID:                    result.UUID,
 				ControllerUUID:          result.ControllerUUID,

--- a/api/client/modelmanager/legacy_test.go
+++ b/api/client/modelmanager/legacy_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelmanager_test
+
+import (
+	"testing"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v6"
+	"github.com/juju/tc"
+	"go.uber.org/mock/gomock"
+
+	"github.com/juju/juju/api/base"
+	basemocks "github.com/juju/juju/api/base/mocks"
+	"github.com/juju/juju/api/client/modelmanager"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/rpc/params"
+)
+
+type modelmanagerCompatSuite struct {
+}
+
+func TestModelmanagerCompatSuite(t *testing.T) {
+	tc.Run(t, &modelmanagerCompatSuite{})
+}
+
+func (s *modelmanagerCompatSuite) TestListModelSummariesWithOlderFacadeVersion(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	userTag := names.NewUserTag("alice@canonical.com")
+	expectedQualifier := string(model.QualifierFromUserTag(userTag))
+	testModelInfo := createModelSummaryLegacy()
+
+	args := params.ModelSummariesRequest{
+		UserTag: userTag.String(),
+		All:     true,
+	}
+
+	tests := []struct {
+		about        string
+		resultValue  params.ModelSummaryResultsLegacy
+		assertResult func(*tc.C, []base.UserModelSummary)
+	}{{
+		about: "model summaries are converted correctly",
+		resultValue: params.ModelSummaryResultsLegacy{
+			Results: []params.ModelSummaryResultLegacy{
+				{Result: testModelInfo},
+				{Error: apiservererrors.ServerError(errors.New("model error"))},
+			},
+		},
+		assertResult: func(c *tc.C, results []base.UserModelSummary) {
+			c.Assert(results, tc.HasLen, 2)
+			c.Assert(results[0], tc.DeepEquals, base.UserModelSummary{Name: testModelInfo.Name,
+				UUID:            testModelInfo.UUID,
+				Type:            model.IAAS,
+				ControllerUUID:  testModelInfo.ControllerUUID,
+				ProviderType:    testModelInfo.ProviderType,
+				Cloud:           "aws",
+				CloudRegion:     "us-east-1",
+				CloudCredential: "foo/bob/one",
+				Qualifier:       model.Qualifier(expectedQualifier),
+				Life:            "alive",
+				Status: base.Status{
+					Status: status.Active,
+					Data:   map[string]interface{}{},
+				},
+				ModelUserAccess: "admin",
+				Counts:          []base.EntityCount{},
+			})
+			c.Assert(errors.Cause(results[1].Error), tc.ErrorMatches, "model error")
+		},
+	}, {
+		about: "no summaries",
+		resultValue: params.ModelSummaryResultsLegacy{
+			Results: []params.ModelSummaryResultLegacy{},
+		},
+		assertResult: func(c *tc.C, results []base.UserModelSummary) {
+			c.Assert(results, tc.HasLen, 0)
+		},
+	}}
+
+	for _, test := range tests {
+		result := new(params.ModelSummaryResultsLegacy)
+
+		mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+		mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "ListModelSummaries", args, result).SetArg(3, test.resultValue).Return(nil)
+		client := modelmanager.NewLegacyClientFromCaller(mockFacadeCaller)
+
+		results, err := client.ListModelSummaries(c.Context(), userTag.Id(), true)
+		c.Assert(err, tc.ErrorIsNil)
+		test.assertResult(c, results)
+	}
+}
+
+func createModelSummaryLegacy() *params.ModelSummaryLegacy {
+	return &params.ModelSummaryLegacy{
+		Name:               "name",
+		UUID:               "uuid",
+		OwnerTag:           "user-alice@canonical.com",
+		Type:               "iaas",
+		ControllerUUID:     "controllerUUID",
+		ProviderType:       "aws",
+		CloudTag:           "cloud-aws",
+		CloudRegion:        "us-east-1",
+		CloudCredentialTag: "cloudcred-foo_bob_one",
+		Life:               life.Alive,
+		Status:             params.EntityStatus{Status: status.Status("active")},
+		UserAccess:         params.ModelAdminAccess,
+		Counts:             []params.ModelEntityCount{},
+	}
+}

--- a/api/client/modelmanager/modelmanager_test.go
+++ b/api/client/modelmanager/modelmanager_test.go
@@ -149,7 +149,7 @@ func (s *modelmanagerSuite) TestCreateModelLegacy(c *tc.C) {
 		ProviderType:   "C-123",
 		Cloud:          "nimbus",
 		CloudRegion:    "catbus",
-		Qualifier:      model.Qualifier("alice@domain.com"),
+		Qualifier:      model.Qualifier("alice-domain-com"),
 		Life:           "alive",
 		Status: base.Status{
 			Data: make(map[string]interface{}),


### PR DESCRIPTION
Fixes the listModelSummariesCompat method in the modelmanager api.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1.  `make install` in juju with this change
2. run `make qa-lxd` in jimm to get JIMM running with a lxd controller (make sure it uses the compiled juju version)
3. run `juju add-model test`
4. run `juju models` and assert that it lists the `test` model