### PR TITLE
ci: remove automatic PostgreSQL K8s workflow trigger on pull requests

### DIFF
--- a/.github/workflows/postgresql-k8s.yml
+++ b/.github/workflows/postgresql-k8s.yml
@@ -2,8 +2,6 @@ name: "Smoke"
 on:
   push:
     branches: ["[0-9].[0-9]+", "[0-9].[0-9]+.[0-9]+", main]
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove the `pull_request` trigger configuration from the PostgreSQL K8s workflow to make it manual-only via `workflow_dispatch`. This prevents automatic test execution on every pull request event.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
just paases cheks
```

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
