### PR TITLE
feat: allow model migration to be reentrant

### DIFF
--- a/domain/removal/state/controller/model.go
+++ b/domain/removal/state/controller/model.go
@@ -100,7 +100,8 @@ func (st *State) GetModelLife(ctx context.Context, mUUID string) (life.Life, err
 	return life, errors.Capture(err)
 }
 
-// IsMigratingModel returns whether the model with the input UUID is currently migrating.
+// IsMigratingModel returns whether the model with the input UUID is currently
+// migrating.
 func (st *State) IsMigratingModel(ctx context.Context, mUUID string) (bool, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -362,6 +363,7 @@ func (st *State) removeBasicModelData(ctx context.Context, tx *sqlair.TX, mUUID 
 		"DELETE FROM secret_backend_reference WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_authorized_keys WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_last_login WHERE model_uuid = $entityUUID.uuid",
+		"DELETE FROM model_migration_import WHERE model_uuid = $entityUUID.uuid",
 	}
 
 	for _, table := range tables {

--- a/domain/removal/state/controller/model_test.go
+++ b/domain/removal/state/controller/model_test.go
@@ -249,6 +249,38 @@ func (s *modelSuite) TestDeleteModelDyingModel(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
 }
 
+func (s *modelSuite) TestDeleteMigratingModel(c *tc.C) {
+	modelUUID := s.getModelUUID(c)
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "UPDATE model SET life_id = 2 WHERE uuid = ?", modelUUID); err != nil {
+			return err
+		}
+
+		_, err := tx.ExecContext(ctx, "INSERT INTO model_migration_import (uuid, model_uuid) VALUES ('blah', ?)", modelUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err = st.DeleteModel(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Ensure the model is gone.
+	exists, err := st.ModelExists(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+
+	// Ensure the migration entry is also gone.
+	var count int
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?", modelUUID).Scan(&count)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+}
+
 func (s *modelSuite) getModelUUID(c *tc.C) string {
 	var modelUUID string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {


### PR DESCRIPTION
If a model migration fails, allow it to try again. There is currently a unique index on model migration imports, that only allow one import per model_uuid. This is a good thing, as it prevents accidents happening. We just need to remove the row when it fails though!

This is broken off from https://github.com/juju/juju/pull/21710

## QA steps

Bootstrap 3.6

```sh
$ /snap/bin/juju bootstrap localhost src
$ /snap/bin/juju add-model offer && /snap/bin/juju deploy juju-qa-dummy-source && /snap/bin/juju offer dummy-source:sink
$ /snap/bin/juju add-model consume && /snap/bin/juju deploy juju-qa-dummy-sink
$ /snap/bin/juju consume admin/offer.dummy-source && /snap/bin/juju relate dummy-source dummy-sink
```

Bootstrap 4.0

```sh
$ juju bootstrap localhost dst
$ juju migrate src:offer dst
```

The migration should fail, but we should be able to try again, without it saying that it failed because of a unique index failure.

```
$ juju migrate src:offer dst
```

## Links



<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9127](https://warthogs.atlassian.net/browse/JUJU-9127)


[JUJU-9127]: https://warthogs.atlassian.net/browse/JUJU-9127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ