### PR TITLE
fix: handle case where external secret not found on delete

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -480,8 +480,11 @@ func (op *DestroyApplicationOperation) deleteSecrets() error {
 					continue
 				}
 				if err = op.SecretContentDeleter(uri, rev.Revision); err != nil {
+					if errors.Is(err, errors.NotFound) {
+						continue
+					}
 					if op.FatalError(err) {
-						return errors.Annotatef(err, "deleting external  content for %s/%d", uri.ID, rev.Revision)
+						return errors.Annotatef(err, "deleting external content for %s/%d", uri.ID, rev.Revision)
 					}
 				}
 			}


### PR DESCRIPTION
When deleting an app, it's secrets are also deleted.
If the secret is stored in an external backend, and the content is already deleted, we need to ignore the not found error.

This fixes a regression from 3.6.10, where the removal of the k8s pod also deletes the secret resource.

## QA steps

```
juju bootstrap microk8s
juju switch controller
juju deploy snappass-test
juju exec -u snappass-test/0 -- secret-add foo=bar
juju secrets
juju remove-application snappass-test
juju secrets
```

## Links

**Issue:** Fixes #21047
