### PR TITLE
fix: disable keep-alives for bakery client http transport

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -145,7 +145,8 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 	bakeryClient.Client.Transport = &hostSwitchingTransport{
 		primaryHost: dialResult.controllerRootAddr.Host,
 		primary: jujuhttp.NewHTTPTLSTransport(jujuhttp.TransportConfig{
-			TLSConfig: dialResult.tlsConfig,
+			TLSConfig:         dialResult.tlsConfig,
+			DisableKeepAlives: true,
 		}),
 		fallback: http.DefaultTransport,
 	}


### PR DESCRIPTION
Juju API clients include a macaroon bakery client for discharging macaroons. This client does not use the RPC connection for Juju API requests, instead using it's own HTTP client.

By default, the bakery client uses the default HTTP client from the standard library and its inner transport is the default HTTP transport to which we supply some options.

There is a long standing issue with the default transport in that it has an infinite timeout threshold for idle HTTP connections. Without disabling keep-alives, repeated API connection creations cause underlying TCP connections to persist, even when we close the API connections.

Fortunately the API presented by the bakery client allows us to disable the keep-alive behaviour, which we do here.

**This is the source of TCP connection (and therefore file-handle) leaks observed on ProdStack.**

Honourable mentions:
@tlm for bringing attention to the venerable [issue](https://github.com/golang/go/issues/24138) in the standard lib.
@jameinel for the analysis that confirmed macaroon discharge as the smoking gun.
@hpidcock for pulling out the notebook to do analysis over beers.

## QA steps

- Apply a patch to periodically drop CMR connections. This simulates the churn observed in-theatre:
```diff
diff --git a/apiserver/admin.go b/apiserver/admin.go
index ccd8ef12b7..ccda0a22b5 100644
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -329,7 +329,13 @@ func (a *admin) authenticate(ctx context.Context, req params.LoginRequest) (*aut
        // TODO(wallyworld) - we can't yet observe anonymous logins as entity must be non-nil
        if !result.anonymousLogin {
                a.apiObserver.Login(a.root.authInfo.Entity.Tag(), a.root.model.ModelTag(), controllerConn, req.UserData)
+       } else {
+               go func() {
+                       <-time.After(time.Minute)
+                       _ = a.root.getRpcConn().Close()
+               }()
        }
+
        a.loggedIn = true

        if startPinger {
```
- Set up the CMR scenario:
```
for c in "cns" "src"; do juju bootstrap lxd $c; done
juju switch src; juju add-model work; juju deploy ./testcharms/charms/dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju add-model work; juju consume src:admin/work.dummy-source; juju deploy ./testcharms/charms/dummy-sink; juju relate dummy-source dummy-sink
juju switch src
```
- `juju ssh -m controller`.
- Over a period of time, observe the sources of external connections to the API with the introspection command:
```
$ juju_api_connection_sources
Selecting top 10 IPs connected to port 17070
      4 127.0.0.1
      4 10.246.27.219
      2 10.246.27.54
      1 10.246.27.14
      1 10.246.27.1
```
Previously this would show a growing count of connections from the `cns` controller, which no longer occurs.