### PR TITLE
fix(cmr): ensure offering-side-CMRs have a status

### DIFF
--- a/domain/application/state/peer_relation.go
+++ b/domain/application/state/peer_relation.go
@@ -213,9 +213,9 @@ func (st *State) insertNewRelationStatus(ctx context.Context, tx *sqlair.TX, uui
 
 	stmt, err := st.Prepare(`
 INSERT INTO relation_status (relation_uuid, relation_status_type_id, updated_at)
-SELECT $setRelationStatus.relation_uuid, status.id, $setRelationStatus.updated_at
-FROM   relation_status_type status
-WHERE  status.name = $setRelationStatus.status`, status)
+SELECT $setRelationStatus.relation_uuid, rst.id, $setRelationStatus.updated_at
+FROM   relation_status_type AS rst
+WHERE  rst.name = $setRelationStatus.status`, status)
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -11,6 +11,7 @@ import (
 
 	corelife "github.com/juju/juju/core/life"
 	coresecrets "github.com/juju/juju/core/secrets"
+	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/crossmodelrelation"
@@ -432,4 +433,14 @@ type unitAddress struct {
 	Scope      string         `db:"scope_name"`
 	SpaceUUID  sql.NullString `db:"space_uuid"`
 	CIDR       sql.NullString `db:"cidr"`
+}
+
+// setRelationStatus represents the structure to insert the status of a relation.
+type setRelationStatus struct {
+	// RelationUUID is the unique identifier of the relation.
+	RelationUUID string `db:"relation_uuid"`
+	// Status indicates the current state of a given relation.
+	Status corestatus.Status `db:"status"`
+	// UpdatedAt specifies the timestamp of the insertion
+	UpdatedAt time.Time `db:"updated_at"`
 }

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -3553,9 +3553,9 @@ func (st *State) insertNewRelationStatus(ctx context.Context, tx *sqlair.TX, uui
 
 	stmt, err := st.Prepare(`
 INSERT INTO relation_status (relation_uuid, relation_status_type_id, updated_at)
-SELECT $setRelationStatus.relation_uuid, status.id, $setRelationStatus.updated_at
-FROM   relation_status_type status
-WHERE  status.name = $setRelationStatus.status`, status)
+SELECT $setRelationStatus.relation_uuid, rst.id, $setRelationStatus.updated_at
+FROM   relation_status_type AS rst
+WHERE  rst.name = $setRelationStatus.status`, status)
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/removal/state/model/offer.go
+++ b/domain/removal/state/model/offer.go
@@ -87,6 +87,14 @@ WHERE relation_uuid IN ($uuids[:])
 		return errors.Errorf("preparing delete relation endpoint query: %w", err)
 	}
 
+	deleteRelationStatusStmt, err := st.Prepare(`
+DELETE FROM relation_status
+WHERE relation_uuid IN ($uuids[:])
+`, uuids{})
+	if err != nil {
+		return errors.Errorf("preparing delete relation status query: %w", err)
+	}
+
 	deleteRelationsStmt, err := st.Prepare(`
 DELETE FROM relation
 WHERE uuid IN ($uuids[:])
@@ -169,6 +177,10 @@ WHERE uuid = $entityUUID.uuid
 
 		if err := tx.Query(ctx, deleteOfferConnectionStmt, offerUUID).Run(); err != nil {
 			return errors.Errorf("deleting offer connections: %w", err)
+		}
+
+		if err := tx.Query(ctx, deleteRelationStatusStmt, relUUIDs).Run(); err != nil {
+			return errors.Errorf("deleting relation status: %w", err)
 		}
 
 		if err := tx.Query(ctx, deleteRelationsStmt, relUUIDs).Run(); err != nil {

--- a/domain/status/state/modelstate.go
+++ b/domain/status/state/modelstate.go
@@ -382,7 +382,7 @@ func (st *ModelState) SetRelationStatus(
 	return nil
 }
 
-// SetRelationStatus sets the given relation status. It can
+// SetRemoteRelationStatus sets the given relation status. It can
 // return the following errors:
 //   - [statuserrors.RelationNotFound] if the relation doesn't exist.
 func (st *ModelState) SetRemoteRelationStatus(


### PR DESCRIPTION
We attempt to update the status of relations for CMRs on the offering side.

However, when we add these relations we forgot to set an initial status. This was causing not found errors, and the uniter to bounce on the offering side.

Fix this by setting this initial status

----

This pull request introduces functionality to track and verify the status of cross-model relations when they are created. The main change is that a "joining" status is now inserted into the database when a new consumed relation is added, and corresponding test coverage has been added to ensure this behavior. Supporting types and imports have also been updated.

**Relation status tracking improvements:**

* When a new consumed relation is added via `AddConsumedRelation`, the system now inserts a "joining" status for the relation by calling the new `insertNewRelationStatus` method.
* The new `insertNewRelationStatus` method has been implemented to insert the initial status into the `relation_status` table using the provided relation UUID and current timestamp.
* The `setRelationStatus` struct has been introduced to represent the data needed for inserting relation status records.

**Testing enhancements:**

* The test suite now verifies that the "joining" status is correctly set for new consumed relations by adding the `assertRelationStatusJoining` helper and invoking it in the relevant test. [[1]](diffhunk://#diff-72d3d7d0a5a63a84df944b4269d21fcada458760a804fe5100c7a967a3aaa627R540-R541) [[2]](diffhunk://#diff-72d3d7d0a5a63a84df944b4269d21fcada458760a804fe5100c7a967a3aaa627R1883-R1900)

**Code consistency:**

* Imports have been updated in multiple files to include the necessary status packages for the new functionality. [[1]](diffhunk://#diff-74de2987091f12b3d5bdf92755e34b0a26576ee596c4d8c61392d19675ee45f2R20) [[2]](diffhunk://#diff-72d3d7d0a5a63a84df944b4269d21fcada458760a804fe5100c7a967a3aaa627R27) [[3]](diffhunk://#diff-b5ad353d56e91f210c13401f0252ea413ddad3f1e33dce21c337af110bd191b3R14)
* The comment for `SetRelationStatus` in `modelstate.go` has been corrected to `SetRemoteRelationStatus` for clarity.

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model offerer
$ juju deploy juju-qa-dummy-source
$ juju offer dummy-source:sink
$ juju add-model consumer
$ juju deploy juju-qa-dummy-sink
$ sleep 15
$ juju consume admin/offerer.dummy-source
$ juju relate dummy-source dummy-sink
```

Then check `juju debug-log -m offerer` shows no errors