### PR TITLE
feat: restart worker delay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -309,3 +309,5 @@ replace go.uber.org/mock => go.uber.org/mock v0.4.0
 replace gopkg.in/check.v1 => github.com/hpidcock/gc-compat-tc v0.0.0-20250523041742-c3a83c867edf
 
 replace github.com/juju/testing => ./internal/testhelpers/compat
+
+replace github.com/juju/worker/v4 => github.com/SimonRichardson/worker/v4 v4.0.0-20251105211049-32f832070207

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/Microsoft/hcsshim v0.9.4 h1:mnUj0ivWy6UzbB1uLFqKR6F+ZyiDc7j4iGgHTpO+5
 github.com/Microsoft/hcsshim v0.9.4/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Rican7/retry v0.3.1 h1:scY4IbO8swckzoA/11HgBwaZRJEyY9vaNJshcdhp1Mc=
 github.com/Rican7/retry v0.3.1/go.mod h1:CxSDrhAyXmTMeEuRAnArMu1FHu48vtfjLREWqVl7Vw0=
+github.com/SimonRichardson/worker/v4 v4.0.0-20251105211049-32f832070207 h1:Tk1OGJVGLrNgt44ntUSjhV7k7lDw/G7lb1hM8ZZXsY4=
+github.com/SimonRichardson/worker/v4 v4.0.0-20251105211049-32f832070207/go.mod h1:yIOAF2j1onxDPxotE0x5O9AktexnjXRM23OJ5ahrxWY=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -482,8 +484,6 @@ github.com/juju/version/v2 v2.0.0/go.mod h1:ZeFjNy+UFEWJDDPdzW7Cm9NeU6dsViGaFYhX
 github.com/juju/webbrowser v0.0.0-20160309143629-54b8c57083b4/go.mod h1:G6PCelgkM6cuvyD10iYJsjLBsSadVXtJ+nBxFAxE2BU=
 github.com/juju/webbrowser v1.0.0 h1:JLdmbFtCGY6Qf2jmS6bVaenJFGIFkdF1/BjUm76af78=
 github.com/juju/webbrowser v1.0.0/go.mod h1:RwVlbBcF91Q4vS+iwlkJ6bZTE3EwlrjbYlM3WMVD6Bc=
-github.com/juju/worker/v4 v4.2.0 h1:x9KT0PrbZyip2hN3do0hGdkzTO8mw/6nECG/PuczsKs=
-github.com/juju/worker/v4 v4.2.0/go.mod h1:yIOAF2j1onxDPxotE0x5O9AktexnjXRM23OJ5ahrxWY=
 github.com/juju/yaml/v2 v2.0.0 h1:94MzcdkHMB4w2AaC6VJ2NQ6YzMhoEFh2OIhMSvyevnc=
 github.com/juju/yaml/v2 v2.0.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/internal/worker/apiremotecaller/worker.go
+++ b/internal/worker/apiremotecaller/worker.go
@@ -106,8 +106,10 @@ func newWorker(cfg WorkerConfig, internalState chan string) (*remoteWorker, erro
 		},
 		// Backoff for 5 seconds before restarting a worker.
 		// This is a lifetime for the life of an API connection.
-		RestartDelay: time.Second * 5,
-		Logger:       internalworker.WrapLogger(cfg.Logger),
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return time.Second * 5
+		},
+		Logger: internalworker.WrapLogger(cfg.Logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/apiremoterelationcaller/worker.go
+++ b/internal/worker/apiremoterelationcaller/worker.go
@@ -89,7 +89,9 @@ func NewWorker(config Config) (worker.Worker, error) {
 		ShouldRestart: internalworker.ShouldRunnerRestart,
 		Clock:         config.Clock,
 		Logger:        internalworker.WrapLogger(config.Logger),
-		RestartDelay:  config.RestartDelay,
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return config.RestartDelay
+		},
 	})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -13,7 +13,6 @@ package caasapplicationprovisioner
 
 import (
 	"context"
-	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -195,7 +194,7 @@ func NewProvisionerWorker(config Config) (worker.Worker, error) {
 		Name:         "provisioner",
 		Clock:        config.Clock,
 		IsFatal:      func(error) bool { return false },
-		RestartDelay: 3 * time.Second,
+		RestartDelay: internalworker.RestartDelay,
 		Logger:       internalworker.WrapLogger(config.Logger.Child("runner")),
 	})
 	if err != nil {

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -244,8 +244,10 @@ func NewWorker(cfg WorkerConfig) (*dbWorker, error) {
 		ShouldRestart: func(err error) bool {
 			return !internalerrors.IsOneOf(err, database.ErrDBDead, database.ErrDBNotFound)
 		},
-		RestartDelay: time.Second * 10,
-		Logger:       internalworker.WrapLogger(cfg.Logger),
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return time.Second * 10
+		},
+		Logger: internalworker.WrapLogger(cfg.Logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/dbreplaccessor/worker.go
+++ b/internal/worker/dbreplaccessor/worker.go
@@ -9,7 +9,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"math/rand/v2"
-	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -149,7 +148,7 @@ func NewWorker(cfg WorkerConfig) (*dbReplWorker, error) {
 			return !errors.Is(err, database.ErrDBDead) &&
 				!errors.Is(err, database.ErrDBNotFound)
 		},
-		RestartDelay: time.Second * 1,
+		RestartDelay: internalworker.RestartDelay,
 		Logger:       internalworker.WrapLogger(cfg.Logger),
 	})
 	if err != nil {

--- a/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
@@ -73,9 +73,11 @@ func New(
 		IsFatal: func(error) bool { return false },
 
 		// If the API connection fails, try again in 1 minute.
-		RestartDelay: time.Minute,
-		Clock:        clock,
-		Logger:       internalworker.WrapLogger(logger),
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return time.Minute
+		},
+		Clock:  clock,
+		Logger: internalworker.WrapLogger(logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/firewaller/firewaller.go
+++ b/internal/worker/firewaller/firewaller.go
@@ -199,7 +199,9 @@ func NewFirewaller(cfg Config) (worker.Worker, error) {
 		IsFatal: func(error) bool { return false },
 
 		// For any failures, try again in 1 minute.
-		RestartDelay: time.Minute,
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return time.Minute
+		},
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/httpclient/worker.go
+++ b/internal/worker/httpclient/worker.go
@@ -82,8 +82,10 @@ func newWorker(cfg WorkerConfig, internalStates chan string) (*httpClientWorker,
 		IsFatal: func(err error) bool {
 			return false
 		},
-		RestartDelay: time.Second * 10,
-		Logger:       internalworker.WrapLogger(cfg.Logger),
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return time.Second * 10
+		},
+		Logger: internalworker.WrapLogger(cfg.Logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/logsink/worker.go
+++ b/internal/worker/logsink/worker.go
@@ -5,7 +5,6 @@ package logsink
 
 import (
 	"context"
-	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
+	internalworker "github.com/juju/juju/internal/worker"
 )
 
 const (
@@ -69,7 +69,7 @@ func newWorker(cfg Config, internalState chan string) (worker.Worker, error) {
 		ShouldRestart: func(err error) bool {
 			return !errors.Is(err, logger.ErrLoggerDying)
 		},
-		RestartDelay: time.Second,
+		RestartDelay: internalworker.RestartDelay,
 		Clock:        cfg.Clock,
 	})
 	if err != nil {

--- a/internal/worker/modelworkermanager/manifold.go
+++ b/internal/worker/modelworkermanager/manifold.go
@@ -5,6 +5,7 @@ package modelworkermanager
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
@@ -17,7 +18,6 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/pki"
 	"github.com/juju/juju/internal/services"
-	jworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/apiremoterelationcaller"
 )
 
@@ -179,7 +179,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		ModelMetrics:                  config.ModelMetrics,
 		LogSinkGetter:                 logSinkGetter,
 		NewModelWorker:                config.NewModelWorker,
-		ErrorDelay:                    jworker.RestartDelay,
+		ErrorDelay:                    time.Second * 3,
 		DomainServicesGetter:          domainServicesGetter,
 		LeaseManager:                  leaseManager,
 		ModelService:                  controllerDomainServices.Model(),

--- a/internal/worker/modelworkermanager/manifold_test.go
+++ b/internal/worker/modelworkermanager/manifold_test.go
@@ -6,6 +6,7 @@ package modelworkermanager_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/tc"
@@ -27,7 +28,6 @@ import (
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/testhelpers"
 	jujutesting "github.com/juju/juju/internal/testing"
-	jworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/apiremoterelationcaller"
 	"github.com/juju/juju/internal/worker/modelworkermanager"
 )
@@ -189,7 +189,7 @@ func (s *ManifoldSuite) TestStart(c *tc.C) {
 	c.Assert(config, tc.DeepEquals, modelworkermanager.Config{
 		Authority:                     s.authority,
 		ModelMetrics:                  dummyModelMetrics{},
-		ErrorDelay:                    jworker.RestartDelay,
+		ErrorDelay:                    time.Second * 3,
 		LeaseManager:                  s.leaseManager,
 		Logger:                        s.logger,
 		LogSinkGetter:                 dummyLogSinkGetter{},

--- a/internal/worker/modelworkermanager/modelworkermanager.go
+++ b/internal/worker/modelworkermanager/modelworkermanager.go
@@ -150,8 +150,10 @@ func New(config Config) (worker.Worker, error) {
 		IsFatal:       neverFatal,
 		ShouldRestart: internalworker.ShouldRunnerRestart,
 		MoreImportant: neverImportant,
-		RestartDelay:  config.ErrorDelay,
-		Logger:        internalworker.WrapLogger(config.Logger),
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return config.ErrorDelay
+		},
+		Logger: internalworker.WrapLogger(config.Logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -5,7 +5,6 @@ package objectstore
 
 import (
 	"context"
-	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -132,7 +131,7 @@ func newWorker(cfg WorkerConfig, internalStates chan string) (*objectStoreWorker
 			return false
 		},
 		ShouldRestart: internalworker.ShouldRunnerRestart,
-		RestartDelay:  time.Second * 10,
+		RestartDelay:  internalworker.RestartDelay,
 		Logger:        internalworker.WrapLogger(cfg.Logger),
 	})
 	if err != nil {

--- a/internal/worker/objectstoredrainer/worker.go
+++ b/internal/worker/objectstoredrainer/worker.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"io"
 	"slices"
-	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/worker/v4"
@@ -168,7 +167,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 			return false
 		},
 		ShouldRestart: internalworker.ShouldRunnerRestart,
-		RestartDelay:  time.Second * 10,
+		RestartDelay:  internalworker.RestartDelay,
 		Clock:         config.Clock,
 		Logger:        internalworker.WrapLogger(config.Logger),
 	})

--- a/internal/worker/providertracker/providerworker.go
+++ b/internal/worker/providertracker/providerworker.go
@@ -5,7 +5,6 @@ package providertracker
 
 import (
 	"context"
-	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -110,7 +109,7 @@ func newWorker(config Config, internalStates chan string) (*providerWorker, erro
 				database.ErrDBNotFound,
 			)
 		},
-		RestartDelay: time.Second * 10,
+		RestartDelay: internalworker.RestartDelay,
 		Clock:        config.Clock,
 		Logger:       internalworker.WrapLogger(config.Logger),
 	})

--- a/internal/worker/remoterelationconsumer/worker.go
+++ b/internal/worker/remoterelationconsumer/worker.go
@@ -281,7 +281,9 @@ func NewWorker(config Config) (ReportableWorker, error) {
 		},
 
 		// For any failures, try again in 15 seconds.
-		RestartDelay: 15 * time.Second,
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return time.Second * 15
+		},
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -11,7 +11,9 @@ import (
 
 // RestartDelay holds the length of time that a worker
 // will wait between exiting and restarting.
-const RestartDelay = 3 * time.Second
+func RestartDelay(attempts int, lastErr error) time.Duration {
+	return time.Second * 3
+}
 
 // Runner is implemented by instances capable of starting and stopping workers.
 type Runner interface {

--- a/internal/worker/storageregistry/worker.go
+++ b/internal/worker/storageregistry/worker.go
@@ -88,8 +88,10 @@ func newWorker(cfg WorkerConfig, internalStates chan string) (*storageRegistryWo
 		ShouldRestart: func(err error) bool {
 			return !errors.Is(err, database.ErrDBDead)
 		},
-		RestartDelay: time.Second * 10,
-		Logger:       internalworker.WrapLogger(cfg.Logger),
+		RestartDelay: func(attempts int, lastErr error) time.Duration {
+			return time.Second * 10
+		},
+		Logger: internalworker.WrapLogger(cfg.Logger),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/trace/worker.go
+++ b/internal/worker/trace/worker.go
@@ -111,7 +111,7 @@ func newWorker(cfg WorkerConfig, internalStates chan string) (*tracerWorker, err
 		IsFatal: func(err error) bool {
 			return false
 		},
-		RestartDelay: time.Second * 10,
+		RestartDelay: internalworker.RestartDelay,
 		Logger:       internalworker.WrapLogger(cfg.Logger),
 	})
 	if err != nil {


### PR DESCRIPTION
This gives us the option to back-off individual workers inside of a runner, depending on the last error message. This allows us to prevent thrashing during the long outages.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
