### PR TITLE
feat: introduce state machine for provisioner task states

### DIFF
--- a/internal/provisionertask/machine_fsm.go
+++ b/internal/provisionertask/machine_fsm.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provisionertask
+
+import (
+	"fmt"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+)
+
+// MachineState represents the state of a machine in the FSM.
+type MachineState string
+
+const (
+	// StatePending indicates the machine has been created but not yet started.
+	StatePending MachineState = "Pending"
+
+	// StateStarting indicates the machine is in the process of being started.
+	StateStarting MachineState = "Starting"
+
+	// StateCancellingStart indicates a request to stop the machine was received
+	// while it was still starting. The machine will transition to Stopping once
+	// the start operation completes.
+	StateCancellingStart MachineState = "CancellingStart"
+
+	// StateRunning indicates the machine has been successfully started and has
+	// an instance ID assigned.
+	StateRunning MachineState = "Running"
+
+	// StateStopping indicates the machine is in the process of being stopped.
+	StateStopping MachineState = "Stopping"
+
+	// StateDead indicates the machine has been stopped and removed. This is a
+	// terminal state.
+	StateDead MachineState = "Dead"
+
+	// StateFailed indicates the machine encountered an error during
+	// provisioning or operation. This is a terminal state.
+	StateFailed MachineState = "Failed"
+)
+
+// ErrIllegalTransition is returned when an illegal state transition is
+// attempted.
+var ErrIllegalTransition = errors.ConstError("illegal state transition")
+
+// allowedTransitions defines the valid state transitions in the FSM.
+// Each state maps to a set of states it can transition to.
+//
+// These transitions follow the following (mermaid) diagram:
+//
+// stateDiagram-v2
+//
+//	[*] --> Pending
+//	Pending --> Starting: machineChange(Alive & no InstanceId)
+//	Pending --> Dead: machineChange(Dead|Dying & no InstanceId)
+//	Starting --> Running: StartSuccess (instance created + info set)
+//	Starting --> Starting: StartTransientErr / backoff (retry loop internal to task today)
+//	Starting --> Failed: StartPermanentErr
+//	Starting --> CancellingStart: machineChange(Dead|Dying while in-flight)
+//	CancellingStart --> Stopping: StartSuccess (instance now exists → compensate)
+//	CancellingStart --> Dead: StartErr(any) (no instance to stop)
+//	Running --> Stopping: machineChange(Dead|Dying|Remove)
+//	Stopping --> Dead: StopSuccess (MarkForRemoval done)
+//	Stopping --> Stopping: StopTransientErr / backoff
+//	Stopping --> Failed: StopPermanentErr
+//	Dead --> [*]
+//	Failed --> [*]
+var allowedTransitions = map[MachineState]set.Strings{
+	StatePending: set.NewStrings(
+		string(StateStarting),
+		string(StateDead),
+	),
+	StateStarting: set.NewStrings(
+		string(StateRunning),
+		string(StateFailed),
+		string(StateCancellingStart),
+		string(StateStarting), // idempotent for transient errors.
+	),
+	StateCancellingStart: set.NewStrings(
+		string(StateStopping),
+		string(StateDead),
+	),
+	StateRunning: set.NewStrings(
+		string(StateStopping),
+	),
+	StateStopping: set.NewStrings(
+		string(StateDead),
+		string(StateFailed),
+		string(StateStopping), // idempotent for transient errors.
+	),
+	StateDead: set.NewStrings(
+		string(StateDead), // terminal, idempotent.
+	),
+	StateFailed: set.NewStrings(
+		string(StateFailed), // terminal, idempotent.
+	),
+}
+
+// MachineFSM represents a finite state machine for a single machine.
+// It tracks the machine's current state and enforces valid state transitions.
+type MachineFSM struct {
+	// ID is the machine's unique identifier.
+	ID string
+
+	// State is the current state of the machine in the FSM.
+	State MachineState
+}
+
+// NewMachineFSM creates a new MachineFSM with the given ID.
+// The FSM is initialized in the Pending state.
+func NewMachineFSM(id string) *MachineFSM {
+	return &MachineFSM{
+		ID:    id,
+		State: StatePending,
+	}
+}
+
+// TransitionTo attempts to transition the FSM to the target state.
+// It returns an error if the transition is not allowed.
+//
+// If the target state is the same as the current state, this is a no-op
+// and returns nil (idempotent transitions are allowed for terminal and
+// transient states).
+func (f *MachineFSM) TransitionTo(target MachineState) error {
+	if f.State == target {
+		return nil
+	}
+
+	// Check if transition is allowed.
+	allowed, exists := allowedTransitions[f.State]
+	if !exists {
+		return errors.Annotatef(ErrIllegalTransition,
+			"machine %s: unknown current state %q", f.ID, f.State)
+	}
+
+	if !allowed.Contains(string(target)) {
+		return errors.Annotatef(ErrIllegalTransition,
+			"machine %s: cannot transition from %q to %q", f.ID, f.State, target)
+	}
+
+	f.State = target
+	return nil
+}
+
+// IsTerminal returns true if the given state is a terminal state.
+// Terminal states are Dead and Failed, which represent the end of a
+// machine's lifecycle in the FSM.
+func IsTerminal(state MachineState) bool {
+	return state == StateDead || state == StateFailed
+}
+
+// String returns a string representation of the FSM.
+func (f *MachineFSM) String() string {
+	return fmt.Sprintf("MachineFSM[%s: %s]", f.ID, f.State)
+}

--- a/internal/provisionertask/machine_fsm_test.go
+++ b/internal/provisionertask/machine_fsm_test.go
@@ -1,0 +1,212 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provisionertask_test
+
+import (
+	"testing"
+
+	"github.com/juju/errors"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/internal/provisionertask"
+)
+
+type MachineFSMSuite struct{}
+
+func TestMachineFSMSuite(t *testing.T) {
+	tc.Run(t, &MachineFSMSuite{})
+}
+
+func (s *MachineFSMSuite) TestNewMachineFSM(c *tc.C) {
+	fsm := provisionertask.NewMachineFSM("42")
+	c.Assert(fsm, tc.NotNil)
+	c.Assert(fsm.ID, tc.Equals, "42")
+	c.Assert(fsm.State, tc.Equals, provisionertask.StatePending)
+}
+
+func (s *MachineFSMSuite) TestIdempotentTransitions(c *tc.C) {
+	testCases := []struct {
+		state       provisionertask.MachineState
+		description string
+	}{
+		{provisionertask.StatePending, "Pending to Pending"},
+		{provisionertask.StateStarting, "Starting to Starting"},
+		{provisionertask.StateStopping, "Stopping to Stopping"},
+		{provisionertask.StateDead, "Dead to Dead"},
+		{provisionertask.StateFailed, "Failed to Failed"},
+	}
+
+	for _, tt := range testCases {
+		fsm := provisionertask.NewMachineFSM("test")
+		fsm.State = tt.state
+		err := fsm.TransitionTo(tt.state)
+		c.Assert(err, tc.IsNil, tc.Commentf("Expected idempotent transition for %s", tt.description))
+		c.Assert(fsm.State, tc.Equals, tt.state)
+	}
+}
+
+func (s *MachineFSMSuite) TestAllowedTransitions(c *tc.C) {
+	testCases := []struct {
+		from        provisionertask.MachineState
+		to          provisionertask.MachineState
+		description string
+	}{
+		// From Pending.
+		{provisionertask.StatePending, provisionertask.StateStarting, "Pending to Starting"},
+		{provisionertask.StatePending, provisionertask.StateDead, "Pending to Dead"},
+
+		// From Starting.
+		{provisionertask.StateStarting, provisionertask.StateRunning, "Starting to Running"},
+		{provisionertask.StateStarting, provisionertask.StateFailed, "Starting to Failed"},
+		{provisionertask.StateStarting, provisionertask.StateCancellingStart, "Starting to CancellingStart"},
+
+		// From CancellingStart.
+		{provisionertask.StateCancellingStart, provisionertask.StateStopping, "CancellingStart to Stopping"},
+		{provisionertask.StateCancellingStart, provisionertask.StateDead, "CancellingStart to Dead"},
+
+		// From Running.
+		{provisionertask.StateRunning, provisionertask.StateStopping, "Running to Stopping"},
+
+		// From Stopping.
+		{provisionertask.StateStopping, provisionertask.StateDead, "Stopping to Dead"},
+		{provisionertask.StateStopping, provisionertask.StateFailed, "Stopping to Failed"},
+	}
+
+	for _, tt := range testCases {
+		fsm := provisionertask.NewMachineFSM("test")
+		fsm.State = tt.from
+		err := fsm.TransitionTo(tt.to)
+		c.Assert(err, tc.IsNil, tc.Commentf("Expected allowed transition for %s", tt.description))
+		c.Assert(fsm.State, tc.Equals, tt.to, tc.Commentf("State should be %s after %s", tt.to, tt.description))
+	}
+}
+
+func (s *MachineFSMSuite) TestIllegalTransitions(c *tc.C) {
+	testCases := []struct {
+		from        provisionertask.MachineState
+		to          provisionertask.MachineState
+		description string
+	}{
+		// From Pending - illegal transitions.
+		{provisionertask.StatePending, provisionertask.StateRunning, "Pending to Running (should go through Starting)"},
+		{provisionertask.StatePending, provisionertask.StateStopping, "Pending to Stopping"},
+		{provisionertask.StatePending, provisionertask.StateFailed, "Pending to Failed"},
+
+		// From Starting - illegal transitions.
+		{provisionertask.StateStarting, provisionertask.StatePending, "Starting to Pending (backwards)"},
+		{provisionertask.StateStarting, provisionertask.StateDead, "Starting to Dead (should go through CancellingStart/Stopping)"},
+
+		// From CancellingStart - illegal transitions.
+		{provisionertask.StateCancellingStart, provisionertask.StateStarting, "CancellingStart to Starting (backwards)"},
+		{provisionertask.StateCancellingStart, provisionertask.StateRunning, "CancellingStart to Running"},
+		{provisionertask.StateCancellingStart, provisionertask.StateFailed, "CancellingStart to Failed"},
+
+		// From Running - illegal transitions.
+		{provisionertask.StateRunning, provisionertask.StatePending, "Running to Pending (backwards)"},
+		{provisionertask.StateRunning, provisionertask.StateStarting, "Running to Starting (backwards)"},
+		{provisionertask.StateRunning, provisionertask.StateDead, "Running to Dead (should go through Stopping)"},
+		{provisionertask.StateRunning, provisionertask.StateFailed, "Running to Failed (should go through Stopping)"},
+
+		// From Stopping - illegal transitions.
+		{provisionertask.StateStopping, provisionertask.StatePending, "Stopping to Pending"},
+		{provisionertask.StateStopping, provisionertask.StateStarting, "Stopping to Starting"},
+		{provisionertask.StateStopping, provisionertask.StateRunning, "Stopping to Running"},
+
+		// From Dead - terminal state, only Dead is allowed (tested in
+		// idempotent).
+		{provisionertask.StateDead, provisionertask.StatePending, "Dead to Pending (terminal state)"},
+		{provisionertask.StateDead, provisionertask.StateStarting, "Dead to Starting (terminal state)"},
+		{provisionertask.StateDead, provisionertask.StateRunning, "Dead to Running (terminal state)"},
+
+		// From Failed - terminal state, only Failed is allowed (tested in
+		// idempotent).
+		{provisionertask.StateFailed, provisionertask.StatePending, "Failed to Pending (terminal state)"},
+		{provisionertask.StateFailed, provisionertask.StateStarting, "Failed to Starting (terminal state)"},
+		{provisionertask.StateFailed, provisionertask.StateRunning, "Failed to Running (terminal state)"},
+	}
+
+	for _, tt := range testCases {
+		fsm := provisionertask.NewMachineFSM("test")
+		fsm.State = tt.from
+		err := fsm.TransitionTo(tt.to)
+		c.Assert(err, tc.NotNil, tc.Commentf("Expected error for illegal transition: %s", tt.description))
+		c.Assert(errors.Is(err, provisionertask.ErrIllegalTransition), tc.IsTrue,
+			tc.Commentf("Expected ErrIllegalTransition for %s, got: %v", tt.description, err))
+		c.Assert(fsm.State, tc.Equals, tt.from, tc.Commentf("State should remain %s after failed transition", tt.from))
+	}
+}
+
+func (s *MachineFSMSuite) TestTerminalStates(c *tc.C) {
+	c.Assert(provisionertask.IsTerminal(provisionertask.StateDead), tc.IsTrue)
+	c.Assert(provisionertask.IsTerminal(provisionertask.StateFailed), tc.IsTrue)
+
+	// Non-terminal states.
+	c.Assert(provisionertask.IsTerminal(provisionertask.StatePending), tc.IsFalse)
+	c.Assert(provisionertask.IsTerminal(provisionertask.StateStarting), tc.IsFalse)
+	c.Assert(provisionertask.IsTerminal(provisionertask.StateCancellingStart), tc.IsFalse)
+	c.Assert(provisionertask.IsTerminal(provisionertask.StateRunning), tc.IsFalse)
+	c.Assert(provisionertask.IsTerminal(provisionertask.StateStopping), tc.IsFalse)
+}
+
+func (s *MachineFSMSuite) TestFSMString(c *tc.C) {
+	fsm := provisionertask.NewMachineFSM("42")
+	c.Assert(fsm.String(), tc.Equals, "MachineFSM[42: Pending]")
+
+	fsm.State = provisionertask.StateRunning
+	c.Assert(fsm.String(), tc.Equals, "MachineFSM[42: Running]")
+}
+
+func (s *MachineFSMSuite) TestCompleteLifecycle(c *tc.C) {
+	// Test a complete lifecycle:
+	// Pending -> Starting -> Running -> Stopping -> Dead
+	fsm := provisionertask.NewMachineFSM("lifecycle-test")
+
+	// Start in Pending.
+	c.Assert(fsm.State, tc.Equals, provisionertask.StatePending)
+
+	// Transition to Starting.
+	err := fsm.TransitionTo(provisionertask.StateStarting)
+	c.Assert(err, tc.IsNil)
+	c.Assert(fsm.State, tc.Equals, provisionertask.StateStarting)
+
+	// Transition to Running.
+	err = fsm.TransitionTo(provisionertask.StateRunning)
+	c.Assert(err, tc.IsNil)
+	c.Assert(fsm.State, tc.Equals, provisionertask.StateRunning)
+
+	// Transition to Stopping.
+	err = fsm.TransitionTo(provisionertask.StateStopping)
+	c.Assert(err, tc.IsNil)
+	c.Assert(fsm.State, tc.Equals, provisionertask.StateStopping)
+
+	// Transition to Dead.
+	err = fsm.TransitionTo(provisionertask.StateDead)
+	c.Assert(err, tc.IsNil)
+	c.Assert(fsm.State, tc.Equals, provisionertask.StateDead)
+	c.Assert(provisionertask.IsTerminal(fsm.State), tc.IsTrue)
+}
+
+func (s *MachineFSMSuite) TestCancellationLifecycle(c *tc.C) {
+	// Test cancellation during start:
+	// Pending -> Starting -> CancellingStart -> Stopping -> Dead
+	fsm := provisionertask.NewMachineFSM("cancellation-test")
+
+	// Transition to Starting.
+	err := fsm.TransitionTo(provisionertask.StateStarting)
+	c.Assert(err, tc.IsNil)
+
+	// Transition to CancellingStart.
+	err = fsm.TransitionTo(provisionertask.StateCancellingStart)
+	c.Assert(err, tc.IsNil)
+	c.Assert(fsm.State, tc.Equals, provisionertask.StateCancellingStart)
+
+	// Transition to Stopping.
+	err = fsm.TransitionTo(provisionertask.StateStopping)
+	c.Assert(err, tc.IsNil)
+
+	// Transition to Dead.
+	err = fsm.TransitionTo(provisionertask.StateDead)
+	c.Assert(err, tc.IsNil)
+	c.Assert(provisionertask.IsTerminal(fsm.State), tc.IsTrue)
+}

--- a/internal/provisionertask/provisioner_task.go
+++ b/internal/provisionertask/provisioner_task.go
@@ -164,6 +164,7 @@ func NewProvisionerTask(cfg TaskConfig) (ProvisionerTask, error) {
 		wp:                           workerpool.NewWorkerPool(cfg.Logger, cfg.NumProvisionWorkers),
 		wpSizeChan:                   make(chan int, 1),
 		eventProcessedCb:             cfg.EventProcessedCb,
+		fsms:                         make(map[string]*MachineFSM),
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Name: "provisioner-task",
@@ -209,6 +210,7 @@ type provisionerTask struct {
 	machinesStopDeferred     map[string]bool                              // machine IDs which were set as dead while starting. They will be stopped once they are online.
 	availabilityZoneMachines []*AvailabilityZoneMachine
 	instances                map[instance.Id]instances.Instance // instanceID -> instance
+	fsms                     map[string]*MachineFSM             // machine ID -> FSM for tracking machine state.
 
 	// A worker pool for starting/stopping instances in parallel.
 	wp         *workerpool.WorkerPool


### PR DESCRIPTION
__Note: This patch is the first out of many that aims to improve the readability and reduce races in the provisioner task.__

This commit introduces a new FSM for modelling the machines' states in the context of the provisioner task.

The main goal here is to get rid of the legacy "defer stop" path. Although this is not done in this commit, the introduction of a CancellingStart state will allow us to rewrite that logic without locks and mutable variables.

_Note to reviewers: Although we usually prescribe against table-based testing, I thought that it would fit nicely in the FSM allowed states tests, because of the combinatorics nature of them._


## QA steps

No behavioral change introduced yet, unit tests should pass though.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
