### PR TITLE
feat: handle different controllers debug-log

### DIFF
--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -403,8 +403,8 @@ func (f logFunc) Log(r []corelogger.LogRecord) error {
 	return f(r)
 }
 
-func (c *debugLogCommand) getControllerAddresses(ctx context.Context) ([]string, error) {
-	controllerName, err := c.ClientStore().CurrentController()
+func (c *debugLogCommand) getControllerAddresses() ([]string, error) {
+	controllerName, err := c.ModelCommandBase.ControllerName()
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting controller details")
 	}
@@ -430,7 +430,7 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Get the controller addresses to connect to.
-	controllerAddrs, err := c.getControllerAddresses(ctx)
+	controllerAddrs, err := c.getControllerAddresses()
 	if err != nil {
 		return err
 	}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -260,7 +260,7 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 		param.AccountDetails.LastKnownAccess = conn.ControllerAccess()
 		err := store.UpdateAccount(controllerName, *param.AccountDetails)
 		if err != nil {
-			logger.Errorf(context.TODO(), "cannot update account information: %v", err)
+			logger.Errorf(ctx, "cannot update account information: %v", err)
 		}
 	}
 	if redirErr, ok := errors.Cause(err).(*api.RedirectError); ok {
@@ -270,7 +270,7 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 		return nil, errors.New("no controller API addresses; is bootstrap still in progress?")
 	}
 	if proxyerrors.IsProxyConnectError(err) {
-		logger.Debugf(context.TODO(), "proxy connection error: %v", err)
+		logger.Debugf(ctx, "proxy connection error: %v", err)
 		if proxyerrors.ProxyType(err) == k8sproxy.ProxierTypeKey {
 			return nil, errors.Annotate(err, "cannot connect to k8s api server; try running 'juju update-k8s --client <k8s cloud name>'")
 		}


### PR DESCRIPTION
Locating the current controller addresses was using the wrong method for getting the current controller name. Essentially we bypassed the base comment maybeInitModel, which then caused us to access the wrong controller with the incorrect certificate.

The fix is to just ask the base command what it thinks is the current controller and that will initialise the model and report back the correct one. Then we can correctly log in to the right one without the TLS certificate error.

---

This one bit me A LOT when debugging with CMR between controllers. The fix is simple.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju bootstrap lxd src
$ juju debug-log -m src:controller --replay
$ juju debug-log -m test:controller --replay
$ juju add-model -c test m
$ juju add-model -c src x
$ juju debug-log -m test:m --replay
$ juju debug-log -m src:x --replay
$ juju switch -m src:controller
$ juju debug-log --replay
$ juju switch -m test:controller
$ juju debug-log --replay
```
