### PR TITLE
fix: flakiness in watcher unit tests on heavily loaded systems

### DIFF
--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -496,12 +496,14 @@ func (s *streamSuite) TestSecondTermDoesNotStartUntilFirstTermDone(c *tc.C) {
 	s.insertNamespace(c, 1000, "foo")
 
 	statesChan := make(chan []string, 1)
+	noTermDeadline := time.Time{}
 	stream := NewInternalStates(uuid.MustNewUUID().String(),
 		s.TxnRunner(),
 		s.FileNotifier,
 		s.clock,
 		s.metrics,
 		loggertesting.WrapCheckLog(c),
+		noTermDeadline,
 		statesChan)
 	defer workertest.DirtyKill(c, stream)
 

--- a/internal/changestream/testing/controllermodelsuite.go
+++ b/internal/changestream/testing/controllermodelsuite.go
@@ -80,16 +80,5 @@ type Idler struct {
 // This is useful to ensure that the change stream is not processing any
 // events before running a test.
 func (idler *Idler) AssertChangeStreamIdle(c *tc.C) {
-	for {
-		select {
-		case states := <-idler.watchableDB.states:
-			for _, state := range states {
-				if state == stateIdle {
-					return
-				}
-			}
-		case <-c.Context().Done():
-			c.Fatalf("timed out waiting for idle state")
-		}
-	}
+	assertChangeStreamIdle(c, idler.watchableDB.states)
 }

--- a/internal/changestream/testing/controllersuite.go
+++ b/internal/changestream/testing/controllersuite.go
@@ -5,14 +5,12 @@ package testing
 
 import (
 	"context"
-	"time"
 
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain/schema/testing"
-	jujutesting "github.com/juju/juju/internal/testing"
 )
 
 // ControllerSuite is used to provide a sql.DB reference to tests.
@@ -54,17 +52,5 @@ func (s *ControllerSuite) GetWatchableDB(ctx context.Context, namespace string) 
 // This is useful to ensure that the change stream is not processing any
 // events before running a test.
 func (w *ControllerSuite) AssertChangeStreamIdle(c *tc.C) {
-	timeout := time.After(jujutesting.LongWait)
-	for {
-		select {
-		case states := <-w.watchableDB.states:
-			for _, state := range states {
-				if state == stateIdle {
-					return
-				}
-			}
-		case <-timeout:
-			c.Fatalf("timed out waiting for idle state")
-		}
-	}
+	assertChangeStreamIdle(c, w.watchableDB.states)
 }

--- a/internal/changestream/testing/modelsuite.go
+++ b/internal/changestream/testing/modelsuite.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"context"
 	"database/sql"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/tc"
@@ -14,7 +13,6 @@ import (
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain/schema/testing"
-	jujutesting "github.com/juju/juju/internal/testing"
 )
 
 // ModelSuite is used to provide a sql.DB reference to tests.
@@ -61,19 +59,7 @@ func (s *ModelSuite) GetWatchableDB(ctx context.Context, namespace string) (chan
 // This is useful to ensure that the change stream is not processing any
 // events before running a test.
 func (s *ModelSuite) AssertChangeStreamIdle(c *tc.C) {
-	timeout := time.After(jujutesting.LongWait)
-	for {
-		select {
-		case states := <-s.watchableDB.states:
-			for _, state := range states {
-				if state == stateIdle {
-					return
-				}
-			}
-		case <-timeout:
-			c.Fatalf("timed out waiting for idle state")
-		}
-	}
+	assertChangeStreamIdle(c, s.watchableDB.states)
 }
 
 // PrimeChangeStream the change stream with some initial data. This ensures


### PR DESCRIPTION
On a heavily loaded system, it is not abnormal for goroutines to be
asleep for a long duration. Since the change stream wants the event
multiplexer to have delivered a term of changes within a fixed time
period, this is often not long enough to ensure subscribers have
received the term's changes.

This PR changes the default term timeout on watcher test suites to be
a fixed deadline that occurs before a test's deadline. To ensure that
change stream idle assertions wait long enough, this change introduces
a dispatch internal event, allowing the idle assertion to wait longer
if the change stream is in the midst of a possibly long dispatch of a
term.

## QA Steps

With the changes in #21333 you are now able to stress test secrets
watcher tests with dqlite and have every single run pass.

This run is with my fork of [stress](https://github.com/hpidcock/stress).
Run on a 16core/32thread machine. `-p 256` pegs my CPU at 100%.
```
$ make go-test-alias
$ alias jt=<...>
$ jt -c -race ./domain/secret
$ stress -fast -p 256 -count 256 ./secret.test
5s: 0 runs so far, 0 failures, 256 active
10s: 0 runs so far, 0 failures, 256 active
15s: 0 runs so far, 0 failures, 256 active
20s: 0 runs so far, 0 failures, 256 active
25s: 0 runs so far, 0 failures, 256 active
30s: 0 runs so far, 0 failures, 256 active
35s: 0 runs so far, 0 failures, 256 active
40s: 0 runs so far, 0 failures, 256 active
45s: 0 runs so far, 0 failures, 256 active
50s: 0 runs so far, 0 failures, 256 active
55s: 0 runs so far, 0 failures, 256 active
1m0s: 0 runs so far, 0 failures, 256 active
1m5s: 0 runs so far, 0 failures, 256 active
1m10s: 0 runs so far, 0 failures, 256 active
1m15s: 8 runs so far, 0 failures, 248 active
1m20s: 74 runs so far, 0 failures, 182 active
1m25s: 161 runs so far, 0 failures, 95 active
1m30s: 247 runs so far, 0 failures, 9 active
1m33s: 256 runs total, 0 failures
```
