### PR TITLE
fix: use sqlair Preparer for space constraints

### DIFF
--- a/domain/machine/state/placement.go
+++ b/domain/machine/state/placement.go
@@ -566,13 +566,18 @@ VALUES ($setConstraint.*)
 		return errors.Capture(err)
 	}
 
-	// note(gfouillet): this Prepare statement use directly sqlair to avoid
-	// a clash with the same query in the application state.
-	// Both prepare uses a setConstraintTag struct from different packages,
-	// which causes a clash in sqlair.Query below.
+	// note(gfouillet): the following Prepare statements use directly sqlair to
+	// avoid a clash with the same query in the application state.
+	// Both prepare uses a setConstraintTag/setConstraintSpace struct from
+	// different packages, which causes a conflict in sqlair.Query below.
 	// See https://github.com/juju/juju/pull/20882 for more details.
 	insertConstraintTagsQuery := `INSERT INTO constraint_tag(*) VALUES ($setConstraintTag.*)`
 	insertConstraintTagsStmt, err := sqlair.Prepare(insertConstraintTagsQuery, setConstraintTag{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	insertConstraintSpacesQuery := `INSERT INTO constraint_space(*) VALUES ($setConstraintSpace.*)`
+	insertConstraintSpacesStmt, err := sqlair.Prepare(insertConstraintSpacesQuery, setConstraintSpace{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -582,12 +587,6 @@ VALUES ($setConstraint.*)
 	selectSpaceStmt, err := preparer.Prepare(selectSpaceQuery, entityUUID{}, entityName{})
 	if err != nil {
 		return errors.Errorf("preparing select space query: %w", err)
-	}
-
-	insertConstraintSpacesQuery := `INSERT INTO constraint_space(*) VALUES ($setConstraintSpace.*)`
-	insertConstraintSpacesStmt, err := preparer.Prepare(insertConstraintSpacesQuery, setConstraintSpace{})
-	if err != nil {
-		return errors.Capture(err)
 	}
 
 	insertConstraintZonesQuery := `INSERT INTO constraint_zone(*) VALUES ($setConstraintZone.*)`


### PR DESCRIPTION
This patch addresses an issue that prevents deploying an app using space constraints. The reason for this being that we have the same db struct name in two different packages, which creates a conflict on the prepared statements cache. The fix is therefore (as it was already done before) to use sqlair.Prepare instead of the injected preparer.

Also, the prepare statements on the `insertMachine` method which runs within a transaction, have been moved out as global variables. This might become a standard in our path to better state layer performance.

As a flyby, unit tests were added.

## QA steps

```
$ juju add-space beta 
# use the subnets you have on your system:
$ juju move-to-space beta 10.254.213.0/24
$ juju deploy ubuntu --constraints "spaces=beta" 
```
Previously, the deploy step would have failed.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #20423.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8751](https://warthogs.atlassian.net/browse/JUJU-8751)


[JUJU-8751]: https://warthogs.atlassian.net/browse/JUJU-8751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ