### PR TITLE
fix: consult charm container volume mounts for the correct mount path

### DIFF
--- a/internal/provider/kubernetes/storage_test.go
+++ b/internal/provider/kubernetes/storage_test.go
@@ -314,9 +314,9 @@ func (s *storageSuite) TestAttachFilesystems(c *tc.C) {
 
 	res, err := fs.AttachFilesystems(c.Context(), params)
 	c.Check(err, tc.ErrorIsNil)
-	c.Check(res, tc.HasLen, 1)
+	c.Assert(res, tc.HasLen, 1)
 	c.Check(res[0].Error, tc.ErrorIsNil)
-	c.Check(*res[0].FilesystemAttachment, tc.DeepEquals, storage.FilesystemAttachment{
+	c.Check(res[0].FilesystemAttachment, tc.DeepEquals, &storage.FilesystemAttachment{
 		Filesystem: params[0].Filesystem,
 		Machine:    params[0].Machine,
 		FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
@@ -511,7 +511,7 @@ func (s *storageSuite) TestAttachFilesystemsErrorMissingCharmContainer(c *tc.C) 
 	res, err := fs.AttachFilesystems(c.Context(), params)
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(res, tc.HasLen, 1)
-	c.Check(res[0].Error, tc.ErrorMatches, `.* charm container fot found`)
+	c.Check(res[0].Error, tc.ErrorMatches, `.* missing charm container`)
 }
 
 // TestAttachFilesystemsErrorMissingVolume tests that it should indicate
@@ -588,7 +588,7 @@ func (s *storageSuite) TestAttachFilesystemsErrorMissingVolume(c *tc.C) {
 	res, err := fs.AttachFilesystems(c.Context(), params)
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(res, tc.HasLen, 1)
-	c.Check(res[0].Error, tc.ErrorMatches, `.* pod volume which references claim "vault-k8s-certs-dd246a-vault-k8s-0" not found`)
+	c.Check(res[0].Error, tc.ErrorMatches, `.* missing pod volume which references claim "vault-k8s-certs-dd246a-vault-k8s-0"`)
 }
 
 // TestAttachFilesystemsErrorMissingVolumeMount tests that it should indicate
@@ -666,5 +666,5 @@ func (s *storageSuite) TestAttachFilesystemsErrorMissingVolumeMount(c *tc.C) {
 	res, err := fs.AttachFilesystems(c.Context(), params)
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(res, tc.HasLen, 1)
-	c.Check(res[0].Error, tc.ErrorMatches, `.* pod volume mount "vault-k8s-certs-dd246a" not found`)
+	c.Check(res[0].Error, tc.ErrorMatches, `.* missing pod volume mount "vault-k8s-certs-dd246a"`)
 }


### PR DESCRIPTION
We have a bug where the storage provisioner was getting an incorrect mount path, in turn when the hook is triggered supplying the mount path, the charm assumes that the mount path exists, and in reality it doesn't. An example can be seen when deploying `vault-k8s`, the charm tries to lookup a certificate file `ca.pem` but fails to find it because the directory isn't mounted in the charm container.

```
...
2025-12-16T03:40:26.654Z [container-agent]     raise OSError(
2025-12-16T03:40:26.654Z [container-agent] OSError: Could not find a suitable TLS CA certificate bundle, invalid path: /var/lib/juju/storage/09f5ee7d-4cb7-4866-876a-4216014e1283/ca.pem
...
```

The correct mount point is actually `/var/lib/juju/storage/<storage-name>-<uniqueid>` which can be grabbed by searching through the volume mounts of the charm container.

As you can see the `/var/lib/juju/storage/certs-0` directory has the following files

```
root@vault-k8s-0:/var/lib/juju/storage/certs-0# ls
ca.pem  cert.pem  key.pem
```

Therefore, this PR contributes to how we report the mount path.

1. In the AttachFilesystems func, we are given a slice of `FilesystemAttachmentParams` in which it contains:
   -  `ProviderId` which corresponds to the pvc name 
   - `InstanceId` which corresponds to the pod name
2. We then get the pod by its name
3. Looking at the pod's volumes, we can match the claim name by the pvc name
4. Once we know the volume (and its name), we search through the charm container's volume mounts (we have the pod from step 2) and match it by the volume name. Once the volume mount is found, we return its mount path.

In this PR's implementation, the `InstanceId` is still missing. This is because the existing implementation assumes that `InstanceId` is a machine identifier. What should happen next is to populate the `InstanceId` with the kubernetes pod's name. This will happen in the next PR https://github.com/juju/juju/pull/21487.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run unit test for now. Once the followup PR to populate the `InstanceId` lands, we can test a deployment.

## Documentation changes

N/A

## Links


**Issue:** Fixes #21379.

**Jira card:** [JUJU-8923](https://warthogs.atlassian.net/browse/JUJU-8923)


[JUJU-8923]: https://warthogs.atlassian.net/browse/JUJU-8923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ