### PR TITLE
fix(tests/storage): ensure proper charm paths in storage tests

### DIFF
--- a/tests/includes/charmcraft.sh
+++ b/tests/includes/charmcraft.sh
@@ -8,5 +8,5 @@ pack_charm() {
 	CHARM_NAME=$(basename "$CHARM_DIR")
 
 	charmcraft pack -p "$CHARM_DIR"
-	echo "./${CHARM_NAME}_*.charm"
+	find . -maxdepth 1 -name "${CHARM_NAME}_*.charm" -print
 }

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -34,8 +34,7 @@ run_charm_storage() {
 
 	# Assess charm storage with the filesystem storage provider
 	echo "Assessing filesystem rootfs"
-	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-fs) --base ubuntu@22.04 --storage data=rootfs,1G
+	juju deploy "$(pack_charm ./testcharms/charms/dummy-storage-fs)" --base ubuntu@22.04 --storage data=rootfs,1G
 	wait_for "dummy-storage-fs" ".applications"
 	if [ "$(unit_exist "data/0")" == "true" ]; then
 		assess_rootfs
@@ -46,8 +45,7 @@ run_charm_storage() {
 
 	# Assess charm storage with the filesystem storage provider
 	echo "Assessing block loop disk 1"
-	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-lp) --base ubuntu@22.04 --storage disks=loop,1G
+	juju deploy "$(pack_charm ./testcharms/charms/dummy-storage-lp)" --base ubuntu@22.04 --storage disks=loop,1G
 	wait_for "dummy-storage-lp" ".applications"
 	# Assert the storage kind name
 	if [ "$(unit_exist "disks/1")" == "true" ]; then
@@ -66,8 +64,7 @@ run_charm_storage() {
 
 	# Assess tmpfs pool for the filesystem provider
 	echo "Assessing filesystem tmpfs"
-	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-tp) --base ubuntu@22.04 --storage data=tmpfs,1G
+	juju deploy -m "${model_name}" "$(pack_charm ./testcharms/charms/dummy-storage-tp)" --base ubuntu@22.04 --storage data=tmpfs,1G
 	wait_for "dummy-storage-tp" ".applications"
 	if [ "$(unit_exist "data/3")" == "true" ]; then
 		assess_tmpfs
@@ -77,8 +74,7 @@ run_charm_storage() {
 	wait_for "{}" ".applications"
 
 	# Assessing for persistent filesystem
-	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-np) --base ubuntu@22.04 --storage data=1G
+	juju deploy -m "${model_name}" "$(pack_charm ./testcharms/charms/dummy-storage-np)" --base ubuntu@22.04 --storage data=1G
 	wait_for "dummy-storage-np" ".applications"
 	if [ "$(unit_exist "data/4")" == "true" ]; then
 		assess_fs
@@ -90,8 +86,7 @@ run_charm_storage() {
 	juju remove-storage data/4
 
 	# Assessing multiple filesystem, block, rootfs, loop
-	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-mp) --base ubuntu@22.04 --storage data=1G
+	juju deploy -m "${model_name}" "$(pack_charm ./testcharms/charms/dummy-storage-mp)" --base ubuntu@22.04 --storage data=1G
 	wait_for "dummy-storage-mp" ".applications"
 	if [ "$(unit_exist "data/5")" == "true" ]; then
 		assess_multiple_fs
@@ -101,7 +96,7 @@ run_charm_storage() {
 	wait_for "{}" ".applications"
 
 	# Assessing storage with a named storage pool
-	juju deploy -m "${model_name}" ./testcharms/charms/dummy-storage --storage single-fs=tempy,1,10M
+	juju deploy -m "${model_name}" "$(pack_charm ./testcharms/charms/dummy-storage)" --storage single-fs=tempy,1,10M
 	wait_for "dummy-storage" ".applications"
 
 	# Verify tmpfs storage details

--- a/tests/suites/storage/model_storage_block.sh
+++ b/tests/suites/storage/model_storage_block.sh
@@ -29,7 +29,7 @@ test_default_block_storage() {
 	juju model-config -m "${model_name}" storage-default-block-source="${storage_type}"
 
 	# Deploy application with block storage without specifying storage type.
-	juju deploy -m "${model_name}" ./testcharms/charms/dummy-storage --storage single-blk=100M
+	juju deploy -m "${model_name}" "$(pack_charm ./testcharms/charms/dummy-storage)" --storage single-blk=100M
 
 	# Wait for the application to be active.
 	wait_for "dummy-storage" "$(active_condition "dummy-storage" 0)"

--- a/tests/suites/storage/model_storage_filesystem.sh
+++ b/tests/suites/storage/model_storage_filesystem.sh
@@ -32,7 +32,7 @@ test_default_filesystem_storage() {
 	juju model-config -m "${model_name}" storage-default-filesystem-source=${test_fs}
 
 	# Deploy application with filesystem storage without specifying storage type.
-	juju deploy -m "${model_name}" ./testcharms/charms/dummy-storage --storage single-fs=100M
+	juju deploy -m "${model_name}" "$(pack_charm ./testcharms/charms/dummy-storage)" --storage single-fs=100M
 
 	# Wait for the application to be active.
 	wait_for "dummy-storage" "$(active_condition "dummy-storage" 0)"


### PR DESCRIPTION
This patch ensures that all charm deployed by directory are properly wrapped in the pack_charm directive since deployment from a directory isn't supported anymore in juju 4.0

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

TBD

Run storage tests. They still fails because create-storage-pool is not available, but doesn't block anymore on the deploy step.