### PR TITLE
fix: ignore goal state for synthetic applications

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -91,6 +91,10 @@ type CrossModelRelationService interface {
 	// relation UUID. This method works for both offerer and consumer side
 	// relations.
 	GetRelationRemoteModelUUID(ctx context.Context, relationUUID corerelation.UUID) (model.UUID, error)
+
+	// IsApplicationSynthetic returns whether the given application is synthetic
+	// in a cross model relation.
+	IsApplicationSynthetic(ctx context.Context, appName string) (bool, error)
 }
 
 // ModelConfigService is used by the provisioner facade to get model config.

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -3769,3 +3769,42 @@ func (c *MockCrossModelRelationServiceGetRelationRemoteModelUUIDCall) DoAndRetur
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// IsApplicationSynthetic mocks base method.
+func (m *MockCrossModelRelationService) IsApplicationSynthetic(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsApplicationSynthetic", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsApplicationSynthetic indicates an expected call of IsApplicationSynthetic.
+func (mr *MockCrossModelRelationServiceMockRecorder) IsApplicationSynthetic(arg0, arg1 any) *MockCrossModelRelationServiceIsApplicationSyntheticCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationSynthetic", reflect.TypeOf((*MockCrossModelRelationService)(nil).IsApplicationSynthetic), arg0, arg1)
+	return &MockCrossModelRelationServiceIsApplicationSyntheticCall{Call: call}
+}
+
+// MockCrossModelRelationServiceIsApplicationSyntheticCall wrap *gomock.Call
+type MockCrossModelRelationServiceIsApplicationSyntheticCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelRelationServiceIsApplicationSyntheticCall) Return(arg0 bool, arg1 error) *MockCrossModelRelationServiceIsApplicationSyntheticCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelRelationServiceIsApplicationSyntheticCall) Do(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationSyntheticCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelRelationServiceIsApplicationSyntheticCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockCrossModelRelationServiceIsApplicationSyntheticCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}


### PR DESCRIPTION
If we get an application not found, ensure that the application isn't a synthetic application. We'll need to revisit this after the release to ensure correctness. We're missing the application URL from the goal states on the consumer side.

## QA steps

Check the unit logs and ensure that postgres status is not in error state on the offering side.

```
$ juju add-model offer 
$ juju deploy postgresql --channel 16/stable
$ juju offer postgresql:replication-offer replication
$ juju add-model consume 
$ juju deploy postgresql --channel 16/stable
$ juju consume c:admin/offer.replication
$ juju relate postgresql:replication replication
$ juju status --relations
```
