### PR TITLE
fix(secret): support filtering secrets by label

### DIFF
--- a/domain/secret/service/exportimport.go
+++ b/domain/secret/service/exportimport.go
@@ -21,7 +21,7 @@ func (s *SecretService) GetSecretsForExport(ctx context.Context) (*SecretExport,
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	secrets, secretRevisions, err := s.secretState.ListSecrets(ctx, nil, nil, secret.NilLabels)
+	secrets, secretRevisions, err := s.secretState.ListAllSecrets(ctx)
 	if err != nil {
 		return nil, errors.Errorf("loading secrets for export: %w", err)
 	}

--- a/domain/secret/service/exportimport_test.go
+++ b/domain/secret/service/exportimport_test.go
@@ -41,7 +41,7 @@ func (s *serviceSuite) TestGetSecretsForExport(c *tc.C) {
 		Revision: 3,
 	}}}
 
-	s.state.EXPECT().ListSecrets(gomock.Any(), nil, nil, domainsecret.NilLabels).Return(
+	s.state.EXPECT().ListAllSecrets(gomock.Any()).Return(
 		secrets, revisions, nil,
 	)
 	s.state.EXPECT().GetSecretValue(gomock.Any(), uri, 1).Return(

--- a/domain/secret/service/interface.go
+++ b/domain/secret/service/interface.go
@@ -56,9 +56,11 @@ type State interface {
 	GetLatestRevision(ctx context.Context, uri *secrets.URI) (int, error)
 	GetLatestRevisions(ctx context.Context, uris []*secrets.URI) (map[string]int, error)
 	GetSecretValue(ctx context.Context, uri *secrets.URI, revision int) (secrets.SecretData, *secrets.ValueRef, error)
-	ListSecrets(ctx context.Context, uri *secrets.URI,
-		revision *int, labels domainsecret.Labels,
-	) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
+	GetSecretByURI(ctx context.Context, uri secrets.URI, revision *int) (*secrets.SecretMetadata,
+		[]*secrets.SecretRevisionMetadata, error)
+	ListSecretsByLabels(ctx context.Context, labels domainsecret.Labels, revision *int) ([]*secrets.SecretMetadata,
+		[][]*secrets.SecretRevisionMetadata, error)
+	ListAllSecrets(ctx context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ListCharmSecrets(ctx context.Context,
 		appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners,
 	) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)

--- a/domain/secret/service/package_mock_test.go
+++ b/domain/secret/service/package_mock_test.go
@@ -1227,6 +1227,46 @@ func (c *MockStateGetSecretAccessRelationScopeCall) DoAndReturn(f func(context.C
 	return c
 }
 
+// GetSecretByURI mocks base method.
+func (m *MockState) GetSecretByURI(arg0 context.Context, arg1 secrets.URI, arg2 *int) (*secrets.SecretMetadata, []*secrets.SecretRevisionMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretByURI", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*secrets.SecretMetadata)
+	ret1, _ := ret[1].([]*secrets.SecretRevisionMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetSecretByURI indicates an expected call of GetSecretByURI.
+func (mr *MockStateMockRecorder) GetSecretByURI(arg0, arg1, arg2 any) *MockStateGetSecretByURICall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretByURI", reflect.TypeOf((*MockState)(nil).GetSecretByURI), arg0, arg1, arg2)
+	return &MockStateGetSecretByURICall{Call: call}
+}
+
+// MockStateGetSecretByURICall wrap *gomock.Call
+type MockStateGetSecretByURICall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetSecretByURICall) Return(arg0 *secrets.SecretMetadata, arg1 []*secrets.SecretRevisionMetadata, arg2 error) *MockStateGetSecretByURICall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetSecretByURICall) Do(f func(context.Context, secrets.URI, *int) (*secrets.SecretMetadata, []*secrets.SecretRevisionMetadata, error)) *MockStateGetSecretByURICall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetSecretByURICall) DoAndReturn(f func(context.Context, secrets.URI, *int) (*secrets.SecretMetadata, []*secrets.SecretRevisionMetadata, error)) *MockStateGetSecretByURICall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetSecretConsumer mocks base method.
 func (m *MockState) GetSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 unit.Name) (*secrets.SecretConsumerMetadata, int, error) {
 	m.ctrl.T.Helper()
@@ -1901,6 +1941,46 @@ func (c *MockStateInitialWatchStatementForSecretsRotationChangesCall) DoAndRetur
 	return c
 }
 
+// ListAllSecrets mocks base method.
+func (m *MockState) ListAllSecrets(arg0 context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllSecrets", arg0)
+	ret0, _ := ret[0].([]*secrets.SecretMetadata)
+	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListAllSecrets indicates an expected call of ListAllSecrets.
+func (mr *MockStateMockRecorder) ListAllSecrets(arg0 any) *MockStateListAllSecretsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllSecrets", reflect.TypeOf((*MockState)(nil).ListAllSecrets), arg0)
+	return &MockStateListAllSecretsCall{Call: call}
+}
+
+// MockStateListAllSecretsCall wrap *gomock.Call
+type MockStateListAllSecretsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateListAllSecretsCall) Return(arg0 []*secrets.SecretMetadata, arg1 [][]*secrets.SecretRevisionMetadata, arg2 error) *MockStateListAllSecretsCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateListAllSecretsCall) Do(f func(context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockStateListAllSecretsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateListAllSecretsCall) DoAndReturn(f func(context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockStateListAllSecretsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListCharmSecrets mocks base method.
 func (m *MockState) ListCharmSecrets(arg0 context.Context, arg1 secret.ApplicationOwners, arg2 secret.UnitOwners) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
@@ -2019,42 +2099,42 @@ func (c *MockStateListGrantedSecretsForBackendCall) DoAndReturn(f func(context.C
 	return c
 }
 
-// ListSecrets mocks base method.
-func (m *MockState) ListSecrets(arg0 context.Context, arg1 *secrets.URI, arg2 *int, arg3 secret.Labels) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+// ListSecretsByLabels mocks base method.
+func (m *MockState) ListSecretsByLabels(arg0 context.Context, arg1 secret.Labels, arg2 *int) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSecrets", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "ListSecretsByLabels", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*secrets.SecretMetadata)
 	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// ListSecrets indicates an expected call of ListSecrets.
-func (mr *MockStateMockRecorder) ListSecrets(arg0, arg1, arg2, arg3 any) *MockStateListSecretsCall {
+// ListSecretsByLabels indicates an expected call of ListSecretsByLabels.
+func (mr *MockStateMockRecorder) ListSecretsByLabels(arg0, arg1, arg2 any) *MockStateListSecretsByLabelsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockState)(nil).ListSecrets), arg0, arg1, arg2, arg3)
-	return &MockStateListSecretsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsByLabels", reflect.TypeOf((*MockState)(nil).ListSecretsByLabels), arg0, arg1, arg2)
+	return &MockStateListSecretsByLabelsCall{Call: call}
 }
 
-// MockStateListSecretsCall wrap *gomock.Call
-type MockStateListSecretsCall struct {
+// MockStateListSecretsByLabelsCall wrap *gomock.Call
+type MockStateListSecretsByLabelsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateListSecretsCall) Return(arg0 []*secrets.SecretMetadata, arg1 [][]*secrets.SecretRevisionMetadata, arg2 error) *MockStateListSecretsCall {
+func (c *MockStateListSecretsByLabelsCall) Return(arg0 []*secrets.SecretMetadata, arg1 [][]*secrets.SecretRevisionMetadata, arg2 error) *MockStateListSecretsByLabelsCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateListSecretsCall) Do(f func(context.Context, *secrets.URI, *int, secret.Labels) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockStateListSecretsCall {
+func (c *MockStateListSecretsByLabelsCall) Do(f func(context.Context, secret.Labels, *int) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockStateListSecretsByLabelsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateListSecretsCall) DoAndReturn(f func(context.Context, *secrets.URI, *int, secret.Labels) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockStateListSecretsCall {
+func (c *MockStateListSecretsByLabelsCall) DoAndReturn(f func(context.Context, secret.Labels, *int) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockStateListSecretsByLabelsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -639,8 +639,6 @@ func (s *SecretService) updateSecret(ctx domain.AtomicContext, uri *secrets.URI,
 }
 
 // ListSecrets returns the secrets matching the specified terms.
-// If multiple values for a given term are specified, secrets matching any of the
-// values for that term are included.
 func (s *SecretService) ListSecrets(ctx context.Context, uri *secrets.URI,
 	revision *int,
 	labels domainsecret.Labels,
@@ -648,7 +646,38 @@ func (s *SecretService) ListSecrets(ctx context.Context, uri *secrets.URI,
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return s.secretState.ListSecrets(ctx, uri, revision, labels)
+	// We look for secret either by URI or by label.
+	if uri != nil && len(labels) > 0 {
+		return nil, nil, errors.Errorf("cannot specify both URI and labels")
+	}
+
+	if uri != nil {
+		metadata, revisions, err := s.secretState.GetSecretByURI(ctx, *uri, revision)
+		if err != nil {
+			return nil, nil, errors.Errorf("getting secret by URI %q: %w", uri.ID, err)
+		}
+		return []*secrets.SecretMetadata{metadata}, [][]*secrets.SecretRevisionMetadata{revisions}, nil
+	}
+
+	if len(labels) > 0 {
+		metadataList, revisionsList, err := s.secretState.ListSecretsByLabels(ctx, labels, revision)
+		if err != nil {
+			return nil, nil, errors.Errorf("getting secrets by labels: %w", err)
+		}
+		return metadataList, revisionsList, nil
+	}
+
+	// If there is no URI or labels, we will list all secrets. In this case, a
+	// revision cannot be specified.
+	if revision != nil {
+		return nil, nil, errors.Errorf("cannot specify revision without URI or labels")
+	}
+
+	metadataList, revisionList, err := s.secretState.ListAllSecrets(ctx)
+	if err != nil {
+		return nil, nil, errors.Errorf("listing all secrets: %w", err)
+	}
+	return metadataList, revisionList, nil
 }
 
 func splitCharmSecretOwners(owners ...CharmSecretOwner) (domainsecret.ApplicationOwners, domainsecret.UnitOwners) {


### PR DESCRIPTION
This patch introduces new methods `GetSecretByURI`, `GetSecretsByLabels`, and `ListAllSecrets` in
`domain/secret/state/state.go` to replace the jack-of-all-trades `ListSecrets`. This significantly
improves clarity and modularity when querying secrets and fixes https://github.com/juju/juju/issues/21296

The changes include:
- Adding `GetSecretByURI` to retrieve a single secret by its URI.
- Adding `GetSecretsByLabels` to fetch secrets based on labels.
- Adding `ListAllSecrets` to retrieve all secrets.
- Refactoring `fetchSecrets` and related helper methods for improved query flexibility.
- Updating the test suite in `state_test.go` to align with the newly introduced methods and
  removing references to the old implementation.
- Enhancing mock support in `service/package_mock_test.go` for the newly added methods.

> ![NOTE]
>
> I believe SQL query can be a bit refactored too, through introducing a view for secret. 
> It implies a significant refactoring, s I focused this PR on fixing bug. I let a todo to keep that in mind.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap and add a model

then create two secrets:
```sh
juju add-secret foo bar=42 # secret-1
juju add-secret <id of secret-1> baz=42  # secret-2
```

Verify following:
```sh
juju secrets # return all secrets
juju show-secret foo # return  secret-1
juju show-secret <id of secret-1> # return  secret-1, even if it is technically the label of secret-2
juju show-secret <id of secret-2> # return  secret-2
juju show-secret secret:<id of secret-1> # return  secret-1
juju show-secret secret:<id of secret-2> # return  secret-2
```

## Documentation changes

This doesn't affect the documentation, it is a deviation from behavior of 3.6

## Links
**Issue:** Fixes #21296.

**Jira card:** [JUJU-8823](https://warthogs.atlassian.net/browse/JUJU-8823)


[JUJU-8823]: https://warthogs.atlassian.net/browse/JUJU-8823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ