### PR TITLE
fix: show-status-log for applications

### DIFF
--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -58,7 +58,7 @@ This command will report the history of status changes for
 a given entity.
 
 The statuses are available for the following types.
--type supports:
+--type supports:
 %v
  and sorted by time of occurrence.
 
@@ -84,7 +84,7 @@ Show the status history for the specified unit with the logs for any date after 
 
 Show the status history for the specified application:
 
-    juju show-status-log -type application wordpress
+    juju show-status-log --type application wordpress
 
 Show the status history for the specified machine:
 
@@ -92,7 +92,7 @@ Show the status history for the specified machine:
 
 Show the status history for the model:
 
-    juju show-status-log -type model
+    juju show-status-log --type model
 `
 
 func (c *statusHistoryCommand) Info() *cmd.Info {

--- a/domain/status/service/leaderservice.go
+++ b/domain/status/service/leaderservice.go
@@ -99,7 +99,7 @@ func (s *LeadershipService) SetApplicationStatusForUnitLeader(
 		return errors.Capture(err)
 	}
 
-	if err := s.statusHistory.RecordStatus(ctx, status.ApplicationNamespace.WithID(appID.String()), statusInfo); err != nil {
+	if err := s.statusHistory.RecordStatus(ctx, status.ApplicationNamespace.WithID(appName), statusInfo); err != nil {
 		s.logger.Warningf(ctx, "recording setting application status history: %v", err)
 	}
 

--- a/domain/status/service/leaderservice_test.go
+++ b/domain/status/service/leaderservice_test.go
@@ -132,7 +132,7 @@ func (s *leaderServiceSuite) TestSetApplicationStatusForUnitLeader(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(s.statusHistory.records, tc.DeepEquals, []statusHistoryRecord{{
-		ns: statushistory.Namespace{Kind: corestatus.KindApplication, ID: applicationUUID.String()},
+		ns: statushistory.Namespace{Kind: corestatus.KindApplication, ID: "foo"},
 		s: corestatus.StatusInfo{
 			Status:  corestatus.Active,
 			Message: "doink",

--- a/domain/status/service/service.go
+++ b/domain/status/service/service.go
@@ -287,7 +287,7 @@ func (s *Service) SetApplicationStatus(
 		return errors.Capture(err)
 	}
 
-	if err := s.statusHistory.RecordStatus(ctx, status.ApplicationNamespace.WithID(applicationID.String()), statusInfo); err != nil {
+	if err := s.statusHistory.RecordStatus(ctx, status.ApplicationNamespace.WithID(applicationName), statusInfo); err != nil {
 		s.logger.Warningf(ctx, "recording setting application status history: %v", err)
 	}
 

--- a/domain/status/service/service_test.go
+++ b/domain/status/service/service_test.go
@@ -165,7 +165,7 @@ func (s *serviceSuite) TestSetApplicationStatus(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(s.statusHistory.records, tc.DeepEquals, []statusHistoryRecord{{
-		ns: statushistory.Namespace{Kind: corestatus.KindApplication, ID: applicationUUID.String()},
+		ns: statushistory.Namespace{Kind: corestatus.KindApplication, ID: "gitlab"},
 		s: corestatus.StatusInfo{
 			Status:  corestatus.Active,
 			Message: "doink",


### PR DESCRIPTION
When we set the status of an application, we were incorrectly recording a status event namespaced under the id of the application, instead of the natural key (i.e. the name)

Fix this

## QA steps

Create a charm with `src/charm.py` equal to:
```
#!/usr/bin/env python3
# Copyright 2020 juju-qa@canonical.com
# See LICENSE file for licensing details.

import logging

from ops.charm import CharmBase
from ops.model import (
    ActiveStatus,
)
from ops.main import main

logger = logging.getLogger(__name__)

class ApitestUbuntuQaCharm(CharmBase):

    def __init__(self, *args):
        logger.debug('Initializing Charm')
        super().__init__(*args)
        self.framework.observe(self.on.install, self._on_install)

    def _on_install(self, _):
        logger.debug('Handling install event')
        self.app.status = ActiveStatus("installed")


if __name__ == "__main__":
    main(ApitestUbuntuQaCharm)
```

(I made this by unzipping `juju-qa-test`, amending, and zipping back up

### And deploy
```
$ juju deploy ./juju-qa-test.charm
$ juju show-status-log --type application juju-qa-test
Time                   Type         Status  Message
25 Nov 2025 10:18:31Z  application  unset   
25 Nov 2025 10:19:06Z  application  active  installed
```
