### PR TITLE
fix: remove check volume backed filesystem warning

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -2021,15 +2021,6 @@ func (s *StorageProvisionerAPIv4) SetFilesystemInfo(ctx context.Context, args pa
 		if fs.Info.Pool != "" {
 			return errors.New("pool field must not be set")
 		}
-		if fs.VolumeTag != "" {
-			// TODO(storage): once volumes are implemented, we need to check that
-			// the volume referenced here is provisioned, attached and owned by
-			// the same storage instance. This could be pushed into the
-			// storageprovisioning service, but that would require it to
-			// understand the provisioned status of a volume.
-			s.logger.Warningf(ctx,
-				"TODO(storage): check fs volume tag matches fs vol back")
-		}
 		info := storageprovisioning.FilesystemProvisionedInfo{
 			ProviderID: fs.Info.ProviderId,
 			SizeMiB:    fs.Info.SizeMiB,


### PR DESCRIPTION
When the storage provisioner reflects back to the controller the filesystem
provisioned info, it is not possible for it to pick which volume backs it. This
is chosen ahead of time and returned in the FilesystemParams facade method. The
reason for the this volume value being sent to the controller from the storage
provisioner worker is from poor re-use of params structures.

## QA steps

Bootstrap AWS.
Check the debug-log to ensure the warning does not exist.
