### PR TITLE
fix: retrieve the synthetic application by offer AND relation UUID

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -134,7 +134,7 @@ func (api *CrossModelRelationsAPIv3) publishOneRelationChange(ctx context.Contex
 		return errors.Annotatef(err, "checking macaroons for relation %q", relationUUID)
 	}
 
-	applicationUUID, err := api.getApplicationUUIDFromToken(ctx, change.ApplicationOrOfferToken)
+	applicationUUID, err := api.getApplicationUUIDFromToken(ctx, change.ApplicationOrOfferToken, relationUUID)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return errors.NotFoundf("application for offer %q", change.ApplicationOrOfferToken)
 	} else if err != nil {
@@ -176,13 +176,14 @@ func (api *CrossModelRelationsAPIv3) publishOneRelationChange(ctx context.Contex
 func (api *CrossModelRelationsAPIv3) getApplicationUUIDFromToken(
 	ctx context.Context,
 	token string,
+	relationUUID corerelation.UUID,
 ) (coreapplication.UUID, error) {
 	offerUUID, err := offer.ParseUUID(token)
 	if err != nil {
 		return "", errors.NotValidf("token %q is not a valid application or offer UUID", token)
 	}
 
-	appUUID, err := api.crossModelRelationService.GetSyntheticApplicationUUIDByOfferUUID(ctx, offerUUID)
+	appUUID, err := api.crossModelRelationService.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(ctx, offerUUID, relationUUID)
 	if err != nil {
 		return "", errors.Annotatef(err, "getting application UUID from offer %q", offerUUID)
 	}

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -130,7 +130,7 @@ func (s *facadeSuite) TestPublishRelationChanges(c *tc.C) {
 		Return(nil)
 
 	s.crossModelRelationService.EXPECT().
-		GetSyntheticApplicationUUIDByOfferUUID(gomock.Any(), offerUUID).
+		GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(gomock.Any(), offerUUID, relationUUID).
 		Return(applicationUUID, nil)
 	s.applicationService.EXPECT().
 		GetApplicationDetails(gomock.Any(), applicationUUID).
@@ -207,7 +207,7 @@ func (s *facadeSuite) TestPublishRelationChangesMissingLife(c *tc.C) {
 		Return(nil)
 
 	s.crossModelRelationService.EXPECT().
-		GetSyntheticApplicationUUIDByOfferUUID(gomock.Any(), offerUUID).
+		GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(gomock.Any(), offerUUID, relationUUID).
 		Return(applicationUUID, nil)
 	s.applicationService.EXPECT().
 		GetApplicationDetails(gomock.Any(), applicationUUID).
@@ -352,7 +352,7 @@ func (s *facadeSuite) TestPublishRelationChangesLifeDead(c *tc.C) {
 		Return(nil)
 
 	s.crossModelRelationService.EXPECT().
-		GetSyntheticApplicationUUIDByOfferUUID(gomock.Any(), offerUUID).
+		GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(gomock.Any(), offerUUID, relationUUID).
 		Return(applicationUUID, nil)
 	s.applicationService.EXPECT().
 		GetApplicationDetails(gomock.Any(), applicationUUID).
@@ -432,7 +432,7 @@ func (s *facadeSuite) TestPublishRelationChangesSuspended(c *tc.C) {
 		Return(nil)
 
 	s.crossModelRelationService.EXPECT().
-		GetSyntheticApplicationUUIDByOfferUUID(gomock.Any(), offerUUID).
+		GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(gomock.Any(), offerUUID, relationUUID).
 		Return(applicationUUID, nil)
 	s.applicationService.EXPECT().
 		GetApplicationDetails(gomock.Any(), applicationUUID).

--- a/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/package_mock_test.go
@@ -284,41 +284,41 @@ func (c *MockCrossModelRelationServiceGetOfferingApplicationTokenCall) DoAndRetu
 	return c
 }
 
-// GetSyntheticApplicationUUIDByOfferUUID mocks base method.
-func (m *MockCrossModelRelationService) GetSyntheticApplicationUUIDByOfferUUID(arg0 context.Context, arg1 offer.UUID) (application.UUID, error) {
+// GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID mocks base method.
+func (m *MockCrossModelRelationService) GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(arg0 context.Context, arg1 offer.UUID, arg2 relation.UUID) (application.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSyntheticApplicationUUIDByOfferUUID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID", arg0, arg1, arg2)
 	ret0, _ := ret[0].(application.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSyntheticApplicationUUIDByOfferUUID indicates an expected call of GetSyntheticApplicationUUIDByOfferUUID.
-func (mr *MockCrossModelRelationServiceMockRecorder) GetSyntheticApplicationUUIDByOfferUUID(arg0, arg1 any) *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall {
+// GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID indicates an expected call of GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID.
+func (mr *MockCrossModelRelationServiceMockRecorder) GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(arg0, arg1, arg2 any) *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyntheticApplicationUUIDByOfferUUID", reflect.TypeOf((*MockCrossModelRelationService)(nil).GetSyntheticApplicationUUIDByOfferUUID), arg0, arg1)
-	return &MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID", reflect.TypeOf((*MockCrossModelRelationService)(nil).GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID), arg0, arg1, arg2)
+	return &MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall{Call: call}
 }
 
-// MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall wrap *gomock.Call
-type MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall struct {
+// MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall wrap *gomock.Call
+type MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall) Return(arg0 application.UUID, arg1 error) *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall {
+func (c *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall) Return(arg0 application.UUID, arg1 error) *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall) Do(f func(context.Context, offer.UUID) (application.UUID, error)) *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall {
+func (c *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall) Do(f func(context.Context, offer.UUID, relation.UUID) (application.UUID, error)) *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall) DoAndReturn(f func(context.Context, offer.UUID) (application.UUID, error)) *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDCall {
+func (c *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall) DoAndReturn(f func(context.Context, offer.UUID, relation.UUID) (application.UUID, error)) *MockCrossModelRelationServiceGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelrelations/service.go
+++ b/apiserver/facades/controller/crossmodelrelations/service.go
@@ -39,9 +39,9 @@ type CrossModelRelationService interface {
 	// UUID for the given offer UUID.
 	GetApplicationNameAndUUIDByOfferUUID(ctx context.Context, offerUUID offer.UUID) (string, coreapplication.UUID, error)
 
-	// GetSyntheticApplicationUUIDByOfferUUID returns the synthetic application
-	// UUID for the given offer UUID.
-	GetSyntheticApplicationUUIDByOfferUUID(ctx context.Context, offerUUID offer.UUID) (coreapplication.UUID, error)
+	// GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID returns the synthetic application
+	// UUID for the given offer UUID and remote relation UUID.
+	GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(ctx context.Context, offerUUID offer.UUID, remoteRelationUUID corerelation.UUID) (coreapplication.UUID, error)
 
 	// GetOfferingApplicationToken returns the offering application token (uuid)
 	// for the given relation UUID.

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -1332,41 +1332,41 @@ func (c *MockModelStateGetSecretValueCall) DoAndReturn(f func(context.Context, *
 	return c
 }
 
-// GetSyntheticApplicationUUIDByOfferUUID mocks base method.
-func (m *MockModelState) GetSyntheticApplicationUUIDByOfferUUID(arg0 context.Context, arg1 string) (string, error) {
+// GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID mocks base method.
+func (m *MockModelState) GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(arg0 context.Context, arg1, arg2 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSyntheticApplicationUUIDByOfferUUID", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSyntheticApplicationUUIDByOfferUUID indicates an expected call of GetSyntheticApplicationUUIDByOfferUUID.
-func (mr *MockModelStateMockRecorder) GetSyntheticApplicationUUIDByOfferUUID(arg0, arg1 any) *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall {
+// GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID indicates an expected call of GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID.
+func (mr *MockModelStateMockRecorder) GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(arg0, arg1, arg2 any) *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyntheticApplicationUUIDByOfferUUID", reflect.TypeOf((*MockModelState)(nil).GetSyntheticApplicationUUIDByOfferUUID), arg0, arg1)
-	return &MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID", reflect.TypeOf((*MockModelState)(nil).GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID), arg0, arg1, arg2)
+	return &MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall{Call: call}
 }
 
-// MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall wrap *gomock.Call
-type MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall struct {
+// MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall wrap *gomock.Call
+type MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall) Return(arg0 string, arg1 error) *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall {
+func (c *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall) Return(arg0 string, arg1 error) *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall) Do(f func(context.Context, string) (string, error)) *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall {
+func (c *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall) Do(f func(context.Context, string, string) (string, error)) *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDCall {
+func (c *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall) DoAndReturn(f func(context.Context, string, string) (string, error)) *MockModelStateGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/crossmodelrelation/service/remoteapplication_test.go
+++ b/domain/crossmodelrelation/service/remoteapplication_test.go
@@ -645,55 +645,70 @@ func (s *remoteApplicationServiceSuite) TestGetApplicationNameAndUUIDByOfferUUID
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
-func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUID(c *tc.C) {
+func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	offerUUID := tc.Must(c, offer.NewUUID)
+	remoteRelationUUID := tc.Must(c, corerelation.NewUUID)
 	appUUID := tc.Must(c, coreapplication.NewUUID)
 
-	s.modelState.EXPECT().GetSyntheticApplicationUUIDByOfferUUID(gomock.Any(), offerUUID.String()).Return(appUUID.String(), nil)
+	s.modelState.EXPECT().GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(gomock.Any(), offerUUID.String(), remoteRelationUUID.String()).Return(appUUID.String(), nil)
 
 	service := s.service(c)
 
-	gotUUID, err := service.GetSyntheticApplicationUUIDByOfferUUID(c.Context(), offerUUID)
+	gotUUID, err := service.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c.Context(), offerUUID, remoteRelationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(gotUUID, tc.Equals, appUUID)
 }
 
-func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUIDNotFound(c *tc.C) {
+func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	offerUUID := tc.Must(c, offer.NewUUID)
+	remoteRelationUUID := tc.Must(c, corerelation.NewUUID)
 
-	s.modelState.EXPECT().GetSyntheticApplicationUUIDByOfferUUID(gomock.Any(), offerUUID.String()).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(gomock.Any(), offerUUID.String(), remoteRelationUUID.String()).Return("", crossmodelrelationerrors.OfferNotFound)
 
 	service := s.service(c)
 
-	_, err := service.GetSyntheticApplicationUUIDByOfferUUID(c.Context(), offerUUID)
+	_, err := service.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c.Context(), offerUUID, remoteRelationUUID)
 	c.Assert(err, tc.ErrorMatches, "offer not found")
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferNotFound)
 }
 
-func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUIDInvalidUUID(c *tc.C) {
+func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDInvalidOfferUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	service := s.service(c)
 
-	_, err := service.GetSyntheticApplicationUUIDByOfferUUID(c.Context(), "invalid-uuid")
+	remoteRelationUUID := tc.Must(c, corerelation.NewUUID)
+	_, err := service.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c.Context(), "invalid-uuid", remoteRelationUUID)
 	c.Assert(err, tc.ErrorMatches, `.*uuid "invalid-uuid" not valid`)
 	c.Assert(err, tc.ErrorIs, errors.NotValid)
 }
 
-func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUIDStateError(c *tc.C) {
+func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDInvalidRelationUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-
-	offerUUID := tc.Must(c, offer.NewUUID)
-
-	s.modelState.EXPECT().GetSyntheticApplicationUUIDByOfferUUID(gomock.Any(), offerUUID.String()).Return("", internalerrors.Errorf("boom"))
 
 	service := s.service(c)
 
-	_, err := service.GetSyntheticApplicationUUIDByOfferUUID(c.Context(), offerUUID)
+	offerUUID := tc.Must(c, offer.NewUUID)
+	_, err := service.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c.Context(), offerUUID, "invalid-uuid")
+	c.Assert(err, tc.ErrorMatches, `.*relation uuid "invalid-uuid".*not valid`)
+	c.Assert(err, tc.ErrorIs, errors.NotValid)
+}
+
+func (s *remoteApplicationServiceSuite) TestGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDStateError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	offerUUID := tc.Must(c, offer.NewUUID)
+	remoteRelationUUID := tc.Must(c, corerelation.NewUUID)
+
+	s.modelState.EXPECT().GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(gomock.Any(), offerUUID.String(), remoteRelationUUID.String()).Return("", internalerrors.Errorf("boom"))
+
+	service := s.service(c)
+
+	_, err := service.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c.Context(), offerUUID, remoteRelationUUID)
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 

--- a/domain/crossmodelrelation/state/model/remoteapplication_test.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication_test.go
@@ -889,21 +889,22 @@ func (s *modelRemoteApplicationSuite) TestGetApplicationUUIDByOfferUUIDNotExists
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
-func (s *modelRemoteApplicationSuite) TestGetSyntheticApplicationUUIDByOfferUUIDNoOfferConnection(c *tc.C) {
+func (s *modelRemoteApplicationSuite) TestGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDNoOfferConnection(c *tc.C) {
 	// Create application, charm and offer first
 	applicationUUID := tc.Must(c, coreapplication.NewUUID)
 	charmUUID := tc.Must(c, internaluuid.NewUUID).String()
 	offerUUID := tc.Must(c, internaluuid.NewUUID).String()
+	remRelationUUID := tc.Must(c, internaluuid.NewUUID).String()
 	s.createOffer(c, offerUUID)
 	s.createCharm(c, charmUUID)
 	s.createApplication(c, applicationUUID, charmUUID, offerUUID)
 
 	// Retrieve application UUID by offer UUID - should return the correct UUID
-	_, err := s.state.GetSyntheticApplicationUUIDByOfferUUID(c.Context(), offerUUID)
+	_, err := s.state.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c.Context(), offerUUID, remRelationUUID)
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
-func (s *modelRemoteApplicationSuite) TestGetSyntheticApplicationUUIDByOfferUUIDWithOfferConnection(c *tc.C) {
+func (s *modelRemoteApplicationSuite) TestGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDWithOfferConnection(c *tc.C) {
 	// Create application, charm and offer first
 	synthApplicationUUID := tc.Must(c, coreapplication.NewUUID)
 	realApplicationUUID := tc.Must(c, coreapplication.NewUUID)
@@ -924,17 +925,18 @@ VALUES (?, ?, ?, 'bob')`, synthApplicationUUID, offerUUID, relUUID)
 INSERT INTO application_remote_consumer (offer_connection_uuid, offerer_application_uuid, consumer_application_uuid, consumer_model_uuid, life_id)
 VALUES (?, ?, ?, ?, 0)`, synthApplicationUUID, realApplicationUUID, tc.Must(c, coreapplication.NewUUID), tc.Must(c, coreapplication.NewUUID))
 
-	// Retrieve application UUID by offer UUID - should return the correct UUID
-	uuid, err := s.state.GetSyntheticApplicationUUIDByOfferUUID(c.Context(), offerUUID)
+	// Retrieve application UUID by offer UUID and remote relation UUID - should return the correct UUID
+	uuid, err := s.state.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c.Context(), offerUUID, relUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(uuid, tc.Equals, synthApplicationUUID.String())
 }
 
-func (s *modelRemoteApplicationSuite) TestGetSyntheticApplicationUUIDByOfferUUIDNotFound(c *tc.C) {
+func (s *modelRemoteApplicationSuite) TestGetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUIDNotFound(c *tc.C) {
 	// Test with non-existing offer UUID - should return application not found
 	// (no linked application)
-	nonExistentUUID := tc.Must(c, internaluuid.NewUUID).String()
-	_, err := s.state.GetSyntheticApplicationUUIDByOfferUUID(c.Context(), nonExistentUUID)
+	nonExistentOfferUUID := tc.Must(c, internaluuid.NewUUID).String()
+	nonExistentRelationUUID := tc.Must(c, internaluuid.NewUUID).String()
+	_, err := s.state.GetSyntheticApplicationUUIDByOfferUUIDAndRemoteRelationUUID(c.Context(), nonExistentOfferUUID, nonExistentRelationUUID)
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 


### PR DESCRIPTION
When having more than one model related to the same offer, we need to be able to retrieve the synthetic application not just from the offer UUID, but from the relation UUID as well, since we should have 2 of them.

This patch fixes this behavior.


## QA steps

We need 3 models: the offering one and two consumer ones.
Then we relate to the same offer on both of them:
```
$ juju add-model offer
$ juju deploy juju-qa-dummy-source --base ubuntu@22.04
$ juju offer dummy-source:sink dummy-offer
$ juju add-model consume1
$ juju deploy juju-qa-dummy-sink
$ juju consume c:admin/offer.dummy-offer
$ juju add-model consume2
$ juju deploy juju-qa-dummy-sink
$ juju consume c:admin/offer.dummy-offer
```
now switch to offering and set the token:
```
$ juju config dummy-source token=yeah-boi
```
and relate on both models:
```
$ juju switch consume1
$ juju relate dummy-sink dummy-offer
$ juju switch consume2
$ juju relate dummy-sink dummy-offer
```
No errors related to the CMR workers should be present in the logs, and both relations should join. Lastly, check the db to make sure that the offering model has both of the synthetic units (starting with `remote-*`).