### PR TITLE
chore: upgrade golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.25.4
+go 1.25.5
 
 require (
 	cloud.google.com/go/compute v1.44.0


### PR DESCRIPTION
This patch upgrades `golang` to 1.25.5 to fix the go vuln check: https://pkg.go.dev/vuln/GO-2025-4155.
