### PR TITLE
fix: returned container creation message on CLI

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -180,6 +180,9 @@ func (mm *MachineManagerAPI) addOneMachine(ctx context.Context, p params.AddMach
 		HardwareCharacteristics: p.HardwareCharacteristics,
 	})
 
+	if addedMachine.ChildMachineName != nil {
+		return *addedMachine.ChildMachineName, err
+	}
 	return addedMachine.MachineName, err
 }
 


### PR DESCRIPTION
This small patch fixes the resulting message when creating a container. The CLI returns a `created machine 0` instead of `created container 0/lxd/0`.

The fix is on the facade where we select the machine name or the machine child name.


## QA steps

Deploy a container on an existing machine:
```
$ juju add-machine
created machine 0
$ juju add-machine lxd:0
created container 0/lxd/0
```
