### PR TITLE
refactor: secret iaas vault integration test

### DIFF
--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -177,8 +177,28 @@ prepare_vault() {
 	export VAULT_ADDR="https://${vault_public_addr}:8200"
 	mkdir -p ~/snap/vault/common/
 	TMP=$(mktemp -d ~/snap/vault/common/cacert-XXXXX)
-	cert_juju_secret_id=$(juju secrets --format=yaml | yq 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key')
-	juju show-secret "${cert_juju_secret_id}" --reveal --format=yaml | yq '.[].content.certificate' >"$TMP/vault.pem"
+	# Wait for the certificate secret to be created by the vault charm.
+	attempt=0
+	cert_juju_secret_id=""
+	until [[ -n $cert_juju_secret_id ]]; do
+		cert_juju_secret_id=$(juju secrets --format=yaml 2>/dev/null | yq 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key')
+		if [[ -z $cert_juju_secret_id ]]; then
+			if [[ ${attempt} -ge 30 ]]; then
+				red "vault certificate secret not found after 60 seconds."
+				exit 1
+			fi
+			echo "[+] Waiting for vault certificate secret (attempt ${attempt})"
+			sleep 2
+			attempt=$((attempt + 1))
+		fi
+	done
+	echo "[+] $(green 'Found vault certificate secret:') ${cert_juju_secret_id}"
+	cert_content=$(juju show-secret "${cert_juju_secret_id}" --reveal --format=yaml | yq -r '.[] | .content.certificate')
+	if [[ -z $cert_content ]]; then
+		red "Failed to extract certificate from secret."
+		exit 1
+	fi
+	echo "$cert_content" >"$TMP/vault.pem"
 	export VAULT_CAPATH="$TMP/vault.pem"
 	vault status || true
 	vault_init_output=$(vault operator init -key-shares=5 -key-threshold=3 -format json)


### PR DESCRIPTION
This change makes the failure mode explicit by clearly pointing to the vault status || true line as the source of the issue. Previously, this entire section failed silently (i.e. without logging “Found vault certificate secret”) when the check failed due to vault status. It was unclear whether the problem was due to the certificate not being ready. With this change, we can at least rule that error out. 

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages


## Links
**Relevant Github PR:** https://github.com/juju/juju/pull/21508