### PR TITLE
docs: add link to lxd rules for bridge

### DIFF
--- a/docs/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
@@ -70,9 +70,10 @@ Attributes:
 <br>(Added in Juju 3.6.4)
 - `trust-password`: the LXD server trust password (optional, required if trust-token is not set)
 
-<!--
+
 ## Notes on `juju bootstrap`
--->
+
+If `juju bootstrap` hangs, it could be due to a firewall issue. See more: [LXD | UFW: Add rules for the bridge](https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/#ufw-add-rules-for-the-bridge).
 
 ## Cloud-specific model configuration keys
 


### PR DESCRIPTION
# Changes  

Issue https://github.com/juju/juju/issues/21227 points out an issue that may arise when bootstrapping on a LXD cloud and suggests a fix. This PR implements the fix after checking with @wallyworld .

# Forward merge

This PR should be forward merged into `4.0` and `main`.

# Future work

Looking at the information flow in our docs, I see our how-to section "Bootstrap a controller" has dropdowns with recommended configuration, tips for production, and tips for troubleshooting, and each of those is split into machines and Kubernetes. 

I think that's both too much -- it's visually cluttered -- and too little -- e.g., in most of our cloud-specific reference docs we have a section called "Notes on bootstrap"  and it would be good to link there too.

All in all, I'd like to 

- create a reference doc "Machine clouds and Juju", on the pattern of "Kubernetes clouds and Juju", both with sections on bootstrap, etc. Then I can make "How to bootstrap a controller" link there.
- update "How to bootstrap a controller" to add links to the cloud-specific docs as well. 

I'll create a separate issue for that.
