### PR TITLE
refactor: updated argument to GetRelationKeyByUUID

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -425,7 +425,7 @@ func (api *CrossModelRelationsAPIv3) registerOneRemoteRelation(
 		return nil, errors.Annotate(err, "adding remote application consumer")
 	}
 
-	relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, relation.RelationToken)
+	relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, corerelation.UUID(relation.RelationToken))
 	if err != nil {
 		return nil, errors.Annotate(err, "getting relation key")
 	}
@@ -485,14 +485,14 @@ func (api *CrossModelRelationsAPIv3) watchOneRelationChanges(
 	var empty params.RemoteRelationChangeEvent
 	// relationToken is the relation UUID.
 	relationToken := arg.Token
+	relationUUID := corerelation.UUID(relationToken)
 
-	relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, relationToken)
+	relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, relationUUID)
 	if err != nil {
 		return nil, empty, internalerrors.Errorf("getting relation key for %q: %w", relationToken, err)
 	}
 	relationTag := names.NewRelationTag(relationKey.String())
 
-	relationUUID := corerelation.UUID(relationToken)
 	if err := api.checkMacaroonsForRelation(ctx, relationUUID, relationTag, arg.Macaroons, arg.BakeryVersion); err != nil {
 		return nil, empty, internalerrors.Capture(err)
 	}
@@ -586,7 +586,8 @@ func (api *CrossModelRelationsAPIv3) WatchRelationsSuspendedStatus(
 	}
 
 	for i, arg := range remoteRelationArgs.Args {
-		relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, arg.Token)
+		relationUUID := corerelation.UUID(arg.Token)
+		relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, relationUUID)
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(
 				internalerrors.Errorf("getting relation key for %q: %w", arg.Token, err))
@@ -594,7 +595,6 @@ func (api *CrossModelRelationsAPIv3) WatchRelationsSuspendedStatus(
 		}
 		relationTag := names.NewRelationTag(relationKey.String())
 
-		relationUUID := corerelation.UUID(arg.Token)
 		if err := api.checkMacaroonsForRelation(ctx, relationUUID, relationTag, arg.Macaroons, arg.BakeryVersion); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
@@ -854,7 +854,7 @@ func (api *CrossModelRelationsAPIv3) WatchEgressAddressesForRelations(ctx contex
 	}
 	for i, arg := range remoteRelationArgs.Args {
 		relationUUID := corerelation.UUID(arg.Token)
-		relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, relationUUID.String())
+		relationKey, err := api.relationService.GetRelationKeyByUUID(ctx, relationUUID)
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -557,7 +557,7 @@ func (s *facadeSuite) TestRegisterRemoteRelationsSuccess(c *tc.C) {
 	appName := "offerapp"
 	appUUIDStr := tc.Must(c, uuid.NewUUID).String()
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relationUUID := tc.Must(c, uuid.NewUUID).String()
+	relationUUID := tc.Must(c, corerelation.NewUUID)
 	remoteAppToken := tc.Must(c, uuid.NewUUID).String()
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
@@ -589,7 +589,7 @@ func (s *facadeSuite) TestRegisterRemoteRelationsSuccess(c *tc.C) {
 		Return(&bakery.Macaroon{}, nil)
 
 	api := s.api(c)
-	arg := s.relationArg(c, remoteAppToken, offerUUID, relationUUID, "remoteapp:db", "db", macaroon.Slice{testMac})
+	arg := s.relationArg(c, remoteAppToken, offerUUID, relationUUID.String(), "remoteapp:db", "db", macaroon.Slice{testMac})
 	results, err := api.RegisterRemoteRelations(c.Context(), params.RegisterConsumingRelationArgs{
 		Relations: []params.RegisterConsumingRelationArg{arg},
 	})
@@ -599,7 +599,7 @@ func (s *facadeSuite) TestRegisterRemoteRelationsSuccess(c *tc.C) {
 	c.Check(results.Results[0].Result.Token, tc.Equals, appUUIDStr)
 
 	c.Check(received.OfferUUID, tc.Equals, offerUUID)
-	c.Check(received.RelationUUID, tc.Equals, relationUUID)
+	c.Check(received.RelationUUID, tc.Equals, relationUUID.String())
 	c.Check(received.ConsumerApplicationUUID, tc.Equals, remoteAppToken)
 	c.Check(received.ConsumerApplicationEndpoint.Name, tc.Equals, "remoteapp:db")
 	c.Check(received.ConsumerApplicationEndpoint.Role, tc.Equals, domaincharm.RelationRole(internalcharm.RoleProvider))
@@ -704,7 +704,7 @@ func (s *facadeSuite) TestRegisterRemoteRelationsCreateMacaroonError(c *tc.C) {
 	appName := "offerapp"
 	appUUIDStr := tc.Must(c, uuid.NewUUID).String()
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relationUUID := tc.Must(c, uuid.NewUUID).String()
+	relationUUID := tc.Must(c, corerelation.NewUUID)
 	remoteAppToken := tc.Must(c, uuid.NewUUID).String()
 
 	s.crossModelRelationService.EXPECT().
@@ -728,7 +728,7 @@ func (s *facadeSuite) TestRegisterRemoteRelationsCreateMacaroonError(c *tc.C) {
 		Return(nil, errors.New("mint failed"))
 
 	api := s.api(c)
-	arg := s.relationArg(c, remoteAppToken, offerUUID, relationUUID, "remoteapp:db", "db", nil)
+	arg := s.relationArg(c, remoteAppToken, offerUUID, relationUUID.String(), "remoteapp:db", "db", nil)
 	results, err := api.RegisterRemoteRelations(c.Context(), params.RegisterConsumingRelationArgs{Relations: []params.RegisterConsumingRelationArg{arg}})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results[0].Error, tc.ErrorMatches, "creating relation macaroon: mint failed")
@@ -914,7 +914,7 @@ func (s *facadeSuite) TestWatchConsumedSecretsChanges(c *tc.C) {
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	appUUID := tc.Must(c, application.NewUUID)
 	uri := coresecrets.NewURI()
 
@@ -957,7 +957,7 @@ func (s *facadeSuite) TestWatchConsumedSecretsChangesNotFound(c *tc.C) {
 
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	appUUID := tc.Must(c, application.NewUUID)
 
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return("", crossmodelrelationerrors.OfferNotFound)
@@ -982,7 +982,7 @@ func (s *facadeSuite) TestWatchConsumedSecretsChangesAuthError(c *tc.C) {
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	appUUID := tc.Must(c, application.NewUUID)
 
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
@@ -1008,7 +1008,7 @@ func (s *facadeSuite) TestPublishIngressNetworkChangesSuccess(c *tc.C) {
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	networks := []string{"192.0.2.0/24", "198.51.100.0/24"}
 	saasIngressAllow := []string{"0.0.0.0/0", "::/0"}
 
@@ -1051,7 +1051,7 @@ func (s *facadeSuite) TestPublishIngressNetworkChangesSuccessSingleNetwork(c *tc
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	network := "10.0.0.0/8"
 	saasIngressAllow := []string{"0.0.0.0/0", "::/0"}
 
@@ -1162,7 +1162,7 @@ func (s *facadeSuite) TestPublishIngressNetworkChangesOfferNotFound(c *tc.C) {
 
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
 	c.Assert(err, tc.ErrorIsNil)
@@ -1194,7 +1194,7 @@ func (s *facadeSuite) TestPublishIngressNetworkChangesAuthError(c *tc.C) {
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
 	c.Assert(err, tc.ErrorIsNil)
@@ -1229,7 +1229,7 @@ func (s *facadeSuite) TestPublishIngressNetworkChangesAddIngressError(c *tc.C) {
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	networks := []string{"192.0.2.0/24"}
 	saasIngressAllow := []string{"0.0.0.0/0", "::/0"}
 
@@ -1341,7 +1341,7 @@ func (s *facadeSuite) TestPublishIngressNetworkChangesEmptyNetworks(c *tc.C) {
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	saasIngressAllow := []string{"0.0.0.0/0", "::/0"}
 
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
@@ -1383,7 +1383,7 @@ func (s *facadeSuite) TestPublishIngressNetworkChangesSubnetNotInWhitelist(c *tc
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	networks := []string{"10.0.0.0/8"}
 	saasIngressAllow := []string{"192.168.0.0/16"}
 
@@ -1430,7 +1430,7 @@ func (s *facadeSuite) TestPublishIngressNetworkChangesModelConfigError(c *tc.C) 
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	networks := []string{"192.0.2.0/24"}
 
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
@@ -1471,11 +1471,11 @@ func (s *facadeSuite) TestWatchRelationChanges(c *tc.C) {
 	relationTag := names.NewRelationTag(relationKey.String())
 	testMac, _ := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	appUUID := tc.Must(c, application.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 	offerUUID := tc.Must(c, offer.NewUUID)
 
 	// Setup successful authentication
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relationKey, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID).Return(relationKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID.String(), relationTag, gomock.Any(), bakery.LatestVersion).Return(nil)
@@ -1562,8 +1562,8 @@ func (s *facadeSuite) TestWatchRelationChangesAuthError(c *tc.C) {
 	relationKey, _ := corerelation.NewKeyFromString("one:db two:use")
 	testMac, _ := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relationKey, nil)
+	relUUID := tc.Must(c, corerelation.NewUUID)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID).Return(relationKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	tag := names.NewRelationTag(relationKey.String())
@@ -1593,13 +1593,13 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelations(c *tc.C) {
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
 	c.Assert(err, tc.ErrorIsNil)
 	relationTag := names.NewRelationTag(relKey.String())
 
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relKey, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID).Return(relKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID.String(), relationTag, gomock.Any(), bakery.LatestVersion).
@@ -1640,9 +1640,9 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsNotFound(c *tc.C) {
 
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(corerelation.Key{}, errors.New("relation not found"))
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID).Return(corerelation.Key{}, errors.New("relation not found"))
 
 	api := s.api(c)
 	results, err := api.WatchEgressAddressesForRelations(c.Context(), params.RemoteEntityArgs{
@@ -1663,12 +1663,12 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsOfferNotFound(c *tc.C)
 
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
 	c.Assert(err, tc.ErrorIsNil)
 
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relKey, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID).Return(relKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return("", crossmodelrelationerrors.OfferNotFound)
 
 	api := s.api(c)
@@ -1691,13 +1691,13 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsAuthError(c *tc.C) {
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
 	c.Assert(err, tc.ErrorIsNil)
 	relationTag := names.NewRelationTag(relKey.String())
 
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relKey, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID).Return(relKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID.String(), relationTag, gomock.Any(), bakery.LatestVersion).
@@ -1723,13 +1723,13 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsWatcherError(c *tc.C) 
 	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)
 	offerUUID := tc.Must(c, offer.NewUUID)
-	relUUID := relationtesting.GenRelationUUID(c)
+	relUUID := tc.Must(c, corerelation.NewUUID)
 
 	relKey, err := corerelation.NewKeyFromString("app1:ep1 app2:ep2")
 	c.Assert(err, tc.ErrorIsNil)
 	relationTag := names.NewRelationTag(relKey.String())
 
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID.String()).Return(relKey, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID).Return(relKey, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID.String(), relationTag, gomock.Any(), bakery.LatestVersion).
@@ -1765,7 +1765,7 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsMultipleRelations(c *t
 	relationTag1 := names.NewRelationTag(relKey1.String())
 
 	// First relation succeeds.
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID1.String()).Return(relKey1, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID1).Return(relKey1, nil)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID1).Return(offerUUID1, nil)
 	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
 	s.authenticator.EXPECT().CheckRelationMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID1.String(), relationTag1, gomock.Any(), bakery.LatestVersion).
@@ -1784,7 +1784,7 @@ func (s *facadeSuite) TestWatchEgressAddressesForRelationsMultipleRelations(c *t
 		})
 
 	// Second relation fails on GetRelationKeyByUUID.
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID2.String()).Return(corerelation.Key{}, errors.New("not found"))
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relUUID2).Return(corerelation.Key{}, errors.New("not found"))
 
 	api := s.api(c)
 	results, err := api.WatchEgressAddressesForRelations(c.Context(), params.RemoteEntityArgs{
@@ -1890,7 +1890,7 @@ func (s *facadeSuite) expectCheckRelationMacaroons(c *tc.C, err error) corerelat
 	relationUUID := tc.Must(c, corerelation.NewUUID)
 
 	relationKey, _ := corerelation.NewKeyFromString("one:one two:two")
-	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relationUUID.String()).Return(relationKey, nil)
+	s.relationService.EXPECT().GetRelationKeyByUUID(gomock.Any(), relationUUID).Return(relationKey, nil)
 
 	offerUUID := tc.Must(c, offer.NewUUID)
 	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relationUUID).Return(offerUUID, nil)

--- a/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
@@ -766,7 +766,7 @@ func (c *MockRelationServiceGetRelationDetailsCall) DoAndReturn(f func(context.C
 }
 
 // GetRelationKeyByUUID mocks base method.
-func (m *MockRelationService) GetRelationKeyByUUID(arg0 context.Context, arg1 string) (relation.Key, error) {
+func (m *MockRelationService) GetRelationKeyByUUID(arg0 context.Context, arg1 relation.UUID) (relation.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationKeyByUUID", arg0, arg1)
 	ret0, _ := ret[0].(relation.Key)
@@ -793,13 +793,13 @@ func (c *MockRelationServiceGetRelationKeyByUUIDCall) Return(arg0 relation.Key, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationKeyByUUIDCall) Do(f func(context.Context, string) (relation.Key, error)) *MockRelationServiceGetRelationKeyByUUIDCall {
+func (c *MockRelationServiceGetRelationKeyByUUIDCall) Do(f func(context.Context, relation.UUID) (relation.Key, error)) *MockRelationServiceGetRelationKeyByUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationKeyByUUIDCall) DoAndReturn(f func(context.Context, string) (relation.Key, error)) *MockRelationServiceGetRelationKeyByUUIDCall {
+func (c *MockRelationServiceGetRelationKeyByUUIDCall) DoAndReturn(f func(context.Context, relation.UUID) (relation.Key, error)) *MockRelationServiceGetRelationKeyByUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelrelations/service.go
+++ b/apiserver/facades/controller/crossmodelrelations/service.go
@@ -115,7 +115,7 @@ type RelationService interface {
 	GetRelationDetails(ctx context.Context, relationUUID corerelation.UUID) (relation.RelationDetails, error)
 
 	// GetRelationKeyByUUID returns the relation key for the given UUID.
-	GetRelationKeyByUUID(ctx context.Context, relationUUID string) (corerelation.Key, error)
+	GetRelationKeyByUUID(ctx context.Context, relationUUID corerelation.UUID) (corerelation.Key, error)
 
 	// GetRelationLifeSuspendedStatus returns a life/suspended status change
 	// struct for a specified relation uuid.

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -1145,16 +1145,16 @@ func (s *Service) GetConsumerRelationUnitsChange(
 }
 
 // GetRelationKeyByUUID returns the relation Key for the given UUID.
-func (s *Service) GetRelationKeyByUUID(ctx context.Context, relationUUIDStr string) (corerelation.Key, error) {
+func (s *Service) GetRelationKeyByUUID(ctx context.Context, relationUUID corerelation.UUID) (corerelation.Key, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	_, err := corerelation.ParseUUID(relationUUIDStr)
-	if err != nil {
-		return corerelation.Key{}, errors.Capture(err)
+	if err := relationUUID.Validate(); err != nil {
+		return corerelation.Key{}, errors.Errorf(
+			"getting relation key:%w", err).Add(relationerrors.RelationUUIDNotValid)
 	}
 
-	relationEndpoints, err := s.st.GetRelationEndpoints(ctx, relationUUIDStr)
+	relationEndpoints, err := s.st.GetRelationEndpoints(ctx, relationUUID.String())
 	if err != nil {
 		return corerelation.Key{}, errors.Capture(err)
 	}


### PR DESCRIPTION
Follow up on PR comments.

The service method should take a relation.UUID rather than a string.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

No change to behavior, unit tests all pass.
