### PR TITLE
fix: log all API requests not just RPC ones

### DIFF
--- a/apiserver/observer/fakeobserver/instance.go
+++ b/apiserver/observer/fakeobserver/instance.go
@@ -20,8 +20,8 @@ type Instance struct {
 }
 
 // Join implements Observer.
-func (f *Instance) Join(req *http.Request, connectionID uint64) {
-	f.AddCall(funcName(), req, connectionID)
+func (f *Instance) Join(req *http.Request, connectionID uint64, fd int) {
+	f.AddCall(funcName(), req, connectionID, fd)
 }
 
 // Leave implements Observer.

--- a/apiserver/observer/metricobserver/metricobserver.go
+++ b/apiserver/observer/metricobserver/metricobserver.go
@@ -108,7 +108,7 @@ type metrics struct {
 func (*Observer) Login(entity names.Tag, _ names.ModelTag, _ bool, _ string) {}
 
 // Join is part of the observer.Observer interface.
-func (*Observer) Join(req *http.Request, connectionID uint64) {}
+func (*Observer) Join(req *http.Request, connectionID uint64, _ int) {}
 
 // Leave is part of the observer.Observer interface.
 func (*Observer) Leave() {}

--- a/apiserver/observer/observer.go
+++ b/apiserver/observer/observer.go
@@ -22,7 +22,7 @@ type Observer interface {
 
 	// Join is called when the connection to the API server's
 	// WebSocket is opened.
-	Join(req *http.Request, connectionID uint64)
+	Join(req *http.Request, connectionID uint64, fd int)
 
 	// Leave is called when the connection to the API server's
 	// WebSocket is closed.
@@ -77,8 +77,8 @@ type Multiplexer struct {
 
 // Join is called when the connection to the API server's WebSocket is
 // opened.
-func (m *Multiplexer) Join(req *http.Request, connectionID uint64) {
-	mapConcurrent(func(o Observer) { o.Join(req, connectionID) }, m.observers)
+func (m *Multiplexer) Join(req *http.Request, connectionID uint64, fd int) {
+	mapConcurrent(func(o Observer) { o.Join(req, connectionID, fd) }, m.observers)
 }
 
 // Leave implements Observer.

--- a/apiserver/observer/observer_test.go
+++ b/apiserver/observer/observer_test.go
@@ -43,10 +43,10 @@ func (*multiplexerSuite) TestJoin_CallsAllObservers(c *gc.C) {
 
 	o := observer.NewMultiplexer(observers[0], observers[1])
 	var req http.Request
-	o.Join(&req, 1234)
+	o.Join(&req, 1234, 2)
 
 	for _, f := range observers {
-		f.CheckCall(c, 0, "Join", &req, uint64(1234))
+		f.CheckCall(c, 0, "Join", &req, uint64(1234), int(2))
 	}
 }
 

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -38,6 +38,7 @@ type RequestObserver struct {
 	// this type.
 	state struct {
 		id                 uint64
+		fd                 int
 		websocketConnected time.Time
 		tag                string
 		model              string
@@ -106,13 +107,15 @@ func (n *RequestObserver) Login(entity names.Tag, model names.ModelTag, fromCont
 }
 
 // Join implements Observer.
-func (n *RequestObserver) Join(req *http.Request, connectionID uint64) {
+func (n *RequestObserver) Join(req *http.Request, connectionID uint64, fd int) {
 	n.state.id = connectionID
+	n.state.fd = fd
 	n.state.websocketConnected = n.clock.Now()
 
 	n.logger.Debugf(
-		"[%X] API connection from %s",
+		"[%X] fd:%v API connection from %s",
 		n.state.id,
+		n.state.fd,
 		req.RemoteAddr,
 	)
 }
@@ -132,8 +135,9 @@ func (n *RequestObserver) Leave() {
 		})
 	}
 	n.logger.Debugf(
-		"[%X] %s API connection terminated after %v",
+		"[%X] fd:%d %s API connection terminated after %v",
 		n.state.id,
+		n.state.fd,
 		n.state.tag,
 		time.Since(n.state.websocketConnected),
 	)

--- a/core/logger/labels.go
+++ b/core/logger/labels.go
@@ -7,6 +7,9 @@ package logger
 type Label = string
 
 const (
+	// API defines a common API label to enable logging of all API connections and requests.
+	API Label = "api"
+
 	// HTTP defines a common HTTP request label.
 	HTTP Label = "http"
 

--- a/docs/howto/manage-logs.md
+++ b/docs/howto/manage-logs.md
@@ -118,6 +118,7 @@ Juju logging is hierarchical and can be granular.
 ```unit``` refers to all logs related to a juju unit.
 #### label
 ```#label-name``` allows for logging based on a topic. Currently available topics are:
+  * api: log all API requests, whether they are RPC requests or whether they are raw HTTP requests.
   * cmr: cross model relations
   * cmr-auth: cross model relations authorization
   * charmhub: dealing with the charmhub client and callers


### PR DESCRIPTION
This updates the root HTTP Mux that we use, so that every connection ends up being logged. Our current system only creates a ConnectionID for RPC connections that are upgraded from raw HTTP connections. That means we weren't logging anything for connections to '/log' or '/offerdispatch', etc.

To make these connections traceable, I just use the underlying socket file descriptor. Which does have the nice property that it matches your lsof output.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model test
$ juju deploy juju-qa-test
```

 2. Update logs to DEBUG level and see the log messages around non-RPC connections.

```sh
$ juju model-config -m controller logging-config="<root>=INFO;juju.apiserver.http=DEBUG;juju.security=WARNING"
$ juju debug-log -m controller
...
machine-0: 17:09:36 DEBUG juju.apiserver.http api -> fd:77 15.973303ms ServeHTTP GET /model/6bf6a242-0b75-419f-888a-c6bb6ec436b4/api?%3Amodeluuid=6bf6a242-0b75-419f-888a-c6bb6ec436b4&
...
machine-0: 17:09:36 DEBUG juju.apiserver.http api <- fd:81 ServeHTTP GET /model/6bf6a242-0b75-419f-888a-c6bb6ec436b4/logsink?version=1
...
machine-0: 17:22:34 DEBUG juju.apiserver.http api <- fd:105 ServeHTTP GET /model/f5e2d66a-4fc5-48aa-88e6-cb34430f9336/logsink?version=1

```

 3. If you deploy for a cross-model relation, you can see the macaroon offers getting dishcharged.

```sh
$ juju deploy juju-qa-dummy-source
$ juju offer dummy-source:sink
$ juju create-model sink
$ juju deploy juju-qa-dummy-sink
$ juju relate test.dummy-source dummy-sink
```
Then in debug-log you should see:
```
machine-0: 17:22:34 DEBUG juju.apiserver.http api <- fd:105 ServeHTTP GET /model/f5e2d66a-4fc5-48aa-88e6-cb34430f9336/logsink?version=1
```

## Documentation changes

We could document the juju.apiserver.http log matcher, but it will also show up when you just DEBUG log the regular juju.apiserver key.

## Links

None