### PR TITLE
fix: set Since field on statuses on caas provisioning

### DIFF
--- a/domain/status/modelmigration/import.go
+++ b/domain/status/modelmigration/import.go
@@ -170,8 +170,10 @@ func (i *importOperation) importStatus(s description.Status) corestatus.StatusIn
 	// set by the lead unit. If that is the case, we make the status what
 	// the new code expects.
 	if s == nil || s.NeverSet() {
+		now := i.clock.Now()
 		return corestatus.StatusInfo{
 			Status: corestatus.Unset,
+			Since:  &now,
 		}
 	}
 

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -481,7 +481,7 @@ func updateState(
 			Address:    &u.Address,
 			Ports:      &u.Ports,
 		}
-		args.AgentStatus, args.CloudContainerStatus = updateStatus(u.Status)
+		args.AgentStatus, args.CloudContainerStatus = updateStatus(u.Status, clk)
 
 		lastStatus, ok := lastReportedStatus[unitName]
 		reportedStatus[unitName] = args
@@ -922,10 +922,11 @@ func provisioningInfo(
 }
 
 // updateStatus constructs the agent and cloud container status values.
-func updateStatus(podStatus status.StatusInfo) (
+func updateStatus(podStatus status.StatusInfo, clk clock.Clock) (
 	agentStatus *status.StatusInfo,
 	cloudContainerStatus *status.StatusInfo,
 ) {
+	now := clk.Now()
 	switch podStatus.Status {
 	case status.Unknown:
 		// The container runtime can spam us with unimportant
@@ -936,41 +937,49 @@ func updateStatus(podStatus status.StatusInfo) (
 		agentStatus = &status.StatusInfo{
 			Status:  status.Allocating,
 			Message: podStatus.Message,
+			Since:   &now,
 		}
 		cloudContainerStatus = &status.StatusInfo{
 			Status:  status.Waiting,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
+			Since:   &now,
 		}
 	case status.Running:
 		// A pod has finished starting so the workload is now active.
 		agentStatus = &status.StatusInfo{
 			Status: status.Idle,
+			Since:  &now,
 		}
 		cloudContainerStatus = &status.StatusInfo{
 			Status:  status.Running,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
+			Since:   &now,
 		}
 	case status.Error:
 		agentStatus = &status.StatusInfo{
 			Status:  status.Error,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
+			Since:   &now,
 		}
 		cloudContainerStatus = &status.StatusInfo{
 			Status:  status.Error,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
+			Since:   &now,
 		}
 	case status.Blocked:
 		agentStatus = &status.StatusInfo{
 			Status: status.Idle,
+			Since:  &now,
 		}
 		cloudContainerStatus = &status.StatusInfo{
 			Status:  status.Blocked,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
+			Since:   &now,
 		}
 	}
 	return agentStatus, cloudContainerStatus


### PR DESCRIPTION
Before this patch, when we ran `juju status --format yaml` we would get a (truncated) status without the `since` field:
```    
    units:
      metallb/0:
        workload-status:
          current: active
          message: Ready
          since: 20 Nov 2025 09:34:49+01:00
        juju-status:
          current: idle
          version: 4.0.0
        leader: true
        address: 10.1.211.250
        provider-id: metallb-0
```

This commit therefore populates `StatusInfo.Since` with the current time from the already present clock in the `caasapplicationprovisioner` worker.


As a flyby, model import now sets a default Since to `.now()`, so that we return a consistent value on status.

## QA steps

Bootstrap a kubernetes controller and add a model, then deploy metallb:
```
$ juju deploy metallb
```
Wait until the unit reaches an idle status, then check the unit status:
```
$ juju status --format yaml
...
    units:
      metallb/0:
        workload-status:
          current: active
          message: Ready
          since: 20 Nov 2025 10:22:51+01:00
        juju-status:
          current: idle
          since: 20 Nov 2025 10:18:29+01:00
          version: 4.0.1
        leader: true
        address: 10.1.211.201
        provider-id: metallb-0
...
```
(truncated output).

## Links

**Issue:** Fixes #21261.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8793](https://warthogs.atlassian.net/browse/JUJU-8793)


[JUJU-8793]: https://warthogs.atlassian.net/browse/JUJU-8793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ