### PR TITLE
docs: fix open-port header threes

### DIFF
--- a/docs/reference/hook-command/list-of-hook-commands/open-port.md
+++ b/docs/reference/hook-command/list-of-hook-commands/open-port.md
@@ -30,15 +30,15 @@ Register a request to open a port or port range.
 
 ## Details
 
-open-port registers a request to open the specified port or port range.
+`open-port` registers a request to open the specified port or port range.
 
 By default, the specified port or port range will be opened for all defined
-application endpoints. The --endpoints option can be used to constrain the
+application endpoints. The `--endpoints` option can be used to constrain the
 open request to a comma-delimited list of application endpoints.
 
 The behavior differs a little bit between machine charms and Kubernetes charms.
 
-Machine charms
+### Machine charms
 On public clouds the port will only be open while the application is exposed.
 It accepts a single port or range of ports with an optional protocol, which
 may be icmp, udp, or tcp. tcp is the default.
@@ -50,11 +50,11 @@ so changes will not be made unless the hook exits successfully.
 Prior to Juju 2.9, when charms requested a particular port range to be opened,
 Juju would automatically mark that port range as opened for all defined
 application endpoints. As of Juju 2.9, charms can constrain opened port ranges
-to a set of application endpoints by providing the --endpoints flag followed by
+to a set of application endpoints by providing the `--endpoints` flag followed by
 a comma-delimited list of application endpoints.
 
-Kubernetes charms
+### Kubernetes charms
 The port will open directly regardless of whether the application is exposed or not.
-This connects to the fact that juju expose currently has no effect on sidecar charms.
+This connects to the fact that `juju expose` currently has no effect on sidecar charms.
 Additionally, it is currently not possible to designate a range of ports to open for
 Kubernetes charms; to open a range, you will have to run open-port multiple times.


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
Fixes #21484. It just ensures that the intended headers for `Machine charms` and `Kubernetes charms` are appropriately marked as h3s. 
Before:
<img width="1317" height="978" alt="image" src="https://github.com/user-attachments/assets/a226f727-4a2b-4d65-99fd-f013bcc94bf8" />

After:
<img width="1298" height="719" alt="image" src="https://github.com/user-attachments/assets/d979774f-ebbc-4a5c-9090-2d578fdb9489" />

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~~Code style: imports ordered, good names, simple structure, etc~~
- [ ] ~~Comments saying why design decisions were made~~
- [ ] ~~Go unit tests, with comments saying what you're testing~~
- [ ] ~~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- [ ] ~~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

<!--

Describe steps to verify that the change works.
Looked at screenshots above in the `after` section to ensure that the changes were correctly applied when the sphinx docs were rendered.
If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
