### PR TITLE
docs: add caveat about juju-restore tool

### DIFF
--- a/docs/howto/manage-controllers.md
+++ b/docs/howto/manage-controllers.md
@@ -579,8 +579,8 @@ See more: {ref}`command-juju-download-backup`
 (restore-a-controller-from-a-backup)=
 ### Restore a controller from a backup
 
-```{important}
-Only supported machine (non-Kubernetes) controllers.
+```{caution}
+Only supported for machine (non-Kubernetes) controllers. Procedure relies on the `juju-restore` tool, which is experimental -- see [the tool's README](https://github.com/juju/juju-restore) for limitations.
 ```
 To restore a controller from a backup, you can use the [stand-alone `juju-restore` tool](https://github.com/juju/juju-restore).
 


### PR DESCRIPTION
# Changes

Issue https://github.com/juju/juju/issues/18881 pointed out that the `juju-restore` tool has limitations, and the docs don't do enough to alert the user to this. This PR addresses that with a caveat at the top of the relevant section.

[See RTD preview](https://canonical-ubuntu-documentation-library--21286.com.readthedocs.build/juju/21286/howto/manage-controllers/#restore-a-controller-from-a-backup)

# Sources

Chat with @wallyworld.

# Forward merge

This doc does not have to be forward merged as the `juju-restore` tool doesn't work for Juju 4, so the section that talks about it does not exist in the Juju 4 docs.