### PR TITLE
feat(dbrepl): introduce a "detached mode" to just create the dqlite file for developer mode

### DIFF
--- a/scripts/dqlite/cmd/main.go
+++ b/scripts/dqlite/cmd/main.go
@@ -39,6 +39,8 @@ var (
 
 	// Prevent the SQL commands from being printed to the console on startup.
 	quietFlag = flag.Bool("q", false, "Quiet mode")
+	// Detached mode just create the sqlite files but don't start the server.'
+	detachedFlag = flag.Bool("d", false, "Detached mode")
 
 	// Having a history of sql commands is useful for debugging and
 	// for re-running commands.
@@ -134,6 +136,10 @@ func main() {
 
 	if _, err := schema.Ensure(ctx, runner); err != nil {
 		panic(err)
+	}
+
+	if *detachedFlag {
+		return
 	}
 
 	go func() {


### PR DESCRIPTION
Having a way to just create the file and let it go is useful while developing to use more convenient tools than the command line.

As a fly by, typo fixing and error handling.

Example (goland)

[dbrepl.webm](https://github.com/user-attachments/assets/e00b6c8c-4893-45bd-b673-9b550d02045c)