### PR TITLE
fix: get dead models even unactivated

### DIFF
--- a/domain/model/state/controller/state.go
+++ b/domain/model/state/controller/state.go
@@ -2226,7 +2226,7 @@ func (st *State) GetDeadModels(ctx context.Context) ([]coremodel.UUID, error) {
 	stmt, err := st.Prepare(`
 SELECT &modelUUID.*
 FROM   model
-WHERE  activated=1 AND life_id = 2
+WHERE  life_id = 2
 `, modelUUID{})
 
 	if err != nil {

--- a/domain/model/state/controller/state_test.go
+++ b/domain/model/state/controller/state_test.go
@@ -2051,6 +2051,39 @@ func (m *stateSuite) TestGetDeadModels(c *tc.C) {
 	c.Check(deadModels[0], tc.Equals, m.uuid)
 }
 
+func (m *stateSuite) TestGetDeadModelsUnactivated(c *tc.C) {
+	m.createControllerModelWithoutActivation(c, m.controllerModelUUID, m.userUUID)
+	m.createModelWithoutActivation(c, "my-test-model", m.uuid, m.userUUID)
+
+	// Test no input model UUIDs.
+	deadModels, err := m.modelState.GetDeadModels(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(deadModels, tc.HasLen, 0)
+
+	err = m.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		// Insert a dying model.
+		_, err := tx.ExecContext(ctx, `UPDATE model SET life_id = 1 WHERE uuid = ?`, m.uuid.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	deadModels, err = m.modelState.GetDeadModels(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(deadModels, tc.HasLen, 0)
+
+	err = m.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		// Insert a dead model.
+		_, err := tx.ExecContext(ctx, `UPDATE model SET life_id = 2 WHERE uuid = ?`, m.uuid.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	deadModels, err = m.modelState.GetDeadModels(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(deadModels, tc.HasLen, 1)
+	c.Check(deadModels[0], tc.Equals, m.uuid)
+}
+
 func (m *stateSuite) TestGetModelLife(c *tc.C) {
 	m.createControllerModel(c, m.controllerModelUUID, m.userUUID)
 
@@ -2280,6 +2313,36 @@ func (m *stateSuite) createControllerModel(c *tc.C, controllerModelUUID coremode
 
 		activator := GetActivator()
 		return activator(ctx, preparer{}, tx, controllerModelUUID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	u, err := uuid.UUIDFromString(m.SeedControllerTable(c, controllerModelUUID))
+	c.Assert(err, tc.ErrorIsNil)
+	return u
+}
+
+// createControllerModel creates a the database for use in tests.
+func (m *stateSuite) createControllerModelWithoutActivation(c *tc.C, controllerModelUUID coremodel.UUID, userUUID user.UUID) uuid.UUID {
+	// Before we can create the model, we need to create a controller model.
+	// This ensures that we
+	err := m.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		err := Create(c.Context(), preparer{}, tx, controllerModelUUID, coremodel.IAAS, model.GlobalModelCreationArgs{
+			Cloud:       "my-cloud",
+			CloudRegion: "my-region",
+			Credential: corecredential.Key{
+				Cloud: "my-cloud",
+				Owner: usertesting.GenNewName(c, "test-user"),
+				Name:  "foobar",
+			},
+			Name:          "controller",
+			Qualifier:     "prod",
+			AdminUsers:    []user.UUID{userUUID},
+			SecretBackend: juju.BackendName,
+		})
+		if err != nil {
+			return err
+		}
+		return nil
 	})
 	c.Assert(err, tc.ErrorIsNil)
 


### PR DESCRIPTION
When a model fails to migrate, we need to ensure that we remove it. This was done previously with a direct call to delete db, but that just isn't needed, as the undertaker can take sole responsibility. It could do, if the model was activated, but now we activate the model at the **end** of the import sequence and not at the **beginning**. This slight change to ordering broke this workflow.

The solution is simple, allow the deletion of dead models. Any dead model will do - nuke it!

## QA steps

Bootstrap 3.6 and deploy the following:

```sh
$ snap install juju --channel=3.6/stable
$ /snap/bin/juju bootstrap localhost src
$ /snap/bin/juju add-model offer && /snap/bin/juju deploy juju-qa-dummy-source && /snap/bin/juju offer dummy-source:sink
$ /snap/bin/juju add-model consume && /snap/bin/juju deploy juju-qa-dummy-sink
$ /snap/bin/juju consume admin/offer.dummy-source && /snap/bin/juju relate dummy-source dummy-sink
```

Bootstrap a 4.0:

```sh
$ juju bootstrap localhost dst
$ juju migrate src:offer dst
```

It should currently fail because of FK constraint issue.

```sh
$ juju ssh -m controller 0
$ juju_db_repl
$ repl (controller)> .switch model-offer
model "offer" not found
```

It's gone!


## Links

Work towards:

**Jira card:** [JUJU-9071](https://warthogs.atlassian.net/browse/JUJU-9071)


[JUJU-9071]: https://warthogs.atlassian.net/browse/JUJU-9071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ