### PR TITLE
test: small fix for refresh and bundle ci tests

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -8,7 +8,7 @@ run_deploy_bundle() {
 
 	ensure "test-bundles-deploy" "${file}"
 
-	juju deploy juju-qa-bundle-test
+	juju deploy juju-qa-bundle-test --channel 2.9/stable
 	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test")"
 	wait_for "dummy-subordinate-focal" "$(idle_subordinate_condition "dummy-subordinate-focal" "juju-qa-test-focal")"
 
@@ -206,7 +206,7 @@ run_deploy_charmhub_bundle() {
 	ensure "${model_name}" "${file}"
 
 	bundle=juju-qa-bundle-test
-	juju deploy "${bundle}"
+	juju deploy "${bundle}" --channel 2.9/stable
 
 	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/stable")"
 	wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "latest/candidate")"

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -12,7 +12,7 @@ run_refresh_switch_local_to_ch_channel() {
 	ensure "${model_name}" "${file}"
 
 	juju download juju-qa-refresher --no-progress - >"${charm_name}"
-	juju deploy --channel=stable "${charm_name}"
+	juju deploy --channel=stable --series focal "${charm_name}"
 	wait_for "refresher" "$(idle_condition "refresher")"
 
 	OUT=$(juju refresh refresher --switch ch:juju-qa-refresher --channel edge 2>&1 || true)
@@ -28,7 +28,7 @@ run_refresh_switch_local_to_ch_channel() {
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "refresher" "$(charm_rev "refresher" "${revision}")"
-	wait_for "refresher" "$(charm_channel "refresher" "latest/edge")"
+	wait_for "refresher" "$(charm_channel "refresher" "edge")"
 	wait_for "refresher" "$(idle_condition "refresher")"
 
 	destroy_model "${model_name}"


### PR DESCRIPTION
Small ci test tweaks to fix the tests on 2.9.

The bundle test won't pass until a new 2.9 compatible bundle is released on charmhub.

## QA steps

`./main.sh -v refresh`

## Links

**Issue:** Fixes #21367.
**Issue:** Fixes #21368.
**Jira card:** [JUJU-8893](https://warthogs.atlassian.net/browse/JUJU-8893)
**Jira card:** [JUJU-8895](https://warthogs.atlassian.net/browse/JUJU-8895)


[JUJU-8893]: https://warthogs.atlassian.net/browse/JUJU-8893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JUJU-8895]: https://warthogs.atlassian.net/browse/JUJU-8895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ