### PR TITLE
feat: get all machines in model with their base

### DIFF
--- a/core/base/base.go
+++ b/core/base/base.go
@@ -30,6 +30,9 @@ const (
 )
 
 // ParseBase constructs a Base from the os and channel string.
+// This method may return the following errors:
+// - [coreerrors.NotValid] if either os or channel is empty.
+// However, a zero value Base and a nil error will be returned if both are empty.
 func ParseBase(os string, channel string) (Base, error) {
 	if os == "" && channel == "" {
 		return Base{}, nil

--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -38,12 +38,6 @@ type AgentBinaryFinder interface {
 type agentBinaryFinderFunc func(semversion.Number) (bool, error)
 
 type ModelState interface {
-	// GetMachineCountNotUsingBase returns the number of machines that are not
-	// using one of the supplied bases. If no machines exist in the model or if
-	// no machines exist that are using a base not in the set provided, zero is
-	// returned with no error.
-	GetMachineCountNotUsingBase(context.Context, []corebase.Base) (int, error)
-
 	// GetMachineAgentBinaryMetadata reports the agent binary metadata that is
 	// currently running a given machine.
 	//
@@ -192,6 +186,19 @@ type ModelState interface {
 	// - [github.com/juju/juju/core/errors.NotSupported] if the architecture is
 	// not known to the database.
 	SetUnitRunningAgentBinaryVersion(context.Context, coreunit.UUID, agentbinary.Version) error
+
+	// GetAllMachinesWithBase returns a map of
+	// machine UUIDs to their resolved platform base.
+	//
+	// Machines for which the channel field is NULL are skipped and do not appear in the
+	// returned map.
+	//
+	// Machines for which the OS and channel field are both empty
+	// will result in a corresponding zero value base returned.
+	//
+	// This method may return the following errors:
+	//   - [coreerrors.NotValid] if, for any machine, either the OS or channel field but not both is non-empty.
+	GetAllMachinesWithBase(ctx context.Context) (map[string]corebase.Base, error)
 }
 
 // ControllerState defines the interface for interacting with the

--- a/domain/modelagent/service/service_mock_test.go
+++ b/domain/modelagent/service/service_mock_test.go
@@ -107,6 +107,45 @@ func (m *MockModelState) EXPECT() *MockModelStateMockRecorder {
 	return m.recorder
 }
 
+// GetAllMachinesWithBase mocks base method.
+func (m *MockModelState) GetAllMachinesWithBase(arg0 context.Context) (map[string]base.Base, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllMachinesWithBase", arg0)
+	ret0, _ := ret[0].(map[string]base.Base)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllMachinesWithBase indicates an expected call of GetAllMachinesWithBase.
+func (mr *MockModelStateMockRecorder) GetAllMachinesWithBase(arg0 any) *MockModelStateGetAllMachinesWithBaseCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllMachinesWithBase", reflect.TypeOf((*MockModelState)(nil).GetAllMachinesWithBase), arg0)
+	return &MockModelStateGetAllMachinesWithBaseCall{Call: call}
+}
+
+// MockModelStateGetAllMachinesWithBaseCall wrap *gomock.Call
+type MockModelStateGetAllMachinesWithBaseCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetAllMachinesWithBaseCall) Return(arg0 map[string]base.Base, arg1 error) *MockModelStateGetAllMachinesWithBaseCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetAllMachinesWithBaseCall) Do(f func(context.Context) (map[string]base.Base, error)) *MockModelStateGetAllMachinesWithBaseCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetAllMachinesWithBaseCall) DoAndReturn(f func(context.Context) (map[string]base.Base, error)) *MockModelStateGetAllMachinesWithBaseCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetMachineAgentBinaryMetadata mocks base method.
 func (m *MockModelState) GetMachineAgentBinaryMetadata(arg0 context.Context, arg1 string) (agentbinary.Metadata, error) {
 	m.ctrl.T.Helper()
@@ -142,45 +181,6 @@ func (c *MockModelStateGetMachineAgentBinaryMetadataCall) Do(f func(context.Cont
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelStateGetMachineAgentBinaryMetadataCall) DoAndReturn(f func(context.Context, string) (agentbinary.Metadata, error)) *MockModelStateGetMachineAgentBinaryMetadataCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetMachineCountNotUsingBase mocks base method.
-func (m *MockModelState) GetMachineCountNotUsingBase(arg0 context.Context, arg1 []base.Base) (int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachineCountNotUsingBase", arg0, arg1)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMachineCountNotUsingBase indicates an expected call of GetMachineCountNotUsingBase.
-func (mr *MockModelStateMockRecorder) GetMachineCountNotUsingBase(arg0, arg1 any) *MockModelStateGetMachineCountNotUsingBaseCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineCountNotUsingBase", reflect.TypeOf((*MockModelState)(nil).GetMachineCountNotUsingBase), arg0, arg1)
-	return &MockModelStateGetMachineCountNotUsingBaseCall{Call: call}
-}
-
-// MockModelStateGetMachineCountNotUsingBaseCall wrap *gomock.Call
-type MockModelStateGetMachineCountNotUsingBaseCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetMachineCountNotUsingBaseCall) Return(arg0 int, arg1 error) *MockModelStateGetMachineCountNotUsingBaseCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetMachineCountNotUsingBaseCall) Do(f func(context.Context, []base.Base) (int, error)) *MockModelStateGetMachineCountNotUsingBaseCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetMachineCountNotUsingBaseCall) DoAndReturn(f func(context.Context, []base.Base) (int, error)) *MockModelStateGetMachineCountNotUsingBaseCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/modelagent/state/model/types.go
+++ b/domain/modelagent/state/model/types.go
@@ -184,3 +184,10 @@ type unitUUID struct {
 type unitUUIDRef struct {
 	UUID coreunit.UUID `db:"unit_uuid"`
 }
+
+// machineBase represents the base information for a machine.
+type machineBase struct {
+	MachineUUID string           `db:"machine_uuid"`
+	OS          string           `db:"os"`
+	Channel     sql.Null[string] `db:"channel"`
+}


### PR DESCRIPTION
This PR implements the state layer to get all machine base info to be used later.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
NA


## Links
**Jira card:** [JUJU-8761](https://warthogs.atlassian.net/browse/JUJU-8761)

[JUJU-8761]: https://warthogs.atlassian.net/browse/JUJU-8761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ