### PR TITLE
fix(status): handle partial storage errors gracefully

### DIFF
--- a/apiserver/facades/client/client/fullstatus_test.go
+++ b/apiserver/facades/client/client/fullstatus_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/apiserver/authentication"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
@@ -23,6 +24,8 @@ import (
 	"github.com/juju/juju/domain/crossmodelrelation"
 	domainnetwork "github.com/juju/juju/domain/network"
 	service "github.com/juju/juju/domain/status/service"
+	"github.com/juju/juju/domain/storage"
+	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/testhelpers"
 	internaluuid "github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/rpc/params"
@@ -263,6 +266,103 @@ func (s *fullStatusSuite) TestFullStatusOffersNotIncluded(c *tc.C) {
 	// Assert
 	c.Assert(err, tc.IsNil)
 	c.Assert(output.Offers, tc.DeepEquals, map[string]params.ApplicationOfferStatus{})
+}
+
+// TestFullStatusStoragePartialFailure tests that storage processing continues
+// even when some storage instances fail (e.g. missing filesystem).
+func (s *fullStatusSuite) TestFullStatusStoragePartialFailure(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	client := s.client(false)
+	s.expectCheckCanRead(client, true)
+	// Not a model admin.
+	s.expectCheckIsAdmin(client, false)
+
+	s.modelInfoService.EXPECT().GetModelInfo(c.Context()).Return(model.ModelInfo{
+		Cloud:     "k8s",
+		CloudType: "k8s",
+		Type:      model.CAAS, // skip fetching machines
+	}, nil)
+	s.statusService.EXPECT().GetModelStatus(gomock.Any()).Return(status.StatusInfo{
+		Status:  status.Available,
+		Message: "testing",
+	}, nil)
+	s.expectEmptyModelModuloOffers(c)
+	s.applicationService.EXPECT().GetUnitsK8sPodInfo(gomock.Any()).Return(nil, nil)
+
+	// Mock Storage Instances
+	s.statusService.EXPECT().GetStorageInstanceStatuses(gomock.Any()).Return([]service.StorageInstance{
+		{
+			ID:   "pgdata/0",
+			Kind: storage.StorageKindFilesystem,
+			Life: life.Alive,
+		},
+		{
+			ID:   "pgdata/1",
+			Kind: storage.StorageKindFilesystem,
+			Life: life.Alive,
+		},
+	}, nil)
+
+	// Mock Filesystem Statuses with one error
+	s.statusService.EXPECT().GetFilesystemStatuses(gomock.Any()).Return(
+		// Filesystems
+		[]service.Filesystem{
+			{
+				ID:        "1",
+				StorageID: "pgdata/1",
+				Status:    status.StatusInfo{Status: status.Active},
+				Life:      life.Alive,
+			},
+		},
+		// Errors
+		[]error{
+			internalerrors.Errorf("filesystem for storage instance \"pgdata/0\" not found"),
+		},
+		nil,
+	)
+
+	// Mock Volume Statuses
+	s.statusService.EXPECT().GetVolumeStatuses(gomock.Any()).Return(nil, nil, nil)
+
+	// Act
+	output, err := client.FullStatus(c.Context(), params.StatusParams{
+		IncludeStorage: true,
+	})
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+
+	// Verify that we got results for both storage instances
+	c.Assert(output.Storage, tc.HasLen, 2)
+
+	// pgdata/0 (the one that failed filesystem lookup) should be present but maybe unknown status
+	// The user wants it to have the ERROR message.
+	// We expect the code to map the filesystem error back to the storage instance.
+
+	var s0 params.StorageDetails
+	var s1 params.StorageDetails
+	for _, s := range output.Storage {
+		if s.StorageTag == "storage-pgdata-0" {
+			s0 = s
+		} else if s.StorageTag == "storage-pgdata-1" {
+			s1 = s
+		}
+	}
+
+	c.Assert(s0.StorageTag, tc.Equals, "storage-pgdata-0")
+	// s0 status should be Error because filesystem loop reported error for it.
+	c.Assert(s0.Status.Status, tc.Equals, status.Error)
+	c.Assert(s0.Status.Info, tc.Equals, "filesystem for storage instance \"pgdata/0\" not found")
+
+	c.Assert(s1.StorageTag, tc.Equals, "storage-pgdata-1")
+
+	c.Assert(s1.Status.Status, tc.Equals, status.Active) // linked to filesystem-1
+
+	// Verify Filesystem results
+	// We expect 1 valid filesystem. The error one is now handled on the storage instance.
+	c.Assert(output.Filesystems, tc.HasLen, 1)
 }
 
 func (s *fullStatusSuite) client(isControllerModel bool) *Client {

--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -83,10 +83,10 @@ type StatusService interface {
 	GetStorageInstanceStatuses(ctx context.Context) ([]statusservice.StorageInstance, error)
 
 	// GetFilesystemStatuses returns all the filesystem statuses for the model.
-	GetFilesystemStatuses(ctx context.Context) ([]statusservice.Filesystem, error)
+	GetFilesystemStatuses(ctx context.Context) ([]statusservice.Filesystem, []error, error)
 
 	// GetVolumeStatuses returns all the volume statuses for the model.
-	GetVolumeStatuses(ctx context.Context) ([]statusservice.Volume, error)
+	GetVolumeStatuses(ctx context.Context) ([]statusservice.Volume, []error, error)
 }
 
 // BlockDeviceService instances can fetch block devices for a machine.

--- a/apiserver/facades/client/client/service_mock_test.go
+++ b/apiserver/facades/client/client/service_mock_test.go
@@ -903,12 +903,13 @@ func (c *MockStatusServiceGetApplicationAndUnitStatusesCall) DoAndReturn(f func(
 }
 
 // GetFilesystemStatuses mocks base method.
-func (m *MockStatusService) GetFilesystemStatuses(arg0 context.Context) ([]service0.Filesystem, error) {
+func (m *MockStatusService) GetFilesystemStatuses(arg0 context.Context) ([]service0.Filesystem, []error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFilesystemStatuses", arg0)
 	ret0, _ := ret[0].([]service0.Filesystem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]error)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetFilesystemStatuses indicates an expected call of GetFilesystemStatuses.
@@ -924,19 +925,19 @@ type MockStatusServiceGetFilesystemStatusesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStatusServiceGetFilesystemStatusesCall) Return(arg0 []service0.Filesystem, arg1 error) *MockStatusServiceGetFilesystemStatusesCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockStatusServiceGetFilesystemStatusesCall) Return(arg0 []service0.Filesystem, arg1 []error, arg2 error) *MockStatusServiceGetFilesystemStatusesCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatusServiceGetFilesystemStatusesCall) Do(f func(context.Context) ([]service0.Filesystem, error)) *MockStatusServiceGetFilesystemStatusesCall {
+func (c *MockStatusServiceGetFilesystemStatusesCall) Do(f func(context.Context) ([]service0.Filesystem, []error, error)) *MockStatusServiceGetFilesystemStatusesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatusServiceGetFilesystemStatusesCall) DoAndReturn(f func(context.Context) ([]service0.Filesystem, error)) *MockStatusServiceGetFilesystemStatusesCall {
+func (c *MockStatusServiceGetFilesystemStatusesCall) DoAndReturn(f func(context.Context) ([]service0.Filesystem, []error, error)) *MockStatusServiceGetFilesystemStatusesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1137,12 +1138,13 @@ func (c *MockStatusServiceGetStorageInstanceStatusesCall) DoAndReturn(f func(con
 }
 
 // GetVolumeStatuses mocks base method.
-func (m *MockStatusService) GetVolumeStatuses(arg0 context.Context) ([]service0.Volume, error) {
+func (m *MockStatusService) GetVolumeStatuses(arg0 context.Context) ([]service0.Volume, []error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVolumeStatuses", arg0)
 	ret0, _ := ret[0].([]service0.Volume)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]error)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetVolumeStatuses indicates an expected call of GetVolumeStatuses.
@@ -1158,19 +1160,19 @@ type MockStatusServiceGetVolumeStatusesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStatusServiceGetVolumeStatusesCall) Return(arg0 []service0.Volume, arg1 error) *MockStatusServiceGetVolumeStatusesCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockStatusServiceGetVolumeStatusesCall) Return(arg0 []service0.Volume, arg1 []error, arg2 error) *MockStatusServiceGetVolumeStatusesCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatusServiceGetVolumeStatusesCall) Do(f func(context.Context) ([]service0.Volume, error)) *MockStatusServiceGetVolumeStatusesCall {
+func (c *MockStatusServiceGetVolumeStatusesCall) Do(f func(context.Context) ([]service0.Volume, []error, error)) *MockStatusServiceGetVolumeStatusesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatusServiceGetVolumeStatusesCall) DoAndReturn(f func(context.Context) ([]service0.Volume, error)) *MockStatusServiceGetVolumeStatusesCall {
+func (c *MockStatusServiceGetVolumeStatusesCall) DoAndReturn(f func(context.Context) ([]service0.Volume, []error, error)) *MockStatusServiceGetVolumeStatusesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1347,11 +1347,11 @@ func processStorage(
 		storageMap[v.ID] = &details
 	}
 
-	filesystems, err := statusService.GetFilesystemStatuses(ctx)
+	filesystems, fsErrs, err := statusService.GetFilesystemStatuses(ctx)
 	if err != nil {
 		return nil, nil, nil, internalerrors.Capture(err)
 	}
-	filesystemResult := make([]params.FilesystemDetails, 0, len(filesystems))
+	filesystemResult := make([]params.FilesystemDetails, 0, len(filesystems)+len(fsErrs))
 	for _, v := range filesystems {
 		details := params.FilesystemDetails{
 			FilesystemTag: names.NewFilesystemTag(v.ID).String(),
@@ -1417,14 +1417,43 @@ func processStorage(
 			}
 			details.Storage = storage
 		}
+
 		filesystemResult = append(filesystemResult, details)
 	}
+	for _, err := range fsErrs {
+		parts := strings.SplitN(err.Error(), "\"", 3)
+		if len(parts) >= 2 {
+			id := parts[1]
+			// Check if the error refers to a storage instance.
+			if st, ok := storageMap[id]; ok {
+				st.Status = params.EntityStatus{
+					Status: status.Error,
+					Info:   err.Error(),
+					Since:  &zeroTime,
+				}
+				continue
+			}
+			if !names.IsValidFilesystem(id) {
+				logger.Debugf(ctx, "skipping invalid filesystem id %q from error: %v", id, err)
+				continue
+			}
+			details := params.FilesystemDetails{
+				FilesystemTag: names.NewFilesystemTag(id).String(),
+				Status: params.EntityStatus{
+					Status: status.Error,
+					Info:   err.Error(),
+					Since:  &zeroTime,
+				},
+			}
+			filesystemResult = append(filesystemResult, details)
+		}
+	}
 
-	volumes, err := statusService.GetVolumeStatuses(ctx)
+	volumes, volErrs, err := statusService.GetVolumeStatuses(ctx)
 	if err != nil {
 		return nil, nil, nil, internalerrors.Capture(err)
 	}
-	volumeResult := make([]params.VolumeDetails, 0, len(volumes))
+	volumeResult := make([]params.VolumeDetails, 0, len(volumes)+len(volErrs))
 	for _, v := range volumes {
 		details := params.VolumeDetails{
 			VolumeTag: names.NewVolumeTag(v.ID).String(),
@@ -1530,6 +1559,33 @@ func processStorage(
 			details.Storage = storage
 		}
 		volumeResult = append(volumeResult, details)
+	}
+	for _, err := range volErrs {
+		parts := strings.SplitN(err.Error(), "\"", 3)
+		if len(parts) >= 2 {
+			id := parts[1]
+			if st, ok := storageMap[id]; ok {
+				st.Status = params.EntityStatus{
+					Status: status.Error,
+					Info:   err.Error(),
+					Since:  &zeroTime,
+				}
+				continue
+			}
+			if !names.IsValidVolume(id) {
+				logger.Debugf(ctx, "skipping invalid volume id %q from error: %v", id, err)
+				continue
+			}
+			details := params.VolumeDetails{
+				VolumeTag: names.NewVolumeTag(id).String(),
+				Status: params.EntityStatus{
+					Status: status.Error,
+					Info:   err.Error(),
+					Since:  &zeroTime,
+				},
+			}
+			volumeResult = append(volumeResult, details)
+		}
 	}
 
 	storageResult := make([]params.StorageDetails, 0, len(storageInstances))

--- a/domain/status/service/package_mock_test.go
+++ b/domain/status/service/package_mock_test.go
@@ -671,12 +671,13 @@ func (c *MockModelStateGetFilesystemUUIDByIDCall) DoAndReturn(f func(context.Con
 }
 
 // GetFilesystems mocks base method.
-func (m *MockModelState) GetFilesystems(ctx context.Context) ([]status.Filesystem, error) {
+func (m *MockModelState) GetFilesystems(ctx context.Context) ([]status.Filesystem, []error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFilesystems", ctx)
 	ret0, _ := ret[0].([]status.Filesystem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]error)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetFilesystems indicates an expected call of GetFilesystems.
@@ -692,19 +693,19 @@ type MockModelStateGetFilesystemsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetFilesystemsCall) Return(arg0 []status.Filesystem, arg1 error) *MockModelStateGetFilesystemsCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockModelStateGetFilesystemsCall) Return(arg0 []status.Filesystem, arg1 []error, arg2 error) *MockModelStateGetFilesystemsCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetFilesystemsCall) Do(f func(context.Context) ([]status.Filesystem, error)) *MockModelStateGetFilesystemsCall {
+func (c *MockModelStateGetFilesystemsCall) Do(f func(context.Context) ([]status.Filesystem, []error, error)) *MockModelStateGetFilesystemsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetFilesystemsCall) DoAndReturn(f func(context.Context) ([]status.Filesystem, error)) *MockModelStateGetFilesystemsCall {
+func (c *MockModelStateGetFilesystemsCall) DoAndReturn(f func(context.Context) ([]status.Filesystem, []error, error)) *MockModelStateGetFilesystemsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1373,12 +1374,13 @@ func (c *MockModelStateGetVolumeUUIDByIDCall) DoAndReturn(f func(context.Context
 }
 
 // GetVolumes mocks base method.
-func (m *MockModelState) GetVolumes(ctx context.Context) ([]status.Volume, error) {
+func (m *MockModelState) GetVolumes(ctx context.Context) ([]status.Volume, []error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVolumes", ctx)
 	ret0, _ := ret[0].([]status.Volume)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]error)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetVolumes indicates an expected call of GetVolumes.
@@ -1394,19 +1396,19 @@ type MockModelStateGetVolumesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetVolumesCall) Return(arg0 []status.Volume, arg1 error) *MockModelStateGetVolumesCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockModelStateGetVolumesCall) Return(arg0 []status.Volume, arg1 []error, arg2 error) *MockModelStateGetVolumesCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetVolumesCall) Do(f func(context.Context) ([]status.Volume, error)) *MockModelStateGetVolumesCall {
+func (c *MockModelStateGetVolumesCall) Do(f func(context.Context) ([]status.Volume, []error, error)) *MockModelStateGetVolumesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetVolumesCall) DoAndReturn(f func(context.Context) ([]status.Volume, error)) *MockModelStateGetVolumesCall {
+func (c *MockModelStateGetVolumesCall) DoAndReturn(f func(context.Context) ([]status.Volume, []error, error)) *MockModelStateGetVolumesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/status/service/storage.go
+++ b/domain/status/service/storage.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/juju/juju/core/machine"
 	corestatus "github.com/juju/juju/core/status"
@@ -54,14 +55,14 @@ type StorageState interface {
 	GetStorageInstanceAttachments(ctx context.Context) ([]status.StorageAttachment, error)
 
 	// GetFilesystems returns all the filesystems for this model.
-	GetFilesystems(ctx context.Context) ([]status.Filesystem, error)
+	GetFilesystems(ctx context.Context) ([]status.Filesystem, []error, error)
 
 	// GetFilesystemAttachments returns all the filesystem attachments for this
 	// model.
 	GetFilesystemAttachments(ctx context.Context) ([]status.FilesystemAttachment, error)
 
 	// GetVolumes returns all the volumes for this model.
-	GetVolumes(ctx context.Context) ([]status.Volume, error)
+	GetVolumes(ctx context.Context) ([]status.Volume, []error, error)
 
 	// GetVolumeAttachments returns all the volume attachments for this model.
 	GetVolumeAttachments(ctx context.Context) ([]status.VolumeAttachment, error)
@@ -198,17 +199,17 @@ func (s *Service) GetStorageInstanceStatuses(
 }
 
 // GetFilesystemStatuses returns all the filesystem statuses for the model.
-func (s *Service) GetFilesystemStatuses(ctx context.Context) ([]Filesystem, error) {
+func (s *Service) GetFilesystemStatuses(ctx context.Context) ([]Filesystem, []error, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	filesystems, err := s.modelState.GetFilesystems(ctx)
+	filesystems, fsErrs, err := s.modelState.GetFilesystems(ctx)
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 	filesystemAttachments, err := s.modelState.GetFilesystemAttachments(ctx)
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	fsMap := map[storageprovisioning.FilesystemUUID]*Filesystem{}
@@ -223,11 +224,13 @@ func (s *Service) GetFilesystemStatuses(ctx context.Context) ([]Filesystem, erro
 		var err error
 		fs.Life, err = dfs.Life.Value()
 		if err != nil {
-			return nil, errors.Capture(err)
+			fsErrs = append(fsErrs, fmt.Errorf("filesystem %q life: %w", dfs.ID, err))
+			continue
 		}
 		fs.Status, err = decodeFilesystemStatus(dfs.Status)
 		if err != nil {
-			return nil, errors.Capture(err)
+			fsErrs = append(fsErrs, fmt.Errorf("filesystem %q status: %w", dfs.ID, err))
+			continue
 		}
 		fsMap[dfs.UUID] = &fs
 	}
@@ -239,7 +242,7 @@ func (s *Service) GetFilesystemStatuses(ctx context.Context) ([]Filesystem, erro
 		var err error
 		fsa.Life, err = dfsa.Life.Value()
 		if err != nil {
-			return nil, errors.Capture(err)
+			return nil, nil, errors.Capture(err)
 		}
 		if fs, ok := fsMap[dfsa.FilesystemUUID]; ok {
 			if dfsa.Unit != nil {
@@ -261,21 +264,21 @@ func (s *Service) GetFilesystemStatuses(ctx context.Context) ([]Filesystem, erro
 	for _, v := range fsMap {
 		ret = append(ret, *v)
 	}
-	return ret, nil
+	return ret, fsErrs, nil
 }
 
 // GetVolumeStatuses returns all the volume statuses for the model.
-func (s *Service) GetVolumeStatuses(ctx context.Context) ([]Volume, error) {
+func (s *Service) GetVolumeStatuses(ctx context.Context) ([]Volume, []error, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	volumes, err := s.modelState.GetVolumes(ctx)
+	volumes, volErrs, err := s.modelState.GetVolumes(ctx)
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 	volumeAttachments, err := s.modelState.GetVolumeAttachments(ctx)
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	volumeMap := map[storage.VolumeUUID]*Volume{}
@@ -292,11 +295,13 @@ func (s *Service) GetVolumeStatuses(ctx context.Context) ([]Volume, error) {
 		var err error
 		v.Life, err = dv.Life.Value()
 		if err != nil {
-			return nil, errors.Capture(err)
+			volErrs = append(volErrs, fmt.Errorf("volume %q life: %w", dv.ID, err))
+			continue
 		}
 		v.Status, err = decodeVolumeStatus(dv.Status)
 		if err != nil {
-			return nil, errors.Capture(err)
+			volErrs = append(volErrs, fmt.Errorf("volume %q status: %w", dv.ID, err))
+			continue
 		}
 		volumeMap[dv.UUID] = &v
 	}
@@ -310,7 +315,7 @@ func (s *Service) GetVolumeStatuses(ctx context.Context) ([]Volume, error) {
 		var err error
 		va.Life, err = dva.Life.Value()
 		if err != nil {
-			return nil, errors.Capture(err)
+			return nil, nil, errors.Capture(err)
 		}
 		if dvap := dva.VolumeAttachmentPlan; dvap != nil {
 			vap := VolumeAttachmentPlan{
@@ -339,5 +344,5 @@ func (s *Service) GetVolumeStatuses(ctx context.Context) ([]Volume, error) {
 	for _, v := range volumeMap {
 		ret = append(ret, *v)
 	}
-	return ret, nil
+	return ret, volErrs, nil
 }

--- a/domain/status/service/storage_test.go
+++ b/domain/status/service/storage_test.go
@@ -375,7 +375,7 @@ func (s *storageServiceSuite) TestGetFilesystemStatuses(c *tc.C) {
 			SizeMiB:    123,
 		},
 	}
-	s.modelState.EXPECT().GetFilesystems(gomock.Any()).Return(fs, nil)
+	s.modelState.EXPECT().GetFilesystems(gomock.Any()).Return(fs, nil, nil)
 	fa := []status.FilesystemAttachment{
 		{
 			FilesystemUUID: fsUUID,
@@ -388,7 +388,7 @@ func (s *storageServiceSuite) TestGetFilesystemStatuses(c *tc.C) {
 	}
 	s.modelState.EXPECT().GetFilesystemAttachments(gomock.Any()).Return(fa, nil)
 
-	res, err := s.service.GetFilesystemStatuses(c.Context())
+	res, _, err := s.service.GetFilesystemStatuses(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.DeepEquals, []Filesystem{
 		{
@@ -451,7 +451,7 @@ func (s *storageServiceSuite) TestGetFilesystemStatusesMultiple(c *tc.C) {
 			SizeMiB:    456,
 		},
 	}
-	s.modelState.EXPECT().GetFilesystems(gomock.Any()).Return(fs, nil)
+	s.modelState.EXPECT().GetFilesystems(gomock.Any()).Return(fs, nil, nil)
 	fa := []status.FilesystemAttachment{
 		{
 			FilesystemUUID: fsUUID0,
@@ -479,7 +479,7 @@ func (s *storageServiceSuite) TestGetFilesystemStatusesMultiple(c *tc.C) {
 	}
 	s.modelState.EXPECT().GetFilesystemAttachments(gomock.Any()).Return(fa, nil)
 
-	res, err := s.service.GetFilesystemStatuses(c.Context())
+	res, _, err := s.service.GetFilesystemStatuses(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.UnorderedMatch[[]Filesystem](tc.DeepEquals), []Filesystem{
 		{
@@ -560,7 +560,7 @@ func (s *storageServiceSuite) TestGetVolumeStatuses(c *tc.C) {
 			Persistent: true,
 		},
 	}
-	s.modelState.EXPECT().GetVolumes(gomock.Any()).Return(vol, nil)
+	s.modelState.EXPECT().GetVolumes(gomock.Any()).Return(vol, nil, nil)
 	va := []status.VolumeAttachment{
 		{
 			VolumeUUID: volUUID,
@@ -581,7 +581,7 @@ func (s *storageServiceSuite) TestGetVolumeStatuses(c *tc.C) {
 	}
 	s.modelState.EXPECT().GetVolumeAttachments(gomock.Any()).Return(va, nil)
 
-	res, err := s.service.GetVolumeStatuses(c.Context())
+	res, _, err := s.service.GetVolumeStatuses(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.DeepEquals, []Volume{
 		{

--- a/domain/status/state/model/storage.go
+++ b/domain/status/state/model/storage.go
@@ -6,6 +6,7 @@ package model
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
@@ -456,10 +457,10 @@ LEFT JOIN machine m ON u.net_node_uuid=m.net_node_uuid
 // GetFilesystems returns all the filesystems for this model.
 func (st *ModelState) GetFilesystems(
 	ctx context.Context,
-) ([]status.Filesystem, error) {
+) ([]status.Filesystem, []error, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	stmt, err := st.Prepare(`
@@ -474,7 +475,7 @@ LEFT JOIN storage_instance_volume siv ON siv.storage_instance_uuid=si.uuid
 LEFT JOIN storage_volume sv ON sv.uuid=siv.storage_volume_uuid
 `, filesystemStatusDetails{})
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	var out []filesystemStatusDetails
@@ -486,19 +487,22 @@ LEFT JOIN storage_volume sv ON sv.uuid=siv.storage_volume_uuid
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 
-	return transform.SliceOrErr(out, func(v filesystemStatusDetails) (status.Filesystem, error) {
+	var result []status.Filesystem
+	var errs []error
+	for _, v := range out {
 		statusValue, err := status.DecodeStorageFilesystemStatus(v.StatusID)
 		if err != nil {
-			return status.Filesystem{}, errors.Capture(err)
+			errs = append(errs, fmt.Errorf("filesystem %q: %w", v.ID, err))
+			continue
 		}
 		var volumeID *string
 		if v.VolumeID.Valid {
 			volumeID = &v.VolumeID.String
 		}
-		return status.Filesystem{
+		result = append(result, status.Filesystem{
 			UUID: storageprovisioning.FilesystemUUID(v.UUID),
 			ID:   v.ID,
 			Life: life.Life(v.LifeID),
@@ -511,8 +515,9 @@ LEFT JOIN storage_volume sv ON sv.uuid=siv.storage_volume_uuid
 			VolumeID:   volumeID,
 			ProviderID: v.ProviderID,
 			SizeMiB:    v.SizeMiB,
-		}, nil
-	})
+		})
+	}
+	return result, errs, nil
 }
 
 // GetFilesystemAttachments returns all the filesystem attachments for this
@@ -576,10 +581,10 @@ LEFT JOIN unit u ON u.uuid=sa.unit_uuid
 // GetVolumes returns all the volumes for this model.
 func (st *ModelState) GetVolumes(
 	ctx context.Context,
-) ([]status.Volume, error) {
+) ([]status.Volume, []error, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	stmt, err := st.Prepare(`
@@ -592,7 +597,7 @@ LEFT JOIN storage_instance_volume siv ON siv.storage_volume_uuid=sv.uuid
 LEFT JOIN storage_instance si ON si.uuid=siv.storage_instance_uuid
 `, volumeStatusDetails{})
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	var out []volumeStatusDetails
@@ -604,15 +609,18 @@ LEFT JOIN storage_instance si ON si.uuid=siv.storage_instance_uuid
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, nil, errors.Capture(err)
 	}
 
-	return transform.SliceOrErr(out, func(v volumeStatusDetails) (status.Volume, error) {
+	var result []status.Volume
+	var errs []error
+	for _, v := range out {
 		statusValue, err := status.DecodeStorageVolumeStatus(v.StatusID)
 		if err != nil {
-			return status.Volume{}, errors.Capture(err)
+			errs = append(errs, fmt.Errorf("volume %q: %w", v.ID, err))
+			continue
 		}
-		return status.Volume{
+		result = append(result, status.Volume{
 			UUID: storage.VolumeUUID(v.UUID),
 			ID:   v.ID,
 			Life: life.Life(v.LifeID),
@@ -627,8 +635,9 @@ LEFT JOIN storage_instance si ON si.uuid=siv.storage_instance_uuid
 			WWN:        v.WWN,
 			Persistent: v.Persistent,
 			SizeMiB:    v.SizeMiB,
-		}, nil
-	})
+		})
+	}
+	return result, errs, nil
 }
 
 // GetVolumeAttachments returns all the volume attachments for this model.

--- a/domain/status/state/model/storage_test.go
+++ b/domain/status/state/model/storage_test.go
@@ -496,7 +496,7 @@ func (s *storageStatusSuite) TestGetStorageInstanceAttachments(c *tc.C) {
 
 func (s *storageStatusSuite) TestGetFilesystemsEmpty(c *tc.C) {
 	st := s.NewModelState(c)
-	res, err := st.GetFilesystems(c.Context())
+	res, _, err := st.GetFilesystems(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.HasLen, 0)
 }
@@ -532,7 +532,7 @@ func (s *storageStatusSuite) TestGetFilesystems(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	res, err := st.GetFilesystems(c.Context())
+	res, _, err := st.GetFilesystems(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.UnorderedMatch[[]status.Filesystem](tc.DeepEquals), []status.Filesystem{
 		{
@@ -622,7 +622,7 @@ func (s *storageStatusSuite) TestGetFilesystemAttachments(c *tc.C) {
 
 func (s *storageStatusSuite) TestGetVolumesEmpty(c *tc.C) {
 	st := s.NewModelState(c)
-	res, err := st.GetVolumes(c.Context())
+	res, _, err := st.GetVolumes(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.HasLen, 0)
 }
@@ -660,7 +660,7 @@ func (s *storageStatusSuite) TestGetVolumes(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	res, err := st.GetVolumes(c.Context())
+	res, _, err := st.GetVolumes(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.UnorderedMatch[[]status.Volume](tc.DeepEquals), []status.Volume{
 		{


### PR DESCRIPTION
one partial storage error would destroy the whole cli response, this pr introduces partial errors to handle it gracefully

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

specific unit tests are added.

## Documentation changes


## Links

**Issue:** Fixes #20186.

**Jira card:** [JUJU-8250](https://warthogs.atlassian.net/browse/JUJU-8250)


[JUJU-8250]: https://warthogs.atlassian.net/browse/JUJU-8250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
