### PR TITLE
fix: login to controllers

### DIFF
--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -66,6 +66,11 @@ type MacaroonDischarger interface {
 	// third party caveats in m, and returns a slice containing all
 	// of them bound to m.
 	DischargeAll(ctx context.Context, m *bakery.Macaroon) (macaroon.Slice, error)
+	// CookieJar returns an http.CookieJar used to store macaroon cookies.
+	CookieJar() http.CookieJar
+	// HandleError allows the discharger to inspect and possibly
+	// handle errors returned from API calls.
+	HandleError(ctx context.Context, reqURL *url.URL, err error) error
 }
 
 // StreamConnector is implemented by the client-facing State object.

--- a/api/httpclient.go
+++ b/api/httpclient.go
@@ -96,7 +96,7 @@ func (doer httpRequestDoer) Do(req *http.Request) (*http.Response, error) {
 // AuthHTTPRequest adds Juju auth info (username, password, nonce, macaroons)
 // to the given HTTP request, suitable for sending to a Juju API server.
 func AuthHTTPRequest(req *http.Request, info *Info) error {
-	lp := NewLegacyLoginProvider(info.Tag, info.Password, info.Nonce, info.Macaroons, nil, nil)
+	lp := NewLegacyLoginProvider(info.Tag, info.Password, info.Nonce, info.Macaroons, nil)
 	return authHTTPRequest(req, lp)
 }
 

--- a/api/legacyloginprovider_test.go
+++ b/api/legacyloginprovider_test.go
@@ -35,7 +35,7 @@ func (s *legacyLoginProviderSuite) TestLegacyProviderLogin(c *gc.C) {
 	username := names.NewUserTag("admin")
 	password := jujutesting.AdminSecret
 
-	lp := api.NewLegacyLoginProvider(username, password, "", nil, nil, nil)
+	lp := api.NewLegacyLoginProvider(username, password, "", nil, nil)
 	apiState, err := api.Open(&api.Info{
 		Addrs:          info.Addrs,
 		ControllerUUID: info.ControllerUUID,
@@ -52,7 +52,7 @@ func (s *legacyLoginProviderSuite) TestLegacyProviderWithNilTag(c *gc.C) {
 	info := s.APIInfo(c)
 	password := jujutesting.AdminSecret
 
-	lp := api.NewLegacyLoginProvider(nil, password, "", nil, nil, nil)
+	lp := api.NewLegacyLoginProvider(nil, password, "", nil, nil)
 	_, err := api.Open(&api.Info{
 		Addrs:          info.Addrs,
 		ControllerUUID: info.ControllerUUID,
@@ -83,7 +83,6 @@ func (s *legacyLoginProviderBasicSuite) TestLegacyProviderAuthHeader(c *gc.C) {
 		nonce,
 		[]macaroon.Slice{},
 		nil,
-		nil,
 	)
 	got, err := lp.AuthHeader()
 	c.Assert(err, jc.ErrorIsNil)
@@ -101,7 +100,6 @@ func (s *legacyLoginProviderBasicSuite) TestLegacyProviderAuthHeaderWithNilTag(c
 		password,
 		nonce,
 		[]macaroon.Slice{},
-		nil,
 		nil,
 	)
 	got, err := lp.AuthHeader()

--- a/api/state.go
+++ b/api/state.go
@@ -117,7 +117,7 @@ type state struct {
 // TODO (alesstimec, wallyworld): This method should be removed and
 // a login provider should be used instead.
 func (st *state) Login(name names.Tag, password, nonce string, ms []macaroon.Slice) error {
-	lp := NewLegacyLoginProvider(name, password, nonce, ms, st.bakeryClient, st.cookieURL)
+	lp := NewLegacyLoginProvider(name, password, nonce, ms, st.cookieURL)
 	result, err := lp.Login(context.Background(), st)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -313,17 +312,6 @@ func (c *loginCommand) existingControllerLogin(ctx *cmd.Context, store jujuclien
 	return c.login(ctx, currentAccountDetails, dial)
 }
 
-func cookieURL(host string) (*url.URL, error) {
-	if strings.Contains(host, ":") {
-		var err error
-		host, _, err = net.SplitHostPort(host)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	return url.Parse(host)
-}
-
 // publicControllerLogin logs into the public controller at the given
 // host. The currentAccountDetails parameter holds existing account
 // information about the controller account.
@@ -353,11 +341,6 @@ func (c *loginCommand) publicControllerLogin(
 		APIEndpoints: []string{host},
 	}
 
-	cookieURL, err := cookieURL(host)
-	if err != nil {
-		return fail(err)
-	}
-
 	// Make a direct API connection because we don't yet know the
 	// controller UUID so can't store the thus-incomplete controller
 	// details to make a conventional connection.
@@ -381,8 +364,17 @@ func (c *loginCommand) publicControllerLogin(
 		sessionToken = currentAccountDetails.SessionToken
 	}
 
+	var userTag names.Tag
+	if c.username != "" {
+		if !names.IsValidUserName(c.username) {
+			return fail(errors.Errorf("%q is not a valid user name", c.username))
+		}
+		userTag = names.NewUserTag(c.username)
+	}
+
 	var oidcLogin bool
-	loginProviders := []api.LoginProvider{
+	dialOpts.LoginProvider = loginprovider.NewTryInOrderLoginProvider(
+		loggo.GetLogger("juju.cmd.loginprovider"),
 		api.NewClientCredentialsLoginProviderFromEnvironment(
 			func() { oidcLogin = true },
 		),
@@ -394,21 +386,15 @@ func (c *loginCommand) publicControllerLogin(
 				sessionToken = t
 			},
 		),
-		api.NewLegacyLoginProvider(nil, "", "", nil, bclient, cookieURL),
-	}
-
-	dialOpts.LoginProvider = loginprovider.NewTryInOrderLoginProvider(
-		loggo.GetLogger("juju.cmd.loginprovider"),
-		loginProviders...,
+		api.NewLegacyLoginProvider(userTag, "", "", nil, api.CookieURLFromHost(host)),
 	)
 
 	// Keep track of existing interactors as the dial callback will create
 	// new ones each time it gets invoked.
 	var existing []httpbakery.Interactor
-	for _, i := range bclient.InteractionMethods {
-		existing = append(existing, i)
-	}
+	existing = append(existing, bclient.InteractionMethods...)
 
+	var password string
 	dial := func(d *jujuclient.AccountDetails) (api.Connection, error) {
 		// Attach an interactor which will be invoked if we attempt to
 		// login without a password and the remote controller does not
@@ -424,7 +410,7 @@ func (c *loginCommand) publicControllerLogin(
 						return c.noPromptPassword, nil
 					}
 					fmt.Fprintln(ctx.Stderr, "reading password from stdin...")
-					password, err := readLine(ctx.Stdin)
+					password, err = readLine(ctx.Stdin)
 					if err != nil {
 						return "", err
 					}
@@ -437,7 +423,8 @@ func (c *loginCommand) publicControllerLogin(
 				// func. As other password getters may rely on
 				// this we just provide a wrapper that calls
 				// pollster with the correct label.
-				return c.pollster.EnterPassword("password")
+				password, err = c.pollster.Enter("password")
+				return password, err
 			})}
 		// Add in any default interactors from the base client.
 		for _, i := range existing {
@@ -464,6 +451,7 @@ func (c *loginCommand) publicControllerLogin(
 	ctrlDetails.ControllerUUID = conn.ControllerTag().Id()
 	ctrlDetails.OIDCLogin = oidcLogin
 	accountDetails.SessionToken = sessionToken
+	accountDetails.Password = password
 	return conn, ctrlDetails, accountDetails, nil
 }
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/juju/juju/pull/21054 which was closed. Below is mostly c/p from that PR with some changes for the new approach.

Login to a controller that wasn't already in the client store using the command `juju login <address>:17070 -c <ctrl-name> -u <user>` was broken for 2 reasons.

1. Construction of the legacy login provider was ignoring the provided username.
2. Construction of the legacy login provider was using a bakery client that didn't contain a controller's custom CA cert.
Note that the legacy login provider is the one that handles username+password/macaroon login.

Back in https://github.com/juju/juju/pull/16955 the login logic was changed so that clients could provide a custom login provider, defining how the authentication logic should be handled. That change, specifically [here](https://github.com/juju/juju/pull/16955/files#diff-a22a5a04a4e0bf080f295a7b51a306c1b2d49013d8b12a15e306037bccfb0a3bR384) and [here](https://github.com/juju/juju/pull/16955/files#diff-5dad8af7a39fbc96262fc8f20b0829d71567703b4d4553c1578cb8fb49aad5d8R164-R166), changed how the bakery client is created. Previously the bakery client used in the legacy login provider was modified inside the Open function with a custom transport. The flow was:

1. Make a websocket connection to the controller
2. Get result with controller address and CA cert
3. Create a custom transport with a TLS config that includes a cert pool with the controller's custom CA cert.
4. Set the custom transport on the bakery client
5. Critically, the bakery client's transport is created AFTER the websocket is established. This allows the username/password login flow to work with custom CA certs, noting that the bakery client is used during the username/password login as part of a macaroon flow to authenticate the user.

When https://github.com/juju/juju/pull/16955 landed, it didn't take the above into account and the bakery client we end up with faces the issues described above.

In this PR I've taken a simpler approach than before to fix the issue. The interface method for `Login` on login providers already provides a bakery client wrapped inside the interface `MacaroonDischarger` (used in cross-model and cross-controller secrets). This bakery client is one that already includes the correct TLS configuration after the websocket connection was established. 

I've extended the `MacaroonDischarger` interface to include 2 new methods that enable the legacyLogin method to perform macaroon login.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. `juju bootstrap localhost test-login`
2. `juju show-controller --show-password` <- record these details
3. `juju unregister test-login --no-prompt`
4. `juju login <address>:17070 -c test-login -u admin` <- get the address from the output above
```
juju login 10.248.83.7:17070 -c ctrl-m10uv7d8 -u admin
Controller "10.248.83.7:17070" (10.248.83.7) presented a CA cert that could not be verified.
CA fingerprint: [B3:1E:2D:ED:44:5A:0C:3C:89:7C:96:A9:74:D8:32:51:21:B0:86:CD:9C:B4:A9:68:58:42:FE:0E:9D:FC:7F:23]
Trust remote controller? (y/N): y

Enter password: 

Welcome, admin. You are now logged into "ctrl-m10uv7d8".

There are 2 models available. Use "juju switch" to select
one of them:
  - juju switch controller
  - juju switch test-deploy-ctl
```
5. `juju models` <- verify the password was saved and subsequent commands work.

Previously the error encountered was 
```
$ juju login -c myController 10.46.26.11:17070 -u admin
Controller "10.46.26.11:17070" (10.46.26.11) presented a CA cert that could not be verified.
CA fingerprint: [FB:89:62:BB:A1:06:A8:91:9C:47:AC:70:40:A1:D5:96:1B:B1:F4:CD:4E:F2:FB:BE:89:E8:98:7A:0F:E3:A8:D3]
Trust remote controller? (y/N): y

ERROR cannot log into "10.46.26.11:17070": failed to authenticate request: unauthorized (unauthorized access)
```
## Links

**Issue:** Fixes https://github.com/juju/juju/issues/21045

**Jira card:** [JUJU-8733](https://warthogs.atlassian.net/browse/JUJU-8733)


[JUJU-8733]: https://warthogs.atlassian.net/browse/JUJU-8733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ