### PR TITLE
feat(removal): secret references for SAAS

### DIFF
--- a/domain/removal/state/model/relation.go
+++ b/domain/removal/state/model/relation.go
@@ -294,6 +294,14 @@ WHERE  relation_endpoint_uuid IN (
 		return errors.Errorf("preparing relation status deletion: %w", err)
 	}
 
+	secretPermissionStmt, err := st.Prepare(`
+DELETE FROM secret_permission
+WHERE  scope_type_id = 3
+AND    scope_uuid = $entityUUID.uuid`, relationUUID)
+	if err != nil {
+		return errors.Errorf("preparing relation secret permission deletion: %w", err)
+	}
+
 	relStmt, err := st.Prepare("DELETE FROM relation WHERE uuid = $entityUUID.uuid ", relationUUID)
 	if err != nil {
 		return errors.Errorf("preparing relation deletion: %w", err)
@@ -325,6 +333,11 @@ WHERE  relation_endpoint_uuid IN (
 	err = tx.Query(ctx, statusStmt, relationUUID).Run()
 	if err != nil {
 		return errors.Errorf("running relation status deletion: %w", err)
+	}
+
+	err = tx.Query(ctx, secretPermissionStmt, relationUUID).Run()
+	if err != nil {
+		return errors.Errorf("running relation secret permission deletion: %w", err)
 	}
 
 	err = tx.Query(ctx, relStmt, relationUUID).Run()

--- a/domain/removal/state/model/remoteapplicationofferer.go
+++ b/domain/removal/state/model/remoteapplicationofferer.go
@@ -52,7 +52,7 @@ WHERE  aro.application_uuid = $entityUUID.uuid
 	return remoteAppOffererUUID.UUID, nil
 }
 
-// GetRemoteApplicationOfferer returns true if a remote application exists
+// RemoteApplicationOffererExists returns true if a remote application exists
 // with the input UUID.
 func (st *State) RemoteApplicationOffererExists(ctx context.Context, rUUID string) (bool, error) {
 	db, err := st.DB(ctx)
@@ -321,6 +321,10 @@ WHERE  uuid = $entityUUID.uuid`, entityUUID{})
 	synthCharmUUID, err := st.getCharmUUIDForApplication(ctx, tx, synthApp.UUID)
 	if err != nil {
 		return errors.Errorf("getting charm UUID for application: %w", err)
+	}
+
+	if err := st.deleteOwnedSecretReferences(ctx, tx, synthApp); err != nil {
+		return errors.Errorf("deleting owned secret references for synthetic application: %w", err)
 	}
 
 	if err := st.deleteSynthUnitsForApplication(ctx, tx, synthApp); err != nil {

--- a/domain/removal/state/model/secret.go
+++ b/domain/removal/state/model/secret.go
@@ -316,3 +316,61 @@ func (st *State) prepareSecretDeletions() ([]*sqlair.Statement, []*sqlair.Statem
 
 	return rdStmts, sdStmts, nil
 }
+
+func (st *State) deleteOwnedSecretReferences(ctx context.Context, tx *sqlair.TX, appUUID entityUUID) error {
+	getConsumedSecretsStmt, err := st.Prepare(`
+SELECT &secretID.*
+FROM   secret_reference
+WHERE  owner_application_uuid = $entityUUID.uuid
+`, secretID{}, appUUID)
+	if err != nil {
+		return errors.Errorf("preparing consumed secrets query: %w", err)
+	}
+
+	deleteSecretUnitConsumerStmt, err := st.Prepare(`
+DELETE FROM secret_unit_consumer
+WHERE  secret_id IN ($secretIDs[:])
+`, secretIDs{})
+	if err != nil {
+		return errors.Errorf("preparing delete secret unit consumers query: %w", err)
+	}
+
+	deleteSecretReferencesStmt, err := st.Prepare(`
+DELETE FROM secret_reference
+WHERE  secret_id IN ($secretIDs[:])
+`, secretIDs{})
+	if err != nil {
+		return errors.Errorf("preparing delete secret references query: %w", err)
+	}
+
+	deleteSecretStmt, err := st.Prepare(`
+DELETE FROM secret
+WHERE  id IN ($secretIDs[:])
+`, secretIDs{})
+	if err != nil {
+		return errors.Errorf("preparing delete secrets query: %w", err)
+	}
+
+	var ids []secretID
+	if err := tx.Query(ctx, getConsumedSecretsStmt, appUUID).GetAll(&ids); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Errorf("getting consumed secrets: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	secretIDs := secretIDs(transform.Slice(ids, func(sid secretID) string { return sid.ID }))
+
+	if err := tx.Query(ctx, deleteSecretUnitConsumerStmt, secretIDs).Run(); err != nil {
+		return errors.Errorf("deleting consumed secret unit consumers: %w", err)
+	}
+
+	if err := tx.Query(ctx, deleteSecretReferencesStmt, secretIDs).Run(); err != nil {
+		return errors.Errorf("deleting consumed secret references: %w", err)
+	}
+
+	if err := tx.Query(ctx, deleteSecretStmt, secretIDs).Run(); err != nil {
+		return errors.Errorf("deleting consumed secrets: %w", err)
+	}
+
+	return nil
+}

--- a/domain/removal/state/model/types.go
+++ b/domain/removal/state/model/types.go
@@ -118,6 +118,12 @@ type storageAttachmentDetachInfo struct {
 	UnitUUID         string `db:"unit_uuid"`
 }
 
+type secretID struct {
+	ID string `db:"secret_id"`
+}
+
+type secretIDs []string
+
 type secretRevision struct {
 	// UUID uniquely identifies a secret revision.
 	UUID string `db:"uuid"`


### PR DESCRIPTION
Remote applications / SAAS can have 'secret references' which need to be cleaned up.

Fix the removal domain to handle these.

## QA steps

```
$ juju bootstrap lxd lxd 
$ juju add-model offerer 
$ juju deploy juju-qa-dummy-source 
$ juju offer dummy-source:sink 
$ juju add-model consumer 
$ juju deploy juju-qa-dummy-sink 
$ juju consume admin/offerer.dummy-source 
$ juju relate dummy-source dummy-sink 
$ juju switch offerer 
$ uri=$(juju exec -u dummy-source/0 -- secret-add foo=bar) 
$ juju exec -u dummy-source/0 -- secret-grant -r 0 $uri 
$ juju switch consumer 
$ juju exec -u dummy-sink/0 -- secret-get $uri

$ juju remove-saas dummy-source
$ juju status
Model     Controller  Cloud/Region   Version      Timestamp
consumer  lxd         lxd/localhost  4.0-beta8.1  15:50:48+01:00

App         Version  Status  Scale  Charm               Channel        Rev  Exposed  Message
dummy-sink           active      1  juju-qa-dummy-sink  latest/stable    7  no       Token is fudge

Unit           Workload  Agent  Machine  Public address  Ports  Message
dummy-sink/0*  active    idle   0        10.51.45.176           Token is fuck

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.176  juju-b58f5f-0  ubuntu@20.04  jack  Running
```