### PR TITLE
fix: ddlgen script for versions with tags

### DIFF
--- a/generate/ddlgen/main.go
+++ b/generate/ddlgen/main.go
@@ -18,7 +18,9 @@ import (
 
 func main() {
 	current := version.Current
-	if current.Patch == 0 {
+
+	// Don't generate any ddls for betas, rcs, or if there are no previous patches.
+	if current.Tag != "" || current.Patch == 0 {
 		return
 	}
 


### PR DESCRIPTION
Fix ddlgen script for versions with tags. It turns out `4.1-beta1` has a `Patch` value of 1

## QA steps

- Try `go run ./generate/ddlgen/main.go` and observe no changes are made/

- Amend `core/version/version.go` so that `const version = "4.1-beta2" and run the same check