### PR TITLE
fix: return correct error removing in use secret backend

### DIFF
--- a/apiserver/facades/client/secretbackends/secrets.go
+++ b/apiserver/facades/client/secretbackends/secrets.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/domain/secretbackend"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	_ "github.com/juju/juju/internal/secrets/provider/all"
 	"github.com/juju/juju/internal/uuid"
@@ -139,6 +140,12 @@ func (s *SecretBackendsAPI) RemoveSecretBackends(ctx context.Context, args param
 				BackendIdentifier: secretbackend.BackendIdentifier{Name: arg.Name},
 				DeleteInUse:       arg.Force,
 			})
+		if errors.Is(err, secretbackenderrors.Forbidden) {
+			err = apiservererrors.ParamsErrorf(
+				params.CodeNotSupported,
+				"deleting in use secret backend not supported",
+			)
+		}
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil


### PR DESCRIPTION
When removing an in use secret backend, the cli client expects a "Not Supported" error.
We need to correctly translate the domain service error.

Fixes secrets_iaas tests
```
	check_contains "$(juju remove-secret-backend myvault 2>&1)" 'backend "myvault" still contains secret content'
```