### PR TITLE
fix: enable migration of /32 devices without subnets

### DIFF
--- a/domain/network/import_integration_test.go
+++ b/domain/network/import_integration_test.go
@@ -504,6 +504,7 @@ func (s *importSuite) TestImportLinkLayerDevicesWithAddresses(c *tc.C) {
 func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXD(c *tc.C) {
 	s.setModel(c, "lxd", model.IAAS.String())
 
+	// Arrange
 	machineSvc := s.setupMachineService(c)
 	res, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
@@ -513,8 +514,10 @@ func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXD(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
+	// Arrange: add 2 subnets for 3 devices. Import will create the 3rd
+	// subnet
 	_, err = s.svc.AddSubnet(c.Context(), network.SubnetInfo{
-		CIDR: "192.168.0.0/24",
+		CIDR: "192.0.2.0/24",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -527,6 +530,7 @@ func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXD(c *tc.C) {
 		Type: string(model.IAAS),
 	})
 
+	// Arrange: 3 devices, 1 with no subnet in the model
 	desc.AddLinkLayerDevice(description.LinkLayerDeviceArgs{
 		Name:        "test-device",
 		MTU:         1500,
@@ -547,13 +551,23 @@ func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXD(c *tc.C) {
 		IsAutoStart: false,
 		IsUp:        false,
 	})
+	desc.AddLinkLayerDevice(description.LinkLayerDeviceArgs{
+		Name:        "cilium_host",
+		MTU:         1500,
+		MachineID:   res.MachineName.String(),
+		Type:        "ethernet",
+		MACAddress:  "42:d7:14:1e:32:58",
+		ProviderID:  "nic-42:d7:14:1e:32:58",
+		IsAutoStart: true,
+		IsUp:        true,
+	})
 
 	desc.AddIPAddress(description.IPAddressArgs{
 		ProviderID:        "ip-address-1",
-		Value:             "192.168.0.1",
-		SubnetCIDR:        "192.168.0.0/24",
+		Value:             "192.0.2.1",
+		SubnetCIDR:        "192.0.2.0/24",
 		ProviderNetworkID: "net-lxdbr0",
-		ProviderSubnetID:  "subnet--192.168.0.0/24",
+		ProviderSubnetID:  "subnet--192.0.2.0/24",
 		Origin:            "machine",
 		MachineID:         res.MachineName.String(),
 		DeviceName:        "test-device",
@@ -570,16 +584,38 @@ func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXD(c *tc.C) {
 		DeviceName:        "another-device",
 		ConfigMethod:      string(network.ConfigDHCP),
 	})
+	desc.AddIPAddress(description.IPAddressArgs{
+		Value:            "203.0.113.7",
+		SubnetCIDR:       "203.0.113.0/32",
+		ProviderSubnetID: "subnet--203.0.113.0/32",
+		Origin:           "machine",
+		MachineID:        res.MachineName.String(),
+		DeviceName:       "cilium_host",
+		ConfigMethod:     string(network.ConfigStatic),
+	})
 
 	networkmodelmigration.RegisterLinkLayerDevicesImport(s.coordinator, loggertesting.WrapCheckLog(c))
+
+	// Act
 	err = s.coordinator.Perform(c.Context(), s.scope, desc)
+
+	// Assert
 	c.Assert(err, tc.ErrorIsNil)
 
 	s.checkLinkLayerDeviceExistsOnMachine(c, res.MachineName, "test-device")
 	s.checkLinkLayerDeviceExistsOnMachine(c, res.MachineName, "another-device")
 
-	s.checkAddressExistsForDeviceOnMachine(c, res.MachineName, "test-device", "192.168.0.1/24")
+	// Assert the device with no subnet was added.
+	s.checkLinkLayerDeviceExistsOnMachine(c, res.MachineName, "cilium_host")
+
+	s.checkAddressExistsForDeviceOnMachine(c, res.MachineName, "test-device", "192.0.2.1/24")
 	s.checkAddressExistsForDeviceOnMachine(c, res.MachineName, "another-device", "2001:db8::1/64")
+
+	// Assert the ip address with no subnet was added.
+	s.checkAddressExistsForDeviceOnMachine(c, res.MachineName, "cilium_host", "203.0.113.7/32")
+
+	// Assert a new /32 subnet was created.
+	s.checkSubnetExists(c, "203.0.113.0/32")
 }
 
 func (s *importSuite) TestImportCloudServices(c *tc.C) {
@@ -687,7 +723,21 @@ func (s *importSuite) checkAddressExistsForDeviceOnMachine(c *tc.C, machineName 
 		`, machineName.String(), deviceName, addressValue).Scan(&count)
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(count, tc.Equals, 1, tc.Commentf("expected 1 ip address for machine %q, device %q with value %q", machineName, deviceName, addressValue))
+	if !c.Check(count, tc.Equals, 1, tc.Commentf("expected 1 ip address for machine %q, device %q with value %q", machineName, deviceName, addressValue)) {
+		s.DumpTable(c, "ip_address", "link_layer_device", "machine")
+	}
+}
+
+func (s *importSuite) checkSubnetExists(c *tc.C, subnetCIDR string) {
+	var count int
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM subnet
+			WHERE cidr = ?
+		`, subnetCIDR).Scan(&count)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1, tc.Commentf("expected 1 subnet for cidr %q, got %d", subnetCIDR, count))
 }
 
 func (s *importSuite) checkAddressExistsForServiceForApp(c *tc.C, appName, addressValue string) {

--- a/domain/network/service/migration.go
+++ b/domain/network/service/migration.go
@@ -6,19 +6,25 @@ package service
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/juju/juju/core/logger"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/domain/network"
+	networkerrors "github.com/juju/juju/domain/network/errors"
 	"github.com/juju/juju/domain/network/internal"
 	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/uuid"
 )
 
 // MigrationState describes methods required
 // for migrating machine network configuration.
 type MigrationState interface {
+	// AddSubnet creates a subnet.
+	AddSubnet(ctx context.Context, subnet corenetwork.SubnetInfo) error
+
 	// AllMachinesAndNetNodes returns all machine names mapped to their
 	// net mode UUIDs in the model.
 	AllMachinesAndNetNodes(ctx context.Context) (map[string]string, error)
@@ -128,7 +134,7 @@ func (s *MigrationService) transformImportLinkLayerDevice(
 	if len(device.Addresses) > 0 {
 		transformedAddresses := make([]internal.ImportIPAddress, 0, len(device.Addresses))
 		for _, addr := range device.Addresses {
-			transformedAddr, err := s.transformImportIPAddress(addr, subnets, subnetByProviderId)
+			transformedAddr, err := s.transformImportIPAddress(ctx, addr, subnets, subnetByProviderId)
 			if err != nil {
 				return internal.ImportLinkLayerDevice{}, errors.Errorf("converting address %q: %w",
 					addr.AddressValue, err)
@@ -142,6 +148,7 @@ func (s *MigrationService) transformImportLinkLayerDevice(
 
 // transformImportIPAddress transforms an ImportIPAddress by finding and setting its subnet UUID
 func (s *MigrationService) transformImportIPAddress(
+	ctx context.Context,
 	addr internal.ImportIPAddress,
 	subnets corenetwork.SubnetInfos,
 	subnetByProviderId map[string]corenetwork.SubnetInfo,
@@ -171,7 +178,38 @@ func (s *MigrationService) transformImportIPAddress(
 	}
 	var err error
 	addr.SubnetUUID, err = s.ensureOneSubnet(candidateSubnets)
+	if errors.Is(err, networkerrors.SubnetNotFound) {
+		return s.maybeAddSubnet(ctx, addr)
+	}
 	return addr, errors.Capture(err)
+}
+
+// maybeAddSubnet creates a subnet if the address provided is a /32
+// or /128. Should only be called if an existing subnet does not match.
+func (s *MigrationService) maybeAddSubnet(ctx context.Context, addr internal.ImportIPAddress) (internal.ImportIPAddress, error) {
+	// Check to see if we have a /32 or /128 CIDR.
+	_, ipNet, err := net.ParseCIDR(addr.SubnetCIDR)
+	if err != nil {
+		return internal.ImportIPAddress{}, errors.Capture(err)
+	}
+	ones, bits := ipNet.Mask.Size()
+	if ones != bits && (bits == 32 || bits == 128) {
+		return internal.ImportIPAddress{}, errors.Errorf("no subnet found, nor created")
+	}
+
+	subnetUUID, err := uuid.NewUUID()
+	if err != nil {
+		return internal.ImportIPAddress{}, errors.Capture(err)
+	}
+	subnetInfo := corenetwork.SubnetInfo{
+		ID:   corenetwork.Id(subnetUUID.String()),
+		CIDR: addr.SubnetCIDR,
+	}
+	if err := s.st.AddSubnet(ctx, subnetInfo); err != nil {
+		return internal.ImportIPAddress{}, errors.Capture(err)
+	}
+	addr.SubnetUUID = subnetUUID.String()
+	return addr, nil
 }
 
 // ImportCloudServices is part of the [modelmigration.MigrationService]
@@ -299,7 +337,7 @@ func (s *MigrationService) transformCloudServiceAddress(
 func (s *MigrationService) ensureOneSubnet(subnets corenetwork.SubnetInfos) (string, error) {
 	// Check if we found any subnets
 	if len(subnets) == 0 {
-		return "", errors.Errorf("no subnet found")
+		return "", errors.Errorf("no subnet found").Add(networkerrors.SubnetNotFound)
 	}
 
 	// Check if we found too many subnets

--- a/domain/network/service/migration_test.go
+++ b/domain/network/service/migration_test.go
@@ -210,7 +210,7 @@ func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProvider(c *tc.C
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnet(c *tc.C) {
+func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnetSlash32(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 	netNodeUUID := uuid.MustNewUUID().String()
@@ -218,36 +218,46 @@ func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnet
 		"88": netNodeUUID,
 	}
 
-	// Create a subnet with a different CIDR than the one in the address
-	subnetUUID := uuid.MustNewUUID().String()
+	s.st.EXPECT().AllMachinesAndNetNodes(gomock.Any()).Return(nameMap, nil)
+	s.st.EXPECT().GetAllSubnets(gomock.Any()).Return(nil, nil)
+
+	// Expect a /32 subnet to be created.
 	subnetInfo := corenetwork.SubnetInfo{
-		ID:   corenetwork.Id(subnetUUID),
-		CIDR: "198.51.100.0/24", // Different CIDR than the one in the address
+		CIDR: "192.0.2.0/32",
 	}
-	subnets := corenetwork.SubnetInfos{subnetInfo}
+	matcher := &spaceInfoAsArgMatcher{
+		c:        c,
+		expected: subnetInfo,
+	}
+	s.st.EXPECT().AddSubnet(gomock.Any(), matcher).Return(nil)
 
 	args := []internal.ImportLinkLayerDevice{
 		{
 			MachineID: "88",
-			Name:      "eth0",
+			Name:      "cillium_host",
 			Addresses: []internal.ImportIPAddress{
 				{
 					AddressValue: "192.0.2.10",
-					SubnetCIDR:   "192.0.2.0/24", // No matching subnet for this CIDR
+					SubnetCIDR:   "192.0.2.0/32", // No matching subnet for this CIDR
 				},
 			},
 		},
 	}
 
-	s.st.EXPECT().AllMachinesAndNetNodes(gomock.Any()).Return(nameMap, nil)
-	s.st.EXPECT().GetAllSubnets(gomock.Any()).Return(subnets, nil)
+	expectedArgs := make([]internal.ImportLinkLayerDevice, len(args))
+	copy(expectedArgs, args)
+	expectedArgs[0].NetNodeUUID = netNodeUUID
+	matcherTwo := &importLinkLayerDeviceArgMatcher{
+		c:        c,
+		expected: expectedArgs,
+	}
+	s.st.EXPECT().ImportLinkLayerDevices(gomock.Any(), matcherTwo).Return(nil)
 
 	// Act
 	err := s.migrationService(c).ImportLinkLayerDevices(c.Context(), args)
 
-	// Assert: error about no subnet found for CIDR
-	c.Assert(err, tc.ErrorMatches,
-		`converting device "eth0" on machine "88":.*converting address "192.0.2.10":.*no subnet found`)
+	// Assert: no error
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderTooMuchSubnet(c *tc.C) {
@@ -778,4 +788,65 @@ func (s *migrationSuite) TestSetMachineNetConfigBadUUIDError(c *tc.C) {
 
 	err := s.service(c).SetMachineNetConfig(c.Context(), mUUID, nil)
 	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+type spaceInfoAsArgMatcher struct {
+	c        *tc.C
+	expected corenetwork.SubnetInfo
+}
+
+func (m spaceInfoAsArgMatcher) Matches(x interface{}) bool {
+	obtained, ok := x.(corenetwork.SubnetInfo)
+	m.c.Assert(ok, tc.IsTrue)
+	if !ok {
+		return false
+	}
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_.ID", tc.IsNonZeroUUID)
+	return m.c.Check(obtained, mc, m.expected)
+}
+
+func (m spaceInfoAsArgMatcher) String() string {
+	return "match the corenetwork.SubnetInfo modulo subnet uuid"
+}
+
+type importLinkLayerDeviceArgMatcher struct {
+	c        *tc.C
+	expected []internal.ImportLinkLayerDevice
+}
+
+func (m importLinkLayerDeviceArgMatcher) Matches(x interface{}) bool {
+	obtained, ok := x.([]internal.ImportLinkLayerDevice)
+	m.c.Assert(ok, tc.IsTrue)
+	if !ok {
+		return false
+	}
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_.Addresses", tc.Ignore)
+	if m.c.Check(
+		obtained,
+		tc.UnorderedMatch[[]internal.ImportLinkLayerDevice](mc),
+		m.expected,
+		tc.Commentf("top level fail"),
+	) == false {
+		return false
+	}
+
+	mc = tc.NewMultiChecker()
+	mc.AddExpr("_.SubnetUUID", tc.IsNonZeroUUID)
+	for i := range m.expected {
+		if m.c.Check(
+			obtained[i].Addresses,
+			tc.UnorderedMatch[[]internal.ImportIPAddress](mc),
+			m.expected[i].Addresses,
+			tc.Commentf("[%d].Addresses fail", i),
+		) == false {
+			return false
+		}
+	}
+	return true
+}
+
+func (m importLinkLayerDeviceArgMatcher) String() string {
+	return "match the internal.ImportLinkLayerDevice"
 }


### PR DESCRIPTION
In 3.6, some devices found have a subnet implied, however no actual subnet was created within juju, e.g. cilium_host. Devices in 3.6 require a subnet, thus import was failing. These should still be imported, so create a subnet to go with them.

This subnets are also created when the device is discovered in juju 4: #21701.

A side effect of this is that the /32 address may be displayed in juju status, or returned as the unit's or machine's public address, depending on ip address sorting. This problem is currently being worked on and will be resolved in a follow up PR.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
# bootstrap 3.6 and create a model to be migrated.
$ juju_36 bootstrap localhost src
$ juju_36 add-model moveme ; juju_36 deploy  k8s --channel=1.33/stable   --base="ubuntu@24.04"   --constraints='cores=2 mem=16G root-disk=40G virt-type=virtual-machine'

# bootstrap a migration target
# juju bootstrap localhost dst

# switch back to the model and await the cilium_host device
juju switch src:moveme

# once the device appears on the host, wait for it to appear in the dump-db data
$ JUJU_DEV_FEATURE_FLAGS=developer-mode juju_36 dump-db | vim -R -

# migrate, successfully
$ juju migrate moveme dst
$ juju switch dst:moveme
$ juju status
Model  Controller  Cloud/Region         Version  Timestamp
moveme     dst       localhost/localhost  4.0.2.1  21:02:33Z
App  Version  Status       Scale  Charm  Channel       Rev  Exposed  Message
k8s  1.33.7   maintenance      1  k8s    1.33/stable  1786  no       Allocating Control_Plane Cluster tokens
Unit    Workload     Agent      Machine  Public address  Ports     Message
k8s/0*  maintenance  executing  0        10.1.0.160       6443/tcp  (config-changed) Allocating Control_Plane Cluster tokens
Machine  State    Address    Inst id        Base          AZ              Message
0        started  10.1.0.160  juju-d8a61c-0  ubuntu@24.04  ubuntu-nuc-two  Running

# check the juju machine and list of subnets to see results
$ juju show-machine 0
$ juju subnets
```

## Links

**Jira card:** [JUJU-9101](https://warthogs.atlassian.net/browse/JUJU-9101)


[JUJU-9101]: https://warthogs.atlassian.net/browse/JUJU-9101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ