### PR TITLE
(WIP) docs: add support guarantees 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ reference/index
 explanation/index
 For contributors <contributor/index>
 releasenotes/index
+support/index
 ```
 
 Juju is an open source orchestration engine for software operators that enables the deployment, integration, and lifecycle management of applications in the cloud using special software operators called ‘charms’.
@@ -79,7 +80,8 @@ Whether you are a CIO or SysAdmin, DevOps engineer, or SRE, Juju helps you take 
 
 Juju is an open source project that warmly welcomes community projects, contributions, suggestions, fixes and constructive feedback.
 
-* [Roadmap & Releases](releasenotes/index.md)
+* [Release notes](releasenotes/index.md)
+* [Support guarantees](support/index.md)
 * [Code of Conduct ](https://ubuntu.com/community/code-of-conduct)
 * [Join our chat](https://matrix.to/#/#charmhub-juju:ubuntu.com)
 * [Join our forum ](https://discourse.charmhub.io/)

--- a/docs/releasenotes/index.md
+++ b/docs/releasenotes/index.md
@@ -8,7 +8,7 @@ myst:
 # Release notes
 
 ```{toctree}
-:maxdepth: 3
+:maxdepth: 1
 :hidden:
 :glob:
 
@@ -17,16 +17,14 @@ Juju 2.9 (LTS) <juju_2.9.x>
 Out of support <unsupported/index>
 ```
 
-> See also: {ref}`upgrade-your-deployment`
+These are the release notes for Juju, that is, the `juju` CLI client and the Juju agents.
 
-These are the notes of Juju releases, that is, the `juju` CLI client and the Juju agents.
+<!-- Juju is [semantically versioned](https://semver.org/). -->
 
-- We release new minor version (the `x` of `m.x.p`) approximately every 3 months.
-- Patch releases for supported series are released every month
-- Once we release a new major version, the latest minor version of the previous release will become an LTS (Long Term Support) release.
-- Minor releases are supported with bug fixes for a period of 4 months from their release date, and a further 2 months of security fixes.
-- LTS releases will receive security fixes for 15 years.
+We release a new minor version of Juju approximately every 3 months.
 
+For each supported minor, we release a new patch version every month.
 
-
-
+```{ibnote}
+See more: {ref}`support-guarantees`, {ref}`juju-cross-version-compatibility`,  {ref}`upgrade-your-deployment`
+```

--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -1,0 +1,17 @@
+(support-guarantees)=
+# Support guarantees
+
+Upon release of a new major of Juju, the latest minor version of the previous major release becomes LTS (Long Term Support), and as such receives security fixes for the following 15 years.
+
+Currently, this means:
+
+|LTS version | bux fixes until | security fixes until |
+| -          | -               | -                    |
+|3.6         | 1 May 2026      | April 2039           |
+|2.9         | expired         | April 2035           |
+
+Any other minor release is supported with bug fixes for a period of 4 months from the release date, and then with security fixes for 2 additional months.
+
+```{ibnote}
+See more: {ref}`release-notes`, {ref}`juju-cross-version-compatibility`,  {ref}`upgrade-your-deployment`
+```


### PR DESCRIPTION
We are looking for a standard way to do release notes across Juju, JujuTF, and JAAS. As a first step, @alesstimec and I took another look at the standard we have at the moment in Juju. We noticed our Release notes mix information about release frequency with information about support guarantees. @alesstimec thought it might be more useful to users if we pulled out the support guarantees to their own separate page. This PR gives that thought a try.
