### PR TITLE
fix(secrets): rotate policy handling

### DIFF
--- a/core/secrets/rotate.go
+++ b/core/secrets/rotate.go
@@ -73,3 +73,16 @@ func (p RotatePolicy) NextRotateTime(lastRotated time.Time) *time.Time {
 	}
 	return &result
 }
+
+// LessThan returns true if the policy is more frequent than other.
+func (p *RotatePolicy) LessThan(other RotatePolicy) bool {
+	if !p.WillRotate() && !other.WillRotate() {
+		return false // those are basically equal
+	} else if !p.WillRotate() {
+		return false // current won't rotate make it less frequent
+	} else if !other.WillRotate() {
+		return true // if the other doesn't rotate, current will be more frequent
+	}
+	now := time.Now()
+	return p.NextRotateTime(now).Before(*other.NextRotateTime(now))
+}

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -500,7 +500,8 @@ func (s *SecretService) UpdateCharmSecret(ctx context.Context, uri *secrets.URI,
 		if err != nil {
 			return errors.Capture(err)
 		}
-		if !policy.WillRotate() {
+		// If the policy is less than the new policy, update the next rotation time.
+		if params.RotatePolicy.LessThan(policy) {
 			p.NextRotateTime = params.RotatePolicy.NextRotateTime(s.clock.Now())
 		}
 	}


### PR DESCRIPTION
When changing the rotation policy for a secret, the next rotate time should only be updated if it is newer than the current rotate time.
eg
if current rotate time is hourly and changed to daily -> no update
if current rotate time is monthly and changed to daily -> update

This fix this behavior in 4.0

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

run `cd tests && ./main.sh -v secrets_iaas test_secrets_juju`

## Links

**Issue:** Fixes #21278

**Jira card:** [JUJU-8800](https://warthogs.atlassian.net/browse/JUJU-8800)


[JUJU-8800]: https://warthogs.atlassian.net/browse/JUJU-8800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ