### PR TITLE
chore: ignore lxd govulnchecks

### DIFF
--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -136,6 +136,15 @@ run_govulncheck() {
 		# The vulnerability below is for a method not used since Juju 1.x.
 		# https://pkg.go.dev/vuln/GO-2025-3798
 		"GO-2025-3798"
+		# TODO(nvinuesa): this ignore is only temporary until we update
+		# LXD to a tagged version that includes the fixes and we address the
+		# breaking changes from it.
+		"GO-2025-3999"
+		"GO-2025-4000"
+		"GO-2025-4001"
+		"GO-2025-4002"
+		"GO-2025-4003"
+		"GO-2025-4005"
 	)
 	ignoreMatcher=$(join "|" "${ignore[@]}")
 


### PR DESCRIPTION
This commit adds a temporary set of govulncheck ignores until LXD fixes them and we address the breaking changes from LXD.


## QA steps

```
$ make static_analysis
```