### PR TITLE
feat: k8s controller shell is more like machine controller shell

### DIFF
--- a/.github/verify-agent-version.sh
+++ b/.github/verify-agent-version.sh
@@ -9,7 +9,7 @@ while true; do
   if [[ "$model_type" == "iaas" ]]; then
     UPDATED=$( (juju ssh -mcontroller 0 sudo cat /var/lib/juju/agents/machine-0/agent.conf || echo "") | yq -r '.upgradedToVersion' )
   elif [[ "$model_type" == "caas" ]]; then
-    UPDATED=$( (juju ssh -mcontroller --container api-server 0 cat /var/lib/juju/agents/controller-0/agent.conf || echo "") | yq -r '.upgradedToVersion' )
+    UPDATED=$( (juju ssh -mcontroller 0 cat /var/lib/juju/agents/controller-0/agent.conf || echo "") | yq -r '.upgradedToVersion' )
   fi
 
   if [[ $UPDATED == $target_version* ]]; then

--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -2,42 +2,22 @@ FROM public.ecr.aws/ubuntu/ubuntu:24.04
 ARG TARGETOS
 ARG TARGETARCH
 
-# Add the syslog user for audit logging.
-RUN useradd --system --no-create-home --shell /usr/sbin/nologin syslog
-# Add the juju and sjuju user for rootless agents.
-# 170 and 171 uid/gid must be updated here and in internal/provider/kubernetes/constants/constants.go
-RUN groupadd --gid 170 juju
-RUN useradd --uid 170 --gid 170 --no-create-home --shell /usr/bin/bash juju
-RUN groupadd --gid 171 sjuju
-RUN useradd --uid 171 --gid 171 --no-create-home --shell /usr/bin/bash sjuju
-RUN mkdir -p /etc/sudoers.d && echo "sjuju ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sjuju
-
-# Some Python dependencies.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    sudo \
-    python3-yaml \
-    python3-pip \
-    python3-setuptools \
-    # for debug-hooks.
-    tmux byobu \
-    curl iproute2 \
+# Add the syslog user for audit logging and juju rootless controller.
+# 170 uid/gid must be updated here and in internal/provider/kubernetes/constants/constants.go
+RUN useradd --system --no-create-home --shell /usr/sbin/nologin syslog \
+    && groupadd --gid 170 juju \
+    && useradd --uid 170 --gid 170 --no-create-home --shell /usr/bin/bash juju \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends vim less ca-certificates \
+    && apt-get remove sudo --purge \
+    && apt-get autoremove --purge \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /root/.cache
 
-# Install the standard charm dependencies.
-ENV WHEELHOUSE=/tmp/wheelhouse
-ENV PIP_WHEEL_DIR=/tmp/wheelhouse
-ENV PIP_FIND_LINKS=/tmp/wheelhouse
-
-RUN mkdir -p /tmp/wheelhouse
-COPY docker-staging/requirements.txt /tmp/wheelhouse/requirements.txt
-RUN pip3 install -r /tmp/wheelhouse/requirements.txt --break-system-packages
-
 WORKDIR /var/lib/juju
-COPY ${TARGETOS}_${TARGETARCH}/bin/jujud /opt/
-COPY ${TARGETOS}_${TARGETARCH}/bin/jujuc /opt/
-COPY ${TARGETOS}_${TARGETARCH}/bin/containeragent /opt/
-COPY ${TARGETOS}_${TARGETARCH}/bin/pebble /opt/
+COPY ${TARGETOS}_${TARGETARCH}/bin/jujud \
+     ${TARGETOS}_${TARGETARCH}/bin/jujuc \
+     ${TARGETOS}_${TARGETARCH}/bin/containeragent \
+     ${TARGETOS}_${TARGETARCH}/bin/pebble /opt/
 
 ENTRYPOINT ["sh", "-c"]

--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -123,13 +123,13 @@ Interact with the Pebble instance in the workload container via the charm contai
 
 **For k8s controller:**
 
-Connect to the api server pod:
+Connect to the controller api-server container:
 
-    juju ssh --container api-server 0
+    juju ssh 0
 
-Connect to the mongo db pod:
+Connect to the controller charm container:
 
-    juju ssh --container mongodb 0
+    juju ssh --container charm 0
 `
 
 const (

--- a/docs/contributor/howto/debug-a-dqlite-core-dump-issue.md
+++ b/docs/contributor/howto/debug-a-dqlite-core-dump-issue.md
@@ -18,8 +18,7 @@ Sometimes logs don’t make it to the database, so also check the controller mac
 
 ```text
 $ juju ssh -m controller <controller machine>
-$ grep “core dump” /var/log/juju/machine-<controller machine ID>.log
-
+$ grep “core dump” /var/log/juju/$(juju_controller_agent_name).log
 ```
 
 If the results show `(core dumped)`, you have a core dump issue.
@@ -75,12 +74,3 @@ gdb> bt
 ```
 
 Grab the output of the backtrace and share it with the Juju team. They will be able to help you diagnose the issue further.
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Previously the k8s controller shell was difficult to use and did not at all feel
like using the shell on a machine controller. This brings them more in line with
each other.

Additionally, since Juju 4.0 no longer supports Pod Spec Kubernetes charms,
this PR also cleans up and slims down the Docker image. This is now in a state
where it could be made into a chiselled Rock.

## QA steps

- Bootstrap k8s
- `juju ssh -mcontroller 0`
- Run `juju_db_repl`
- Run `juju_engine_report`

## Documentation changes

Updated documentation to use normal command.
