### PR TITLE
test: fix various ci test issues

### DIFF
--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -39,6 +39,10 @@ func WorkloadSeries(now time.Time, requestedSeries, imageStream string) (set.Str
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// Noble is opt in for 2.9 so remove it
+	// from the default choices. The user can
+	// still use --force if they want noble.
+	delete(supported, Noble)
 	return set.NewStrings(workloadSeries(supported, false)...), nil
 }
 

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -192,7 +192,7 @@ func (s *SupportedSeriesSuite) TestWorkloadSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
 		"bionic", "centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kubernetes",
-		"noble", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv",
+		"opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv",
 		"win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019",
 		"win7", "win8", "win81", "xenial"})
 }

--- a/testcharms/charm-hub/bundles/juju-qa-bundle-test/bundle.yaml
+++ b/testcharms/charm-hub/bundles/juju-qa-bundle-test/bundle.yaml
@@ -16,13 +16,15 @@ applications:
     to:
     - "1"
     constraints: arch=amd64
-  ntp:
-    charm: ntp
-    channel: stable
-  ntp-focal:
-    charm: ntp
-    channel: stable
+  dummy-subordinate:
+    charm: juju-qa-dummy-subordinate
+    options:
+      token: token
+  dummy-subordinate-focal:
+    charm: juju-qa-dummy-subordinate
     series: focal
+    options:
+      token: token
 machines:
   "0":
     constraints: arch=amd64
@@ -31,7 +33,7 @@ machines:
     constraints: arch=amd64
     series: focal
 relations:
-- - ntp:juju-info
+- - dummy-subordinate:juju-info
   - juju-qa-test:juju-info
-- - ntp-focal:juju-info
+- - dummy-subordinate-focal:juju-info
   - juju-qa-test-focal:juju-info

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -9,8 +9,8 @@ run_deploy_bundle() {
 	ensure "test-bundles-deploy" "${file}"
 
 	juju deploy juju-qa-bundle-test
-	wait_for "juju-qa-test" ".applications | keys[0]"
-	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"
+	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test")"
+	wait_for "dummy-subordinate-focal" "$(idle_subordinate_condition "dummy-subordinate-focal" "juju-qa-test-focal")"
 
 	destroy_model "test-bundles-deploy"
 }
@@ -210,10 +210,12 @@ run_deploy_charmhub_bundle() {
 
 	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/stable")"
 	wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "latest/candidate")"
-	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-	wait_for "juju-qa-test-focal" "$(idle_condition "juju-qa-test-focal" 1)"
-	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"
-	wait_for "ntp-focal" "$(idle_subordinate_condition "ntp-focal" "juju-qa-test-focal")"
+	# Relying on hardcoded app index is fragile should a change in their order occur.
+	# We should find time to refactor this.
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 2)"
+	wait_for "juju-qa-test-focal" "$(idle_condition "juju-qa-test-focal" 3)"
+	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test")"
+	wait_for "dummy-subordinate-focal" "$(idle_subordinate_condition "dummy-subordinate-focal" "juju-qa-test-focal")"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -104,7 +104,7 @@ run_refresh_channel_no_new_revision() {
 
 	juju refresh juju-qa-fixed-rev --channel edge
 
-	wait_for "juju-qa-fixed-rev" "$(charm_channel "juju-qa-fixed-rev" "latest/edge")"
+	wait_for "juju-qa-fixed-rev" "$(charm_channel "juju-qa-fixed-rev" "edge")"
 	wait_for "juju-qa-fixed-rev" "$(charm_rev "juju-qa-fixed-rev" "${cs_revision}")"
 	wait_for "juju-qa-fixed-rev" "$(idle_condition "juju-qa-fixed-rev")"
 
@@ -126,7 +126,7 @@ run_refresh_revision() {
 	# refresh to a revision not at the tip of the stable channel
 	juju refresh juju-qa-test --revision 23
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "23")"
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "latest/stable")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "stable")"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	# do a generic refresh, should pick up revision from latest stable
@@ -138,7 +138,7 @@ run_refresh_revision() {
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "latest/stable")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "stable")"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	destroy_model "${model_name}"


### PR DESCRIPTION
Fix various 2.9 ci test failures.
The main issues:

1. test bundles used outdated charms which no longer deploy (ntp)
2. the incorrect charm track was being used when checking results
3. migration tests were timing out
4. deploys were defaulting to noble not jammy

On the last point, 2.9 is supposed to deploy to jammy if not otherwise specified. When support for deploying to noble was added, it should have been opt in. The quickest fix is simply to remove noble from the workload series list. We still know about it so it can be used, but not by default.

## QA 

Check the jammy default behaviour

`juju deploy ubuntu`
`juju deploy ubuntu --series noble`

