### PR TITLE
fix: relation incompatible bases issue

### DIFF
--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -235,11 +235,11 @@ func (s *RelationSuite) TestAddContainerRelationSeriesMustMatch(c *gc.C) {
 	loggingEP, err := logging.Endpoint("info")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddRelation(wordpressEP, loggingEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": principal and subordinate applications' bases must match`)
+	c.Assert(err, gc.ErrorMatches, `.*subordinate must support principal application's base.*`)
 }
 
 func (s *RelationSuite) TestAddContainerRelationMultiSeriesMatch(c *gc.C) {
-	principal := s.AddTestingApplication(c, "multi-series", s.AddSeriesCharm(c, "multi-series", "quantal"))
+	principal := s.AddTestingApplication(c, "multi-series", s.AddSeriesCharm(c, "multi-series", "bionic"))
 	principalEP, err := principal.Endpoint("multi-directory")
 	c.Assert(err, jc.ErrorIsNil)
 	subord := s.AddTestingApplication(c, "multi-series-subordinate", s.AddSeriesCharm(c, "multi-series-subordinate", "bionic"))
@@ -275,7 +275,7 @@ requires:
 
 	_, err = s.State.AddRelation(principalEP, subordEP)
 	principalEP.Scope = charm.ScopeContainer
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "multi-series-subordinate:multi-directory multi-series:multi-directory": principal and subordinate applications' bases must match`)
+	c.Assert(err, gc.ErrorMatches, `.*subordinate must support principal application's base.*`)
 }
 
 func (s *RelationSuite) TestAddContainerRelationWithNoSubordinate(c *gc.C) {

--- a/testcharms/charm-repo/quantal/multi-series-subordinate/metadata.yaml
+++ b/testcharms/charm-repo/quantal/multi-series-subordinate/metadata.yaml
@@ -8,6 +8,7 @@ series:
   - jammy
   - focal
   - bionic
+  - precise
 provides:
     multi-client:
        interface: logging

--- a/testcharms/charm-repo/quantal/wordpress-noble/manifest.yaml
+++ b/testcharms/charm-repo/quantal/wordpress-noble/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+- architectures:
+  - amd64
+  channel: '24.04'
+  name: ubuntu

--- a/testcharms/charm-repo/quantal/wordpress-noble/metadata.yaml
+++ b/testcharms/charm-repo/quantal/wordpress-noble/metadata.yaml
@@ -1,0 +1,9 @@
+name: wordpress-noble
+summary: A WordPress principal charm supporting 24.04
+description: A test principal charm that supports only 24.04
+provides:
+  website:
+    interface: http
+requires:
+  db:
+    interface: mysql


### PR DESCRIPTION
## Problem summary
When relating a subordinate charm to a principal charm, Juju was not validating correctly whether the subordinate charm supports the base (OS version) that the principal charm is deployed on. This could lead to subordinate units being deployed on incompatible bases, potentially causing runtime failures. 

More specifically, the existing validation in a principal-subordinate relationship passes as long as both the charms share a common base.

## Design Consideration
The validation checks if the subordinate charm supports only the principal's currently deployed base, rather than requiring the subordinate to support all bases declared in the principal charm's manifest to allow for greater flexibility in charm compatibility, even though users could potentially run set-application-base later, but that should be the responsibility of the user to understand what could be potentially affected. Perhaps this could be reflected in the docs.

## QA steps

1. Bootstrap a controller
```sh
juju bootstrap lxd lxdtest && juju add-model
```

2. Deploy the following applications and relate them

_Juju relate passes even with incompatible bases_
```sh
juju deploy kubernetes-worker —base ubuntu@22.04
juju deploy grafana-agent (base 24.04)
juju relate kubernetes-worker grafana-agent
```

_Juju relate fails due to incompatible bases_
```sh
juju deploy infra-node
juju deploy logrotated
juju relate infra-node logrotated
```


## Expected result with current change

_Juju relate fails due to incompatible bases_
```sh
juju deploy kubernetes-worker —base ubuntu@22.04
juju deploy grafana-agent (base 24.04)
juju relate kubernetes-worker grafana-agent
```

_This should still work since subordinate supports principal deployed base even though subordinate deployed base is different_
```sh
juju deploy cinder-backup --base ubuntu@20.04 (supports 20.04 and 22.04)
juju deploy kubernetes-worker --base ubuntu@22.04
juju relate kubernetes-worker cinder-backup
```

## Links

**Issue:**: https://github.com/juju/juju/issues/20354
**Jira card:** [JUJU-8378](https://warthogs.atlassian.net/browse/JUJU-8378)


[JUJU-8378]: https://warthogs.atlassian.net/browse/JUJU-8378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ