### PR TITLE
fix: k8s missing secret backend value integration test

### DIFF
--- a/tests/suites/secrets_iaas/k8s.sh
+++ b/tests/suites/secrets_iaas/k8s.sh
@@ -11,7 +11,7 @@ run_secrets_k8s() {
 	model_name='model-secrets-k8s-charm-owned'
 	add_model "$model_name"
 	juju --show-log model-secret-backend myk8s -m "$model_name"
-	check_secrets "${model_name}-local"
+	check_secrets "myk8s"
 	destroy_model "$model_name"
 
 	model_name='model-secrets-k8s-model-owned'


### PR DESCRIPTION
Minor fix for integration test running k8s secret on iaas

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages


## Links
**Relevant Github PR:** https://github.com/juju/juju/pull/21508