### PR TITLE
docs: fix leftover terminal and blueprint issues

### DIFF
--- a/docs/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development.md
+++ b/docs/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development.md
@@ -7,13 +7,13 @@ myst:
 (set-things-up)=
 # Set up your deployment - local testing and development
 
-```{important}
-The logic is always the same: set up an isolated environment; get Juju, a cloud, and charms; start deploying. However, for certain steps there is an automatic path that greatly facilitates things -- we strongly recommend you take it.
+```{note}
+You can set things up
 
+- automatically, i.e., in a Juju-ready Ubuntu VM launched with Multipass and the Multipass `charm-dev` cloud init, or
+- manually -- with or without Multipass.
 
-If you however wish to follow the manual path and to skip the blueprint or the entire Multipass VM: For best results try to stay very close to [the definition of the `charm-dev` blueprint](https://github.com/canonical/multipass-blueprints/blob/ae90147b811a79eaf4508f4776390141e0195fe7/v1/charm-dev.yaml#L134).
-
-Depending on your use case you may also wish to install further Juju clients or charm development tools; we include those steps too, though feel free to skip them if they don't apply.
+For local testing and development we strongly recommend the automatic path. However, if that is not possible or desired, and you end up using the manual path, we recommend you stick close to the setup in the automatic path: https://raw.githubusercontent.com/canonical/multipass/refs/heads/main/data/cloud-init-yaml/cloud-init-charm-dev.yaml
 ```
 
 1. Create an isolated environment, as below:
@@ -34,15 +34,14 @@ Use Multipass to create an isolated environment:
 ``````{tabs}
 `````{group-tab} automatically
 
-Launch a Juju-ready VM called `my-juju-vm`:
+Use the Multipass `charm-dev` cloud init to launch a Juju-ready VM called `my-juju-vm`:
 
 ```{note}
 This step may take a few minutes to complete (e.g., 10 mins).
 
 This is because the command downloads, installs, (updates,) and configures a number of packages, and the speed will be affected by network bandwidth (not just your own, but also that of the package sources).
 
-However, once it’s done, you’ll have everything you’ll need – all in a nice isolated environment that you can clean up easily. (See more: [GitHub > multipass-blueprints > charm-dev.yaml](https://github.com/canonical/multipass-blueprints/blob/ae90147b811a79eaf4508f4776390141e0195fe7/v1/charm-dev.yaml#L134).)
-
+However, once it’s done, you’ll have everything you’ll need – all in a nice isolated environment that you can clean up easily.
 ```
 
 ```text
@@ -94,7 +93,7 @@ If the VM launch fails, run `multipass delete --purge my-juju-vm` to clean up, t
 ``````{tabs}
 `````{group-tab} automatically
 
-Thanks to the `charm-dev` blueprint, you should already have everything you need:
+Thanks to the `charm-dev` cloud init, you should already have everything you need:
 
 ```text
 # Verify that you have juju:

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/migrate.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/migrate.md
@@ -12,6 +12,7 @@ Migrate a workload model to another controller.
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
+| `--dry-run` | false | Runs the migration prechecks, but does not start the migration. Returns nothing if the migration can proceed. |
 
 ## Details
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -27,6 +27,7 @@ First, [install Multipass](https://documentation.ubuntu.com/multipass/en/latest/
 Now, launch an Ubuntu VM and open a shell in the VM:
 
 ```{terminal}
+:copy:
 :user:
 :host:
 multipass launch --cpus 4 --memory 8G --disk 50G --name my-juju-vm
@@ -35,6 +36,7 @@ Launched: my-juju-vm
 ```
 
 ```{terminal}
+:copy:
 :user:
 :host:
 multipass shell my-juju-vm
@@ -107,13 +109,10 @@ This includes traditional machine clouds (Amazon AWS, Google GCE, Microsoft Azur
 
 In this tutorial we will use MicroK8s, a lightweight Kubernetes that you can also use to get a small, single-node localhost Kubernetes cluster. Let's set it up on your VM:
 
-```{terminal}
-:user: ubuntu
-:host: my-juju-vm
-# Install the MicroK8s package:
-```
+<!-- # Install the MicroK8s package: -->
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo snap install microk8s --channel 1.28-strict
@@ -121,28 +120,31 @@ sudo snap install microk8s --channel 1.28-strict
 2025-08-01T09:47:10+02:00 INFO Waiting for automatic snapd restart...
 microk8s (1.28-strict/stable) v1.28.15 from Canonical✓ installed
 
-# Add your user to the `microk8s` group for unprivileged access:
 ```
 
+<!-- # Add your user to the `microk8s` group for unprivileged access: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo adduser $USER snap_microk8s
 
 info: Adding user `ubuntu' to group `snap_microk8s' ...
 
-# Give your user permissions to read the ~/.kube directory:
 ```
 
+<!-- # Give your user permissions to read the ~/.kube directory: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo chown -f -R $USER ~/.kube
 
-# Wait for MicroK8s to finish initialising:
 ```
 
+<!-- # Wait for MicroK8s to finish initialising: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo microk8s status --wait-ready
@@ -176,10 +178,11 @@ addons:
     rook-ceph            # (core) Distributed Ceph storage using Rook
     storage              # (core) Alias to hostpath-storage add-on, deprecated
 
-# Enable the 'storage' and 'dns' addons (required for the Juju controller):
 ```
 
+<!-- # Enable the 'storage' and 'dns' addons (required for the Juju controller): -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo microk8s enable hostpath-storage dns
@@ -201,10 +204,11 @@ clusterrolebinding.rbac.authorization.k8s.io/microk8s-hostpath created
 Storage will be available soon.
 Addon core/dns is already enabled
 
-# Alias kubectl so it interacts with MicroK8s by default:
 ```
 
+<!-- # Alias kubectl so it interacts with MicroK8s by default: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo snap alias microk8s.kubectl kubectl
@@ -212,19 +216,21 @@ sudo snap alias microk8s.kubectl kubectl
 Added:
   - microk8s.kubectl as kubectl
 
-# Ensure your new group membership is apparent in the current terminal:
-# (Not required once you have logged out and back in again)
 ```
 
+<!-- # Ensure your new group membership is apparent in the current terminal: -->
+<!-- # (Not required once you have logged out and back in again) -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 newgrp snap_microk8s
 
-# Since the juju package is strictly confined, you also need to manually create a path:
 ```
 
+<!-- # Since the juju package is strictly confined, you also need to manually create a path: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 mkdir -p ~/.local/share
@@ -244,6 +250,7 @@ In Juju a (user-facing) client is anything that can talk to a Juju controller. T
 In your VM, install the `juju` CLI client:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo snap install juju
@@ -254,6 +261,7 @@ juju (3/stable) 3.6.8 from Canonical✓ installed
 Now, ensure the client has access to your cloud (i.e., knows where to find your cloud and has the credentials to access your cloud). For a localhost MicroK8s cloud installed from a strictly confined snap like ours, your `juju` client can read the local kubeconfig file and retrieve the cloud definition (and credentials) from there automatically, as you can verify:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju clouds --client
@@ -273,6 +281,7 @@ microk8s   1        localhost  k8s   1            built-in  A Kubernetes Cluster
 Ensure also that the client has access to Charmhub by performing a random search, e.g., using the keyword "ingress", and then asking for more information about one of the results it shows:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju find ingress
@@ -282,6 +291,7 @@ juju find ingress
 ```
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju info traefik-k8s
@@ -299,6 +309,7 @@ A Juju controller is your Juju control plane -- the entity that holds the Juju A
 In your VM, use your client and its access to the MicroK8s cloud to bootstrap a Juju controller:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju bootstrap microk8s my-first-juju-controller
@@ -345,6 +356,7 @@ At this point we could connect to it further clouds or set up the Juju dashboard
 Your client and controller can already talk to a cloud and Charmhub, but they don't run on their own -- enter the user! In Juju, the user is any person that can log in to a controller, and what they can do can be controlled at the level of the controller or some of the smaller entities associated with that controller. As the entity that has bootstrapped the controller, you have automatically been logged in and given `superuser` access. Let's verify:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju whoami
@@ -355,6 +367,7 @@ User:        admin
 ```
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju show-user admin
@@ -389,6 +402,7 @@ At this point you could add further users and control their permissions. However
 Anything you provision or deploy and operate with a Juju controller goes onto a workspace called a 'model'. Let's create the model that will hold our chat applications:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju add-model my-chat-model
@@ -404,6 +418,7 @@ First, [Mattermost](https://charmhub.io/mattermost-k8s):
 
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju deploy mattermost-k8s --constraints "mem=2G"
@@ -414,6 +429,7 @@ Deployed "mattermost-k8s" from charm-hub charm "mattermost-k8s", revision 27 in 
 Now, its dependencies. Mattermost needs a PostgreSQL database, and [its charmed version supports an easy way to integrate with such a database](https://charmhub.io/mattermost-k8s/integrations#db). Let's deploy [the PostgreSQL charm for Kubernetes](https://charmhub.io/postgresql-k8s) in the recommended way, from track `14` with risk `stable`; with `--trust` -- i.e., permission to use our cloud credentials (this charm needs to create and manage some Kubernetes resources); because we're just playing around, setting [the `profile` config](https://charmhub.io/postgresql-k8s/configurations#profile) to `testing`, so we don't use too many resources; and, just for fun, with `-n 2`, that is, two replicas (in a real life setting you'll want to distribute them over multiple nodes -- something Juju would do automatically here too, except we're doing everything on a single node).
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju deploy postgresql-k8s --channel 14/stable --trust --config profile=testing -n 2
@@ -424,18 +440,20 @@ Deployed "postgresql-k8s" from charm-hub charm "postgresql-k8s", revision 495 in
 Mattermost wants PostgreSQL status to be TLS-encrypted. There are a few ways to do that. Because we're just trying things out, we can use [Self Signed X.509 Certificates](https://charmhub.io/self-signed-certificates) (don't do this in production!). Let's deploy it and integrate it with our PostgreSQL to enable TLS encryption on our PostgreSQL cluster:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju deploy self-signed-certificates
 
 Deployed "self-signed-certificates" from charm-hub charm "self-signed-certificates", revision 317 in channel 1/stable on ubuntu@24.04/stable
 
-# Two charmed application can be integrated with one another if they have endpoints that
-# support the same interface (e.g., 'tls-certificates') and
-# have opposite endpoint roles ('requires' vs. 'provides').
 ```
 
+<!-- # Two charmed applications can be integrated with one another if they have endpoints that
+# support the same interface (e.g., 'tls-certificates') and
+# have opposite endpoint roles ('requires' vs. 'provides'). -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju integrate self-signed-certificates postgresql-k8s
@@ -445,6 +463,7 @@ juju integrate self-signed-certificates postgresql-k8s
 Finally, time to integrate Postgresql with Mattermost:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju integrate postgresql-k8s:db mattermost-k8s
@@ -454,6 +473,7 @@ juju integrate postgresql-k8s:db mattermost-k8s
 While executing any of these commands returns automatically so you can execute the next, standing things up in the cloud takes a little bit of time; watch your progress with `juju status --relations --color --watch 1s`. Things are all set when the output looks similar to the one below:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju status --relations --color
@@ -483,6 +503,7 @@ self-signed-certificates:certificates  postgresql-k8s:certificates    tls-certif
 Time to test the results! From the output of `juju status`> `Unit` > `mattermost-k8s/0`, retrieve the IP address and the port and feed them to `curl` on the template `curl <IP address>:<port number>/api/v4/system/ping`. Given the IP we got above:
 
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 curl 10.1.32.142:8065/api/v4/system/ping
@@ -502,15 +523,11 @@ To tear everything down at once, skip to the step where you delete your Multipas
 
 Tear down your Juju deployment:
 
-```{terminal}
-:user: ubuntu
-:host: my-juju-vm
-# Destroy any models you've created
+<!-- # Destroy any models you've created
 # (this will also remove applications along with their configs, relations, etc.,
-# and the cloud resources associated with them):
-```
-
+# and the cloud resources associated with them): -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju destroy-model my-chat-model --destroy-storage
@@ -531,11 +548,11 @@ Waiting for model to be removed, 2 application(s).....
 Waiting for model to be removed, 1 application(s)............
 Waiting for model to be removed........
 Model destroyed.
-
-# Destroy any controllers you've created:
 ```
 
+<!-- # Destroy any controllers you've created: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 juju destroy-controller my-first-juju-controller
@@ -548,20 +565,22 @@ Destroying controller
 Waiting for model resources to be reclaimed
 All models reclaimed, cleaning up controller machines
 
-# Uninstall the juju client:
 ```
 
+<!-- # Uninstall the juju client: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo snap remove juju
 
 juju removed
 
-# Reset Microk8s:
 ```
 
+<!-- # Reset Microk8s: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo microk8s reset
@@ -598,20 +617,22 @@ Removing StorageClasses
 Restarting cluster
 Setting up the CNI
 
-# Uninstall Microk8s:
 ```
 
+<!-- # Uninstall Microk8s: -->
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 $ sudo snap remove microk8s
 
 microk8s removed
 
-# Remove your user from the snap_microk8s group:
 ```
 
+% # Remove your user from the snap_microk8s group:
 ```{terminal}
+:copy:
 :user: ubuntu
 :host: my-juju-vm
 sudo gpasswd -d $USER snap_microk8s
@@ -622,6 +643,7 @@ Removing user ubuntu from group snap_microk8s
 Now exit the VM (in your terminal type `exit`); then, from your host machine, delete the VM:
 
 ```{terminal}
+:copy:
 :user:
 :host:
 multipass delete --purge my-juju-vm
@@ -629,6 +651,7 @@ multipass delete --purge my-juju-vm
 ```
 
 ```{terminal}
+:copy:
 :user:
 :host:
 multipass list


### PR DESCRIPTION
## Changes

### Primary

Due to upstream updates, our terminal excerpts in the tutorial no longer showed comments correctly (see issue https://github.com/juju/juju/issues/21527). They also lacked a copy  button. This PR fixes both (though I ended up having to remove the comments altogether -- left them in as HTML comments in case we figure out a way to bring them back).

Also, in a previous PR we moved away from the Multipass `charm-dev` blueprint (which is deprecated) to the `charm-dev` cloud init, but forgot to clean up a few things -- this PR fixes that.

### Drive-by

When building the documentation a CLI doc was autogenerated. (Someone must have forgotten to generate it after modifying the source. We need to introduce a check to prevent that.)

## Forward merge

This PR should be forward merged into `4.0` and `main`.