### PR TITLE
feat(removal): remove synth units on remote relation removal

### DIFF
--- a/domain/removal/internal/types.go
+++ b/domain/removal/internal/types.go
@@ -196,7 +196,7 @@ func (c CascadedApplicationLives) IsEmpty() bool {
 		len(c.RelationUUIDs) == 0
 }
 
-// CascadedUnitLives contains identifiers for entities that were ensured to be
+// CascadedMachineLives contains identifiers for entities that were ensured to be
 // "dying" along with a machine. It is intended to inform the service layer
 // which entities should have removal jobs scheduled for them.
 type CascadedMachineLives struct {
@@ -231,6 +231,16 @@ type CascadedRemoteApplicationOffererLives struct {
 
 func (c CascadedRemoteApplicationOffererLives) IsEmpty() bool {
 	return len(c.RelationUUIDs) == 0
+}
+
+// CascadedRemoteRelationLives contains identifiers for entities that need to
+// be removed along with the relations. Remote relations is somewhat of a
+// special case, since there exist synthetic units (i.e. without a uniter)
+// that need to be departed manually.
+type CascadedRemoteRelationLives struct {
+	// SyntheticRelationUnitUUIDs identify the relation units that need to be
+	// departed to remove the relation.
+	SyntheticRelationUnitUUIDs []string
 }
 
 // StorageAttachmentDetachInfo contains the information required to establish

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -1601,11 +1601,12 @@ func (c *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall) DoAn
 }
 
 // EnsureRemoteRelationNotAliveCascade mocks base method.
-func (m *MockModelDBState) EnsureRemoteRelationNotAliveCascade(arg0 context.Context, arg1 string) error {
+func (m *MockModelDBState) EnsureRemoteRelationNotAliveCascade(arg0 context.Context, arg1 string) (internal.CascadedRemoteRelationLives, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureRemoteRelationNotAliveCascade", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(internal.CascadedRemoteRelationLives)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // EnsureRemoteRelationNotAliveCascade indicates an expected call of EnsureRemoteRelationNotAliveCascade.
@@ -1621,19 +1622,19 @@ type MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) Return(arg0 error) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) Return(arg0 internal.CascadedRemoteRelationLives, arg1 error) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) Do(f func(context.Context, string) error) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) Do(f func(context.Context, string) (internal.CascadedRemoteRelationLives, error)) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) (internal.CascadedRemoteRelationLives, error)) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/state/model/remoteapplicationofferer_test.go
+++ b/domain/removal/state/model/remoteapplicationofferer_test.go
@@ -267,15 +267,14 @@ func (s *remoteApplicationOffererSuite) TestDeleteRemoteApplicationOffererWithUn
 	cmrState := crossmodelrelationstate.NewState(
 		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
 	)
-	// Call twice to ensure some units share a net node, but not all.
-	cmrState.EnsureUnitsExist(c.Context(), appUUID.String(), []string{"foo/0", "foo/1"})
-	cmrState.EnsureUnitsExist(c.Context(), appUUID.String(), []string{"foo/2"})
+	err := cmrState.EnsureUnitsExist(c.Context(), appUUID.String(), []string{"foo/0", "foo/1", "foo/2"})
+	c.Assert(err, tc.ErrorIsNil)
 
 	s.advanceRemoteApplicationOffererLife(c, remoteAppUUID.String(), life.Dying)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err := st.DeleteRemoteApplicationOfferer(c.Context(), remoteAppUUID.String())
+	err = st.DeleteRemoteApplicationOfferer(c.Context(), remoteAppUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 
 	exists, err := st.RemoteApplicationOffererExists(c.Context(), remoteAppUUID.String())

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -530,9 +530,18 @@ func (s *baseSuite) createRemoteRelation(c *tc.C) (relation.UUID, coreapplicatio
 	cmrState := crossmodelrelationstate.NewState(
 		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
 	)
-	// Call twice to ensure some units share a net node, but not all.
-	cmrState.EnsureUnitsExist(c.Context(), synthAppUUID.String(), []string{"foo/0", "foo/1"})
-	cmrState.EnsureUnitsExist(c.Context(), synthAppUUID.String(), []string{"foo/2"})
+	err = cmrState.EnsureUnitsExist(c.Context(), synthAppUUID.String(), []string{"foo/0", "foo/1", "foo/2"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = relSvc.SetRelationRemoteApplicationAndUnitSettings(c.Context(), synthAppUUID, relUUID,
+		map[string]string{"do": "da"},
+		map[unit.Name]map[string]string{
+			unit.Name("foo/0"): {"do": "da"},
+			unit.Name("foo/1"): {"do": "da"},
+			unit.Name("foo/2"): {"do": "da"},
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
 
 	return relUUID, synthAppUUID
 }
@@ -563,9 +572,8 @@ func (s *baseSuite) createRemoteRelationBetween(c *tc.C, synthAppName, appName s
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	// Call twice to ensure some units share a net node, but not all.
-	cmrState.EnsureUnitsExist(c.Context(), synthAppUUID, []string{unit0name, unit1name})
-	cmrState.EnsureUnitsExist(c.Context(), synthAppUUID, []string{unit2name})
+	err = cmrState.EnsureUnitsExist(c.Context(), synthAppUUID, []string{unit0name, unit1name, unit2name})
+	c.Assert(err, tc.ErrorIsNil)
 
 	return relUUID
 }


### PR DESCRIPTION
We recently fixed remote relations for the creation synth units on the consumer. These need to be removed.

Synth units do not have their own uniter, unlike normal units. This means the removal domain itself needs to handle departing. Also, since we don't have a uniter, we can directly remove synth units when they depart

Implement this & wire up

## QA steps

```
$ juju bootstrap lxd lxd 
$ juju add-model offerer 
$ juju deploy juju-qa-dummy-source 
$ juju offer dummy-source:sink 
$ juju add-model consumer 
$ juju deploy juju-qa-dummy-sink 
$ juju consume admin/offerer.dummy-source 
$ juju relate dummy-source dummy-sink 
$ juju config -m offerer dummy-source token=fudge

$ juju remove-relation dummy-sink dummy-source
$ juju status --relations
Model     Controller  Cloud/Region   Version      Timestamp
consumer  lxd         lxd/localhost  4.0-beta8.1  11:12:09+01:00

SAAS          Status       Store  URL
dummy-source  maintenance  local  admin/offerer.dummy-source

App         Version  Status  Scale  Charm               Channel        Rev  Exposed  Message
dummy-sink           active      1  juju-qa-dummy-sink  latest/stable    7  no       Token is fudge

Unit           Workload  Agent  Machine  Public address  Ports  Message
dummy-sink/0*  active    idle   0        10.51.45.155           Token is fudge

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.155  juju-d4ae20-0  ubuntu@20.04  jack  Running
```
and check there are no errors in logs

## Copilot Summary

This pull request introduces improvements and bug fixes around the handling and removal of synthetic units in remote relations, as well as refactoring related code for clarity and correctness. The most significant changes involve ensuring synthetic units are properly departed and deleted when remote relations are removed, updating interfaces and mocks to reflect new return types, and improving test coverage for these scenarios.

### Synthetic Unit Removal and Cleanup

* Added logic to ensure synthetic units associated with remote relations are explicitly departed when a remote relation is removed, since these units lack their own uniter and require manual cleanup (`domain/removal/service/remoterelation.go`).
* Implemented a new method `deleteSynthUnit` to safely remove synthetic units and their associated net nodes from the database (`domain/removal/state/model/remoteapplicationofferer.go`).
* Modified `LeaveScope` to detect and delete synthetic units during the removal process (`domain/removal/state/model/relation.go`). (F40ae7baL417R444)

### Interface and Mock Refactoring

* Changed the `EnsureRemoteRelationNotAliveCascade` interface to return a new struct `CascadedRemoteRelationLives`, which contains the synthetic unit UUIDs needing departure, and updated all mock and test code to reflect this change (`domain/removal/service/remoterelation.go`, `domain/removal/service/package_mock_test.go`). [[1]](diffhunk://#diff-4194c7567dd7bb2fb6cf1ad0eb5cb408f074b6a8066fa1b7d017564e47b5c824L28-R30) [[2]](diffhunk://#diff-1c2e9a257333c6d3396e207c0665f1221cc2e32820654c6e8f8e3139372a0e6aL1604-R1609) [[3]](diffhunk://#diff-1c2e9a257333c6d3396e207c0665f1221cc2e32820654c6e8f8e3139372a0e6aL1624-R1637)
* Added the new struct `CascadedRemoteRelationLives` to internal types for tracking synthetic units to be removed with relations (`domain/removal/internal/types.go`).

### Testing Improvements

* Added a new test to verify that synthetic units are properly departed when a remote relation is removed (`domain/removal/service/remoterelation_test.go`).
* Added a test to ensure that synthetic units are deleted from the database when their scope is left (`domain/removal/state/model/relation_test.go`).

### Minor Refactoring and Documentation

* Renamed and clarified function names related to synthetic unit deletion for consistency (`domain/removal/state/model/remoteapplicationofferer.go`). [[1]](diffhunk://#diff-462b82eb2b30b2426c29e1e7b0546210f49dd986439c3484dba3da7943ff977bL326-R326) [[2]](diffhunk://#diff-462b82eb2b30b2426c29e1e7b0546210f49dd986439c3484dba3da7943ff977bL347-R347)
* Updated comments and documentation to clarify the purpose and handling of synthetic units and relations (`domain/removal/internal/types.go`).

These changes collectively improve the reliability and maintainability of synthetic unit handling in remote relation removal workflows, ensuring proper cleanup and more robust test coverage.