### PR TITLE
fix: get correct controller uuid for image metadata cli

### DIFF
--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -55,10 +55,14 @@ func prepare(ctx *cmd.Context, controllerName string, store jujuclient.ClientSto
 	// identify region and endpoint info that we need. Not sure what
 	// we'll do about simplestreams.MetadataValidator yet. Probably
 	// move it to the EnvironProvider interface.
+	ctrl, err := store.ControllerByName(controllerName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return environs.New(context.TODO(), environs.OpenParams{
 		Cloud:          params.Cloud,
 		Config:         cfg,
-		ControllerUUID: bootstrapConfig.ControllerConfig.ControllerUUID(),
+		ControllerUUID: ctrl.ControllerUUID,
 	})
 }
 

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/provider/dummy"
 	"github.com/juju/juju/jujuclient"
@@ -148,8 +149,13 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLTS(c *gc.C) {
 		"region":          "us-east-1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	// The controller config used for bootstrap config
+	// does not have the controller uuid or ca cart.
+	controllerCfg := testing.FakeControllerConfig()
+	delete(controllerCfg, controller.ControllerUUIDKey)
+	delete(controllerCfg, controller.CACertKey)
 	s.store.BootstrapConfig["ec2-controller"] = jujuclient.BootstrapConfig{
-		ControllerConfig: testing.FakeControllerConfig(),
+		ControllerConfig: controllerCfg,
 		Cloud:            "ec2",
 		CloudRegion:      "us-east-1",
 		Config:           ec2Config.AllAttrs(),

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/controller"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
@@ -134,8 +135,13 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclient.MemStore) {
 		User: "admin",
 	}
 
+	// The controller config used for bootstrap config
+	// does not have the controller uuid or ca cart.
+	controllerCfg := coretesting.FakeControllerConfig()
+	delete(controllerCfg, controller.ControllerUUIDKey)
+	delete(controllerCfg, controller.CACertKey)
 	store.BootstrapConfig["ec2-controller"] = jujuclient.BootstrapConfig{
-		ControllerConfig:    coretesting.FakeControllerConfig(),
+		ControllerConfig:    controllerCfg,
 		ControllerModelUUID: ec2UUID,
 		Config:              ec2Config.AllAttrs(),
 		Cloud:               "ec2",


### PR DESCRIPTION
The OpenParams for a provider needs a controller UUID. For the image metadata cli, the controller uuid was being looked up from the wrong place. It needs to be fetched from the client store controller details, not the bootstrap config.

## QA steps

bootstrap a controller
`juju metadata generate-image`

without this fix it panics.

## Links

**Issue:** Fixes #20757.

**Jira card:** [JUJU-8798](https://warthogs.atlassian.net/browse/JUJU-8798)


[JUJU-8798]: https://warthogs.atlassian.net/browse/JUJU-8798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ