### PR TITLE
feat: add tooling to view tables within transaction before rollback

### DIFF
--- a/internal/database/testing/database.go
+++ b/internal/database/testing/database.go
@@ -7,11 +7,14 @@ import (
 	"bufio"
 	"bytes"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/canonical/sqlair"
+	"github.com/juju/collections/transform"
 	"github.com/juju/tc"
 )
 
@@ -73,4 +76,102 @@ func DumpTable(c *tc.C, queryable Queryable, table string, extraTables ...string
 		_, _ = fmt.Fprintln(os.Stdout, strings.Repeat("-", width-4))
 		_, _ = fmt.Fprintln(os.Stdout)
 	}
+}
+
+type columnName struct {
+	Name string `db:"name"`
+}
+
+type tableName struct {
+	Name string `db:"name"`
+}
+
+// DumpTableSqlair dumps the contents of the given table to stdout using an
+// sqlair.TX. This is useful for debugging tests. It is not intended for use
+// in production code.
+func DumpTableSqlair(c *tc.C, preparer preparer, tx *sqlair.TX, table string, extraTables ...string) {
+	getColumnsNamesStmt, err := preparer.Prepare("SELECT &columnName.* FROM pragma_table_info($tableName.name)", columnName{}, tableName{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	for _, t := range append([]string{table}, extraTables...) {
+		var columnNames []columnName
+		err = tx.Query(c.Context(), getColumnsNamesStmt, tableName{Name: t}).GetAll(&columnNames)
+		c.Assert(err, tc.ErrorIsNil)
+
+		getAllQuery := fmt.Sprintf("SELECT %s FROM %q",
+			strings.Join(transform.Slice(columnNames, func(cn columnName) string { return fmt.Sprintf("&M.%s", cn.Name) }), ", "),
+			t)
+		getAllStmt, err := preparer.Prepare(getAllQuery, sqlair.M{})
+		c.Assert(err, tc.ErrorIsNil)
+
+		var rows []sqlair.M
+		err = tx.Query(c.Context(), getAllStmt).GetAll(&rows)
+		if !errors.Is(err, sqlair.ErrNoRows) {
+			c.Assert(err, tc.ErrorIsNil)
+		}
+
+		buffer := new(bytes.Buffer)
+		writer := tabwriter.NewWriter(buffer, 0, 8, 4, ' ', 0)
+		for _, col := range columnNames {
+			_, _ = fmt.Fprintf(writer, "%s\t", col.Name)
+		}
+		_, _ = fmt.Fprintln(writer)
+
+		for _, row := range rows {
+			for _, col := range columnNames {
+				_, _ = fmt.Fprintf(writer, "%v\t", row[col.Name])
+			}
+			_, _ = fmt.Fprintln(writer)
+		}
+		err = writer.Flush()
+		c.Assert(err, tc.ErrorIsNil)
+
+		_, _ = fmt.Fprintf(os.Stdout, "Table - %s:\n", t)
+
+		var width int
+		scanner := bufio.NewScanner(bytes.NewBuffer(buffer.Bytes()))
+		for scanner.Scan() {
+			if num := len(scanner.Text()); num > width {
+				width = num
+			}
+		}
+
+		_, _ = fmt.Fprintln(os.Stdout, strings.Repeat("-", width-4))
+		_, _ = fmt.Fprintln(os.Stdout, buffer.String())
+		_, _ = fmt.Fprintln(os.Stdout, strings.Repeat("-", width-4))
+		_, _ = fmt.Fprintln(os.Stdout)
+	}
+}
+
+// DumpForeignKeysForTableSqlair dumps the contents of all the tables that have
+// a foreign key constraint targeting the given table, using an sqlair.TX. This
+// is useful for debugging tests. It is not intended for use in production code.
+func DumpForeignKeysForTableSqlair(c *tc.C, preparer preparer, tx *sqlair.TX, table string) {
+	getForeignKeysStmt, err := preparer.Prepare(`
+WITH tbls(name) AS ( 
+	SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' 
+) 
+SELECT DISTINCT
+	t.name    AS &tableName.name 
+FROM tbls t, pragma_foreign_key_list(t.name) AS fk 
+WHERE fk."table" = $tableName.name
+`, tableName{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	var sourceTables []tableName
+	err = tx.Query(c.Context(), getForeignKeysStmt, tableName{Name: table}).GetAll(&sourceTables)
+	if !errors.Is(err, sqlair.ErrNoRows) {
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	if len(sourceTables) == 0 {
+		_, _ = fmt.Fprintf(os.Stdout, "Table %q has no foreign key links.\n", table)
+		return
+	}
+	DumpTableSqlair(c, preparer, tx, sourceTables[0].Name, transform.Slice(sourceTables[1:], func(t tableName) string { return t.Name })...)
+}
+
+// Preparer is an interface that prepares SQL statements for sqlair.
+type preparer interface {
+	Prepare(query string, typeSamples ...any) (*sqlair.Statement, error)
 }


### PR DESCRIPTION
We have been witnessing _a lot_ of foreign key constraint errors within the removal domain. Also, SQLite returns really bad errors when this happens. Simply 'foreign key constraint violation', without even telling us what table was being modified, or what table caused the error

Also, when we see this error, the very next step is to rollback the transaction, so the existing DumpTable helper function is inadequate, we lose the state that resulted in this error.

As a result, these errors are very difficult to debug.

Patch our testing txnRunner for the DqliteSuite to shim the txn function, allowing us to inject a posthook to run when the usual function exits but before the transaction is rolled back.

This allows us to inspect the state of the database when the error was thrown

Also, write some helper functions, particularly
DumpForeignKeysForTableSqlair, which uses a sqlair.TX to dump the contents of all tables that have a foreign key link to the provided table

## QA steps

Apply the following diff:
```
diff --git a/domain/removal/state/model/unit.go b/domain/removal/state/model/unit.go
index 3f76a7717c..7fceb9a289 100644
--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -775,7 +775,7 @@ func (st *State) deleteForeignKeyUnitReferences(ctx context.Context, tx *sqlair.
                "DELETE FROM unit_agent_status WHERE unit_uuid = $entityUUID.uuid",
                "DELETE FROM unit_workload_status WHERE unit_uuid = $entityUUID.uuid",
                "DELETE FROM unit_workload_version WHERE unit_uuid = $entityUUID.uuid",
-               "DELETE FROM unit_principal WHERE unit_uuid = $entityUUID.uuid",
+               // "DELETE FROM unit_principal WHERE unit_uuid = $entityUUID.uuid",
                "DELETE FROM unit_resolved WHERE unit_uuid = $entityUUID.uuid",
                "DELETE FROM unit_resource WHERE unit_uuid = $entityUUID.uuid",
                "DELETE FROM k8s_pod_status WHERE unit_uuid = $entityUUID.uuid",
diff --git a/domain/removal/state/model/unit_test.go b/domain/removal/state/model/unit_test.go
index d21686181f..5965cc1b93 100644
--- a/domain/removal/state/model/unit_test.go
+++ b/domain/removal/state/model/unit_test.go
@@ -10,6 +10,7 @@ import (
        "testing"
        "time"
 
+       "github.com/canonical/sqlair"
        "github.com/juju/tc"
 
        "github.com/juju/juju/core/instance"
@@ -19,6 +20,7 @@ import (
        applicationservice "github.com/juju/juju/domain/application/service"
        "github.com/juju/juju/domain/life"
        removalerrors "github.com/juju/juju/domain/removal/errors"
+       databasetesting "github.com/juju/juju/internal/database/testing"
        loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -625,6 +627,10 @@ func (s *unitSuite) TestDeleteSubordinateUnit(c *tc.C) {
 
        st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
+       s.InjectPostTxnHook(func(ctx context.Context, tx *sqlair.TX) {
+               databasetesting.DumpForeignKeysForTableSqlair(c, st, tx, "unit")
+       })
+
        err = st.DeleteUnit(c.Context(), subUnitUUID.String(), false)
        c.Assert(err, tc.ErrorIsNil)
 }
```

And run `go test ./domain/removal/state/model/ -run TestUnitSuite/TestDeleteSubordinateUnit`

You will observe in the failure logs:
```
Table - unit_storage_directive:
---------------------------------------------------------------------------------
unit_uuid    charm_uuid    storage_name    storage_pool_uuid    size_mib    count    

---------------------------------------------------------------------------------

Table - storage_unit_owner:
----------------------------------
storage_instance_uuid    unit_uuid    

----------------------------------

Table - storage_attachment:
-----------------------------------------------------
uuid    storage_instance_uuid    unit_uuid    life_id    

-----------------------------------------------------

Table - secret_unit_owner:
-------------------------------
secret_id    unit_uuid    label    

-------------------------------

Table - secret_unit_consumer:
------------------------------------------------------------------------
secret_id    source_model_uuid    unit_uuid    label    current_revision    

------------------------------------------------------------------------

Table - annotation_unit:
--------------------
uuid    key    value    

--------------------

Table - unit_principal:
----------------------------------------------------------------------------
unit_uuid                               principal_uuid                          
f36f954b-c96d-4978-81fe-74d189d076ff    d4c42833-7fa2-4135-8f9b-5aed7980bded    

----------------------------------------------------------------------------

Table - unit_workload_version:
-----------------------------------------------
unit_uuid                               version    
d4c42833-7fa2-4135-8f9b-5aed7980bded               

-----------------------------------------------

Table - unit_agent_version:
---------------------------------------
unit_uuid    version    architecture_id    

---------------------------------------

Table - unit_state:
----------------------------------------------------------
unit_uuid    uniter_state    storage_state    secret_state    

----------------------------------------------------------

Table - unit_state_charm:
-------------------------
unit_uuid    key    value    

-------------------------

Table - unit_state_relation:
-------------------------
unit_uuid    key    value    

-------------------------

Table - k8s_pod:
------------------------
unit_uuid    provider_id    

------------------------

Table - unit_agent_status:
----------------------------------------------------------------------------------------------------------------
unit_uuid                               status_id    message    data     updated_at                                 
d4c42833-7fa2-4135-8f9b-5aed7980bded    0                       <nil>    2025-11-28 17:42:57.165433836 +0000 UTC    

----------------------------------------------------------------------------------------------------------------

Table - unit_workload_status:
----------------------------------------------------------------------------------------------------------------------------
unit_uuid                               status_id    message                data     updated_at                                 
d4c42833-7fa2-4135-8f9b-5aed7980bded    3            waiting for machine    <nil>    2025-11-28 17:42:57.165433836 +0000 UTC    

----------------------------------------------------------------------------------------------------------------------------

Table - k8s_pod_status:
-------------------------------------------------------
unit_uuid    status_id    message    data    updated_at    

-------------------------------------------------------

Table - unit_agent_presence:
----------------------
unit_uuid    last_seen    

----------------------

Table - unit_resolved:
--------------------
unit_uuid    mode_id    

--------------------

Table - port_range:
-------------------------------------------------------------------------
uuid    protocol_id    from_port    to_port    relation_uuid    unit_uuid    

-------------------------------------------------------------------------

Table - unit_resource:
--------------------------------------
resource_uuid    unit_uuid    added_at    

--------------------------------------

Table - relation_unit:
-------------------------------------------
uuid    relation_endpoint_uuid    unit_uuid    

-------------------------------------------

Table - operation_unit_task:
----------------------
task_uuid    unit_uuid    

----------------------
```