### PR TITLE
revert: target controller addition to add-model args

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -211,10 +211,6 @@ func (m *ModelManagerAPIV9) CreateModel(args params.ModelCreateArgs) (params.Mod
 func (m *ModelManagerAPI) createModel(args params.ModelCreateArgs, withDefaultOS bool) (params.ModelInfo, error) {
 	result := params.ModelInfo{}
 
-	if args.TargetController != "" {
-		return result, errors.NewNotSupported(nil, "target-controller parameter is only supported on JAAS")
-	}
-
 	// Get the controller model first. We need it both for the state
 	// server owner and the ability to get the config.
 	controllerModel, err := m.ctlrState.Model()

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -393,19 +393,6 @@ func (s *modelManagerSuite) TestModelInfoWithReadAccess(c *gc.C) {
 	c.Assert(modelInfoReader.Results[0].Result, jc.DeepEquals, &expectedModelInfo)
 }
 
-func (s *modelManagerSuite) TestCreateModelWithTargetControllerSet(c *gc.C) {
-	args := params.ModelCreateArgs{
-		Name:               "foo",
-		OwnerTag:           "user-admin",
-		CloudTag:           "cloud-some-cloud",
-		CloudRegion:        "qux",
-		CloudCredentialTag: "cloudcred-some-cloud_admin_some-credential",
-		TargetController:   "some-controller",
-	}
-	_, err := s.api.CreateModel(args)
-	c.Assert(err, gc.ErrorMatches, `target-controller parameter is only supported on JAAS`)
-}
-
 func (s *modelManagerSuite) TestCreateModelArgsWithCloudNotFound(c *gc.C) {
 	s.st.SetErrors(errors.NotFoundf("cloud"))
 	args := params.ModelCreateArgs{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12407,9 +12407,6 @@
                         },
                         "region": {
                             "type": "string"
-                        },
-                        "target-controller": {
-                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
@@ -12605,9 +12602,6 @@
                             "items": {
                                 "$ref": "#/definitions/SupportedFeature"
                             }
-                        },
-                        "target-controller": {
-                            "type": "string"
                         },
                         "type": {
                             "type": "string"

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -144,10 +144,6 @@ type ModelCreateArgs struct {
 	// and the owner is the controller owner, the same credential
 	// used for the controller model will be used.
 	CloudCredentialTag string `json:"credential,omitempty"`
-
-	// TargetController is a JAAS specific field to specify the
-	// name of the controller that hosts the model.
-	TargetController string `json:"target-controller,omitempty"`
 }
 
 // Model holds the result of an API call returning a name and UUID

--- a/rpc/params/model.go
+++ b/rpc/params/model.go
@@ -192,10 +192,6 @@ type ModelInfo struct {
 	// entries (e.g. juju version) and other features that depend on the
 	// substrate the model is deployed to.
 	SupportedFeatures []SupportedFeature `json:"supported-features,omitempty"`
-
-	// TargetController is a JAAS specific field to specify the
-	// name of the controller that hosts the model.
-	TargetController string `json:"target-controller,omitempty"`
 }
 
 // SupportedFeature describes a feature that is supported by a particular model.


### PR DESCRIPTION
This reverts https://github.com/juju/juju/pull/21306. After some discussion about other resources where we may need to add the `target-controller` flag to support JAAS, we found a total of 3 - clouds, models, secret-backends. These are resources that are not model-scoped.

For clouds, JAAS already had its own `AddCloudToController` method that could be used through the JAAS cli. We've decided to revert the changes that introduce the `target-controller` field to Juju's RPC args and instead use JAAS specific facade methods in clients for adding models, clouds, secret-backends.

In a follow-up PR, I'll adjust the Juju CLI's `add-model` command to add a `--target-controller` flag much like `add-cloud`. Specifying the flag will have it fall through to calling the JAAS plugin which can make the JAAS-specific facade call.
