### PR TITLE
feat: detect virtual ethernet devices

### DIFF
--- a/core/network/linklayer.go
+++ b/core/network/linklayer.go
@@ -32,6 +32,9 @@ const (
 
 	// VXLANDevice is used for Virtual Extensible LAN devices.
 	VXLANDevice LinkLayerDeviceType = "vxlan"
+
+	// VirtualEthernetDevice is used for virtual Ethernet devices.
+	VirtualEthernetDevice LinkLayerDeviceType = "veth"
 )
 
 func (t LinkLayerDeviceType) String() string {
@@ -42,7 +45,7 @@ func (t LinkLayerDeviceType) String() string {
 // link-layer network device type.
 func IsValidLinkLayerDeviceType(value string) bool {
 	switch LinkLayerDeviceType(value) {
-	case LoopbackDevice, EthernetDevice, VLAN8021QDevice, BondDevice, BridgeDevice, VXLANDevice:
+	case LoopbackDevice, EthernetDevice, VLAN8021QDevice, BondDevice, BridgeDevice, VXLANDevice, VirtualEthernetDevice:
 		return true
 	}
 	return false

--- a/core/network/linklayer_test.go
+++ b/core/network/linklayer_test.go
@@ -28,6 +28,7 @@ func (s *linkLayerSuite) TestIsValidLinkLayerDeviceTypeValid(c *tc.C) {
 		BondDevice,
 		BridgeDevice,
 		VXLANDevice,
+		VirtualEthernetDevice,
 	}
 
 	for _, value := range validTypes {

--- a/core/network/source_netlink.go
+++ b/core/network/source_netlink.go
@@ -64,6 +64,8 @@ func (n netlinkNIC) Type() LinkLayerDeviceType {
 		return BondDevice
 	case "vxlan":
 		return VXLANDevice
+	case "veth":
+		return VirtualEthernetDevice
 	}
 
 	if n.nic.Attrs().Flags&net.FlagLoopback > 0 {

--- a/core/network/source_netlink_test.go
+++ b/core/network/source_netlink_test.go
@@ -76,6 +76,9 @@ func (s *sourceNetlinkSuite) TestNetlinkNICType(c *tc.C) {
 	link.linkType = "vxlan"
 	c.Check(nic.Type(), tc.Equals, VXLANDevice)
 
+	link.linkType = "veth"
+	c.Check(nic.Type(), tc.Equals, VirtualEthernetDevice)
+
 	// Infer loopback from flags.
 	link.linkType = ""
 	link.flags = net.FlagUp | net.FlagLoopback

--- a/domain/network/modelmigration/import_linklayerdevices.go
+++ b/domain/network/modelmigration/import_linklayerdevices.go
@@ -223,6 +223,10 @@ func encodeDeviceType(t string) (network.DeviceType, error) {
 		return network.DeviceTypeBridge, nil
 	case corenetwork.VXLANDevice.String():
 		return network.DeviceTypeVXLAN, nil
+	// This device type was never actually used in 3.6,
+	// but is added here for completeness.
+	case corenetwork.VirtualEthernetDevice.String():
+		return network.DeviceTypeVeth, nil
 	default:
 		return -1, errors.Errorf("unknown link layer device type: %q", t)
 	}

--- a/domain/network/types.go
+++ b/domain/network/types.go
@@ -89,6 +89,7 @@ const (
 	DeviceTypeBond
 	DeviceTypeBridge
 	DeviceTypeVXLAN
+	DeviceTypeVeth
 )
 
 // VirtualPortType represents the type of a link layer device port, as

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -145,6 +145,7 @@ var modelPostPatchFilesByVersion = []struct {
 	files: []string{
 		"0043-k8s-provider-id.PATCH.sql",
 		"0044-secret.PATCH.sql",
+		"0045-veth-nic-type.PATCH.sql",
 	},
 }}
 

--- a/domain/schema/model/sql/0045-veth-nic-type.PATCH.sql
+++ b/domain/schema/model/sql/0045-veth-nic-type.PATCH.sql
@@ -1,0 +1,2 @@
+INSERT INTO link_layer_device_type VALUES
+(7, 'veth');


### PR DESCRIPTION
Virtual Ethernet devices are now indicated as such instead of falling back to being designated as normal Ethernet.

At present this has no effect, but will allow us to better select addresses for status and relation network configuration in subsequent changes.

## QA steps

- Bootstrap to LXD and add a model.
- `juju deploy k8s --channel=1.33/stable --base="ubuntu@24.04" --constraints='cores=2 mem=16G root-disk=40G virt-type=virtual-machine'`.
- Wait for it to settle, the SSH to the machine and run `systemctl restart jujud-machine-0`.
- Connect to the DB REPL and check devices in the model (7=veth):
```
select name, device_type_id from link_layer_device
name            device_type_id
lo              1
enp5s0          2
cilium_net      7
cilium_host     7
cilium_vxlan    6
lxc_health      7
lxc538d696cf5ee 7
lxce8c2444052b0 7
lxc7a8d6e1e624d 7
lxc93e188bba551 7
```

