### PR TITLE
fix(ci): update ubuntu charm in run_secret_drain

### DIFF
--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -51,7 +51,7 @@ run_secret_drain() {
 	vault_backend_name='myvault'
 	juju add-secret-backend "$vault_backend_name" vault endpoint="$VAULT_ADDR" token="$VAULT_TOKEN" ca-cert="$(cat "$VAULT_CAPATH")"
 
-	juju --show-log deploy jameinel-ubuntu-lite
+	juju --show-log deploy ubuntu-lite
 	wait_for "active" '.applications["ubuntu-lite"] | ."application-status".current'
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite" 0)"
 


### PR DESCRIPTION
Replaces `jameinel-ubuntu-lite` with `ubuntu-lite`. Former name cannot be deployed anymore, which
causes the test fails.

As a fly by, I replaced echo for error displayinb by `red` to make those more spotable in case of error.


## Checklist

- ~Code style: imports ordered, good names, simple structure, etc~
- ~Comments saying why design decisions were made~
- ~Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run drain tests:

```sh
cd tests && ./main.sh -v secrets_iaas test_secret_drain                                                                                                                                                        
```
## Links
**Jira card:** [JUJU-8605](https://warthogs.atlassian.net/browse/JUJU-8605)


[JUJU-8605]: https://warthogs.atlassian.net/browse/JUJU-8605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ