### PR TITLE
fix(juju): fix silent failure when removing space with model constraints

### DIFF
--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -203,11 +203,11 @@ func buildRemoveErrorList(removeSpace RemoveSpace, currentModel string) []string
 	if len(removeSpace.Constraints) > 0 {
 		msg = "- %q is used as a constraint on: %v"
 		list = append(list, fmt.Sprintf(msg, spaceName, strings.Join(constraints, ", ")))
+	}
 
-		if removeSpace.HasModelConstraint {
-			msg = "- %q is used as a model constraint: %v"
-			list = append(list, fmt.Sprintf(msg, spaceName, currentModel))
-		}
+	if removeSpace.HasModelConstraint {
+		msg = "- %q is used as a model constraint: %v"
+		list = append(list, fmt.Sprintf(msg, spaceName, currentModel))
 	}
 	if len(removeSpace.Bindings) > 0 {
 		msg = "- %q is used as a binding on: %v"

--- a/cmd/juju/space/remove_test.go
+++ b/cmd/juju/space/remove_test.go
@@ -209,3 +209,31 @@ func (s *RemoveSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "")
 
 }
+
+func (s *RemoveSuite) TestRunWithModelConstraintOnly(c *gc.C) {
+	ctrl, api := setUpMocks(c)
+	defer ctrl.Finish()
+
+	spaceName := "myspace"
+	// Model tag in Constraints list, but no other constraints.
+	// This simulates the scenario where convertEntitiesToStringAndSkipModel returns empty [],
+	// but hasModelConstraint returns true.
+	spaceRemove := params.RemoveSpaceResult{
+		Constraints:        []params.Entity{{Tag: "model-f47ac10b-58cc-4372-a567-0e02b2c3d479"}},
+		Bindings:           nil,
+		ControllerSettings: nil,
+	}
+	api.EXPECT().RemoveSpace(spaceName, false, false).Return(spaceRemove, nil)
+	expectedErrMsg := `
+Cannot remove space "myspace"
+
+- "myspace" is used as a model constraint: bar/currentfoo
+
+Use --force to remove space
+`[1:]
+
+	ctx, _, err := s.runCommand(c, api, spaceName)
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(err.Error(), gc.Equals, expectedErrMsg)
+}


### PR DESCRIPTION
Description:

Currently, juju remove-space silently succeeds (noop) when attempting to remove a space that is defined in the model constraints. This leaves the model in an inconsistent state where constraints reference a non-existent space.

This PR adds a validation check to ensure remove-space fails with a descriptive error if the space is currently being used by model constraints.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Verified via the new unit test case added in this PR.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links


https://github.com/juju/juju/issues/20329
https://warthogs.atlassian.net/browse/JUJU-8336
**Issue:** Fixes #20329.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8336](https://warthogs.atlassian.net/browse/JUJU-8336)


[JUJU-8336]: https://warthogs.atlassian.net/browse/JUJU-8336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ