### PR TITLE
fix: facade endpoint AddPendingResources

### DIFF
--- a/apiserver/facades/client/resources/service.go
+++ b/apiserver/facades/client/resources/service.go
@@ -43,9 +43,6 @@ type ResourceService interface {
 
 // ApplicationService defines methods to manage application.
 type ApplicationService interface {
-	// GetApplicationUUIDByName returns an application UUID by application name.
-	GetApplicationUUIDByName(ctx context.Context, name string) (coreapplication.UUID, error)
-
 	// GetApplicationDetailsByName returns the application details for the given
 	// application name. This includes the UUID, life status, name, and whether
 	// the application is synthetic.

--- a/apiserver/facades/client/resources/service_mock_test.go
+++ b/apiserver/facades/client/resources/service_mock_test.go
@@ -84,45 +84,6 @@ func (c *MockApplicationServiceGetApplicationDetailsByNameCall) DoAndReturn(f fu
 	return c
 }
 
-// GetApplicationUUIDByName mocks base method.
-func (m *MockApplicationService) GetApplicationUUIDByName(arg0 context.Context, arg1 string) (application.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetApplicationUUIDByName", arg0, arg1)
-	ret0, _ := ret[0].(application.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetApplicationUUIDByName indicates an expected call of GetApplicationUUIDByName.
-func (mr *MockApplicationServiceMockRecorder) GetApplicationUUIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationUUIDByNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationUUIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationUUIDByName), arg0, arg1)
-	return &MockApplicationServiceGetApplicationUUIDByNameCall{Call: call}
-}
-
-// MockApplicationServiceGetApplicationUUIDByNameCall wrap *gomock.Call
-type MockApplicationServiceGetApplicationUUIDByNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Return(arg0 application.UUID, arg1 error) *MockApplicationServiceGetApplicationUUIDByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetApplicationUUIDByNameCall) Do(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetApplicationUUIDByNameCall) DoAndReturn(f func(context.Context, string) (application.UUID, error)) *MockApplicationServiceGetApplicationUUIDByNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // MockResourceService is a mock of ResourceService interface.
 type MockResourceService struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
AddPendingResources, as per the description, can be used to add pending resources for applications which don't yet exist.

However, we were calling the service method GetApplicationDetails without handing the ApplicationNotFound error.

Fix this facade endpoint to handle this case correctly. Also, optimise the facade by removing a superfluous service call.

## QA steps

```
$ cat bundle.yaml 
applications:
  juju-qa-test:
    charm: juju-qa-test
    num_units: 1

$ juju deploy ./bundle.yaml
Located charm "juju-qa-test" in charm-hub, channel latest/stable
Executing changes:
- upload charm juju-qa-test from charm-hub
- deploy application juju-qa-test from charm-hub
  added resource foo-file
- add unit juju-qa-test/0 to new machine 0
Deploy of bundle completed.

$ juju status
Model  Controller  Cloud/Region   Version  Timestamp
model  lxd         lxd/localhost  4.0.1.1  12:34:55Z

App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  no       hello

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0*  active    idle   0        10.51.45.7             hello

Machine  State    Address     Inst id        Base          AZ    Message
0        started  10.51.45.7  juju-6cfa0a-0  ubuntu@22.04  jack  Running
```

----

Fixes: https://github.com/juju/juju/issues/21611
