### PR TITLE
refactor: serve connection

### DIFF
--- a/apiserver/internal/handlers/crossmodel/offerauth.go
+++ b/apiserver/internal/handlers/crossmodel/offerauth.go
@@ -26,7 +26,7 @@ const (
 type CrossModelAuthContextProvider interface {
 	// NewCrossModelAuthContext creates a new OfferAuthContext for the
 	// given request host.
-	NewCrossModelAuthContext(ctx context.Context, requestHost string) (facade.CrossModelAuthContext, error)
+	NewCrossModelAuthContext(requestHost string) (facade.CrossModelAuthContext, error)
 }
 
 // AddOfferAuthHandlers adds the HTTP handlers used for application offer
@@ -59,7 +59,7 @@ type localOfferAuthHandler struct {
 func (h *localOfferAuthHandler) checkThirdPartyCaveat(ctx context.Context, req *http.Request, cavInfo *bakery.ThirdPartyCaveatInfo, _ *httpbakery.DischargeToken) ([]checkers.Caveat, error) {
 	h.logger.Debugf(ctx, "check offer third party caveat %q", cavInfo.Condition)
 
-	authContext, err := h.authContextProvider.NewCrossModelAuthContext(ctx, req.Host)
+	authContext, err := h.authContextProvider.NewCrossModelAuthContext(req.Host)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/internal/handlers/crossmodel/service_mock_test.go
+++ b/apiserver/internal/handlers/crossmodel/service_mock_test.go
@@ -10,7 +10,6 @@
 package crossmodel
 
 import (
-	context "context"
 	reflect "reflect"
 
 	facade "github.com/juju/juju/apiserver/facade"
@@ -41,18 +40,18 @@ func (m *MockCrossModelAuthContextProvider) EXPECT() *MockCrossModelAuthContextP
 }
 
 // NewCrossModelAuthContext mocks base method.
-func (m *MockCrossModelAuthContextProvider) NewCrossModelAuthContext(arg0 context.Context, arg1 string) (facade.CrossModelAuthContext, error) {
+func (m *MockCrossModelAuthContextProvider) NewCrossModelAuthContext(arg0 string) (facade.CrossModelAuthContext, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCrossModelAuthContext", arg0, arg1)
+	ret := m.ctrl.Call(m, "NewCrossModelAuthContext", arg0)
 	ret0, _ := ret[0].(facade.CrossModelAuthContext)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewCrossModelAuthContext indicates an expected call of NewCrossModelAuthContext.
-func (mr *MockCrossModelAuthContextProviderMockRecorder) NewCrossModelAuthContext(arg0, arg1 any) *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall {
+func (mr *MockCrossModelAuthContextProviderMockRecorder) NewCrossModelAuthContext(arg0 any) *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCrossModelAuthContext", reflect.TypeOf((*MockCrossModelAuthContextProvider)(nil).NewCrossModelAuthContext), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCrossModelAuthContext", reflect.TypeOf((*MockCrossModelAuthContextProvider)(nil).NewCrossModelAuthContext), arg0)
 	return &MockCrossModelAuthContextProviderNewCrossModelAuthContextCall{Call: call}
 }
 
@@ -68,13 +67,13 @@ func (c *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall) Return(a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall) Do(f func(context.Context, string) (facade.CrossModelAuthContext, error)) *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall {
+func (c *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall) Do(f func(string) (facade.CrossModelAuthContext, error)) *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall) DoAndReturn(f func(context.Context, string) (facade.CrossModelAuthContext, error)) *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall {
+func (c *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall) DoAndReturn(f func(string) (facade.CrossModelAuthContext, error)) *MockCrossModelAuthContextProviderNewCrossModelAuthContextCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -146,27 +146,8 @@ func newAPIHandler(
 	connectionID uint64,
 	serverHost string,
 	crossModelAuthContext facade.CrossModelAuthContext,
-) (*apiHandler, error) {
-	exists, err := domainServices.Model().CheckModelExists(ctx, modelUUID)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if !exists {
-		// If this model used to be hosted on this controller but got
-		// migrated allow clients to connect and wait for a login
-		// request to decide whether the users should be redirected to
-		// the new controller for this model or not.
-		if _, migErr := domainServices.Model().ModelRedirection(ctx, modelUUID); migErr != nil {
-			// Return not found on any error.
-			// TODO (stickupkid): This is very brute force. What if there
-			// is an error with the database? The caller will assume that it
-			// is no longer on this controller. If we return a different error
-			// then it can at least retry the request.
-			return nil, errors.NotFoundf("model %q", modelUUID)
-		}
-	}
-
-	r := &apiHandler{
+) *apiHandler {
+	return &apiHandler{
 		domainServices:        domainServices,
 		domainServicesGetter:  domainServicesGetter,
 		tracer:                tracer,
@@ -182,8 +163,6 @@ func newAPIHandler(
 		serverHost:            serverHost,
 		crossModelAuthContext: crossModelAuthContext,
 	}
-
-	return r, nil
 }
 
 // WatcherRegistry returns the watcher registry for tracking watchers between

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -183,9 +183,8 @@ func newSharedServerContext(config sharedServerConfig) (*sharedServerContext, er
 
 // NewCrossModelAuthContext returns a new CrossModelAuthContext for the given
 // server host.
-func (c *sharedServerContext) NewCrossModelAuthContext(ctx context.Context, serverHost string) (facade.CrossModelAuthContext, error) {
+func (c *sharedServerContext) NewCrossModelAuthContext(serverHost string) (facade.CrossModelAuthContext, error) {
 	crossModelAuthContext, err := newOfferAuthContext(
-		ctx,
 		c.controllerDomainServices.Access(),
 		c.controllerDomainServices.Macaroon(),
 		c.offersThirdPartyKeyPair,


### PR DESCRIPTION
This refactors the serveConn method to ensure that any prerequisites for a connection are satisified before attempting the facade connections. One of the main changes, is that the apiHandler no longer checks for the model, that instead is done in the serveConn method. This reduces potential starvation attacks against the controller, that want access an invalid model. Previously, we would try and get the domain services, tracer, objectstore, and more, which aren't exactly cheap to access.

It should be noted that if we can't access any of the prerequisite dependencies previously, that would only log an error. This could leave the connection open and tax the controller. Instead, the change here will explicitly close the connection and free critical resources.

This a fundamental change and we should ensure correctness.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8968](https://warthogs.atlassian.net/browse/JUJU-8968)


[JUJU-8968]: https://warthogs.atlassian.net/browse/JUJU-8968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ