### PR TITLE
fix: do not impose a relation limit of zero

### DIFF
--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -3634,7 +3634,7 @@ func (st *State) precheckUpgradeRelation(ctx context.Context, tx *sqlair.TX, app
 			return errors.Errorf("cannot change interface of relation %q from %s to %s", appRelation.Name, appRelation.Interface, charmRelation.Interface)
 		} else if charmRelation.Scope == string(charm.ScopeContainer) && appRelation.Scope == string(charm.ScopeGlobal) {
 			return errors.Errorf("cannot change scope of relation %q from %s to %s", appRelation.Name, appRelation.Scope, charmRelation.Scope)
-		} else if appRelation.Count > charmRelation.Capacity {
+		} else if charmRelation.Capacity > 0 && appRelation.Count > charmRelation.Capacity {
 			return errors.Errorf("new charm version imposes a maximum relation limit of %d for %q which cannot be"+
 				" satisfied by the number of already established relations (%d)", charmRelation.Capacity,
 				appRelation.Name, appRelation.Count)

--- a/domain/application/state/application_refresh_test.go
+++ b/domain/application/state/application_refresh_test.go
@@ -165,6 +165,41 @@ func (s *applicationRefreshSuite) TestSetApplicationCharmSuccessWithRelationEsta
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestSetApplicationCharmSuccessWithRelationEstablishedNoLimit verifies that an
+// application charm can be updated successfully when an active relation exists
+// and the charm has no relation limit (0).
+func (s *applicationRefreshSuite) TestSetApplicationCharmSuccessWithRelationEstablishedNoLimit(c *tc.C) {
+	// Arrange
+	appID := s.createApplication(c, createApplicationArgs{
+		relations: []charm.Relation{
+			{
+				Name:      "established",
+				Role:      charm.RoleProvider,
+				Interface: "limited",
+				Limit:     0,
+			},
+		},
+	})
+	s.establishRelationWith(c, appID, "established", charm.RoleRequirer)
+	s.establishRelationWith(c, appID, "established", charm.RoleRequirer)
+
+	// Simulate updating the charm with the same relation/limit.
+	charmID := s.createCharm(c, createCharmArgs{name: "foo", relations: []charm.Relation{
+		{
+			Name:      "established",
+			Role:      charm.RoleProvider,
+			Interface: "limited",
+			Limit:     0,
+		},
+	}})
+
+	// Act
+	err := s.state.SetApplicationCharm(c.Context(), appID, charmID, application.SetCharmStateParams{})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *applicationRefreshSuite) TestSetApplicationCharmChangeChannel(c *tc.C) {
 	// Arrange
 	appID := s.createApplication(c, createApplicationArgs{})


### PR DESCRIPTION
When there is no declared relation count limit (0) we were incorrectly applying this to an existing charm upon refresh.

## QA steps

Reproducer on the [linked issue](https://github.com/juju/juju/issues/21028).

## Links

**Issue:** Fixes #21028.
