### PR TITLE
feat: add remote application import support

### DIFF
--- a/domain/crossmodelrelation/import_integration_test.go
+++ b/domain/crossmodelrelation/import_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/domain/crossmodelrelation/service"
 	controllerstate "github.com/juju/juju/domain/crossmodelrelation/state/controller"
 	modelstate "github.com/juju/juju/domain/crossmodelrelation/state/model"
+	"github.com/juju/juju/domain/life"
 	migrationtesting "github.com/juju/juju/domain/modelmigration/testing"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -36,11 +37,16 @@ func TestImportSuite(t *testing.T) {
 	tc.Run(t, &importSuite{})
 }
 
-func (s *importSuite) TestOfferImport(c *tc.C) {
+// TestImport is a comprehensive happy-path test that verifies the complete
+// import process for both offers and remote applications with all fields populated.
+// This ensures no data is lost during migration.
+func (s *importSuite) TestImport(c *tc.C) {
 	// Arrange: set up the import data
 	desc := description.NewModel(description.ModelArgs{
 		Type: string(model.IAAS),
 	})
+
+	// Set up application with offers.
 	appName := "foo"
 	app := desc.AddApplication(description.ApplicationArgs{
 		Name:     appName,
@@ -102,6 +108,8 @@ func (s *importSuite) TestOfferImport(c *tc.C) {
 			},
 		},
 	})
+
+	// Add offers for the application.
 	offerOneUUID := tc.Must(c, uuid.NewUUID).String()
 	offerOneName := "foo"
 	app.AddOffer(description.ApplicationOfferArgs{
@@ -119,6 +127,70 @@ func (s *importSuite) TestOfferImport(c *tc.C) {
 		ApplicationName: appName,
 	})
 
+	// Set up remote applications.
+	remoteOfferUUID := tc.Must(c, uuid.NewUUID).String()
+	remoteSourceModelUUID := tc.Must(c, uuid.NewUUID).String()
+	remoteMacaroon1 := newMacaroon(c, "kafka-macaroon")
+	remoteMacaroon1JSON := string(tc.Must(c, remoteMacaroon1.MarshalJSON))
+
+	remoteApp1 := desc.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "remote-kafka",
+		OfferUUID:       remoteOfferUUID,
+		URL:             "ctrl:admin/production.kafka",
+		SourceModelUUID: remoteSourceModelUUID,
+		IsConsumerProxy: false,
+		ConsumeVersion:  2, // Note: ConsumeVersion is not currently imported
+		Macaroon:        remoteMacaroon1JSON,
+		Bindings:        map[string]string{"client": "alpha", "zookeeper": "beta"}, // Note: Bindings are not currently imported
+	})
+	remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "client",
+		Role:      "provider",
+		Interface: "kafka",
+	})
+	remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "zookeeper",
+		Role:      "requirer",
+		Interface: "zookeeper",
+	})
+
+	// Add a second remote application to test multiple remote apps.
+	remoteOfferUUID2 := tc.Must(c, uuid.NewUUID).String()
+	remoteSourceModelUUID2 := tc.Must(c, uuid.NewUUID).String()
+	remoteMacaroon2 := newMacaroon(c, "redis-macaroon")
+	remoteMacaroon2JSON := string(tc.Must(c, remoteMacaroon2.MarshalJSON))
+
+	remoteApp2 := desc.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "remote-redis",
+		OfferUUID:       remoteOfferUUID2,
+		URL:             "ctrl:admin/staging.redis",
+		SourceModelUUID: remoteSourceModelUUID2,
+		IsConsumerProxy: false,
+		Macaroon:        remoteMacaroon2JSON,
+	})
+	remoteApp2.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "cache",
+		Role:      "provider",
+		Interface: "redis",
+	})
+
+	// Add a consumer proxy remote application (should be skipped during import).
+	consumerProxyMacaroon := newMacaroon(c, "proxy-macaroon")
+	consumerProxyMacaroonJSON := string(tc.Must(c, consumerProxyMacaroon.MarshalJSON))
+	consumerProxyApp := desc.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "remote-consumer-proxy",
+		OfferUUID:       tc.Must(c, uuid.NewUUID).String(),
+		URL:             "ctrl:admin/consumer.app",
+		SourceModelUUID: tc.Must(c, uuid.NewUUID).String(),
+		IsConsumerProxy: true, // This should be skipped during import
+		Macaroon:        consumerProxyMacaroonJSON,
+	})
+	consumerProxyApp.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "endpoint",
+		Role:      "provider",
+		Interface: "http",
+	})
+
 	// Arrange: setup the db and import
 	coordinator, scope, svc := s.setupCoordinatorScopeAndService(c)
 
@@ -128,6 +200,7 @@ func (s *importSuite) TestOfferImport(c *tc.C) {
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
 
+	// Verify offers were imported correctly.
 	obtainedOffers, err := svc.GetOffers(c.Context(), []service.OfferFilter{{}})
 	c.Assert(err, tc.ErrorIsNil)
 	mc := tc.NewMultiChecker()
@@ -146,6 +219,7 @@ func (s *importSuite) TestOfferImport(c *tc.C) {
 		},
 	}, tc.Commentf("%+v\n%+v", obtainedOffers[0], obtainedOffers[1]))
 
+	// Verify offer endpoints.
 	obtainedEndpoints := transform.SliceToMap(obtainedOffers, func(in *crossmodelrelation.OfferDetail) (string, []crossmodelrelation.OfferEndpoint) {
 		return in.OfferName, in.Endpoints
 	})
@@ -176,6 +250,45 @@ func (s *importSuite) TestOfferImport(c *tc.C) {
 			},
 		})
 	}
+
+	// Verify remote applications were imported correctly.
+	// Consumer proxy should be skipped, so only 2 remote apps are expected.
+	obtainedRemoteApps, err := svc.GetRemoteApplicationOfferers(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(obtainedRemoteApps), tc.Equals, 2, tc.Commentf("Expected 2 remote apps (consumer proxy should be skipped)"))
+
+	// Build a map for easier lookup.
+	remoteAppsByName := transform.SliceToMap(obtainedRemoteApps, func(in crossmodelrelation.RemoteApplicationOfferer) (string, crossmodelrelation.RemoteApplicationOfferer) {
+		return in.ApplicationName, in
+	})
+
+	// Verify remote-kafka.
+	kafkaApp, ok := remoteAppsByName["remote-kafka"]
+	if c.Check(ok, tc.IsTrue, tc.Commentf("missing remote-kafka")) {
+		c.Check(kafkaApp.ApplicationName, tc.Equals, "remote-kafka")
+		c.Check(kafkaApp.OfferUUID, tc.Equals, remoteOfferUUID)
+		c.Check(kafkaApp.OfferURL, tc.Equals, "ctrl:admin/production.kafka")
+		c.Check(kafkaApp.OffererModelUUID, tc.Equals, remoteSourceModelUUID)
+		c.Check(kafkaApp.Life, tc.Equals, life.Alive)
+		// Verify macaroon was stored correctly.
+		c.Check(kafkaApp.Macaroon, tc.DeepEquals, remoteMacaroon1)
+	}
+
+	// Verify remote-redis.
+	redisApp, ok := remoteAppsByName["remote-redis"]
+	if c.Check(ok, tc.IsTrue, tc.Commentf("missing remote-redis")) {
+		c.Check(redisApp.ApplicationName, tc.Equals, "remote-redis")
+		c.Check(redisApp.OfferUUID, tc.Equals, remoteOfferUUID2)
+		c.Check(redisApp.OfferURL, tc.Equals, "ctrl:admin/staging.redis")
+		c.Check(redisApp.OffererModelUUID, tc.Equals, remoteSourceModelUUID2)
+		c.Check(redisApp.Life, tc.Equals, life.Alive)
+		// Verify macaroon was stored correctly.
+		c.Check(redisApp.Macaroon, tc.DeepEquals, remoteMacaroon2)
+	}
+
+	// Verify consumer proxy was NOT imported.
+	_, ok = remoteAppsByName["remote-consumer-proxy"]
+	c.Check(ok, tc.IsFalse, tc.Commentf("consumer proxy should not be imported"))
 }
 
 // setupCoordinatorScopeAndService returns the coordinator, scope and service

--- a/domain/crossmodelrelation/modelmigration/import.go
+++ b/domain/crossmodelrelation/modelmigration/import.go
@@ -62,7 +62,6 @@ func (i *importOperation) Name() string {
 // Setup implements Operation.
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	i.importService = service.NewMigrationService(
-		// TODO(import) - get model UUID and pass it in here
 		modelstate.NewState(scope.ModelDB(), "", i.clock, i.logger),
 		i.logger,
 	)

--- a/domain/crossmodelrelation/modelmigration/import.go
+++ b/domain/crossmodelrelation/modelmigration/import.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	"github.com/juju/juju/domain/crossmodelrelation/service"
 	modelstate "github.com/juju/juju/domain/crossmodelrelation/state/model"
@@ -38,6 +39,10 @@ func RegisterImport(coordinator Coordinator, clock clock.Clock, logger logger.Lo
 type ImportService interface {
 	// ImportOffers adds offers being migrated to the current model.
 	ImportOffers(context.Context, []crossmodelrelation.OfferImport) error
+
+	// ImportRemoteApplications adds remote application offerers being migrated
+	// to the current model.
+	ImportRemoteApplications(context.Context, []crossmodelrelation.RemoteApplicationImport) error
 }
 
 type importOperation struct {
@@ -68,6 +73,9 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
 	if err := i.importOffers(ctx, model.Applications()); err != nil {
 		return errors.Errorf("importing offers: %w", err)
+	}
+	if err := i.importRemoteApplications(ctx, model.RemoteApplications()); err != nil {
+		return errors.Errorf("importing remote applications: %w", err)
 	}
 	return nil
 }
@@ -101,4 +109,53 @@ func (i *importOperation) importOffers(ctx context.Context, apps []description.A
 		return nil
 	}
 	return i.importService.ImportOffers(ctx, input)
+}
+
+func (i *importOperation) importRemoteApplications(ctx context.Context, remoteApps []description.RemoteApplication) error {
+	input := make([]crossmodelrelation.RemoteApplicationImport, 0, len(remoteApps))
+	for _, remoteApp := range remoteApps {
+		endpoints := make([]crossmodelrelation.RemoteApplicationEndpoint, 0, len(remoteApp.Endpoints()))
+		for _, ep := range remoteApp.Endpoints() {
+			role, err := parseRelationRole(ep.Role())
+			if err != nil {
+				return errors.Errorf("parsing role for endpoint %q on remote app %q: %w",
+					ep.Name(), remoteApp.Name(), err)
+			}
+			endpoints = append(endpoints, crossmodelrelation.RemoteApplicationEndpoint{
+				Name:      ep.Name(),
+				Role:      role,
+				Interface: ep.Interface(),
+			})
+		}
+
+		imp := crossmodelrelation.RemoteApplicationImport{
+			Name:            remoteApp.Name(),
+			OfferUUID:       remoteApp.OfferUUID(),
+			URL:             remoteApp.URL(),
+			SourceModelUUID: remoteApp.SourceModelUUID(),
+			Macaroon:        remoteApp.Macaroon(),
+			Endpoints:       endpoints,
+			Bindings:        remoteApp.Bindings(),
+			IsConsumerProxy: remoteApp.IsConsumerProxy(),
+		}
+		input = append(input, imp)
+	}
+	if len(input) == 0 {
+		return nil
+	}
+	return i.importService.ImportRemoteApplications(ctx, input)
+}
+
+// parseRelationRole parses a string role to a charm.RelationRole.
+func parseRelationRole(role string) (charm.RelationRole, error) {
+	switch role {
+	case "provider":
+		return charm.RoleProvider, nil
+	case "requirer":
+		return charm.RoleRequirer, nil
+	case "peer":
+		return charm.RolePeer, nil
+	default:
+		return "", errors.Errorf("unknown relation role %q", role)
+	}
 }

--- a/domain/crossmodelrelation/modelmigration/package_mock_test.go
+++ b/domain/crossmodelrelation/modelmigration/package_mock_test.go
@@ -77,3 +77,41 @@ func (c *MockImportServiceImportOffersCall) DoAndReturn(f func(context.Context, 
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// ImportRemoteApplications mocks base method.
+func (m *MockImportService) ImportRemoteApplications(arg0 context.Context, arg1 []crossmodelrelation.RemoteApplicationImport) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImportRemoteApplications", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ImportRemoteApplications indicates an expected call of ImportRemoteApplications.
+func (mr *MockImportServiceMockRecorder) ImportRemoteApplications(arg0, arg1 any) *MockImportServiceImportRemoteApplicationsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportRemoteApplications", reflect.TypeOf((*MockImportService)(nil).ImportRemoteApplications), arg0, arg1)
+	return &MockImportServiceImportRemoteApplicationsCall{Call: call}
+}
+
+// MockImportServiceImportRemoteApplicationsCall wrap *gomock.Call
+type MockImportServiceImportRemoteApplicationsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceImportRemoteApplicationsCall) Return(arg0 error) *MockImportServiceImportRemoteApplicationsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceImportRemoteApplicationsCall) Do(f func(context.Context, []crossmodelrelation.RemoteApplicationImport) error) *MockImportServiceImportRemoteApplicationsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceImportRemoteApplicationsCall) DoAndReturn(f func(context.Context, []crossmodelrelation.RemoteApplicationImport) error) *MockImportServiceImportRemoteApplicationsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/domain/crossmodelrelation/service/migration.go
+++ b/domain/crossmodelrelation/service/migration.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	"github.com/juju/juju/internal/errors"
 )
@@ -17,6 +18,10 @@ import (
 type ModelMigrationState interface {
 	// ImportOffers adds offers being migrated to the current model.
 	ImportOffers(context.Context, []crossmodelrelation.OfferImport) error
+
+	// ImportRemoteApplications adds remote application offerers being migrated
+	// to the current model.
+	ImportRemoteApplications(context.Context, []crossmodelrelation.RemoteApplicationImport) error
 }
 
 // MigrationService provides the API for model migration actions within
@@ -44,4 +49,62 @@ func (s *MigrationService) ImportOffers(ctx context.Context, imports []crossmode
 	defer span.End()
 
 	return errors.Capture(s.modelState.ImportOffers(ctx, imports))
+}
+
+// ImportRemoteApplications adds remote application offerers being migrated to
+// the current model. These are applications that this model is consuming from
+// other models.
+func (s *MigrationService) ImportRemoteApplications(ctx context.Context, imports []crossmodelrelation.RemoteApplicationImport) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	// Build synthetic charms for each remote application in the service layer.
+	importsWithCharms := make([]crossmodelrelation.RemoteApplicationImport, len(imports))
+	for i, imp := range imports {
+		importsWithCharms[i] = imp
+		importsWithCharms[i].SyntheticCharm = buildSyntheticCharm(imp.Name, imp.Endpoints)
+	}
+
+	return errors.Capture(s.modelState.ImportRemoteApplications(ctx, importsWithCharms))
+}
+
+// BuildSyntheticCharmForTest creates a synthetic charm from the remote application's
+// endpoints. This is used during migration to recreate the charm that
+// represents a remote application.
+// This is exported for testing purposes.
+func BuildSyntheticCharmForTest(appName string, endpoints []crossmodelrelation.RemoteApplicationEndpoint) charm.Charm {
+	return buildSyntheticCharm(appName, endpoints)
+}
+
+// buildSyntheticCharm creates a synthetic charm from the remote application's
+// endpoints. This is used during migration to recreate the charm that
+// represents a remote application.
+func buildSyntheticCharm(appName string, endpoints []crossmodelrelation.RemoteApplicationEndpoint) charm.Charm {
+	provides := make(map[string]charm.Relation)
+	requires := make(map[string]charm.Relation)
+
+	for _, ep := range endpoints {
+		rel := charm.Relation{
+			Name:      ep.Name,
+			Role:      ep.Role,
+			Interface: ep.Interface,
+			Scope:     charm.ScopeGlobal,
+		}
+		switch ep.Role {
+		case charm.RoleProvider:
+			provides[ep.Name] = rel
+		case charm.RoleRequirer:
+			requires[ep.Name] = rel
+		}
+	}
+
+	return charm.Charm{
+		Metadata: charm.Metadata{
+			Name:     appName,
+			Provides: provides,
+			Requires: requires,
+		},
+		Source:        charm.CMRSource,
+		ReferenceName: appName,
+	}
 }

--- a/domain/crossmodelrelation/service/migration.go
+++ b/domain/crossmodelrelation/service/migration.go
@@ -68,14 +68,6 @@ func (s *MigrationService) ImportRemoteApplications(ctx context.Context, imports
 	return errors.Capture(s.modelState.ImportRemoteApplications(ctx, importsWithCharms))
 }
 
-// BuildSyntheticCharmForTest creates a synthetic charm from the remote application's
-// endpoints. This is used during migration to recreate the charm that
-// represents a remote application.
-// This is exported for testing purposes.
-func BuildSyntheticCharmForTest(appName string, endpoints []crossmodelrelation.RemoteApplicationEndpoint) charm.Charm {
-	return buildSyntheticCharm(appName, endpoints)
-}
-
 // buildSyntheticCharm creates a synthetic charm from the remote application's
 // endpoints. This is used during migration to recreate the charm that
 // represents a remote application.

--- a/domain/crossmodelrelation/service/migration_test.go
+++ b/domain/crossmodelrelation/service/migration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
+	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -68,6 +69,243 @@ func (s *migrationSuite) TestImportOffersFail(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
+func (s *migrationSuite) TestImportRemoteApplications(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	input := []crossmodelrelation.RemoteApplicationImport{
+		{
+			Name:            "remote-app1",
+			OfferUUID:       uuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/model.app1",
+			SourceModelUUID: uuid.MustNewUUID().String(),
+			Macaroon:        "macaroon-data",
+			Endpoints: []crossmodelrelation.RemoteApplicationEndpoint{
+				{
+					Name:      "db",
+					Role:      "provider",
+					Interface: "mysql",
+				},
+			},
+			Bindings:        map[string]string{"db": "alpha"},
+			IsConsumerProxy: false,
+		},
+		{
+			Name:            "remote-app2",
+			OfferUUID:       uuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/model.app2",
+			SourceModelUUID: uuid.MustNewUUID().String(),
+			Macaroon:        "macaroon-data-2",
+			Endpoints: []crossmodelrelation.RemoteApplicationEndpoint{
+				{
+					Name:      "endpoint",
+					Role:      "requirer",
+					Interface: "http",
+				},
+			},
+			Bindings:        map[string]string{"endpoint": "beta"},
+			IsConsumerProxy: false,
+		},
+	}
+	// Verify the service builds synthetic charms correctly
+	s.modelMigrationState.EXPECT().ImportRemoteApplications(
+		gomock.Any(),
+		syntheticCharmMatcher{
+			expectedApps: input,
+		},
+	).Return(nil)
+
+	// Act
+	err := s.service(c).ImportRemoteApplications(c.Context(), input)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *migrationSuite) TestImportRemoteApplicationsEmpty(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	input := []crossmodelrelation.RemoteApplicationImport{}
+	s.modelMigrationState.EXPECT().ImportRemoteApplications(
+		gomock.Any(),
+		syntheticCharmMatcher{
+			expectedApps: input,
+		},
+	).Return(nil)
+
+	// Act
+	err := s.service(c).ImportRemoteApplications(c.Context(), input)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *migrationSuite) TestImportRemoteApplicationsFail(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	input := []crossmodelrelation.RemoteApplicationImport{
+		{
+			Name:            "remote-app",
+			OfferUUID:       uuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/model.app",
+			SourceModelUUID: uuid.MustNewUUID().String(),
+			Macaroon:        "macaroon-data",
+			Endpoints: []crossmodelrelation.RemoteApplicationEndpoint{
+				{
+					Name:      "db",
+					Role:      "provider",
+					Interface: "mysql",
+				},
+			},
+			IsConsumerProxy: false,
+		},
+	}
+	s.modelMigrationState.EXPECT().ImportRemoteApplications(
+		gomock.Any(),
+		syntheticCharmMatcher{
+			expectedApps: input,
+		},
+	).Return(applicationerrors.ApplicationNotFound)
+
+	// Act
+	err := s.service(c).ImportRemoteApplications(c.Context(), input)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
+func (s *migrationSuite) TestImportRemoteApplicationsPeerIgnored(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange - import with a peer endpoint to verify it's ignored in synthetic charm
+	input := []crossmodelrelation.RemoteApplicationImport{
+		{
+			Name:            "remote-app",
+			OfferUUID:       uuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/model.app",
+			SourceModelUUID: uuid.MustNewUUID().String(),
+			Macaroon:        "macaroon-data",
+			Endpoints: []crossmodelrelation.RemoteApplicationEndpoint{
+				{
+					Name:      "provider-ep",
+					Role:      "provider",
+					Interface: "http",
+				},
+				{
+					Name:      "peer-ep",
+					Role:      "peer",
+					Interface: "cluster",
+				},
+				{
+					Name:      "requirer-ep",
+					Role:      "requirer",
+					Interface: "db",
+				},
+			},
+			IsConsumerProxy: false,
+		},
+	}
+	// Verify the synthetic charm excludes peer endpoints
+	s.modelMigrationState.EXPECT().ImportRemoteApplications(
+		gomock.Any(),
+		syntheticCharmMatcher{
+			expectedApps: input,
+		},
+	).Return(nil)
+
+	// Act
+	err := s.service(c).ImportRemoteApplications(c.Context(), input)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// syntheticCharmMatcher is a custom gomock matcher that verifies
+// RemoteApplicationImport slices have correctly built synthetic charms.
+type syntheticCharmMatcher struct {
+	expectedApps []crossmodelrelation.RemoteApplicationImport
+}
+
+func (m syntheticCharmMatcher) Matches(x interface{}) bool {
+	actual, ok := x.([]crossmodelrelation.RemoteApplicationImport)
+	if !ok {
+		return false
+	}
+
+	if len(actual) != len(m.expectedApps) {
+		return false
+	}
+
+	for i, app := range actual {
+		expected := m.expectedApps[i]
+
+		// Verify basic fields match
+		if app.Name != expected.Name ||
+			app.OfferUUID != expected.OfferUUID ||
+			app.URL != expected.URL ||
+			app.SourceModelUUID != expected.SourceModelUUID ||
+			app.Macaroon != expected.Macaroon ||
+			app.IsConsumerProxy != expected.IsConsumerProxy {
+			return false
+		}
+
+		// Verify endpoints match
+		if len(app.Endpoints) != len(expected.Endpoints) {
+			return false
+		}
+		for j, ep := range app.Endpoints {
+			if ep.Name != expected.Endpoints[j].Name ||
+				ep.Role != expected.Endpoints[j].Role ||
+				ep.Interface != expected.Endpoints[j].Interface {
+				return false
+			}
+		}
+
+		// Verify synthetic charm was built correctly
+		if app.SyntheticCharm.Metadata.Name != app.Name {
+			return false
+		}
+		if app.SyntheticCharm.Source != charm.CMRSource {
+			return false
+		}
+		if app.SyntheticCharm.ReferenceName != app.Name {
+			return false
+		}
+
+		// Verify charm endpoints match input endpoints
+		for _, ep := range expected.Endpoints {
+			switch ep.Role {
+			case "provider":
+				rel, ok := app.SyntheticCharm.Metadata.Provides[ep.Name]
+				if !ok || rel.Interface != ep.Interface {
+					return false
+				}
+			case "requirer":
+				rel, ok := app.SyntheticCharm.Metadata.Requires[ep.Name]
+				if !ok || rel.Interface != ep.Interface {
+					return false
+				}
+			case "peer":
+				// Peer relations should not be in synthetic charm
+				if _, inProvides := app.SyntheticCharm.Metadata.Provides[ep.Name]; inProvides {
+					return false
+				}
+				if _, inRequires := app.SyntheticCharm.Metadata.Requires[ep.Name]; inRequires {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+func (m syntheticCharmMatcher) String() string {
+	return "matches RemoteApplicationImport with correctly built synthetic charms"
 }
 
 func (s *migrationSuite) service(c *tc.C) *MigrationService {

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -2165,6 +2165,44 @@ func (c *MockModelMigrationStateImportOffersCall) DoAndReturn(f func(context.Con
 	return c
 }
 
+// ImportRemoteApplications mocks base method.
+func (m *MockModelMigrationState) ImportRemoteApplications(arg0 context.Context, arg1 []crossmodelrelation.RemoteApplicationImport) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImportRemoteApplications", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ImportRemoteApplications indicates an expected call of ImportRemoteApplications.
+func (mr *MockModelMigrationStateMockRecorder) ImportRemoteApplications(arg0, arg1 any) *MockModelMigrationStateImportRemoteApplicationsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportRemoteApplications", reflect.TypeOf((*MockModelMigrationState)(nil).ImportRemoteApplications), arg0, arg1)
+	return &MockModelMigrationStateImportRemoteApplicationsCall{Call: call}
+}
+
+// MockModelMigrationStateImportRemoteApplicationsCall wrap *gomock.Call
+type MockModelMigrationStateImportRemoteApplicationsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelMigrationStateImportRemoteApplicationsCall) Return(arg0 error) *MockModelMigrationStateImportRemoteApplicationsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelMigrationStateImportRemoteApplicationsCall) Do(f func(context.Context, []crossmodelrelation.RemoteApplicationImport) error) *MockModelMigrationStateImportRemoteApplicationsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelMigrationStateImportRemoteApplicationsCall) DoAndReturn(f func(context.Context, []crossmodelrelation.RemoteApplicationImport) error) *MockModelMigrationStateImportRemoteApplicationsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockModelRelationNetworkState is a mock of ModelRelationNetworkState interface.
 type MockModelRelationNetworkState struct {
 	ctrl     *gomock.Controller

--- a/domain/crossmodelrelation/state/model/import.go
+++ b/domain/crossmodelrelation/state/model/import.go
@@ -72,10 +72,6 @@ INSERT INTO offer (*) VALUES ($nameAndUUID.*)`, nameAndUUID{})
 // the current model. These are applications that this model is consuming from
 // other models.
 func (st *State) ImportRemoteApplications(ctx context.Context, imports []crossmodelrelation.RemoteApplicationImport) error {
-	if len(imports) == 0 {
-		return nil
-	}
-
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/crossmodelrelation/state/model/import.go
+++ b/domain/crossmodelrelation/state/model/import.go
@@ -79,12 +79,6 @@ func (st *State) ImportRemoteApplications(ctx context.Context, imports []crossmo
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		for _, imp := range imports {
-			// Skip consumer proxies - they represent consumers on the
-			// offering side and are handled differently.
-			if imp.IsConsumerProxy {
-				continue
-			}
-
 			// Generate UUIDs for the application, charm, and remote app record.
 			applicationUUID, err := internaluuid.NewUUID()
 			if err != nil {

--- a/domain/crossmodelrelation/state/model/import.go
+++ b/domain/crossmodelrelation/state/model/import.go
@@ -11,7 +11,9 @@ import (
 	"github.com/juju/collections/transform"
 
 	"github.com/juju/juju/domain/crossmodelrelation"
+	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/internal/errors"
+	internaluuid "github.com/juju/juju/internal/uuid"
 )
 
 // ImportOffers adds offers being migrated to the current model.
@@ -61,6 +63,78 @@ INSERT INTO offer (*) VALUES ($nameAndUUID.*)`, nameAndUUID{})
 			}
 		}
 
+		return nil
+	})
+	return errors.Capture(err)
+}
+
+// ImportRemoteApplications adds remote application offerers being migrated to
+// the current model. These are applications that this model is consuming from
+// other models.
+func (st *State) ImportRemoteApplications(ctx context.Context, imports []crossmodelrelation.RemoteApplicationImport) error {
+	if len(imports) == 0 {
+		return nil
+	}
+
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		for _, imp := range imports {
+			// Skip consumer proxies - they represent consumers on the
+			// offering side and are handled differently.
+			if imp.IsConsumerProxy {
+				continue
+			}
+
+			// Generate UUIDs for the application, charm, and remote app record.
+			applicationUUID, err := internaluuid.NewUUID()
+			if err != nil {
+				return errors.Errorf("generating application UUID for %q: %w", imp.Name, err)
+			}
+			charmUUID, err := internaluuid.NewUUID()
+			if err != nil {
+				return errors.Errorf("generating charm UUID for %q: %w", imp.Name, err)
+			}
+			remoteAppUUID, err := internaluuid.NewUUID()
+			if err != nil {
+				return errors.Errorf("generating remote app UUID for %q: %w", imp.Name, err)
+			}
+
+			// Insert the application (which also inserts the charm).
+			// The synthetic charm is pre-built in the service layer.
+			if err := st.insertApplication(ctx, tx, imp.Name, insertApplicationArgs{
+				ApplicationUUID: applicationUUID.String(),
+				CharmUUID:       charmUUID.String(),
+				Charm:           imp.SyntheticCharm,
+			}); err != nil {
+				return errors.Errorf("inserting application %q: %w", imp.Name, err)
+			}
+
+			// Insert the remote application offerer record.
+			remoteApp := remoteApplicationOfferer{
+				UUID:             remoteAppUUID.String(),
+				LifeID:           life.Alive,
+				ApplicationUUID:  applicationUUID.String(),
+				OfferUUID:        imp.OfferUUID,
+				OfferURL:         imp.URL,
+				OffererModelUUID: imp.SourceModelUUID,
+				Macaroon:         []byte(imp.Macaroon),
+			}
+
+			insertRemoteAppStmt, err := st.Prepare(`
+INSERT INTO application_remote_offerer (*) VALUES ($remoteApplicationOfferer.*);`,
+				remoteApp)
+			if err != nil {
+				return errors.Errorf("preparing remote app insert for %q: %w", imp.Name, err)
+			}
+
+			if err := tx.Query(ctx, insertRemoteAppStmt, remoteApp).Run(); err != nil {
+				return errors.Errorf("inserting remote app offerer record for %q: %w", imp.Name, err)
+			}
+		}
 		return nil
 	})
 	return errors.Capture(err)

--- a/domain/crossmodelrelation/state/model/import_test.go
+++ b/domain/crossmodelrelation/state/model/import_test.go
@@ -4,11 +4,15 @@
 package state
 
 import (
+	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/juju/tc"
 
+	appcharm "github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/crossmodelrelation"
+	"github.com/juju/juju/domain/crossmodelrelation/service"
 	"github.com/juju/juju/internal/charm"
 	internaluuid "github.com/juju/juju/internal/uuid"
 )
@@ -97,4 +101,283 @@ func (s *importOfferSuite) TestImportOffers(c *tc.C) {
 			EndpointUUID: endpointUUID3,
 		},
 	})
+}
+
+func (s *importOfferSuite) TestImportOffersMultipleApplications(c *tc.C) {
+	// Arrange
+	charmUUID1 := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID1, false)
+	relation1 := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "mysql",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID1 := s.addCharmRelation(c, charmUUID1, relation1)
+	appName1 := "app1"
+	appUUID1 := s.addApplication(c, charmUUID1, appName1)
+	endpointUUID1 := s.addApplicationEndpoint(c, appUUID1, relationUUID1)
+
+	charmUUID2 := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID2, false)
+	relation2 := charm.Relation{
+		Name:      "endpoint",
+		Role:      charm.RoleProvider,
+		Interface: "http",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID2 := s.addCharmRelation(c, charmUUID2, relation2)
+	appName2 := "app2"
+	appUUID2 := s.addApplication(c, charmUUID2, appName2)
+	endpointUUID2 := s.addApplicationEndpoint(c, appUUID2, relationUUID2)
+
+	args := []crossmodelrelation.OfferImport{
+		{
+			UUID:            internaluuid.MustNewUUID(),
+			ApplicationName: appName1,
+			Endpoints:       []string{relation1.Name},
+			Name:            "offer1",
+		},
+		{
+			UUID:            internaluuid.MustNewUUID(),
+			ApplicationName: appName2,
+			Endpoints:       []string{relation2.Name},
+			Name:            "offer2",
+		},
+	}
+
+	// Act
+	err := s.state.ImportOffers(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+	obtainedOffers := s.readOffers(c)
+	c.Check(obtainedOffers, tc.SameContents, []nameAndUUID{
+		{
+			UUID: args[0].UUID.String(),
+			Name: args[0].Name,
+		}, {
+			UUID: args[1].UUID.String(),
+			Name: args[1].Name,
+		},
+	})
+	obtainedEndpoints := s.readOfferEndpoints(c)
+	c.Check(obtainedEndpoints, tc.SameContents, []offerEndpoint{
+		{
+			OfferUUID:    args[0].UUID.String(),
+			EndpointUUID: endpointUUID1,
+		}, {
+			OfferUUID:    args[1].UUID.String(),
+			EndpointUUID: endpointUUID2,
+		},
+	})
+}
+
+type importRemoteApplicationSuite struct {
+	baseSuite
+}
+
+func TestImportRemoteApplicationSuite(t *testing.T) {
+	tc.Run(t, &importRemoteApplicationSuite{})
+}
+
+func (s *importRemoteApplicationSuite) TestImportRemoteApplications(c *tc.C) {
+	// Arrange - import a remote application with provider and requirer endpoints
+	endpoints := []crossmodelrelation.RemoteApplicationEndpoint{
+		{
+			Name:      "client",
+			Role:      appcharm.RoleProvider,
+			Interface: "kafka",
+		},
+		{
+			Name:      "zookeeper",
+			Role:      appcharm.RoleRequirer,
+			Interface: "zookeeper",
+		},
+	}
+	args := []crossmodelrelation.RemoteApplicationImport{
+		{
+			Name:            "remote-kafka",
+			OfferUUID:       internaluuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/prod.kafka",
+			SourceModelUUID: internaluuid.MustNewUUID().String(),
+			Macaroon:        "test-macaroon-data",
+			Endpoints:       endpoints,
+			SyntheticCharm:  service.BuildSyntheticCharmForTest("remote-kafka", endpoints),
+			Bindings:        map[string]string{"client": "alpha", "zookeeper": "beta"},
+			IsConsumerProxy: false,
+		},
+	}
+
+	// Act
+	err := s.state.ImportRemoteApplications(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+
+	// Verify remote application offerer was created
+	var (
+		offerUUID        string
+		offerURL         string
+		offererModelUUID string
+		macaroon         string
+	)
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT offer_uuid, offer_url, offerer_model_uuid, macaroon
+			FROM application_remote_offerer rao
+			JOIN application a ON rao.application_uuid = a.uuid
+			WHERE a.name = ?
+		`, args[0].Name).Scan(&offerUUID, &offerURL, &offererModelUUID, &macaroon)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(offerUUID, tc.Equals, args[0].OfferUUID)
+	c.Check(offerURL, tc.Equals, args[0].URL)
+	c.Check(offererModelUUID, tc.Equals, args[0].SourceModelUUID)
+	c.Check(macaroon, tc.Equals, args[0].Macaroon)
+
+	// Verify synthetic charm endpoints (excluding juju-info)
+	var endpointCount int
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM charm_relation cr
+			JOIN charm c ON cr.charm_uuid = c.uuid
+			JOIN application a ON a.charm_uuid = c.uuid
+			WHERE a.name = ? AND cr.name != 'juju-info'
+		`, args[0].Name).Scan(&endpointCount)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(endpointCount, tc.Equals, 2, tc.Commentf("Expected 2 user-defined endpoints"))
+}
+
+func (s *importRemoteApplicationSuite) TestImportRemoteApplicationsMultiple(c *tc.C) {
+	// Arrange - import multiple remote applications
+	endpoints1 := []crossmodelrelation.RemoteApplicationEndpoint{
+		{
+			Name:      "db",
+			Role:      appcharm.RoleProvider,
+			Interface: "mysql",
+		},
+	}
+	endpoints2 := []crossmodelrelation.RemoteApplicationEndpoint{
+		{
+			Name:      "db",
+			Role:      appcharm.RoleProvider,
+			Interface: "pgsql",
+		},
+	}
+	args := []crossmodelrelation.RemoteApplicationImport{
+		{
+			Name:            "remote-mysql",
+			OfferUUID:       internaluuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/model.mysql",
+			SourceModelUUID: internaluuid.MustNewUUID().String(),
+			Macaroon:        "macaroon1",
+			Endpoints:       endpoints1,
+			SyntheticCharm:  service.BuildSyntheticCharmForTest("remote-mysql", endpoints1),
+			IsConsumerProxy: false,
+		},
+		{
+			Name:            "remote-postgres",
+			OfferUUID:       internaluuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/model.postgres",
+			SourceModelUUID: internaluuid.MustNewUUID().String(),
+			Macaroon:        "macaroon2",
+			Endpoints:       endpoints2,
+			SyntheticCharm:  service.BuildSyntheticCharmForTest("remote-postgres", endpoints2),
+			IsConsumerProxy: false,
+		},
+	}
+
+	// Act
+	err := s.state.ImportRemoteApplications(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+
+	// Verify both remote applications were created
+	var count int
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM application_remote_offerer").Scan(&count)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(count, tc.Equals, 2)
+}
+
+func (s *importRemoteApplicationSuite) TestImportRemoteApplicationsConsumerProxySkipped(c *tc.C) {
+	// Arrange - import both a consumer proxy and a regular remote app
+	endpoints := []crossmodelrelation.RemoteApplicationEndpoint{
+		{
+			Name:      "endpoint",
+			Role:      appcharm.RoleProvider,
+			Interface: "http",
+		},
+	}
+	args := []crossmodelrelation.RemoteApplicationImport{
+		{
+			Name:            "remote-consumer-proxy",
+			OfferUUID:       internaluuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/model.app",
+			SourceModelUUID: internaluuid.MustNewUUID().String(),
+			Macaroon:        "macaroon-proxy",
+			Endpoints:       endpoints,
+			SyntheticCharm:  service.BuildSyntheticCharmForTest("remote-consumer-proxy", endpoints),
+			IsConsumerProxy: true, // Should be skipped
+		},
+		{
+			Name:            "remote-normal",
+			OfferUUID:       internaluuid.MustNewUUID().String(),
+			URL:             "ctrl:admin/model.normal",
+			SourceModelUUID: internaluuid.MustNewUUID().String(),
+			Macaroon:        "macaroon-normal",
+			Endpoints:       endpoints,
+			SyntheticCharm:  service.BuildSyntheticCharmForTest("remote-normal", endpoints),
+			IsConsumerProxy: false, // Should be imported
+		},
+	}
+
+	// Act
+	err := s.state.ImportRemoteApplications(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+
+	// Verify only non-consumer-proxy was created
+	var count int
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM application_remote_offerer").Scan(&count)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(count, tc.Equals, 1, tc.Commentf("Expected only the non-consumer-proxy remote app"))
+
+	// Verify it's the correct one
+	var appName string
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT a.name
+			FROM application_remote_offerer rao
+			JOIN application a ON rao.application_uuid = a.uuid
+		`).Scan(&appName)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(appName, tc.Equals, "remote-normal")
+}
+
+func (s *importRemoteApplicationSuite) TestImportRemoteApplicationsEmpty(c *tc.C) {
+	// Arrange
+	args := []crossmodelrelation.RemoteApplicationImport{}
+
+	// Act
+	err := s.state.ImportRemoteApplications(c.Context(), args)
+
+	// Assert - should succeed with no operations
+	c.Assert(err, tc.IsNil)
+
+	var count int
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM application_remote_offerer").Scan(&count)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(count, tc.Equals, 0)
 }

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -126,6 +126,50 @@ type OfferImport struct {
 	Endpoints       []string
 }
 
+// RemoteApplicationEndpoint contains details about an endpoint on a remote
+// application. This is used during migration to reconstruct the synthetic
+// charm.
+type RemoteApplicationEndpoint struct {
+	Name      string
+	Role      charm.RelationRole
+	Interface string
+}
+
+// RemoteApplicationImport contains details to import a remote application
+// (offerer) during migration. This represents a remote application that this
+// model is consuming from another model.
+type RemoteApplicationImport struct {
+	// Name is the name of the remote application in this model.
+	Name string
+
+	// OfferUUID is the UUID of the offer being consumed.
+	OfferUUID string
+
+	// URL is the offer URL.
+	URL string
+
+	// SourceModelUUID is the UUID of the model offering the application.
+	SourceModelUUID string
+
+	// Macaroon is the authentication macaroon for the offer.
+	Macaroon string
+
+	// SyntheticCharm is the synthetic charm built from the remote endpoints.
+	// This is created in the service layer from the Endpoints field.
+	SyntheticCharm charm.Charm
+
+	// Endpoints are the remote endpoints for creating the synthetic charm.
+	// This is kept for backwards compatibility and service layer processing.
+	Endpoints []RemoteApplicationEndpoint
+
+	// Bindings are the endpoint-to-space bindings.
+	Bindings map[string]string
+
+	// IsConsumerProxy indicates if this is a consumer proxy (on the offerer
+	// side) rather than a remote offerer (on the consumer side).
+	IsConsumerProxy bool
+}
+
 // RemoteApplicationConsumer represents a remote application
 // that is consuming an offer from this model.
 type RemoteApplicationConsumer struct {


### PR DESCRIPTION
This patch implements the migration import of remote applications as part of the cross model relation domain. 

An integration test has been added to check the full input being added to the DB (offers + remote applications).


## QA steps
The scenario is to migrate both 3.6 models (offer and consumer) to a 4.0 controller. These models are created following the `offer_consume.sh` cmr integration test. 
Migration will fail due to an unrelated issue:

```
machine-0: 12:19:58 WARNING juju.apiserver.keymanager disregarding authorized key during model migration because it has a comment containing "juju-system-key"
machine-0: 12:19:58 ERROR juju.apiserver import failed: execute operation import model authorized keys: adding public keys for the admin user from model config: adding public keys for user "50020e73-ed45-4d39-8b43-f70d530246d6" to model "412a7a9b-5153-43bc-8264-99afe7671115": checking model "412a7a9b-5153-43bc-8264-99afe7671115" exists, model not found
```

The (updated) integration test should pass though.

## Links

**Jira card:** [JUJU-8487](https://warthogs.atlassian.net/browse/JUJU-8487)


[JUJU-8487]: https://warthogs.atlassian.net/browse/JUJU-8487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ