### PR TITLE
fix(ci): metrics tests didn't check the right logger

### DIFF
--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -9,9 +9,10 @@ run_model_metrics() {
 	ensure "${testname}" "${file}"
 
 	# Deploy ubuntu with a different name, check that the metric send the charm name, not the application name.
-	juju deploy ubuntu app-one --base ubuntu@24.04
-	juju deploy juju-qa-test --base ubuntu@24.04
-	juju deploy juju-qa-dummy-subordinate --base ubuntu@24.04
+	ubuntu_base="ubuntu@20.04"
+	juju deploy ubuntu app-one --base "$ubuntu_base"
+	juju deploy juju-qa-test --base "$ubuntu_base"
+	juju deploy juju-qa-dummy-subordinate --base "$ubuntu_base"
 	juju config dummy-subordinate token=becomegreen
 	juju relate dummy-subordinate app-one
 
@@ -22,32 +23,31 @@ run_model_metrics() {
 	juju relate dummy-subordinate:juju-info juju-qa-test:juju-info
 	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test" 1)"
 
-	juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE"
+	juju model-config -m "$testname" logging-config="<root>=INFO;#charmhub=TRACE"
 
-	# Restarting the controller service causes the charmrevisionupdater worker to run.
+	# Restarting the controller service causes the charmrevisioner worker to run.
 	juju ssh -m controller 0 -- sudo systemctl restart jujud-machine-0.service
 
-	echo "Sleep 45, give charmrevisionupdater time to kick off after controller jujud restart."
+	echo "Sleep 45, give charmrevisioner time to kick off after controller jujud restart."
 	sleep 45
 
 	attempt=0
 	while true; do
-		OUT=$(juju debug-log -m controller --include-module juju.apiserver.charmrevisionupdater.client | grep metrics || true)
+		OUT=$(juju debug-log -m "$testname" --include-module juju.worker.charmrevisioner.client | grep metrics || true)
 		if echo "${OUT}" | grep -e '"metrics":{"relations":"juju-qa-test,ubuntu","units":"2"}' -e '"metrics":{"relations":"dummy-subordinate","units":"1"}' -e '"model":{"applications":"3",' -e '"machines":"2",'; then
+			green "found expected metrics in debug log"
 			break
 		fi
 		echo "${OUT}"
 		attempt=$((attempt + 1))
 		if [ $attempt -eq 10 ]; then
-			# shellcheck disable=SC2046
-			echo $(red "timeout: waiting for metrics in debug log 50sec")
+			red "timeout: waiting for metrics in debug log 50sec"
 			exit 5
 		fi
 		sleep 5
 	done
 
 	# clean up
-	juju model-config -m controller logging-config="<root>=INFO"
 	destroy_model "${testname}"
 }
 
@@ -65,32 +65,31 @@ run_empty_model_metrics() {
 	wait_for_machine_agent_status 0 "started"
 	wait_for_machine_agent_status 1 "started"
 	wait_for_machine_agent_status 2 "started"
-	juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE"
+	juju model-config -m "$testname" logging-config="<root>=INFO;#charmhub=TRACE"
 
-	# Restarting the controller service causes the charmrevisionupdater worker to run.
+	# Restarting the controller service causes the charmrevisioner worker to run.
 	juju ssh -m controller 0 -- sudo systemctl restart jujud-machine-0.service
 
-	echo "Sleep 45, give charmrevisionupdater time to kick off after controller jujud restart."
+	echo "Sleep 45, give charmrevisioner time to kick off after controller jujud restart."
 	sleep 45
 
 	attempt=0
 	while true; do
-		OUT=$(juju debug-log -m controller --include-module juju.apiserver.charmrevisionupdater.client --replay | grep metrics || true)
+		OUT=$(juju debug-log -m "$testname" --include-module juju.worker.charmrevisioner.client --replay | grep metrics || true)
 		if echo "${OUT}" | grep '"machines":"3"'; then
+			green "found expected empty model metrics in debug log"
 			break
 		fi
 		echo "${OUT}"
 		attempt=$((attempt + 1))
 		if [ $attempt -eq 10 ]; then
-			# shellcheck disable=SC2046
-			echo $(red "timeout: waiting for empty model metrics in debug log 50sec")
+			red "timeout: waiting for empty model metrics in debug log 50sec"
 			exit 5
 		fi
 		sleep 5
 	done
 
 	# clean up
-	juju model-config -m controller logging-config="<root>=INFO"
 	destroy_model "${testname}"
 }
 
@@ -108,32 +107,30 @@ run_model_metrics_disabled() {
 	wait_for "ubuntu" "$(idle_condition "ubuntu" 0)"
 	wait_for "ubuntu" "$(idle_condition "ubuntu" 1)"
 	juju model-config disable-telemetry=true
-	juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE"
+	juju model-config -m "$testname" logging-config="<root>=INFO;#charmhub=TRACE"
 
-	# Restarting the controller service causes the charmrevisionupdater worker to run.
+	# Restarting the controller service causes the charmrevisioner worker to run.
 	juju ssh -m controller 0 -- sudo systemctl restart jujud-machine-0.service
 
-	echo "Sleep 120, give charmrevisionupdater time to kick off after controller jujud restart."
+	echo "Sleep 120, give charmrevisioner time to kick off after controller jujud restart."
 	sleep 120
 
 	attempt=0
 	while true; do
-		OUT=$(juju debug-log -m controller --include-module juju.apiserver.charmrevisionupdater.client --replay | grep metrics || true)
+		OUT=$(juju debug-log -m "$testname" --include-module juju.worker.charmrevisioner.client --replay | grep metrics || true)
 		if echo "${OUT}" | grep "metrics" | grep -v '"machines":"2"'; then
 			break
 		fi
 		echo "${OUT}"
 		attempt=$((attempt + 1))
 		if [ $attempt -eq 10 ]; then
-			# shellcheck disable=SC2046
-			echo $(red "timeout: waiting for no model metrics in debug log 50sec")
+			red "timeout: waiting for no model metrics in debug log 50sec"
 			exit 5
 		fi
 		sleep 5
 	done
 
 	# clean up
-	juju model-config -m controller logging-config="<root>=INFO"
 	destroy_model "${testname}"
 }
 


### PR DESCRIPTION
This patch refactors the `metrics.sh` test script to check the correct logger.
Juju 4 has refactored several part of the charm refresh workload, moving code to a worker which 
use directly the domain, without passing through a facade. 
So the logs weren't in the controller log anymore, but instead directly in model logs, under another
logger (not the facade logger).

As a fly-by, there is a minor refactoring of the way we select the base of the ubuntu image to 
define it once in run_model_metrics, which helps maintainability when we want to upgrade the base 
(subordinate relation requires that all application in the test use the same base).

In short:
- Replacing hardcoded model names with the `$testname` variable.
- Updating logging configurations to align with the `$testname` model context.
- Renaming `charmrevisionupdater` to `charmrevisioner` for consistency with worker naming.
- Using a variable for the Ubuntu base to streamline version changes.

> [!NOTE]
>
> I set the base image for run_model_metrics to ubuntu@20.04 because 22.04 and 24.04 weren't available for each of the three app (ubuntu, juju-qa-test, juju-qa-dummy-subordinate).

## Checklist

- ~Code style: imports ordered, good names, simple structure, etc~
- ~Comments saying why design decisions were made~
- ~Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

### Prerequisites
Running those test requires a controller with a wrench that reduce the interval for charmrevisioner

* bootstrap a lxd controller
* in the controller machine create the directory `/var/lib/juju/wrench`
* then create a file `/var/lib/juju/wrench/charmrevisioner` containing the string `shortinterval`

To verify it works, check the controller logs. Every 10s, you should be able to see a charmrevisioner log which post a refresh on charmhub

### Test

run the model metrics CI suites

```sh
cd tests && ./main.sh -v -l ci model test_model_metrics # ci is the controller created above
```

## Links

**Jira card:** [JUJU-8734](https://warthogs.atlassian.net/browse/JUJU-8734)


[JUJU-8734]: https://warthogs.atlassian.net/browse/JUJU-8734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ