### PR TITLE
fix(cmr): fixes cmr auth

### DIFF
--- a/apiserver/common/crossmodel/bakery.go
+++ b/apiserver/common/crossmodel/bakery.go
@@ -84,12 +84,14 @@ func NewLocalOfferBakery(
 	locator := bakeryutil.BakeryThirdPartyLocator{PublicKey: key.Public}
 	localOfferBakery := bakery.New(
 		bakery.BakeryParams{
-			Checker:       checker,
-			RootKeyStore:  store,
-			Locator:       locator,
-			Key:           key,
-			OpsAuthorizer: CrossModelAuthorizer{},
-			Location:      location,
+			Checker:      checker,
+			RootKeyStore: store,
+			Locator:      locator,
+			Key:          key,
+			// Note (alesstimec): we should not be authorizing operations
+			// other than those already authorized.
+			//OpsAuthorizer: CrossModelAuthorizer{},
+			Location: location,
 		},
 	)
 	bakery := &bakeryutil.ExpirableStorageBakery{


### PR DESCRIPTION
Fixes the CMR in case somebody presents a macaroon that was not minted by this controller. Before this change a discharge required error was returned trusting declared caveats  in the invalid macaroon, which was a potential attack vector as demonstrated in test comments.

Note to reviewers and developers: please ALWAYS SPECIFY FIELD NAMES WHEN CREATING STRUCTS! This was causing test failures as the bakery.Op was created wrong!

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. make install
2. juju bootstrap lxd
3. juju add-model source
4. juju deploy juju-qa-dummy-source
5. juju config dummy-source token="hello" 
6.  juju offer dummy-source:sink 
7. juju add-model sink
8. juju consume admin/source.dummy-source  
9. juju deploy juju-qa-dummy-sink 
10.  juju relate dummy-sink dummy-source   
11. wait
12. juju status and assert the message is equal to "Token is hello"
