### PR TITLE
docs: fix virt-type in constraint and cloud docs, fix broken links in…

### DIFF
--- a/docs/explanation/juju-security.md
+++ b/docs/explanation/juju-security.md
@@ -303,7 +303,7 @@ Example threats:
 - {ref}`threats-confidentiality`: If a malicious actor gains unauthorized access to the secrets stored within the Juju model, they could potentially extract sensitive information such as API keys, passwords, or encryption keys.
 - {ref}`threats-integrity`: An attacker could modify the secrets stored in the Juju model.
 
-Controls: {ref}`controls-secrets`, {ref}`controls-secret-backend-can-be-external`, {ref}`controls-user-authentication`
+Controls: {ref}`controls-secrets`, {ref}`controls-secret-backends-can-be-external`, {ref}`controls-user-authentication`
 
 (assets-ssh-keys-and-agent-credentials)=
 ### SSH keys and agent credentials
@@ -638,7 +638,7 @@ A controller on a machine cloud can operate in high availability mode. Depending
 See more: {ref}`high-availability`
 ```
 
-(no-cloud-credentials-in-juju)=
+(controls-no-cloud-credentials-in-juju)=
 ### No cloud credentials in Juju
 
 In a typical Juju workflow you allow your client to read your locally stored cloud credentials, then copy them to the controller, so that the controller can use them to authenticate with the cloud. However, for some clouds, Juju now supports a workflow where  neither your client nor your controller know your credentials directly -- you can just supply an instance profile (AWS) or a managed identity (Azure).

--- a/docs/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
@@ -109,7 +109,7 @@ With LXD system containers, constraints are interpreted as resource *maximums* (
 | - {ref}`constraint-root-disk-source`   | &#10003;  <br> `root-disk-source` is the LXD storage pool for the root disk. The default LXD storage pool is used if root-disk-source is not specified. |
 | - {ref}`constraint-spaces`             | &#10005;                                                                                                                                                |
 | - {ref}`constraint-tags`               | &#10005;                                                                                                                                                |
-| - {ref}`constraint-virt-type`          | &#10005;                                                                                                                                                |
+| - {ref}`constraint-virt-type`          | &#10003; <br> Valid values: `[container, virtual-machine]`. <br> Default value: `container`.                                                                                                                                               |
 | - {ref}`constraint-zones`              | &#10003;  <br> `zones` are the LXD node name(s).                                                                                                        |
 
 

--- a/docs/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju.md
@@ -111,7 +111,7 @@ The network label or UUID to bring machines up on when multiple networks exist.
 
 | {ref}`CONSTRAINT <constraint>`         |                                                                                                |
 |----------------------------------------|------------------------------------------------------------------------------------------------|
-| conflicting:                           | `{ref}`instance-type]` vs. `[mem, root-disk, cores]`                                           |
+| conflicting:                           | `[instance-type]` vs. `[mem, root-disk, cores]`                                           |
 | supported?                             |                                                                                                |
 | - {ref}`constraint-allocate-public-ip` | &#10003;                                                                                       |
 | - {ref}`constraint-arch`               | &#10003;                                                                                       |

--- a/docs/reference/constraint.md
+++ b/docs/reference/constraint.md
@@ -113,7 +113,7 @@ Comma-delimited tags assigned to the machine. Tags can be positive, denoting an 
 (constraint-virt-type)=
 ## `virt-type`
 
-Virtualisation type. <p> Only supported by {ref}`LXD <cloud-lxd>` and {ref}`Openstack <cloud-openstack>`. **Valid values:** Cloud-dependent.
+Virtualisation type. <p> Only supported by {ref}`LXD <cloud-lxd>` and {ref}`OpenStack <cloud-openstack>`. **Valid values:** Cloud-dependent.
 
 (constraint-zones)=
 ## `zones`

--- a/docs/reference/constraint.md
+++ b/docs/reference/constraint.md
@@ -113,7 +113,7 @@ Comma-delimited tags assigned to the machine. Tags can be positive, denoting an 
 (constraint-virt-type)=
 ## `virt-type`
 
-Virtualisation type. <p> **Valid values:** `kvm`, `virtual-machine`.
+Virtualisation type. <p> Only supported by {ref}`LXD <cloud-lxd>` and {ref}`Openstack <cloud-openstack>`. **Valid values:** Cloud-dependent.
 
 (constraint-zones)=
 ## `zones`


### PR DESCRIPTION
## Changes

> [RTD preview](https://canonical-ubuntu-documentation-library--21269.com.readthedocs.build/juju/21269/)

### Main

Our documentation on the `virt-type` constraint was incorrect: https://github.com/juju/juju/issues/19262 . This PR updates the main constraints doc as well as the LXD and Openstack doc.

### Drive-by 

Fixed two references in the Security doc.

## Sources

https://github.com/juju/juju/blob/2c36c946fe3e2054f715c29ba569cfcbb2d60c19/internal/provider/lxd/environ_policy.go#L42 (suggestion from Copilot)
https://github.com/juju/juju/blob/f1472d7cfb79f2d44108bfbf4c84d4be920fdece/internal/provider/openstack/local_test.go#L1614 (suggestion from @wallyworld , Copilot)

### Copilot usage

I used the following prompt:

> Check the Juju codebase, esp. core/constraints/constraints.go and related, and tell me: What are the possible values for the `virt-type` constraint?

The original answer was:

> container (directory -- a confusing answer, I know), `virtual-machine`

I then asked:

> What about `kvm` and `lxd`? Are they valid values too?

It gave me a confident no.

I asked 

> What values does the openstack provider support for virt-type?

Here it correctly mentioned `'kvm` and `lxd` and gave me the sources in the codebase. I asked the same for LXD and it gave me container (directory) and `virtual-machine`.

## Forward merge

`kvm` was dropped in 4, so we shouldn't forward merge that bit. The rest are valid improvements for `4.0` and `main` too.