### PR TITLE
feat: fetch storage info and perform storage reconciliation

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -704,10 +704,9 @@ func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetChar
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = api.applicationService.SetApplicationCharm(ctx, args.ApplicationName, newCharmLocator, application.SetCharmParams{
-		CharmOrigin: charmOrigin,
 
-		// Storage: args.StorageDirectives,
+	err = api.applicationService.SetApplicationCharm(ctx, args.ApplicationName, newCharmLocator, application.SetCharmParams{
+		CharmOrigin:         charmOrigin,
 		CharmUpgradeOnError: args.Force,
 		EndpointBindings:    transform.Map(args.EndpointBindings, func(k, v string) (string, network.SpaceName) { return k, network.SpaceName(v) }),
 	})

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -393,3 +393,27 @@ func (u UnitStorageMinViolation) Error() string {
 		u.UnitUUID, u.CharmStorageName, u.RequiredMinimum,
 	)
 }
+
+// CharmStorageTypeChanged describes an error that occurs when a charm's
+// storage type changes during a refresh for a named storage definition.
+// Example of this would be the previous charm's storage `foo` changing from
+// filesystem to block storage.
+type CharmStorageTypeChanged struct {
+	// StorageName is the name of the storage whose type was being changed in
+	// the operation.
+	StorageName string
+	// OldType is the existing storage type.
+	OldType string
+	// NewType is the new storage type that is different from the old type.
+	NewType string
+}
+
+// Error returns a string representation of the [CharmStorageTypeChanged] error
+// providing context of the storage name, old type and new type for the violation.
+// This func implements the [error] interface.
+func (s CharmStorageTypeChanged) Error() string {
+	return fmt.Sprintf(
+		"existing storage %q type changed from %q to %q",
+		s.StorageName, s.OldType, s.NewType,
+	)
+}

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -13,6 +13,10 @@ import (
 // associated with an application.
 type CreateApplicationStorageDirectiveArg = CreateStorageDirectiveArg
 
+// ApplyApplicationStorageDirectiveArg defines the arguments required to
+// apply an existing storage directive associated with an application.
+type ApplyApplicationStorageDirectiveArg = CreateStorageDirectiveArg
+
 // CreateStorageDirectiveArg defines the arguments required to add a storage
 // directive to the model.
 type CreateStorageDirectiveArg struct {

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/application/internal"
+	"github.com/juju/juju/domain/application/service/storage"
 	"github.com/juju/juju/domain/constraints"
 	"github.com/juju/juju/domain/deployment"
 	internalcharm "github.com/juju/juju/domain/deployment/charm"
@@ -439,6 +440,12 @@ type ApplicationState interface {
 	// GetMachinesForApplication returns the names of the machines which have a unit.
 	// of the specified application deployed to it.
 	GetMachinesForApplication(ctx context.Context, appUUID string) ([]string, error)
+
+	// GetModelStoragePools returns the default storage pools
+	// that have been set for the model.
+	GetModelStoragePools(
+		context.Context,
+	) (internal.ModelStoragePools, error)
 }
 
 func validateCharmAndApplicationParams(
@@ -761,33 +768,6 @@ func makeResourcesArgs(resolvedResources ResolvedResources) []application.AddApp
 		})
 	}
 	return result
-}
-
-// SetApplicationCharm sets a new charm for the application, validating that aspects such
-// as storage are still viable with the new charm.
-func (s *Service) SetApplicationCharm(ctx context.Context, appName string, charmLocator charm.CharmLocator, params application.SetCharmParams) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
-	if err != nil {
-		return errors.Errorf("getting application UUID: %w", err)
-	}
-	charmID, err := s.st.GetCharmID(ctx, charmLocator.Name, charmLocator.Revision, charmLocator.Source)
-	if err != nil {
-		return errors.Errorf("getting charm ID: %w", err)
-	}
-
-	paramsState, err := makeSetCharmStateArg(params)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	err = s.st.SetApplicationCharm(ctx, appUUID, charmID, paramsState)
-	if err != nil {
-		return errors.Errorf("setting application %q charm: %w", appName, err)
-	}
-	return nil
 }
 
 // GetApplicationName returns the name of the specified application.
@@ -1689,6 +1669,68 @@ func (s *Service) GetMachinesForApplication(ctx context.Context, appName string)
 	return transform.Slice(machineNames, func(v string) coremachine.Name {
 		return coremachine.Name(v)
 	}), nil
+}
+
+// SetApplicationCharm sets a new charm for the application, validating that aspects such
+// as storage are still viable with the new charm. It reconciles existing application
+// storage directives with the new charm's storage requirements.
+func (s *ProviderService) SetApplicationCharm(ctx context.Context, appName string, charmLocator charm.CharmLocator, params application.SetCharmParams) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
+	if err != nil {
+		return errors.Errorf("getting application UUID: %w", err)
+	}
+	charmID, err := s.st.GetCharmID(ctx, charmLocator.Name, charmLocator.Revision, charmLocator.Source)
+	if err != nil {
+		return errors.Errorf("getting charm ID: %w", err)
+	}
+	// Retrieve the current storage directives for the application.
+	storageDirectives, err := s.storageService.GetApplicationStorageDirectives(ctx, appUUID)
+	if err != nil {
+		return errors.Errorf("getting application storage directives: %w", err)
+	}
+	// Get new charm's storage requirements.
+	charmMetadataStorage, err := s.st.GetCharmMetadataStorage(ctx, charmID)
+	if err != nil {
+		return errors.Errorf("getting charm storage metadata: %w", err)
+	}
+	// Decode charm storage to internal charm format.
+	newCharmStorage, err := decodeMetadataStorage(charmMetadataStorage)
+	if err != nil {
+		return errors.Errorf("decoding charm storage: %w", err)
+	}
+	// Initial validation for the new charm's storage requirements.
+	if err := validateCharmStorage(newCharmStorage); err != nil {
+		return errors.Errorf("validating charm storage: %w", err)
+	}
+	// Reconcile storage directives between existing and new charm storage.
+	modelStoragePools, err := s.st.GetModelStoragePools(ctx)
+	if err != nil {
+		return errors.Errorf("getting default storage provisioners for model: %w", err)
+	}
+	toApply, toDelete, err := storage.ReconcileUpdatedCharmStorageDirective(newCharmStorage, storageDirectives, modelStoragePools)
+	if err != nil {
+		return errors.Errorf("reconciling storage directives: %w", err)
+	}
+
+	// TODO: Override toApply with user provided storage directives in params.
+
+	// TODO: Validate storage directives in toApply against new charm requirements again.
+
+	paramsState, err := makeSetCharmStateArg(params)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	paramsState.StorageDirectivesToApply = toApply
+	paramsState.StorageDirectivesToDelete = toDelete
+
+	err = s.st.SetApplicationCharm(ctx, appUUID, charmID, paramsState)
+	if err != nil {
+		return errors.Errorf("setting application %q charm: %w", appName, err)
+	}
+	return nil
 }
 
 func getTrustSettingFromConfig(cfg map[string]string) (*bool, error) {

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"context"
 	"math/rand/v2"
 	"testing"
 	"time"
@@ -35,9 +36,11 @@ import (
 	applicationcharm "github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/application/charm/store"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/application/internal"
 	"github.com/juju/juju/domain/deployment"
 	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/life"
+	domainstorage "github.com/juju/juju/domain/storage"
 	domaintesting "github.com/juju/juju/domain/testing"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -1590,12 +1593,16 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithChannel(c *tc.C) {
 	}
 	channel, err := encodeChannel(params.CharmOrigin.Channel)
 	c.Assert(err, tc.ErrorIsNil)
-	paramsToExpect := application.SetCharmStateParams{
-		Channel: channel,
-	}
 	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
 	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
-	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, paramsToExpect).Return(nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]application.StorageDirective{}, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(map[string]applicationcharm.Storage{}, nil)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(internal.ModelStoragePools{}, nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).
+		Do(func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
+			c.Assert(params.Channel, tc.DeepEquals, channel)
+			return nil
+		})
 
 	err = s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
 	c.Assert(err, tc.ErrorIsNil)
@@ -1614,13 +1621,132 @@ func (s *applicationServiceSuite) TestSetApplicationCharmEmptyChannel(c *tc.C) {
 	params := application.SetCharmParams{
 		CharmOrigin: origin,
 	}
-	paramsToExpect := application.SetCharmStateParams{}
 	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
 	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
-	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, paramsToExpect).Return(nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]application.StorageDirective{}, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(map[string]applicationcharm.Storage{}, nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(internal.ModelStoragePools{}, nil)
 
 	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorage(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	// Combination of: update storage count, update storage size, delete old storage, add new storage.
+	existingStorageDirectives := []application.StorageDirective{
+		// storage "data" size and count will be updated.
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,   // Will be increased to 2
+			Size:             512, // Will be updated to 1024
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+		// storage "cache" will be deleted.
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "cache",
+			Count:            1,
+			Size:             256,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    2,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+		// storage "logs" will be created.
+		"logs": {
+			Type:        applicationcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    3,
+			MinimumSize: 512,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
+	// Expect complex changes: update data count, delete cache, add logs
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).
+		Do(func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
+			c.Assert(params.StorageDirectivesToApply, tc.HasLen, 2)
+			c.Assert(params.StorageDirectivesToDelete, tc.HasLen, 1)
+			c.Assert(params.StorageDirectivesToDelete[0], tc.Equals, "cache")
+
+			// Check that we have both updated and new storage
+			var dataUpdate, logsCreate *internal.ApplyApplicationStorageDirectiveArg
+			for i := range params.StorageDirectivesToApply {
+				if string(params.StorageDirectivesToApply[i].Name) == "data" {
+					dataUpdate = &params.StorageDirectivesToApply[i]
+				} else if string(params.StorageDirectivesToApply[i].Name) == "logs" {
+					logsCreate = &params.StorageDirectivesToApply[i]
+				}
+			}
+
+			c.Assert(dataUpdate, tc.Not(tc.IsNil))
+			c.Assert(dataUpdate.Count, tc.Equals, uint32(2))
+			c.Assert(dataUpdate.Size, tc.Equals, uint64(1024))
+			c.Assert(dataUpdate.PoolUUID, tc.Equals, *modelStoragePools.BlockDevicePoolUUID)
+
+			c.Assert(logsCreate, tc.Not(tc.IsNil))
+			c.Assert(logsCreate.Count, tc.Equals, uint32(1))
+			c.Assert(logsCreate.Size, tc.Equals, uint64(512))
+			c.Assert(logsCreate.PoolUUID, tc.Equals, *modelStoragePools.FilesystemPoolUUID)
+			return nil
+		})
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.IsNil)
+}
+
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageInvalidMinMaxCount(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            5,
+			Size:             1024,
+		},
+	}
+
+	// New charm storage count min is higher than max, this is invalid.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    5,
+			CountMax:    3,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorMatches, `.*minimum count greater than maximum count.*`)
 }
 
 func (s *applicationServiceSuite) TestGetApplicationLife(c *tc.C) {
@@ -1665,4 +1791,13 @@ func (s *applicationServiceSuite) TestGetApplicationDetailsInvalidAppUUID(c *tc.
 
 	_, err := s.service.GetApplicationDetails(c.Context(), "!!!")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationUUIDNotValid)
+}
+
+func makeModelStoragePools(c *tc.C) internal.ModelStoragePools {
+	fakeFilesytemPoolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	fakeBlockdevicePoolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	return internal.ModelStoragePools{
+		FilesystemPoolUUID:  &fakeFilesytemPoolUUID,
+		BlockDevicePoolUUID: &fakeBlockdevicePoolUUID,
+	}
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -33,6 +33,7 @@ import (
 	architecture "github.com/juju/juju/domain/application/architecture"
 	charm0 "github.com/juju/juju/domain/application/charm"
 	store "github.com/juju/juju/domain/application/charm/store"
+	internal "github.com/juju/juju/domain/application/internal"
 	constraints0 "github.com/juju/juju/domain/constraints"
 	life "github.com/juju/juju/domain/life"
 	network0 "github.com/juju/juju/domain/network"
@@ -2984,6 +2985,45 @@ func (c *MockStateGetModelConstraintsCall) Do(f func(context.Context) (constrain
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetModelConstraintsCall) DoAndReturn(f func(context.Context) (constraints0.Constraints, error)) *MockStateGetModelConstraintsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetModelStoragePools mocks base method.
+func (m *MockState) GetModelStoragePools(arg0 context.Context) (internal.ModelStoragePools, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModelStoragePools", arg0)
+	ret0, _ := ret[0].(internal.ModelStoragePools)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetModelStoragePools indicates an expected call of GetModelStoragePools.
+func (mr *MockStateMockRecorder) GetModelStoragePools(arg0 any) *MockStateGetModelStoragePoolsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModelStoragePools", reflect.TypeOf((*MockState)(nil).GetModelStoragePools), arg0)
+	return &MockStateGetModelStoragePoolsCall{Call: call}
+}
+
+// MockStateGetModelStoragePoolsCall wrap *gomock.Call
+type MockStateGetModelStoragePoolsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetModelStoragePoolsCall) Return(arg0 internal.ModelStoragePools, arg1 error) *MockStateGetModelStoragePoolsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetModelStoragePoolsCall) Do(f func(context.Context) (internal.ModelStoragePools, error)) *MockStateGetModelStoragePoolsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetModelStoragePoolsCall) DoAndReturn(f func(context.Context) (internal.ModelStoragePools, error)) *MockStateGetModelStoragePoolsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/storage/directive.go
+++ b/domain/application/service/storage/directive.go
@@ -6,6 +6,8 @@ package storage
 import (
 	"context"
 
+	"github.com/juju/collections/transform"
+
 	coreapplication "github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/domain/application"
@@ -315,4 +317,151 @@ func validateApplicationStorageDirectiveOverride(
 	}
 
 	return nil
+}
+
+// ReconcileUpdatedCharmStorageDirective merges existing application storage directives with
+// new charm storage requirements.
+func ReconcileUpdatedCharmStorageDirective(
+	newCharmStorages map[string]internalcharm.Storage,
+	existingStorageDirectives []application.StorageDirective,
+	modelStoragePools internal.ModelStoragePools,
+) (
+	toApply []internal.ApplyApplicationStorageDirectiveArg,
+	toDelete []string,
+	err error,
+) {
+	toApply = []internal.ApplyApplicationStorageDirectiveArg{}
+	toDelete = []string{}
+
+	// To check later on which new storage should be created.
+	processedNewCharmStorage := make(map[string]bool)
+
+	existingStorageDirectivesMap := transform.SliceToMap(existingStorageDirectives, func(d application.StorageDirective) (string, application.StorageDirective) {
+		return d.Name.String(), d
+	})
+
+	// Process existing directives against new charm storage.
+	// We process only overlapping storage names here for update.
+	for storageName, existingStorageDirective := range existingStorageDirectivesMap {
+		newCharmStorage, existsInCharm := newCharmStorages[storageName]
+
+		// Storage no longer in charm, mark for deletion.
+		if !existsInCharm {
+			toDelete = append(toDelete, storageName)
+			continue
+		}
+
+		// We return an error if the storage type has changed for the same storage name,
+		// preserving the behaviour and err message we had in 3.6.
+		if existingStorageDirective.CharmStorageType.String() != newCharmStorage.Type.String() {
+			return nil, nil, &applicationerrors.CharmStorageTypeChanged{
+				StorageName: storageName,
+				OldType:     existingStorageDirective.CharmStorageType.String(),
+				NewType:     newCharmStorage.Type.String(),
+			}
+		}
+
+		// Reconcile this directive.
+		reconciledArg := reconcileStorageDirective(existingStorageDirective, storageName, newCharmStorage)
+
+		// Only include in toApply if something changed.
+		if hasStorageDirectiveChanged(existingStorageDirective, reconciledArg) {
+			toApply = append(toApply, reconciledArg)
+		}
+
+		processedNewCharmStorage[storageName] = true
+	}
+
+	// Process creating new charm storage that are not in existing directives.
+	for charmStorageName, newCharmStorage := range newCharmStorages {
+		if processedNewCharmStorage[charmStorageName] {
+			continue
+		}
+
+		arg := createApplyApplicationStorageDirectiveArg(
+			charmStorageName,
+			newCharmStorage,
+			modelStoragePools,
+		)
+		toApply = append(toApply, arg)
+	}
+
+	return toApply, toDelete, nil
+}
+
+// reconcileStorageDirective reconciles an existing directive with new charm requirements.
+func reconcileStorageDirective(
+	existingStorageDirective application.StorageDirective,
+	storageName string,
+	newCharmStorage internalcharm.Storage,
+) internal.ApplyApplicationStorageDirectiveArg {
+	arg := internal.ApplyApplicationStorageDirectiveArg{
+		Name: domainstorage.Name(storageName),
+	}
+
+	// Increase count if below new minimum.
+	minCount := uint32(max(newCharmStorage.CountMin, 0))
+	count := max(minCount, existingStorageDirective.Count)
+
+	// If the charm has a max count defined (!= -1) and the max count is greater
+	// then the existing storage directive count decrease the storage directive
+	// count to match.
+	maxCount := uint32(newCharmStorage.CountMax)
+	if newCharmStorage.CountMax >= 0 && count > maxCount {
+		count = maxCount
+	}
+
+	// Reconcile storage count.
+	arg.Count = count
+
+	// Reconcile storage size.
+	arg.Size = max(existingStorageDirective.Size, newCharmStorage.MinimumSize)
+
+	// Preserve the existing pool UUID.
+	arg.PoolUUID = existingStorageDirective.PoolUUID
+
+	return arg
+}
+
+// hasStorageDirectiveChanged checks if a directive needs updating.
+func hasStorageDirectiveChanged(
+	existing application.StorageDirective,
+	proposed internal.ApplyApplicationStorageDirectiveArg,
+) bool {
+	storageCountChanged := proposed.Count != existing.Count
+	storageSizeChanged := proposed.Size != existing.Size
+	storagePoolChanged := proposed.PoolUUID != existing.PoolUUID
+
+	return storageCountChanged || storageSizeChanged || storagePoolChanged
+}
+
+// createApplyApplicationStorageDirectiveArg creates a directive for new storage in the charm.
+// This is intended to be used for charm refresh.
+func createApplyApplicationStorageDirectiveArg(
+	storageName string,
+	charmStorage internalcharm.Storage,
+	modelStoragePools internal.ModelStoragePools,
+) internal.ApplyApplicationStorageDirectiveArg {
+
+	arg := internal.ApplyApplicationStorageDirectiveArg{
+		Name: domainstorage.Name(storageName),
+	}
+	// Set count.
+	if charmStorage.CountMin > 0 {
+		arg.Count = uint32(charmStorage.CountMin)
+	}
+
+	// Set size.
+	arg.Size = defaultStorageDirectiveSize
+	if charmStorage.MinimumSize > 0 {
+		arg.Size = charmStorage.MinimumSize
+	}
+
+	// Set poolUUID.
+	if charmStorage.Type == internalcharm.StorageBlock && modelStoragePools.BlockDevicePoolUUID != nil {
+		arg.PoolUUID = *modelStoragePools.BlockDevicePoolUUID
+	} else if charmStorage.Type == internalcharm.StorageFilesystem && modelStoragePools.FilesystemPoolUUID != nil {
+		arg.PoolUUID = *modelStoragePools.FilesystemPoolUUID
+	}
+	return arg
 }

--- a/domain/application/service/storage/directive_test.go
+++ b/domain/application/service/storage/directive_test.go
@@ -26,6 +26,15 @@ type directiveSuite struct {
 	state        *MockState
 }
 
+func makeModelStoragePools(c *tc.C) internal.ModelStoragePools {
+	fakeFilesytemPoolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	fakeBlockdevicePoolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	return internal.ModelStoragePools{
+		FilesystemPoolUUID:  &fakeFilesytemPoolUUID,
+		BlockDevicePoolUUID: &fakeBlockdevicePoolUUID,
+	}
+}
+
 func TestDirectiveSuite(t *testing.T) {
 	tc.Run(t, &directiveSuite{})
 }
@@ -44,10 +53,7 @@ func (s *directiveSuite) setupMocks(t *testing.T) *gomock.Controller {
 // TestMakeApplicationStorageDirectiveArgs tests the expected merges performed
 // by [Service.MakeApplicationStorageDirectiveArgs].
 func (s *directiveSuite) TestMakeApplicationStorageDirectiveArgs(c *tc.C) {
-	// Set of fake values to reference in the sub tests.
-	fakeFilesytemPoolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
-	fakeBlockdevicePoolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
-
+	modelStoragePools := makeModelStoragePools(c)
 	tests := []struct {
 		Name              string
 		ModelStoragePools internal.ModelStoragePools
@@ -75,15 +81,12 @@ func (s *directiveSuite) TestMakeApplicationStorageDirectiveArgs(c *tc.C) {
 					MinimumSize: 256,
 				},
 			},
-			ModelStoragePools: internal.ModelStoragePools{
-				FilesystemPoolUUID:  &fakeFilesytemPoolUUID,
-				BlockDevicePoolUUID: &fakeBlockdevicePoolUUID,
-			},
+			ModelStoragePools: modelStoragePools,
 			Expected: []internal.CreateApplicationStorageDirectiveArg{
 				{
 					Count:    2,
 					Name:     domainstorage.Name("foo"),
-					PoolUUID: fakeFilesytemPoolUUID,
+					PoolUUID: *modelStoragePools.FilesystemPoolUUID,
 					Size:     256,
 				},
 			},
@@ -102,7 +105,7 @@ func (s *directiveSuite) TestMakeApplicationStorageDirectiveArgs(c *tc.C) {
 				},
 			},
 			ModelStoragePools: internal.ModelStoragePools{
-				BlockDevicePoolUUID: &fakeBlockdevicePoolUUID,
+				BlockDevicePoolUUID: modelStoragePools.BlockDevicePoolUUID,
 			},
 
 			Expected: []internal.CreateApplicationStorageDirectiveArg{
@@ -127,15 +130,15 @@ func (s *directiveSuite) TestMakeApplicationStorageDirectiveArgs(c *tc.C) {
 				},
 			},
 			ModelStoragePools: internal.ModelStoragePools{
-				FilesystemPoolUUID:  &fakeFilesytemPoolUUID,
-				BlockDevicePoolUUID: &fakeBlockdevicePoolUUID,
+				FilesystemPoolUUID:  modelStoragePools.FilesystemPoolUUID,
+				BlockDevicePoolUUID: modelStoragePools.BlockDevicePoolUUID,
 			},
 
 			Expected: []internal.CreateApplicationStorageDirectiveArg{
 				{
 					Count:    2,
 					Name:     domainstorage.Name("foo"),
-					PoolUUID: fakeBlockdevicePoolUUID,
+					PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
 					Size:     256,
 				},
 			},
@@ -342,4 +345,350 @@ func (s *directiveSuite) TestMakeStorageDirectiveFromApplicationArg(c *tc.C) {
 		"kratos", charmStorage, createArgs,
 	)
 	c.Assert(gotDirectives, tc.SameContents, expected)
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveNoChanges tests that when existing
+// storage directives match new charm storage exactly, no changes are proposed.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveNoChanges(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			CharmStorageType: domainapplicationcharm.StorageFilesystem,
+			Name:             "data",
+			Count:            1,
+			Size:             1024,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(err, tc.IsNil)
+	c.Assert(toApply, tc.HasLen, 0)
+	c.Assert(toDelete, tc.HasLen, 0)
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveIncreaseSize tests that when new
+// charm storage minimum size is higher than existing, the size is increased.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveIncreaseSize(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             1024,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 2048,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(err, tc.IsNil)
+	c.Assert(toApply, tc.HasLen, 1)
+	c.Assert(toApply[0].Size, tc.Equals, uint64(2048))
+	c.Assert(toApply[0].Name, tc.Equals, domainstorage.Name("data"))
+	c.Assert(toDelete, tc.HasLen, 0)
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveNoSizeChange tests that when existing
+// storage size is already above new charm minimum, no size change occurs.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveNoSizeChange(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             4096,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 2048,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(err, tc.IsNil)
+	c.Assert(toApply, tc.HasLen, 0)
+	c.Assert(toDelete, tc.HasLen, 0)
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveIncreaseCount tests that when new
+// charm storage minimum count is higher than existing, the count is increased.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveIncreaseCount(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             1024,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageBlock,
+			CountMin:    3,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(err, tc.IsNil)
+	c.Assert(toApply, tc.HasLen, 1)
+	c.Assert(toApply[0].Count, tc.Equals, uint32(3))
+	c.Assert(toApply[0].Name, tc.Equals, domainstorage.Name("data"))
+	c.Assert(toDelete, tc.HasLen, 0)
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveDecreaseCount tests that when new
+// charm storage maximum count is lower than existing, the count is decreased.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveDecreaseCount(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            5,
+			Size:             1024,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    4,
+			MinimumSize: 1024,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(err, tc.IsNil)
+	c.Assert(toApply, tc.HasLen, 1)
+	c.Assert(toApply[0].Count, tc.Equals, uint32(4))
+	c.Assert(toApply[0].Name, tc.Equals, domainstorage.Name("data"))
+	c.Assert(toDelete, tc.HasLen, 0)
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveDeleteOldStorage tests that storage
+// present in existing directives but not in new charm is marked for deletion.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveDeleteOldStorage(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             1024,
+		},
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "logs",
+			Count:            1,
+			Size:             512,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(err, tc.IsNil)
+	c.Assert(toApply, tc.HasLen, 0)
+	c.Assert(toDelete, tc.HasLen, 1)
+	c.Assert(toDelete[0], tc.Equals, "logs")
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveAddNewStorage tests that storage
+// present in new charm but not in existing directives is added.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveAddNewStorage(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             1024,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+		"logs": {
+			Type:        internalcharm.StorageFilesystem,
+			CountMin:    2,
+			CountMax:    5,
+			MinimumSize: 512,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(err, tc.IsNil)
+	c.Assert(toApply, tc.HasLen, 1)
+	c.Assert(string(toApply[0].Name), tc.Equals, "logs")
+	c.Assert(toApply[0].Count, tc.Equals, uint32(2))
+	c.Assert(toApply[0].Size, tc.Equals, uint64(512))
+	c.Assert(toApply[0].PoolUUID, tc.Equals, *modelStoragePools.FilesystemPoolUUID)
+	c.Assert(toDelete, tc.HasLen, 0)
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveIncompatibleType tests that when
+// storage type changes between existing and new charm, an error is returned.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveIncompatibleType(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			Name:             "data",
+			Count:            1,
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Size:             1024,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(toApply, tc.IsNil)
+	c.Assert(toDelete, tc.IsNil)
+	c.Assert(err, tc.ErrorMatches, `.*existing storage "data" type changed from "block" to "filesystem".*`)
+	var incompatibleErr *applicationerrors.CharmStorageTypeChanged
+	c.Assert(errors.As(err, &incompatibleErr), tc.Equals, true)
+	c.Assert(incompatibleErr.StorageName, tc.Equals, "data")
+	c.Assert(incompatibleErr.OldType, tc.Equals, "block")
+	c.Assert(incompatibleErr.NewType, tc.Equals, "filesystem")
+}
+
+// TestReconcileUpdatedCharmStorageDirectiveComplexReconciliation tests a
+// combination of operations: update storage count and size, delete old storage,
+// and add new storage.
+func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveComplexReconciliation(c *tc.C) {
+	modelStoragePools := makeModelStoragePools(c)
+
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	existingStorageDirectives := []domainapplication.StorageDirective{
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         poolUUID,
+		},
+		{
+			CharmStorageType: domainapplicationcharm.StorageBlock,
+			Name:             "cache",
+			Count:            1,
+			Size:             256,
+		},
+	}
+
+	newCharmStorages := map[string]internalcharm.Storage{
+		"data": {
+			Type:        internalcharm.StorageBlock,
+			CountMin:    2,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+		"logs": {
+			Type:        internalcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    3,
+			MinimumSize: 512,
+		},
+	}
+
+	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
+		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	)
+
+	c.Assert(err, tc.IsNil)
+	c.Assert(toApply, tc.HasLen, 2)
+	c.Assert(toDelete, tc.HasLen, 1)
+	c.Assert(toDelete[0], tc.Equals, "cache")
+
+	// Check for updated "data" storage
+	var dataUpdate, logsCreate *internal.ApplyApplicationStorageDirectiveArg
+	for i := range toApply {
+		if string(toApply[i].Name) == "data" {
+			dataUpdate = &toApply[i]
+		} else if string(toApply[i].Name) == "logs" {
+			logsCreate = &toApply[i]
+		}
+	}
+
+	c.Assert(dataUpdate, tc.Not(tc.IsNil))
+	c.Assert(dataUpdate.Count, tc.Equals, uint32(2))
+	c.Assert(dataUpdate.Size, tc.Equals, uint64(1024))
+	c.Assert(dataUpdate.PoolUUID, tc.Equals, poolUUID)
+
+	c.Assert(logsCreate, tc.Not(tc.IsNil))
+	c.Assert(logsCreate.Count, tc.Equals, uint32(1))
+	c.Assert(logsCreate.Size, tc.Equals, uint64(512))
+	c.Assert(logsCreate.PoolUUID, tc.Equals, *modelStoragePools.FilesystemPoolUUID)
 }

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1696,7 +1696,7 @@ WHERE  uuid = $entityUUID.uuid
 			return errors.Capture(err)
 		}
 
-		//TODO(storage) - update storage directive for app
+		//TODO(storage) - upsert storage directive for app
 
 		bindings := transform.Map(params.EndpointBindings, func(k string, v network.SpaceName) (string, string) {
 			return k, v.String()

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/resource"
-	"github.com/juju/juju/core/storage"
 	coreunit "github.com/juju/juju/core/unit"
 	domaincharm "github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/application/internal"
@@ -488,13 +487,6 @@ type InsertApplicationArgs struct {
 type SetCharmParams struct {
 	// CharmOrigin contains the origin information for the new charm.
 	CharmOrigin charm.Origin
-	// Storage contains the storage directives to add or update when
-	// upgrading the charm.
-	//
-	// Any existing storage instances for the named stores will be
-	// unaffected; the storage directives will only be used for
-	// provisioning new storage instances.
-	Storage map[string]storage.Directive
 
 	// CharmUpgradeOnError indicates whether the charm must be upgraded
 	// even when on error.
@@ -515,6 +507,18 @@ type SetCharmStateParams struct {
 	// EndpointBindings is an operator-defined map of endpoint names to
 	// space names that should be merged with any existing bindings.
 	EndpointBindings map[string]network.SpaceName
+
+	// StorageDirectivesToApply contains storage directives that need to be
+	// applied based on the new charm's storage requirements.
+	StorageDirectivesToApply []internal.ApplyApplicationStorageDirectiveArg
+
+	// StorageDirectivesToDelete contains the names of storage directives that
+	// should be removed because the storage is no longer in the charm.
+	// These are tracked separately from StorageDirectivesToApply because the
+	// apply list may not contain the complete set of storage directives.
+	// Splitting them this way avoids unnecessary database churn and watcher
+	// events that would occur if we replaced all directives on every update.
+	StorageDirectivesToDelete []string
 }
 
 // ApplicationDetails contains details about an application.


### PR DESCRIPTION
This PR adds support for handling updated charm storage requirements when an application’s charm is refreshed. A charm refresh updates the charm revision, and during this process the charm’s declared storage requirements may change. This work focuses on reconciling the existing storage directives with the updated requirements defined by the new charm.

**PLEASE NOTE**
User-provided storage directives supplied at refresh time (for example via the --storage flag) are not handled in this PR. Validation of user input against the new charm requirements, as well as persisting any updated storage directives to state, will be addressed in a follow-up PR. These are indicated in the 3 TODOs in the PR changes.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps - Checking if juju refresh still works normally

1. Bootstrap a lxd controller and add a model.
```sh
juju bootstrap lxd lxdtest --destebug && juju add-model lxdtestmodel
```

2. Deploy ubuntu on revision 25
```sh
juju deploy ubuntu --channel latest/stable --revision 25
```

3. Check juju status
```sh
test@alvinchee98-Adder-WS:~/Desktop/repos/juju$ juju status
Model                  Controller        Cloud/Region         Version  Timestamp
alvinreconcile40model  alvinreconcile40  localhost/localhost  4.0.2.1  15:50:11+08:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  24.04    active      1  ubuntu  latest/stable   25  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.43.69.139           

Machine  State    Address       Inst id        Base          AZ                    Message
0        started  10.43.69.139  juju-e0dd2d-0  ubuntu@24.04  alvinchee98-Adder-WS  Running
```

4. Refresh to latest revision
```sh
test@alvinchee98-Adder-WS:~/Desktop/repos/juju$ juju refresh ubuntu
Added charm-hub charm "ubuntu", revision 26 in channel latest/stable, to the model
no change to endpoint in space "alpha": juju-info
```

5. Check juju status - if revision has been updated without err
```sh
test@alvinchee98-Adder-WS:~/Desktop/repos/juju$ juju status
Model                  Controller        Cloud/Region         Version  Timestamp
alvinreconcile40model  alvinreconcile40  localhost/localhost  4.0.2.1  15:50:24+08:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  24.04    active      1  ubuntu  latest/stable   26  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.43.69.139           

Machine  State    Address       Inst id        Base          AZ                    Message
0        started  10.43.69.139  juju-e0dd2d-0  ubuntu@24.04  alvinchee98-Adder-WS  Running
```

## Links
[JUJU-9110]: https://warthogs.atlassian.net/browse/JUJU-9110