### PR TITLE
feat: check both endpoints not remote before relating

### DIFF
--- a/domain/relation/errors/errors.go
+++ b/domain/relation/errors/errors.go
@@ -14,6 +14,10 @@ const (
 	// the relation.
 	ApplicationNotFoundForRelation = errors.ConstError("application not found in relation")
 
+	// BothEndpointsRemote describes an error that occurs when attempting to
+	// create a relation where both endpoints are remote (CMR) applications.
+	BothEndpointsRemote = errors.ConstError("both endpoints are remote applications")
+
 	// CompatibleEndpointsNotFound is returned when no matching relation is found when trying
 	// to relate two application
 	CompatibleEndpointsNotFound = errors.ConstError("no compatible endpoints found between applications")


### PR DESCRIPTION
This patch adds a check when creating a relation: make sure that both passed endpoints are not SAASs (remote applications).

Before this patch, you could relate two SAAS which is incorect and doesn't make sense, but the domain didn't stop you from doing so.


## QA steps

Let's create two offers and consume them both from a separate model:
```
$ juju add-model offer
$ juju deploy postgresql --channel 16/stable
$ juju offer postgresql:replication-offer replication
$ juju offer postgresql:replication r2
$ juju add-model consume
$ juju deploy postgresql --channel 16/stable
$ juju consume c:admin/offer.r2
$ juju consume c:admin/offer.replication
```
Now this should fail with the following error:
```
$ juu relate replication r2
ERROR adding relation between endpoints "replication" and "r2": unable to integrate two cross model applications together
```


## Links


**Jira card:** [JUJU-8721](https://warthogs.atlassian.net/browse/JUJU-8721)


[JUJU-8721]: https://warthogs.atlassian.net/browse/JUJU-8721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ