### PR TITLE
fix(ssh): disable PTY allocation when remote command is provided

### DIFF
--- a/cmd/juju/ssh/pty_test.go
+++ b/cmd/juju/ssh/pty_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package ssh
+
+import (
+	"context"
+	"testing"
+
+	"github.com/juju/retry"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/client/client"
+	"github.com/juju/juju/internal/cmd"
+	jujussh "github.com/juju/juju/internal/network/ssh"
+	"github.com/juju/juju/rpc/params"
+)
+
+type PTYSuite struct{}
+
+var _ = gc.Suite(&PTYSuite{})
+
+func TestPTY(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type mockSSHProvider struct {
+	args       []string
+	ptyEnabled bool
+	target     *resolvedTarget
+}
+
+// Implement sshProvider interface methods
+func (m *mockSSHProvider) initRun(context.Context, ModelCommand) error { return nil }
+func (m *mockSSHProvider) cleanupRun()                                 {}
+func (m *mockSSHProvider) setLeaderAPI(context.Context, LeaderAPI)     {}
+func (m *mockSSHProvider) setHostChecker(jujussh.ReachableChecker)     {}
+func (m *mockSSHProvider) resolveTarget(context.Context, string) (*resolvedTarget, error) {
+	return &resolvedTarget{host: "0"}, nil
+}
+func (m *mockSSHProvider) maybePopulateTargetViaField(context.Context, *resolvedTarget, func(context.Context, *client.StatusArgs) (*params.FullStatus, error)) error {
+	return nil
+}
+func (m *mockSSHProvider) maybeResolveLeaderUnit(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (m *mockSSHProvider) ssh(ctx Context, enablePty bool, target *resolvedTarget) error {
+	m.ptyEnabled = enablePty
+	m.target = target
+	return nil
+}
+func (m *mockSSHProvider) copy(Context) error { return nil }
+
+func (m *mockSSHProvider) getTarget() string       { return "" }
+func (m *mockSSHProvider) setTarget(target string) {}
+
+func (m *mockSSHProvider) getArgs() []string {
+	return m.args
+}
+func (m *mockSSHProvider) setArgs(args []string) {
+	m.args = args
+}
+
+func (m *mockSSHProvider) setRetryStrategy(retry.CallArgs)          {}
+func (m *mockSSHProvider) setPublicKeyRetryStrategy(retry.CallArgs) {}
+
+func (s *PTYSuite) TestRunPTYLogic(c *gc.C) {
+	tests := []struct {
+		about       string
+		args        []string // args passed to the command (target is args[0])
+		flags       []string // flags like --pty=true
+		isTerminal  bool
+		expectedPTY bool
+	}{
+		{
+			about:       "no command, is terminal -> pty=true",
+			args:        []string{"0"},
+			isTerminal:  true,
+			expectedPTY: true,
+		},
+		{
+			about:       "no command, not terminal -> pty=false",
+			args:        []string{"0"},
+			isTerminal:  false,
+			expectedPTY: false,
+		},
+		{
+			about:       "command provided, is terminal -> pty=false",
+			args:        []string{"0", "ls"},
+			isTerminal:  true,
+			expectedPTY: false,
+		},
+		{
+			about:       "command provided, --pty=true -> pty=true",
+			args:        []string{"0", "ls"},
+			flags:       []string{"--pty=true"},
+			isTerminal:  true,
+			expectedPTY: true,
+		},
+		{
+			about:       "command provided, --pty=false -> pty=false",
+			args:        []string{"0", "ls"},
+			flags:       []string{"--pty=false"},
+			isTerminal:  true,
+			expectedPTY: false,
+		},
+		{
+			about:       "no command, --pty=true -> pty=true",
+			args:        []string{"0"},
+			flags:       []string{"--pty=true"},
+			isTerminal:  false,
+			expectedPTY: true, // forced
+		},
+	}
+
+	for i, t := range tests {
+		c.Logf("test %d: %s", i, t.about)
+
+		mock := &mockSSHProvider{}
+		sshCmd := &sshCommand{
+			provider:   mock,
+			isTerminal: func(interface{}) bool { return t.isTerminal },
+			// sshMachine/sshContainer embedded fields are zero-valued
+		}
+
+		// 1. Simulate flag parsing
+		// Since pty is autoBoolValue, default is nil.
+		if len(t.flags) > 0 {
+			for _, f := range t.flags {
+				if f == "--pty=true" || f == "--pty" {
+					b := true
+					sshCmd.pty.b = &b
+				} else if f == "--pty=false" {
+					b := false
+					sshCmd.pty.b = &b
+				}
+			}
+		}
+
+		// 2. Set Args
+		// args[0] is target. args[1:] are command args.
+		if len(t.args) > 1 {
+			mock.args = t.args[1:]
+		}
+
+		// 3. Run
+		ctx := &cmd.Context{Stdin: nil, Stdout: nil, Stderr: nil}
+		err := sshCmd.Run(ctx)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Assert(mock.ptyEnabled, gc.Equals, t.expectedPTY)
+	}
+}

--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -282,20 +282,26 @@ func (c *sshCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	var pty bool
+	return c.provider.ssh(ctx, c.enablePty(ctx), target)
+}
+
+// enablePty determines whether a pseudo-terminal should be allocated
+// for the SSH session, based on the --pty flag and terminal availability.
+func (c *sshCommand) enablePty(ctx *cmd.Context) bool {
 	if c.pty.b != nil {
-		pty = *c.pty.b
-	} else {
-		// Flag was not specified: create a pty
-		// on the remote side if this process
-		// has a terminal.
-		isTerminal := isTerminal
-		if c.isTerminal != nil {
-			isTerminal = c.isTerminal
-		}
-		pty = isTerminal(ctx.Stdin)
+		return *c.pty.b
 	}
-	return c.provider.ssh(ctx, pty, target)
+	// Flag was not specified.
+	// If a command is supplied, we shouldn't use a pty
+	// unless requested (which is handled above).
+	// If no command is supplied, we use a pty if we have a terminal.
+	if len(c.provider.getArgs()) > 0 {
+		return false
+	}
+	if c.isTerminal != nil {
+		return c.isTerminal(ctx.Stdin)
+	}
+	return isTerminal(ctx.Stdin)
 }
 
 // autoBoolValue is like gnuflag.boolValue, but remembers


### PR DESCRIPTION
Fixes #19576

This PR fixes an issue where juju ssh would unconditionally allocate a PTY (pseudo-terminal) even when a remote command was provided. This caused stdout to contain DOS-style line endings (\r\n), which breaks downstream automation scripts and parsing logic (e.g., populating Bash arrays).

This change aligns juju ssh behavior with standard OpenSSH:

Interactive (No command): PTY allocated (unchanged).

Non-interactive (Command provided): PTY NOT allocated (new behavior).

Explicit Override: Users can still force PTY allocation using -t / --pty if needed.

## Checklist



- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

specific unit tests are added.

## Documentation changes


## Links

**Issue:** Fixes #19576.

**Jira card:** [JUJU-7914](https://warthogs.atlassian.net/browse/JUJU-7914)



[JUJU-7914]: https://warthogs.atlassian.net/browse/JUJU-7914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ