### PR TITLE
fix(bundle): coerce numeric option type in BuildModelRepresentation

### DIFF
--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -240,10 +240,26 @@ func applicationConfigValue(key string, valueMap interface{}) (interface{}, erro
 	if source == "unset" {
 		return nil, nil
 	}
-	value, found := vm["value"]
+
+	return coerceConfigType(vm)
+}
+
+// coerceConfigType ensures that the application config value is of the
+// type specified in the option definitions.
+func coerceConfigType(valueMap map[string]interface{}) (interface{}, error) {
+	value, found := valueMap["value"]
+
 	if !found {
 		return nil, errors.Errorf("missing application config value 'value'")
 	}
+
+	switch v := value.(type) {
+	case float64:
+		if configType, found := valueMap["type"]; found && configType == "int" {
+			return int(v), nil
+		}
+	}
+
 	return value, nil
 }
 

--- a/cmd/juju/application/bundle/bundle_test.go
+++ b/cmd/juju/application/bundle/bundle_test.go
@@ -136,8 +136,9 @@ func (s *buildModelRepSuite) TestBuildModelRepresentationApplicationsWithSubordi
 	obtainedWordpress, ok := obtainedModel.Applications["wordpress"]
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(obtainedWordpress.Options, gc.HasLen, 1)
-	_, ok = obtainedWordpress.Options["skill-level"]
+	skillLevel, ok := obtainedWordpress.Options["skill-level"]
 	c.Assert(ok, jc.IsTrue)
+	c.Assert(skillLevel, jc.DeepEquals, 42) // check int option is of proper type
 	_, ok = obtainedModel.Applications["sub"]
 	c.Assert(ok, jc.IsTrue)
 
@@ -189,8 +190,9 @@ func (s *buildModelRepSuite) expectGetConfigSubWordpress() {
 			"description": "A number indicating skill.",
 			"source":      "user",
 			"type":        "int",
-			"value":       42,
-		}}
+			"value":       42.0, // json unmarshals int as float
+		},
+	}
 	retval := []map[string]interface{}{
 		{},           // sub
 		wordpressCfg, // wordpress


### PR DESCRIPTION
Json by default unmarshals all numeric types to floats.

As a result issues like #21532 arise, where identical values
compare as different between the bundle and model.

This change uses the known type information of application config to ensure
that integer options are are properly cast to int type.

Additionally, diff-bundle test slightly modified to reflect that json
unmarshalling of types as mentioned above.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This code path is hit by `juju diff-bundle` and `juju deploy` when using a bundle a simple test, which exercises these and  verifies that #21532 is actually fixed is

```
juju add-model coerce-numeric-options
juju deploy apache2
juju export-bundle --include-charm-defaults --include-series > bundle.yaml
```

Then run
```
juju diff-bundle bundle.yaml
```
and ensure that the result is an empty map.

Change, some integer options in bundle.yaml to different values and ensure 
```
juju diff-bundle bundle.yaml
```
now reflects that.

Finally,
```
juju deploy ./bundle.yaml
````
and now
```
juju diff-bundle bundle.yaml
````
should again be an empty map.

## Links

**Issue:** Fixes #21532.