### PR TITLE
fix: add missing suspended field for uniter relation retrieve

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2247,9 +2247,10 @@ func (u *UniterAPI) prepareRelationResult(
 		ModelUUID:       u.modelUUID.String(),
 	}
 	return params.RelationResultV2{
-		Id:   rel.ID,
-		Key:  rel.Key.String(),
-		Life: rel.Life,
+		Id:        rel.ID,
+		Key:       rel.Key.String(),
+		Life:      rel.Life,
+		Suspended: rel.Suspended,
 		Endpoint: params.Endpoint{
 			ApplicationName: unitEp.ApplicationName,
 			Relation:        params.NewCharmRelation(unitEp.Relation),


### PR DESCRIPTION
This patch fixes the suspend relation workflow, which made the uniter not to pick up the suspended column changes for a cross model relation. The fix is simply to include the missing `suspended` field into the response in the facade. Tests were added and fixed accordingly.

## QA steps

We need to add a CMR and then suspend it. This fix is validated by checking that the status is `suspended` instead of `suspending` in juju status.
```
$ juju add-model offer
$ juju deploy juju-qa-dummy-source --base ubuntu@22.04
$ juju offer dummy-source:sink dummy-offer
$ juju add-model consume
$ juju deploy juju-qa-dummy-sink
$ juju consume c:admin/offer.dummy-offer
$ juju relate dummy-sink dummy-offer
```
Then we can suspend and validate the status:
```
$ juju suspend-relation 0 --message "test suspending"
$ juju status --relations
Model    Controller  Cloud/Region   Version      Timestamp
consume  c           aws/eu-west-3  4.0-beta8.1  18:37:33+01:00

SAAS         Status   Store  URL
dummy-offer  blocked  c      admin/offer.dummy-offer

App         Version  Status       Scale  Charm               Channel        Rev  Exposed  Message
dummy-sink           maintenance      1  juju-qa-dummy-sink  latest/stable    7  no       Started

Unit           Workload     Agent  Machine  Public address  Ports  Message
dummy-sink/0*  maintenance  idle   0        52.47.83.110           Started

Machine  State    Address       Inst id              Base          AZ          Message
0        started  52.47.83.110  i-0c3debb1c5333be8a  ubuntu@20.04  eu-west-3a  running

Integration provider  Requirer          Interface    Type     Message
dummy-sink:source     dummy-offer:sink  dummy-token  regular  suspended  test suspending
```