### PR TITLE
fix: timeout idle fds

### DIFF
--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -211,6 +211,18 @@ var newConfigTests = []struct {
 	},
 	expectError: `api-port-open-delay: conversion to duration: time: missing unit in duration "15"`,
 }, {
+	about: "idle-connection-timeout not a string",
+	config: controller.Config{
+		controller.IdleConnectionTimeout: 99,
+	},
+	expectError: `idle-connection-timeout: expected string or time.Duration, got int\(99\)`,
+}, {
+	about: "idle-connection-timeout not a duration",
+	config: controller.Config{
+		controller.IdleConnectionTimeout: "99",
+	},
+	expectError: `idle-connection-timeout: conversion to duration: time: missing unit in duration "99"`,
+}, {
 	about: "txn-prune-sleep-time not a duration",
 	config: controller.Config{
 		controller.PruneTxnSleepTime: "15",

--- a/controller/configschema.go
+++ b/controller/configschema.go
@@ -21,6 +21,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AuditLogExcludeMethods:           schema.List(schema.String()),
 	APIPort:                          schema.ForceInt(),
 	APIPortOpenDelay:                 schema.TimeDuration(),
+	IdleConnectionTimeout:            schema.TimeDuration(),
 	ControllerAPIPort:                schema.ForceInt(),
 	ControllerName:                   schema.NonEmptyString(ControllerName),
 	StatePort:                        schema.ForceInt(),
@@ -68,6 +69,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AgentRateLimitRate:               schema.Omit,
 	APIPort:                          DefaultAPIPort,
 	APIPortOpenDelay:                 DefaultAPIPortOpenDelay,
+	IdleConnectionTimeout:            DefaultIdleConnectionTimeout,
 	ControllerAPIPort:                schema.Omit,
 	ControllerName:                   schema.Omit,
 	AuditingEnabled:                  DefaultAuditingEnabled,
@@ -162,6 +164,13 @@ var ConfigSchema = environschema.Fields{
 between when the controller has been deemed to be ready to open 
 the api-port and when the api-port is actually opened 
 (only used when a controller-api-port value is set).`,
+	},
+	IdleConnectionTimeout: {
+		Type: environschema.Tstring,
+		Description: `The time the controller will wait between
+resets of all idle connections. By default, every 10 minutes
+the controller will close all idle connections.
+`,
 	},
 	ControllerAPIPort: {
 		Type: environschema.Tint,

--- a/internal/worker/httpserver/manifold.go
+++ b/internal/worker/httpserver/manifold.go
@@ -177,18 +177,19 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	}
 
 	w, err := config.NewWorker(Config{
-		AgentName:            config.AgentName,
-		Clock:                config.Clock,
-		PrometheusRegisterer: config.PrometheusRegisterer,
-		Hub:                  hub,
-		TLSConfig:            tlsConfig,
-		Mux:                  mux,
-		MuxShutdownWait:      config.MuxShutdownWait,
-		LogDir:               config.LogDir,
-		Logger:               config.Logger,
-		APIPort:              controllerConfig.APIPort(),
-		APIPortOpenDelay:     controllerConfig.APIPortOpenDelay(),
-		ControllerAPIPort:    controllerConfig.ControllerAPIPort(),
+		AgentName:             config.AgentName,
+		Clock:                 config.Clock,
+		PrometheusRegisterer:  config.PrometheusRegisterer,
+		Hub:                   hub,
+		TLSConfig:             tlsConfig,
+		Mux:                   mux,
+		MuxShutdownWait:       config.MuxShutdownWait,
+		LogDir:                config.LogDir,
+		Logger:                config.Logger,
+		APIPort:               controllerConfig.APIPort(),
+		APIPortOpenDelay:      controllerConfig.APIPortOpenDelay(),
+		ControllerAPIPort:     controllerConfig.ControllerAPIPort(),
+		IdleConnectionTimeout: controllerConfig.IdleConnectionTimeout(),
 	})
 	if err != nil {
 		_ = stTracker.Done()

--- a/internal/worker/httpserver/manifold_test.go
+++ b/internal/worker/httpserver/manifold_test.go
@@ -190,18 +190,19 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config := newWorkerArgs[0].(httpserver.Config)
 
 	c.Assert(config, jc.DeepEquals, httpserver.Config{
-		AgentName:            "machine-42",
-		Clock:                s.clock,
-		PrometheusRegisterer: &s.prometheusRegisterer,
-		Hub:                  s.hub,
-		TLSConfig:            s.tlsConfig,
-		Mux:                  s.mux,
-		APIPort:              1024,
-		APIPortOpenDelay:     5 * time.Second,
-		ControllerAPIPort:    2048,
-		MuxShutdownWait:      1 * time.Minute,
-		LogDir:               "log-dir",
-		Logger:               s.config.Logger,
+		AgentName:             "machine-42",
+		Clock:                 s.clock,
+		PrometheusRegisterer:  &s.prometheusRegisterer,
+		Hub:                   s.hub,
+		TLSConfig:             s.tlsConfig,
+		Mux:                   s.mux,
+		APIPort:               1024,
+		APIPortOpenDelay:      5 * time.Second,
+		ControllerAPIPort:     2048,
+		MuxShutdownWait:       1 * time.Minute,
+		LogDir:                "log-dir",
+		Logger:                s.config.Logger,
+		IdleConnectionTimeout: 30 * time.Second,
 	})
 }
 

--- a/internal/worker/httpserver/worker_test.go
+++ b/internal/worker/httpserver/worker_test.go
@@ -395,11 +395,12 @@ func (s *WorkerControllerPortSuite) TestDualPortListenerWithDelay(c *gc.C) {
 		"status":     "waiting for signal to open agent port",
 	}
 	report := map[string]interface{}{
-		"api-port":            s.config.APIPort,
-		"api-port-open-delay": s.config.APIPortOpenDelay,
-		"controller-api-port": s.config.ControllerAPIPort,
-		"status":              "running",
-		"ports":               reportPorts,
+		"api-port":                s.config.APIPort,
+		"api-port-open-delay":     s.config.APIPortOpenDelay,
+		"controller-api-port":     s.config.ControllerAPIPort,
+		"idle-connection-timeout": s.config.IdleConnectionTimeout,
+		"status":                  "running",
+		"ports":                   reportPorts,
 	}
 	c.Check(worker.Report(), jc.DeepEquals, report)
 

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -38,6 +38,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.AgentRateLimitRate,
 		controller.AllowModelAccessKey,
 		controller.APIPortOpenDelay,
+		controller.IdleConnectionTimeout,
 		controller.AuditLogExcludeMethods,
 		controller.AutocertURLKey,
 		controller.AutocertDNSNameKey,


### PR DESCRIPTION
The http.Transport object defaults to keeping all idle connections forever if the IdleTimeout is 0 and/or the MaxIdleConnections is 0. The DefaultTransport uses a value of 100 idle connections, and an IdleTimeout of 90s. We can be a bit more aggresive about this, because we don't really reuse the Transport object.
Arguably another good step would be to use a shared Transport across the same Juju controller. We need a different Transport for a different controller, because we don't expect their CA Cert to be the same, but we could otherwise cache the Transport.
However, we can also update our controller side so that it forcefully resets idle connections periodically.  There doesn't seems to be a native Go way to tell it to cap idle connections at a given timeout (eg server-side set 2min per idle connection), so instead we just reset all idle connections with a controller-config, defaulting to 10 minutes.

Note that both the client side fix and the server side fix indepedently "fix" the leaking file descriptors. However, doing both is sane, since it will protect us from other clients and other servers (eg cross model relations with a 3.4 controller).

https://bugs.launchpad.net/juju/+bug/1952942

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

 1. Hack the codebase to forcibly reset connections periodically:
```diff
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -6,6 +6,7 @@ package apiserver
 import (
        "context"
        "fmt"
+       "math/rand"
        "sync"
        "time"
 
 // RedirectInfo returns redirected host information for the model.
@@ -327,10 +328,23 @@ func (a *admin) authenticate(ctx context.Context, req params.LoginRequest) (*aut
                return nil, errors.Unauthorizedf("invalid entity name or password")
        }
        // TODO(wallyworld) - we can't yet observe anonymous logins as entity must be non-nil
-       if !result.anonymousLogin {
-               a.apiObserver.Login(a.root.authInfo.Entity.Tag(), a.root.model.ModelTag(), controllerConn, req.UserData)
+       var tag names.Tag
+       if result.anonymousLogin {
+               tag = names.NewUserTag(api.AnonymousUsername)
+       } else {
+               tag = a.root.authInfo.Entity.Tag()
        }
+       a.apiObserver.Login(tag, a.root.model.ModelTag(), controllerConn, req.UserData)
        a.loggedIn = true
+       if result.anonymousLogin {
+               go func() {
+                       // 1min +/- 20%
+                       delay := time.Minute - (12 * time.Second) + time.Duration(rand.Int63n(int64(24*time.Second)))
+                       <-time.After(delay)
+                       logger.Criticalf("Resetting Anonymous Login")
+                       _ = a.root.getRpcConn().Close()
+               }()
+       }
 
        if startPinger {
                if err := setupPingTimeoutDisconnect(a.srv.pingClock, a.root); err != nil {
```

2. Bootstrap a juju controller, and set up several cross model relations. All we really need is a lot of connections that get reset periodically that need macaroon authentication, but this is the easiest way to get that.
```sh
juju bootstrap lxd src36
juju add-model source
juju deploy juju-qa-dummy-source ds00
juju offer source.ds00:sink
sleep 1
for i in `seq -f %02.0f 1 9`; do juju deploy juju-qa-dummy-source --to 0 ds$i; juju offer source.ds$i:sink; done
juju add-model sink
juju deploy juju-qa-dummy-sink dsk00
juju relate source.ds00 dsk00
sleep 1
for i in `seq -f %02.0f 1 9`; do juju deploy juju-qa-dummy-sink --to 0 dsk$i; juju relate source.ds$i dsk$i; done
```

Use ps and lsof to monitor the number of file handles in the juju controller.
```sh
lxcid="$(juju status -m controller --format=json | jq -r '.machines["0"]."instance-id"')"
jujupid=$(lxc exec $lxcid pgrep jujud)
while true; do lxc exec $lxcid -- lsof -i -n -P -p $jujupid  > files-$(date -Iseconds).txt; sleep $((160 - 1$(date +%S))); done
```

You can break this change up into the client side (api/apiclient.go) and server side (internal/httpserver/worker.go).
Without both of these changes, you should see the file handles increasing over time. In my testing, after 1 hr, the file handles roughly changed like:
```sh
$ wc -l files-* | head -n 60 | head -n -1 | sed -n '1p;$p'
      218 files-2025-11-02T22:12:42+01:00.txt
     1142 files-2025-11-02T23:10:00+01:00.txt
```

With either of the changes, they did not:
```sh
$ wc -l files-* | head -n 60 | head -n -1 | sed -n '1p;$p'
    230 files-2025-11-03T07:04:33+01:00.txt
    234 files-2025-11-03T08:42:00+01:00.txt
```

## Documentation changes

Needs an update to the Controller Configuration documentation to document `idle-connection-timeout`.

## Links

https://bugs.launchpad.net/juju/+bug/1952942

Fixes: #20277 
