### PR TITLE
chore(smoke-jaas): fix smoke jaas

### DIFF
--- a/.github/workflows/jaas-smoke.yml
+++ b/.github/workflows/jaas-smoke.yml
@@ -16,21 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      # We can't use docker snap, because it is confined to /home and we are checking out the repository under /opt
-      - name: Install docker via apt
-        run: |
-          sudo apt-get update
-          sudo apt-get install ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
 
       - name: Install Dependencies
         shell: bash
@@ -63,7 +50,7 @@ jobs:
         uses: canonical/jimm/.github/actions/test-server@v3
         id: jaas
         with:
-          jimm-version: v3.2.2
+          jimm-version: v3.3.8
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
           dump-logs: true
           use-charmed-k8s-action: "false"


### PR DESCRIPTION
# Description

Before it was failing because installing docker via apt was installing 1.29 which broke traefik,
used in the JIMM composite action. Now docker is installed via snap (1.28) and we will update
traefik on JIMM's side with the fix by the time they release 1.29 to docker snap as well.