### PR TITLE
docs: clarify canonical k8s path requirements

### DIFF
--- a/docs/reference/cloud/list-of-supported-clouds/the-canonical-ks-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-canonical-ks-cloud-and-juju.md
@@ -29,9 +29,9 @@ As the differences related to (1) are already documented generically in the rest
 
 Before you bootstrap:
 
-- You need to create a custom `containerd` path, e.g., `export containerdBaseDir="/run/containerd-k8s"`.
+- Create a custom `containerd` path, e.g., `export containerdBaseDir="/run/containerd-k8s"`.
 
-- For most purposes, you should also resize `/run`, e.g., `sudo mount -o remount,size=10G /run`.
+- Resize `/run`, e.g., `sudo mount -o remount,size=10G /run`.
 
 ```{ibnote}
 See more: https://github.com/canonical/k8s-snap/issues/1612


### PR DESCRIPTION
# Changes

Issue https://github.com/juju/juju/issues/21234 points out our language around the `containerd` path for Canonical K8s is misleading. This PR touches it up cf. discussion with @wallyworld (https://github.com/juju/juju/issues/21234#issuecomment-3584575010).

# Forward merge

This PR should be forward merged into `4.0` and `main`.