### PR TITLE
chore(bump-go-version): bump to go 1.24.9 to address GO-2025-4007

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.24.6
+go 1.24.9
 
 require (
 	cloud.google.com/go/compute v1.44.0


### PR DESCRIPTION
https://osv.dev/vulnerability/GO-2025-4007 fixed in 1.24.9