### PR TITLE
fix: unmanaged bootstrap with form ssh:ubuntu@<host>

### DIFF
--- a/internal/provider/unmanaged/provider.go
+++ b/internal/provider/unmanaged/provider.go
@@ -130,6 +130,7 @@ func (p UnmanagedProvider) Open(ctx context.Context, args environs.OpenParams, i
 	// Open.
 	envConfig := newModelConfig(args.Config, args.Config.UnknownAttrs())
 	host, user := args.Cloud.Endpoint, ""
+	host = strings.TrimPrefix(host, "ssh:")
 	if i := strings.IndexRune(host, '@'); i >= 0 {
 		user, host = host[:i], host[i+1:]
 	}

--- a/internal/provider/unmanaged/provider_test.go
+++ b/internal/provider/unmanaged/provider_test.go
@@ -79,8 +79,8 @@ func (s *providerSuite) TestBootstrap(c *tc.C) {
 	s.CheckCall(c, 2, "DetectBaseAndHardwareCharacteristics", "hostname", "")
 }
 
-// TestBootstrapUserHost tests the bootstrap process for an unmanaged provider with
-// a "user@host" endpoint configuration.
+// TestBootstrapUserHost tests the bootstrap process for an unmanaged provider
+// with a "user@host" endpoint configuration.
 func (s *providerSuite) TestBootstrapUserHost(c *tc.C) {
 	ctx, err := s.testBootstrap(c, testBootstrapArgs{
 		endpoint: "user@hostwithuser",
@@ -89,6 +89,18 @@ func (s *providerSuite) TestBootstrapUserHost(c *tc.C) {
 	s.CheckCall(c, 0, "CheckProvisioned", "hostwithuser", "user")
 	s.CheckCall(c, 1, "InitUbuntuUser", "hostwithuser", "user", "", "", ctx.GetStdin(), ctx.GetStdout())
 	s.CheckCall(c, 2, "DetectBaseAndHardwareCharacteristics", "hostwithuser", "user")
+}
+
+// TestBootstrapSSHUserHost tests the bootstrap process for an unmanaged
+// provider with a "ssh:user@host" endpoint configuration.
+func (s *providerSuite) TestBootstrapUserSSHHost(c *tc.C) {
+	ctx, err := s.testBootstrap(c, testBootstrapArgs{
+		endpoint: "ssh:user@host",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	s.CheckCall(c, 0, "CheckProvisioned", "host", "user")
+	s.CheckCall(c, 1, "InitUbuntuUser", "host", "user", "", "", ctx.GetStdin(), ctx.GetStdout())
+	s.CheckCall(c, 2, "DetectBaseAndHardwareCharacteristics", "host", "user")
 }
 
 // TestBootstrapUserHostAuthorizedKeys tests bootstrapping with authorized SSH


### PR DESCRIPTION
This was actually a long-standing latent bug that was not introduced, but _was_ exposed by https://github.com/juju/juju/pull/18572.

In that patch, we changed `DetectBaseAndHardwareCharacteristics` to receive the environ's `user` from which we never trimmed the "ssh:" prefix if we bootstrapped with `juju bootstrap unmanaged/ssh:ubuntu@<host>`.

Stripping the "ssh:" prefix causes the correct user to be passed to the environ, and used with SSH commands.

## QA Steps

- Create a LXD profile that includes your public key from ~/.local/share/juju/ssh. This is the stanza to add to the default profile:
```
config:
  user.user-data: |+
    #cloud-config
    ssh_authorized_keys:
      - <public key content>
```
- Launch a LXD container with `--profile <your profile name>`
- `juju bootstrap unmanaged/ssh:ubuntu@<container IP>` will succeed.

## Links

**Jira card:** [JUJU-8602](https://warthogs.atlassian.net/browse/JUJU-8602)


[JUJU-8602]: https://warthogs.atlassian.net/browse/JUJU-8602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ