### PR TITLE
feat!: remove centos

### DIFF
--- a/core/base/base_test.go
+++ b/core/base/base_test.go
@@ -67,11 +67,6 @@ func (s *BaseSuite) TestParseManifestBases(c *tc.C) {
 			Risk:  "stable",
 		},
 		Architectures: []string{"arm64"},
-	}, {
-		Name: "centos", Channel: charm.Channel{
-			Track: "9",
-			Risk:  "candidate",
-		},
 	}}
 	obtained, err := ParseManifestBases(manifestBases)
 	c.Assert(err, tc.ErrorIsNil)
@@ -79,7 +74,6 @@ func (s *BaseSuite) TestParseManifestBases(c *tc.C) {
 	expected := []Base{
 		{OS: "ubuntu", Channel: Channel{Track: "18.04", Risk: "stable"}},
 		{OS: "ubuntu", Channel: Channel{Track: "20.04", Risk: "edge"}},
-		{OS: "centos", Channel: Channel{Track: "9", Risk: "candidate"}},
 	}
 	c.Assert(obtained, tc.DeepEquals, expected)
 }
@@ -110,9 +104,6 @@ var nonUbuntuLTS = []Base{
 
 	MustParseBaseFromString("ubuntu@22.04-blah"),
 	MustParseBaseFromString("ubuntu@22.04.1234"),
-
-	MustParseBaseFromString("centos@7"),
-	MustParseBaseFromString("centos@20.04"),
 }
 
 func (s *BaseSuite) TestIsUbuntuLTSForNonLTSes(c *tc.C) {

--- a/core/charm/baseselector_test.go
+++ b/core/charm/baseselector_test.go
@@ -229,28 +229,6 @@ func (s *baseSelectorSuite) TestConfigureBaseSelector(c *tc.C) {
 	c.Check(obtained.supportedBases, tc.DeepEquals, []base.Base{jammy, focal})
 }
 
-func (s *baseSelectorSuite) TestConfigureBaseSelectorCentos(c *tc.C) {
-	defer s.setup(c).Finish()
-
-	s.cfg.EXPECT().DefaultBase()
-	c7 := base.MustParseBaseFromString("centos@7/stable")
-	c8 := base.MustParseBaseFromString("centos@8/stable")
-	c6 := base.MustParseBaseFromString("centos@6/stable")
-	cfg := SelectorConfig{
-		Config:              s.cfg,
-		Force:               false,
-		Logger:              s.logger,
-		RequestedBase:       base.Base{},
-		SupportedCharmBases: []base.Base{c6, c7, c8},
-		WorkloadBases:       []base.Base{c7, c8},
-		UsingImageID:        false,
-	}
-
-	obtained, err := ConfigureBaseSelector(cfg)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(obtained.supportedBases, tc.DeepEquals, []base.Base{c7, c8})
-}
-
 func (s *baseSelectorSuite) TestConfigureBaseSelectorDefaultBase(c *tc.C) {
 	defer s.setup(c).Finish()
 

--- a/core/charm/computedbase_test.go
+++ b/core/charm/computedbase_test.go
@@ -177,5 +177,5 @@ func (s *computedBaseSuite) TestOSIsCompatibleWithCharm(c *tc.C) {
 	}).AnyTimes()
 
 	c.Assert(OSIsCompatibleWithCharm("ubuntu", cm), tc.ErrorIsNil)
-	c.Assert(OSIsCompatibleWithCharm("centos", cm), tc.ErrorIs, coreerrors.NotSupported)
+	c.Assert(OSIsCompatibleWithCharm("genericlinux", cm), tc.ErrorIs, coreerrors.NotSupported)
 }

--- a/core/os/base_linux_test.go
+++ b/core/os/base_linux_test.go
@@ -61,20 +61,6 @@ VERSION_ID='12.04'
 	corebase.MustParseBaseFromString("ubuntu@12.04"),
 	"",
 }, {
-	`NAME="CentOS Linux"
-ID="centos"
-VERSION_ID="7"
-`,
-	corebase.MustParseBaseFromString("centos@7"),
-	"",
-}, {
-	`NAME="openSUSE Leap"
-ID=opensuse
-VERSION_ID="42.2"
-`,
-	corebase.MustParseBaseFromString("opensuse@42.2"),
-	"",
-}, {
 	`NAME="Ubuntu"
 VERSION="14.04.1 LTS, Trusty Tahr"
 ID=ubuntu
@@ -87,37 +73,7 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 `,
 	corebase.MustParseBaseFromString("ubuntu@14.04"),
 	"",
-}, {
-	`NAME=Fedora
-VERSION="24 (Twenty Four)"
-ID=fedora
-VERSION_ID=24
-PRETTY_NAME="Fedora 24 (Twenty Four)"
-CPE_NAME="cpe:/o:fedoraproject:fedora:24"
-HOME_URL="https://fedoraproject.org/"
-BUG_REPORT_URL="https://bugzilla.redhat.com/"
-`,
-	corebase.MustParseBaseFromString("fedora@24"),
-	"",
-}, {
-
-	"",
-	corebase.Base{},
-	"OS release file is missing ID",
-}, {
-	`NAME="CentOS Linux"
-ID="centos"
-`,
-	corebase.Base{},
-	"OS release file is missing VERSION_ID",
-}, {
-	`NAME=openSUSE
-ID=opensuse
-VERSION_ID="42.3"`,
-	corebase.MustParseBaseFromString("opensuse@42.3"),
-	"",
-},
-}
+}}
 
 func (s *linuxBaseSuite) TestReadSeries(c *tc.C) {
 	d := c.MkDir()

--- a/core/os/os_linux.go
+++ b/core/os/os_linux.go
@@ -39,8 +39,6 @@ func updateOS(f string) (ostype.OSType, error) {
 	switch values["ID"] {
 	case strings.ToLower(ostype.Ubuntu.String()):
 		return ostype.Ubuntu, nil
-	case strings.ToLower(ostype.CentOS.String()):
-		return ostype.CentOS, nil
 	default:
 		return ostype.GenericLinux, nil
 	}

--- a/core/os/os_test.go
+++ b/core/os/os_test.go
@@ -30,7 +30,7 @@ func (s *osSuite) TestHostOS(c *tc.C) {
 		// TODO(mjs) - this should really do more by patching out
 		// osReleaseFile and testing the corner cases.
 		switch os {
-		case ostype.Ubuntu, ostype.CentOS, ostype.GenericLinux:
+		case ostype.Ubuntu, ostype.GenericLinux:
 		default:
 			c.Fatalf("unknown linux version: %v", os)
 		}

--- a/core/os/ostype/ostype.go
+++ b/core/os/ostype/ostype.go
@@ -17,7 +17,6 @@ const (
 	Ubuntu
 	Windows
 	OSX
-	CentOS
 	GenericLinux
 	Kubernetes
 )
@@ -30,8 +29,6 @@ func (t OSType) String() string {
 		return "Windows"
 	case OSX:
 		return "OSX"
-	case CentOS:
-		return "CentOS"
 	case GenericLinux:
 		return "GenericLinux"
 	case Kubernetes:
@@ -52,7 +49,7 @@ func (t OSType) EquivalentTo(t2 OSType) bool {
 // IsLinux returns true if the OS type is a Linux variant.
 func (t OSType) IsLinux() bool {
 	switch t {
-	case Ubuntu, CentOS, GenericLinux:
+	case Ubuntu, GenericLinux:
 		return true
 	}
 	return false
@@ -62,7 +59,6 @@ var validOSTypeNames = map[string]OSType{
 	"ubuntu":       Ubuntu,
 	"windows":      Windows,
 	"osx":          OSX,
-	"centos":       CentOS,
 	"genericlinux": GenericLinux,
 	"kubernetes":   Kubernetes,
 }

--- a/core/os/ostype/ostype_test.go
+++ b/core/os/ostype/ostype_test.go
@@ -16,15 +16,13 @@ func TestOsTypeSuite(t *testing.T) {
 }
 
 func (s *osTypeSuite) TestEquivalentTo(c *tc.C) {
-	c.Check(Ubuntu.EquivalentTo(CentOS), tc.IsTrue)
 	c.Check(Ubuntu.EquivalentTo(GenericLinux), tc.IsTrue)
 	c.Check(GenericLinux.EquivalentTo(Ubuntu), tc.IsTrue)
-	c.Check(CentOS.EquivalentTo(CentOS), tc.IsTrue)
+	c.Check(Ubuntu.EquivalentTo(Ubuntu), tc.IsTrue)
 }
 
 func (s *osTypeSuite) TestIsLinux(c *tc.C) {
 	c.Check(Ubuntu.IsLinux(), tc.IsTrue)
-	c.Check(CentOS.IsLinux(), tc.IsTrue)
 	c.Check(GenericLinux.IsLinux(), tc.IsTrue)
 
 	c.Check(Windows.IsLinux(), tc.IsFalse)
@@ -49,7 +47,6 @@ func (s *osTypeSuite) TestParseOSType(c *tc.C) {
 		{str: "uBuntu", t: Ubuntu},
 		{str: "winDOwS", t: Windows},
 		{str: "OSX", t: OSX},
-		{str: "CentOS", t: CentOS},
 		{str: "GenericLinux", t: GenericLinux},
 		{str: "Kubernetes", t: Kubernetes},
 	}

--- a/docs/contributor/howto/compile-and-run-juju-agents-on-different-architectures.md
+++ b/docs/contributor/howto/compile-and-run-juju-agents-on-different-architectures.md
@@ -13,7 +13,6 @@ their current host. Alternatively in this workflow it is commonplace to want to 
 
 Examples of this would be:
 - ubuntu/amd64 -> ubuntu/s390x
-- ubuntu/amd64 -> centos/amd64
 - macos/amd64 -> ubuntu/amd64
 - macos/arm64 -> ubutnu/amd64
 

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -740,11 +740,11 @@ func (s *importSuite) TestImportCharmManifest(c *tc.C) {
 func (s *importSuite) TestImportCharmManifestWithInvalidBase(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Notice that we do allow centos here for now. We probably want to
+	// Notice that we do allow genericlinux here for now. We probably want to
 	// consider preventing a migration with anything other than ubuntu.
 
 	baseExp := s.charmBase.EXPECT()
-	baseExp.Name().Return("centos")
+	baseExp.Name().Return("genericlinux")
 	baseExp.Channel().Return("4.0/blah")
 
 	exp := s.charmManifest.EXPECT()

--- a/domain/modelagent/service/service_test.go
+++ b/domain/modelagent/service/service_test.go
@@ -1278,7 +1278,7 @@ func (s *modelUpgradeSuite) TestMachinesUsingSupportedBase(c *tc.C) {
 		},
 		// Should stay: different OS
 		"m4": {
-			OS: "centos",
+			OS: "genericlinux",
 			Channel: corebase.Channel{
 				Track: "24.04",
 				Risk:  "stable",
@@ -1311,7 +1311,7 @@ func (s *modelUpgradeSuite) TestMachinesUsingSupportedBase(c *tc.C) {
 			},
 		},
 		"m4": {
-			OS: "centos",
+			OS: "genericlinux",
 			Channel: corebase.Channel{
 				Track: "24.04",
 				Risk:  "stable",
@@ -1366,7 +1366,7 @@ func (s *modelUpgradeSuite) TestMachinesUsingSupportedBaseNilSupportedBases(c *t
 			},
 		},
 		"m4": {
-			OS: "centos",
+			OS: "genericlinux",
 			Channel: corebase.Channel{
 				Track: "24.04",
 				Risk:  "stable",
@@ -1417,7 +1417,7 @@ func (s *modelUpgradeSuite) TestMachinesUsingSupportedBaseNilSupportedBases(c *t
 			},
 		},
 		"m4": {
-			OS: "centos",
+			OS: "genericlinux",
 			Channel: corebase.Channel{
 				Track: "24.04",
 				Risk:  "stable",

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -670,10 +670,10 @@ func (s *bootstrapSuite) TestBootstrapImageMetadataFromAllSources(c *tc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapLocalTools(c *tc.C) {
-	// Client host is CentOS system, wanting to bootstrap a trusty
+	// Client host is GenericLinux system, wanting to bootstrap a trusty
 	// controller. This is fine.
 
-	s.PatchValue(&jujuos.HostOS, func() ostype.OSType { return ostype.CentOS })
+	s.PatchValue(&jujuos.HostOS, func() ostype.OSType { return ostype.GenericLinux })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
 		return nil, errors.NotFoundf("tools")

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -52,7 +52,7 @@ var DefaultBaseURL = streamsAgentURL
 // metadata for a tools tarball by finding alternative release names to create
 // metadata for.
 var toolsReleaseAltMapping = map[string][]string{
-	"linux":  {"ubuntu", "centos", "genericlinux"},
+	"linux":  {"ubuntu", "genericlinux"},
 	"darwin": {"osx"},
 }
 

--- a/environs/tools/versionfile_test.go
+++ b/environs/tools/versionfile_test.go
@@ -37,7 +37,7 @@ func (s *versionSuite) TestParseVersions(c *tc.C) {
 			Version: "2.2.4-windows-amd64",
 			SHA256:  "eeead9934c597c7678e989e7fd20bf57056a52ce8e25ace371a83711ad484d0c",
 		}, {
-			Version: "2.2.4-centos-amd64",
+			Version: "2.2.4-genericlinux-amd64",
 			SHA256:  "eeead9934c597c7678e989e7fd20bf57056a52ce8e25ace371a83711ad484d0c",
 		}, {
 			Version: "2.2.4-ubuntu-arm64",
@@ -53,7 +53,7 @@ func (s *versionSuite) TestVersionsMatching(c *tc.C) {
 	c.Assert(results, tc.DeepEquals, []string{
 		"2.2.4-ubuntu-amd64",
 		"2.2.4-windows-amd64",
-		"2.2.4-centos-amd64",
+		"2.2.4-genericlinux-amd64",
 	})
 	results, err = v.VersionsMatching(bytes.NewReader([]byte(fakeContent2)))
 	c.Assert(err, tc.ErrorIsNil)
@@ -69,7 +69,7 @@ func (s *versionSuite) TestVersionsMatchingHash(c *tc.C) {
 	c.Assert(results, tc.DeepEquals, []string{
 		"2.2.4-ubuntu-amd64",
 		"2.2.4-windows-amd64",
-		"2.2.4-centos-amd64",
+		"2.2.4-genericlinux-amd64",
 	})
 	results = tools.VersionsMatchingHash(v,
 		"f6cf381fc20545d827b307dd413377bff3c123e1894fdf6c239f07a4143beb47")
@@ -85,7 +85,7 @@ versions:
     sha256: eeead9934c597c7678e989e7fd20bf57056a52ce8e25ace371a83711ad484d0c
   - version: 2.2.4-windows-amd64
     sha256: eeead9934c597c7678e989e7fd20bf57056a52ce8e25ace371a83711ad484d0c
-  - version: 2.2.4-centos-amd64
+  - version: 2.2.4-genericlinux-amd64
     sha256: eeead9934c597c7678e989e7fd20bf57056a52ce8e25ace371a83711ad484d0c
   - version: 2.2.4-ubuntu-arm64
     sha256: f6cf381fc20545d827b307dd413377bff3c123e1894fdf6c239f07a4143beb47

--- a/internal/charm/repository/charmhub_test.go
+++ b/internal/charm/repository/charmhub_test.go
@@ -1271,11 +1271,11 @@ func (s *selectNextBaseSuite) TestSelectNextBaseWithValidBases(c *tc.C) {
 	}})
 }
 
-func (s *selectNextBaseSuite) TestSelectNextBaseWithCentosBase(c *tc.C) {
+func (s *selectNextBaseSuite) TestSelectNextBaseWithGenericLinuxBase(c *tc.C) {
 	repo := new(CharmHubRepository)
 	platform, err := repo.selectNextBases([]transport.Base{{
 		Architecture: "amd64",
-		Name:         "centos",
+		Name:         "genericlinux",
 		Channel:      "7",
 	}}, corecharm.Origin{
 		Platform: corecharm.Platform{
@@ -1287,7 +1287,7 @@ func (s *selectNextBaseSuite) TestSelectNextBaseWithCentosBase(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(platform, tc.DeepEquals, []corecharm.Platform{{
 		Architecture: "amd64",
-		OS:           "centos",
+		OS:           "genericlinux",
 		Channel:      "7",
 	}})
 }
@@ -1475,7 +1475,7 @@ func (s *composeSuggestionsSuite) TestCentosSuggestion(c *tc.C) {
 	}
 	suggestions := repo.composeSuggestions(c.Context(), []transport.Release{{
 		Base: transport.Base{
-			Name:         "centos",
+			Name:         "genericlinux",
 			Channel:      "7",
 			Architecture: "c",
 		},
@@ -1486,7 +1486,7 @@ func (s *composeSuggestionsSuite) TestCentosSuggestion(c *tc.C) {
 		},
 	})
 	c.Assert(suggestions, tc.DeepEquals, []string{
-		`channel "latest/stable": available bases are: centos@7`,
+		`channel "latest/stable": available bases are: genericlinux@7`,
 	})
 }
 

--- a/internal/container/lxd/image_test.go
+++ b/internal/container/lxd/image_test.go
@@ -260,11 +260,11 @@ func (s *imageSuite) TestFindImageRemoteServersNotFound(c *tc.C) {
 }
 
 func (s *imageSuite) TestConstructBaseRemoteAliasNotSupported(c *tc.C) {
-	_, err := lxd.ConstructBaseRemoteAlias(corebase.MakeDefaultBase("centos", "7"), "arm64")
-	c.Assert(err, tc.ErrorMatches, `base "centos@7" not supported`)
+	_, err := lxd.ConstructBaseRemoteAlias(corebase.MakeDefaultBase("genericlinux", "7"), "arm64")
+	c.Assert(err, tc.ErrorMatches, `base "genericlinux@7" not supported`)
 
-	_, err = lxd.ConstructBaseRemoteAlias(corebase.MakeDefaultBase("centos", "8"), "arm64")
-	c.Assert(err, tc.ErrorMatches, `base "centos@8" not supported`)
+	_, err = lxd.ConstructBaseRemoteAlias(corebase.MakeDefaultBase("genericlinux", "8"), "arm64")
+	c.Assert(err, tc.ErrorMatches, `base "genericlinux@8" not supported`)
 
 	_, err = lxd.ConstructBaseRemoteAlias(corebase.MakeDefaultBase("opensuse", "opensuse42"), "s390x")
 	c.Assert(err, tc.ErrorMatches, `base "opensuse@opensuse42" not supported`)

--- a/internal/provider/common/disk_test.go
+++ b/internal/provider/common/disk_test.go
@@ -24,7 +24,6 @@ func (s *DiskSuite) TestMinRootDiskSizeGiB(c *tc.C) {
 		expectedSize uint64
 	}{
 		{"ubuntu", 8},
-		{"centos", 8},
 	}
 	for _, t := range diskTests {
 		actualSize := common.MinRootDiskSizeGiB(ostype.OSTypeForName(t.osname))

--- a/internal/provider/oci/environ_integration_test.go
+++ b/internal/provider/oci/environ_integration_test.go
@@ -774,7 +774,7 @@ func (s *environSuite) TestBootstrapNoMatchingTools(c *tc.C) {
 	ctx := envtesting.BootstrapTestContext(c)
 	_, err := s.env.Bootstrap(ctx, environs.BootstrapParams{
 		ControllerConfig:        testing.FakeControllerConfig(),
-		AvailableTools:          makeToolsList("centos"),
+		AvailableTools:          makeToolsList("genericlinux"),
 		BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
 		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	})

--- a/internal/tools/list_test.go
+++ b/internal/tools/list_test.go
@@ -37,20 +37,17 @@ func extend(lists ...tools.List) tools.List {
 var (
 	t100ubuntu   = mustParseTools("1.0.0-ubuntu-amd64")
 	t100ubuntu32 = mustParseTools("1.0.0-ubuntu-i386")
-	t100centos   = mustParseTools("1.0.0-centos-amd64")
 	t100all      = tools.List{
-		t100ubuntu, t100ubuntu32, t100centos,
+		t100ubuntu, t100ubuntu32,
 	}
 	t190ubuntu   = mustParseTools("1.9.0-ubuntu-amd64")
 	t190ubuntu32 = mustParseTools("1.9.0-ubuntu-i386")
-	t190centos   = mustParseTools("1.9.0-centos-amd64")
 	t190all      = tools.List{
-		t190ubuntu, t190ubuntu32, t190centos,
+		t190ubuntu, t190ubuntu32,
 	}
-	t200ubuntu   = mustParseTools("2.0.0-ubuntu-amd64")
-	t200centos32 = mustParseTools("2.0.0-centos-i386")
-	t200all      = tools.List{
-		t200ubuntu, t200centos32,
+	t200ubuntu = mustParseTools("2.0.0-ubuntu-amd64")
+	t200all    = tools.List{
+		t200ubuntu,
 	}
 	t2001ubuntu   = mustParseTools("2.0.0.1-ubuntu-amd64")
 	tAllBefore210 = extend(t100all, t190all, append(t200all, t2001ubuntu))
@@ -74,7 +71,7 @@ var releaseTests = []releaseTest{{
 	expect: []string{"ubuntu"},
 }, {
 	src:    tAllBefore210,
-	expect: []string{"centos", "ubuntu"},
+	expect: []string{"ubuntu"},
 }}
 
 func (s *ListSuite) TestReleases(c *tc.C) {
@@ -97,7 +94,7 @@ var archesTests = []archTest{{
 	src:    tools.List{t100ubuntu},
 	expect: "amd64",
 }, {
-	src:    tools.List{t100ubuntu, t100centos, t200ubuntu},
+	src:    tools.List{t100ubuntu, t200ubuntu},
 	expect: "amd64",
 }, {
 	src: tAllBefore210,
@@ -124,19 +121,14 @@ func (s *ListSuite) TestURLs(c *tc.C) {
 	empty := tools.List{}
 	c.Check(empty.URLs(), tc.DeepEquals, map[semversion.Binary][]string{})
 
-	alt := *t100centos
+	alt := *t2001ubuntu
 	alt.URL = strings.Replace(alt.URL, "testing.invalid", "testing.invalid2", 1)
 	full := tools.List{
 		t100ubuntu,
-		t190centos,
-		t100centos,
 		&alt,
-		t2001ubuntu,
 	}
 	c.Check(full.URLs(), tc.DeepEquals, map[semversion.Binary][]string{
 		t100ubuntu.Version:  {t100ubuntu.URL},
-		t100centos.Version:  {t100centos.URL, alt.URL},
-		t190centos.Version:  {t190centos.URL},
 		t2001ubuntu.Version: {t2001ubuntu.URL},
 	})
 }
@@ -276,10 +268,10 @@ var excludeTests = []struct {
 }, {
 	t100all,
 	tools.List{t100ubuntu},
-	tools.List{t100ubuntu32, t100centos},
+	tools.List{t100ubuntu32},
 }, {
 	t100all,
-	tools.List{t100ubuntu32, t100centos},
+	tools.List{t100ubuntu32},
 	tools.List{t100ubuntu},
 }, {
 	t100all, t190all, t100all,
@@ -320,28 +312,16 @@ var matchTests = []struct {
 	nil,
 }, {
 	tAllBefore210,
-	tools.Filter{OSType: "centos"},
-	tools.List{t100centos, t190centos, t200centos32},
-}, {
-	tAllBefore210,
 	tools.Filter{OSType: "opensuse"},
 	nil,
 }, {
 	tAllBefore210,
 	tools.Filter{Arch: "i386"},
-	tools.List{t100ubuntu32, t190ubuntu32, t200centos32},
+	tools.List{t100ubuntu32, t190ubuntu32},
 }, {
 	tAllBefore210,
 	tools.Filter{Arch: "arm"},
 	nil,
-}, {
-	tAllBefore210,
-	tools.Filter{
-		Number: semversion.MustParse("2.0.0"),
-		OSType: "centos",
-		Arch:   "i386",
-	},
-	tools.List{t200centos32},
 }}
 
 func (s *ListSuite) TestMatch(c *tc.C) {


### PR DESCRIPTION
Centos as an OS is dead, or at least it is dead in terms of how Juju interprets it. It's an oddity that 4.x still talks about centos, esp. considering we do not support in anyway or form the deployment of any charm with centos in 4 period. We don't support YUM (it was removed), we don't support the OS series in the database schema. There is no way to interact with or deploy it.

This is just code that we should have removed.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model foo
$ juju deploy juju-qa-test
```

Make simplestreams, and notice we no longer write out the centos stanza:

```sh
$ make simplestreams
$ cat _build/simplestreams/tools/streams/v1/com.ubuntu.juju-released-agents.json
```