### PR TITLE
docs: adjust the documentation for SSH keys to align with Juju 4.0

### DIFF
--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -57,6 +57,7 @@ can be used to disable these checks. Use of this option is not recommended as
 it opens up the possibility of a man-in-the-middle attack.
 
 The default identity known to Juju and used by this command is ` + "`~/.ssh/id_ed25519`" + `.
+For models on a machine cloud, an appropriate SSH key must be added to the model first.
 
 Options can be passed to the local OpenSSH client (ssh) on platforms
 where it is available. This is done by inserting them between the target and

--- a/docs/howto/manage-machines.md
+++ b/docs/howto/manage-machines.md
@@ -288,7 +288,7 @@ There are two ways you can connect to a Juju machine: via `juju ssh` or via a st
 First, make sure you have `admin` access to the model and your public SSH key has been added to the model.
 
 ```{important}
-If you are the model creator, your public SSH key is already known to `juju` and you already have `admin` access for the model. If you are not the model creator, see {ref}`manage-users` and {ref}`user-access-levels` for how to gain `admin` access to a model and {ref}`manage-ssh-keys` for how to add your SSH key to the model.
+If you are the model creator, you already have `admin` access for the model. If you are not the model creator, see {ref}`manage-users` and {ref}`user-access-levels` for how to gain `admin` access to a model and {ref}`manage-ssh-keys` for how to add your SSH key to the model.
 ```
 
 <!--
@@ -337,7 +337,7 @@ juju ssh 0 -i ~/.ssh/my-private-key
 First, make sure you've added a public SSH key for your user to the target model.
 
 ```{important}
-If you are the model creator, your public SSH key is already known to `juju` and you already have `admin` access for the model. If you are not the model creator, see {ref}`manage-users` and {ref}`user-access-levels` for how to gain `admin` access to a model and {ref}`manage-ssh-keys` for how to add your SSH key to the model.
+If you are the model creator, you already have `admin` access for the model. If you are not the model creator, see {ref}`manage-users` and {ref}`user-access-levels` for how to gain `admin` access to a model and {ref}`manage-ssh-keys` for how to add your SSH key to the model.
 ```
 
 Alternatively, for direct access using a standard SSH client, it is also possible to add the key to an individual machine using standard methods (manually copying a key to the `authorized_keys` file or by way of a command such as `ssh-import-id` in the case of Ubuntu).

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
@@ -107,6 +107,7 @@ can be used to disable these checks. Use of this option is not recommended as
 it opens up the possibility of a man-in-the-middle attack.
 
 The default identity known to Juju and used by this command is `~/.ssh/id_ed25519`.
+For machine charms, an appropriate SSH key must be added to the model first.
 
 Options can be passed to the local OpenSSH client (ssh) on platforms
 where it is available. This is done by inserting them between the target and

--- a/docs/reference/ssh-key.md
+++ b/docs/reference/ssh-key.md
@@ -21,7 +21,7 @@ This means that a model creator will always be able to connect to any machine wi
 
 An **SSH key** is an access  key in the [SSH](https://www.ssh.com/academy/ssh-keys) protocol. In Juju it refers to a way of accessing a machine provisioned by Juju individually.
 
-Juju maintains a per-model cache of public SSH keys which it copies to each unit (including units already deployed). By default this includes the key of the user who created the model (assuming it is stored in the default location ~/.ssh/). You can also add further keys via `juju add-ssh-key` or `juju import-ssh-key`. Any key added to the model is placed on all machines (present and future) in the model.
+Juju maintains a per-model cache of public SSH keys which it copies to each machine (including machines already deployed). You can add keys via `juju add-ssh-key` or `juju import-ssh-key`. Any key added to the model is placed on all machines (present and future) in the model.
 
 Each Juju machine provides a user account named 'ubuntu' and it is to this account that public keys are added when using the Juju SSH commands `add-ssh-key` and `import-ssh-key`. Because this user is effectively the 'root' user (passwordless sudo privileges), the granting of SSH access must be done with due consideration.
 


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

Juju does not automatically add SSH keys for machine models like Juju 3 does. This PR updates the documentation to reflect that. (It is already in the [release notes](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/).)

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Build and read the docs.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

Covered above.

## Links

N/A