### PR TITLE
feat: compat with 3.6 for bundle export

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -21,15 +21,20 @@ func SupportedFacadeVersions() facades.FacadeVersions {
 // New facades should start at 1.
 // We no longer support facade versions at 0.
 var facadeVersions = facades.FacadeVersions{
-	"Action":                       {7},
-	"Agent":                        {3},
-	"AgentLifeFlag":                {1},
-	"Annotations":                  {2},
-	"Application":                  {19, 20, 21, 22},
-	"ApplicationOffers":            {5, 6},
-	"Backups":                      {3},
-	"Block":                        {2},
-	"Bundle":                       {8},
+	"Action":            {7},
+	"Agent":             {3},
+	"AgentLifeFlag":     {1},
+	"Annotations":       {2},
+	"Application":       {19, 20, 21, 22},
+	"ApplicationOffers": {5, 6},
+	"Backups":           {3},
+	"Block":             {2},
+	// Note that this version of Juju does not implement version 6 of the
+	// facade, but 3.6 does. Care must be taken not to break client
+	// compatibility with the prior version.
+	// Version 8 here just reports the inability of Juju 4+ to export bundles.
+	// We should probably just remove the facade altogether.
+	"Bundle":                       {6, 8},
 	"CAASAgent":                    {2},
 	"CAASAdmission":                {1},
 	"CAASApplication":              {1},


### PR DESCRIPTION
As was done with `MachineManager`, we simply add the latest version of the `Bundle` facade from 3.6 to the supported list.

4.0 removes bundle export functionality altogether, but this allows us to export bundles from 3.6.

## QA steps

- Bootstrap a 3.6 controller on LXD.
- `juju add-model work`
- `juju deploy juju-qa-dummy-sink`
- `juju deploy juju-qa-dummy-source --config token=COMPATIBILITY`
- `juju relate dummy-source dummy-sink`
- With a client built from this patch `juju export-bundle` should yield valid output:
```
default-base: ubuntu@20.04/stable
applications:
  dummy-sink:
    charm: juju-qa-dummy-sink
    channel: latest/stable
    revision: 7
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
  dummy-source:
    charm: juju-qa-dummy-source
    channel: latest/stable
    revision: 6
    num_units: 1
    to:
    - "1"
    options:
      token: COMPATIBILITY
    constraints: arch=amd64
machines:
  "0":
    constraints: arch=amd64
  "1":
    constraints: arch=amd64
relations:
- - dummy-source:sink
  - dummy-sink:source
```