### PR TITLE
fix(secretbackend): immutability for built-in backends

### DIFF
--- a/domain/schema/controller/sql/0026-secret-backend-immutable-trigger.PATCH.sql
+++ b/domain/schema/controller/sql/0026-secret-backend-immutable-trigger.PATCH.sql
@@ -1,0 +1,25 @@
+-- When merging into main, update the file domain/schema/controller.go:
+--  - triggersForImmutableTable "secret_backend" needs to be updated to below condition and message
+--  - this file needs to be removed
+
+DROP TRIGGER IF EXISTS trg_secret_backend_immutable_update;
+
+CREATE TRIGGER trg_secret_backend_immutable_update
+    BEFORE UPDATE ON secret_backend
+    FOR EACH ROW
+    WHEN OLD.name IN ('internal', 'kubernetes')
+BEGIN
+    SELECT RAISE(FAIL, 'built-in secret backends named "internal" or "kubernetes" are immutable');
+END;
+
+
+DROP TRIGGER IF EXISTS trg_secret_backend_immutable_delete;
+
+CREATE TRIGGER trg_secret_backend_immutable_delete
+    BEFORE DELETE ON secret_backend
+    FOR EACH ROW
+    WHEN OLD.name IN ('internal', 'kubernetes')
+BEGIN
+    SELECT RAISE(FAIL, 'built-in secret backends named "internal" or "kubernetes" are immutable');
+END;
+

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -634,7 +634,7 @@ func (s *stateSuite) TestUpdateSecretBackendFailedForInternalBackend(c *tc.C) {
 	_, err := s.state.CreateSecretBackend(c.Context(), secretbackend.CreateSecretBackendParams{
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID:   backendID,
-			Name: "my-backend",
+			Name: juju.BackendName,
 		},
 		BackendType: "controller",
 	})
@@ -656,7 +656,7 @@ func (s *stateSuite) TestUpdateSecretBackendFailedForKubernetesBackend(c *tc.C) 
 	_, err := s.state.CreateSecretBackend(c.Context(), secretbackend.CreateSecretBackendParams{
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID:   backendID,
-			Name: "my-backend",
+			Name: kubernetes.BackendName,
 		},
 		BackendType: "kubernetes",
 	})
@@ -779,7 +779,7 @@ func (s *stateSuite) TestDeleteSecretBackendFailedForInternalBackend(c *tc.C) {
 	_, err := s.state.CreateSecretBackend(c.Context(), secretbackend.CreateSecretBackendParams{
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID:   backendID,
-			Name: "my-backend",
+			Name: juju.BackendName,
 		},
 		BackendType: "controller",
 	})
@@ -795,7 +795,7 @@ func (s *stateSuite) TestDeleteSecretBackendFailedForKubernetesBackend(c *tc.C) 
 	_, err := s.state.CreateSecretBackend(c.Context(), secretbackend.CreateSecretBackendParams{
 		BackendIdentifier: secretbackend.BackendIdentifier{
 			ID:   backendID,
-			Name: "my-backend",
+			Name: kubernetes.BackendName,
 		},
 		BackendType: "kubernetes",
 	})


### PR DESCRIPTION
This patch fixes the database triggers which ensure "internal" and "kubernetes" secret backends are immutable.

Before this patch, these triggers used the backend_type_id to ensure immutability, asserting that backend with types "controller" and "kubernetes" cannot be removed. This caused an issue when someone adds a new backend on k8s as done in test suites `secrets_iaas test_secrets_k8s`

After this patch, the trigger uses the names (`internal` and `kubernetes`) which fixes the issue.

Note: this patch is meant to be merged in the released 4.0 branch, for main it should be done in `domain/schema/controller.go` directly.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

You will need a working microk8s

### prepare microk8s

```sh
export TEST_DIR=$(mktemp -d)
endpoint=$(microk8s.config | yq ".clusters[0] .cluster .server")
cacert=$(microk8s.config | yq ".clusters[0] .cluster .certificate-authority-data" | base64 -d | sed 's/^/  /')
namespace=juju-secrets
serviceaccount=default
microk8s.kubectl create ns ${namespace} --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config -n ${namespace} serviceaccount ${serviceaccount} --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config clusterrole juju-secrets --verb='*' \
	--resource=namespaces,secrets,serviceaccounts,serviceaccounts/token,clusterroles,clusterrolebindings --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config clusterrolebinding juju-secrets --clusterrole=juju-secrets \
	--serviceaccount=${namespace}:${serviceaccount} --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config role juju-secrets --namespace=${namespace} --verb='*' \
	--resource=secrets,serviceaccounts,serviceaccounts/token,roles,rolebindings --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config rolebinding juju-secrets --namespace=${namespace} --role=juju-secrets \
	--serviceaccount=${namespace}:${serviceaccount} --dry-run=client -o yaml | microk8s.kubectl apply -f -
token=$(microk8s.kubectl create token ${serviceaccount} --namespace ${namespace})
cat >"${TEST_DIR}/k8sconfig.yaml" <<EOF
endpoint: ${endpoint}
namespace: ${namespace}
ca-cert: |
${cacert}
token: ${token}
EOF
```

### Add the backend

```sh
juju add-secret-backend myk8s kubernetes --config "${TEST_DIR}/k8sconfig.yaml"
```

### Kill things

```sh
 juju remove-secret-backend myk8s   # should works
 juju remove-secret-backend internal   # should not work
 juju remove-secret-backend kubernetes   # should not work
``` 

## Links

**Jira card:** [JUJU-8605](https://warthogs.atlassian.net/browse/JUJU-8605)


[JUJU-8605]: https://warthogs.atlassian.net/browse/JUJU-8605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ