### PR TITLE
feat: compat with 3.6 for MachineManager facade

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -62,7 +62,10 @@ var facadeVersions = facades.FacadeVersions{
 	"LeadershipService":            {2},
 	"Logger":                       {1},
 	"MachineActions":               {1},
-	"MachineManager":               {11},
+	// Note that this version of Juju does not implement version 10
+	// of the facade, but 3.6 does. Care must be taken not to break
+	// client compatibility with the prior version.
+	"MachineManager":               {10, 11},
 	"Machiner":                     {5, 6},
 	"MigrationFlag":                {1},
 	"MigrationMaster":              {4, 5},


### PR DESCRIPTION
The `MachineManager` facade in Juju 4+ no longer provides version 10, because we are finally dropping the deprecated _series_ argumentation in favour of _base_.

However, the payload for version 10 on 3.6 is still compatible with the 4.0 client so here, we declare that we we can work with that version.

We should cover this compatibility guarantee with integration tests in the future, but the author does not have time for that at present.

## QA steps

- Bootstrap a 3.6 LXD controller, then build a client with this patch.
- `juju switch controller`
- `juju add-machine`
- `juju add-machine --base ubuntu@22.04`
- Wait for the machines to come up.
- `juju remove-machine 1`
- `juju remove-machine 2 --no-prompt`
- `lxc launch ubuntu:22.04 manual-m1 --profile juju-manual` (the profile adds my key to authorized_keys).
- `lxc list` and get the IP.
- `juju add-machine ssh:ubuntu@<IP> --debug`
