### PR TITLE
docs(watcher): add test harness guidelines

### DIFF
--- a/.github/instructions/watcher-review.instructions.md
+++ b/.github/instructions/watcher-review.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "**/*_test.go"
+---
+
+When using the watcher test harness (`core/watcher/watchertest`):
+ * each test must use a single transaction for all mutations that cause the watcher under test to fire. 
+   * This is to ensure that those change stream events are in the same term.
+* if mutations emit change events for a watcher under test, AssertChangeStreamIdle shall be called before creating the watcher.
+    * This is to ensure initial events are tested correctly in your watcher.
+


### PR DESCRIPTION
This patch introduces testing guidelines for the watcher test harness in `
 .github/instructions/watcher-review.instructions.md` to help copilot review and coding agent.

Ref:
[configure-custom-instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#creating-path-specific-custom-instructions-2)