### PR TITLE
chore: merge 3.6 into 4.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,8 @@ git checkout -b 3.6-new-stuff # your feature branch
 
 8. Make the desired changes. Test changes locally.
 
+---
 
-----------------
 <details>
 
 <summary>Further info: Docs</summary>
@@ -130,35 +130,38 @@ errors, try `make clean`, then `make run` again. For other checks, see `make
 
 </details>
 
-----------------
+---
 
-----------------
 <details>
 
 <summary>Further info: Code</summary>
 
-### Installing Go
+### Install prerequisites
 
-`juju` is written in [Go](https://go.dev/). To install Go see [Go
-docs](https://golang.org/doc/install#install).
+#### Install Go 
+To install Go see [Go docs](https://golang.org/doc/install#install).
 
-### Building Juju and its dependencies
+#### Install project dependencies
 
-Fork and clone the Juju repo, then navigate to the root directory and run `make
-install`:
-
+```sh
+make install-dependencies
 ```
-git clone https://github.com/<user>/juju.git
-cd juju
+
+### Build and install Juju
+To compile the Juju source code and install the resulting binaries into your `$GOBIN` directory (typically `~/go/bin`):
+
+```sh
 make install
 ```
+
+> Note: Ensure your PATH includes the Go bin directory so you can run the
+> `juju` command globally.
 
 ### Updating Go dependencies
 
 Juju uses Go modules to manage dependencies. To update a dependency, use the
 following, ensuring that the dependency is using a version where possible, or a
 commit hash if not available:
-
 
 ```
 go get -u github.com/the/dependency@v1.2.3
@@ -209,9 +212,7 @@ For more information see [CODING.md](CODING.md)
 
 </details>
 
-----------------
-
-
+---
 
 9. As you make your changes, ensure that you always remain in sync with the upstream:
 

--- a/README.md
+++ b/README.md
@@ -4,131 +4,17 @@
   <img alt="Juju logo next to the text Canonical Juju" src="docs/.sphinx/_static/logos/juju-logo.png?raw=true" width="30%">
 </picture>
 
-Juju is an open source application orchestration engine that enables any application operation (deployment, integration, lifecycle management) on any infrastructure (Kubernetes or otherwise) at any scale (development or production) in the same easy way (typically, one line of code), through special operators called ‘charms’.
+Juju is an open source application orchestration engine that enables any
+application operation (deployment, integration, lifecycle management) on any
+infrastructure (Kubernetes or otherwise) at any scale (development or
+production) in the same easy way (typically, one line of code), through special
+operators called ‘charms’.
 
 [![juju](https://snapcraft.io/juju/badge.svg)](https://snapcraft.io/juju)
 [![snap](https://github.com/juju/juju/actions/workflows/snap.yml/badge.svg)](https://github.com/juju/juju/actions/workflows/snap.yml)
 [![build](https://github.com/juju/juju/actions/workflows/build.yml/badge.svg)](https://github.com/juju/juju/actions/workflows/build.yml)
 
-
-## Give it a try!
-
-Let's use Juju to deploy, configure, and integrate some Kubernetes charms:
-
-
-### Set up
-
-You will need a cloud and Juju. The quickest way is to use a Multipass VM launched with the `charm-dev` blueprint.
-
-[Install Multipass](https://canonical.com/multipass/docs/install-multipass). On Linux:
-
-```
-sudo snap install multipass
-```
-
-Use Multipass to launch an Ubuntu VM with the `charm-dev` blueprint:
-
-```
-multipass launch --cpus 4 --memory 8G --disk 50G --name tutorial-vm charm-dev
-```
-
-Open a shell into the VM:
-
-```
-multipass shell tutorial-vm
-```
-
-Verify that you have Juju and two localhost clouds:
-
-```
-juju clouds
-```
-
-Bootstrap a Juju controller into the MicroK8s cloud:
-
-```
-juju bootstrap microk8s tutorial-controller
-```
-
-Add a workspace, or 'model':
-
-```
-juju add-model tutorial-model
-```
-
-### Deploy, configure, and integrate a few things
-
-Deploy Mattermost:
-
-```
-juju deploy mattermost-k8s
-```
-> See more: [Charmhub | `mattermost-k8s`](https://charmhub.io/mattermost-k8s)
-
-Deploy PostgreSQL:
-
-```
-juju deploy postgresql-k8s --channel 14/stable --trust
-```
-
-> See more: [Charmhub | `postgresql-k8s`](https://charmhub.io/postgresql-k8s)
-
-Enable security in your PostgreSQL deployment:
-
-```
-juju deploy tls-certificates-operator
-juju config tls-certificates-operator generate-self-signed-certificates="true" ca-common-name="Test CA"
-juju integrate postgresql-k8s tls-certificates-operator
-```
-
-Integrate Mattermost with PostgreSQL:
-
-```
-juju integrate mattermost-k8s postgresql-k8s:db
-```
-
-Watch your deployment come to life:
-
-```
-watch -n 1 -c juju status --color
-```
-
-Use the `--relations` flag to view more information about your integrations.
-Use the `--storage` flag to view more information about your storages.
-
-### Test your deployment
-
-When everything is in `active` or `idle` status, note the IP address and port of Mattermost and pass them to `curl`:
-
-```
-curl <IP address>:<port>/api/v4/system/ping
-```
-
-You should see the output below:
-
-```
-{"AndroidLatestVersion":"","AndroidMinVersion":"","IosLatestVersion":"","IosMinVersion":"","status":"OK"}
-```
-### Congratulations!
-
-You now have a Kubernetes deployment consisting of a Mattermost backed by PosgreSQL with TLS-encrypted traffic!
-
-### Clean up
-
-Delete your Multipass VM:
-
-```
-multipass delete --purge tutorial-vm
-```
-
-[Uninstall Multipass](https://canonical.com/multipass/docs/install-multipass). On Linux:
-
-```
-snap remove multipass
-```
-
-## Next steps
-
+- [Give it a try!](https://documentation.ubuntu.com/juju/latest/tutorial/)
 - Read the [docs](https://canonical-juju.readthedocs-hosted.com).
 - Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and join our [chat](https://matrix.to/#/#charmhub-juju:ubuntu.com) and [forum](https://discourse.charmhub.io/) or [open an issue](https://github.com/juju/juju/issues).
 - Read our [CONTRIBUTING guide](./CONTRIBUTING.md) and contribute!

--- a/docs/releasenotes/juju_3.6.x.md
+++ b/docs/releasenotes/juju_3.6.x.md
@@ -14,6 +14,111 @@ myst:
 Juju 3.6 series is LTS
 ```
 
+## 🔸 **Juju 3.6.13**
+🗓️ 19 Jan 2026
+
+⚙️ Features:
+
+### CLI auto-completion
+The transition to a strictly confined snap for the Juju CLI broke auto-completion.
+This releases restores that feature.
+
+* feat: snap terminal auto-completion by @nicolasbock in https://github.com/juju/juju/pull/21032
+
+### Pebble version bump
+
+* feat: update Pebble version to v1.26.0 (latest) from v1.19.2 by @benhoyt in https://github.com/juju/juju/pull/21335
+
+### Read/write timeout configuration
+Two new controller configuration attributes are available, which control HTTP read and write timeouts for
+Juju agents:
+- `http-server-read-timeout`:  the maximum duration for reading the entire HTTP request, including the body.
+- `http-server-write-timeout`:  the maximum duration before timing out HTTP write operations.
+
+The default values specify no timeouts (wait forever).
+
+* feat: allow read and write timeouts configuration. by @marceloneppel in https://github.com/juju/juju/pull/21434
+
+### Model migration dry run
+Using the `--dry-run` argument with model migration will run the pre-checks and stop
+just before migration is initiated.
+
+* feat: enable migrate to be dry run by @ale8k in https://github.com/juju/juju/pull/21552
+
+🛠️ Fixes:
+
+### LXD deployments with multiple network devices
+On LXD VMs, the netplan config omitted the stanza to match on MAC address which
+resulted in network interfaces failing to come up.
+Where the netplan config contains multiple devices obtaining a DHCP address, the
+default route metric resulted in problems for traffic egress. The netplan config
+now specifies different metrics for each interface, alleviating the problem.
+
+* fix: ensure correct netplan for multi nic lxd vm by @wallyworld in https://github.com/juju/juju/pull/21548
+* fix: avoid creating duplicate default routes for vms with multiple nics by @wallyworld in https://github.com/juju/juju/pull/21549
+
+### LXD storage readiness
+In some cases, the storage attached hook would run before storage was mounted on LXD deployments.
+This caused the hook to fail. Juju now configures the jujud systemd service to wait until storage
+is available before starting the jujud agent.
+
+* fix: wait for local storage mounts before starting jujud service by @wallyworld in https://github.com/juju/juju/pull/21304
+
+### k8s deployments
+Juju registers a mutating webhook so it can track resources created by an application.
+This release contains 2 fixes to that implementation aspect.
+Firstly, if a resource already contains a `managed-by` label, Juju will not overwrite it. This
+fixes an issue in the 3.6.11 release.
+Secondly, the webhook was registered for almost every cluster wide resource create/update event.
+Juju now only listens to events for which it has an active interest, eliminating an efficiency bottleneck
+and vastly improving the observed speed of non-trivial deployments. 
+
+* fix: overriding managed-by label by @CodingCookieRookie in https://github.com/juju/juju/pull/21477
+* fix: reduce the scope of the resources the mutating webhook matches on by @wallyworld in #21377
+
+### Fix nil pointer errors for some Juju commands
+Running `juju metadata generate-image` or `kill-controller` could result in a nil pointer error.
+
+* fix: get correct controller uuid for image metadata cli by @wallyworld in https://github.com/juju/juju/pull/21376
+* fix: handle empty credential for kill-controller by @wallyworld in https://github.com/juju/juju/pull/21514
+ 
+### Transition to modern apt mirror config for cloud init
+Where an apt mirror was specified, Juju was generating an out of date cloud init config
+for the provisioned instance. The deprecated syntax stopped working and now Juju uses the
+modern form of the cloud init config syntax.
+
+* fix: use new apt mirror spec with cloud init by @wallyworld in https://github.com/juju/juju/pull/21509
+
+### Subordinate charm compatibility
+When relating a subordinate charm to a principal charm, Juju was not validating correctly whether
+the subordinate charm supports the base (OS version) that the principal charm is deployed on.
+This could lead to subordinate units being deployed on incompatible bases, potentially causing runtime failures.
+
+* fix: relation incompatible bases issue by @CodingCookieRookie in https://github.com/juju/juju/pull/21419
+
+### Other fixes
+
+* fix: transaction rollback handling by @manadart in https://github.com/juju/juju/pull/21370
+* fix: tighten permissions on netplan config files by @wallyworld in https://github.com/juju/juju/pull/21380
+* fix: enable provisioning check of manual machines to be done by the provisioning user by @ale8k in https://github.com/juju/juju/pull/20937
+* fix(juju): fix silent failure when removing space with model constraints by @kooltuoehias in https://github.com/juju/juju/pull/21554
+
+🗒️ Docs:<br>
+This release has many doc improvements and small fixes.<br>
+Besides maintenance tasks such as fixing some broken links, highlights include:
+
+* docs: fix typos, heading levels, images in dark mode using copilot by @tmihoc in https://github.com/juju/juju/pull/21266
+* docs: refactor scale docs by @CodingCookieRookie in https://github.com/juju/juju/pull/20931
+* docs: fix virt-type in constraint and cloud docs by @tmihoc in https://github.com/juju/juju/pull/21269
+* docs: clarify refresh on k8s by @tmihoc in https://github.com/juju/juju/pull/21287
+* docs: add caveat about juju-restore tool by @tmihoc in https://github.com/juju/juju/pull/21286
+* docs: clarify canonical k8s path requirements by @tmihoc in https://github.com/juju/juju/pull/21343
+* docs: add link to lxd rules for bridge by @tmihoc in https://github.com/juju/juju/pull/21346
+* docs: clarify revision paragraph in attach-resource by @tmihoc in https://github.com/juju/juju/pull/21345
+* docs: fix metadata glitch, update multipass to cloud-init by @tmihoc in https://github.com/juju/juju/pull/21564
+* docs: improve form in hook command docs by @tmihoc in https://github.com/juju/juju/pull/21497
+* docs: add metadata to all non-autogenerated files by @tmihoc in https://github.com/juju/juju/pull/21447
+
 ## 🔸 **Juju 3.6.12**
 🗓️ 26 Nov 2025
 

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -178,7 +178,7 @@ prepare_vault() {
 	export VAULT_ADDR="https://${vault_public_addr}:8200"
 	mkdir -p ~/snap/vault/common/
 	TMP=$(mktemp -d ~/snap/vault/common/cacert-XXXXX)
-	
+
 	# Wait for the certificate secret to be created by the vault charm.
 	attempt=0
 	cert_juju_secret_id=""
@@ -195,7 +195,7 @@ prepare_vault() {
 		fi
 	done
 	echo "[+] $(green 'Found vault certificate secret:') ${cert_juju_secret_id}"
-	
+
 	cert_content=$(juju show-secret "${cert_juju_secret_id}" --reveal --format=yaml | yq -r '.[] | .content.certificate')
 	if [[ -z "$cert_content" ]]; then
 		red "Failed to extract certificate from secret."


### PR DESCRIPTION
## Merge 3.6 into 4.0

### Pull requests
- https://github.com/juju/juju/pull/21610 @wallyworld 
- https://github.com/juju/juju/pull/21597 @CodingCookieRookie 
- https://github.com/juju/juju/pull/21614 @wallyworld 
- https://github.com/juju/juju/pull/21575 @iyiguncevik 

### Commits
- **docs: add 3.6.13 release notes**
- **docs: update myst-parser to 4.0**
- **refactor: secret iaas vault integration test**
- **docs: add links to 3.6.13 release notes PR references**
- **docs: include new build dependency in build instructions**
- **docs: update link to multipass documentation**
- **docs: rephrase dependencies section**
- **docs: replace the instructions with link to Tutorial**
- **docs: remove repetitive fork and clone instruction**
- **docs: rephrase Go installation instructions**

### Conflicts
- `README.md`: There was a change in 4.0 about watch command. It's removed with the whole section.
- `tests/suites/secrets_iaas/vault.sh`: @CodingCookieRookie Your change was already in 4.0 apart from new lines and double quotes around variables, there was no difference. 

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links
