### PR TITLE
docs: clarify revision paragraph in attach-resource

### DIFF
--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -77,8 +77,8 @@ as follows:
 
     a. For a resource that has been uploaded to Charmhub: the resource revision number.
 
-	b. For a local resource: the path to the local file for your private OCI image as well as the
-	username and password required to access the private OCI image. Caveat: If you choose this,
+	b. For a local resource: the path to the local ` + "`json`" + ` or ` + "`yaml`" + ` file that contains the details
+	for your private OCI image (OCI image path, username, password, etc.). Caveat: If you choose this,
 	you will not be able to go back to using a resource from Charmhub.
 
     c. For a resource that has been uploaded to a public OCI registry: a link to the public OCI image.

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -86,7 +86,7 @@ where ` + "`<resource name>`" + ` is the name from the ` + "`metadata.yaml`" +
 
 `
 	attachExample = `
-    juju attach-resource mysql resource-name=foo
+    juju attach-resource easyrsa easyrsa=./EasyRSA-3.0.7.tgz
 
     juju attach-resource ubuntu-k8s ubuntu_image=ubuntu
 

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -62,24 +62,24 @@ The format is
 
     <resource name>=<resource>
 
-where ` + "`<resource name>`" + ` is the name from the ` + "`metadata.yaml`" + ` (` + "`charmcraft.yaml`" + `) file
-of the charm and where, depending on the type of the resource, ` + "`<resource>`" + ` can be specified
-as follows:
+where ` + "`<resource name>`" + ` is the name from the ` + "`metadata.yaml`" +
+		` (` + "`charmcraft.yaml`" + `) file of the charm and ` + "`<resource>`" +
+		` is the resource itself, which can be supplied as follows:
 
-- If the resource is type ` + "`file`" + `, you can specify it by providing one of the following:
+- For a resource type ` + "`file`" + `:
 
-    a. For a resource that has been uploaded to Charmhub: the resource revision number.
+    a. that has been uploaded to Charmhub: the resource revision number.
 
-    b. For a local resource: a path to a local file. Caveat: If you choose this, you will not be able
-	 to go back to using a resource from Charmhub.
+    b. that is local to your machine: a path to the local file. Caveat: If you choose this, you will
+	not be able to go back to using a resource from Charmhub.
 
-- If the resource is type ` + "`oci-image`" + `, you can specify it by providing one of the following:
+- For a resource type ` + "`oci-image`" + `:
 
-    a. For a resource that has been uploaded to Charmhub: the resource revision number.
+    a. that has been uploaded to Charmhub: the resource revision number.
 
-	b. For a local resource: the path to the local ` + "`json`" + ` or ` + "`yaml`" + ` file that contains the details
-	for your private OCI image (OCI image path, username, password, etc.). Caveat: If you choose this,
-	you will not be able to go back to using a resource from Charmhub.
+	b. that is local to your machine: a path to the local ` + "`json`" + ` or ` + "`yaml`" + ` file
+	that contains the details for your private OCI image (local image path, username, password, etc.).
+	Caveat: If you choose this, you will not be able to go back to using a resource from Charmhub.
 
     c. For a resource that has been uploaded to a public OCI registry: a link to the public OCI image.
 	Caveat: If you choose this, you will not be able to go back to using a resource from Charmhub.

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -62,28 +62,27 @@ The format is
 
     <resource name>=<resource>
 
-where the resource name is the name from the metadata.yaml file of the charm
-and where, depending on the type of the resource, the resource can be specified
+where ` + "`<resource name>`" + ` is the name from the ` + "`metadata.yaml`" + ` (` + "`charmcraft.yaml`" + `) file
+of the charm and where, depending on the type of the resource, ` + "`<resource>`" + ` can be specified
 as follows:
 
 - If the resource is type ` + "`file`" + `, you can specify it by providing one of the following:
 
-    a. the resource revision number.
+    a. For a resource that has been uploaded to Charmhub: the resource revision number.
 
-    b. a path to a local file. Caveat: If you choose this, you will not be able
+    b. For a local resource: a path to a local file. Caveat: If you choose this, you will not be able
 	 to go back to using a resource from Charmhub.
 
 - If the resource is type ` + "`oci-image`" + `, you can specify it by providing one of the following:
 
-    a. the resource revision number.
+    a. For a resource that has been uploaded to Charmhub: the resource revision number.
 
-	b. a path to the local file for your private OCI image as well as the
-	username and password required to access the private OCI image.
-	Caveat: If you choose this, you will not be able to go back to using a
-	resource from Charmhub.
+	b. For a local resource: the path to the local file for your private OCI image as well as the
+	username and password required to access the private OCI image. Caveat: If you choose this,
+	you will not be able to go back to using a resource from Charmhub.
 
-    c. a link to a public OCI image. Caveat: If you choose this, you will not be
-	 able to go back to using a resource from Charmhub.
+    c. For a resource that has been uploaded to a public OCI registry: a link to the public OCI image.
+	Caveat: If you choose this, you will not be able to go back to using a resource from Charmhub.
 
 `
 	attachExample = `
@@ -98,10 +97,11 @@ as follows:
 // Info implements cmd.Command.Info
 func (c *UploadCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "attach-resource",
-		Args:    "application <resource name>=<resource>",
-		Purpose: "Update a resource for an application.",
-		Doc:     attachDoc,
+		Name:     "attach-resource",
+		Args:     "application <resource name>=<resource>",
+		Purpose:  "Update a resource for an application.",
+		Doc:      attachDoc,
+		Examples: attachExample,
 		SeeAlso: []string{
 			"resources",
 			"charm-resources",

--- a/docs/howto/manage-units.md
+++ b/docs/howto/manage-units.md
@@ -105,18 +105,6 @@ postgresql-k8s/0*  active    idle   10.1.179.149  5432/TCP  Pod configured
 See more: {ref}`command-juju-status`, {ref}`unit-status`
 ```
 
-## Set the meter status on a unit
-
-To set the meter status on a unit, use the `set-meter-status` command followed by the unit name. For example:
-
-```text
-juju set-meter-status myapp/0
-```
-
-```{ibnote}
-See more: {ref}`command-juju-set-meter-status`
-```
-
 (mark-unit-errors-as-resolved)=
 ## Mark unit errors as resolved
 

--- a/docs/reference/juju-cli.md
+++ b/docs/reference/juju-cli.md
@@ -59,11 +59,6 @@ LXD itself can operate over the network and Juju does support this (`v.2.5.0`).
 
 You can also configure the Juju client using various environment variables. For more, see {ref}`juju-environment-variables`.
 
-
-## Plugins
-
-The Juju client can be extended with plugins. For more, see {ref}`plugin`, {ref}`list-of-known-juju-plugins`.
-
 ## Roadmap and releases
 
 Each Juju release is accompanied by a set of release notes that highlight the changes and bug fixes for each release. For more, see  {ref}`juju-roadmap-and-releases`.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
@@ -31,24 +31,22 @@ The format is
 
     <resource name>=<resource>
 
-where `<resource name>` is the name from the `metadata.yaml` (`charmcraft.yaml`) file
-of the charm and where, depending on the type of the resource, `<resource>` can be specified
-as follows:
+where `<resource name>` is the name from the `metadata.yaml` (`charmcraft.yaml`) file of the charm and `<resource>` is the resource itself, which can be supplied as follows:
 
-- If the resource is type `file`, you can specify it by providing one of the following:
+- For a resource type `file`:
 
-    a. For a resource that has been uploaded to Charmhub: the resource revision number.
+    a. that has been uploaded to Charmhub: the resource revision number.
 
-    b. For a local resource: a path to a local file. Caveat: If you choose this, you will not be able
-	 to go back to using a resource from Charmhub.
+    b. that is local to your machine: a path to the local file. Caveat: If you choose this, you will
+	not be able to go back to using a resource from Charmhub.
 
-- If the resource is type `oci-image`, you can specify it by providing one of the following:
+- For a resource type `oci-image`:
 
-    a. For a resource that has been uploaded to Charmhub: the resource revision number.
+    a. that has been uploaded to Charmhub: the resource revision number.
 
-	b. For a local resource: the path to the local `json` or `yaml` file that contains the details
-	for your private OCI image (OCI image path, username, password, etc.). Caveat: If you choose this,
-	you will not be able to go back to using a resource from Charmhub.
+	b. that is local to your machine: a path to the local `json` or `yaml` file
+	that contains the details for your private OCI image (local image path, username, password, etc.).
+	Caveat: If you choose this, you will not be able to go back to using a resource from Charmhub.
 
     c. For a resource that has been uploaded to a public OCI registry: a link to the public OCI image.
 	Caveat: If you choose this, you will not be able to go back to using a resource from Charmhub.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
@@ -14,6 +14,15 @@ Update a resource for an application.
 | `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 
+## Examples
+
+    juju attach-resource mysql resource-name=foo
+
+    juju attach-resource ubuntu-k8s ubuntu_image=ubuntu
+
+    juju attach-resource redis-k8s redis-image=redis
+
+
 ## Details
 
 This command updates a resource for an application.
@@ -22,25 +31,24 @@ The format is
 
     <resource name>=<resource>
 
-where the resource name is the name from the metadata.yaml file of the charm
-and where, depending on the type of the resource, the resource can be specified
+where `<resource name>` is the name from the `metadata.yaml` (`charmcraft.yaml`) file
+of the charm and where, depending on the type of the resource, `<resource>` can be specified
 as follows:
 
 - If the resource is type `file`, you can specify it by providing one of the following:
 
-    a. the resource revision number.
+    a. For a resource that has been uploaded to Charmhub: the resource revision number.
 
-    b. a path to a local file. Caveat: If you choose this, you will not be able
+    b. For a local resource: a path to a local file. Caveat: If you choose this, you will not be able
 	 to go back to using a resource from Charmhub.
 
 - If the resource is type `oci-image`, you can specify it by providing one of the following:
 
-    a. the resource revision number.
+    a. For a resource that has been uploaded to Charmhub: the resource revision number.
 
-	b. a path to the local file for your private OCI image as well as the
-	username and password required to access the private OCI image.
-	Caveat: If you choose this, you will not be able to go back to using a
-	resource from Charmhub.
+	b. For a local resource: the path to the local file for your private OCI image as well as the
+	username and password required to access the private OCI image. Caveat: If you choose this,
+	you will not be able to go back to using a resource from Charmhub.
 
-    c. a link to a public OCI image. Caveat: If you choose this, you will not be
-	 able to go back to using a resource from Charmhub.
+    c. For a resource that has been uploaded to a public OCI registry: a link to the public OCI image.
+	Caveat: If you choose this, you will not be able to go back to using a resource from Charmhub.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
@@ -16,7 +16,7 @@ Update a resource for an application.
 
 ## Examples
 
-    juju attach-resource mysql resource-name=foo
+    juju attach-resource easyrsa easyrsa=./EasyRSA-3.0.7.tgz
 
     juju attach-resource ubuntu-k8s ubuntu_image=ubuntu
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/attach-resource.md
@@ -46,8 +46,8 @@ as follows:
 
     a. For a resource that has been uploaded to Charmhub: the resource revision number.
 
-	b. For a local resource: the path to the local file for your private OCI image as well as the
-	username and password required to access the private OCI image. Caveat: If you choose this,
+	b. For a local resource: the path to the local `json` or `yaml` file that contains the details
+	for your private OCI image (OCI image path, username, password, etc.). Caveat: If you choose this,
 	you will not be able to go back to using a resource from Charmhub.
 
     c. For a resource that has been uploaded to a public OCI registry: a link to the public OCI image.


### PR DESCRIPTION
# Changes

## Primary

Issue https://github.com/juju/juju/issues/19076 pointed out some vagueness in our doc for `juju attach-resource`. This PR fixes it cf. https://github.com/juju/juju/issues/19076#issuecomment-3585862940 (based on discussion with @wallyworld ).

## Other

The `attach-resource` doc was also missing the Examples section; this PR makes sure it's surfaced as well.

The doc on the `juju` CLI client still referenced plugins, which were otherwise recently removed; this PR deletes the reference.

Our how-to on units was still mentioning then now removed `set-meter-status`; this PR removes the embedding section.


# Forward merge

This PR should be forward merged into `4.0` and `main`.

