### PR TITLE
feat(removal): always schedule force jobs for filesystem and volumes

### DIFF
--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -1678,18 +1678,18 @@ func (c *MockModelDBStateEnsureStorageAttachmentNotAliveWithFulfilmentCall) DoAn
 }
 
 // EnsureStorageInstanceNotAliveCascade mocks base method.
-func (m *MockModelDBState) EnsureStorageInstanceNotAliveCascade(arg0 context.Context, arg1 string, arg2 bool) (internal.CascadedStorageFilesystemVolumeLives, error) {
+func (m *MockModelDBState) EnsureStorageInstanceNotAliveCascade(arg0 context.Context, arg1 string, arg2, arg3 bool) (internal.CascadedStorageFilesystemVolumeLives, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureStorageInstanceNotAliveCascade", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureStorageInstanceNotAliveCascade", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(internal.CascadedStorageFilesystemVolumeLives)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureStorageInstanceNotAliveCascade indicates an expected call of EnsureStorageInstanceNotAliveCascade.
-func (mr *MockModelDBStateMockRecorder) EnsureStorageInstanceNotAliveCascade(arg0, arg1, arg2 any) *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall {
+func (mr *MockModelDBStateMockRecorder) EnsureStorageInstanceNotAliveCascade(arg0, arg1, arg2, arg3 any) *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureStorageInstanceNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureStorageInstanceNotAliveCascade), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureStorageInstanceNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureStorageInstanceNotAliveCascade), arg0, arg1, arg2, arg3)
 	return &MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall{Call: call}
 }
 
@@ -1705,13 +1705,13 @@ func (c *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall) Return(arg0 i
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall) Do(f func(context.Context, string, bool) (internal.CascadedStorageFilesystemVolumeLives, error)) *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall) Do(f func(context.Context, string, bool, bool) (internal.CascadedStorageFilesystemVolumeLives, error)) *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall) DoAndReturn(f func(context.Context, string, bool) (internal.CascadedStorageFilesystemVolumeLives, error)) *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall) DoAndReturn(f func(context.Context, string, bool, bool) (internal.CascadedStorageFilesystemVolumeLives, error)) *MockModelDBStateEnsureStorageInstanceNotAliveCascadeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/service/storage.go
+++ b/domain/removal/service/storage.go
@@ -86,8 +86,10 @@ type StorageState interface {
 
 	// EnsureStorageInstanceNotAliveCascade ensures that there is no storage
 	// instance identified by the input UUID, that is still alive.
+	// Passing cascadeForce will cause this to always return the filesystem and/
+	// or volume.
 	EnsureStorageInstanceNotAliveCascade(
-		ctx context.Context, siUUID string, obliterate bool,
+		ctx context.Context, siUUID string, obliterate bool, cascadeForce bool,
 	) (internal.CascadedStorageFilesystemVolumeLives, error)
 
 	// GetStorageInstanceLife returns the life of the storage instance with
@@ -637,7 +639,7 @@ func (s *Service) RemoveStorageInstance(
 	}
 
 	cascaded, err := s.modelState.EnsureStorageInstanceNotAliveCascade(
-		ctx, uuid.String(), obliterate)
+		ctx, uuid.String(), obliterate, force)
 	if errors.Is(err, storageerrors.StorageInstanceNotFound) {
 		return errors.Errorf(
 			"storage instance %q not found", uuid,


### PR DESCRIPTION
If you have removed a storage instance without force, then later to decided
that you need to force its removal, you will not get any force jobs for the
filesystem or volume of that storage instance.

To ensure scheduling these jobs, `EnsureStorageInstanceNotAliveCascade`,
when passed force, will always return the filesystem uuid and volume uuid,
so that the service layer can schedule their force removal jobs.

## QA steps
- Bootstrap lxd
- Deploy an application that has detachable storage (e.g. allows storage to go
  down one instance), using a machine provisioned provider (e.g. tmpfs or loop).
- Stop the machine agent by stopping the systemd service.
- Remove the storage without force.
- See jobs trying to run in debug log.
- Remove the storage with --force.
- See storage is removed.