### PR TITLE
feat: prevent panic during bootstrap

### DIFF
--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -433,6 +433,8 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 	controllerAddrs, err := c.getControllerAddresses(ctx)
 	if err != nil {
 		return err
+	} else if len(controllerAddrs) == 0 {
+		return errors.New("no controller addresses found")
 	}
 
 	// The default log buffer size is 1 for a single controller


### PR DESCRIPTION
If bootstrapping and running debug-log at the same time, it will cause the debug-log to panic stating that all goroutines are asleep. This is because the number of controller addresses is 0.


## QA steps

Using the HEAD of 4.0, run the following. You'll need two shells at the same time:

```sh
$ juju bootstrap lxd test
```

In another shell at the same time, run:

```sh
$ juju debug-log -m controller --replay
```

After sometime it will panic with the following:

```sh
$ juju debug-log -m controller --replay
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [select]:
github.com/juju/juju/cmd/juju/commands.(*debugLogCommand).Run(0xc000a36248, 0xc00051aa20)
        /home/simon-richardson/go/src/github.com/juju/juju/cmd/juju/commands/debuglog.go:485 +0x45f
github.com/juju/juju/cmd/modelcmd.(*modelCommandWrapper).Run(0xc000a4d170, 0xc00051aa20)
        /home/simon-richardson/go/src/github.com/juju/juju/cmd/modelcmd/modelcommand.go:660 +0x124
github.com/juju/juju/cmd/modelcmd.(*baseCommandWrapper).Run(0xc000198590, 0xc00051aa20)
        /home/simon-richardson/go/src/github.com/juju/juju/cmd/modelcmd/base.go:572 +0x95
github.com/juju/juju/internal/cmd.(*SuperCommand).Run(0xc00083fce0, 0xc00051aa20)
        /home/simon-richardson/go/src/github.com/juju/juju/internal/cmd/supercommand.go:562 +0x38b
github.com/juju/juju/internal/cmd.Main({0x7039560, 0xc00083fce0}, 0xc00051aa20, {0xc00032b980, 0x4, 0x4})
        /home/simon-richardson/go/src/github.com/juju/juju/internal/cmd/cmd.go:449 +0x232
github.com/juju/juju/cmd/juju/commands.jujuMain.Run({0xc00032a3c0?}, {0xc0000b4050, 0x5, 0x5})
        /home/simon-richardson/go/src/github.com/juju/juju/cmd/juju/commands/main.go:195 +0x8a7
github.com/juju/juju/cmd/juju/commands.Main(...)
        /home/simon-richardson/go/src/github.com/juju/juju/cmd/juju/commands/main.go:119
main.main()
        /home/simon-richardson/go/src/github.com/juju/juju/cmd/juju/main.go:29 +0x6c
```

After the fix is applied:

```sh
$ juju debug-log -m controller --replay
ERROR no controller addresses found
```

I'm happy to riff on the error message, but for now we just want to stop the panic.