### PR TITLE
feat: finish machine import

### DIFF
--- a/domain/constraints/modelmigration/decode.go
+++ b/domain/constraints/modelmigration/decode.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelmigration
+
+import (
+	"github.com/juju/description/v11"
+
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
+)
+
+// DecodeConstraints decodes a description.Constraints into constraints.Value.
+func DecodeConstraints(cons description.Constraints) constraints.Value {
+	res := constraints.Value{}
+
+	if cons == nil {
+		return res
+	}
+
+	if allocate := cons.AllocatePublicIP(); allocate {
+		res.AllocatePublicIP = &allocate
+	}
+	if arch := cons.Architecture(); arch != "" {
+		res.Arch = &arch
+	}
+	if container := instance.ContainerType(cons.Container()); container != "" {
+		res.Container = &container
+	}
+	if cpuCores := cons.CpuCores(); cpuCores != 0 {
+		res.CpuCores = &cpuCores
+	}
+	if cpuPower := cons.CpuPower(); cpuPower != 0 {
+		res.CpuPower = &cpuPower
+	}
+	if instanceType := cons.InstanceType(); instanceType != "" {
+		res.InstanceType = &instanceType
+	}
+	if memory := cons.Memory(); memory != 0 {
+		res.Mem = &memory
+	}
+	if imageID := cons.ImageID(); imageID != "" {
+		res.ImageID = &imageID
+	}
+	if rootDisk := cons.RootDisk(); rootDisk != 0 {
+		res.RootDisk = &rootDisk
+	}
+	if rootDiskSource := cons.RootDiskSource(); rootDiskSource != "" {
+		res.RootDiskSource = &rootDiskSource
+	}
+	if spaces := cons.Spaces(); len(spaces) > 0 {
+		res.Spaces = &spaces
+	}
+	if tags := cons.Tags(); len(tags) > 0 {
+		res.Tags = &tags
+	}
+	if virtType := cons.VirtType(); virtType != "" {
+		res.VirtType = &virtType
+	}
+	if zones := cons.Zones(); len(zones) > 0 {
+		res.Zones = &zones
+	}
+
+	return res
+}

--- a/domain/machine/import_integration_test.go
+++ b/domain/machine/import_integration_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine_test
+
+import (
+	"testing"
+
+	"github.com/juju/clock"
+	"github.com/juju/description/v11"
+	"github.com/juju/tc"
+
+	corebase "github.com/juju/juju/core/base"
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/domain"
+	machinemodelmigration "github.com/juju/juju/domain/machine/modelmigration"
+	"github.com/juju/juju/domain/machine/service"
+	"github.com/juju/juju/domain/machine/state"
+	networkstate "github.com/juju/juju/domain/network/state"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/uuid"
+)
+
+type importSuite struct {
+	schematesting.ModelSuite
+
+	spaceUUID network.SpaceUUID
+	subnetID  network.Id
+}
+
+func TestImportSuite(t *testing.T) {
+	tc.Run(t, &importSuite{})
+}
+
+func (s *importSuite) SetUpTest(c *tc.C) {
+	s.ModelSuite.SetUpTest(c)
+
+	s.spaceUUID = tc.Must(c, network.NewSpaceUUID)
+	s.subnetID = network.Id(tc.Must(c, uuid.NewUUID).String())
+
+	networkState := networkstate.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err := networkState.AddSpace(c.Context(), s.spaceUUID, "test-space", "provider-space-id", []string{})
+	c.Assert(err, tc.ErrorIsNil)
+	err = networkState.AddSubnet(c.Context(), network.SubnetInfo{
+		ID:                s.subnetID,
+		SpaceID:           s.spaceUUID,
+		CIDR:              "10.0.0.0/24",
+		AvailabilityZones: []string{"zone1", "zone2"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportMachine(c *tc.C) {
+	desc := description.NewModel(description.ModelArgs{})
+	m0 := desc.AddMachine(description.MachineArgs{
+		Id:                  "0",
+		Nonce:               "nonce-0",
+		PasswordHash:        "h@sh",
+		Base:                "ubuntu@24.04",
+		ContainerType:       "lxd",
+		SupportedContainers: &[]string{"lxd"},
+	})
+	m0.SetAddresses([]description.AddressArgs{{
+		Value:   "192.168.0.1",
+		Type:    "ipv4",
+		Scope:   "machine",
+		Origin:  "manual",
+		SpaceID: s.spaceUUID.String(),
+	}}, []description.AddressArgs{{
+		Value:   "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		Type:    "ipv6",
+		Scope:   "model",
+		Origin:  "manual",
+		SpaceID: s.spaceUUID.String(),
+	}})
+	m0.SetAnnotations(map[string]string{
+		"annotation-key": "annotation-value",
+	})
+	m0.SetConstraints(description.ConstraintsArgs{
+		CpuCores: 4,
+		Memory:   8192,
+		RootDisk: 1024,
+		Tags:     []string{"tag1", "tag2"},
+	})
+	m0.SetInstance(description.CloudInstanceArgs{
+		InstanceId:       "inst-0",
+		DisplayName:      "test instance",
+		Architecture:     "amd64",
+		Memory:           16384,
+		RootDisk:         20480,
+		RootDiskSource:   "/dev/sda1",
+		CpuCores:         8,
+		CpuPower:         32,
+		Tags:             []string{"cloud-tag1", "cloud-tag2"},
+		AvailabilityZone: "zone1",
+		VirtType:         "kvm",
+	})
+	m0.SetTools(description.AgentToolsArgs{
+		Version: "1.2.3",
+		URL:     "http://example.com/tools",
+		SHA256:  "abc123",
+		Size:    123,
+	})
+
+	coordinator := modelmigration.NewCoordinator(loggertesting.WrapCheckLog(c))
+	machinemodelmigration.RegisterImport(coordinator, clock.WallClock, loggertesting.WrapCheckLog(c))
+	err := coordinator.Perform(c.Context(), modelmigration.NewScope(nil, s.TxnRunnerFactory(),
+		nil, model.UUID(s.ModelUUID())), desc)
+	c.Assert(err, tc.ErrorIsNil)
+
+	svc := s.setupService(c)
+	machineNames, err := svc.AllMachineNames(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(machineNames, tc.DeepEquals, []machine.Name{"0"})
+	machineName := machineNames[0]
+
+	machineUUID, err := svc.GetMachineUUID(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	instanceID, err := svc.GetInstanceID(c.Context(), machineUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(instanceID, tc.Equals, instance.Id("inst-0"))
+
+	base, err := svc.GetMachineBase(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(base, tc.Equals, corebase.MustParseBaseFromString("ubuntu@24.04"))
+
+	cons, err := svc.GetMachineConstraints(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cons, tc.DeepEquals, constraints.Value{
+		CpuCores: ptr(uint64(4)),
+		Mem:      ptr(uint64(8192)),
+		RootDisk: ptr(uint64(1024)),
+		Tags:     &[]string{"tag1", "tag2"},
+	})
+
+	placement, err := svc.GetMachinePlacementDirective(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(placement, tc.IsNil)
+
+	containerTypes, err := svc.GetSupportedContainersTypes(c.Context(), machineUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(containerTypes, tc.DeepEquals, []instance.ContainerType{"lxd"})
+
+	machineHardwareCharacteristics, err := svc.GetHardwareCharacteristics(c.Context(), machineUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(machineHardwareCharacteristics, tc.DeepEquals, instance.HardwareCharacteristics{
+		Arch:             ptr("amd64"),
+		Mem:              ptr(uint64(16384)),
+		RootDisk:         ptr(uint64(20480)),
+		RootDiskSource:   ptr("/dev/sda1"),
+		CpuCores:         ptr(uint64(8)),
+		CpuPower:         ptr(uint64(32)),
+		Tags:             &[]string{"cloud-tag1", "cloud-tag2"},
+		AvailabilityZone: ptr("zone1"),
+		VirtType:         ptr("kvm"),
+	})
+}
+
+func (s *importSuite) TestImportMachineParentSubordinate(c *tc.C) {
+	desc := description.NewModel(description.ModelArgs{})
+	m0 := desc.AddMachine(description.MachineArgs{
+		Id:            "0",
+		ContainerType: "lxd",
+		Base:          "ubuntu@24.04",
+	})
+
+	m0.AddContainer(description.MachineArgs{
+		Id:        "0/lxd/0",
+		Placement: "lxd:0",
+		Base:      "ubuntu@24.04",
+	})
+
+	coordinator := modelmigration.NewCoordinator(loggertesting.WrapCheckLog(c))
+	machinemodelmigration.RegisterImport(coordinator, clock.WallClock, loggertesting.WrapCheckLog(c))
+	err := coordinator.Perform(c.Context(), modelmigration.NewScope(nil, s.TxnRunnerFactory(),
+		nil, model.UUID(s.ModelUUID())), desc)
+	c.Assert(err, tc.ErrorIsNil)
+
+	svc := s.setupService(c)
+	machineNames, err := svc.AllMachineNames(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(machineNames, tc.DeepEquals, []machine.Name{"0", "0/lxd/0"})
+
+	parentUUID, err := svc.GetMachineUUID(c.Context(), machine.Name("0"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	subordinateUUID, err := svc.GetMachineUUID(c.Context(), machine.Name("0/lxd/0"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	subordinateParentUUID, err := svc.GetMachineParentUUID(c.Context(), subordinateUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(subordinateParentUUID, tc.Equals, parentUUID)
+
+	parentSubordinates, err := svc.GetMachineContainers(c.Context(), parentUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(parentSubordinates, tc.DeepEquals, []machine.Name{"0/lxd/0"})
+}
+
+func (s *importSuite) setupService(c *tc.C) *service.Service {
+	return service.NewService(
+		state.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c)),
+		domain.NewStatusHistory(loggertesting.WrapCheckLog(c), clock.WallClock),
+		clock.WallClock,
+		loggertesting.WrapCheckLog(c),
+	)
+}

--- a/domain/machine/modelmigration/migrations_mock_test.go
+++ b/domain/machine/modelmigration/migrations_mock_test.go
@@ -16,6 +16,7 @@ import (
 	instance "github.com/juju/juju/core/instance"
 	machine "github.com/juju/juju/core/machine"
 	modelmigration "github.com/juju/juju/core/modelmigration"
+	constraints "github.com/juju/juju/domain/constraints"
 	deployment "github.com/juju/juju/domain/deployment"
 	machine0 "github.com/juju/juju/domain/machine"
 	gomock "go.uber.org/mock/gomock"
@@ -104,18 +105,18 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2 *string, arg3 deployment.Platform) (machine.UUID, error) {
+func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2 *string, arg3 deployment.Platform, arg4 deployment.Placement, arg5 constraints.Constraints) (machine.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateMachine indicates an expected call of CreateMachine.
-func (mr *MockImportServiceMockRecorder) CreateMachine(arg0, arg1, arg2, arg3 any) *MockImportServiceCreateMachineCall {
+func (mr *MockImportServiceMockRecorder) CreateMachine(arg0, arg1, arg2, arg3, arg4, arg5 any) *MockImportServiceCreateMachineCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockImportService)(nil).CreateMachine), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockImportService)(nil).CreateMachine), arg0, arg1, arg2, arg3, arg4, arg5)
 	return &MockImportServiceCreateMachineCall{Call: call}
 }
 
@@ -131,13 +132,52 @@ func (c *MockImportServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, machine.Name, *string, deployment.Platform) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, machine.Name, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, *string, deployment.Platform) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// CreateSubordinateMachine mocks base method.
+func (m *MockImportService) CreateSubordinateMachine(arg0 context.Context, arg1 machine.Name, arg2 machine.UUID, arg3 *string, arg4 deployment.Platform, arg5 deployment.Placement, arg6 constraints.Constraints) (machine.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSubordinateMachine", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret0, _ := ret[0].(machine.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSubordinateMachine indicates an expected call of CreateSubordinateMachine.
+func (mr *MockImportServiceMockRecorder) CreateSubordinateMachine(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *MockImportServiceCreateSubordinateMachineCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubordinateMachine", reflect.TypeOf((*MockImportService)(nil).CreateSubordinateMachine), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return &MockImportServiceCreateSubordinateMachineCall{Call: call}
+}
+
+// MockImportServiceCreateSubordinateMachineCall wrap *gomock.Call
+type MockImportServiceCreateSubordinateMachineCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceCreateSubordinateMachineCall) Return(arg0 machine.UUID, arg1 error) *MockImportServiceCreateSubordinateMachineCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceCreateSubordinateMachineCall) Do(f func(context.Context, machine.Name, machine.UUID, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceCreateSubordinateMachineCall) DoAndReturn(f func(context.Context, machine.Name, machine.UUID, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/migration_mock_test.go
+++ b/domain/machine/service/migration_mock_test.go
@@ -196,6 +196,44 @@ func (c *MockMigrationStateInsertMigratingMachineCall) DoAndReturn(f func(contex
 	return c
 }
 
+// InsertMigratingSubordinateMachine mocks base method.
+func (m *MockMigrationState) InsertMigratingSubordinateMachine(ctx context.Context, machineName, parentUUID string, args machine.CreateMachineArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertMigratingSubordinateMachine", ctx, machineName, parentUUID, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertMigratingSubordinateMachine indicates an expected call of InsertMigratingSubordinateMachine.
+func (mr *MockMigrationStateMockRecorder) InsertMigratingSubordinateMachine(ctx, machineName, parentUUID, args any) *MockMigrationStateInsertMigratingSubordinateMachineCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertMigratingSubordinateMachine", reflect.TypeOf((*MockMigrationState)(nil).InsertMigratingSubordinateMachine), ctx, machineName, parentUUID, args)
+	return &MockMigrationStateInsertMigratingSubordinateMachineCall{Call: call}
+}
+
+// MockMigrationStateInsertMigratingSubordinateMachineCall wrap *gomock.Call
+type MockMigrationStateInsertMigratingSubordinateMachineCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMigrationStateInsertMigratingSubordinateMachineCall) Return(arg0 error) *MockMigrationStateInsertMigratingSubordinateMachineCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMigrationStateInsertMigratingSubordinateMachineCall) Do(f func(context.Context, string, string, machine.CreateMachineArgs) error) *MockMigrationStateInsertMigratingSubordinateMachineCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMigrationStateInsertMigratingSubordinateMachineCall) DoAndReturn(f func(context.Context, string, string, machine.CreateMachineArgs) error) *MockMigrationStateInsertMigratingSubordinateMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetMachineCloudInstance mocks base method.
 func (m *MockMigrationState) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3, arg4 string, arg5 *instance.HardwareCharacteristics) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -33,6 +33,7 @@ func (s *stateSuite) TestGetHardwareCharacteristics(c *tc.C) {
 	c.Check(*hc.CpuPower, tc.Equals, uint64(75))
 	c.Check(*hc.AvailabilityZone, tc.Equals, "az-1")
 	c.Check(*hc.VirtType, tc.Equals, "virtual-machine")
+	c.Check(*hc.Tags, tc.DeepEquals, []string{"tag1", "tag2"})
 }
 
 func (s *stateSuite) TestGetHardwareCharacteristicsWithoutAvailabilityZone(c *tc.C) {
@@ -68,6 +69,7 @@ func (s *stateSuite) TestGetHardwareCharacteristicsWithoutAvailabilityZone(c *tc
 	c.Check(*hc.CpuPower, tc.Equals, uint64(75))
 	c.Check(hc.AvailabilityZone, tc.IsNil)
 	c.Check(*hc.VirtType, tc.Equals, "virtual-machine")
+	c.Check(*hc.Tags, tc.DeepEquals, []string{"tag1", "tag2"})
 }
 
 func (s *stateSuite) TestAvailabilityZoneWithNoMachine(c *tc.C) {

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -7,6 +7,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/juju/collections/transform"
+
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain/constraints"
@@ -71,6 +73,10 @@ type instanceTag struct {
 	Tag         string `db:"tag"`
 }
 
+type tag struct {
+	Tag string `db:"tag"`
+}
+
 func tagsFromHardwareCharacteristics(machineUUID string, hc *instance.HardwareCharacteristics) []instanceTag {
 	if hc == nil || hc.Tags == nil {
 		return nil
@@ -85,8 +91,8 @@ func tagsFromHardwareCharacteristics(machineUUID string, hc *instance.HardwareCh
 	return res
 }
 
-func (d *instanceDataResult) toHardwareCharacteristics() instance.HardwareCharacteristics {
-	return instance.HardwareCharacteristics{
+func (d *instanceDataResult) toHardwareCharacteristics(tags []tag) instance.HardwareCharacteristics {
+	ret := instance.HardwareCharacteristics{
 		Arch:             d.Arch,
 		Mem:              d.Mem,
 		RootDisk:         d.RootDisk,
@@ -96,6 +102,10 @@ func (d *instanceDataResult) toHardwareCharacteristics() instance.HardwareCharac
 		AvailabilityZone: d.AvailabilityZone,
 		VirtType:         d.VirtType,
 	}
+	if len(tags) > 0 {
+		ret.Tags = ptr(transform.Slice(tags, func(t tag) string { return t.Tag }))
+	}
+	return ret
 }
 
 // machineLife represents the struct to be used for the life_id column within
@@ -140,6 +150,10 @@ type availabilityZoneName struct {
 
 type machineName struct {
 	Name string `db:"name"`
+}
+
+type machineUUID struct {
+	UUID string `db:"machine_uuid"`
 }
 
 type count struct {

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -13,7 +13,6 @@ import (
 	coreconstraints "github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/credential"
 	coreerrors "github.com/juju/juju/core/errors"
-	coreinstance "github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/modelmigration"
@@ -22,6 +21,7 @@ import (
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	accessservice "github.com/juju/juju/domain/access/service"
 	accessstate "github.com/juju/juju/domain/access/state"
+	constraintsmigration "github.com/juju/juju/domain/constraints/modelmigration"
 	domainmodel "github.com/juju/juju/domain/model"
 	modelservice "github.com/juju/juju/domain/model/service"
 	modelmigrationservice "github.com/juju/juju/domain/model/service/migration"
@@ -304,48 +304,7 @@ func (i *importModelConstraintsOperation) Execute(
 	if descCons == nil {
 		return nil
 	}
-
-	cons := coreconstraints.Value{}
-	if allocatePublicIP := descCons.AllocatePublicIP(); allocatePublicIP {
-		cons.AllocatePublicIP = &allocatePublicIP
-	}
-	if arch := descCons.Architecture(); arch != "" {
-		cons.Arch = &arch
-	}
-	if container := coreinstance.ContainerType(descCons.Container()); container != "" {
-		cons.Container = &container
-	}
-	if cores := descCons.CpuCores(); cores != 0 {
-		cons.CpuCores = &cores
-	}
-	if power := descCons.CpuPower(); power != 0 {
-		cons.CpuPower = &power
-	}
-	if inst := descCons.InstanceType(); inst != "" {
-		cons.InstanceType = &inst
-	}
-	if mem := descCons.Memory(); mem != 0 {
-		cons.Mem = &mem
-	}
-	if disk := descCons.RootDisk(); disk != 0 {
-		cons.RootDisk = &disk
-	}
-	if source := descCons.RootDiskSource(); source != "" {
-		cons.RootDiskSource = &source
-	}
-	if spaces := descCons.Spaces(); len(spaces) > 0 {
-		cons.Spaces = &spaces
-	}
-	if tags := descCons.Tags(); len(tags) > 0 {
-		cons.Tags = &tags
-	}
-	if virt := descCons.VirtType(); virt != "" {
-		cons.VirtType = &virt
-	}
-	if zones := descCons.Zones(); len(zones) > 0 {
-		cons.Zones = &zones
-	}
-
+	cons := constraintsmigration.DecodeConstraints(descCons)
 	// If no constraints are set we will noop from here.
 	if coreconstraints.IsEmpty(&cons) {
 		return nil


### PR DESCRIPTION
Machine import was only half implemented. Finish this off by implementing the imports that were missing.

This meant including machine placement, constraints, and containers.

For constraints, I have extracted a helper to decode description constraints which is used for models, applications and machines.

Add some integration tests for machine import

## QA steps

Unfortunately it seems there is a bug in link layer devices import, which means we cannot complete the migration I would like to demonstrate this

```
$ juju-40 bootstrap aws/eu-west-2 40
$ juju-36 bootstrap aws/eu-west-2 36
$ juju add-model model
$ juju model-config container-networking-method=local
$ juju model-config fan-config=""
$ juju add-machine
$ juju add-machine lxd:0
$ juju status
Model  Controller  Cloud/Region   Version  Timestamp
model  36          aws/eu-west-2  3.6.12   12:50:05Z

Machine  State    Address         Inst id              Base          AZ          Message
0        started  18.130.133.248  i-01a5d46d7943f6205  ubuntu@24.04  eu-west-2a  running
0/lxd/0  started  10.13.143.239   juju-6bd182-0-lxd-0  ubuntu@24.04  eu-west-2a  Container started

$ juju migrate model 40
```
^ the migration will fail, but if you check the debug logs:
```
$ juju debug-log -m controller
...
machine-0: 12:50:14 ERROR juju.worker.migrationmaster.ac40bc logger-tags:migration model data transfer failed, failed to import model into target controller: execute operation import link layer devices: importing link layer devices: converting device "lxdbr0" on machine "0": converting address "10.13.143.1/24": no subnet found
...
```
the migration has failed on the link layer devices stage, which is executed after machine imports are complete
