### PR TITLE
feat: filter synthetic relations in status

### DIFF
--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -1946,6 +1946,72 @@ func (s *relationSuite) TestGetAllRelationDetailsFiltersSyntheticRelations(c *tc
 	c.Check(details[0].Endpoints, tc.SameContents, []domainrelation.Endpoint{endpoint1, endpoint2})
 }
 
+func (s *relationSuite) TestGetAllRelationDetailsWithMissingEndpoints(c *tc.C) {
+	// This test verifies that the defensive checks in GetAllRelationDetails
+	// work correctly when relations are missing endpoints (data inconsistency).
+	// The method should return an error rather than crash or return partial
+	// data.
+
+	// Arrange: Create a relation without endpoints (simulates data
+	// inconsistency), this will trigger the "missing endpoints" defensive
+	// check
+	relationID1 := 7
+	_ = s.addRelationWithLifeAndID(c, corelife.Alive, relationID1)
+	// Intentionally NOT adding relation_endpoint entries
+
+	// Act: Get all relation details
+	_, err := s.state.GetAllRelationDetails(c.Context())
+
+	// Assert: Should return an error about missing endpoints
+	c.Assert(err, tc.ErrorMatches, `.*missing endpoints for relation.*`)
+}
+
+func (s *relationSuite) TestGetAllRelationDetailsWithMissingInScopeCount(c *tc.C) {
+	// Arrange: Create a relation with endpoints but no units
+	relationID1 := 7
+	endpoint1 := domainrelation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Optional:  false,
+			Limit:     5,
+			Scope:     charm.ScopeGlobal,
+		},
+	}
+	endpoint2 := domainrelation.Endpoint{
+		ApplicationName: s.fakeApplicationName2,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-2",
+			Role:      charm.RoleRequirer,
+			Interface: "database",
+			Optional:  false,
+			Limit:     5,
+			Scope:     charm.ScopeGlobal,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	charmRelationUUID2 := s.addCharmRelation(c, s.fakeCharmUUID2, endpoint2.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	applicationEndpointUUID2 := s.addApplicationEndpoint(c, s.fakeApplicationUUID2, charmRelationUUID2)
+	relationUUID1 := s.addRelationWithLifeAndID(c, corelife.Alive, relationID1)
+	s.addRelationEndpoint(c, relationUUID1, applicationEndpointUUID1)
+	s.addRelationEndpoint(c, relationUUID1, applicationEndpointUUID2)
+	// Intentionally NOT adding any relation_unit entries
+
+	// Act: Get all relation details
+	details, err := s.state.GetAllRelationDetails(c.Context())
+
+	// Assert: Should succeed with in-scope count of 0
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(details, tc.HasLen, 1)
+	c.Check(details[0].ID, tc.Equals, relationID1)
+	c.Check(details[0].UUID, tc.Equals, relationUUID1)
+	c.Check(details[0].InScopeUnits, tc.Equals, 0, tc.Commentf("Relations with no units should have in-scope count of 0"))
+	c.Check(details[0].Endpoints, tc.SameContents, []domainrelation.Endpoint{endpoint1, endpoint2})
+}
+
 func (s *relationSuite) TestEnterScope(c *tc.C) {
 	// Arrange: Populate charm metadata with subordinate data.
 	s.addCharmMetadata(c, s.fakeCharmUUID1, false)

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -350,3 +350,31 @@ type relationStatus struct {
 	Message      string     `db:"message"`
 	Since        *time.Time `db:"updated_at"`
 }
+
+type getRelation struct {
+	UUID      string     `db:"uuid"`
+	ID        int        `db:"relation_id"`
+	Life      life.Value `db:"value"`
+	Suspended bool       `db:"suspended"`
+}
+
+type relationWithDetails struct {
+	UUID      string     `db:"uuid"`
+	ID        int        `db:"relation_id"`
+	Life      life.Value `db:"life"`
+	Suspended bool       `db:"suspended"`
+}
+
+// endpointWithRelationUUID combines an Endpoint with its Relation UUID, needed
+// for returning relation endpoints mapped by relation.
+type endpointWithRelationUUID struct {
+	Endpoint
+	RelationUUID string `db:"relation_uuid"`
+}
+
+// countResultWithRelationUUID is used to return counts grouped by relation
+// UUID.
+type countResultWithRelationUUID struct {
+	RelationUUID string `db:"relation_uuid"`
+	Count        int    `db:"count"`
+}


### PR DESCRIPTION
This patch filters the synthetic relations (on the offering model, if any) so they are not returned in status, since that doesn't make any sense.

As a flyby, the queries in GetAllRelationDetails were reworked to avoid hitting the db with N+1 queries. Now only 3 db queries are needed.

## QA steps

Create a CMR.
```
$ juju add-model offer 
$ juju deploy postgresql --channel 16/stable
$ juju offer postgresql:replication-offer replication
$ juju add-model consume 
$ juju deploy postgresql --channel 16/stable
$ juju consume c:admin/offer.replication
$ juju relate postgresql:replication replication
$ juju status --relations
Model    Controller  Cloud/Region   Version      Timestamp
consume  c           lxd/localhost  4.0-beta8.1  11:15:01+01:00

SAAS         Status       Store  URL
replication  maintenance  c      admin/offer.replication

App         Version  Status       Scale  Charm       Channel    Rev  Exposed  Message
postgresql  16.10    maintenance      1  postgresql  16/stable  952  no       installing PostgreSQL

Unit           Workload     Agent      Machine  Public address  Ports  Message
postgresql/0*  maintenance  executing  0        10.32.147.3            (install) installing PostgreSQL

Machine  State    Address      Inst id        Base          AZ       Message
0        started  10.32.147.3  juju-73e2ee-0  ubuntu@24.04  newells  Running

Integration provider           Requirer                    Interface         Type     Message
postgresql:database-peers      postgresql:database-peers   postgresql_peers  peer     joining
postgresql:refresh-v-three     postgresql:refresh-v-three  refresh           peer     joining
postgresql:restart             postgresql:restart          rolling_op        peer     joining
replication:replication-offer  postgresql:replication      postgresql_async  regular  joining
```
But on the offering side, the CMR should not be listed:
```$ juju status --relations
Model  Controller  Cloud/Region   Version      Timestamp
offer  c           lxd/localhost  4.0-beta8.1  11:15:35+01:00

App         Version  Status       Scale  Charm       Channel    Rev  Exposed  Message
postgresql  16.10    maintenance      1  postgresql  16/stable  952  no       installing PostgreSQL

Unit           Workload     Agent      Machine  Public address  Ports  Message
postgresql/0*  maintenance  executing  0        10.32.147.244          (install) installing PostgreSQL

Machine  State    Address        Inst id        Base          AZ       Message
0        started  10.32.147.244  juju-4950e3-0  ubuntu@24.04  newells  Running

Offer        Application  Charm       Rev  Connected  Endpoint           Interface         Role
replication  postgresql   postgresql  952  0/1        replication-offer  postgresql_async  provider

Integration provider        Requirer                    Interface         Type  Message
postgresql:database-peers   postgresql:database-peers   postgresql_peers  peer  joining
postgresql:refresh-v-three  postgresql:refresh-v-three  refresh           peer  joining
postgresql:restart          postgresql:restart          rolling_op        peer  joining
```
## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8735](https://warthogs.atlassian.net/browse/JUJU-8735)


[JUJU-8735]: https://warthogs.atlassian.net/browse/JUJU-8735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ