### PR TITLE
test(secrets_iaas): use `juju model-secret-backend` in k8s and vault

### DIFF
--- a/tests/suites/secrets_iaas/k8s.sh
+++ b/tests/suites/secrets_iaas/k8s.sh
@@ -10,20 +10,20 @@ run_secrets_k8s() {
 
 	model_name='model-secrets-k8s-charm-owned'
 	add_model "$model_name"
-	juju --show-log model-config secret-backend=myk8s -m "$model_name"
+	juju --show-log model-secret-backend myk8s -m "$model_name"
 	check_secrets
 	destroy_model "$model_name"
 
 	model_name='model-secrets-k8s-model-owned'
 	add_model "$model_name"
-	juju --show-log model-config secret-backend=myk8s -m "$model_name"
+	juju --show-log model-secret-backend myk8s -m "$model_name"
 	run_user_secrets "$model_name"
 	destroy_model "$model_name"
 
 	# test remove-secret-backend with force.
 	model_name='model-remove-secret-backend-with-force'
 	add_model "$model_name"
-	juju --show-log model-config secret-backend=myk8s -m "$model_name"
+	juju --show-log model-secret-backend myk8s -m "$model_name"
 	# add a secret to the k8s backend to make sure the backend is in-use.
 	juju add-secret foo token=1
 	check_contains "$(juju show-secret-backend myk8s | yq -r .myk8s.secrets)" 1

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -17,14 +17,14 @@ run_secrets_vault() {
 
 	model_name='model-secrets-vault-model-owned'
 	add_model "$model_name"
-	juju --show-log model-config secret-backend=myvault -m "$model_name"
+	juju --show-log model-secret-backend myvault -m "$model_name"
 	run_user_secrets "$model_name"
 	destroy_model "$model_name"
 
 	# test remove-secret-backend with force.
 	model_name='model-remove-secret-backend-with-force'
 	add_model "$model_name"
-	juju --show-log model-config secret-backend=myvault -m "$model_name"
+	juju --show-log model-secret-backend myvault -m "$model_name"
 	# add a secret to the vault backend to make sure the backend is in-use.
 	# (make it a large secret which encodes to approx 1MB in size).
 	echo "data: $(cat /dev/zero | tr '\0' A | head -c 749500)" >"${TEST_DIR}/secret.txt"
@@ -179,7 +179,7 @@ prepare_vault() {
 	mkdir -p ~/snap/vault/common/
 	TMP=$(mktemp -d ~/snap/vault/common/cacert-XXXXX)
 	cert_juju_secret_id=$(juju secrets --format=yaml | yq 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key')
-	juju show-secret "${cert_juju_secret_id}" --reveal --format=yaml | yq '.[].content.certificate' > "$TMP/vault.pem"
+	juju show-secret "${cert_juju_secret_id}" --reveal --format=yaml | yq '.[].content.certificate' >"$TMP/vault.pem"
 	export VAULT_CAPATH="$TMP/vault.pem"
 	vault status || true
 	vault_init_output=$(vault operator init -key-shares=5 -key-threshold=3 -format json)


### PR DESCRIPTION
This PR replaces deprecated `juju model-config secret-backend=<name>` with the dedicated `juju model-secret-backend <name>` command across secrets test scripts.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
cd tests
./main.sh -v -l ci secrets_iaas test_secrets_k8s
./main.sh -v -l ci secrets_iaas test_secrets_vault
```

## Documentation changes

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
