### PR TITLE
docs: add Juju 3.6.14 release notes

### DIFF
--- a/docs/releasenotes/juju_3.6.x.md
+++ b/docs/releasenotes/juju_3.6.x.md
@@ -14,6 +14,33 @@ myst:
 Juju 3.6 series is LTS
 ```
 
+## 🔸 **Juju 3.6.14**
+
+🗓️ 28 Jan 2026
+
+This is a point release in the 3.6 LTS series focused on more accurate improving controller 
+database robustness under load and JAAS login errors.
+
+⚙️ **Features:**
+
+### Improved JAAS login error reporting
+
+Practically, `juju login` against JAAS now surfaces the actual failure (for example, OAuth device-flow errors) instead 
+of a misleading legacy error, making debugging login issues significantly easier. 
+
+* feat(fatal-login-error): add fatal login error code and logic to tryinorderloginprovider by @SimoneDutto in https://github.com/juju/juju/pull/21541
+
+🛠️ **Fixes:**
+
+### dqlite upgrade and optimisation
+
+Juju’s embedded dqlite has been upgraded to version **1.18.5**. And we introduce a back port of how we apply pool limits 
+from the 4.x branch. The fix allows better reuse of pooled database connections under high load. 
+
+* feat: update dqlite 1.18.5 by @SimonRichardson in https://github.com/juju/juju/pull/21656
+* feat: apply db limits to prevent pool exhaustion by @SimonRichardson in https://github.com/juju/juju/pull/21649
+
+
 ## 🔸 **Juju 3.6.13**
 🗓️ 19 Jan 2026
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.25.5
+go 1.25.6
 
 require (
 	cloud.google.com/go/compute v1.44.0


### PR DESCRIPTION
This PR adds the 3.6.14 release notes in our documentation.

## QA steps

```sh
# passes the check
```

## Documentation changes

Adds 3.6.14 release notes

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
