### PR TITLE
fix(cmd): remove ReadAuthorizedKeys cmd.Context arg

### DIFF
--- a/cmd/juju/common/authkeys.go
+++ b/cmd/juju/common/authkeys.go
@@ -11,8 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/v4"
 	"github.com/juju/utils/v4/ssh"
-
-	"github.com/juju/juju/internal/cmd"
 )
 
 // ErrNoAuthorizedKeys is returned by ReadAuthorizedKeys when no
@@ -33,7 +31,7 @@ var ErrNoAuthorizedKeys = errors.New("no public ssh keys found")
 //
 // If no SSH keys are found, ReadAuthorizedKeys returns
 // ErrNoAuthorizedKeys.
-func ReadAuthorizedKeys(ctx *cmd.Context, path string) (string, error) {
+func ReadAuthorizedKeys(path string) (string, error) {
 	files := ssh.PublicKeyFiles()
 	if path == "" {
 		files = append(files, "id_ed25519.pub", "id_ecdsa.pub", "id_rsa.pub", "identity.pub")
@@ -62,7 +60,6 @@ func ReadAuthorizedKeys(ctx *cmd.Context, path string) (string, error) {
 		}
 		keyData = append(keyData, bytes.Trim(data, "\n")...)
 		keyData = append(keyData, '\n')
-		ctx.Verbosef("Adding contents of %q to authorized-keys", f)
 	}
 	if len(keyData) == 0 {
 		if firstError == nil {

--- a/cmd/juju/common/authkeys_test.go
+++ b/cmd/juju/common/authkeys_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/utils/v4/ssh"
 
 	"github.com/juju/juju/cmd/juju/common"
-	"github.com/juju/juju/internal/cmd/cmdtesting"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -45,11 +44,10 @@ func (s *AuthKeysSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *AuthKeysSuite) TestReadAuthorizedKeysErrors(c *tc.C) {
-	ctx := cmdtesting.Context(c)
-	_, err := common.ReadAuthorizedKeys(ctx, "")
+	_, err := common.ReadAuthorizedKeys("")
 	c.Assert(err, tc.ErrorMatches, "no public ssh keys found")
 	c.Assert(err, tc.Equals, common.ErrNoAuthorizedKeys)
-	_, err = common.ReadAuthorizedKeys(ctx, filepath.Join(s.dotssh, "notthere.pub"))
+	_, err = common.ReadAuthorizedKeys(filepath.Join(s.dotssh, "notthere.pub"))
 	c.Assert(err, tc.ErrorMatches, "no public ssh keys found")
 	c.Assert(err, tc.Equals, common.ErrNoAuthorizedKeys)
 }
@@ -60,22 +58,20 @@ func writeFile(c *tc.C, filename string, contents string) {
 }
 
 func (s *AuthKeysSuite) TestReadAuthorizedKeys(c *tc.C) {
-	ctx := cmdtesting.Context(c)
 	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "id_rsa")
 	writeFile(c, filepath.Join(s.dotssh, "id_dsa.pub"), "id_dsa") // Check dsa is NOT loaded
 	writeFile(c, filepath.Join(s.dotssh, "id_ed25519.pub"), "id_ed25519")
 	writeFile(c, filepath.Join(s.dotssh, "identity.pub"), "identity")
 	writeFile(c, filepath.Join(s.dotssh, "test.pub"), "test")
-	keys, err := common.ReadAuthorizedKeys(ctx, "")
+	keys, err := common.ReadAuthorizedKeys("")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(keys, tc.Equals, "id_ed25519\nid_rsa\nidentity\n")
-	keys, err = common.ReadAuthorizedKeys(ctx, "test.pub") // relative to ~/.ssh
+	keys, err = common.ReadAuthorizedKeys("test.pub") // relative to ~/.ssh
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(keys, tc.Equals, "test\n")
 }
 
 func (s *AuthKeysSuite) TestReadAuthorizedKeysClientKeys(c *tc.C) {
-	ctx := cmdtesting.Context(c)
 	keydir := filepath.Join(s.dotssh, "juju")
 	err := ssh.LoadClientKeys(keydir) // auto-generates a key pair
 	c.Assert(err, tc.ErrorIsNil)
@@ -87,13 +83,13 @@ func (s *AuthKeysSuite) TestReadAuthorizedKeysClientKeys(c *tc.C) {
 
 	writeFile(c, filepath.Join(s.dotssh, "id_rsa.pub"), "id_rsa")
 	writeFile(c, filepath.Join(s.dotssh, "test.pub"), "test")
-	keys, err := common.ReadAuthorizedKeys(ctx, "")
+	keys, err := common.ReadAuthorizedKeys("")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(keys, tc.Equals, prefix+"id_rsa\n")
-	keys, err = common.ReadAuthorizedKeys(ctx, "test.pub")
+	keys, err = common.ReadAuthorizedKeys("test.pub")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(keys, tc.Equals, prefix+"test\n")
-	keys, err = common.ReadAuthorizedKeys(ctx, "notthere.pub")
+	keys, err = common.ReadAuthorizedKeys("notthere.pub")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(keys, tc.Equals, prefix)
 }

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -402,7 +402,7 @@ func (c *addCommand) tryManualProvision(ctx *cmd.Context, client manual.Provisio
 		return errNonManualScope
 	}
 
-	authKeys, err := common.ReadAuthorizedKeys(ctx, c.PublicKey)
+	authKeys, err := common.ReadAuthorizedKeys(c.PublicKey)
 	if err != nil {
 		return errors.Annotatef(err, "cannot reading authorized-keys")
 	}


### PR DESCRIPTION
# Description

the cmd wasn't used outside of a warn log and the cmd package was in internal. So in a effort to make the terraform provider compile with juju 4, I've just removed the arg.

Following up on: https://github.com/juju/juju/pull/21657, we move `internal/charm` to `domain/deployment/charm` in an effort to compile the terraform provider with Juju 4.
I've kept "moving" commits and "fixing the use of `juju/errors`" separated to make it easier to review, since it's a huge pr.

Comprehensive list of compile errors in the tf provider, which mostly will be solved by this:
- [X] https://github.com/juju/juju/blob/main/cmd/juju/common/authkeys.go#L36 using cmd from internal
- [ ] https://github.com/juju/juju/blob/main/cmd/juju/application/utils/origin.go#L19 using charm from internal
- [ ] https://github.com/juju/juju/blob/main/api/client/charms/client.go#L148 using charm from internal
- [ ] https://github.com/juju/juju/blob/main/api/common/charms/common.go#L66 using charm from internal
- [ ] https://github.com/juju/juju/blob/main/core/resource/resource.go#L33 using resource from internal
- [ ] https://github.com/juju/juju/blob/main/api/client/resources/client.go#L157 using resource from internal

# QA
If it compiles it should be fine.