### PR TITLE
feat: enable migrate to be dry run

### DIFF
--- a/api/controller/controller/controller.go
+++ b/api/controller/controller/controller.go
@@ -316,7 +316,7 @@ func (s *MigrationSpec) Validate() error {
 // The API server supports starting multiple migrations in one request
 // but we don't need that at the client side yet (and may never) so
 // this call just supports starting one migration at a time.
-func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
+func (c *Client) InitiateMigration(spec MigrationSpec, dryRun bool) (string, error) {
 	if err := spec.Validate(); err != nil {
 		return "", errors.Annotatef(err, "client-side validation failed")
 	}
@@ -327,6 +327,7 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 	}
 
 	args := params.InitiateMigrationArgs{
+		DryRun: dryRun,
 		Specs: []params.MigrationSpec{{
 			ModelTag: names.NewModelTag(spec.ModelUUID).String(),
 			TargetInfo: params.MigrationTargetInfo{

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -694,7 +694,7 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec, dryRun b
 		return "", errors.Trace(err)
 	}
 
-	// We return "" with no error to suggest that a dryrun was requested and successful.
+	// We return "" with no error to signal that a dryrun was requested and successful.
 	if dryRun {
 		return "", nil
 	}

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -618,7 +618,7 @@ func (c *ControllerAPI) InitiateMigration(reqArgs params.InitiateMigrationArgs) 
 	for i, spec := range reqArgs.Specs {
 		result := &out.Results[i]
 		result.ModelTag = spec.ModelTag
-		id, err := c.initiateOneMigration(spec)
+		id, err := c.initiateOneMigration(spec, reqArgs.DryRun)
 		if err != nil {
 			result.Error = apiservererrors.ServerError(err)
 		} else {
@@ -628,7 +628,7 @@ func (c *ControllerAPI) InitiateMigration(reqArgs params.InitiateMigrationArgs) 
 	return out, nil
 }
 
-func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string, error) {
+func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec, dryRun bool) (string, error) {
 	modelTag, err := names.ParseModelTag(spec.ModelTag)
 	if err != nil {
 		return "", errors.Annotate(err, "model tag")
@@ -692,6 +692,11 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 		leaders,
 	); err != nil {
 		return "", errors.Trace(err)
+	}
+
+	// We return "" with no error to suggest that a dryrun was requested and successful.
+	if dryRun {
+		return "", nil
 	}
 
 	// Trigger the migration.

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -648,7 +648,7 @@ func (s *controllerSuite) TestInitiateMigrationDryRunFails(c *gc.C) {
 	// Ensure the precheck failed is reported on dry runs.
 	c.Assert(result.Error, gc.ErrorMatches, "precheck failed")
 	c.Check(result.ModelTag, gc.Equals, spec.ModelTag)
-	expectedId := "" // "" Represents a dry run.
+	expectedId := "" // "" Is the expected response, even on failure.
 	c.Check(result.MigrationId, gc.Equals, expectedId)
 
 	// Ensure the migration made did not made it to the db.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9047,6 +9047,9 @@
                 "InitiateMigrationArgs": {
                     "type": "object",
                     "properties": {
+                        "dry-run": {
+                            "type": "boolean"
+                        },
                         "specs": {
                             "type": "array",
                             "items": {

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -17,7 +17,8 @@ const MigrationModelHTTPHeader = "X-Juju-Migration-Model-UUID"
 // InitiateMigrationArgs holds the details required to start one or
 // more model migrations.
 type InitiateMigrationArgs struct {
-	Specs []MigrationSpec `json:"specs"`
+	Specs  []MigrationSpec `json:"specs"`
+	DryRun bool            `json:"dry-run,omitempty"`
 }
 
 // MigrationSpec holds the details required to start the migration of


### PR DESCRIPTION
Enables juju migrate to be dry run. This runs the migrate command up until the final InitiateMigration call, ensuring pre-checks pass. 

It is needed because JIMM will run all models prechecks ahead of migrating them in the automated upgrades, and if one should fail, then the workflows will not run. Without this, we cannot precheck many models ahead of time.

I don't think this is strictly necessary for ordinary Juju users because of the rollback / prechecks on the migrate would error anyway. And I'm aware upgrades cannot be rolled back like migrates. But it does make the two commands fairly consistent I suppose.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
```
juju bootstrap lxd dryrun
juju add-model test
juju deploy ubuntu --constraints="arch=arm64"
juju bootstrap lxd dryrun-2
juju switch dryrun
juju migrate test dryrun-2 --dry-run=true
```

I haven't QA'd a precheck failure but I think it'll be ok as it is covered by the tests.
## Links


<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8808](https://warthogs.atlassian.net/browse/JUJU-8808)



[JUJU-8808]: https://warthogs.atlassian.net/browse/JUJU-8808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ