### PR TITLE
fix: ensure correct netplan for multi nic lxd vm

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -258,6 +258,7 @@ func (s *Server) ContainerAddresses(name string) ([]corenetwork.ProviderAddress,
 func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error) {
 	logger.Infof("starting new container %q (image %q)", spec.Name, spec.Image.Image.Filename)
 	logger.Debugf("new container has profiles %v", spec.Profiles)
+	logger.Debugf("new container has devices: %v", spec.Devices)
 
 	ephemeral := false
 	req := api.InstancesPost{

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -384,7 +384,7 @@ func (s *networkSuite) TestInterfaceInfoFromDevices(c *gc.C) {
 			"hwaddr":  "00:16:3e:00:00:00",
 		},
 		"eno9": {
-			"parent":  "br1",
+			"network": "br1",
 			"type":    "nic",
 			"nictype": "macvlan",
 			"hwaddr":  "00:16:3e:00:00:3e",

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/canonical/lxd/shared/api"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/instance"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
@@ -195,7 +197,16 @@ func (env *environ) getContainerSpec(
 	}
 	cSpec.ApplyConstraints(serverVersion, args.Constraints)
 
-	cloudCfg, err := cloudinit.New(args.InstanceConfig.Base.OS)
+	virtType := api.InstanceTypeContainer
+	if args.Constraints.HasVirtType() {
+		v, err := instance.ParseVirtType(*args.Constraints.VirtType)
+		if err != nil {
+			return lxd.ContainerSpec{}, errors.Trace(err)
+		}
+		virtType = v
+	}
+	cloudCfg, err := cloudinit.New(
+		args.InstanceConfig.Base.OS, cloudinit.WithNetplanMACMatch(virtType == api.InstanceTypeVM))
 	if err != nil {
 		return cSpec, errors.Trace(err)
 	}
@@ -238,7 +249,7 @@ func (env *environ) getContainerSpec(
 	// correctly.  It likely has to do with the HTTP transport, much
 	// as we have to b64encode the userdata for GCE.  Until that is
 	// resolved we simply pass the plain text.
-	//cfg[lxd.UserDataKey] = utils.Gzip(userData)
+	// cfg[lxd.UserDataKey] = utils.Gzip(userData)
 	cSpec.Config[lxd.UserDataKey] = string(userData)
 
 	for k, v := range args.InstanceConfig.Tags {
@@ -277,9 +288,8 @@ func (env *environ) assignContainerNICs(instStartParams environs.StartInstancePa
 	requestedNICNames := set.NewStrings()
 	for nicName, details := range assignedNICs {
 		requestedNICNames.Add(nicName)
-		if len(details) != 0 {
-			requestedHostBridges.Add(details["parent"])
-		}
+		netName := lxd.NetworkName(details)
+		requestedHostBridges.Add(netName)
 	}
 
 	// Assign any extra NICs required to satisfy the subnet requirements
@@ -322,10 +332,11 @@ func (env *environ) assignContainerNICs(instStartParams environs.StartInstancePa
 				}
 				break
 			}
-
+			hwaddr := corenetwork.GenerateVirtualMACAddress()
 			assignedNICs[devName] = map[string]string{
 				"name":    devName,
 				"type":    "nic",
+				"hwaddr":  hwaddr,
 				"nictype": "bridged",
 				"parent":  hostBridge,
 			}

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -207,6 +207,17 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 		// As the subnet IDs are map keys, the additional generated NIC
 		// indices depend on the key iteration order so we need to test
 		// both possible variants here.
+		// First check the hwaddr values. These are random with
+		// a fixed prefix.
+		for i := range 2 {
+			name := fmt.Sprintf("eth%d", i)
+			details, ok := spec.Devices[name]
+			c.Assert(ok, jc.IsTrue)
+			hwaddr := details["hwaddr"]
+			c.Assert(hwaddr, jc.HasPrefix, "00:16:3e:")
+			delete(details, "hwaddr")
+			spec.Devices[name] = details
+		}
 		matchedNICs := reflect.DeepEqual(spec.Devices, map[string]map[string]string{
 			"eno9": profileNICs["eno9"],
 			"eth0": {


### PR DESCRIPTION
The netplan config for lxd vms was missing directives to match on hw address. This is needed because the nic naming
scheme on vms is enpXsp0 not ethX.

There's a fair bit of code duplication between the lxd provider and lxd container packages. The fix uses the same implementation as for the containers. Ideally we'd look to refactor the code, but not for this PR.

## QA steps

bootstrap on lxd with 3 networks
add 2 spaces
```
juju add-space sp1 <cidr1>
juju add-space sp2 <cidr2>
```
Add a vm machine
`juju add-machine --constraints "spaces=sp1,sp2 virt-type=virtual-machine"`

Check the netplan
```
cat /etc/netplan/99-juju.yaml 
network:
  version: 2
  ethernets:
    eth0:
      match:
        macaddress: 00:16:3e:78:ea:07
      dhcp4: true
    eth1:
      match:
        macaddress: 00:16:3e:36:09:f4
      dhcp4: true
    eth2:
      match:
        macaddress: 00:16:3e:37:a4:dd
      dhcp4: true
```

Note: due to #20540 you need to exec into the machine and delete the duplicate default routes for the machine to fully come up and become active in the juju model. This is fixed here https://github.com/juju/juju/pull/21549

## Links

**Issue:** Fixes #21547.

**Jira card:** [JUJU-9044](https://warthogs.atlassian.net/browse/JUJU-9044)


[JUJU-9044]: https://warthogs.atlassian.net/browse/JUJU-9044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ