### PR TITLE
refactor(removal): rename RemoteRelation to RelationWithRemoteOfferer

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1418,7 +1418,7 @@ func (api *APIBase) DestroyRelation(ctx context.Context, args params.DestroyRela
 		return internalerrors.Capture(err)
 	}
 
-	removalUUID, err = api.removalService.RemoveRemoteRelation(ctx, relUUID, force, maxWait)
+	removalUUID, err = api.removalService.RemoveRelationWithRemoteOfferer(ctx, relUUID, force, maxWait)
 	if errors.Is(err, relationerrors.RelationNotFound) {
 		return nil
 	} else if err != nil {

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1352,7 +1352,7 @@ func (s *applicationSuite) TestDestroyRelationCrossModel(c *tc.C) {
 	removalUUID := tc.Must(c, removal.NewUUID)
 
 	s.removalService.EXPECT().RemoveRelation(gomock.Any(), relUUID, false, time.Duration(0)).Return("", removalerrors.RelationIsCrossModel)
-	s.removalService.EXPECT().RemoveRemoteRelation(gomock.Any(), relUUID, false, time.Duration(0)).Return(removalUUID, nil)
+	s.removalService.EXPECT().RemoveRelationWithRemoteOfferer(gomock.Any(), relUUID, false, time.Duration(0)).Return(removalUUID, nil)
 
 	arg := params.DestroyRelation{
 		RelationId: getUUIDArgs.RelationID,

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -549,7 +549,7 @@ type RemovalService interface {
 		wait time.Duration,
 	) (removal.UUID, error)
 
-	// RemoveRelation checks if a relation with the input UUID exists.
+	// RemoveRelationWithRemoteOfferer checks if a relation with the input UUID exists.
 	// If it does, the relation is guaranteed after this call to be:
 	// - No longer alive.
 	// - Removed or scheduled to be removed with the input force qualification.
@@ -557,7 +557,7 @@ type RemovalService interface {
 	// life-cycle advancement and removal to finish before forcefully removing the
 	// remote application. This duration is ignored if the force argument is false.
 	// The UUID for the scheduled removal job is returned.
-	RemoveRemoteRelation(
+	RemoveRelationWithRemoteOfferer(
 		ctx context.Context,
 		relUUID corerelation.UUID,
 		force bool,

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -2738,6 +2738,45 @@ func (c *MockRemovalServiceRemoveRelationCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
+// RemoveRelationWithRemoteOfferer mocks base method.
+func (m *MockRemovalService) RemoveRelationWithRemoteOfferer(arg0 context.Context, arg1 relation.UUID, arg2 bool, arg3 time.Duration) (removal.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveRelationWithRemoteOfferer", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(removal.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveRelationWithRemoteOfferer indicates an expected call of RemoveRelationWithRemoteOfferer.
+func (mr *MockRemovalServiceMockRecorder) RemoveRelationWithRemoteOfferer(arg0, arg1, arg2, arg3 any) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRelationWithRemoteOfferer", reflect.TypeOf((*MockRemovalService)(nil).RemoveRelationWithRemoteOfferer), arg0, arg1, arg2, arg3)
+	return &MockRemovalServiceRemoveRelationWithRemoteOffererCall{Call: call}
+}
+
+// MockRemovalServiceRemoveRelationWithRemoteOffererCall wrap *gomock.Call
+type MockRemovalServiceRemoveRelationWithRemoteOffererCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveRemoteApplicationOfferer mocks base method.
 func (m *MockRemovalService) RemoveRemoteApplicationOfferer(arg0 context.Context, arg1 remoteapplication.UUID, arg2 bool, arg3 time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
@@ -2773,45 +2812,6 @@ func (c *MockRemovalServiceRemoveRemoteApplicationOffererCall) Do(f func(context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockRemovalServiceRemoveRemoteApplicationOffererCall) DoAndReturn(f func(context.Context, remoteapplication.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteApplicationOffererCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// RemoveRemoteRelation mocks base method.
-func (m *MockRemovalService) RemoveRemoteRelation(arg0 context.Context, arg1 relation.UUID, arg2 bool, arg3 time.Duration) (removal.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveRemoteRelation", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(removal.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RemoveRemoteRelation indicates an expected call of RemoveRemoteRelation.
-func (mr *MockRemovalServiceMockRecorder) RemoveRemoteRelation(arg0, arg1, arg2, arg3 any) *MockRemovalServiceRemoveRemoteRelationCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteRelation), arg0, arg1, arg2, arg3)
-	return &MockRemovalServiceRemoveRemoteRelationCall{Call: call}
-}
-
-// MockRemovalServiceRemoveRemoteRelationCall wrap *gomock.Call
-type MockRemovalServiceRemoveRemoteRelationCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRemovalServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -154,7 +154,7 @@ func (api *CrossModelRelationsAPIv3) publishOneRelationChange(ctx context.Contex
 		// Relations only transition to dying and are removed, so we can safely
 		// just remove the relation and return early.
 		forceCleanup := change.ForceCleanup != nil && *change.ForceCleanup
-		_, err := api.removalService.RemoveRemoteRelation(ctx, relationUUID, forceCleanup, 0)
+		_, err := api.removalService.RemoveRelationWithRemoteOfferer(ctx, relationUUID, forceCleanup, 0)
 		if errors.Is(err, relationerrors.RelationNotFound) {
 			return nil
 		}

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -361,7 +361,7 @@ func (s *facadeSuite) TestPublishRelationChangesLifeDead(c *tc.C) {
 			Name: "foo",
 		}, nil)
 	s.removalService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID, true, time.Duration(0)).
+		RemoveRelationWithRemoteOfferer(gomock.Any(), relationUUID, true, time.Duration(0)).
 		Return("", nil)
 
 	api := s.api(c)

--- a/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
@@ -1260,41 +1260,41 @@ func (c *MockRemovalServiceLeaveScopeCall) DoAndReturn(f func(context.Context, r
 	return c
 }
 
-// RemoveRemoteRelation mocks base method.
-func (m *MockRemovalService) RemoveRemoteRelation(arg0 context.Context, arg1 relation.UUID, arg2 bool, arg3 time.Duration) (removal.UUID, error) {
+// RemoveRelationWithRemoteOfferer mocks base method.
+func (m *MockRemovalService) RemoveRelationWithRemoteOfferer(arg0 context.Context, arg1 relation.UUID, arg2 bool, arg3 time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveRemoteRelation", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "RemoveRelationWithRemoteOfferer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(removal.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RemoveRemoteRelation indicates an expected call of RemoveRemoteRelation.
-func (mr *MockRemovalServiceMockRecorder) RemoveRemoteRelation(arg0, arg1, arg2, arg3 any) *MockRemovalServiceRemoveRemoteRelationCall {
+// RemoveRelationWithRemoteOfferer indicates an expected call of RemoveRelationWithRemoteOfferer.
+func (mr *MockRemovalServiceMockRecorder) RemoveRelationWithRemoteOfferer(arg0, arg1, arg2, arg3 any) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteRelation), arg0, arg1, arg2, arg3)
-	return &MockRemovalServiceRemoveRemoteRelationCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRelationWithRemoteOfferer", reflect.TypeOf((*MockRemovalService)(nil).RemoveRelationWithRemoteOfferer), arg0, arg1, arg2, arg3)
+	return &MockRemovalServiceRemoveRelationWithRemoteOffererCall{Call: call}
 }
 
-// MockRemovalServiceRemoveRemoteRelationCall wrap *gomock.Call
-type MockRemovalServiceRemoveRemoteRelationCall struct {
+// MockRemovalServiceRemoveRelationWithRemoteOffererCall wrap *gomock.Call
+type MockRemovalServiceRemoveRelationWithRemoteOffererCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRemoteRelationCall {
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRemovalServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelrelations/service.go
+++ b/apiserver/facades/controller/crossmodelrelations/service.go
@@ -175,11 +175,11 @@ type ApplicationService interface {
 
 // RemovalService provides the ability to remove remote relations.
 type RemovalService interface {
-	// RemoveRelation checks if a relation with the input UUID exists.
-	// If it does, the relation is guaranteed after this call to be:
+	// RemoveRelationWithRemoteOfferer checks if a relation with the input UUID
+	// exists. If it does, the relation is guaranteed after this call to be:
 	// - No longer alive.
 	// - Removed or scheduled to be removed with the input force qualification.
-	RemoveRemoteRelation(
+	RemoveRelationWithRemoteOfferer(
 		ctx context.Context, relUUID corerelation.UUID, force bool, wait time.Duration,
 	) (removal.UUID, error)
 

--- a/domain/removal/internal/types.go
+++ b/domain/removal/internal/types.go
@@ -233,11 +233,11 @@ func (c CascadedRemoteApplicationOffererLives) IsEmpty() bool {
 	return len(c.RelationUUIDs) == 0
 }
 
-// CascadedRemoteRelationLives contains identifiers for entities that need to
-// be removed along with the relations. Remote relations is somewhat of a
+// CascadedRelationWithRemoteOffererLives contains identifiers for entities that
+// need to be removed along with the relations. Remote relations is somewhat of a
 // special case, since there exist synthetic units (i.e. without a uniter)
 // that need to be departed manually.
-type CascadedRemoteRelationLives struct {
+type CascadedRelationWithRemoteOffererLives struct {
 	// SyntheticRelationUnitUUIDs identify the relation units that need to be
 	// departed to remove the relation.
 	SyntheticRelationUnitUUIDs []string

--- a/domain/removal/service/model.go
+++ b/domain/removal/service/model.go
@@ -405,7 +405,7 @@ func (s *Service) removeRelations(ctx context.Context, uuids []string, force boo
 
 		// This is a CMR relation, so we need to remove it with
 		// RemoveRemoteRelation.
-		if _, err := s.RemoveRemoteRelation(ctx, relation.UUID(relationUUID), force, wait); errors.Is(err, relationerrors.RelationNotFound) {
+		if _, err := s.RemoveRelationWithRemoteOfferer(ctx, relation.UUID(relationUUID), force, wait); errors.Is(err, relationerrors.RelationNotFound) {
 			// There could be a chance that the relation has already been
 			// removed by another process. We can safely ignore this error and
 			// continue with the next relation.

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -1026,6 +1026,44 @@ func (c *MockModelDBStateDeleteRelationUnitsCall) DoAndReturn(f func(context.Con
 	return c
 }
 
+// DeleteRelationWithRemoteOfferer mocks base method.
+func (m *MockModelDBState) DeleteRelationWithRemoteOfferer(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRelationWithRemoteOfferer", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRelationWithRemoteOfferer indicates an expected call of DeleteRelationWithRemoteOfferer.
+func (mr *MockModelDBStateMockRecorder) DeleteRelationWithRemoteOfferer(arg0, arg1 any) *MockModelDBStateDeleteRelationWithRemoteOffererCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRelationWithRemoteOfferer", reflect.TypeOf((*MockModelDBState)(nil).DeleteRelationWithRemoteOfferer), arg0, arg1)
+	return &MockModelDBStateDeleteRelationWithRemoteOffererCall{Call: call}
+}
+
+// MockModelDBStateDeleteRelationWithRemoteOffererCall wrap *gomock.Call
+type MockModelDBStateDeleteRelationWithRemoteOffererCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateDeleteRelationWithRemoteOffererCall) Return(arg0 error) *MockModelDBStateDeleteRelationWithRemoteOffererCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateDeleteRelationWithRemoteOffererCall) Do(f func(context.Context, string) error) *MockModelDBStateDeleteRelationWithRemoteOffererCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateDeleteRelationWithRemoteOffererCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateDeleteRelationWithRemoteOffererCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DeleteRemoteApplicationOfferer mocks base method.
 func (m *MockModelDBState) DeleteRemoteApplicationOfferer(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -1060,44 +1098,6 @@ func (c *MockModelDBStateDeleteRemoteApplicationOffererCall) Do(f func(context.C
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateDeleteRemoteApplicationOffererCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateDeleteRemoteApplicationOffererCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// DeleteRemoteRelation mocks base method.
-func (m *MockModelDBState) DeleteRemoteRelation(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRemoteRelation", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRemoteRelation indicates an expected call of DeleteRemoteRelation.
-func (mr *MockModelDBStateMockRecorder) DeleteRemoteRelation(arg0, arg1 any) *MockModelDBStateDeleteRemoteRelationCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRemoteRelation", reflect.TypeOf((*MockModelDBState)(nil).DeleteRemoteRelation), arg0, arg1)
-	return &MockModelDBStateDeleteRemoteRelationCall{Call: call}
-}
-
-// MockModelDBStateDeleteRemoteRelationCall wrap *gomock.Call
-type MockModelDBStateDeleteRemoteRelationCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelDBStateDeleteRemoteRelationCall) Return(arg0 error) *MockModelDBStateDeleteRemoteRelationCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateDeleteRemoteRelationCall) Do(f func(context.Context, string) error) *MockModelDBStateDeleteRemoteRelationCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateDeleteRemoteRelationCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateDeleteRemoteRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1561,6 +1561,45 @@ func (c *MockModelDBStateEnsureRelationNotAliveCall) DoAndReturn(f func(context.
 	return c
 }
 
+// EnsureRelationWithRemoteOffererNotAliveCascade mocks base method.
+func (m *MockModelDBState) EnsureRelationWithRemoteOffererNotAliveCascade(arg0 context.Context, arg1 string) (internal.CascadedRelationWithRemoteOffererLives, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureRelationWithRemoteOffererNotAliveCascade", arg0, arg1)
+	ret0, _ := ret[0].(internal.CascadedRelationWithRemoteOffererLives)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnsureRelationWithRemoteOffererNotAliveCascade indicates an expected call of EnsureRelationWithRemoteOffererNotAliveCascade.
+func (mr *MockModelDBStateMockRecorder) EnsureRelationWithRemoteOffererNotAliveCascade(arg0, arg1 any) *MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureRelationWithRemoteOffererNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureRelationWithRemoteOffererNotAliveCascade), arg0, arg1)
+	return &MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall{Call: call}
+}
+
+// MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall wrap *gomock.Call
+type MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall) Return(arg0 internal.CascadedRelationWithRemoteOffererLives, arg1 error) *MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall) Do(f func(context.Context, string) (internal.CascadedRelationWithRemoteOffererLives, error)) *MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) (internal.CascadedRelationWithRemoteOffererLives, error)) *MockModelDBStateEnsureRelationWithRemoteOffererNotAliveCascadeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // EnsureRemoteApplicationOffererNotAliveCascade mocks base method.
 func (m *MockModelDBState) EnsureRemoteApplicationOffererNotAliveCascade(arg0 context.Context, arg1 string) (internal.CascadedRemoteApplicationOffererLives, error) {
 	m.ctrl.T.Helper()
@@ -1596,45 +1635,6 @@ func (c *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall) Do(f
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) (internal.CascadedRemoteApplicationOffererLives, error)) *MockModelDBStateEnsureRemoteApplicationOffererNotAliveCascadeCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// EnsureRemoteRelationNotAliveCascade mocks base method.
-func (m *MockModelDBState) EnsureRemoteRelationNotAliveCascade(arg0 context.Context, arg1 string) (internal.CascadedRemoteRelationLives, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureRemoteRelationNotAliveCascade", arg0, arg1)
-	ret0, _ := ret[0].(internal.CascadedRemoteRelationLives)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EnsureRemoteRelationNotAliveCascade indicates an expected call of EnsureRemoteRelationNotAliveCascade.
-func (mr *MockModelDBStateMockRecorder) EnsureRemoteRelationNotAliveCascade(arg0, arg1 any) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureRemoteRelationNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureRemoteRelationNotAliveCascade), arg0, arg1)
-	return &MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall{Call: call}
-}
-
-// MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall wrap *gomock.Call
-type MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) Return(arg0 internal.CascadedRemoteRelationLives, arg1 error) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) Do(f func(context.Context, string) (internal.CascadedRemoteRelationLives, error)) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) (internal.CascadedRemoteRelationLives, error)) *MockModelDBStateEnsureRemoteRelationNotAliveCascadeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -3615,6 +3615,83 @@ func (c *MockModelDBStateRelationScheduleRemovalCall) DoAndReturn(f func(context
 	return c
 }
 
+// RelationWithRemoteOffererExists mocks base method.
+func (m *MockModelDBState) RelationWithRemoteOffererExists(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RelationWithRemoteOffererExists", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RelationWithRemoteOffererExists indicates an expected call of RelationWithRemoteOffererExists.
+func (mr *MockModelDBStateMockRecorder) RelationWithRemoteOffererExists(arg0, arg1 any) *MockModelDBStateRelationWithRemoteOffererExistsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationWithRemoteOffererExists", reflect.TypeOf((*MockModelDBState)(nil).RelationWithRemoteOffererExists), arg0, arg1)
+	return &MockModelDBStateRelationWithRemoteOffererExistsCall{Call: call}
+}
+
+// MockModelDBStateRelationWithRemoteOffererExistsCall wrap *gomock.Call
+type MockModelDBStateRelationWithRemoteOffererExistsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateRelationWithRemoteOffererExistsCall) Return(arg0 bool, arg1 error) *MockModelDBStateRelationWithRemoteOffererExistsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateRelationWithRemoteOffererExistsCall) Do(f func(context.Context, string) (bool, error)) *MockModelDBStateRelationWithRemoteOffererExistsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateRelationWithRemoteOffererExistsCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockModelDBStateRelationWithRemoteOffererExistsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RelationWithRemoteOffererScheduleRemoval mocks base method.
+func (m *MockModelDBState) RelationWithRemoteOffererScheduleRemoval(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RelationWithRemoteOffererScheduleRemoval", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RelationWithRemoteOffererScheduleRemoval indicates an expected call of RelationWithRemoteOffererScheduleRemoval.
+func (mr *MockModelDBStateMockRecorder) RelationWithRemoteOffererScheduleRemoval(arg0, arg1, arg2, arg3, arg4 any) *MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationWithRemoteOffererScheduleRemoval", reflect.TypeOf((*MockModelDBState)(nil).RelationWithRemoteOffererScheduleRemoval), arg0, arg1, arg2, arg3, arg4)
+	return &MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall{Call: call}
+}
+
+// MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall wrap *gomock.Call
+type MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall) Return(arg0 error) *MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall) Do(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRelationWithRemoteOffererScheduleRemovalCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoteApplicationOffererExists mocks base method.
 func (m *MockModelDBState) RemoteApplicationOffererExists(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -3688,83 +3765,6 @@ func (c *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall) Do(f func(
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRemoteApplicationOffererScheduleRemovalCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// RemoteRelationExists mocks base method.
-func (m *MockModelDBState) RemoteRelationExists(arg0 context.Context, arg1 string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoteRelationExists", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RemoteRelationExists indicates an expected call of RemoteRelationExists.
-func (mr *MockModelDBStateMockRecorder) RemoteRelationExists(arg0, arg1 any) *MockModelDBStateRemoteRelationExistsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteRelationExists", reflect.TypeOf((*MockModelDBState)(nil).RemoteRelationExists), arg0, arg1)
-	return &MockModelDBStateRemoteRelationExistsCall{Call: call}
-}
-
-// MockModelDBStateRemoteRelationExistsCall wrap *gomock.Call
-type MockModelDBStateRemoteRelationExistsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelDBStateRemoteRelationExistsCall) Return(arg0 bool, arg1 error) *MockModelDBStateRemoteRelationExistsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateRemoteRelationExistsCall) Do(f func(context.Context, string) (bool, error)) *MockModelDBStateRemoteRelationExistsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateRemoteRelationExistsCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockModelDBStateRemoteRelationExistsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// RemoteRelationScheduleRemoval mocks base method.
-func (m *MockModelDBState) RemoteRelationScheduleRemoval(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 time.Time) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoteRelationScheduleRemoval", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoteRelationScheduleRemoval indicates an expected call of RemoteRelationScheduleRemoval.
-func (mr *MockModelDBStateMockRecorder) RemoteRelationScheduleRemoval(arg0, arg1, arg2, arg3, arg4 any) *MockModelDBStateRemoteRelationScheduleRemovalCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteRelationScheduleRemoval", reflect.TypeOf((*MockModelDBState)(nil).RemoteRelationScheduleRemoval), arg0, arg1, arg2, arg3, arg4)
-	return &MockModelDBStateRemoteRelationScheduleRemovalCall{Call: call}
-}
-
-// MockModelDBStateRemoteRelationScheduleRemovalCall wrap *gomock.Call
-type MockModelDBStateRemoteRelationScheduleRemovalCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelDBStateRemoteRelationScheduleRemovalCall) Return(arg0 error) *MockModelDBStateRemoteRelationScheduleRemovalCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateRemoteRelationScheduleRemovalCall) Do(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRemoteRelationScheduleRemovalCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateRemoteRelationScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockModelDBStateRemoteRelationScheduleRemovalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/service/relationwithremoteofferer_test.go
+++ b/domain/removal/service/relationwithremoteofferer_test.go
@@ -19,15 +19,15 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
-type remoteRelationSuite struct {
+type relationWithRemoteOffererSuite struct {
 	baseSuite
 }
 
-func TestRemoteRelationSuite(t *testing.T) {
-	tc.Run(t, &remoteRelationSuite{})
+func TestRelationWithRemoteOffererSuite(t *testing.T) {
+	tc.Run(t, &relationWithRemoteOffererSuite{})
 }
 
-func (s *remoteRelationSuite) TestRemoveRemoteRelationNoForceSuccess(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestRemoveRelationWithRemoteOffererNoForceSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relUUID := tc.Must(c, relation.NewUUID)
@@ -36,16 +36,16 @@ func (s *remoteRelationSuite) TestRemoveRemoteRelationNoForceSuccess(c *tc.C) {
 	s.clock.EXPECT().Now().Return(when)
 
 	exp := s.modelState.EXPECT()
-	exp.RemoteRelationExists(gomock.Any(), relUUID.String()).Return(true, nil)
-	exp.EnsureRemoteRelationNotAliveCascade(gomock.Any(), relUUID.String()).Return(internal.CascadedRemoteRelationLives{}, nil)
-	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), false, when.UTC()).Return(nil)
+	exp.RelationWithRemoteOffererExists(gomock.Any(), relUUID.String()).Return(true, nil)
+	exp.EnsureRelationWithRemoteOffererNotAliveCascade(gomock.Any(), relUUID.String()).Return(internal.CascadedRelationWithRemoteOffererLives{}, nil)
+	exp.RelationWithRemoteOffererScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), false, when.UTC()).Return(nil)
 
-	jobUUID, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, false, 0)
+	jobUUID, err := s.newService(c).RemoveRelationWithRemoteOfferer(c.Context(), relUUID, false, 0)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestRemoveRemoteRelationForceNoWaitSuccess(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestRemoveRelationWithRemoteOffererForceNoWaitSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relUUID := tc.Must(c, relation.NewUUID)
@@ -54,16 +54,16 @@ func (s *remoteRelationSuite) TestRemoveRemoteRelationForceNoWaitSuccess(c *tc.C
 	s.clock.EXPECT().Now().Return(when)
 
 	exp := s.modelState.EXPECT()
-	exp.RemoteRelationExists(gomock.Any(), relUUID.String()).Return(true, nil)
-	exp.EnsureRemoteRelationNotAliveCascade(gomock.Any(), relUUID.String()).Return(internal.CascadedRemoteRelationLives{}, nil)
-	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), true, when.UTC()).Return(nil)
+	exp.RelationWithRemoteOffererExists(gomock.Any(), relUUID.String()).Return(true, nil)
+	exp.EnsureRelationWithRemoteOffererNotAliveCascade(gomock.Any(), relUUID.String()).Return(internal.CascadedRelationWithRemoteOffererLives{}, nil)
+	exp.RelationWithRemoteOffererScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), true, when.UTC()).Return(nil)
 
-	jobUUID, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, true, 0)
+	jobUUID, err := s.newService(c).RemoveRelationWithRemoteOfferer(c.Context(), relUUID, true, 0)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestRemoveRemoteRelationForceWaitSuccess(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestRemoveRelationWithRemoteOffererForceWaitSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relUUID := tc.Must(c, relation.NewUUID)
@@ -72,21 +72,21 @@ func (s *remoteRelationSuite) TestRemoveRemoteRelationForceWaitSuccess(c *tc.C) 
 	s.clock.EXPECT().Now().Return(when).MinTimes(1)
 
 	exp := s.modelState.EXPECT()
-	exp.RemoteRelationExists(gomock.Any(), relUUID.String()).Return(true, nil)
-	exp.EnsureRemoteRelationNotAliveCascade(gomock.Any(), relUUID.String()).Return(internal.CascadedRemoteRelationLives{}, nil)
+	exp.RelationWithRemoteOffererExists(gomock.Any(), relUUID.String()).Return(true, nil)
+	exp.EnsureRelationWithRemoteOffererNotAliveCascade(gomock.Any(), relUUID.String()).Return(internal.CascadedRelationWithRemoteOffererLives{}, nil)
 
 	// The first normal removal scheduled immediately.
-	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), false, when.UTC()).Return(nil)
+	exp.RelationWithRemoteOffererScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), false, when.UTC()).Return(nil)
 
 	// The forced removal scheduled after the wait duration.
-	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), true, when.UTC().Add(time.Minute)).Return(nil)
+	exp.RelationWithRemoteOffererScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), true, when.UTC().Add(time.Minute)).Return(nil)
 
-	jobUUID, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, true, time.Minute)
+	jobUUID, err := s.newService(c).RemoveRelationWithRemoteOfferer(c.Context(), relUUID, true, time.Minute)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestRemoveRemoteRelationDepartedSyntheticUnits(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestRemoveRelationWithRemoteOffererDepartedSyntheticUnits(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relUUID := tc.Must(c, relation.NewUUID)
@@ -97,45 +97,45 @@ func (s *remoteRelationSuite) TestRemoveRemoteRelationDepartedSyntheticUnits(c *
 	s.clock.EXPECT().Now().Return(when).MinTimes(1)
 
 	exp := s.modelState.EXPECT()
-	exp.RemoteRelationExists(gomock.Any(), relUUID.String()).Return(true, nil)
-	exp.EnsureRemoteRelationNotAliveCascade(gomock.Any(), relUUID.String()).Return(internal.CascadedRemoteRelationLives{
+	exp.RelationWithRemoteOffererExists(gomock.Any(), relUUID.String()).Return(true, nil)
+	exp.EnsureRelationWithRemoteOffererNotAliveCascade(gomock.Any(), relUUID.String()).Return(internal.CascadedRelationWithRemoteOffererLives{
 		SyntheticRelationUnitUUIDs: []string{relUnitUUID1.String(), relUnitUUID2.String()},
 	}, nil)
 	exp.LeaveScope(gomock.Any(), relUnitUUID1.String()).Return(nil)
 	exp.LeaveScope(gomock.Any(), relUnitUUID2.String()).Return(nil)
-	exp.RemoteRelationScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), false, when.UTC()).Return(nil)
+	exp.RelationWithRemoteOffererScheduleRemoval(gomock.Any(), gomock.Any(), relUUID.String(), false, when.UTC()).Return(nil)
 
-	jobUUID, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, false, 0)
+	jobUUID, err := s.newService(c).RemoveRelationWithRemoteOfferer(c.Context(), relUUID, false, 0)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestRemoveRemoteRelationNotFound(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestRemoveRelationWithRemoteOffererNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relUUID := tc.Must(c, relation.NewUUID)
 
-	s.modelState.EXPECT().RemoteRelationExists(gomock.Any(), relUUID.String()).Return(false, nil)
+	s.modelState.EXPECT().RelationWithRemoteOffererExists(gomock.Any(), relUUID.String()).Return(false, nil)
 
-	_, err := s.newService(c).RemoveRemoteRelation(c.Context(), relUUID, false, 0)
+	_, err := s.newService(c).RemoveRelationWithRemoteOfferer(c.Context(), relUUID, false, 0)
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
-func (s *remoteRelationSuite) TestProcessRemoteRelationRemovalJobInvalidJobType(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestProcessRelationWithRemoteOffererRemovalJobInvalidJobType(c *tc.C) {
 	var invalidJobType removal.JobType = 500
 
 	job := removal.Job{
 		RemovalType: invalidJobType,
 	}
 
-	err := s.newService(c).processRemoteRelationRemovalJob(c.Context(), job)
+	err := s.newService(c).processRelationWithRemoteOffererRemovalJob(c.Context(), job)
 	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobTypeNotValid)
 }
 
-func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationNotFound(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestExecuteJobForRelationWithRemoteOffererNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	j := newRemoteRelationJob(c)
+	j := newRelationWithRemoteOffererJob(c)
 
 	exp := s.modelState.EXPECT()
 	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(-1, relationerrors.RelationNotFound)
@@ -145,10 +145,10 @@ func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationError(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestExecuteJobForRelationWithRemoteOffererError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	j := newRemoteRelationJob(c)
+	j := newRelationWithRemoteOffererJob(c)
 
 	exp := s.modelState.EXPECT()
 	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(-1, errors.Errorf("the front fell off"))
@@ -157,10 +157,10 @@ func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
 }
 
-func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationStillAlive(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestExecuteJobForRelationWithRemoteOffererStillAlive(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	j := newRemoteRelationJob(c)
+	j := newRelationWithRemoteOffererJob(c)
 
 	exp := s.modelState.EXPECT()
 	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Alive, nil)
@@ -169,10 +169,10 @@ func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationStillAlive(c *tc.C)
 	c.Assert(err, tc.ErrorIs, removalerrors.EntityStillAlive)
 }
 
-func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationUnitsInScope(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestExecuteJobForRelationWithRemoteOffererUnitsInScope(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	j := newRemoteRelationJob(c)
+	j := newRelationWithRemoteOffererJob(c)
 
 	exp := s.modelState.EXPECT()
 	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
@@ -182,59 +182,59 @@ func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationUnitsInScope(c *tc.
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationUnitsInScopeForce(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestExecuteJobForRelationWithRemoteOffererUnitsInScopeForce(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	j := newRemoteRelationJob(c)
+	j := newRelationWithRemoteOffererJob(c)
 	j.Force = true
 
 	exp := s.modelState.EXPECT()
 	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
 	exp.UnitNamesInScope(gomock.Any(), j.EntityUUID).Return([]string{"unit/0"}, nil)
 	exp.DeleteRelationUnits(gomock.Any(), j.EntityUUID).Return(nil)
-	exp.DeleteRemoteRelation(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteRelationWithRemoteOfferer(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationDyingDeleteRemoteRelation(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestExecuteJobForRelationWithRemoteOffererDyingDeleteRelationWithRemoteOfferer(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	j := newRemoteRelationJob(c)
+	j := newRelationWithRemoteOffererJob(c)
 
 	exp := s.modelState.EXPECT()
 	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
 	exp.UnitNamesInScope(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.DeleteRemoteRelation(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteRelationWithRemoteOfferer(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestExecuteJobForRemoteRelationDyingDeleteRemoteRelationError(c *tc.C) {
+func (s *relationWithRemoteOffererSuite) TestExecuteJobForRelationWithRemoteOffererDyingDeleteRelationWithRemoteOffererError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	j := newRemoteRelationJob(c)
+	j := newRelationWithRemoteOffererJob(c)
 
 	exp := s.modelState.EXPECT()
 	exp.GetRelationLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
 	exp.UnitNamesInScope(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.DeleteRemoteRelation(gomock.Any(), j.EntityUUID).Return(errors.Errorf("the front fell off"))
+	exp.DeleteRelationWithRemoteOfferer(gomock.Any(), j.EntityUUID).Return(errors.Errorf("the front fell off"))
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
 }
 
-func newRemoteRelationJob(c *tc.C) removal.Job {
+func newRelationWithRemoteOffererJob(c *tc.C) removal.Job {
 	jUUID, err := removal.NewUUID()
 	c.Assert(err, tc.ErrorIsNil)
 
 	return removal.Job{
 		UUID:        jUUID,
-		RemovalType: removal.RemoteRelationJob,
+		RemovalType: removal.RelationWithRemoteOffererJob,
 		EntityUUID:  tc.Must(c, relation.NewUUID).String(),
 	}
 }

--- a/domain/removal/service/service.go
+++ b/domain/removal/service/service.go
@@ -48,7 +48,7 @@ type ModelDBState interface {
 	ModelState
 	StorageState
 	RemoteApplicationOffererState
-	RemoteRelationState
+	RelationWithRemoteOfferer
 	OfferState
 	SecretModelState
 
@@ -181,8 +181,8 @@ func (s *Service) ExecuteJob(ctx context.Context, job removal.Job) error {
 	case removal.RemoteApplicationOffererJob:
 		err = s.processRemoteApplicationOffererRemovalJob(ctx, job)
 
-	case removal.RemoteRelationJob:
-		err = s.processRemoteRelationRemovalJob(ctx, job)
+	case removal.RelationWithRemoteOffererJob:
+		err = s.processRelationWithRemoteOffererRemovalJob(ctx, job)
 
 	default:
 		err = errors.Errorf("removal job type %q not supported", job.RemovalType).Add(

--- a/domain/removal/state/model/relation_test.go
+++ b/domain/removal/state/model/relation_test.go
@@ -46,7 +46,7 @@ func (s *relationSuite) TestRelationExistsDoesNotExist(c *tc.C) {
 }
 
 func (s *relationSuite) TestRelationExistsCrossModelRelation(c *tc.C) {
-	relUUID, _ := s.createRemoteRelation(c)
+	relUUID, _ := s.createRelationWithRemoteOfferer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -306,9 +306,7 @@ VALUES (?, ?, 'old-key', 'old-value')`, rel, unit)
 
 func (s *relationSuite) TestLeaveScopeDeletesSyntheticUnits(c *tc.C) {
 	// Arrange
-	s.createRemoteRelation(c)
-
-	s.DumpTable(c, "unit", "relation_unit")
+	s.createRelationWithRemoteOfferer(c)
 
 	var relUnitUUID string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {

--- a/domain/removal/state/model/relationwithremoteofferer_test.go
+++ b/domain/removal/state/model/relationwithremoteofferer_test.go
@@ -21,45 +21,45 @@ type remoteRelationSuite struct {
 	baseSuite
 }
 
-func TestRemoteRelationSuite(t *testing.T) {
+func TestRelationWithRemoteOffererSuite(t *testing.T) {
 	tc.Run(t, &remoteRelationSuite{})
 }
 
-func (s *remoteRelationSuite) TestRemoteRelationExists(c *tc.C) {
-	relUUID, _ := s.createRemoteRelation(c)
+func (s *remoteRelationSuite) TestRelationWithRemoteOffererExists(c *tc.C) {
+	relUUID, _ := s.createRelationWithRemoteOfferer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	exists, err := st.RemoteRelationExists(c.Context(), relUUID.String())
+	exists, err := st.RelationWithRemoteOffererExists(c.Context(), relUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(exists, tc.Equals, true)
 }
 
-func (s *remoteRelationSuite) TestRemoteRelationExistsFalseForRegularRelation(c *tc.C) {
+func (s *remoteRelationSuite) TestRelationWithRemoteOffererExistsFalseForRegularRelation(c *tc.C) {
 	relUUID := s.createRelation(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	exists, err := st.RemoteRelationExists(c.Context(), relUUID.String())
+	exists, err := st.RelationWithRemoteOffererExists(c.Context(), relUUID.String())
 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(exists, tc.Equals, false)
 }
 
-func (s *remoteRelationSuite) TestRemoteRelationExistsFalseForNonExistingRelation(c *tc.C) {
+func (s *remoteRelationSuite) TestRelationWithRemoteOffererExistsFalseForNonExistingRelation(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	exists, err := st.RemoteRelationExists(c.Context(), "not-today-henry")
+	exists, err := st.RelationWithRemoteOffererExists(c.Context(), "not-today-henry")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(exists, tc.Equals, false)
 }
 
-func (s *remoteRelationSuite) TestEnsureRemoteRelationNotAliveCascadeNormalSuccess(c *tc.C) {
-	relUUID, synthAppUUID := s.createRemoteRelation(c)
+func (s *remoteRelationSuite) TestEnsureRelationWithRemoteOffererNotAliveCascadeNormalSuccess(c *tc.C) {
+	relUUID, synthAppUUID := s.createRelationWithRemoteOfferer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	artifacts, err := st.EnsureRemoteRelationNotAliveCascade(c.Context(), relUUID.String())
+	artifacts, err := st.EnsureRelationWithRemoteOffererNotAliveCascade(c.Context(), relUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 
 	var lifeID int
@@ -103,21 +103,21 @@ WHERE           ru.uuid IN (?, ?, ?)
 	c.Check(gotAppUUID, tc.Equals, synthAppUUID.String())
 }
 
-func (s *remoteRelationSuite) TestEnsureRemoteRelationNotAliveCascadeNotExistsSuccess(c *tc.C) {
+func (s *remoteRelationSuite) TestEnsureRelationWithRemoteOffererNotAliveCascadeNotExistsSuccess(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	// We don't care if it's already gone.
-	_, err := st.EnsureRemoteRelationNotAliveCascade(c.Context(), "some-relation-uuid")
+	_, err := st.EnsureRelationWithRemoteOffererNotAliveCascade(c.Context(), "some-relation-uuid")
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *remoteRelationSuite) TestRemoteRelationScheduleRemovalNormalSuccess(c *tc.C) {
-	relUUID, _ := s.createRemoteRelation(c)
+func (s *remoteRelationSuite) TestRelationWithRemoteOffererScheduleRemovalNormalSuccess(c *tc.C) {
+	relUUID, _ := s.createRelationWithRemoteOfferer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	when := time.Now().UTC()
-	err := st.RemoteRelationScheduleRemoval(
+	err := st.RelationWithRemoteOffererScheduleRemoval(
 		c.Context(), "removal-uuid", relUUID.String(), false, when,
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -137,17 +137,17 @@ where  r.uuid = ?`, "removal-uuid",
 	err = row.Scan(&removalType, &rUUID, &force, &scheduledFor)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Check(removalType, tc.Equals, "remote relation")
+	c.Check(removalType, tc.Equals, "relation with remote offerer")
 	c.Check(rUUID, tc.Equals, relUUID.String())
 	c.Check(force, tc.Equals, false)
 	c.Check(scheduledFor, tc.Equals, when)
 }
 
-func (s *remoteRelationSuite) TestRemoteRelationScheduleRemovalNotExistsSuccess(c *tc.C) {
+func (s *remoteRelationSuite) TestRelationWithRemoteOffererScheduleRemovalNotExistsSuccess(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	when := time.Now().UTC()
-	err := st.RemoteRelationScheduleRemoval(
+	err := st.RelationWithRemoteOffererScheduleRemoval(
 		c.Context(), "removal-uuid", "some-relation-uuid", true, when,
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -167,26 +167,26 @@ where  r.uuid = ?`, "removal-uuid",
 	err = row.Scan(&removalType, &rUUID, &force, &scheduledFor)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Check(removalType, tc.Equals, "remote relation")
+	c.Check(removalType, tc.Equals, "relation with remote offerer")
 	c.Check(rUUID, tc.Equals, "some-relation-uuid")
 	c.Check(force, tc.Equals, true)
 	c.Check(scheduledFor, tc.Equals, when)
 }
 
-func (s *relationSuite) TestDeleteRemoteRelationUnitsUnitsStillInScope(c *tc.C) {
-	relUUID, _ := s.createRemoteRelation(c)
+func (s *relationSuite) TestDeleteRelationWithRemoteOffererUnitsUnitsStillInScope(c *tc.C) {
+	relUUID, _ := s.createRelationWithRemoteOfferer(c)
 
 	s.advanceRelationLife(c, relUUID, life.Dying)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err := st.DeleteRemoteRelation(c.Context(), relUUID.String())
+	err := st.DeleteRelationWithRemoteOfferer(c.Context(), relUUID.String())
 	c.Assert(err, tc.ErrorIs, removalerrors.UnitsStillInScope)
 }
 
-func (s *relationSuite) TestDeleteRemoteRelationUnits(c *tc.C) {
+func (s *relationSuite) TestDeleteRelationWithRemoteOffererUnits(c *tc.C) {
 	// Arrange
-	relUUID, synthAppUUID := s.createRemoteRelation(c)
+	relUUID, synthAppUUID := s.createRelationWithRemoteOfferer(c)
 
 	s.advanceRelationLife(c, relUUID, life.Dying)
 
@@ -196,7 +196,7 @@ func (s *relationSuite) TestDeleteRemoteRelationUnits(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Act
-	err = st.DeleteRemoteRelation(c.Context(), relUUID.String())
+	err = st.DeleteRelationWithRemoteOfferer(c.Context(), relUUID.String())
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -215,7 +215,7 @@ func (s *relationSuite) TestDeleteRemoteRelationUnits(c *tc.C) {
 	c.Check(count, tc.Equals, 0)
 }
 
-func (s *relationSuite) TestDeleteRemoteRelationWhenRemoteAppHasMultipleRelations(c *tc.C) {
+func (s *relationSuite) TestDeleteRelationWithRemoteOffererWhenRemoteAppHasMultipleRelations(c *tc.C) {
 	synthAppUUID, _ := s.createRemoteApplicationOfferer(c, "foo")
 	s.createIAASApplication(c, s.setupApplicationService(c), "app1",
 		applicationservice.AddIAASUnitArg{},
@@ -228,7 +228,7 @@ func (s *relationSuite) TestDeleteRemoteRelationWhenRemoteAppHasMultipleRelation
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err := st.DeleteRemoteRelation(c.Context(), relUUID.String())
+	err := st.DeleteRelationWithRemoteOfferer(c.Context(), relUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 
 	// The synth app should NOT be deleted.

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -507,11 +507,11 @@ func (s *baseSuite) createRelation(c *tc.C) relation.UUID {
 	return relUUID
 }
 
-// createRemoteRelation creates a remote relation. This is done by creating
+// createRelationWithRemoteOfferer creates a remote relation. This is done by creating
 // a synthetic app & a regular app, and then establishing a relation between
 // them. We also add some units to the each app for good measure. Returns the
 // relation UUID and the synthetic app UUID.
-func (s *baseSuite) createRemoteRelation(c *tc.C) (relation.UUID, coreapplication.UUID) {
+func (s *baseSuite) createRelationWithRemoteOfferer(c *tc.C) (relation.UUID, coreapplication.UUID) {
 	synthAppUUID, _ := s.createRemoteApplicationOfferer(c, "foo")
 	s.createIAASApplication(c, s.setupApplicationService(c), "bar",
 		applicationservice.AddIAASUnitArg{},

--- a/domain/removal/types.go
+++ b/domain/removal/types.go
@@ -43,8 +43,8 @@ const (
 	// RemoteApplicationOffererJob indicates a job to remove a remote
 	// application offerer.
 	RemoteApplicationOffererJob
-	// RemoteRelationJob indicates a job to remove a remote relation.
-	RemoteRelationJob
+	// RelationWithRemoteOffererJob indicates a job to remove a remote relation.
+	RelationWithRemoteOffererJob
 )
 
 // String is used in logging output make job type identifiers readable.
@@ -77,8 +77,8 @@ func (t JobType) String() string {
 		return "storage volume attachment plan"
 	case RemoteApplicationOffererJob:
 		return "remote application offerer"
-	case RemoteRelationJob:
-		return "remote relation"
+	case RelationWithRemoteOffererJob:
+		return "relation with remote offerer"
 	default:
 		return strconv.FormatInt(int64(t), 10)
 	}

--- a/domain/schema/model/sql/0028-cleanup.sql
+++ b/domain/schema/model/sql/0028-cleanup.sql
@@ -20,7 +20,7 @@ INSERT INTO removal_type VALUES
 (10, 'storage volume attachment plan'),
 (11, 'storage filesystem attachment'),
 (12, 'remote application offerer'),
-(13, 'remote relation');
+(13, 'relation with remote offerer');
 
 CREATE TABLE removal (
     uuid TEXT NOT NULL PRIMARY KEY,

--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -1004,7 +1004,7 @@ func (w *localConsumerWorker) handleOffererRelationRemoved(ctx context.Context, 
 	// Remove the remote relation from the local model. This will ensure that
 	// all the associated data is cleaned up for the relation. The synthetic
 	// unit in the relation will also be removed as part of this process.
-	_, err := w.crossModelService.RemoveRemoteRelation(ctx, relationUUID, false, 0)
+	_, err := w.crossModelService.RemoveRelationWithRemoteOfferer(ctx, relationUUID, false, 0)
 	if err != nil && !errors.Is(err, relationerrors.RelationNotFound) {
 		return errors.Annotatef(err, "removing remote relation %q", relationUUID)
 	}
@@ -1084,7 +1084,7 @@ func (w *localConsumerWorker) handleOffererRelationChange(ctx context.Context, c
 	if isNotAlive(change.Life) {
 		// If the relation is dying or dead, then we're done here. The units
 		// will have already transitioned to departed.
-		_, err := w.crossModelService.RemoveRemoteRelation(ctx, change.ConsumerRelationUUID, false, 0)
+		_, err := w.crossModelService.RemoveRelationWithRemoteOfferer(ctx, change.ConsumerRelationUUID, false, 0)
 		if errors.Is(err, relationerrors.RelationNotFound) {
 			return nil
 		}

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -1996,7 +1996,7 @@ func (s *localConsumerWorkerSuite) TestHandleOffererRelationUnitChangeDyingRelat
 		GetRelationDetails(gomock.Any(), relationUUID).
 		Return(domainrelation.RelationDetails{}, nil)
 	s.crossModelService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID, false, time.Duration(0)).
+		RemoveRelationWithRemoteOfferer(gomock.Any(), relationUUID, false, time.Duration(0)).
 		DoAndReturn(func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error) {
 			close(sync)
 			return "", nil
@@ -2054,7 +2054,7 @@ func (s *localConsumerWorkerSuite) TestHandleOffererRelationUnitChangeDeadRelati
 		GetRelationDetails(gomock.Any(), relationUUID).
 		Return(domainrelation.RelationDetails{}, nil)
 	s.crossModelService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID, false, time.Duration(0)).
+		RemoveRelationWithRemoteOfferer(gomock.Any(), relationUUID, false, time.Duration(0)).
 		DoAndReturn(func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error) {
 			close(sync)
 			return "", nil
@@ -2568,7 +2568,7 @@ func (s *localConsumerWorkerSuite) TestHandleOffererRelationChangeDying(c *tc.C)
 
 	sync := make(chan struct{})
 	s.crossModelService.EXPECT().
-		RemoveRemoteRelation(gomock.Any(), relationUUID, false, time.Duration(0)).
+		RemoveRelationWithRemoteOfferer(gomock.Any(), relationUUID, false, time.Duration(0)).
 		DoAndReturn(func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error) {
 			close(sync)
 			return "", nil

--- a/internal/worker/remoterelationconsumer/service_mock_test.go
+++ b/internal/worker/remoterelationconsumer/service_mock_test.go
@@ -780,6 +780,45 @@ func (c *MockCrossModelServiceLeaveScopeCall) DoAndReturn(f func(context.Context
 	return c
 }
 
+// RemoveRelationWithRemoteOfferer mocks base method.
+func (m *MockCrossModelService) RemoveRelationWithRemoteOfferer(ctx context.Context, relUUID relation.UUID, force bool, wait time.Duration) (removal.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveRelationWithRemoteOfferer", ctx, relUUID, force, wait)
+	ret0, _ := ret[0].(removal.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveRelationWithRemoteOfferer indicates an expected call of RemoveRelationWithRemoteOfferer.
+func (mr *MockCrossModelServiceMockRecorder) RemoveRelationWithRemoteOfferer(ctx, relUUID, force, wait any) *MockCrossModelServiceRemoveRelationWithRemoteOffererCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRelationWithRemoteOfferer", reflect.TypeOf((*MockCrossModelService)(nil).RemoveRelationWithRemoteOfferer), ctx, relUUID, force, wait)
+	return &MockCrossModelServiceRemoveRelationWithRemoteOffererCall{Call: call}
+}
+
+// MockCrossModelServiceRemoveRelationWithRemoteOffererCall wrap *gomock.Call
+type MockCrossModelServiceRemoveRelationWithRemoteOffererCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelServiceRemoveRelationWithRemoteOffererCall) Return(arg0 removal.UUID, arg1 error) *MockCrossModelServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelServiceRemoveRelationWithRemoteOffererCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockCrossModelServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelServiceRemoveRelationWithRemoteOffererCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockCrossModelServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveRemoteApplicationOffererByApplicationUUID mocks base method.
 func (m *MockCrossModelService) RemoveRemoteApplicationOffererByApplicationUUID(ctx context.Context, appUUID application.UUID, force bool, duration time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
@@ -815,45 +854,6 @@ func (c *MockCrossModelServiceRemoveRemoteApplicationOffererByApplicationUUIDCal
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelServiceRemoveRemoteApplicationOffererByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID, bool, time.Duration) (removal.UUID, error)) *MockCrossModelServiceRemoveRemoteApplicationOffererByApplicationUUIDCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// RemoveRemoteRelation mocks base method.
-func (m *MockCrossModelService) RemoveRemoteRelation(ctx context.Context, relUUID relation.UUID, force bool, wait time.Duration) (removal.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveRemoteRelation", ctx, relUUID, force, wait)
-	ret0, _ := ret[0].(removal.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RemoveRemoteRelation indicates an expected call of RemoveRemoteRelation.
-func (mr *MockCrossModelServiceMockRecorder) RemoveRemoteRelation(ctx, relUUID, force, wait any) *MockCrossModelServiceRemoveRemoteRelationCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockCrossModelService)(nil).RemoveRemoteRelation), ctx, relUUID, force, wait)
-	return &MockCrossModelServiceRemoveRemoteRelationCall{Call: call}
-}
-
-// MockCrossModelServiceRemoveRemoteRelationCall wrap *gomock.Call
-type MockCrossModelServiceRemoveRemoteRelationCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockCrossModelServiceRemoveRemoteRelationCall) Return(arg0 removal.UUID, arg1 error) *MockCrossModelServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockCrossModelServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockCrossModelServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1858,6 +1858,45 @@ func (c *MockRemovalServiceLeaveScopeCall) DoAndReturn(f func(context.Context, r
 	return c
 }
 
+// RemoveRelationWithRemoteOfferer mocks base method.
+func (m *MockRemovalService) RemoveRelationWithRemoteOfferer(ctx context.Context, relUUID relation.UUID, force bool, wait time.Duration) (removal.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveRelationWithRemoteOfferer", ctx, relUUID, force, wait)
+	ret0, _ := ret[0].(removal.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveRelationWithRemoteOfferer indicates an expected call of RemoveRelationWithRemoteOfferer.
+func (mr *MockRemovalServiceMockRecorder) RemoveRelationWithRemoteOfferer(ctx, relUUID, force, wait any) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRelationWithRemoteOfferer", reflect.TypeOf((*MockRemovalService)(nil).RemoveRelationWithRemoteOfferer), ctx, relUUID, force, wait)
+	return &MockRemovalServiceRemoveRelationWithRemoteOffererCall{Call: call}
+}
+
+// MockRemovalServiceRemoveRelationWithRemoteOffererCall wrap *gomock.Call
+type MockRemovalServiceRemoveRelationWithRemoteOffererCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRemovalServiceRemoveRelationWithRemoteOffererCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRelationWithRemoteOffererCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveRemoteApplicationOffererByApplicationUUID mocks base method.
 func (m *MockRemovalService) RemoveRemoteApplicationOffererByApplicationUUID(ctx context.Context, appUUID application.UUID, force bool, duration time.Duration) (removal.UUID, error) {
 	m.ctrl.T.Helper()
@@ -1893,45 +1932,6 @@ func (c *MockRemovalServiceRemoveRemoteApplicationOffererByApplicationUUIDCall) 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockRemovalServiceRemoveRemoteApplicationOffererByApplicationUUIDCall) DoAndReturn(f func(context.Context, application.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteApplicationOffererByApplicationUUIDCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// RemoveRemoteRelation mocks base method.
-func (m *MockRemovalService) RemoveRemoteRelation(ctx context.Context, relUUID relation.UUID, force bool, wait time.Duration) (removal.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveRemoteRelation", ctx, relUUID, force, wait)
-	ret0, _ := ret[0].(removal.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RemoveRemoteRelation indicates an expected call of RemoveRemoteRelation.
-func (mr *MockRemovalServiceMockRecorder) RemoveRemoteRelation(ctx, relUUID, force, wait any) *MockRemovalServiceRemoveRemoteRelationCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteRelation", reflect.TypeOf((*MockRemovalService)(nil).RemoveRemoteRelation), ctx, relUUID, force, wait)
-	return &MockRemovalServiceRemoveRemoteRelationCall{Call: call}
-}
-
-// MockRemovalServiceRemoveRemoteRelationCall wrap *gomock.Call
-type MockRemovalServiceRemoveRemoteRelationCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Return(arg0 removal.UUID, arg1 error) *MockRemovalServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockRemovalServiceRemoveRemoteRelationCall) Do(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRemovalServiceRemoveRemoteRelationCall) DoAndReturn(f func(context.Context, relation.UUID, bool, time.Duration) (removal.UUID, error)) *MockRemovalServiceRemoveRemoteRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/remoterelationconsumer/worker.go
+++ b/internal/worker/remoterelationconsumer/worker.go
@@ -182,9 +182,9 @@ type StatusService interface {
 // RemovalService is an interface that defines the methods for
 // removing relations directly on the local model database.
 type RemovalService interface {
-	// RemoveRemoteRelation sets the relation with the given relation UUID
+	// RemoveRelationWithRemoteOfferer sets the relation with the given relation UUID
 	// from the local model to dying.
-	RemoveRemoteRelation(
+	RemoveRelationWithRemoteOfferer(
 		ctx context.Context, relUUID corerelation.UUID, force bool, wait time.Duration,
 	) (removal.UUID, error)
 


### PR DESCRIPTION
There are really two kinds of 'remote'/'synthetic' relations for a CMR. The relation on the offering model, and the consuming model.

These relations behave differently, they can't just be treated the same.

This piece of work is the first step towards bifurcating the remote relations removal domain.

## QA steps

Unit tests and static analysis passes