### PR TITLE
fix: ensure charms can be deployed on noble

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"net"
 	"reflect"
-	"time"
 
 	"github.com/juju/charm/v8"
 	csparams "github.com/juju/charmrepo/v6/csclient/params"
@@ -1466,7 +1465,7 @@ func (api *APIBase) applicationSetCharm(
 // default and falls back to the charm's series (no support for "--series",
 // series in charm URL, or default LTS).
 func sidecarUpgradeSeries(modelConfig *environsconfig.Config, supported []string) (string, error) {
-	supportedJuju, err := series.WorkloadSeries(time.Now(), "", modelConfig.ImageStream())
+	supportedJuju, err := series.WorkloadSeries("", modelConfig.ImageStream())
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -16,7 +16,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
@@ -172,7 +171,7 @@ func (s *DeploySuiteBase) SetUpTest(c *gc.C) {
 		c.Skip("Mongo failures on macOS")
 	}
 	s.RepoSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
+	s.PatchValue(&supportedJujuSeries, func(string, string) (set.Strings, error) {
 		return defaultSupportedJujuSeries, nil
 	})
 	s.CmdBlockHelper = coretesting.NewCmdBlockHelper(s.APIState)
@@ -1032,7 +1031,7 @@ func (s *CAASDeploySuiteBase) expectDeployer(c *gc.C, cfg deployer.DeployerConfi
 
 func (s *CAASDeploySuiteBase) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
+	s.PatchValue(&supportedJujuSeries, func(string, string) (set.Strings, error) {
 		return defaultSupportedJujuSeries, nil
 	})
 	cookiesFile := filepath.Join(c.MkDir(), ".go-cookies")
@@ -1459,7 +1458,7 @@ func (s *DeploySuite) setupNonESMSeries(c *gc.C) (string, string) {
 	supportedNotEMS := supported.Difference(set.NewStrings(series.ESMSupportedJujuSeries()...))
 	c.Assert(supportedNotEMS.Size(), jc.GreaterThan, 0)
 
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
+	s.PatchValue(&supportedJujuSeries, func(string, string) (set.Strings, error) {
 		return supported, nil
 	})
 
@@ -2316,7 +2315,7 @@ var _ = gc.Suite(&DeployUnitTestSuite{})
 
 func (s *DeployUnitTestSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
+	s.PatchValue(&supportedJujuSeries, func(string, string) (set.Strings, error) {
 		return defaultSupportedJujuSeries, nil
 	})
 	cookiesFile := filepath.Join(c.MkDir(), ".go-cookies")

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
-	jujuclock "github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -111,8 +110,6 @@ type bundleHandler struct {
 	dryRun bool
 	force  bool
 	trust  bool
-
-	clock jujuclock.Clock
 
 	// bundleDir is the path where the bundle file is located for local bundles.
 	bundleDir string
@@ -224,9 +221,6 @@ func makeBundleHandler(defaultCharmSchema charm.Schema, bundleData *charm.Bundle
 		applications.Add(name)
 	}
 	return &bundleHandler{
-		// TODO (stickupkid): pass this through from the constructor.
-		clock: jujuclock.WallClock,
-
 		dryRun:               spec.dryRun,
 		force:                spec.force,
 		trust:                spec.trust,
@@ -714,7 +708,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	case url.Series == "bundle" || resolvedOrigin.Type == "bundle":
 		return errors.Errorf("expected charm, got bundle %q %v", ch.Name, resolvedOrigin)
 	case resolvedOrigin.Series == "":
-		modelCfg, workloadSeries, err := seriesSelectorRequirements(h.deployAPI, h.clock, url)
+		modelCfg, workloadSeries, err := seriesSelectorRequirements(h.deployAPI, url)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1063,7 +1057,7 @@ func (h *bundleHandler) selectedSeries(ch charm.CharmMeta, chID application.Char
 		supportedSeries = []string{chID.URL.Series}
 	}
 
-	workloadSeries, err := supportedJujuSeries(h.clock.Now(), chSeries, h.modelConfig.ImageStream())
+	workloadSeries, err := supportedJujuSeries(chSeries, h.modelConfig.ImageStream())
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/juju/charm/v8"
-	jujuclock "github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -416,7 +415,6 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 type repositoryCharm struct {
 	deployCharm
 	userRequestedURL *charm.URL
-	clock            jujuclock.Clock
 }
 
 // String returns a string description of the deployer.
@@ -451,7 +449,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 	ctx.Verbosef("Preparing to deploy %q from the %s", userRequestedURL.Name, location)
 
-	modelCfg, workloadSeries, err := seriesSelectorRequirements(deployAPI, c.clock, userRequestedURL)
+	modelCfg, workloadSeries, err := seriesSelectorRequirements(deployAPI, userRequestedURL)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
-	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/gnuflag"
@@ -86,7 +85,6 @@ func (s *charmSuite) TestRepositoryCharmDeployDryRun(c *gc.C) {
 	repoCharm := &repositoryCharm{
 		deployCharm:      *dCharm,
 		userRequestedURL: s.url,
-		clock:            clock.WallClock,
 	}
 
 	err := repoCharm.PrepareAndDeploy(s.ctx, s.deployerAPI, s.resolver, nil)
@@ -110,7 +108,6 @@ func (s *charmSuite) TestRepositoryCharmDeployDryRunDefaultSeriesForce(c *gc.C) 
 	repoCharm := &repositoryCharm{
 		deployCharm:      *dCharm,
 		userRequestedURL: s.url,
-		clock:            clock.WallClock,
 	}
 
 	stdOut := mocks.NewMockWriter(ctrl)

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
-	jujuclock "github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -42,7 +41,6 @@ var logger = loggo.GetLogger("juju.cmd.juju.application.deployer")
 // function dependencies required by every deployer.
 func NewDeployerFactory(dep DeployerDependencies) DeployerFactory {
 	d := &factory{
-		clock:                jujuclock.WallClock,
 		model:                dep.Model,
 		fileSystem:           dep.FileSystem,
 		charmReader:          dep.CharmReader,
@@ -189,9 +187,6 @@ type factory struct {
 	bundleMachines     map[string]string
 	trust              bool
 	flagSet            *gnuflag.FlagSet
-
-	// Private
-	clock jujuclock.Clock
 }
 
 func (d *factory) maybePredeployedLocalCharm() (Deployer, error) {
@@ -346,7 +341,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 		}
 
 		imageStream = modelCfg.ImageStream()
-		workloadSeries, err := supportedJujuSeries(d.clock.Now(), d.series, imageStream)
+		workloadSeries, err := supportedJujuSeries(d.series, imageStream)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -541,7 +536,6 @@ func (d *factory) repositoryCharm() (Deployer, error) {
 	return &repositoryCharm{
 		deployCharm:      deployCharm,
 		userRequestedURL: userRequestedURL,
-		clock:            d.clock,
 	}, nil
 }
 
@@ -581,7 +575,7 @@ func appsRequiringTrust(appSpecList map[string]*charm.ApplicationSpec) []string 
 	return tl
 }
 
-func seriesSelectorRequirements(api ModelConfigGetter, cl jujuclock.Clock, chURL *charm.URL) (*config.Config, set.Strings, error) {
+func seriesSelectorRequirements(api ModelConfigGetter, chURL *charm.URL) (*config.Config, set.Strings, error) {
 	// resolver.resolve potentially updates the series of anything
 	// passed in. Store this for use in seriesSelector.
 	userRequestedSeries := chURL.Series
@@ -592,7 +586,7 @@ func seriesSelectorRequirements(api ModelConfigGetter, cl jujuclock.Clock, chURL
 	}
 
 	imageStream := modelCfg.ImageStream()
-	workloadSeries, err := supportedJujuSeries(cl.Now(), userRequestedSeries, imageStream)
+	workloadSeries, err := supportedJujuSeries(userRequestedSeries, imageStream)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -615,7 +609,7 @@ func (d *factory) validateCharmSeries(seriesName string, imageStream string) err
 
 	// attempt to locate the charm series from the list of known juju series
 	// that we currently support.
-	workloadSeries, err := supportedJujuSeries(d.clock.Now(), seriesName, imageStream)
+	workloadSeries, err := supportedJujuSeries(seriesName, imageStream)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
-	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -407,7 +406,6 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithApplicationName(c *gc.C)
 	s.charm.EXPECT().Meta().Return(&charm.Meta{Series: []string{"focal"}}).AnyTimes()
 
 	f := &factory{
-		clock:           clock.WallClock,
 		applicationName: "meshuggah",
 		charmOrBundle:   "local:meshuggah",
 		charmReader:     s.charmReader,
@@ -427,7 +425,6 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc
 	s.charm.EXPECT().Meta().Return(&charm.Meta{Name: "meshuggah", Series: []string{"focal"}}).AnyTimes()
 
 	f := &factory{
-		clock:         clock.WallClock,
 		charmOrBundle: "local:meshuggah",
 		charmReader:   s.charmReader,
 		model:         s.modelCommand,

--- a/cmd/juju/application/unexpose_test.go
+++ b/cmd/juju/application/unexpose_test.go
@@ -5,7 +5,6 @@ package application
 
 import (
 	"runtime"
-	"time"
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -30,7 +29,7 @@ func (s *UnexposeSuite) SetUpTest(c *gc.C) {
 		c.Skip("Mongo failures on macOS")
 	}
 	s.RepoSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
+	s.PatchValue(&supportedJujuSeries, func(string, string) (set.Strings, error) {
 		return defaultSupportedJujuSeries, nil
 	})
 	s.CmdBlockHelper = testing.NewCmdBlockHelper(s.APIState)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/juju/charm/v8"
-	jujuclock "github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/featureflag"
@@ -203,7 +202,6 @@ const (
 
 func newBootstrapCommand() cmd.Command {
 	command := &bootstrapCommand{}
-	command.clock = jujuclock.WallClock
 	command.CanClearCurrentModel = true
 	return modelcmd.Wrap(command,
 		modelcmd.WrapSkipModelFlags,
@@ -215,8 +213,6 @@ func newBootstrapCommand() cmd.Command {
 // environment, and setting up everything necessary to continue working.
 type bootstrapCommand struct {
 	modelcmd.ModelCommandBase
-
-	clock jujuclock.Clock
 
 	Constraints              constraints.Value
 	ConstraintsStr           string
@@ -733,8 +729,7 @@ to create a new model to deploy %sworkloads.
 	if cfg, ok := bootstrapCfg.bootstrapModel["image-stream"]; ok {
 		imageStream = cfg.(string)
 	}
-	now := c.clock.Now()
-	supportedBootstrapSeries, err := supportedJujuSeries(now, c.BootstrapSeries, imageStream)
+	supportedBootstrapSeries, err := supportedJujuSeries(c.BootstrapSeries, imageStream)
 	if err != nil {
 		return errors.Annotate(err, "error reading supported bootstrap series")
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/clock/testclock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/collections/set"
@@ -73,7 +72,6 @@ type BootstrapSuite struct {
 	tw    loggo.TestWriter
 
 	bootstrapCmd bootstrapCommand
-	clock        *testclock.Clock
 }
 
 var _ = gc.Suite(&BootstrapSuite{})
@@ -136,8 +134,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	})
 
-	s.clock = testclock.NewClock(time.Now())
-	s.bootstrapCmd = bootstrapCommand{clock: s.clock}
+	s.bootstrapCmd = bootstrapCommand{}
 }
 
 func (s *BootstrapSuite) TearDownSuite(c *gc.C) {
@@ -215,7 +212,7 @@ type bootstrapTest struct {
 func (s *BootstrapSuite) patchVersionAndSeries(c *gc.C, hostSeries string) {
 	resetJujuXDGDataHome(c)
 	s.PatchValue(&series.HostSeries, func() (string, error) { return hostSeries, nil })
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
+	s.PatchValue(&supportedJujuSeries, func(string, string) (set.Strings, error) {
 		return set.NewStrings(hostSeries).Union(defaultSupportedJujuSeries), nil
 	})
 	s.patchVersion(c)
@@ -1390,7 +1387,7 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 	// so we can test that an upload is forced.
 	s.PatchValue(&jujuversion.Current, version.MustParse(vers))
 	s.PatchValue(&series.HostSeries, func() (string, error) { return ser, nil })
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
+	s.PatchValue(&supportedJujuSeries, func(string, string) (set.Strings, error) {
 		return set.NewStrings(ser).Union(defaultSupportedJujuSeries), nil
 	})
 

--- a/cmd/juju/machine/upgrademachine.go
+++ b/cmd/juju/machine/upgrademachine.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/set"
@@ -208,7 +207,7 @@ func (c *upgradeSeriesCommand) Init(args []string) error {
 
 	if c.subCommand == PrepareCommand {
 		seriesArg := args[2]
-		workloadSeries, err := series.WorkloadSeries(time.Now(), seriesArg, "")
+		workloadSeries, err := series.WorkloadSeries(seriesArg, "")
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -6,7 +6,6 @@ package series
 import (
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -24,7 +23,7 @@ const (
 
 // ControllerSeries returns all the controller series available to it at the
 // execution time.
-func ControllerSeries(now time.Time, requestedSeries, imageStream string) (set.Strings, error) {
+func ControllerSeries(requestedSeries, imageStream string) (set.Strings, error) {
 	supported, err := seriesForTypes(requestedSeries, imageStream)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -34,7 +33,7 @@ func ControllerSeries(now time.Time, requestedSeries, imageStream string) (set.S
 
 // WorkloadSeries returns the supported workload series available to it at the
 // execution time.
-func WorkloadSeries(now time.Time, requestedSeries, imageStream string) (set.Strings, error) {
+func WorkloadSeries(requestedSeries, imageStream string) (set.Strings, error) {
 	supported, err := seriesForTypes(requestedSeries, imageStream)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -4,8 +4,6 @@
 package series
 
 import (
-	"time"
-
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -188,7 +186,7 @@ func (s *SupportedSeriesSuite) TestUbuntuInvalidSeriesVersion(c *gc.C) {
 }
 
 func (s *SupportedSeriesSuite) TestWorkloadSeries(c *gc.C) {
-	series, err := WorkloadSeries(time.Time{}, "", "")
+	series, err := WorkloadSeries("", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
 		"bionic", "centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kubernetes",


### PR DESCRIPTION
Noble isn't supported out of the box on 2.9, but `--force` should allow noble charms to be deployed.
There was an issue where a pre-filled map containing all known series had the noble entry deleted for a particular use case, but the deleted entry then messed up subsequent operations.
The fix is to take a copy of the data before deleting noble.
https://github.com/juju/juju/pull/21570/changes#diff-6c7be23f35811c808fc6caee2404ddba660cc5718add2e1d9e8930173793c56aR41

As a drive by, commit 2 in this PR removed now unused code since calculating supported series no longer needs a clock.

## QA steps

bootstrap
for a charm just supporting focal (I used a local copy of the ubuntu charm with just focal added)
```
juju deploy . --series noble    
ERROR series "noble" not supported by charm, supported series are: focal

juju deploy . --series noble --force
Deploying "ubuntu" from local charm "ubuntu", revision 1 on noble
```

Previously the 2nd case above would fail with a noble not valid error.

## Links

**Issue:** Fixes #21562.

**Jira card:** [JUJU-9050](https://warthogs.atlassian.net/browse/JUJU-9050)


[JUJU-9050]: https://warthogs.atlassian.net/browse/JUJU-9050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ