### PR TITLE
feat(charm): support 'integer' as synonym for 'int' in config.yaml

### DIFF
--- a/internal/charm/config.go
+++ b/internal/charm/config.go
@@ -87,6 +87,7 @@ func (option Option) validate(name string, value interface{}) (_ interface{}, er
 var optionTypeCheckers = map[string]schema.Checker{
 	"string":  schema.String(),
 	"int":     schema.Int(),
+	"integer": schema.Int(),
 	"float":   schema.Float(),
 	"boolean": schema.Bool(),
 	"secret":  secretC{},
@@ -96,7 +97,7 @@ func (option Option) parse(name, str string) (val interface{}, err error) {
 	switch option.Type {
 	case "string", "secret":
 		return str, nil
-	case "int":
+	case "int", "integer":
 		val, err = strconv.ParseInt(str, 10, 64)
 	case "float":
 		val, err = strconv.ParseFloat(str, 64)
@@ -149,6 +150,9 @@ func ReadConfig(r io.Reader) (*ConfigSpec, error) {
 		}
 	}
 	for name, option := range config.Options {
+		if option.Type == "integer" {
+			option.Type = "int"
+		}
 		switch option.Type {
 		case "string", "secret", "int", "float", "boolean":
 		case "":

--- a/internal/charm/config_test.go
+++ b/internal/charm/config_test.go
@@ -444,6 +444,7 @@ func (s *ConfigSuite) TestDefaultType(c *tc.C) {
 	assertDefault("string", `""`, "")
 	assertDefault("float", "2.211", 2.211)
 	assertDefault("int", "99", int64(99))
+	assertDefault("integer", "99", int64(99))
 
 	assertTypeError := func(type_, str, value string) {
 		config := fmt.Sprintf(`options: {t: {type: %s, default: %s}}`, type_, str)


### PR DESCRIPTION
Description:

This PR adds support for using type: integer in config.yaml as a valid synonym for type: int.

integer is a commonly used type name in many configuration formats and languages. Allowing it as an alias for int improves the developer experience by reducing friction for charm authors who might intuitively use integer.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

go test -v github.com/juju/juju/internal/charm


## Documentation changes

This change allows integer to be used interchangeably with int in charm config.yaml files. No CLI or API workflow changes are required for end users

## Links

**Issue:** Fixes #19979.

