### PR TITLE
fix(juju): fix silent failure when removing space with model constraints

### DIFF
--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -203,11 +203,11 @@ func buildRemoveErrorList(removeSpace RemoveSpace, currentModel string) []string
 	if len(removeSpace.Constraints) > 0 {
 		msg = "- %q is used as a constraint on: %v"
 		list = append(list, fmt.Sprintf(msg, spaceName, strings.Join(constraints, ", ")))
+	}
 
-		if removeSpace.HasModelConstraint {
-			msg = "- %q is used as a model constraint: %v"
-			list = append(list, fmt.Sprintf(msg, spaceName, currentModel))
-		}
+	if removeSpace.HasModelConstraint {
+		msg = "- %q is used as a model constraint: %v"
+		list = append(list, fmt.Sprintf(msg, spaceName, currentModel))
 	}
 	if len(removeSpace.Bindings) > 0 {
 		msg = "- %q is used as a binding on: %v"


### PR DESCRIPTION
Description:

Currently, juju remove-space silently succeeds (noop) when attempting to remove a space that is defined in the model constraints. This leaves the model in an inconsistent state where constraints reference a non-existent space.

This PR adds a validation check to ensure remove-space fails with a descriptive error if the space is currently being used by model constraints.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Verified via the new unit test case added in this PR.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links


https://github.com/juju/juju/issues/20329
https://warthogs.atlassian.net/browse/JUJU-8336
**Issue:** Fixes #20329.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8336](https://warthogs.atlassian.net/browse/JUJU-8336)


[JUJU-8336]: https://warthogs.atlassian.net/browse/JUJU-8336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ