### PR TITLE
fix(deploy-local-charm): add return after CreateCAASApplication to avoid CreateIAASApplication

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -182,6 +182,7 @@ func DeployApplication(
 		if err != nil {
 			return handleApplicationDomainError(errors.Capture(err))
 		}
+		return nil
 	}
 
 	unitArgs, err := makeIAASUnitArgs(args)


### PR DESCRIPTION
# Description

`juju deploy ./ubuntu.charm` was returning the error:

`
[1:50:59] ➜  juju git:(main) ✗ juju deploy ./ubuntu.charm ubuntu1
Located local charm "refresher", revision 1
Deploying "ubuntu1" from local charm "refresher", revision 1 on ubuntu@20.04/stable
ERROR cannot deploy "ubuntu1": creating IAAS application "ubuntu1": creating IAAS application "ubuntu1": inserting IAAS application "ubuntu1": checking if application "ubuntu1" exists: application already exists
`

The code was missing the early return in case of CAAS applications.

# QA

`juju deploy ./ubuntu.charm`
And it should work without error.