### PR TITLE
refactor(modelmigration): remove peer relation import logic

### DIFF
--- a/domain/application/modelmigration/import.go
+++ b/domain/application/modelmigration/import.go
@@ -159,8 +159,6 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			return errors.Errorf("importing exposed endpoints: %w", err)
 		}
 
-		peerRelations := i.importPeerRelations(app.Name(), model.Relations())
-
 		// TODO hml 04-30-2024
 		// Investigate how device constraints for an application are
 		// migrated and implemented if necessary.
@@ -181,8 +179,6 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			// name and not the charm name in the metadata, but the name of
 			// the charm from the store if it's a charm from the store.
 			ReferenceName: chURL.Name,
-
-			PeerRelations: peerRelations,
 		}
 
 		switch modelType {
@@ -761,18 +757,6 @@ func (i *importOperation) importExposedEndpoints(ctx context.Context, app descri
 		}
 	}
 	return exposedEndpoints, nil
-}
-
-func (i *importOperation) importPeerRelations(appName string, modelRelations []description.Relation) map[string]int {
-	result := make(map[string]int)
-	for _, rel := range modelRelations {
-		endpoints := rel.Endpoints()
-		if len(endpoints) != 1 || endpoints[0].ApplicationName() != appName {
-			continue
-		}
-		result[endpoints[0].Name()] = rel.Id()
-	}
-	return result
 }
 
 func importCharmUser(data description.CharmMetadata) (internalcharm.RunAs, error) {

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -1505,57 +1505,6 @@ func (s *importSuite) TestApplicationImportSubordinate(c *tc.C) {
 	}})
 }
 
-func (s *importSuite) TestImportPeerRelations(c *tc.C) {
-	model := description.NewModel(description.ModelArgs{})
-
-	rel1 := model.AddRelation(description.RelationArgs{
-		Id: 1,
-	})
-	rel1.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "prometheus",
-		Name:            "testtwo",
-		Role:            "peer",
-	})
-	rel2 := model.AddRelation(description.RelationArgs{
-		Id: 7,
-	})
-	rel2.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "prometheus",
-		Name:            "testone",
-		Role:            "peer",
-	})
-	// rel3 is a peer relation for a different application
-	// should not be found.
-	rel3 := model.AddRelation(description.RelationArgs{
-		Id: 27,
-	})
-	rel3.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "failme",
-		Name:            "testone",
-		Role:            "peer",
-	})
-	rel4 := model.AddRelation(description.RelationArgs{
-		Id: 29,
-	})
-	// rel4 is a non peer relation with the application
-	// under test, should not be found.
-	rel4.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "prometheus",
-		Name:            "testone",
-		Role:            "provider",
-	})
-	rel4.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "failme",
-		Name:            "testone",
-		Role:            "requirer",
-	})
-	expected := map[string]int{"testone": 7, "testtwo": 1}
-
-	op := &importOperation{}
-	obtained := op.importPeerRelations("prometheus", model.Relations())
-	c.Check(obtained, tc.DeepEquals, expected)
-}
-
 func (s *importSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -470,7 +470,6 @@ func makeInsertApplicationArg(
 		Resources:        makeResourcesArgs(args.ResolvedResources),
 		Config:           applicationConfig,
 		Settings:         args.ApplicationSettings,
-		PeerRelations:    args.PeerRelations,
 	}, nil
 }
 

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -240,9 +240,6 @@ type ImportApplicationArgs struct {
 
 	// ExposedEndpoints is the exposed endpoints for the application.
 	ExposedEndpoints map[string]application.ExposedEndpoint
-
-	// PeerRelations is a map of peer relation endpoint to relation id.
-	PeerRelations map[string]int
 }
 
 // ImportIAASApplicationArgs contains arguments for importing an IAAS

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -481,8 +481,6 @@ type InsertApplicationArgs struct {
 	// EndpointBindings is a map to bind application endpoint by name to a
 	// specific space. The default space is referenced by an empty key, if any.
 	EndpointBindings map[string]network.SpaceName
-	// PeerRelations is a map of peer relation endpoint to relation id.
-	PeerRelations map[string]int
 }
 
 // SetCharmParams contains the parameters for updating


### PR DESCRIPTION
Eliminated `importPeerRelations` method and related data structures from the application domain. It is done in the relation domain import.

## QA steps

Only dead code removed. Unit test should pass.
## Links

**Jira card:** [JUJU-8860](https://warthogs.atlassian.net/browse/JUJU-8860)


[JUJU-8860]: https://warthogs.atlassian.net/browse/JUJU-8860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ