### PR TITLE
docs: add additionalProperties to the list of breaking changes

### DIFF
--- a/docs/releasenotes/juju_4.0.x/juju_4.0.0.md
+++ b/docs/releasenotes/juju_4.0.x/juju_4.0.0.md
@@ -61,8 +61,9 @@ until a replacement arrives).
 * **Wait-for**: `juju wait-for` (and subcommands `wait-for model|application|machine|unit`) — removed. In `3.6` this 
 family streamed deltas and let you express goal states via a small DSL; it’s no longer available in `4.0`. Workarounds: 
 poll `juju status --format=json` (optionally with `--watch <interval>`) and evaluate readiness client-side.
-* **`private-address` removed**:  it is no longer automatically maintained in relation data. It was a copy 
+* **`private-address` removed**:  it is no longer automatically maintained in relation data. It was a copy
 of `ingres-address`, which is the only value that should be used now.
+* **`additionalProperties` default changed**: in action parameter configuration, the `additionalProperties` default value no longer matches JSONSchema, and is instead `false`. Explicitly include `additionalProperties` rather than relying on the default value to have consistency across Juju 3.6 and Juju 4.
 
 #### 🐛 Known issues / deferred items
 


### PR DESCRIPTION
In Juju 4.0 the default value for `additionalProperties` changes from `true` to `false`. This is a breaking change for charms (charms that previously would accept and process any additional values will now error), but it is missing from the list of breaking changes.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Read the release notes.

## Documentation changes

Adds one line to the 4.0.0 release notes.

## Links

https://github.com/juju/juju/issues/21294