### PR TITLE
test(firewall/expose_app): assert exposed-endpoints via show-application

### DIFF
--- a/tests/suites/firewall/expose_app.sh
+++ b/tests/suites/firewall/expose_app.sh
@@ -67,14 +67,24 @@ assert_ingress_cidrs_for_exposed_app() {
 
 assert_export_bundle_output_includes_exposed_endpoints() {
 
-	echo "==> Checking that export-bundle output contains the exposed endpoint settings"
+	echo "==> Checking that show-application output contains the exposed endpoint settings"
 
-	# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
-	got=$(juju export-bundle 2>&1 1>/dev/null)
-	if [[ $got != *"not implemented"* ]]; then
-		echo "ERROR: export-bundle should return 'not implemented'."
-		exit 1
-	fi
+	exp=$(
+		cat <<'EOF'
+ "":
+   expose-to-cidrs:
+   - 10.0.0.0/24
+   - 192.168.0.0/24
+ ubuntu:
+   expose-to-cidrs:
+   - 10.42.0.0/16
+   - 2002:0:0:1234::/64
+EOF
+	)
+
+	got=$(juju show-application ubuntu-lite | yq -r '.["ubuntu-lite"]["exposed-endpoints"]')
+
+	check_contains "$got" "$exp"
 }
 
 test_expose_app_ec2() {


### PR DESCRIPTION
This PR replaces the temporary “export-bundle not implemented” check with a real assertion that validates the exposed endpoints serialized by Juju.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
cd test
./main.sh -v -l aws firewall test_expose_app_ec2
```

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
