### PR TITLE
feat: add one to the tracker connection pools

### DIFF
--- a/internal/worker/dbaccessor/tracker.go
+++ b/internal/worker/dbaccessor/tracker.go
@@ -529,14 +529,14 @@ func jitter(interval time.Duration, factor float64) time.Duration {
 
 func applyDBLimits(db *sql.DB) {
 	// Set the maximum number of idle and open connections to be the same and
-	// set to 2 (default is 0 for MaxOpenConns). From testing, it's better to
+	// set to 3 (default is 0 for MaxOpenConns). From testing, it's better to
 	// have both set to the same value, and not setting these values can lead to
 	// a large number of open connections being created and not closed, which
 	// can lead to unbounded connections.
 	//
-	// If and when we change this number, be aware that a database will have 2
+	// If and when we change this number, be aware that a database will have 3
 	// connections per database, per dqlite App. So if we have 100 databases
-	// then that is 200 connections per dqlite App. Changing that number to
+	// then that is 300 connections per dqlite App. Changing that number to
 	// match runtime.GOMAXPROCS will then be len(database) * runtime.GOMAXPROCS
 	// per dqlite App. This can lead to a lot of open connections, so be
 	// careful.
@@ -545,6 +545,6 @@ func applyDBLimits(db *sql.DB) {
 	// dqlite App will be less because the number of databases per dqlite App
 	// will be less. Testing will need to be done to determine the best number
 	// for this.
-	db.SetMaxIdleConns(2)
-	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(3)
+	db.SetMaxOpenConns(3)
 }


### PR DESCRIPTION
The limiting of the connection pool for each database to 2 was used as a de-facto semaphore to prevent a stampeding herd as we approached the limit of Dqlite and began retrying all transactions.

Experiments show that 3 is significantly faster than 2, with no evident ill-effects.

We will pursue performance further, but at this time we take the easy win.

## QA steps

Bootstrap, deploy something.