### PR TITLE
fix(docs): redirect manual cloud documentation to unmanaged cloud

### DIFF
--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -38,8 +38,8 @@ The command operates in three modes, depending on the options provided:
 
   - provision a new machine from the cloud (default, see "Provisioning
     a new machine")
-  - connect to a live computer and allocate it as a machine (see "Manual
-    provisioning")
+  - connect to a live computer and allocate it as a machine (see "Adding
+    a pre-existing machine")
   - create an operating system container (see "Container creation")
 
 The ` + "`add-machine` " + `command is unavailable in Kubernetes clouds. Provisioning
@@ -67,12 +67,12 @@ about how to allocate the machine in the cloud. For example, one can direct
 the MAAS provider to acquire a particular node by specifying its hostname.
 
 
-### Manual provisioning
+### Adding a pre-existing machine
 
 Call ` + "`add-machine` " + ` with the address of a network-accessible computer to
 allocate that machine to the model.
 
-Manual provisioning is the process of installing Juju on an existing machine
+This is the process of installing Juju on an existing machine
 and bringing it under Juju's management. The Juju controller must be able to
 access the new machine over the network.
 

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,5 +1,6 @@
 # <old URL> <new URL>
 
+reference/cloud/list-of-supported-clouds/the-manual-cloud-and-juju reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju
 reference/charm/charm-development-best-practices/ reference/charm
 # redirects after updating landing pages
 explanation/performance-with-juju explanation/juju-performance

--- a/docs/reference/cloud/list-of-supported-clouds/index.md
+++ b/docs/reference/cloud/list-of-supported-clouds/index.md
@@ -11,12 +11,12 @@ Google GCE <the-google-gce-cloud-and-juju>
 Google GKE <the-google-gke-cloud-and-juju>
 LXD <the-lxd-cloud-and-juju>
 MAAS <the-maas-cloud-and-juju>
-Unmanaged <the-unmanaged-cloud-and-juju>
 MicroK8s <the-microk8s-cloud-and-juju>
 Microsoft Azure <the-microsoft-azure-cloud-and-juju>
 Microsoft AKS <the-microsoft-aks-cloud-and-juju>
 OpenStack <the-openstack-cloud-and-juju>
 Oracle OCI <the-oracle-oci-cloud-and-juju>
+Unmanaged <the-unmanaged-cloud-and-juju>
 VMware vSphere <the-vmware-vsphere-cloud-and-juju>
 ```
 
@@ -29,10 +29,10 @@ Juju supports all of the following clouds. Click to find out more about using yo
 - {ref}`Google GCE <cloud-gce>`
 - {ref}`LXD <cloud-lxd>`
 - {ref}`MAAS <cloud-maas>`
-- {ref}`Unmanaged <cloud-unmanaged>`
 - {ref}`Microsoft Azure <cloud-azure>`
 - {ref}`OpenStack <cloud-openstack>`
 - {ref}`Oracle OCI <cloud-oci>`
+- {ref}`Unmanaged <cloud-unmanaged>`
 - {ref}`VMware vSphere <cloud-vsphere>`
 
 (list-of-supported-kubernetes-clouds)=

--- a/docs/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-unmanaged-cloud-and-juju.md
@@ -27,7 +27,7 @@ As the differences related to (1) are already documented generically in the rest
 
 ## Notes on `juju add-cloud`
 
-Type in Juju: `manual`
+Type in Juju: `unmanaged`
 
 Name in Juju: User-defined.
 

--- a/docs/reference/space.md
+++ b/docs/reference/space.md
@@ -78,7 +78,7 @@ This is the case for the Unmanaged provider, as described below.
 
 #### Unmanaged
 
-For the Unmanaged provider, space support differs somewhat from other providers. The `reload-spaces` command does not discover subnets. Instead, each time a manual machine is provisioned, its discovered network devices are used to update Juju's known subnet list.
+For the Unmanaged provider, space support differs somewhat from other providers. The `reload-spaces` command does not discover subnets. Instead, each time a machine is manually added, its discovered network devices are used to update Juju's known subnet list.
 
 Accordingly, the machines to be used in an Unmanaged provider must be provisioned by Juju before their subnets can be grouped into spaces. When provisioning a machine results in discovery of a new subnet, that subnet will reside in the _alpha_ space.
 


### PR DESCRIPTION
This PR renames the manual cloud documentation page to unmanaged cloud and add a redirect from the old URL to maintain backward compatibility with existing links and bookmarks.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
# checks should pass
```
## Documentation changes

No more `manual`, and correct redirects