### PR TITLE
fix(secretbackend): support complex config values

### DIFF
--- a/apiserver/facades/client/secretbackends/secrets.go
+++ b/apiserver/facades/client/secretbackends/secrets.go
@@ -5,9 +5,7 @@ package secretbackends
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
@@ -84,9 +82,7 @@ func (s *SecretBackendsAPI) UpdateSecretBackends(ctx context.Context, args param
 			Reset:    arg.Reset,
 		}
 		if len(arg.Config) > 0 {
-			params.Config = transform.Map(arg.Config, func(k string, v interface{}) (string, string) {
-				return k, fmt.Sprintf("%v", v)
-			})
+			params.Config = arg.Config
 		}
 		err := s.backendService.UpdateSecretBackend(ctx, params)
 		result.Results[i].Error = apiservererrors.ServerError(err)

--- a/apiserver/facades/client/secretbackends/secrets_test.go
+++ b/apiserver/facades/client/secretbackends/secrets_test.go
@@ -213,7 +213,7 @@ func (s *SecretsSuite) TestUpdateSecretBackends(c *tc.C) {
 				BackendIdentifier:   secretbackend.BackendIdentifier{Name: "myvault"},
 				NewName:             ptr("new-name"),
 				TokenRotateInterval: ptr(200 * time.Minute),
-				Config: map[string]string{
+				Config: map[string]any{
 					"endpoint":        "http://vault",
 					"namespace":       "foo",
 					"tls-server-name": "server-name",

--- a/domain/secretbackend/params.go
+++ b/domain/secretbackend/params.go
@@ -30,7 +30,7 @@ type CreateSecretBackendParams struct {
 	BackendType         string
 	TokenRotateInterval *time.Duration
 	NextRotateTime      *time.Time
-	Config              map[string]string
+	Config              map[string]any
 }
 
 // Validate checks that the parameters are valid.
@@ -50,7 +50,9 @@ func (p CreateSecretBackendParams) Validate() error {
 				"%w: empty config key for %q", backenderrors.NotValid, p.Name)
 
 		}
-		if v == "" {
+		// Config values must be non-nil and non-empty strings.
+		// Nil values are rejected to ensure all config entries are explicitly set.
+		if str, ok := v.(string); v == nil || (ok && str == "") {
 			return errors.Errorf(
 				"%w: empty config value for %q", backenderrors.NotValid, p.Name)
 
@@ -65,7 +67,7 @@ type UpdateSecretBackendParams struct {
 	NewName             *string
 	TokenRotateInterval *time.Duration
 	NextRotateTime      *time.Time
-	Config              map[string]string
+	Config              map[string]any
 }
 
 // Validate checks that the parameters are valid.
@@ -88,10 +90,9 @@ func (p UpdateSecretBackendParams) Validate() error {
 				"%w: empty config key for %q", backenderrors.NotValid, p.ID)
 
 		}
-		if v == "" {
+		if str, ok := v.(string); v == nil || (ok && str == "") {
 			return errors.Errorf(
 				"%w: empty config value for %q", backenderrors.NotValid, p.ID)
-
 		}
 	}
 	return nil

--- a/domain/secretbackend/params_test.go
+++ b/domain/secretbackend/params_test.go
@@ -59,7 +59,7 @@ func (s *paramsSuite) TestCreateSecretBackendParamsValidate(c *tc.C) {
 			Name: "backend-name",
 		},
 		BackendType: "vault",
-		Config: map[string]string{
+		Config: map[string]any{
 			"": "value",
 		},
 	}
@@ -73,7 +73,7 @@ func (s *paramsSuite) TestCreateSecretBackendParamsValidate(c *tc.C) {
 			Name: "backend-name",
 		},
 		BackendType: "vault",
-		Config: map[string]string{
+		Config: map[string]any{
 			"key": "",
 		},
 	}
@@ -112,7 +112,7 @@ func (s *paramsSuite) TestUpdateSecretBackendParamsValidate(c *tc.C) {
 		BackendIdentifier: BackendIdentifier{
 			ID: "backend-id",
 		},
-		Config: map[string]string{
+		Config: map[string]any{
 			"": "value",
 		},
 	}
@@ -124,7 +124,7 @@ func (s *paramsSuite) TestUpdateSecretBackendParamsValidate(c *tc.C) {
 		BackendIdentifier: BackendIdentifier{
 			ID: "backend-id",
 		},
-		Config: map[string]string{
+		Config: map[string]any{
 			"key": "",
 		},
 	}

--- a/domain/secretbackend/service/service_test.go
+++ b/domain/secretbackend/service/service_test.go
@@ -1126,7 +1126,7 @@ func (s *serviceSuite) TestCreateSecretBackend(c *tc.C) {
 		BackendType:         vault.BackendType,
 		TokenRotateInterval: ptr(200 * time.Minute),
 		NextRotateTime:      ptr(now.Add(150 * time.Minute)),
-		Config:              convertConfigToString(addedConfig),
+		Config:              addedConfig,
 	}).Return("backend-uuid", nil)
 	s.mockRegistry.EXPECT().NewBackend(&provider.ModelBackendConfig{
 		BackendConfig: provider.BackendConfig{
@@ -1244,7 +1244,7 @@ func (s *serviceSuite) assertUpdateSecretBackend(c *tc.C, byName, skipPing bool)
 		NewName:             ptr("new-name"),
 		TokenRotateInterval: ptr(200 * time.Minute),
 		NextRotateTime:      ptr(now.Add(150 * time.Minute)),
-		Config:              convertConfigToString(updatedConfig),
+		Config:              updatedConfig,
 	}).Return("", nil)
 	s.mockRegistry.EXPECT().Type().Return("vault").AnyTimes()
 	if !skipPing {
@@ -1264,7 +1264,7 @@ func (s *serviceSuite) assertUpdateSecretBackend(c *tc.C, byName, skipPing bool)
 	arg.BackendIdentifier = identifier
 	arg.NewName = ptr("new-name")
 	arg.TokenRotateInterval = ptr(200 * time.Minute)
-	arg.Config = map[string]string{
+	arg.Config = map[string]any{
 		"tls-server-name": "server-name",
 	}
 
@@ -1332,7 +1332,7 @@ func (s *serviceSuite) TestRotateBackendToken(c *tc.C) {
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID: "backend-uuid",
 		},
-		Config: map[string]string{
+		Config: map[string]any{
 			"endpoint": "http://vault",
 			"token":    "3h20m0s",
 		},
@@ -1372,7 +1372,7 @@ func (s *serviceSuite) TestRotateBackendTokenRetry(c *tc.C) {
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID: "backend-uuid",
 		},
-		Config: map[string]string{
+		Config: map[string]any{
 			"endpoint": "http://vault",
 			"token":    "3h20m0s",
 		},

--- a/domain/secretbackend/state/encode.go
+++ b/domain/secretbackend/state/encode.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"encoding/json"
+
+	"github.com/juju/juju/internal/errors"
+)
+
+// encodeConfigValue encodes the input value to a string that can be stored
+// in the database.
+func encodeConfigValue(value any) (string, error) {
+	str, err := json.Marshal(value)
+	return string(str), err
+}
+
+// decodeConfigValue decodes the input string stored in the DB
+// to its original type.
+func decodeConfigValue(storedStr string) (any, error) {
+	var value any
+	err := json.Unmarshal([]byte(storedStr), &value)
+	if err != nil {
+		return nil, err
+	}
+	if str, ok := value.(string); ok && str == "" {
+		return nil, errors.New("empty string")
+	}
+	return value, nil
+}

--- a/domain/secretbackend/state/state.go
+++ b/domain/secretbackend/state/state.go
@@ -451,7 +451,7 @@ GROUP BY b.name, c.name`, kubernetes.BackendName)
 	if err != nil {
 		return nil, errors.Errorf("cannot list secret backends: %w", err)
 	}
-	return append(result, nonK8sRows.toSecretBackends()...), nil
+	return append(result, nonK8sRows.toSecretBackends(ctx, s.logger)...), nil
 }
 
 // listInUseKubernetesSecretBackends returns a list of all kubernetes secret backends which contain secrets.
@@ -624,7 +624,7 @@ WHERE  m.uuid = $M.uuid
 	}
 
 	var result []*secretbackend.SecretBackend
-	for _, b := range rows.toSecretBackends() {
+	for _, b := range rows.toSecretBackends(ctx, s.logger) {
 		if modelType == coremodel.CAAS && b.Name == juju.BackendName {
 			continue
 		}
@@ -754,7 +754,7 @@ WHERE b.%s = $M.identifier`, columName)
 	if err != nil {
 		return nil, errors.Errorf("querying secret backends: %w", err)
 	}
-	return rows.toSecretBackends()[0], nil
+	return rows.toSecretBackends(ctx, s.logger)[0], nil
 }
 
 // GetActiveModelSecretBackend returns the active secret backend ID and config for the given model.

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -137,7 +137,7 @@ func (s *stateSuite) createModelWithName(c *tc.C, modelType coremodel.ModelType,
 			Name: "my-backend",
 		},
 		BackendType: "vault",
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -302,7 +302,7 @@ WHERE backend_uuid = ?`[1:], expectedSecretBackend.ID)
 			var k, v string
 			err = rows.Scan(&k, &v)
 			c.Check(err, tc.IsNil)
-			actual.Config[k] = v
+			actual.Config[k] = tc.Must1(c, decodeConfigValue, v)
 		}
 	} else {
 		var count int
@@ -329,7 +329,7 @@ func (s *stateSuite) TestCreateSecretBackendFailed(c *tc.C) {
 		BackendType:         "vault",
 		TokenRotateInterval: &rotateInternal,
 		NextRotateTime:      &nextRotateTime,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "",
 		},
 	})
@@ -344,7 +344,7 @@ func (s *stateSuite) TestCreateSecretBackendFailed(c *tc.C) {
 		BackendType:         "vault",
 		TokenRotateInterval: &rotateInternal,
 		NextRotateTime:      &nextRotateTime,
-		Config: map[string]string{
+		Config: map[string]any{
 			"": "value1",
 		},
 	})
@@ -364,7 +364,7 @@ func (s *stateSuite) TestCreateSecretBackend(c *tc.C) {
 		BackendType:         "vault",
 		TokenRotateInterval: &rotateInternal,
 		NextRotateTime:      &nextRotateTime,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -423,7 +423,7 @@ func (s *stateSuite) TestUpsertSecretBackendInvalidArg(c *tc.C) {
 		ID:          backendID,
 		Name:        "my-backend",
 		BackendType: "vault",
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "",
 		},
 	})
@@ -434,7 +434,7 @@ func (s *stateSuite) TestUpsertSecretBackendInvalidArg(c *tc.C) {
 		ID:          backendID,
 		Name:        "my-backend",
 		BackendType: "vault",
-		Config: map[string]string{
+		Config: map[string]any{
 			"": "value1",
 		},
 	})
@@ -454,7 +454,7 @@ func (s *stateSuite) TestUpdateSecretBackend(c *tc.C) {
 		BackendType:         "vault",
 		TokenRotateInterval: &rotateInternal,
 		NextRotateTime:      &nextRotateTime,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -501,7 +501,7 @@ func (s *stateSuite) TestUpdateSecretBackend(c *tc.C) {
 		},
 		TokenRotateInterval: &newRotateInternal,
 		NextRotateTime:      &newNextRotateTime,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1-updated",
 			"key3": "value3",
 		},
@@ -532,7 +532,7 @@ func (s *stateSuite) TestUpdateSecretBackendWithNoRotateNoConfig(c *tc.C) {
 		BackendType:         "vault",
 		TokenRotateInterval: &rotateInternal,
 		NextRotateTime:      &nextRotateTime,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -610,7 +610,7 @@ func (s *stateSuite) TestUpdateSecretBackendFailed(c *tc.C) {
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID: backendID2,
 		},
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "",
 		},
 	})
@@ -621,7 +621,7 @@ func (s *stateSuite) TestUpdateSecretBackendFailed(c *tc.C) {
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID: backendID2,
 		},
-		Config: map[string]string{
+		Config: map[string]any{
 			"": "value1",
 		},
 	})
@@ -900,7 +900,7 @@ func (s *stateSuite) TestListSecretBackendsIAAS(c *tc.C) {
 		BackendType:         "vault",
 		TokenRotateInterval: &rotateInternal1,
 		NextRotateTime:      &nextRotateTime1,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key3": "value3",
 			"key4": "value4",
 		},
@@ -979,7 +979,7 @@ func (s *stateSuite) TestListSecretBackendsCAAS(c *tc.C) {
 		BackendType:         "kubernetes",
 		TokenRotateInterval: &rotateInternal2,
 		NextRotateTime:      &nextRotateTime2,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key5": "value5",
 			"key6": "value6",
 		},
@@ -1047,7 +1047,7 @@ func (s *stateSuite) TestListSecretBackendIDs(c *tc.C) {
 			Name: "my-backend1",
 		},
 		BackendType: "vault",
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -1065,7 +1065,7 @@ func (s *stateSuite) TestListSecretBackendIDs(c *tc.C) {
 		BackendType:         "kubernetes",
 		TokenRotateInterval: &rotateInternal2,
 		NextRotateTime:      &nextRotateTime2,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key3": "value3",
 			"key4": "value4",
 		},
@@ -1097,7 +1097,7 @@ func (s *stateSuite) assertListSecretBackendsForModelIAAS(c *tc.C, includeEmpty 
 		BackendType:         "vault",
 		TokenRotateInterval: &rotateInternal1,
 		NextRotateTime:      &nextRotateTime1,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -1125,7 +1125,7 @@ func (s *stateSuite) assertListSecretBackendsForModelIAAS(c *tc.C, includeEmpty 
 		BackendType:         "kubernetes",
 		TokenRotateInterval: &rotateInternal2,
 		NextRotateTime:      &nextRotateTime2,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key3": "value3",
 			"key4": "value4",
 		},
@@ -1214,7 +1214,7 @@ func (s *stateSuite) assertListSecretBackendsForModelCAAS(c *tc.C, includeEmpty 
 		BackendType:         "vault",
 		TokenRotateInterval: &rotateInternal1,
 		NextRotateTime:      &nextRotateTime1,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -1242,7 +1242,7 @@ func (s *stateSuite) assertListSecretBackendsForModelCAAS(c *tc.C, includeEmpty 
 		BackendType:         "kubernetes",
 		TokenRotateInterval: &rotateInternal2,
 		NextRotateTime:      &nextRotateTime2,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key3": "value3",
 			"key4": "value4",
 		},
@@ -1438,7 +1438,7 @@ func (s *stateSuite) TestGetSecretBackendByName(c *tc.C) {
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID: backendID,
 		},
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -1511,7 +1511,7 @@ func (s *stateSuite) TestGetSecretBackend(c *tc.C) {
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID: backendID,
 		},
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},

--- a/domain/secretbackend/state/types_test.go
+++ b/domain/secretbackend/state/types_test.go
@@ -40,7 +40,7 @@ func (s *typesSuite) TestToSecretBackends(c *tc.C) {
 				Valid:    true,
 			},
 			ConfigName:    "config11",
-			ConfigContent: "content11",
+			ConfigContent: tc.Must1(c, encodeConfigValue, "content11"),
 		},
 		{
 			ID:          "uuid1",
@@ -51,7 +51,7 @@ func (s *typesSuite) TestToSecretBackends(c *tc.C) {
 				Valid:    true,
 			},
 			ConfigName:    "config12",
-			ConfigContent: "content12",
+			ConfigContent: tc.Must1(c, encodeConfigValue, "content12"),
 		},
 		{
 			ID:          "uuid2",
@@ -61,7 +61,7 @@ func (s *typesSuite) TestToSecretBackends(c *tc.C) {
 				Valid: false,
 			},
 			ConfigName:    "config21",
-			ConfigContent: "content21",
+			ConfigContent: tc.Must1(c, encodeConfigValue, "content21"),
 		},
 		{
 			ID:          "uuid3",
@@ -72,7 +72,7 @@ func (s *typesSuite) TestToSecretBackends(c *tc.C) {
 				Valid:    true,
 			},
 			ConfigName:    "config31",
-			ConfigContent: "content31",
+			ConfigContent: tc.Must1(c, encodeConfigValue, "content31"),
 		},
 		{
 			ID:          "uuid1",
@@ -83,7 +83,7 @@ func (s *typesSuite) TestToSecretBackends(c *tc.C) {
 				Valid:    true,
 			},
 			ConfigName:    "config13",
-			ConfigContent: "content13",
+			ConfigContent: tc.Must1(c, encodeConfigValue, "content13"),
 		},
 		{
 			ID:          "uuid4",
@@ -95,17 +95,35 @@ func (s *typesSuite) TestToSecretBackends(c *tc.C) {
 			Name:          "name5",
 			BackendType:   "vault",
 			ConfigName:    "config51",
-			ConfigContent: "content51",
+			ConfigContent: tc.Must1(c, encodeConfigValue, "content51"),
 		},
 		{
 			ID:            "uuid5",
 			Name:          "name5",
 			BackendType:   "vault",
 			ConfigName:    "config52",
-			ConfigContent: "content52",
+			ConfigContent: tc.Must1(c, encodeConfigValue, "content52"),
+		},
+		{
+			ID:          "uuid6",
+			Name:        "name6",
+			BackendType: "vault",
+			ConfigName:  "slice",
+			ConfigContent: tc.Must1(c, encodeConfigValue, any([]any{`some
+lines`, "some-other-lines"})),
+		},
+		{
+			ID:          "uuid6",
+			Name:        "name6",
+			BackendType: "vault",
+			ConfigName:  "map",
+			ConfigContent: tc.Must1(c, encodeConfigValue, any(map[string]any{
+				"key1": "value1",
+				"key2": "value2",
+			})),
 		},
 	}
-	result := rows.toSecretBackends()
+	result := rows.toSecretBackends(c.Context(), loggertesting.WrapCheckLog(c))
 	c.Assert(result, tc.DeepEquals, []*secretbackend.SecretBackend{
 		{
 			ID:                  "uuid1",
@@ -147,6 +165,18 @@ func (s *typesSuite) TestToSecretBackends(c *tc.C) {
 			Config: map[string]any{
 				"config51": "content51",
 				"config52": "content52",
+			},
+		},
+		{
+			ID:          "uuid6",
+			Name:        "name6",
+			BackendType: "vault",
+			Config: map[string]any{
+				"slice": []any{"some\nlines", "some-other-lines"},
+				"map": map[string]any{
+					"key1": "value1",
+					"key2": "value2",
+				},
 			},
 		},
 	})

--- a/domain/secretbackend/watcher_test.go
+++ b/domain/secretbackend/watcher_test.go
@@ -67,7 +67,7 @@ func (s *watcherSuite) TestWatchSecretBackendRotationChanges(c *tc.C) {
 			BackendType:         "vault",
 			TokenRotateInterval: &rotateInternal,
 			NextRotateTime:      &nextRotateTime,
-			Config: map[string]string{
+			Config: map[string]any{
 				"key1": "value1",
 				"key2": "value2",
 			},
@@ -86,7 +86,7 @@ func (s *watcherSuite) TestWatchSecretBackendRotationChanges(c *tc.C) {
 			BackendType:         "vault",
 			TokenRotateInterval: &rotateInternal,
 			NextRotateTime:      &nextRotateTime,
-			Config: map[string]string{
+			Config: map[string]any{
 				"key1": "value1",
 				"key2": "value2",
 			},
@@ -115,7 +115,7 @@ func (s *watcherSuite) TestWatchSecretBackendRotationChanges(c *tc.C) {
 			ID: backendID1,
 		},
 		NewName: &nameChange,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1-updated",
 			"key3": "value3",
 		},
@@ -132,7 +132,7 @@ func (s *watcherSuite) TestWatchSecretBackendRotationChanges(c *tc.C) {
 		},
 		TokenRotateInterval: &newRotateInternal,
 		NextRotateTime:      &newNextRotateTime,
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1-updated",
 			"key3": "value3",
 		},
@@ -217,7 +217,7 @@ func (s *watcherSuite) createModel(c *tc.C, st *state.State, txnRunner database.
 			Name: "my-backend",
 		},
 		BackendType: "vault",
-		Config: map[string]string{
+		Config: map[string]any{
 			"key1": "value1",
 			"key2": "value2",
 		},


### PR DESCRIPTION
This patch adds support for encoding and decoding complex configuration values in
 `domain/secretbackend` ensuring enhanced flexibility and robustness.

Before this patch, an array was encoded as a string with `fmt.Sprintf("%+v")` and thus, not symmetrically decoded. This causes the TLS certificate verification fails for k8s secret provider, because the logic wasn't able to properly decode the content of `ca-certs` configuration key, which contains a slice of string, each string as a unique certificate.

After this patch, we use json.Marshal/json.Unmarshal to insert/select values from the secret backend configuration. This fixes the issue with TLS verification, which was triggered in CI suite `secrets_iaas/test_secrets_k8s`

If a configuration is malformed, cannot be marshalled or unmarshalled, a log will be produced, and the key will be ignored.

The encoding/decoding are pushed down into the state, since it is the responsibility of the DB layer to know how to store whatever it is pushed to it.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
juju bootstrap lxd ci
./main.sh -v -l ci secrets_iaas test_secrets_k8s
```

The test still fails due to a secret which is not properly removed, but it is unrelated (will fix it in followup, this is due to the fact the `--force` flag when `remove-secret-backend` is ignored)
```sh
    | Success: "backend "myk8s" still contains secret content" found
    | ERROR backend "myk8s" still contains secret content
```

Check in the db that the certs are correctly encoded:

```sh
repl (controller)> select * FROM secret_backend_config
backend_uuid				name		content																											
db5b5046-9a72-4892-8e43-68325af18937	ca-certs	["-----BEGIN CERTIFICATE-----\nMIIDDzCCAfegAwIBAgIUVjFk7525NWv3SVYPprmYwzHxM/AwDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGA1UEAwwMMTAuMTUyLjE4My4xMB4XDTI1MTExMjE0NDAxMVoXDTM1\nMTExMDE0NDAxMVowFzEVMBMGA1UEAwwMMTAuMTUyLjE4My4xMIIBIjANBgkqhkiG\n9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2WjgDp7z7RqvZfZJNws9C1P0xOg8K7yVmykS\nxl1hiF4RTGIUYqrzmMqOiLdWP0VnNgICIx/5IfJQWy7ThzAEPncly4mDllQ3+EDB\nxz01z+d/NTgSu9g8U35wbHXQ2UsO0wHrtbqxdbC8ZQ4K2KVhB+w92yb9E0HD+Z9y\nwDFifvjruSn4yYO3vp9WQfrRsN6IkoARlO1iSvbcdcImL4o/SovdKhUEeedYuYfn\nOLo0lzeoftY7S4rUvljP+oVBMQ8pnNI9Mx3qz8sW3CA5e2uZ47vB9vLyqNKI2KL8\naky8KvHdTvDbUmb9aMQILc9pMDVLQDBZE44m8FJsUEIgmsj3WwIDAQABo1MwUTAd\nBgNVHQ4EFgQUo6EPUPwbqpvEDqxlkrDBg4iVfFswHwYDVR0jBBgwFoAUo6EPUPwb\nqpvEDqxlkrDBg4iVfFswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC\nAQEAcTDK3gz4sSG+TBplA9KrTowtfFSTE5x/1eVHpyqH1ZALfz51zzU9NAzFUIDl\nfnwidvXgSv56ajOfjTOCWjbEmriQDOLUndHB/ZRJdFs7a5ULzJ6tW24YgkYlHNDG\n+aOVcsMpi7afctEYux/qQP6rEZW8fNi2ZEAJuv282WZZTCQcaaXGZPu5mKeLqO9N\naOIOfuYayBj6xwcITiwD05JpQU+O+hOQI3Z4RXEndJfFb6XLBCteh2s4Y3mjyNEY\n9eURQc9J6hXb/+g46DGT3CULG4yrByamqIFBl8yXQ9koNkvUxBY5RVdoSN+gBbmW\nO78+vjT4IoUAePK1BsKCk3tthg==\n-----END CERTIFICATE-----\n"]
```

check that `juju show-secret-backend` return a well formed certificates.
```sh
❯ juju show-secret-backend myk8s
myk8s:
  backend: kubernetes
  config:
    ca-certs:
    - |
      -----BEGIN CERTIFICATE-----
      MIIDDzCCAfegAwIBAgIUVjFk7525NWv3SVYPprmYwzHxM/AwDQYJKoZIhvcNAQEL
      BQAwFzEVMBMGA1UEAwwMMTAuMTUyLjE4My4xMB4XDTI1MTExMjE0NDAxMVoXDTM1
      MTExMDE0NDAxMVowFzEVMBMGA1UEAwwMMTAuMTUyLjE4My4xMIIBIjANBgkqhkiG
      9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2WjgDp7z7RqvZfZJNws9C1P0xOg8K7yVmykS
      xl1hiF4RTGIUYqrzmMqOiLdWP0VnNgICIx/5IfJQWy7ThzAEPncly4mDllQ3+EDB
      xz01z+d/NTgSu9g8U35wbHXQ2UsO0wHrtbqxdbC8ZQ4K2KVhB+w92yb9E0HD+Z9y
      wDFifvjruSn4yYO3vp9WQfrRsN6IkoARlO1iSvbcdcImL4o/SovdKhUEeedYuYfn
      OLo0lzeoftY7S4rUvljP+oVBMQ8pnNI9Mx3qz8sW3CA5e2uZ47vB9vLyqNKI2KL8
      aky8KvHdTvDbUmb9aMQILc9pMDVLQDBZE44m8FJsUEIgmsj3WwIDAQABo1MwUTAd
      BgNVHQ4EFgQUo6EPUPwbqpvEDqxlkrDBg4iVfFswHwYDVR0jBBgwFoAUo6EPUPwb
      qpvEDqxlkrDBg4iVfFswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
      AQEAcTDK3gz4sSG+TBplA9KrTowtfFSTE5x/1eVHpyqH1ZALfz51zzU9NAzFUIDl
      fnwidvXgSv56ajOfjTOCWjbEmriQDOLUndHB/ZRJdFs7a5ULzJ6tW24YgkYlHNDG
      +aOVcsMpi7afctEYux/qQP6rEZW8fNi2ZEAJuv282WZZTCQcaaXGZPu5mKeLqO9N
      aOIOfuYayBj6xwcITiwD05JpQU+O+hOQI3Z4RXEndJfFb6XLBCteh2s4Y3mjyNEY
      9eURQc9J6hXb/+g46DGT3CULG4yrByamqIFBl8yXQ9koNkvUxBY5RVdoSN+gBbmW
      O78+vjT4IoUAePK1BsKCk3tthg==
      -----END CERTIFICATE-----
    endpoint: https://192.168.1.178:16443
    namespace: juju-secrets
  secrets: 1
  status: active
```

## Links

**Jira card:** [JUJU-8605](https://warthogs.atlassian.net/browse/JUJU-8605)


[JUJU-8605]: https://warthogs.atlassian.net/browse/JUJU-8605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ