### PR TITLE
feat: only update the controller agent version on upsert

### DIFF
--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -178,10 +178,12 @@ WHERE controller_id = $controllerNodeAgentVersion.controller_id
 		return errors.Capture(err)
 	}
 
+	// We only update the version on upsert because there will never be a time
+	// the same controller node will change its architecture.
 	upsertControllerNodeAgentVerStmt, err := st.Prepare(`
 INSERT INTO controller_node_agent_version (*) VALUES ($controllerNodeAgentVersion.*)
 ON CONFLICT (controller_id) DO
-UPDATE SET version = excluded.version, architecture_id = excluded.architecture_id
+UPDATE SET version = excluded.version
 `, controllerNodeAgentVer)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -190,7 +190,9 @@ func (s *stateSuite) TestSetRunningAgentBinaryVersionSuccess(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtainedControllerID, tc.Equals, controllerID)
 	c.Check(obtainedVersion, tc.Equals, updatedVer.Number.String())
-	c.Check(obtainedArchName, tc.Equals, updatedVer.Arch)
+	// A controller's node cannot change its architecture so the architecture
+	// value still refers to the one during insertion.
+	c.Check(obtainedArchName, tc.Equals, ver.Arch)
 }
 
 func (s *stateSuite) TestSetRunningAgentBinaryVersionControllerNodeNotFound(c *tc.C) {


### PR DESCRIPTION
A follow up to https://github.com/juju/juju/pull/21297.

This is to address Simon's feedback ([ref](https://github.com/juju/juju/pull/21297#discussion_r2555394140)) that the same controller node will never change its architecture. So when we do the upsert, it's sufficient to only set the agent version.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Same as in #21297.

## Documentation changes

N/A

## Links

**Issue:** Fixes #21256.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8782](https://warthogs.atlassian.net/browse/JUJU-8782)


[JUJU-8782]: https://warthogs.atlassian.net/browse/JUJU-8782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ