### PR TITLE
fix: revert saving macaroon on the offering side

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -439,10 +439,6 @@ func (api *CrossModelRelationsAPIv3) registerOneRemoteRelation(
 	if err != nil {
 		return nil, errors.Annotate(err, "creating relation macaroon")
 	}
-	// Save the macaroon, many different calls try to find it.
-	if err := api.crossModelRelationService.SaveMacaroonForRelation(ctx, corerelation.UUID(relation.RelationToken), relationMacaroon.M()); err != nil {
-		return nil, internalerrors.Errorf("saving macaroon for %q: %w", relation.RelationToken, err)
-	}
 	return &params.ConsumingRelationDetails{
 		// The offering model application UUID is used as the token for the
 		// remote model.
@@ -560,7 +556,6 @@ func (api *CrossModelRelationsAPIv3) getRemoteRelationChangeEvent(
 		ApplicationSettings:     appSettings,
 		ChangedUnits:            unitSettings,
 		InScopeUnits:            change.InScopeUnits,
-		Macaroons:               change.Macaroons,
 	}, nil
 }
 

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -584,11 +584,8 @@ func (s *facadeSuite) TestRegisterRemoteRelationsSuccess(c *tc.C) {
 
 	offererRemoteRelationTag := names.NewRelationTag(relKey.String())
 
-	mac := &bakery.Macaroon{}
 	s.crossModelAuthContext.EXPECT().CreateRemoteRelationMacaroon(gomock.Any(), s.modelUUID, offerUUID.String(), "bob", offererRemoteRelationTag, bakery.LatestVersion).
-		Return(mac, nil)
-
-	s.crossModelRelationService.EXPECT().SaveMacaroonForRelation(gomock.Any(), corerelation.UUID(relationUUID), mac.M())
+		Return(&bakery.Macaroon{}, nil)
 
 	api := s.api(c)
 	arg := s.relationArg(c, remoteAppToken, offerUUID, relationUUID, "remoteapp:db", "db", macaroon.Slice{testMac})

--- a/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
@@ -27,7 +27,6 @@ import (
 	removal "github.com/juju/juju/domain/removal"
 	config "github.com/juju/juju/environs/config"
 	gomock "go.uber.org/mock/gomock"
-	macaroon "gopkg.in/macaroon.v2"
 )
 
 // MockCrossModelRelationService is a mock of CrossModelRelationService interface.
@@ -281,44 +280,6 @@ func (c *MockCrossModelRelationServiceGetOfferingApplicationTokenCall) Do(f func
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelRelationServiceGetOfferingApplicationTokenCall) DoAndReturn(f func(context.Context, relation.UUID) (application.UUID, error)) *MockCrossModelRelationServiceGetOfferingApplicationTokenCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SaveMacaroonForRelation mocks base method.
-func (m *MockCrossModelRelationService) SaveMacaroonForRelation(arg0 context.Context, arg1 relation.UUID, arg2 *macaroon.Macaroon) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveMacaroonForRelation", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SaveMacaroonForRelation indicates an expected call of SaveMacaroonForRelation.
-func (mr *MockCrossModelRelationServiceMockRecorder) SaveMacaroonForRelation(arg0, arg1, arg2 any) *MockCrossModelRelationServiceSaveMacaroonForRelationCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveMacaroonForRelation", reflect.TypeOf((*MockCrossModelRelationService)(nil).SaveMacaroonForRelation), arg0, arg1, arg2)
-	return &MockCrossModelRelationServiceSaveMacaroonForRelationCall{Call: call}
-}
-
-// MockCrossModelRelationServiceSaveMacaroonForRelationCall wrap *gomock.Call
-type MockCrossModelRelationServiceSaveMacaroonForRelationCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) Return(arg0 error) *MockCrossModelRelationServiceSaveMacaroonForRelationCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) Do(f func(context.Context, relation.UUID, *macaroon.Macaroon) error) *MockCrossModelRelationServiceSaveMacaroonForRelationCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) DoAndReturn(f func(context.Context, relation.UUID, *macaroon.Macaroon) error) *MockCrossModelRelationServiceSaveMacaroonForRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelrelations/service.go
+++ b/apiserver/facades/controller/crossmodelrelations/service.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"time"
 
-	"gopkg.in/macaroon.v2"
-
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/offer"
 	corerelation "github.com/juju/juju/core/relation"
@@ -54,10 +52,6 @@ type CrossModelRelationService interface {
 	// EnsureUnitsExist ensures that the given synthetic units exist in the local
 	// model.
 	EnsureUnitsExist(ctx context.Context, appUUID coreapplication.UUID, units []unit.Name) error
-
-	// SaveMacaroonForRelation saves the given macaroon for the specified remote
-	// application.
-	SaveMacaroonForRelation(context.Context, corerelation.UUID, *macaroon.Macaroon) error
 
 	// WatchRemoteConsumedSecretsChanges watches secrets remotely consumed by any
 	// unit of the specified app and returns a watcher which notifies of secret URIs

--- a/domain/relation/state/package_test.go
+++ b/domain/relation/state/package_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
 	"github.com/juju/tc"
-	"gopkg.in/macaroon.v2"
 
 	coreapplication "github.com/juju/juju/core/application"
 	corecharm "github.com/juju/juju/core/charm"
@@ -202,23 +201,6 @@ func (s *baseRelationSuite) setLife(c *tc.C, table string, uuid string, dying li
 	s.query(c, fmt.Sprintf(`
 UPDATE %s SET life_id = ?
 WHERE uuid = ?`, table), dying, uuid)
-}
-
-func (s *baseRelationSuite) addMacaroon(c *tc.C, relUUID string) []byte {
-	mac := newMacaroon(c, "macaroon")
-	macBytes := tc.Must(c, mac.MarshalJSON)
-
-	s.query(c, `
-INSERT INTO application_remote_offerer_relation_macaroon (relation_uuid, macaroon)
-VALUES (?, ?)
-`, relUUID, macBytes)
-	return macBytes
-}
-
-func newMacaroon(c *tc.C, id string) *macaroon.Macaroon {
-	mac, err := macaroon.New(nil, []byte(id), "", macaroon.LatestVersion)
-	c.Assert(err, tc.ErrorIsNil)
-	return mac
 }
 
 // addRelation inserts a new relation into the database with default relation

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -2374,7 +2374,6 @@ func (s *relationSuite) TestGetFullRelationUnitsChange(c *tc.C) {
 	s.addRelationUnitSetting(c, relUnitUUID, "foo", "bar")
 	s.addRelationApplicationSetting(c, withSettingRelationEndpointUUID, "baz", "simple")
 	s.setRelationSuspended(c, relationUUID)
-	expectedMacBytes := s.addMacaroon(c, relationUUID.String())
 	expected := domainrelation.FullRelationUnitChange{
 		RelationUnitChange: domainrelation.RelationUnitChange{
 			RelationUUID: relationUUID,
@@ -2402,11 +2401,6 @@ func (s *relationSuite) TestGetFullRelationUnitsChange(c *tc.C) {
 	mc.AddExpr("_.RelationUnitChange.InScopeUnits", tc.SameContents, []int{0, 3})
 	mc.AddExpr("_.Macaroons", tc.Ignore)
 	c.Check(obtained, mc, expected)
-	if c.Check(obtained.Macaroons, tc.HasLen, 1) {
-		obtainedMac := obtained.Macaroons[0]
-		obtainedMacBytes := tc.Must(c, obtainedMac.MarshalJSON)
-		c.Check(obtainedMacBytes, tc.DeepEquals, expectedMacBytes)
-	}
 }
 
 func (s *relationSuite) TestGetFullRelationUnitsChangeRelationNotFound(c *tc.C) {

--- a/domain/relation/types.go
+++ b/domain/relation/types.go
@@ -9,9 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
-	"gopkg.in/macaroon.v2"
-
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/life"
 	corerelation "github.com/juju/juju/core/relation"
@@ -397,12 +394,6 @@ type FullRelationUnitChange struct {
 
 	// SuspendedReason is an optional message to explain why suspended is true.
 	SuspendedReason string
-
-	// Macaroons are used for authentication.
-	Macaroons macaroon.Slice
-
-	// BakeryVersion is the version of the bakery used to mint macaroons.
-	BakeryVersion bakery.Version
 }
 
 // ConsumerRelationUnitsChange encapsulates a consumer relation event.


### PR DESCRIPTION
This patch reverts the changes from
https://github.com/juju/juju/pull/21011 because we shouldn't be saving the macaroon on the offering side, only the consuming side and that's already done by the CMR worker.


## QA steps

The following errors should not appear on the logs:
```
watching remote relation c9bbabe1-aa36-48ef-8b73-73f2af103c71: getting initial change: getting relation macaroon: macaroon for relation "c9bbabe1-aa36-48ef-8b73-73f2af103c71" not found
```

```
$ juju debug-log  --replay --tail | grep "watching remote relation"
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
