### PR TITLE
fix(resources): allows empty resources

### DIFF
--- a/internal/resource/store/fileresourcestore.go
+++ b/internal/resource/store/fileresourcestore.go
@@ -46,9 +46,6 @@ func (f fileResourceStore) Put(
 	if r == nil {
 		return store.ID{}, 0, store.Fingerprint{}, errors.Errorf("validating resource: reader is nil")
 	}
-	if size == 0 {
-		return store.ID{}, 0, store.Fingerprint{}, errors.Errorf("validating resource size: size is 0")
-	}
 	if err := fingerprint.Validate(); err != nil {
 		return store.ID{}, 0, store.Fingerprint{}, errors.Errorf("validating resource fingerprint: %w", err)
 	}

--- a/tests/suites/resources/empty.sh
+++ b/tests/suites/resources/empty.sh
@@ -1,0 +1,30 @@
+run_empty_resource_fileobjectstore() {
+	echo
+	name="empty-resource-fileobjectstore"
+
+	file="${TEST_DIR}/test-${name}.log"
+
+	ensure "test-${name}" "${file}"
+
+	touch "${TEST_DIR}/empty-file.txt"
+	juju deploy juju-qa-test qa
+	wait_for "qa" "$(idle_condition "qa")"
+	juju attach-resource qa foo-file="${TEST_DIR}/empty-file.txt"
+
+	destroy_model "test-${name}"
+}
+
+test_empty_resources() {
+	if [ "$(skip 'test_empty_resources')" ]; then
+		echo "==> TEST SKIPPED: Resource empty"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_empty_resource_fileobjectstore"
+	)
+}

--- a/tests/suites/resources/task.sh
+++ b/tests/suites/resources/task.sh
@@ -15,6 +15,7 @@ test_resources() {
 
 	test_basic_resources
 	test_upgrade_resources
+	test_empty_resources
 
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"k8s")


### PR DESCRIPTION
This patch removes the check against having an empty file as a resource.

It updates the tests accordingly and adds a CI test to enforce the behavior.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


```sh
juju bootstrap lxd
juju add-model m
juju deploy juju-qa-test qa
touch test.txt # generate an empty file
juju attach-resource qa foo-file=./test.txt
```

This should works without any error message.

## Links

**Issue:** Fixes #21213.

**Jira card:** [JUJU-8755](https://warthogs.atlassian.net/browse/JUJU-8755)

[JUJU-8755]: https://warthogs.atlassian.net/browse/JUJU-8755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ