### PR TITLE
feat: record the offering app with the consumer record

### DIFF
--- a/apiserver/facades/agent/secretsmanager/mocks/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secrets.go
@@ -518,44 +518,6 @@ func (c *MockSecretsConsumerRevokeSecretAccessCall) DoAndReturn(f func(context.C
 	return c
 }
 
-// SaveSecretConsumer mocks base method.
-func (m *MockSecretsConsumer) SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name, md secrets.SecretConsumerMetadata) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveSecretConsumer", ctx, uri, unitName, md)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SaveSecretConsumer indicates an expected call of SaveSecretConsumer.
-func (mr *MockSecretsConsumerMockRecorder) SaveSecretConsumer(ctx, uri, unitName, md any) *MockSecretsConsumerSaveSecretConsumerCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).SaveSecretConsumer), ctx, uri, unitName, md)
-	return &MockSecretsConsumerSaveSecretConsumerCall{Call: call}
-}
-
-// MockSecretsConsumerSaveSecretConsumerCall wrap *gomock.Call
-type MockSecretsConsumerSaveSecretConsumerCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockSecretsConsumerSaveSecretConsumerCall) Return(arg0 error) *MockSecretsConsumerSaveSecretConsumerCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerSaveSecretConsumerCall) Do(f func(context.Context, *secrets.URI, unit.Name, secrets.SecretConsumerMetadata) error) *MockSecretsConsumerSaveSecretConsumerCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerSaveSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name, secrets.SecretConsumerMetadata) error) *MockSecretsConsumerSaveSecretConsumerCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // WatchConsumedSecretsChanges mocks base method.
 func (m *MockSecretsConsumer) WatchConsumedSecretsChanges(ctx context.Context, unitName unit.Name) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
@@ -1124,6 +1086,44 @@ func (c *MockCrossModelRelationServiceGetMacaroonForRelationCall) Do(f func(cont
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelRelationServiceGetMacaroonForRelationCall) DoAndReturn(f func(context.Context, relation.UUID) (*macaroon.Macaroon, error)) *MockCrossModelRelationServiceGetMacaroonForRelationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SaveRemoteSecretConsumer mocks base method.
+func (m *MockCrossModelRelationService) SaveRemoteSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name, md secrets.SecretConsumerMetadata, applicationUUID application.UUID, relationUUID relation.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveRemoteSecretConsumer", ctx, uri, unitName, md, applicationUUID, relationUUID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveRemoteSecretConsumer indicates an expected call of SaveRemoteSecretConsumer.
+func (mr *MockCrossModelRelationServiceMockRecorder) SaveRemoteSecretConsumer(ctx, uri, unitName, md, applicationUUID, relationUUID any) *MockCrossModelRelationServiceSaveRemoteSecretConsumerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveRemoteSecretConsumer", reflect.TypeOf((*MockCrossModelRelationService)(nil).SaveRemoteSecretConsumer), ctx, uri, unitName, md, applicationUUID, relationUUID)
+	return &MockCrossModelRelationServiceSaveRemoteSecretConsumerCall{Call: call}
+}
+
+// MockCrossModelRelationServiceSaveRemoteSecretConsumerCall wrap *gomock.Call
+type MockCrossModelRelationServiceSaveRemoteSecretConsumerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelRelationServiceSaveRemoteSecretConsumerCall) Return(arg0 error) *MockCrossModelRelationServiceSaveRemoteSecretConsumerCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelRelationServiceSaveRemoteSecretConsumerCall) Do(f func(context.Context, *secrets.URI, unit.Name, secrets.SecretConsumerMetadata, application.UUID, relation.UUID) error) *MockCrossModelRelationServiceSaveRemoteSecretConsumerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelRelationServiceSaveRemoteSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name, secrets.SecretConsumerMetadata, application.UUID, relation.UUID) error) *MockCrossModelRelationServiceSaveRemoteSecretConsumerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -1060,9 +1060,9 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelNewConsumer(c *tc.C)
 			},
 		}, 666, true, nil)
 
-	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(), uri, consumer, coresecrets.SecretConsumerMetadata{
+	s.crossModelRelationService.EXPECT().SaveRemoteSecretConsumer(gomock.Any(), uri, consumer, coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 666,
-	})
+	}, appUUID, relUUID)
 
 	results, err := s.facade.GetSecretContentInfo(c.Context(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
@@ -1277,10 +1277,10 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 			},
 		}, 666, true, nil)
 
-	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(), uri, consumer, coresecrets.SecretConsumerMetadata{
+	s.crossModelRelationService.EXPECT().SaveRemoteSecretConsumer(gomock.Any(), uri, consumer, coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 666,
 		Label:           "foo",
-	})
+	}, appUUID, relUUID)
 
 	results, err := s.facade.GetSecretContentInfo(c.Context(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{

--- a/apiserver/facades/agent/secretsmanager/service.go
+++ b/apiserver/facades/agent/secretsmanager/service.go
@@ -32,7 +32,6 @@ type SecretsConsumer interface {
 	GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name) (*secrets.SecretConsumerMetadata, error)
 	GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName unit.Name) (*secrets.SecretConsumerMetadata, int, error)
 	GetURIByConsumerLabel(ctx context.Context, label string, unitName unit.Name) (*secrets.URI, error)
-	SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name, md secrets.SecretConsumerMetadata) error
 	GetConsumedRevision(
 		ctx context.Context, uri *secrets.URI, unitName unit.Name,
 		refresh, peek bool, labelToUpdate *string) (int, error)
@@ -76,4 +75,7 @@ type ApplicationService interface {
 type CrossModelRelationService interface {
 	// GetMacaroonForRelation gets the given macaroon for the specified remote relation.
 	GetMacaroonForRelation(ctx context.Context, relationUUID corerelation.UUID) (*macaroon.Macaroon, error)
+	// SaveRemoteSecretConsumer saves the consumer metadata for the given remote secret and unit.
+	SaveRemoteSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name, md secrets.SecretConsumerMetadata,
+		applicationUUID coreapplication.UUID, relationUUID corerelation.UUID) error
 }

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -1410,6 +1410,45 @@ func (c *MockModelStateGetUnitAddressesForRelationCall) DoAndReturn(f func(conte
 	return c
 }
 
+// GetUnitUUID mocks base method.
+func (m *MockModelState) GetUnitUUID(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitUUID", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitUUID indicates an expected call of GetUnitUUID.
+func (mr *MockModelStateMockRecorder) GetUnitUUID(arg0, arg1 any) *MockModelStateGetUnitUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitUUID", reflect.TypeOf((*MockModelState)(nil).GetUnitUUID), arg0, arg1)
+	return &MockModelStateGetUnitUUIDCall{Call: call}
+}
+
+// MockModelStateGetUnitUUIDCall wrap *gomock.Call
+type MockModelStateGetUnitUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetUnitUUIDCall) Return(arg0 string, arg1 error) *MockModelStateGetUnitUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetUnitUUIDCall) Do(f func(context.Context, string) (string, error)) *MockModelStateGetUnitUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetUnitUUIDCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockModelStateGetUnitUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // InitialWatchStatementForConsumerRelations mocks base method.
 func (m *MockModelState) InitialWatchStatementForConsumerRelations() (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
@@ -1873,6 +1912,44 @@ func (c *MockModelStateSaveMacaroonForRelationCall) DoAndReturn(f func(context.C
 	return c
 }
 
+// SaveRemoteSecretConsumer mocks base method.
+func (m *MockModelState) SaveRemoteSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 secrets.SecretConsumerMetadata, arg4, arg5 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveRemoteSecretConsumer", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveRemoteSecretConsumer indicates an expected call of SaveRemoteSecretConsumer.
+func (mr *MockModelStateMockRecorder) SaveRemoteSecretConsumer(arg0, arg1, arg2, arg3, arg4, arg5 any) *MockModelStateSaveRemoteSecretConsumerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveRemoteSecretConsumer", reflect.TypeOf((*MockModelState)(nil).SaveRemoteSecretConsumer), arg0, arg1, arg2, arg3, arg4, arg5)
+	return &MockModelStateSaveRemoteSecretConsumerCall{Call: call}
+}
+
+// MockModelStateSaveRemoteSecretConsumerCall wrap *gomock.Call
+type MockModelStateSaveRemoteSecretConsumerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateSaveRemoteSecretConsumerCall) Return(arg0 error) *MockModelStateSaveRemoteSecretConsumerCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateSaveRemoteSecretConsumerCall) Do(f func(context.Context, *secrets.URI, string, secrets.SecretConsumerMetadata, string, string) error) *MockModelStateSaveRemoteSecretConsumerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateSaveRemoteSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, string, secrets.SecretConsumerMetadata, string, string) error) *MockModelStateSaveRemoteSecretConsumerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SaveSecretRemoteConsumer mocks base method.
 func (m *MockModelState) SaveSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 secrets.SecretConsumerMetadata) error {
 	m.ctrl.T.Helper()
@@ -1912,17 +1989,17 @@ func (c *MockModelStateSaveSecretRemoteConsumerCall) DoAndReturn(f func(context.
 }
 
 // UpdateRemoteSecretRevision mocks base method.
-func (m *MockModelState) UpdateRemoteSecretRevision(arg0 context.Context, arg1 *secrets.URI, arg2 int) error {
+func (m *MockModelState) UpdateRemoteSecretRevision(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRemoteSecretRevision", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateRemoteSecretRevision", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateRemoteSecretRevision indicates an expected call of UpdateRemoteSecretRevision.
-func (mr *MockModelStateMockRecorder) UpdateRemoteSecretRevision(arg0, arg1, arg2 any) *MockModelStateUpdateRemoteSecretRevisionCall {
+func (mr *MockModelStateMockRecorder) UpdateRemoteSecretRevision(arg0, arg1, arg2, arg3 any) *MockModelStateUpdateRemoteSecretRevisionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteSecretRevision", reflect.TypeOf((*MockModelState)(nil).UpdateRemoteSecretRevision), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteSecretRevision", reflect.TypeOf((*MockModelState)(nil).UpdateRemoteSecretRevision), arg0, arg1, arg2, arg3)
 	return &MockModelStateUpdateRemoteSecretRevisionCall{Call: call}
 }
 
@@ -1938,13 +2015,13 @@ func (c *MockModelStateUpdateRemoteSecretRevisionCall) Return(arg0 error) *MockM
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateUpdateRemoteSecretRevisionCall) Do(f func(context.Context, *secrets.URI, int) error) *MockModelStateUpdateRemoteSecretRevisionCall {
+func (c *MockModelStateUpdateRemoteSecretRevisionCall) Do(f func(context.Context, *secrets.URI, int, string) error) *MockModelStateUpdateRemoteSecretRevisionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateUpdateRemoteSecretRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, int) error) *MockModelStateUpdateRemoteSecretRevisionCall {
+func (c *MockModelStateUpdateRemoteSecretRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, int, string) error) *MockModelStateUpdateRemoteSecretRevisionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -293,6 +293,11 @@ type applicationUUID struct {
 	UUID string `db:"uuid"`
 }
 
+type unit struct {
+	UUID string `db:"uuid"`
+	Name string `db:"name"`
+}
+
 type secretRevisions []revisionUUID
 type revisionUUID struct {
 	UUID string `db:"uuid"`
@@ -322,8 +327,17 @@ type secretRef struct {
 }
 
 type secretLatestRevision struct {
-	ID             string `db:"secret_id"`
-	LatestRevision int    `db:"latest_revision"`
+	ID              string `db:"secret_id"`
+	LatestRevision  int    `db:"latest_revision"`
+	ApplicationUUID string `db:"owner_application_uuid"`
+}
+
+type secretUnitConsumer struct {
+	UnitUUID        string `db:"unit_uuid"`
+	SecretID        string `db:"secret_id"`
+	SourceModelUUID string `db:"source_model_uuid"`
+	Label           string `db:"label"`
+	CurrentRevision int    `db:"current_revision"`
 }
 
 type secretRevisionObsolete struct {

--- a/domain/crossmodelrelation/watcher_test.go
+++ b/domain/crossmodelrelation/watcher_test.go
@@ -424,7 +424,7 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *tc.C) {
 	// A remote consumed secret change event of uri1 should be fired.
 	harness.AddTest(c, func(c *tc.C) {
 		s.addRevision(c, db, uri1, map[string]string{"foo": "bar2"})
-		err = st.UpdateRemoteSecretRevision(ctx, uri1, 2)
+		err = st.UpdateRemoteSecretRevision(ctx, uri1, 2, appUUID.String())
 		c.Assert(err, tc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.Check(

--- a/domain/removal/state/model/secret_test.go
+++ b/domain/removal/state/model/secret_test.go
@@ -25,8 +25,8 @@ func (s *secretSuite) TestDeleteUnitOwnedSecrets(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	ctx := c.Context()
-	sec := s.addSecretWithRevisionsAndContent(c)
-	_, unit := s.addAppAndUnit(c)
+	app, unit := s.addAppAndUnit(c)
+	sec := s.addSecretWithRevisionsAndContent(c, app)
 
 	_, err := s.DB().ExecContext(
 		ctx,
@@ -54,8 +54,8 @@ func (s *secretSuite) TestDeleteApplicationOwnedSecrets(c *tc.C) {
 
 	ctx := c.Context()
 
-	sec := s.addSecretWithRevisionsAndContent(c)
 	app, _ := s.addAppAndUnit(c)
+	sec := s.addSecretWithRevisionsAndContent(c, app)
 
 	_, err := s.DB().ExecContext(
 		ctx, "INSERT INTO secret_application_owner (secret_id, application_uuid) VALUES (?, ?)", sec, app)
@@ -80,8 +80,8 @@ func (s *secretSuite) TestGetApplicationOwnedSecretRevisionRefs(c *tc.C) {
 
 	ctx := c.Context()
 
-	sec := s.addSecretWithRevisionsAndContent(c)
 	app, _ := s.addAppAndUnit(c)
+	sec := s.addSecretWithRevisionsAndContent(c, app)
 
 	_, err := s.DB().ExecContext(
 		ctx, "INSERT INTO secret_application_owner (secret_id, application_uuid) VALUES (?, ?)", sec, app)
@@ -98,8 +98,8 @@ func (s *secretSuite) TestGetUnitOwnedSecretRevisionRefs(c *tc.C) {
 
 	ctx := c.Context()
 
-	sec := s.addSecretWithRevisionsAndContent(c)
-	_, unit := s.addAppAndUnit(c)
+	app, unit := s.addAppAndUnit(c)
+	sec := s.addSecretWithRevisionsAndContent(c, app)
 
 	_, err := s.DB().ExecContext(
 		ctx, "INSERT INTO secret_unit_owner (secret_id, unit_uuid) VALUES (?, ?)", sec, unit)
@@ -111,7 +111,7 @@ func (s *secretSuite) TestGetUnitOwnedSecretRevisionRefs(c *tc.C) {
 	c.Check(ids, tc.SameContents, []string{"0", "1", "2"})
 }
 
-func (s *secretSuite) addSecretWithRevisionsAndContent(c *tc.C) string {
+func (s *secretSuite) addSecretWithRevisionsAndContent(c *tc.C, appUUID string) string {
 	ctx := c.Context()
 
 	sec := "secret_id"
@@ -123,7 +123,7 @@ func (s *secretSuite) addSecretWithRevisionsAndContent(c *tc.C) string {
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.DB().ExecContext(
-		ctx, "INSERT INTO secret_reference (secret_id, latest_revision) VALUES (?, ?)", sec, 0)
+		ctx, "INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid) VALUES (?, ?, ?)", sec, 0, appUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.DB().ExecContext(

--- a/domain/schema/model/sql/0012-secret.sql
+++ b/domain/schema/model/sql/0012-secret.sql
@@ -30,9 +30,13 @@ CREATE TABLE secret (
 CREATE TABLE secret_reference (
     secret_id TEXT NOT NULL PRIMARY KEY,
     latest_revision INT NOT NULL,
+    owner_application_uuid TEXT NOT NULL,
     CONSTRAINT fk_secret_id
     FOREIGN KEY (secret_id)
-    REFERENCES secret (id)
+    REFERENCES secret (id),
+    CONSTRAINT fk_secret_reference_application_uuid
+    FOREIGN KEY (owner_application_uuid)
+    REFERENCES application (uuid)
 );
 
 CREATE TABLE secret_metadata (

--- a/domain/schema/model/triggers/secret-triggers.gen.go
+++ b/domain/schema/model/triggers/secret-triggers.gen.go
@@ -109,7 +109,8 @@ CREATE TRIGGER trg_log_secret_reference_update
 AFTER UPDATE ON secret_reference FOR EACH ROW
 WHEN 
 	NEW.secret_id != OLD.secret_id OR
-	NEW.latest_revision != OLD.latest_revision 
+	NEW.latest_revision != OLD.latest_revision OR
+	NEW.owner_application_uuid != OLD.owner_application_uuid 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));

--- a/domain/secret/service/exportimport.go
+++ b/domain/secret/service/exportimport.go
@@ -331,19 +331,19 @@ func (s *SecretService) importRemoteSecrets(ctx context.Context, remoteSecrets [
 	//		return errors.Errorf("saving remote secret reference for %q: %w", uri, err)
 	//	}
 	//}
-	for _, rs := range remoteSecrets {
-		unitName, err := unit.NewName(rs.Accessor.ID)
-		if err != nil {
-			return errors.Errorf("invalid remote secret consumer: %w", err)
-		}
-		if err := s.secretState.SaveSecretConsumer(ctx, rs.URI, unitName, coresecrets.SecretConsumerMetadata{
-			Label:           rs.Label,
-			CurrentRevision: rs.CurrentRevision,
-		}); err != nil {
-			return errors.Errorf("saving remote consumer %s-%s for secret %q: %w",
-				rs.Accessor.Kind, rs.Accessor.ID, rs.URI.ID, err)
-
-		}
-	}
+	//for _, rs := range remoteSecrets {
+	//	unitName, err := unit.NewName(rs.Accessor.ID)
+	//	if err != nil {
+	//		return errors.Errorf("invalid remote secret consumer: %w", err)
+	//	}
+	//	if err := s.secretState.SaveRemoteSecretConsumer(ctx, rs.URI, unitName, coresecrets.SecretConsumerMetadata{
+	//		Label:           rs.Label,
+	//		CurrentRevision: rs.CurrentRevision,
+	//	}); err != nil {
+	//		return errors.Errorf("saving remote consumer %s-%s for secret %q: %w",
+	//			rs.Accessor.Kind, rs.Accessor.ID, rs.URI.ID, err)
+	//
+	//	}
+	//}
 	return nil
 }

--- a/domain/secret/service/exportimport_test.go
+++ b/domain/secret/service/exportimport_test.go
@@ -192,10 +192,10 @@ func (s *serviceSuite) TestImportSecrets(c *tc.C) {
 
 	// TODO(secrets) - move to crossmodelrelation domain
 	// s.state.EXPECT().UpdateRemoteSecretRevision(gomock.Any(), uri2, 668)
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri2, unittesting.GenNewName(c, "mysql/0"), coresecrets.SecretConsumerMetadata{
-		Label:           "remote label",
-		CurrentRevision: 666,
-	})
+	//s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri2, unittesting.GenNewName(c, "mysql/0"), coresecrets.SecretConsumerMetadata{
+	//	Label:           "remote label",
+	//	CurrentRevision: 666,
+	//})
 
 	appUUID := tc.Must(c, coreapplication.NewUUID)
 	s.state.EXPECT().GetApplicationUUID(domaintesting.IsAtomicContextChecker, "mysql").Return(appUUID, nil).AnyTimes()

--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -397,7 +397,7 @@ func (w *localConsumerWorker) loop() (err error) {
 			w.logger.Debugf(ctx, "secrets changed: %v", changes)
 
 			for _, change := range changes {
-				err := w.crossModelService.UpdateRemoteSecretRevision(ctx, change.URI, change.Revision)
+				err := w.crossModelService.UpdateRemoteSecretRevision(ctx, change.URI, change.Revision, w.applicationUUID)
 				if err != nil {
 					return errors.Annotatef(err, "consuming secrets change %#v from remote model %v", changes, w.offererModelUUID)
 				}

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -33,7 +33,7 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	domainrelation "github.com/juju/juju/domain/relation"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
-	removal "github.com/juju/juju/domain/removal"
+	"github.com/juju/juju/domain/removal"
 	"github.com/juju/juju/internal/charm"
 	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
@@ -1390,8 +1390,8 @@ func (s *localConsumerWorkerSuite) TestHandleSecretRevisionChange(c *tc.C) {
 
 	secretUpdated := make(chan struct{})
 	uri := coresecrets.NewURI()
-	s.crossModelService.EXPECT().UpdateRemoteSecretRevision(gomock.Any(), uri, 666).
-		DoAndReturn(func(ctx context.Context, uri *coresecrets.URI, revision int) error {
+	s.crossModelService.EXPECT().UpdateRemoteSecretRevision(gomock.Any(), uri, 666, s.applicationUUID).
+		DoAndReturn(func(ctx context.Context, uri *coresecrets.URI, revision int, appUUID application.UUID) error {
 			defer close(secretUpdated)
 			return nil
 		})

--- a/internal/worker/remoterelationconsumer/service_mock_test.go
+++ b/internal/worker/remoterelationconsumer/service_mock_test.go
@@ -1011,17 +1011,17 @@ func (c *MockCrossModelServiceSetRemoteRelationSuspendedStateCall) DoAndReturn(f
 }
 
 // UpdateRemoteSecretRevision mocks base method.
-func (m *MockCrossModelService) UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int) error {
+func (m *MockCrossModelService) UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int, applicationUUID application.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRemoteSecretRevision", ctx, uri, latestRevision)
+	ret := m.ctrl.Call(m, "UpdateRemoteSecretRevision", ctx, uri, latestRevision, applicationUUID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateRemoteSecretRevision indicates an expected call of UpdateRemoteSecretRevision.
-func (mr *MockCrossModelServiceMockRecorder) UpdateRemoteSecretRevision(ctx, uri, latestRevision any) *MockCrossModelServiceUpdateRemoteSecretRevisionCall {
+func (mr *MockCrossModelServiceMockRecorder) UpdateRemoteSecretRevision(ctx, uri, latestRevision, applicationUUID any) *MockCrossModelServiceUpdateRemoteSecretRevisionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteSecretRevision", reflect.TypeOf((*MockCrossModelService)(nil).UpdateRemoteSecretRevision), ctx, uri, latestRevision)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteSecretRevision", reflect.TypeOf((*MockCrossModelService)(nil).UpdateRemoteSecretRevision), ctx, uri, latestRevision, applicationUUID)
 	return &MockCrossModelServiceUpdateRemoteSecretRevisionCall{Call: call}
 }
 
@@ -1037,13 +1037,13 @@ func (c *MockCrossModelServiceUpdateRemoteSecretRevisionCall) Return(arg0 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelServiceUpdateRemoteSecretRevisionCall) Do(f func(context.Context, *secrets.URI, int) error) *MockCrossModelServiceUpdateRemoteSecretRevisionCall {
+func (c *MockCrossModelServiceUpdateRemoteSecretRevisionCall) Do(f func(context.Context, *secrets.URI, int, application.UUID) error) *MockCrossModelServiceUpdateRemoteSecretRevisionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelServiceUpdateRemoteSecretRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, int) error) *MockCrossModelServiceUpdateRemoteSecretRevisionCall {
+func (c *MockCrossModelServiceUpdateRemoteSecretRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, int, application.UUID) error) *MockCrossModelServiceUpdateRemoteSecretRevisionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1660,17 +1660,17 @@ func (c *MockCrossModelRelationServiceSaveMacaroonForRelationCall) DoAndReturn(f
 }
 
 // UpdateRemoteSecretRevision mocks base method.
-func (m *MockCrossModelRelationService) UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int) error {
+func (m *MockCrossModelRelationService) UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int, applicationUUID application.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRemoteSecretRevision", ctx, uri, latestRevision)
+	ret := m.ctrl.Call(m, "UpdateRemoteSecretRevision", ctx, uri, latestRevision, applicationUUID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateRemoteSecretRevision indicates an expected call of UpdateRemoteSecretRevision.
-func (mr *MockCrossModelRelationServiceMockRecorder) UpdateRemoteSecretRevision(ctx, uri, latestRevision any) *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall {
+func (mr *MockCrossModelRelationServiceMockRecorder) UpdateRemoteSecretRevision(ctx, uri, latestRevision, applicationUUID any) *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteSecretRevision", reflect.TypeOf((*MockCrossModelRelationService)(nil).UpdateRemoteSecretRevision), ctx, uri, latestRevision)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteSecretRevision", reflect.TypeOf((*MockCrossModelRelationService)(nil).UpdateRemoteSecretRevision), ctx, uri, latestRevision, applicationUUID)
 	return &MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall{Call: call}
 }
 
@@ -1686,13 +1686,13 @@ func (c *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall) Return(arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall) Do(f func(context.Context, *secrets.URI, int) error) *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall {
+func (c *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall) Do(f func(context.Context, *secrets.URI, int, application.UUID) error) *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, int) error) *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall {
+func (c *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, int, application.UUID) error) *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/remoterelationconsumer/worker.go
+++ b/internal/worker/remoterelationconsumer/worker.go
@@ -160,7 +160,7 @@ type CrossModelRelationService interface {
 
 	// UpdateRemoteSecretRevision records the specified revision for the secret
 	// which has been consumed from a different model.
-	UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int) error
+	UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int, applicationUUID application.UUID) error
 
 	// SaveMacaroonForRelation saves the given macaroon for the specified remote
 	// application.


### PR DESCRIPTION
When consuming a secret from another model, we record the uuid of the offering app with the secret reference so it can be cleaned up when the synthetic app is removed.

The consuming model uses a `secret_reference` table to record the uri and revision of secrets originating from an app in the offering model. We add a new `owner_application_uuid` column to this table to record the synthetic app from the consuming model which owns the secret. This allows any secret references to be removed when the synthetic app is removed.

The secret domain was providing the `SaveSecretConsumer` api used to update the model for both local and remote secrets. This is now split and the "remote" implementation is moved to the crossmodelrelations domain.  The original implementation was done before the crossmodelrelations domain existed.

NB There's still a watcher which could be moved across in the future.

So now there's a `SaveRemoteSecretConsumer` method which takes the app uuid along with the consuming info. This method is called when a secret is first consumed.
Additionally, there's a `UpdateRemoteSecretRevision` which is called when a watcher for changes to the remote secret fires. This method now also takes the owning app UUID as a parameter.

When the removal of synthetic apps is implemented, it will now need to delete any relevant remote secret references.

## QA steps

create and consume a cross model secret
```
juju bootstrap
juju switch controller
juju deploy juju-qa-dummy-source        
juju offer dummy-source:sink    
juju add-model work                                     
juju deploy juju-qa-dummy-sink  
juju relate dummy-sink controller.dummy-source
juju switch controller                        
uri=$(juju exec -u dummy-source/0 -- secret-add foo=bar)
juju exec -u dummy-source/0 -- secret-grant -r 1 $uri
juju switch work                                     
juju exec -u dummy-sink/0 -- secret-get $uri         
```

Then look at the `secret_reference` table to ensure the app uuid has been recorded. `dummy-source` is the synthetic app in the consuming model representing the offer.
```
select * from application;
uuid                                    name            life_id charm_uuid                              charm_modified_version  charm_upgrade_on_error  space_uuid
e0711631-4085-440e-867a-8504f4f6d746    dummy-sink      0       71ec06da-a25b-4254-8fc4-9dddf8a146c7    0                       false                   656b4a82-e28c-53d6-a014-f0dd53417eb6
820b7691-1d82-4e35-89e5-261e2a2a28d2    dummy-source    0       5d8f327d-eacc-4afc-8886-38d58a8944eb    0                       false                   656b4a82-e28c-53d6-a014-f0dd53417eb6

select * from secret_reference;
secret_id               latest_revision owner_application_uuid
d455p4cfm2ls86q5a77g    1               820b7691-1d82-4e35-89e5-261e2a2a28d2
```