### PR TITLE
fix: sqlair error no rows error in block devices

### DIFF
--- a/domain/blockdevice/state/state.go
+++ b/domain/blockdevice/state/state.go
@@ -208,7 +208,7 @@ WHERE  machine_uuid = $entityUUID.uuid
 		retVal[uuid] = r
 	}
 
-	return retVal, errors.Capture(err)
+	return retVal, nil
 }
 
 func (st *State) checkMachineNotDead(


### PR DESCRIPTION
We had an sqlair error no rows coming up when setting block devices. This was because we ignore the err no rows but still use it at the end of the func.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Deploy postgres to openstack.

## Documentation changes

N/A
