### PR TITLE
feat: remove application sequence on removal

### DIFF
--- a/domain/removal/state/model/types.go
+++ b/domain/removal/state/model/types.go
@@ -65,6 +65,10 @@ type count struct {
 	Count int `db:"count"`
 }
 
+type namespace struct {
+	Value string `db:"value"`
+}
+
 // unitMachineLifeSummary holds the counts of alive, not alive, and machine parent
 // entities associated with a unit identified by the UUID. It is used to
 // summarize the state of a unit in terms of its associated entities.
@@ -82,6 +86,14 @@ type unitMachineLifeSummary struct {
 
 // entityLife holds an entity's life in integer
 type entityLife struct {
+	Life int `db:"life_id"`
+}
+
+// entityNameLife holds an entity's name and life
+type entityNameLife struct {
+	// Name is the name of the entity.
+	Name string `db:"name"`
+	// Life is the life of the entity.
 	Life int `db:"life_id"`
 }
 


### PR DESCRIPTION
Application sequences are used to ensure that units are uniquely names (0, 1, 2, 3). Upon removal, the sequence is supposed to reset for a given application. Except that wasn't happening, this changeset amends that issue.

This also has the added advantage that we're not exporting sequences for removed applications.

## QA steps

```sh
$ juju boostrap lxd test
$ juju add-model default
$ juju deploy ubuntu
$ juju status
Model    Controller  Cloud/Region  Version  Timestamp
default  test        lxd/default   4.0.1.1  11:26:22Z

App     Version  Status   Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           waiting    0/1  ubuntu  latest/stable   26  no       waiting for machine

Unit      Workload  Agent       Machine  Public address  Ports  Message
ubuntu/0  waiting   allocating  0                               waiting for machine

Machine  State    Address  Inst id        Base          AZ          Message
0        pending           juju-ea1e1a-0  ubuntu@24.04  simon-work  Container started
$ juju remove-application ubuntu --no-prompt
$ juju deploy ubuntu
$ juju status
Model    Controller  Cloud/Region  Version  Timestamp
default  test        lxd/default   4.0.1.1  11:27:16Z

App     Version  Status   Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           waiting    0/1  ubuntu  latest/stable   26  no       waiting for machine

Unit       Workload  Agent       Machine  Public address  Ports  Message
ubuntu/0*  waiting   allocating  1                               waiting for machine

Machine  State    Address  Inst id        Base          AZ          Message
1        pending           juju-ea1e1a-1  ubuntu@24.04  simon-work  Container started
```

Notice that ubuntu is reset to 0, but the machine has incremented.

## Links

Fixes: https://github.com/juju/juju/issues/21422

