### PR TITLE
feat: add target controller field

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -211,6 +211,10 @@ func (m *ModelManagerAPIV9) CreateModel(args params.ModelCreateArgs) (params.Mod
 func (m *ModelManagerAPI) createModel(args params.ModelCreateArgs, withDefaultOS bool) (params.ModelInfo, error) {
 	result := params.ModelInfo{}
 
+	if args.TargetController != "" {
+		return result, errors.NewNotSupported(nil, "target-controller parameter is only supported on JAAS")
+	}
+
 	// Get the controller model first. We need it both for the state
 	// server owner and the ability to get the config.
 	controllerModel, err := m.ctlrState.Model()

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -393,6 +393,19 @@ func (s *modelManagerSuite) TestModelInfoWithReadAccess(c *gc.C) {
 	c.Assert(modelInfoReader.Results[0].Result, jc.DeepEquals, &expectedModelInfo)
 }
 
+func (s *modelManagerSuite) TestCreateModelWithTargetControllerSet(c *gc.C) {
+	args := params.ModelCreateArgs{
+		Name:               "foo",
+		OwnerTag:           "user-admin",
+		CloudTag:           "cloud-some-cloud",
+		CloudRegion:        "qux",
+		CloudCredentialTag: "cloudcred-some-cloud_admin_some-credential",
+		TargetController:   "some-controller",
+	}
+	_, err := s.api.CreateModel(args)
+	c.Assert(err, gc.ErrorMatches, `target-controller parameter is only supported on JAAS`)
+}
+
 func (s *modelManagerSuite) TestCreateModelArgsWithCloudNotFound(c *gc.C) {
 	s.st.SetErrors(errors.NotFoundf("cloud"))
 	args := params.ModelCreateArgs{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12407,6 +12407,9 @@
                         },
                         "region": {
                             "type": "string"
+                        },
+                        "target-controller": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
@@ -12602,6 +12605,9 @@
                             "items": {
                                 "$ref": "#/definitions/SupportedFeature"
                             }
+                        },
+                        "target-controller": {
+                            "type": "string"
                         },
                         "type": {
                             "type": "string"

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -144,6 +144,10 @@ type ModelCreateArgs struct {
 	// and the owner is the controller owner, the same credential
 	// used for the controller model will be used.
 	CloudCredentialTag string `json:"credential,omitempty"`
+
+	// TargetController is a JAAS specific field to specify the
+	// name of the controller that hosts the model.
+	TargetController string `json:"target-controller,omitempty"`
 }
 
 // Model holds the result of an API call returning a name and UUID

--- a/rpc/params/model.go
+++ b/rpc/params/model.go
@@ -192,6 +192,10 @@ type ModelInfo struct {
 	// entries (e.g. juju version) and other features that depend on the
 	// substrate the model is deployed to.
 	SupportedFeatures []SupportedFeature `json:"supported-features,omitempty"`
+
+	// TargetController is a JAAS specific field to specify the
+	// name of the controller that hosts the model.
+	TargetController string `json:"target-controller,omitempty"`
 }
 
 // SupportedFeature describes a feature that is supported by a particular model.


### PR DESCRIPTION
This PR adds a new field to the `ModelCreateArgs` and `ModelInfo` types. The field, `TargetController` is only intended for use by JAAS controllers which manage multiple Juju controllers. When the field is specified, it allows a client to target a specific controller to host a model.

This change looks a bit strange because it is the first time JAAS is leaking its abstraction of managing multiple Juju controllers. This is intentional. The path we are heading towards is one where JAAS acts as a enterprise/premium offering over what Juju provides. This new field in Juju will extend its API to provide JAAS with better capabilities.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Links

**Jira card:** [JUJU-8814](https://warthogs.atlassian.net/browse/JUJU-8814)


[JUJU-8814]: https://warthogs.atlassian.net/browse/JUJU-8814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ