### PR TITLE
feat(add-model): adds a target-controller flag to the `add-model` command

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -62,6 +62,11 @@ type addModelCommand struct {
 	CloudRegion    string
 	Config         common.ConfigFlag
 	noSwitch       bool
+	// targetController holds a controller name when adding a model
+	// to a controller managed by JAAS.
+	// A non-empty value for this member causes an error to be returned
+	// to the user if the JAAS plugin is not installed.
+	targetController string
 }
 
 const addModelHelpDoc = `
@@ -131,9 +136,16 @@ func (c *addModelCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.CredentialName, "credential", "", "Specify the credential to be used by the model")
 	f.Var(&c.Config, "config", "Specify the path to a YAML model configuration file or individual configuration options (`--config config.yaml [--config key=value ...]`)")
 	f.BoolVar(&c.noSwitch, "no-switch", false, "Choose not to switch to the newly created model")
+	f.StringVar(&c.targetController, "target-controller", "", "The name of a JAAS managed controller to add a model to")
 }
 
 func (c *addModelCommand) Init(args []string) error {
+	// If the JAAS plugin is installed, this error causes the plugin version
+	// of the command to be executed. Otherwise it is returned to the user.
+	if c.targetController != "" {
+		return cmd.ErrCommandMissing
+	}
+
 	if len(args) == 0 {
 		return common.MissingModelNameError("add-model")
 	}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -706,6 +706,11 @@ func (s *AddModelSuite) TestNamespaceAnnotationsErr(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot create model "foobar": a namespace called "foobar" already exists on this k8s cluster. Please pick a different model name.`)
 }
 
+func (s *AddModelSuite) TestSpecifyingTargetControllerFlag(c *gc.C) {
+	_, err := s.run(c, "test", "--target-controller", "test-target-controller")
+	c.Assert(err, jc.ErrorIs, cmd.ErrCommandMissing)
+}
+
 // fakeAddClient is used to mock out the behavior of the real
 // AddModel command.
 type fakeAddClient struct {


### PR DESCRIPTION
When the target-controller flag is specified for the add-model command it returns an ErrCommandMissing error. This means that execution will be passed on to the JAAS plugin.

## Checklist
- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and try adding a model with `--target-controller test`.

```sh
$ juju bootstrap lxd src36
$ juju add-model test --target-controller test
```

 2. Assert the `missing command` error is returned (assuming you don't have the JAAS plugin installed)


```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes
 
TBD

