### PR TITLE
fix(secret): updates a secret while passing the label

### DIFF
--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -2081,6 +2081,39 @@ func (s *stateSuite) TestUpdateUserSecretFailedLabelAlreadyExists(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, secreterrors.SecretLabelAlreadyExists)
 }
 
+func (s *stateSuite) TestUpdateUserSecretExistingLabelSameID(c *tc.C) {
+	ctx := c.Context()
+
+	// Create a user secret with label "dup" on a given URI (ID).
+	uri := coresecrets.NewURI()
+	sp := domainsecret.UpsertSecretParams{
+		RevisionID:  ptr(uuid.MustNewUUID().String()),
+		Label:       ptr("dup"),
+		Description: ptr("first"),
+		Data:        coresecrets.SecretData{"k": "v"},
+	}
+	err := createUserSecret(ctx, s.state, 1, uri, sp)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Update the same secret (same ID) keeping the same label. This should work.
+	err = s.state.UpdateSecret(ctx, uri, domainsecret.UpsertSecretParams{
+		RevisionID:  ptr(uuid.MustNewUUID().String()),
+		Label:       ptr("dup"),
+		Description: ptr("updated"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	md, err := s.state.GetSecret(ctx, uri)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(md.Version, tc.Equals, 1)
+	c.Assert(md.Label, tc.Equals, "dup")
+	c.Assert(md.Description, tc.Equals, "updated")
+	c.Assert(md.LatestRevision, tc.Equals, 1)
+
+	now := time.Now()
+	c.Assert(md.UpdateTime, tc.Almost, now)
+}
+
 func (s *stateSuite) TestUpdateUserSecretFailedRevisionIDMissing(c *tc.C) {
 
 	sp := domainsecret.UpsertSecretParams{
@@ -2173,6 +2206,41 @@ func (s *stateSuite) TestUpdateApplicationSecretFailedLabelAlreadyExists(c *tc.C
 	c.Assert(err, tc.ErrorIs, secreterrors.SecretLabelAlreadyExists)
 }
 
+func (s *stateSuite) TestUpdateApplicationSecretExistingLabelSameID(c *tc.C) {
+	s.setupUnits(c, "mysql")
+
+	ctx := c.Context()
+
+	// Create an application secret with label "dup" on a given URI (ID).
+	uri := coresecrets.NewURI()
+	sp := domainsecret.UpsertSecretParams{
+		RevisionID:  ptr(uuid.MustNewUUID().String()),
+		Label:       ptr("dup"),
+		Description: ptr("first"),
+		Data:        coresecrets.SecretData{"k": "v"},
+	}
+	err := createCharmApplicationSecret(ctx, s.state, 1, uri, "mysql", sp)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Update the same secret (same ID) keeping the same label. This should work.
+	err = s.state.UpdateSecret(ctx, uri, domainsecret.UpsertSecretParams{
+		RevisionID:  ptr(uuid.MustNewUUID().String()),
+		Label:       ptr("dup"),
+		Description: ptr("updated"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	md, err := s.state.GetSecret(ctx, uri)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(md.Version, tc.Equals, 1)
+	c.Assert(md.Label, tc.Equals, "dup")
+	c.Assert(md.Description, tc.Equals, "updated")
+	c.Assert(md.LatestRevision, tc.Equals, 1)
+
+	now := time.Now()
+	c.Assert(md.UpdateTime, tc.Almost, now)
+}
+
 func (s *stateSuite) TestUpdateCharmUnitSecretMetadataOnly(c *tc.C) {
 
 	s.setupUnits(c, "mysql")
@@ -2241,6 +2309,41 @@ func (s *stateSuite) TestUpdateUnitSecretFailedLabelAlreadyExists(c *tc.C) {
 		Label:      ptr("dup"),
 	})
 	c.Assert(err, tc.ErrorIs, secreterrors.SecretLabelAlreadyExists)
+}
+
+func (s *stateSuite) TestUpdateUnitSecretExistingLabelSameID(c *tc.C) {
+	s.setupUnits(c, "mysql")
+
+	ctx := c.Context()
+
+	// Create a unit secret with label "dup" on a given URI (ID).
+	uri := coresecrets.NewURI()
+	sp := domainsecret.UpsertSecretParams{
+		RevisionID:  ptr(uuid.MustNewUUID().String()),
+		Label:       ptr("dup"),
+		Description: ptr("first"),
+		Data:        coresecrets.SecretData{"k": "v"},
+	}
+	err := createCharmUnitSecret(ctx, s.state, 1, uri, "mysql/0", sp)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Update the same secret (same ID) keeping the same label. This should work.
+	err = s.state.UpdateSecret(ctx, uri, domainsecret.UpsertSecretParams{
+		RevisionID:  ptr(uuid.MustNewUUID().String()),
+		Label:       ptr("dup"),
+		Description: ptr("updated"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	md, err := s.state.GetSecret(ctx, uri)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(md.Version, tc.Equals, 1)
+	c.Assert(md.Label, tc.Equals, "dup")
+	c.Assert(md.Description, tc.Equals, "updated")
+	c.Assert(md.LatestRevision, tc.Equals, 1)
+
+	now := time.Now()
+	c.Assert(md.UpdateTime, tc.Almost, now)
 }
 
 func fillDataForUpsertSecretParams(c *tc.C, p *domainsecret.UpsertSecretParams, data coresecrets.SecretData) {


### PR DESCRIPTION
This patch ensures that labels can be reused during secret updates when the same secret ID is provided.
Updates include logic adjustments for label conflict checks and new tests for user, application,
 and unit secret updates under this condition.

> [!WARNING]
>
> This is  the minimal fix for this bug. Code may be refactored since I am working on the cleanup of the secret domain: that's why I take a special care to add the required unit test.
>
> If you have suggestion about how it could be refactored, feel free to comment, but I may just note it and apply it as a followup.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Create a secret then update it while passing the name:

```sh
juju add-secret banana foo=bar
juju update-secret <secret uri> --name banana foo=baz
```

This should works

You can also run the reproduction from the JIRA task:
```sh
juju add-model test
juju deploy k8s --channel=1.33/stable   --base="ubuntu@24.04"   --constraints='cores=2 mem=16G root-disk=40G virt-type=virtual-machine' 
juju deploy k8s-worker --channel=1.33/stable   --base="ubuntu@24.04"   --constraints='cores=2 mem=16G root-disk=40G virt-type=virtual-machine'
juju config k8s dns-enabled=true dns-cluster-domain=cluster.local 
juju integrate k8s k8s-worker:cluster 
juju integrate k8s k8s-worker:containerd
```

## Links

**Jira card:** [JUJU-8946](https://warthogs.atlassian.net/browse/JUJU-8946)


[JUJU-8946]: https://warthogs.atlassian.net/browse/JUJU-8946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ