### PR TITLE
fix: convert legacy sequence names during import

### DIFF
--- a/domain/sequence/modelmigration/import.go
+++ b/domain/sequence/modelmigration/import.go
@@ -5,11 +5,16 @@ package modelmigration
 
 import (
 	"context"
+	"regexp"
+	"strings"
 
 	"github.com/juju/description/v11"
 
 	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/machine"
 	"github.com/juju/juju/domain/operation"
+	"github.com/juju/juju/domain/sequence"
 	"github.com/juju/juju/domain/sequence/service"
 	"github.com/juju/juju/domain/sequence/state"
 )
@@ -17,7 +22,27 @@ import (
 const (
 	// legacyOperationSequenceName is the sequence name for operations in Juju 3.
 	legacyOperationSequenceName = "task"
+
+	// legacyStorageSequenceName is the sequence name for storage in Juju 3.
+	legacyStorageSequenceName = "stores"
+
+	// legacyApplicationPrefix is the prefix for application sequences in Juju 3.
+	// In Juju 3, application sequences are named "application-{appName}".
+	legacyApplicationPrefix = "application-"
+
+	// legacyContainerSuffix is the suffix for container sequences in Juju 3.
+	// In Juju 3, container sequences are named "machine{parentId}{containerType}Container".
+	legacyContainerSuffix = "Container"
+
+	// storageSequenceNamespace is the sequence namespace for storage in Juju 4.
+	storageSequenceNamespace = "storage"
 )
+
+// legacyContainerRegex matches container sequence names from Juju 3.
+// Format: "machine{parentId}{containerType}Container"
+// Examples: "machine0lxdContainer", "machine1/lxd/0kvmContainer"
+// The parentId can contain slashes for nested containers.
+var legacyContainerRegex = regexp.MustCompile(`^machine(.+?)(lxd|kvm)Container$`)
 
 // Coordinator is the interface that is used to add operations to a migration.
 type Coordinator interface {
@@ -69,14 +94,50 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 	s := make(map[string]uint64, len(seqs))
 	for k, v := range seqs {
-		switch k {
-		case legacyOperationSequenceName:
-			// The sequence name for operation has been changed between
-			// juju 3 and Juju 4. This is necessary for retro-compatibility.
-			k = operation.OperationSequenceNamespace.String()
-		}
+		k = convertLegacySequenceName(k)
 		s[k] = uint64(v)
 	}
 
 	return i.service.ImportSequences(ctx, s)
+}
+
+// convertLegacySequenceName converts a Juju 3.x sequence name to the
+// corresponding Juju 4.x sequence namespace format.
+func convertLegacySequenceName(name string) string {
+	switch {
+	case name == legacyOperationSequenceName:
+		// "task" -> "operation"
+		return operation.OperationSequenceNamespace.String()
+
+	case name == legacyStorageSequenceName:
+		// "stores" -> "storage"
+		return storageSequenceNamespace
+
+	case strings.HasPrefix(name, legacyApplicationPrefix):
+		// "application-myapp" -> "application_myapp"
+		appName := strings.TrimPrefix(name, legacyApplicationPrefix)
+		return sequence.MakePrefixNamespace(application.ApplicationSequenceNamespace, appName).String()
+
+	case strings.HasSuffix(name, legacyContainerSuffix) && strings.HasPrefix(name, "machine"):
+		// "machine0lxdContainer" -> "machine_container_0"
+		// "machine1/lxd/0kvmContainer" -> "machine_container_1/lxd/0"
+		if converted := convertContainerSequenceName(name); converted != "" {
+			return converted
+		}
+	}
+
+	return name
+}
+
+// convertContainerSequenceName converts a Juju 3.x container sequence name
+// to the Juju 4.x format.
+// Input format: "machine{parentId}{containerType}Container"
+// Output format: "machine_container_{parentId}"
+func convertContainerSequenceName(name string) string {
+	matches := legacyContainerRegex.FindStringSubmatch(name)
+	if matches == nil {
+		return ""
+	}
+	parentID := matches[1]
+	return sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, parentID).String()
 }

--- a/domain/sequence/modelmigration/import_test.go
+++ b/domain/sequence/modelmigration/import_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/juju/tc"
 	gomock "go.uber.org/mock/gomock"
 
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/machine"
 	"github.com/juju/juju/domain/operation"
+	"github.com/juju/juju/domain/sequence"
 	"github.com/juju/juju/internal/testhelpers"
 )
 
@@ -53,7 +56,7 @@ func (s *importSuite) TestImportSequencesEmpty(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *importSuite) TestImportSequencesLegacy(c *tc.C) {
+func (s *importSuite) TestImportSequencesLegacyOperation(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
@@ -69,6 +72,264 @@ func (s *importSuite) TestImportSequencesLegacy(c *tc.C) {
 
 	err := op.Execute(c.Context(), model)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportSequencesLegacyStorage(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
+		storageSequenceNamespace: 42,
+	}).Return(nil)
+
+	op := s.newImportOperation()
+
+	model := description.NewModel(description.ModelArgs{})
+	model.SetSequence(legacyStorageSequenceName, 42)
+
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportSequencesLegacyApplication(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// "application-myapp" -> "application_myapp"
+	expectedNamespace := sequence.MakePrefixNamespace(application.ApplicationSequenceNamespace, "myapp").String()
+
+	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
+		expectedNamespace: 10,
+	}).Return(nil)
+
+	op := s.newImportOperation()
+
+	model := description.NewModel(description.ModelArgs{})
+	model.SetSequence("application-myapp", 10)
+
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportSequencesLegacyApplicationWithHyphen(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// "application-my-cool-app" -> "application_my-cool-app"
+	expectedNamespace := sequence.MakePrefixNamespace(application.ApplicationSequenceNamespace, "my-cool-app").String()
+
+	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
+		expectedNamespace: 5,
+	}).Return(nil)
+
+	op := s.newImportOperation()
+
+	model := description.NewModel(description.ModelArgs{})
+	model.SetSequence("application-my-cool-app", 5)
+
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportSequencesLegacyContainerLXD(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// "machine0lxdContainer" -> "machine_container_0"
+	expectedNamespace := sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, "0").String()
+
+	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
+		expectedNamespace: 3,
+	}).Return(nil)
+
+	op := s.newImportOperation()
+
+	model := description.NewModel(description.ModelArgs{})
+	model.SetSequence("machine0lxdContainer", 3)
+
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportSequencesLegacyContainerKVM(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// "machine1kvmContainer" -> "machine_container_1"
+	expectedNamespace := sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, "1").String()
+
+	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
+		expectedNamespace: 7,
+	}).Return(nil)
+
+	op := s.newImportOperation()
+
+	model := description.NewModel(description.ModelArgs{})
+	model.SetSequence("machine1kvmContainer", 7)
+
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportSequencesLegacyNestedContainer(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// "machine1/lxd/0kvmContainer" -> "machine_container_1/lxd/0"
+	expectedNamespace := sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, "1/lxd/0").String()
+
+	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
+		expectedNamespace: 2,
+	}).Return(nil)
+
+	op := s.newImportOperation()
+
+	model := description.NewModel(description.ModelArgs{})
+	model.SetSequence("machine1/lxd/0kvmContainer", 2)
+
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportSequencesMultipleLegacyConversions(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appNamespace := sequence.MakePrefixNamespace(application.ApplicationSequenceNamespace, "ubuntu").String()
+	containerNamespace := sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, "0").String()
+
+	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
+		operation.OperationSequenceNamespace.String(): 100,
+		storageSequenceNamespace:                      50,
+		appNamespace:                                  25,
+		containerNamespace:                            10,
+		"machine":                                     5,
+		"relation":                                    3,
+	}).Return(nil)
+
+	op := s.newImportOperation()
+
+	model := description.NewModel(description.ModelArgs{})
+	model.SetSequence("task", 100)
+	model.SetSequence("stores", 50)
+	model.SetSequence("application-ubuntu", 25)
+	model.SetSequence("machine0lxdContainer", 10)
+	model.SetSequence("machine", 5)
+	model.SetSequence("relation", 3)
+
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestConvertLegacySequenceNameUnchanged(c *tc.C) {
+	// Test that sequences that don't match any legacy pattern are unchanged.
+	tests := []string{
+		"machine",
+		"relation",
+		"filesystem",
+		"volume",
+		"subnet",
+		"block",
+		"branch",
+		"controller",
+		"modelmigration",
+		"random-sequence",
+	}
+
+	for _, name := range tests {
+		c.Check(convertLegacySequenceName(name), tc.Equals, name,
+			tc.Commentf("sequence name %q should remain unchanged", name))
+	}
+}
+
+func (s *importSuite) TestConvertLegacySequenceNameOperation(c *tc.C) {
+	result := convertLegacySequenceName("task")
+	c.Assert(result, tc.Equals, operation.OperationSequenceNamespace.String())
+}
+
+func (s *importSuite) TestConvertLegacySequenceNameStorage(c *tc.C) {
+	result := convertLegacySequenceName("stores")
+	c.Assert(result, tc.Equals, "storage")
+}
+
+func (s *importSuite) TestConvertLegacySequenceNameApplication(c *tc.C) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "application-myapp",
+			expected: "application_myapp",
+		},
+		{
+			input:    "application-my-cool-app",
+			expected: "application_my-cool-app",
+		},
+		{
+			input:    "application-ubuntu",
+			expected: "application_ubuntu",
+		},
+		{
+			input:    "application-a",
+			expected: "application_a",
+		},
+	}
+
+	for _, test := range tests {
+		result := convertLegacySequenceName(test.input)
+		c.Check(result, tc.Equals, test.expected,
+			tc.Commentf("converting %q", test.input))
+	}
+}
+
+func (s *importSuite) TestConvertLegacySequenceNameContainer(c *tc.C) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "machine0lxdContainer",
+			expected: "machine_container_0",
+		},
+		{
+			input:    "machine1kvmContainer",
+			expected: "machine_container_1",
+		},
+		{
+			input:    "machine10lxdContainer",
+			expected: "machine_container_10",
+		},
+		{
+			input:    "machine1/lxd/0lxdContainer",
+			expected: "machine_container_1/lxd/0",
+		},
+		{
+			input:    "machine1/lxd/0kvmContainer",
+			expected: "machine_container_1/lxd/0",
+		},
+		{
+			input:    "machine0/kvm/0lxdContainer",
+			expected: "machine_container_0/kvm/0",
+		},
+	}
+
+	for _, test := range tests {
+		result := convertLegacySequenceName(test.input)
+		c.Check(result, tc.Equals, test.expected,
+			tc.Commentf("converting %q", test.input))
+	}
+}
+
+func (s *importSuite) TestConvertContainerSequenceNameInvalid(c *tc.C) {
+	// These should not match the container pattern and return empty string.
+	tests := []string{
+		"machineContainer",        // No parent ID or container type
+		"machine0Container",       // No container type
+		"0lxdContainer",           // Missing "machine" prefix
+		"machine0lxd",             // Missing "Container" suffix
+		"somethingElseContainer",  // Wrong prefix
+		"machine0dockerContainer", // Invalid container type
+		"machine0LXDContainer",    // Wrong case for container type
+	}
+
+	for _, name := range tests {
+		result := convertContainerSequenceName(name)
+		c.Check(result, tc.Equals, "",
+			tc.Commentf("invalid container sequence %q should return empty string", name))
+	}
 }
 
 func (s *importSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/domain/sequence/modelmigration/import_test.go
+++ b/domain/sequence/modelmigration/import_test.go
@@ -30,9 +30,11 @@ func TestImportSuite(t *testing.T) {
 func (s *importSuite) TestImportSequences(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	// Juju 3.x stores "next value to return", Juju 4.x stores "last value returned".
+	// Input values are decremented by 1 during import.
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		"foo": 1,
-		"bar": 2,
+		"foo": 0, // input 1 - 1
+		"bar": 1, // input 2 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -60,8 +62,8 @@ func (s *importSuite) TestImportSequencesLegacyOperation(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		operation.OperationSequenceNamespace.String(): 1,
-		"bar": 2,
+		operation.OperationSequenceNamespace.String(): 0, // input 1 - 1
+		"bar": 1, // input 2 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -78,7 +80,7 @@ func (s *importSuite) TestImportSequencesLegacyStorage(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		storageSequenceNamespace: 42,
+		storageSequenceNamespace: 41, // input 42 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -97,7 +99,7 @@ func (s *importSuite) TestImportSequencesLegacyApplication(c *tc.C) {
 	expectedNamespace := sequence.MakePrefixNamespace(application.ApplicationSequenceNamespace, "myapp").String()
 
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		expectedNamespace: 10,
+		expectedNamespace: 9, // input 10 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -116,7 +118,7 @@ func (s *importSuite) TestImportSequencesLegacyApplicationWithHyphen(c *tc.C) {
 	expectedNamespace := sequence.MakePrefixNamespace(application.ApplicationSequenceNamespace, "my-cool-app").String()
 
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		expectedNamespace: 5,
+		expectedNamespace: 4, // input 5 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -135,7 +137,7 @@ func (s *importSuite) TestImportSequencesLegacyContainerLXD(c *tc.C) {
 	expectedNamespace := sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, "0").String()
 
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		expectedNamespace: 3,
+		expectedNamespace: 2, // input 3 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -154,7 +156,7 @@ func (s *importSuite) TestImportSequencesLegacyContainerKVM(c *tc.C) {
 	expectedNamespace := sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, "1").String()
 
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		expectedNamespace: 7,
+		expectedNamespace: 6, // input 7 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -173,7 +175,7 @@ func (s *importSuite) TestImportSequencesLegacyNestedContainer(c *tc.C) {
 	expectedNamespace := sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, "1/lxd/0").String()
 
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		expectedNamespace: 2,
+		expectedNamespace: 1, // input 2 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -191,13 +193,14 @@ func (s *importSuite) TestImportSequencesMultipleLegacyConversions(c *tc.C) {
 	appNamespace := sequence.MakePrefixNamespace(application.ApplicationSequenceNamespace, "ubuntu").String()
 	containerNamespace := sequence.MakePrefixNamespace(machine.ContainerSequenceNamespace, "0").String()
 
+	// All values are decremented by 1 during import (Juju 3 -> Juju 4 semantics).
 	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
-		operation.OperationSequenceNamespace.String(): 100,
-		storageSequenceNamespace:                      50,
-		appNamespace:                                  25,
-		containerNamespace:                            10,
-		"machine":                                     5,
-		"relation":                                    3,
+		operation.OperationSequenceNamespace.String(): 99, // input 100 - 1
+		storageSequenceNamespace:                      49, // input 50 - 1
+		appNamespace:                                  24, // input 25 - 1
+		containerNamespace:                            9,  // input 10 - 1
+		"machine":                                     4,  // input 5 - 1
+		"relation":                                    2,  // input 3 - 1
 	}).Return(nil)
 
 	op := s.newImportOperation()
@@ -209,6 +212,26 @@ func (s *importSuite) TestImportSequencesMultipleLegacyConversions(c *tc.C) {
 	model.SetSequence("machine0lxdContainer", 10)
 	model.SetSequence("machine", 5)
 	model.SetSequence("relation", 3)
+
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportSequencesSkipsZeroValues(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Sequences with value 0 or negative should be skipped as they were never used.
+	// Only "bar" with value 2 should be imported (as 1 after decrement).
+	s.importService.EXPECT().ImportSequences(gomock.Any(), map[string]uint64{
+		"bar": 1, // input 2 - 1
+	}).Return(nil)
+
+	op := s.newImportOperation()
+
+	model := description.NewModel(description.ModelArgs{})
+	model.SetSequence("foo", 0)  // Should be skipped
+	model.SetSequence("bar", 2)  // Should be imported as 1
+	model.SetSequence("baz", -1) // Should be skipped (negative)
 
 	err := op.Execute(c.Context(), model)
 	c.Assert(err, tc.ErrorIsNil)


### PR DESCRIPTION
This patch fixes the sequence import by addressing 3 wrongly imported sequences:
- application
- machine containers
- storage

## QA steps

To flex this, we need to migrate a 3.6 controller into 4.0, containing an app and a container machine:
```
# On a 3.6 (src36) model:
juju deploy juju-qa-dummy-source --base ubuntu@22.04
juju deploy juju-qa-dummy-sink --base ubuntu@22.04
juju relate dummy-sink dummy-source
juju config dummy-source token=yeah-boi

juju migrate m tgt40
```
Then, we should try adding a new unit to the `ubuntu` application (to test that the application sequence is correctly interpreted:
```
# On the 4.0 (migrated) model:
juju add-unit dummy-sink
```

This should work and no errors should appear in the logs.

Also, the relation should be shown in the status and the correct number for the new unit and machine should appear:
```
juju status --relations --color
Model  Controller  Cloud/Region         Version  Timestamp
m      tgt40       localhost/localhost  3.6.12   17:44:06+01:00

App           Version  Status   Scale  Charm                 Channel        Rev  Exposed  Message
dummy-sink             waiting    1/2  juju-qa-dummy-sink    latest/stable    7  no       waiting for machine
dummy-source           active       1  juju-qa-dummy-source  latest/stable    6  no       Token is yeah-boi

Unit             Workload  Agent       Machine  Public address  Ports  Message
dummy-sink/0*    active    idle        1        10.42.73.68            Token is yeah-boi
dummy-sink/1     waiting   allocating  2                               waiting for machine
dummy-source/0*  active    idle        0        10.42.73.105           Token is yeah-boi

Machine  State    Address       Inst id        Base          AZ        Message
0        started  10.42.73.105  juju-e94c77-0  ubuntu@22.04  thinkpad  Running
1        started  10.42.73.68   juju-e94c77-1  ubuntu@22.04  thinkpad  Running
2        pending                juju-e94c77-2  ubuntu@22.04  thinkpad  Running

Integration provider  Requirer           Interface    Type     Message
dummy-sink:source     dummy-source:sink  dummy-token  regular
```
