### PR TITLE
chore: remove unused firewaller facade method

### DIFF
--- a/api/controller/firewaller/firewaller.go
+++ b/api/controller/firewaller/firewaller.go
@@ -146,39 +146,6 @@ func (c *Client) Relation(ctx context.Context, tag names.RelationTag) (*Relation
 	}, nil
 }
 
-// WatchEgressAddressesForRelation returns a watcher that notifies when addresses,
-// from which connections will originate to the provider side of the relation, change.
-// Each event contains the entire set of addresses which the provider side is required
-// to allow for access from the other side of the relation.
-func (c *Client) WatchEgressAddressesForRelation(ctx context.Context, relationTag names.RelationTag) (watcher.StringsWatcher, error) {
-	args := params.Entities{Entities: []params.Entity{{Tag: relationTag.String()}}}
-	var results params.StringsWatchResults
-	err := c.facade.FacadeCall(ctx, "WatchEgressAddressesForRelations", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
-	return w, nil
-}
-
-// WatchIngressAddressesForRelation returns a watcher that notifies when addresses,
-// from which connections will originate for the relation, change.
-// Each event contains the entire set of addresses which are required
-// for ingress into this model from the other requirer side of the relation.
-func (c *Client) WatchIngressAddressesForRelation(ctx context.Context, relationTag names.RelationTag) (watcher.StringsWatcher, error) {
-	// todo(gfouillet): re-enable this watcher call whenever CMR will be fully
-	//   implemented in the new domain. The facade implementation return a
-	//   not implemented exception, so it is not necessary to try to fetch it.
-	return common.NewDisabledWatcher(), nil
-}
-
 // ControllerAPIInfoForModels returns the controller api connection details for the specified model.
 func (c *Client) ControllerAPIInfoForModel(ctx context.Context, modelUUID string) (*api.Info, error) {
 	modelTag := names.NewModelTag(modelUUID)

--- a/api/controller/firewaller/firewaller_test.go
+++ b/api/controller/firewaller/firewaller_test.go
@@ -94,57 +94,6 @@ func (s *firewallerSuite) TestWatchModelMachines(c *tc.C) {
 	c.Check(callCount, tc.Equals, 1)
 }
 
-func (s *firewallerSuite) TestWatchEgressAddressesForRelation(c *tc.C) {
-	var callCount int
-	relationTag := names.NewRelationTag("mediawiki:db mysql:db")
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, tc.Equals, "Firewaller")
-		c.Check(version, tc.Equals, 0)
-		c.Check(id, tc.Equals, "")
-		c.Check(request, tc.Equals, "WatchEgressAddressesForRelations")
-		c.Assert(arg, tc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: relationTag.String()}}})
-		c.Assert(result, tc.FitsTypeOf, &params.StringsWatchResults{})
-		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
-			Results: []params.StringsWatchResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		callCount++
-		return nil
-	})
-	client, err := firewaller.NewClient(apiCaller)
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = client.WatchEgressAddressesForRelation(c.Context(), relationTag)
-	c.Check(err, tc.ErrorMatches, "FAIL")
-	c.Check(callCount, tc.Equals, 1)
-}
-
-func (s *firewallerSuite) TestWatchIngressAddressesForRelation(c *tc.C) {
-	c.Skip("Re-enable this test whenever CMR will be fully implemented and the related watcher rewired.")
-	var callCount int
-	relationTag := names.NewRelationTag("mediawiki:db mysql:db")
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, tc.Equals, "Firewaller")
-		c.Check(version, tc.Equals, 0)
-		c.Check(id, tc.Equals, "")
-		c.Check(request, tc.Equals, "WatchIngressAddressesForRelations")
-		c.Assert(arg, tc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: relationTag.String()}}})
-		c.Assert(result, tc.FitsTypeOf, &params.StringsWatchResults{})
-		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
-			Results: []params.StringsWatchResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		callCount++
-		return nil
-	})
-	client, err := firewaller.NewClient(apiCaller)
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = client.WatchIngressAddressesForRelation(c.Context(), relationTag)
-	c.Check(err, tc.ErrorMatches, "FAIL")
-	c.Check(callCount, tc.Equals, 1)
-}
-
 func (s *firewallerSuite) TestControllerAPIInfoForModel(c *tc.C) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -234,19 +234,6 @@ func (f *FirewallerAPI) WatchModelFirewallRules(ctx context.Context) (params.Not
 	return params.NotifyWatchResult{NotifyWatcherId: watcherId}, nil
 }
 
-// WatchEgressAddressesForRelations creates a watcher that notifies when addresses, from which
-// connections will originate for the relation, change.
-// Each event contains the entire set of addresses which are required for ingress for the relation.
-func (f *FirewallerAPI) WatchEgressAddressesForRelations(ctx context.Context, relations params.Entities) (params.StringsWatchResults, error) {
-	return params.StringsWatchResults{}, nil
-}
-
-// WatchIngressAddressesForRelations creates a watcher that returns the ingress networks
-// that have been recorded against the specified relations.
-func (f *FirewallerAPI) WatchIngressAddressesForRelations(ctx context.Context, relations params.Entities) (params.StringsWatchResults, error) {
-	return params.StringsWatchResults{}, nil
-}
-
 // MacaroonForRelations returns the macaroon for the specified relations.
 func (f *FirewallerAPI) MacaroonForRelations(ctx context.Context, args params.Entities) (params.MacaroonResults, error) {
 	var result params.MacaroonResults


### PR DESCRIPTION
The WatchIngressAddressesForRelation domain method is now called directly from the controller only worker.

The facade version is not changing as this is a controller facade which cannot be used by different version of the juju agent. Future work change the facade calls to direct domain calls and remove is necessary.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

There should be no errors in the unit tests.

## Links

**Jira card:** [JUJU-7921](https://warthogs.atlassian.net/browse/JUJU-7921)


[JUJU-7921]: https://warthogs.atlassian.net/browse/JUJU-7921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ