### PR TITLE
test: fix flakey test in change stream test

### DIFF
--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -221,7 +221,7 @@ func (s *streamSuite) TestOneChangeWithClosedAbort(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectFileNotifyWatcher()
-	s.expectTermAfterAnyTimes()
+	s.expectAfterWithoutTermTimeout()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()


### PR DESCRIPTION
There isn't a guarantee that the time after will always be the default timeout, because the loop might have already processed the next event. In this case, there already exists a different expect method for when this happens, and we didn't use it in the test. This was a mistake.

## QA steps

```sh
$ go test -v ./internal/changestream/stream -run=".+/TestOneChangeWithClosedAbort" -race -c
$ stress ./stream.test
5s: 0 runs so far, 0 failures, 32 active
10s: 0 runs so far, 0 failures, 32 active
15s: 0 runs so far, 0 failures, 32 active
20s: 0 runs so far, 0 failures, 32 active
25s: 0 runs so far, 0 failures, 32 active
30s: 0 runs so far, 0 failures, 32 active
```