### PR TITLE
feat(secrets): add support for vault mount path

### DIFF
--- a/docs/reference/secret.md
+++ b/docs/reference/secret.md
@@ -122,15 +122,16 @@ The `vault` backend is the only one that supports it for now.
 
 The `vault` backend supports the following configuration keys:
 
-|||
-|---|---|
-|`ca-cert`|The path to a PEM-encoded CA certificate file on the local disk. This file is used to verify the Vault server's SSL certificate.|
-|`client-cert`|The path to a PEM-encoded client certificate on the local disk. This file is used for TLS communication with the Vault server.|
-|`client-key`|The path to an unencrypted, PEM-encoded private key on disk which corresponds to the matching client certificate.|
-|`endpoint`||
-|`namespace`|The namespace to use for the command. Setting this is not necessary but allows using relative paths.|
-|`tls-server-name`|The name to use as the SNI host when connecting via TLS.|
-|`token`|The vault authentication token.|
+|                   |                                                                                                                                                 |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ca-cert`         | The path to a PEM-encoded CA certificate file on the local disk. This file is used to verify the Vault server's SSL certificate.                |
+| `client-cert`     | The path to a PEM-encoded client certificate on the local disk. This file is used for TLS communication with the Vault server.                  |
+| `client-key`      | The path to an unencrypted, PEM-encoded private key on disk which corresponds to the matching client certificate.                               |
+| `endpoint`        |                                                                                                                                                 |
+| `namespace`       | The namespace to use for the secret store. Setting this is not necessary but allows using relative paths.                                       |
+| `mount-point`     | The mount point to use as a prefix for the secret store. If specified, secrets are stored under `<mount-point>/<model-name>-<model-shortuuid>`. |
+| `tls-server-name` | The name to use as the SNI host when connecting via TLS.                                                                                        |
+| `token`           | The vault authentication token.                                                                                                                 |
 
 ```{ibnote}
 See more: [Vault | `vault server`](https://fig.io/manual/vault/server), [Hashicorp | Vault CLI](https://developer.hashicorp.com/vault/docs/commands). <br> (You will see more options there as we currently support only a subset.)

--- a/secrets/provider/vault/config.go
+++ b/secrets/provider/vault/config.go
@@ -18,6 +18,7 @@ import (
 const (
 	EndpointKey      = "endpoint"
 	NamespaceKey     = "namespace"
+	MountPathKey     = "mount-path"
 	TokenKey         = "token"
 	CACertKey        = "ca-cert"
 	ClientCertKey    = "client-cert"
@@ -40,6 +41,12 @@ var configSchema = environschema.Fields{
 	NamespaceKey: {
 		Description: "The namespace in which to store secrets.",
 		Type:        environschema.Tstring,
+		Immutable:   true,
+	},
+	MountPathKey: {
+		Description: "The mount path for the secret store.",
+		Type:        environschema.Tstring,
+		Immutable:   true,
 	},
 	CACertKey: {
 		Description: "The vault CA certificate.",
@@ -72,6 +79,11 @@ func (c *backendConfig) endpoint() string {
 
 func (c *backendConfig) namespace() string {
 	v, _ := c.validAttrs[NamespaceKey].(string)
+	return v
+}
+
+func (c *backendConfig) mountPath() string {
+	v, _ := c.validAttrs[MountPathKey].(string)
 	return v
 }
 

--- a/secrets/provider/vault/provider_test.go
+++ b/secrets/provider/vault/provider_test.go
@@ -341,3 +341,29 @@ func (s *providerSuite) TestNewBackend(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(jujuvault.MountPath(b), gc.Equals, "fred-06f00d")
 }
+
+func (s *providerSuite) TestNewBackendWithMountPath(c *gc.C) {
+	ctrl, newVaultClient := s.newVaultClient(c, nil)
+	defer ctrl.Finish()
+	s.PatchValue(&jujuvault.NewVaultClient, newVaultClient)
+	p, err := provider.Provider(jujuvault.BackendType)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg := &provider.ModelBackendConfig{
+		ModelName: "fred",
+		ModelUUID: coretesting.ModelTag.Id(),
+		BackendConfig: provider.BackendConfig{
+			BackendType: jujuvault.BackendType,
+			Config: map[string]interface{}{
+				"endpoint":        "http://vault-ip:8200/",
+				"token":           "vault-token",
+				"mount-path":      "/some/path/",
+				"ca-cert":         coretesting.CACert,
+				"tls-server-name": "tls-server",
+			},
+		},
+	}
+	b, err := p.NewBackend(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(jujuvault.MountPath(b), gc.Equals, "/some/path/fred-06f00d")
+}

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -6,7 +6,7 @@ run_secrets_vault() {
 
 	prepare_vault
 
-	juju add-secret-backend myvault vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN" ca-cert="$(cat "$VAULT_CAPATH")"
+	juju add-secret-backend myvault vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN" mount-path=some-path ca-cert="$(cat "$VAULT_CAPATH")"
 
 	model_name='model-secrets-vault-charm-owned'
 	add_model "$model_name"


### PR DESCRIPTION
This PR adds support for a vault secret backend "mount-path" config option.
If set, the path for storing secrets for a given model will be `mountpath/modelname-uuid`.
Without a mount path configured, the secrets path is still `modelname-uuid` as before.

## QA steps

`.main.sh -v secrets_iaas  test_secrets_vault`

Essentially, add a vault backend
`juju add-secret-backend mine vault endpoint=http://<ip>:8200 mount-path=foo token=...`
Set it as model secret backend
` juju model-config secret-backend=mine`
Add a secret
`juju exec -u controller/0 -- secret-add foo=bar`
Use the vault UI to check the secret is created at `foo/modelname-modeluuid`

## Documentation changes

Updated vault config doc.

## Links

**Issue:** Fixes #20457.

**Jira card:** [JUJU-8507](https://warthogs.atlassian.net/browse/JUJU-8507)


[JUJU-8507]: https://warthogs.atlassian.net/browse/JUJU-8507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ