### PR TITLE
feat: persist unit workload version on import

### DIFF
--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -402,12 +402,13 @@ func (st *State) importCAASUnit(
 	err = st.unitState.insertUnit(
 		ctx, tx, appUUID, unitUUID, netNodeUUID.String(),
 		insertUnitArg{
-			CharmUUID:      charmUUID,
-			UnitName:       args.UnitName.String(),
-			CloudContainer: args.CloudContainer,
-			Password:       args.Password,
-			Constraints:    args.Constraints,
-			UnitStatusArg:  args.UnitStatusArg,
+			CharmUUID:       charmUUID,
+			UnitName:        args.UnitName.String(),
+			CloudContainer:  args.CloudContainer,
+			Password:        args.Password,
+			Constraints:     args.Constraints,
+			WorkloadVersion: args.WorkloadVersion,
+			UnitStatusArg:   args.UnitStatusArg,
 		},
 	)
 	if err != nil {
@@ -496,11 +497,12 @@ func (st *State) importIAASUnit(
 	}
 
 	if err := st.unitState.insertUnit(ctx, tx, appUUID, unitUUID, netNodeUUID, insertUnitArg{
-		CharmUUID:     charmUUID,
-		UnitName:      args.UnitName.String(),
-		Password:      args.Password,
-		Constraints:   args.Constraints,
-		UnitStatusArg: args.UnitStatusArg,
+		CharmUUID:       charmUUID,
+		UnitName:        args.UnitName.String(),
+		Password:        args.Password,
+		Constraints:     args.Constraints,
+		WorkloadVersion: args.WorkloadVersion,
+		UnitStatusArg:   args.UnitStatusArg,
 	}); err != nil {
 		return errors.Errorf("importing unit for application %q: %w", appUUID, err)
 	}

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -150,11 +150,12 @@ func (st *InsertIAASUnitState) InsertIAASUnit(
 }
 
 type insertUnitArg struct {
-	CharmUUID      string
-	UnitName       string
-	CloudContainer *application.CloudContainer
-	Password       *application.PasswordInfo
-	Constraints    constraints.Constraints
+	CharmUUID       string
+	UnitName        string
+	CloudContainer  *application.CloudContainer
+	Password        *application.PasswordInfo
+	Constraints     constraints.Constraints
+	WorkloadVersion string
 	application.UnitStatusArg
 }
 
@@ -223,7 +224,7 @@ func (st *InsertIAASUnitState) insertUnit(
 	if err := st.setUnitWorkloadStatus(ctx, tx, unitUUID, args.WorkloadStatus); err != nil {
 		return errors.Errorf("setting workload status for unit %q: %w", args.UnitName, err)
 	}
-	if err := st.setUnitWorkloadVersion(ctx, tx, unitUUID, ""); err != nil {
+	if err := st.setUnitWorkloadVersion(ctx, tx, unitUUID, args.WorkloadVersion); err != nil {
 		return errors.Errorf("setting workload version for unit %q: %w", args.UnitName, err)
 	}
 	return nil


### PR DESCRIPTION
This patch completes the unit import by adding `WorkloadVersion` through the import path and store it in unit records. 

Also, add state and integration tests for CAAS and IAAS units to verify GetUnitWorkloadVersion returns expected values.



## QA steps

Migrate a 3.6 -> 4.0 model:
```
juju_36 add-model m
juju_36 deploy ubuntu
```
Then migrate:
```
juju migrate m tgt40
```
You should see the migrated model in the new 4.0 controller and no debug-log errors.

## Links

**Jira card:** [JUJU-8857](https://warthogs.atlassian.net/browse/JUJU-8857)


[JUJU-8857]: https://warthogs.atlassian.net/browse/JUJU-8857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ