### PR TITLE
fix(import): generate and include NetNodeUUID when creating machines

### DIFF
--- a/domain/machine/service/migration.go
+++ b/domain/machine/service/migration.go
@@ -13,6 +13,7 @@ import (
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/domain/machine"
+	"github.com/juju/juju/domain/network"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -72,10 +73,15 @@ func (s *MigrationService) CreateMachine(ctx context.Context, machineName corema
 	// the state layer we don't keep regenerating.
 	machineUUID, err := createUUIDs()
 	if err != nil {
-		return "", errors.Errorf("creating machine %q: %w", machineName, err)
+		return "", errors.Errorf("creating UUID for machine %q: %w", machineName, err)
+	}
+	netNodeUUID, err := network.NewNetNodeUUID()
+	if err != nil {
+		return "", errors.Errorf("creating net node UUID for machine %q: %w", machineName, err)
 	}
 	err = s.st.InsertMigratingMachine(ctx, machineName.String(), machine.CreateMachineArgs{
 		MachineUUID: machineUUID,
+		NetNodeUUID: netNodeUUID,
 		Nonce:       nonce,
 	})
 	if err != nil {

--- a/domain/machine/service/migration_test.go
+++ b/domain/machine/service/migration_test.go
@@ -106,6 +106,7 @@ func (s *migrationServiceSuite) TestCreateMachine(c *tc.C) {
 	s.state.EXPECT().InsertMigratingMachine(gomock.Any(), "666", gomock.Any()).
 		DoAndReturn(func(ctx context.Context, machineName string, args machine.CreateMachineArgs) error {
 			expectedUUID = args.MachineUUID
+			c.Check(args.NetNodeUUID, tc.Not(tc.Equals), "")
 			return nil
 		})
 
@@ -124,6 +125,7 @@ func (s *migrationServiceSuite) TestCreateMachineSuccessNonce(c *tc.C) {
 		DoAndReturn(func(ctx context.Context, machineName string, args machine.CreateMachineArgs) error {
 			expectedUUID = args.MachineUUID
 			c.Check(*args.Nonce, tc.Equals, "foo")
+			c.Check(args.NetNodeUUID, tc.Not(tc.Equals), "")
 			return nil
 		})
 

--- a/domain/machine/state/migration.go
+++ b/domain/machine/state/migration.go
@@ -119,6 +119,7 @@ func (st *State) InsertMigratingMachine(ctx context.Context, machineName string,
 		}
 		return CreateMachineWithName(ctx, tx, st, st.clock, machineName, CreateMachineArgs{
 			MachineUUID: args.MachineUUID.String(),
+			NetNodeUUID: args.NetNodeUUID.String(),
 			Platform:    args.Platform,
 			Nonce:       args.Nonce,
 		})

--- a/domain/machine/types.go
+++ b/domain/machine/types.go
@@ -40,6 +40,10 @@ type CreateMachineArgs struct {
 	// Platform is the deployment platform for the machine being created.
 	Platform deployment.Platform
 
+	// NetNodeUUID represents the uuid of the new machines net node that is
+	// created.
+	NetNodeUUID network.NetNodeUUID
+
 	// Nonce is an optional nonce to associate with the machine being created.
 	Nonce *string
 }


### PR DESCRIPTION
The machine creation path during import was missing the netnode UUID as argument.

Generate a net node UUID in MigrationService and pass it through CreateMachineArgs into the state. 
Add NetNodeUUID to the machine types.


## QA steps

```
$ juju  bootstrap lxd dst --build-agent
$ juju_36 bootstrap lxd src36
$ juju_36 add-model m
$ juju_36 deploy juju-qa-dummy-source && juju deploy juju-qa-dummy-sink
$ juju_36 migrate m dst
```
The status should show that the model was migrated and no errors regarding machines should be present in the debug logs.

**Jira card:** [JUJU-8487](https://warthogs.atlassian.net/browse/JUJU-8487)


[JUJU-8487]: https://warthogs.atlassian.net/browse/JUJU-8487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ