### PR TITLE
feat: add egress subnets to unit network info

### DIFF
--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -732,6 +732,10 @@ type negativeSpaceConstraintFailure struct {
 	Address     string `db:"address_value"`
 }
 
+type egressCIDR struct {
+	CIDR string `db:"cidr"`
+}
+
 func nilstr[T ~string](s *string) *T {
 	var res *T
 	if s != nil {


### PR DESCRIPTION
This patch adds the egress subnets to the network info for a given unit. The egress CIDRs are taken from the relation_network_egress, which is set when a user integrates (on CMRs) with the --via option, passing the egress subnets.


## QA steps

To flex this missing feature, we need to add a CMR, and then relate but using the `--via` flag, which will set the egress subnets for the relation. Then get the network info to compare.


Offer model:
```
$ juju add-model offer
$ juju deploy postgresql --channel 16/stable
$ juju offer postgresql:replication-offer replication
```
Consumer model:
```
$ juju add-model consume
$ juju deploy postgresql --channel 16/stable
$ juju consume offer:admin/offer.replication
# Wait until everything is idle
```
Let's check the network info before relating:
```
$ juju exec --unit postgresql/0 network-get replication
bind-addresses:
- mac-address: 00:16:3e:7c:ef:44
  interface-name: eth0
  addresses:
  - hostname: 10.32.147.107
    value: 10.32.147.107
    cidr: 10.32.147.0/24
    address: 10.32.147.107
  macaddress: 00:16:3e:7c:ef:44
  interfacename: eth0
ingress-addresses:
- 10.32.147.107
```
Now let's relate with an egress subnet:
```
$ juju relate postgresql:replication replication --via 10.42.42.0/24
 ```
And check again:
```
$ juju exec --unit postgresql/0 network-get replication
bind-addresses:
- mac-address: 00:16:3e:7c:ef:44
  interface-name: eth0
  addresses:
  - hostname: 10.32.147.107
    value: 10.32.147.107
    cidr: 10.32.147.0/24
    address: 10.32.147.107
  macaddress: 00:16:3e:7c:ef:44
  interfacename: eth0
egress-subnets:
- 10.42.42.0/24
ingress-addresses:
- 10.32.147.107
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8489](https://warthogs.atlassian.net/browse/JUJU-8489)


[JUJU-8489]: https://warthogs.atlassian.net/browse/JUJU-8489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ