### PR TITLE
fix(application-channel): set application-channel primary key as application-uuid

### DIFF
--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1699,7 +1699,7 @@ func (st *State) upsertApplicationChannel(ctx context.Context, tx *sqlair.TX, ch
 	upsertAppChannelStmt, err := st.Prepare(`
 INSERT INTO application_channel (*)
 VALUES ($applicationChannel.*)
-ON CONFLICT(application_uuid, track, risk, branch) DO UPDATE SET
+ON CONFLICT(application_uuid) DO UPDATE SET
 	track = excluded.track,
 	risk = excluded.risk,
 	branch = excluded.branch;

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -204,7 +204,7 @@ CREATE TABLE application_channel (
     CONSTRAINT fk_application_origin_application
     FOREIGN KEY (application_uuid)
     REFERENCES application (uuid),
-    PRIMARY KEY (application_uuid, track, risk, branch)
+    PRIMARY KEY (application_uuid)
 );
 
 CREATE TABLE application_status (


### PR DESCRIPTION
# Description

Before the primary key was spanning all fields in the table, this was causing issues because when we update `application_channel` during `SetApplicationCharm` (which is called by `juju refresh`) we can't set the `ON CONFLICT` clause just on application_uuid. This is needed to make sure we update the channel for an application and we have a single row in application_channel for each application.

> Fly-by added a count in the test where we update the channel to make sure we have a single row for application_uuid after the update.

# QA

Both `refresh_basic` and `refresh_switch` work now.