### PR TITLE
fix(ci): add CA certificate to secret backend setup

### DIFF
--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -6,7 +6,7 @@ run_secrets_vault() {
 
 	prepare_vault
 
-	juju add-secret-backend myvault vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN" ca-cert="$(cat $VAULT_CAPATH)"
+	juju add-secret-backend myvault vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN" ca-cert="$(cat "$VAULT_CAPATH")"
 
 	model_name='model-secrets-vault-charm-owned'
 	add_model "$model_name"
@@ -49,7 +49,7 @@ run_secret_drain() {
 	add_model "$model_name"
 
 	vault_backend_name='myvault'
-	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
+	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN" ca-cert="$(cat "$VAULT_CAPATH")"
 
 	juju --show-log deploy jameinel-ubuntu-lite
 	wait_for "active" '.applications["ubuntu-lite"] | ."application-status".current'
@@ -100,7 +100,7 @@ run_user_secret_drain() {
 	prepare_vault
 
 	vault_backend_name='myvault'
-	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN"
+	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN" ca-cert="$(cat "$VAULT_CAPATH")"
 
 	model_name='model-user-secrets-drain'
 	add_model "$model_name"


### PR DESCRIPTION
This patch updates `tests/suites/secrets_iaas/vault.sh` to include the CA certificate when configuring the Vault backend using `juju add-secret-backend`.

The CA certificate is read from `$VAULT_CAPATH` and added to the `ca-cert` parameter.

It is required because without this config param, adding the backend would fail with a TLS error, due to the self-signed certificate.

## QA steps


run the CI tests

```sh
 ./main.sh -v -c localhost secrets_iaas test_secret_drain     
```

It shouldn't fails on TLS / self signed certificate error anymore.

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-8605)
