### PR TITLE
fix: ensure secret rotate policy can be updated

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -521,7 +521,7 @@ func (s *watcherSuite) setupSecretRotationWatcher(
 	})
 	store := state.NewSecrets(s.State)
 	uri := secrets.NewURI()
-	nexRotateTime := time.Now().Add(time.Hour)
+	nexRotateTime := time.Now().Add(2 * time.Hour)
 	_, err := store.CreateSecret(uri, state.CreateSecretParams{
 		Owner: unit.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
@@ -593,7 +593,7 @@ func (s *watcherSuite) TestSecretsRotationWatcher(c *gc.C) {
 
 	store := state.NewSecrets(s.State)
 
-	nexRotateTime := time.Now().Add(24 * time.Hour).Round(time.Second)
+	nexRotateTime := time.Now().Add(time.Hour).Round(time.Second)
 	_, err := store.UpdateSecret(uri, state.UpdateSecretParams{
 		LeaderToken:    &fakeToken{},
 		NextRotateTime: ptr(nexRotateTime),
@@ -628,7 +628,7 @@ func (s *watcherSuite) setupSecretExpiryWatcher(
 	})
 	store := state.NewSecrets(s.State)
 	uri := secrets.NewURI()
-	nexRotateTime := time.Now().Add(time.Hour)
+	nexRotateTime := time.Now().Add(2 * time.Hour)
 	_, err := store.CreateSecret(uri, state.CreateSecretParams{
 		Owner: unit.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
@@ -694,7 +694,7 @@ func (s *watcherSuite) TestSecretsExpiryWatcher(c *gc.C) {
 
 	store := state.NewSecrets(s.State)
 
-	nexRotateTime := time.Now().Add(24 * time.Hour).Round(time.Second)
+	nexRotateTime := time.Now().Add(time.Hour).Round(time.Second)
 	_, err := store.UpdateSecret(uri, state.UpdateSecretParams{
 		LeaderToken:    &fakeToken{},
 		NextRotateTime: ptr(nexRotateTime),

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -368,12 +368,8 @@ func (s *SecretsManagerAPI) updateSecret(arg params.UpdateSecretArg) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	md, err := s.secretsState.GetSecret(uri)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	var nextRotateTime *time.Time
-	if !md.RotatePolicy.WillRotate() && arg.RotatePolicy.WillRotate() {
+	if arg.RotatePolicy.WillRotate() {
 		nextRotateTime = arg.RotatePolicy.NextRotateTime(s.clock.Now())
 	}
 	_, err = s.secretsState.UpdateSecret(uri, fromUpsertParams(arg.UpsertSecretArg, token, nextRotateTime))

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -373,7 +373,6 @@ func (s *SecretsManagerSuite) TestUpdateSecrets(c *gc.C) {
 	p.Checksum = "deadbeef"
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.secretsState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil).Times(2)
 	s.secretsState.EXPECT().UpdateSecret(&expectURI, p).DoAndReturn(
 		func(uri *coresecrets.URI, p state.UpdateSecretParams) (*coresecrets.SecretMetadata, error) {
 			md := &coresecrets.SecretMetadata{
@@ -452,7 +451,6 @@ func (s *SecretsManagerSuite) TestUpdateSecretDuplicateLabel(c *gc.C) {
 	)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
-	s.secretsState.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{}, nil)
 	s.expectSecretAccessQuery(2)
 
 	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -1,78 +1,101 @@
 check_secrets() {
-	juju --show-log deploy easyrsa
-	juju --show-log deploy etcd
-	juju --show-log integrate etcd easyrsa
+	juju --show-log deploy juju-qa-dummy-source
+	juju --show-log deploy juju-qa-dummy-sink
+	juju --show-log integrate dummy-sink dummy-source
+	juju config dummy-source token=foo
 
-	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
-	wait_for "active" '.applications["etcd"] | ."application-status".current' 900
-	wait_for "easyrsa" "$(idle_condition "easyrsa" 0 0)"
-	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
-	wait_for "active" "$(workload_status "etcd" 0).current"
+	wait_for "active" '.applications["dummy-source"] | ."application-status".current'
+	wait_for "active" '.applications["dummy-sink"] | ."application-status".current' 900
+	wait_for "active" "$(workload_status "dummy-source" 0).current"
+	wait_for "active" "$(workload_status "dummy-sink" 0).current"
 
 	echo "Apps deployed, creating secrets"
-	secret_owned_by_easyrsa_0=$(juju exec --unit easyrsa/0 -- secret-add --owner unit owned-by=easyrsa/0)
-	secret_owned_by_easyrsa_0_id=${secret_owned_by_easyrsa_0##*/}
-	secret_owned_by_easyrsa=$(juju exec --unit easyrsa/0 -- secret-add owned-by=easyrsa-app)
-	secret_owned_by_easyrsa_id=${secret_owned_by_easyrsa##*/}
+	secret_owned_by_dummy_source_0=$(juju exec --unit dummy-source/0 -- secret-add --owner unit owned-by=dummy-source/0)
+	secret_owned_by_dummy_source_0_id=${secret_owned_by_dummy_source_0##*/}
+	secret_owned_by_dummy_source=$(juju exec --unit dummy-source/0 -- secret-add owned-by=dummy-source-app)
+	secret_owned_by_dummy_source_id=${secret_owned_by_dummy_source##*/}
 
-	echo "Set same content again for $secret_owned_by_easyrsa."
-	juju exec --unit easyrsa/0 -- secret-set "$secret_owned_by_easyrsa_id" owned-by=easyrsa-app
+	echo "Set same content again for $secret_owned_by_dummy_source."
+	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_id" owned-by=dummy-source-app
 
 	echo "Checking secret ids"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-ids)" "$secret_owned_by_easyrsa_id"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-ids)" "$secret_owned_by_easyrsa_0_id"
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-ids)" "$secret_owned_by_dummy_source_id"
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-ids)" "$secret_owned_by_dummy_source_0_id"
 
-	echo "Set a label for the unit owned secret $secret_owned_by_easyrsa_0."
-	juju exec --unit easyrsa/0 -- secret-set "$secret_owned_by_easyrsa_0" --label=easyrsa_0
-	echo "Set a consumer label for the app owned secret $secret_owned_by_easyrsa."
-	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" --label=easyrsa-app
+	echo "Set a label for the unit owned secret $secret_owned_by_dummy_source_0."
+	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_0" --label=dummy-source_0
+	echo "Set a consumer label for the app owned secret $secret_owned_by_dummy_source."
+	juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source" --label=dummy-source-app
 
 	echo "Checking: secret-get by URI - content"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa_0")" 'owned-by: easyrsa/0'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa")" 'owned-by: easyrsa-app'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source_0")" 'owned-by: dummy-source/0'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source")" 'owned-by: dummy-source-app'
 
 	echo "Checking: secret-get by URI - metadata"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa_0" --format json | jq ".${secret_owned_by_easyrsa_0_id}.owner")" 'unit'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa_id}.owner")" 'application'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa_id}.revision")" '1'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source_0" --format json | jq ".${secret_owned_by_dummy_source_0_id}.owner")" 'unit'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | jq ".${secret_owned_by_dummy_source_id}.owner")" 'application'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | jq ".${secret_owned_by_dummy_source_id}.revision")" '1'
 
 	echo "Checking: secret-get by label or consumer label - content"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get --label=easyrsa_0)" 'owned-by: easyrsa/0'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get --label=easyrsa-app)" 'owned-by: easyrsa-app'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-get --label=dummy-source_0)" 'owned-by: dummy-source/0'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-get --label=dummy-source-app)" 'owned-by: dummy-source-app'
 
 	echo "Checking: secret-get by label - metadata"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get --label=easyrsa_0 --format json | jq ".${secret_owned_by_easyrsa_0_id}.label")" 'easyrsa_0'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get --label=dummy-source_0 --format json | jq ".${secret_owned_by_dummy_source_0_id}.label")" 'dummy-source_0'
 
-	relation_id=$(juju --show-log show-unit easyrsa/0 --format json | jq '."easyrsa/0"."relation-info"[0]."relation-id"')
-	juju exec --unit easyrsa/0 -- secret-grant "$secret_owned_by_easyrsa_0" -r "$relation_id"
-	juju exec --unit easyrsa/0 -- secret-grant "$secret_owned_by_easyrsa" -r "$relation_id"
+	relation_id=$(juju --show-log show-unit dummy-source/0 --format json | jq '."dummy-source/0"."relation-info"[0]."relation-id"')
+	juju exec --unit dummy-source/0 -- secret-grant "$secret_owned_by_dummy_source_0" -r "$relation_id"
+	juju exec --unit dummy-source/0 -- secret-grant "$secret_owned_by_dummy_source" -r "$relation_id"
 
 	echo "Checking: secret-get by URI - consume content by ID"
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa_0" --label=consumer_label_secret_owned_by_easyrsa_0)" 'owned-by: easyrsa/0'
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa" --label=consumer_label_secret_owned_by_easyrsa)" 'owned-by: easyrsa-app'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source_0" --label=consumer_label_secret_owned_by_dummy_source_0)" 'owned-by: dummy-source/0'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source" --label=consumer_label_secret_owned_by_dummy_source)" 'owned-by: dummy-source-app'
 
 	echo "Checking: secret-get by URI - consume content by label"
-	check_contains "$(juju exec --unit etcd/0 -- secret-get --label=consumer_label_secret_owned_by_easyrsa_0)" 'owned-by: easyrsa/0'
-	check_contains "$(juju exec --unit etcd/0 -- secret-get --label=consumer_label_secret_owned_by_easyrsa)" 'owned-by: easyrsa-app'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label=consumer_label_secret_owned_by_dummy_source_0)" 'owned-by: dummy-source/0'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label=consumer_label_secret_owned_by_dummy_source)" 'owned-by: dummy-source-app'
 
-	echo "Set different content for $secret_owned_by_easyrsa."
-	juju exec --unit easyrsa/0 -- secret-set "$secret_owned_by_easyrsa_id" foo=bar
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa_id}.revision")" '2'
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get --refresh "$secret_owned_by_easyrsa")" 'foo: bar'
+	echo "Set different content for $secret_owned_by_dummy_source."
+	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_id" foo=bar
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | jq ".${secret_owned_by_dummy_source_id}.revision")" '2'
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-get --refresh "$secret_owned_by_dummy_source")" 'foo: bar'
 
 	echo "Checking: secret-revoke by relation ID"
-	juju exec --unit easyrsa/0 -- secret-revoke "$secret_owned_by_easyrsa" --relation "$relation_id"
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa" 2>&1)" 'permission denied'
+	juju exec --unit dummy-source/0 -- secret-revoke "$secret_owned_by_dummy_source" --relation "$relation_id"
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source" 2>&1)" 'permission denied'
 
 	echo "Checking: secret-revoke by app name"
-	juju exec --unit easyrsa/0 -- secret-revoke "$secret_owned_by_easyrsa_0" --app etcd
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa_0" 2>&1)" 'permission denied'
+	juju exec --unit dummy-source/0 -- secret-revoke "$secret_owned_by_dummy_source_0" --app dummy-sink
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source_0" 2>&1)" 'permission denied'
+
+	echo "Checking secret rotate"
+	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_0" --rotate daily
+	check_contains "$(juju show-secret "$secret_owned_by_dummy_source_0" --format json | jq ".[].rotation")" "daily"
+	original_rotate_time="$(juju show-secret "$secret_owned_by_dummy_source_0" --format json | jq ".[].rotates")"
+	# We set a new rotate time into the future and we need to retain
+	# the current next rotate time.
+	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_0" --rotate monthly
+	check_contains "$(juju show-secret "$secret_owned_by_dummy_source_0" --format json | jq ".[].rotation")" "monthly"
+	next_rotate_time="$(juju show-secret "$secret_owned_by_dummy_source_0" --format json | jq ".[].rotates")"
+	if [[ $original_rotate_time != "$next_rotate_time" ]]; then
+		echo "secret next rotate time was updated in error"
+		exit 1
+	fi
+	# We set a new rotate time sooner than the current rotate time so we need to
+	# update the next rotate time.
+	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_0" --rotate hourly
+	check_contains "$(juju show-secret "$secret_owned_by_dummy_source_0" --format json | jq ".[].rotation")" "hourly"
+	next_rotate_time="$(juju show-secret "$secret_owned_by_dummy_source_0" --format json | jq ".[].rotates")"
+	if [[ $original_rotate_time == "$next_rotate_time" ]]; then
+		echo "secret next rotate time was not updated"
+		exit 1
+	fi
 
 	echo "Checking: secret-remove"
-	juju exec --unit easyrsa/0 -- secret-remove "$secret_owned_by_easyrsa_0"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa_0" 2>&1)" 'not found'
-	juju exec --unit easyrsa/0 -- secret-remove "$secret_owned_by_easyrsa"
-	check_contains "$(juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" 2>&1)" 'not found'
+	juju exec --unit dummy-source/0 -- secret-remove "$secret_owned_by_dummy_source_0"
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source_0" 2>&1)" 'not found'
+	juju exec --unit dummy-source/0 -- secret-remove "$secret_owned_by_dummy_source"
+	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source" 2>&1)" 'not found'
 }
 
 run_user_secrets() {
@@ -80,8 +103,10 @@ run_user_secrets() {
 
 	model_name=${1}
 
-	app_name='easyrsa-user-secrets'
-	juju --show-log deploy easyrsa "$app_name"
+	app_name='dummy-user-secrets'
+	juju --show-log deploy juju-qa-test "$app_name"
+
+	wait_for "active" '.applications["dummy-user-secrets"] | ."application-status".current'
 
 	# first test the creation of a large secret which encodes to approx 1MB in size.
 	echo "data: $(cat /dev/zero | tr '\0' A | head -c 749500)" >"${TEST_DIR}/secret.txt"
@@ -174,15 +199,16 @@ test_secrets_juju() {
 }
 
 obsolete_secret_revisions() {
-	local secret_short_uri
-	secret_short_uri=${1}
+	local secret_id
+	secret_id=${1}
 
-	out=$(
-		juju ssh ubuntu-lite/0 sh <<EOF
+	yaml_out=$(
+		juju ssh juju-qa-test/0 sh <<EOF
 . /etc/profile.d/juju-introspection.sh
-juju_engine_report | sed 1d | yq '..style="flow" | .manifolds.deployer.report.units.workers.ubuntu-lite/0.report.manifolds.uniter.report.secrets.obsolete-revisions."'"${secret_short_uri}"'"'
+juju_engine_report
 EOF
 	)
+	out=$(echo "${yaml_out}" | sed 1d | yq "..style=\"flow\" | .manifolds.deployer.report.handler.units.workers.juju-qa-test/0.report.manifolds.uniter.report.secrets.obsolete-revisions.\"${secret_id}\"")
 	echo "${out}"
 }
 
@@ -191,20 +217,21 @@ run_obsolete_revisions() {
 
 	model_name=${1}
 
-	juju --show-log deploy jameinel-ubuntu-lite
-	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
-	juju ssh ubuntu-lite/0 "sudo snap install yq"
+	juju --show-log deploy juju-qa-test
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
-	secret_uri=$(juju --show-log exec -u ubuntu-lite/0 -- secret-add foo=bar)
-	secret_short_uri="secret:${secret_uri##*/}"
+	secret_uri=$(juju --show-log exec -u juju-qa-test/0 -- secret-add foo=bar)
+	# Extract bare secret id (without "secret:" prefix) for matching logs and keep prefixed form for engine report keys.
+	secret_id=${secret_uri##*/}
+	secret_short_uri="secret:${secret_id}"
 
 	# Create 10 new revisions, so we'll have 11 in total. 1-10 will be obsolete.
-	for i in $(seq 10); do juju --show-log exec --unit ubuntu-lite/0 -- secret-set "$secret_uri" foo="$i"; done
+	for i in $(seq 10); do juju --show-log exec --unit juju-qa-test/0 -- secret-set "$secret_uri" foo="$i"; done
 
 	# Check that the secret-remove hook is run for the 10 obsolete revisions.
 	attempt=0
 	while true; do
-		num_hooks=$(juju show-status-log ubuntu-lite/0 --format yaml -n 100 | yq -o json | jq -r '[.[] | select(.message != null) | select(.message | contains("running secret-remove hook for '"${secret_short_uri}"'"))] | length')
+		num_hooks=$(juju show-status-log juju-qa-test/0 --format json -n 100 | jq -r "[.[] | select(.message != null) | select(.message | contains(\"running secret-remove hook\") and contains(\"${secret_id}\"))] | length")
 		if [ "$num_hooks" -eq 10 ]; then
 			break
 		fi
@@ -221,7 +248,7 @@ run_obsolete_revisions() {
 	echo "Checking initial obsolete revisions 1..10"
 	attempt=0
 	while true; do
-		obsolete=$(obsolete_secret_revisions "${secret_short_uri}")
+		obsolete=$(obsolete_secret_revisions "${secret_id}")
 		if [ "$obsolete" == "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]" ]; then
 			break
 		fi
@@ -235,13 +262,13 @@ run_obsolete_revisions() {
 	done
 
 	# Remove a single revision.
-	juju --show-log exec --unit ubuntu-lite/0 -- secret-remove "$secret_uri" --revision 6
+	juju --show-log exec --unit juju-qa-test/0 -- secret-remove "$secret_uri" --revision 6
 
 	# Check that the unit state has the deleted revision removed.
 	echo "Checking revision 6 has been removed from the obsolete revisions"
 	attempt=0
 	while true; do
-		obsolete=$(obsolete_secret_revisions "${secret_short_uri}")
+		obsolete=$(obsolete_secret_revisions "${secret_id}")
 		if [ "$obsolete" == "[1, 2, 3, 4, 5, 7, 8, 9, 10]" ]; then
 			break
 		fi
@@ -255,13 +282,13 @@ run_obsolete_revisions() {
 	done
 
 	# Delete the entire secret.
-	juju --show-log exec --unit ubuntu-lite/0 -- secret-remove "$secret_uri"
+	juju --show-log exec --unit juju-qa-test/0 -- secret-remove "$secret_uri"
 
 	# Check that all the obsolete revisions are removed from unit state.
 	echo "Checking all obsolete revision are removed when the secret is deleted"
 	attempt=0
 	while true; do
-		obsolete=$(obsolete_secret_revisions "${secret_short_uri}")
+		obsolete=$(obsolete_secret_revisions "${secret_id}")
 		if [ $obsolete == null ]; then
 			break
 		fi


### PR DESCRIPTION
There was an error trying to change the secret rotate policy.
The logic was meant to stop a secret next rotate time from being changed if it were to occur after any current rotate time already recorded.

This PR fixes that and adds a ci test for rotation. The existing ci test that was enhanced has the changed from 4.0 backported so that better charms are used.

## QA steps

`./main.sh -v secrets_iaas test_secrets_juju`

## Links

**Issue:** Fixes #20928.

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
