### PR TITLE
chore: merge 2.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.25.4
+go 1.25.5
 
 require (
 	cloud.google.com/go/compute v1.44.0


### PR DESCRIPTION
No op merge of 2.9 into 3.6 to enable seamless subsequent merge forwards. All commits are discarded as they are already in 3.6.

Includes update to go 1.25.5 for go vuln 4155.