### PR TITLE
refactor: move service types to domain package

### DIFF
--- a/apiserver/common/secrets/drain_test.go
+++ b/apiserver/common/secrets/drain_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/domain/secret"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	backendservice "github.com/juju/juju/domain/secretbackend/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -111,11 +112,11 @@ func (s *secretsDrainSuite) assertGetSecretsToDrain(c *tc.C, expectedRevions ...
 	}
 	s.secretService.EXPECT().ListCharmSecretsToDrain(
 		gomock.Any(),
-		[]secretservice.CharmSecretOwner{{
-			Kind: secretservice.UnitOwner,
+		[]secret.CharmSecretOwner{{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mariadb/0",
 		}, {
-			Kind: secretservice.ApplicationOwner,
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mariadb",
 		}}).Return([]*coresecrets.SecretMetadataForDrain{{
 		URI:       uri,
@@ -261,8 +262,8 @@ func (s *secretsDrainSuite) TestChangeSecretBackend(c *tc.C) {
 		gomock.Any(),
 		uri1, 666,
 		secretservice.ChangeSecretBackendParams{
-			Accessor: secretservice.SecretAccessor{
-				Kind: secretservice.UnitAccessor,
+			Accessor: secret.SecretAccessor{
+				Kind: secret.UnitAccessor,
 				ID:   s.authTag.Id(),
 			},
 			ValueRef: &coresecrets.ValueRef{
@@ -275,8 +276,8 @@ func (s *secretsDrainSuite) TestChangeSecretBackend(c *tc.C) {
 		gomock.Any(),
 		uri2, 888,
 		secretservice.ChangeSecretBackendParams{
-			Accessor: secretservice.SecretAccessor{
-				Kind: secretservice.UnitAccessor,
+			Accessor: secret.SecretAccessor{
+				Kind: secret.UnitAccessor,
 				ID:   s.authTag.Id(),
 			},
 			Data: map[string]string{"foo": "bar"},

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -16,6 +16,7 @@ import (
 	model "github.com/juju/juju/core/model"
 	secrets "github.com/juju/juju/core/secrets"
 	watcher "github.com/juju/juju/core/watcher"
+	secret "github.com/juju/juju/domain/secret"
 	service "github.com/juju/juju/domain/secret/service"
 	service0 "github.com/juju/juju/domain/secretbackend/service"
 	gomock "go.uber.org/mock/gomock"
@@ -83,7 +84,7 @@ func (c *MockSecretServiceChangeSecretBackendCall) DoAndReturn(f func(context.Co
 }
 
 // ListCharmSecretsToDrain mocks base method.
-func (m *MockSecretService) ListCharmSecretsToDrain(arg0 context.Context, arg1 ...service.CharmSecretOwner) ([]*secrets.SecretMetadataForDrain, error) {
+func (m *MockSecretService) ListCharmSecretsToDrain(arg0 context.Context, arg1 ...secret.CharmSecretOwner) ([]*secrets.SecretMetadataForDrain, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0}
 	for _, a := range arg1 {
@@ -115,13 +116,13 @@ func (c *MockSecretServiceListCharmSecretsToDrainCall) Return(arg0 []*secrets.Se
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceListCharmSecretsToDrainCall) Do(f func(context.Context, ...service.CharmSecretOwner) ([]*secrets.SecretMetadataForDrain, error)) *MockSecretServiceListCharmSecretsToDrainCall {
+func (c *MockSecretServiceListCharmSecretsToDrainCall) Do(f func(context.Context, ...secret.CharmSecretOwner) ([]*secrets.SecretMetadataForDrain, error)) *MockSecretServiceListCharmSecretsToDrainCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceListCharmSecretsToDrainCall) DoAndReturn(f func(context.Context, ...service.CharmSecretOwner) ([]*secrets.SecretMetadataForDrain, error)) *MockSecretServiceListCharmSecretsToDrainCall {
+func (c *MockSecretServiceListCharmSecretsToDrainCall) DoAndReturn(f func(context.Context, ...secret.CharmSecretOwner) ([]*secrets.SecretMetadataForDrain, error)) *MockSecretServiceListCharmSecretsToDrainCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/common/secrets/service.go
+++ b/apiserver/common/secrets/service.go
@@ -9,6 +9,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/secret"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	backendservice "github.com/juju/juju/domain/secretbackend/service"
 )
@@ -16,7 +17,7 @@ import (
 // SecretService instances provide secret service apis.
 type SecretService interface {
 	ListCharmSecretsToDrain(
-		ctx context.Context, owners ...secretservice.CharmSecretOwner,
+		ctx context.Context, owners ...secret.CharmSecretOwner,
 	) ([]*secrets.SecretMetadataForDrain, error)
 	ListUserSecretsToDrain(ctx context.Context) ([]*secrets.SecretMetadataForDrain, error)
 	ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params secretservice.ChangeSecretBackendParams) error

--- a/apiserver/facades/agent/secretsmanager/mocks/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secrets.go
@@ -18,6 +18,7 @@ import (
 	secrets "github.com/juju/juju/core/secrets"
 	unit "github.com/juju/juju/core/unit"
 	watcher "github.com/juju/juju/core/watcher"
+	secret "github.com/juju/juju/domain/secret"
 	service "github.com/juju/juju/domain/secret/service"
 	service0 "github.com/juju/juju/domain/secretbackend/service"
 	provider "github.com/juju/juju/internal/secrets/provider"
@@ -87,7 +88,7 @@ func (c *MockSecretTriggersSecretRotatedCall) DoAndReturn(f func(context.Context
 }
 
 // WatchDeletedSecrets mocks base method.
-func (m *MockSecretTriggers) WatchDeletedSecrets(ctx context.Context, owners ...service.CharmSecretOwner) (watcher.StringsWatcher, error) {
+func (m *MockSecretTriggers) WatchDeletedSecrets(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range owners {
@@ -119,19 +120,19 @@ func (c *MockSecretTriggersWatchDeletedSecretsCall) Return(arg0 watcher.StringsW
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretTriggersWatchDeletedSecretsCall) Do(f func(context.Context, ...service.CharmSecretOwner) (watcher.StringsWatcher, error)) *MockSecretTriggersWatchDeletedSecretsCall {
+func (c *MockSecretTriggersWatchDeletedSecretsCall) Do(f func(context.Context, ...secret.CharmSecretOwner) (watcher.StringsWatcher, error)) *MockSecretTriggersWatchDeletedSecretsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretTriggersWatchDeletedSecretsCall) DoAndReturn(f func(context.Context, ...service.CharmSecretOwner) (watcher.StringsWatcher, error)) *MockSecretTriggersWatchDeletedSecretsCall {
+func (c *MockSecretTriggersWatchDeletedSecretsCall) DoAndReturn(f func(context.Context, ...secret.CharmSecretOwner) (watcher.StringsWatcher, error)) *MockSecretTriggersWatchDeletedSecretsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchObsoleteSecrets mocks base method.
-func (m *MockSecretTriggers) WatchObsoleteSecrets(ctx context.Context, owners ...service.CharmSecretOwner) (watcher.StringsWatcher, error) {
+func (m *MockSecretTriggers) WatchObsoleteSecrets(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range owners {
@@ -163,19 +164,19 @@ func (c *MockSecretTriggersWatchObsoleteSecretsCall) Return(arg0 watcher.Strings
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretTriggersWatchObsoleteSecretsCall) Do(f func(context.Context, ...service.CharmSecretOwner) (watcher.StringsWatcher, error)) *MockSecretTriggersWatchObsoleteSecretsCall {
+func (c *MockSecretTriggersWatchObsoleteSecretsCall) Do(f func(context.Context, ...secret.CharmSecretOwner) (watcher.StringsWatcher, error)) *MockSecretTriggersWatchObsoleteSecretsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretTriggersWatchObsoleteSecretsCall) DoAndReturn(f func(context.Context, ...service.CharmSecretOwner) (watcher.StringsWatcher, error)) *MockSecretTriggersWatchObsoleteSecretsCall {
+func (c *MockSecretTriggersWatchObsoleteSecretsCall) DoAndReturn(f func(context.Context, ...secret.CharmSecretOwner) (watcher.StringsWatcher, error)) *MockSecretTriggersWatchObsoleteSecretsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchSecretRevisionsExpiryChanges mocks base method.
-func (m *MockSecretTriggers) WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...service.CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
+func (m *MockSecretTriggers) WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range owners {
@@ -207,19 +208,19 @@ func (c *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall) Return(arg0 wa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall) Do(f func(context.Context, ...service.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)) *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall {
+func (c *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall) Do(f func(context.Context, ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)) *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall) DoAndReturn(f func(context.Context, ...service.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)) *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall {
+func (c *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall) DoAndReturn(f func(context.Context, ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)) *MockSecretTriggersWatchSecretRevisionsExpiryChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchSecretsRotationChanges mocks base method.
-func (m *MockSecretTriggers) WatchSecretsRotationChanges(ctx context.Context, owners ...service.CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
+func (m *MockSecretTriggers) WatchSecretsRotationChanges(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range owners {
@@ -251,13 +252,13 @@ func (c *MockSecretTriggersWatchSecretsRotationChangesCall) Return(arg0 watcher.
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretTriggersWatchSecretsRotationChangesCall) Do(f func(context.Context, ...service.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)) *MockSecretTriggersWatchSecretsRotationChangesCall {
+func (c *MockSecretTriggersWatchSecretsRotationChangesCall) Do(f func(context.Context, ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)) *MockSecretTriggersWatchSecretsRotationChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretTriggersWatchSecretsRotationChangesCall) DoAndReturn(f func(context.Context, ...service.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)) *MockSecretTriggersWatchSecretsRotationChangesCall {
+func (c *MockSecretTriggersWatchSecretsRotationChangesCall) DoAndReturn(f func(context.Context, ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)) *MockSecretTriggersWatchSecretsRotationChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -443,7 +444,7 @@ func (c *MockSecretsConsumerGetURIByConsumerLabelCall) DoAndReturn(f func(contex
 }
 
 // GrantSecretAccess mocks base method.
-func (m *MockSecretsConsumer) GrantSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 service.SecretAccessParams) error {
+func (m *MockSecretsConsumer) GrantSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 secret.SecretAccessParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GrantSecretAccess", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -469,19 +470,19 @@ func (c *MockSecretsConsumerGrantSecretAccessCall) Return(arg0 error) *MockSecre
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerGrantSecretAccessCall) Do(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretsConsumerGrantSecretAccessCall {
+func (c *MockSecretsConsumerGrantSecretAccessCall) Do(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretsConsumerGrantSecretAccessCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerGrantSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretsConsumerGrantSecretAccessCall {
+func (c *MockSecretsConsumerGrantSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretsConsumerGrantSecretAccessCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RevokeSecretAccess mocks base method.
-func (m *MockSecretsConsumer) RevokeSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 service.SecretAccessParams) error {
+func (m *MockSecretsConsumer) RevokeSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 secret.SecretAccessParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeSecretAccess", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -507,13 +508,13 @@ func (c *MockSecretsConsumerRevokeSecretAccessCall) Return(arg0 error) *MockSecr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerRevokeSecretAccessCall) Do(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretsConsumerRevokeSecretAccessCall {
+func (c *MockSecretsConsumerRevokeSecretAccessCall) Do(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretsConsumerRevokeSecretAccessCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerRevokeSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretsConsumerRevokeSecretAccessCall {
+func (c *MockSecretsConsumerRevokeSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretsConsumerRevokeSecretAccessCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -697,7 +698,7 @@ func (c *MockSecretServiceGetSecretGrantsCall) DoAndReturn(f func(context.Contex
 }
 
 // GetSecretValue mocks base method.
-func (m *MockSecretService) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error) {
+func (m *MockSecretService) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretValue", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(secrets.SecretValue)
@@ -725,19 +726,19 @@ func (c *MockSecretServiceGetSecretValueCall) Return(arg0 secrets.SecretValue, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceGetSecretValueCall) Do(f func(context.Context, *secrets.URI, int, service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
+func (c *MockSecretServiceGetSecretValueCall) Do(f func(context.Context, *secrets.URI, int, secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceGetSecretValueCall) DoAndReturn(f func(context.Context, *secrets.URI, int, service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
+func (c *MockSecretServiceGetSecretValueCall) DoAndReturn(f func(context.Context, *secrets.URI, int, secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListCharmSecrets mocks base method.
-func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 ...secret.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0}
 	for _, a := range arg1 {
@@ -770,19 +771,19 @@ func (c *MockSecretServiceListCharmSecretsCall) Return(arg0 []*secrets.SecretMet
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceListCharmSecretsCall) Do(f func(context.Context, ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockSecretServiceListCharmSecretsCall {
+func (c *MockSecretServiceListCharmSecretsCall) Do(f func(context.Context, ...secret.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockSecretServiceListCharmSecretsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceListCharmSecretsCall) DoAndReturn(f func(context.Context, ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockSecretServiceListCharmSecretsCall {
+func (c *MockSecretServiceListCharmSecretsCall) DoAndReturn(f func(context.Context, ...secret.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockSecretServiceListCharmSecretsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListGrantedSecretsForBackend mocks base method.
-func (m *MockSecretService) ListGrantedSecretsForBackend(ctx context.Context, backendID string, role secrets.SecretRole, consumers ...service.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
+func (m *MockSecretService) ListGrantedSecretsForBackend(ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, backendID, role}
 	for _, a := range consumers {
@@ -814,13 +815,13 @@ func (c *MockSecretServiceListGrantedSecretsForBackendCall) Return(arg0 []*secre
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceListGrantedSecretsForBackendCall) Do(f func(context.Context, string, secrets.SecretRole, ...service.SecretAccessor) ([]*secrets.SecretRevisionRef, error)) *MockSecretServiceListGrantedSecretsForBackendCall {
+func (c *MockSecretServiceListGrantedSecretsForBackendCall) Do(f func(context.Context, string, secrets.SecretRole, ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error)) *MockSecretServiceListGrantedSecretsForBackendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceListGrantedSecretsForBackendCall) DoAndReturn(f func(context.Context, string, secrets.SecretRole, ...service.SecretAccessor) ([]*secrets.SecretRevisionRef, error)) *MockSecretServiceListGrantedSecretsForBackendCall {
+func (c *MockSecretServiceListGrantedSecretsForBackendCall) DoAndReturn(f func(context.Context, string, secrets.SecretRole, ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error)) *MockSecretServiceListGrantedSecretsForBackendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -24,6 +24,7 @@ import (
 	coresecrets "github.com/juju/juju/core/secrets"
 	unittesting "github.com/juju/juju/core/unit/testing"
 	corewatcher "github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
@@ -143,8 +144,8 @@ func (s *SecretsManagerSuite) TestGetSecretBackendConfigs(c *tc.C) {
 	s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), backendConfigParamsMatcher{c: c,
 		expected: secretbackendservice.BackendConfigParams{
 			LeaderToken: s.token,
-			Accessor: secretservice.SecretAccessor{
-				Kind: secretservice.UnitAccessor,
+			Accessor: secret.SecretAccessor{
+				Kind: secret.UnitAccessor,
 				ID:   "mariadb/0",
 			},
 			ModelUUID:      model.UUID(coretesting.ModelTag.Id()),
@@ -193,8 +194,8 @@ func (s *SecretsManagerSuite) TestGetSecretBackendConfigsForDrain(c *tc.C) {
 	s.secretBackendService.EXPECT().DrainBackendConfigInfo(gomock.Any(), backendConfigParamsMatcher{c: c,
 		expected: secretbackendservice.DrainBackendConfigParams{
 			LeaderToken: s.token,
-			Accessor: secretservice.SecretAccessor{
-				Kind: secretservice.UnitAccessor,
+			Accessor: secret.SecretAccessor{
+				Kind: secret.UnitAccessor,
 				ID:   "mariadb/0",
 			},
 			ModelUUID: model.UUID(coretesting.ModelTag.Id()),
@@ -328,11 +329,11 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *tc.C) {
 
 	now := time.Now()
 	uri := coresecrets.NewURI()
-	s.secretService.EXPECT().ListCharmSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
-		Kind: secretservice.UnitOwner,
+	s.secretService.EXPECT().ListCharmSecrets(gomock.Any(), []secret.CharmSecretOwner{{
+		Kind: secret.UnitCharmSecretOwner,
 		ID:   "mariadb/0",
 	}, {
-		Kind: secretservice.ApplicationOwner,
+		Kind: secret.ApplicationCharmSecretOwner,
 		ID:   "mariadb",
 	}}).Return([]*coresecrets.SecretMetadata{{
 		URI:                    uri,
@@ -357,12 +358,12 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *tc.C) {
 	}}, nil)
 	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return([]secretservice.SecretAccess{
 		{
-			Scope: secretservice.SecretAccessScope{
-				Kind: secretservice.RelationAccessScope,
+			Scope: secret.SecretAccessScope{
+				Kind: secret.RelationAccessScope,
 				ID:   "gitlab:server mysql:db",
 			},
-			Subject: secretservice.SecretAccessor{
-				Kind: secretservice.ApplicationAccessor,
+			Subject: secret.SecretAccessor{
+				Kind: secret.ApplicationAccessor,
 				ID:   "gitlab",
 			},
 			Role: coresecrets.RoleView,
@@ -411,8 +412,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretURIArg(c *tc.C) 
 	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(668, nil)
 
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		val, nil, nil,
@@ -443,8 +444,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretLabelArg(c *tc.C
 	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(668, nil)
 
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		val, nil, nil,
@@ -474,8 +475,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentForAppSecretUpdateLabel(c *tc.
 
 	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(668, nil)
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		val, nil, nil,
@@ -506,8 +507,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentForUnitAccessApplicationOwnedS
 	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(668, nil)
 
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		val, nil, nil,
@@ -538,8 +539,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUnitAgent(c *tc.C) {
 	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "").Return(uri, nil, nil)
 	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(666, nil)
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		val, nil, nil,
@@ -568,8 +569,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerLabelOnly(c *tc.C) {
 	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), nil, "label").Return(uri, nil, nil)
 	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(666, nil)
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		val, nil, nil,
@@ -599,8 +600,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateArg(c *tc.C) {
 	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), true, false, ptr("label")).
 		Return(668, nil)
 
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		val, nil, nil,
@@ -629,8 +630,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerPeekArg(c *tc.C) {
 	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "").Return(uri, nil, nil)
 	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, true, nil).
 		Return(668, nil)
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		val, nil, nil,
@@ -684,8 +685,8 @@ func (s *SecretsManagerSuite) TestGetSecretRevisionContentInfo(c *tc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secretservice.SecretAccessor{
-		Kind: secretservice.UnitAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   "mariadb/0",
 	}).Return(
 		nil, &coresecrets.ValueRef{
@@ -697,8 +698,8 @@ func (s *SecretsManagerSuite) TestGetSecretRevisionContentInfo(c *tc.C) {
 	s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), backendConfigParamsMatcher{c: c,
 		expected: secretbackendservice.BackendConfigParams{
 			LeaderToken: s.token,
-			Accessor: secretservice.SecretAccessor{
-				Kind: secretservice.UnitAccessor,
+			Accessor: secret.SecretAccessor{
+				Kind: secret.UnitAccessor,
 				ID:   "mariadb/0",
 			},
 			ModelUUID:      model.UUID(coretesting.ModelTag.Id()),
@@ -751,11 +752,11 @@ func (s *SecretsManagerSuite) TestWatchObsolete(c *tc.C) {
 
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
-	s.secretTriggers.EXPECT().WatchObsoleteSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
-		Kind: secretservice.UnitOwner,
+	s.secretTriggers.EXPECT().WatchObsoleteSecrets(gomock.Any(), []secret.CharmSecretOwner{{
+		Kind: secret.UnitCharmSecretOwner,
 		ID:   "mariadb/0",
 	}, {
-		Kind: secretservice.ApplicationOwner,
+		Kind: secret.ApplicationCharmSecretOwner,
 		ID:   "mariadb",
 	}}).Return(
 		s.secretsWatcher, nil,
@@ -786,11 +787,11 @@ func (s *SecretsManagerSuite) TestWatchDeleted(c *tc.C) {
 
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
-	s.secretTriggers.EXPECT().WatchDeletedSecrets(gomock.Any(), []secretservice.CharmSecretOwner{{
-		Kind: secretservice.UnitOwner,
+	s.secretTriggers.EXPECT().WatchDeletedSecrets(gomock.Any(), []secret.CharmSecretOwner{{
+		Kind: secret.UnitCharmSecretOwner,
 		ID:   "mariadb/0",
 	}, {
-		Kind: secretservice.ApplicationOwner,
+		Kind: secret.ApplicationCharmSecretOwner,
 		ID:   "mariadb",
 	}}).Return(
 		s.secretsWatcher, nil,
@@ -822,11 +823,11 @@ func (s *SecretsManagerSuite) TestWatchSecretsRotationChanges(c *tc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
 	s.secretTriggers.EXPECT().WatchSecretsRotationChanges(gomock.Any(),
-		[]secretservice.CharmSecretOwner{{
-			Kind: secretservice.UnitOwner,
+		[]secret.CharmSecretOwner{{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mariadb/0",
 		}, {
-			Kind: secretservice.ApplicationOwner,
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mariadb",
 		}}).Return(
 		s.secretsTriggerWatcher, nil,
@@ -864,8 +865,8 @@ func (s *SecretsManagerSuite) TestSecretsRotated(c *tc.C) {
 
 	uri := coresecrets.NewURI()
 	s.secretTriggers.EXPECT().SecretRotated(gomock.Any(), uri, secretservice.SecretRotatedParams{
-		Accessor: secretservice.SecretAccessor{
-			Kind: secretservice.UnitAccessor,
+		Accessor: secret.SecretAccessor{
+			Kind: secret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		OriginalRevision: 666,
@@ -898,8 +899,8 @@ func (s *SecretsManagerSuite) TestSecretsRotatedRetry(c *tc.C) {
 
 	uri := coresecrets.NewURI()
 	s.secretTriggers.EXPECT().SecretRotated(gomock.Any(), uri, secretservice.SecretRotatedParams{
-		Accessor: secretservice.SecretAccessor{
-			Kind: secretservice.UnitAccessor,
+		Accessor: secret.SecretAccessor{
+			Kind: secret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		OriginalRevision: 666,
@@ -927,8 +928,8 @@ func (s *SecretsManagerSuite) TestSecretsRotatedForce(c *tc.C) {
 
 	uri := coresecrets.NewURI()
 	s.secretTriggers.EXPECT().SecretRotated(gomock.Any(), uri, secretservice.SecretRotatedParams{
-		Accessor: secretservice.SecretAccessor{
-			Kind: secretservice.UnitAccessor,
+		Accessor: secret.SecretAccessor{
+			Kind: secret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		OriginalRevision: 666,
@@ -957,11 +958,11 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *tc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
 	s.secretTriggers.EXPECT().WatchSecretRevisionsExpiryChanges(gomock.Any(),
-		[]secretservice.CharmSecretOwner{{
-			Kind: secretservice.UnitOwner,
+		[]secret.CharmSecretOwner{{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mariadb/0",
 		}, {
-			Kind: secretservice.ApplicationOwner,
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mariadb",
 		}}).Return(
 		s.secretsTriggerWatcher, nil,

--- a/apiserver/facades/agent/secretsmanager/service.go
+++ b/apiserver/facades/agent/secretsmanager/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/secret"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/internal/secrets/provider"
@@ -20,10 +21,10 @@ import (
 
 // SecretTriggers instances provide secret rotation/expiry apis.
 type SecretTriggers interface {
-	WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...secretservice.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)
-	WatchSecretsRotationChanges(ctx context.Context, owners ...secretservice.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)
-	WatchObsoleteSecrets(ctx context.Context, owners ...secretservice.CharmSecretOwner) (watcher.StringsWatcher, error)
-	WatchDeletedSecrets(ctx context.Context, owners ...secretservice.CharmSecretOwner) (watcher.StringsWatcher, error)
+	WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)
+	WatchSecretsRotationChanges(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error)
+	WatchObsoleteSecrets(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.StringsWatcher, error)
+	WatchDeletedSecrets(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.StringsWatcher, error)
 	SecretRotated(ctx context.Context, uri *secrets.URI, params secretservice.SecretRotatedParams) error
 }
 
@@ -36,22 +37,22 @@ type SecretsConsumer interface {
 		ctx context.Context, uri *secrets.URI, unitName unit.Name,
 		refresh, peek bool, labelToUpdate *string) (int, error)
 	WatchConsumedSecretsChanges(ctx context.Context, unitName unit.Name) (watcher.StringsWatcher, error)
-	GrantSecretAccess(context.Context, *secrets.URI, secretservice.SecretAccessParams) error
-	RevokeSecretAccess(context.Context, *secrets.URI, secretservice.SecretAccessParams) error
+	GrantSecretAccess(context.Context, *secrets.URI, secret.SecretAccessParams) error
+	RevokeSecretAccess(context.Context, *secrets.URI, secret.SecretAccessParams) error
 }
 
 // SecretService provides core secrets operations.
 type SecretService interface {
 	CreateSecretURIs(ctx context.Context, count int) ([]*secrets.URI, error)
-	GetSecretValue(context.Context, *secrets.URI, int, secretservice.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)
-	ListCharmSecrets(context.Context, ...secretservice.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
+	GetSecretValue(context.Context, *secrets.URI, int, secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)
+	ListCharmSecrets(context.Context, ...secret.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ProcessCharmSecretConsumerLabel(
 		ctx context.Context, unitName unit.Name, uri *secrets.URI, label string,
 	) (*secrets.URI, *string, error)
 	ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params secretservice.ChangeSecretBackendParams) error
 	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secretservice.SecretAccess, error)
 	ListGrantedSecretsForBackend(
-		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secretservice.SecretAccessor,
+		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secret.SecretAccessor,
 	) ([]*secrets.SecretRevisionRef, error)
 }
 

--- a/apiserver/facades/agent/uniter/secret_mocks_test.go
+++ b/apiserver/facades/agent/uniter/secret_mocks_test.go
@@ -15,7 +15,7 @@ import (
 
 	secrets "github.com/juju/juju/core/secrets"
 	unit "github.com/juju/juju/core/unit"
-	service "github.com/juju/juju/domain/secret/service"
+	secret "github.com/juju/juju/domain/secret"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -43,7 +43,7 @@ func (m *MockSecretService) EXPECT() *MockSecretServiceMockRecorder {
 }
 
 // CreateCharmSecret mocks base method.
-func (m *MockSecretService) CreateCharmSecret(arg0 context.Context, arg1 *secrets.URI, arg2 service.CreateCharmSecretParams) error {
+func (m *MockSecretService) CreateCharmSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secret.CreateCharmSecretParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCharmSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -69,19 +69,19 @@ func (c *MockSecretServiceCreateCharmSecretCall) Return(arg0 error) *MockSecretS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceCreateCharmSecretCall) Do(f func(context.Context, *secrets.URI, service.CreateCharmSecretParams) error) *MockSecretServiceCreateCharmSecretCall {
+func (c *MockSecretServiceCreateCharmSecretCall) Do(f func(context.Context, *secrets.URI, secret.CreateCharmSecretParams) error) *MockSecretServiceCreateCharmSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceCreateCharmSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, service.CreateCharmSecretParams) error) *MockSecretServiceCreateCharmSecretCall {
+func (c *MockSecretServiceCreateCharmSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.CreateCharmSecretParams) error) *MockSecretServiceCreateCharmSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DeleteSecret mocks base method.
-func (m *MockSecretService) DeleteSecret(arg0 context.Context, arg1 *secrets.URI, arg2 service.DeleteSecretParams) error {
+func (m *MockSecretService) DeleteSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secret.DeleteSecretParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -107,13 +107,13 @@ func (c *MockSecretServiceDeleteSecretCall) Return(arg0 error) *MockSecretServic
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceDeleteSecretCall) Do(f func(context.Context, *secrets.URI, service.DeleteSecretParams) error) *MockSecretServiceDeleteSecretCall {
+func (c *MockSecretServiceDeleteSecretCall) Do(f func(context.Context, *secrets.URI, secret.DeleteSecretParams) error) *MockSecretServiceDeleteSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceDeleteSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, service.DeleteSecretParams) error) *MockSecretServiceDeleteSecretCall {
+func (c *MockSecretServiceDeleteSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.DeleteSecretParams) error) *MockSecretServiceDeleteSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -158,7 +158,7 @@ func (c *MockSecretServiceGetConsumedRevisionCall) DoAndReturn(f func(context.Co
 }
 
 // GetSecretValue mocks base method.
-func (m *MockSecretService) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error) {
+func (m *MockSecretService) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretValue", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(secrets.SecretValue)
@@ -186,19 +186,19 @@ func (c *MockSecretServiceGetSecretValueCall) Return(arg0 secrets.SecretValue, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceGetSecretValueCall) Do(f func(context.Context, *secrets.URI, int, service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
+func (c *MockSecretServiceGetSecretValueCall) Do(f func(context.Context, *secrets.URI, int, secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceGetSecretValueCall) DoAndReturn(f func(context.Context, *secrets.URI, int, service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
+func (c *MockSecretServiceGetSecretValueCall) DoAndReturn(f func(context.Context, *secrets.URI, int, secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GrantSecretAccess mocks base method.
-func (m *MockSecretService) GrantSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 service.SecretAccessParams) error {
+func (m *MockSecretService) GrantSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 secret.SecretAccessParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GrantSecretAccess", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -224,19 +224,19 @@ func (c *MockSecretServiceGrantSecretAccessCall) Return(arg0 error) *MockSecretS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceGrantSecretAccessCall) Do(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretServiceGrantSecretAccessCall {
+func (c *MockSecretServiceGrantSecretAccessCall) Do(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretServiceGrantSecretAccessCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceGrantSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretServiceGrantSecretAccessCall {
+func (c *MockSecretServiceGrantSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretServiceGrantSecretAccessCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RevokeSecretAccess mocks base method.
-func (m *MockSecretService) RevokeSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 service.SecretAccessParams) error {
+func (m *MockSecretService) RevokeSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 secret.SecretAccessParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeSecretAccess", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -262,19 +262,19 @@ func (c *MockSecretServiceRevokeSecretAccessCall) Return(arg0 error) *MockSecret
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceRevokeSecretAccessCall) Do(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretServiceRevokeSecretAccessCall {
+func (c *MockSecretServiceRevokeSecretAccessCall) Do(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretServiceRevokeSecretAccessCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceRevokeSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretServiceRevokeSecretAccessCall {
+func (c *MockSecretServiceRevokeSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretServiceRevokeSecretAccessCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdateCharmSecret mocks base method.
-func (m *MockSecretService) UpdateCharmSecret(arg0 context.Context, arg1 *secrets.URI, arg2 service.UpdateCharmSecretParams) error {
+func (m *MockSecretService) UpdateCharmSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secret.UpdateCharmSecretParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCharmSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -300,13 +300,13 @@ func (c *MockSecretServiceUpdateCharmSecretCall) Return(arg0 error) *MockSecretS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceUpdateCharmSecretCall) Do(f func(context.Context, *secrets.URI, service.UpdateCharmSecretParams) error) *MockSecretServiceUpdateCharmSecretCall {
+func (c *MockSecretServiceUpdateCharmSecretCall) Do(f func(context.Context, *secrets.URI, secret.UpdateCharmSecretParams) error) *MockSecretServiceUpdateCharmSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceUpdateCharmSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, service.UpdateCharmSecretParams) error) *MockSecretServiceUpdateCharmSecretCall {
+func (c *MockSecretServiceUpdateCharmSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.UpdateCharmSecretParams) error) *MockSecretServiceUpdateCharmSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/secrets/mocks/secretservice.go
+++ b/apiserver/facades/client/secrets/mocks/secretservice.go
@@ -83,7 +83,7 @@ func (c *MockSecretServiceCreateUserSecretCall) DoAndReturn(f func(context.Conte
 }
 
 // DeleteSecret mocks base method.
-func (m *MockSecretService) DeleteSecret(arg0 context.Context, arg1 *secrets.URI, arg2 service.DeleteSecretParams) error {
+func (m *MockSecretService) DeleteSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secret.DeleteSecretParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -109,13 +109,13 @@ func (c *MockSecretServiceDeleteSecretCall) Return(arg0 error) *MockSecretServic
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceDeleteSecretCall) Do(f func(context.Context, *secrets.URI, service.DeleteSecretParams) error) *MockSecretServiceDeleteSecretCall {
+func (c *MockSecretServiceDeleteSecretCall) Do(f func(context.Context, *secrets.URI, secret.DeleteSecretParams) error) *MockSecretServiceDeleteSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceDeleteSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, service.DeleteSecretParams) error) *MockSecretServiceDeleteSecretCall {
+func (c *MockSecretServiceDeleteSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.DeleteSecretParams) error) *MockSecretServiceDeleteSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -238,7 +238,7 @@ func (c *MockSecretServiceGetUserSecretURIByLabelCall) DoAndReturn(f func(contex
 }
 
 // GrantSecretAccess mocks base method.
-func (m *MockSecretService) GrantSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 service.SecretAccessParams) error {
+func (m *MockSecretService) GrantSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 secret.SecretAccessParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GrantSecretAccess", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -264,19 +264,19 @@ func (c *MockSecretServiceGrantSecretAccessCall) Return(arg0 error) *MockSecretS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceGrantSecretAccessCall) Do(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretServiceGrantSecretAccessCall {
+func (c *MockSecretServiceGrantSecretAccessCall) Do(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretServiceGrantSecretAccessCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceGrantSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretServiceGrantSecretAccessCall {
+func (c *MockSecretServiceGrantSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretServiceGrantSecretAccessCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListCharmSecrets mocks base method.
-func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 ...secret.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0}
 	for _, a := range arg1 {
@@ -309,13 +309,13 @@ func (c *MockSecretServiceListCharmSecretsCall) Return(arg0 []*secrets.SecretMet
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceListCharmSecretsCall) Do(f func(context.Context, ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockSecretServiceListCharmSecretsCall {
+func (c *MockSecretServiceListCharmSecretsCall) Do(f func(context.Context, ...secret.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockSecretServiceListCharmSecretsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceListCharmSecretsCall) DoAndReturn(f func(context.Context, ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockSecretServiceListCharmSecretsCall {
+func (c *MockSecretServiceListCharmSecretsCall) DoAndReturn(f func(context.Context, ...secret.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)) *MockSecretServiceListCharmSecretsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -361,7 +361,7 @@ func (c *MockSecretServiceListSecretsCall) DoAndReturn(f func(context.Context, *
 }
 
 // RevokeSecretAccess mocks base method.
-func (m *MockSecretService) RevokeSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 service.SecretAccessParams) error {
+func (m *MockSecretService) RevokeSecretAccess(arg0 context.Context, arg1 *secrets.URI, arg2 secret.SecretAccessParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeSecretAccess", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -387,13 +387,13 @@ func (c *MockSecretServiceRevokeSecretAccessCall) Return(arg0 error) *MockSecret
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceRevokeSecretAccessCall) Do(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretServiceRevokeSecretAccessCall {
+func (c *MockSecretServiceRevokeSecretAccessCall) Do(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretServiceRevokeSecretAccessCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceRevokeSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, service.SecretAccessParams) error) *MockSecretServiceRevokeSecretAccessCall {
+func (c *MockSecretServiceRevokeSecretAccessCall) DoAndReturn(f func(context.Context, *secrets.URI, secret.SecretAccessParams) error) *MockSecretServiceRevokeSecretAccessCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -121,12 +121,12 @@ func (s *SecretsSuite) assertListSecrets(c *tc.C, reveal bool) {
 	)
 	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return([]secretservice.SecretAccess{
 		{
-			Scope: secretservice.SecretAccessScope{
-				Kind: secretservice.RelationAccessScope,
+			Scope: secret.SecretAccessScope{
+				Kind: secret.RelationAccessScope,
 				ID:   "gitlab:server mysql:db",
 			},
-			Subject: secretservice.SecretAccessor{
-				Kind: secretservice.ApplicationAccessor,
+			Subject: secret.SecretAccessor{
+				Kind: secret.ApplicationAccessor,
 				ID:   "gitlab",
 			},
 			Role: coresecrets.RoleView,
@@ -350,8 +350,8 @@ func (s *SecretsSuite) TestRemoveSecrets(c *tc.C) {
 	uri := coresecrets.NewURI()
 	expectURI := *uri
 	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
-	s.secretService.EXPECT().DeleteSecret(gomock.Any(), &expectURI, secretservice.DeleteSecretParams{
-		Accessor:  secretservice.SecretAccessor{Kind: secretservice.ModelAccessor, ID: coretesting.ModelTag.Id()},
+	s.secretService.EXPECT().DeleteSecret(gomock.Any(), &expectURI, secret.DeleteSecretParams{
+		Accessor:  secret.SecretAccessor{Kind: secret.ModelAccessor, ID: coretesting.ModelTag.Id()},
 		Revisions: []int{666},
 	}).Return(nil)
 
@@ -395,8 +395,8 @@ func (s *SecretsSuite) TestRemoveSecretRevision(c *tc.C) {
 	uri := coresecrets.NewURI()
 	expectURI := *uri
 	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
-	s.secretService.EXPECT().DeleteSecret(gomock.Any(), &expectURI, secretservice.DeleteSecretParams{
-		Accessor:  secretservice.SecretAccessor{Kind: secretservice.ModelAccessor, ID: coretesting.ModelTag.Id()},
+	s.secretService.EXPECT().DeleteSecret(gomock.Any(), &expectURI, secret.DeleteSecretParams{
+		Accessor:  secret.SecretAccessor{Kind: secret.ModelAccessor, ID: coretesting.ModelTag.Id()},
 		Revisions: []int{666},
 	}).Return(nil)
 
@@ -421,8 +421,8 @@ func (s *SecretsSuite) TestRemoveSecretNotFound(c *tc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.secretService.EXPECT().DeleteSecret(gomock.Any(), &expectURI, secretservice.DeleteSecretParams{
-		Accessor:  secretservice.SecretAccessor{Kind: secretservice.ModelAccessor, ID: coretesting.ModelTag.Id()},
+	s.secretService.EXPECT().DeleteSecret(gomock.Any(), &expectURI, secret.DeleteSecretParams{
+		Accessor:  secret.SecretAccessor{Kind: secret.ModelAccessor, ID: coretesting.ModelTag.Id()},
 		Revisions: []int{666},
 	}).Return(secreterrors.SecretNotFound)
 
@@ -446,23 +446,23 @@ func (s *SecretsSuite) TestGrantSecret(c *tc.C) {
 
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
+		func(_ context.Context, arg *coresecrets.URI, params secret.SecretAccessParams) error {
 			c.Assert(arg, tc.DeepEquals, uri)
 			c.Assert(params.Scope, tc.DeepEquals,
-				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+				secret.SecretAccessScope{Kind: secret.ModelAccessScope, ID: coretesting.ModelTag.Id()})
 			c.Assert(params.Subject, tc.DeepEquals,
-				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "gitlab"})
+				secret.SecretAccessor{Kind: secret.ApplicationAccessor, ID: "gitlab"})
 			c.Assert(params.Role, tc.Equals, coresecrets.RoleView)
 			return nil
 		},
 	)
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
+		func(_ context.Context, arg *coresecrets.URI, params secret.SecretAccessParams) error {
 			c.Assert(arg, tc.DeepEquals, uri)
 			c.Assert(params.Scope, tc.DeepEquals,
-				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+				secret.SecretAccessScope{Kind: secret.ModelAccessScope, ID: coretesting.ModelTag.Id()})
 			c.Assert(params.Subject, tc.DeepEquals,
-				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "mysql"})
+				secret.SecretAccessor{Kind: secret.ApplicationAccessor, ID: "mysql"})
 			c.Assert(params.Role, tc.Equals, coresecrets.RoleView)
 			return nil
 		},
@@ -490,23 +490,23 @@ func (s *SecretsSuite) TestGrantSecretByName(c *tc.C) {
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().GetUserSecretURIByLabel(gomock.Any(), "my-secret").Return(uri, nil)
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
+		func(_ context.Context, arg *coresecrets.URI, params secret.SecretAccessParams) error {
 			c.Assert(arg, tc.DeepEquals, uri)
 			c.Assert(params.Scope, tc.DeepEquals,
-				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+				secret.SecretAccessScope{Kind: secret.ModelAccessScope, ID: coretesting.ModelTag.Id()})
 			c.Assert(params.Subject, tc.DeepEquals,
-				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "gitlab"})
+				secret.SecretAccessor{Kind: secret.ApplicationAccessor, ID: "gitlab"})
 			c.Assert(params.Role, tc.Equals, coresecrets.RoleView)
 			return nil
 		},
 	)
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
+		func(_ context.Context, arg *coresecrets.URI, params secret.SecretAccessParams) error {
 			c.Assert(arg, tc.DeepEquals, uri)
 			c.Assert(params.Scope, tc.DeepEquals,
-				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+				secret.SecretAccessScope{Kind: secret.ModelAccessScope, ID: coretesting.ModelTag.Id()})
 			c.Assert(params.Subject, tc.DeepEquals,
-				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "mysql"})
+				secret.SecretAccessor{Kind: secret.ApplicationAccessor, ID: "mysql"})
 			c.Assert(params.Role, tc.Equals, coresecrets.RoleView)
 			return nil
 		},
@@ -548,23 +548,23 @@ func (s *SecretsSuite) TestRevokeSecret(c *tc.C) {
 
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().RevokeSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
+		func(_ context.Context, arg *coresecrets.URI, params secret.SecretAccessParams) error {
 			c.Assert(arg, tc.DeepEquals, uri)
 			c.Assert(params.Scope, tc.DeepEquals,
-				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+				secret.SecretAccessScope{Kind: secret.ModelAccessScope, ID: coretesting.ModelTag.Id()})
 			c.Assert(params.Subject, tc.DeepEquals,
-				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "gitlab"})
+				secret.SecretAccessor{Kind: secret.ApplicationAccessor, ID: "gitlab"})
 			c.Assert(params.Role, tc.Equals, coresecrets.RoleView)
 			return nil
 		},
 	)
 	s.secretService.EXPECT().RevokeSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, arg *coresecrets.URI, params secretservice.SecretAccessParams) error {
+		func(_ context.Context, arg *coresecrets.URI, params secret.SecretAccessParams) error {
 			c.Assert(arg, tc.DeepEquals, uri)
 			c.Assert(params.Scope, tc.DeepEquals,
-				secretservice.SecretAccessScope{Kind: secretservice.ModelAccessScope, ID: coretesting.ModelTag.Id()})
+				secret.SecretAccessScope{Kind: secret.ModelAccessScope, ID: coretesting.ModelTag.Id()})
 			c.Assert(params.Subject, tc.DeepEquals,
-				secretservice.SecretAccessor{Kind: secretservice.ApplicationAccessor, ID: "mysql"})
+				secret.SecretAccessor{Kind: secret.ApplicationAccessor, ID: "mysql"})
 			c.Assert(params.Role, tc.Equals, coresecrets.RoleView)
 			return nil
 		},

--- a/apiserver/facades/client/secrets/service.go
+++ b/apiserver/facades/client/secrets/service.go
@@ -28,17 +28,17 @@ type SecretService interface {
 		revision *int,
 		labels domainsecret.Labels,
 	) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
-	ListCharmSecrets(ctx context.Context, owners ...secretservice.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
+	ListCharmSecrets(ctx context.Context, owners ...domainsecret.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 
 	// Delete secrets.
 
-	DeleteSecret(ctx context.Context, uri *secrets.URI, params secretservice.DeleteSecretParams) error
+	DeleteSecret(ctx context.Context, uri *secrets.URI, params domainsecret.DeleteSecretParams) error
 
 	// Grant/revoke secret access.
 
 	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secretservice.SecretAccess, error)
-	GrantSecretAccess(ctx context.Context, uri *secrets.URI, p secretservice.SecretAccessParams) error
-	RevokeSecretAccess(ctx context.Context, uri *secrets.URI, p secretservice.SecretAccessParams) error
+	GrantSecretAccess(ctx context.Context, uri *secrets.URI, p domainsecret.SecretAccessParams) error
+	RevokeSecretAccess(ctx context.Context, uri *secrets.URI, p domainsecret.SecretAccessParams) error
 }
 
 // SecretBackendService provides access to the secret backend service,

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -26,8 +26,8 @@ import (
 	"github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
+	"github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
-	"github.com/juju/juju/domain/secret/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/secrets"
@@ -140,8 +140,8 @@ func (s *CrossModelSecretsAPI) getSecretAccessScope(ctx context.Context, arg par
 
 func (s *CrossModelSecretsAPI) accessScope(ctx context.Context, secretService SecretService, uri *coresecrets.URI, unitName unit.Name) (relation.UUID, error) {
 	s.logger.Debugf(ctx, "scope for %q on secret %s", unitName, uri.ID)
-	relationUUID, err := secretService.GetSecretAccessRelationScope(ctx, uri, service.SecretAccessor{
-		Kind: service.UnitAccessor,
+	relationUUID, err := secretService.GetSecretAccessRelationScope(ctx, uri, secret.SecretAccessor{
+		Kind: secret.UnitAccessor,
 		ID:   unitName.String(),
 	})
 	if err == nil {
@@ -150,8 +150,8 @@ func (s *CrossModelSecretsAPI) accessScope(ctx context.Context, secretService Se
 	if !errors.Is(err, secreterrors.SecretAccessScopeNotFound) {
 		return "", errors.Capture(err)
 	}
-	relationUUID, err = secretService.GetSecretAccessRelationScope(ctx, uri, service.SecretAccessor{
-		Kind: service.ApplicationAccessor,
+	relationUUID, err = secretService.GetSecretAccessRelationScope(ctx, uri, secret.SecretAccessor{
+		Kind: secret.ApplicationAccessor,
 		ID:   unitName.Application(),
 	})
 	if err != nil {
@@ -340,8 +340,8 @@ func (s *CrossModelSecretsAPI) getBackend(ctx context.Context, modelUUID model.U
 	}
 	cfgInfo, err := s.secretBackendService.BackendConfigInfo(ctx, secretbackendservice.BackendConfigParams{
 		GrantedSecretsGetter: secretService.ListGrantedSecretsForBackend,
-		Accessor: service.SecretAccessor{
-			Kind: service.UnitAccessor,
+		Accessor: secret.SecretAccessor{
+			Kind: secret.UnitAccessor,
 			ID:   consumer.String(),
 		},
 		ModelUUID:      modelUUID,

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/juju/juju/core/relation"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
-	"github.com/juju/juju/domain/secret/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/secrets/provider"
@@ -194,8 +194,8 @@ func (s *CrossModelSecretsSuite) TestGetSecretContentInfo(c *tc.C) {
 			c.Assert(params.GrantedSecretsGetter, tc.NotNil)
 			params.GrantedSecretsGetter = nil
 			c.Assert(params, tc.DeepEquals, secretbackendservice.BackendConfigParams{
-				Accessor: service.SecretAccessor{
-					Kind: service.UnitAccessor,
+				Accessor: secret.SecretAccessor{
+					Kind: secret.UnitAccessor,
 					ID:   "mediawiki/666",
 				},
 				ModelUUID:      model.UUID(uri.SourceUUID),

--- a/apiserver/facades/controller/crossmodelsecrets/package_mock_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/package_mock_test.go
@@ -17,8 +17,8 @@ import (
 	relation "github.com/juju/juju/core/relation"
 	secrets "github.com/juju/juju/core/secrets"
 	unit "github.com/juju/juju/core/unit"
-	service "github.com/juju/juju/domain/secret/service"
-	service0 "github.com/juju/juju/domain/secretbackend/service"
+	secret "github.com/juju/juju/domain/secret"
+	service "github.com/juju/juju/domain/secretbackend/service"
 	provider "github.com/juju/juju/internal/secrets/provider"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -47,7 +47,7 @@ func (m *MockSecretService) EXPECT() *MockSecretServiceMockRecorder {
 }
 
 // GetSecretAccessRelationScope mocks base method.
-func (m *MockSecretService) GetSecretAccessRelationScope(arg0 context.Context, arg1 *secrets.URI, arg2 service.SecretAccessor) (relation.UUID, error) {
+func (m *MockSecretService) GetSecretAccessRelationScope(arg0 context.Context, arg1 *secrets.URI, arg2 secret.SecretAccessor) (relation.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretAccessRelationScope", arg0, arg1, arg2)
 	ret0, _ := ret[0].(relation.UUID)
@@ -62,7 +62,7 @@ func (mr *MockSecretServiceMockRecorder) GetSecretAccessRelationScope(arg0, arg1
 }
 
 // ListGrantedSecretsForBackend mocks base method.
-func (m *MockSecretService) ListGrantedSecretsForBackend(arg0 context.Context, arg1 string, arg2 secrets.SecretRole, arg3 ...service.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
+func (m *MockSecretService) ListGrantedSecretsForBackend(arg0 context.Context, arg1 string, arg2 secrets.SecretRole, arg3 ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -105,7 +105,7 @@ func (m *MockSecretBackendService) EXPECT() *MockSecretBackendServiceMockRecorde
 }
 
 // BackendConfigInfo mocks base method.
-func (m *MockSecretBackendService) BackendConfigInfo(arg0 context.Context, arg1 service0.BackendConfigParams) (*provider.ModelBackendConfigInfo, error) {
+func (m *MockSecretBackendService) BackendConfigInfo(arg0 context.Context, arg1 service.BackendConfigParams) (*provider.ModelBackendConfigInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BackendConfigInfo", arg0, arg1)
 	ret0, _ := ret[0].(*provider.ModelBackendConfigInfo)

--- a/apiserver/facades/controller/crossmodelsecrets/service.go
+++ b/apiserver/facades/controller/crossmodelsecrets/service.go
@@ -10,7 +10,7 @@ import (
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/unit"
-	secretservice "github.com/juju/juju/domain/secret/service"
+	"github.com/juju/juju/domain/secret"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/internal/secrets/provider"
 )
@@ -19,9 +19,9 @@ import (
 
 // SecretService provides access to the secret service,
 type SecretService interface {
-	GetSecretAccessRelationScope(ctx context.Context, uri *secrets.URI, accessor secretservice.SecretAccessor) (corerelation.UUID, error)
+	GetSecretAccessRelationScope(ctx context.Context, uri *secrets.URI, accessor secret.SecretAccessor) (corerelation.UUID, error)
 	ListGrantedSecretsForBackend(
-		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secretservice.SecretAccessor,
+		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secret.SecretAccessor,
 	) ([]*secrets.SecretRevisionRef, error)
 }
 

--- a/apiserver/facades/controller/usersecretsdrain/drain.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain.go
@@ -12,7 +12,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
-	secretservice "github.com/juju/juju/domain/secret/service"
+	"github.com/juju/juju/domain/secret"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/secrets"
@@ -45,8 +45,8 @@ func (s *SecretsDrainAPI) GetSecretBackendConfigs(ctx context.Context, arg param
 	}
 	cfgInfo, err := s.secretBackendService.DrainBackendConfigInfo(ctx, secretbackendservice.DrainBackendConfigParams{
 		GrantedSecretsGetter: s.secretService.ListGrantedSecretsForBackend,
-		Accessor: secretservice.SecretAccessor{
-			Kind: secretservice.ModelAccessor,
+		Accessor: secret.SecretAccessor{
+			Kind: secret.ModelAccessor,
 			ID:   s.modelUUID.String(),
 		},
 		ModelUUID: s.modelUUID,
@@ -130,8 +130,8 @@ func (s *SecretsDrainAPI) getSecretContent(ctx context.Context, arg params.GetSe
 		return nil, nil, false, errors.Trace(err)
 	}
 
-	val, valueRef, err := s.secretService.GetSecretValue(ctx, md.URI, md.LatestRevision, secretservice.SecretAccessor{
-		Kind: secretservice.ModelAccessor,
+	val, valueRef, err := s.secretService.GetSecretValue(ctx, md.URI, md.LatestRevision, secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
 		ID:   s.modelUUID.String(),
 	})
 	if err != nil {
@@ -150,8 +150,8 @@ func (s *SecretsDrainAPI) getSecretContent(ctx context.Context, arg params.GetSe
 func (s *SecretsDrainAPI) getBackend(ctx context.Context, backendID string) (*provider.ModelBackendConfig, bool, error) {
 	cfgInfo, err := s.secretBackendService.BackendConfigInfo(ctx, secretbackendservice.BackendConfigParams{
 		GrantedSecretsGetter: s.secretService.ListGrantedSecretsForBackend,
-		Accessor: secretservice.SecretAccessor{
-			Kind: secretservice.ModelAccessor,
+		Accessor: secret.SecretAccessor{
+			Kind: secret.ModelAccessor,
 			ID:   s.modelUUID.String(),
 		},
 		ModelUUID:      s.modelUUID,
@@ -187,8 +187,8 @@ func (s *SecretsDrainAPI) GetSecretRevisionContentInfo(ctx context.Context, arg 
 	}
 
 	for i, rev := range arg.Revisions {
-		val, valueRef, err := s.secretService.GetSecretValue(ctx, uri, rev, secretservice.SecretAccessor{
-			Kind: secretservice.ModelAccessor,
+		val, valueRef, err := s.secretService.GetSecretValue(ctx, uri, rev, secret.SecretAccessor{
+			Kind: secret.ModelAccessor,
 			ID:   s.modelUUID.String(),
 		})
 		if err != nil {

--- a/apiserver/facades/controller/usersecretsdrain/drain_test.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/usersecretsdrain/mocks"
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
-	secretservice "github.com/juju/juju/domain/secret/service"
+	"github.com/juju/juju/domain/secret"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/internal/secrets/provider"
 	"github.com/juju/juju/internal/testhelpers"
@@ -81,8 +81,8 @@ func (s *drainSuite) TestGetSecretBackendConfigs(c *tc.C) {
 
 	s.secretBackendService.EXPECT().DrainBackendConfigInfo(gomock.Any(), backendConfigParamsMatcher{c: c,
 		expected: secretbackendservice.DrainBackendConfigParams{
-			Accessor: secretservice.SecretAccessor{
-				Kind: secretservice.ModelAccessor,
+			Accessor: secret.SecretAccessor{
+				Kind: secret.ModelAccessor,
 				ID:   coretesting.ModelTag.Id(),
 			},
 			ModelUUID: model.UUID(coretesting.ModelTag.Id()),
@@ -140,8 +140,8 @@ func (s *drainSuite) TestGetSecretContentInternal(c *tc.C) {
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().GetSecret(gomock.Any(), uri).Return(&coresecrets.SecretMetadata{URI: uri, LatestRevision: 668}, nil)
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
-		Kind: secretservice.ModelAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
 		ID:   coretesting.ModelTag.Id(),
 	}).Return(
 		val, nil, nil,
@@ -165,8 +165,8 @@ func (s *drainSuite) TestGetSecretContentExternal(c *tc.C) {
 
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().GetSecret(gomock.Any(), uri).Return(&coresecrets.SecretMetadata{URI: uri, LatestRevision: 668}, nil)
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
-		Kind: secretservice.ModelAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
 		ID:   coretesting.ModelTag.Id(),
 	}).Return(
 		nil, &coresecrets.ValueRef{
@@ -176,8 +176,8 @@ func (s *drainSuite) TestGetSecretContentExternal(c *tc.C) {
 	)
 	s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), backendConfigParamsMatcher{c: c,
 		expected: secretbackendservice.BackendConfigParams{
-			Accessor: secretservice.SecretAccessor{
-				Kind: secretservice.ModelAccessor,
+			Accessor: secret.SecretAccessor{
+				Kind: secret.ModelAccessor,
 				ID:   coretesting.ModelTag.Id(),
 			},
 			ModelUUID:      model.UUID(coretesting.ModelTag.Id()),
@@ -232,8 +232,8 @@ func (s *drainSuite) TestGetSecretRevisionContentInfoInternal(c *tc.C) {
 	uri := coresecrets.NewURI()
 	data := map[string]string{"foo": "bar"}
 	val := coresecrets.NewSecretValue(data)
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secretservice.SecretAccessor{
-		Kind: secretservice.ModelAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
 		ID:   coretesting.ModelTag.Id(),
 	}).Return(
 		val, nil, nil,
@@ -255,8 +255,8 @@ func (s *drainSuite) TestGetSecretRevisionContentInfoExternal(c *tc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secretservice.SecretAccessor{
-		Kind: secretservice.ModelAccessor,
+	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
 		ID:   coretesting.ModelTag.Id(),
 	}).Return(
 		nil, &coresecrets.ValueRef{
@@ -266,8 +266,8 @@ func (s *drainSuite) TestGetSecretRevisionContentInfoExternal(c *tc.C) {
 	)
 	s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), backendConfigParamsMatcher{c: c,
 		expected: secretbackendservice.BackendConfigParams{
-			Accessor: secretservice.SecretAccessor{
-				Kind: secretservice.ModelAccessor,
+			Accessor: secret.SecretAccessor{
+				Kind: secret.ModelAccessor,
 				ID:   coretesting.ModelTag.Id(),
 			},
 			ModelUUID:      model.UUID(coretesting.ModelTag.Id()),

--- a/apiserver/facades/controller/usersecretsdrain/mocks/service_mock.go
+++ b/apiserver/facades/controller/usersecretsdrain/mocks/service_mock.go
@@ -14,8 +14,8 @@ import (
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
-	service "github.com/juju/juju/domain/secret/service"
-	service0 "github.com/juju/juju/domain/secretbackend/service"
+	secret "github.com/juju/juju/domain/secret"
+	service "github.com/juju/juju/domain/secretbackend/service"
 	provider "github.com/juju/juju/internal/secrets/provider"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -83,7 +83,7 @@ func (c *MockSecretServiceGetSecretCall) DoAndReturn(f func(context.Context, *se
 }
 
 // GetSecretValue mocks base method.
-func (m *MockSecretService) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error) {
+func (m *MockSecretService) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretValue", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(secrets.SecretValue)
@@ -111,19 +111,19 @@ func (c *MockSecretServiceGetSecretValueCall) Return(arg0 secrets.SecretValue, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceGetSecretValueCall) Do(f func(context.Context, *secrets.URI, int, service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
+func (c *MockSecretServiceGetSecretValueCall) Do(f func(context.Context, *secrets.URI, int, secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceGetSecretValueCall) DoAndReturn(f func(context.Context, *secrets.URI, int, service.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
+func (c *MockSecretServiceGetSecretValueCall) DoAndReturn(f func(context.Context, *secrets.URI, int, secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)) *MockSecretServiceGetSecretValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListGrantedSecretsForBackend mocks base method.
-func (m *MockSecretService) ListGrantedSecretsForBackend(arg0 context.Context, arg1 string, arg2 secrets.SecretRole, arg3 ...service.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
+func (m *MockSecretService) ListGrantedSecretsForBackend(arg0 context.Context, arg1 string, arg2 secrets.SecretRole, arg3 ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -155,13 +155,13 @@ func (c *MockSecretServiceListGrantedSecretsForBackendCall) Return(arg0 []*secre
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceListGrantedSecretsForBackendCall) Do(f func(context.Context, string, secrets.SecretRole, ...service.SecretAccessor) ([]*secrets.SecretRevisionRef, error)) *MockSecretServiceListGrantedSecretsForBackendCall {
+func (c *MockSecretServiceListGrantedSecretsForBackendCall) Do(f func(context.Context, string, secrets.SecretRole, ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error)) *MockSecretServiceListGrantedSecretsForBackendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceListGrantedSecretsForBackendCall) DoAndReturn(f func(context.Context, string, secrets.SecretRole, ...service.SecretAccessor) ([]*secrets.SecretRevisionRef, error)) *MockSecretServiceListGrantedSecretsForBackendCall {
+func (c *MockSecretServiceListGrantedSecretsForBackendCall) DoAndReturn(f func(context.Context, string, secrets.SecretRole, ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error)) *MockSecretServiceListGrantedSecretsForBackendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -190,7 +190,7 @@ func (m *MockSecretBackendService) EXPECT() *MockSecretBackendServiceMockRecorde
 }
 
 // BackendConfigInfo mocks base method.
-func (m *MockSecretBackendService) BackendConfigInfo(arg0 context.Context, arg1 service0.BackendConfigParams) (*provider.ModelBackendConfigInfo, error) {
+func (m *MockSecretBackendService) BackendConfigInfo(arg0 context.Context, arg1 service.BackendConfigParams) (*provider.ModelBackendConfigInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BackendConfigInfo", arg0, arg1)
 	ret0, _ := ret[0].(*provider.ModelBackendConfigInfo)
@@ -217,19 +217,19 @@ func (c *MockSecretBackendServiceBackendConfigInfoCall) Return(arg0 *provider.Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretBackendServiceBackendConfigInfoCall) Do(f func(context.Context, service0.BackendConfigParams) (*provider.ModelBackendConfigInfo, error)) *MockSecretBackendServiceBackendConfigInfoCall {
+func (c *MockSecretBackendServiceBackendConfigInfoCall) Do(f func(context.Context, service.BackendConfigParams) (*provider.ModelBackendConfigInfo, error)) *MockSecretBackendServiceBackendConfigInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretBackendServiceBackendConfigInfoCall) DoAndReturn(f func(context.Context, service0.BackendConfigParams) (*provider.ModelBackendConfigInfo, error)) *MockSecretBackendServiceBackendConfigInfoCall {
+func (c *MockSecretBackendServiceBackendConfigInfoCall) DoAndReturn(f func(context.Context, service.BackendConfigParams) (*provider.ModelBackendConfigInfo, error)) *MockSecretBackendServiceBackendConfigInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DrainBackendConfigInfo mocks base method.
-func (m *MockSecretBackendService) DrainBackendConfigInfo(arg0 context.Context, arg1 service0.DrainBackendConfigParams) (*provider.ModelBackendConfigInfo, error) {
+func (m *MockSecretBackendService) DrainBackendConfigInfo(arg0 context.Context, arg1 service.DrainBackendConfigParams) (*provider.ModelBackendConfigInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DrainBackendConfigInfo", arg0, arg1)
 	ret0, _ := ret[0].(*provider.ModelBackendConfigInfo)
@@ -256,13 +256,13 @@ func (c *MockSecretBackendServiceDrainBackendConfigInfoCall) Return(arg0 *provid
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretBackendServiceDrainBackendConfigInfoCall) Do(f func(context.Context, service0.DrainBackendConfigParams) (*provider.ModelBackendConfigInfo, error)) *MockSecretBackendServiceDrainBackendConfigInfoCall {
+func (c *MockSecretBackendServiceDrainBackendConfigInfoCall) Do(f func(context.Context, service.DrainBackendConfigParams) (*provider.ModelBackendConfigInfo, error)) *MockSecretBackendServiceDrainBackendConfigInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretBackendServiceDrainBackendConfigInfoCall) DoAndReturn(f func(context.Context, service0.DrainBackendConfigParams) (*provider.ModelBackendConfigInfo, error)) *MockSecretBackendServiceDrainBackendConfigInfoCall {
+func (c *MockSecretBackendServiceDrainBackendConfigInfoCall) DoAndReturn(f func(context.Context, service.DrainBackendConfigParams) (*provider.ModelBackendConfigInfo, error)) *MockSecretBackendServiceDrainBackendConfigInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/usersecretsdrain/service.go
+++ b/apiserver/facades/controller/usersecretsdrain/service.go
@@ -7,7 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/secrets"
-	secretservice "github.com/juju/juju/domain/secret/service"
+	"github.com/juju/juju/domain/secret"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/internal/secrets/provider"
 )
@@ -15,9 +15,9 @@ import (
 // SecretService provides access to the secret service.
 type SecretService interface {
 	GetSecret(ctx context.Context, uri *secrets.URI) (*secrets.SecretMetadata, error)
-	GetSecretValue(context.Context, *secrets.URI, int, secretservice.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)
+	GetSecretValue(context.Context, *secrets.URI, int, secret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)
 	ListGrantedSecretsForBackend(
-		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secretservice.SecretAccessor,
+		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secret.SecretAccessor,
 	) ([]*secrets.SecretRevisionRef, error)
 }
 

--- a/domain/secret/modelmigration/export.go
+++ b/domain/secret/modelmigration/export.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/domain/secret"
 	"github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/domain/secret/state"
 	secretbackendstate "github.com/juju/juju/domain/secretbackend/state"
@@ -68,27 +69,27 @@ func ownerTagFromOwner(owner secrets.Owner) (names.Tag, error) {
 	return nil, errors.Errorf("owner kind %q %w", owner.Kind, coreerrors.NotValid)
 }
 
-func scopeTagFromAccessScope(scope service.SecretAccessScope) (names.Tag, error) {
+func scopeTagFromAccessScope(scope secret.SecretAccessScope) (names.Tag, error) {
 	switch scope.Kind {
-	case service.ApplicationAccessScope:
+	case secret.ApplicationAccessScope:
 		return names.NewApplicationTag(scope.ID), nil
-	case service.UnitAccessScope:
+	case secret.UnitAccessScope:
 		return names.NewUnitTag(scope.ID), nil
-	case service.RelationAccessScope:
+	case secret.RelationAccessScope:
 		return names.NewRelationTag(scope.ID), nil
-	case service.ModelAccessScope:
+	case secret.ModelAccessScope:
 		return names.NewModelTag(scope.ID), nil
 	}
 	return nil, errors.Errorf("scope kind %q %w", scope.Kind, coreerrors.NotValid)
 }
 
-func accessorTagFromAccessor(subject service.SecretAccessor) (names.Tag, error) {
+func accessorTagFromAccessor(subject secret.SecretAccessor) (names.Tag, error) {
 	switch subject.Kind {
-	case service.ApplicationAccessor:
+	case secret.ApplicationAccessor:
 		return names.NewApplicationTag(subject.ID), nil
-	case service.UnitAccessor:
+	case secret.UnitAccessor:
 		return names.NewUnitTag(subject.ID), nil
-	case service.ModelAccessor:
+	case secret.ModelAccessor:
 		return names.NewModelTag(subject.ID), nil
 	}
 	return nil, errors.Errorf("subject kind %q %w", subject.Kind, coreerrors.NotValid)

--- a/domain/secret/modelmigration/export_test.go
+++ b/domain/secret/modelmigration/export_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/domain/secret"
 	"github.com/juju/juju/domain/secret/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testing"
@@ -132,7 +133,7 @@ func backendSecrets(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, tim
 					Label:           "mysecret",
 					CurrentRevision: 2,
 				},
-				Accessor: service.SecretAccessor{
+				Accessor: secret.SecretAccessor{
 					Kind: "unit",
 					ID:   "mariadb/0",
 				},
@@ -142,7 +143,7 @@ func backendSecrets(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, tim
 					Label:           "",
 					CurrentRevision: 1,
 				},
-				Accessor: service.SecretAccessor{
+				Accessor: secret.SecretAccessor{
 					Kind: "unit",
 					ID:   "mariadb/0",
 				},
@@ -154,7 +155,7 @@ func backendSecrets(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, tim
 				SecretConsumerMetadata: secrets.SecretConsumerMetadata{
 					CurrentRevision: 1,
 				},
-				Accessor: service.SecretAccessor{
+				Accessor: secret.SecretAccessor{
 					Kind: "unit",
 					ID:   "remote-deadbeef/0",
 				},
@@ -164,32 +165,32 @@ func backendSecrets(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, tim
 		},
 		Access: map[string][]service.SecretAccess{
 			uri1.ID: {{
-				Scope: service.SecretAccessScope{
+				Scope: secret.SecretAccessScope{
 					Kind: "relation",
 					ID:   "mysql:server mariadb:db",
 				},
-				Subject: service.SecretAccessor{
+				Subject: secret.SecretAccessor{
 					Kind: "application",
 					ID:   "mariadb",
 				},
 				Role: "view",
 			}, {
-				Scope: service.SecretAccessScope{
+				Scope: secret.SecretAccessScope{
 					Kind: "relation",
 					ID:   "mysql:server remote-deadbeef:db",
 				},
-				Subject: service.SecretAccessor{
+				Subject: secret.SecretAccessor{
 					Kind: "application",
 					ID:   "remote-deadbeef",
 				},
 				Role: "view",
 			}},
 			uri2.ID: {{
-				Scope: service.SecretAccessScope{
+				Scope: secret.SecretAccessScope{
 					Kind: "model",
 					ID:   testing.ModelTag.Id(),
 				},
-				Subject: service.SecretAccessor{
+				Subject: secret.SecretAccessor{
 					Kind: "model",
 					ID:   testing.ModelTag.Id(),
 				},
@@ -202,7 +203,7 @@ func backendSecrets(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, tim
 			Label:           "mylabel",
 			CurrentRevision: 1,
 			LatestRevision:  666,
-			Accessor: service.SecretAccessor{
+			Accessor: secret.SecretAccessor{
 				Kind: "unit",
 				ID:   "mariadb/0",
 			},

--- a/domain/secret/modelmigration/import.go
+++ b/domain/secret/modelmigration/import.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/domain/secret/state"
@@ -91,42 +92,42 @@ func ownerFromTag(owner names.Tag) (secrets.Owner, error) {
 	return secrets.Owner{}, errors.Errorf("tag kind %q %w", owner.Kind(), coreerrors.NotValid)
 }
 
-func accessorFromTag(tag names.Tag) (service.SecretAccessor, error) {
-	result := service.SecretAccessor{
+func accessorFromTag(tag names.Tag) (secret.SecretAccessor, error) {
+	result := secret.SecretAccessor{
 		ID: tag.Id(),
 	}
 	switch kind := tag.Kind(); kind {
 	case names.ApplicationTagKind:
-		result.Kind = service.ApplicationAccessor
+		result.Kind = secret.ApplicationAccessor
 	case names.UnitTagKind:
-		result.Kind = service.UnitAccessor
+		result.Kind = secret.UnitAccessor
 	case names.ModelTagKind:
-		result.Kind = service.ModelAccessor
+		result.Kind = secret.ModelAccessor
 	default:
-		return service.SecretAccessor{}, errors.Errorf("tag kind %q not valid", kind)
+		return secret.SecretAccessor{}, errors.Errorf("tag kind %q not valid", kind)
 	}
 	return result, nil
 }
 
-func scopeFromTag(scope string) (service.SecretAccessScope, error) {
+func scopeFromTag(scope string) (secret.SecretAccessScope, error) {
 	tag, err := names.ParseTag(scope)
 	if err != nil {
-		return service.SecretAccessScope{}, errors.Capture(err)
+		return secret.SecretAccessScope{}, errors.Capture(err)
 	}
-	result := service.SecretAccessScope{
+	result := secret.SecretAccessScope{
 		ID: tag.Id(),
 	}
 	switch kind := tag.Kind(); kind {
 	case names.ApplicationTagKind:
-		result.Kind = service.ApplicationAccessScope
+		result.Kind = secret.ApplicationAccessScope
 	case names.UnitTagKind:
-		result.Kind = service.UnitAccessScope
+		result.Kind = secret.UnitAccessScope
 	case names.RelationTagKind:
-		result.Kind = service.RelationAccessScope
+		result.Kind = secret.RelationAccessScope
 	case names.ModelTagKind:
-		result.Kind = service.ModelAccessScope
+		result.Kind = secret.ModelAccessScope
 	default:
-		return service.SecretAccessScope{}, errors.Errorf("tag kind %q not valid", kind)
+		return secret.SecretAccessScope{}, errors.Errorf("tag kind %q not valid", kind)
 	}
 	return result, nil
 }

--- a/domain/secret/service/access_test.go
+++ b/domain/secret/service/access_test.go
@@ -22,8 +22,8 @@ func (s *serviceSuite) TestGetManagementCaveatOwnerUnit(c *tc.C) {
 		SubjectID:     "mariadb/0",
 	}).Return("manage", nil)
 
-	_, err := s.service.getManagementCaveat(c.Context(), uri, SecretAccessor{
-		Kind: UnitAccessor,
+	_, err := s.service.getManagementCaveat(c.Context(), uri, domainsecret.SecretAccessor{
+		Kind: domainsecret.UnitAccessor,
 		ID:   "mariadb/0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -45,8 +45,8 @@ func (s *serviceSuite) TestGetManagementCaveatLeaderUnitAppSecret(c *tc.C) {
 
 	s.ensurer.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(goodToken{})
 
-	_, err := s.service.getManagementCaveat(c.Context(), uri, SecretAccessor{
-		Kind: UnitAccessor,
+	_, err := s.service.getManagementCaveat(c.Context(), uri, domainsecret.SecretAccessor{
+		Kind: domainsecret.UnitAccessor,
 		ID:   "mariadb/0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -63,8 +63,8 @@ func (s *serviceSuite) TestGetManagementCaveatUserSecrets(c *tc.C) {
 		SubjectID:     "model-uuid",
 	}).Return("manage", nil)
 
-	_, err := s.service.getManagementCaveat(c.Context(), uri, SecretAccessor{
-		Kind: ModelAccessor,
+	_, err := s.service.getManagementCaveat(c.Context(), uri, domainsecret.SecretAccessor{
+		Kind: domainsecret.ModelAccessor,
 		ID:   "model-uuid",
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -85,8 +85,8 @@ func (s *serviceSuite) TestCanReadAppSecret(c *tc.C) {
 		SubjectID:     "mariadb",
 	}).Return("view", nil)
 
-	err := s.service.canRead(c.Context(), uri, SecretAccessor{
-		Kind: UnitAccessor,
+	err := s.service.canRead(c.Context(), uri, domainsecret.SecretAccessor{
+		Kind: domainsecret.UnitAccessor,
 		ID:   "mariadb/0",
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -123,7 +123,7 @@ func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.UR
 // secrets from the specified backend for which the specified consumers
 // have been granted the specified access.
 func (s *SecretService) ListGrantedSecretsForBackend(
-	ctx context.Context, backendID string, role secrets.SecretRole, consumers ...SecretAccessor,
+	ctx context.Context, backendID string, role secrets.SecretRole, consumers ...domainsecret.SecretAccessor,
 ) ([]*secrets.SecretRevisionRef, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -134,11 +134,11 @@ func (s *SecretService) ListGrantedSecretsForBackend(
 			SubjectID: consumer.ID,
 		}
 		switch consumer.Kind {
-		case UnitAccessor:
+		case domainsecret.UnitAccessor:
 			accessor.SubjectTypeID = domainsecret.SubjectUnit
-		case ApplicationAccessor:
+		case domainsecret.ApplicationAccessor:
 			accessor.SubjectTypeID = domainsecret.SubjectApplication
-		case ModelAccessor:
+		case domainsecret.ModelAccessor:
 			accessor.SubjectTypeID = domainsecret.SubjectModel
 		default:
 			return nil, errors.Errorf("consumer kind %q %w", consumer.Kind, coreerrors.NotValid)

--- a/domain/secret/service/delete.go
+++ b/domain/secret/service/delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/secret"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -31,7 +32,7 @@ func (s *SecretService) DeleteObsoleteUserSecretRevisions(ctx context.Context) e
 // DeleteSecret removes the specified secret.
 // If revisions is nil or the last remaining revisions are removed.
 // It returns [secreterrors.PermissionDenied] if the secret cannot be managed by the accessor.
-func (s *SecretService) DeleteSecret(ctx context.Context, uri *secrets.URI, params DeleteSecretParams) error {
+func (s *SecretService) DeleteSecret(ctx context.Context, uri *secrets.URI, params secret.DeleteSecretParams) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/secret/service/delete_test.go
+++ b/domain/secret/service/delete_test.go
@@ -46,9 +46,9 @@ func (s *serviceSuite) TestDeleteSecret(c *tc.C) {
 	revs.Add(uri, "rev-id1")
 	revs.Add(uri, "rev-id2")
 
-	err := s.service.DeleteSecret(c.Context(), uri, DeleteSecretParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err := s.service.DeleteSecret(c.Context(), uri, domainsecret.DeleteSecretParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Revisions: []int{1, 2},

--- a/domain/secret/service/exportimport.go
+++ b/domain/secret/service/exportimport.go
@@ -47,8 +47,8 @@ func (s *SecretService) GetSecretsForExport(ctx context.Context) (*SecretExport,
 			Label:           info.Label,
 			CurrentRevision: info.CurrentRevision,
 			LatestRevision:  info.LatestRevision,
-			Accessor: SecretAccessor{
-				Kind: SecretAccessorKind(info.SubjectTypeID.String()),
+			Accessor: secret.SecretAccessor{
+				Kind: secret.SecretAccessorKind(info.SubjectTypeID.String()),
 				ID:   info.SubjectID,
 			},
 		}
@@ -84,12 +84,12 @@ func (s *SecretService) GetSecretsForExport(ctx context.Context) (*SecretExport,
 		secretAccess := make([]SecretAccess, len(grants))
 		for i, grant := range grants {
 			access := SecretAccess{
-				Scope: SecretAccessScope{
-					Kind: SecretAccessScopeKind(grant.ScopeTypeID.String()),
+				Scope: secret.SecretAccessScope{
+					Kind: secret.SecretAccessScopeKind(grant.ScopeTypeID.String()),
 					ID:   grant.ScopeID,
 				},
-				Subject: SecretAccessor{
-					Kind: SecretAccessorKind(grant.SubjectTypeID.String()),
+				Subject: secret.SecretAccessor{
+					Kind: secret.SecretAccessorKind(grant.SubjectTypeID.String()),
 					ID:   grant.SubjectID,
 				},
 				Role: coresecrets.SecretRole(grant.RoleID.String()),
@@ -111,8 +111,8 @@ func (s *SecretService) GetSecretsForExport(ctx context.Context) (*SecretExport,
 					Label:           consumer.Label,
 					CurrentRevision: consumer.CurrentRevision,
 				},
-				Accessor: SecretAccessor{
-					Kind: SecretAccessorKind(consumer.SubjectTypeID.String()),
+				Accessor: secret.SecretAccessor{
+					Kind: secret.SecretAccessorKind(consumer.SubjectTypeID.String()),
 					ID:   consumer.SubjectID,
 				},
 			}
@@ -133,8 +133,8 @@ func (s *SecretService) GetSecretsForExport(ctx context.Context) (*SecretExport,
 					Label:           consumer.Label,
 					CurrentRevision: consumer.CurrentRevision,
 				},
-				Accessor: SecretAccessor{
-					Kind: SecretAccessorKind(consumer.SubjectTypeID.String()),
+				Accessor: secret.SecretAccessor{
+					Kind: secret.SecretAccessorKind(consumer.SubjectTypeID.String()),
 					ID:   consumer.SubjectID,
 				},
 			}
@@ -194,12 +194,12 @@ func (s *SecretService) ImportSecrets(ctx context.Context, modelSecrets *SecretE
 		//}
 
 		for _, access := range modelSecrets.Access[md.URI.ID] {
-			p, err := s.grantParams(ctx, SecretAccessParams{
-				Scope: SecretAccessScope{
+			p, err := s.grantParams(ctx, secret.SecretAccessParams{
+				Scope: secret.SecretAccessScope{
 					Kind: access.Scope.Kind,
 					ID:   access.Scope.ID,
 				},
-				Subject: SecretAccessor{
+				Subject: secret.SecretAccessor{
 					Kind: access.Subject.Kind,
 					ID:   access.Subject.ID,
 				},

--- a/domain/secret/service/exportimport_test.go
+++ b/domain/secret/service/exportimport_test.go
@@ -104,7 +104,7 @@ func (s *serviceSuite) TestGetSecretsForExport(c *tc.C) {
 					Label:           "my label",
 					CurrentRevision: 666,
 				},
-				Accessor: SecretAccessor{
+				Accessor: domainsecret.SecretAccessor{
 					Kind: "unit",
 					ID:   "mysql/0",
 				},
@@ -115,7 +115,7 @@ func (s *serviceSuite) TestGetSecretsForExport(c *tc.C) {
 				SecretConsumerMetadata: coresecrets.SecretConsumerMetadata{
 					CurrentRevision: 668,
 				},
-				Accessor: SecretAccessor{
+				Accessor: domainsecret.SecretAccessor{
 					Kind: "unit",
 					ID:   "remote-app/0",
 				},
@@ -123,11 +123,11 @@ func (s *serviceSuite) TestGetSecretsForExport(c *tc.C) {
 		},
 		Access: map[string][]SecretAccess{
 			uri.ID: {{
-				Scope: SecretAccessScope{
+				Scope: domainsecret.SecretAccessScope{
 					Kind: "application",
 					ID:   "wordpress",
 				},
-				Subject: SecretAccessor{
+				Subject: domainsecret.SecretAccessor{
 					Kind: "application",
 					ID:   "wordpress",
 				},
@@ -297,7 +297,7 @@ func (s *serviceSuite) TestImportSecrets(c *tc.C) {
 					Label:           "my label",
 					CurrentRevision: 666,
 				},
-				Accessor: SecretAccessor{
+				Accessor: domainsecret.SecretAccessor{
 					Kind: "unit",
 					ID:   "mysql/0",
 				},
@@ -308,7 +308,7 @@ func (s *serviceSuite) TestImportSecrets(c *tc.C) {
 				SecretConsumerMetadata: coresecrets.SecretConsumerMetadata{
 					CurrentRevision: 668,
 				},
-				Accessor: SecretAccessor{
+				Accessor: domainsecret.SecretAccessor{
 					Kind: "unit",
 					ID:   "remote-app/0",
 				},
@@ -316,22 +316,22 @@ func (s *serviceSuite) TestImportSecrets(c *tc.C) {
 		},
 		Access: map[string][]SecretAccess{
 			uri.ID: {{
-				Scope: SecretAccessScope{
+				Scope: domainsecret.SecretAccessScope{
 					Kind: "relation",
 					ID:   "wordpress:db mysql:server",
 				},
-				Subject: SecretAccessor{
+				Subject: domainsecret.SecretAccessor{
 					Kind: "unit",
 					ID:   "wordpress/0",
 				},
 				Role: "view",
 			}},
 			uri3.ID: {{
-				Scope: SecretAccessScope{
+				Scope: domainsecret.SecretAccessScope{
 					Kind: "application",
 					ID:   "mysql",
 				},
-				Subject: SecretAccessor{
+				Subject: domainsecret.SecretAccessor{
 					Kind: "application",
 					ID:   "mysql",
 				},
@@ -343,7 +343,7 @@ func (s *serviceSuite) TestImportSecrets(c *tc.C) {
 			Label:           "remote label",
 			CurrentRevision: 666,
 			LatestRevision:  668,
-			Accessor: SecretAccessor{
+			Accessor: domainsecret.SecretAccessor{
 				Kind: "unit",
 				ID:   "mysql/0",
 			},

--- a/domain/secret/service/params.go
+++ b/domain/secret/service/params.go
@@ -5,33 +5,10 @@ package service
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/domain/secret"
 )
-
-// CreateCharmSecretParams are used to create charm a secret.
-type CreateCharmSecretParams struct {
-	UpdateCharmSecretParams
-	Version int
-
-	CharmOwner CharmSecretOwner
-}
-
-// UpdateCharmSecretParams are used to update a charm secret.
-type UpdateCharmSecretParams struct {
-	Accessor SecretAccessor
-
-	RotatePolicy *secrets.RotatePolicy
-	ExpireTime   *time.Time
-	Description  *string
-	Label        *string
-	Params       map[string]interface{}
-	Data         secrets.SecretData
-	ValueRef     *secrets.ValueRef
-	Checksum     string
-}
 
 // CreateUserSecretParams are used to create a user secret.
 type CreateUserSecretParams struct {
@@ -41,7 +18,7 @@ type CreateUserSecretParams struct {
 
 // UpdateUserSecretParams are used to update a user secret.
 type UpdateUserSecretParams struct {
-	Accessor SecretAccessor
+	Accessor secret.SecretAccessor
 
 	Description *string
 	Label       *string
@@ -51,102 +28,33 @@ type UpdateUserSecretParams struct {
 	AutoPrune   *bool
 }
 
-// DeleteSecretParams are used to delete a secret.
-type DeleteSecretParams struct {
-	Accessor SecretAccessor
-
-	Revisions []int
-}
-
 // SecretRotatedParams are used to mark a secret as rotated.
 type SecretRotatedParams struct {
-	Accessor SecretAccessor
+	Accessor secret.SecretAccessor
 
 	OriginalRevision int
 	Skip             bool
 }
 
-// SecretAccessParams are used to define access to a secret.
-type SecretAccessParams struct {
-	Accessor SecretAccessor
-
-	Scope   SecretAccessScope
-	Subject SecretAccessor
-	Role    secrets.SecretRole
-}
-
 // ChangeSecretBackendParams are used to change the backend of a secret.
 type ChangeSecretBackendParams struct {
-	Accessor SecretAccessor
+	Accessor secret.SecretAccessor
 
 	ValueRef *secrets.ValueRef
 	Data     secrets.SecretData
 }
 
-// SecretAccessorKind represents the kind of an entity which can access a secret.
-type SecretAccessorKind string
-
-// These represent the kinds of secret accessor.
-const (
-	ApplicationAccessor SecretAccessorKind = "application"
-	UnitAccessor        SecretAccessorKind = "unit"
-	ModelAccessor       SecretAccessorKind = "model"
-)
-
 // GrantedSecretsGetter returns the revisions on the given backend for which
 // consumers have access with the given role.
 type GrantedSecretsGetter func(
-	ctx context.Context, backendID string, role secrets.SecretRole, consumers ...SecretAccessor,
+	ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secret.SecretAccessor,
 ) ([]*secrets.SecretRevisionRef, error)
-
-// SecretAccessor represents an entity that can access a secret.
-type SecretAccessor struct {
-	Kind SecretAccessorKind
-	ID   string
-}
-
-// SecretAccessScopeKind represents the kind of an access scope for a secret permission.
-type SecretAccessScopeKind string
-
-// These represent the kinds of secret accessor.
-const (
-	ApplicationAccessScope SecretAccessScopeKind = "application"
-	UnitAccessScope        SecretAccessScopeKind = "unit"
-	RelationAccessScope    SecretAccessScopeKind = "relation"
-	ModelAccessScope       SecretAccessScopeKind = "model"
-)
-
-// SecretAccessScope represents the scope of a secret permission.
-type SecretAccessScope struct {
-	Kind SecretAccessScopeKind
-	ID   string
-}
 
 // SecretAccess is used to define access to a secret.
 type SecretAccess struct {
-	Scope   SecretAccessScope
-	Subject SecretAccessor
+	Scope   secret.SecretAccessScope
+	Subject secret.SecretAccessor
 	Role    secrets.SecretRole
-}
-
-// CharmSecretOwnerKind represents the kind of a charm secret owner entity.
-type CharmSecretOwnerKind string
-
-// These represent the kinds of charm secret owner.
-const (
-	ApplicationOwner CharmSecretOwnerKind = "application"
-	UnitOwner        CharmSecretOwnerKind = "unit"
-)
-
-// CharmSecretOwner is the owner of a secret.
-// This is used to query or watch secrets for specified owners.
-type CharmSecretOwner struct {
-	Kind CharmSecretOwnerKind
-	ID   string
-}
-
-func (o CharmSecretOwner) String() string {
-	return fmt.Sprintf("%s-%s", o.Kind, o.ID)
 }
 
 // SecretExport defines all the secret data from a model
@@ -171,7 +79,7 @@ type SecretExport struct {
 // ConsumerInfo holds information about the consumer of a secret.
 type ConsumerInfo struct {
 	secrets.SecretConsumerMetadata
-	Accessor SecretAccessor
+	Accessor secret.SecretAccessor
 }
 
 // RemoteSecret holds information about a cross model secret.
@@ -180,5 +88,5 @@ type RemoteSecret struct {
 	Label           string
 	CurrentRevision int
 	LatestRevision  int
-	Accessor        SecretAccessor
+	Accessor        secret.SecretAccessor
 }

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -92,7 +92,7 @@ func (s *SecretService) getBackend(cfg *provider.ModelBackendConfig) (provider.S
 	return p.NewBackend(cfg)
 }
 
-func (s *SecretService) getBackendForUserSecrets(ctx context.Context, accessor SecretAccessor) (provider.SecretsBackend, string, error) {
+func (s *SecretService) getBackendForUserSecrets(ctx context.Context, accessor domainsecret.SecretAccessor) (provider.SecretsBackend, string, error) {
 	modelUUID, err := s.secretState.GetModelUUID(ctx)
 	if err != nil {
 		return nil, "", errors.Errorf("getting model UUID: %w", err)
@@ -288,7 +288,7 @@ func ptr[T any](s T) *T {
 // CreateCharmSecret creates a charm secret with the specified parameters,
 // returning an error satisfying [secreterrors.SecretLabelAlreadyExists] if the
 // secret owner already has a secret with the same label.
-func (s *SecretService) CreateCharmSecret(ctx context.Context, uri *secrets.URI, params CreateCharmSecretParams) (errOut error) {
+func (s *SecretService) CreateCharmSecret(ctx context.Context, uri *secrets.URI, params domainsecret.CreateCharmSecretParams) (errOut error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer func() {
 		span.RecordError(errOut)
@@ -340,7 +340,7 @@ func (s *SecretService) CreateCharmSecret(ctx context.Context, uri *secrets.URI,
 			}
 		}
 	}()
-	if params.CharmOwner.Kind == ApplicationOwner {
+	if params.CharmOwner.Kind == domainsecret.ApplicationCharmSecretOwner {
 		unitName, err := coreunit.NewName(params.Accessor.ID)
 		if err != nil {
 			return errors.Capture(err)
@@ -473,7 +473,7 @@ func (s *SecretService) UpdateUserSecret(ctx context.Context, uri *secrets.URI, 
 // It also returns an error satisfying [secreterrors.SecretLabelAlreadyExists] if
 // the secret owner already has a secret with the same label.
 // It returns [secreterrors.PermissionDenied] if the secret cannot be managed by the accessor.
-func (s *SecretService) UpdateCharmSecret(ctx context.Context, uri *secrets.URI, params UpdateCharmSecretParams) error {
+func (s *SecretService) UpdateCharmSecret(ctx context.Context, uri *secrets.URI, params domainsecret.UpdateCharmSecretParams) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -680,13 +680,13 @@ func (s *SecretService) ListSecrets(ctx context.Context, uri *secrets.URI,
 	return metadataList, revisionList, nil
 }
 
-func splitCharmSecretOwners(owners ...CharmSecretOwner) (domainsecret.ApplicationOwners, domainsecret.UnitOwners) {
+func splitCharmSecretOwners(owners ...domainsecret.CharmSecretOwner) (domainsecret.ApplicationOwners, domainsecret.UnitOwners) {
 	var (
 		appOwners  domainsecret.ApplicationOwners
 		unitOwners domainsecret.UnitOwners
 	)
 	for _, owner := range owners {
-		if owner.Kind == ApplicationOwner {
+		if owner.Kind == domainsecret.ApplicationCharmSecretOwner {
 			appOwners = append(appOwners, owner.ID)
 		} else {
 			unitOwners = append(unitOwners, owner.ID)
@@ -699,7 +699,7 @@ func splitCharmSecretOwners(owners ...CharmSecretOwner) (domainsecret.Applicatio
 // The result contains secrets owned by any of the non nil owner attributes.
 // The count of secret and revisions in the result must match.
 func (s *SecretService) ListCharmSecrets(
-	ctx context.Context, owners ...CharmSecretOwner,
+	ctx context.Context, owners ...domainsecret.CharmSecretOwner,
 ) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -730,7 +730,7 @@ func (s *SecretService) GetUserSecretURIByLabel(ctx context.Context, label strin
 // the secrets owned by the specified apps and units.
 func (s *SecretService) ListCharmSecretsToDrain(
 	ctx context.Context,
-	owners ...CharmSecretOwner,
+	owners ...domainsecret.CharmSecretOwner,
 ) ([]*secrets.SecretMetadataForDrain, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -749,7 +749,7 @@ func (s *SecretService) ListUserSecretsToDrain(ctx context.Context) ([]*secrets.
 
 // GetSecretValue returns the value of the specified secret revision.
 // If returns [secreterrors.SecretRevisionNotFound] is there's no such secret revision.
-func (s *SecretService) GetSecretValue(ctx context.Context, uri *secrets.URI, rev int, accessor SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error) {
+func (s *SecretService) GetSecretValue(ctx context.Context, uri *secrets.URI, rev int, accessor domainsecret.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -858,10 +858,10 @@ func (s *SecretService) ProcessCharmSecretConsumerLabel(
 					// model and don't do the update. The logic should be reworked so local lookups
 					// can ge done in a single txn.
 					// Update the label.
-					err := s.UpdateCharmSecret(ctx, uri, UpdateCharmSecretParams{
+					err := s.UpdateCharmSecret(ctx, uri, domainsecret.UpdateCharmSecretParams{
 						Label: &label,
-						Accessor: SecretAccessor{
-							Kind: UnitAccessor,
+						Accessor: domainsecret.SecretAccessor{
+							Kind: domainsecret.UnitAccessor,
 							ID:   unitName.String(),
 						},
 					})
@@ -926,11 +926,11 @@ func (s *SecretService) getAppOwnedOrUnitOwnedSecretMetadata(
 	}
 
 	appName := unitName.Application()
-	owners := []CharmSecretOwner{{
-		Kind: ApplicationOwner,
+	owners := []domainsecret.CharmSecretOwner{{
+		Kind: domainsecret.ApplicationCharmSecretOwner,
 		ID:   appName,
 	}, {
-		Kind: UnitOwner,
+		Kind: domainsecret.UnitCharmSecretOwner,
 		ID:   unitName.String(),
 	}}
 	metadata, _, err := s.ListCharmSecrets(ctx, owners...)

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -228,8 +228,8 @@ func (s *serviceSuite) assertCreateUserSecret(c *tc.C, isInternal, finalStepFail
 
 	err := s.service.CreateUserSecret(c.Context(), uri, CreateUserSecretParams{
 		UpdateUserSecretParams: UpdateUserSecretParams{
-			Accessor: SecretAccessor{
-				Kind: ModelAccessor,
+			Accessor: domainsecret.SecretAccessor{
+				Kind: domainsecret.ModelAccessor,
 				ID:   s.modelID.String(),
 			},
 			Description: ptr("a secret"),
@@ -381,8 +381,8 @@ func (s *serviceSuite) assertUpdateUserSecret(c *tc.C, isInternal, finalStepFail
 	}
 
 	err := s.service.UpdateUserSecret(c.Context(), uri, UpdateUserSecretParams{
-		Accessor: SecretAccessor{
-			Kind: ModelAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.ModelAccessor,
 			ID:   s.modelID.String(),
 		},
 		Description: ptr("a secret"),
@@ -441,10 +441,10 @@ func (s *serviceSuite) TestCreateCharmUnitSecret(c *tc.C) {
 		return nil
 	}, nil)
 
-	err = s.service.CreateCharmSecret(c.Context(), uri, CreateCharmSecretParams{
-		UpdateCharmSecretParams: UpdateCharmSecretParams{
-			Accessor: SecretAccessor{
-				Kind: UnitAccessor,
+	err = s.service.CreateCharmSecret(c.Context(), uri, domainsecret.CreateCharmSecretParams{
+		UpdateCharmSecretParams: domainsecret.UpdateCharmSecretParams{
+			Accessor: domainsecret.SecretAccessor{
+				Kind: domainsecret.UnitAccessor,
 				ID:   "mariadb/0",
 			},
 			Description:  ptr("a secret"),
@@ -455,8 +455,8 @@ func (s *serviceSuite) TestCreateCharmUnitSecret(c *tc.C) {
 			RotatePolicy: ptr(coresecrets.RotateHourly),
 		},
 		Version: 1,
-		CharmOwner: CharmSecretOwner{
-			Kind: UnitOwner,
+		CharmOwner: domainsecret.CharmSecretOwner{
+			Kind: domainsecret.UnitCharmSecretOwner,
 			ID:   "mariadb/0",
 		},
 	})
@@ -482,10 +482,10 @@ func (s *serviceSuite) TestCreateCharmUnitSecretFailedLabelAlreadyExists(c *tc.C
 		return nil
 	}, nil)
 
-	err = s.service.CreateCharmSecret(c.Context(), uri, CreateCharmSecretParams{
-		UpdateCharmSecretParams: UpdateCharmSecretParams{
-			Accessor: SecretAccessor{
-				Kind: UnitAccessor,
+	err = s.service.CreateCharmSecret(c.Context(), uri, domainsecret.CreateCharmSecretParams{
+		UpdateCharmSecretParams: domainsecret.UpdateCharmSecretParams{
+			Accessor: domainsecret.SecretAccessor{
+				Kind: domainsecret.UnitAccessor,
 				ID:   "mariadb/0",
 			},
 			Description:  ptr("a secret"),
@@ -496,8 +496,8 @@ func (s *serviceSuite) TestCreateCharmUnitSecretFailedLabelAlreadyExists(c *tc.C
 			RotatePolicy: ptr(coresecrets.RotateHourly),
 		},
 		Version: 1,
-		CharmOwner: CharmSecretOwner{
-			Kind: UnitOwner,
+		CharmOwner: domainsecret.CharmSecretOwner{
+			Kind: domainsecret.UnitCharmSecretOwner,
 			ID:   "mariadb/0",
 		},
 	})
@@ -546,10 +546,10 @@ func (s *serviceSuite) TestCreateCharmApplicationSecret(c *tc.C) {
 		return nil
 	}, nil)
 
-	err = s.service.CreateCharmSecret(c.Context(), uri, CreateCharmSecretParams{
-		UpdateCharmSecretParams: UpdateCharmSecretParams{
-			Accessor: SecretAccessor{
-				Kind: UnitAccessor,
+	err = s.service.CreateCharmSecret(c.Context(), uri, domainsecret.CreateCharmSecretParams{
+		UpdateCharmSecretParams: domainsecret.UpdateCharmSecretParams{
+			Accessor: domainsecret.SecretAccessor{
+				Kind: domainsecret.UnitAccessor,
 				ID:   "mariadb/0",
 			},
 			Description:  ptr("a secret"),
@@ -560,8 +560,8 @@ func (s *serviceSuite) TestCreateCharmApplicationSecret(c *tc.C) {
 			RotatePolicy: ptr(coresecrets.RotateHourly),
 		},
 		Version: 1,
-		CharmOwner: CharmSecretOwner{
-			Kind: ApplicationOwner,
+		CharmOwner: domainsecret.CharmSecretOwner{
+			Kind: domainsecret.ApplicationCharmSecretOwner,
 			ID:   "mariadb",
 		},
 	})
@@ -589,10 +589,10 @@ func (s *serviceSuite) TestCreateCharmApplicationSecretFailedLabelExists(c *tc.C
 		return nil
 	}, nil)
 
-	err = s.service.CreateCharmSecret(c.Context(), uri, CreateCharmSecretParams{
-		UpdateCharmSecretParams: UpdateCharmSecretParams{
-			Accessor: SecretAccessor{
-				Kind: UnitAccessor,
+	err = s.service.CreateCharmSecret(c.Context(), uri, domainsecret.CreateCharmSecretParams{
+		UpdateCharmSecretParams: domainsecret.UpdateCharmSecretParams{
+			Accessor: domainsecret.SecretAccessor{
+				Kind: domainsecret.UnitAccessor,
 				ID:   "mariadb/0",
 			},
 			Description:  ptr("a secret"),
@@ -603,8 +603,8 @@ func (s *serviceSuite) TestCreateCharmApplicationSecretFailedLabelExists(c *tc.C
 			RotatePolicy: ptr(coresecrets.RotateHourly),
 		},
 		Version: 1,
-		CharmOwner: CharmSecretOwner{
-			Kind: ApplicationOwner,
+		CharmOwner: domainsecret.CharmSecretOwner{
+			Kind: domainsecret.ApplicationCharmSecretOwner,
 			ID:   "mariadb",
 		},
 	})
@@ -645,9 +645,9 @@ func (s *serviceSuite) TestUpdateCharmSecretNoRotate(c *tc.C) {
 	s.state.EXPECT().CheckUnitSecretLabelExists(domaintesting.IsAtomicContextChecker, unitUUID, "my secret").Return(false, nil)
 	s.state.EXPECT().UpdateSecret(domaintesting.IsAtomicContextChecker, uri, p).Return(nil)
 
-	err = s.service.UpdateCharmSecret(c.Context(), uri, UpdateCharmSecretParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err = s.service.UpdateCharmSecret(c.Context(), uri, domainsecret.UpdateCharmSecretParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Description: ptr("a secret"),
@@ -705,9 +705,9 @@ func (s *serviceSuite) TestUpdateCharmSecretForUnitOwned(c *tc.C) {
 		return nil
 	})
 
-	err = s.service.UpdateCharmSecret(c.Context(), uri, UpdateCharmSecretParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err = s.service.UpdateCharmSecret(c.Context(), uri, domainsecret.UpdateCharmSecretParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Description:  ptr("a secret"),
@@ -820,9 +820,9 @@ func (s *serviceSuite) runRotatePolicyUpdateCase(c *tc.C, uri *coresecrets.URI, 
 		return nil
 	})
 
-	err = s.service.UpdateCharmSecret(c.Context(), uri, UpdateCharmSecretParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err = s.service.UpdateCharmSecret(c.Context(), uri, domainsecret.UpdateCharmSecretParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Label:        ptr("my secret"),
@@ -873,9 +873,9 @@ func (s *serviceSuite) TestUpdateCharmSecret_DoNotRecomputeNextRotateTimeIfLessF
 	s.state.EXPECT().CheckUnitSecretLabelExists(domaintesting.IsAtomicContextChecker, unitUUID, "my secret").Return(false, nil)
 	s.state.EXPECT().UpdateSecret(domaintesting.IsAtomicContextChecker, uri, p).Return(nil)
 
-	err = s.service.UpdateCharmSecret(c.Context(), uri, UpdateCharmSecretParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err = s.service.UpdateCharmSecret(c.Context(), uri, domainsecret.UpdateCharmSecretParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Description:  ptr("a secret"),
@@ -914,9 +914,9 @@ func (s *serviceSuite) TestUpdateCharmSecretForUnitOwnedFailedLabelExists(c *tc.
 	s.state.EXPECT().GetSecretOwner(domaintesting.IsAtomicContextChecker, uri).Return(domainsecret.Owner{Kind: domainsecret.UnitOwner, UUID: unitUUID.String()}, nil)
 	s.state.EXPECT().CheckUnitSecretLabelExists(domaintesting.IsAtomicContextChecker, unitUUID, "my secret").Return(true, nil)
 
-	err = s.service.UpdateCharmSecret(c.Context(), uri, UpdateCharmSecretParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err = s.service.UpdateCharmSecret(c.Context(), uri, domainsecret.UpdateCharmSecretParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Description:  ptr("a secret"),
@@ -974,9 +974,9 @@ func (s *serviceSuite) TestUpdateCharmSecretForAppOwned(c *tc.C) {
 		return nil
 	})
 
-	err = s.service.UpdateCharmSecret(c.Context(), uri, UpdateCharmSecretParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err = s.service.UpdateCharmSecret(c.Context(), uri, domainsecret.UpdateCharmSecretParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Description:  ptr("a secret"),
@@ -1015,9 +1015,9 @@ func (s *serviceSuite) TestUpdateCharmSecretForAppOwnedFailedLabelExists(c *tc.C
 	s.state.EXPECT().GetSecretOwner(domaintesting.IsAtomicContextChecker, uri).Return(domainsecret.Owner{Kind: domainsecret.ApplicationOwner, UUID: appUUID.String()}, nil)
 	s.state.EXPECT().CheckApplicationSecretLabelExists(domaintesting.IsAtomicContextChecker, appUUID, "my secret").Return(true, nil)
 
-	err = s.service.UpdateCharmSecret(c.Context(), uri, UpdateCharmSecretParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err = s.service.UpdateCharmSecret(c.Context(), uri, domainsecret.UpdateCharmSecretParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Description:  ptr("a secret"),
@@ -1057,8 +1057,8 @@ func (s *serviceSuite) TestGetSecretValue(c *tc.C) {
 	}).Return("manage", nil)
 	s.state.EXPECT().GetSecretValue(gomock.Any(), uri, 666).Return(coresecrets.SecretData{"foo": "bar"}, nil, nil)
 
-	data, ref, err := s.service.GetSecretValue(c.Context(), uri, 666, SecretAccessor{
-		Kind: UnitAccessor,
+	data, ref, err := s.service.GetSecretValue(c.Context(), uri, 666, domainsecret.SecretAccessor{
+		Kind: domainsecret.UnitAccessor,
 		ID:   "mariadb/0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -1143,11 +1143,11 @@ func (s *serviceSuite) TestListCharmSecretsToDrain(c *tc.C) {
 	s.state.EXPECT().ListCharmSecretsToDrain(
 		gomock.Any(), domainsecret.ApplicationOwners{"mariadb"}, domainsecret.UnitOwners{"mariadb/0"}).Return(md, nil)
 
-	got, err := s.service.ListCharmSecretsToDrain(c.Context(), []CharmSecretOwner{{
-		Kind: UnitOwner,
+	got, err := s.service.ListCharmSecretsToDrain(c.Context(), []domainsecret.CharmSecretOwner{{
+		Kind: domainsecret.UnitCharmSecretOwner,
 		ID:   "mariadb/0",
 	}, {
-		Kind: ApplicationOwner,
+		Kind: domainsecret.ApplicationCharmSecretOwner,
 		ID:   "mariadb",
 	}}...)
 	c.Assert(err, tc.ErrorIsNil)
@@ -1178,11 +1178,11 @@ func (s *serviceSuite) TestListUserSecretsToDrain(c *tc.C) {
 func (s *serviceSuite) TestListCharmSecrets(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	owners := []CharmSecretOwner{{
-		Kind: ApplicationOwner,
+	owners := []domainsecret.CharmSecretOwner{{
+		Kind: domainsecret.ApplicationCharmSecretOwner,
 		ID:   "mysql",
 	}, {
-		Kind: UnitOwner,
+		Kind: domainsecret.UnitCharmSecretOwner,
 		ID:   "mysql/0",
 	}}
 	md := []*coresecrets.SecretMetadata{{Label: "one"}}
@@ -1331,8 +1331,8 @@ func (s *serviceSuite) TestListSecretsAllError(c *tc.C) {
 func (s *serviceSuite) TestListCharmJustApplication(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	owners := []CharmSecretOwner{{
-		Kind: ApplicationOwner,
+	owners := []domainsecret.CharmSecretOwner{{
+		Kind: domainsecret.ApplicationCharmSecretOwner,
 		ID:   "mysql",
 	}}
 	md := []*coresecrets.SecretMetadata{{Label: "one"}}
@@ -1350,8 +1350,8 @@ func (s *serviceSuite) TestListCharmJustApplication(c *tc.C) {
 func (s *serviceSuite) TestListCharmJustUnit(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	owners := []CharmSecretOwner{{
-		Kind: UnitOwner,
+	owners := []domainsecret.CharmSecretOwner{{
+		Kind: domainsecret.UnitCharmSecretOwner,
 		ID:   "mysql/0",
 	}}
 	md := []*coresecrets.SecretMetadata{{Label: "one"}}
@@ -1397,17 +1397,17 @@ func (s *serviceSuite) TestGrantSecretUnitAccess(c *tc.C) {
 		RoleID:        domainsecret.RoleManage,
 	}).Return(nil)
 
-	err := s.service.GrantSecretAccess(c.Context(), uri, SecretAccessParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err := s.service.GrantSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "another/0",
 		},
-		Scope: SecretAccessScope{
-			Kind: ApplicationAccessScope,
+		Scope: domainsecret.SecretAccessScope{
+			Kind: domainsecret.ApplicationAccessScope,
 			ID:   "mysql",
 		},
-		Subject: SecretAccessor{
-			Kind: UnitAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mysql/0",
 		},
 		Role: "manage",
@@ -1433,17 +1433,17 @@ func (s *serviceSuite) TestGrantSecretApplicationAccess(c *tc.C) {
 		RoleID:        domainsecret.RoleView,
 	}).Return(nil)
 
-	err := s.service.GrantSecretAccess(c.Context(), uri, SecretAccessParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err := s.service.GrantSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "another/0",
 		},
-		Scope: SecretAccessScope{
-			Kind: ApplicationAccessScope,
+		Scope: domainsecret.SecretAccessScope{
+			Kind: domainsecret.ApplicationAccessScope,
 			ID:   "mysql",
 		},
-		Subject: SecretAccessor{
-			Kind: ApplicationAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.ApplicationAccessor,
 			ID:   "mysql",
 		},
 		Role: "view",
@@ -1465,16 +1465,16 @@ func (s *serviceSuite) TestGrantSecretModelAccess(c *tc.C) {
 		RoleID:        domainsecret.RoleManage,
 	}).Return(nil)
 
-	err := s.service.GrantSecretAccess(c.Context(), uri, SecretAccessParams{
-		Accessor: SecretAccessor{
-			Kind: ModelAccessor,
+	err := s.service.GrantSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.ModelAccessor,
 			ID:   "model-uuid",
 		},
-		Scope: SecretAccessScope{
-			Kind: ModelAccessScope,
+		Scope: domainsecret.SecretAccessScope{
+			Kind: domainsecret.ModelAccessScope,
 		},
-		Subject: SecretAccessor{
-			Kind: ModelAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.ModelAccessor,
 		},
 		Role: "manage",
 	})
@@ -1509,17 +1509,17 @@ func (s *serviceSuite) TestGrantSecretRelationScope(c *tc.C) {
 		RoleID:        domainsecret.RoleView,
 	}).Return(nil)
 
-	err := s.service.GrantSecretAccess(c.Context(), uri, SecretAccessParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err := s.service.GrantSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "another/0",
 		},
-		Scope: SecretAccessScope{
-			Kind: RelationAccessScope,
+		Scope: domainsecret.SecretAccessScope{
+			Kind: domainsecret.RelationAccessScope,
 			ID:   "mediawiki:db mysql:db",
 		},
-		Subject: SecretAccessor{
-			Kind: ApplicationAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.ApplicationAccessor,
 			ID:   "mysql",
 		},
 		Role: "view",
@@ -1542,13 +1542,13 @@ func (s *serviceSuite) TestRevokeSecretUnitAccess(c *tc.C) {
 		SubjectUUID:   unitUUID.String(),
 	}).Return(nil)
 
-	err := s.service.RevokeSecretAccess(c.Context(), uri, SecretAccessParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err := s.service.RevokeSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mysql/0",
 		},
-		Subject: SecretAccessor{
-			Kind: UnitAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "another/0",
 		},
 	})
@@ -1570,13 +1570,13 @@ func (s *serviceSuite) TestRevokeSecretApplicationAccess(c *tc.C) {
 		SubjectUUID:   appUUID.String(),
 	}).Return(nil)
 
-	err := s.service.RevokeSecretAccess(c.Context(), uri, SecretAccessParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+	err := s.service.RevokeSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mysql/0",
 		},
-		Subject: SecretAccessor{
-			Kind: ApplicationAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.ApplicationAccessor,
 			ID:   "another",
 		},
 	})
@@ -1598,13 +1598,13 @@ func (s *serviceSuite) TestRevokeSecretModelAccess(c *tc.C) {
 		SubjectUUID:   appUUID.String(),
 	}).Return(nil)
 
-	err := s.service.RevokeSecretAccess(c.Context(), uri, SecretAccessParams{
-		Accessor: SecretAccessor{
-			Kind: ModelAccessor,
+	err := s.service.RevokeSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.ModelAccessor,
 			ID:   "model-uuid",
 		},
-		Subject: SecretAccessor{
-			Kind: ApplicationAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.ApplicationAccessor,
 			ID:   "mysql",
 		},
 	})
@@ -1620,8 +1620,8 @@ func (s *serviceSuite) TestGetSecretAccess(c *tc.C) {
 		SubjectID:     "mysql",
 	}).Return("manage", nil)
 
-	role, err := s.service.getSecretAccess(c.Context(), uri, SecretAccessor{
-		Kind: ApplicationAccessor,
+	role, err := s.service.getSecretAccess(c.Context(), uri, domainsecret.SecretAccessor{
+		Kind: domainsecret.ApplicationAccessor,
 		ID:   "mysql",
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -1637,8 +1637,8 @@ func (s *serviceSuite) TestGetSecretAccessNone(c *tc.C) {
 		SubjectID:     "mysql",
 	}).Return("", nil)
 
-	role, err := s.service.getSecretAccess(c.Context(), uri, SecretAccessor{
-		Kind: ApplicationAccessor,
+	role, err := s.service.getSecretAccess(c.Context(), uri, domainsecret.SecretAccessor{
+		Kind: domainsecret.ApplicationAccessor,
 		ID:   "mysql",
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -1655,8 +1655,8 @@ func (s *serviceSuite) TestGetSecretAccessRelationScope(c *tc.C) {
 		SubjectID:     "mysql",
 	}).Return(relUUID.String(), nil)
 
-	got, err := s.service.GetSecretAccessRelationScope(c.Context(), uri, SecretAccessor{
-		Kind: ApplicationAccessor,
+	got, err := s.service.GetSecretAccessRelationScope(c.Context(), uri, domainsecret.SecretAccessor{
+		Kind: domainsecret.ApplicationAccessor,
 		ID:   "mysql",
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -1693,22 +1693,22 @@ func (s *serviceSuite) TestGetSecretGrants(c *tc.C) {
 	g, err := s.service.GetSecretGrants(c.Context(), uri, coresecrets.RoleView)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(g, tc.DeepEquals, []SecretAccess{{
-		Scope: SecretAccessScope{
-			Kind: ModelAccessScope,
+		Scope: domainsecret.SecretAccessScope{
+			Kind: domainsecret.ModelAccessScope,
 			ID:   "model-uuid",
 		},
-		Subject: SecretAccessor{
-			Kind: ApplicationAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.ApplicationAccessor,
 			ID:   "mysql",
 		},
 		Role: coresecrets.RoleView,
 	}, {
-		Scope: SecretAccessScope{
-			Kind: RelationAccessScope,
+		Scope: domainsecret.SecretAccessScope{
+			Kind: domainsecret.RelationAccessScope,
 			ID:   "mediawiki:db mysql:db",
 		},
-		Subject: SecretAccessor{
-			Kind: UnitAccessor,
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mediawiki/0",
 		},
 		Role: coresecrets.RoleView,
@@ -1739,8 +1739,8 @@ func (s *serviceSuite) TestChangeSecretBackendToExternalBackend(c *tc.C) {
 	}, nil)
 
 	err := s.service.ChangeSecretBackend(ctx, uri, 1, ChangeSecretBackendParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		ValueRef: valueRef,
@@ -1769,8 +1769,8 @@ func (s *serviceSuite) TestChangeSecretBackendToInternalBackend(c *tc.C) {
 	}, nil)
 
 	err := s.service.ChangeSecretBackend(ctx, uri, 1, ChangeSecretBackendParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Data: map[string]string{"foo": "bar"},
@@ -1799,8 +1799,8 @@ func (s *serviceSuite) TestChangeSecretBackendFailedAndRollback(c *tc.C) {
 	}, nil)
 
 	err := s.service.ChangeSecretBackend(ctx, uri, 1, ChangeSecretBackendParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Data: map[string]string{"foo": "bar"},
@@ -1823,8 +1823,8 @@ func (s *serviceSuite) TestChangeSecretBackendFailedPermissionDenied(c *tc.C) {
 	}).Return("view", nil)
 
 	err := s.service.ChangeSecretBackend(ctx, uri, 1, ChangeSecretBackendParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Data: map[string]string{"foo": "bar"},
@@ -1852,8 +1852,8 @@ func (s *serviceSuite) TestChangeSecretBackendFailedSecretNotFound(c *tc.C) {
 	}, nil)
 
 	err := s.service.ChangeSecretBackend(ctx, uri, 1, ChangeSecretBackendParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Data: map[string]string{"foo": "bar"},
@@ -1884,8 +1884,8 @@ func (s *serviceSuite) TestSecretsRotated(c *tc.C) {
 	}, nil)
 
 	err := s.service.SecretRotated(ctx, uri, SecretRotatedParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		OriginalRevision: 666,
@@ -1915,8 +1915,8 @@ func (s *serviceSuite) TestSecretsRotatedRetry(c *tc.C) {
 	}, nil)
 
 	err := s.service.SecretRotated(ctx, uri, SecretRotatedParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		OriginalRevision: 666,
@@ -1947,8 +1947,8 @@ func (s *serviceSuite) TestSecretsRotatedForce(c *tc.C) {
 	}, nil)
 
 	err := s.service.SecretRotated(ctx, uri, SecretRotatedParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		OriginalRevision: 666,
@@ -1972,8 +1972,8 @@ func (s *serviceSuite) TestSecretsRotatedThenNever(c *tc.C) {
 	}, nil)
 
 	err := s.service.SecretRotated(ctx, uri, SecretRotatedParams{
-		Accessor: SecretAccessor{
-			Kind: UnitAccessor,
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		OriginalRevision: 666,
@@ -2456,16 +2456,16 @@ func (s *serviceSuite) TestWatchObsolete(c *tc.C) {
 	svc := NewWatchableService(
 		s.state, s.secretBackendState, s.ensurer, mockWatcherFactory, loggertesting.WrapCheckLog(c))
 	w, err := svc.WatchObsoleteSecrets(c.Context(),
-		CharmSecretOwner{
-			Kind: ApplicationOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
-		CharmSecretOwner{
-			Kind: UnitOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.UnitCharmSecretOwner,
 			ID:   "mysql/0",
 		},
-		CharmSecretOwner{
-			Kind: UnitOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.UnitCharmSecretOwner,
 			ID:   "mysql/1",
 		},
 	)
@@ -2612,16 +2612,16 @@ func (s *serviceSuite) TestWatchSecretsRotationChanges(c *tc.C) {
 	svc := NewWatchableService(
 		s.state, s.secretBackendState, s.ensurer, mockWatcherFactory, loggertesting.WrapCheckLog(c))
 	w, err := svc.WatchSecretsRotationChanges(c.Context(),
-		CharmSecretOwner{
-			Kind: ApplicationOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.ApplicationCharmSecretOwner,
 			ID:   "mediawiki",
 		},
-		CharmSecretOwner{
-			Kind: UnitOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.UnitCharmSecretOwner,
 			ID:   "mysql/0",
 		},
-		CharmSecretOwner{
-			Kind: UnitOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.UnitCharmSecretOwner,
 			ID:   "mysql/1",
 		},
 	)
@@ -2698,16 +2698,16 @@ func (s *serviceSuite) TestWatchSecretRevisionsExpiryChanges(c *tc.C) {
 	svc := NewWatchableService(
 		s.state, s.secretBackendState, s.ensurer, mockWatcherFactory, loggertesting.WrapCheckLog(c))
 	w, err := svc.WatchSecretRevisionsExpiryChanges(c.Context(),
-		CharmSecretOwner{
-			Kind: ApplicationOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.ApplicationCharmSecretOwner,
 			ID:   "mediawiki",
 		},
-		CharmSecretOwner{
-			Kind: UnitOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.UnitCharmSecretOwner,
 			ID:   "mysql/0",
 		},
-		CharmSecretOwner{
-			Kind: UnitOwner,
+		domainsecret.CharmSecretOwner{
+			Kind: domainsecret.UnitCharmSecretOwner,
 			ID:   "mysql/1",
 		},
 	)

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -175,7 +175,7 @@ func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unit
 //     has any consumers
 //
 // Obsolete revisions results are "uri/revno".
-func (s *WatchableService) WatchObsoleteSecrets(ctx context.Context, owners ...CharmSecretOwner) (watcher.StringsWatcher, error) {
+func (s *WatchableService) WatchObsoleteSecrets(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.StringsWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -235,7 +235,7 @@ func (s *SecretService) obsoleteWatcherMapperFunc(
 //
 // Deleted revisions results are "uri/revno" and deleted
 // secret results are "uri".
-func (s *WatchableService) WatchDeletedSecrets(ctx context.Context, owners ...CharmSecretOwner) (watcher.StringsWatcher, error) {
+func (s *WatchableService) WatchDeletedSecrets(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.StringsWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -415,7 +415,7 @@ func splitSecretRevision(s string) (string, int) {
 }
 
 // WatchSecretRevisionsExpiryChanges returns a watcher that notifies when the expiry time of a secret revision changes.
-func (s *WatchableService) WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
+func (s *WatchableService) WatchSecretRevisionsExpiryChanges(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -453,7 +453,7 @@ func (s *WatchableService) WatchSecretRevisionsExpiryChanges(ctx context.Context
 }
 
 // WatchSecretsRotationChanges returns a watcher that notifies when the rotation time of a secret changes.
-func (s *WatchableService) WatchSecretsRotationChanges(ctx context.Context, owners ...CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
+func (s *WatchableService) WatchSecretsRotationChanges(ctx context.Context, owners ...secret.CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/secret/service_test.go
+++ b/domain/secret/service_test.go
@@ -69,9 +69,9 @@ func (s *serviceSuite) TestDeleteSecretInternal(c *tc.C) {
 	s.secretBackendState.EXPECT().AddSecretBackendReference(gomock.Any(), nil, s.modelUUID, gomock.Any())
 	uri := s.createSecret(c, map[string]string{"foo": "bar"}, nil)
 
-	err := s.svc.DeleteSecret(c.Context(), uri, service.DeleteSecretParams{
-		Accessor: service.SecretAccessor{
-			Kind: service.UnitAccessor,
+	err := s.svc.DeleteSecret(c.Context(), uri, secret.DeleteSecretParams{
+		Accessor: secret.SecretAccessor{
+			Kind: secret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Revisions: []int{1},
@@ -92,9 +92,9 @@ func (s *serviceSuite) TestDeleteSecretExternal(c *tc.C) {
 	s.secretBackendState.EXPECT().AddSecretBackendReference(gomock.Any(), ref, s.modelUUID, gomock.Any())
 	uri := s.createSecret(c, nil, ref)
 
-	err := s.svc.DeleteSecret(c.Context(), uri, service.DeleteSecretParams{
-		Accessor: service.SecretAccessor{
-			Kind: service.UnitAccessor,
+	err := s.svc.DeleteSecret(c.Context(), uri, secret.DeleteSecretParams{
+		Accessor: secret.SecretAccessor{
+			Kind: secret.UnitAccessor,
 			ID:   "mariadb/0",
 		},
 		Revisions: []int{1},
@@ -169,14 +169,14 @@ func (s *serviceSuite) createSecret(c *tc.C, data map[string]string, valueRef *c
 	c.Assert(err, tc.ErrorIsNil)
 
 	uri := coresecrets.NewURI()
-	err = s.svc.CreateCharmSecret(ctx, uri, service.CreateCharmSecretParams{
-		UpdateCharmSecretParams: service.UpdateCharmSecretParams{
+	err = s.svc.CreateCharmSecret(ctx, uri, secret.CreateCharmSecretParams{
+		UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
 			Data:     data,
 			ValueRef: valueRef,
 		},
 		Version: 1,
-		CharmOwner: service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		CharmOwner: secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mariadb/0",
 		},
 	})

--- a/domain/secret/types.go
+++ b/domain/secret/types.go
@@ -4,6 +4,7 @@
 package secret
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/juju/core/secrets"
@@ -154,3 +155,94 @@ type RemoteSecretInfo struct {
 	CurrentRevision int
 	LatestRevision  int
 }
+
+// CreateCharmSecretParams are used to create charm a secret.
+type CreateCharmSecretParams struct {
+	UpdateCharmSecretParams
+	Version int
+
+	CharmOwner CharmSecretOwner
+}
+
+// UpdateCharmSecretParams are used to update a charm secret.
+type UpdateCharmSecretParams struct {
+	Accessor SecretAccessor
+
+	RotatePolicy *secrets.RotatePolicy
+	ExpireTime   *time.Time
+	Description  *string
+	Label        *string
+	Params       map[string]interface{}
+	Data         secrets.SecretData
+	ValueRef     *secrets.ValueRef
+	Checksum     string
+}
+
+// DeleteSecretParams are used to delete a secret.
+type DeleteSecretParams struct {
+	Accessor SecretAccessor
+
+	Revisions []int
+}
+
+// CharmSecretOwnerKind represents the kind of a charm secret owner entity.
+type CharmSecretOwnerKind string
+
+// These represent the kinds of charm secret owner.
+const (
+	ApplicationCharmSecretOwner CharmSecretOwnerKind = "application"
+	UnitCharmSecretOwner        CharmSecretOwnerKind = "unit"
+)
+
+// SecretAccessParams are used to define access to a secret.
+type SecretAccessParams struct {
+	Accessor SecretAccessor
+
+	Scope   SecretAccessScope
+	Subject SecretAccessor
+	Role    secrets.SecretRole
+}
+
+// SecretAccessor represents an entity that can access a secret.
+type SecretAccessor struct {
+	Kind SecretAccessorKind
+	ID   string
+}
+
+// CharmSecretOwner is the owner of a secret.
+// This is used to query or watch secrets for specified owners.
+type CharmSecretOwner struct {
+	Kind CharmSecretOwnerKind
+	ID   string
+}
+
+func (o CharmSecretOwner) String() string {
+	return fmt.Sprintf("%s-%s", o.Kind, o.ID)
+}
+
+// SecretAccessorKind represents the kind of an entity which can access a secret.
+type SecretAccessorKind string
+
+// These represent the kinds of secret accessor.
+const (
+	ApplicationAccessor SecretAccessorKind = "application"
+	UnitAccessor        SecretAccessorKind = "unit"
+	ModelAccessor       SecretAccessorKind = "model"
+)
+
+// SecretAccessScope represents the scope of a secret permission.
+type SecretAccessScope struct {
+	Kind SecretAccessScopeKind
+	ID   string
+}
+
+// SecretAccessScopeKind represents the kind of an access scope for a secret permission.
+type SecretAccessScopeKind string
+
+// These represent the kinds of secret accessor.
+const (
+	ApplicationAccessScope SecretAccessScopeKind = "application"
+	UnitAccessScope        SecretAccessScopeKind = "unit"
+	RelationAccessScope    SecretAccessScopeKind = "relation"
+	ModelAccessScope       SecretAccessScopeKind = "model"
+)

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -83,21 +83,21 @@ func (s *watcherSuite) TestWatchObsoleteForAppsAndUnitsOwned(c *tc.C) {
 	s.AssertChangeStreamIdle(c)
 
 	w, err := svc.WatchObsoleteSecrets(ctx,
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
-		service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mysql/0",
 		},
 
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mediawiki",
 		},
-		service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mediawiki/0",
 		},
 	)
@@ -165,8 +165,8 @@ func (s *watcherSuite) TestWatchObsoleteForAppsOwned(c *tc.C) {
 	s.AssertChangeStreamIdle(c)
 
 	w, err := svc.WatchObsoleteSecrets(ctx,
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
 	)
@@ -228,8 +228,8 @@ func (s *watcherSuite) TestWatchObsoleteForUnitsOwned(c *tc.C) {
 	s.AssertChangeStreamIdle(c)
 
 	w, err := svc.WatchObsoleteSecrets(ctx,
-		service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mysql/0",
 		},
 	)
@@ -365,8 +365,8 @@ func (s *watcherSuite) TestWatchDeletedForAppOwnedSecret(c *tc.C) {
 	s.AssertChangeStreamIdle(c)
 
 	w, err := svc.WatchDeletedSecrets(ctx,
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
 	)
@@ -422,8 +422,8 @@ func (s *watcherSuite) TestWatchDeletedSecretRemovesRevisionFromChangeSet(c *tc.
 	s.AssertChangeStreamIdle(c)
 
 	w, err := svc.WatchDeletedSecrets(ctx,
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
 	)
@@ -482,8 +482,8 @@ func (s *watcherSuite) TestWatchDeletedForUnitsOwnedSecret(c *tc.C) {
 	s.AssertChangeStreamIdle(c)
 
 	w, err := svc.WatchDeletedSecrets(ctx,
-		service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mysql/0",
 		},
 	)
@@ -723,12 +723,12 @@ func (s *watcherSuite) TestWatchSecretsRotationChanges(c *tc.C) {
 	s.AssertChangeStreamIdle(c)
 
 	w, err := svc.WatchSecretsRotationChanges(c.Context(),
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
-		service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mediawiki/0",
 		},
 	)
@@ -781,12 +781,12 @@ func (s *watcherSuite) TestWatchSecretsRotationChanges(c *tc.C) {
 
 	// Pretend that the agent restarted and the watcher is re-created.
 	w1, err := svc.WatchSecretsRotationChanges(c.Context(),
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
-		service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mediawiki/0",
 		},
 	)
@@ -834,12 +834,12 @@ func (s *watcherSuite) TestWatchSecretsRevisionExpiryChanges(c *tc.C) {
 	s.AssertChangeStreamIdle(c)
 
 	w, err := svc.WatchSecretRevisionsExpiryChanges(c.Context(),
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
-		service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mediawiki/0",
 		},
 	)
@@ -896,12 +896,12 @@ func (s *watcherSuite) TestWatchSecretsRevisionExpiryChanges(c *tc.C) {
 
 	// Pretend that the agent restarted and the watcher is re-created.
 	w1, err := svc.WatchSecretRevisionsExpiryChanges(c.Context(),
-		service.CharmSecretOwner{
-			Kind: service.ApplicationOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.ApplicationCharmSecretOwner,
 			ID:   "mysql",
 		},
-		service.CharmSecretOwner{
-			Kind: service.UnitOwner,
+		secret.CharmSecretOwner{
+			Kind: secret.UnitCharmSecretOwner,
 			ID:   "mediawiki/0",
 		},
 	)

--- a/domain/secretbackend/service/interface.go
+++ b/domain/secretbackend/service/interface.go
@@ -9,6 +9,7 @@ import (
 
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/secret"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/domain/secretbackend"
 	"github.com/juju/juju/internal/secrets/provider"
@@ -49,10 +50,10 @@ func AdminBackendConfigGetterFunc(
 // UserSecretBackendConfigGetterFunc returns a function that gets the
 // config for a given model's current secret backend for creating or updating user secrets.
 func UserSecretBackendConfigGetterFunc(backendService *WatchableService, modelUUID coremodel.UUID) func(
-	stdCtx context.Context, gsg secretservice.GrantedSecretsGetter, accessor secretservice.SecretAccessor,
+	stdCtx context.Context, gsg secretservice.GrantedSecretsGetter, accessor secret.SecretAccessor,
 ) (*provider.ModelBackendConfigInfo, error) {
 	return func(
-		stdCtx context.Context, gsg secretservice.GrantedSecretsGetter, accessor secretservice.SecretAccessor,
+		stdCtx context.Context, gsg secretservice.GrantedSecretsGetter, accessor secret.SecretAccessor,
 	) (*provider.ModelBackendConfigInfo, error) {
 		return backendService.BackendConfigInfo(stdCtx, BackendConfigParams{
 			GrantedSecretsGetter: gsg,

--- a/domain/secretbackend/service/params.go
+++ b/domain/secretbackend/service/params.go
@@ -6,6 +6,7 @@ package service
 import (
 	"github.com/juju/juju/core/leadership"
 	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/domain/secret"
 	secretservice "github.com/juju/juju/domain/secret/service"
 )
 
@@ -13,7 +14,7 @@ import (
 type DrainBackendConfigParams struct {
 	GrantedSecretsGetter secretservice.GrantedSecretsGetter
 	LeaderToken          leadership.Token
-	Accessor             secretservice.SecretAccessor
+	Accessor             secret.SecretAccessor
 	ModelUUID            coremodel.UUID
 	BackendID            string
 }
@@ -22,7 +23,7 @@ type DrainBackendConfigParams struct {
 type BackendConfigParams struct {
 	GrantedSecretsGetter secretservice.GrantedSecretsGetter
 	LeaderToken          leadership.Token
-	Accessor             secretservice.SecretAccessor
+	Accessor             secret.SecretAccessor
 	ModelUUID            coremodel.UUID
 	BackendIDs           []string
 	SameController       bool


### PR DESCRIPTION
These types will be used by other domains as well. Put them at the domain level rather than the service level to reduce dependencies in the other domains. This fits the pattern which emerged as more domains were implemented.

To resolve a conflict in const naming for secret owner types the following changes were made to CharmSecretOwnerKind constants:
* ApplicationOwner -> ApplicationCharmSecretOwner 
* UnitOwner -> UnitCharmSecretOwner 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unit tests pass, no change to current behavior.

## Links

Prep work for 
**Jira card:** [JUJU-7886](https://warthogs.atlassian.net/browse/JUJU-7886)


[JUJU-7886]: https://warthogs.atlassian.net/browse/JUJU-7886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ