### PR TITLE
docs: add references to umask(2)

### DIFF
--- a/doc/architectural-overview.txt
+++ b/doc/architectural-overview.txt
@@ -205,6 +205,11 @@ XXXX
 
 XXXX
 
+Charm authors are responsible to set an appropriate
+[`umask(2)`](https://manpages.ubuntu.com/manpages/noble/man2/umask.2.html)
+setting. Future versions of Juju may use a different default than previous
+versions of Juju.
+
 
 ### The Relation Model
 

--- a/doc/charms-in-action.txt
+++ b/doc/charms-in-action.txt
@@ -105,6 +105,11 @@ following characteristics:
     with: the command line tools won't work without them).
   * $JUJU_API_ADDRESSES holds a space separated list of juju API addresses.
   * $JUJU_MODEL_NAME holds the human friendly name of the current model.
+  * Current versions of Juju use a very permissive
+    [`umask(2)`](https://manpages.ubuntu.com/manpages/noble/man2/umask.2.html)
+    setting. Charm authors are responsible for setting this value, and
+    using Unix users and groups, necessary for the correct operation of
+    their charms.
 
 Hook tools
 ----------


### PR DESCRIPTION
Charm authors are responsible for managing their umask and other system resources.

**Issue:** Fixes https://github.com/juju/juju/issues/21240.

