### PR TITLE
feat(cmr): implement the service methods for remote relation watcher

### DIFF
--- a/apiserver/service.go
+++ b/apiserver/service.go
@@ -105,9 +105,10 @@ type RelationService interface {
 		relationUUID relation.UUID,
 	) (domainrelation.RelationLifeSuspendedStatus, error)
 
-	// GetSettingsForApplication returns the settings for the given application.
-	GetSettingsForApplication(context.Context, application.UUID) (map[string]interface{}, error)
-
 	// GetUnitSettingsForUnits returns the settings for the given units.
-	GetUnitSettingsForUnits(context.Context, []unit.Name) (map[unit.Name]map[string]interface{}, error)
+	GetUnitSettingsForUnits(context.Context, relation.UUID, []unit.Name) ([]domainrelation.UnitSettings, error)
+
+	// GetRelationApplicationSettings returns the application settings
+	// for the given application and relation identifier combination.
+	GetRelationApplicationSettings(context.Context, relation.UUID, application.UUID) (map[string]string, error)
 }

--- a/apiserver/service_mock_test.go
+++ b/apiserver/service_mock_test.go
@@ -123,6 +123,45 @@ func (c *MockRelationServiceGetInScopeUnitsCall) DoAndReturn(f func(context.Cont
 	return c
 }
 
+// GetRelationApplicationSettings mocks base method.
+func (m *MockRelationService) GetRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRelationApplicationSettings", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelationApplicationSettings indicates an expected call of GetRelationApplicationSettings.
+func (mr *MockRelationServiceMockRecorder) GetRelationApplicationSettings(arg0, arg1, arg2 any) *MockRelationServiceGetRelationApplicationSettingsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationApplicationSettings", reflect.TypeOf((*MockRelationService)(nil).GetRelationApplicationSettings), arg0, arg1, arg2)
+	return &MockRelationServiceGetRelationApplicationSettingsCall{Call: call}
+}
+
+// MockRelationServiceGetRelationApplicationSettingsCall wrap *gomock.Call
+type MockRelationServiceGetRelationApplicationSettingsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRelationServiceGetRelationApplicationSettingsCall) Return(arg0 map[string]string, arg1 error) *MockRelationServiceGetRelationApplicationSettingsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRelationServiceGetRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.UUID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRelationServiceGetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.UUID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationLifeSuspendedStatus mocks base method.
 func (m *MockRelationService) GetRelationLifeSuspendedStatus(arg0 context.Context, arg1 relation.UUID) (relation0.RelationLifeSuspendedStatus, error) {
 	m.ctrl.T.Helper()
@@ -162,58 +201,19 @@ func (c *MockRelationServiceGetRelationLifeSuspendedStatusCall) DoAndReturn(f fu
 	return c
 }
 
-// GetSettingsForApplication mocks base method.
-func (m *MockRelationService) GetSettingsForApplication(arg0 context.Context, arg1 application.UUID) (map[string]any, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSettingsForApplication", arg0, arg1)
-	ret0, _ := ret[0].(map[string]any)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSettingsForApplication indicates an expected call of GetSettingsForApplication.
-func (mr *MockRelationServiceMockRecorder) GetSettingsForApplication(arg0, arg1 any) *MockRelationServiceGetSettingsForApplicationCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSettingsForApplication", reflect.TypeOf((*MockRelationService)(nil).GetSettingsForApplication), arg0, arg1)
-	return &MockRelationServiceGetSettingsForApplicationCall{Call: call}
-}
-
-// MockRelationServiceGetSettingsForApplicationCall wrap *gomock.Call
-type MockRelationServiceGetSettingsForApplicationCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceGetSettingsForApplicationCall) Return(arg0 map[string]any, arg1 error) *MockRelationServiceGetSettingsForApplicationCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetSettingsForApplicationCall) Do(f func(context.Context, application.UUID) (map[string]any, error)) *MockRelationServiceGetSettingsForApplicationCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetSettingsForApplicationCall) DoAndReturn(f func(context.Context, application.UUID) (map[string]any, error)) *MockRelationServiceGetSettingsForApplicationCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetUnitSettingsForUnits mocks base method.
-func (m *MockRelationService) GetUnitSettingsForUnits(arg0 context.Context, arg1 []unit.Name) (map[unit.Name]map[string]any, error) {
+func (m *MockRelationService) GetUnitSettingsForUnits(arg0 context.Context, arg1 relation.UUID, arg2 []unit.Name) ([]relation0.UnitSettings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitSettingsForUnits", arg0, arg1)
-	ret0, _ := ret[0].(map[unit.Name]map[string]any)
+	ret := m.ctrl.Call(m, "GetUnitSettingsForUnits", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]relation0.UnitSettings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUnitSettingsForUnits indicates an expected call of GetUnitSettingsForUnits.
-func (mr *MockRelationServiceMockRecorder) GetUnitSettingsForUnits(arg0, arg1 any) *MockRelationServiceGetUnitSettingsForUnitsCall {
+func (mr *MockRelationServiceMockRecorder) GetUnitSettingsForUnits(arg0, arg1, arg2 any) *MockRelationServiceGetUnitSettingsForUnitsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitSettingsForUnits", reflect.TypeOf((*MockRelationService)(nil).GetUnitSettingsForUnits), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitSettingsForUnits", reflect.TypeOf((*MockRelationService)(nil).GetUnitSettingsForUnits), arg0, arg1, arg2)
 	return &MockRelationServiceGetUnitSettingsForUnitsCall{Call: call}
 }
 
@@ -223,19 +223,19 @@ type MockRelationServiceGetUnitSettingsForUnitsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceGetUnitSettingsForUnitsCall) Return(arg0 map[unit.Name]map[string]any, arg1 error) *MockRelationServiceGetUnitSettingsForUnitsCall {
+func (c *MockRelationServiceGetUnitSettingsForUnitsCall) Return(arg0 []relation0.UnitSettings, arg1 error) *MockRelationServiceGetUnitSettingsForUnitsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetUnitSettingsForUnitsCall) Do(f func(context.Context, []unit.Name) (map[unit.Name]map[string]any, error)) *MockRelationServiceGetUnitSettingsForUnitsCall {
+func (c *MockRelationServiceGetUnitSettingsForUnitsCall) Do(f func(context.Context, relation.UUID, []unit.Name) ([]relation0.UnitSettings, error)) *MockRelationServiceGetUnitSettingsForUnitsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetUnitSettingsForUnitsCall) DoAndReturn(f func(context.Context, []unit.Name) (map[unit.Name]map[string]any, error)) *MockRelationServiceGetUnitSettingsForUnitsCall {
+func (c *MockRelationServiceGetUnitSettingsForUnitsCall) DoAndReturn(f func(context.Context, relation.UUID, []unit.Name) ([]relation0.UnitSettings, error)) *MockRelationServiceGetUnitSettingsForUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -140,14 +140,17 @@ func (s *remoteRelationWatcherSuite) TestNext(c *tc.C) {
 	inScopeUnitNames := []unit.Name{"foo/1", "foo/2", "foo/3"}
 	s.relationService.EXPECT().GetInScopeUnits(gomock.Any(), appUUID, relUUID).Return(inScopeUnitNames, nil)
 
-	unitSettings := map[unit.Name]map[string]interface{}{
-		"foo/1": {"thing": 1},
-		"foo/2": {"thing": 2},
-	}
-	s.relationService.EXPECT().GetUnitSettingsForUnits(gomock.Any(), gomock.InAnyOrder([]unit.Name{"foo/1", "foo/2"})).Return(unitSettings, nil)
+	unitSettings := []domainrelation.UnitSettings{{
+		UnitID:   1,
+		Settings: map[string]string{"thing1": "thing2"},
+	}, {
+		UnitID:   2,
+		Settings: map[string]string{"thing2": "thing1"},
+	}}
+	s.relationService.EXPECT().GetUnitSettingsForUnits(gomock.Any(), relUUID, gomock.InAnyOrder([]unit.Name{"foo/1", "foo/2"})).Return(unitSettings, nil)
 
-	appSettings := map[string]interface{}{"foo": 1}
-	s.relationService.EXPECT().GetSettingsForApplication(gomock.Any(), appUUID).Return(appSettings, nil)
+	appSettings := map[string]string{"foo": "bar"}
+	s.relationService.EXPECT().GetRelationApplicationSettings(gomock.Any(), relUUID, appUUID).Return(appSettings, nil)
 
 	res, err := s.api.Next(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -162,13 +165,13 @@ func (s *remoteRelationWatcherSuite) TestNext(c *tc.C) {
 		DepartedUnits:           []int{0},
 		InScopeUnits:            []int{1, 2, 3},
 		UnitCount:               3,
-		ApplicationSettings:     appSettings,
+		ApplicationSettings:     map[string]interface{}{"foo": "bar"},
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId:   1,
-			Settings: unitSettings["foo/1"],
+			Settings: map[string]interface{}{"thing1": "thing2"},
 		}, {
 			UnitId:   2,
-			Settings: unitSettings["foo/2"],
+			Settings: map[string]interface{}{"thing2": "thing1"},
 		}},
 	})
 }
@@ -195,11 +198,14 @@ func (s *remoteRelationWatcherSuite) TestNextNoApplicationSettingsChange(c *tc.C
 	inScopeUnitNames := []unit.Name{"foo/1", "foo/2", "foo/3"}
 	s.relationService.EXPECT().GetInScopeUnits(gomock.Any(), appUUID, relUUID).Return(inScopeUnitNames, nil)
 
-	unitSettings := map[unit.Name]map[string]interface{}{
-		"foo/1": {"thing": 1},
-		"foo/2": {"thing": 2},
-	}
-	s.relationService.EXPECT().GetUnitSettingsForUnits(gomock.Any(), gomock.InAnyOrder([]unit.Name{"foo/1", "foo/2"})).Return(unitSettings, nil)
+	unitSettings := []domainrelation.UnitSettings{{
+		UnitID:   1,
+		Settings: map[string]string{"thing1": "thing2"},
+	}, {
+		UnitID:   2,
+		Settings: map[string]string{"thing2": "thing1"},
+	}}
+	s.relationService.EXPECT().GetUnitSettingsForUnits(gomock.Any(), relUUID, gomock.InAnyOrder([]unit.Name{"foo/1", "foo/2"})).Return(unitSettings, nil)
 
 	res, err := s.api.Next(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -217,10 +223,10 @@ func (s *remoteRelationWatcherSuite) TestNextNoApplicationSettingsChange(c *tc.C
 		ApplicationSettings:     nil,
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId:   1,
-			Settings: unitSettings["foo/1"],
+			Settings: map[string]interface{}{"thing1": "thing2"},
 		}, {
 			UnitId:   2,
-			Settings: unitSettings["foo/2"],
+			Settings: map[string]interface{}{"thing2": "thing1"},
 		}},
 	})
 }

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -363,6 +363,45 @@ func (c *MockStateGetGoalStateRelationDataForApplicationCall) DoAndReturn(f func
 	return c
 }
 
+// GetInScopeUnits mocks base method.
+func (m *MockState) GetInScopeUnits(arg0 context.Context, arg1, arg2 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInScopeUnits", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInScopeUnits indicates an expected call of GetInScopeUnits.
+func (mr *MockStateMockRecorder) GetInScopeUnits(arg0, arg1, arg2 any) *MockStateGetInScopeUnitsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInScopeUnits", reflect.TypeOf((*MockState)(nil).GetInScopeUnits), arg0, arg1, arg2)
+	return &MockStateGetInScopeUnitsCall{Call: call}
+}
+
+// MockStateGetInScopeUnitsCall wrap *gomock.Call
+type MockStateGetInScopeUnitsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetInScopeUnitsCall) Return(arg0 []string, arg1 error) *MockStateGetInScopeUnitsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetInScopeUnitsCall) Do(f func(context.Context, string, string) ([]string, error)) *MockStateGetInScopeUnitsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetInScopeUnitsCall) DoAndReturn(f func(context.Context, string, string) ([]string, error)) *MockStateGetInScopeUnitsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetMapperDataForWatchLifeSuspendedStatus mocks base method.
 func (m *MockState) GetMapperDataForWatchLifeSuspendedStatus(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (relation0.RelationLifeSuspendedData, error) {
 	m.ctrl.T.Helper()
@@ -1139,6 +1178,45 @@ func (c *MockStateGetRelationsStatusForUnitCall) Do(f func(context.Context, unit
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetRelationsStatusForUnitCall) DoAndReturn(f func(context.Context, unit.UUID) ([]relation0.RelationUnitStatusResult, error)) *MockStateGetRelationsStatusForUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitSettingsForUnits mocks base method.
+func (m *MockState) GetUnitSettingsForUnits(arg0 context.Context, arg1 string, arg2 []string) ([]relation0.UnitSettings, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitSettingsForUnits", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]relation0.UnitSettings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitSettingsForUnits indicates an expected call of GetUnitSettingsForUnits.
+func (mr *MockStateMockRecorder) GetUnitSettingsForUnits(arg0, arg1, arg2 any) *MockStateGetUnitSettingsForUnitsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitSettingsForUnits", reflect.TypeOf((*MockState)(nil).GetUnitSettingsForUnits), arg0, arg1, arg2)
+	return &MockStateGetUnitSettingsForUnitsCall{Call: call}
+}
+
+// MockStateGetUnitSettingsForUnitsCall wrap *gomock.Call
+type MockStateGetUnitSettingsForUnitsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitSettingsForUnitsCall) Return(arg0 []relation0.UnitSettings, arg1 error) *MockStateGetUnitSettingsForUnitsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitSettingsForUnitsCall) Do(f func(context.Context, string, []string) ([]relation0.UnitSettings, error)) *MockStateGetUnitSettingsForUnitsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitSettingsForUnitsCall) DoAndReturn(f func(context.Context, string, []string) ([]relation0.UnitSettings, error)) *MockStateGetUnitSettingsForUnitsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -35,6 +35,8 @@ type applicationUUID struct {
 	UUID string `db:"application_uuid"`
 }
 
+type names []string
+
 type name struct {
 	Name string `db:"name"`
 }
@@ -165,6 +167,12 @@ type relationUnitSetting struct {
 	UUID  string `db:"relation_unit_uuid"`
 	Key   string `db:"key"`
 	Value string `db:"value"`
+}
+
+type relationUnitSettingName struct {
+	UnitName string `db:"name"`
+	Key      string `db:"key"`
+	Value    string `db:"value"`
 }
 
 type applicationSettingsHash struct {


### PR DESCRIPTION
We recently implemented the remote relation watcher, but wired it up to stub service methods.

Implement these service methods

## QA steps

```
juju bootstrap lxd lxd && juju add-model offerer && juju deploy juju-qa-dummy-source && juju offer dummy-source:sink && juju add-model consumer && juju deploy juju-qa-dummy-sink && sleep 15 && juju consume admin/offerer.dummy-source && juju relate dummy-source dummy-sink
```
And check there are no errors in debug log for either model