### PR TITLE
feat: introduce a third provisioning scope into the Juju model

### DIFF
--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -250,7 +250,10 @@ CREATE TABLE storage_provision_scope (
 
 INSERT INTO storage_provision_scope (id, scope) VALUES
 (0, 'model'),
-(1, 'machine');
+(1, 'machine'),
+-- external provision scope is used on storage entities that are provisioned
+-- externall to Juju.
+(2, 'external');
 
 -- storage_volume describes a volume held by a storage_instance.
 --

--- a/domain/storageprovisioning/doc.go
+++ b/domain/storageprovisioning/doc.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The storage provisioning domain is responsible for managing all storage
+// requirements for a model making sure that storage is provisioned and attached
+// to the correct entities in the model.
+//
+// The domain mostly exists to provide information into the storage provisioning
+// worker.
+//
+// # Provisioning Scope
+// For legacy reasons Juju manages the provisioning of storage bases on one of
+// two scpes. The first scope is "model" which indicates that the provisioning
+// logic for a given storage entity runs within the scope of the model. This can
+// be thought of as running on the controller itself.
+//
+// The second scope is "machine" where the provisiong of the storage happens
+// on the actual machine where the storage is to be used. This second scope only
+// ever applies to models which deploy machines to run units. A common case for
+// machine provisioned storage entities is filesystems where the paritioning and
+// making of the filesystem needs to be run from the actual machine itself.
+//
+// A third scope has been introduced into our modeling of storage that is not
+// yet in use but it exists as a place holder to support future directions and
+// also requirements that exist today. This scope is "external" where the
+// provisioner of the storage does not exist within Juju and is performed by
+// another process outside the normal control loop of Juju. An example of this
+// today would be Kubernetes where storage is provisioned and handled by
+// the statefulset controller.
+//
+// A forward looking design would would need "external" provisiong scope  to
+// move away from a singular storage provisioning worker to one where each
+// provider of storage registers themselves into the controller as being able
+// to provision a set of the storage requirements for a model. This design every
+// storage provider would become an "external" provisioner.
+package storageprovisioning

--- a/domain/storageprovisioning/scope.go
+++ b/domain/storageprovisioning/scope.go
@@ -15,6 +15,12 @@ const (
 	// ProvisionScopeMachine indicates that the provisioner for the storage is
 	// to be run within the context of the machine.
 	ProvisionScopeMachine
+
+	// ProvisionScopeExternal indicates that the provisioner for the storage is
+	// external to Juju.
+	//
+	// STOP: This is a placeholder value for future use and should not be used
+	ProvisionScopeExternal
 )
 
 // OwnershipScope declares to the model in what context a storage entity needs

--- a/domain/storageprovisioning/scope_test.go
+++ b/domain/storageprovisioning/scope_test.go
@@ -48,7 +48,8 @@ func (s *scopeSuite) TestProvisionScopeValuesAligned(c *tc.C) {
 	}
 
 	c.Check(dbValues, tc.DeepEquals, map[ProvisionScope]string{
-		ProvisionScopeModel:   "model",
-		ProvisionScopeMachine: "machine",
+		ProvisionScopeModel:    "model",
+		ProvisionScopeMachine:  "machine",
+		ProvisionScopeExternal: "external",
 	})
 }


### PR DESCRIPTION
This commit introduces a third provisioning scope into the Juju model for talking about storage that is externally provisioned to the controller. That is the provider and provisioner of the storage does not run under Juju's normal control loop.

This is a draft idea in support of some storage work being done by @hpidcock  for k8s. It may not land but aids to seed discussion if we want to include this in a 4.0 release at the start. I have added a doc.go to the storage provisioner that hopefully explains the thought behind this a little better.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests are fine for this PR.

## Documentation changes

N/A
