### PR TITLE
fix: flaky TestRemoteRelationProviderRoleConsumingSide test in firewaller

### DIFF
--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -1480,6 +1480,7 @@ func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSide(c *tc.C)
 	app, _ := s.addApplication(ctrl, "wordpress", true)
 	_, m, _ := s.addUnit(c, ctrl, app)
 	s.machinesCh <- []string{m.Tag().Id()}
+	s.waitForMachineFlush(c)
 	relSubnetCh, mac := s.setupRemoteRelationRequirerRoleConsumingSide(c)
 
 	// Have a unit on the consuming app enter the relation scope.
@@ -1585,6 +1586,7 @@ func (s *InstanceModeSuite) TestRemoteRelationProviderRoleConsumingSide(c *tc.C)
 	app, _ := s.addApplication(ctrl, "mysql", true)
 	_, m, _ := s.addUnit(c, ctrl, app)
 	s.machinesCh <- []string{m.Tag().Id()}
+	s.waitForMachineFlush(c)
 
 	mac, err := jujutesting.NewMacaroon("id")
 	c.Assert(err, tc.ErrorIsNil)
@@ -1671,6 +1673,7 @@ func (s *InstanceModeSuite) TestRemoteRelationIngressRejected(c *tc.C) {
 	app, _ := s.addApplication(ctrl, "wordpress", true)
 	_, m, _ := s.addUnit(c, ctrl, app)
 	s.machinesCh <- []string{m.Tag().Id()}
+	s.waitForMachineFlush(c)
 
 	mac, err := jujutesting.NewMacaroon("id")
 	c.Assert(err, tc.ErrorIsNil)


### PR DESCRIPTION
This commit fixes a flaky test seen failing in CI although very difficult to reproduce locally.

The fix consists of adding a sync point for waiting the rules to be flushed after the machine is added. This is consistent to what is being done in other tests in the suite (like `TestNotExposedApplication` and `TestExposedApplication`).


## QA steps

```
go test github.com/juju/juju/internal/worker/firewaller/... -cover -race -run TestInstanceModeSuite/TestRemoteRelationProviderRoleConsumingSide -count 10
```
