### PR TITLE
fix(status): return the newest entry in GetStatusHistory

### DIFF
--- a/domain/status/service/statushistory.go
+++ b/domain/status/service/statushistory.go
@@ -44,9 +44,10 @@ func (s *Service) GetStatusHistory(ctx context.Context, request StatusHistoryReq
 
 		results = append(results, record.Status)
 
-		// If we have more than the requested limit, so we can stop reading.
-		if limit := request.Filter.Size; limit > 0 && len(results) >= limit {
-			return true, nil
+		// If we have more than the requested limit, move the slice forward.
+		// (this will allow freeing space on the next realloc)
+		if limit := request.Filter.Size; limit > 0 && len(results) > limit {
+			results = results[1:]
 		}
 
 		return false, nil


### PR DESCRIPTION
This patch updates `domain/status/service/statushistory.go` to ensure that when a size limit is provided, the returned statuses are the newest, not the oldest.

Fix tests and add a specific test to verify it.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Bootstrap a controller, add a model, deploy ubuntu.

Run the command:

```sh
juju show-status-log ubuntu/0 -n 3
``` 

Verify it display the last 3 status and not the first 3 status of the unit.

## Links

**Issue:** Fixes #21290.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8812](https://warthogs.atlassian.net/browse/JUJU-8812)


[JUJU-8812]: https://warthogs.atlassian.net/browse/JUJU-8812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ