### PR TITLE
refactor: export bundle help doc

### DIFF
--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -34,7 +34,22 @@ type exportBundleCommand struct {
 }
 
 const exportBundleHelpDoc = `
-Exports the current model configuration as a reusable bundle.
+Exports the current model's applications and relations as a reusable bundle.
+
+The bundle does not mirror the model configuration. It is a self-contained
+definition derived from the applications currently deployed in the model, so
+that the same set of applications and relations can be reproduced in another
+model.
+
+Juju may optimise how information is represented in the exported bundle.
+For example, if all applications share the same base, Juju may set a
+bundle-level default-base. 
+
+Exposure rules and application offers may
+also be captured in an overlay as a second YAML document within the same
+file (for example, using exposed-endpoints and offers entries). These
+optimisations change only how the bundle is expressed and do not affect
+the resulting deployment.
 
 If ` + "`--filename`" + ` is not used, the configuration is printed to ` + "`stdout`" + `.
 ` + "` --filename`" + ` specifies an output file.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/export-bundle.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/export-bundle.md
@@ -25,7 +25,22 @@ Exports the current model configuration as a reusable bundle.
 
 ## Details
 
-Exports the current model configuration as a reusable bundle.
+Exports the current model's applications and relations as a reusable bundle.
+
+The bundle does not mirror the model configuration. It is a self-contained
+definition derived from the applications currently deployed in the model, so
+that the same set of applications and relations can be reproduced in another
+model.
+
+Juju may optimise how information is represented in the exported bundle.
+For example, if all applications share the same base, Juju may set a
+bundle-level default-base. 
+
+Exposure rules and application offers may
+also be captured in an overlay as a second YAML document within the same
+file (for example, using exposed-endpoints and offers entries). These
+optimisations change only how the bundle is expressed and do not affect
+the resulting deployment.
 
 If `--filename` is not used, the configuration is printed to `stdout`.
 ` --filename` specifies an output file.


### PR DESCRIPTION
This PR updates the export-bundle command help text to better reflect how the command actually behaves.

Currently, the help text says that export-bundle “exports the current model configuration as a reusable bundle”, which can be misleading. 

The exported bundle:
- Contains applications, relations, machines, and related settings needed to recreate them in another model.
- Does not mirror the full model configuration (e.g. model defaults such as default-base).
- May represent bases using either a bundle-level default-base or per-application bases, derived from the applications currently deployed in the model.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
 1. Check help docs for `juju export-bundle`
```sh
make install && juju help export-bundle
```

## Links
**Github issues:** https://github.com/juju/juju/issues/20125
[JUJU-8377]: https://warthogs.atlassian.net/browse/JUJU-8377