### PR TITLE
fix: handle empty uri list in latest revisions query

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -708,6 +708,10 @@ func (api *CrossModelRelationsAPIv3) WatchConsumedSecretsChanges(ctx context.Con
 }
 
 func (api *CrossModelRelationsAPIv3) getSecretChanges(ctx context.Context, uriStr []string) ([]params.SecretRevisionChange, error) {
+	// Secret api does the right thing, but no need to call it unnecessarily.
+	if len(uriStr) == 0 {
+		return nil, nil
+	}
 	uris := make([]*secrets.URI, len(uriStr))
 	for i, s := range uriStr {
 		uri, err := secrets.ParseURI(s)

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -1021,5 +1021,8 @@ func (s *SecretService) GetLatestRevisions(ctx context.Context, uris []*secrets.
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
+	if len(uris) == 0 {
+		return nil, nil
+	}
 	return s.secretState.GetLatestRevisions(ctx, uris)
 }

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -300,6 +300,14 @@ func (s *stateSuite) TestGetLatestRevisionsSomeNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, secreterrors.SecretNotFound)
 }
 
+func (s *stateSuite) TestGetLatestRevisionsNone(c *tc.C) {
+	st := newSecretState(c, s.TxnRunnerFactory())
+
+	got, err := st.GetLatestRevisions(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(got, tc.HasLen, 0)
+}
+
 func (s *stateSuite) TestGetRotatePolicy(c *tc.C) {
 	s.setupUnits(c, "mysql")
 


### PR DESCRIPTION
Fixes an issue where there are no secrets when watching for consumed revision changes in the remote relations consumer worker.

Seen in the logs
```
machine-0: 13:30:11 DEBUG juju.worker.remoterelationconsumer logger-tags:cmr no restart, removing "offerer-unit-relation:a2a37338-255c-49c0-853e-065fefc30f93" from known workers
machine-0: 13:30:11 ERROR juju.worker.remoterelationconsumer logger-tags:cmr error in remote application worker for dummy-source: handling change for relation "a2a37338-255c-49c0-853e-065fefc30f93": watching consumed secret changes: sql: no rows in result set
```

## QA Steps

``` 
juju bootstrap ...
juju switch controller
juju deploy juju-qa-dummy-source
juju offer dummy-source:sink
juju add-model another
juju deploy juju-qa-dummy-sink
juju relate dummy-sink controller.dummy-source
```

check logs