### PR TITLE
fix: application status history record

### DIFF
--- a/domain/status/service/leaderservice_test.go
+++ b/domain/status/service/leaderservice_test.go
@@ -24,6 +24,7 @@ import (
 	statuserrors "github.com/juju/juju/domain/status/errors"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/statushistory"
 )
 
 type leaderServiceSuite struct {
@@ -129,6 +130,16 @@ func (s *leaderServiceSuite) TestSetApplicationStatusForUnitLeader(c *tc.C) {
 		Since:   &now,
 	})
 	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(s.statusHistory.records, tc.DeepEquals, []statusHistoryRecord{{
+		ns: statushistory.Namespace{Kind: corestatus.KindApplication, ID: applicationUUID.String()},
+		s: corestatus.StatusInfo{
+			Status:  corestatus.Active,
+			Message: "doink",
+			Data:    map[string]any{"foo": "bar"},
+			Since:   &now,
+		},
+	}})
 }
 
 func (s *leaderServiceSuite) TestSetApplicationStatusForUnitLeaderNotLeader(c *tc.C) {


### PR DESCRIPTION
We forget to record the status history for applications in this service method.

Fix this by adding a call to RecordStatus

## QA steps

Unit tests pass

```
$ juju deploy juju-qa-test -n2
$ juju status
Model  Controller  Cloud/Region   Version  Timestamp
m      lxd         lxd/localhost  4.0.1.1  14:46:45Z

App           Version  Status       Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active           2  juju-qa-test  latest/stable   25  no       

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0   active    idle   3        10.51.45.220           it is now: 11/21/2025, 14:44:50
juju-qa-test/1*  active    idle   4        10.51.45.108           it is now: 11/21/2025, 14:44:50

Machine  State    Address       Inst id        Base          AZ    Message
3        started  10.51.45.220  juju-fe2b7a-3  ubuntu@20.04  jack  Running
4        started  10.51.45.108  juju-fe2b7a-4  ubuntu@20.04  jack  Running

$ juju exec --unit juju-qa-test/0 "status-set --application maintenance blah"
ERROR this unit is not the leader

$ juju exec --unit juju-qa-test/1 "status-set --application maintenance blah"
```
And check the debug logs for:
```
machine-0: 14:46:42 INFO juju.services.status.status-history category:status-history,data:null,kind:application,logger-tags:status-history,message:blah,namespace_id:12a421e2-174c-4080-8e14-c7f108d4df2c,since:2025-11-21T14:46:42Z,status:maintenance status-history (status: "maintenance", status-message: "blah")
```