### PR TITLE
fix(ci): remove tests relying on export bundles

### DIFF
--- a/tests/suites/firewall/expose_app.sh
+++ b/tests/suites/firewall/expose_app.sh
@@ -15,9 +15,6 @@ run_expose_app_ec2() {
 	# Ensure that CIDRs are correctly generated
 	assert_ingress_cidrs_for_exposed_app
 
-	# Ensure that the per-endpoint rules are included in exported bundles
-	assert_export_bundle_output_includes_exposed_endpoints
-
 	destroy_model "expose-app"
 }
 
@@ -63,28 +60,6 @@ assert_ingress_cidrs_for_exposed_app() {
 	# Port 1234 should only be opened for the CIDR specified for the ubuntu endpoint
 	wait_for_aws_ingress_cidrs_for_port_range "1234" "1234" "10.42.0.0/16" "ipv4"
 	wait_for_aws_ingress_cidrs_for_port_range "1234" "1234" "2002:0:0:1234::/64" "ipv6"
-}
-
-assert_export_bundle_output_includes_exposed_endpoints() {
-
-	echo "==> Checking that show-application output contains the exposed endpoint settings"
-
-	exp=$(
-		cat <<'EOF'
- "":
-   expose-to-cidrs:
-   - 10.0.0.0/24
-   - 192.168.0.0/24
- ubuntu:
-   expose-to-cidrs:
-   - 10.42.0.0/16
-   - 2002:0:0:1234::/64
-EOF
-	)
-
-	got=$(juju show-application ubuntu-lite | yq -r '.["ubuntu-lite"]["exposed-endpoints"]')
-
-	check_contains "$got" "$exp"
 }
 
 test_expose_app_ec2() {


### PR DESCRIPTION
This patch removes the `assert_export_bundle_output_includes_exposed_endpoints` function and its invocation from `tests/suites/firewall/expose_app.sh`.

This check relies on export bundles functionality, which is no more supported in Juju 4.0. If it is reintroduced, the check may need to be rewritten anyway, since the exact content of a bundle may have varied.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

run test:

```
 ./main.sh -v -c aws firewall test_expose_app_ec2
 ```
 
 It should succeed.