### PR TITLE
docs: fix menu link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "https://canonical.com/juju/docs",
+    "product_page": "canonical.com/juju/docs",
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # TODO: To add a tag image, uncomment and update as needed.


### PR DESCRIPTION
## Changes

Because of my inattention + a strange UX issue in the Starter Pack (https://github.com/canonical/sphinx-docs-starter-pack/issues/518#top), the Menu link to the Juju docs entrypoint page was broken. This PR fixes it.

## QA

Use the RTD link in the CI to open a docs preview (https://canonical-ubuntu-documentation-library--21697.com.readthedocs.build/juju/21697/). In the top left-hand corner, click on the little Juju with the logo and verify that it works. See screenshot for reference.

<img width="319" height="203" alt="image" src="https://github.com/user-attachments/assets/a1326b22-d147-4d3c-bd4e-40c3c1710f5d" />


## Forward merge

This PR should be forward merged into `4.0` and `main`.