### PR TITLE
fix: maintain compatibility with 3.6 display status

### DIFF
--- a/domain/status/service/status.go
+++ b/domain/status/service/status.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/juju/collections/set"
+
 	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/status"
@@ -549,12 +551,33 @@ func selectWorkloadOrK8sPodStatus(
 	}
 
 	if containerStatus.Status == status.K8sPodStatusRunning {
-		if workloadStatus.Status == status.WorkloadStatusWaiting {
-			return decodeK8sPodStatus(containerStatus)
+		if legacyIsStatusModified(workloadStatus) {
+			return decodeUnitWorkloadStatus(workloadStatus, present)
 		}
+		return decodeK8sPodStatus(containerStatus)
 	}
 
 	return decodeUnitWorkloadStatus(workloadStatus, present)
+}
+
+// legacyIsStatusModified returns true if workload status should be used and
+// false if the container status should be used for the unit status. This is legacy
+// behavior which users depend on.
+func legacyIsStatusModified(s status.StatusInfo[status.WorkloadStatusType]) bool {
+	if s.Status != status.WorkloadStatusUnset && s.Status != status.WorkloadStatusWaiting {
+		return true
+	}
+
+	// Replicate behaviour from Juju 3
+	if set.NewStrings(
+		corestatus.MessageWaitForContainer,
+		corestatus.MessageInitializingAgent,
+		corestatus.MessageInstallingAgent,
+	).Contains(s.Message) {
+		return false
+	}
+
+	return true
 }
 
 // statusSeverities holds status values with a severity measure.

--- a/domain/status/service/status_test.go
+++ b/domain/status/service/status_test.go
@@ -394,7 +394,7 @@ func (s *statusSuite) TestSelectWorkloadOrK8sPodStatusContainerWaitingDominatesA
 	})
 }
 
-func (s *statusSuite) TestSelectWorkloadOrK8sPodStatusContainerRunningDominatesWaitingWorkload(c *tc.C) {
+func (s *statusSuite) TestSelectWorkloadOrK8sPodStatusContainerRunningDominatesWaitingWorkloadForCertainMessages(c *tc.C) {
 	workloadStatus := status.StatusInfo[status.WorkloadStatusType]{
 		Status: status.WorkloadStatusWaiting,
 	}
@@ -406,11 +406,40 @@ func (s *statusSuite) TestSelectWorkloadOrK8sPodStatusContainerRunningDominatesW
 		Since:   &s.now,
 	}
 
+	for _, msg := range []string{
+		corestatus.MessageWaitForContainer,
+		corestatus.MessageInitializingAgent,
+		corestatus.MessageInstallingAgent,
+	} {
+		workloadStatus.Message = msg
+		info, err := selectWorkloadOrK8sPodStatus(workloadStatus, containerStatus, true)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(info, tc.DeepEquals, corestatus.StatusInfo{
+			Status:  corestatus.Running,
+			Message: "msg",
+			Data:    map[string]interface{}{"key": "value"},
+			Since:   &s.now,
+		})
+	}
+}
+
+func (s *statusSuite) TestSelectWorkloadOrK8sPodStatusContainerRunnerWorkloadDominatedForMiscMessages(c *tc.C) {
+	workloadStatus := status.StatusInfo[status.WorkloadStatusType]{
+		Status:  status.WorkloadStatusWaiting,
+		Message: "foo",
+		Data:    []byte(`{"key":"value"}`),
+		Since:   &s.now,
+	}
+
+	containerStatus := status.StatusInfo[status.K8sPodStatusType]{
+		Status: status.K8sPodStatusRunning,
+	}
+
 	info, err := selectWorkloadOrK8sPodStatus(workloadStatus, containerStatus, true)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(info, tc.DeepEquals, corestatus.StatusInfo{
-		Status:  corestatus.Running,
-		Message: "msg",
+	c.Check(info, tc.DeepEquals, corestatus.StatusInfo{
+		Status:  corestatus.Waiting,
+		Message: "foo",
 		Data:    map[string]interface{}{"key": "value"},
 		Since:   &s.now,
 	})


### PR DESCRIPTION
In 3.6, we did some horrible nonsense to pick between displaying the container status and the workload status of a unit.

https://github.com/juju/juju/blob/09a08eda66b2a543502b6a48725adae6e203f3c8/core/status/caas.go#L51-L57

This was so bad, I couldn't bring myself to bring this over into new, shiny 4.0 domain code.

However, sometimes charms rely on this behvaiour, so unfortunately it needs to be restored.

## QA steps

```
$ juju bootstrap microk8s 40
$ juju add-model m
$ juju deploy mysql-test-app
$ juju status
Model  Controller  Cloud/Region        Version  Timestamp
m      40          microk8s/localhost  4.0.2    16:44:46Z

App             Version  Status   Scale  Charm           Channel        Rev  Address  Exposed  Message
mysql-test-app  0.0.2    waiting      1  mysql-test-app  latest/stable   63           no       

Unit               Workload  Agent  Address       Ports  Message
mysql-test-app/0*  waiting   idle   10.1.170.148         
```
