### PR TITLE
fix: check for unit not found error for goal state in consuming

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2519,8 +2519,8 @@ func (u *UniterAPI) oneGoalState(ctx context.Context, unitName coreunit.Name) (*
 	appName := unitName.Application()
 
 	appID, err := u.applicationService.GetApplicationUUIDByUnitName(ctx, unitName)
-	if errors.Is(err, applicationerrors.ApplicationNotFound) {
-		return nil, errors.NotFoundf("application %q", appName)
+	if errors.Is(err, applicationerrors.UnitNotFound) {
+		return nil, errors.NotFoundf("unit %q", appName)
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -2627,7 +2627,6 @@ func (u *UniterAPI) goalStateRelations(
 // goalStateUnits loops through all application units related to principalName,
 // and stores the goal state status in UnitsGoalState.
 func (u *UniterAPI) goalStateUnits(ctx context.Context, appName string, appID application.UUID, principalName coreunit.Name) (params.UnitsGoalState, error) {
-
 	allUnitNames, err := u.applicationService.GetUnitNamesForApplication(ctx, appName)
 	if errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return nil, errors.NotFoundf("application %q", appName)

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -2279,23 +2279,6 @@ ON CONFLICT(application_uuid) DO UPDATE SET
 	})
 }
 
-func (s *applicationStateSuite) TestGetApplicationConfigAndSettingsForSyntheticCMRApplication(c *tc.C) {
-	id := s.createIAASApplication(c, "foo", life.Alive)
-
-	// Switch the source_id of a charm to a synthetic CMR charm.
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-UPDATE charm SET source_id = 2, architecture_id = NULL WHERE uuid = (
-SELECT charm_uuid FROM application WHERE uuid = ?
-)`, id)
-		return err
-	})
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, _, err = s.state.GetApplicationConfigAndSettings(c.Context(), id)
-	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
-}
-
 func (s *applicationStateSuite) TestGetApplicationConfigAndSettingsNotFound(c *tc.C) {
 	// If the application is not found, it should return application not found.
 	id := tc.Must(c, coreapplication.NewUUID)

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -1396,7 +1396,7 @@ func (st *State) checkApplicationLife(ctx context.Context, tx *sqlair.TX, appUUI
 SELECT &life.*
 FROM application AS a
 JOIN charm AS c ON a.charm_uuid = c.uuid
-WHERE a.uuid = $entityUUID.uuid AND c.source_id < 2;
+WHERE a.uuid = $entityUUID.uuid;
 `
 	stmt, err := st.Prepare(query, ident, life{})
 	if err != nil {

--- a/domain/application/state/state_test.go
+++ b/domain/application/state/state_test.go
@@ -77,27 +77,6 @@ func (s *stateSuite) TestCheckApplication(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *stateSuite) TestCheckApplicationSyntheticCMRApplication(c *tc.C) {
-	id := s.createIAASApplication(c, "foo", life.Alive)
-
-	// Switch the source_id of a charm to a synthetic CMR charm.
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-UPDATE charm SET source_id = 2, architecture_id = NULL WHERE uuid = (
-SELECT charm_uuid FROM application WHERE uuid = ?
-)`, id)
-		return err
-	})
-	c.Assert(err, tc.ErrorIsNil)
-
-	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-
-	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return st.checkApplicationNotDead(ctx, tx, id)
-	})
-	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
-}
-
 func (s *stateSuite) TestCheckApplicationExistsNotFound(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 
@@ -138,25 +117,4 @@ func (s *stateSuite) TestCheckApplicationExistsAlive(c *tc.C) {
 		return st.checkApplicationAlive(ctx, tx, id)
 	})
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotAlive)
-}
-
-func (s *stateSuite) TestCheckApplicationExistsAliveSyntheticCMRApplication(c *tc.C) {
-	id := s.createIAASApplication(c, "foo", life.Dying)
-
-	// Switch the source_id of a charm to a synthetic CMR charm.
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-UPDATE charm SET source_id = 2, architecture_id = NULL WHERE uuid = (
-SELECT charm_uuid FROM application WHERE uuid = ?
-)`, id)
-		return err
-	})
-	c.Assert(err, tc.ErrorIsNil)
-
-	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-
-	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return st.checkApplicationAlive(ctx, tx, id)
-	})
-	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }


### PR DESCRIPTION
Small patch to fix goal state error in the case of CMR. 
The problem was that the returned error was UnitNotFound and we were checking for ApplicationNotFound.

As a flyby, remove the check on CMR source for application life check.


## QA steps

Create a CMR:
```
$ juju add-model offer 
$ juju deploy postgresql --channel 16/stable
$ juju offer postgresql:replication-offer replication
$ juju add-model consume 
$ juju deploy postgresql --channel 16/stable
$ juju consume c:admin/offer.replication
$ juju relate postgresql:replication replication
```
You should not see any errors *on the consuming side*, specifically look for charm errors when calling goal-state.