### PR TITLE
docs: clarify refresh on k8s

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -238,6 +238,12 @@ cause unexpected behavior.
 ` + "`--force`" + ` option for LXD Profiles is not generally recommended when upgrading an
 application; overriding profiles on the container may cause unexpected
 behavior.
+
+### Behavior on machines vs. Kubernetes
+
+ On machines, charm upgrades happen at the same time on all units of an application.
+ However, on Kubernetes, because of the way Kubernetes works, charm upgrades happen
+ sequentially, unit by unit.
 `
 
 const refreshExamples = `

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -242,7 +242,7 @@ behavior.
 ### Behavior on machines vs. Kubernetes
 
 On machines, charm upgrades happen at the same time on all units of an application.
-However, on Kubernetes, because Juju deploys applications as StatefulSets
+However, on Kubernetes, because Juju deploys applications as ` + "`StatefulSets`" + `
 with rolling updates, charm upgrades happen sequentially, unit by unit.
 `
 

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -241,9 +241,9 @@ behavior.
 
 ### Behavior on machines vs. Kubernetes
 
- On machines, charm upgrades happen at the same time on all units of an application.
- However, on Kubernetes, because of the way Kubernetes works, charm upgrades happen
- sequentially, unit by unit.
+On machines, charm upgrades happen at the same time on all units of an application.
+However, on Kubernetes, because of the way Kubernetes works, charm upgrades happen
+sequentially, unit by unit.
 `
 
 const refreshExamples = `

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -242,8 +242,8 @@ behavior.
 ### Behavior on machines vs. Kubernetes
 
 On machines, charm upgrades happen at the same time on all units of an application.
-However, on Kubernetes, because of the way Kubernetes works, charm upgrades happen
-sequentially, unit by unit.
+However, on Kubernetes, because Juju deploys applications as StatefulSets
+with rolling updates, charm upgrades happen sequentially, unit by unit.
 `
 
 const refreshExamples = `

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
@@ -124,5 +124,5 @@ behavior.
 ### Behavior on machines vs. Kubernetes
 
 On machines, charm upgrades happen at the same time on all units of an application.
-However, on Kubernetes, because Juju deploys applications as StatefulSets
+However, on Kubernetes, because Juju deploys applications as `StatefulSets`
 with rolling updates, charm upgrades happen sequentially, unit by unit.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
@@ -120,3 +120,9 @@ cause unexpected behavior.
 `--force` option for LXD Profiles is not generally recommended when upgrading an
 application; overriding profiles on the container may cause unexpected
 behavior.
+
+### Behavior on machines vs. Kubernetes
+
+ On machines, charm upgrades happen at the same time on all units of an application.
+ However, on Kubernetes, because of the way Kubernetes works, charm upgrades happen
+ sequentially, unit by unit.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
@@ -123,6 +123,6 @@ behavior.
 
 ### Behavior on machines vs. Kubernetes
 
- On machines, charm upgrades happen at the same time on all units of an application.
- However, on Kubernetes, because of the way Kubernetes works, charm upgrades happen
- sequentially, unit by unit.
+On machines, charm upgrades happen at the same time on all units of an application.
+However, on Kubernetes, because Juju deploys applications as StatefulSets
+with rolling updates, charm upgrades happen sequentially, unit by unit.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/scale-application.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/scale-application.md
@@ -23,4 +23,4 @@ Set the desired number of k8s application units.
 
 Scale a Kubernetes application by specifying how many units there should be.
 The new number of units can be greater or less than the current number, thus
-allowing both scale up and scale down.
+allowing both scale out and scale in.


### PR DESCRIPTION
# Changes

## Primary

Issue https://github.com/juju/juju/issues/18889 points out that `juju refresh` behaves differently on machines vs. on K8s, and our docs don't give any hint about that. This PR updates the help and doc for `juju refresh` to mention this difference.

## Other

Building the docs also updated the `.md` file for `scale-application`, probably because of an older PR that change the source there without rebuilding the docs.

# Sources

@wallyworld 

# Forward merge

This change should probably be forward-merged into `4.0` and `main`.

# Links

JIRA-[7733](https://warthogs.atlassian.net/browse/JUJU-7733)