### PR TITLE
feat: display and update application storage cmd interface

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -1221,37 +1221,34 @@ func paramsFromDeployFromRepositoryArg(arg DeployFromRepositoryArg) params.Deplo
 	}
 }
 
-// ApplicationStorageInfo contains the storage information for an application.
-type ApplicationStorageInfo struct {
-	Error error
-	// StorageConstraints is a map of storage names to storage constraints to
-	// update during the upgrade. This field is only understood by Application
-	// facade version 2 and greater.
-	StorageConstraints map[string]storage.Constraints `json:"storage-constraints,omitempty"`
+// ApplicationStorageDirectives contains the storage directives for an application.
+type ApplicationStorageDirectives struct {
+	// StorageDirectives is a map of storage names to storage directives to
+	// update. This field is only understood by Application facade version 22 and greater.
+	StorageDirectives map[string]storage.Constraints
 }
 
-// GetApplicationStorage retrieves storage information for the specified applications.
-func (c *Client) GetApplicationStorage(applicationName string) (ApplicationStorageInfo, error) {
+// GetApplicationStorageDirectives retrieves storage information for the specified applications.
+func (c *Client) GetApplicationStorageDirectives(applicationName string) (ApplicationStorageDirectives, error) {
 	application := names.NewApplicationTag(applicationName)
 	in := params.Entities{Entities: []params.Entity{{Tag: application.String()}}}
 	var out params.ApplicationStorageGetResults
-	err := c.facade.FacadeCall("GetApplicationStorage", in, &out)
+	err := c.facade.FacadeCall("GetApplicationStorageDirectives", in, &out)
 	if err != nil {
-		return ApplicationStorageInfo{}, errors.Trace(err)
+		return ApplicationStorageDirectives{}, errors.Trace(err)
 	}
 	if resultsLen := len(out.Results); resultsLen != 1 {
-		return ApplicationStorageInfo{}, errors.Errorf("expected 1 result, got %d", resultsLen)
+		return ApplicationStorageDirectives{}, errors.Errorf("expected 1 result, got %d", resultsLen)
 	}
-	return applicationInfoFromParams(out.Results[0]), nil
+	res := out.Results[0]
+	if res.Error != nil {
+		return ApplicationStorageDirectives{}, apiservererrors.RestoreError(res.Error)
+	}
+	return makeApplicationStorageDirectiveInfo(res), nil
 }
 
-func applicationInfoFromParams(param params.ApplicationStorageGetResult) ApplicationStorageInfo {
-	if param.Error != nil {
-		return ApplicationStorageInfo{
-			Error: apiservererrors.RestoreError(param.Error),
-		}
-	}
-	sc := make(map[string]storage.Constraints)
+func makeApplicationStorageDirectiveInfo(param params.ApplicationStorageGetResult) ApplicationStorageDirectives {
+	sd := make(map[string]storage.Constraints, len(param.StorageConstraints))
 	for k, v := range param.StorageConstraints {
 		con := storage.Constraints{
 			Pool: v.Pool,
@@ -1262,11 +1259,11 @@ func applicationInfoFromParams(param params.ApplicationStorageGetResult) Applica
 		if v.Count != nil {
 			con.Count = *v.Count
 		}
-		sc[k] = con
+		sd[k] = con
 	}
 
-	return ApplicationStorageInfo{
-		StorageConstraints: sc,
+	return ApplicationStorageDirectives{
+		StorageDirectives: sd,
 	}
 }
 
@@ -1274,33 +1271,32 @@ func applicationInfoFromParams(param params.ApplicationStorageGetResult) Applica
 type ApplicationStorageUpdate struct {
 	ApplicationTag names.ApplicationTag
 
-	// StorageConstraints is a map of storage names to storage constraints to
-	// update during the upgrade. This field is only understood by Application
-	// facade version 2 and greater.
-	StorageConstraints map[string]storage.Constraints `json:"storage-constraints,omitempty"`
+	// StorageDirectives is a map of storage names to storage directives to
+	// update. This field is only understood by Application facade version 22 and greater.
+	StorageDirectives map[string]storage.Directives
 }
 
-// UpdateApplicationStorage updates the storage constraints for multiple existing applications in bulk.
-func (c *Client) UpdateApplicationStorage(applicationStorageUpdate ApplicationStorageUpdate) error {
-	sc := make(map[string]params.StorageConstraints)
-	for k, v := range applicationStorageUpdate.StorageConstraints {
-		sc[k] = params.StorageConstraints{
+// UpdateApplicationStorageDirectives updates the storage directives for multiple existing applications in bulk.
+func (c *Client) UpdateApplicationStorageDirectives(applicationStorageUpdate ApplicationStorageUpdate) error {
+	sd := make(map[string]params.StorageConstraints)
+	for k, v := range applicationStorageUpdate.StorageDirectives {
+		sd[k] = params.StorageConstraints{
 			Pool:  v.Pool,
-			Size:  &v.Size,
-			Count: &v.Count,
+			Size:  v.Size,
+			Count: v.Count,
 		}
 	}
 	in := params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
 			{
-				ApplicationTag:     applicationStorageUpdate.ApplicationTag.String(),
-				StorageConstraints: sc,
+				ApplicationTag:    applicationStorageUpdate.ApplicationTag.String(),
+				StorageDirectives: sd,
 			},
 		},
 	}
 
 	var out params.ErrorResults
-	err := c.facade.FacadeCall("UpdateApplicationStorage", in, &out)
+	err := c.facade.FacadeCall("UpdateApplicationStorageDirectives", in, &out)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -1551,13 +1551,13 @@ func (s *applicationSuite) TestGetApplicationStorageSuccessful(c *gc.C) {
 		},
 	}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("GetApplicationStorage", args, result).SetArg(2, results).Return(nil)
+	mockFacadeCaller.EXPECT().FacadeCall("GetApplicationStorageDirectives", args, result).SetArg(2, results).Return(nil)
 
 	client := application.NewClientFromCaller(mockFacadeCaller)
-	info, err := client.GetApplicationStorage("storage-block")
+	info, err := client.GetApplicationStorageDirectives("storage-block")
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.StorageConstraints, gc.DeepEquals, map[string]storage.Constraints{
+	c.Assert(info.StorageDirectives, gc.DeepEquals, map[string]storage.Constraints{
 		"storage-block": {
 			Pool:  "loop",
 			Size:  uint64(5),
@@ -1587,13 +1587,12 @@ func (s *applicationSuite) TestGetApplicationStorageServerError(c *gc.C) {
 		},
 	}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("GetApplicationStorage", args, result).SetArg(2, results).Return(nil)
+	mockFacadeCaller.EXPECT().FacadeCall("GetApplicationStorageDirectives", args, result).SetArg(2, results).Return(nil)
 
 	client := application.NewClientFromCaller(mockFacadeCaller)
-	info, err := client.GetApplicationStorage("storage-block")
+	_, err := client.GetApplicationStorageDirectives("storage-block")
 
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.Error, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func (s *applicationSuite) TestUpdateApplicationStorageSuccessful(c *gc.C) {
@@ -1605,7 +1604,7 @@ func (s *applicationSuite) TestUpdateApplicationStorageSuccessful(c *gc.C) {
 
 	args := params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
-			{ApplicationTag: "application-storage-block", StorageConstraints: map[string]params.StorageConstraints{
+			{ApplicationTag: "application-storage-block", StorageDirectives: map[string]params.StorageConstraints{
 				"storage-block": {
 					Pool:  "loop",
 					Size:  &sbSize,
@@ -1623,19 +1622,19 @@ func (s *applicationSuite) TestUpdateApplicationStorageSuccessful(c *gc.C) {
 		},
 	}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorage", args, result).SetArg(2, results).Return(nil)
+	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorageDirectives", args, result).SetArg(2, results).Return(nil)
 
 	applicationStorageUpdate := application.ApplicationStorageUpdate{
-		ApplicationTag: names.NewApplicationTag("storage-block"), StorageConstraints: map[string]storage.Constraints{
+		ApplicationTag: names.NewApplicationTag("storage-block"), StorageDirectives: map[string]storage.Directives{
 			"storage-block": {
 				Pool:  "loop",
-				Size:  uint64(5),
-				Count: uint64(1),
+				Size:  toUint64Ptr(5),
+				Count: toUint64Ptr(1),
 			},
 		},
 	}
 	client := application.NewClientFromCaller(mockFacadeCaller)
-	err := client.UpdateApplicationStorage(applicationStorageUpdate)
+	err := client.UpdateApplicationStorageDirectives(applicationStorageUpdate)
 
 	c.Assert(err, gc.IsNil)
 }
@@ -1649,7 +1648,7 @@ func (s *applicationSuite) TestUpdateApplicationStorageServerError(c *gc.C) {
 
 	args := params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
-			{ApplicationTag: "application-storage-block", StorageConstraints: map[string]params.StorageConstraints{
+			{ApplicationTag: "application-storage-block", StorageDirectives: map[string]params.StorageConstraints{
 				"storage-block": {
 					Pool:  "loop",
 					Size:  &sbSize,
@@ -1667,21 +1666,25 @@ func (s *applicationSuite) TestUpdateApplicationStorageServerError(c *gc.C) {
 		},
 	}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorage", args, result).SetArg(2, results).Return(nil)
+	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorageDirectives", args, result).SetArg(2, results).Return(nil)
 
 	applicationStorageUpdate := application.ApplicationStorageUpdate{
-		ApplicationTag: names.NewApplicationTag("storage-block"), StorageConstraints: map[string]storage.Constraints{
+		ApplicationTag: names.NewApplicationTag("storage-block"), StorageDirectives: map[string]storage.Directives{
 			"storage-block": {
 				Pool:  "loop",
-				Size:  uint64(5),
-				Count: uint64(1),
+				Size:  toUint64Ptr(5),
+				Count: toUint64Ptr(1),
 			},
 		},
 	}
 
 	client := application.NewClientFromCaller(mockFacadeCaller)
-	err := client.UpdateApplicationStorage(applicationStorageUpdate)
+	err := client.UpdateApplicationStorageDirectives(applicationStorageUpdate)
 
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.DeepEquals, "test error1")
+}
+
+func toUint64Ptr(i uint64) *uint64 {
+	return &i
 }

--- a/apiserver/embeddedcli_whitelist.go
+++ b/apiserver/embeddedcli_whitelist.go
@@ -14,6 +14,7 @@ var allowedEmbeddedCommands = []string{
 	"add-unit",
 	"add-user",
 	"agreements",
+	"application-storage",
 	"attach",
 	"attach-resource",
 	"attach-storage",

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -3131,7 +3131,7 @@ func (api *APIBase) DeployFromRepository(args params.DeployFromRepositoryArgs) (
 	}, nil
 }
 
-func (api *APIBase) getOneApplicationStorage(entity params.Entity) (map[string]params.StorageConstraints, error) {
+func (api *APIBase) getOneApplicationStorageDirective(entity params.Entity) (map[string]params.StorageConstraints, error) {
 	appTag, err := names.ParseTag(entity.Tag)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -3140,24 +3140,24 @@ func (api *APIBase) getOneApplicationStorage(entity params.Entity) (map[string]p
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	storageConstraints, err := app.StorageConstraints()
+	storageDirectives, err := app.StorageConstraints()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	sc := make(map[string]params.StorageConstraints)
-	for key, cons := range storageConstraints {
-		sc[key] = params.StorageConstraints{
+	sd := make(map[string]params.StorageConstraints)
+	for key, cons := range storageDirectives {
+		sd[key] = params.StorageConstraints{
 			Pool:  cons.Pool,
 			Size:  &cons.Size,
 			Count: &cons.Count,
 		}
 	}
-	return sc, nil
+	return sd, nil
 }
 
-// GetApplicationStorage returns the current storage constraints for the specified applications in bulk.
-func (api *APIBase) GetApplicationStorage(args params.Entities) (params.ApplicationStorageGetResults, error) {
+// GetApplicationStorageDirectives returns the current storage constraints for the specified applications in bulk.
+func (api *APIBase) GetApplicationStorageDirectives(args params.Entities) (params.ApplicationStorageGetResults, error) {
 	resp := params.ApplicationStorageGetResults{
 		Results: make([]params.ApplicationStorageGetResult, len(args.Entities)),
 	}
@@ -3165,20 +3165,20 @@ func (api *APIBase) GetApplicationStorage(args params.Entities) (params.Applicat
 		return resp, errors.Trace(err)
 	}
 	for i, entity := range args.Entities {
-		sc, err := api.getOneApplicationStorage(entity)
+		sd, err := api.getOneApplicationStorageDirective(entity)
 		if err != nil {
 			resp.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		resp.Results[i].StorageConstraints = sc
+		resp.Results[i].StorageConstraints = sd
 	}
 	return resp, nil
 }
 
-// GetApplicationStorage isn't on the v21 API.
-func (api *APIv21) GetApplicationStorage(_ struct{}) {}
+// GetApplicationStorageDirectives isn't on the v21 API.
+func (api *APIv21) GetApplicationStorageDirectives(_ struct{}) {}
 
-func (api *APIBase) updateOneApplicationStorage(storageUpdate params.ApplicationStorageUpdate) error {
+func (api *APIBase) updateOneApplicationStorageDirective(storageUpdate params.ApplicationStorageUpdate) error {
 	appTag, err := names.ParseTag(storageUpdate.ApplicationTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -3188,29 +3188,29 @@ func (api *APIBase) updateOneApplicationStorage(storageUpdate params.Application
 		return errors.Trace(err)
 	}
 
-	sCons := make(map[string]state.StorageConstraints)
-	for storageName, con := range storageUpdate.StorageConstraints {
-		sc := state.StorageConstraints{
-			Pool: con.Pool,
+	storageDirectivesUpdate := make(map[string]state.StorageDirectivesUpdate)
+	for storageName, directive := range storageUpdate.StorageDirectives {
+		sd := state.StorageDirectivesUpdate{
+			Pool: directive.Pool,
 		}
-		if con.Size != nil {
-			sc.Size = *con.Size
+		if directive.Size != nil {
+			sd.Size = directive.Size
 		}
-		if con.Count != nil {
-			sc.Count = *con.Count
+		if directive.Count != nil {
+			sd.Count = directive.Count
 		}
-		sCons[storageName] = sc
+		storageDirectivesUpdate[storageName] = sd
 	}
 
-	return app.UpdateStorageConstraints(sCons)
+	return app.UpdateStorageConstraints(storageDirectivesUpdate)
 }
 
-// UpdateApplicationStorage updates the storage constraints for multiple existing applications in bulk.
+// UpdateApplicationStorageDirectives updates the storage directives for multiple existing applications in bulk.
 // We do not create new storage constraints since it is handled by addDefaultStorageConstraints during
 // application deployment. The storage constraints passed are validated against the charm's declared storage meta.
 // The following apiserver codes can be returned in each ErrorResult:
 //   - [params.CodeNotSupported]: If the update request includes a storage name not supported by the charm.
-func (api *APIBase) UpdateApplicationStorage(args params.ApplicationStorageUpdateRequest) (params.ErrorResults, error) {
+func (api *APIBase) UpdateApplicationStorageDirectives(args params.ApplicationStorageUpdateRequest) (params.ErrorResults, error) {
 	resp := params.ErrorResults{}
 	if err := api.checkCanWrite(); err != nil {
 		return resp, errors.Trace(err)
@@ -3220,12 +3220,12 @@ func (api *APIBase) UpdateApplicationStorage(args params.ApplicationStorageUpdat
 	resp.Results = res
 
 	for i, storageUpdate := range args.ApplicationStorageUpdates {
-		err := api.updateOneApplicationStorage(storageUpdate)
+		err := api.updateOneApplicationStorageDirective(storageUpdate)
 		res[i].Error = apiservererrors.ServerError(err)
 	}
 
 	return resp, nil
 }
 
-// UpdateApplicationStorage isn't on the v21 API.
-func (api *APIv21) UpdateApplicationStorage(_ struct{}) {}
+// UpdateApplicationStorageDirectives isn't on the v21 API.
+func (api *APIv21) UpdateApplicationStorageDirectives(_ struct{}) {}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1699,8 +1699,8 @@ func (s *applicationSuite) TestGetOneApplicationStorageSuccess(c *gc.C) {
 	c.Assert(application, gc.NotNil)
 	c.Assert(application.Name(), gc.Equals, "storage-block")
 
-	// Asserts that the application has defined resp constraints.
-	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
+	// Asserts that the application has defined the given directives.
+	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1736,7 +1736,7 @@ func (s *applicationSuite) TestGetMultipleApplicationStorageSuccess(c *gc.C) {
 	c.Assert(application2.Name(), gc.Equals, "cockroachdb")
 
 	// Retrieves info for both applications
-	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application1.Tag().String(),
 		},
@@ -1771,7 +1771,7 @@ func (s *applicationSuite) TestGetApplicationStorageDefaultExists(c *gc.C) {
 	c.Assert(application.Name(), gc.Equals, "storage-block")
 
 	// Asserts that the application has default storage constraints.
-	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1792,8 +1792,8 @@ func (s *applicationSuite) TestUpdateOneApplicationStorageSuccess(c *gc.C) {
 	c.Assert(application, gc.NotNil)
 	c.Assert(application.Name(), gc.Equals, "storage-block")
 
-	// Asserts that the application has defined resp constraints.
-	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
+	// Asserts that the application has defined the given directives.
+	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1816,18 +1816,18 @@ func (s *applicationSuite) TestUpdateOneApplicationStorageSuccess(c *gc.C) {
 			Count: &count,
 		},
 	}
-	_, err = s.applicationAPI.UpdateApplicationStorage(params.ApplicationStorageUpdateRequest{
+	_, err = s.applicationAPI.UpdateApplicationStorageDirectives(params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
 			{
-				ApplicationTag:     application.Tag().String(),
-				StorageConstraints: newSC,
+				ApplicationTag:    application.Tag().String(),
+				StorageDirectives: newSC,
 			},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Asserts that the application has newly defined storage constraints.
-	resp, err = s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
+	resp, err = s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1863,7 +1863,7 @@ func (s *applicationSuite) TestUpdateMultipleApplicationStorageSuccess(c *gc.C) 
 	c.Assert(application2.Name(), gc.Equals, "cockroachdb")
 
 	// Asserts that both the applications have defined resp constraints.
-	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application1.Tag().String(),
 		},
@@ -1908,22 +1908,22 @@ func (s *applicationSuite) TestUpdateMultipleApplicationStorageSuccess(c *gc.C) 
 			Count: &count,
 		},
 	}
-	_, err = s.applicationAPI.UpdateApplicationStorage(params.ApplicationStorageUpdateRequest{
+	_, err = s.applicationAPI.UpdateApplicationStorageDirectives(params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
 			{
-				ApplicationTag:     application1.Tag().String(),
-				StorageConstraints: newSC1,
+				ApplicationTag:    application1.Tag().String(),
+				StorageDirectives: newSC1,
 			},
 			{
-				ApplicationTag:     application2.Tag().String(),
-				StorageConstraints: newSC2,
+				ApplicationTag:    application2.Tag().String(),
+				StorageDirectives: newSC2,
 			},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Asserts that the applications have newly defined storage constraints.
-	resp, err = s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
+	resp, err = s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application1.Tag().String(),
 		},
@@ -1962,8 +1962,8 @@ func (s *applicationSuite) TestUpdateApplicationStorageNameServerError(c *gc.C) 
 	c.Assert(application, gc.NotNil)
 	c.Assert(application.Name(), gc.Equals, "storage-block")
 
-	// Asserts that the application has defined resp constraints.
-	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
+	// Asserts that the application has defined the given directives.
+	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1979,11 +1979,11 @@ func (s *applicationSuite) TestUpdateApplicationStorageNameServerError(c *gc.C) 
 	// Updates the application with newly defined storage constraints that contains 2 unsupported storage names.
 	size := uint64(4096)
 	count := uint64(2)
-	res, err := s.applicationAPI.UpdateApplicationStorage(params.ApplicationStorageUpdateRequest{
+	res, err := s.applicationAPI.UpdateApplicationStorageDirectives(params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
 			{
 				ApplicationTag: application.Tag().String(),
-				StorageConstraints: map[string]params.StorageConstraints{
+				StorageDirectives: map[string]params.StorageConstraints{
 					charmStore: {
 						Pool:  "loop",
 						Size:  &size,

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1509,7 +1509,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 	s.model.EXPECT().UUID().Return("")
 
-	storageConstraints := map[string]storage.Constraints{
+	storageDirectives := map[string]storage.Constraints{
 		"data": {
 			Count: 1,
 			Size:  1024,
@@ -1521,7 +1521,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 		CharmURL:        curl,
 		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
-		Storage:         storageConstraints,
+		Storage:         storageDirectives,
 	}
 	results, err := s.api.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{args}},
@@ -1531,7 +1531,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 
-	c.Assert(s.deployParams["my-app"].Storage, gc.DeepEquals, storageConstraints)
+	c.Assert(s.deployParams["my-app"].Storage, gc.DeepEquals, storageDirectives)
 }
 
 func (s *ApplicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -120,7 +120,7 @@ type Application interface {
 	MergeBindings(*state.Bindings, bool) error
 	Relations() ([]Relation, error)
 	StorageConstraints() (map[string]state.StorageConstraints, error)
-	UpdateStorageConstraints(map[string]state.StorageConstraints) error
+	UpdateStorageConstraints(map[string]state.StorageDirectivesUpdate) error
 }
 
 // Bindings defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -1513,7 +1513,7 @@ func (mr *MockApplicationMockRecorder) UpdateCharmConfig(arg0, arg1 any) *gomock
 }
 
 // UpdateStorageConstraints mocks base method.
-func (m *MockApplication) UpdateStorageConstraints(arg0 map[string]state.StorageConstraints) error {
+func (m *MockApplication) UpdateStorageConstraints(arg0 map[string]state.StorageDirectivesUpdate) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStorageConstraints", arg0)
 	ret0, _ := ret[0].(error)

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -35,7 +35,7 @@ func Register(registry facade.FacadeRegistry) {
 		return newFacadeV21(ctx) // Added ScaleApplication attach storage support
 	}, reflect.TypeOf((*APIv21)(nil)))
 	registry.MustRegister("Application", 22, func(ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV22(ctx) // Added GetApplicationStorage and UpdateApplicationStorage storage constraints support
+		return newFacadeV22(ctx) // Added GetApplicationStorageDirectives and UpdateApplicationStorageDirectives storage constraints support
 	}, reflect.TypeOf((*APIv22)(nil)))
 }
 

--- a/apiserver/facades/client/application/updatebase_mocks_test.go
+++ b/apiserver/facades/client/application/updatebase_mocks_test.go
@@ -555,7 +555,7 @@ func (mr *MockApplicationMockRecorder) UpdateCharmConfig(arg0, arg1 any) *gomock
 }
 
 // UpdateStorageConstraints mocks base method.
-func (m *MockApplication) UpdateStorageConstraints(arg0 map[string]state.StorageConstraints) error {
+func (m *MockApplication) UpdateStorageConstraints(arg0 map[string]state.StorageDirectivesUpdate) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStorageConstraints", arg0)
 	ret0, _ := ret[0].(error)

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -120,7 +120,7 @@ func (s *bundleSuite) TestGetChangesBundleStorageError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, gc.IsNil)
 	c.Assert(r.Errors, jc.SameContents, []string{
-		`invalid storage "bad" in application "django": cannot parse count: count must be greater than zero, got "0"`,
+		`invalid storage "bad" in application "django": parsing storage count: count must be greater than zero, got "0"`,
 	})
 }
 
@@ -450,7 +450,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleStorageError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, gc.IsNil)
 	c.Assert(r.Errors, jc.SameContents, []string{
-		`invalid storage "bad" in application "django": cannot parse count: count must be greater than zero, got "0"`,
+		`invalid storage "bad" in application "django": parsing storage count: count must be greater than zero, got "0"`,
 	})
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1285,7 +1285,7 @@
                         }
                     }
                 },
-                "GetApplicationStorage": {
+                "GetApplicationStorageDirectives": {
                     "type": "object",
                     "properties": {
                         "Params": {
@@ -1463,7 +1463,7 @@
                         }
                     }
                 },
-                "UpdateApplicationStorage": {
+                "UpdateApplicationStorageDirectives": {
                     "type": "object",
                     "properties": {
                         "Params": {
@@ -2161,7 +2161,7 @@
                         "application-tag": {
                             "type": "string"
                         },
-                        "storage-constraints": {
+                        "storage-directives": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -2173,7 +2173,7 @@
                     "additionalProperties": false,
                     "required": [
                         "application-tag",
-                        "storage-constraints"
+                        "storage-directives"
                     ]
                 },
                 "ApplicationStorageUpdateRequest": {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -418,6 +418,12 @@ behaviour use the ` + "`set-constraints`" + ` command to change the application'
 constraints or add a machine (` + "`add-machine`" + `) with a certain constraint and then
 target that machine with ` + "`add-unit`" + ` by using the ` + "`--to`" + `option.
 
+Use the ` + "`--storage`" + ` option to specify a storage directive for the application;
+see more: https://documentation.ubuntu.com/juju/3.6/reference/storage/#storage-directive. 
+These directives will control the application's default persistent storage layout (i.e. they are used when the application is later
+scaled out with the ` + "`add-unit`" + ` command and new units need storage provisioned). To change this behaviour after deployment,
+use the  ` + "`application-storage`" + ` command -- this will update the application's default storage directives.
+
 Use the ` + "`--device`" + ` option to specify GPU device requirements (with Kubernetes).
 The below format is used for this option's value, where the 'label' is named in
 the charm metadata file:
@@ -577,6 +583,10 @@ Deploy 3 units, one on machine 3 and the remaining two on new machines:
 Deploy to a machine with at least 8 GiB of memory:
 
     juju deploy postgresql --constraints mem=8G
+
+Deploy using the LXD storage pool with one 3 GiB volume:
+
+	juju deploy postgresql --storage pgdata=lxd,1,3G
 
 Deploy to a specific availability zone (provider-dependent):
 

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -230,3 +230,9 @@ func NewConfigCommandForTest(api ApplicationAPI, store jujuclient.ClientStore) m
 	c.SetClientStore(store)
 	return c
 }
+
+func NewStorageCommandForTest(api StorageDirectivesAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
+	cmd := &applicationStorageCommand{api: api}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}

--- a/cmd/juju/application/storage.go
+++ b/cmd/juju/application/storage.go
@@ -1,0 +1,263 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v5"
+
+	"github.com/juju/juju/api/client/application"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/config"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	appStorageConfigSummary = "Displays or sets storage directives for an application."
+
+	appStorageConfigDoc = `
+A storage directive describes to juju how the storage required by a charm should be provisioned
+and takes the form <storage-name>[=<storage-specification>]; for details
+see https://documentation.ubuntu.com/juju/3.6/reference/storage/#storage-directive.
+
+To view all storage directives for the given application:
+
+    juju application-storage <application>
+
+By default, the storage directives will be printed in a tabular format. You can instead
+print it in ` + "`json`" + ` or ` + "`yaml`" + ` format using the ` + "`--format`" + ` flag:
+
+   	juju application-storage <application> --format json
+    juju application-storage <application> --format yaml
+
+To view the directive for a single storage name:
+
+    juju application-storage <application> <storage-name>
+
+To set storage directives for an application:
+
+    juju application-storage <application> <storagename1>=<storage-specification> <storagename2>=<storage-specification> ...
+
+`
+	appStorageConfigExamples = `
+Print the storage directives for all storage names of the postgresql application:
+
+    juju application-storage postgresql
+
+Print the storage directives for the storage name 'pgdata' of the postgresql application:
+
+    juju application-storage postgresql pgdata
+
+Set the size to 10GiB, pool name to "rootfs", and count to 1 for the mysql application's 'database' storage specification:
+
+    juju application-storage mysql database=10G,rootfs,1
+`
+)
+
+// NewStorageCommand wraps configCommand with sane application settings.
+func NewStorageCommand() cmd.Command {
+	applicationStorageConfigBase := config.ConfigCommandBase{
+		Resettable: false,
+	}
+	return modelcmd.Wrap(&applicationStorageCommand{configBase: applicationStorageConfigBase})
+}
+
+type applicationStorageCommand struct {
+	modelcmd.ModelCommandBase
+	configBase config.ConfigCommandBase
+	out        cmd.Output
+
+	api             StorageDirectivesAPI
+	applicationName string
+}
+
+// Info returns the name and usage details for the application storage command,
+// providing guidance to the user.
+// It implements the [cmd.Command] interface.
+func (c *applicationStorageCommand) Info() *cmd.Info {
+	info := &cmd.Info{
+		Name:     "application-storage",
+		Args:     "<application-name> [<storage-name>[={<size>,<pool>,<count>}]] ...",
+		Purpose:  appStorageConfigSummary,
+		Examples: appStorageConfigExamples,
+		Doc:      appStorageConfigDoc,
+		SeeAlso: []string{
+			"storage",
+			"storage-pools",
+			"add-storage",
+			"add-unit",
+		},
+	}
+
+	return jujucmd.Info(info)
+}
+
+// SetFlags implements part of the cmd.Command interface.
+func (c *applicationStorageCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	c.configBase.SetFlags(f)
+
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"json":    cmd.FormatJson,
+		"tabular": formatConfigTabular,
+		"yaml":    cmd.FormatYaml,
+	})
+}
+
+// Init parses the command arguments and validates the application name.
+// It implements the [cmd.Command] interface.
+func (c *applicationStorageCommand) Init(args []string) error {
+	nArgs := len(args)
+	if nArgs == 0 {
+		return errors.Errorf("no application specified")
+	}
+
+	if !names.IsValidApplication(args[0]) {
+		return errors.Errorf("invalid application name %q", args[0])
+	}
+	c.applicationName = args[0]
+	return c.configBase.Init(args[1:])
+}
+
+// getAPI returns the API. This allows passing in a test configCommandAPI
+// implementation.
+func (c *applicationStorageCommand) getAPI() (StorageDirectivesAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Annotate(err, "opening API connection")
+	}
+	client := application.NewClient(api)
+	return client, nil
+}
+
+// Run executes the main logic for the application storage command.
+// It processes the configured actions by either retrieving the
+// storage directive for a single storage name, setting storage
+// directives, or listing all storage directives for the given application.
+// It implements the [cmd.Command] interface.
+func (c *applicationStorageCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	for _, action := range c.configBase.Actions {
+		var err error
+		switch action {
+		case config.GetOne:
+			err = c.getConfig(ctx, client)
+		case config.SetArgs:
+			err = c.setConfig(client, c.configBase.ValsToSet)
+		default:
+			err = c.getAllConfig(ctx, client)
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// StorageDirectivesAPI defines the API methods that the application storage command uses.
+type StorageDirectivesAPI interface {
+	Close() error
+	GetApplicationStorageDirectives(applicationName string) (application.ApplicationStorageDirectives, error)
+	UpdateApplicationStorageDirectives(applicationStorageUpdateParams application.ApplicationStorageUpdate) error
+}
+
+// setConfig sets the provided key/value pairs on the application.
+func (c *applicationStorageCommand) setConfig(client StorageDirectivesAPI, attrs config.Attrs) error {
+	sd := make(map[string]storage.Directives, len(attrs))
+	for k, v := range attrs {
+		// This should give us a string of the form "10G,rootfs,1".
+		constraintsStr := fmt.Sprint(v)
+		parsedCons, err := storage.ParseDirectives(constraintsStr)
+		if err != nil {
+			return errors.Annotatef(err, "parsing storage constraints for %q", k)
+		}
+		sd[k] = parsedCons
+	}
+
+	updateParams := application.ApplicationStorageUpdate{
+		ApplicationTag:    names.NewApplicationTag(c.applicationName),
+		StorageDirectives: sd,
+	}
+
+	return client.UpdateApplicationStorageDirectives(updateParams)
+}
+
+// getConfig writes the value of a single application config key to the cmd.Context.
+func (c *applicationStorageCommand) getConfig(ctx *cmd.Context, client StorageDirectivesAPI) error {
+	applicationStorageInfo, err := client.GetApplicationStorageDirectives(c.applicationName)
+	if err != nil {
+		return err
+	}
+
+	if len(c.configBase.KeysToGet) == 0 {
+		return errors.New("no storage key specified")
+	}
+
+	storeKey := c.configBase.KeysToGet[0]
+	storageConsForKey, ok := applicationStorageInfo.StorageDirectives[storeKey]
+	if !ok {
+		return errors.NotFoundf("storage %q", storeKey)
+	}
+
+	// Convert it to the desired map format so that the output package can format it.
+	storageConsForKeyMap := map[string]storage.Constraints{
+		storeKey: storageConsForKey,
+	}
+
+	return c.out.Write(ctx, storageConsForKeyMap)
+}
+
+// getAllConfig returns the entire configuration for the selected application.
+func (c *applicationStorageCommand) getAllConfig(ctx *cmd.Context, client StorageDirectivesAPI) error {
+	applicationStorageInfo, err := client.GetApplicationStorageDirectives(c.applicationName)
+	if err != nil {
+		return err
+	}
+
+	return c.out.Write(ctx, applicationStorageInfo.StorageDirectives)
+}
+
+// formatConfigTabular writes a tabular summary of config information.
+func formatConfigTabular(writer io.Writer, value interface{}) error {
+	configValues, ok := value.(map[string]storage.Constraints)
+	if !ok {
+		return errors.Errorf("expected value of type %T, got %T", map[string]storage.Constraints{}, value)
+	}
+
+	tw := output.TabWriter(writer)
+	w := output.Wrapper{
+		TabWriter: tw,
+	}
+
+	var valueNames []string
+	for name := range configValues {
+		valueNames = append(valueNames, name)
+	}
+	sort.Strings(valueNames)
+	w.Println("Storage", "Pool", "Size", "Count")
+
+	for _, name := range valueNames {
+		info := configValues[name]
+		w.Println(name, info.Pool, info.Size, info.Count)
+	}
+
+	tw.Flush()
+	return nil
+}

--- a/cmd/juju/application/storage_test.go
+++ b/cmd/juju/application/storage_test.go
@@ -1,0 +1,295 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/names/v5"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apiapplication "github.com/juju/juju/api/client/application"
+	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/storage"
+	jujutesting "github.com/juju/juju/testing"
+)
+
+type ApplicationStorageSuite struct {
+	jujutesting.FakeJujuXDGDataHomeSuite
+	store   *jujuclient.MemStore
+	mockAPI *mockStorageDirectivesAPI
+}
+
+var _ = gc.Suite(&ApplicationStorageSuite{})
+
+func (s *ApplicationStorageSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+
+	s.store = jujuclient.NewMemStore()
+	s.store.CurrentControllerName = "testing"
+	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Models["testing"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin/controller": {},
+		},
+		CurrentModel: "admin/controller",
+	}
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin",
+	}
+
+	// Default mock returns one application with two storage keys.
+	s.mockAPI = &mockStorageDirectivesAPI{
+		getFunc: func(app string) (apiapplication.ApplicationStorageDirectives, error) {
+			return apiapplication.ApplicationStorageDirectives{
+				StorageDirectives: map[string]storage.Constraints{
+					"data":    {Pool: "rootfs", Size: 10240, Count: 1}, // 10 GiB (MiB units)
+					"allecto": {Pool: "loop", Size: 20480, Count: 2},   // 20 GiB
+				},
+			}, nil
+		},
+		updateFunc: func(up apiapplication.ApplicationStorageUpdate) error {
+			return nil
+		},
+	}
+}
+
+func (s *ApplicationStorageSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, application.NewStorageCommandForTest(s.mockAPI, s.store), args...)
+}
+
+func (s *ApplicationStorageSuite) TestNoArguments(c *gc.C) {
+	ctx, err := s.run(c)
+	c.Assert(err, gc.ErrorMatches, "no application specified")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "ERROR no application specified\n")
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesInvalidApplicationName(c *gc.C) {
+	ctx, err := s.run(c, "so-42-far-not-good")
+	c.Assert(err, gc.ErrorMatches, `invalid application name "so-42-far-not-good"`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "ERROR invalid application name \"so-42-far-not-good\"\n")
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesAllJSON(c *gc.C) {
+	context, err := s.run(c, "--format=json", "storage-block")
+	c.Assert(err, jc.ErrorIsNil)
+
+	want := "" +
+		"{\"allecto\":{\"Pool\":\"loop\",\"Size\":20480,\"Count\":2}," +
+		"\"data\":{\"Pool\":\"rootfs\",\"Size\":10240,\"Count\":1}}\n"
+
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, want)
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesAllYAML(c *gc.C) {
+	context, err := s.run(c, "--format=yaml", "storage-block")
+	c.Assert(err, jc.ErrorIsNil)
+
+	want := "" +
+		"allecto:\n" +
+		"  pool: loop\n" +
+		"  size: 20480\n" +
+		"  count: 2\n" +
+		"data:\n" +
+		"  pool: rootfs\n" +
+		"  size: 10240\n" +
+		"  count: 1\n"
+
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, want)
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesAllTabular(c *gc.C) {
+	ctx, err := s.run(c, "storage-block")
+	c.Assert(err, jc.ErrorIsNil)
+
+	out := strings.TrimSpace(cmdtesting.Stdout(ctx))
+	lines := strings.Split(out, "\n")
+	c.Assert(len(lines), gc.Equals, 3)
+
+	assertTabLine(c, lines[0], "Storage", "Pool", "Size", "Count")
+	assertTabLine(c, lines[1], "allecto", "loop", "20480", "2")
+	assertTabLine(c, lines[2], "data", "rootfs", "10240", "1")
+
+	c.Assert(strings.TrimSpace(cmdtesting.Stderr(ctx)), gc.Equals, "")
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesSingleKeyTabular(c *gc.C) {
+	ctx, err := s.run(c, "storage-block", "data")
+	c.Assert(err, jc.ErrorIsNil)
+
+	out := strings.TrimSpace(cmdtesting.Stdout(ctx))
+	lines := strings.Split(out, "\n")
+	c.Assert(len(lines), gc.Equals, 2)
+
+	assertTabLine(c, lines[0], "Storage", "Pool", "Size", "Count")
+	assertTabLine(c, lines[1], "data", "rootfs", "10240", "1")
+
+	c.Assert(strings.TrimSpace(cmdtesting.Stderr(ctx)), gc.Equals, "")
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesSingleKeyJSON(c *gc.C) {
+	ctx, err := s.run(c, "storage-block", "data", "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `{"data":{"Pool":"rootfs","Size":10240,"Count":1}}`+"\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesSingleKeyYAML(c *gc.C) {
+	ctx, err := s.run(c, "storage-block", "data", "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ""+
+		"data:\n"+
+		"  pool: rootfs\n"+
+		"  size: 10240\n"+
+		"  count: 1\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesKeyNotFound(c *gc.C) {
+	ctx, err := s.run(c, "storage-block", "doesnotexist")
+	c.Assert(err, gc.ErrorMatches, `storage "doesnotexist" not found`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+}
+
+func (s *ApplicationStorageSuite) TestGetDirectivesAPIError(c *gc.C) {
+	s.mockAPI.getFunc = func(app string) (apiapplication.ApplicationStorageDirectives, error) {
+		return apiapplication.ApplicationStorageDirectives{}, fmt.Errorf("api error")
+	}
+	_, err := s.run(c, "storage-block")
+	c.Assert(err, gc.ErrorMatches, "api error")
+}
+
+func (s *ApplicationStorageSuite) TestSetDirectivesAllFields(c *gc.C) {
+	var got apiapplication.ApplicationStorageUpdate
+	s.mockAPI.updateFunc = func(up apiapplication.ApplicationStorageUpdate) error {
+		got = up
+		return nil
+	}
+
+	ctx, err := s.run(c, "storage-block", "data=100G,rootfs,1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(strings.TrimSpace(cmdtesting.Stderr(ctx)), gc.Equals, "")
+
+	// Assert application tag.
+	c.Assert(got.ApplicationTag, gc.Equals, names.NewApplicationTag("storage-block"))
+
+	data := got.StorageDirectives["data"]
+	c.Assert(data.Pool, gc.Equals, "rootfs")
+	c.Assert(data.Count, gc.NotNil)
+	c.Assert(data.Size, gc.NotNil)
+	c.Assert(*data.Count, gc.Equals, uint64(1))
+	c.Assert(*data.Size, gc.Equals, uint64(102400))
+}
+
+func (s *ApplicationStorageSuite) TestSetDirectivesAllFieldsShuffledOrder(c *gc.C) {
+	var got apiapplication.ApplicationStorageUpdate
+	s.mockAPI.updateFunc = func(up apiapplication.ApplicationStorageUpdate) error {
+		got = up
+		return nil
+	}
+
+	ctx, err := s.run(c, "storage-block", "data=rootfs,1,100G")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(strings.TrimSpace(cmdtesting.Stderr(ctx)), gc.Equals, "")
+
+	// Assert application tag.
+	c.Assert(got.ApplicationTag, gc.Equals, names.NewApplicationTag("storage-block"))
+
+	data := got.StorageDirectives["data"]
+	c.Assert(data.Pool, gc.Equals, "rootfs")
+	c.Assert(data.Count, gc.NotNil)
+	c.Assert(data.Size, gc.NotNil)
+	c.Assert(*data.Count, gc.Equals, uint64(1))
+	c.Assert(*data.Size, gc.Equals, uint64(102400))
+}
+
+func (s *ApplicationStorageSuite) TestSetDirectivesOneField(c *gc.C) {
+	var got apiapplication.ApplicationStorageUpdate
+	s.mockAPI.updateFunc = func(up apiapplication.ApplicationStorageUpdate) error {
+		got = up
+		return nil
+	}
+
+	// Only pool provided.
+	ctx, err := s.run(c, "storage-block", "data=,rootfs,")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(strings.TrimSpace(cmdtesting.Stderr(ctx)), gc.Equals, "")
+
+	c.Assert(got.ApplicationTag, gc.Equals, names.NewApplicationTag("storage-block"))
+
+	data := got.StorageDirectives["data"]
+	c.Assert(data.Pool, gc.Equals, "rootfs")
+	c.Assert(data.Count, gc.IsNil)
+	c.Assert(data.Size, gc.IsNil)
+}
+
+func (s *ApplicationStorageSuite) TestSetDirectivesMultipleStorageKeys(c *gc.C) {
+	var got apiapplication.ApplicationStorageUpdate
+	s.mockAPI.updateFunc = func(up apiapplication.ApplicationStorageUpdate) error {
+		got = up
+		return nil
+	}
+
+	ctx, err := s.run(c, "storage-block", "data=100G,rootfs,1", "allecto=,loop,2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(strings.TrimSpace(cmdtesting.Stderr(ctx)), gc.Equals, "")
+
+	c.Assert(got.ApplicationTag, gc.Equals, names.NewApplicationTag("storage-block"))
+
+	data := got.StorageDirectives["data"]
+	c.Assert(data.Pool, gc.Equals, "rootfs")
+	c.Assert(data.Count, gc.NotNil)
+	c.Assert(*data.Count, gc.Equals, uint64(1))
+	c.Assert(data.Size, gc.NotNil)
+	c.Assert(*data.Size, gc.Equals, uint64(102400))
+
+	allecto := got.StorageDirectives["allecto"]
+	c.Assert(allecto.Pool, gc.Equals, "loop")
+	c.Assert(allecto.Count, gc.NotNil)
+	c.Assert(*allecto.Count, gc.Equals, uint64(2))
+	c.Assert(allecto.Size, gc.IsNil)
+}
+
+func (s *ApplicationStorageSuite) TestSetDirectivesAPIError(c *gc.C) {
+	s.mockAPI.updateFunc = func(up apiapplication.ApplicationStorageUpdate) error {
+		return fmt.Errorf("api error")
+	}
+	_, err := s.run(c, "storage-block", "data=100G,rootfs,1")
+	c.Assert(err, gc.ErrorMatches, "api error")
+}
+
+func (s *ApplicationStorageSuite) TestSetDirectivesParseError(c *gc.C) {
+	_, err := s.run(c, "storage-block", "data=not-a-size,rootfs,one")
+	c.Assert(err, gc.ErrorMatches, `parsing storage constraints for "data": .*`)
+}
+
+func assertTabLine(c *gc.C, line string, fields ...string) {
+	cols := strings.Fields(strings.TrimSpace(line))
+	c.Assert(cols, gc.DeepEquals, fields)
+}
+
+// Mocks
+type mockStorageDirectivesAPI struct {
+	getFunc    func(app string) (apiapplication.ApplicationStorageDirectives, error)
+	updateFunc func(apiapplication.ApplicationStorageUpdate) error
+}
+
+func (m *mockStorageDirectivesAPI) Close() error { return nil }
+
+func (m *mockStorageDirectivesAPI) GetApplicationStorageDirectives(applicationName string) (apiapplication.ApplicationStorageDirectives, error) {
+	return m.getFunc(applicationName)
+}
+
+func (m *mockStorageDirectivesAPI) UpdateApplicationStorageDirectives(up apiapplication.ApplicationStorageUpdate) error {
+	return m.updateFunc(up)
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -487,6 +487,7 @@ func registerCommands(r commandRegistry) {
 	r.Register(application.NewDiffBundleCommand())
 	r.Register(application.NewShowApplicationCommand())
 	r.Register(application.NewShowUnitCommand())
+	r.Register(application.NewStorageCommand())
 
 	// Operation protection commands
 	r.Register(block.NewDisableCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -321,6 +321,7 @@ var commandNames = []string{
 	"add-user",
 	"agree",
 	"agreements",
+	"application-storage",
 	"attach-resource",
 	"attach-storage",
 	"autoload-credentials",

--- a/cmd/juju/machine/flags_test.go
+++ b/cmd/juju/machine/flags_test.go
@@ -22,7 +22,7 @@ func (*FlagsSuite) TestDisksFlagErrors(c *gc.C) {
 	var disks []storage.Constraints
 	f := machine.NewDisksFlag(&disks)
 	err := f.Set("-1")
-	c.Assert(err, gc.ErrorMatches, `cannot parse disk constraints: cannot parse count: count must be greater than zero, got "-1"`)
+	c.Assert(err, gc.ErrorMatches, `cannot parse disk constraints: parsing storage count: count must be greater than zero, got "-1"`)
 	c.Assert(disks, gc.HasLen, 0)
 }
 

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -38,8 +38,8 @@ You can target a specific model using the ` + "`-m`" + ` flag:
     juju model-config -m <model>
     juju model-config -m <controller>:<model>
 
-	By default, the config will be printed in a tabular format. You can instead
-print it in the ` + "`json`" + ` or ` + "`yaml`" + ` format using the ` + "`--format`" + ` flag:
+By default, the config will be printed in a tabular format. You can instead
+print it in ` + "`json`" + ` or ` + "`yaml`" + ` format using the ` + "`--format`" + ` flag:
 
     juju model-config --format json
     juju model-config --format yaml

--- a/cmd/juju/storage/add_test.go
+++ b/cmd/juju/storage/add_test.go
@@ -76,7 +76,7 @@ var errorTsts = []tstData{
 	{
 		args:        []string{"tst/123", "data=-676"},
 		expectedErr: `count must be greater than zero, got "-676"`,
-		visibleErr:  `cannot parse constraints for storage "data": cannot parse count: count must be greater than zero, got "-676"`,
+		visibleErr:  `cannot parse constraints for storage "data": parsing storage count: count must be greater than zero, got "-676"`,
 	},
 	{
 		args:        []string{"tst/123", "data=676", "data=676"},

--- a/docs/howto/manage-applications.md
+++ b/docs/howto/manage-applications.md
@@ -391,6 +391,47 @@ juju set-constraints apache2 mem=
 See more: {ref}`command-juju-set-constraints`
 ```
 
+(manage-storage-for-an-application)=
+## Manage storage for an application
+
+```{ibnote}
+See also: {ref}`storage`
+```
+
+**Set values.** You can set storage directives for an application during deployment or later.
+
+- To set storage directives for an application during deployment, run the `deploy` command with the `--storage` flag followed by the relevant key-value pair or a quotes-enclosed list of key-value pairs. For example, to deploy MySQL with a storage volume that has at least 6 GiB of memory using the `rootfs` pool:
+
+``` text
+juju deploy mysql --storage pgdata=6G,rootfs,1
+```
+
+```{ibnote}
+See more: {ref}`command-juju-deploy`
+```
+
+- To set storage directives for an application after deployment, run the `application-storage` command
+followed by the desired ("-enclosed list of) key-value pair(s), as in the example below.
+Note: This will affect any future units you may add to the application.
+
+``` text
+juju application-storage mysql database=1,3G,lxd
+```
+
+```{ibnote}
+See more: {ref}`command-juju-application-storage`
+```
+
+**Get values.** To view an application's current storage directives, use the `application-storage` command. For example:
+
+``` text
+juju application-storage mysql
+```
+
+```{ibnote}
+See more: {ref}`command-juju-application-storage`
+```
+
 ## Change space bindings for an application
 
 You can set space bindings for an application during deployment or post-deployment. In both cases you can set either a default space for the entire application or a specific space for one or more individual application endpoints or both.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/application-storage.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/application-storage.md
@@ -1,0 +1,59 @@
+(command-juju-application-storage)=
+# `juju application-storage`
+> See also: [storage](#storage), [storage-pools](#storage-pools), [add-storage](#add-storage), [add-unit](#add-unit)
+
+## Summary
+Displays or sets storage directives for an application.
+
+## Usage
+```juju application-storage [options] <application-name> [<storage-name>[={<size>,<pool>,<count>}]] ...```
+
+### Options
+| Flag | Default | Usage |
+| --- | --- | --- |
+| `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
+| `--color` | false | Use ANSI color codes in output |
+| `--file` |  | Path to yaml-formatted configuration file |
+| `--format` | tabular | Specify output format (json&#x7c;tabular&#x7c;yaml) |
+| `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
+| `--no-color` | false | Disable ANSI color codes in tabular output |
+| `-o`, `--output` |  | Specify an output file |
+
+## Examples
+
+Print the storage directives for all storage names of the postgresql application:
+
+    juju application-storage postgresql
+
+Print the storage directives for the storage name 'pgdata' of the postgresql application:
+
+    juju application-storage postgresql pgdata
+
+Set the size to 10GiB, pool name to "rootfs", and count to 1 for the mysql application's 'database' storage specification:
+
+    juju application-storage mysql database=10G,rootfs,1
+
+
+## Details
+
+A storage directive describes to juju how the storage required by a charm should be provisioned
+and takes the form &lt;storage-name&gt;[=&lt;storage-specification&gt;]; for details
+see https://documentation.ubuntu.com/juju/3.6/reference/storage/#storage-directive.
+
+To view all storage directives for the given application:
+
+    juju application-storage <application>
+
+By default, the storage directives will be printed in a tabular format. You can instead
+print it in `json` or `yaml` format using the `--format` flag:
+
+   	juju application-storage &lt;application&gt; --format json
+    juju application-storage <application> --format yaml
+
+To view the directive for a single storage name:
+
+    juju application-storage <application> <storage-name>
+
+To set storage directives for an application:
+
+    juju application-storage <application> <storagename1>=<storage-specification> <storagename2>=<storage-specification> ...

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/deploy.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/deploy.md
@@ -66,6 +66,10 @@ Deploy to a machine with at least 8 GiB of memory:
 
     juju deploy postgresql --constraints mem=8G
 
+Deploy using the LXD storage pool with one 3 GiB volume:
+
+	juju deploy postgresql --storage pgdata=lxd,1,3G
+
 Deploy to a specific availability zone (provider-dependent):
 
     juju deploy mysql --to zone=us-east-1a
@@ -162,6 +166,12 @@ application is later scaled out with the `add-unit` command). To overcome this
 behaviour use the `set-constraints` command to change the application's default
 constraints or add a machine (`add-machine`) with a certain constraint and then
 target that machine with `add-unit` by using the `--to`option.
+
+Use the `--storage` option to specify a storage directive for the application;
+see more: https://documentation.ubuntu.com/juju/3.6/reference/storage/#storage-directive. 
+These directives will control the application's default persistent storage layout (i.e. they are used when the application is later
+scaled out with the `add-unit` command and new units need storage provisioned). To change this behaviour after deployment,
+use the  `application-storage` command -- this will update the application's default storage directives.
 
 Use the `--device` option to specify GPU device requirements (with Kubernetes).
 The below format is used for this option's value, where the 'label' is named in

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/model-config.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/model-config.md
@@ -59,8 +59,8 @@ You can target a specific model using the `-m` flag:
     juju model-config -m <model>
     juju model-config -m <controller>:<model>
 
-	By default, the config will be printed in a tabular format. You can instead
-print it in the `json` or `yaml` format using the `--format` flag:
+By default, the config will be printed in a tabular format. You can instead
+print it in `json` or `yaml` format using the `--format` flag:
 
     juju model-config --format json
     juju model-config --format yaml

--- a/internal/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/internal/worker/uniter/runner/jujuc/storage-add_test.go
@@ -39,7 +39,7 @@ type tstData struct {
 func (s *storageAddSuite) TestStorageAddInit(c *gc.C) {
 	tests := []tstData{
 		{[]string{}, 1, "storage add requires a storage directive"},
-		{[]string{"data=-676"}, 1, `.*cannot parse count: count must be gre.*`},
+		{[]string{"data=-676"}, 1, `.*parsing storage count: count must be gre.*`},
 		{[]string{"data="}, 1, ".*storage constraints require at least one.*"},
 		{[]string{"data=pool"}, 1, `.*only count can be specified for "data".*`},
 		{[]string{"data=pool,1M"}, 1, `.*only count can be specified for "data".*`},

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -735,5 +735,5 @@ type ApplicationStorageUpdate struct {
 	ApplicationTag string `json:"application-tag"`
 
 	// Holds the application storage constraints where the key is the storage name.
-	StorageConstraints map[string]StorageConstraints `json:"storage-constraints"`
+	StorageDirectives map[string]StorageConstraints `json:"storage-directives"`
 }

--- a/state/application.go
+++ b/state/application.go
@@ -3647,8 +3647,8 @@ func (a *Application) StorageConstraints() (map[string]StorageConstraints, error
 }
 
 // UpdateStorageConstraints updates the storage constraints for the application.
-func (a *Application) UpdateStorageConstraints(cons map[string]StorageConstraints) error {
-	if len(cons) == 0 {
+func (a *Application) UpdateStorageConstraints(storageDirectivesUpdate map[string]StorageDirectivesUpdate) error {
+	if len(storageDirectivesUpdate) == 0 {
 		return nil
 	}
 
@@ -3671,7 +3671,7 @@ func (a *Application) UpdateStorageConstraints(cons map[string]StorageConstraint
 			}
 		}
 
-		currentCons := maps.Clone(cons)
+		currentCons := maps.Clone(storageDirectivesUpdate)
 
 		storageConstraintsKey := a.storageConstraintsKey()
 
@@ -3681,15 +3681,37 @@ func (a *Application) UpdateStorageConstraints(cons map[string]StorageConstraint
 			return nil, errors.Trace(err)
 		}
 
-		if err := addDefaultStorageConstraints(sb, currentCons, ch.Meta()); err != nil {
-			return nil, errors.Annotate(err, "adding default storage constraints")
+		storageConsToUpdate, err := a.StorageConstraints()
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
-		if err := validateStorageConstraints(sb, currentCons, ch.Meta()); err != nil {
+
+		for storageName, storageCons := range currentCons {
+			originalStorageCons := storageConsToUpdate[storageName]
+			sc := StorageConstraints{
+				Pool:  originalStorageCons.Pool,
+				Size:  originalStorageCons.Size,
+				Count: originalStorageCons.Count,
+			}
+
+			if storageCons.Pool != "" {
+				sc.Pool = storageCons.Pool
+			}
+			if storageCons.Size != nil {
+				sc.Size = *storageCons.Size
+			}
+			if storageCons.Count != nil {
+				sc.Count = *storageCons.Count
+			}
+			storageConsToUpdate[storageName] = sc
+		}
+
+		if err := validateStorageConstraints(sb, storageConsToUpdate, ch.Meta()); err != nil {
 			return nil, errors.Annotate(err, "validating storage constraints")
 		}
 
 		storageConstraintsOp := replaceStorageConstraintsOp(
-			storageConstraintsKey, currentCons,
+			storageConstraintsKey, storageConsToUpdate,
 		)
 		return []txn.Op{storageConstraintsOp}, nil
 	}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -4164,8 +4164,8 @@ func (s *ApplicationSuite) TestWatchStorageConstraints(c *gc.C) {
 	appWc.AssertOneChange()
 
 	// Make one change, check one event.
-	constraints := map[string]state.StorageConstraints{
-		"data0": {Count: 5, Size: 1024, Pool: "loop"},
+	constraints := map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(5)),
 	}
 	err = app.UpdateStorageConstraints(constraints)
 	c.Assert(err, jc.ErrorIsNil)
@@ -4184,8 +4184,8 @@ func (s *ApplicationSuite) TestWatchStorageConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Make another change, check one event.
-	constraints = map[string]state.StorageConstraints{
-		"data0": {Count: 6, Size: 2048, Pool: "loop"},
+	constraints = map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("loop", uint64p(2048), uint64p(6)),
 	}
 	err = appForUpdates.UpdateStorageConstraints(constraints)
 	c.Assert(err, jc.ErrorIsNil)
@@ -4219,8 +4219,8 @@ func (s *ApplicationSuite) TestWatchStorageConstraintsDoesNotCrossApplications(c
 	sbWc.AssertOneChange()
 
 	// Check mysql watcher does not react when storage block is updated.
-	constraints := map[string]state.StorageConstraints{
-		"data": {Count: 1, Size: 1024, Pool: "loop"},
+	constraints := map[string]state.StorageDirectivesUpdate{
+		"data": makeStorageDirectivesToUpdate("loop", uint64p(1024), uint64p(1)),
 	}
 	err = storageBlockApp.UpdateStorageConstraints(constraints)
 	c.Assert(err, jc.ErrorIsNil)
@@ -6098,8 +6098,8 @@ func (s *ApplicationSuite) TestUpdateStorageConstraints(c *gc.C) {
 		Size:  uint64(100),
 	})
 
-	newSC := map[string]state.StorageConstraints{
-		"data0": makeStorageCons("loop", 4096, 3),
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(3)),
 	}
 
 	err = app.UpdateStorageConstraints(newSC)
@@ -6108,9 +6108,113 @@ func (s *ApplicationSuite) TestUpdateStorageConstraints(c *gc.C) {
 	cons, err = app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, gc.HasLen, 1)
-	c.Assert(cons["data0"].Pool, gc.Equals, "loop")
-	c.Assert(cons["data0"].Count, gc.Equals, uint64(3))
-	c.Assert(cons["data0"].Size, gc.Equals, uint64(4096))
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(3),
+		Size:  uint64(4096),
+	})
+}
+
+func (s *ApplicationSuite) TestUpdateStorageConstraintsCountOnly(c *gc.C) {
+	oldSC := map[string]state.StorageConstraints{
+		"data0": makeStorageCons("loop", 100, 5),
+	}
+	oldMeta := mysqlBaseMeta + oneRequiredStorageMeta + storageRange(1, 5)
+	charm := s.AddMetaCharm(c, "mysql", oldMeta, 2)
+	app := s.AddTestingApplicationWithStorage(c, "testing", charm, oldSC)
+
+	cons, err := app.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.HasLen, 1)
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(5),
+		Size:  uint64(100),
+	})
+
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("", nil, uint64p(3)),
+	}
+
+	err = app.UpdateStorageConstraints(newSC)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err = app.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.HasLen, 1)
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(3),
+		Size:  uint64(100),
+	})
+}
+
+func (s *ApplicationSuite) TestUpdateStorageConstraintsSizeOnly(c *gc.C) {
+	oldSC := map[string]state.StorageConstraints{
+		"data0": makeStorageCons("loop", 100, 5),
+	}
+	oldMeta := mysqlBaseMeta + oneRequiredStorageMeta + storageRange(1, 5)
+	charm := s.AddMetaCharm(c, "mysql", oldMeta, 2)
+	app := s.AddTestingApplicationWithStorage(c, "testing", charm, oldSC)
+
+	cons, err := app.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.HasLen, 1)
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(5),
+		Size:  uint64(100),
+	})
+
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("", uint64p(2048), nil),
+	}
+
+	err = app.UpdateStorageConstraints(newSC)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err = app.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.HasLen, 1)
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(5),
+		Size:  uint64(2048),
+	})
+}
+
+func (s *ApplicationSuite) TestUpdateStorageConstraintsPoolOnly(c *gc.C) {
+	oldSC := map[string]state.StorageConstraints{
+		"data0": makeStorageCons("rootfs", 100, 5),
+	}
+	oldMeta := mysqlBaseMeta + oneRequiredFilesystemStorageMeta + storageRange(1, 5)
+	charm := s.AddMetaCharm(c, "mysql", oldMeta, 2)
+	app := s.AddTestingApplicationWithStorage(c, "testing", charm, oldSC)
+
+	cons, err := app.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.HasLen, 1)
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "rootfs",
+		Count: uint64(5),
+		Size:  uint64(100),
+	})
+
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("loop", nil, nil),
+	}
+
+	err = app.UpdateStorageConstraints(newSC)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err = app.StorageConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, gc.HasLen, 1)
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(5),
+		Size:  uint64(100),
+	})
 }
 
 func (s *ApplicationSuite) TestUpdateStorageConstraintsInvalidStoreKey(c *gc.C) {
@@ -6129,8 +6233,8 @@ func (s *ApplicationSuite) TestUpdateStorageConstraintsInvalidStoreKey(c *gc.C) 
 		Count: uint64(5),
 		Size:  uint64(100),
 	})
-	newSC := map[string]state.StorageConstraints{
-		"wrong-storage-key": makeStorageCons("loop", 4096, 3),
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"wrong-storage-key": makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(3)),
 	}
 
 	err = app.UpdateStorageConstraints(newSC)
@@ -6153,11 +6257,11 @@ func (s *ApplicationSuite) TestUpdateStorageConstraintsInvalidCount(c *gc.C) {
 		Count: uint64(5),
 		Size:  uint64(100),
 	})
-	newSC := map[string]state.StorageConstraints{
-		"data0": makeStorageCons("loop", 4096, 6),
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(6)),
 	}
 
-	// This fails because storage constraint count of storage-constraint1 charm is 1-5.
+	// This fails because storage constraint count of first mysql charm is 1-5.
 	err = app.UpdateStorageConstraints(newSC)
 	c.Assert(err, gc.NotNil)
 }
@@ -6179,10 +6283,10 @@ func (s *ApplicationSuite) TestUpdateStorageConstraintsInvalidStorageType(c *gc.
 		Size:  uint64(100),
 	})
 
-	newSC := map[string]state.StorageConstraints{
-		"data0":          makeStorageCons("loop", 4096, 1),
-		"not-supported1": makeStorageCons("loop", 4096, 1),
-		"not-supported2": makeStorageCons("loop", 4096, 1),
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"data0":          makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(3)),
+		"not-supported1": makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(1)),
+		"not-supported2": makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(1)),
 	}
 
 	err = app.UpdateStorageConstraints(newSC)
@@ -6200,19 +6304,21 @@ func (s *ApplicationSuite) TestUpdateStorageConstraintsConcurrentCharmUpdate(c *
 	cons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, gc.HasLen, 1)
-	c.Assert(cons["data0"].Pool, gc.Equals, "loop")
-	c.Assert(cons["data0"].Count, gc.DeepEquals, uint64(1))
-	c.Assert(cons["data0"].Size, gc.Equals, uint64(100))
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(1),
+		Size:  uint64(100),
+	})
 
-	// Storage constraint count of 5 should work for both storage-constraint1 and storage-constraint2 charms.
-	newSC := map[string]state.StorageConstraints{
-		"data0": makeStorageCons("loop", 4096, 5),
+	// Storage constraint count of 5 should work for both old and new mysql charms.
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(5)),
 	}
 
 	newMeta := mysqlBaseMeta + oneRequiredStorageMeta + storageRange(5, 10)
 	newCh := s.AddMetaCharm(c, "mysql", newMeta, 3)
 
-	// Set charm to new charm with storage constraint size
+	// Set charm to new charm with storage constraint count
 	// from 6-10 before running replaceStorageConstraintsOp txn.
 	defer state.SetBeforeHooks(c, s.State, func() {
 		err := app.SetCharm(state.SetCharmConfig{
@@ -6243,9 +6349,11 @@ func (s *ApplicationSuite) TestUpdateStorageConstraintsConcurrentCharmUpdate(c *
 	cons, err = app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, gc.HasLen, 1)
-	c.Assert(cons["data0"].Pool, gc.Equals, "loop")
-	c.Assert(cons["data0"].Count, gc.Equals, uint64(5))
-	c.Assert(cons["data0"].Size, gc.Equals, uint64(4096))
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(5),
+		Size:  uint64(4096),
+	})
 }
 
 func (s *ApplicationSuite) TestUpdateStorageConstraintsConcurrentCharmUpdateIncompatible(c *gc.C) {
@@ -6259,18 +6367,21 @@ func (s *ApplicationSuite) TestUpdateStorageConstraintsConcurrentCharmUpdateInco
 	cons, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cons, gc.HasLen, 1)
-	c.Assert(cons["data0"].Pool, gc.Equals, "loop")
-	c.Assert(cons["data0"].Count, gc.DeepEquals, uint64(1))
-	c.Assert(cons["data0"].Size, gc.Equals, uint64(100))
+	c.Assert(cons["data0"], jc.DeepEquals, state.StorageConstraints{
+		Pool:  "loop",
+		Count: uint64(1),
+		Size:  uint64(100),
+	})
 
-	// We try to update original application charm storage constraint size to 3.
-	newSC := map[string]state.StorageConstraints{
-		"data0": makeStorageCons("loop", 4096, 3),
+	// We try to update original application charm storage constraint count to 3.
+	newSC := map[string]state.StorageDirectivesUpdate{
+		"data0": makeStorageDirectivesToUpdate("loop", uint64p(4096), uint64p(3)),
 	}
+
 	newMeta := mysqlBaseMeta + oneRequiredStorageMeta + storageRange(5, 10)
 	newCh := s.AddMetaCharm(c, "mysql", newMeta, 3)
 
-	// Set charm to new charm with storage constraint size
+	// Set charm to new charm with storage constraint count
 	// from 6-10 before running replaceStorageConstraintsOp txn.
 	defer state.SetBeforeHooks(c, s.State, func() {
 		err := app.SetCharm(state.SetCharmConfig{
@@ -6287,10 +6398,10 @@ func (s *ApplicationSuite) TestUpdateStorageConstraintsConcurrentCharmUpdateInco
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 
-	// This should fail since we try to set storage constraint size to 3 in
-	// the new charm with storage constraint size of range 5-10.
+	// This should fail since we try to set storage constraint count to 3 in
+	// the new charm with storage constraint count of range 5-10.
 	err = app.UpdateStorageConstraints(newSC)
-	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, `.* 5 instances required, 3 specified`)
 
 	// Charm storage constraints should be updated to new charm
 	// with new storage constraints since the hook update is successful.

--- a/state/storage.go
+++ b/state/storage.go
@@ -1690,6 +1690,20 @@ type StorageConstraints struct {
 	Count uint64 `bson:"count"`
 }
 
+// StorageDirectivesUpdate contains the user-specified constraints for updating
+// storage directives for an application unit.
+type StorageDirectivesUpdate struct {
+	// Pool is the name of the storage pool from which to provision the
+	// storage instances.
+	Pool string
+
+	// Size is the required size of the storage instances, in MiB.
+	Size *uint64
+
+	// Count is the required number of storage instances.
+	Count *uint64
+}
+
 func createStorageConstraintsOp(key string, cons map[string]StorageConstraints) txn.Op {
 	return txn.Op{
 		C:      storageConstraintsC,

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -454,6 +454,10 @@ func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
 	return state.StorageConstraints{Pool: pool, Size: size, Count: count}
 }
 
+func makeStorageDirectivesToUpdate(pool string, size, count *uint64) state.StorageDirectivesUpdate {
+	return state.StorageDirectivesUpdate{Pool: pool, Size: size, Count: count}
+}
+
 type StorageStateSuite struct {
 	StorageStateSuiteBase
 }

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -27,6 +27,20 @@ type Constraints struct {
 	Count uint64
 }
 
+// Directives describes a set of storage directives.
+type Directives struct {
+	// Pool is the name of the storage pool (ebs, ceph, custompool, ...)
+	// that must provide the storage, or "" if the default pool should be
+	// used.
+	Pool string
+
+	// Size is the minimum size of the storage in MiB.
+	Size *uint64
+
+	// Count is the number of instances of the storage to create.
+	Count *uint64
+}
+
 var (
 	poolRE  = regexp.MustCompile("^[a-zA-Z]+[-?a-zA-Z0-9]*$")
 	countRE = regexp.MustCompile("^-?[0-9]+$")
@@ -34,7 +48,7 @@ var (
 )
 
 // ParseConstraints parses the specified string and creates a
-// Constraints structure.
+// Constraints structure. It defaults count to 1 if count is not specified.
 //
 // The acceptable format for storage constraints is a comma separated
 // sequence of: POOL, COUNT, and SIZE, where
@@ -67,7 +81,7 @@ func ParseConstraints(s string) (Constraints, error) {
 		}
 		if count, ok, err := parseCount(field); ok {
 			if err != nil {
-				return cons, errors.Annotate(err, "cannot parse count")
+				return cons, errors.Annotate(err, "parsing storage count")
 			}
 			if cons.Count != 0 {
 				return cons, errors.NotValidf("storage instance count is already set to %d, new value %d", cons.Count, count)
@@ -92,6 +106,66 @@ func ParseConstraints(s string) (Constraints, error) {
 	}
 	if cons.Count == 0 {
 		cons.Count = 1
+	}
+	return cons, nil
+}
+
+// ParseDirectives parses the specified string and creates a
+// storage directives structure.
+//
+// The acceptable format for storage directives is a comma separated
+// sequence of: POOL, COUNT, and SIZE, where
+//
+//	POOL identifies the storage pool. POOL can be a string
+//	starting with a letter, followed by zero or more digits
+//	or letters optionally separated by hyphens.
+//
+//	COUNT is a positive integer indicating how many instances
+//	of the storage to create. If unspecified, and SIZE is
+//	specified, COUNT defaults to 1.
+//
+//	SIZE describes the minimum size of the storage instances to
+//	create. SIZE is a floating point number and multiplier from
+//	the set (M, G, T, P, E, Z, Y), which are all treated as
+//	powers of 1024.
+func ParseDirectives(s string) (Directives, error) {
+	var cons Directives
+	fields := strings.Split(s, ",")
+	for _, field := range fields {
+		if field == "" {
+			continue
+		}
+		if IsValidPoolName(field) {
+			if cons.Pool != "" {
+				return cons, errors.NotValidf("pool name is already set to %q, new value %q", cons.Pool, field)
+			}
+			cons.Pool = field
+			continue
+		}
+		if count, ok, err := parseCount(field); ok {
+			if err != nil {
+				return cons, errors.Annotate(err, "parsing storage count")
+			}
+			if cons.Count != nil {
+				return cons, errors.NotValidf("storage instance count is already set to %d, new value %d", cons.Count, count)
+			}
+			cons.Count = &count
+			continue
+		}
+		if size, ok, err := parseSize(field); ok {
+			if err != nil {
+				return cons, errors.Annotate(err, "cannot parse size")
+			}
+			if cons.Size != nil {
+				return cons, errors.NotValidf("storage size is already set to %d, new value %d", cons.Size, size)
+			}
+			cons.Size = &size
+			continue
+		}
+		return cons, errors.NotValidf("unrecognized storage constraint %q", field)
+	}
+	if cons.Count == nil && cons.Size == nil && cons.Pool == "" {
+		return Directives{}, errors.New("storage directives require at least one field to be specified")
 	}
 	return cons, nil
 }

--- a/storage/constraints_test.go
+++ b/storage/constraints_test.go
@@ -65,9 +65,9 @@ func (s *ConstraintsSuite) TestParseConstraintsOptions(c *gc.C) {
 }
 
 func (s *ConstraintsSuite) TestParseConstraintsCountRange(c *gc.C) {
-	s.testParseError(c, "p,0,100M", `cannot parse count: count must be greater than zero, got "0"`)
-	s.testParseError(c, "p,00,100M", `cannot parse count: count must be greater than zero, got "00"`)
-	s.testParseError(c, "p,-1,100M", `cannot parse count: count must be greater than zero, got "-1"`)
+	s.testParseError(c, "p,0,100M", `parsing storage count: count must be greater than zero, got "0"`)
+	s.testParseError(c, "p,00,100M", `parsing storage count: count must be greater than zero, got "00"`)
+	s.testParseError(c, "p,-1,100M", `parsing storage count: count must be greater than zero, got "-1"`)
 	s.testParseError(c, "", `storage constraints require at least one field to be specified`)
 	s.testParseError(c, ",", `storage constraints require at least one field to be specified`)
 }

--- a/tests/suites/storage/application_storage.sh
+++ b/tests/suites/storage/application_storage.sh
@@ -1,0 +1,97 @@
+run_application_storage_directives() {
+	echo
+
+	model_name="application-storage"
+	file="${TEST_DIR}/test-${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+	app_name="postgresql"
+
+	# Deploy an application with storage directive pgdata=2G.
+	if [ "${BOOTSTRAP_PROVIDER:-}" = "k8s" ]; then
+		echo "Deploying k8s application"
+		app_name="postgresql-k8s"
+		juju deploy "$app_name" --storage pgdata=2G --trust
+	else
+		echo "Deploying non-k8s application"
+		app_name="postgresql"
+		juju deploy "$app_name" --storage pgdata=2G
+	fi
+
+	# Wait for application to be active.
+	wait_for true ".applications[\"$app_name\"][\"application-status\"].current==\"active\""
+
+	juju application-storage "$app_name" --format=yaml
+	old_size=$(juju application-storage "$app_name" --format=json | jq -r '.pgdata.Size')
+	if [ "$old_size" != "2048" ]; then
+		echo "Expected storage size 2048Mi, got $old_size"
+		exit 1
+	fi
+
+	# For k8s, verify initial PVC size.
+	if [ "${BOOTSTRAP_PROVIDER:-}" = "k8s" ]; then
+		echo "Checking initial PVC size"
+
+		# Get storageclass and PVC name (assumes single PVC for pgdata)
+		pvc_name=$(kubectl -n "${model_name}" get pvc -o json | jq -r '.items[0].metadata.name')
+		pvc_size=$(kubectl -n "${model_name}" get pvc "$pvc_name" -o json | jq -r '.spec.resources.requests.storage')
+
+		if [ "$pvc_size" != "2Gi" ]; then
+			echo "Expected PVC size 2Gi, got $pvc_size"
+			exit 1
+		fi
+	fi
+
+	# Update the storage directive pgdata=3G.
+	juju application-storage "$app_name" pgdata=3G
+	new_size=$(juju application-storage "$app_name" --format=json | jq -r '.pgdata.Size')
+	if [ "$new_size" != "3072" ]; then
+		echo "Expected updated storage size to be 3072Mi, got $new_size"
+		exit 1
+	fi
+
+	# For k8s, verify the updated PVC size.
+	if [ "${BOOTSTRAP_PROVIDER:-}" = "k8s" ]; then
+		echo "Checking updated PVC size"
+
+		pvc_name=$(kubectl -n "${model_name}" get pvc -o json | jq -r '.items[0].metadata.name')
+		pvc_size=$(kubectl -n "${model_name}" get pvc "$pvc_name" -o json | jq -r '.spec.resources.requests.storage')
+
+		if [ "$pvc_size" != "3Gi" ]; then
+			echo "Expected updated PVC size 3Gi, got $pvc_size"
+			exit 1
+		fi
+	fi
+
+	# Add 2 more units and check their storage size is 3G.
+	juju add-unit "$app_name" -n 2
+	wait_for "${app_name}/1" ".applications"
+	wait_for "${app_name}/2" ".applications"
+
+	unit_1_size=$(juju storage --format=json | jq -r --arg u "${app_name}/1" \
+		'.filesystems[] | select(.attachments.units[$u]) | .size')
+	unit_2_size=$(juju storage --format=json | jq -r --arg u "${app_name}/2" \
+		'.filesystems[] | select(.attachments.units[$u]) | .size')
+
+	if [ "$unit_1_size" != "3072" ] || [ "$unit_2_size" != "3072" ]; then
+		echo "Expected new units storage size to be 3072Mi, got $unit_1_size and $unit_2_size"
+		exit 1
+	fi
+
+	destroy_model "${model_name}"
+}
+
+test_application_storage() {
+	if [ "$(skip 'test_application_storage')" ]; then
+		echo "==> TEST SKIPPED: application storage tests"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_application_storage_directives"
+	)
+}

--- a/tests/suites/storage/task.sh
+++ b/tests/suites/storage/task.sh
@@ -17,6 +17,7 @@ test_storage() {
 	test_model_storage_block
 	test_model_storage_filesystem
 	test_persistent_storage
+	test_application_storage
 
 	destroy_controller "test-storage"
 }


### PR DESCRIPTION
This PR implements the command interface to display and update application storage. "storage constraints" field names have been changed to "storage directives" as a drive-by in the second commit.

The card has been split into 3 PRs for better readability and fill in the placeholders for other parallel work :

**Server**
1. Implement API server logic to get and set application storage command 

**Client**

2. Implement juju application-storage get/set client logic 

**Comand**
3. Implement juju application-storage command interface (Current PR)


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages


## QA steps 

### IAAS
1. Check if help command makes sense
```sh
juju help application-storage
```

2. Bootstrap a lxd controller
```sh
juju bootstrap lxd mylxd
```

3. Add a model
```sh
juju add-model mylxdmodel
```

4. Deploy an application
```sh
juju deploy postgresql
```

5. Verify application storage GET works
```sh
juju application-storage postgresql
Storage  Pool  Size  Count
pgdata rootfs   1024  1
```

6. Add a unit and check juju storage
```sh
juju add-unit postgresql && juju storage
Unit     Storage ID  Type        Pool    Size     Status    Message
postgresql/0  database/0  filesystem  rootfs  36 GiB   attached  
postgresql/1  database/1  filesystem  rootfs  35 GiB   attached  
```

7. Verify application storage UPDATE works
```sh
juju application-storage postgresql pgdata=lxd,3G,1
juju application-storage postgresql
Storage  Pool  Size  Count
pgdata   lxd   3072  1
```

8. Add 3 units and check juju storage
```sh
juju add-unit postgresql -n 3
juju storage
Unit     Storage ID  Type        Pool    Size     Status    Message
postgresql/0  database/0  filesystem  rootfs  36 GiB   attached  
postgresql/1  database/1  filesystem  rootfs  35 GiB   attached  
postgresql/2  database/2  filesystem  lxd     3.0 GiB  attached  
postgresql/3  database/3  filesystem  lxd     3.0 GiB  attached  
postgresql/4  database/4  filesystem  lxd     3.0 GiB  attached  
```

### CAAS
1. Bootstrap a caas controller
```sh
juju bootstrap minikube myk8s
```

3. Add a model
```sh
juju add-model myk8smodel
```

4. Deploy an application
```sh
juju deploy postgresql-k8s --trust
```

5. Verify application storage GET works
```sh
juju application-storage postgresql-k8s
Storage  Pool  Size  Count
pgdata kubernetes   1024  1
```

6. Add a unit and check juju storage
```sh
juju add-unit postgresq-k8sl && juju storage
Unit              Storage ID  Type        Pool        Size     Status    Message
postgresql-k8s/0  pgdata/0    filesystem  kubernetes  1.0 GiB  attached  Successfully provisioned volume pvc-0b281e06-cd47-4f89-9252-086a891f19e6
postgresql-k8s/1  pgdata/1    filesystem  kubernetes  1.0 GiB  attached  Successfully provisioned volume pvc-6bee9c0a-0251-4a42-a566-1c6bc470de2b
```

7. Verify application storage UPDATE works
```sh
juju application-storage postgresql-k8s pgdata=rootfs,3G,1
juju application-storage postgresql-k8s
Storage  Pool  Size  Count
pgdata   rootfs   3072  1
```

8. Add 3 units and check juju storage
```sh
juju add-unit postgresql-k8s -n 3
juju storage

Unit              Storage ID  Type        Pool        Size     Status    Message
postgresql-k8s/0  pgdata/0    filesystem  kubernetes  1.0 GiB  attached  Successfully provisioned volume pvc-e1578614-d2c2-4fe3-b79a-fd96ef75fa21
postgresql-k8s/1  pgdata/1    filesystem  kubernetes  1.0 GiB  attached  Successfully provisioned volume pvc-161ee8fa-9729-4028-b20a-9452df3e6fd2
postgresql-k8s/2  pgdata/2    filesystem  rootfs      3.0 GiB  attached  
postgresql-k8s/3  pgdata/4    filesystem  rootfs      3.0 GiB  attached  
postgresql-k8s/4  pgdata/3    filesystem  rootfs      3.0 GiB  attached

```


## Links
**Parent PR:** https://github.com/juju/juju/pull/20719
**Jira card:** https://warthogs.atlassian.net/browse/JUJU-8443