### PR TITLE
 feat: implement a map util func for removing bases that match

### DIFF
--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"slices"
 
 	"github.com/juju/juju/core/agentbinary"
 	corebase "github.com/juju/juju/core/base"
@@ -909,6 +910,18 @@ func (s *Service) validateModelCanBeUpgraded(
 	//}
 
 	return nil
+}
+
+// machineUsesSupportedBase returns a predicate for maps.DeleteFunc that
+// removes machines whose base matches one of the supported bases.
+// Bases are considered equal if their OS and track match while risk and branch are ignored.
+func machineUsesSupportedBase(supported []corebase.Base) func(uuid string, b corebase.Base) bool {
+	return func(_ string, b corebase.Base) bool {
+		// We only compare OS and Track.
+		return slices.ContainsFunc(supported, func(s corebase.Base) bool {
+			return b.OS == s.OS && b.Channel.Track == s.Channel.Track
+		})
+	}
 }
 
 // validateModelCanBeUpgradedTo checks to see if the model can be upgraded to


### PR DESCRIPTION
This PR implements the map util function to remove bases that match in order to determine if the presence of machine bases that are not supported, to validate if the model can be upgraded.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
NA

## Links
**Jira card:** [JUJU-8762](https://warthogs.atlassian.net/browse/JUJU-8762)

[JUJU-8762]: https://warthogs.atlassian.net/browse/JUJU-8762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ