### PR TITLE
fix(removal): offer removal

### DIFF
--- a/domain/removal/state/model/offer_test.go
+++ b/domain/removal/state/model/offer_test.go
@@ -67,8 +67,7 @@ func (s *offerSuite) TestDeleteOfferSuperfluousForce(c *tc.C) {
 }
 
 func (s *offerSuite) TestDeleteOfferFailsWithRelations(c *tc.C) {
-	offerUUID := s.createOffer(c, "foo")
-	s.createRemoteApplicationConsumer(c, "bar", offerUUID)
+	_, _, offerUUID := s.createRelationWithRemoteConsumer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -78,8 +77,7 @@ func (s *offerSuite) TestDeleteOfferFailsWithRelations(c *tc.C) {
 }
 
 func (s *offerSuite) TestDeleteOfferForceWithRelations(c *tc.C) {
-	offerUUID := s.createOffer(c, "foo")
-	s.createRemoteApplicationConsumer(c, "bar", offerUUID)
+	_, _, offerUUID := s.createRelationWithRemoteConsumer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 

--- a/domain/removal/state/model/relationwithremoteconsumer_test.go
+++ b/domain/removal/state/model/relationwithremoteconsumer_test.go
@@ -25,7 +25,7 @@ func TestRelationWithRemoteConsumerSuite(t *testing.T) {
 }
 
 func (s *relationWithRemoteConsumer) TestRelationWithRemoteConsumerExists(c *tc.C) {
-	relUUID, _ := s.createRelationWithRemoteConsumer(c)
+	relUUID, _, _ := s.createRelationWithRemoteConsumer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -54,7 +54,7 @@ func (s *relationWithRemoteConsumer) TestRelationWithRemoteConsumerExistsFalseFo
 }
 
 func (s *relationWithRemoteConsumer) TestEnsureRelationWithRemoteConsumerNotAliveCascadeNormalSuccess(c *tc.C) {
-	relUUID, synthAppUUID := s.createRelationWithRemoteConsumer(c)
+	relUUID, synthAppUUID, _ := s.createRelationWithRemoteConsumer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -111,7 +111,7 @@ func (s *relationWithRemoteConsumer) TestEnsureRelationWithRemoteConsumerNotAliv
 }
 
 func (s *relationWithRemoteConsumer) TestRelationWithRemoteConsumerScheduleRemovalNormalSuccess(c *tc.C) {
-	relUUID, _ := s.createRelationWithRemoteConsumer(c)
+	relUUID, _, _ := s.createRelationWithRemoteConsumer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -173,7 +173,7 @@ where  r.uuid = ?`, "removal-uuid",
 }
 
 func (s *relationWithRemoteConsumer) TestDeleteRelationWithRemoteConsumerUnitsUnitsStillInScope(c *tc.C) {
-	relUUID, _ := s.createRelationWithRemoteConsumer(c)
+	relUUID, _, _ := s.createRelationWithRemoteConsumer(c)
 
 	s.advanceRelationLife(c, relUUID, life.Dying)
 
@@ -185,7 +185,7 @@ func (s *relationWithRemoteConsumer) TestDeleteRelationWithRemoteConsumerUnitsUn
 
 func (s *relationWithRemoteConsumer) TestDeleteRelationWithRemoteConsumerUnits(c *tc.C) {
 	// Arrange
-	relUUID, synthAppUUID := s.createRelationWithRemoteConsumer(c)
+	relUUID, synthAppUUID, _ := s.createRelationWithRemoteConsumer(c)
 
 	s.advanceRelationLife(c, relUUID, life.Dying)
 

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -378,6 +378,9 @@ func (s *baseSuite) createOfferForApplication(c *tc.C, appName string, offerName
 	return offerUUID
 }
 
+// createRemoteApplicationOfferer creates a synthetic application intended to
+// correspond to an offering app in another model. Since SAAS are standalone
+// entities, we do not create a relation alongside it.
 func (s *baseSuite) createRemoteApplicationOfferer(
 	c *tc.C,
 	name string,
@@ -429,6 +432,9 @@ func (s *baseSuite) createRemoteApplicationOfferer(
 	return appUUID, remoteAppUUID
 }
 
+// createRemoteApplicationConsumer creates a synthetic application intended to
+// correspond to a consuming app in another model. Since these apps are NOT
+// standalone entities, we need to create a relation to an offer alongside.
 func (s *baseSuite) createRemoteApplicationConsumer(
 	c *tc.C,
 	name string,
@@ -546,7 +552,7 @@ func (s *baseSuite) createRelationWithRemoteOfferer(c *tc.C) (relation.UUID, cor
 	return relUUID, synthAppUUID
 }
 
-func (s *baseSuite) createRelationWithRemoteConsumer(c *tc.C) (relation.UUID, coreapplication.UUID) {
+func (s *baseSuite) createRelationWithRemoteConsumer(c *tc.C) (relation.UUID, coreapplication.UUID, offer.UUID) {
 	svc := s.setupApplicationService(c)
 	s.createIAASApplication(c, svc, "bar")
 	offerUUID := s.createOfferForApplication(c, "bar", "some-offer")
@@ -575,7 +581,7 @@ func (s *baseSuite) createRelationWithRemoteConsumer(c *tc.C) (relation.UUID, co
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
-	return relUUID, synthAppUUID
+	return relUUID, synthAppUUID, offerUUID
 }
 
 func (s *baseSuite) createRemoteRelationBetween(c *tc.C, synthAppName, appName string) relation.UUID {


### PR DESCRIPTION
Offer removal has broken when they had connections.

This was because we incorrectly remove the relation. Now that we have removal for RelationWithRemoteConsumer, we can just re-use that code to remove the relation

This simplifies and fixes offer removal

## QA steps

```
$ juju bootstrap lxd lxd 
$ juju add-model offerer 
$ juju deploy juju-qa-dummy-source 
$ juju offer dummy-source:sink 
$ juju add-model consumer 
$ juju deploy juju-qa-dummy-sink 
$ juju consume admin/offerer.dummy-source 
$ juju relate dummy-source dummy-sink 
$ juju config -m offerer dummy-source token=fuck

$ juju switch offerer
$ juju remove-offer dummy-source --force

$ juju status
Model    Controller  Cloud/Region   Version      Timestamp
offerer  lxd         lxd/localhost  4.0-beta8.1  12:04:57+01:00

App           Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
dummy-source           active      1  juju-qa-dummy-source  latest/stable    6  no       Token is fuck

Unit             Workload  Agent  Machine  Public address  Ports  Message
dummy-source/0*  active    idle   0        10.51.45.156           Token is fuck

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.156  juju-c014c1-0  ubuntu@20.04  jack  Running
```
& valid there are no removal errors in logs