### PR TITLE
fix(domain/removal): ignore missing models during controller removal

### DIFF
--- a/domain/removal/service/controller.go
+++ b/domain/removal/service/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/domain/life"
+	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -72,7 +73,8 @@ func (s *Service) RemoveController(
 	}
 
 	for _, modelUUID := range modelUUIDs {
-		if _, err := s.removeModel(ctx, model.UUID(modelUUID), force, wait); err != nil {
+		if _, err := s.removeModel(ctx, model.UUID(modelUUID), force, wait); err != nil &&
+			!errors.Is(err, modelerrors.NotFound) {
 			return errors.Capture(err)
 		}
 	}

--- a/domain/removal/service/controller_test.go
+++ b/domain/removal/service/controller_test.go
@@ -79,3 +79,37 @@ func (s *controllerSuite) TestRemoveControllerNotController(c *tc.C) {
 	err := s.newService(c).RemoveController(c.Context(), false, 0)
 	c.Assert(err, tc.ErrorMatches, `.*not the controller model.*`)
 }
+
+// Ensures that RemoveController ignores model-not-found errors when attempting
+// to remove non-controller models. The controller model is scheduled for
+// removal, while a secondary model disappears between controller and model DB
+// checks causing removeModel to return modelerrors.NotFound, which must be
+// ignored by RemoveController.
+func (s *controllerSuite) TestRemoveControllerIgnoresModelNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	when := time.Now()
+	// Only the controller model removal schedules a job, so Now() is called once.
+	s.clock.EXPECT().Now().Return(when).Times(1)
+
+	mExp := s.modelState.EXPECT()
+	mExp.IsControllerModel(gomock.Any(), s.modelUUID.String()).Return(true, nil)
+	mExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(true, nil)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), s.modelUUID.String(), false).Return(removal.ModelArtifacts{}, nil)
+	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), s.modelUUID.String(), false, when.UTC()).Return(nil)
+
+	cExp := s.controllerState.EXPECT()
+	cExp.GetModelUUIDs(gomock.Any()).Return([]string{"model-1"}, nil)
+	// Controller model still exists in controller DB and can be cascaded.
+	cExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(true, nil)
+	cExp.EnsureModelNotAliveCascade(gomock.Any(), s.modelUUID.String(), false).Return(nil)
+	// For the non-controller model, the controller DB no longer has the model.
+	cExp.ModelExists(gomock.Any(), "model-1").Return(false, nil)
+	// EnsureModelNotAliveCascade is always invoked; treat as no-op success.
+	cExp.EnsureModelNotAliveCascade(gomock.Any(), "model-1", false).Return(nil)
+	// The model DB also doesn't have the model, triggering NotFound path inside removeModel.
+	mExp.ModelExists(gomock.Any(), "model-1").Return(false, nil)
+
+	err := s.newService(c).RemoveController(c.Context(), false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+}


### PR DESCRIPTION
Fix a possible  issue that can occurs while running unit test, when the controller try to be destroyed and destroy the underlying model. Models can have been already deleted, and the destroy controller job can end up in an infinite reschedule.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

happens sometimes on `controllercharm` test suite. Run int.