### PR TITLE
feat: update linux containers url to a Canonical host

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1803,7 +1803,7 @@ var _ = gc.Suite(&withImageMetadataSuite{})
 func (s *withImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.ConfigAttrs = map[string]interface{}{
 		config.ContainerImageStreamKey:      "daily",
-		config.ContainerImageMetadataURLKey: "https://images.linuxcontainers.org/",
+		config.ContainerImageMetadataURLKey: "https://images.lxd.canonical.com/",
 	}
 	s.setUpTest(c, false)
 }
@@ -1813,7 +1813,7 @@ func (s *withImageMetadataSuite) TestContainerManagerConfigImageMetadata(c *gc.C
 	c.Assert(cfg, jc.DeepEquals, map[string]string{
 		container.ConfigModelUUID:           coretesting.ModelTag.Id(),
 		config.ContainerImageStreamKey:      "daily",
-		config.ContainerImageMetadataURLKey: "https://images.linuxcontainers.org/",
+		config.ContainerImageMetadataURLKey: "https://images.lxd.canonical.com/",
 		config.LXDSnapChannel:               "5.0/stable",
 		config.ContainerNetworkingMethod:    config.ConfigDefaults()[config.ContainerNetworkingMethod].(string),
 	})

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -196,13 +196,13 @@ func (s *KVMSuite) TestCreateContainerUsesSetImageMetadataURL(c *gc.C) {
 
 	s.manager, err = kvm.NewContainerManager(container.ManagerConfig{
 		container.ConfigModelUUID:           coretesting.ModelTag.Id(),
-		config.ContainerImageMetadataURLKey: "https://images.linuxcontainers.org",
+		config.ContainerImageMetadataURLKey: "https://images.lxd.canonical.com",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst := containertesting.CreateContainerWithMachineConfig(c, s.manager, instanceConfig)
 	startParams := kvm.ContainerFromInstance(inst).(*mock.MockContainer).StartParams
-	c.Assert(startParams.ImageDownloadURL, gc.Equals, "https://images.linuxcontainers.org")
+	c.Assert(startParams.ImageDownloadURL, gc.Equals, "https://images.lxd.canonical.com")
 }
 
 func (s *KVMSuite) TestImageAcquisitionUsesSimpleStream(c *gc.C) {

--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -123,8 +123,8 @@ var CloudImagesDailyRemote = ServerSpec{
 // CloudImagesLinuxContainersRemote hosts images for other distributions.
 // These will be used for pulling CentOS images.
 var CloudImagesLinuxContainersRemote = ServerSpec{
-	Name:     "images.linuxcontainers.org",
-	Host:     "https://images.linuxcontainers.org",
+	Name:     "images.lxd.canonical.com",
+	Host:     "https://images.lxd.canonical.com",
 	Protocol: SimpleStreamsProtocol,
 }
 

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -731,7 +731,7 @@ func (s *environBrokerSuite) TestImageSourcesDefault(c *gc.C) {
 
 	s.checkSources(c, sources, []string{
 		"https://cloud-images.ubuntu.com/releases/",
-		"https://images.linuxcontainers.org",
+		"https://images.lxd.canonical.com",
 	})
 }
 
@@ -750,7 +750,7 @@ func (s *environBrokerSuite) TestImageMetadataURL(c *gc.C) {
 	s.checkSources(c, sources, []string{
 		"https://my-test.com/images/",
 		"https://cloud-images.ubuntu.com/releases/",
-		"https://images.linuxcontainers.org",
+		"https://images.lxd.canonical.com",
 	})
 }
 
@@ -770,7 +770,7 @@ func (s *environBrokerSuite) TestImageMetadataURLEnsuresHTTPS(c *gc.C) {
 	s.checkSources(c, sources, []string{
 		"https://my-test.com/images/",
 		"https://cloud-images.ubuntu.com/releases/",
-		"https://images.linuxcontainers.org",
+		"https://images.lxd.canonical.com",
 	})
 }
 
@@ -788,7 +788,7 @@ func (s *environBrokerSuite) TestImageStreamReleased(c *gc.C) {
 
 	s.checkSources(c, sources, []string{
 		"https://cloud-images.ubuntu.com/releases/",
-		"https://images.linuxcontainers.org",
+		"https://images.lxd.canonical.com",
 	})
 }
 
@@ -806,7 +806,7 @@ func (s *environBrokerSuite) TestImageStreamDaily(c *gc.C) {
 
 	s.checkSources(c, sources, []string{
 		"https://cloud-images.ubuntu.com/daily/",
-		"https://images.linuxcontainers.org",
+		"https://images.lxd.canonical.com",
 	})
 }
 


### PR DESCRIPTION
We need to amend the host used to fetch non-ubuntu container images.
Old: linuxcontainers.org
New: lxc.canonical.com

## QA steps

Deploying non ubuntu instances requires a bit of messy metadata and agent binary packaging.
To avoid that, force agent binaries to look for "ubuntu" - the binary is the same.
```
diff --git a/apiserver/common/tools.go b/apiserver/common/tools.go
index bb86f9c89b..37def1bc4d 100644
--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -405,7 +405,7 @@ func toolsFilter(args FindAgentsParams) coretools.Filter {
        return coretools.Filter{
                Number: args.Number,
                Arch:   args.Arch,
-               OSType: args.OSType,
+               OSType: "ubuntu",
        }
 }
 
diff --git a/environs/tools/tools.go b/environs/tools/tools.go
index 07100260c9..dc35082e9b 100644
--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -125,6 +125,7 @@ func FindToolsForCloud(ss SimplestreamsFetcher,
 
                seenBinary = make(map[version.Binary]bool)
        )
+       filter.OSType = "ubuntu"
        for _, stream := range streams {
                toolsConstraint, err := makeToolsConstraint(cloudSpec, stream, majorVersion, minorVersion, filter)
                if err != nil {
@@ -178,7 +179,7 @@ func FindExactTools(ss SimplestreamsFetcher, env environs.Environ, vers version.
        // Discard all that are known to be irrelevant.
        filter := coretools.Filter{
                Number: vers,
-               OSType: osType,
+               OSType: "ubuntu",
                Arch:   arch,
        }
        streams := PreferredStreams(&vers, env.Config().Development(), env.Config().AgentStream())
```
```
juju bootstrap lxd
juju add-machine --series centos9
```

Then ssh to the added machine
```
$ cat /etc/redhat-release 
CentOS Stream release 9
```

## Links

**Issue:** Fixes #19994.
**Jira card:** [JUJU-8135](https://warthogs.atlassian.net/browse/JUJU-8135)


[JUJU-8135]: https://warthogs.atlassian.net/browse/JUJU-8135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ