### PR TITLE
feat: update to description pkg sha e19a7ca61eb3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/juju/ansiterm v1.0.0
 	github.com/juju/clock v1.1.1
 	github.com/juju/collections v1.0.4
-	github.com/juju/description/v11 v11.0.0-20251203091952-63fec6169be0
+	github.com/juju/description/v11 v11.0.0-20260115203504-e19a7ca61eb3
 	github.com/juju/errors v1.0.0
 	github.com/juju/gnuflag v1.0.0
 	github.com/juju/gojsonschema v1.0.0
@@ -114,6 +114,7 @@ require (
 	golang.org/x/tools v0.39.0
 	google.golang.org/api v0.256.0
 	google.golang.org/grpc v1.77.0
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/errgo.v1 v1.0.1
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.67.0
@@ -289,7 +290,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251111163417-95abcf5c77ba // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251111163417-95abcf5c77ba // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.4 h1:GjL+aN512m2rVDqhPII7P6qB0e+iYFubz8sqBhZaZtk=
 github.com/juju/collections v1.0.4/go.mod h1:hVrdB0Zwq9wIU1Fl6ItD2+UETeNeOEs+nGvJufVe+0c=
-github.com/juju/description/v11 v11.0.0-20251203091952-63fec6169be0 h1:RnvRXCkRgeHPE26QWWorCnQz78z8NHBZn/EeSUzMkfc=
-github.com/juju/description/v11 v11.0.0-20251203091952-63fec6169be0/go.mod h1:7O7UhXGw29sIx7AoACdKSGq8rmwXkqfGinpCOn0fprE=
+github.com/juju/description/v11 v11.0.0-20260115203504-e19a7ca61eb3 h1:5u7WACJ2dZ39G/oMTNhcf3QHBk29qmGt23SDjVCqgZo=
+github.com/juju/description/v11 v11.0.0-20260115203504-e19a7ca61eb3/go.mod h1:7O7UhXGw29sIx7AoACdKSGq8rmwXkqfGinpCOn0fprE=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=


### PR DESCRIPTION
Use description package sha from https://github.com/juju/description/pull/193 in juju 4. 

Fixes an issue with model migration from 3.6.13 where it fails precheck as 4.0 didn't support description application v14.

## QA steps

Try model migration from 3.6.13 to this code. Should not longer fail with `ERROR target prechecks failed: cannot deserialize model "b5998942-41bd-4b0c-861e-9cbd7a59f3c2" description during prechecks: applications: version 14 not valid (not valid)
`

```
$ js
Model  Controller  Cloud/Region         Version   Timestamp
six    src         localhost/localhost  3.6.13.1  23:05:07Z

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  24.04    active      1  ubuntu  latest/stable   26  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.21.51.92

Machine  State    Address      Inst id        Base          AZ              Message
0        started  10.21.51.92  juju-33e3bd-0  ubuntu@24.04  ubuntu-nuc-two  Running
$ juju migrate six today
Migration started with ID "1db40752-cb50-4a63-8a59-0d5d9c33e3bd:0"
```