### PR TITLE
fix: use correct relation key in discharge macaroon

### DIFF
--- a/apiserver/errors/types.go
+++ b/apiserver/errors/types.go
@@ -6,15 +6,12 @@ package errors
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
-	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"gopkg.in/macaroon.v2"
 
-	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
 )
@@ -82,17 +79,6 @@ func (e *DischargeRequiredError) Unwrap() error {
 func (e *DischargeRequiredError) SendError(w http.ResponseWriter) error {
 	w.Header().Set("WWW-Authenticate", `Basic realm="juju"`)
 	return sendError(w, e)
-}
-
-// NewErrIncompatibleBase returns an error indicating that the base is not
-// supported by the charm.
-func NewErrIncompatibleBase(baseList []base.Base, b base.Base, charmName string) error {
-	return fmt.Errorf("base %q not supported by charm %q, supported bases are: %s%w",
-		b.DisplayString(),
-		charmName,
-		strings.Join(transform.Slice(baseList, func(b base.Base) string { return b.DisplayString() }), ", "),
-		errors.Hide(IncompatibleBaseError),
-	)
 }
 
 // RedirectError is the error returned when a model (previously accessible by

--- a/apiserver/internal/crossmodel/authcontext.go
+++ b/apiserver/internal/crossmodel/authcontext.go
@@ -41,7 +41,7 @@ type OfferBakery interface {
 	GetConsumeOfferCaveats(offerUUID, sourceModelUUID, username, relation string) []checkers.Caveat
 	// GetRemoteRelationCaveats returns the caveats for accessing a remote relation.
 	GetRemoteRelationCaveats(offerUUID, sourceModelUUID, username, relation string) []checkers.Caveat
-	// InferDeclared retrieves any declared information from
+	// InferDeclaredFromMacaroon retrieves any declared information from
 	// the given macaroons and returns it as a key-value map.
 	InferDeclaredFromMacaroon(macaroon.Slice, map[string]string) crossmodelbakery.DeclaredValues
 	// NewMacaroon creates a new macaroon for the given version, caveats and ops.
@@ -61,7 +61,7 @@ type OfferBakery interface {
 	// GetRelationRequiredValues returns the required values for the specified
 	// relation access.
 	GetRelationRequiredValues(sourceModelUUID, offerUUID, relation string) (map[string]string, error)
-	// AllowedMacaroonAuth checks the specified macaroon is valid for the operation
+	// AllowedAuth checks the specified macaroon is valid for the operation
 	// and returns the associated AuthInfo.
 	AllowedAuth(ctx context.Context, op bakery.Op, mac macaroon.Slice) ([]string, error)
 }

--- a/apiserver/internal/crossmodel/bakery/bakery.go
+++ b/apiserver/internal/crossmodel/bakery/bakery.go
@@ -212,21 +212,21 @@ func (o *baseBakery) GetOfferRequiredValues(sourceModelUUID, offerUUID string) (
 
 // GetRelationRequiredValues returns the required values for the specified
 // relation access.
-func (o *baseBakery) GetRelationRequiredValues(sourceModelUUID, offerUUID, relationKey string) (map[string]string, error) {
+func (o *baseBakery) GetRelationRequiredValues(sourceModelUUID, offerUUID, relationValue string) (map[string]string, error) {
 	if sourceModelUUID == "" {
 		return nil, internalerrors.New("source model uuid is required").Add(coreerrors.NotValid)
 	}
 	if offerUUID == "" {
 		return nil, internalerrors.New("offer uuid is required").Add(coreerrors.NotValid)
 	}
-	if relationKey == "" {
+	if relationValue == "" {
 		return nil, internalerrors.New("relation key is required").Add(coreerrors.NotValid)
 	}
 
 	return map[string]string{
 		sourceModelKey: sourceModelUUID,
 		offerUUIDKey:   offerUUID,
-		relationKey:    relationKey,
+		relationKey:    relationValue,
 	}, nil
 }
 

--- a/apiserver/internal/crossmodel/bakery/jaas.go
+++ b/apiserver/internal/crossmodel/bakery/jaas.go
@@ -46,7 +46,7 @@ func NewJAASOfferBakery(
 	clock clock.Clock,
 	logger logger.Logger,
 ) (*JAASOfferBakery, error) {
-	store := internalmacaroon.NewRootKeyStore(backingStore, offerPermissionExpiryTime, clock)
+	store := internalmacaroon.NewRootKeyStore(backingStore, internalmacaroon.DefaultPolicy, clock)
 
 	externalKeyLocator := newExternalPublicKeyLocator(endpoint, httpClient, logger)
 	bakery := &bakeryutil.StorageBakery{
@@ -142,8 +142,6 @@ func (o *JAASOfferBakery) CreateDischargeMacaroon(
 	declaredValues DeclaredValues,
 	op bakery.Op, version bakery.Version,
 ) (*bakery.Macaroon, error) {
-	// TODO (stickupkid): If these are required values we should check that
-	// they're not empty.
 	requiredOffer := requiredValues[offerUUIDKey]
 	conditionParts := []string{
 		"is-consumer",

--- a/apiserver/internal/crossmodel/bakery/local.go
+++ b/apiserver/internal/crossmodel/bakery/local.go
@@ -38,7 +38,7 @@ func NewLocalOfferBakery(
 	clock clock.Clock,
 	logger logger.Logger,
 ) (*LocalOfferBakery, error) {
-	store := internalmacaroon.NewRootKeyStore(backingStore, offerPermissionExpiryTime, clock)
+	store := internalmacaroon.NewRootKeyStore(backingStore, internalmacaroon.DefaultPolicy, clock)
 
 	locator := bakeryutil.BakeryThirdPartyLocator{PublicKey: keyPair.Public}
 
@@ -129,8 +129,6 @@ func (o *LocalOfferBakery) CreateDischargeMacaroon(
 	declaredValues DeclaredValues,
 	op bakery.Op, version bakery.Version,
 ) (*bakery.Macaroon, error) {
-	// TODO (stickupkid): If these are required values we should check that
-	// they're not empty.
 	requiredSourceModelUUID := requiredValues[sourceModelKey]
 	requiredOffer := requiredValues[offerUUIDKey]
 	requiredRelation := requiredValues[relationKey]

--- a/apiserver/stateauthenticator/export_test.go
+++ b/apiserver/stateauthenticator/export_test.go
@@ -6,6 +6,7 @@ package stateauthenticator
 import (
 	"context"
 
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
 
 	"github.com/juju/juju/apiserver/authentication"
@@ -27,8 +28,11 @@ func ServerBakeryExpiresImmediately(ctx context.Context, a *Authenticator, ident
 		controllerConfigService: controllerConfigService,
 		macaroonService:         macaroonService,
 		clock:                   a.authContext.clock,
-		expiryTime:              0,
-		identClient:             identClient,
+		policy: dbrootkeystore.Policy{
+			ExpiryDuration:   0,
+			GenerateInterval: 0,
+		},
+		identClient: identClient,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/macaroon/store.go
+++ b/internal/macaroon/store.go
@@ -11,8 +11,11 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 )
 
-// DefaultExpiration is a sensible default duration for root keys before expiration.
-var DefaultExpiration = 24 * time.Hour
+// DefaultPolicy is a sensible default policy for root keys before expiration.
+var DefaultPolicy = dbrootkeystore.Policy{
+	ExpiryDuration:   24 * time.Hour,
+	GenerateInterval: 24 * time.Hour,
+}
 
 type storage struct {
 	store bakery.RootKeyStore
@@ -21,11 +24,9 @@ type storage struct {
 // NewRootKeyStore returns a new root key store that uses the given backing
 // store to persist root keys with the given expiration duration. The clock is
 // used to determine when keys expire.
-func NewRootKeyStore(backing dbrootkeystore.ContextBacking, expireAfter time.Duration, clock dbrootkeystore.Clock) bakery.RootKeyStore {
+func NewRootKeyStore(backing dbrootkeystore.ContextBacking, policy dbrootkeystore.Policy, clock dbrootkeystore.Clock) bakery.RootKeyStore {
 	return &storage{
-		store: dbrootkeystore.NewRootKeys(5, clock).NewContextStore(backing, dbrootkeystore.Policy{
-			ExpiryDuration: expireAfter,
-		}),
+		store: dbrootkeystore.NewRootKeys(5, clock).NewContextStore(backing, policy),
 	}
 }
 


### PR DESCRIPTION
When generating the discharge macaroon, we were putting the relation key value onto the declared caveats and were using the relation key value as the map key, not "relation-key".

We also add validation that the expected caveats are present.

And we change the root key validity time to 24 hours and expire time to 48 hours to lessen the root key churn. This approach is similar to what is done for other products in the Canonical suite.

## QA steps

bootstrap
deploy dummy-source and dummy-sink in a cmr scenario
wait 3 minutes
set the dummy-source token
ensure it is replicated
check logs for errors