### PR TITLE
feat: encode machine arch

### DIFF
--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -9,11 +9,15 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/description/v11"
 
+	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/application/architecture"
+	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/domain/machine/state"
 	"github.com/juju/juju/internal/errors"
@@ -45,7 +49,7 @@ type importOperation struct {
 // another controller model to this controller.
 type ImportService interface {
 	// CreateMachine creates the specified machine.
-	CreateMachine(ctx context.Context, machineName machine.Name, nonce *string) (machine.UUID, error)
+	CreateMachine(ctx context.Context, machineName machine.Name, nonce *string, platform deployment.Platform) (machine.UUID, error)
 	// SetMachineCloudInstance sets an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
 	SetMachineCloudInstance(ctx context.Context, machineUUID machine.UUID, instanceID instance.Id, displayName, nonce string, hardwareCharacteristics *instance.HardwareCharacteristics) error
@@ -68,8 +72,23 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
 	for _, m := range model.Machines() {
+		osType, channel, err := encodeBaseFromMachine(m)
+		if err != nil {
+			return errors.Errorf("importing machine %q: %w", m.Id(), err)
+		}
+
+		arch, err := encodeArchitectureFromMachine(m.Constraints(), m.Instance())
+		if err != nil {
+			return errors.Errorf("importing machine %q: %w", m.Id(), err)
+		}
+		machinePlatform := deployment.Platform{
+			Channel:      channel,
+			OSType:       osType,
+			Architecture: arch,
+		}
+
 		// We need skeleton machines in dqlite.
-		machineUUID, err := i.service.CreateMachine(ctx, machine.Name(m.Id()), ptr(m.Nonce()))
+		machineUUID, err := i.service.CreateMachine(ctx, machine.Name(m.Id()), ptr(m.Nonce()), machinePlatform)
 		if err != nil {
 			return errors.Errorf("importing machine %q: %w", m.Id(), err)
 		}
@@ -81,14 +100,14 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		}
 
 		hardwareCharacteristics := &instance.HardwareCharacteristics{
-			Arch:             nilZeroPtr(cloudInstance.Architecture()),
-			Mem:              nilZeroPtr(cloudInstance.Memory()),
-			RootDisk:         nilZeroPtr(cloudInstance.RootDisk()),
-			RootDiskSource:   nilZeroPtr(cloudInstance.RootDiskSource()),
-			CpuCores:         nilZeroPtr(cloudInstance.CpuCores()),
-			CpuPower:         nilZeroPtr(cloudInstance.CpuPower()),
-			AvailabilityZone: nilZeroPtr(cloudInstance.AvailabilityZone()),
-			VirtType:         nilZeroPtr(cloudInstance.VirtType()),
+			Arch:             ptrOrZero(cloudInstance.Architecture()),
+			Mem:              ptrOrZero(cloudInstance.Memory()),
+			RootDisk:         ptrOrZero(cloudInstance.RootDisk()),
+			RootDiskSource:   ptrOrZero(cloudInstance.RootDiskSource()),
+			CpuCores:         ptrOrZero(cloudInstance.CpuCores()),
+			CpuPower:         ptrOrZero(cloudInstance.CpuPower()),
+			AvailabilityZone: ptrOrZero(cloudInstance.AvailabilityZone()),
+			VirtType:         ptrOrZero(cloudInstance.VirtType()),
 		}
 		if tags := cloudInstance.Tags(); len(tags) != 0 {
 			hardwareCharacteristics.Tags = &tags
@@ -107,7 +126,73 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	return nil
 }
 
-func nilZeroPtr[T comparable](v T) *T {
+func encodeBaseFromMachine(m description.Machine) (deployment.OSType, string, error) {
+	b, err := base.ParseBaseFromString(m.Base())
+	if err != nil {
+		return -1, "", err
+	}
+	osType, err := encodeOSType(b)
+	if err != nil {
+		return -1, "", err
+	}
+	return osType, b.Channel.String(), nil
+}
+
+func encodeOSType(b base.Base) (deployment.OSType, error) {
+	switch b.OS {
+	case base.UbuntuOS:
+		return deployment.Ubuntu, nil
+	default:
+		return -1, errors.Errorf("unknown os type %q", b)
+	}
+}
+
+func encodeArchitectureFromMachine(constraints description.Constraints, instance description.CloudInstance) (deployment.Architecture, error) {
+	// Look first at the constraints.
+	if constraints != nil {
+		arch, err := encodeArchitecture(constraints.Architecture())
+		if err != nil {
+			return -1, err
+		} else if arch >= 0 {
+			return arch, nil
+		}
+	}
+
+	// Next look at the instance information.
+	if instance != nil {
+		arch, err := encodeArchitecture(instance.Architecture())
+		if err != nil {
+			return -1, err
+		} else if arch >= 0 {
+			return arch, nil
+		}
+	}
+
+	// If there is no constraint or instance architecture, then we can fall
+	// back to the default architecture.
+	return encodeArchitecture(arch.DefaultArchitecture)
+}
+
+func encodeArchitecture(a string) (deployment.Architecture, error) {
+	switch a {
+	case arch.AMD64:
+		return architecture.AMD64, nil
+	case arch.ARM64:
+		return architecture.ARM64, nil
+	case arch.PPC64EL:
+		return architecture.PPC64EL, nil
+	case arch.S390X:
+		return architecture.S390X, nil
+	case arch.RISCV64:
+		return architecture.RISCV64, nil
+	case "":
+		return -1, nil
+	default:
+		return -1, errors.Errorf("unknown architecture %q", a)
+	}
+}
+
+func ptrOrZero[T comparable](v T) *T {
 	var zero T
 	if v == zero {
 		return nil

--- a/domain/machine/modelmigration/migrations_mock_test.go
+++ b/domain/machine/modelmigration/migrations_mock_test.go
@@ -16,6 +16,7 @@ import (
 	instance "github.com/juju/juju/core/instance"
 	machine "github.com/juju/juju/core/machine"
 	modelmigration "github.com/juju/juju/core/modelmigration"
+	deployment "github.com/juju/juju/domain/deployment"
 	machine0 "github.com/juju/juju/domain/machine"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -103,18 +104,18 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2 *string) (machine.UUID, error) {
+func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2 *string, arg3 deployment.Platform) (machine.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateMachine indicates an expected call of CreateMachine.
-func (mr *MockImportServiceMockRecorder) CreateMachine(arg0, arg1, arg2 any) *MockImportServiceCreateMachineCall {
+func (mr *MockImportServiceMockRecorder) CreateMachine(arg0, arg1, arg2, arg3 any) *MockImportServiceCreateMachineCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockImportService)(nil).CreateMachine), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockImportService)(nil).CreateMachine), arg0, arg1, arg2, arg3)
 	return &MockImportServiceCreateMachineCall{Call: call}
 }
 
@@ -130,13 +131,13 @@ func (c *MockImportServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, machine.Name, *string) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, machine.Name, *string, deployment.Platform) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, *string) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, *string, deployment.Platform) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/migration.go
+++ b/domain/machine/service/migration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/machine"
 	"github.com/juju/juju/domain/network"
 	"github.com/juju/juju/internal/errors"
@@ -64,7 +65,7 @@ func NewMigrationService(
 // CreateMachine creates the specified machine.
 // It returns a MachineAlreadyExists error if a machine with the same name
 // already exists.
-func (s *MigrationService) CreateMachine(ctx context.Context, machineName coremachine.Name, nonce *string) (coremachine.UUID, error) {
+func (s *MigrationService) CreateMachine(ctx context.Context, machineName coremachine.Name, nonce *string, platform deployment.Platform) (coremachine.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -83,6 +84,7 @@ func (s *MigrationService) CreateMachine(ctx context.Context, machineName corema
 		MachineUUID: machineUUID,
 		NetNodeUUID: netNodeUUID,
 		Nonce:       nonce,
+		Platform:    platform,
 	})
 	if err != nil {
 		return machineUUID, errors.Errorf("creating machine %q: %w", machineName, err)

--- a/domain/machine/service/migration_test.go
+++ b/domain/machine/service/migration_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/juju/juju/core/instance"
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/domain/application/architecture"
+	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	domainstatus "github.com/juju/juju/domain/status"
@@ -112,7 +114,9 @@ func (s *migrationServiceSuite) TestCreateMachine(c *tc.C) {
 
 	s.expectCreateMachineStatusHistory(c)
 
-	obtainedUUID, err := s.service.CreateMachine(c.Context(), "666", nil)
+	obtainedUUID, err := s.service.CreateMachine(c.Context(), "666", nil, deployment.Platform{
+		Architecture: architecture.AMD64,
+	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtainedUUID, tc.Equals, expectedUUID)
 }
@@ -131,7 +135,9 @@ func (s *migrationServiceSuite) TestCreateMachineSuccessNonce(c *tc.C) {
 
 	s.expectCreateMachineStatusHistory(c)
 
-	obtainedUUID, err := s.service.CreateMachine(c.Context(), "666", ptr("foo"))
+	obtainedUUID, err := s.service.CreateMachine(c.Context(), "666", ptr("foo"), deployment.Platform{
+		Architecture: architecture.AMD64,
+	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtainedUUID, tc.Equals, expectedUUID)
 }
@@ -144,7 +150,9 @@ func (s *migrationServiceSuite) TestCreateMachineError(c *tc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().InsertMigratingMachine(gomock.Any(), "666", gomock.Any()).Return(rErr)
 
-	_, err := s.service.CreateMachine(c.Context(), "666", nil)
+	_, err := s.service.CreateMachine(c.Context(), "666", nil, deployment.Platform{
+		Architecture: architecture.AMD64,
+	})
 	c.Assert(err, tc.ErrorIs, rErr)
 	c.Check(err, tc.ErrorMatches, `creating machine "666": boom`)
 }
@@ -158,7 +166,9 @@ func (s *migrationServiceSuite) TestCreateMachineAlreadyExists(c *tc.C) {
 
 	s.state.EXPECT().InsertMigratingMachine(gomock.Any(), "666", gomock.Any()).Return(machineerrors.MachineAlreadyExists)
 
-	_, err := s.service.CreateMachine(c.Context(), coremachine.Name("666"), nil)
+	_, err := s.service.CreateMachine(c.Context(), coremachine.Name("666"), nil, deployment.Platform{
+		Architecture: architecture.AMD64,
+	})
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineAlreadyExists)
 }
 


### PR DESCRIPTION
This fixes the machine import code, whereby the machine platform, more specifically the architecture for a platform wasn't correctly imported. The code here, will attempt to look at the constraints first, then if there are none, we check the instance data. As we should always have instance data before a migration is allowed, we can use that. If in the very rare cases that we have neither, we fallback to the default architecture, allowing the migration to complete.

This is broken off from auto-upgrading model task, that if we're migrating a model containing an architecture not present in the destination controller, that we don't just convert the machine to what ever is available on the destination controller (i.e. src model with arm64 doesn't automagically become dst model with amd64).

## QA steps

Install 3.6 as a snap, then bootstrap 3.6

```sh
$ /snap/bin/juju bootstrap aws/eu-west-1 src --constraints "cores=8 mem=16G arch=arm64" --model-default "container-networking-method=local"
$ /snap/bin/juju add-model m
$ /snap/bin/juju deploy juju-qa-test test --constraints "cores=4 mem=16G arch=arm64"
```

Bootstrap a 4.0 version:

```sh
$ juju bootstrap aws/eu-west-1 dst
$ juju migrate src:m dst
```

Verify in the database that the new machine platform is arm64 and not amd64!

## Links

**Jira card:** [JUJU-8968](https://warthogs.atlassian.net/browse/JUJU-8968)


[JUJU-8968]: https://warthogs.atlassian.net/browse/JUJU-8968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ