### PR TITLE
fix(secretbackend): immutability for built-in backends

### DIFF
--- a/domain/schema/controller/sql/0026-secret-backend.PATCH.sql
+++ b/domain/schema/controller/sql/0026-secret-backend.PATCH.sql
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * Licensed under the AGPLv3, see LICENCE file for details.
+ */
+
+-- Patch 0026: Add origin to secret backends.
+--
+-- This patch introduces a new table to capture the origin of a
+-- secret backend and augments the secret_backend table with an origin_id
+-- that references it.
+
+-- Drop the triggers that enforce immutability on the secret_backend table.
+DROP TRIGGER trg_secret_backend_immutable_update;
+DROP TRIGGER trg_secret_backend_immutable_delete;
+
+-- Create the origin table with the two supported origins.
+CREATE TABLE secret_backend_origin (
+    id INT NOT NULL PRIMARY KEY,
+    origin TEXT NOT NULL UNIQUE,
+    CONSTRAINT chk_secret_backend_origin_not_empty
+    CHECK (origin <> '')
+);
+
+-- Seed known origins.
+INSERT INTO secret_backend_origin (id, origin) VALUES
+(0, 'built-in'),
+(1, 'user');
+
+-- Add the origin_id column to secret_backend; Defaulted to 1 (user).
+-- Include a column-level FK reference for SQLite.
+ALTER TABLE secret_backend
+-- ideally origin_id should be set NOT NULL DEFAULT 1 but can't since sqlite doesn't allows that while ALTER TABLE
+ADD COLUMN origin_id INT -- NOT NULL DEFAULT 1
+REFERENCES secret_backend_origin (id);
+
+-- Backfill existing secret backends: the built-in ones are named
+-- 'internal' (the Juju controller backend) and 'kubernetes'.
+UPDATE secret_backend
+SET origin_id = 0
+WHERE name IN ('internal', 'kubernetes');
+
+-- The rest are user-created.
+UPDATE secret_backend
+SET origin_id = 1
+WHERE name NOT IN ('internal', 'kubernetes');
+
+-- When merging into main, update the file domain/schema/controller.go:
+--  - triggersForImmutableTable "secret_backend" needs to be updated to below condition and message
+--  - this file needs to be removed
+-- Note: the immutability is enforced by business logic, so those triggers are not strictly necessary, but it's
+-- nice to have.
+CREATE TRIGGER trg_secret_backend_immutable_update -- noqa: PRS
+    BEFORE UPDATE ON secret_backend
+    FOR EACH ROW
+    WHEN OLD.origin_id = 0
+BEGIN
+    SELECT RAISE(FAIL, 'built-in secret backends are immutable');
+END;
+
+CREATE TRIGGER trg_secret_backend_immutable_delete -- noqa: PRS
+    BEFORE DELETE ON secret_backend
+    FOR EACH ROW
+    WHEN OLD.origin_id = 0
+BEGIN
+    SELECT RAISE(FAIL, 'built-in secret backends are immutable');
+END;

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -126,6 +126,7 @@ func (s *controllerSchemaSuite) TestControllerTables(c *tc.C) {
 		// Secret backends
 		"secret_backend",
 		"secret_backend_config",
+		"secret_backend_origin",
 		"secret_backend_rotation",
 		"secret_backend_type",
 		"secret_backend_reference",
@@ -302,22 +303,22 @@ func (s *controllerSchemaSuite) TestControllerTriggersForImmutableTables(c *tc.C
 	backendUUID1 := utils.MustNewUUID().String()
 	backendUUID2 := utils.MustNewUUID().String()
 	s.assertExecSQL(c,
-		"INSERT INTO secret_backend (uuid, name, backend_type_id) VALUES (?, 'controller-sb', 0);",
+		"INSERT INTO secret_backend (uuid, name, backend_type_id, origin_id) VALUES (?, 'controller-sb', 0, 0);",
 		backendUUID1)
 	s.assertExecSQL(c,
-		"INSERT INTO secret_backend (uuid, name, backend_type_id) VALUES (?, 'kubernetes-sb', 1);",
+		"INSERT INTO secret_backend (uuid, name, backend_type_id, origin_id) VALUES (?, 'kubernetes-sb', 1, 0);",
 		backendUUID2)
 	s.assertExecSQLError(c,
 		"UPDATE secret_backend SET name = 'new-name' WHERE uuid = ?",
-		"secret backends with type controller or kubernetes are immutable", backendUUID1)
+		"built-in secret backends are immutable", backendUUID1)
 	s.assertExecSQLError(c,
 		"UPDATE secret_backend SET name = 'new-name' WHERE uuid = ?",
-		"secret backends with type controller or kubernetes are immutable", backendUUID2)
+		"built-in secret backends are immutable", backendUUID2)
 
 	s.assertExecSQLError(c,
 		"DELETE FROM secret_backend WHERE uuid = ?;",
-		"secret backends with type controller or kubernetes are immutable", backendUUID1)
+		"built-in secret backends are immutable", backendUUID1)
 	s.assertExecSQLError(c,
 		"DELETE FROM secret_backend WHERE uuid = ?;",
-		"secret backends with type controller or kubernetes are immutable", backendUUID2)
+		"built-in secret backends are immutable", backendUUID2)
 }

--- a/domain/secretbackend/bootstrap/bootstrap.go
+++ b/domain/secretbackend/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	domainsecretbackend "github.com/juju/juju/domain/secretbackend"
+	"github.com/juju/juju/domain/secretbackend/internal"
 	"github.com/juju/juju/domain/secretbackend/state"
 	internaldatabase "github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
@@ -44,7 +45,7 @@ func createBackend(ctx context.Context, tx *sqlair.TX, backendName string, backe
 	}
 	insertBackendStmt, err := sqlair.Prepare(`
 INSERT INTO secret_backend
-    (uuid, name, backend_type_id)
+    (uuid, name, backend_type_id, origin_id)
 VALUES ($SecretBackend.*)`, state.SecretBackend{})
 	if err != nil {
 		return errors.Capture(err)
@@ -55,6 +56,8 @@ VALUES ($SecretBackend.*)`, state.SecretBackend{})
 		Name:                backendName,
 		BackendTypeID:       backendType,
 		TokenRotateInterval: internaldatabase.NullDuration{},
+		// Backends created at bootstrap are considered built-in.
+		OriginID: int(internal.BuiltIn),
 	}).Run()
 	if err != nil {
 		return errors.Errorf("cannot create secret backend %q: %w", backendName, err)

--- a/domain/secretbackend/internal/origin.go
+++ b/domain/secretbackend/internal/origin.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package internal
+
+import "github.com/juju/juju/internal/errors"
+
+// Origin represents the origin of a secret backend as recorded in the
+// secret_backend_origin lookup table.
+type Origin int
+
+const (
+	// BuiltIn indicates a built-in secret backend managed by Juju itself.
+	BuiltIn Origin = iota
+	// User indicates a secret backend that was created by a user.
+	User
+)
+
+// Value returns the string value corresponding to this origin as stored in the
+// controller database lookup table `secret_backend_origin`.
+func (o Origin) Value() (string, error) {
+	switch o {
+	case BuiltIn:
+		return "built-in", nil
+	case User:
+		return "user", nil
+	}
+	return "", errors.Errorf("invalid origin value %d", o)
+}

--- a/domain/secretbackend/internal/origin_test.go
+++ b/domain/secretbackend/internal/origin_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type originSuite struct {
+	schematesting.ControllerSuite
+}
+
+func TestOriginSuite(t *testing.T) {
+	tc.Run(t, &originSuite{})
+}
+
+// TestOriginDBValues ensures there's no skew between what's in the
+// database table for secret backend origin and the typed consts used in the
+// domain packages.
+func (s *originSuite) TestOriginDBValues(c *tc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, origin FROM secret_backend_origin")
+	c.Assert(err, tc.ErrorIsNil)
+	defer rows.Close()
+
+	dbValues := make(map[Origin]string)
+	for rows.Next() {
+		var (
+			id     int
+			origin string
+		)
+		err := rows.Scan(&id, &origin)
+		c.Assert(err, tc.ErrorIsNil)
+		dbValues[Origin(id)] = origin
+	}
+	c.Assert(dbValues, tc.DeepEquals, map[Origin]string{
+		BuiltIn: "built-in",
+		User:    "user",
+	})
+}
+
+func (s *originSuite) TestValueBuiltIn(c *tc.C) {
+	result, err := BuiltIn.Value()
+	c.Assert(err, tc.IsNil)
+	c.Check(result, tc.Equals, "built-in")
+}
+
+func (s *originSuite) TestValueUser(c *tc.C) {
+	result, err := User.Value()
+	c.Assert(err, tc.IsNil)
+	c.Check(result, tc.Equals, "user")
+}
+
+func (s *originSuite) TestValueInvalid(c *tc.C) {
+	_, err := Origin(42).Value()
+	c.Assert(err, tc.ErrorMatches, "invalid origin value 42")
+}

--- a/domain/secretbackend/state/types.go
+++ b/domain/secretbackend/state/types.go
@@ -126,6 +126,8 @@ type SecretBackend struct {
 	BackendTypeID secretbackend.BackendType `db:"backend_type_id"`
 	// TokenRotateInterval is the interval at which the token for the secret backend should be rotated.
 	TokenRotateInterval database.NullDuration `db:"token_rotate_interval"`
+	// OriginID is the id of the secret backend origin.
+	OriginID int `db:"origin_id"`
 }
 
 // SecretBackendRotation represents a single row from the state database's
@@ -406,4 +408,9 @@ type SecretBackendReference struct {
 type Count struct {
 	// Num is the number of rows.
 	Num int `db:"num"`
+}
+
+// entityUUID is a helper struct to store a UUID.
+type entityUUID struct {
+	UUID string `db:"uuid"`
 }


### PR DESCRIPTION
This patch introduces the concept of "origins" for secret backends to distinguish between built-in
 and user-defined entries.

Before this patch, these triggers used the backend_type_id to ensure immutability, asserting that backend with types "controller" and "kubernetes" cannot be removed. This caused an issue when someone adds a new backend on k8s as done in test suites secrets_iaas test_secrets_k8s

After this patch, a new `secret_backend_origin` table and association column have been introduced, and the business logic relies on those origins to define if we can or cannot remove or update a backend.

Triggers have been updated to also rely on origin instead of type, even if the business logic doesn't rely on it anymore.

This follows the discussion of https://github.com/juju/juju/pull/21225

Note: secret backend needs an in-deep refactoring since it is one of our earliest domain. This PR "just" fix the issue on backend removal, refactoring will be done in follow-up PR.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

You will need a working microk8s

### prepare microk8s

```sh
export TEST_DIR=$(mktemp -d)
endpoint=$(microk8s.config | yq ".clusters[0] .cluster .server")
cacert=$(microk8s.config | yq ".clusters[0] .cluster .certificate-authority-data" | base64 -d | sed 's/^/  /')
namespace=juju-secrets
serviceaccount=default
microk8s.kubectl create ns ${namespace} --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config -n ${namespace} serviceaccount ${serviceaccount} --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config clusterrole juju-secrets --verb='*' \
	--resource=namespaces,secrets,serviceaccounts,serviceaccounts/token,clusterroles,clusterrolebindings --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config clusterrolebinding juju-secrets --clusterrole=juju-secrets \
	--serviceaccount=${namespace}:${serviceaccount} --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config role juju-secrets --namespace=${namespace} --verb='*' \
	--resource=secrets,serviceaccounts,serviceaccounts/token,roles,rolebindings --dry-run=client -o yaml | microk8s.kubectl apply -f -
microk8s.kubectl create --save-config rolebinding juju-secrets --namespace=${namespace} --role=juju-secrets \
	--serviceaccount=${namespace}:${serviceaccount} --dry-run=client -o yaml | microk8s.kubectl apply -f -
token=$(microk8s.kubectl create token ${serviceaccount} --namespace ${namespace})
cat >"${TEST_DIR}/k8sconfig.yaml" <<EOF
endpoint: ${endpoint}
namespace: ${namespace}
ca-cert: |
${cacert}
token: ${token}
EOF
```

### Add the backend

```sh
juju add-secret-backend myk8s kubernetes --config "${TEST_DIR}/k8sconfig.yaml"
```

### Kill things

```sh
 juju remove-secret-backend myk8s   # should works
 juju remove-secret-backend internal   # should not work
 juju remove-secret-backend kubernetes   # should not work
``` 

## Links

**Jira card:** [JUJU-8605](https://warthogs.atlassian.net/browse/JUJU-8605)


[JUJU-8605]: https://warthogs.atlassian.net/browse/JUJU-8605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ