### PR TITLE
fix: ensure remote secrets watcher returns results - fix query joins

### DIFF
--- a/domain/crossmodelrelation/service/secrets.go
+++ b/domain/crossmodelrelation/service/secrets.go
@@ -25,7 +25,7 @@ type ModelSecretsState interface {
 	// of changes to consumed secrets in an offering model.
 	InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide(appUUID string) (string, eventsource.NamespaceQuery)
 	// GetRemoteConsumedSecretURIsWithChangesFromOfferingSide composes changes to consumed secrets in an offering model.
-	GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(ctx context.Context, appUUID string, secretIDs ...string) ([]string, error)
+	GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(ctx context.Context, appUUID string, revisionUUIDs ...string) ([]string, error)
 
 	// GetSecretRemoteConsumer returns the secret consumer info from a cross model consumer
 	// for the specified unit and secret.

--- a/domain/crossmodelrelation/service/service.go
+++ b/domain/crossmodelrelation/service/service.go
@@ -218,8 +218,8 @@ func (s *WatchableService) WatchRemoteConsumedSecretsChanges(ctx context.Context
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	processChanges := func(ctx context.Context, secretIDs ...string) ([]string, error) {
-		return s.modelState.GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(ctx, appUUID.String(), secretIDs...)
+	processChanges := func(ctx context.Context, revisionUUIDs ...string) ([]string, error) {
+		return s.modelState.GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(ctx, appUUID.String(), revisionUUIDs...)
 	}
 	return secret.NewSecretStringWatcher(w, s.logger, processChanges)
 }

--- a/domain/crossmodelrelation/state/model/secrets.go
+++ b/domain/crossmodelrelation/state/model/secrets.go
@@ -35,7 +35,8 @@ SELECT DISTINCT sr.uuid AS &revisionUUID.uuid
 FROM      secret_remote_unit_consumer sruc
 LEFT JOIN secret_revision sr ON sr.secret_id = sruc.secret_id
 JOIN      application app ON app.name = substr(sruc.unit_name, 1, instr(sruc.unit_name, '/')-1)
-WHERE     app.uuid = $applicationUUID.uuid
+JOIN      application_remote_consumer arc ON arc.offer_connection_uuid = app.uuid
+WHERE     arc.offerer_application_uuid = $applicationUUID.uuid
 GROUP BY  sruc.secret_id
 HAVING    sruc.current_revision < MAX(sr.revision)`
 		app := applicationUUID{UUID: appUUID}
@@ -79,7 +80,8 @@ SELECT DISTINCT sruc.secret_id AS &secretRemoteUnitConsumer.secret_id
 FROM      secret_remote_unit_consumer sruc
 LEFT JOIN secret_revision sr ON sr.secret_id = sruc.secret_id
 JOIN      application app ON app.name = substr(sruc.unit_name, 1, instr(sruc.unit_name, '/')-1)
-WHERE     app.uuid = $applicationUUID.uuid`
+JOIN      application_remote_consumer arc ON arc.offer_connection_uuid = app.uuid
+WHERE     arc.offerer_application_uuid = $applicationUUID.uuid`
 	queryParams := []any{
 		applicationUUID{UUID: appUUID},
 	}

--- a/domain/crossmodelrelation/state/model/secrets_test.go
+++ b/domain/crossmodelrelation/state/model/secrets_test.go
@@ -195,19 +195,20 @@ func (s *modelSecretsSuite) prepareWatchForRemoteConsumedSecretsChangesFromOffer
 	s.createSecret(c, uri2, map[string]string{"foo": "bar", "hello": "world"}, nil)
 	uri2.SourceUUID = s.ModelUUID()
 
-	appUUID := s.setupRemoteApp(c, "mediawiki")
+	_, _, realApplicationUUID, syntheticApplicationUUID := s.setupRemoteApplicationConsumer(c)
 
 	// The consumed revision 1.
-	saveRemoteConsumer(uri1, 1, "mediawiki/0")
+	saveRemoteConsumer(uri1, 1, syntheticApplicationUUID+"/0")
 	// The consumed revision 1.
-	saveRemoteConsumer(uri2, 1, "mediawiki/0")
+	saveRemoteConsumer(uri2, 1, syntheticApplicationUUID+"/0")
 
 	// create revision 2.
 	s.addRevision(c, uri1, map[string]string{"foo": "bar2"})
 
-	err := s.state.UpdateRemoteSecretRevision(ctx, uri1, 2, appUUID)
+	err := s.state.UpdateRemoteSecretRevision(ctx, uri1, 2, syntheticApplicationUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	return appUUID, uri1, uri2
+
+	return realApplicationUUID, uri1, uri2
 }
 
 func (s *modelSecretsSuite) TestInitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide(c *tc.C) {

--- a/domain/secret/watcher.go
+++ b/domain/secret/watcher.go
@@ -87,7 +87,9 @@ func (w *secretWatcher[T]) loop() error {
 			historyIDs.Add(id)
 		}
 
-		out = w.out
+		if len(changes) != 0 {
+			out = w.out
+		}
 		return nil
 	}
 


### PR DESCRIPTION
When the remote secrets changes watcher was written, the application_remote_consumer table didn't exist.
his PR adds that table to the joins used to populate the above watcher.

## QA steps

```
juju switch controller  
juju deploy juju-qa-dummy-source                      
juju offer dummy-source:sink    
juju add-model work                                     
juju deploy juju-qa-dummy-sink  
juju relate dummy-sink controller.dummy-source        
juju switch controller                        
uri=$(juju exec -u dummy-source/0 -- secret-add foo=bar)
juju exec -u dummy-source/0 -- secret-grant -r 1 $uri   
juju switch work                                     
juju exec -u dummy-sink/0 -- secret-get $uri --refresh
juju switch controller                                
juju exec -u dummy-source/0 -- secret-set $uri foo=baz
juju switch work
juju show-status-log dummy-sink/0
```
The secret-changed hook should have run on dummy-sink/0
