### PR TITLE
fix: avoid empty spaces from distorting output

### DIFF
--- a/apiserver/facades/client/client/fullstatus_test.go
+++ b/apiserver/facades/client/client/fullstatus_test.go
@@ -100,6 +100,11 @@ func (s *fullStatusSuite) TestFullStatusNetworkInterfaces(c *tc.C) {
 					{
 						AddressValue: "172.16.0.0",
 						AddressType:  "ipv4",
+						Space:        "alpha",
+					},
+					{
+						AddressValue: "172.16.0.1",
+						AddressType:  "ipv4",
 						Space:        "",
 					},
 				},
@@ -113,7 +118,7 @@ func (s *fullStatusSuite) TestFullStatusNetworkInterfaces(c *tc.C) {
 				Name: "eth1",
 				Addrs: []domainnetwork.NetAddr{
 					{
-						AddressValue: "172.16.0.1",
+						AddressValue: "3.16.0.1",
 						AddressType:  "ipv4",
 						Space:        "space1",
 					},
@@ -146,15 +151,15 @@ func (s *fullStatusSuite) TestFullStatusNetworkInterfaces(c *tc.C) {
 	c.Check(machine0.NetworkInterfaces, tc.DeepEquals,
 		map[string]params.NetworkInterface{
 			"eth0": {
-				IPAddresses:    []string{"172.16.0.0"},
+				IPAddresses:    []string{"172.16.0.0", "172.16.0.1"},
 				MACAddress:     "",
 				Gateway:        "",
 				DNSNameservers: nil,
-				Space:          "",
+				Space:          "alpha",
 				IsUp:           false,
 			},
 			"eth1": {
-				IPAddresses:    []string{"172.16.0.1"},
+				IPAddresses:    []string{"3.16.0.1"},
 				MACAddress:     macAddr,
 				Gateway:        gatewayAddr,
 				DNSNameservers: []string{"8.8.8.8"},

--- a/domain/removal/state/model/model.go
+++ b/domain/removal/state/model/model.go
@@ -429,7 +429,7 @@ func (st *State) checkNoModelDependents(ctx context.Context, tx *sqlair.TX) erro
 	if err != nil {
 		return errors.Errorf("getting application count: %w", err)
 	} else if count.Count > 0 {
-		return errors.Errorf("still %d application still exist it", count.Count).Add(removalerrors.EntityStillAlive)
+		return errors.Errorf("%d application(s) still exist", count.Count).Add(removalerrors.EntityStillAlive)
 	}
 
 	machinesStmt, err := st.Prepare(`SELECT COUNT(*) AS &count.count FROM machine`, count)
@@ -441,7 +441,7 @@ func (st *State) checkNoModelDependents(ctx context.Context, tx *sqlair.TX) erro
 	if err != nil {
 		return errors.Errorf("getting machine count: %w", err)
 	} else if count.Count > 0 {
-		return errors.Errorf("still %d machines still exist", count.Count).Add(removalerrors.EntityStillAlive)
+		return errors.Errorf("%d machine(s) still exist", count.Count).Add(removalerrors.EntityStillAlive)
 	}
 
 	return nil


### PR DESCRIPTION
This PR fixes an issue where `juju show-machine` for an instance on AWS would show `space: 'alpha '`.

In Juju 3.6 network addresses with empty spaces are filtered out. In Juju 4 we were not doing that and on AWS a network interface with 2 addresses has the public address in an empty space while the private address is in the "alpha" space. Joining the 2 together resulted in the string "alpha " (note the extra whitespace at the end). As an extra, I've removed the `spaces` field from the `statusContext` struct since it was no longer populated or used.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
$ juju bootstrap aws test-spaces
$ juju add-model foo
$ juju deploy ubuntu
# Wait for the machine to become ready
$ juju show-machine 0
```

Observe `Spaces: alpha`.

## Links

**Jira card:** [JUJU-8603](https://warthogs.atlassian.net/browse/JUJU-8603)


[JUJU-8603]: https://warthogs.atlassian.net/browse/JUJU-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ