### PR TITLE
feat: update go version to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.25.4
+go 1.25.5
 
 require (
 	cloud.google.com/go/compute v1.44.0


### PR DESCRIPTION
Updates go version in Juju to 1.25.5 to address [GO-2025-4155](https://pkg.go.dev/vuln/GO-2025-4155).