### PR TITLE
fix(domain/schema): machine unit life trigger never record unit deletion

### DIFF
--- a/domain/schema/triggers.go
+++ b/domain/schema/triggers.go
@@ -135,10 +135,8 @@ AFTER INSERT ON unit FOR EACH ROW
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
 	SELECT 1, %[1]d, m.name, DATETIME('now')
-	FROM unit AS u
-	JOIN net_node AS n ON n.uuid = u.net_node_uuid
-	JOIN machine AS m ON m.net_node_uuid = n.uuid
-	WHERE u.uuid = NEW.uuid;
+	FROM machine AS m
+	WHERE m.net_node_uuid = NEW.net_node_uuid;
 END;
 
 CREATE TRIGGER trg_log_custom_machine_unit_name_lifecycle_update
@@ -148,10 +146,8 @@ WHEN
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
 	SELECT 2, %[1]d, m.name, DATETIME('now')
-	FROM unit AS u
-	JOIN net_node AS n ON n.uuid = u.net_node_uuid
-	JOIN machine AS m ON m.net_node_uuid = n.uuid
-	WHERE u.uuid = OLD.uuid;
+	FROM machine AS m
+	WHERE m.net_node_uuid = OLD.net_node_uuid;
 END;
 
 CREATE TRIGGER trg_log_custom_machine_unit_name_lifecycle_delete
@@ -159,10 +155,8 @@ AFTER DELETE ON unit FOR EACH ROW
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
 	SELECT 4, %[1]d, m.name, DATETIME('now')
-	FROM unit AS u
-	JOIN net_node AS n ON n.uuid = u.net_node_uuid
-	LEFT JOIN machine AS m ON m.net_node_uuid = n.uuid
-	WHERE u.uuid = OLD.uuid;
+	FROM machine AS m
+	WHERE m.net_node_uuid = OLD.net_node_uuid;
  END;`[1:], namespace)
 		return schema.MakePatch(stmt)
 	}


### PR DESCRIPTION
This patch fixes the behavior of machine unit life trigger when a unit is deleted.

Before this patch, it never generates any events when a unit is deleted, since it fetches the unit table AFTER the deletion.

After this patch, it uses the net_node_uuid of the deleted unit to get the right machine name, which
 is the right behavior.

This fixes a possible race while destroying a model with --force: In this case, a unit can be deleted when set to dying, so the machiner never gets triggered when transitioning to dead. Since the machiner can't record the death of a machine with an alive unit. This could end up in a state where the machine never gets destroyed.

As a fly-by, I also update all the trigger code, removing the Join between machine and unit table since we can just use the net_node_uuid from both unit and machine table.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run CI tests ` ./main.sh -v secrets_iaas test_secrets_juju` which often trigger the issue.