### PR TITLE
fix(secret): allows several units having the same label for owned secret

### DIFF
--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -192,17 +192,15 @@ func (st State) CheckUnitSecretLabelExists(ctx domain.AtomicContext, unitUUID co
 SELECT COUNT(*) AS &count.num
 FROM (
     SELECT secret_id
-    FROM   secret_application_owner sao
-           JOIN unit u ON sao.application_uuid = u.application_uuid
+    FROM   secret_application_owner AS sao
+           JOIN unit AS u ON sao.application_uuid = u.application_uuid
     WHERE  label = $secretUnitOwner.label
     AND    u.uuid = $secretUnitOwner.unit_uuid
-    UNION
-    SELECT DISTINCT secret_id
-    FROM   secret_unit_owner suo
-           JOIN unit u ON suo.unit_uuid = u.uuid
-           JOIN unit peer ON peer.application_uuid = u.application_uuid
+    UNION ALL
+    SELECT secret_id
+    FROM   secret_unit_owner AS suo
     WHERE  label = $secretUnitOwner.label
-    AND peer.uuid != u.uuid
+    AND    suo.unit_uuid = $secretUnitOwner.unit_uuid
 )`
 
 	checkExistsStmt, err := st.Prepare(checkLabelExistsSQL, input, count)


### PR DESCRIPTION
This is a minimal changes on the sql to fix #21344

I am working on an ongoing PR which will remove RunAtomic from secret domain, but it is a huge work even for simple paths so i choose to split the work.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

follow step from joined bug, ie:

* deploy postgresql, wait for up
* add unit


Should works without error, and two secrets with label `database-peers.postgresql.unit` should exists, one for each unit.


## Links

**Issue:** Fixes #21344.

**Jira card:** [JUJU-8871](https://warthogs.atlassian.net/browse/JUJU-8871)


[JUJU-8871]: https://warthogs.atlassian.net/browse/JUJU-8871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ