### PR TITLE
fix: use correct discharge macaroon for cmr secrets

### DIFF
--- a/api/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -270,6 +270,7 @@ func (c *Client) GetRemoteSecretContentInfo(
 			}
 			args.Args[0].Macaroons = mac
 			args.Args[0].BakeryVersion = bakery.LatestVersion
+			c.cache.Upsert(appUUID.String(), mac)
 			return false
 		},
 		Delay:    retryDelay,

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/juju/names/v6"
 	"gopkg.in/macaroon.v2"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -263,7 +264,8 @@ func (s *CrossModelSecretsAPI) checkRelationMacaroons(
 
 	// A cross model secret can only be accessed if the corresponding cross model relation
 	// it is scoped to is accessible by the supplied macaroon.
-	_, err = s.auth.Authenticator().CheckOfferMacaroons(ctx, s.modelUUID.String(), offerUUID, mac, version)
+	relationTag := names.NewRelationTag(key.String())
+	err = s.auth.Authenticator().CheckRelationMacaroons(ctx, s.modelUUID.String(), offerUUID, relationTag, mac, version)
 	return err
 }
 


### PR DESCRIPTION
When accessing remote secret content, we were creating an offer macaroon not a relation one.
We also add the macaroon to the cache in the api caller.

## QA steps
```
juju bootstrap
juju switch controller  
juju deploy juju-qa-dummy-source                      
juju offer dummy-source:sink    
juju add-model work                                     
juju deploy juju-qa-dummy-sink  
juju relate dummy-sink controller.dummy-source        
juju switch controller                        
uri=$(juju exec -u dummy-source/0 -- secret-add foo=bar)
juju exec -u dummy-source/0 -- secret-grant -r 1 $uri
juju switch work                                     
... wait 3 minutes ...
juju exec -u dummy-sink/0 -- secret-get $uri
```