### PR TITLE
fix: tighten permissions on netplan config files

### DIFF
--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -325,9 +325,9 @@ func (cfg *ubuntuCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceI
 		if err != nil {
 			return errors.Trace(err)
 		}
-		cfg.AddBootTextFile(jujuNetplanFile, netPlan, 0644)
-		cfg.AddBootTextFile(systemNetworkInterfacesFile+".templ", eni, 0644)
-		cfg.AddBootTextFile(systemNetworkInterfacesFile+".py", NetworkInterfacesScript, 0744)
+		cfg.AddBootTextFile(jujuNetplanFile, netPlan, 0600)
+		cfg.AddBootTextFile(systemNetworkInterfacesFile+".templ", eni, 0600)
+		cfg.AddBootTextFile(systemNetworkInterfacesFile+".py", NetworkInterfacesScript, 0700)
 		cfg.AddBootCmd(populateNetworkInterfaces(systemNetworkInterfacesFile))
 	}
 	return nil

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -120,7 +120,7 @@ func (s *NetworkUbuntuSuite) SetUpTest(c *gc.C) {
 	s.expectedSampleConfigHeader = `#cloud-config
 bootcmd:
 `
-	s.expectedSampleConfigWriting = `- install -D -m 644 /dev/null '%[1]s.templ'
+	s.expectedSampleConfigWriting = `- install -D -m 600 /dev/null '%[1]s.templ'
 - |-
   echo '
   auto lo {ethaa_bb_cc_dd_ee_f0} {ethaa_bb_cc_dd_ee_f1} {ethaa_bb_cc_dd_ee_f3} {ethaa_bb_cc_dd_ee_f5}
@@ -183,7 +183,7 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
 	networkInterfacesScriptYamled = strings.Replace(networkInterfacesScriptYamled, "%", "%%", -1)
 	networkInterfacesScriptYamled = strings.Replace(networkInterfacesScriptYamled, "'", "'\"'\"'", -1)
 
-	s.expectedSampleUserData = `- install -D -m 744 /dev/null '%[2]s'
+	s.expectedSampleUserData = `- install -D -m 700 /dev/null '%[2]s'
 - |-
   echo '` + networkInterfacesScriptYamled + ` ' > '%[2]s'
 - |2
@@ -214,7 +214,7 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
   fi
 `[1:]
 	s.expectedFullNetplanYaml = `
-- install -D -m 644 /dev/null '%[1]s'
+- install -D -m 600 /dev/null '%[1]s'
 - |-
   echo 'network:
     version: 2
@@ -500,13 +500,13 @@ func (s *NetworkUbuntuSuite) runENIScript(c *gc.C, pythonBinary, ipCommand, inpu
 	templFile := filepath.Join(s.tempFolder, "interfaces.templ")
 	scriptFile := filepath.Join(s.tempFolder, "script.py")
 
-	err := os.WriteFile(dataFile, []byte(s.originalSystemNetworkInterfaces), 0644)
+	err := os.WriteFile(dataFile, []byte(s.originalSystemNetworkInterfaces), 0600)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("Can't write interfaces file"))
 
-	err = os.WriteFile(templFile, []byte(input), 0644)
+	err = os.WriteFile(templFile, []byte(input), 0600)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("Can't write interfaces.templ file"))
 
-	err = os.WriteFile(scriptFile, []byte(cloudinit.NetworkInterfacesScript), 0755)
+	err = os.WriteFile(scriptFile, []byte(cloudinit.NetworkInterfacesScript), 0700)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("Can't write script file"))
 
 	script := fmt.Sprintf("%q %q --interfaces-file %q --output-file %q --command %q --wait %d --retries %d",
@@ -537,7 +537,7 @@ func (s *NetworkUbuntuSuite) createMockCommand(c *gc.C, outputs []string) string
 	lastFile := ""
 	for i, output := range outputs {
 		dataFile := filepath.Join(s.tempFolder, fmt.Sprintf("%s.%d", baseName, i))
-		err := os.WriteFile(dataFile, []byte(output), 0644)
+		err := os.WriteFile(dataFile, []byte(output), 0600)
 		c.Assert(err, jc.ErrorIsNil, gc.Commentf("can't write mock file"))
 		if lastFile != "" {
 			script += fmt.Sprintf("mv %q %q || true\n", dataFile, lastFile)


### PR DESCRIPTION
The `/etc/netplan/99-juju.yaml` file was being created with 0644 whereas the other such files use 0600.
Also the `etc/network/interfaces.py` file should be similarly restricted to just 0700.

This PR changes the cloud init script to use the more restrictive permissions.

## QA steps

Use a lxd profile with a second network interface configured, eg `lxc network create lxdbr1`
bootstrap lxd with this profile
Use `juju subnets` to check the networks contain both `net-lxdbr0` and `net-lxdbr1`
ssh to the lxd machine and check file permissions
```
ls -l /etc/netplan/
total 4
-rw------- 1 root root 92 Dec  2 03:35 99-juju.yaml
ls -l /etc/network/interfaces.*
-rwx------ 1 root root 3421 Dec  2 03:35 /etc/network/interfaces.py
-rw------- 1 root root  160 Dec  2 03:35 /etc/network/interfaces.templ
```

## Links

**Issue:** Fixes #18702.

**Jira card:** [JUJU-7483](https://warthogs.atlassian.net/browse/JUJU-7483)


[JUJU-7483]: https://warthogs.atlassian.net/browse/JUJU-7483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ