### PR TITLE
docs: fix add-ssh-key doc, update other autogen

### DIFF
--- a/cmd/juju/sshkeys/add_sshkeys.go
+++ b/cmd/juju/sshkeys/add_sshkeys.go
@@ -18,10 +18,8 @@ Adds a public SSH key to a model.`[1:]
 
 var usageAddSSHKeyDetails = `
 Juju maintains a per-model cache of public SSH keys which it copies to
-each unit (including units already deployed). By default this includes the
-key of the user who created the model (assuming it is stored in the
-default location ` + "`~/.ssh/`" + `). Additional keys may be added with this command,
-quoting the entire public key as an argument.
+each unit (including units already deployed). All keys must be added to a model
+explicitly with this command, quoting the entire public key as an argument.
 
 `[1:]
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/add-ssh-key.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/add-ssh-key.md
@@ -34,9 +34,6 @@ to the command:
 
 
 ## Details
-
 Juju maintains a per-model cache of public SSH keys which it copies to
-each unit (including units already deployed). By default this includes the
-key of the user who created the model (assuming it is stored in the
-default location `~/.ssh/`. Additional keys may be added with this command,
-quoting the entire public key as an argument.
+each unit (including units already deployed). All keys must be added to a model
+explicitly with this command, quoting the entire public key as an argument.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/controller-config.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/controller-config.md
@@ -106,8 +106,8 @@ Controller configuration keys:
         time a writer will wait for others to finish writing on the
         same database.
     features:
-      type: list
-      description: A list of runtime changeable features to be updated
+      type: string
+      description: A comma-delimited list of runtime changeable features to be updated
     idle-connection-timeout:
       type: string
       description: |

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/scale-application.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/scale-application.md
@@ -23,4 +23,4 @@ Set the desired number of k8s application units.
 
 Scale a Kubernetes application by specifying how many units there should be.
 The new number of units can be greater or less than the current number, thus
-allowing both scale up and scale down.
+allowing both scale out and scale in.


### PR DESCRIPTION
# Context

Issue https://github.com/juju/juju/issues/21159#event-20985435558 notes SSH keys are not automatically added to a model, contrary to what the docs say.

@wallyworld explained this was a change in behavior that we forgot to update in the docs.

# Changes

## Primary 

This PR updates the `juju add-ssh-key` doc to say every key must be added explicitly.

## Other

Building the docs also produced changes in the autogenerated `.md` for `juju controller-config` and `juju scale-application`. Note: During last week's cross-team I reminded people to be more careful: If you're changing the source for a CLI command, controller config, or hook command, also build the docs (in `juju/docs` run `make clean && make run`) to make sure the corresponding `.md` files are correctly autogenerated.

# Sources

@wallyworld 

# Forward merge

This PR should be merged forward into `main`.