### PR TITLE
docs: fix typos and clarify breaking changes in release notes

### DIFF
--- a/docs/releasenotes/juju_4.0.x/juju_4.0.0.md
+++ b/docs/releasenotes/juju_4.0.x/juju_4.0.0.md
@@ -57,13 +57,16 @@ to build them, then juju deploy the built artifact.
 until a replacement arrives).
 * **Offers update (`juju offer`)**: Updating an existing offer is removed; use create/remove flows.
 * **Provider type rename (`manual` → `unmanaged`)**: Update all relevant cloud commands, bootstrap scripts, CI, and docs.
-
 * **Wait-for**: `juju wait-for` (and subcommands `wait-for model|application|machine|unit`) — removed. In `3.6` this 
 family streamed deltas and let you express goal states via a small DSL; it’s no longer available in `4.0`. Workarounds: 
-poll `juju status --format=json` (optionally with `--watch <interval>`) and evaluate readiness client-side.
+poll `juju status --format=json` and evaluate readiness client-side.
+* **Juju status`--watch` flag is dropped**: it is no longer available on commands like `juju status`. The alternative is 
+to use any available watcher on the client side. For example: `watch -n 1 --color juju status --color`
 * **`private-address` removed**:  it is no longer automatically maintained in relation data. It was a copy
 of `ingres-address`, which is the only value that should be used now.
-* **`additionalProperties` default changed**: in action parameter configuration, the `additionalProperties` default value no longer matches JSONSchema, and is instead `false`. Explicitly include `additionalProperties` rather than relying on the default value to have consistency across Juju 3.6 and Juju 4.
+* **`additionalProperties` default changed**: in action parameter configuration, the `additionalProperties` default 
+value no longer matches JSONSchema, and is instead `false`. Explicitly include `additionalProperties` rather than relying 
+on the default value to have consistency across Juju 3.6 and Juju 4.
 
 #### 🐛 Known issues / deferred items
 

--- a/docs/releasenotes/juju_4.0.x/juju_4.0.1.md
+++ b/docs/releasenotes/juju_4.0.x/juju_4.0.1.md
@@ -92,7 +92,7 @@ that loses the address it needs to recover.
 * [fix: api remote caller reconnect on broken](https://github.com/juju/juju/pull/21385#top)
 * [fix: show a helpful error message when destroying a controller with live models](https://github.com/juju/juju/pull/21382#top)
 * [fix: persist controller node agent version](https://github.com/juju/juju/pull/21297#top)
-* [ix: handle empty credential for kill-controller](https://github.com/juju/juju/pull/21514#top)
+* [fix: handle empty credential for kill-controller](https://github.com/juju/juju/pull/21514#top)
 
 ### 🔎 Status/history/logging
 
@@ -107,7 +107,7 @@ status-log.
 * [fix: log all API requests not just RPC ones](https://github.com/juju/juju/pull/21102#top)
 * [fix(status): return the newest entry in GetStatusHistory](https://github.com/juju/juju/pull/21299#top)
 * [fix: application status history record](https://github.com/juju/juju/pull/21301#top)
-* [ix: show-status-log for applications](https://github.com/juju/juju/pull/21310#top)
+* [fix: show-status-log for applications](https://github.com/juju/juju/pull/21310#top)
 * [fix: set Since field on statuses on caas provisioning](https://github.com/juju/juju/pull/21281#top)
 
 ### 🌐 Networking, ports, firewalling, MAAS


### PR DESCRIPTION
This PR fixes the following: 

- Fix Wait-for workaround description by removing `--watch <interval>` option
- Add new breaking change entry for `juju status --watch` being dropped
- Fix typo: "ix:" → "fix:" for PR reference

## QA steps

```sh
# pass checks
```

## Documentation changes

Fix release notes for 4.0.0 and 4.0.1

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
