### PR TITLE
feat(removal): ensure relation network egress are removed

### DIFF
--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -542,7 +542,7 @@ func (s *baseSuite) createRemoteRelationBetween(c *tc.C, synthAppName, appName s
 
 	ep1Name := fmt.Sprintf("%s:foo", synthAppName)
 	ep2Name := fmt.Sprintf("%s:bar", appName)
-	ep1, ep2, err := relSvc.AddRelation(c.Context(), ep1Name, ep2Name)
+	ep1, ep2, err := relSvc.AddRelation(c.Context(), ep1Name, ep2Name, "0.0.0.0/0")
 	c.Assert(err, tc.ErrorIsNil)
 	relUUID, err := relSvc.GetRelationUUIDForRemoval(c.Context(), domainrelation.GetRelationUUIDForRemovalArgs{
 		Endpoints: []string{ep1.String(), ep2.String()},


### PR DESCRIPTION
The relation_network_egress table was recently added. It stores network cidrs for egress for CMR relations (i.e. remote relations on the consuming side).

Ensure this table is tidied up when removing these relations

## QA steps

To flex this missing feature, we need to add a CMR, and then relate but using the `--via` flag, which will set the egress subnets for the relation. Then get the network info to compare.


Offer model:
```
$ juju add-model offer
$ juju deploy postgresql --channel 16/stable
$ juju offer postgresql:replication-offer replication
```
Consumer model:
```
$ juju add-model consume
$ juju deploy postgresql --channel 16/stable
$ juju consume offer:admin/offer.replication
# Wait until everything is idle
$ juju relate postgresql:replication replication --via 10.42.42.0/24
$ juju remove-relation postgresql:replication replication
```