### PR TITLE
docs: fix lxd storage provider upstream link

### DIFF
--- a/docs/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
@@ -182,7 +182,7 @@ Configuration options:
 
 - `lxd-pool`:  The name to give to the corresponding storage pool in LXD.
 
-Any other parameters will be passed to LXD (e.g. zfs.pool_name). See upstream [LXD storage configuration](https://github.com/lxc/lxd/blob/master/doc/storage.md) for LXD storage parameters.
+Any other parameters will be passed to LXD (e.g. `zfs.pool_name`). See upstream [LXD storage configuration](https://documentation.ubuntu.com/lxd/latest/reference/storage_drivers/) for LXD storage parameters.
 
 Every LXD-based model comes with a minimum of one LXD-specific Juju storage pool called 'lxd'. If ZFS and/or BTRFS are present when the controller is created then pools 'lxd-zfs' and/or 'lxd-btrfs' will also be available. The following output to the `juju storage-pools` command shows all three Juju LXD-specific pools:
 


### PR DESCRIPTION
# Changes

Issue https://github.com/juju/juju/issues/21462 points out we're using the wrong upstream link for lxd storage provider configs. This PR fixes that.

# Forward merge

This PR should be forward-merged into `4.0` and `main`.