### PR TITLE
fix: ensure lxd vms with multiple nics are supported

### DIFF
--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -250,6 +250,8 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
         match:
           macaddress: aa:bb:cc:dd:ee:f3
         dhcp4: true
+        dhcp4-overrides:
+          use-routes: false
       any4:
         match:
           macaddress: aa:bb:cc:dd:ee:f4
@@ -297,6 +299,8 @@ network:
       match:
         macaddress: aa:bb:cc:dd:ee:f3
       dhcp4: true
+      dhcp4-overrides:
+        use-routes: false
     any4:
       match:
         macaddress: aa:bb:cc:dd:ee:f4

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -258,6 +258,7 @@ func (s *Server) ContainerAddresses(name string) ([]corenetwork.ProviderAddress,
 func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error) {
 	logger.Infof("starting new container %q (image %q)", spec.Name, spec.Image.Image.Filename)
 	logger.Debugf("new container has profiles %v", spec.Profiles)
+	logger.Debugf("new container has devices: %v", spec.Devices)
 
 	ephemeral := false
 	req := api.InstancesPost{

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -384,7 +384,7 @@ func (s *networkSuite) TestInterfaceInfoFromDevices(c *gc.C) {
 			"hwaddr":  "00:16:3e:00:00:00",
 		},
 		"eno9": {
-			"parent":  "br1",
+			"network": "br1",
 			"type":    "nic",
 			"nictype": "macvlan",
 			"hwaddr":  "00:16:3e:00:00:3e",

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/canonical/lxd/shared/api"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/instance"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
@@ -195,7 +197,16 @@ func (env *environ) getContainerSpec(
 	}
 	cSpec.ApplyConstraints(serverVersion, args.Constraints)
 
-	cloudCfg, err := cloudinit.New(args.InstanceConfig.Base.OS)
+	virtType := api.InstanceTypeContainer
+	if args.Constraints.HasVirtType() {
+		v, err := instance.ParseVirtType(*args.Constraints.VirtType)
+		if err != nil {
+			return lxd.ContainerSpec{}, errors.Trace(err)
+		}
+		virtType = v
+	}
+	cloudCfg, err := cloudinit.New(
+		args.InstanceConfig.Base.OS, cloudinit.WithNetplanMACMatch(virtType == api.InstanceTypeVM))
 	if err != nil {
 		return cSpec, errors.Trace(err)
 	}
@@ -238,7 +249,7 @@ func (env *environ) getContainerSpec(
 	// correctly.  It likely has to do with the HTTP transport, much
 	// as we have to b64encode the userdata for GCE.  Until that is
 	// resolved we simply pass the plain text.
-	//cfg[lxd.UserDataKey] = utils.Gzip(userData)
+	// cfg[lxd.UserDataKey] = utils.Gzip(userData)
 	cSpec.Config[lxd.UserDataKey] = string(userData)
 
 	for k, v := range args.InstanceConfig.Tags {
@@ -277,9 +288,8 @@ func (env *environ) assignContainerNICs(instStartParams environs.StartInstancePa
 	requestedNICNames := set.NewStrings()
 	for nicName, details := range assignedNICs {
 		requestedNICNames.Add(nicName)
-		if len(details) != 0 {
-			requestedHostBridges.Add(details["parent"])
-		}
+		netName := lxd.NetworkName(details)
+		requestedHostBridges.Add(netName)
 	}
 
 	// Assign any extra NICs required to satisfy the subnet requirements
@@ -322,10 +332,11 @@ func (env *environ) assignContainerNICs(instStartParams environs.StartInstancePa
 				}
 				break
 			}
-
+			hwaddr := corenetwork.GenerateVirtualMACAddress()
 			assignedNICs[devName] = map[string]string{
 				"name":    devName,
 				"type":    "nic",
+				"hwaddr":  hwaddr,
 				"nictype": "bridged",
 				"parent":  hostBridge,
 			}

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -207,6 +207,17 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 		// As the subnet IDs are map keys, the additional generated NIC
 		// indices depend on the key iteration order so we need to test
 		// both possible variants here.
+		// First check the hwaddr values. These are random with
+		// a fixed prefix.
+		for i := range 2 {
+			name := fmt.Sprintf("eth%d", i)
+			details, ok := spec.Devices[name]
+			c.Assert(ok, jc.IsTrue)
+			hwaddr := details["hwaddr"]
+			c.Assert(hwaddr, jc.HasPrefix, "00:16:3e:")
+			delete(details, "hwaddr")
+			spec.Devices[name] = details
+		}
 		matchedNICs := reflect.DeepEqual(spec.Devices, map[string]map[string]string{
 			"eno9": profileNICs["eno9"],
 			"eth0": {

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -24,6 +24,11 @@ type Nameservers struct {
 	Addresses []string `yaml:"addresses,omitempty,flow"`
 }
 
+// Overrides contains extra config for an interface.
+type Overrides struct {
+	UseRoutes bool `yaml:"use-routes"`
+}
+
 // Interface includes all the fields that are common between all interfaces (ethernet, wifi, bridge, bond)
 type Interface struct {
 	AcceptRA  *bool    `yaml:"accept-ra,omitempty"`
@@ -32,6 +37,7 @@ type Interface struct {
 	Critical bool `yaml:"critical,omitempty"`
 	// DHCP4 defaults to true, so we must use a pointer to know if it was specified as false
 	DHCP4          *bool         `yaml:"dhcp4,omitempty"`
+	DHCP4Overrides *Overrides    `yaml:"dhcp4-overrides,omitempty"`
 	DHCP6          *bool         `yaml:"dhcp6,omitempty"`
 	DHCPIdentifier string        `yaml:"dhcp-identifier,omitempty"` // "duid" or  "mac"
 	Gateway4       string        `yaml:"gateway4,omitempty"`


### PR DESCRIPTION
The netplan config for lxd vms was missing directives to match on hw address. This is needed because the nic naming 
scheme on vms is enpXsp0 not ethX.

There's a fair bit of code duplication between the lxd provider and lxd container packages. The fix uses the same implementation as for the containers. Ideally we'd look to refactor the code, but not for this PR.

Also, we don't want more than one dhcp configured nic to get a default route. If this happens, it can prevent network traffic egress which is fixed by manually deleting the offending route entries. So add the extra netplan override to prevent it. Ideally there'd be a way to model what nic gets egress and/or configure the routes for each nic but the netplan we write for lxd is quite rigid. ie we just write a really simple netplan with `dhcp4: true` and don't provide a way to model/configure other aspects that I can see (apart from the matching algorithm).

**Edit:** after doing this PR, I saw this issue
https://github.com/juju/juju/issues/20540
which looks like the same issue I ran into, ie multiple default routes preventing egress
From the bug:
```
$ ip route show default
default via 192.168.200.1 dev eth2 proto dhcp src 192.168.200.133 metric 100 
default via 192.168.100.1 dev eth3 proto dhcp src 192.168.100.110 metric 100 
default via 10.175.141.1 dev eth0 proto dhcp src 10.175.141.144 metric 100 
default via 10.175.141.1 dev eth1 proto dhcp src 10.175.141.73 metric 100 
```
In the absence of a modelled approach, I just chose to allow a default route for the first dhcp enabled nic only, which I think is eth0.

## QA steps

Create 2 additional lxd networks besides the lxdbr0 one.
```
lxc network create lxdbr1 ipv4.address=10.68.48.1/24 ipv6.address=none
lxc network create lxdbr2 ipv4.address=10.68.49.1/24 ipv6.address=none
```

Add one of the above to the default profile to create conditions for a corner case.
```
devices:
  eth0:
    nictype: bridged
    parent: lxdbr0
    type: nic
  eth1:
    nictype: bridged
    parent: lxdbr1
    type: nic
```

Test with lxd container and vm. For the vm test, do the same steps but with additional constraints `virt-type=virtual-machine mem=4G`

```
juju bootstrap lxd test
juju switch controller
juju add-space clients 10.68.48.0/24
juju add-space peers 10.68.49.0/24
juju deploy postgresql --channel 16/stable --constraints "spaces=clients,peers " --bind="database-peers=peers database=clients" 
```
Check postgres comes up and is active.
Check netplan
eg container case
```
cat /etc/netplan/99-juju.yaml 
network:
  version: 2
  ethernets:
    eth0:
      dhcp4: true
    eth1:
      dhcp4: true
      dhcp4-overrides:
        use-routes: false
    eth2:
      dhcp4: true
      dhcp4-overrides:
        use-routes: false
```
eg vm case
```
cat /etc/netplan/99-juju.yaml 
network:
  version: 2
  ethernets:
    eth0:
      match:
        macaddress: 00:16:3e:e5:a3:e9
      dhcp4: true
    eth1:
      match:
        macaddress: 00:16:3e:5a:29:c7
      dhcp4: true
      dhcp4-overrides:
        use-routes: false
    eth2:
      match:
        macaddress: 00:16:3e:5c:08:b0
      dhcp4: true
      dhcp4-overrides:
        use-routes: false
```

## Links

**Issue:** Fixes #20440.

**Jira card:** [JUJU-8421](https://warthogs.atlassian.net/browse/JUJU-8421)


[JUJU-8421]: https://warthogs.atlassian.net/browse/JUJU-8421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ