### PR TITLE
fix: set/get/unset config on SAAS should return application not found 

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -50,8 +50,8 @@ type ApplicationState interface {
 
 	// GetApplicationUUIDByName returns the application UUID for the named
 	// application.
-	// If no application is found, an error satisfying
-	// [applicationerrors.ApplicationNotFound] is returned.
+	// Note: This method filters out synthetic applications (remote offerers and
+	// remote consumers).
 	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// CreateIAASApplication creates an application. Returns the application UUID,
@@ -799,11 +799,12 @@ func (s *Service) GetApplicationName(ctx context.Context, appUUID coreapplicatio
 	return name, nil
 }
 
-// GetApplicationUUIDByName returns an application UUID by application name. It
-// returns an error if the application can not be found by the name.
+// GetApplicationUUIDByName returns an application UUID by application name.
+// Note: This method filters out synthetic applications (remote offerers and
+// remote consumers).
 //
-// Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
-// and [applicationerrors.ApplicationNotFound] if the application is not found.
+// Returns [applicationerrors.ApplicationNotFound] if the application is not
+// found or if it is a synthetic SAAS application.
 func (s *Service) GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/status/service/service.go
+++ b/domain/status/service/service.go
@@ -39,6 +39,8 @@ type ModelState interface {
 
 	// GetApplicationUUIDByName returns the application UUID for the named
 	// application.
+	// Note: This method filters out synthetic applications (remote offerers and
+	// remote consumers).
 	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
 
 	// GetApplicationUUIDAndNameByUnitName returns the application UUID and name


### PR DESCRIPTION
 This patch prevents setting the config on a SAAS (synthetic
 application) by updating the implementation of
 GetApplicationUUIDByName, filtering out the synthetic applications. 

 By doing so, the facade now returns the correct error (i.e. application
 not found).

## QA steps

Setting up a SAAS and trying to set the config should return app not found:
```
$ juju add-model offer && juju deploy juju-qa-dummy-source && juju offer dummy-source:sink
$ juju add-model consume && juju deploy juju-qa-dummy-sink
$ juju consume admin/offer.dummy-source && juju relate dummy-source dummy-sink 
$ juju config dummy-source token=foo
ERROR application "dummy-source" not found
```
Getting all config, one specific config and resetting should also return app not found:
```
$ juju config dummy-source
{}
ERROR application dummy-source not found (not found)
$ juju config dummy-source token
{}
ERROR application dummy-source not found (not found)
$ juju config dummy-source --reset token
{}
ERROR application dummy-source not found
```

## Links

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21124.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8769](https://warthogs.atlassian.net/browse/JUJU-8769)


[JUJU-8769]: https://warthogs.atlassian.net/browse/JUJU-8769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ