### PR TITLE
feat: allow debug-log command against 3.x

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/core/facades"
 	"github.com/juju/juju/core/network"
 	jujuversion "github.com/juju/juju/core/version"
+	internalerrors "github.com/juju/juju/internal/errors"
 	jujuhttp "github.com/juju/juju/internal/http"
 	internallogger "github.com/juju/juju/internal/logger"
 	jujuproxy "github.com/juju/juju/internal/proxy"
@@ -51,6 +52,9 @@ const (
 	// ConnectionDialTimedOut is returned when the api connection failed to open
 	// within the specified time.
 	ConnectionDialTimedOut = errors.ConstError("api connection dial timed out")
+
+	// ConnectionFailure is returned when the api client is unable to connect.
+	ConnectionFailure = errors.ConstError("api connection failure")
 
 	// PingPeriod defines how often the internal connection health check
 	// will run.
@@ -1124,7 +1128,7 @@ func (d dialer) dial(done <-chan struct{}) (io.Closer, error) {
 		}
 	}
 	if lastErr != nil {
-		return nil, errors.Annotatef(lastErr, "unable to connect to API")
+		return nil, internalerrors.Errorf("unable to connect to API: %w", lastErr).Add(ConnectionFailure)
 	}
 	logger.Debugf(d.ctx, "no error, but not connected, probably cancelled before we started")
 	return nil, parallel.ErrStopped

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -718,10 +718,10 @@ func (s *apiclientSuite) TestOpenWithNoCACert(c *tc.C) {
 		Timeout:    time.Hour,
 		RetryDelay: time.Nanosecond,
 	})
-	switch errType := errors.Cause(err).(type) {
-	case *tls.CertificateVerificationError:
-	default:
-		c.Fatalf("unexpected error type %v", errType)
+
+	var certErr *tls.CertificateVerificationError
+	if !errors.As(err, &certErr) {
+		c.Fatalf("unexpected certificate error: %v", certErr)
 	}
 }
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -190,7 +190,7 @@ func (s *BootstrapSuite) TestRunTests(c *tc.C) {
 	for i, test := range bootstrapTests {
 		c.Logf("\ntest %d: %s", i, test.info)
 		c.Run(fmt.Sprintf("Test%d", i), func(t *testing.T) {
-			c := &tc.TBC{t}
+			c := &tc.TBC{TB: t}
 			s.run(c, test)
 		})
 	}

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -472,7 +472,7 @@ func (c *debugLogCommand) getDebugLogClients(ctx context.Context, warningLogger 
 	var clients []DebugLogAPI
 	for _, details := range controllers {
 		client, err := getDebugLogAPIForAddresses(ctx, c, details.APIEndpoints)
-		if errors.Is(err, api.ConnectionFailure) {
+		if len(controllers) > 1 && errors.Is(err, api.ConnectionFailure) {
 			warningLogger.Warningf("cannot connect to debug log API for controller %q at addresses %v: %v", details.ControllerID, details.APIEndpoints, err)
 			continue
 		} else if err != nil {

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mattn/go-isatty"
 
 	apiclient "github.com/juju/juju/api/client/client"
+	"github.com/juju/juju/api/client/highavailability"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/jujuclient"
 	jujucmd "github.com/juju/juju/cmd"
@@ -377,16 +378,48 @@ func (c *debugLogCommand) parseEntity(entity string) string {
 
 // DebugLogAPI provides access to the client facade.
 type DebugLogAPI interface {
+	// WatchDebugLog streams debug log messages according to the specified
+	// parameters.
 	WatchDebugLog(ctx context.Context, params common.DebugLogParams) (<-chan common.LogMessage, error)
+	// Close closes the API client.
 	Close() error
 }
 
-var getDebugLogAPI = func(ctx context.Context, c *debugLogCommand, addr []string) (DebugLogAPI, error) {
-	root, err := c.NewAPIRootWithAddressOverride(ctx, addr)
+var getDebugLogAPI = func(ctx context.Context, c *debugLogCommand) (DebugLogAPI, error) {
+	root, err := c.NewAPIRoot(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return apiclient.NewClient(root, logger), nil
+}
+
+var getDebugLogAPIForAddresses = func(ctx context.Context, c *debugLogCommand, addrs []string) (DebugLogAPI, error) {
+	root, err := c.NewAPIRootWithAddressOverride(ctx, addrs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return apiclient.NewClient(root, logger), nil
+}
+
+// ControllerDetailsAPI provides access to the high availability facade.
+type ControllerDetailsAPI interface {
+	// ControllerDetails returns details about all controllers known to the
+	// client.
+	ControllerDetails(ctx context.Context) (map[string]highavailability.ControllerDetails, error)
+
+	// BestAPIVersion returns the best API version supported by the server.
+	BestAPIVersion() int
+
+	// Close closes the API client.
+	Close() error
+}
+
+var getControllerDetailsClient = func(ctx context.Context, c *debugLogCommand) (ControllerDetailsAPI, error) {
+	root, err := c.NewAPIRoot(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return highavailability.NewClient(root), nil
 }
 
 func isTerminal(f interface{}) bool {
@@ -403,18 +436,40 @@ func (f logFunc) Log(r []corelogger.LogRecord) error {
 	return f(r)
 }
 
-func (c *debugLogCommand) getControllerAddresses() ([]string, error) {
-	controllerName, err := c.ModelCommandBase.ControllerName()
+func (c *debugLogCommand) getDebugLogClients(ctx context.Context) ([]DebugLogAPI, error) {
+	api, err := getControllerDetailsClient(ctx, c)
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting controller addresses")
+	}
+	defer api.Close()
+
+	// If we're connected to a HA facade that is less that 3, that indicates
+	// that the controller details API is not supported, so we fall back to
+	// using the address of the connected controller only.
+	if api.BestAPIVersion() < 3 {
+		client, err := getDebugLogAPI(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+		return []DebugLogAPI{client}, nil
+	}
+
+	// We're connected to a HA controller that supports the controller details
+	// API, so we can get the addresses of all controllers.
+	controllers, err := api.ControllerDetails(ctx)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting controller details")
 	}
 
-	details, err := c.ClientStore().ControllerByName(controllerName)
-	if err != nil {
-		return nil, errors.Annotatef(err, "getting controller details")
+	var clients []DebugLogAPI
+	for _, details := range controllers {
+		client, err := getDebugLogAPIForAddresses(ctx, c, details.APIEndpoints)
+		if err != nil {
+			return nil, errors.Annotatef(err, "getting debug log API for controller %q", details.ControllerID)
+		}
+		clients = append(clients, client)
 	}
-
-	return details.APIEndpoints, nil
+	return clients, nil
 }
 
 // Run retrieves the debug log via the API.
@@ -429,13 +484,18 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 		c.params.NoTail = !isTerminal(ctx.Stdout)
 	}
 
-	// Get the controller addresses to connect to.
-	controllerAddrs, err := c.getControllerAddresses()
+	// Get the controller debug-log clients to connect to.
+	clients, err := c.getDebugLogClients(ctx)
 	if err != nil {
 		return err
-	} else if len(controllerAddrs) == 0 {
-		return errors.New("no controller addresses found")
+	} else if len(clients) == 0 {
+		return errors.New("no controller debug-log clients available; is bootstrap still in progress?")
 	}
+	defer func() {
+		for _, client := range clients {
+			_ = client.Close()
+		}
+	}()
 
 	// The default log buffer size is 1 for a single controller
 	// (stream log entries as they arrive).
@@ -448,7 +508,7 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 	// printed out of order. Ideally we'd have a variable flush timeout
 	// depending on the rate of incoming messages but the buffered logger
 	// doesn't support that.
-	if len(controllerAddrs) > 1 {
+	if len(clients) > 1 {
 		if c.params.Replay || c.params.NoTail {
 			bufferSize = 500
 		} else {
@@ -456,6 +516,9 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
+	// Buffered log writer will batch log records and flush them either when the
+	// buffer is full or after the specified time interval. This also allows to
+	// remove duplicates when multiple controllers are streaming logs.
 	buf := corelogger.NewBufferedLogWriter(logFunc(func(recs []corelogger.LogRecord) error {
 		for _, r := range recs {
 			_ = c.out.Write(ctx, &r)
@@ -463,21 +526,19 @@ func (c *debugLogCommand) Run(ctx *cmd.Context) error {
 		return nil
 	}), bufferSize, time.Second, clock.WallClock)
 
-	// Start one log streamer per controller.
-	numStreams := len(controllerAddrs)
-	// Size of errors channel and wait group needs to match the number of debug log streams.
+	pollCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Size of errors channel and wait group needs to match the number of debug
+	// log streams.
 	var (
-		errs = make(chan error, numStreams)
+		errs = make(chan error, len(clients))
 		wg   sync.WaitGroup
 	)
-	wg.Add(numStreams)
-
-	pollCtx, cancel := context.WithCancel(ctx)
-	for _, addr := range controllerAddrs {
-		go func(addr string) {
-			c.streamLogs(pollCtx, []string{addr}, buf, errs)
-			wg.Done()
-		}(addr)
+	for _, client := range clients {
+		wg.Go(func() {
+			errs <- c.streamLogs(pollCtx, client, buf)
+		})
 	}
 
 	// Wait for the streams to exit.
@@ -486,12 +547,17 @@ loop:
 	for {
 		select {
 		case <-ctx.Done():
-			break loop
+			// If the context is done, flush the buffer and exit. We don't need
+			// to wait for the streamers to exit and stop.
+			_ = buf.Flush()
+			return nil
+
 		case pollErr = <-errs:
 			// Exit on the first error.
 			break loop
 		}
 	}
+
 	// Cancel the message polling before flushing the buffer.
 	cancel()
 	wg.Wait()
@@ -501,15 +567,9 @@ loop:
 
 // streamLogs watches debug logs from the specified controller and logs any results
 // into the supplied buffered logger. Any error is reported to the errors channel.
-func (c *debugLogCommand) streamLogs(ctx context.Context, controllerAddr []string, buf *corelogger.BufferedLogWriter, errs chan error) {
+func (c *debugLogCommand) streamLogs(ctx context.Context, client DebugLogAPI, buf *corelogger.BufferedLogWriter) error {
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {
-			client, err := getDebugLogAPI(ctx, c, controllerAddr)
-			if err != nil {
-				return err
-			}
-			defer client.Close()
-
 			messages, err := client.WatchDebugLog(ctx, c.params)
 			if err != nil {
 				return err
@@ -546,7 +606,7 @@ func (c *debugLogCommand) streamLogs(ctx context.Context, controllerAddr []strin
 			return true
 		},
 		NotifyFunc: func(err error, attempt int) {
-			logger.Debugf(context.TODO(), "retrying to connect to debug log")
+			logger.Debugf(ctx, "retrying to connect to debug log")
 		},
 		Attempts: -1,
 		Clock:    clock.WallClock,
@@ -560,15 +620,17 @@ func (c *debugLogCommand) streamLogs(ctx context.Context, controllerAddr []strin
 	if errors.Is(err, ErrConnectionClosed) {
 		err = nil
 	}
+
 	// Unwrap the retry call error trace for all errors. We don't want to show
 	// that to the user as part of the error message.
-	errs <- errors.Cause(err)
+	return errors.Cause(err)
 }
 
 // ErrConnectionClosed is a sentinel error used to signal that the connection
 // is closed.
 var ErrConnectionClosed = errors.ConstError("connection closed")
 
+// SeverityColor maps log severity levels to ansiterm color contexts.
 var SeverityColor = map[corelogger.Level]*ansiterm.Context{
 	corelogger.TRACE:   ansiterm.Foreground(ansiterm.Default),
 	corelogger.DEBUG:   ansiterm.Foreground(ansiterm.Green),

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/juju/loggo/v2"
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/api/client/highavailability"
 	"github.com/juju/juju/api/common"
-	"github.com/juju/juju/api/jujuclient"
 	"github.com/juju/juju/api/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/internal/cmd/cmdtesting"
@@ -192,17 +192,17 @@ func (s *DebugLogSuite) TestArgParsing(c *tc.C) {
 }
 
 func (s *DebugLogSuite) TestParamsPassed(c *tc.C) {
+	s.PatchValue(&getControllerDetailsClient, func(_ context.Context, _ *debugLogCommand) (ControllerDetailsAPI, error) {
+		return &fakeControllerDetailsAPI{
+			apiVersion: 2,
+		}, nil
+	})
 	fake := &fakeDebugLogAPI{}
-	s.PatchValue(&getDebugLogAPI, func(ctx context.Context, _ *debugLogCommand, _ []string) (DebugLogAPI, error) {
+	s.PatchValue(&getDebugLogAPI, func(ctx context.Context, _ *debugLogCommand) (DebugLogAPI, error) {
 		return fake, nil
 	})
 
 	store := jujuclienttesting.MinimalStore()
-	store.Controllers = map[string]jujuclient.ControllerDetails{
-		"arthur": {
-			APIEndpoints: []string{"address-666"},
-		},
-	}
 
 	_, err := cmdtesting.RunCommand(c, newDebugLogCommand(store),
 		"-i", "machine-1*", "-x", "machine-1-lxd-1",
@@ -236,19 +236,18 @@ func (s *DebugLogSuite) TestLogOutput(c *tc.C) {
 			},
 		}},
 	}
-	s.PatchValue(&getDebugLogAPI, func(_ context.Context, _ *debugLogCommand, addr []string) (DebugLogAPI, error) {
-		c.Assert(addr, tc.HasLen, 1)
-		api, ok := debugStreams[addr[0]]
+	s.PatchValue(&getControllerDetailsClient, func(_ context.Context, _ *debugLogCommand) (ControllerDetailsAPI, error) {
+		return &fakeControllerDetailsAPI{
+			apiVersion: 2,
+		}, nil
+	})
+	s.PatchValue(&getDebugLogAPI, func(_ context.Context, _ *debugLogCommand) (DebugLogAPI, error) {
+		api, ok := debugStreams["address-666"]
 		c.Assert(ok, tc.IsTrue)
 		return api, nil
 	})
 
 	store := jujuclienttesting.MinimalStore()
-	store.Controllers = map[string]jujuclient.ControllerDetails{
-		"arthur": {
-			APIEndpoints: []string{"address-666"},
-		},
-	}
 
 	checkOutput := func(args ...string) {
 		count := len(args)
@@ -280,7 +279,7 @@ func (s *DebugLogSuite) TestLogOutput(c *tc.C) {
 		`{"model-uuid":"model-uuid","timestamp":"2016-10-09T08:15:23.345Z","entity":"machine-0","level":"INFO","module":"test.module","location":"somefile.go:123","message":"this is the log output"}`+"\n")
 }
 
-func (s *DebugLogSuite) TestAllControllers(c *tc.C) {
+func (s *DebugLogSuite) TestAllControllersAgainstFacadeVersion2(c *tc.C) {
 	// test timezone is 6 hours east of UTC
 	tz := time.FixedZone("test", 6*60*60)
 	debugStreams := map[string]DebugLogAPI{
@@ -305,19 +304,86 @@ func (s *DebugLogSuite) TestAllControllers(c *tc.C) {
 			},
 		}},
 	}
-	s.PatchValue(&getDebugLogAPI, func(_ context.Context, _ *debugLogCommand, addr []string) (DebugLogAPI, error) {
-		c.Assert(addr, tc.HasLen, 1)
-		api, ok := debugStreams[addr[0]]
+	s.PatchValue(&getControllerDetailsClient, func(_ context.Context, _ *debugLogCommand) (ControllerDetailsAPI, error) {
+		return &fakeControllerDetailsAPI{
+			apiVersion: 2,
+		}, nil
+	})
+	s.PatchValue(&getDebugLogAPI, func(_ context.Context, _ *debugLogCommand) (DebugLogAPI, error) {
+		api, ok := debugStreams["address-666"]
 		c.Assert(ok, tc.IsTrue)
 		return api, nil
 	})
 
 	store := jujuclienttesting.MinimalStore()
-	store.Controllers = map[string]jujuclient.ControllerDetails{
-		"arthur": {
-			APIEndpoints: []string{"address-666", "address-668"},
-		},
+
+	checkOutput := func(args ...string) {
+		count := len(args)
+		args, expected := args[:count-1], args[count-1]
+		ctx, err := cmdtesting.RunCommand(c, newDebugLogCommandTZ(store, tz), args...)
+		c.Check(err, tc.ErrorIsNil)
+		out := cmdtesting.Stdout(ctx)
+		lines := strings.Split(out, "\n")
+		c.Assert(lines, tc.Not(tc.HasLen), 0)
+		expectedLines := strings.Split(expected, "\n")
+		c.Check(lines[0], tc.Equals, expectedLines[0])
+		// Depending on the exact moment the log stream was stopped, we may miss the last line.
+		if len(lines) > 1 && lines[1] != "" {
+			c.Check(lines[1], tc.Equals, expectedLines[1])
+		}
 	}
+	checkOutput(
+		"machine-0: 14:15:23 INFO test.module this is the log output for 0\n")
+}
+
+func (s *DebugLogSuite) TestAllControllersAgainstFacadeVersion3(c *tc.C) {
+	// test timezone is 6 hours east of UTC
+	tz := time.FixedZone("test", 6*60*60)
+	debugStreams := map[string]DebugLogAPI{
+		"address-666": &fakeDebugLogAPI{log: []common.LogMessage{
+			{
+				Entity:    "machine-0",
+				Timestamp: time.Date(2016, 10, 9, 8, 15, 23, 345000000, time.UTC),
+				Severity:  "INFO",
+				Module:    "test.module",
+				Location:  "somefile.go:123",
+				Message:   "this is the log output for 0",
+			},
+		}},
+		"address-668": &fakeDebugLogAPI{log: []common.LogMessage{
+			{
+				Entity:    "machine-1",
+				Timestamp: time.Date(2016, 10, 9, 8, 15, 20, 345000000, time.UTC),
+				Severity:  "INFO",
+				Module:    "test.module",
+				Location:  "anotherfile.go:123",
+				Message:   "this is the log output for 1",
+			},
+		}},
+	}
+	s.PatchValue(&getControllerDetailsClient, func(_ context.Context, _ *debugLogCommand) (ControllerDetailsAPI, error) {
+		return &fakeControllerDetailsAPI{
+			details: map[string]highavailability.ControllerDetails{
+				"0": {
+					ControllerID: "0",
+					APIEndpoints: []string{"address-666"},
+				},
+				"1": {
+					ControllerID: "1",
+					APIEndpoints: []string{"address-668"},
+				},
+			},
+			apiVersion: 3,
+		}, nil
+	})
+	s.PatchValue(&getDebugLogAPIForAddresses, func(_ context.Context, _ *debugLogCommand, addrs []string) (DebugLogAPI, error) {
+		c.Assert(addrs, tc.HasLen, 1)
+		api, ok := debugStreams[addrs[0]]
+		c.Assert(ok, tc.IsTrue)
+		return api, nil
+	})
+
+	store := jujuclienttesting.MinimalStore()
 
 	checkOutput := func(args ...string) {
 		count := len(args)
@@ -354,19 +420,18 @@ func (s *DebugLogSuite) TestLogOutputWithLogs(c *tc.C) {
 			},
 		}},
 	}
-	s.PatchValue(&getDebugLogAPI, func(_ context.Context, _ *debugLogCommand, addr []string) (DebugLogAPI, error) {
-		c.Assert(addr, tc.HasLen, 1)
-		api, ok := debugStreams[addr[0]]
+	s.PatchValue(&getControllerDetailsClient, func(_ context.Context, _ *debugLogCommand) (ControllerDetailsAPI, error) {
+		return &fakeControllerDetailsAPI{
+			apiVersion: 2,
+		}, nil
+	})
+	s.PatchValue(&getDebugLogAPI, func(_ context.Context, _ *debugLogCommand) (DebugLogAPI, error) {
+		api, ok := debugStreams["address-666"]
 		c.Assert(ok, tc.IsTrue)
 		return api, nil
 	})
 
 	store := jujuclienttesting.MinimalStore()
-	store.Controllers = map[string]jujuclient.ControllerDetails{
-		"arthur": {
-			APIEndpoints: []string{"address-666"},
-		},
-	}
 
 	checkOutput := func(args ...string) {
 		count := len(args)
@@ -417,5 +482,22 @@ func (fake *fakeDebugLogAPI) WatchDebugLog(ctx context.Context, params common.De
 }
 
 func (fake *fakeDebugLogAPI) Close() error {
+	return nil
+}
+
+type fakeControllerDetailsAPI struct {
+	details    map[string]highavailability.ControllerDetails
+	apiVersion int
+}
+
+func (api *fakeControllerDetailsAPI) ControllerDetails(ctx context.Context) (map[string]highavailability.ControllerDetails, error) {
+	return api.details, nil
+}
+
+func (api *fakeControllerDetailsAPI) BestAPIVersion() int {
+	return api.apiVersion
+}
+
+func (api *fakeControllerDetailsAPI) Close() error {
 	return nil
 }

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -389,46 +389,35 @@ func (c *ModelCommandBase) modelFromStore(controllerName, modelIdentifier string
 // NewAPIRoot returns a new connection to the API server for the environment
 // directed to the model specified on the command line.
 func (c *ModelCommandBase) NewAPIRoot(ctx context.Context) (api.Connection, error) {
-	return c.NewAPIRootWithAddressOverride(ctx, nil)
-}
-
-// NewAPIRootWithAddressOverride returns a new connection to the API server for the environment
-// directed to the model specified on the command line, using any address overrides.
-func (c *ModelCommandBase) NewAPIRootWithAddressOverride(ctx context.Context, addresses []string) (api.Connection, error) {
-	// We need to call ModelDetails() here and not just ModelName() to force
-	// a refresh of the internal model details if those are not yet stored locally.
-	modelName, _, err := c.ModelDetails(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	conn, err := c.newAPIRoot(ctx, modelName, nil, addresses)
-	return conn, errors.Trace(err)
+	return c.NewAPIRootWithDialOpts(ctx, nil)
 }
 
 // NewAPIRootWithDialOpts returns a new connection to the API server for the
 // environment directed to the model specified on the command line (and with
 // the given dial options if non-nil).
-func (c *ModelCommandBase) NewAPIRootWithDialOpts(ctx context.Context, dialOpts *api.DialOpts) (api.Connection, error) {
-	// We need to call ModelDetails() here and not just ModelName() to force
-	// a refresh of the internal model details if those are not yet stored locally.
+func (c *ModelCommandBase) NewAPIRootWithDialOpts(ctx context.Context, dialOpts *api.DialOpts, overrideAddresses ...string) (api.Connection, error) {
+	// We need to call ModelDetails() here and not just ModelName() to force a
+	// refresh of the internal model details if those are not yet stored
+	// locally.
 	modelName, _, err := c.ModelDetails(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	conn, err := c.newAPIRoot(ctx, modelName, dialOpts, nil)
+	conn, err := c.newAPIRoot(ctx, modelName, dialOpts, overrideAddresses)
 	return conn, errors.Trace(err)
 }
 
-// NewControllerAPIRoot returns a new connection to the API server for the environment
-// directed to the controller specified on the command line.
-// This is for the use of model-centered commands that still want
-// to talk to controller-only APIs.
+// NewControllerAPIRoot returns a new connection to the API server for the
+// environment directed to the controller specified on the command line. This is
+// for the use of model-centered commands that still want to talk to
+// controller-only APIs.
 func (c *ModelCommandBase) NewControllerAPIRoot(ctx context.Context) (api.Connection, error) {
 	return c.newAPIRoot(ctx, "", nil, nil)
 }
 
-// newAPIRoot is the internal implementation of NewAPIRoot and NewControllerAPIRoot;
-// if modelName is empty, it makes a controller-only connection.
+// newAPIRoot is the internal implementation of NewAPIRoot and
+// NewControllerAPIRoot; if modelName is empty, it makes a controller-only
+// connection.
 func (c *ModelCommandBase) newAPIRoot(ctx context.Context, modelName string, dialOpts *api.DialOpts, addressOverride []string) (api.Connection, error) {
 	controllerName, err := c.ControllerName()
 	if err != nil {

--- a/juju/api.go
+++ b/juju/api.go
@@ -91,7 +91,7 @@ func NewAPIConnection(ctx context.Context, args NewAPIConnectionParams) (_ api.C
 	// we'll update the entry correctly.
 	dnsCache := dnsCacheMap(controller.DNSCache).copy()
 	args.DialOpts.DNSCache = dnsCache
-	logger.Infof(context.TODO(), "connecting to API addresses: %v", apiInfo.Addrs)
+	logger.Infof(ctx, "connecting to API addresses: %v", apiInfo.Addrs)
 	st, err := args.OpenAPI(ctx, apiInfo, args.DialOpts)
 	if err != nil {
 		var redirErr *api.RedirectError
@@ -164,7 +164,7 @@ func NewAPIConnection(ctx context.Context, args NewAPIConnectionParams) (_ api.C
 	}
 	err = updateControllerDetailsFromLogin(args.ControllerStore, args.ControllerName, controller, params)
 	if err != nil {
-		logger.Errorf(context.TODO(), "cannot cache API addresses: %v", err)
+		logger.Errorf(ctx, "cannot cache API addresses: %v", err)
 	}
 
 	return st, nil


### PR DESCRIPTION
Provides _client_ backwards capability to talk to a 3.x controller for streaming debug-logs. This piggy backs off of the HA facade and inspecting if there is a way to get the ControllerDetails. If there is, it will use a connector to each individual controller, otherwise if it isn't available, it will connect to the current controller and stream it from mongo that way.

This is the pre-requisite for fixing `juju show-status-log`, which also requires this set of treatment. In order to tackle that, we also need to ensure that the infrastructure is in place. So debug-log also needs to work in the same manor.

## QA steps

### Juju 4.0

```sh
$ juju bootstrap lxd test
$ juju debug-log -m controller
$ juju add-model m && juju deploy ubuntu
$ juju debug-log -m m
$ juju add-unit -m controller controller -n 2
$ juju debug-log -m controller
```

> [!NOTE]
> Running `juju debug-log -m controller` will snap shot the current controllers, and will make no effort to watch the current number of controllers. Thus, moving into HA, you'll have to call `juju debug-log -m controller` again once everything has settled.

#### Down controller

```sh
$ juju bootstrap lxd test
$ juju debug-log -m controller
$ juju add-model m && juju deploy ubuntu
$ juju debug-log -m m
$ juju add-unit -m controller controller -n 2
$ juju ssh -m controller 1
$ systemctl stop jujud-machine-1.service
$ juju debug-log -m controller
```

There should be a warning about it not being able to connect to controller 1, but the debug logs should still work.

### Juju 3.6

`juju` without the `/snap/bin` prefix, assumes you're using the juju 4.0 client. You can check this by running `juju version`

```sh
$ snap install juju --channel=3/stable
$ /snap/bin/juju bootstrap lxd test
$ juju debug-log -m controller
$ juju add-model m && juju deploy ubuntu
$ juju debug-log -m m
$ /snap/bin/juju enable-ha
$ juju debug-log -m controller
```

> [!NOTE]
> This doesn't have the same problem with concerns to the snap shot-ing of the current controllers, as all the logs are streamed from mongo directly.

## Links

**Issue:**  Fixes https://github.com/juju/juju/issues/21258

**Jira card:** [JUJU-8792](https://warthogs.atlassian.net/browse/JUJU-8792)


[JUJU-8792]: https://warthogs.atlassian.net/browse/JUJU-8792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ