### PR TITLE
feat: prevent gocheck from landing in 4.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,22 +174,22 @@ See the project's [coding style guide](STYLE.md), the coding style guidelines us
 Some tests may require local lxd to be installed, see
 [installing lxd via snap](https://stgraber.org/2016/10/17/lxd-snap-available/).
 
-Juju uses the `gocheck` testing framework, which is automatically installed
-as a dependency of `juju`. You can read more about `gocheck` at
-http://godoc.org/gopkg.in/check.v1. `gocheck` is integrated into the source of
-each package so the standard `go test` command is used to run `gocheck` tests.
+Juju uses the `tc` testing framework, which is automatically installed
+as a dependency of `juju`. You can read more about `tc` at
+http://godoc.org/github.com/juju/tc. `tc` is integrated into the source of
+each package so the standard `go test` command is used to run `tc` tests.
 For example:
 
 ```
 go test -v github.com/juju/juju/core/config
 ```
 
-By default `gocheck` will run all tests
-in a package, selected tests can by run by passing `-gocheck.f` to match a
+By default `tc` will run all tests
+in a package, selected tests can by run by passing `-run` to match a
 subset of test names.
 
 ```
-go test -gocheck.f '$REGEX'
+go test -run='$REGEX'
 ```
 
 

--- a/Makefile
+++ b/Makefile
@@ -626,7 +626,7 @@ vendor-dependencies:
 ## vendor-dependencies: updates vendored dependencies
 	@go mod vendor
 
-GOCHECK_COUNT="$(shell go list -f '{{join .Deps "\n"}}' ${PROJECT}/... | grep -c "gopkg.in/check.v*")"
+GOCHECK_COUNT="$(shell go list -f '{{join .Deps "\n"}}' ${PROJECT}/... | grep -c "github.com/juju/tc*")"
 .PHONY: check-deps
 check-deps:
 ## check-deps: Check dependencies are correct versions

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/utils/v4"
-	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api"
@@ -697,7 +696,7 @@ func (s *AddModelSuite) TestNamespaceAnnotationsErr(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `cannot create model "foobar": a namespace called "foobar" already exists on this k8s cluster. Please pick a different model name.`)
 }
 
-func (s *AddModelSuite) TestSpecifyingTargetControllerFlag(c *gc.C) {
+func (s *AddModelSuite) TestSpecifyingTargetControllerFlag(c *tc.C) {
 	_, err := s.run(c, "test", "--target-controller", "test-target-controller")
 	c.Assert(err, tc.ErrorIs, cmd.ErrCommandMissing)
 }

--- a/domain/application/import_integration_test.go
+++ b/domain/application/import_integration_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/description/v11"
 	"github.com/juju/tc"
-	"gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/database"
@@ -1245,7 +1244,7 @@ func (s *importSuite) TestApplicationExposedEndpoints(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	obtained, err := s.svc.GetExposedEndpoints(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(obtained, check.DeepEquals, map[string]application.ExposedEndpoint{
+	c.Check(obtained, tc.DeepEquals, map[string]application.ExposedEndpoint{
 		"db": {ExposeToSpaceIDs: set.Strings{"space-uuid": true},
 			ExposeToCIDRs: set.Strings{"198.51.100.42/24": true}}})
 }

--- a/go.mod
+++ b/go.mod
@@ -309,7 +309,7 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
 // until the issue is resolved.
 replace go.uber.org/mock => go.uber.org/mock v0.4.0
 
-replace gopkg.in/check.v1 => github.com/hpidcock/gc-compat-tc v0.0.0-20250523041742-c3a83c867edf
+replace gopkg.in/check.v1 => github.com/hpidcock/gc-compat-tc v0.0.0-20260112233041-5b2ef070e94b
 
 replace github.com/juju/testing => ./internal/testhelpers/compat
 

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/hashicorp/vault/api v1.10.0 h1:/US7sIjWN6Imp4o/Rj1Ce2Nr5bki/AXi9vAW3p
 github.com/hashicorp/vault/api v1.10.0/go.mod h1:jo5Y/ET+hNyz+JnKDt8XLAdKs+AM0G5W0Vp1IrFI8N8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hpidcock/gc-compat-tc v0.0.0-20250523041742-c3a83c867edf h1:sFwkVpTbk799e1EPlDfWLULd5/+w5EuMv2z5koBa908=
-github.com/hpidcock/gc-compat-tc v0.0.0-20250523041742-c3a83c867edf/go.mod h1:lyEaDukSWSGyb/L0YGDaS1hU2p40qb5s/Ck6qm4CneU=
+github.com/hpidcock/gc-compat-tc v0.0.0-20260112233041-5b2ef070e94b h1:JpZH2VBCeWlQTRzWYRDvlru3/ZOQjEgMjfEbGWK9hTY=
+github.com/hpidcock/gc-compat-tc v0.0.0-20260112233041-5b2ef070e94b/go.mod h1:lyEaDukSWSGyb/L0YGDaS1hU2p40qb5s/Ck6qm4CneU=
 github.com/icza/backscanner v0.0.0-20241124160932-dff01ac50250 h1:BNmTcPx0VddsU1pIgq3GoXtO8ek6tygVtj+l37Dcqo0=
 github.com/icza/backscanner v0.0.0-20241124160932-dff01ac50250/go.mod h1:GYeBD1CF7AqnKZK+UCytLcY3G+UKo0ByXX/3xfdNyqQ=
 github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=

--- a/internal/worker/caasadmission/handler_test.go
+++ b/internal/worker/caasadmission/handler_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/juju/tc"
-	gc "gopkg.in/check.v1"
 	admission "k8s.io/api/admission/v1beta1"
 	authentication "k8s.io/api/authentication/v1"
 	core "k8s.io/api/core/v1"
@@ -354,11 +353,11 @@ func (h *HandlerSuite) TestPatchLabelsReplace(c *tc.C) {
 
 	managedByPath := fmt.Sprintf("/metadata/labels/%s", patchEscape(constants.LabelKubernetesAppManaged))
 	for _, op := range patchOperations {
-		c.Check(op.Path, gc.Not(gc.Equals), managedByPath)
+		c.Check(op.Path, tc.Not(tc.Equals), managedByPath)
 	}
 }
 
-func (h *HandlerSuite) TestPatchForLabelsSkipManagedByLabelReplace(c *gc.C) {
+func (h *HandlerSuite) TestPatchForLabelsSkipManagedByLabelReplace(c *tc.C) {
 	labels := map[string]string{
 		constants.LabelJujuAppCreatedBy:     "spark",
 		constants.LabelKubernetesAppManaged: "spark8t",
@@ -381,17 +380,17 @@ func (h *HandlerSuite) TestPatchForLabelsSkipManagedByLabelReplace(c *gc.C) {
 	var foundCreatedByAddLabelOp bool
 	for _, op := range patchOperations {
 		if op.Path == createdByPath {
-			c.Check(op.Op, gc.Equals, replaceOp)
+			c.Check(op.Op, tc.Equals, replaceOp)
 			foundCreatedByAddLabelOp = true
 		}
 		// Ensure no managed-by label ops are present for replace.
-		c.Check(op.Path, gc.Not(gc.Equals), managedByPath)
+		c.Check(op.Path, tc.Not(tc.Equals), managedByPath)
 	}
 
 	c.Check(foundCreatedByAddLabelOp, tc.IsTrue)
 }
 
-func (h *HandlerSuite) TestPatchForLabelsRetainsManagedByLabelAdd(c *gc.C) {
+func (h *HandlerSuite) TestPatchForLabelsRetainsManagedByLabelAdd(c *tc.C) {
 	labels := map[string]string{
 		"not-a-defined-label": "spark8t",
 	}
@@ -415,10 +414,10 @@ func (h *HandlerSuite) TestPatchForLabelsRetainsManagedByLabelAdd(c *gc.C) {
 	for _, op := range patchOperations {
 		switch op.Path {
 		case createdByPath:
-			c.Check(op.Op, gc.Equals, addOp)
+			c.Check(op.Op, tc.Equals, addOp)
 			foundCreatedByAddLabelOp = true
 		case managedByPath:
-			c.Check(op.Op, gc.Equals, addOp)
+			c.Check(op.Op, tc.Equals, addOp)
 			foundManagedByAddLabelOp = true
 		}
 	}

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -2754,7 +2754,12 @@ func (s *NoneModeSuite) TestStopImmediately(c *tc.C) {
 	}
 
 	fw, err := firewaller.NewFirewaller(cfg)
-	defer workertest.CheckNilOrKill(c, fw)
+	defer func() {
+		if fw == nil {
+			return
+		}
+		workertest.CleanKill(c, fw)
+	}()
 	c.Assert(err, tc.ErrorMatches, `invalid firewall-mode "none"`)
 }
 

--- a/internal/worker/httpserver/manifold_test.go
+++ b/internal/worker/httpserver/manifold_test.go
@@ -225,8 +225,10 @@ func (s *ManifoldSuite) TestValidate(c *tc.C) {
 		test.f(&config)
 		manifold := httpserver.Manifold(config)
 		w, err := manifold.Start(c.Context(), s.getter)
-		workertest.CheckNilOrKill(c, w)
 		c.Check(err, tc.ErrorMatches, test.expect)
+		if w != nil {
+			workertest.CleanKill(c, w)
+		}
 	}
 }
 

--- a/internal/worker/httpserverargs/manifold_test.go
+++ b/internal/worker/httpserverargs/manifold_test.go
@@ -184,8 +184,10 @@ func (s *ManifoldSuite) TestValidate(c *tc.C) {
 
 		manifold := httpserverargs.Manifold(config)
 		w, err := manifold.Start(c.Context(), s.getter)
-		workertest.CheckNilOrKill(c, w)
 		c.Check(err, tc.ErrorMatches, test.expect)
+		if w != nil {
+			workertest.CleanKill(c, w)
+		}
 	}
 }
 


### PR DESCRIPTION
gocheck is being actively used in < 4.x, but everytime someone merges forward they keep bring in the gocheck dependency. When we transitioned from gocheck to juju/tc we made a compatability layer that allowed us to do incremently. Now that compat layer panics everytime it's used. This will cause any merge forward to fail. This will prevent anyone using gc in 4.x juju.

I'm tired of fixing this after every merge, so I'm pulling out a big hammer here.

Hammer: https://github.com/hpidcock/gc-compat-tc/pull/1


## QA steps

Remove the following commit [refactor: use tc instead of gc](https://github.com/juju/juju/commit/2e0c7acd5fb14edbf140f092daed603a80aecb77), then run `go test -v ./internal/worker/caasadmission`

You should see a massive panic...

```
go test -v ./internal/worker/caasadmission
=== RUN   TestHandlerSuite
=== RUN   TestHandlerSuite/TestCompareGroupVersionKind
    /home/simon-richardson/go/src/github.com/juju/juju/internal/worker/caasadmission/handler_test.go:58
=== RUN   TestHandlerSuite/TestEmptyBodyFails
    /home/simon-richardson/go/src/github.com/juju/juju/internal/worker/caasadmission/handler_test.go:106
=== RUN   TestHandlerSuite/TestPatchForLabelsRetainsManagedByLabelAdd
    /home/simon-richardson/go/src/github.com/juju/juju/internal/worker/caasadmission/handler_test.go:394
--- FAIL: TestHandlerSuite (0.00s)
    --- PASS: TestHandlerSuite/TestCompareGroupVersionKind (0.00s)
    --- PASS: TestHandlerSuite/TestEmptyBodyFails (0.00s)
    --- FAIL: TestHandlerSuite/TestPatchForLabelsRetainsManagedByLabelAdd (0.00s)
panic: use tc.C [recovered, repanicked]

goroutine 61 [running]:
testing.tRunner.func1.2({0x222bea0, 0x2b14330})
        /home/simon-richardson/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
        /home/simon-richardson/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/testing/testing.go:1875 +0x35b
panic({0x222bea0?, 0x2b14330?})
        /home/simon-richardson/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/runtime/panic.go:783 +0x132
gopkg.in/check%2ev1.panicChecker.Info(...)
        /home/simon-richardson/go/pkg/mod/github.com/hpidcock/gc-compat-tc@v0.0.0-20260112233041-5b2ef070e94b/compat.go:47
github.com/juju/tc.internalCheck({0x2b6ee08, 0xc0003d9c80}, {0x279bfd2, 0x5}, {0x222bea0, 0xc000598df0}, {0x2b26bd8, 0x40c6e00}, {0xc00001b688, 0x1, ...})
        /home/simon-richardson/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/helpers.go:145 +0x34f
github.com/juju/tc.(*C).Check(0xc0003d9c80, {0x222bea0, 0xc000598df0}, {0x2b26bd8, 0x40c6e00}, {0xc00001b688, 0x1, 0x1})
        /home/simon-richardson/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/helpers.go:91 +0xb0
github.com/juju/juju/internal/worker/caasadmission.(*HandlerSuite).TestPatchForLabelsRetainsManagedByLabelAdd(0xc0003d9a40, 0xc0003d9c80)
        /home/simon-richardson/go/src/github.com/juju/juju/internal/worker/caasadmission/handler_test.go:421 +0x3fd
reflect.Value.call({0x262f3c0?, 0xc0003d9a40?, 0x559aac?}, {0x279b35e, 0x4}, {0xc00001bd78, 0x1, 0x2?})
        /home/simon-richardson/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/reflect/value.go:581 +0xcc6
reflect.Value.Call({0x262f3c0?, 0xc0003d9a40?, 0x400c0000e5d38?}, {0xc00001bd78?, 0x21d7480?, 0x20?})
        /home/simon-richardson/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/reflect/value.go:365 +0xb9
github.com/juju/tc.(*methodType).Call(0xc00029fce0, 0xc0003d9c80)
        /home/simon-richardson/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/check.go:88 +0x16e
github.com/juju/tc.(*suiteRunner).runTest(0xc000419770, 0xc000583500, 0xc00029fce0)
        /home/simon-richardson/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/check.go:225 +0x47b
github.com/juju/tc.(*suiteRunner).run.func3(0xc000583500?)
        /home/simon-richardson/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/check.go:184 +0x25
testing.tRunner(0xc000583500, 0xc0000136b0)
        /home/simon-richardson/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 58
        /home/simon-richardson/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/testing/testing.go:1997 +0x465
FAIL    github.com/juju/juju/internal/worker/caasadmission      0.017s
FAIL
```

