### PR TITLE
fix: use new apt mirror spec with cloud init

### DIFF
--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -56,8 +56,8 @@ type cloudConfig struct {
 	//
 	// used only for Ubuntu but implemented as runcmds on CentOS:
 	// apt_proxy			string
-	// apt_mirror			string/bool
 	// apt_sources			[]*packaging.Source
+	// apt					map[string][]AptMirrorInfo
 	//
 	// instead, the following corresponding options are used temporarily,
 	// but are translated to runcmds and removed right before rendering:

--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -61,7 +61,16 @@ var ctests = []struct {
 }, {
 	"PackageMirror",
 	map[string]any{
-		"apt_mirror": "http://foo.com",
+		"apt": map[string][]cloudinit.AptMirrorInfo{
+			"primary": {cloudinit.AptMirrorInfo{
+				"search": {"http://foo.com"},
+				"arches": {"default"},
+			}},
+			"security": {cloudinit.AptMirrorInfo{
+				"search": {"http://foo.com"},
+				"arches": {"default"},
+			}},
+		},
 	},
 	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetPackageMirror("http://foo.com")

--- a/cloudconfig/cloudinit/helpers.go
+++ b/cloudconfig/cloudinit/helpers.go
@@ -17,7 +17,9 @@ func addPackageCommandsCommon(
 	addUpgradeScripts bool,
 ) error {
 	// Set the package mirror.
-	cfg.SetPackageMirror(proxyCfg.AptMirror())
+	if proxyCfg.AptMirror() != "" {
+		cfg.SetPackageMirror(proxyCfg.AptMirror())
+	}
 
 	// Bring packages up-to-date.
 	cfg.SetSystemUpdate(addUpdateScripts)


### PR DESCRIPTION
Replace the use of the deprecated and now unsupported cloud init apt_mirror attribute.

The use of `apt_mirror` with cloud init was deprecated back in 2018 and is now removed (deprecated in 22.1 and removed in 27.1). Creating a cloud init configuration with this attribute causes the parsing to fail and cloud init to not complete properly.

Current ubuntu images from bionic onwards have the recent cloud init versions. Only bionic originally shipped with a cloud init version that was old. But current images are good and 3.6 ostensibly doesn't support bionic anyway.

This PR uses the new syntax
```
apt:
  primary:
    - arches: [default]
      search:
        - http://archive.ubuntu.com
```
We can still only support a single mirror because other juju logic and upstream would require a more extensive change. This PR simply retains the current functionality of a single mirror in model config.

## QA steps

bootstrap
add a model
set apt mirror config:
`juju model-config apt-mirror=http://us.archive.ubuntu.com/ubuntu`

`juju add-machine --base ubuntu@18.04`
`juju add-machine`

ssh into the machines
```
$ cloud-init status --long
status: done
boot_status_code: enabled-by-generator
last_update: Fri, 19 Dec 2025 03:19:40 +0000
detail:
DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
```
previously this would show a parsing error

On noble
```
$ cat /etc/apt/sources.list.d/ubuntu.sources
...
Types: deb
URIs: http://us.archive.ubuntu.com/ubuntu
Suites: noble noble-updates noble-backports
Components: main universe restricted multiverse
Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

## Ubuntu security updates. Aside from URIs and Suites,
## this should mirror your choices in the previous section.
Types: deb
URIs: http://us.archive.ubuntu.com/ubuntu
Suites: noble-security
Components: main universe restricted multiverse
Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
```

On bionic
```
$ cat /etc/apt/sources.list
...
deb http://us.archive.ubuntu.com/ubuntu bionic-security main restricted
# deb-src http://us.archive.ubuntu.com/ubuntu bionic-security main restricted
deb http://us.archive.ubuntu.com/ubuntu bionic-security universe
# deb-src http://us.archive.ubuntu.com/ubuntu bionic-security universe
deb http://us.archive.ubuntu.com/ubuntu bionic-security multiverse
# deb-src http://us.archive.ubuntu.com/ubuntu bionic-security multiverse

```

## Links

**Issue:** Fixes #21461.
**Jira card:** [JUJU-8977](https://warthogs.atlassian.net/browse/JUJU-8977)


[JUJU-8977]: https://warthogs.atlassian.net/browse/JUJU-8977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ