### PR TITLE
feat: re-enable machine bases check for model upgrade

### DIFF
--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -5,6 +5,8 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"maps"
 	"slices"
 
 	"github.com/juju/juju/core/agentbinary"
@@ -889,25 +891,20 @@ func (s *Service) validateModelCanBeUpgraded(
 		).Add(modelagenterrors.CannotUpgradeControllerModel)
 	}
 
-	// TODO(@adisazhar123): discussed with @tlm we can comment out for now.
-	// Will require a future effort to fix this.
-	//failedMachineCount, err := s.modelSt.GetMachineCountNotUsingBase(ctx, corebase.WorkloadBases())
-	//if err != nil {
-	//	return errors.Errorf(
-	//		"getting count of machines in model not running a supported workload base: %w",
-	//		err,
-	//	)
-	//}
-	//
-	//if failedMachineCount > 0 {
-	//	return modelagenterrors.ModelUpgradeBlocker{
-	//		Reason: fmt.Sprintf(
-	//			"model has %d machines using unsupported bases: %v",
-	//			failedMachineCount, corebase.WorkloadBases(),
-	//		),
-	//	}
-	//}
+	machineBases, err := s.modelSt.GetAllMachinesWithBase(ctx)
+	if err != nil {
+		return errors.Errorf("getting machine bases from state: %w", err)
+	}
 
+	maps.DeleteFunc(machineBases, machineUsesSupportedBase(corebase.WorkloadBases()))
+	if len(machineBases) > 0 {
+		return modelagenterrors.ModelUpgradeBlocker{
+			Reason: fmt.Sprintf(
+				"model has %d machines using unsupported bases, the supported bases are: %v",
+				len(machineBases), corebase.WorkloadBases(),
+			),
+		}
+	}
 	return nil
 }
 
@@ -1002,8 +999,7 @@ func (s *Service) validateModelCanBeUpgradedTo(
 func (s *Service) getRecommendedVersion(
 	ctx context.Context,
 ) (semversion.Number, error) {
-	versions, err := s.controllerSt.
-		GetControllerAgentVersions(ctx)
+	versions, err := s.controllerSt.GetControllerAgentVersions(ctx)
 	if err != nil {
 		return semversion.Zero, errors.Capture(err)
 	}


### PR DESCRIPTION
This task is to take the work done in 
https://github.com/juju/juju/pull/21231
and
https://github.com/juju/juju/pull/21282
and re-implement the machine bases check that was commented out.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

0. Change version in core/version.go to 4.0.0
```sh
const version = "4.0.0"
```

1. Bootstrap two 4.0.0 controllers 
```sh
$ make install && juju bootstrap lxd test400a  && juju bootstrap lxd test400b
```

2. Add a test model and deploy ubuntu with base ubuntu@20.04 for first controller test400a
```sh
$ juju switch test400a
$ juju add-model test400model1
$ juju deploy ubuntu --base ubuntu@20.04
```

3. Add another test model and deploy ubuntu with base ubuntu@20.04 for controller test400b
```sh
$ juju switch test400b
$ juju add-model test400model2
$ juju deploy ubuntu --base ubuntu@20.04
```

4. Change version in core/version.go to 4.0.1
```sh
const version = "4.0.1"
```

5. Run make simplestreams for agent binary upgrade
```sh
$ make simplestreams
$ export JUJU_METADATA_SOURCE="..." 
```

6. Sync agent binary so that controller state has the agent binary upgrade
```sh
$ juju switch test400a:controller
$ juju sync-agent-binary --agent-version 4.0.1
```

7. Upgrade controller to 4.0.1
```sh
$ juju upgrade-controller --agent-version 4.0.1
```

8. Upgrade test400model1 model to 4.0.1 agent-binary and run `juju status` to verify
```sh
$ juju switch test400model1
$ juju upgrade-model --agent-version 4.0.1
$ juju status
```

9. Change version in core/version.go to 4.0.2
```sh
const version = "4.0.2"
```

10. Remove 20.04 from WorkloadBases in supportedbases.go
```sh
func WorkloadBases() []Base {
	return []Base{
		MakeDefaultBase(UbuntuOS, "20.04"),
		MakeDefaultBase(UbuntuOS, "22.04"),
		MakeDefaultBase(UbuntuOS, "23.10"),
		MakeDefaultBase(UbuntuOS, "24.04"),
	}
}

 |
V

func WorkloadBases() []Base {
	return []Base{
		MakeDefaultBase(UbuntuOS, "22.04"),
		MakeDefaultBase(UbuntuOS, "23.10"),
		MakeDefaultBase(UbuntuOS, "24.04"),
	}
}
```

11. Run make simplestreams for agent binary upgrade
```sh
$ make simplestreams
$ export JUJU_METADATA_SOURCE="..." 
```

12. Sync agent binary for second controller test400b so that controller state has the agent binary upgrade
```sh
$ juju switch test400b:controller
$ juju sync-agent-binary --agent-version 4.0.2
```

13. Upgrade controller to 4.0.2
```sh
$ juju upgrade-controller --agent-version 4.0.2
```

14. Upgrade test400model2 model to 4.0.2 agent-binary. We should see an upgrade error due to unsupported base now.
```sh
$ juju switch test400model2
$ juju upgrade-model --agent-version 4.0.2
ERROR model upgrading is blocked for reason: model has 1 machines using unsupported bases, the supported bases are: [ubuntu@22.04/stable ubuntu@23.10/stable ubuntu@24.04/stable]

```

## Links
**Jira card:** [JUJU-8763](https://warthogs.atlassian.net/browse/JUJU-8763)

[JUJU-8763]: https://warthogs.atlassian.net/browse/JUJU-8763