### PR TITLE
feat(import): all statuses

### DIFF
--- a/domain/status/modelmigration/import_test.go
+++ b/domain/status/modelmigration/import_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
+	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	corestatus "github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
@@ -34,6 +35,84 @@ func (s *importSuite) TestImportBlank(c *tc.C) {
 	defer s.setUpMocks(c).Finish()
 
 	model := description.NewModel(description.ModelArgs{})
+
+	importOp := importOperation{
+		serviceGetter: func(u coremodel.UUID) ImportService {
+			return s.importService
+		},
+		clock: clock.WallClock,
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportMachineStatus(c *tc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	now := time.Now().UTC()
+
+	model := description.NewModel(description.ModelArgs{})
+	m0 := model.AddMachine(description.MachineArgs{
+		Id: "0",
+	})
+	m0.SetInstance(description.CloudInstanceArgs{})
+
+	m0.SetStatus(description.StatusArgs{
+		Value:   "running",
+		Message: "machine is running",
+		Data:    map[string]any{"baz": "qux"},
+		Updated: now,
+	})
+	m0.Instance().SetStatus(description.StatusArgs{
+		Value:   "active",
+		Message: "instance is active",
+		Data:    map[string]any{"biz": "qax"},
+		Updated: now,
+	})
+
+	m1 := model.AddMachine(description.MachineArgs{
+		Id: "1",
+	})
+	m1.SetInstance(description.CloudInstanceArgs{})
+
+	m1.SetStatus(description.StatusArgs{
+		Value:   "stopped",
+		Message: "machine is stopped",
+		Data:    map[string]any{"buz": "qix"},
+		Updated: now,
+	})
+	m1.Instance().SetStatus(description.StatusArgs{
+		Value:   "error",
+		Message: "instance is error",
+		Data:    map[string]any{"boz": "qox"},
+		Updated: now,
+	})
+
+	s.importService.EXPECT().SetMachineStatus(gomock.Any(), coremachine.Name("0"), corestatus.StatusInfo{
+		Status:  corestatus.Running,
+		Message: "machine is running",
+		Data:    map[string]any{"baz": "qux"},
+		Since:   ptr(now),
+	})
+	s.importService.EXPECT().SetInstanceStatus(gomock.Any(), coremachine.Name("0"), corestatus.StatusInfo{
+		Status:  corestatus.Status("active"),
+		Message: "instance is active",
+		Data:    map[string]any{"biz": "qax"},
+		Since:   ptr(now),
+	})
+	s.importService.EXPECT().SetMachineStatus(gomock.Any(), coremachine.Name("1"), corestatus.StatusInfo{
+		Status:  corestatus.Stopped,
+		Message: "machine is stopped",
+		Data:    map[string]any{"buz": "qix"},
+		Since:   ptr(now),
+	})
+	s.importService.EXPECT().SetInstanceStatus(gomock.Any(), coremachine.Name("1"), corestatus.StatusInfo{
+		Status:  corestatus.Error,
+		Message: "instance is error",
+		Data:    map[string]any{"boz": "qox"},
+		Since:   ptr(now),
+	})
 
 	importOp := importOperation{
 		serviceGetter: func(u coremodel.UUID) ImportService {
@@ -206,6 +285,156 @@ func (s *importSuite) TestImportRelationStatus(c *tc.C) {
 			return s.importService
 		},
 		clock: clock,
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportRemoteApplicationOffererStatus(c *tc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	now := time.Now().UTC()
+
+	model := description.NewModel(description.ModelArgs{})
+	remoteApp1 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name: "remote-app",
+	})
+	remoteApp1.SetStatus(description.StatusArgs{
+		Value:   "active",
+		Message: "bar",
+		Data:    map[string]any{"baz": "qux"},
+		Updated: now,
+	})
+
+	remoteApp2 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name: "remote-app-2",
+	})
+	remoteApp2.SetStatus(description.StatusArgs{
+		Value:   "blocked",
+		Message: "bar2",
+		Data:    map[string]any{"baz2": "qux2"},
+		Updated: now,
+	})
+
+	s.importService.EXPECT().SetRemoteApplicationOffererStatus(gomock.Any(), "remote-app", corestatus.StatusInfo{
+		Status:  corestatus.Active,
+		Message: "bar",
+		Data:    map[string]any{"baz": "qux"},
+		Since:   ptr(now),
+	})
+	s.importService.EXPECT().SetRemoteApplicationOffererStatus(gomock.Any(), "remote-app-2", corestatus.StatusInfo{
+		Status:  corestatus.Blocked,
+		Message: "bar2",
+		Data:    map[string]any{"baz2": "qux2"},
+		Since:   ptr(now),
+	})
+
+	importOp := importOperation{
+		serviceGetter: func(u coremodel.UUID) ImportService {
+			return s.importService
+		},
+		clock: clock.WallClock,
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportFilesystemStatus(c *tc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	now := time.Now().UTC()
+
+	model := description.NewModel(description.ModelArgs{})
+	fs1 := model.AddFilesystem(description.FilesystemArgs{
+		ID: "fs-1",
+	})
+	fs1.SetStatus(description.StatusArgs{
+		Value:   "active",
+		Message: "active is available",
+		Data:    map[string]any{"baz": "qux"},
+		Updated: now,
+	})
+
+	fs2 := model.AddFilesystem(description.FilesystemArgs{
+		ID: "fs-2",
+	})
+	fs2.SetStatus(description.StatusArgs{
+		Value:   "error",
+		Message: "error occurred",
+		Data:    map[string]any{"baz2": "qux2"},
+		Updated: now,
+	})
+
+	s.importService.EXPECT().SetFilesystemStatus(gomock.Any(), "fs-1", corestatus.StatusInfo{
+		Status:  corestatus.Active,
+		Message: "active is available",
+		Data:    map[string]any{"baz": "qux"},
+		Since:   ptr(now),
+	})
+	s.importService.EXPECT().SetFilesystemStatus(gomock.Any(), "fs-2", corestatus.StatusInfo{
+		Status:  corestatus.Error,
+		Message: "error occurred",
+		Data:    map[string]any{"baz2": "qux2"},
+		Since:   ptr(now),
+	})
+
+	importOp := importOperation{
+		serviceGetter: func(u coremodel.UUID) ImportService {
+			return s.importService
+		},
+		clock: clock.WallClock,
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportVolumeStatus(c *tc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	now := time.Now().UTC()
+
+	model := description.NewModel(description.ModelArgs{})
+	vol1 := model.AddVolume(description.VolumeArgs{
+		ID: "vol-1",
+	})
+	vol1.SetStatus(description.StatusArgs{
+		Value:   "active",
+		Message: "volume is active",
+		Data:    map[string]any{"baz": "qux"},
+		Updated: now,
+	})
+
+	vol2 := model.AddVolume(description.VolumeArgs{
+		ID: "vol-2",
+	})
+	vol2.SetStatus(description.StatusArgs{
+		Value:   "pending",
+		Message: "volume is pending",
+		Data:    map[string]any{"baz2": "qux2"},
+		Updated: now,
+	})
+
+	s.importService.EXPECT().SetVolumeStatus(gomock.Any(), "vol-1", corestatus.StatusInfo{
+		Status:  corestatus.Active,
+		Message: "volume is active",
+		Data:    map[string]any{"baz": "qux"},
+		Since:   ptr(now),
+	})
+	s.importService.EXPECT().SetVolumeStatus(gomock.Any(), "vol-2", corestatus.StatusInfo{
+		Status:  corestatus.Pending,
+		Message: "volume is pending",
+		Data:    map[string]any{"baz2": "qux2"},
+		Since:   ptr(now),
+	})
+
+	importOp := importOperation{
+		serviceGetter: func(u coremodel.UUID) ImportService {
+			return s.importService
+		},
+		clock: clock.WallClock,
 	}
 
 	err := importOp.Execute(c.Context(), model)

--- a/domain/status/modelmigration/migrations_mock_test.go
+++ b/domain/status/modelmigration/migrations_mock_test.go
@@ -118,6 +118,158 @@ func (c *MockImportServiceSetApplicationStatusCall) DoAndReturn(f func(context.C
 	return c
 }
 
+// SetFilesystemStatus mocks base method.
+func (m *MockImportService) SetFilesystemStatus(arg0 context.Context, arg1 string, arg2 status.StatusInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetFilesystemStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetFilesystemStatus indicates an expected call of SetFilesystemStatus.
+func (mr *MockImportServiceMockRecorder) SetFilesystemStatus(arg0, arg1, arg2 any) *MockImportServiceSetFilesystemStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFilesystemStatus", reflect.TypeOf((*MockImportService)(nil).SetFilesystemStatus), arg0, arg1, arg2)
+	return &MockImportServiceSetFilesystemStatusCall{Call: call}
+}
+
+// MockImportServiceSetFilesystemStatusCall wrap *gomock.Call
+type MockImportServiceSetFilesystemStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceSetFilesystemStatusCall) Return(arg0 error) *MockImportServiceSetFilesystemStatusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceSetFilesystemStatusCall) Do(f func(context.Context, string, status.StatusInfo) error) *MockImportServiceSetFilesystemStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceSetFilesystemStatusCall) DoAndReturn(f func(context.Context, string, status.StatusInfo) error) *MockImportServiceSetFilesystemStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetInstanceStatus mocks base method.
+func (m *MockImportService) SetInstanceStatus(arg0 context.Context, arg1 machine.Name, arg2 status.StatusInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetInstanceStatus indicates an expected call of SetInstanceStatus.
+func (mr *MockImportServiceMockRecorder) SetInstanceStatus(arg0, arg1, arg2 any) *MockImportServiceSetInstanceStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockImportService)(nil).SetInstanceStatus), arg0, arg1, arg2)
+	return &MockImportServiceSetInstanceStatusCall{Call: call}
+}
+
+// MockImportServiceSetInstanceStatusCall wrap *gomock.Call
+type MockImportServiceSetInstanceStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceSetInstanceStatusCall) Return(arg0 error) *MockImportServiceSetInstanceStatusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceSetInstanceStatusCall) Do(f func(context.Context, machine.Name, status.StatusInfo) error) *MockImportServiceSetInstanceStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceSetInstanceStatusCall) DoAndReturn(f func(context.Context, machine.Name, status.StatusInfo) error) *MockImportServiceSetInstanceStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetMachineStatus mocks base method.
+func (m *MockImportService) SetMachineStatus(arg0 context.Context, arg1 machine.Name, arg2 status.StatusInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMachineStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMachineStatus indicates an expected call of SetMachineStatus.
+func (mr *MockImportServiceMockRecorder) SetMachineStatus(arg0, arg1, arg2 any) *MockImportServiceSetMachineStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMachineStatus", reflect.TypeOf((*MockImportService)(nil).SetMachineStatus), arg0, arg1, arg2)
+	return &MockImportServiceSetMachineStatusCall{Call: call}
+}
+
+// MockImportServiceSetMachineStatusCall wrap *gomock.Call
+type MockImportServiceSetMachineStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceSetMachineStatusCall) Return(arg0 error) *MockImportServiceSetMachineStatusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceSetMachineStatusCall) Do(f func(context.Context, machine.Name, status.StatusInfo) error) *MockImportServiceSetMachineStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceSetMachineStatusCall) DoAndReturn(f func(context.Context, machine.Name, status.StatusInfo) error) *MockImportServiceSetMachineStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetRemoteApplicationOffererStatus mocks base method.
+func (m *MockImportService) SetRemoteApplicationOffererStatus(arg0 context.Context, arg1 string, arg2 status.StatusInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRemoteApplicationOffererStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRemoteApplicationOffererStatus indicates an expected call of SetRemoteApplicationOffererStatus.
+func (mr *MockImportServiceMockRecorder) SetRemoteApplicationOffererStatus(arg0, arg1, arg2 any) *MockImportServiceSetRemoteApplicationOffererStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteApplicationOffererStatus", reflect.TypeOf((*MockImportService)(nil).SetRemoteApplicationOffererStatus), arg0, arg1, arg2)
+	return &MockImportServiceSetRemoteApplicationOffererStatusCall{Call: call}
+}
+
+// MockImportServiceSetRemoteApplicationOffererStatusCall wrap *gomock.Call
+type MockImportServiceSetRemoteApplicationOffererStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceSetRemoteApplicationOffererStatusCall) Return(arg0 error) *MockImportServiceSetRemoteApplicationOffererStatusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceSetRemoteApplicationOffererStatusCall) Do(f func(context.Context, string, status.StatusInfo) error) *MockImportServiceSetRemoteApplicationOffererStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceSetRemoteApplicationOffererStatusCall) DoAndReturn(f func(context.Context, string, status.StatusInfo) error) *MockImportServiceSetRemoteApplicationOffererStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetUnitAgentStatus mocks base method.
 func (m *MockImportService) SetUnitAgentStatus(arg0 context.Context, arg1 unit.Name, arg2 status.StatusInfo) error {
 	m.ctrl.T.Helper()
@@ -190,6 +342,44 @@ func (c *MockImportServiceSetUnitWorkloadStatusCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockImportServiceSetUnitWorkloadStatusCall) DoAndReturn(f func(context.Context, unit.Name, status.StatusInfo) error) *MockImportServiceSetUnitWorkloadStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetVolumeStatus mocks base method.
+func (m *MockImportService) SetVolumeStatus(arg0 context.Context, arg1 string, arg2 status.StatusInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetVolumeStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetVolumeStatus indicates an expected call of SetVolumeStatus.
+func (mr *MockImportServiceMockRecorder) SetVolumeStatus(arg0, arg1, arg2 any) *MockImportServiceSetVolumeStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVolumeStatus", reflect.TypeOf((*MockImportService)(nil).SetVolumeStatus), arg0, arg1, arg2)
+	return &MockImportServiceSetVolumeStatusCall{Call: call}
+}
+
+// MockImportServiceSetVolumeStatusCall wrap *gomock.Call
+type MockImportServiceSetVolumeStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceSetVolumeStatusCall) Return(arg0 error) *MockImportServiceSetVolumeStatusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceSetVolumeStatusCall) Do(f func(context.Context, string, status.StatusInfo) error) *MockImportServiceSetVolumeStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceSetVolumeStatusCall) DoAndReturn(f func(context.Context, string, status.StatusInfo) error) *MockImportServiceSetVolumeStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
Wire up importing statuses of all entities into the
status/modelmigration domain

We needed to add:
- machines / instances
- remote applications (i.e. SAAS)
- volumes
- file-systems

## QA steps

All we can do atm is ensure unit tests pass