### PR TITLE
fix: remove internal type for MakeOrigin

### DIFF
--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -108,7 +108,7 @@ func (s *BundleDeploySuite) setupCharmMaybeForce(c *tc.C, url, name string, abas
 					OS:           b.OS,
 					Channel:      b.Channel.Track,
 				}
-				origin, err := apputils.MakeOrigin(charm.Schema(url.Schema), url.Revision, charm.Channel{}, platform)
+				origin, err := apputils.MakeOrigin(apputils.Schema(url.Schema), url.Revision, apputils.Channel{}, platform)
 				c.Assert(err, tc.ErrorIsNil)
 
 				s.fakeAPI.Call("ResolveCharm", url, origin, false).Returns(
@@ -152,7 +152,7 @@ func (s *BundleDeploySuite) setupFakeBundle(c *tc.C, url string, allBase ...base
 	// Resolve a bundle with no revision and return a url with a version.  Ensure
 	// GetBundle expects the url with revision.
 	for _, b := range allBase {
-		origin, err := apputils.MakeOrigin(charm.Schema(bundleResolveURL.Schema), bundleResolveURL.Revision, charm.Channel{}, corecharm.Platform{
+		origin, err := apputils.MakeOrigin(apputils.Schema(bundleResolveURL.Schema), bundleResolveURL.Revision, apputils.Channel{}, corecharm.Platform{
 			OS: b.OS, Channel: b.Channel.Track})
 		c.Assert(err, tc.ErrorIsNil)
 		origin.Revision = nil

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1668,7 +1668,7 @@ func withCharmDeployableWithDevicesAndStorage(
 ) {
 	deployURL := *url
 	platform := apputils.MakePlatform(constraints.Value{}, base, constraints.Value{})
-	origin, _ := apputils.MakeOrigin(charm.Schema(url.Schema), url.Revision, charm.Channel{}, platform)
+	origin, _ := apputils.MakeOrigin(apputils.Schema(url.Schema), url.Revision, apputils.Channel{}, platform)
 	fakeAPI.Call("AddCharm", &deployURL, origin, force).Returns(origin, error(nil))
 	fakeAPI.Call("CharmInfo", deployURL.String()).Returns(
 		&apicommoncharms.CharmInfo{

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -348,7 +348,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints(ctx context.Context) error {
 		}
 
 		// We return early with local charms, so here we know the charm must be from charmhub.
-		channel, origin, err := h.constructChannelAndOrigin(charm.CharmHub, ch.Revision, base, spec.Channel, cons)
+		channel, origin, err := h.constructChannelAndOrigin(utils.CharmHub, ch.Revision, base, spec.Channel, cons)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -417,7 +417,7 @@ func (h *bundleHandler) resolveCharmChannelAndRevision(ctx context.Context, char
 	}
 
 	// We return early with local charms, so here we know the charm must be from charmhub.
-	_, origin, err := h.constructChannelAndOrigin(charm.CharmHub, ch.Revision, charmBase, charmChannel, cons)
+	_, origin, err := h.constructChannelAndOrigin(utils.CharmHub, ch.Revision, charmBase, charmChannel, cons)
 
 	if err != nil {
 		return "", -1, errors.Trace(err)
@@ -437,7 +437,7 @@ func (h *bundleHandler) resolveCharmChannelAndRevision(ctx context.Context, char
 // constructChannelAndOrigin attempts to construct a fully qualified channel
 // along with an origin that matches the hardware constraints and the charm url
 // source.
-func (h *bundleHandler) constructChannelAndOrigin(schema charm.Schema, revision int, charmBase corebase.Base, charmChannel string, cons constraints.Value) (charm.Channel, commoncharm.Origin, error) {
+func (h *bundleHandler) constructChannelAndOrigin(schema utils.Schema, revision int, charmBase corebase.Base, charmChannel string, cons constraints.Value) (charm.Channel, commoncharm.Origin, error) {
 	var channel charm.Channel
 	if charmChannel != "" {
 		var err error
@@ -447,7 +447,11 @@ func (h *bundleHandler) constructChannelAndOrigin(schema charm.Schema, revision 
 	}
 
 	platform := utils.MakePlatform(cons, charmBase, h.modelConstraints)
-	origin, err := utils.MakeOrigin(schema, revision, channel, platform)
+	origin, err := utils.MakeOrigin(schema, revision, utils.Channel{
+		Track:  channel.Track,
+		Risk:   channel.Risk.String(),
+		Branch: channel.Branch,
+	}, platform)
 	if err != nil {
 		return charm.Channel{}, commoncharm.Origin{}, errors.Trace(err)
 	}
@@ -625,7 +629,11 @@ func (h *bundleHandler) addCharm(ctx context.Context, change *bundlechanges.AddC
 
 	platform := utils.MakePlatform(cons, base, h.modelConstraints)
 	// We return early with local charms, so here we know the charm must be from charmhub.
-	origin, err := utils.MakeOrigin(charm.CharmHub, revision, channel, platform)
+	origin, err := utils.MakeOrigin(utils.CharmHub, revision, utils.Channel{
+		Track:  channel.Track,
+		Risk:   channel.Risk.String(),
+		Branch: channel.Branch,
+	}, platform)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -26,6 +26,7 @@ import (
 	commoncharm "github.com/juju/juju/api/common/charm"
 	apicharms "github.com/juju/juju/api/common/charms"
 	"github.com/juju/juju/cmd/juju/application/deployer/mocks"
+	apputils "github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/modelcmd"
 	corebase "github.com/juju/juju/core/base"
 	corecharm "github.com/juju/juju/core/charm"
@@ -2563,7 +2564,7 @@ func (s *BundleHandlerOriginSuite) TestConstructChannelAndOrigin(c *tc.C) {
 		Arch: &arch,
 	}
 
-	resultChannel, resultOrigin, err := handler.constructChannelAndOrigin(charm.CharmHub, -1, base, channel, cons)
+	resultChannel, resultOrigin, err := handler.constructChannelAndOrigin(apputils.CharmHub, -1, base, channel, cons)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(resultChannel, tc.DeepEquals, corecharm.MustParseChannel("stable"))
 	c.Assert(resultOrigin, tc.DeepEquals, commoncharm.Origin{
@@ -2584,7 +2585,7 @@ func (s *BundleHandlerOriginSuite) TestConstructChannelAndOriginEmptyChannel(c *
 		Arch: &arch,
 	}
 
-	resultChannel, resultOrigin, err := handler.constructChannelAndOrigin(charm.CharmHub, -1, base, channel, cons)
+	resultChannel, resultOrigin, err := handler.constructChannelAndOrigin(apputils.CharmHub, -1, base, channel, cons)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(resultChannel, tc.DeepEquals, charm.Channel{})
 	c.Assert(resultOrigin, tc.DeepEquals, commoncharm.Origin{

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -246,7 +246,7 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 
 	ctx.Infof("%s", formatLocatedText(d.userCharmURL, commoncharm.Origin{}))
 	platform := utils.MakePlatform(d.constraints, d.base, d.modelConstraints)
-	origin, err := utils.MakeOrigin(charm.Local, userCharmURL.Revision, charm.Channel{}, platform)
+	origin, err := utils.MakeOrigin(utils.Local, userCharmURL.Revision, utils.Channel{}, platform)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -288,7 +288,7 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 
 	platform := utils.MakePlatform(l.constraints, l.base, l.modelConstraints)
 	// Local charms don't need a channel.
-	origin, err := utils.MakeOrigin(charm.Local, curl.Revision, charm.Channel{}, platform)
+	origin, err := utils.MakeOrigin(utils.Local, curl.Revision, utils.Channel{}, platform)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -150,7 +150,11 @@ func (d *factory) GetDeployer(ctx context.Context, cfg DeployerConfig, deployAPI
 
 		// Make the origin
 		platform := utils.MakePlatform(d.constraints, d.base, d.modelConstraints)
-		origin, err := utils.MakeOrigin(charm.CharmHub, revision, d.channel, platform)
+		origin, err := utils.MakeOrigin(utils.CharmHub, revision, utils.Channel{
+			Track:  d.channel.Track,
+			Risk:   d.channel.Risk.String(),
+			Branch: d.channel.Branch,
+		}, platform)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -307,7 +307,11 @@ func (c *diffBundleCommand) bundleDataSource(ctx *cmd.Context, apiRoot base.APIC
 		Arch: &c.arch,
 	}, base, modelConstraints)
 	// We return early with local bundles, so here we know the bundle must be from charmhub
-	origin, err := utils.MakeOrigin(charm.CharmHub, bURL.Revision, c.channel, platform)
+	origin, err := utils.MakeOrigin(utils.CharmHub, bURL.Revision, utils.Channel{
+		Track:  c.channel.Track,
+		Risk:   c.channel.Risk.String(),
+		Branch: c.channel.Branch,
+	}, platform)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -504,7 +504,7 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := apputils.MakeOrigin(charm.Schema(s.resolvedCharmURL.Schema), s.resolvedCharmURL.Revision, charm.Channel{Risk: charm.Beta}, corecharm.Platform{
+	origin, _ := apputils.MakeOrigin(apputils.Schema(s.resolvedCharmURL.Schema), s.resolvedCharmURL.Revision, apputils.Channel{Risk: charm.Beta.String()}, corecharm.Platform{
 		Architecture: arch.DefaultArchitecture,
 	})
 	origin.ID = "testing"
@@ -563,7 +563,7 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *tc.C)
 	c.Assert(err, tc.ErrorIsNil)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := apputils.MakeOrigin(charm.Schema(s.resolvedCharmURL.Schema), s.resolvedCharmURL.Revision, charm.Channel{Risk: charm.Beta}, s.testPlatform)
+	origin, _ := apputils.MakeOrigin(apputils.Schema(s.resolvedCharmURL.Schema), s.resolvedCharmURL.Revision, apputils.Channel{Risk: charm.Beta.String()}, s.testPlatform)
 	origin.ID = "testing"
 	origin.Revision = (*int)(nil)
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
@@ -601,7 +601,7 @@ func (s *RefreshSuite) TestSwitch(c *tc.C) {
 	s.charmClient.CheckCallNames(c, "CharmInfo", "CharmInfo")
 	s.charmClient.CheckCall(c, 0, "CharmInfo", s.resolvedCharmURL.String())
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := apputils.MakeOrigin(charm.Schema(s.resolvedCharmURL.Schema), s.resolvedCharmURL.Revision, charm.Channel{Risk: charm.Stable}, s.testPlatform)
+	origin, _ := apputils.MakeOrigin(apputils.Schema(s.resolvedCharmURL.Schema), s.resolvedCharmURL.Revision, apputils.Channel{Risk: charm.Stable.String()}, s.testPlatform)
 
 	c.Assert(err, tc.ErrorIsNil)
 	origin.Revision = (*int)(nil)

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -306,7 +306,11 @@ func (r baseRefresher) ResolveCharm(ctx context.Context) (*charm.URL, commonchar
 // stdOriginResolver attempts to resolve the origin required to resolve a
 // charm.
 func stdOriginResolver(curl *charm.URL, origin corecharm.Origin, channel charm.Channel) (commoncharm.Origin, error) {
-	result, err := utils.MakeOrigin(charm.Schema(curl.Schema), curl.Revision, channel, origin.Platform)
+	result, err := utils.MakeOrigin(utils.Schema(curl.Schema), curl.Revision, utils.Channel{
+		Track:  channel.Track,
+		Risk:   channel.Risk.String(),
+		Branch: channel.Branch,
+	}, origin.Platform)
 	if err != nil {
 		return commoncharm.Origin{}, errors.Trace(err)
 	}

--- a/cmd/juju/application/store/store_test.go
+++ b/cmd/juju/application/store/store_test.go
@@ -35,7 +35,7 @@ func (s *storeSuite) TestAddCharmFromURLAddCharmSuccess(c *tc.C) {
 
 	curl, err := charm.ParseURL("ch:testme")
 	c.Assert(err, tc.ErrorIsNil)
-	origin, err := utils.MakeOrigin(charm.CharmHub, -1, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.MakeOrigin(utils.CharmHub, -1, utils.Channel{Risk: charm.Beta.String()}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, tc.ErrorIsNil)
 
 	obtainedCurl, _, err := store.AddCharmFromURL(
@@ -54,7 +54,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFail(c *tc.C) {
 	s.expectAddCharm(errors.NotFoundf("testing"))
 	curl, err := charm.ParseURL("ch:testme")
 	c.Assert(err, tc.ErrorIsNil)
-	origin, err := utils.MakeOrigin(charm.CharmHub, -1, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.MakeOrigin(utils.CharmHub, -1, utils.Channel{Risk: charm.Beta.String()}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, tc.ErrorIsNil)
 
 	obtainedCurl, _, err := store.AddCharmFromURL(
@@ -76,7 +76,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFailUnauthorized(c *tc.C) {
 	})
 	curl, err := charm.ParseURL("ch:testme")
 	c.Assert(err, tc.ErrorIsNil)
-	origin, err := utils.MakeOrigin(charm.CharmHub, -1, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.MakeOrigin(utils.CharmHub, -1, utils.Channel{Risk: charm.Beta.String()}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, tc.ErrorIsNil)
 
 	obtainedCurl, _, err := store.AddCharmFromURL(

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -10,22 +10,21 @@ import (
 	corebase "github.com/juju/juju/core/base"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/internal/charm"
 )
 
 // MakeOrigin creates an origin from a schema, revision, channel and a platform.
 // Depending on what the schema is, will then construct the correct
 // origin for that application.
-func MakeOrigin(schema charm.Schema, revision int, channel charm.Channel, platform corecharm.Platform) (commoncharm.Origin, error) {
+func MakeOrigin(schema Schema, revision int, channel Channel, platform corecharm.Platform) (commoncharm.Origin, error) {
 
 	var origin commoncharm.Origin
 	switch schema {
-	case charm.Local:
+	case Local:
 		origin = commoncharm.Origin{
 			Source:       commoncharm.OriginLocal,
 			Architecture: platform.Architecture,
 		}
-	case charm.CharmHub:
+	case CharmHub:
 		var track *string
 		if channel.Track != "" {
 			track = &channel.Track
@@ -36,7 +35,7 @@ func MakeOrigin(schema charm.Schema, revision int, channel charm.Channel, platfo
 		}
 		origin = commoncharm.Origin{
 			Source:       commoncharm.OriginCharmHub,
-			Risk:         string(channel.Risk),
+			Risk:         channel.Risk,
 			Track:        track,
 			Branch:       branch,
 			Architecture: platform.Architecture,

--- a/cmd/juju/application/utils/types.go
+++ b/cmd/juju/application/utils/types.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+// Channel identifies and describes completely a store channel.
+//
+// A channel consists of, and is subdivided by, tracks, risk-levels and
+// branches:
+//   - Tracks enable snap developers to publish multiple supported releases of
+//     their application under the same snap name.
+//   - Risk-levels represent a progressive potential trade-off between stability
+//     and new features.
+//   - Branches are _optional_ and hold temporary releases intended to help with
+//     bug-fixing.
+//
+// The complete channel name can be structured as three distinct parts separated
+// by slashes:
+//
+//	<track>/<risk>/<branch>
+type Channel struct {
+	Track  string
+	Risk   string
+	Branch string
+}
+
+// Platform describes the platform used to install the charm with.
+type Platform struct {
+	Architecture string
+	// TODO: This should be of type ostype.OSType
+	OS      string
+	Channel string
+}
+
+// Schema represents the source of the charm.
+type Schema string
+
+const (
+	// Local represents a local charm.
+	Local Schema = "local"
+	// CharmHub represents a charm from the new charmHub.
+	CharmHub Schema = "charm-hub"
+)

--- a/cmd/juju/application/utils/types_test.go
+++ b/cmd/juju/application/utils/types_test.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/juju/juju/cmd/juju/application/utils"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/charm"
+)
+
+type typeSuite struct{}
+
+func TestTypeSuite(t *testing.T) {
+	tc.Run(t, &typeSuite{})
+}
+
+func (*typeSuite) TestSourceMatchSourceInternal(c *tc.C) {
+	c.Assert(string(utils.Local), tc.Equals, charm.Local.String())
+	c.Assert(string(utils.CharmHub), tc.Equals, charm.CharmHub.String())
+}


### PR DESCRIPTION
# Description

Before MakeOrigin's args were internal types, making impossible to call this function from the terraform provider. Copy paste Channel and Schema to types.go in the utils pkg and fix compile errors.

BREAKING CHANGE: MakeOrigin use different types which requires manual intervention to fix.

# Follow-ups
This is just an example on how to tackle compile problems in the terraform provider switching to juju 4 dependency.
Here is a comprehensive list:
- https://github.com/juju/juju/blob/main/cmd/juju/common/authkeys.go#L36 using cmd from internal
- https://github.com/juju/juju/blob/main/cmd/juju/application/utils/origin.go#L19 using charm from internal
- https://github.com/juju/juju/blob/main/api/client/charms/client.go#L148 using charm from internal
- https://github.com/juju/juju/blob/main/api/common/charms/common.go#L66 using charm from internal
- https://github.com/juju/juju/blob/main/core/resource/resource.go#L33 using resource from internal
- https://github.com/juju/juju/blob/main/api/client/resources/client.go#L157 using charmresource from internal
I've also noticed the new client doesn't implement UploadPendingResource("context".Context, string, "github.com/juju/charm/v12/resource".Resource, string, io.ReadSeeker) (string, error) anymore and it implements have UploadPendingResource("context".Context, resources.UploadPendingResourceArgs) (string, error).

