### PR TITLE
feat(login): improve juju login by logging a generic message when all providers fail.

### DIFF
--- a/api/clientcredentialsloginprovider.go
+++ b/api/clientcredentialsloginprovider.go
@@ -61,6 +61,10 @@ type clientCredentialsLoginProvider struct {
 	afterLoginCallback func()
 }
 
+func (p *clientCredentialsLoginProvider) String() string {
+	return "ClientCredentialsLoginProvider"
+}
+
 // AuthHeader implements the [LoginProvider.AuthHeader] method.
 // It returns an HTTP header with basic auth set.
 func (p *clientCredentialsLoginProvider) AuthHeader() (http.Header, error) {

--- a/api/interface.go
+++ b/api/interface.go
@@ -198,6 +198,7 @@ type LoginProvider interface {
 	// can be performed.
 	// Other errors are also possible indicating an internal error in the provider.
 	AuthHeader() (http.Header, error)
+	String() string
 }
 
 // DialOpts holds configuration parameters that control the

--- a/api/legacyloginprovider.go
+++ b/api/legacyloginprovider.go
@@ -59,6 +59,10 @@ type legacyLoginProvider struct {
 	cookieURL    *url.URL
 }
 
+func (p *legacyLoginProvider) String() string {
+	return "LegacyLoginProvider"
+}
+
 // AuthHeader implements the [LoginProvider.AuthHeader] method.
 // Returns an HTTP header with basic auth if a user tag is provided.
 // The header will also include any macaroons as cookies.

--- a/api/sessiontokenloginprovider.go
+++ b/api/sessiontokenloginprovider.go
@@ -103,6 +103,10 @@ func (p *sessionTokenLoginProvider) printOutput(format string, params ...any) er
 	return err
 }
 
+func (p *sessionTokenLoginProvider) String() string {
+	return "SessionTokenLoginProvider"
+}
+
 func (p *sessionTokenLoginProvider) initiateDeviceLogin(ctx context.Context, caller base.APICaller) error {
 	type loginRequest struct{}
 

--- a/cmd/internal/loginprovider/tryinorderloginprovider.go
+++ b/cmd/internal/loginprovider/tryinorderloginprovider.go
@@ -37,6 +37,10 @@ type tryInOrderLoginProviders struct {
 	authHeader func() (http.Header, error)
 }
 
+func (p *tryInOrderLoginProviders) String() string {
+	return "TryInOrderLoginProvider"
+}
+
 // AuthHeader implements the [LoginProvider.AuthHeader] method.
 // It attempts to retrieve the auth header from the last successful login provider.
 // If login was never attempted/successful, an ErrorLoginFirst error is returned.
@@ -46,17 +50,15 @@ func (p *tryInOrderLoginProviders) AuthHeader() (http.Header, error) {
 
 // Login implements the LoginProvider.Login method.
 func (p *tryInOrderLoginProviders) Login(ctx context.Context, caller base.APICaller) (*api.LoginResultParams, error) {
-	var lastError error
-	for i, provider := range p.providers {
+	for _, provider := range p.providers {
 		result, err := provider.Login(ctx, caller)
 		if err != nil {
-			p.logger.Debugf("login error using provider %d - %s", i, err.Error())
+			p.logger.Debugf("login error using provider %s - %s", provider, err.Error())
 		} else {
-			p.logger.Debugf("successful login using provider %d", i)
+			p.logger.Debugf("successful login using provider %s", provider)
 			p.authHeader = func() (http.Header, error) { return provider.AuthHeader() }
 			return result, nil
 		}
-		lastError = err
 	}
-	return nil, errors.Trace(lastError)
+	return nil, errors.New("login failed (use --debug for more information)")
 }

--- a/cmd/internal/loginprovider/tryinorderloginprovider_test.go
+++ b/cmd/internal/loginprovider/tryinorderloginprovider_test.go
@@ -49,6 +49,10 @@ type mockLoginProvider struct {
 	header http.Header
 }
 
+func (p *mockLoginProvider) String() string {
+	return "MockLoginProvider"
+}
+
 func (p *mockLoginProvider) AuthHeader() (http.Header, error) {
 	return p.header, nil
 }


### PR DESCRIPTION
# Description
Currently, when users encounter login errors with JAAS, they always see this misleading error message:

```console
ERROR cannot log into "jaas.ps7.canonical.com:443/k8s-jaas-ps7-jimm-jimm":  JIMM does not support login from old clients (not supported)
```

This happens because the Juju CLI tries multiple login providers in sequence:

```go
dialOpts.LoginProvider = loginprovider.NewTryInOrderLoginProvider(
    loggo.GetLogger("juju. cmd.loginprovider"),
    api.NewClientCredentialsLoginProviderFromEnvironment(
        func() { supportsOIDCLogin = true },
    ),
    api.NewSessionTokenLoginProvider(
        "",
        ctx.Stderr,
        func(t string) {
            supportsOIDCLogin = true
            sessionToken = t
        },
    ),
    api.NewLegacyLoginProvider(names. UserTag{}, "", "", nil, api.CookieURLFromHost(host)),
)
```
The last provider (NewLegacyLoginProvider) always returns the "old clients not supported" error, which masks the actual error from earlier providers.

The new implementation will log a generic error if all providers fail, and advice the user to use --debug to get more info.

Before:

```console
ERROR cannot log into "jimm.localhost": JIMM does not support login from old clients (not supported)
```

After (after i've manually stop the keycloack container to simulate a failure):

```console
[11:31:30] ➜  jimm git:(fix-govulncheck) ✗ juju login jimm.localhost -c jimm-dev --debug
11:31:33 INFO  juju.cmd supercommand.go:56 running juju [3.6.13 3ee294398ca0242be1697530eb948c0b88ddb1cd gc go1.25.5]
11:31:33 DEBUG juju.cmd supercommand.go:57   args: []string{"juju", "login", "jimm.localhost", "-c", "jimm-dev", "--debug"}
11:31:33 DEBUG juju.api apiclient.go:731 looked up jimm.localhost -> [::1 127.0.0.1]
11:31:33 DEBUG juju.api apiclient.go:836 unable to retrieve CA cert from remote host; skipping CA verification
11:31:33 DEBUG juju.api apiclient.go:731 looked up jimm.localhost -> [::1 127.0.0.1]
11:31:33 DEBUG juju.api apiclient.go:1089 successfully dialed "wss://jimm.localhost:443/api"
11:31:33 INFO  juju.api apiclient.go:610 connection established to "wss://jimm.localhost:443/api"
11:31:33 DEBUG juju.cmd.loginprovider tryinorderloginprovider.go:56 login error using provider ClientCredentialsLoginProvider - both client id and client secret must be set
11:31:33 DEBUG juju.cmd.loginprovider tryinorderloginprovider.go:56 login error using provider SessionTokenLoginProvider - device auth call failed: Post "http://keycloak.localhost:8082/realms/jimm/protocol/openid-connect/auth/device": dial tcp [::1]:8082: connect: connection refused (unauthorized access)
11:31:33 DEBUG juju.cmd.loginprovider tryinorderloginprovider.go:56 login error using provider LegacyLoginProvider - JIMM does not support login from old clients (not supported)
ERROR cannot log into "jimm.localhost": login failed (use --debug for more information)
11:31:33 DEBUG cmd supercommand.go:571 error stack: 
github.com/juju/juju/cmd/internal/loginprovider.(*tryInOrderLoginProviders).Login:63: login failed (use --debug for more information)
github.com/juju/juju/api.loginWithContext:267: 
github.com/juju/juju/api.Open:204: 
github.com/juju/juju/cmd/juju/user.(*loginCommand).login:522: 
github.com/juju/juju/cmd/juju/user.(*loginCommand).publicControllerLogin:448: 
github.com/juju/juju/cmd/juju/user.(*loginCommand).run:238: cannot log into "jimm.localhost"
```