### PR TITLE
DEMONSTRATIVE: demo inject hook for foreign key violation

### DIFF
--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -775,7 +775,7 @@ func (st *State) deleteForeignKeyUnitReferences(ctx context.Context, tx *sqlair.
 		"DELETE FROM unit_agent_status WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_workload_status WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_workload_version WHERE unit_uuid = $entityUUID.uuid",
-		"DELETE FROM unit_principal WHERE unit_uuid = $entityUUID.uuid",
+		// "DELETE FROM unit_principal WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_resolved WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM unit_resource WHERE unit_uuid = $entityUUID.uuid",
 		"DELETE FROM k8s_pod_status WHERE unit_uuid = $entityUUID.uuid",

--- a/domain/removal/state/model/unit_test.go
+++ b/domain/removal/state/model/unit_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/instance"
@@ -19,6 +20,7 @@ import (
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/life"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
+	databasetesting "github.com/juju/juju/internal/database/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -624,6 +626,10 @@ func (s *unitSuite) TestDeleteSubordinateUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	s.InjectPostTxnHook(func(ctx context.Context, tx *sqlair.TX) {
+		databasetesting.DumpForeignKeysForTableSqlair(c, st, tx, "unit")
+	})
 
 	err = st.DeleteUnit(c.Context(), subUnitUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)


### PR DESCRIPTION
Demo `InjectPostTxnHook` and `DumpForeignKeysForTableSqlair`

## QA Steps

Run `go test ./domain/removal/state/model/ -run TestUnitSuite/TestDeleteSubordinateUnit`

I see:
```
Table - unit_storage_directive:
---------------------------------------------------------------------------------
unit_uuid    charm_uuid    storage_name    storage_pool_uuid    size_mib    count    

---------------------------------------------------------------------------------

Table - storage_unit_owner:
----------------------------------
storage_instance_uuid    unit_uuid    

----------------------------------

Table - storage_attachment:
-----------------------------------------------------
uuid    storage_instance_uuid    unit_uuid    life_id    

-----------------------------------------------------

Table - secret_unit_owner:
-------------------------------
secret_id    unit_uuid    label    

-------------------------------

Table - secret_unit_consumer:
------------------------------------------------------------------------
secret_id    source_model_uuid    unit_uuid    label    current_revision    

------------------------------------------------------------------------

Table - annotation_unit:
--------------------
uuid    key    value    

--------------------

Table - unit_principal:
----------------------------------------------------------------------------
unit_uuid                               principal_uuid                          
0b677ef4-3de1-4a05-826a-98a32b36f9e0    4b1e0e53-3bdd-461e-8f00-32ba23347184    

----------------------------------------------------------------------------

Table - unit_workload_version:
-----------------------------------------------
unit_uuid                               version    
4b1e0e53-3bdd-461e-8f00-32ba23347184               

-----------------------------------------------

Table - unit_agent_version:
---------------------------------------
unit_uuid    version    architecture_id    

---------------------------------------

Table - unit_state:
----------------------------------------------------------
unit_uuid    uniter_state    storage_state    secret_state    

----------------------------------------------------------

Table - unit_state_charm:
-------------------------
unit_uuid    key    value    

-------------------------

Table - unit_state_relation:
-------------------------
unit_uuid    key    value    

-------------------------

Table - k8s_pod:
------------------------
unit_uuid    provider_id    

------------------------

Table - unit_agent_status:
----------------------------------------------------------------------------------------------------------------
unit_uuid                               status_id    message    data     updated_at                                 
4b1e0e53-3bdd-461e-8f00-32ba23347184    0                       <nil>    2025-12-02 11:39:01.442303864 +0000 UTC    

----------------------------------------------------------------------------------------------------------------

Table - unit_workload_status:
----------------------------------------------------------------------------------------------------------------------------
unit_uuid                               status_id    message                data     updated_at                                 
4b1e0e53-3bdd-461e-8f00-32ba23347184    3            waiting for machine    <nil>    2025-12-02 11:39:01.442303864 +0000 UTC    

----------------------------------------------------------------------------------------------------------------------------

Table - k8s_pod_status:
-------------------------------------------------------
unit_uuid    status_id    message    data    updated_at    

-------------------------------------------------------

Table - unit_agent_presence:
----------------------
unit_uuid    last_seen    

----------------------

Table - unit_resolved:
--------------------
unit_uuid    mode_id    

--------------------

Table - port_range:
-------------------------------------------------------------------------
uuid    protocol_id    from_port    to_port    relation_uuid    unit_uuid    

-------------------------------------------------------------------------

Table - unit_resource:
--------------------------------------
resource_uuid    unit_uuid    added_at    

--------------------------------------

Table - relation_unit:
-------------------------------------------
uuid    relation_endpoint_uuid    unit_uuid    

-------------------------------------------

Table - operation_unit_task:
----------------------
task_uuid    unit_uuid    

----------------------

--- FAIL: TestUnitSuite (0.18s)
    --- FAIL: TestUnitSuite/TestDeleteSubordinateUnit (0.18s)
        /home/jack/juju/juju/domain/removal/state/model/unit_test.go:607
        unit.go:1430: DEBUG: placing unit with args: machine.PlaceMachineArgs{Constraints:constraints.Constraints{Arch:(*string)(nil), Container:(*instance.ContainerType)(nil), CpuCores:(*uint64)(nil), CpuPower:(*uint64)(nil), Mem:(*uint64)(nil), RootDisk:(*uint64)(nil), RootDiskSource:(*string)(nil), Tags:(*[]string)(nil), InstanceRole:(*string)(nil), InstanceType:(*string)(nil), Spaces:(*[]constraints.SpaceConstraint)(nil), VirtType:(*string)(nil), Zones:(*[]string)(nil), AllocatePublicIP:(*bool)(nil), ImageID:(*string)(nil)}, Directive:deployment.Placement{Type:0, Container:0, Directive:""}, Platform:deployment.Platform{Channel:"24.04", OSType:0, Architecture:0}, MachineUUID:"caeb5e39-91c9-4d63-88f4-1a4294bab0ca", NetNodeUUID:"702ae113-d385-4fcd-81c5-270ae4fab1d6", Nonce:(*string)(nil), HardwareCharacteristics:instance.HardwareCharacteristics{Arch:(*string)(nil), Mem:(*uint64)(nil), RootDisk:(*uint64)(nil), RootDiskSource:(*string)(nil), CpuCores:(*uint64)(nil), CpuPower:(*uint64)(nil), Tags:(*[]string)(nil), AvailabilityZone:(*string)(nil), VirtType:(*string)(nil)}}
        provider.go:143: INFO: created application "foo" with ID "c8d6a93e-189e-4abd-8531-2c397eb91836"
        logger.go:48: INFO: status-history status-history (status: "pending", status-message: "")
        logger.go:48: INFO: status-history status-history (status: "pending", status-message: "")
        unit.go:1430: DEBUG: placing unit with args: machine.PlaceMachineArgs{Constraints:constraints.Constraints{Arch:(*string)(nil), Container:(*instance.ContainerType)(nil), CpuCores:(*uint64)(nil), CpuPower:(*uint64)(nil), Mem:(*uint64)(nil), RootDisk:(*uint64)(nil), RootDiskSource:(*string)(nil), Tags:(*[]string)(nil), InstanceRole:(*string)(nil), InstanceType:(*string)(nil), Spaces:(*[]constraints.SpaceConstraint)(nil), VirtType:(*string)(nil), Zones:(*[]string)(nil), AllocatePublicIP:(*bool)(nil), ImageID:(*string)(nil)}, Directive:deployment.Placement{Type:0, Container:0, Directive:""}, Platform:deployment.Platform{Channel:"24.04", OSType:0, Architecture:0}, MachineUUID:"c1ab437b-afd2-4121-8366-42b0f10d933e", NetNodeUUID:"83802690-076c-4704-889a-460d4707c335", Nonce:(*string)(nil), HardwareCharacteristics:instance.HardwareCharacteristics{Arch:(*string)(nil), Mem:(*uint64)(nil), RootDisk:(*uint64)(nil), RootDiskSource:(*string)(nil), CpuCores:(*uint64)(nil), CpuPower:(*uint64)(nil), Tags:(*[]string)(nil), AvailabilityZone:(*string)(nil), VirtType:(*string)(nil)}}
        provider.go:143: INFO: created application "baz" with ID "b54a22ec-18eb-4dc9-83ea-b62bd266ed01"
        logger.go:48: INFO: status-history status-history (status: "pending", status-message: "")
        logger.go:48: INFO: status-history status-history (status: "pending", status-message: "")
        transaction.go:319: ERROR juju.database constraint error deleting unit for unit "0b677ef4-3de1-4a05-826a-98a32b36f9e0": FOREIGN KEY constraint failed - running queries:
         
        unit_test.go:635: 
                c.Assert(err, tc.ErrorIsNil)
            ... value errors.link = errors.link{error:errors.frameTracer{error:(*fmt.wrapError)(0xc0002b6720), pc:0x19b3465}} ("delete unit transaction: deleting unit for unit \"0b677ef4-3de1-4a05-826a-98a32b36f9e0\": FOREIGN KEY constraint failed")
FAIL
FAIL	github.com/juju/juju/domain/removal/state/model	0.192s
FAIL
```

Observe the error message contains `deleting unit for unit \"0b677ef4-3de1-4a05-826a-98a32b36f9e0\": FOREIGN KEY constraint failed"`

Searching for `0b677ef4-3de1-4a05-826a-98a32b36f9e0` reveals
```
Table - unit_principal:
----------------------------------------------------------------------------
unit_uuid                               principal_uuid                          
0b677ef4-3de1-4a05-826a-98a32b36f9e0    4b1e0e53-3bdd-461e-8f00-32ba23347184    

----------------------------------------------------------------------------
```
Meaning I have successfully identified which table & entry is causing the constraint violation error