### PR TITLE
feat: update Pebble version to v1.26.0 (latest) from v1.19.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20251112203541-660577aa1183
-	github.com/canonical/pebble v1.19.2
+	github.com/canonical/pebble v1.26.0
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVy
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20251112203541-660577aa1183 h1:RIcZMvVRrpT4RHiKr8byTa1rHYCQZF0q5rgVlbiovMM=
 github.com/canonical/lxd v0.0.0-20251112203541-660577aa1183/go.mod h1:MYdE1ID6Km0wWecLfqErbD0v6rqOgLQk91H/zSCWj0I=
-github.com/canonical/pebble v1.19.2 h1:5KTtTu4OK0q2+MCrlEm2hfar2kcdbJvIyM9JlvLfsFo=
-github.com/canonical/pebble v1.19.2/go.mod h1:fPtK3xrfuiRQBKSzfm3iBfdmIxlD/nup8yS1FVS8ZKQ=
+github.com/canonical/pebble v1.26.0 h1:jsPJmHe/E5PU6epAoq8QC/U2itPsMX947/oP4zcsWCA=
+github.com/canonical/pebble v1.26.0/go.mod h1:HtGFWX2hq+/jxXHvN3ibXUAqFGCRXmT2e4jYkpZi/O0=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=


### PR DESCRIPTION
3.6 branch: This PR updates the included Pebble version from v1.19.2 to v1.26.0. We take care to keep Pebble backwards-compatible, so this bump shouldn't be an issue.