### PR TITLE
feat(removal): cascade remove SAAS apps and remote relations

### DIFF
--- a/domain/removal/errors/errors.go
+++ b/domain/removal/errors/errors.go
@@ -56,6 +56,10 @@ const (
 	// deleted because it still has offer connections
 	ApplicationHasOfferConnections = errors.ConstError("application has offer connections")
 
+	// ApplicationIsRemoteOfferer indicates that an application cannot be deleted
+	// because it is a remote application offerer
+	ApplicationIsRemoteOfferer = errors.ConstError("application is remote")
+
 	// ForceRequired indicates that a removal job requires the force flag to
 	// be set to true in order to proceed.
 	ForceRequired = errors.ConstError("force required for removal job")

--- a/domain/removal/service/model.go
+++ b/domain/removal/service/model.go
@@ -7,11 +7,18 @@ import (
 	"context"
 	"time"
 
+	"github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/core/unit"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	relationerrors "github.com/juju/juju/domain/relation/errors"
 	"github.com/juju/juju/domain/removal"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/internal/errors"
@@ -344,4 +351,112 @@ func (s *Service) aliveOrDyingModelsExist(ctx context.Context, modelUUIDs []stri
 		}
 	}
 	return false, nil
+}
+
+func (s *Service) removeUnits(ctx context.Context, uuids []string, destroyStorage, force bool, wait time.Duration) {
+	for _, unitUUID := range uuids {
+		if _, err := s.RemoveUnit(
+			ctx, unit.UUID(unitUUID), destroyStorage, force, wait,
+		); errors.Is(err, applicationerrors.UnitNotFound) {
+			// There could be a chance that the unit has already been removed by
+			// another process. We can safely ignore this error and continue
+			// with the next unit.
+			continue
+		} else if err != nil {
+			// If the unit fails to be scheduled for removal, we log out the
+			// error. The units are already transitioned to dying and there is
+			// no way to transition them back to alive.
+			s.logger.Errorf(ctx, "scheduling removal of unit %q: %v", unitUUID, err)
+		}
+	}
+}
+
+func (s *Service) removeMachines(ctx context.Context, uuids []string, force bool, wait time.Duration) {
+	for _, machineUUID := range uuids {
+		if _, err := s.RemoveMachine(ctx, machine.UUID(machineUUID), force, wait); errors.Is(err, machineerrors.MachineNotFound) {
+			// There could be a chance that the machine has already been removed
+			// by another process. We can safely ignore this error and continue
+			// with the next machine.
+			continue
+		} else if err != nil {
+			// If the machine fails to be scheduled for removal, we log out the
+			// error. The machines are already transitioned to dying and there
+			// is no way to transition them back to alive.
+			s.logger.Errorf(ctx, "scheduling removal of machine %q: %v", machineUUID, err)
+		}
+	}
+}
+
+func (s *Service) removeRelations(ctx context.Context, uuids []string, force bool, wait time.Duration) {
+	for _, relationUUID := range uuids {
+		if _, err := s.RemoveRelation(ctx, relation.UUID(relationUUID), force, wait); errors.Is(err, relationerrors.RelationNotFound) {
+			// There could be a chance that the relation has already been
+			// removed by another process. We can safely ignore this error and
+			// continue with the next relation.
+			continue
+		} else if err != nil && !errors.Is(err, removalerrors.RelationIsCrossModel) {
+			// If the unit fails to be scheduled for removal, we log out the
+			// error. The relations are already transitioned to dying and there
+			// is no way to transition them back to alive.
+			s.logger.Errorf(ctx, "scheduling removal of relation %q: %v", relationUUID, err)
+		} else if err == nil {
+			continue
+		}
+
+		// This is a CMR relation, so we need to remove it with
+		// RemoveRemoteRelation.
+		if _, err := s.RemoveRemoteRelation(ctx, relation.UUID(relationUUID), force, wait); errors.Is(err, relationerrors.RelationNotFound) {
+			// There could be a chance that the relation has already been
+			// removed by another process. We can safely ignore this error and
+			// continue with the next relation.
+			continue
+		} else if err != nil {
+			// If the unit fails to be scheduled for removal, we log out the
+			// error. The relations are already transitioned to dying and there
+			// is no way to transition them back to alive.
+			s.logger.Errorf(ctx, "scheduling removal of relation %q: %v", relationUUID, err)
+		}
+	}
+}
+
+func (s *Service) removeApplications(
+	ctx context.Context, uuids []string, destroyStorage, force bool, wait time.Duration,
+) {
+	for _, applicationUUID := range uuids {
+		if _, err := s.RemoveApplication(
+			ctx, application.UUID(applicationUUID), destroyStorage, force, wait,
+		); errors.Is(err, applicationerrors.ApplicationNotFound) {
+			// There could be a chance that the application has already been
+			// removed by another process. We can safely ignore this error and
+			// continue with the next application.
+			continue
+		} else if err != nil && !errors.Is(err, removalerrors.ApplicationIsRemoteOfferer) {
+			// If the unit fails to be scheduled for removal, we log out the
+			// error. The applications are already transitioned to dying and
+			// there is no way to transition them back to alive.
+			s.logger.Errorf(ctx, "scheduling removal of application %q: %v", applicationUUID, err)
+		} else if err == nil {
+			continue
+		}
+
+		// This is a remote application offerer, so we need to remove it with
+		// RemoveRemoteApplicationOffererByApplicationUUID.
+		if _, err := s.RemoveRemoteApplicationOffererByApplicationUUID(
+			ctx, application.UUID(applicationUUID), force, wait,
+		); errors.Is(err, applicationerrors.ApplicationNotFound) {
+			// There could be a chance that the application has already been
+			// removed by another process. We can safely ignore this error and
+			// continue with the next application.
+			continue
+		} else if err != nil {
+			// If the unit fails to be scheduled for removal, we log out the
+			// error. The applications are already transitioned to dying and
+			// there is no way to transition them back to alive.
+			s.logger.Errorf(ctx, "scheduling removal of application %q: %v", applicationUUID, err)
+		} else if err == nil {
+			continue
+		}
+
+		// TODO: Handle remote application consumers
+	}
 }

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -39,7 +39,7 @@ func TestApplicationSuite(t *testing.T) {
 	tc.Run(t, &applicationSuite{})
 }
 
-func (s *applicationSuite) TestApplicationExists(c *tc.C) {
+func (s *applicationSuite) TestApplicationExistsTrue(c *tc.C) {
 	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 
@@ -48,9 +48,23 @@ func (s *applicationSuite) TestApplicationExists(c *tc.C) {
 	exists, err := st.ApplicationExists(c.Context(), appUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(exists, tc.Equals, true)
+}
 
-	exists, err = st.ApplicationExists(c.Context(), "not-today-henry")
+func (s *applicationSuite) TestApplicationExistsFalse(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	exists, err := st.ApplicationExists(c.Context(), "not-today-henry")
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+}
+
+func (s *applicationSuite) TestApplicationExistsRemoteApplicationOfferer(c *tc.C) {
+	appUUID, _ := s.createRemoteApplicationOfferer(c, "foo")
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	exists, err := st.ApplicationExists(c.Context(), appUUID.String())
+	c.Check(err, tc.ErrorIs, removalerrors.ApplicationIsRemoteOfferer)
 	c.Check(exists, tc.Equals, false)
 }
 


### PR DESCRIPTION
Remote relations and remote application offerers cannot be removed the same way relations and application can be removed. They are a special case.

Re-wire the removal of models to cascade remove these entities properly

## QA steps

```
$ juju add-model offerer
$ juju deploy juju-qa-dummy-source 
$ juju offer dummy-source:sink 
$ juju add-model consumer 
$ juju deploy juju-qa-dummy-sink 
$ juju consume admin/offerer.dummy-source 
$ juju relate dummy-source dummy-sink
(wait to settle)
$ juju destroy-model consumer
(wait)
$ juju models
Controller: lxd

Model       Cloud/Region   Type  Status     Machines  Units  Access  Last connection
controller  lxd/localhost        available         1      1  admin   just now
offerer     lxd/localhost  lxd   available         1      1  admin   10 minutes ago
```