### PR TITLE
feat: add backend support for attaching unit storage

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -30,6 +30,8 @@ import (
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/deployment/charm/assumes"
+	domainstorage "github.com/juju/juju/domain/storage"
+	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/rpc/params"
@@ -162,6 +164,26 @@ func DeployApplication(
 		}
 	}
 
+	if len(args.AttachStorage) > 0 && args.NumUnits != 1 {
+		return errors.Errorf(
+			"AttachStorage is non-empty but NumUnits is %d, must be 1",
+			args.NumUnits)
+	}
+
+	var storageUUIDsToAttach []domainstorage.StorageInstanceUUID
+	for _, storageTag := range args.AttachStorage {
+		storageUUID, err := storageService.GetStorageInstanceUUIDForID(ctx, storageTag.Id())
+		if errors.Is(err, storageerrors.StorageInstanceNotFound) {
+			return apiservererrors.ParamsErrorf(params.CodeNotFound, "storage %q does not exist", storageTag.Id())
+		} else if err != nil {
+			return errors.Errorf(
+				"getting storage instance uuid for storage id %q: %w",
+				storageTag.Id(), err,
+			)
+		}
+		storageUUIDsToAttach = append(storageUUIDsToAttach, storageUUID)
+	}
+
 	var downloadInfo *applicationcharm.DownloadInfo
 	if args.CharmOrigin.Source == corecharm.CharmHub {
 		var err error
@@ -203,6 +225,10 @@ func DeployApplication(
 		if err != nil {
 			return errors.Capture(err)
 		}
+		// Unit args length with attach storage has been validated above.
+		if len(unitArgs) == 1 {
+			unitArgs[0].StorageToAttach = storageUUIDsToAttach
+		}
 
 		_, err = applicationService.CreateCAASApplication(
 			ctx,
@@ -221,6 +247,11 @@ func DeployApplication(
 	unitArgs, err := makeIAASUnitArgs(args)
 	if err != nil {
 		return errors.Capture(err)
+	}
+
+	// Unit args length with attach storage has been validated above.
+	if len(unitArgs) == 1 {
+		unitArgs[0].StorageToAttach = storageUUIDsToAttach
 	}
 
 	_, err = applicationService.CreateIAASApplication(

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/names/v6"
 
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	coreassumes "github.com/juju/juju/core/assumes"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -31,6 +32,7 @@ import (
 	"github.com/juju/juju/domain/deployment/charm/assumes"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/rpc/params"
 )
 
 // ModelService provides access to the model state.
@@ -70,7 +72,7 @@ type DeployApplicationParams struct {
 // does not exist then the original error will be returned.
 func handleApplicationDomainError(err error) error {
 	switch {
-	// When the supplied storage directive overrides violates the chamrs
+	// When the supplied storage directive overrides violates the charm's
 	// storage.
 	case errors.HasType[applicationerrors.StorageCountLimitExceeded](err):
 		limitErr, _ := errors.AsType[applicationerrors.StorageCountLimitExceeded](err)
@@ -85,8 +87,25 @@ func handleApplicationDomainError(err error) error {
 				limitErr.StorageName, limitErr.Requested, *limitErr.Maximum,
 			).Add(coreerrors.NotValid)
 		}
-
-	// When the charm storage location violateds a prohibited filesystem mount
+	// When a request is made to attach storage but it's not allowed.
+	case errors.HasType[applicationerrors.StorageAttachmentNotAllowed](err):
+		attachErr, _ := errors.AsType[applicationerrors.StorageAttachmentNotAllowed](err)
+		if len(attachErr.AttachedToUnits) > 0 {
+			return apiservererrors.ParamsErrorf(params.CodeNotValid,
+				"storage is already attached to other unit(s): %v",
+				attachErr.AttachedToUnits,
+			)
+		}
+		if attachErr.ExistingStorageMachineOwner != nil {
+			return apiservererrors.ParamsErrorf(params.CodeNotValid,
+				"storage is attached to machine %v",
+				*attachErr.ExistingStorageMachineOwner,
+			)
+		}
+		return apiservererrors.ParamsErrorf(params.CodeNotValid,
+			"storage attachment not allowed",
+		)
+	// When the charm storage location violates a prohibited filesystem mount
 	// point.
 	case errors.HasType[applicationerrors.CharmStorageLocationProhibited](err):
 		prohibitErr, _ := errors.AsType[applicationerrors.CharmStorageLocationProhibited](err)

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -100,7 +100,7 @@ func handleApplicationDomainError(err error) error {
 		}
 		if attachErr.ExistingStorageMachineOwner != nil {
 			return apiservererrors.ParamsErrorf(params.CodeNotValid,
-				"storage is attached to machine %v",
+				"storage is bound to machine %v but the unit is assigned to a different machine",
 				*attachErr.ExistingStorageMachineOwner,
 			)
 		}
@@ -166,8 +166,8 @@ func DeployApplication(
 
 	if len(args.AttachStorage) > 0 && args.NumUnits != 1 {
 		return errors.Errorf(
-			"AttachStorage is non-empty but NumUnits is %d, must be 1",
-			args.NumUnits)
+			"attaching existing storage to a new deployment can only be performed when the number of units is 1",
+		).Add(coreerrors.NotValid)
 	}
 
 	var storageUUIDsToAttach []domainstorage.StorageInstanceUUID
@@ -221,13 +221,9 @@ func DeployApplication(
 		StorageDirectiveOverrides: sdo,
 	}
 	if modelType == coremodel.CAAS {
-		unitArgs, err := makeCAASUnitArgs(args)
+		unitArgs, err := makeCAASUnitArgs(args, storageUUIDsToAttach)
 		if err != nil {
 			return errors.Capture(err)
-		}
-		// Unit args length with attach storage has been validated above.
-		if len(unitArgs) == 1 {
-			unitArgs[0].StorageToAttach = storageUUIDsToAttach
 		}
 
 		_, err = applicationService.CreateCAASApplication(
@@ -244,14 +240,9 @@ func DeployApplication(
 		return nil
 	}
 
-	unitArgs, err := makeIAASUnitArgs(args)
+	unitArgs, err := makeIAASUnitArgs(args, storageUUIDsToAttach)
 	if err != nil {
 		return errors.Capture(err)
-	}
-
-	// Unit args length with attach storage has been validated above.
-	if len(unitArgs) == 1 {
-		unitArgs[0].StorageToAttach = storageUUIDsToAttach
 	}
 
 	_, err = applicationService.CreateIAASApplication(
@@ -269,7 +260,9 @@ func DeployApplication(
 	return nil
 }
 
-func makeIAASUnitArgs(args DeployApplicationParams) ([]applicationservice.AddIAASUnitArg, error) {
+func makeIAASUnitArgs(
+	args DeployApplicationParams, storageUUIDsToAttach []domainstorage.StorageInstanceUUID,
+) ([]applicationservice.AddIAASUnitArg, error) {
 	unitArgs := make([]applicationservice.AddIAASUnitArg, args.NumUnits)
 	for i := range args.NumUnits {
 		var unitPlacement *instance.Placement
@@ -281,12 +274,17 @@ func makeIAASUnitArgs(args DeployApplicationParams) ([]applicationservice.AddIAA
 				Placement: unitPlacement,
 			},
 		}
+		if i == 0 {
+			unitArgs[i].StorageToAttach = storageUUIDsToAttach
+		}
 	}
 
 	return unitArgs, nil
 }
 
-func makeCAASUnitArgs(args DeployApplicationParams) ([]applicationservice.AddUnitArg, error) {
+func makeCAASUnitArgs(
+	args DeployApplicationParams, storageUUIDsToAttach []domainstorage.StorageInstanceUUID,
+) ([]applicationservice.AddUnitArg, error) {
 	unitArgs := make([]applicationservice.AddUnitArg, args.NumUnits)
 	for i := range args.NumUnits {
 		var unitPlacement *instance.Placement
@@ -295,6 +293,9 @@ func makeCAASUnitArgs(args DeployApplicationParams) ([]applicationservice.AddUni
 		}
 		unitArgs[i] = applicationservice.AddUnitArg{
 			Placement: unitPlacement,
+		}
+		if i == 0 {
+			unitArgs[i].StorageToAttach = storageUUIDsToAttach
 		}
 	}
 

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -435,6 +435,9 @@ type StorageService interface {
 	// GetStoragePoolUUIDsByName returns pool UUIDs keyed by pool name for
 	// the supplied names. Unknown names are omitted.
 	GetStoragePoolUUIDsByName(ctx context.Context, names []string) (map[string]domainstorage.StoragePoolUUID, error)
+	// GetStorageInstanceUUIDForID returns the StorageInstanceUUID for the given
+	// storage ID.
+	GetStorageInstanceUUIDForID(context.Context, string) (domainstorage.StorageInstanceUUID, error)
 }
 
 // StatusService provides access to the status service.

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -2354,6 +2354,45 @@ func (m *MockStorageService) EXPECT() *MockStorageServiceMockRecorder {
 	return m.recorder
 }
 
+// GetStorageInstanceUUIDForID mocks base method.
+func (m *MockStorageService) GetStorageInstanceUUIDForID(arg0 context.Context, arg1 string) (storage.StorageInstanceUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageInstanceUUIDForID", arg0, arg1)
+	ret0, _ := ret[0].(storage.StorageInstanceUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStorageInstanceUUIDForID indicates an expected call of GetStorageInstanceUUIDForID.
+func (mr *MockStorageServiceMockRecorder) GetStorageInstanceUUIDForID(arg0, arg1 any) *MockStorageServiceGetStorageInstanceUUIDForIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageInstanceUUIDForID", reflect.TypeOf((*MockStorageService)(nil).GetStorageInstanceUUIDForID), arg0, arg1)
+	return &MockStorageServiceGetStorageInstanceUUIDForIDCall{Call: call}
+}
+
+// MockStorageServiceGetStorageInstanceUUIDForIDCall wrap *gomock.Call
+type MockStorageServiceGetStorageInstanceUUIDForIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStorageServiceGetStorageInstanceUUIDForIDCall) Return(arg0 storage.StorageInstanceUUID, arg1 error) *MockStorageServiceGetStorageInstanceUUIDForIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStorageServiceGetStorageInstanceUUIDForIDCall) Do(f func(context.Context, string) (storage.StorageInstanceUUID, error)) *MockStorageServiceGetStorageInstanceUUIDForIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStorageServiceGetStorageInstanceUUIDForIDCall) DoAndReturn(f func(context.Context, string) (storage.StorageInstanceUUID, error)) *MockStorageServiceGetStorageInstanceUUIDForIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetStoragePoolUUID mocks base method.
 func (m *MockStorageService) GetStoragePoolUUID(arg0 context.Context, arg1 string) (storage.StoragePoolUUID, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/storage/domain_mock_test.go
+++ b/apiserver/facades/client/storage/domain_mock_test.go
@@ -125,78 +125,40 @@ func (c *MockApplicationServiceAddStorageForIAASUnitCall) DoAndReturn(f func(con
 	return c
 }
 
-// AttachStorageToCAASUnit mocks base method.
-func (m *MockApplicationService) AttachStorageToCAASUnit(arg0 context.Context, arg1 storage1.StorageInstanceUUID, arg2 unit.UUID) error {
+// AttachStorageToUnit mocks base method.
+func (m *MockApplicationService) AttachStorageToUnit(arg0 context.Context, arg1 storage1.StorageInstanceUUID, arg2 unit.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachStorageToCAASUnit", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AttachStorageToUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AttachStorageToCAASUnit indicates an expected call of AttachStorageToCAASUnit.
-func (mr *MockApplicationServiceMockRecorder) AttachStorageToCAASUnit(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageToCAASUnitCall {
+// AttachStorageToUnit indicates an expected call of AttachStorageToUnit.
+func (mr *MockApplicationServiceMockRecorder) AttachStorageToUnit(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageToUnitCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToCAASUnit", reflect.TypeOf((*MockApplicationService)(nil).AttachStorageToCAASUnit), arg0, arg1, arg2)
-	return &MockApplicationServiceAttachStorageToCAASUnitCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToUnit", reflect.TypeOf((*MockApplicationService)(nil).AttachStorageToUnit), arg0, arg1, arg2)
+	return &MockApplicationServiceAttachStorageToUnitCall{Call: call}
 }
 
-// MockApplicationServiceAttachStorageToCAASUnitCall wrap *gomock.Call
-type MockApplicationServiceAttachStorageToCAASUnitCall struct {
+// MockApplicationServiceAttachStorageToUnitCall wrap *gomock.Call
+type MockApplicationServiceAttachStorageToUnitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceAttachStorageToCAASUnitCall) Return(arg0 error) *MockApplicationServiceAttachStorageToCAASUnitCall {
+func (c *MockApplicationServiceAttachStorageToUnitCall) Return(arg0 error) *MockApplicationServiceAttachStorageToUnitCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceAttachStorageToCAASUnitCall) Do(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToCAASUnitCall {
+func (c *MockApplicationServiceAttachStorageToUnitCall) Do(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceAttachStorageToCAASUnitCall) DoAndReturn(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToCAASUnitCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// AttachStorageToIAASUnit mocks base method.
-func (m *MockApplicationService) AttachStorageToIAASUnit(arg0 context.Context, arg1 storage1.StorageInstanceUUID, arg2 unit.UUID) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachStorageToIAASUnit", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AttachStorageToIAASUnit indicates an expected call of AttachStorageToIAASUnit.
-func (mr *MockApplicationServiceMockRecorder) AttachStorageToIAASUnit(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageToIAASUnitCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToIAASUnit", reflect.TypeOf((*MockApplicationService)(nil).AttachStorageToIAASUnit), arg0, arg1, arg2)
-	return &MockApplicationServiceAttachStorageToIAASUnitCall{Call: call}
-}
-
-// MockApplicationServiceAttachStorageToIAASUnitCall wrap *gomock.Call
-type MockApplicationServiceAttachStorageToIAASUnitCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceAttachStorageToIAASUnitCall) Return(arg0 error) *MockApplicationServiceAttachStorageToIAASUnitCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceAttachStorageToIAASUnitCall) Do(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToIAASUnitCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceAttachStorageToIAASUnitCall) DoAndReturn(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToIAASUnitCall {
+func (c *MockApplicationServiceAttachStorageToUnitCall) DoAndReturn(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/storage/domain_mock_test.go
+++ b/apiserver/facades/client/storage/domain_mock_test.go
@@ -125,40 +125,78 @@ func (c *MockApplicationServiceAddStorageForIAASUnitCall) DoAndReturn(f func(con
 	return c
 }
 
-// AttachStorageToUnit mocks base method.
-func (m *MockApplicationService) AttachStorageToUnit(arg0 context.Context, arg1 storage1.StorageInstanceUUID, arg2 unit.UUID) error {
+// AttachStorageToCAASUnit mocks base method.
+func (m *MockApplicationService) AttachStorageToCAASUnit(arg0 context.Context, arg1 storage1.StorageInstanceUUID, arg2 unit.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachStorageToUnit", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AttachStorageToCAASUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AttachStorageToUnit indicates an expected call of AttachStorageToUnit.
-func (mr *MockApplicationServiceMockRecorder) AttachStorageToUnit(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageToUnitCall {
+// AttachStorageToCAASUnit indicates an expected call of AttachStorageToCAASUnit.
+func (mr *MockApplicationServiceMockRecorder) AttachStorageToCAASUnit(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageToCAASUnitCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToUnit", reflect.TypeOf((*MockApplicationService)(nil).AttachStorageToUnit), arg0, arg1, arg2)
-	return &MockApplicationServiceAttachStorageToUnitCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToCAASUnit", reflect.TypeOf((*MockApplicationService)(nil).AttachStorageToCAASUnit), arg0, arg1, arg2)
+	return &MockApplicationServiceAttachStorageToCAASUnitCall{Call: call}
 }
 
-// MockApplicationServiceAttachStorageToUnitCall wrap *gomock.Call
-type MockApplicationServiceAttachStorageToUnitCall struct {
+// MockApplicationServiceAttachStorageToCAASUnitCall wrap *gomock.Call
+type MockApplicationServiceAttachStorageToCAASUnitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceAttachStorageToUnitCall) Return(arg0 error) *MockApplicationServiceAttachStorageToUnitCall {
+func (c *MockApplicationServiceAttachStorageToCAASUnitCall) Return(arg0 error) *MockApplicationServiceAttachStorageToCAASUnitCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceAttachStorageToUnitCall) Do(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToUnitCall {
+func (c *MockApplicationServiceAttachStorageToCAASUnitCall) Do(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToCAASUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceAttachStorageToUnitCall) DoAndReturn(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToUnitCall {
+func (c *MockApplicationServiceAttachStorageToCAASUnitCall) DoAndReturn(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToCAASUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// AttachStorageToIAASUnit mocks base method.
+func (m *MockApplicationService) AttachStorageToIAASUnit(arg0 context.Context, arg1 storage1.StorageInstanceUUID, arg2 unit.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachStorageToIAASUnit", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AttachStorageToIAASUnit indicates an expected call of AttachStorageToIAASUnit.
+func (mr *MockApplicationServiceMockRecorder) AttachStorageToIAASUnit(arg0, arg1, arg2 any) *MockApplicationServiceAttachStorageToIAASUnitCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToIAASUnit", reflect.TypeOf((*MockApplicationService)(nil).AttachStorageToIAASUnit), arg0, arg1, arg2)
+	return &MockApplicationServiceAttachStorageToIAASUnitCall{Call: call}
+}
+
+// MockApplicationServiceAttachStorageToIAASUnitCall wrap *gomock.Call
+type MockApplicationServiceAttachStorageToIAASUnitCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceAttachStorageToIAASUnitCall) Return(arg0 error) *MockApplicationServiceAttachStorageToIAASUnitCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceAttachStorageToIAASUnitCall) Do(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToIAASUnitCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceAttachStorageToIAASUnitCall) DoAndReturn(f func(context.Context, storage1.StorageInstanceUUID, unit.UUID) error) *MockApplicationServiceAttachStorageToIAASUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -1364,6 +1364,9 @@ func handleAttachStorageToUnitError(err error, unitName coreunit.Name, storageID
 	case errors.Is(err, applicationerrors.StorageNameNotSupported):
 		return apiservererrors.ParamsErrorf(params.CodeNotSupported,
 			"storage %q not supported by the charm", storageID)
+	case errors.Is(err, applicationerrors.UnitNotAssigned):
+		return apiservererrors.ParamsErrorf(params.CodeNotAssigned,
+			"cannot attach storage when the unit is not assigned to a machine")
 	case errors.HasType[applicationerrors.StorageCountLimitExceeded](err):
 		limitErr, _ := errors.AsType[applicationerrors.StorageCountLimitExceeded](err)
 		if limitErr.Maximum != nil && limitErr.Requested > *limitErr.Maximum {
@@ -1372,6 +1375,25 @@ func handleAttachStorageToUnitError(err error, unitName coreunit.Name, storageID
 				limitErr.StorageName, limitErr.Requested, *limitErr.Maximum,
 			)
 		}
+	case errors.HasType[applicationerrors.StorageAttachmentNotAllowed](err):
+		attachErr, _ := errors.AsType[applicationerrors.StorageAttachmentNotAllowed](err)
+		if len(attachErr.AttachedToUnits) > 0 {
+			return apiservererrors.ParamsErrorf(params.CodeNotValid,
+				"%v is already attached to other unit(s): %v",
+				storageID,
+				attachErr.AttachedToUnits,
+			)
+		}
+		if attachErr.ExistingStorageMachineOwner != nil {
+			return apiservererrors.ParamsErrorf(params.CodeNotValid,
+				"%v is attached to machine %v",
+				storageID,
+				*attachErr.ExistingStorageMachineOwner,
+			)
+		}
+		return apiservererrors.ParamsErrorf(params.CodeNotValid,
+			"storage attachment not allowed",
+		)
 	}
 	return err
 }

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -220,13 +220,9 @@ type ApplicationService interface {
 		applicationstorageservice.AddUnitStorageOverride,
 	) ([]corestorage.ID, error)
 
-	// AttachStorageToIAASUnit ensures the specified storage instance is attached to the specified unit.
+	// AttachStorageToUnit ensures the specified storage instance is attached to the specified unit.
 	// If the attachment already exists, the result is a no op.
-	AttachStorageToIAASUnit(ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
-
-	// AttachStorageToCAASUnit ensures the specified storage instance is attached to the specified unit.
-	// If the attachment already exists, the result is a no op.
-	AttachStorageToCAASUnit(ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
+	AttachStorageToUnit(ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
 }
 
 // MachineService defines the service methods required by the Storage facade for
@@ -1349,12 +1345,7 @@ func (a *StorageAPI) attachOneStorage(ctx context.Context, one params.StorageAtt
 		)
 	}
 
-	if a.modelType == coremodel.CAAS {
-		err = a.applicationService.AttachStorageToCAASUnit(ctx, storageUUID, unitUUID)
-	} else {
-		err = a.applicationService.AttachStorageToIAASUnit(ctx, storageUUID, unitUUID)
-	}
-
+	err = a.applicationService.AttachStorageToUnit(ctx, storageUUID, unitUUID)
 	err = handleAttachStorageToUnitError(err, unitName, storageTag.Id())
 	return err
 }

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -1363,7 +1363,7 @@ func handleAttachStorageToUnitError(err error, unitName coreunit.Name, storageID
 			"storage %q not found", storageID)
 	case errors.Is(err, applicationerrors.StorageNameNotSupported):
 		return apiservererrors.ParamsErrorf(params.CodeNotSupported,
-			"storage %q not supported by the charm", storageID)
+			"storage %q not supported by the unit's charm", storageID)
 	case errors.Is(err, applicationerrors.UnitNotAssigned):
 		return apiservererrors.ParamsErrorf(params.CodeNotAssigned,
 			"cannot attach storage when the unit is not assigned to a machine")
@@ -1386,7 +1386,7 @@ func handleAttachStorageToUnitError(err error, unitName coreunit.Name, storageID
 		}
 		if attachErr.ExistingStorageMachineOwner != nil {
 			return apiservererrors.ParamsErrorf(params.CodeNotValid,
-				"%v is attached to machine %v",
+				"%v is bound to machine %v but the unit is assigned to a different machine",
 				storageID,
 				*attachErr.ExistingStorageMachineOwner,
 			)

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -222,11 +222,11 @@ type ApplicationService interface {
 
 	// AttachStorageToIAASUnit ensures the specified storage instance is attached to the specified unit.
 	// If the attachment already exists, the result is a no op.
-	AttachStorageToIAASUnit(ctx context.Context, storageID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
+	AttachStorageToIAASUnit(ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
 
 	// AttachStorageToCAASUnit ensures the specified storage instance is attached to the specified unit.
 	// If the attachment already exists, the result is a no op.
-	AttachStorageToCAASUnit(ctx context.Context, storageID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
+	AttachStorageToCAASUnit(ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
 }
 
 // MachineService defines the service methods required by the Storage facade for

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -220,9 +220,13 @@ type ApplicationService interface {
 		applicationstorageservice.AddUnitStorageOverride,
 	) ([]corestorage.ID, error)
 
-	// AttachStorageToUnit ensures the specified storage instance is attached to the specified unit.
+	// AttachStorageToIAASUnit ensures the specified storage instance is attached to the specified unit.
 	// If the attachment already exists, the result is a no op.
-	AttachStorageToUnit(ctx context.Context, storageID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
+	AttachStorageToIAASUnit(ctx context.Context, storageID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
+
+	// AttachStorageToCAASUnit ensures the specified storage instance is attached to the specified unit.
+	// If the attachment already exists, the result is a no op.
+	AttachStorageToCAASUnit(ctx context.Context, storageID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
 }
 
 // MachineService defines the service methods required by the Storage facade for
@@ -1345,7 +1349,12 @@ func (a *StorageAPI) attachOneStorage(ctx context.Context, one params.StorageAtt
 		)
 	}
 
-	err = a.applicationService.AttachStorageToUnit(ctx, storageUUID, unitUUID)
+	if a.modelType == coremodel.CAAS {
+		err = a.applicationService.AttachStorageToCAASUnit(ctx, storageUUID, unitUUID)
+	} else {
+		err = a.applicationService.AttachStorageToIAASUnit(ctx, storageUUID, unitUUID)
+	}
+
 	err = handleAttachStorageToUnitError(err, unitName, storageTag.Id())
 	return err
 }

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -1370,6 +1370,9 @@ func handleAttachStorageToUnitError(err error, unitName coreunit.Name, storageID
 	case errors.Is(err, storageerrors.StorageInstanceNotFound):
 		return apiservererrors.ParamsErrorf(params.CodeNotFound,
 			"storage %q not found", storageID)
+	case errors.Is(err, applicationerrors.StorageNameNotSupported):
+		return apiservererrors.ParamsErrorf(params.CodeNotSupported,
+			"storage %q not supported by the charm", storageID)
 	case errors.HasType[applicationerrors.StorageCountLimitExceeded](err):
 		limitErr, _ := errors.AsType[applicationerrors.StorageCountLimitExceeded](err)
 		if limitErr.Maximum != nil && limitErr.Requested > *limitErr.Maximum {

--- a/domain/agentpassword/state/modelstate_test.go
+++ b/domain/agentpassword/state/modelstate_test.go
@@ -648,6 +648,7 @@ func (s *modelStateSuite) createUnit(c *tc.C) unit.Name {
 	netNodeUUID := tc.Must(c, network.NewNetNodeUUID)
 	unitNames, _, err := applicationSt.AddIAASUnits(ctx, appID, application.AddIAASUnitArg{
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    tc.Must(c, unit.NewUUID),
 			NetNodeUUID: netNodeUUID,
 		},
 		Nonce:              ptr("foo"),

--- a/domain/application/charm/types.go
+++ b/domain/application/charm/types.go
@@ -381,12 +381,12 @@ const (
 
 // Storage represents a charm's storage requirement.
 type Storage struct {
-	// Name is the name of the store.
+	// Name is the name of the storage.
 	//
 	// Name has no default, and must be specified.
 	Name string
 
-	// Description is a description of the store.
+	// Description is a description of the storage.
 	//
 	// Description has no default, and is optional.
 	Description string

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/juju/juju/internal/errors"
 )
@@ -378,6 +379,27 @@ func (s StorageCountLimitExceeded) Error() string {
 		maxStr,
 		s.Requested,
 	)
+}
+
+// StorageAttachmentNotAllowed describes an error that occurs when attempting to
+// attach storage to a unit and the unit is not in the allow list.
+type StorageAttachmentNotAllowed struct {
+	// AttachedToUnits is the unexpected units to which
+	// the storage is already attached.
+	AttachedToUnits []string
+	// ExistingStorageMachineOwner is the machine that owns the
+	// storage that is being attached.
+	ExistingStorageMachineOwner *string
+}
+
+// Error implements error.
+func (e StorageAttachmentNotAllowed) Error() string {
+	if len(e.AttachedToUnits) > 0 {
+		return "storage is already attached to units: " + strings.Join(e.AttachedToUnits, ", ")
+	} else if e.ExistingStorageMachineOwner != nil {
+		return "storage is already attached to machine: " + *e.ExistingStorageMachineOwner
+	}
+	return "storage attachment not allowed"
 }
 
 // Error returns a string representation of the [UnitStorageMinViolation] error

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -319,10 +319,6 @@ const (
 	// StorageNameNotSupported describes an error that occurs when
 	// a storage name is not supported by the charm.
 	StorageNameNotSupported = errors.ConstError("storage name not supported")
-
-	// InvalidStorageCount describes an error that occurs when
-	// a storage attachment would violate charm expectations for cardinality.
-	InvalidStorageCount = errors.ConstError("invalid storage count")
 )
 
 // StorageCountLimitExceeded describes an error that occurs when an operation

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -4,6 +4,7 @@
 package internal
 
 import (
+	"github.com/juju/juju/domain/deployment/charm"
 	domainnetwork "github.com/juju/juju/domain/network"
 	domainstorage "github.com/juju/juju/domain/storage"
 	domainstorageprov "github.com/juju/juju/domain/storageprovisioning"
@@ -41,6 +42,24 @@ type CreateStorageDirectiveArg struct {
 // has occurred so that any pre-conditions for completing a storage add/attach are violated.
 const MaxStorageCountPreconditonFailed = errors.ConstError("max storage count precondiiton failed")
 
+// ValidateStorageArg holds attributes used to validate storage.
+type ValidateStorageArg struct {
+	// Name is the name of the store.
+	Name string
+
+	// Type is the storage type: filesystem or block-device.
+	Type charm.StorageType
+
+	// CountMin is the minimum number of storage instances.
+	CountMin int
+
+	// CountMax is the largest number of storage instances.
+	CountMax int
+
+	// MinimumSize is the minimum size of the storage.
+	MinimumSize uint64
+}
+
 // UnitAddStorageArg represents the arguments required for add storage
 // to a unit. This will instantiate the instances and attachments for the unit.
 type UnitAddStorageArg struct {
@@ -74,6 +93,48 @@ type IAASUnitAddStorageArg struct {
 
 	// VolumesToOwn defines volumes that will be owned by the unit's machine.
 	VolumesToOwn []domainstorage.VolumeUUID
+}
+
+// UnitAttachStorageArg represents the arguments required to attach storage
+// to a unit.
+type UnitAttachStorageArg struct {
+	// StorageToAttach defines the storage instances that should be attached to
+	// the unit.
+	StorageToAttach []CreateUnitStorageAttachmentArg
+
+	// StorageName is the name of the storage being attached.
+	StorageName string
+
+	// CountLessThanEqual is the maximum storage count allowed at the time
+	// the add is performed in order for the attach operation to be considered successful.
+	CountLessThanEqual uint32
+}
+
+// IAASUnitAttachStorageArg represents the arguments required for attaching storage
+// to an IASS unit. This complements [UnitAttachStorageArg], allowing for an
+// IAAS unit to augment storage that is destined for a machine.
+type IAASUnitAttachStorageArg struct {
+	UnitAttachStorageArg
+	// FilesystemsToOwn defines filesystems that will be owned by the unit's
+	// machine.
+	FilesystemsToOwn []domainstorage.FilesystemUUID
+
+	// VolumesToOwn defines volumes that will be owned by the unit's machine.
+	VolumesToOwn []domainstorage.VolumeUUID
+}
+
+// StorageInstanceInfo holds the current number of storage instances of the
+// same named storage already attached to a unit, and the pool of an instance.
+type StorageInstanceInfo struct {
+	// AlreadyAttachedCount is the count of attached instances of the same
+	// underlying storage name already attached.
+	AlreadyAttachedCount uint32
+
+	// PoolUUID is the storage pool UUID of the instance.
+	PoolUUID domainstorage.StoragePoolUUID
+
+	// SizeMiB is the size of the storage.
+	SizeMiB uint64
 }
 
 // CreateUnitStorageArg represents the arguments required for making storage
@@ -238,6 +299,22 @@ type CreateUnitStorageVolumeAttachmentArg struct {
 	// ProviderID if set, forms the pre-determined volume attachment
 	// provider id.
 	ProviderID *string
+}
+
+// UnitStorageInstanceArg describes a storage instance attached to a unit.
+type UnitStorageInstanceArg struct {
+	// Filesystem describes the properties of a new filesystem to be created
+	// alongside the  storage instance. If this value is not nil a new
+	// filesystem will be created with the storage instance.
+	Filesystem *CreateUnitStorageFilesystemArg
+
+	// Volume describes the properties of a new volume to be created alongside
+	// the storage instance. If this value is not nil a new volume will be
+	// created with the storage instance.
+	Volume *CreateUnitStorageVolumeArg
+
+	// UUID is the unique identifier of the storage instance.
+	UUID domainstorage.StorageInstanceUUID
 }
 
 // ModelStoragePools provides the default storage pools that have been set

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -71,7 +71,7 @@ type UnitAddStorageArg struct {
 	// the unit. New storage instances defined in
 	// [CreateUnitStorageArg.StorageInstances] are not automatically attached to
 	// the unit and should be included in this list.
-	StorageToAttach []UnitStorageAttachmentArg
+	StorageToAttach []CreateUnitStorageAttachmentArg
 
 	// StorageToOwn defines the storage instances that should be owned by the
 	// unit.
@@ -100,7 +100,7 @@ type IAASUnitAddStorageArg struct {
 type UnitAttachStorageArg struct {
 	// StorageToAttach defines the storage instances that should be attached to
 	// the unit.
-	StorageToAttach []UnitStorageAttachmentArg
+	StorageToAttach []CreateUnitStorageAttachmentArg
 
 	// StorageName is the name of the storage being attached.
 	StorageName string
@@ -153,7 +153,7 @@ type CreateUnitStorageArg struct {
 	// the unit. New storage instances defined in
 	// [CreateUnitStorageArg.StorageInstances] are not automatically attached to
 	// the unit and should be included in this list.
-	StorageToAttach []UnitStorageAttachmentArg
+	StorageToAttach []CreateUnitStorageAttachmentArg
 
 	// StorageToOwn defines the storage instances that should be owned by the
 	// unit.
@@ -173,15 +173,15 @@ type IAASUnitStorageArg struct {
 	VolumesToOwn []domainstorage.VolumeUUID
 }
 
-// UnitStorageAttachmentArg describes the arguments required for describing a
+// CreateUnitStorageAttachmentArg describes the arguments required for creating a
 // storage attachment.
-type UnitStorageAttachmentArg struct {
+type CreateUnitStorageAttachmentArg struct {
 	// UUID is the unique identifier to associate with the storage attachment.
 	UUID domainstorage.StorageAttachmentUUID
 
 	// FilesystemAttachment describes a filesystem to attach for the storage
 	// instance attachment.
-	FilesystemAttachment *UnitStorageFilesystemAttachmentArg
+	FilesystemAttachment *CreateUnitStorageFilesystemAttachmentArg
 
 	// StorageInstanceUUID is the unique identifier of the storage instance
 	// to attach to the unit.
@@ -189,16 +189,16 @@ type UnitStorageAttachmentArg struct {
 
 	// VolumeAttachment describes a volume to attach for the storage
 	// instance attachment.
-	VolumeAttachment *UnitStorageVolumeAttachmentArg
+	VolumeAttachment *CreateUnitStorageVolumeAttachmentArg
 }
 
 // CreateUnitStorageDirectiveArg describes the arguments required for making storage
 // directives on a unit.
 type CreateUnitStorageDirectiveArg = CreateStorageDirectiveArg
 
-// UnitStorageFilesystemArg describes a set of attributes describing
-// a filesystem that can exist as part of a unit's storage.
-type UnitStorageFilesystemArg struct {
+// CreateUnitStorageFilesystemArg describes a set of arguments for a filesystem
+// that should be created as part of a unit's storage.
+type CreateUnitStorageFilesystemArg struct {
 	// UUID describes the unique identifier of the filesystem to
 	// create alongside the storage instance.
 	UUID domainstorage.FilesystemUUID
@@ -208,10 +208,10 @@ type UnitStorageFilesystemArg struct {
 	ProvisionScope domainstorageprov.ProvisionScope
 }
 
-// UnitStorageFilesystemAttachmentArg describes a set of arguments for a
-// filesystem attachment that should exist alongside a unit's storage in
+// CreateUnitStorageFilesystemAttachmentArg describes a set of arguments for a
+// filesystem attachment that should be created alongside a unit's storage in
 // the model.
-type UnitStorageFilesystemAttachmentArg struct {
+type CreateUnitStorageFilesystemAttachmentArg struct {
 	// FilesystemUUID is the unique identifier of the filesystem to be attached.
 	FilesystemUUID domainstorage.FilesystemUUID
 
@@ -239,7 +239,7 @@ type CreateUnitStorageInstanceArg struct {
 	// Filesystem describes the properties of a new filesystem to be created
 	// alongside the  storage instance. If this value is not nil a new
 	// filesystem will be created with the storage instance.
-	Filesystem *UnitStorageFilesystemArg
+	Filesystem *CreateUnitStorageFilesystemArg
 
 	// Kind defines the type of storage that is being created.
 	Kind domainstorage.StorageKind
@@ -260,15 +260,15 @@ type CreateUnitStorageInstanceArg struct {
 	// Volume describes the properties of a new volume to be created alongside
 	// the storage instance. If this value is not nil a new volume will be
 	// created with the storage instance.
-	Volume *UnitStorageVolumeArg
+	Volume *CreateUnitStorageVolumeArg
 
 	// UUID is the unique identifier to associate with the storage instance.
 	UUID domainstorage.StorageInstanceUUID
 }
 
-// UnitStorageVolumeArg describes a set of attributes describing
-// a volume that can exist as part of a unit's storage.
-type UnitStorageVolumeArg struct {
+// CreateUnitStorageVolumeArg describes a set of arguments for a volume
+// that should be created as part of a unit's storage.
+type CreateUnitStorageVolumeArg struct {
 	// UUID describes the unique identifier of the volume to
 	// create alongside the storage instance.
 	UUID domainstorage.VolumeUUID
@@ -278,10 +278,10 @@ type UnitStorageVolumeArg struct {
 	ProvisionScope domainstorageprov.ProvisionScope
 }
 
-// UnitStorageVolumeAttachmentArg describes a set of arguments for a
-// volume attachment that should exist alongside a unit's storage in
+// CreateUnitStorageVolumeAttachmentArg describes a set of arguments for a
+// volume attachment that should be created alongside a unit's storage in
 // the model.
-type UnitStorageVolumeAttachmentArg struct {
+type CreateUnitStorageVolumeAttachmentArg struct {
 	// NetNodeUUID is the net node of the model entity that volume will be
 	// attached to.
 	NetNodeUUID domainnetwork.NetNodeUUID
@@ -307,12 +307,12 @@ type UnitStorageInstanceArg struct {
 	// Filesystem describes the properties of a new filesystem to be created
 	// alongside the  storage instance. If this value is not nil a new
 	// filesystem will be created with the storage instance.
-	Filesystem *UnitStorageFilesystemArg
+	Filesystem *CreateUnitStorageFilesystemArg
 
 	// Volume describes the properties of a new volume to be created alongside
 	// the storage instance. If this value is not nil a new volume will be
 	// created with the storage instance.
-	Volume *UnitStorageVolumeArg
+	Volume *CreateUnitStorageVolumeArg
 
 	// UUID is the unique identifier of the storage instance.
 	UUID domainstorage.StorageInstanceUUID

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -214,6 +214,12 @@ type CreateUnitStorageArg struct {
 	// the unit and should be included in this list.
 	StorageToAttach []CreateUnitStorageAttachmentArg
 
+	// ExistingStorageToAttach defines already provisioned storage instances,
+	// previously detached from another unit, that should be attached to the
+	// new unit, as opposed to new storage created and attached as defined in
+	// [CreateUnitStorageArg.StorageToAttach].
+	ExistingStorageToAttach []AttachStorageToUnitArg
+
 	// StorageToOwn defines the storage instances that should be owned by the
 	// unit.
 	StorageToOwn []domainstorage.StorageInstanceUUID

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -177,9 +177,9 @@ type StorageInfoForAttach struct {
 	// ProvisionedSizeMiB is the size of the storage.
 	ProvisionedSizeMiB uint64
 
-	// AlreadyAttachedToUnits holds the unit UUIDs to which the storage
-	// is already attached.
-	AlreadyAttachedToUnits []string
+	// AlreadyAttachedToUnits maps unit UUIDs to unit names for units
+	// to which the storage is already attached.
+	AlreadyAttachedToUnits map[string]string
 }
 
 // StorageAlreadyAttached describes an error that occurs when attempting to

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -123,9 +123,59 @@ type IAASUnitAttachStorageArg struct {
 	VolumesToOwn []domainstorage.VolumeUUID
 }
 
-// StorageInstanceInfo holds the current number of storage instances of the
-// same named storage already attached to a unit, and the pool of an instance.
-type StorageInstanceInfo struct {
+type StorageInfoForAdd struct {
+	// Name is the name of the storage.
+	Name string
+
+	// Type is the storage type: filesystem or block-device.
+	Type charm.StorageType
+
+	// CountMin is the number of storage instances that must be attached
+	// to the charm for it to be useful; the charm will not install until
+	// this number has been satisfied. This must be a non-negative number.
+	CountMin int
+
+	// CountMax is the largest number of storage instances that can be
+	// attached to the charm. If CountMax is -1, then there is no upper
+	// bound.
+	CountMax int
+
+	// MinimumSize is the minimum size of store that the charm needs to
+	// work at all. This is not a recommended size or a comfortable size
+	// or a will-work-well size, just a bare minimum below which the charm
+	// is going to break.
+	// MinimumSize requires a unit, one of MGTPEZY, and is stored as MiB.
+	MinimumSize uint64
+
+	// AlreadyAttachedCount is the count of attached instances of the same
+	// underlying storage name already attached.
+	AlreadyAttachedCount uint32
+}
+
+type StorageInfoForAttach struct {
+	// Name is the name of the storage.
+	Name string
+
+	// Type is the storage type: filesystem or block-device.
+	Type charm.StorageType
+
+	// CountMin is the number of storage instances that must be attached
+	// to the charm for it to be useful; the charm will not install until
+	// this number has been satisfied. This must be a non-negative number.
+	CountMin int
+
+	// CountMax is the largest number of storage instances that can be
+	// attached to the charm. If CountMax is -1, then there is no upper
+	// bound.
+	CountMax int
+
+	// MinimumSize is the minimum size of store that the charm needs to
+	// work at all. This is not a recommended size or a comfortable size
+	// or a will-work-well size, just a bare minimum below which the charm
+	// is going to break.
+	// MinimumSize requires a unit, one of MGTPEZY, and is stored as MiB.
+	MinimumSize uint64
+
 	// AlreadyAttachedCount is the count of attached instances of the same
 	// underlying storage name already attached.
 	AlreadyAttachedCount uint32

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -181,7 +181,7 @@ type UnitStorageAttachmentArg struct {
 
 	// FilesystemAttachment describes a filesystem to attach for the storage
 	// instance attachment.
-	FilesystemAttachment *CreateUnitStorageFilesystemAttachmentArg
+	FilesystemAttachment *UnitStorageFilesystemAttachmentArg
 
 	// StorageInstanceUUID is the unique identifier of the storage instance
 	// to attach to the unit.
@@ -189,16 +189,16 @@ type UnitStorageAttachmentArg struct {
 
 	// VolumeAttachment describes a volume to attach for the storage
 	// instance attachment.
-	VolumeAttachment *CreateUnitStorageVolumeAttachmentArg
+	VolumeAttachment *UnitStorageVolumeAttachmentArg
 }
 
 // CreateUnitStorageDirectiveArg describes the arguments required for making storage
 // directives on a unit.
 type CreateUnitStorageDirectiveArg = CreateStorageDirectiveArg
 
-// CreateUnitStorageFilesystemArg describes a set of arguments for a filesystem
-// that should be created as part of a unit's storage.
-type CreateUnitStorageFilesystemArg struct {
+// UnitStorageFilesystemArg describes a set of attributes describing
+// a filesystem that can exist as part of a unit's storage.
+type UnitStorageFilesystemArg struct {
 	// UUID describes the unique identifier of the filesystem to
 	// create alongside the storage instance.
 	UUID domainstorage.FilesystemUUID
@@ -208,10 +208,10 @@ type CreateUnitStorageFilesystemArg struct {
 	ProvisionScope domainstorageprov.ProvisionScope
 }
 
-// CreateUnitStorageFilesystemAttachmentArg describes a set of arguments for a
-// filesystem attachment that should be created alongside a unit's storage in
+// UnitStorageFilesystemAttachmentArg describes a set of arguments for a
+// filesystem attachment that should exist alongside a unit's storage in
 // the model.
-type CreateUnitStorageFilesystemAttachmentArg struct {
+type UnitStorageFilesystemAttachmentArg struct {
 	// FilesystemUUID is the unique identifier of the filesystem to be attached.
 	FilesystemUUID domainstorage.FilesystemUUID
 
@@ -239,7 +239,7 @@ type CreateUnitStorageInstanceArg struct {
 	// Filesystem describes the properties of a new filesystem to be created
 	// alongside the  storage instance. If this value is not nil a new
 	// filesystem will be created with the storage instance.
-	Filesystem *CreateUnitStorageFilesystemArg
+	Filesystem *UnitStorageFilesystemArg
 
 	// Kind defines the type of storage that is being created.
 	Kind domainstorage.StorageKind
@@ -260,15 +260,15 @@ type CreateUnitStorageInstanceArg struct {
 	// Volume describes the properties of a new volume to be created alongside
 	// the storage instance. If this value is not nil a new volume will be
 	// created with the storage instance.
-	Volume *CreateUnitStorageVolumeArg
+	Volume *UnitStorageVolumeArg
 
 	// UUID is the unique identifier to associate with the storage instance.
 	UUID domainstorage.StorageInstanceUUID
 }
 
-// CreateUnitStorageVolumeArg describes a set of arguments for a volume
-// that should be created as part of a unit's storage.
-type CreateUnitStorageVolumeArg struct {
+// UnitStorageVolumeArg describes a set of attributes describing
+// a volume that can exist as part of a unit's storage.
+type UnitStorageVolumeArg struct {
 	// UUID describes the unique identifier of the volume to
 	// create alongside the storage instance.
 	UUID domainstorage.VolumeUUID
@@ -278,10 +278,10 @@ type CreateUnitStorageVolumeArg struct {
 	ProvisionScope domainstorageprov.ProvisionScope
 }
 
-// CreateUnitStorageVolumeAttachmentArg describes a set of arguments for a
-// volume attachment that should be created alongside a unit's storage in
+// UnitStorageVolumeAttachmentArg describes a set of arguments for a
+// volume attachment that should exist alongside a unit's storage in
 // the model.
-type CreateUnitStorageVolumeAttachmentArg struct {
+type UnitStorageVolumeAttachmentArg struct {
 	// NetNodeUUID is the net node of the model entity that volume will be
 	// attached to.
 	NetNodeUUID domainnetwork.NetNodeUUID
@@ -307,12 +307,12 @@ type UnitStorageInstanceArg struct {
 	// Filesystem describes the properties of a new filesystem to be created
 	// alongside the  storage instance. If this value is not nil a new
 	// filesystem will be created with the storage instance.
-	Filesystem *CreateUnitStorageFilesystemArg
+	Filesystem *UnitStorageFilesystemArg
 
 	// Volume describes the properties of a new volume to be created alongside
 	// the storage instance. If this value is not nil a new volume will be
 	// created with the storage instance.
-	Volume *CreateUnitStorageVolumeArg
+	Volume *UnitStorageVolumeArg
 
 	// UUID is the unique identifier of the storage instance.
 	UUID domainstorage.StorageInstanceUUID

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -4,8 +4,6 @@
 package internal
 
 import (
-	"strings"
-
 	"github.com/juju/juju/domain/deployment/charm"
 	domainnetwork "github.com/juju/juju/domain/network"
 	domainstorage "github.com/juju/juju/domain/storage"
@@ -147,6 +145,14 @@ type StorageInfoForAdd struct {
 	AlreadyAttachedCount uint32
 }
 
+// MachineIdentifier describes the identifying information for a machine.
+type MachineIdentifier struct {
+	// UUID is the machine uuid.
+	UUID string
+	// Name is the machine name.
+	Name string
+}
+
 // StorageInfoForAttach represents the arguments required to
 // attach storage to a unit.
 type StorageInfoForAttach struct {
@@ -180,24 +186,15 @@ type StorageInfoForAttach struct {
 	// AlreadyAttachedToUnits maps unit UUIDs to unit names for units
 	// to which the storage is already attached.
 	AlreadyAttachedToUnits map[string]string
+
+	// StorageMachineOwner, if not nil, is the machine that owns
+	// the storage being attached.
+	StorageMachineOwner *MachineIdentifier
 }
 
 // StorageAlreadyAttached describes an error that occurs when attempting to
 // attach storage to a unit and the storage is already attached to the unit.
 const StorageAlreadyAttached = errors.ConstError("storage already attached")
-
-// StorageAttachmentNotAllowed describes an error that occurs when attempting to
-// attach storage to a unit and the unit is not in the allow list.
-type StorageAttachmentNotAllowed struct {
-	// AttachedToUnits is the unexpected units to which
-	// the storage is already attached.
-	AttachedToUnits []string
-}
-
-// Error implements error.
-func (e StorageAttachmentNotAllowed) Error() string {
-	return "storage is already attached to units: " + strings.Join(e.AttachedToUnits, ", ")
-}
 
 // CreateUnitStorageArg represents the arguments required for making storage
 // for a unit. This will create and set the unit's storage directives and then

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -44,7 +44,7 @@ const MaxStorageCountPreconditonFailed = errors.ConstError("max storage count pr
 
 // ValidateStorageArg holds attributes used to validate storage.
 type ValidateStorageArg struct {
-	// Name is the name of the store.
+	// Name is the name of the storage.
 	Name string
 
 	// Type is the storage type: filesystem or block-device.
@@ -60,9 +60,9 @@ type ValidateStorageArg struct {
 	MinimumSize uint64
 }
 
-// UnitAddStorageArg represents the arguments required for add storage
+// AddStorageToUnitArg represents the arguments required for add storage
 // to a unit. This will instantiate the instances and attachments for the unit.
-type UnitAddStorageArg struct {
+type AddStorageToUnitArg struct {
 	// StorageInstances defines the new storage instances that must be created
 	// for the unit.
 	StorageInstances []CreateUnitStorageInstanceArg
@@ -83,10 +83,10 @@ type UnitAddStorageArg struct {
 }
 
 // IAASUnitAddStorageArg represents the arguments required for making storage
-// for an IAAS unit. This complements [UnitAddStorageArg], allowing for an
+// for an IAAS unit. This complements [AddStorageToUnitArg], allowing for an
 // IAAS unit to augment storage that is destined for a machine.
 type IAASUnitAddStorageArg struct {
-	UnitAddStorageArg
+	AddStorageToUnitArg
 	// FilesystemsToOwn defines filesystems that will be owned by the unit's
 	// machine.
 	FilesystemsToOwn []domainstorage.FilesystemUUID
@@ -95,9 +95,9 @@ type IAASUnitAddStorageArg struct {
 	VolumesToOwn []domainstorage.VolumeUUID
 }
 
-// UnitAttachStorageArg represents the arguments required to attach storage
+// AttachStorageToUnitArg represents the arguments required to attach storage
 // to a unit.
-type UnitAttachStorageArg struct {
+type AttachStorageToUnitArg struct {
 	// StorageToAttach defines the storage instances that should be attached to
 	// the unit.
 	StorageToAttach []CreateUnitStorageAttachmentArg
@@ -111,10 +111,10 @@ type UnitAttachStorageArg struct {
 }
 
 // IAASUnitAttachStorageArg represents the arguments required for attaching storage
-// to an IASS unit. This complements [UnitAttachStorageArg], allowing for an
+// to an IASS unit. This complements [AttachStorageToUnitArg], allowing for an
 // IAAS unit to augment storage that is destined for a machine.
 type IAASUnitAttachStorageArg struct {
-	UnitAttachStorageArg
+	AttachStorageToUnitArg
 	// FilesystemsToOwn defines filesystems that will be owned by the unit's
 	// machine.
 	FilesystemsToOwn []domainstorage.FilesystemUUID
@@ -160,11 +160,11 @@ type CreateUnitStorageArg struct {
 	StorageToOwn []domainstorage.StorageInstanceUUID
 }
 
-// IAASUnitStorageArg represents the arguments required to describe storage
+// CreateIAASUnitStorageArg represents the arguments required to describe storage
 // for an IAAS unit. This complements base args [CreateUnitStorageArg],
-// [UnitAddStorageArg], or [UnitAttachStorageArg] allowing for an
+// [AddStorageToUnitArg], or [AttachStorageToUnitArg] allowing for an
 // IAAS unit to augment storage that is destined for a machine.
-type IAASUnitStorageArg struct {
+type CreateIAASUnitStorageArg struct {
 	// FilesystemsToOwn defines filesystems that will be owned by the unit's
 	// machine.
 	FilesystemsToOwn []domainstorage.FilesystemUUID

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -173,10 +173,6 @@ type StorageInfoForAttach struct {
 	StorageMachineOwner *MachineIdentifier
 }
 
-// StorageAlreadyAttached describes an error that occurs when attempting to
-// attach storage to a unit and the storage is already attached to the unit.
-const StorageAlreadyAttached = errors.ConstError("storage already attached")
-
 // CreateUnitStorageArg represents the arguments required for making storage
 // for a unit. This will create and set the unit's storage directives and then
 // instantiate the instances and attachments for the units.

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -4,6 +4,8 @@
 package internal
 
 import (
+	"strings"
+
 	"github.com/juju/juju/domain/deployment/charm"
 	domainnetwork "github.com/juju/juju/domain/network"
 	domainstorage "github.com/juju/juju/domain/storage"
@@ -108,6 +110,10 @@ type AttachStorageToUnitArg struct {
 	// CountLessThanEqual is the maximum storage count allowed at the time
 	// the add is performed in order for the attach operation to be considered successful.
 	CountLessThanEqual uint32
+
+	// AllowedExistingUnitAttachments are the unit UUIDs to which the storage
+	// being attached is allowed to already be attached.
+	AllowedExistingUnitAttachments []string
 }
 
 // AttachStorageToIAASUnitArg represents the arguments required for attaching storage
@@ -183,6 +189,27 @@ type StorageInfoForAttach struct {
 
 	// ProvisionedSizeMiB is the size of the storage.
 	ProvisionedSizeMiB uint64
+
+	// AlreadyAttachedToUnits holds the unit UUIDs to which the storage
+	// is already attached.
+	AlreadyAttachedToUnits []string
+}
+
+// StorageAlreadyAttached describes an error that occurs when attempting to
+// attach storage to a unit and the storage is already attached to the unit.
+const StorageAlreadyAttached = errors.ConstError("storage already attached")
+
+// StorageAttachmentNotAllowed describes an error that occurs when attempting to
+// attach storage to a unit and the unit is not in the allow list.
+type StorageAttachmentNotAllowed struct {
+	// AttachedToUnits is the unexpected units to which
+	// the storage is already attached.
+	AttachedToUnits []string
+}
+
+// Error implements error.
+func (e StorageAttachmentNotAllowed) Error() string {
+	return "storage is already attached to units: " + strings.Join(e.AttachedToUnits, ", ")
 }
 
 // CreateUnitStorageArg represents the arguments required for making storage

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -71,7 +71,7 @@ type UnitAddStorageArg struct {
 	// the unit. New storage instances defined in
 	// [CreateUnitStorageArg.StorageInstances] are not automatically attached to
 	// the unit and should be included in this list.
-	StorageToAttach []CreateUnitStorageAttachmentArg
+	StorageToAttach []UnitStorageAttachmentArg
 
 	// StorageToOwn defines the storage instances that should be owned by the
 	// unit.
@@ -100,7 +100,7 @@ type IAASUnitAddStorageArg struct {
 type UnitAttachStorageArg struct {
 	// StorageToAttach defines the storage instances that should be attached to
 	// the unit.
-	StorageToAttach []CreateUnitStorageAttachmentArg
+	StorageToAttach []UnitStorageAttachmentArg
 
 	// StorageName is the name of the storage being attached.
 	StorageName string
@@ -153,17 +153,18 @@ type CreateUnitStorageArg struct {
 	// the unit. New storage instances defined in
 	// [CreateUnitStorageArg.StorageInstances] are not automatically attached to
 	// the unit and should be included in this list.
-	StorageToAttach []CreateUnitStorageAttachmentArg
+	StorageToAttach []UnitStorageAttachmentArg
 
 	// StorageToOwn defines the storage instances that should be owned by the
 	// unit.
 	StorageToOwn []domainstorage.StorageInstanceUUID
 }
 
-// CreateIAASUnitStorageArg represents the arguments required for making storage
-// for an IAAS unit. This complements [CreateUnitStorageArg], allowing for an
+// IAASUnitStorageArg represents the arguments required to describe storage
+// for an IAAS unit. This complements base args [CreateUnitStorageArg],
+// [UnitAddStorageArg], or [UnitAttachStorageArg] allowing for an
 // IAAS unit to augment storage that is destined for a machine.
-type CreateIAASUnitStorageArg struct {
+type IAASUnitStorageArg struct {
 	// FilesystemsToOwn defines filesystems that will be owned by the unit's
 	// machine.
 	FilesystemsToOwn []domainstorage.FilesystemUUID
@@ -172,9 +173,9 @@ type CreateIAASUnitStorageArg struct {
 	VolumesToOwn []domainstorage.VolumeUUID
 }
 
-// CreateUnitStorageAttachmentArg describes the arguments required for creating a
+// UnitStorageAttachmentArg describes the arguments required for describing a
 // storage attachment.
-type CreateUnitStorageAttachmentArg struct {
+type UnitStorageAttachmentArg struct {
 	// UUID is the unique identifier to associate with the storage attachment.
 	UUID domainstorage.StorageAttachmentUUID
 

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -98,9 +98,9 @@ type IAASUnitAddStorageArg struct {
 // AttachStorageToUnitArg represents the arguments required to attach storage
 // to a unit.
 type AttachStorageToUnitArg struct {
-	// StorageToAttach defines the storage instances that should be attached to
+	// StorageToAttach defines the storage instance that should be attached to
 	// the unit.
-	StorageToAttach []CreateUnitStorageAttachmentArg
+	StorageToAttach CreateUnitStorageAttachmentArg
 
 	// StorageName is the name of the storage being attached.
 	StorageName string

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -67,11 +67,11 @@ type AddStorageToUnitArg struct {
 	// for the unit.
 	StorageInstances []CreateUnitStorageInstanceArg
 
-	// StorageToAttach defines the storage instances that should be attached to
+	// NewStorageToAttach defines the storage instances that should be attached to
 	// the unit. New storage instances defined in
 	// [CreateUnitStorageArg.StorageInstances] are not automatically attached to
 	// the unit and should be included in this list.
-	StorageToAttach []CreateUnitStorageAttachmentArg
+	NewStorageToAttach []AttachStorageToUnitArg
 
 	// StorageToOwn defines the storage instances that should be owned by the
 	// unit.
@@ -93,25 +93,6 @@ type AddStorageToIAASUnitArg struct {
 
 	// VolumesToOwn defines volumes that will be owned by the unit's machine.
 	VolumesToOwn []domainstorage.VolumeUUID
-}
-
-// AttachStorageToUnitArg represents the arguments required to attach storage
-// to a unit.
-type AttachStorageToUnitArg struct {
-	// StorageToAttach defines the storage instance that should be attached to
-	// the unit.
-	StorageToAttach CreateUnitStorageAttachmentArg
-
-	// StorageName is the name of the storage being attached.
-	StorageName string
-
-	// CountLessThanEqual is the maximum storage count allowed at the time
-	// the add is performed in order for the attach operation to be considered successful.
-	CountLessThanEqual uint32
-
-	// AllowedExistingUnitAttachments are the unit UUIDs to which the storage
-	// being attached is allowed to already be attached.
-	AllowedExistingUnitAttachments []string
 }
 
 // StorageInfoForAdd represents the arguments required to
@@ -208,17 +189,17 @@ type CreateUnitStorageArg struct {
 	// for the unit.
 	StorageInstances []CreateUnitStorageInstanceArg
 
-	// StorageToAttach defines the storage instances that should be attached to
-	// the unit. New storage instances defined in
+	// NewStorageToAttach defines the storage instances that should be attached
+	// to the unit. New storage instances defined in
 	// [CreateUnitStorageArg.StorageInstances] are not automatically attached to
 	// the unit and should be included in this list.
-	StorageToAttach []CreateUnitStorageAttachmentArg
+	NewStorageToAttach []AttachStorageToUnitArg
 
 	// ExistingStorageToAttach defines already provisioned storage instances,
 	// previously detached from another unit, that should be attached to the
 	// new unit, as opposed to new storage created and attached as defined in
-	// [CreateUnitStorageArg.StorageToAttach].
-	ExistingStorageToAttach []AttachStorageToUnitArg
+	// [CreateUnitStorageArg.NewStorageToAttach].
+	ExistingStorageToAttach []AttachExistingStorageToUnitArg
 
 	// StorageToOwn defines the storage instances that should be owned by the
 	// unit.
@@ -238,9 +219,9 @@ type CreateIAASUnitStorageArg struct {
 	VolumesToOwn []domainstorage.VolumeUUID
 }
 
-// CreateUnitStorageAttachmentArg describes the arguments required for creating a
+// AttachStorageToUnitArg describes the arguments required for creating a
 // storage attachment.
-type CreateUnitStorageAttachmentArg struct {
+type AttachStorageToUnitArg struct {
 	// UUID is the unique identifier to associate with the storage attachment.
 	UUID domainstorage.StorageAttachmentUUID
 
@@ -255,6 +236,23 @@ type CreateUnitStorageAttachmentArg struct {
 	// VolumeAttachment describes a volume to attach for the storage
 	// instance attachment.
 	VolumeAttachment *CreateUnitStorageVolumeAttachmentArg
+}
+
+// AttachExistingStorageToUnitArg describes the arguments required for creating
+// a storage attachment for existing storage.
+type AttachExistingStorageToUnitArg struct {
+	AttachStorageToUnitArg
+
+	// StorageName is the name of the storage being attached.
+	StorageName string
+
+	// CountLessThanEqual is the maximum storage count allowed at the time
+	// the add is performed in order for the attach operation to be considered successful.
+	CountLessThanEqual uint32
+
+	// AllowedExistingUnitAttachments are the unit UUIDs to which the storage
+	// being attached is allowed to already be attached.
+	AllowedExistingUnitAttachments []string
 }
 
 // CreateUnitStorageDirectiveArg describes the arguments required for making storage

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -116,19 +116,6 @@ type AttachStorageToUnitArg struct {
 	AllowedExistingUnitAttachments []string
 }
 
-// AttachStorageToIAASUnitArg represents the arguments required for attaching storage
-// to an IASS unit. This complements [AttachStorageToUnitArg], allowing for an
-// IAAS unit to augment storage that is destined for a machine.
-type AttachStorageToIAASUnitArg struct {
-	AttachStorageToUnitArg
-	// FilesystemsToOwn defines filesystems that will be owned by the unit's
-	// machine.
-	FilesystemsToOwn []domainstorage.FilesystemUUID
-
-	// VolumesToOwn defines volumes that will be owned by the unit's machine.
-	VolumesToOwn []domainstorage.VolumeUUID
-}
-
 // StorageInfoForAdd represents the arguments required to
 // add storage to a unit.
 type StorageInfoForAdd struct {
@@ -377,8 +364,9 @@ type CreateUnitStorageVolumeAttachmentArg struct {
 	ProviderID *string
 }
 
-// UnitStorageInstanceArg describes a storage instance attached to a unit.
-type UnitStorageInstanceArg struct {
+// AddStorageInstanceArg describes a set of arguments used
+// to add a unit storage instance.
+type AddStorageInstanceArg struct {
 	// Filesystem describes the properties of a new filesystem to be created
 	// alongside the  storage instance. If this value is not nil a new
 	// filesystem will be created with the storage instance.
@@ -392,6 +380,10 @@ type UnitStorageInstanceArg struct {
 	// UUID is the unique identifier of the storage instance.
 	UUID domainstorage.StorageInstanceUUID
 }
+
+// AttachStorageInstanceArg describes a set of arguments used
+// to attach a unit storage instance.
+type AttachStorageInstanceArg AddStorageInstanceArg
 
 // ModelStoragePools provides the default storage pools that have been set
 // within the model. If a value is nil then no default exists.

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -156,9 +156,6 @@ type StorageInfoForAttach struct {
 	// Name is the name of the storage.
 	Name string
 
-	// Type is the storage type: filesystem or block-device.
-	Type charm.StorageType
-
 	// CountMin is the number of storage instances that must be attached
 	// to the charm for it to be useful; the charm will not install until
 	// this number has been satisfied. This must be a non-negative number.
@@ -179,9 +176,6 @@ type StorageInfoForAttach struct {
 	// AlreadyAttachedCount is the count of attached instances of the same
 	// underlying storage name already attached.
 	AlreadyAttachedCount uint32
-
-	// PoolUUID is the storage pool UUID of the instance.
-	PoolUUID domainstorage.StoragePoolUUID
 
 	// SizeMiB is the size of the storage.
 	SizeMiB uint64

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -60,7 +60,7 @@ type ValidateStorageArg struct {
 	MinimumSize uint64
 }
 
-// AddStorageToUnitArg represents the arguments required for add storage
+// AddStorageToUnitArg represents the arguments required for adding storage
 // to a unit. This will instantiate the instances and attachments for the unit.
 type AddStorageToUnitArg struct {
 	// StorageInstances defines the new storage instances that must be created
@@ -82,10 +82,10 @@ type AddStorageToUnitArg struct {
 	CountLessThanEqual uint32
 }
 
-// IAASUnitAddStorageArg represents the arguments required for making storage
+// AddStorageToIAASUnitArg represents the arguments required for making storage
 // for an IAAS unit. This complements [AddStorageToUnitArg], allowing for an
 // IAAS unit to augment storage that is destined for a machine.
-type IAASUnitAddStorageArg struct {
+type AddStorageToIAASUnitArg struct {
 	AddStorageToUnitArg
 	// FilesystemsToOwn defines filesystems that will be owned by the unit's
 	// machine.
@@ -110,10 +110,10 @@ type AttachStorageToUnitArg struct {
 	CountLessThanEqual uint32
 }
 
-// IAASUnitAttachStorageArg represents the arguments required for attaching storage
+// AttachStorageToIAASUnitArg represents the arguments required for attaching storage
 // to an IASS unit. This complements [AttachStorageToUnitArg], allowing for an
 // IAAS unit to augment storage that is destined for a machine.
-type IAASUnitAttachStorageArg struct {
+type AttachStorageToIAASUnitArg struct {
 	AttachStorageToUnitArg
 	// FilesystemsToOwn defines filesystems that will be owned by the unit's
 	// machine.
@@ -123,9 +123,11 @@ type IAASUnitAttachStorageArg struct {
 	VolumesToOwn []domainstorage.VolumeUUID
 }
 
+// StorageInfoForAdd represents the arguments required to
+// add storage to a unit.
 type StorageInfoForAdd struct {
-	// Name is the name of the storage.
-	Name string
+	// CharmStorageName is the name of the storage.
+	CharmStorageName string
 
 	// Type is the storage type: filesystem or block-device.
 	Type charm.StorageType
@@ -152,9 +154,11 @@ type StorageInfoForAdd struct {
 	AlreadyAttachedCount uint32
 }
 
+// StorageInfoForAttach represents the arguments required to
+// attach storage to a unit.
 type StorageInfoForAttach struct {
-	// Name is the name of the storage.
-	Name string
+	// CharmStorageName is the name of the storage.
+	CharmStorageName string
 
 	// CountMin is the number of storage instances that must be attached
 	// to the charm for it to be useful; the charm will not install until
@@ -177,8 +181,8 @@ type StorageInfoForAttach struct {
 	// underlying storage name already attached.
 	AlreadyAttachedCount uint32
 
-	// SizeMiB is the size of the storage.
-	SizeMiB uint64
+	// ProvisionedSizeMiB is the size of the storage.
+	ProvisionedSizeMiB uint64
 }
 
 // CreateUnitStorageArg represents the arguments required for making storage

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -1679,8 +1679,17 @@ func (s *ProviderService) SetApplicationCharm(ctx context.Context, appName strin
 	// Validate that the user provided storage directive overrides are valid
 	// against the new charm storage requirements.
 	userStorageDirectiveOverrides := params.StorageDirectiveOverrides
+	charmStorageDefs := transform.Map(newCharmStorage, func(name string, def internalcharm.Storage) (string, internal.ValidateStorageArg) {
+		return name, internal.ValidateStorageArg{
+			Name:        def.Name,
+			Type:        def.Type,
+			CountMin:    def.CountMin,
+			CountMax:    def.CountMax,
+			MinimumSize: def.MinimumSize,
+		}
+	})
 	if err := s.storageService.ValidateApplicationStorageDirectiveOverrides(
-		ctx, newCharmStorage, userStorageDirectiveOverrides,
+		ctx, charmStorageDefs, userStorageDirectiveOverrides,
 	); err != nil {
 		return errors.Errorf("validating storage directives: %w", err)
 	}

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -9,13 +9,13 @@ import (
 	"math/rand/v2"
 	"testing"
 	"time"
-	
+
 	"github.com/juju/clock"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/collections/transform"
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
-	
+
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/changestream"

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -9,13 +9,13 @@ import (
 	"math/rand/v2"
 	"testing"
 	"time"
-
+	
 	"github.com/juju/clock"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/collections/transform"
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
-
+	
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/changestream"
@@ -24,7 +24,7 @@ import (
 	"github.com/juju/juju/core/devices"
 	coreerrors "github.com/juju/juju/core/errors"
 	corelife "github.com/juju/juju/core/life"
-	machine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	networktesting "github.com/juju/juju/core/network/testing"
@@ -2708,7 +2708,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 	)
 	// Expect the override pool UUID validation to succeed.
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			override, exists := overrides["data"]
 			c.Assert(exists, tc.IsTrue)
 			c.Assert(override.PoolUUID, tc.NotNil)
@@ -2790,7 +2790,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 	)
 	// Expect the override pool UUID validation to fail.
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			override, exists := overrides["data"]
 			c.Assert(exists, tc.IsTrue)
 			c.Assert(override.PoolUUID, tc.NotNil)
@@ -2919,7 +2919,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 		nil,
 	)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			override, exists := overrides["data"]
 			c.Assert(exists, tc.IsTrue)
 			c.Assert(override.Count, tc.NotNil)
@@ -2996,7 +2996,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 		nil,
 	)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			override, exists := overrides["data"]
 			c.Assert(exists, tc.IsTrue)
 			c.Assert(override.Count, tc.NotNil)
@@ -3070,7 +3070,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 		nil,
 	)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			override, exists := overrides["data"]
 			c.Assert(exists, tc.IsTrue)
 			c.Assert(override.Count, tc.NotNil)
@@ -3143,7 +3143,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 		nil,
 	)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			override, exists := overrides["data"]
 			c.Assert(exists, tc.IsTrue)
 			c.Assert(override.Size, tc.NotNil)
@@ -3219,7 +3219,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 		nil,
 	)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			override, exists := overrides["data"]
 			c.Assert(exists, tc.IsTrue)
 			c.Assert(override.Size, tc.NotNil)
@@ -3291,7 +3291,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 		nil,
 	)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			override, exists := overrides["data"]
 			c.Assert(exists, tc.IsTrue)
 			c.Assert(override.Size, tc.NotNil)
@@ -3357,7 +3357,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
 	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			_, exists := overrides["data"]
 			c.Assert(exists, tc.IsFalse)
 			return errors.New("storage directive not-data does not exist in the application")
@@ -3523,7 +3523,7 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOv
 	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
 	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+		func(_ context.Context, _ map[string]internal.ValidateStorageArg, overrides map[string]storage.StorageDirectiveOverride) error {
 			c.Assert(len(overrides), tc.Equals, 2)
 			c.Assert(overrides["data"].Size, tc.NotNil)
 			c.Assert(*overrides["data"].Size, tc.Equals, uint64(2048))

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -640,7 +640,7 @@ func (c *MockStateAddIAASUnitsCall) DoAndReturn(f func(context.Context, applicat
 }
 
 // AddStorageForCAASUnit mocks base method.
-func (m *MockState) AddStorageForCAASUnit(arg0 context.Context, arg1 unit.UUID, arg2 storage.Name, arg3 internal.UnitAddStorageArg) ([]storage.ID, error) {
+func (m *MockState) AddStorageForCAASUnit(arg0 context.Context, arg1 unit.UUID, arg2 storage.Name, arg3 internal.AddStorageToUnitArg) ([]storage.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddStorageForCAASUnit", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]storage.ID)
@@ -667,13 +667,13 @@ func (c *MockStateAddStorageForCAASUnitCall) Return(arg0 []storage.ID, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAddStorageForCAASUnitCall) Do(f func(context.Context, unit.UUID, storage.Name, internal.UnitAddStorageArg) ([]storage.ID, error)) *MockStateAddStorageForCAASUnitCall {
+func (c *MockStateAddStorageForCAASUnitCall) Do(f func(context.Context, unit.UUID, storage.Name, internal.AddStorageToUnitArg) ([]storage.ID, error)) *MockStateAddStorageForCAASUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAddStorageForCAASUnitCall) DoAndReturn(f func(context.Context, unit.UUID, storage.Name, internal.UnitAddStorageArg) ([]storage.ID, error)) *MockStateAddStorageForCAASUnitCall {
+func (c *MockStateAddStorageForCAASUnitCall) DoAndReturn(f func(context.Context, unit.UUID, storage.Name, internal.AddStorageToUnitArg) ([]storage.ID, error)) *MockStateAddStorageForCAASUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -718,7 +718,7 @@ func (c *MockStateAddStorageForIAASUnitCall) DoAndReturn(f func(context.Context,
 }
 
 // AttachStorageToCAASUnit mocks base method.
-func (m *MockState) AttachStorageToCAASUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.UnitAttachStorageArg) error {
+func (m *MockState) AttachStorageToCAASUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.AttachStorageToUnitArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachStorageToCAASUnit", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -744,13 +744,13 @@ func (c *MockStateAttachStorageToCAASUnitCall) Return(arg0 error) *MockStateAtta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAttachStorageToCAASUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.UnitAttachStorageArg) error) *MockStateAttachStorageToCAASUnitCall {
+func (c *MockStateAttachStorageToCAASUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToUnitArg) error) *MockStateAttachStorageToCAASUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAttachStorageToCAASUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.UnitAttachStorageArg) error) *MockStateAttachStorageToCAASUnitCall {
+func (c *MockStateAttachStorageToCAASUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToUnitArg) error) *MockStateAttachStorageToCAASUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -3458,6 +3458,45 @@ func (c *MockStateGetUnitNamesForNetNodeCall) DoAndReturn(f func(context.Context
 	return c
 }
 
+// GetUnitNetNodeUUID mocks base method.
+func (m *MockState) GetUnitNetNodeUUID(arg0 context.Context, arg1 unit.UUID) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitNetNodeUUID", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitNetNodeUUID indicates an expected call of GetUnitNetNodeUUID.
+func (mr *MockStateMockRecorder) GetUnitNetNodeUUID(arg0, arg1 any) *MockStateGetUnitNetNodeUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNetNodeUUID", reflect.TypeOf((*MockState)(nil).GetUnitNetNodeUUID), arg0, arg1)
+	return &MockStateGetUnitNetNodeUUIDCall{Call: call}
+}
+
+// MockStateGetUnitNetNodeUUIDCall wrap *gomock.Call
+type MockStateGetUnitNetNodeUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitNetNodeUUIDCall) Return(arg0 string, arg1 error) *MockStateGetUnitNetNodeUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitNetNodeUUIDCall) Do(f func(context.Context, unit.UUID) (string, error)) *MockStateGetUnitNetNodeUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitNetNodeUUIDCall) DoAndReturn(f func(context.Context, unit.UUID) (string, error)) *MockStateGetUnitNetNodeUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetUnitNetNodesByName mocks base method.
 func (m *MockState) GetUnitNetNodesByName(arg0 context.Context, arg1 unit.Name) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -678,7 +678,7 @@ func (c *MockStateAddStorageForCAASUnitCall) DoAndReturn(f func(context.Context,
 }
 
 // AddStorageForIAASUnit mocks base method.
-func (m *MockState) AddStorageForIAASUnit(arg0 context.Context, arg1 unit.UUID, arg2 storage.Name, arg3 internal.IAASUnitAddStorageArg) ([]storage.ID, error) {
+func (m *MockState) AddStorageForIAASUnit(arg0 context.Context, arg1 unit.UUID, arg2 storage.Name, arg3 internal.AddStorageToIAASUnitArg) ([]storage.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddStorageForIAASUnit", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]storage.ID)
@@ -705,13 +705,13 @@ func (c *MockStateAddStorageForIAASUnitCall) Return(arg0 []storage.ID, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAddStorageForIAASUnitCall) Do(f func(context.Context, unit.UUID, storage.Name, internal.IAASUnitAddStorageArg) ([]storage.ID, error)) *MockStateAddStorageForIAASUnitCall {
+func (c *MockStateAddStorageForIAASUnitCall) Do(f func(context.Context, unit.UUID, storage.Name, internal.AddStorageToIAASUnitArg) ([]storage.ID, error)) *MockStateAddStorageForIAASUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAddStorageForIAASUnitCall) DoAndReturn(f func(context.Context, unit.UUID, storage.Name, internal.IAASUnitAddStorageArg) ([]storage.ID, error)) *MockStateAddStorageForIAASUnitCall {
+func (c *MockStateAddStorageForIAASUnitCall) DoAndReturn(f func(context.Context, unit.UUID, storage.Name, internal.AddStorageToIAASUnitArg) ([]storage.ID, error)) *MockStateAddStorageForIAASUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -755,7 +755,7 @@ func (c *MockStateAttachStorageToCAASUnitCall) DoAndReturn(f func(context.Contex
 }
 
 // AttachStorageToIAASUnit mocks base method.
-func (m *MockState) AttachStorageToIAASUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.IAASUnitAttachStorageArg) error {
+func (m *MockState) AttachStorageToIAASUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.AttachStorageToIAASUnitArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachStorageToIAASUnit", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -781,13 +781,13 @@ func (c *MockStateAttachStorageToIAASUnitCall) Return(arg0 error) *MockStateAtta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAttachStorageToIAASUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.IAASUnitAttachStorageArg) error) *MockStateAttachStorageToIAASUnitCall {
+func (c *MockStateAttachStorageToIAASUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToIAASUnitArg) error) *MockStateAttachStorageToIAASUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAttachStorageToIAASUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.IAASUnitAttachStorageArg) error) *MockStateAttachStorageToIAASUnitCall {
+func (c *MockStateAttachStorageToIAASUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToIAASUnitArg) error) *MockStateAttachStorageToIAASUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -716,78 +716,40 @@ func (c *MockStateAddStorageForIAASUnitCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
-// AttachStorageToCAASUnit mocks base method.
-func (m *MockState) AttachStorageToCAASUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.AttachStorageToUnitArg) error {
+// AttachStorageToUnit mocks base method.
+func (m *MockState) AttachStorageToUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.AttachStorageToUnitArg) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachStorageToCAASUnit", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AttachStorageToUnit", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AttachStorageToCAASUnit indicates an expected call of AttachStorageToCAASUnit.
-func (mr *MockStateMockRecorder) AttachStorageToCAASUnit(arg0, arg1, arg2, arg3 any) *MockStateAttachStorageToCAASUnitCall {
+// AttachStorageToUnit indicates an expected call of AttachStorageToUnit.
+func (mr *MockStateMockRecorder) AttachStorageToUnit(arg0, arg1, arg2, arg3 any) *MockStateAttachStorageToUnitCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToCAASUnit", reflect.TypeOf((*MockState)(nil).AttachStorageToCAASUnit), arg0, arg1, arg2, arg3)
-	return &MockStateAttachStorageToCAASUnitCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToUnit", reflect.TypeOf((*MockState)(nil).AttachStorageToUnit), arg0, arg1, arg2, arg3)
+	return &MockStateAttachStorageToUnitCall{Call: call}
 }
 
-// MockStateAttachStorageToCAASUnitCall wrap *gomock.Call
-type MockStateAttachStorageToCAASUnitCall struct {
+// MockStateAttachStorageToUnitCall wrap *gomock.Call
+type MockStateAttachStorageToUnitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateAttachStorageToCAASUnitCall) Return(arg0 error) *MockStateAttachStorageToCAASUnitCall {
+func (c *MockStateAttachStorageToUnitCall) Return(arg0 error) *MockStateAttachStorageToUnitCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAttachStorageToCAASUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToUnitArg) error) *MockStateAttachStorageToCAASUnitCall {
+func (c *MockStateAttachStorageToUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToUnitArg) error) *MockStateAttachStorageToUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAttachStorageToCAASUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToUnitArg) error) *MockStateAttachStorageToCAASUnitCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// AttachStorageToIAASUnit mocks base method.
-func (m *MockState) AttachStorageToIAASUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.AttachStorageToIAASUnitArg) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachStorageToIAASUnit", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AttachStorageToIAASUnit indicates an expected call of AttachStorageToIAASUnit.
-func (mr *MockStateMockRecorder) AttachStorageToIAASUnit(arg0, arg1, arg2, arg3 any) *MockStateAttachStorageToIAASUnitCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToIAASUnit", reflect.TypeOf((*MockState)(nil).AttachStorageToIAASUnit), arg0, arg1, arg2, arg3)
-	return &MockStateAttachStorageToIAASUnitCall{Call: call}
-}
-
-// MockStateAttachStorageToIAASUnitCall wrap *gomock.Call
-type MockStateAttachStorageToIAASUnitCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateAttachStorageToIAASUnitCall) Return(arg0 error) *MockStateAttachStorageToIAASUnitCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateAttachStorageToIAASUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToIAASUnitArg) error) *MockStateAttachStorageToIAASUnitCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAttachStorageToIAASUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToIAASUnitArg) error) *MockStateAttachStorageToIAASUnitCall {
+func (c *MockStateAttachStorageToUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToUnitArg) error) *MockStateAttachStorageToUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -3617,6 +3617,45 @@ func (c *MockStateGetUnitRefreshAttributesCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
+// GetUnitStorageAttachmentExists mocks base method.
+func (m *MockState) GetUnitStorageAttachmentExists(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitStorageAttachmentExists", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitStorageAttachmentExists indicates an expected call of GetUnitStorageAttachmentExists.
+func (mr *MockStateMockRecorder) GetUnitStorageAttachmentExists(arg0, arg1, arg2 any) *MockStateGetUnitStorageAttachmentExistsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitStorageAttachmentExists", reflect.TypeOf((*MockState)(nil).GetUnitStorageAttachmentExists), arg0, arg1, arg2)
+	return &MockStateGetUnitStorageAttachmentExistsCall{Call: call}
+}
+
+// MockStateGetUnitStorageAttachmentExistsCall wrap *gomock.Call
+type MockStateGetUnitStorageAttachmentExistsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitStorageAttachmentExistsCall) Return(arg0 bool, arg1 error) *MockStateGetUnitStorageAttachmentExistsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitStorageAttachmentExistsCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID) (bool, error)) *MockStateGetUnitStorageAttachmentExistsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitStorageAttachmentExistsCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID) (bool, error)) *MockStateGetUnitStorageAttachmentExistsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetUnitSubordinates mocks base method.
 func (m *MockState) GetUnitSubordinates(arg0 context.Context, arg1 unit.Name) ([]unit.Name, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -39,6 +39,7 @@ import (
 	charm1 "github.com/juju/juju/domain/deployment/charm"
 	life "github.com/juju/juju/domain/life"
 	network0 "github.com/juju/juju/domain/network"
+	storage0 "github.com/juju/juju/domain/storage"
 	environs "github.com/juju/juju/environs"
 	statushistory "github.com/juju/juju/internal/statushistory"
 	gomock "go.uber.org/mock/gomock"
@@ -712,6 +713,82 @@ func (c *MockStateAddStorageForIAASUnitCall) Do(f func(context.Context, unit.UUI
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateAddStorageForIAASUnitCall) DoAndReturn(f func(context.Context, unit.UUID, storage.Name, internal.IAASUnitAddStorageArg) ([]storage.ID, error)) *MockStateAddStorageForIAASUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// AttachStorageToCAASUnit mocks base method.
+func (m *MockState) AttachStorageToCAASUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.UnitAttachStorageArg) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachStorageToCAASUnit", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AttachStorageToCAASUnit indicates an expected call of AttachStorageToCAASUnit.
+func (mr *MockStateMockRecorder) AttachStorageToCAASUnit(arg0, arg1, arg2, arg3 any) *MockStateAttachStorageToCAASUnitCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToCAASUnit", reflect.TypeOf((*MockState)(nil).AttachStorageToCAASUnit), arg0, arg1, arg2, arg3)
+	return &MockStateAttachStorageToCAASUnitCall{Call: call}
+}
+
+// MockStateAttachStorageToCAASUnitCall wrap *gomock.Call
+type MockStateAttachStorageToCAASUnitCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAttachStorageToCAASUnitCall) Return(arg0 error) *MockStateAttachStorageToCAASUnitCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAttachStorageToCAASUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.UnitAttachStorageArg) error) *MockStateAttachStorageToCAASUnitCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAttachStorageToCAASUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.UnitAttachStorageArg) error) *MockStateAttachStorageToCAASUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// AttachStorageToIAASUnit mocks base method.
+func (m *MockState) AttachStorageToIAASUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.IAASUnitAttachStorageArg) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachStorageToIAASUnit", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AttachStorageToIAASUnit indicates an expected call of AttachStorageToIAASUnit.
+func (mr *MockStateMockRecorder) AttachStorageToIAASUnit(arg0, arg1, arg2, arg3 any) *MockStateAttachStorageToIAASUnitCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToIAASUnit", reflect.TypeOf((*MockState)(nil).AttachStorageToIAASUnit), arg0, arg1, arg2, arg3)
+	return &MockStateAttachStorageToIAASUnitCall{Call: call}
+}
+
+// MockStateAttachStorageToIAASUnitCall wrap *gomock.Call
+type MockStateAttachStorageToIAASUnitCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAttachStorageToIAASUnitCall) Return(arg0 error) *MockStateAttachStorageToIAASUnitCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAttachStorageToIAASUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.IAASUnitAttachStorageArg) error) *MockStateAttachStorageToIAASUnitCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAttachStorageToIAASUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.IAASUnitAttachStorageArg) error) *MockStateAttachStorageToIAASUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2753,6 +2830,46 @@ func (c *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall) Do(f func(conte
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall) DoAndReturn(f func(context.Context, unit.UUID, storage.Name) (charm1.Storage, uint32, error)) *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID mocks base method.
+func (m *MockState) GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(arg0 context.Context, arg1 unit.UUID, arg2 storage0.StorageInstanceUUID) (charm1.Storage, internal.StorageInstanceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(charm1.Storage)
+	ret1, _ := ret[1].(internal.StorageInstanceInfo)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID indicates an expected call of GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID.
+func (mr *MockStateMockRecorder) GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(arg0, arg1, arg2 any) *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID", reflect.TypeOf((*MockState)(nil).GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID), arg0, arg1, arg2)
+	return &MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall{Call: call}
+}
+
+// MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall wrap *gomock.Call
+type MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall) Return(arg0 charm1.Storage, arg1 internal.StorageInstanceInfo, arg2 error) *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall) Do(f func(context.Context, unit.UUID, storage0.StorageInstanceUUID) (charm1.Storage, internal.StorageInstanceInfo, error)) *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall) DoAndReturn(f func(context.Context, unit.UUID, storage0.StorageInstanceUUID) (charm1.Storage, internal.StorageInstanceInfo, error)) *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -36,7 +36,6 @@ import (
 	store "github.com/juju/juju/domain/application/charm/store"
 	internal "github.com/juju/juju/domain/application/internal"
 	constraints0 "github.com/juju/juju/domain/constraints"
-	charm1 "github.com/juju/juju/domain/deployment/charm"
 	life "github.com/juju/juju/domain/life"
 	network0 "github.com/juju/juju/domain/network"
 	storage0 "github.com/juju/juju/domain/storage"
@@ -2794,86 +2793,6 @@ func (c *MockStateGetCharmModifiedVersionCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
-// GetCharmStorageAndInstanceCountByUnitUUID mocks base method.
-func (m *MockState) GetCharmStorageAndInstanceCountByUnitUUID(arg0 context.Context, arg1 unit.UUID, arg2 storage.Name) (charm1.Storage, uint32, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmStorageAndInstanceCountByUnitUUID", arg0, arg1, arg2)
-	ret0, _ := ret[0].(charm1.Storage)
-	ret1, _ := ret[1].(uint32)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetCharmStorageAndInstanceCountByUnitUUID indicates an expected call of GetCharmStorageAndInstanceCountByUnitUUID.
-func (mr *MockStateMockRecorder) GetCharmStorageAndInstanceCountByUnitUUID(arg0, arg1, arg2 any) *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmStorageAndInstanceCountByUnitUUID", reflect.TypeOf((*MockState)(nil).GetCharmStorageAndInstanceCountByUnitUUID), arg0, arg1, arg2)
-	return &MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall{Call: call}
-}
-
-// MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall wrap *gomock.Call
-type MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall) Return(arg0 charm1.Storage, arg1 uint32, arg2 error) *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall) Do(f func(context.Context, unit.UUID, storage.Name) (charm1.Storage, uint32, error)) *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall) DoAndReturn(f func(context.Context, unit.UUID, storage.Name) (charm1.Storage, uint32, error)) *MockStateGetCharmStorageAndInstanceCountByUnitUUIDCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID mocks base method.
-func (m *MockState) GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(arg0 context.Context, arg1 unit.UUID, arg2 storage0.StorageInstanceUUID) (charm1.Storage, internal.StorageInstanceInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID", arg0, arg1, arg2)
-	ret0, _ := ret[0].(charm1.Storage)
-	ret1, _ := ret[1].(internal.StorageInstanceInfo)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID indicates an expected call of GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID.
-func (mr *MockStateMockRecorder) GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(arg0, arg1, arg2 any) *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID", reflect.TypeOf((*MockState)(nil).GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID), arg0, arg1, arg2)
-	return &MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall{Call: call}
-}
-
-// MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall wrap *gomock.Call
-type MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall) Return(arg0 charm1.Storage, arg1 internal.StorageInstanceInfo, arg2 error) *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall) Do(f func(context.Context, unit.UUID, storage0.StorageInstanceUUID) (charm1.Storage, internal.StorageInstanceInfo, error)) *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall) DoAndReturn(f func(context.Context, unit.UUID, storage0.StorageInstanceUUID) (charm1.Storage, internal.StorageInstanceInfo, error)) *MockStateGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetDeviceConstraints mocks base method.
 func (m *MockState) GetDeviceConstraints(arg0 context.Context, arg1 application.UUID) (map[string]devices.Constraints, error) {
 	m.ctrl.T.Helper()
@@ -3261,6 +3180,84 @@ func (c *MockStateGetSpaceUUIDByNameCall) Do(f func(context.Context, string) (ne
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetSpaceUUIDByNameCall) DoAndReturn(f func(context.Context, string) (network.SpaceUUID, error)) *MockStateGetSpaceUUIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetStorageAddInfoByUnitUUID mocks base method.
+func (m *MockState) GetStorageAddInfoByUnitUUID(arg0 context.Context, arg1 unit.UUID, arg2 storage.Name) (internal.StorageInfoForAdd, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageAddInfoByUnitUUID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(internal.StorageInfoForAdd)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStorageAddInfoByUnitUUID indicates an expected call of GetStorageAddInfoByUnitUUID.
+func (mr *MockStateMockRecorder) GetStorageAddInfoByUnitUUID(arg0, arg1, arg2 any) *MockStateGetStorageAddInfoByUnitUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageAddInfoByUnitUUID", reflect.TypeOf((*MockState)(nil).GetStorageAddInfoByUnitUUID), arg0, arg1, arg2)
+	return &MockStateGetStorageAddInfoByUnitUUIDCall{Call: call}
+}
+
+// MockStateGetStorageAddInfoByUnitUUIDCall wrap *gomock.Call
+type MockStateGetStorageAddInfoByUnitUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetStorageAddInfoByUnitUUIDCall) Return(arg0 internal.StorageInfoForAdd, arg1 error) *MockStateGetStorageAddInfoByUnitUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetStorageAddInfoByUnitUUIDCall) Do(f func(context.Context, unit.UUID, storage.Name) (internal.StorageInfoForAdd, error)) *MockStateGetStorageAddInfoByUnitUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetStorageAddInfoByUnitUUIDCall) DoAndReturn(f func(context.Context, unit.UUID, storage.Name) (internal.StorageInfoForAdd, error)) *MockStateGetStorageAddInfoByUnitUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetStorageAttachInfoByUnitUUIDAndStorageUUID mocks base method.
+func (m *MockState) GetStorageAttachInfoByUnitUUIDAndStorageUUID(arg0 context.Context, arg1 unit.UUID, arg2 storage0.StorageInstanceUUID) (internal.StorageInfoForAttach, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageAttachInfoByUnitUUIDAndStorageUUID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(internal.StorageInfoForAttach)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStorageAttachInfoByUnitUUIDAndStorageUUID indicates an expected call of GetStorageAttachInfoByUnitUUIDAndStorageUUID.
+func (mr *MockStateMockRecorder) GetStorageAttachInfoByUnitUUIDAndStorageUUID(arg0, arg1, arg2 any) *MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageAttachInfoByUnitUUIDAndStorageUUID", reflect.TypeOf((*MockState)(nil).GetStorageAttachInfoByUnitUUIDAndStorageUUID), arg0, arg1, arg2)
+	return &MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall{Call: call}
+}
+
+// MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall wrap *gomock.Call
+type MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall) Return(arg0 internal.StorageInfoForAttach, arg1 error) *MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall) Do(f func(context.Context, unit.UUID, storage0.StorageInstanceUUID) (internal.StorageInfoForAttach, error)) *MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall) DoAndReturn(f func(context.Context, unit.UUID, storage0.StorageInstanceUUID) (internal.StorageInfoForAttach, error)) *MockStateGetStorageAttachInfoByUnitUUIDAndStorageUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -3614,45 +3614,6 @@ func (c *MockStateGetUnitRefreshAttributesCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// GetUnitStorageAttachmentExists mocks base method.
-func (m *MockState) GetUnitStorageAttachmentExists(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitStorageAttachmentExists", arg0, arg1, arg2)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUnitStorageAttachmentExists indicates an expected call of GetUnitStorageAttachmentExists.
-func (mr *MockStateMockRecorder) GetUnitStorageAttachmentExists(arg0, arg1, arg2 any) *MockStateGetUnitStorageAttachmentExistsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitStorageAttachmentExists", reflect.TypeOf((*MockState)(nil).GetUnitStorageAttachmentExists), arg0, arg1, arg2)
-	return &MockStateGetUnitStorageAttachmentExistsCall{Call: call}
-}
-
-// MockStateGetUnitStorageAttachmentExistsCall wrap *gomock.Call
-type MockStateGetUnitStorageAttachmentExistsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitStorageAttachmentExistsCall) Return(arg0 bool, arg1 error) *MockStateGetUnitStorageAttachmentExistsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitStorageAttachmentExistsCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID) (bool, error)) *MockStateGetUnitStorageAttachmentExistsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitStorageAttachmentExistsCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID) (bool, error)) *MockStateGetUnitStorageAttachmentExistsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetUnitSubordinates mocks base method.
 func (m *MockState) GetUnitSubordinates(arg0 context.Context, arg1 unit.Name) ([]unit.Name, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -717,7 +717,7 @@ func (c *MockStateAddStorageForIAASUnitCall) DoAndReturn(f func(context.Context,
 }
 
 // AttachStorageToUnit mocks base method.
-func (m *MockState) AttachStorageToUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.AttachStorageToUnitArg) error {
+func (m *MockState) AttachStorageToUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID, arg3 internal.AttachExistingStorageToUnitArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachStorageToUnit", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -743,13 +743,13 @@ func (c *MockStateAttachStorageToUnitCall) Return(arg0 error) *MockStateAttachSt
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAttachStorageToUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToUnitArg) error) *MockStateAttachStorageToUnitCall {
+func (c *MockStateAttachStorageToUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachExistingStorageToUnitArg) error) *MockStateAttachStorageToUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAttachStorageToUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachStorageToUnitArg) error) *MockStateAttachStorageToUnitCall {
+func (c *MockStateAttachStorageToUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID, internal.AttachExistingStorageToUnitArg) error) *MockStateAttachStorageToUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_test.go
+++ b/domain/application/service/package_test.go
@@ -52,10 +52,11 @@ type baseSuite struct {
 //
 // This checker will:
 // - Deep equals check all values in the slice.
-// - It will not deep equals check unit NetNodeUUID values, instead they will be
-// checked to make sure they're a non zero uuid value.
+// - It will not deep equals check unit UnitUUID or NetNodeUUID values,
+// instead they will be checked to make sure they're a non zero uuid value.
 func createAddCAASUnitArgsChecker() *tc.MultiChecker {
 	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_[_].AddUnitArg.UnitUUID`, tc.IsNonZeroUUID)
 	mc.AddExpr(`_[_].AddUnitArg.NetNodeUUID`, tc.IsNonZeroUUID)
 	return mc
 }

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -104,7 +104,11 @@ type AddressParams struct {
 
 // AddUnitArg contains parameters for adding a unit to the model.
 type AddUnitArg struct {
-	Placement       *instance.Placement
+	// Placement is the placement of the unit.
+	Placement *instance.Placement
+	// StorageToAttach contains the list of UUIDs
+	// of existing, provisioned storage to be attached
+	// to the unit upon creation.
 	StorageToAttach []domainstorage.StorageInstanceUUID
 }
 

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/domain/application/service/storage"
 	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
+	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -103,9 +104,8 @@ type AddressParams struct {
 
 // AddUnitArg contains parameters for adding a unit to the model.
 type AddUnitArg struct {
-	Placement *instance.Placement
-
-	// Storage params go here.
+	Placement       *instance.Placement
+	StorageToAttach []domainstorage.StorageInstanceUUID
 }
 
 // AddIAASUnitArg contains parameters for adding a IAAS unit to the model.

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1281,6 +1281,21 @@ func (s *ProviderService) AttachStorageToUnit(
 			unitUUID, storageUUID, err,
 		)
 	}
+
+	if storageAttachInfo.StorageMachineOwner != nil {
+		unitMachineUUID, err := s.st.GetUnitMachineUUID(ctx, unitUUID.String())
+		if err != nil {
+			return errors.Errorf(
+				"getting machine for unit %q: %w",
+				unitUUID, err)
+		}
+		if unitMachineUUID != storageAttachInfo.StorageMachineOwner.UUID {
+			return applicationerrors.StorageAttachmentNotAllowed{
+				ExistingStorageMachineOwner: &storageAttachInfo.StorageMachineOwner.Name,
+			}
+		}
+	}
+
 	attachedToMap := storageAttachInfo.AlreadyAttachedToUnits
 	attachedUUIDs := set.NewStrings()
 	for uuid := range attachedToMap {
@@ -1297,10 +1312,9 @@ func (s *ProviderService) AttachStorageToUnit(
 		for _, uuid := range attachedUUIDs.SortedValues() {
 			otherNames = append(otherNames, attachedToMap[uuid])
 		}
-		return errors.Errorf(
-			"storage is already attached to other unit(s): %v",
-			otherNames,
-		)
+		return applicationerrors.StorageAttachmentNotAllowed{
+			AttachedToUnits: otherNames,
+		}
 	}
 
 	unitAttachStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID, storageAttachInfo)
@@ -1310,7 +1324,6 @@ func (s *ProviderService) AttachStorageToUnit(
 
 	err = s.st.AttachStorageToUnit(ctx, storageUUID, unitUUID, unitAttachStorageArgs)
 
-	var attachmentNotAllowed internal.StorageAttachmentNotAllowed
 	switch {
 	case errors.Is(err, internal.MaxStorageCountPreconditonFailed):
 		maxCount := int(unitAttachStorageArgs.CountLessThanEqual + 1)
@@ -1319,11 +1332,6 @@ func (s *ProviderService) AttachStorageToUnit(
 			Requested:   1,
 			StorageName: unitAttachStorageArgs.StorageName,
 		}
-	case errors.As(err, &attachmentNotAllowed):
-		return errors.Errorf(
-			"storage is already attached to other unit(s): %v",
-			attachmentNotAllowed.AttachedToUnits,
-		)
 	}
 	return errors.Capture(err)
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1048,7 +1048,7 @@ func (s *ProviderService) populateAddStorageArgs(
 		)
 	}
 
-	charmStorage, existingCount, err := s.st.GetCharmStorageAndInstanceCountByUnitUUID(ctx, unitUUID, storageName)
+	storageAddInfo, err := s.st.GetStorageAddInfoByUnitUUID(ctx, unitUUID, storageName)
 	if err != nil {
 		return internal.AddStorageToUnitArg{}, errors.Errorf(
 			"getting unit %q charm storage %q and count: %w",
@@ -1058,11 +1058,11 @@ func (s *ProviderService) populateAddStorageArgs(
 
 	charmStorageDefs := map[string]internal.ValidateStorageArg{
 		storageName.String(): {
-			Name:        charmStorage.Name,
-			Type:        charmStorage.Type,
-			CountMin:    charmStorage.CountMin,
-			CountMax:    charmStorage.CountMax,
-			MinimumSize: charmStorage.MinimumSize,
+			Name:        storageAddInfo.Name,
+			Type:        storageAddInfo.Type,
+			CountMin:    storageAddInfo.CountMin,
+			CountMax:    storageAddInfo.CountMax,
+			MinimumSize: storageAddInfo.MinimumSize,
 		},
 	}
 
@@ -1074,7 +1074,7 @@ func (s *ProviderService) populateAddStorageArgs(
 		storageDirective.Size = *arg.SizeMiB
 	}
 
-	wantCount := addCount + existingCount
+	wantCount := addCount + storageAddInfo.AlreadyAttachedCount
 	toCheck := map[string]storage.StorageDirectiveOverride{
 		storageName.String(): {
 			Count:    &wantCount,
@@ -1099,8 +1099,8 @@ func (s *ProviderService) populateAddStorageArgs(
 	// Record the max allowed count precondition.
 	// This will be checked inside the transaction.
 	args.CountLessThanEqual = uint32(math.MaxUint32)
-	if charmStorage.CountMax > 0 {
-		args.CountLessThanEqual = uint32(charmStorage.CountMax) - addCount
+	if storageAddInfo.CountMax > 0 {
+		args.CountLessThanEqual = uint32(storageAddInfo.CountMax) - addCount
 	}
 	return args, nil
 }
@@ -1201,7 +1201,7 @@ func (s *ProviderService) populateAttachStorageArgs(
 	storageUUID domainstorage.StorageInstanceUUID,
 	unitUUID coreunit.UUID,
 ) (internal.AttachStorageToUnitArg, error) {
-	charmStorage, instInfo, err := s.st.GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
+	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Errorf(
 			"getting unit %q charm storage and count for %q: %w",
@@ -1210,15 +1210,15 @@ func (s *ProviderService) populateAttachStorageArgs(
 	}
 
 	charmStorageDef := internal.ValidateStorageArg{
-		Name:        charmStorage.Name,
-		Type:        charmStorage.Type,
-		CountMin:    charmStorage.CountMin,
-		CountMax:    charmStorage.CountMax,
-		MinimumSize: charmStorage.MinimumSize,
+		Name:        storageAttachInfo.Name,
+		Type:        storageAttachInfo.Type,
+		CountMin:    storageAttachInfo.CountMin,
+		CountMax:    storageAttachInfo.CountMax,
+		MinimumSize: storageAttachInfo.MinimumSize,
 	}
 
-	wantCount := 1 + instInfo.AlreadyAttachedCount
-	err = s.storageService.ValidateAttachStorage(ctx, charmStorageDef, wantCount, instInfo.SizeMiB, instInfo.PoolUUID)
+	wantCount := 1 + storageAttachInfo.AlreadyAttachedCount
+	err = s.storageService.ValidateAttachStorage(ctx, charmStorageDef, wantCount, storageAttachInfo.SizeMiB, storageAttachInfo.PoolUUID)
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}
@@ -1233,14 +1233,14 @@ func (s *ProviderService) populateAttachStorageArgs(
 	}
 	args := internal.AttachStorageToUnitArg{
 		StorageToAttach:    attachArgs,
-		StorageName:        charmStorage.Name,
+		StorageName:        storageAttachInfo.Name,
 		CountLessThanEqual: uint32(math.MaxUint32),
 	}
 
 	// Record the max allowed count precondition.
 	// This will be checked inside the transaction.
-	if charmStorage.CountMax > 0 {
-		args.CountLessThanEqual = uint32(charmStorage.CountMax) - 1
+	if storageAttachInfo.CountMax > 0 {
+		args.CountLessThanEqual = uint32(storageAttachInfo.CountMax) - 1
 	}
 	return args, nil
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1284,27 +1284,22 @@ func (s *ProviderService) AttachStorageToIAASUnit(
 		return errors.Capture(err)
 	}
 
-	storageInst := transform.Slice(unitAttachStorageArgs.StorageToAttach,
-		func(in internal.CreateUnitStorageAttachmentArg) internal.UnitStorageInstanceArg {
-			result := internal.UnitStorageInstanceArg{
-				UUID: in.StorageInstanceUUID,
-			}
-			if in.FilesystemAttachment != nil {
-				result.Filesystem = &internal.CreateUnitStorageFilesystemArg{
-					UUID:           in.FilesystemAttachment.FilesystemUUID,
-					ProvisionScope: in.FilesystemAttachment.ProvisionScope,
-				}
-			}
-			if in.VolumeAttachment != nil {
-				result.Volume = &internal.CreateUnitStorageVolumeArg{
-					UUID:           in.VolumeAttachment.VolumeUUID,
-					ProvisionScope: in.VolumeAttachment.ProvisionScope,
-				}
-			}
-			return result
-		})
-	iaasUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(
-		storageInst)
+	arg := internal.UnitStorageInstanceArg{
+		UUID: unitAttachStorageArgs.StorageToAttach.StorageInstanceUUID,
+	}
+	if unitAttachStorageArgs.StorageToAttach.FilesystemAttachment != nil {
+		arg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
+			UUID:           unitAttachStorageArgs.StorageToAttach.FilesystemAttachment.FilesystemUUID,
+			ProvisionScope: unitAttachStorageArgs.StorageToAttach.FilesystemAttachment.ProvisionScope,
+		}
+	}
+	if unitAttachStorageArgs.StorageToAttach.VolumeAttachment != nil {
+		arg.Volume = &internal.CreateUnitStorageVolumeArg{
+			UUID:           unitAttachStorageArgs.StorageToAttach.VolumeAttachment.VolumeUUID,
+			ProvisionScope: unitAttachStorageArgs.StorageToAttach.VolumeAttachment.ProvisionScope,
+		}
+	}
+	iaasUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs([]internal.UnitStorageInstanceArg{arg})
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1276,7 +1276,7 @@ func (s *ProviderService) AttachStorageToIAASUnit(
 	}
 
 	storageInst := transform.Slice(unitStorageArgs.StorageToAttach,
-		func(in internal.CreateUnitStorageAttachmentArg) internal.UnitStorageInstanceArg {
+		func(in internal.UnitStorageAttachmentArg) internal.UnitStorageInstanceArg {
 			result := internal.UnitStorageInstanceArg{
 				UUID: in.StorageInstanceUUID,
 			}

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -748,9 +748,18 @@ func (s *ProviderService) validateCreateApplicationArgs(
 		return AddApplicationArgs{}, errors.Errorf("invalid charm storage: %w", err)
 	}
 
+	charmStorageDef := transform.Map(charm.Meta().Storage, func(k string, v internalcharm.Storage) (string, internal.ValidateStorageArg) {
+		return k, internal.ValidateStorageArg{
+			Name:        v.Name,
+			Type:        v.Type,
+			CountMin:    v.CountMin,
+			CountMax:    v.CountMax,
+			MinimumSize: v.MinimumSize,
+		}
+	})
 	err = s.storageService.ValidateApplicationStorageDirectiveOverrides(
 		ctx,
-		charm.Meta().Storage,
+		charmStorageDef,
 		args.StorageDirectiveOverrides,
 	)
 	if err != nil {
@@ -1047,10 +1056,7 @@ func (s *ProviderService) populateAddStorageArgs(
 		)
 	}
 
-	// TODO - We only care about a subset of the attributes for validation.
-	//   Ideally the ValidateApplicationStorageDirectiveOverrides method
-	//   would take a bespoke arg type.
-	charmStorageDefs := map[string]internalcharm.Storage{
+	charmStorageDefs := map[string]internal.ValidateStorageArg{
 		storageName.String(): {
 			Name:        charmStorage.Name,
 			Type:        charmStorage.Type,
@@ -1124,16 +1130,23 @@ func (s *ProviderService) AddStorageForIAASUnit(
 		return nil, errors.Capture(err)
 	}
 
-	iassUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(
-		ctx, unitStorageArgs.StorageInstances)
+	storageInst := transform.Slice(unitStorageArgs.StorageInstances,
+		func(in internal.CreateUnitStorageInstanceArg) internal.UnitStorageInstanceArg {
+			return internal.UnitStorageInstanceArg{
+				Filesystem: in.Filesystem,
+				Volume:     in.Volume,
+				UUID:       in.UUID,
+			}
+		})
+	iaasUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(storageInst)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
 	added, err := s.st.AddStorageForIAASUnit(ctx, unitUUID, storageName, internal.IAASUnitAddStorageArg{
 		UnitAddStorageArg: unitStorageArgs,
-		FilesystemsToOwn:  iassUnitStorageArgs.FilesystemsToOwn,
-		VolumesToOwn:      iassUnitStorageArgs.VolumesToOwn,
+		FilesystemsToOwn:  iaasUnitStorageArgs.FilesystemsToOwn,
+		VolumesToOwn:      iaasUnitStorageArgs.VolumesToOwn,
 	})
 	if errors.Is(err, internal.MaxStorageCountPreconditonFailed) {
 		maxCount := int(unitStorageArgs.CountLessThanEqual + count)
@@ -1183,12 +1196,65 @@ func (s *ProviderService) AddStorageForCAASUnit(
 	return added, errors.Capture(err)
 }
 
-// AttachStorageToUnit ensures the specified storage instance is attached to the
-// specified unit.
+func (s *ProviderService) populateAttachStorageArgs(
+	ctx context.Context,
+	storageUUID domainstorage.StorageInstanceUUID,
+	unitUUID coreunit.UUID,
+) (internal.UnitAttachStorageArg, error) {
+	if storageUUID.Validate() != nil {
+		return internal.UnitAttachStorageArg{}, errors.New("storage uuid is not valid").Add(coreerrors.NotValid)
+	}
+	if unitUUID.Validate() != nil {
+		return internal.UnitAttachStorageArg{}, errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
+	}
+
+	charmStorage, instInfo, err := s.st.GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
+	if err != nil {
+		return internal.UnitAttachStorageArg{}, errors.Errorf(
+			"getting unit %q charm storage and count for %q: %w",
+			unitUUID, storageUUID, err,
+		)
+	}
+
+	charmStorageDef := internal.ValidateStorageArg{
+		Name:        charmStorage.Name,
+		Type:        charmStorage.Type,
+		CountMin:    charmStorage.CountMin,
+		CountMax:    charmStorage.CountMax,
+		MinimumSize: charmStorage.MinimumSize,
+	}
+
+	wantCount := 1 + instInfo.AlreadyAttachedCount
+	err = s.storageService.ValidateAttachStorage(ctx, charmStorageDef, wantCount, instInfo.SizeMiB, instInfo.PoolUUID)
+	if err != nil {
+		return internal.UnitAttachStorageArg{}, errors.Capture(err)
+	}
+
+	args, err := s.storageService.MakeUnitAttachStorageArgs(
+		ctx,
+		unitUUID,
+		storageUUID,
+	)
+	if err != nil {
+		return internal.UnitAttachStorageArg{}, errors.Capture(err)
+	}
+	args.StorageName = charmStorage.Name
+
+	// Record the max allowed count precondition.
+	// This will be checked inside the transaction.
+	args.CountLessThanEqual = uint32(math.MaxUint32)
+	if charmStorage.CountMax > 0 {
+		args.CountLessThanEqual = uint32(charmStorage.CountMax) - 1
+	}
+	return args, nil
+}
+
+// AttachStorageToIAASUnit ensures the specified storage instance is attached to
+// the specified IAAS unit.
 // If the attachment already exists, the result is a no op.
 // The following error types can be expected:
-// - [github.com/juju/juju/domain/storage/errors.StorageNotFound] when the
-// storage doesn't exist.
+// - [github.com/juju/juju/domain/storage/errors.StorageInstanceNotFound] when
+// the storage doesn't exist.
 // - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
 // unit does not exist.
 // - [github.com/juju/juju/domain/application/errors.UnitNotAlive]: when the
@@ -1197,9 +1263,93 @@ func (s *ProviderService) AddStorageForCAASUnit(
 // storage is not alive.
 // - [github.com/juju/juju/domain/application/errors.StorageCountLimitExceeded]
 // when the requested storage falls outside of the bounds defined by the charm.
-func (s *ProviderService) AttachStorageToUnit(
+func (s *ProviderService) AttachStorageToIAASUnit(
 	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
 ) error {
-	// TODO (tlm): re-implement in DQlite
-	return errors.New("not implemented")
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	// Unit UUID and storage UUID are validated in populateAttachStorageArgs.
+	unitStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	storageInst := transform.Slice(unitStorageArgs.StorageToAttach,
+		func(in internal.CreateUnitStorageAttachmentArg) internal.UnitStorageInstanceArg {
+			result := internal.UnitStorageInstanceArg{
+				UUID: in.StorageInstanceUUID,
+			}
+			if in.FilesystemAttachment != nil {
+				result.Filesystem = &internal.CreateUnitStorageFilesystemArg{
+					UUID:           in.FilesystemAttachment.FilesystemUUID,
+					ProvisionScope: in.FilesystemAttachment.ProvisionScope,
+				}
+			}
+			if in.VolumeAttachment != nil {
+				result.Volume = &internal.CreateUnitStorageVolumeArg{
+					UUID:           in.VolumeAttachment.VolumeUUID,
+					ProvisionScope: in.VolumeAttachment.ProvisionScope,
+				}
+			}
+			return result
+		})
+	iassUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(
+		storageInst)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = s.st.AttachStorageToIAASUnit(ctx, storageUUID, unitUUID, internal.IAASUnitAttachStorageArg{
+		UnitAttachStorageArg: unitStorageArgs,
+		FilesystemsToOwn:     iassUnitStorageArgs.FilesystemsToOwn,
+		VolumesToOwn:         iassUnitStorageArgs.VolumesToOwn,
+	})
+	if errors.Is(err, internal.MaxStorageCountPreconditonFailed) {
+		maxCount := int(unitStorageArgs.CountLessThanEqual + 1)
+		return applicationerrors.StorageCountLimitExceeded{
+			Maximum:     &maxCount,
+			Requested:   1,
+			StorageName: unitStorageArgs.StorageName,
+		}
+	}
+	return errors.Capture(err)
+}
+
+// AttachStorageToCAASUnit ensures the specified storage instance is attached to
+// the specified CAAS unit.
+// If the attachment already exists, the result is a no op.
+// The following error types can be expected:
+// - [github.com/juju/juju/domain/storage/errors.StorageInstanceNotFound] when
+// the storage doesn't exist.
+// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
+// unit does not exist.
+// - [github.com/juju/juju/domain/application/errors.UnitNotAlive]: when the
+// unit is not alive.
+// - [github.com/juju/juju/domain/application/errors.StorageNotAlive]: when the
+// storage is not alive.
+// - [github.com/juju/juju/domain/application/errors.StorageCountLimitExceeded]
+// when the requested storage falls outside of the bounds defined by the charm.
+func (s *ProviderService) AttachStorageToCAASUnit(
+	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
+) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	// Unit UUID and storage UUID are validated in populateAttachStorageArgs.
+	unitStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = s.st.AttachStorageToCAASUnit(ctx, storageUUID, unitUUID, unitStorageArgs)
+	if errors.Is(err, internal.MaxStorageCountPreconditonFailed) {
+		maxCount := int(unitStorageArgs.CountLessThanEqual + 1)
+		return applicationerrors.StorageCountLimitExceeded{
+			Maximum:     &maxCount,
+			Requested:   1,
+			StorageName: unitStorageArgs.StorageName,
+		}
+	}
+	return errors.Capture(err)
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1225,11 +1225,18 @@ func (s *ProviderService) populateAttachStorageArgs(
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}
+	var allowedUUIDs []string
+	if len(storageAttachInfo.AlreadyAttachedToUnits) > 0 {
+		allowedUUIDs = make([]string, 0, len(storageAttachInfo.AlreadyAttachedToUnits))
+		for uuid := range storageAttachInfo.AlreadyAttachedToUnits {
+			allowedUUIDs = append(allowedUUIDs, uuid)
+		}
+	}
 	args := internal.AttachStorageToUnitArg{
 		StorageToAttach:                attachArgs,
 		StorageName:                    storageAttachInfo.CharmStorageName,
 		CountLessThanEqual:             uint32(math.MaxUint32),
-		AllowedExistingUnitAttachments: storageAttachInfo.AlreadyAttachedToUnits,
+		AllowedExistingUnitAttachments: allowedUUIDs,
 	}
 
 	// Record the max allowed count precondition.
@@ -1274,17 +1281,25 @@ func (s *ProviderService) AttachStorageToUnit(
 			unitUUID, storageUUID, err,
 		)
 	}
-	attachedTo := set.NewStrings(storageAttachInfo.AlreadyAttachedToUnits...)
-	if attachedTo.Size() == 1 && attachedTo.Contains(unitUUID.String()) {
+	attachedToMap := storageAttachInfo.AlreadyAttachedToUnits
+	attachedUUIDs := set.NewStrings()
+	for uuid := range attachedToMap {
+		attachedUUIDs.Add(uuid)
+	}
+	if attachedUUIDs.Size() == 1 && attachedUUIDs.Contains(unitUUID.String()) {
 		// The storage is already attached to the unit, so this is a no-op.
 		return nil
 	}
-	attachedTo.Remove(unitUUID.String())
+	attachedUUIDs.Remove(unitUUID.String())
 	// Shared storage is not supported.
-	if attachedTo.Size() > 0 {
+	if attachedUUIDs.Size() > 0 {
+		otherNames := make([]string, 0, attachedUUIDs.Size())
+		for _, uuid := range attachedUUIDs.SortedValues() {
+			otherNames = append(otherNames, attachedToMap[uuid])
+		}
 		return errors.Errorf(
-			"storage instance %q is already attached to other unit(s): %v",
-			storageUUID, attachedTo.Values(),
+			"storage is already attached to other unit(s): %v",
+			otherNames,
 		)
 	}
 
@@ -1306,7 +1321,9 @@ func (s *ProviderService) AttachStorageToUnit(
 		}
 	case errors.As(err, &attachmentNotAllowed):
 		return errors.Errorf(
-			"attaching storage %q to unit %q: %w", unitAttachStorageArgs.StorageName, unitUUID, attachmentNotAllowed)
+			"storage is already attached to other unit(s): %v",
+			attachmentNotAllowed.AttachedToUnits,
+		)
 	}
 	return errors.Capture(err)
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1252,7 +1252,7 @@ func (s *ProviderService) AttachStorageToUnit(
 		return nil
 	}
 
-	unitAttachStorageArgs, err := s.makeAttachStorageToUnitArgs(
+	unitAttachStorageArgs, err := s.makeAttachExistingStorageToUnitArgs(
 		ctx, storageUUID, unitUUID, netNodeUUID, &unitMachineUUID, storageAttachInfo)
 	if err != nil {
 		return errors.Capture(err)
@@ -1272,11 +1272,11 @@ func (s *ProviderService) AttachStorageToUnit(
 	return errors.Capture(err)
 }
 
-func (s *ProviderService) makeAttachStorageToUnitArgs(
+func (s *ProviderService) makeAttachExistingStorageToUnitArgs(
 	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID,
 	unitUUID coreunit.UUID, netNodeUUID string, unitPlacementMachineUUID *string,
 	storageAttachInfo internal.StorageInfoForAttach,
-) (internal.AttachStorageToUnitArg, error) {
+) (internal.AttachExistingStorageToUnitArg, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1284,7 +1284,7 @@ func (s *ProviderService) makeAttachStorageToUnitArgs(
 	// It's an error if the storage is attached to any other unit,
 	// as we don't support shared storage.
 	if len(storageAttachInfo.AlreadyAttachedToUnits) > 0 {
-		return internal.AttachStorageToUnitArg{}, applicationerrors.StorageAttachmentNotAllowed{
+		return internal.AttachExistingStorageToUnitArg{}, applicationerrors.StorageAttachmentNotAllowed{
 			AttachedToUnits: slices.Collect(maps.Values(storageAttachInfo.AlreadyAttachedToUnits)),
 		}
 	}
@@ -1294,21 +1294,21 @@ func (s *ProviderService) makeAttachStorageToUnitArgs(
 	if storageAttachInfo.StorageMachineOwner != nil {
 		// unitPlacementMachineUUID is nil when the unit is being added to a new machine.
 		if unitPlacementMachineUUID == nil || *unitPlacementMachineUUID != storageAttachInfo.StorageMachineOwner.UUID {
-			return internal.AttachStorageToUnitArg{}, applicationerrors.StorageAttachmentNotAllowed{
+			return internal.AttachExistingStorageToUnitArg{}, applicationerrors.StorageAttachmentNotAllowed{
 				ExistingStorageMachineOwner: &storageAttachInfo.StorageMachineOwner.Name,
 			}
 		}
 	}
 
-	return s.populateAttachStorageArgs(ctx, storageUUID, netNodeUUID, storageAttachInfo)
+	return s.populateAttachExistingStorageArgs(ctx, storageUUID, netNodeUUID, storageAttachInfo)
 }
 
-func (s *ProviderService) populateAttachStorageArgs(
+func (s *ProviderService) populateAttachExistingStorageArgs(
 	ctx context.Context,
 	storageUUID domainstorage.StorageInstanceUUID,
 	netNodeUUID string,
 	storageAttachInfo internal.StorageInfoForAttach,
-) (internal.AttachStorageToUnitArg, error) {
+) (internal.AttachExistingStorageToUnitArg, error) {
 
 	charmStorageDef := internal.ValidateStorageArg{
 		Name:        storageAttachInfo.CharmStorageName,
@@ -1320,30 +1320,17 @@ func (s *ProviderService) populateAttachStorageArgs(
 	err := s.storageService.ValidateAttachStorage(
 		charmStorageDef, storageAttachInfo.AlreadyAttachedCount, storageAttachInfo.ProvisionedSizeMiB)
 	if err != nil {
-		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
+		return internal.AttachExistingStorageToUnitArg{}, errors.Capture(err)
 	}
 
-	attachArgs, err := s.storageService.MakeUnitAttachStorageArgs(
+	attachArgs, err := s.storageService.MakeAttachExistingStorageArgs(
 		ctx,
 		netNodeUUID,
 		storageUUID,
+		storageAttachInfo,
 	)
 	if err != nil {
-		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
+		return internal.AttachExistingStorageToUnitArg{}, errors.Capture(err)
 	}
-
-	allowedUUIDs := slices.Collect(maps.Keys(storageAttachInfo.AlreadyAttachedToUnits))
-	args := internal.AttachStorageToUnitArg{
-		StorageToAttach:                attachArgs,
-		StorageName:                    storageAttachInfo.CharmStorageName,
-		CountLessThanEqual:             uint32(math.MaxUint32),
-		AllowedExistingUnitAttachments: allowedUUIDs,
-	}
-
-	// Record the max allowed count precondition.
-	// This will be checked inside the transaction.
-	if storageAttachInfo.CountMax > 0 {
-		args.CountLessThanEqual = uint32(storageAttachInfo.CountMax) - 1
-	}
-	return args, nil
+	return attachArgs, nil
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -5,12 +5,13 @@ package service
 
 import (
 	"context"
+	"maps"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/juju/clock"
-	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
 
 	"github.com/juju/juju/caas"
@@ -1229,13 +1230,8 @@ func (s *ProviderService) populateAttachStorageArgs(
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}
-	var allowedUUIDs []string
-	if len(storageAttachInfo.AlreadyAttachedToUnits) > 0 {
-		allowedUUIDs = make([]string, 0, len(storageAttachInfo.AlreadyAttachedToUnits))
-		for uuid := range storageAttachInfo.AlreadyAttachedToUnits {
-			allowedUUIDs = append(allowedUUIDs, uuid)
-		}
-	}
+
+	allowedUUIDs := slices.Collect(maps.Keys(storageAttachInfo.AlreadyAttachedToUnits))
 	args := internal.AttachStorageToUnitArg{
 		StorageToAttach:                attachArgs,
 		StorageName:                    storageAttachInfo.CharmStorageName,
@@ -1320,13 +1316,6 @@ func (s *ProviderService) makeAttachStorageToUnitArgs(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	if storageUUID.Validate() != nil {
-		return internal.AttachStorageToUnitArg{}, errors.New("storage uuid is not valid").Add(coreerrors.NotValid)
-	}
-	if unitUUID.Validate() != nil {
-		return internal.AttachStorageToUnitArg{}, errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
-	}
-
 	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Errorf(
@@ -1336,25 +1325,15 @@ func (s *ProviderService) makeAttachStorageToUnitArgs(
 	}
 
 	// First check to see if the storage is already attached to the unit.
-	attachedToMap := storageAttachInfo.AlreadyAttachedToUnits
-	attachedUUIDs := set.NewStrings()
-	for uuid := range attachedToMap {
-		attachedUUIDs.Add(uuid)
-	}
-	if attachedUUIDs.Size() == 1 && attachedUUIDs.Contains(unitUUID.String()) {
-		// The storage is already attached to the unit, so this is a no-op.
+	if _, alreadyAttached := storageAttachInfo.AlreadyAttachedToUnits[unitUUID.String()]; alreadyAttached {
 		return internal.AttachStorageToUnitArg{}, alreadyAttachedError
 	}
+	delete(storageAttachInfo.AlreadyAttachedToUnits, unitUUID.String())
 	// It's an error if the storage is attached to any other unit,
 	// as we don't support shared storage.
-	attachedUUIDs.Remove(unitUUID.String())
-	if attachedUUIDs.Size() > 0 {
-		otherNames := make([]string, 0, attachedUUIDs.Size())
-		for _, uuid := range attachedUUIDs.SortedValues() {
-			otherNames = append(otherNames, attachedToMap[uuid])
-		}
+	if len(storageAttachInfo.AlreadyAttachedToUnits) > 0 {
 		return internal.AttachStorageToUnitArg{}, applicationerrors.StorageAttachmentNotAllowed{
-			AttachedToUnits: otherNames,
+			AttachedToUnits: slices.Collect(maps.Values(storageAttachInfo.AlreadyAttachedToUnits)),
 		}
 	}
 

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1283,18 +1283,18 @@ func (s *ProviderService) AttachStorageToIAASUnit(
 	}
 
 	storageInst := transform.Slice(unitAttachStorageArgs.StorageToAttach,
-		func(in internal.UnitStorageAttachmentArg) internal.UnitStorageInstanceArg {
+		func(in internal.CreateUnitStorageAttachmentArg) internal.UnitStorageInstanceArg {
 			result := internal.UnitStorageInstanceArg{
 				UUID: in.StorageInstanceUUID,
 			}
 			if in.FilesystemAttachment != nil {
-				result.Filesystem = &internal.UnitStorageFilesystemArg{
+				result.Filesystem = &internal.CreateUnitStorageFilesystemArg{
 					UUID:           in.FilesystemAttachment.FilesystemUUID,
 					ProvisionScope: in.FilesystemAttachment.ProvisionScope,
 				}
 			}
 			if in.VolumeAttachment != nil {
-				result.Volume = &internal.UnitStorageVolumeArg{
+				result.Volume = &internal.CreateUnitStorageVolumeArg{
 					UUID:           in.VolumeAttachment.VolumeUUID,
 					ProvisionScope: in.VolumeAttachment.ProvisionScope,
 				}

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1058,7 +1058,7 @@ func (s *ProviderService) populateAddStorageArgs(
 
 	charmStorageDefs := map[string]internal.ValidateStorageArg{
 		storageName.String(): {
-			Name:        storageAddInfo.Name,
+			Name:        storageAddInfo.CharmStorageName,
 			Type:        storageAddInfo.Type,
 			CountMin:    storageAddInfo.CountMin,
 			CountMax:    storageAddInfo.CountMax,
@@ -1098,7 +1098,7 @@ func (s *ProviderService) populateAddStorageArgs(
 	}
 	// Record the max allowed count precondition.
 	// This will be checked inside the transaction.
-	args.CountLessThanEqual = uint32(math.MaxUint32)
+	args.CountLessThanEqual = uint32(math.MaxUint32) - addCount
 	if storageAddInfo.CountMax > 0 {
 		args.CountLessThanEqual = uint32(storageAddInfo.CountMax) - addCount
 	}
@@ -1143,7 +1143,7 @@ func (s *ProviderService) AddStorageForIAASUnit(
 		return nil, errors.Capture(err)
 	}
 
-	added, err := s.st.AddStorageForIAASUnit(ctx, unitUUID, storageName, internal.IAASUnitAddStorageArg{
+	added, err := s.st.AddStorageForIAASUnit(ctx, unitUUID, storageName, internal.AddStorageToIAASUnitArg{
 		AddStorageToUnitArg: unitStorageArgs,
 		FilesystemsToOwn:    iaasUnitStorageArgs.FilesystemsToOwn,
 		VolumesToOwn:        iaasUnitStorageArgs.VolumesToOwn,
@@ -1210,14 +1210,14 @@ func (s *ProviderService) populateAttachStorageArgs(
 	}
 
 	charmStorageDef := internal.ValidateStorageArg{
-		Name:        storageAttachInfo.Name,
+		Name:        storageAttachInfo.CharmStorageName,
 		CountMin:    storageAttachInfo.CountMin,
 		CountMax:    storageAttachInfo.CountMax,
 		MinimumSize: storageAttachInfo.MinimumSize,
 	}
 
 	err = s.storageService.ValidateAttachStorage(
-		charmStorageDef, storageAttachInfo.AlreadyAttachedCount, storageAttachInfo.SizeMiB)
+		charmStorageDef, storageAttachInfo.AlreadyAttachedCount, storageAttachInfo.ProvisionedSizeMiB)
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}
@@ -1232,7 +1232,7 @@ func (s *ProviderService) populateAttachStorageArgs(
 	}
 	args := internal.AttachStorageToUnitArg{
 		StorageToAttach:    attachArgs,
-		StorageName:        storageAttachInfo.Name,
+		StorageName:        storageAttachInfo.CharmStorageName,
 		CountLessThanEqual: uint32(math.MaxUint32),
 	}
 
@@ -1304,7 +1304,7 @@ func (s *ProviderService) AttachStorageToIAASUnit(
 		return errors.Capture(err)
 	}
 
-	err = s.st.AttachStorageToIAASUnit(ctx, storageUUID, unitUUID, internal.IAASUnitAttachStorageArg{
+	err = s.st.AttachStorageToIAASUnit(ctx, storageUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
 		AttachStorageToUnitArg: unitAttachStorageArgs,
 		FilesystemsToOwn:       iaasUnitStorageArgs.FilesystemsToOwn,
 		VolumesToOwn:           iaasUnitStorageArgs.VolumesToOwn,

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1201,13 +1201,6 @@ func (s *ProviderService) populateAttachStorageArgs(
 	storageUUID domainstorage.StorageInstanceUUID,
 	unitUUID coreunit.UUID,
 ) (internal.UnitAttachStorageArg, error) {
-	if storageUUID.Validate() != nil {
-		return internal.UnitAttachStorageArg{}, errors.New("storage uuid is not valid").Add(coreerrors.NotValid)
-	}
-	if unitUUID.Validate() != nil {
-		return internal.UnitAttachStorageArg{}, errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
-	}
-
 	charmStorage, instInfo, err := s.st.GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
 	if err != nil {
 		return internal.UnitAttachStorageArg{}, errors.Errorf(
@@ -1269,48 +1262,62 @@ func (s *ProviderService) AttachStorageToIAASUnit(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	// Unit UUID and storage UUID are validated in populateAttachStorageArgs.
-	unitStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID)
+	if storageUUID.Validate() != nil {
+		return errors.New("storage uuid is not valid").Add(coreerrors.NotValid)
+	}
+	if unitUUID.Validate() != nil {
+		return errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
+	}
+	exists, err := s.st.GetUnitStorageAttachmentExists(ctx, storageUUID, unitUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if exists {
+		return nil
+	}
+
+	unitAttachStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID)
+
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	storageInst := transform.Slice(unitStorageArgs.StorageToAttach,
+	storageInst := transform.Slice(unitAttachStorageArgs.StorageToAttach,
 		func(in internal.UnitStorageAttachmentArg) internal.UnitStorageInstanceArg {
 			result := internal.UnitStorageInstanceArg{
 				UUID: in.StorageInstanceUUID,
 			}
 			if in.FilesystemAttachment != nil {
-				result.Filesystem = &internal.CreateUnitStorageFilesystemArg{
+				result.Filesystem = &internal.UnitStorageFilesystemArg{
 					UUID:           in.FilesystemAttachment.FilesystemUUID,
 					ProvisionScope: in.FilesystemAttachment.ProvisionScope,
 				}
 			}
 			if in.VolumeAttachment != nil {
-				result.Volume = &internal.CreateUnitStorageVolumeArg{
+				result.Volume = &internal.UnitStorageVolumeArg{
 					UUID:           in.VolumeAttachment.VolumeUUID,
 					ProvisionScope: in.VolumeAttachment.ProvisionScope,
 				}
 			}
 			return result
 		})
-	iassUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(
+	iaasUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(
 		storageInst)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	err = s.st.AttachStorageToIAASUnit(ctx, storageUUID, unitUUID, internal.IAASUnitAttachStorageArg{
-		UnitAttachStorageArg: unitStorageArgs,
-		FilesystemsToOwn:     iassUnitStorageArgs.FilesystemsToOwn,
-		VolumesToOwn:         iassUnitStorageArgs.VolumesToOwn,
+		UnitAttachStorageArg: unitAttachStorageArgs,
+		FilesystemsToOwn:     iaasUnitStorageArgs.FilesystemsToOwn,
+		VolumesToOwn:         iaasUnitStorageArgs.VolumesToOwn,
 	})
 	if errors.Is(err, internal.MaxStorageCountPreconditonFailed) {
-		maxCount := int(unitStorageArgs.CountLessThanEqual + 1)
+		maxCount := int(unitAttachStorageArgs.CountLessThanEqual + 1)
 		return applicationerrors.StorageCountLimitExceeded{
 			Maximum:     &maxCount,
 			Requested:   1,
-			StorageName: unitStorageArgs.StorageName,
+			StorageName: unitAttachStorageArgs.StorageName,
 		}
 	}
 	return errors.Capture(err)
@@ -1336,7 +1343,20 @@ func (s *ProviderService) AttachStorageToCAASUnit(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	// Unit UUID and storage UUID are validated in populateAttachStorageArgs.
+	if storageUUID.Validate() != nil {
+		return errors.New("storage uuid is not valid").Add(coreerrors.NotValid)
+	}
+	if unitUUID.Validate() != nil {
+		return errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
+	}
+	exists, err := s.st.GetUnitStorageAttachmentExists(ctx, storageUUID, unitUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if exists {
+		return nil
+	}
+
 	unitStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1202,51 +1202,6 @@ func (s *ProviderService) AddStorageForCAASUnit(
 	return added, errors.Capture(err)
 }
 
-func (s *ProviderService) populateAttachStorageArgs(
-	ctx context.Context,
-	storageUUID domainstorage.StorageInstanceUUID,
-	netNodeUUID string,
-	storageAttachInfo internal.StorageInfoForAttach,
-) (internal.AttachStorageToUnitArg, error) {
-
-	charmStorageDef := internal.ValidateStorageArg{
-		Name:        storageAttachInfo.CharmStorageName,
-		CountMin:    storageAttachInfo.CountMin,
-		CountMax:    storageAttachInfo.CountMax,
-		MinimumSize: storageAttachInfo.MinimumSize,
-	}
-
-	err := s.storageService.ValidateAttachStorage(
-		charmStorageDef, storageAttachInfo.AlreadyAttachedCount, storageAttachInfo.ProvisionedSizeMiB)
-	if err != nil {
-		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
-	}
-
-	attachArgs, err := s.storageService.MakeUnitAttachStorageArgs(
-		ctx,
-		netNodeUUID,
-		storageUUID,
-	)
-	if err != nil {
-		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
-	}
-
-	allowedUUIDs := slices.Collect(maps.Keys(storageAttachInfo.AlreadyAttachedToUnits))
-	args := internal.AttachStorageToUnitArg{
-		StorageToAttach:                attachArgs,
-		StorageName:                    storageAttachInfo.CharmStorageName,
-		CountLessThanEqual:             uint32(math.MaxUint32),
-		AllowedExistingUnitAttachments: allowedUUIDs,
-	}
-
-	// Record the max allowed count precondition.
-	// This will be checked inside the transaction.
-	if storageAttachInfo.CountMax > 0 {
-		args.CountLessThanEqual = uint32(storageAttachInfo.CountMax) - 1
-	}
-	return args, nil
-}
-
 // AttachStorageToUnit ensures the specified storage instance is attached to
 // the specified unit.
 // If the attachment already exists, the result is a no op.
@@ -1346,4 +1301,49 @@ func (s *ProviderService) makeAttachStorageToUnitArgs(
 	}
 
 	return s.populateAttachStorageArgs(ctx, storageUUID, netNodeUUID, storageAttachInfo)
+}
+
+func (s *ProviderService) populateAttachStorageArgs(
+	ctx context.Context,
+	storageUUID domainstorage.StorageInstanceUUID,
+	netNodeUUID string,
+	storageAttachInfo internal.StorageInfoForAttach,
+) (internal.AttachStorageToUnitArg, error) {
+
+	charmStorageDef := internal.ValidateStorageArg{
+		Name:        storageAttachInfo.CharmStorageName,
+		CountMin:    storageAttachInfo.CountMin,
+		CountMax:    storageAttachInfo.CountMax,
+		MinimumSize: storageAttachInfo.MinimumSize,
+	}
+
+	err := s.storageService.ValidateAttachStorage(
+		charmStorageDef, storageAttachInfo.AlreadyAttachedCount, storageAttachInfo.ProvisionedSizeMiB)
+	if err != nil {
+		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
+	}
+
+	attachArgs, err := s.storageService.MakeUnitAttachStorageArgs(
+		ctx,
+		netNodeUUID,
+		storageUUID,
+	)
+	if err != nil {
+		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
+	}
+
+	allowedUUIDs := slices.Collect(maps.Keys(storageAttachInfo.AlreadyAttachedToUnits))
+	args := internal.AttachStorageToUnitArg{
+		StorageToAttach:                attachArgs,
+		StorageName:                    storageAttachInfo.CharmStorageName,
+		CountLessThanEqual:             uint32(math.MaxUint32),
+		AllowedExistingUnitAttachments: allowedUUIDs,
+	}
+
+	// Record the max allowed count precondition.
+	// This will be checked inside the transaction.
+	if storageAttachInfo.CountMax > 0 {
+		args.CountLessThanEqual = uint32(storageAttachInfo.CountMax) - 1
+	}
+	return args, nil
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1216,8 +1216,8 @@ func (s *ProviderService) populateAttachStorageArgs(
 		MinimumSize: storageAttachInfo.MinimumSize,
 	}
 
-	wantCount := 1 + storageAttachInfo.AlreadyAttachedCount
-	err = s.storageService.ValidateAttachStorage(charmStorageDef, wantCount, storageAttachInfo.SizeMiB)
+	err = s.storageService.ValidateAttachStorage(
+		charmStorageDef, storageAttachInfo.AlreadyAttachedCount, storageAttachInfo.SizeMiB)
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1132,8 +1132,8 @@ func (s *ProviderService) AddStorageForIAASUnit(
 	}
 
 	storageInst := transform.Slice(unitStorageArgs.StorageInstances,
-		func(in internal.CreateUnitStorageInstanceArg) internal.UnitStorageInstanceArg {
-			return internal.UnitStorageInstanceArg{
+		func(in internal.CreateUnitStorageInstanceArg) internal.AddStorageInstanceArg {
+			return internal.AddStorageInstanceArg{
 				Filesystem: in.Filesystem,
 				Volume:     in.Volume,
 				UUID:       in.UUID,
@@ -1240,8 +1240,8 @@ func (s *ProviderService) populateAttachStorageArgs(
 	return args, nil
 }
 
-// AttachStorageToIAASUnit ensures the specified storage instance is attached to
-// the specified IAAS unit.
+// AttachStorageToUnit ensures the specified storage instance is attached to
+// the specified unit.
 // If the attachment already exists, the result is a no op.
 // The following error types can be expected:
 // - [github.com/juju/juju/domain/storage/errors.StorageInstanceNotFound] when
@@ -1254,103 +1254,7 @@ func (s *ProviderService) populateAttachStorageArgs(
 // storage is not alive.
 // - [github.com/juju/juju/domain/application/errors.StorageCountLimitExceeded]
 // when the requested storage falls outside of the bounds defined by the charm.
-func (s *ProviderService) AttachStorageToIAASUnit(
-	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	if storageUUID.Validate() != nil {
-		return errors.New("storage uuid is not valid").Add(coreerrors.NotValid)
-	}
-	if unitUUID.Validate() != nil {
-		return errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
-	}
-
-	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
-	if err != nil {
-		return errors.Errorf(
-			"getting unit %q charm storage and attachment info for %q: %w",
-			unitUUID, storageUUID, err,
-		)
-	}
-	attachedTo := set.NewStrings(storageAttachInfo.AlreadyAttachedToUnits...)
-	if attachedTo.Size() == 1 && attachedTo.Contains(unitUUID.String()) {
-		// The storage is already attached to the unit, so this is a no-op.
-		return nil
-	}
-	attachedTo.Remove(unitUUID.String())
-	// Shared storage is not supported.
-	if attachedTo.Size() > 0 {
-		return errors.Errorf(
-			"storage instance %q is already attached to other unit(s): %v",
-			storageUUID, attachedTo.Values(),
-		)
-	}
-
-	unitAttachStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID, storageAttachInfo)
-
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	arg := internal.UnitStorageInstanceArg{
-		UUID: unitAttachStorageArgs.StorageToAttach.StorageInstanceUUID,
-	}
-	if unitAttachStorageArgs.StorageToAttach.FilesystemAttachment != nil {
-		arg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
-			UUID:           unitAttachStorageArgs.StorageToAttach.FilesystemAttachment.FilesystemUUID,
-			ProvisionScope: unitAttachStorageArgs.StorageToAttach.FilesystemAttachment.ProvisionScope,
-		}
-	}
-	if unitAttachStorageArgs.StorageToAttach.VolumeAttachment != nil {
-		arg.Volume = &internal.CreateUnitStorageVolumeArg{
-			UUID:           unitAttachStorageArgs.StorageToAttach.VolumeAttachment.VolumeUUID,
-			ProvisionScope: unitAttachStorageArgs.StorageToAttach.VolumeAttachment.ProvisionScope,
-		}
-	}
-	iaasUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs([]internal.UnitStorageInstanceArg{arg})
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	err = s.st.AttachStorageToIAASUnit(ctx, storageUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
-		AttachStorageToUnitArg: unitAttachStorageArgs,
-		FilesystemsToOwn:       iaasUnitStorageArgs.FilesystemsToOwn,
-		VolumesToOwn:           iaasUnitStorageArgs.VolumesToOwn,
-	})
-
-	var attachmentNotAllowed internal.StorageAttachmentNotAllowed
-	switch {
-	case errors.Is(err, internal.MaxStorageCountPreconditonFailed):
-		maxCount := int(unitAttachStorageArgs.CountLessThanEqual + 1)
-		return applicationerrors.StorageCountLimitExceeded{
-			Maximum:     &maxCount,
-			Requested:   1,
-			StorageName: unitAttachStorageArgs.StorageName,
-		}
-	case errors.As(err, &attachmentNotAllowed):
-		return errors.Errorf(
-			"attaching storage %q to unit %q: %w", unitAttachStorageArgs.StorageName, unitUUID, attachmentNotAllowed)
-	}
-	return errors.Capture(err)
-}
-
-// AttachStorageToCAASUnit ensures the specified storage instance is attached to
-// the specified CAAS unit.
-// If the attachment already exists, the result is a no op.
-// The following error types can be expected:
-// - [github.com/juju/juju/domain/storage/errors.StorageInstanceNotFound] when
-// the storage doesn't exist.
-// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
-// unit does not exist.
-// - [github.com/juju/juju/domain/application/errors.UnitNotAlive]: when the
-// unit is not alive.
-// - [github.com/juju/juju/domain/application/errors.StorageNotAlive]: when the
-// storage is not alive.
-// - [github.com/juju/juju/domain/application/errors.StorageCountLimitExceeded]
-// when the requested storage falls outside of the bounds defined by the charm.
-func (s *ProviderService) AttachStorageToCAASUnit(
+func (s *ProviderService) AttachStorageToUnit(
 	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
 ) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
@@ -1389,7 +1293,7 @@ func (s *ProviderService) AttachStorageToCAASUnit(
 		return errors.Capture(err)
 	}
 
-	err = s.st.AttachStorageToCAASUnit(ctx, storageUUID, unitUUID, unitAttachStorageArgs)
+	err = s.st.AttachStorageToUnit(ctx, storageUUID, unitUUID, unitAttachStorageArgs)
 
 	var attachmentNotAllowed internal.StorageAttachmentNotAllowed
 	switch {

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1247,8 +1247,6 @@ func (s *ProviderService) populateAttachStorageArgs(
 	return args, nil
 }
 
-const alreadyAttachedError = errors.ConstError("alreadyAttached")
-
 // AttachStorageToUnit ensures the specified storage instance is attached to
 // the specified unit.
 // If the attachment already exists, the result is a no op.
@@ -1287,11 +1285,21 @@ func (s *ProviderService) AttachStorageToUnit(
 			unitUUID, err)
 	}
 
-	unitAttachStorageArgs, err := s.makeAttachStorageToUnitArgs(ctx, storageUUID, unitUUID, netNodeUUID, &unitMachineUUID)
-	if errors.Is(err, alreadyAttachedError) {
+	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
+	if err != nil {
+		return errors.Errorf(
+			"getting unit %q charm storage and attachment info for %q: %w",
+			unitUUID, storageUUID, err,
+		)
+	}
+	if _, alreadyAttached := storageAttachInfo.AlreadyAttachedToUnits[unitUUID.String()]; alreadyAttached {
 		// The storage is already attached to the unit, so this is a no-op.
 		return nil
-	} else if err != nil {
+	}
+
+	unitAttachStorageArgs, err := s.makeAttachStorageToUnitArgs(
+		ctx, storageUUID, unitUUID, netNodeUUID, &unitMachineUUID, storageAttachInfo)
+	if err != nil {
 		return errors.Capture(err)
 	}
 
@@ -1312,22 +1320,11 @@ func (s *ProviderService) AttachStorageToUnit(
 func (s *ProviderService) makeAttachStorageToUnitArgs(
 	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID,
 	unitUUID coreunit.UUID, netNodeUUID string, unitPlacementMachineUUID *string,
+	storageAttachInfo internal.StorageInfoForAttach,
 ) (internal.AttachStorageToUnitArg, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
-	if err != nil {
-		return internal.AttachStorageToUnitArg{}, errors.Errorf(
-			"getting unit %q charm storage and attachment info for %q: %w",
-			unitUUID, storageUUID, err,
-		)
-	}
-
-	// First check to see if the storage is already attached to the unit.
-	if _, alreadyAttached := storageAttachInfo.AlreadyAttachedToUnits[unitUUID.String()]; alreadyAttached {
-		return internal.AttachStorageToUnitArg{}, alreadyAttachedError
-	}
 	delete(storageAttachInfo.AlreadyAttachedToUnits, unitUUID.String())
 	// It's an error if the storage is attached to any other unit,
 	// as we don't support shared storage.

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1039,10 +1039,10 @@ func (s *ProviderService) populateAddStorageArgs(
 	ctx context.Context,
 	storageName corestorage.Name,
 	unitUUID coreunit.UUID, addCount uint32, arg storage.AddUnitStorageOverride,
-) (internal.UnitAddStorageArg, error) {
+) (internal.AddStorageToUnitArg, error) {
 	unitStorageDirective, err := s.storageService.GetUnitStorageDirectiveByName(ctx, unitUUID, storageName)
 	if err != nil {
-		return internal.UnitAddStorageArg{}, errors.Errorf(
+		return internal.AddStorageToUnitArg{}, errors.Errorf(
 			"getting unit %q storage directive: %w",
 			unitUUID, err,
 		)
@@ -1050,7 +1050,7 @@ func (s *ProviderService) populateAddStorageArgs(
 
 	charmStorage, existingCount, err := s.st.GetCharmStorageAndInstanceCountByUnitUUID(ctx, unitUUID, storageName)
 	if err != nil {
-		return internal.UnitAddStorageArg{}, errors.Errorf(
+		return internal.AddStorageToUnitArg{}, errors.Errorf(
 			"getting unit %q charm storage %q and count: %w",
 			unitUUID, storageName, err,
 		)
@@ -1084,7 +1084,7 @@ func (s *ProviderService) populateAddStorageArgs(
 	}
 	err = s.storageService.ValidateApplicationStorageDirectiveOverrides(ctx, charmStorageDefs, toCheck)
 	if err != nil {
-		return internal.UnitAddStorageArg{}, errors.Capture(err)
+		return internal.AddStorageToUnitArg{}, errors.Capture(err)
 	}
 
 	args, err := s.storageService.MakeUnitAddStorageArgs(
@@ -1094,7 +1094,7 @@ func (s *ProviderService) populateAddStorageArgs(
 		storageDirective,
 	)
 	if err != nil {
-		return internal.UnitAddStorageArg{}, errors.Capture(err)
+		return internal.AddStorageToUnitArg{}, errors.Capture(err)
 	}
 	// Record the max allowed count precondition.
 	// This will be checked inside the transaction.
@@ -1144,9 +1144,9 @@ func (s *ProviderService) AddStorageForIAASUnit(
 	}
 
 	added, err := s.st.AddStorageForIAASUnit(ctx, unitUUID, storageName, internal.IAASUnitAddStorageArg{
-		UnitAddStorageArg: unitStorageArgs,
-		FilesystemsToOwn:  iaasUnitStorageArgs.FilesystemsToOwn,
-		VolumesToOwn:      iaasUnitStorageArgs.VolumesToOwn,
+		AddStorageToUnitArg: unitStorageArgs,
+		FilesystemsToOwn:    iaasUnitStorageArgs.FilesystemsToOwn,
+		VolumesToOwn:        iaasUnitStorageArgs.VolumesToOwn,
 	})
 	if errors.Is(err, internal.MaxStorageCountPreconditonFailed) {
 		maxCount := int(unitStorageArgs.CountLessThanEqual + count)
@@ -1200,10 +1200,10 @@ func (s *ProviderService) populateAttachStorageArgs(
 	ctx context.Context,
 	storageUUID domainstorage.StorageInstanceUUID,
 	unitUUID coreunit.UUID,
-) (internal.UnitAttachStorageArg, error) {
+) (internal.AttachStorageToUnitArg, error) {
 	charmStorage, instInfo, err := s.st.GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
 	if err != nil {
-		return internal.UnitAttachStorageArg{}, errors.Errorf(
+		return internal.AttachStorageToUnitArg{}, errors.Errorf(
 			"getting unit %q charm storage and count for %q: %w",
 			unitUUID, storageUUID, err,
 		)
@@ -1220,22 +1220,25 @@ func (s *ProviderService) populateAttachStorageArgs(
 	wantCount := 1 + instInfo.AlreadyAttachedCount
 	err = s.storageService.ValidateAttachStorage(ctx, charmStorageDef, wantCount, instInfo.SizeMiB, instInfo.PoolUUID)
 	if err != nil {
-		return internal.UnitAttachStorageArg{}, errors.Capture(err)
+		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}
 
-	args, err := s.storageService.MakeUnitAttachStorageArgs(
+	attachArgs, err := s.storageService.MakeUnitAttachStorageArgs(
 		ctx,
 		unitUUID,
 		storageUUID,
 	)
 	if err != nil {
-		return internal.UnitAttachStorageArg{}, errors.Capture(err)
+		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}
-	args.StorageName = charmStorage.Name
+	args := internal.AttachStorageToUnitArg{
+		StorageToAttach:    attachArgs,
+		StorageName:        charmStorage.Name,
+		CountLessThanEqual: uint32(math.MaxUint32),
+	}
 
 	// Record the max allowed count precondition.
 	// This will be checked inside the transaction.
-	args.CountLessThanEqual = uint32(math.MaxUint32)
 	if charmStorage.CountMax > 0 {
 		args.CountLessThanEqual = uint32(charmStorage.CountMax) - 1
 	}
@@ -1308,9 +1311,9 @@ func (s *ProviderService) AttachStorageToIAASUnit(
 	}
 
 	err = s.st.AttachStorageToIAASUnit(ctx, storageUUID, unitUUID, internal.IAASUnitAttachStorageArg{
-		UnitAttachStorageArg: unitAttachStorageArgs,
-		FilesystemsToOwn:     iaasUnitStorageArgs.FilesystemsToOwn,
-		VolumesToOwn:         iaasUnitStorageArgs.VolumesToOwn,
+		AttachStorageToUnitArg: unitAttachStorageArgs,
+		FilesystemsToOwn:       iaasUnitStorageArgs.FilesystemsToOwn,
+		VolumesToOwn:           iaasUnitStorageArgs.VolumesToOwn,
 	})
 	if errors.Is(err, internal.MaxStorageCountPreconditonFailed) {
 		maxCount := int(unitAttachStorageArgs.CountLessThanEqual + 1)

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1211,14 +1211,13 @@ func (s *ProviderService) populateAttachStorageArgs(
 
 	charmStorageDef := internal.ValidateStorageArg{
 		Name:        storageAttachInfo.Name,
-		Type:        storageAttachInfo.Type,
 		CountMin:    storageAttachInfo.CountMin,
 		CountMax:    storageAttachInfo.CountMax,
 		MinimumSize: storageAttachInfo.MinimumSize,
 	}
 
 	wantCount := 1 + storageAttachInfo.AlreadyAttachedCount
-	err = s.storageService.ValidateAttachStorage(ctx, charmStorageDef, wantCount, storageAttachInfo.SizeMiB, storageAttachInfo.PoolUUID)
+	err = s.storageService.ValidateAttachStorage(charmStorageDef, wantCount, storageAttachInfo.SizeMiB)
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/clock"
+	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
 
 	"github.com/juju/juju/caas"
@@ -1200,14 +1201,8 @@ func (s *ProviderService) populateAttachStorageArgs(
 	ctx context.Context,
 	storageUUID domainstorage.StorageInstanceUUID,
 	unitUUID coreunit.UUID,
+	storageAttachInfo internal.StorageInfoForAttach,
 ) (internal.AttachStorageToUnitArg, error) {
-	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
-	if err != nil {
-		return internal.AttachStorageToUnitArg{}, errors.Errorf(
-			"getting unit %q charm storage and count for %q: %w",
-			unitUUID, storageUUID, err,
-		)
-	}
 
 	charmStorageDef := internal.ValidateStorageArg{
 		Name:        storageAttachInfo.CharmStorageName,
@@ -1216,7 +1211,7 @@ func (s *ProviderService) populateAttachStorageArgs(
 		MinimumSize: storageAttachInfo.MinimumSize,
 	}
 
-	err = s.storageService.ValidateAttachStorage(
+	err := s.storageService.ValidateAttachStorage(
 		charmStorageDef, storageAttachInfo.AlreadyAttachedCount, storageAttachInfo.ProvisionedSizeMiB)
 	if err != nil {
 		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
@@ -1231,9 +1226,10 @@ func (s *ProviderService) populateAttachStorageArgs(
 		return internal.AttachStorageToUnitArg{}, errors.Capture(err)
 	}
 	args := internal.AttachStorageToUnitArg{
-		StorageToAttach:    attachArgs,
-		StorageName:        storageAttachInfo.CharmStorageName,
-		CountLessThanEqual: uint32(math.MaxUint32),
+		StorageToAttach:                attachArgs,
+		StorageName:                    storageAttachInfo.CharmStorageName,
+		CountLessThanEqual:             uint32(math.MaxUint32),
+		AllowedExistingUnitAttachments: storageAttachInfo.AlreadyAttachedToUnits,
 	}
 
 	// Record the max allowed count precondition.
@@ -1270,15 +1266,29 @@ func (s *ProviderService) AttachStorageToIAASUnit(
 	if unitUUID.Validate() != nil {
 		return errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
 	}
-	exists, err := s.st.GetUnitStorageAttachmentExists(ctx, storageUUID, unitUUID)
+
+	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
 	if err != nil {
-		return errors.Capture(err)
+		return errors.Errorf(
+			"getting unit %q charm storage and attachment info for %q: %w",
+			unitUUID, storageUUID, err,
+		)
 	}
-	if exists {
+	attachedTo := set.NewStrings(storageAttachInfo.AlreadyAttachedToUnits...)
+	if attachedTo.Size() == 1 && attachedTo.Contains(unitUUID.String()) {
+		// The storage is already attached to the unit, so this is a no-op.
 		return nil
 	}
+	attachedTo.Remove(unitUUID.String())
+	// Shared storage is not supported.
+	if attachedTo.Size() > 0 {
+		return errors.Errorf(
+			"storage instance %q is already attached to other unit(s): %v",
+			storageUUID, attachedTo.Values(),
+		)
+	}
 
-	unitAttachStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID)
+	unitAttachStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID, storageAttachInfo)
 
 	if err != nil {
 		return errors.Capture(err)
@@ -1309,13 +1319,19 @@ func (s *ProviderService) AttachStorageToIAASUnit(
 		FilesystemsToOwn:       iaasUnitStorageArgs.FilesystemsToOwn,
 		VolumesToOwn:           iaasUnitStorageArgs.VolumesToOwn,
 	})
-	if errors.Is(err, internal.MaxStorageCountPreconditonFailed) {
+
+	var attachmentNotAllowed internal.StorageAttachmentNotAllowed
+	switch {
+	case errors.Is(err, internal.MaxStorageCountPreconditonFailed):
 		maxCount := int(unitAttachStorageArgs.CountLessThanEqual + 1)
 		return applicationerrors.StorageCountLimitExceeded{
 			Maximum:     &maxCount,
 			Requested:   1,
 			StorageName: unitAttachStorageArgs.StorageName,
 		}
+	case errors.As(err, &attachmentNotAllowed):
+		return errors.Errorf(
+			"attaching storage %q to unit %q: %w", unitAttachStorageArgs.StorageName, unitUUID, attachmentNotAllowed)
 	}
 	return errors.Capture(err)
 }
@@ -1346,27 +1362,47 @@ func (s *ProviderService) AttachStorageToCAASUnit(
 	if unitUUID.Validate() != nil {
 		return errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
 	}
-	exists, err := s.st.GetUnitStorageAttachmentExists(ctx, storageUUID, unitUUID)
+
+	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
 	if err != nil {
-		return errors.Capture(err)
+		return errors.Errorf(
+			"getting unit %q charm storage and attachment info for %q: %w",
+			unitUUID, storageUUID, err,
+		)
 	}
-	if exists {
+	attachedTo := set.NewStrings(storageAttachInfo.AlreadyAttachedToUnits...)
+	if attachedTo.Size() == 1 && attachedTo.Contains(unitUUID.String()) {
+		// The storage is already attached to the unit, so this is a no-op.
 		return nil
 	}
+	attachedTo.Remove(unitUUID.String())
+	// Shared storage is not supported.
+	if attachedTo.Size() > 0 {
+		return errors.Errorf(
+			"storage instance %q is already attached to other unit(s): %v",
+			storageUUID, attachedTo.Values(),
+		)
+	}
 
-	unitStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID)
+	unitAttachStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID, storageAttachInfo)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	err = s.st.AttachStorageToCAASUnit(ctx, storageUUID, unitUUID, unitStorageArgs)
-	if errors.Is(err, internal.MaxStorageCountPreconditonFailed) {
-		maxCount := int(unitStorageArgs.CountLessThanEqual + 1)
+	err = s.st.AttachStorageToCAASUnit(ctx, storageUUID, unitUUID, unitAttachStorageArgs)
+
+	var attachmentNotAllowed internal.StorageAttachmentNotAllowed
+	switch {
+	case errors.Is(err, internal.MaxStorageCountPreconditonFailed):
+		maxCount := int(unitAttachStorageArgs.CountLessThanEqual + 1)
 		return applicationerrors.StorageCountLimitExceeded{
 			Maximum:     &maxCount,
 			Requested:   1,
-			StorageName: unitStorageArgs.StorageName,
+			StorageName: unitAttachStorageArgs.StorageName,
 		}
+	case errors.As(err, &attachmentNotAllowed):
+		return errors.Errorf(
+			"attaching storage %q to unit %q: %w", unitAttachStorageArgs.StorageName, unitUUID, attachmentNotAllowed)
 	}
 	return errors.Capture(err)
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -518,9 +518,12 @@ func (s *ProviderService) RegisterCAASUnit(
 	}
 
 	if !isRegistered {
-		// TODO (tlm): This code SHOULD be responsible for generating the unit
-		// uuid of a new CAAS unit. However this is still done in state. We need
-		// to fix this and have this driven from above.
+		unitUUID, err = coreunit.NewUUID()
+		if err != nil {
+			return "", "", errors.Errorf(
+				"generating new unit %q uuid: %w", unitName, err,
+			)
+		}
 		unitNetNodeUUID, err = domainnetwork.NewNetNodeUUID()
 		if err != nil {
 			return "", "", errors.Errorf(
@@ -529,6 +532,7 @@ func (s *ProviderService) RegisterCAASUnit(
 		}
 	}
 
+	registerArgs.UnitUUID = unitUUID
 	registerArgs.NetNodeUUID = unitNetNodeUUID
 
 	// Find the pod/unit in the provider.
@@ -1200,7 +1204,7 @@ func (s *ProviderService) AddStorageForCAASUnit(
 func (s *ProviderService) populateAttachStorageArgs(
 	ctx context.Context,
 	storageUUID domainstorage.StorageInstanceUUID,
-	unitUUID coreunit.UUID,
+	netNodeUUID string,
 	storageAttachInfo internal.StorageInfoForAttach,
 ) (internal.AttachStorageToUnitArg, error) {
 
@@ -1219,7 +1223,7 @@ func (s *ProviderService) populateAttachStorageArgs(
 
 	attachArgs, err := s.storageService.MakeUnitAttachStorageArgs(
 		ctx,
-		unitUUID,
+		netNodeUUID,
 		storageUUID,
 	)
 	if err != nil {
@@ -1246,6 +1250,8 @@ func (s *ProviderService) populateAttachStorageArgs(
 	}
 	return args, nil
 }
+
+const alreadyAttachedError = errors.ConstError("alreadyAttached")
 
 // AttachStorageToUnit ensures the specified storage instance is attached to
 // the specified unit.
@@ -1274,51 +1280,22 @@ func (s *ProviderService) AttachStorageToUnit(
 		return errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
 	}
 
-	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
+	netNodeUUID, err := s.st.GetUnitNetNodeUUID(ctx, unitUUID)
+	if err != nil {
+		return errors.Errorf("getting unit net node uuid: %w", err)
+	}
+	unitMachineUUID, err := s.st.GetUnitMachineUUID(ctx, unitUUID.String())
 	if err != nil {
 		return errors.Errorf(
-			"getting unit %q charm storage and attachment info for %q: %w",
-			unitUUID, storageUUID, err,
-		)
+			"getting machine for unit %q: %w",
+			unitUUID, err)
 	}
 
-	if storageAttachInfo.StorageMachineOwner != nil {
-		unitMachineUUID, err := s.st.GetUnitMachineUUID(ctx, unitUUID.String())
-		if err != nil {
-			return errors.Errorf(
-				"getting machine for unit %q: %w",
-				unitUUID, err)
-		}
-		if unitMachineUUID != storageAttachInfo.StorageMachineOwner.UUID {
-			return applicationerrors.StorageAttachmentNotAllowed{
-				ExistingStorageMachineOwner: &storageAttachInfo.StorageMachineOwner.Name,
-			}
-		}
-	}
-
-	attachedToMap := storageAttachInfo.AlreadyAttachedToUnits
-	attachedUUIDs := set.NewStrings()
-	for uuid := range attachedToMap {
-		attachedUUIDs.Add(uuid)
-	}
-	if attachedUUIDs.Size() == 1 && attachedUUIDs.Contains(unitUUID.String()) {
+	unitAttachStorageArgs, err := s.makeAttachStorageToUnitArgs(ctx, storageUUID, unitUUID, netNodeUUID, &unitMachineUUID)
+	if errors.Is(err, alreadyAttachedError) {
 		// The storage is already attached to the unit, so this is a no-op.
 		return nil
-	}
-	attachedUUIDs.Remove(unitUUID.String())
-	// Shared storage is not supported.
-	if attachedUUIDs.Size() > 0 {
-		otherNames := make([]string, 0, attachedUUIDs.Size())
-		for _, uuid := range attachedUUIDs.SortedValues() {
-			otherNames = append(otherNames, attachedToMap[uuid])
-		}
-		return applicationerrors.StorageAttachmentNotAllowed{
-			AttachedToUnits: otherNames,
-		}
-	}
-
-	unitAttachStorageArgs, err := s.populateAttachStorageArgs(ctx, storageUUID, unitUUID, storageAttachInfo)
-	if err != nil {
+	} else if err != nil {
 		return errors.Capture(err)
 	}
 
@@ -1334,4 +1311,63 @@ func (s *ProviderService) AttachStorageToUnit(
 		}
 	}
 	return errors.Capture(err)
+}
+
+func (s *ProviderService) makeAttachStorageToUnitArgs(
+	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID,
+	unitUUID coreunit.UUID, netNodeUUID string, unitPlacementMachineUUID *string,
+) (internal.AttachStorageToUnitArg, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if storageUUID.Validate() != nil {
+		return internal.AttachStorageToUnitArg{}, errors.New("storage uuid is not valid").Add(coreerrors.NotValid)
+	}
+	if unitUUID.Validate() != nil {
+		return internal.AttachStorageToUnitArg{}, errors.New("unit uuid is not valid").Add(coreerrors.NotValid)
+	}
+
+	storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(ctx, unitUUID, storageUUID)
+	if err != nil {
+		return internal.AttachStorageToUnitArg{}, errors.Errorf(
+			"getting unit %q charm storage and attachment info for %q: %w",
+			unitUUID, storageUUID, err,
+		)
+	}
+
+	// First check to see if the storage is already attached to the unit.
+	attachedToMap := storageAttachInfo.AlreadyAttachedToUnits
+	attachedUUIDs := set.NewStrings()
+	for uuid := range attachedToMap {
+		attachedUUIDs.Add(uuid)
+	}
+	if attachedUUIDs.Size() == 1 && attachedUUIDs.Contains(unitUUID.String()) {
+		// The storage is already attached to the unit, so this is a no-op.
+		return internal.AttachStorageToUnitArg{}, alreadyAttachedError
+	}
+	// It's an error if the storage is attached to any other unit,
+	// as we don't support shared storage.
+	attachedUUIDs.Remove(unitUUID.String())
+	if attachedUUIDs.Size() > 0 {
+		otherNames := make([]string, 0, attachedUUIDs.Size())
+		for _, uuid := range attachedUUIDs.SortedValues() {
+			otherNames = append(otherNames, attachedToMap[uuid])
+		}
+		return internal.AttachStorageToUnitArg{}, applicationerrors.StorageAttachmentNotAllowed{
+			AttachedToUnits: otherNames,
+		}
+	}
+
+	// If the storage is owned by a machine, then it can only be
+	// attached to units on the same machine.
+	if storageAttachInfo.StorageMachineOwner != nil {
+		// unitPlacementMachineUUID is nil when the unit is being added to a new machine.
+		if unitPlacementMachineUUID == nil || *unitPlacementMachineUUID != storageAttachInfo.StorageMachineOwner.UUID {
+			return internal.AttachStorageToUnitArg{}, applicationerrors.StorageAttachmentNotAllowed{
+				ExistingStorageMachineOwner: &storageAttachInfo.StorageMachineOwner.Name,
+			}
+		}
+	}
+
+	return s.populateAttachStorageArgs(ctx, storageUUID, netNodeUUID, storageAttachInfo)
 }

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3207,7 +3207,7 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			}
 		})
 	s.storageService.EXPECT().MakeIAASUnitStorageArgs(storageInst).
-		Return(internal.CreateIAASUnitStorageArg{
+		Return(internal.IAASUnitStorageArg{
 			FilesystemsToOwn: fsToOwn,
 			VolumesToOwn:     volToOwn,
 		}, nil)

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3372,20 +3372,6 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, nil)
 }
 
-func (s *providerServiceSuite) TestAttachStorageForIAASUnitNotFound(c *tc.C) {
-	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
-	defer ctrl.Finish()
-
-	unitUUID := tc.Must(c, coreunit.NewUUID)
-	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-
-	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
-		Return(false, applicationerrors.UnitNotFound)
-
-	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
-	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
-}
-
 func (s *providerServiceSuite) TestAttachStorageForIAASStorageNotFound(c *tc.C) {
 	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
 	defer ctrl.Finish()
@@ -3393,8 +3379,8 @@ func (s *providerServiceSuite) TestAttachStorageForIAASStorageNotFound(c *tc.C) 
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
-	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
-		Return(false, storageerrors.StorageInstanceNotFound)
+	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internal.StorageInfoForAttach{}, storageerrors.StorageInstanceNotFound)
 
 	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
 	c.Assert(err, tc.ErrorIs, storageerrors.StorageInstanceNotFound)
@@ -3407,8 +3393,6 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnitValidates(c *tc.C) {
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
-	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
-		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
 			CharmStorageName:     "pgdata",
@@ -3439,8 +3423,6 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
 
-	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
-		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
 			CharmStorageName:     "pgdata",
@@ -3499,20 +3481,6 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *providerServiceSuite) TestAttachStorageForCAASUnitNotFound(c *tc.C) {
-	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
-	defer ctrl.Finish()
-
-	unitUUID := tc.Must(c, coreunit.NewUUID)
-	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-
-	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
-		Return(false, applicationerrors.UnitNotFound)
-
-	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
-	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
-}
-
 func (s *providerServiceSuite) TestAttachStorageForCAASStorageNotFound(c *tc.C) {
 	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
 	defer ctrl.Finish()
@@ -3520,8 +3488,8 @@ func (s *providerServiceSuite) TestAttachStorageForCAASStorageNotFound(c *tc.C) 
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
-	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
-		Return(false, storageerrors.StorageInstanceNotFound)
+	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internal.StorageInfoForAttach{}, storageerrors.StorageInstanceNotFound)
 
 	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
 	c.Assert(err, tc.ErrorIs, storageerrors.StorageInstanceNotFound)
@@ -3534,8 +3502,6 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnitValidates(c *tc.C) {
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
-	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
-		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
 			CharmStorageName:     "pgdata",
@@ -3565,8 +3531,6 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	fsUUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
 
-	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
-		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
 			CharmStorageName:     "pgdata",

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3465,9 +3465,9 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 		Return(nil)
 
 	unitStorageArgs := internal.UnitAttachStorageArg{
-		StorageToAttach: []internal.UnitStorageAttachmentArg{{
+		StorageToAttach: []internal.CreateUnitStorageAttachmentArg{{
 			UUID: saUUID,
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: fsUUID,
 				ProvisionScope: 1,
 			},
@@ -3482,7 +3482,7 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), unitUUID, siUUID).
 		Return(unitStorageArgs, nil)
 	storageInst := []internal.UnitStorageInstanceArg{{
-		Filesystem: &internal.UnitStorageFilesystemArg{
+		Filesystem: &internal.CreateUnitStorageFilesystemArg{
 			UUID:           fsUUID,
 			ProvisionScope: 1,
 		},
@@ -3601,8 +3601,8 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
 
 	unitStorageArgs := internal.UnitAttachStorageArg{
 		// UUID
-		StorageToAttach: []internal.UnitStorageAttachmentArg{{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+		StorageToAttach: []internal.CreateUnitStorageAttachmentArg{{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: fsUUUID,
 				ProvisionScope: 1,
 			},

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3181,7 +3181,7 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			Size:     ptr(uint64(6)),
 		},
 	})
-	unitStorageArgs := internal.UnitAddStorageArg{
+	unitStorageArgs := internal.AddStorageToUnitArg{
 		StorageInstances: []internal.CreateUnitStorageInstanceArg{{
 			Name: "pgdata",
 		}},
@@ -3208,15 +3208,15 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			}
 		})
 	s.storageService.EXPECT().MakeIAASUnitStorageArgs(storageInst).
-		Return(internal.IAASUnitStorageArg{
+		Return(internal.CreateIAASUnitStorageArg{
 			FilesystemsToOwn: fsToOwn,
 			VolumesToOwn:     volToOwn,
 		}, nil)
 
 	s.state.EXPECT().AddStorageForIAASUnit(gomock.Any(), unitUUID, corestorage.Name("pgdata"), internal.IAASUnitAddStorageArg{
-		UnitAddStorageArg: unitStorageArgs,
-		FilesystemsToOwn:  fsToOwn,
-		VolumesToOwn:      volToOwn,
+		AddStorageToUnitArg: unitStorageArgs,
+		FilesystemsToOwn:    fsToOwn,
+		VolumesToOwn:        volToOwn,
 	})
 
 	_, err := s.service.AddStorageForIAASUnit(c.Context(), "pgdata", unitUUID, uint32(10), storage.AddUnitStorageOverride{
@@ -3343,7 +3343,7 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnit(c *tc.C) {
 			Size:     ptr(uint64(6)),
 		},
 	})
-	unitStorageArgs := internal.UnitAddStorageArg{
+	unitStorageArgs := internal.AddStorageToUnitArg{
 		StorageInstances: []internal.CreateUnitStorageInstanceArg{{
 			Name: "pgdata",
 		}},
@@ -3464,23 +3464,19 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 	}, uint32(67), uint64(6), poolUUID).
 		Return(nil)
 
-	unitStorageArgs := internal.UnitAttachStorageArg{
-		StorageToAttach: []internal.CreateUnitStorageAttachmentArg{{
-			UUID: saUUID,
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
-				FilesystemUUID: fsUUID,
-				ProvisionScope: 1,
-			},
-			StorageInstanceUUID: siUUID,
-		}},
-		StorageName:        "pgdata",
-		CountLessThanEqual: 665,
-	}
+	storageToAttach := []internal.CreateUnitStorageAttachmentArg{{
+		UUID: saUUID,
+		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemUUID: fsUUID,
+			ProvisionScope: 1,
+		},
+		StorageInstanceUUID: siUUID,
+	}}
 	fsToOwn := []domainstorage.FilesystemUUID{tc.Must(c, domainstorage.NewFilesystemUUID)}
 	volToOwn := []domainstorage.VolumeUUID{tc.Must(c, domainstorage.NewVolumeUUID)}
 
 	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), unitUUID, siUUID).
-		Return(unitStorageArgs, nil)
+		Return(storageToAttach, nil)
 	storageInst := []internal.UnitStorageInstanceArg{{
 		Filesystem: &internal.CreateUnitStorageFilesystemArg{
 			UUID:           fsUUID,
@@ -3489,15 +3485,20 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 		UUID: siUUID,
 	}}
 	s.storageService.EXPECT().MakeIAASUnitStorageArgs(storageInst).
-		Return(internal.IAASUnitStorageArg{
+		Return(internal.CreateIAASUnitStorageArg{
 			FilesystemsToOwn: fsToOwn,
 			VolumesToOwn:     volToOwn,
 		}, nil)
 
+	unitStorageArgs := internal.AttachStorageToUnitArg{
+		StorageToAttach:    storageToAttach,
+		StorageName:        "pgdata",
+		CountLessThanEqual: 665,
+	}
 	s.state.EXPECT().AttachStorageToIAASUnit(gomock.Any(), siUUID, unitUUID, internal.IAASUnitAttachStorageArg{
-		UnitAttachStorageArg: unitStorageArgs,
-		FilesystemsToOwn:     fsToOwn,
-		VolumesToOwn:         volToOwn,
+		AttachStorageToUnitArg: unitStorageArgs,
+		FilesystemsToOwn:       fsToOwn,
+		VolumesToOwn:           volToOwn,
 	})
 
 	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
@@ -3599,21 +3600,22 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
 	}, uint32(67), uint64(6), poolUUID).
 		Return(nil)
 
-	unitStorageArgs := internal.UnitAttachStorageArg{
+	storageToAttach := []internal.CreateUnitStorageAttachmentArg{{
+		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemUUID: fsUUUID,
+			ProvisionScope: 1,
+		},
+		StorageInstanceUUID: siUUID,
+	}}
+	unitStorageArgs := internal.AttachStorageToUnitArg{
 		// UUID
-		StorageToAttach: []internal.CreateUnitStorageAttachmentArg{{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
-				FilesystemUUID: fsUUUID,
-				ProvisionScope: 1,
-			},
-			StorageInstanceUUID: siUUID,
-		}},
+		StorageToAttach:    storageToAttach,
 		StorageName:        "pgdata",
 		CountLessThanEqual: 665,
 	}
 
 	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), unitUUID, siUUID).
-		Return(unitStorageArgs, nil)
+		Return(storageToAttach, nil)
 	s.state.EXPECT().AttachStorageToCAASUnit(gomock.Any(), siUUID, unitUUID, unitStorageArgs)
 
 	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -67,6 +67,7 @@ func (s *providerServiceSuite) TestCreateCAASApplication(c *tc.C) {
 	now := ptr(s.clock.Now())
 	us := []application.AddCAASUnitArg{{
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    tc.Must(c, coreunit.NewUUID),
 			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -3377,10 +3378,14 @@ func (s *providerServiceSuite) TestAttachStorageNotFound(c *tc.C) {
 	defer ctrl.Finish()
 
 	unitUUID := tc.Must(c, coreunit.NewUUID)
+	machineUUID := tc.Must(c, coremachine.NewUUID)
+	netnodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{}, storageerrors.StorageInstanceNotFound)
+	s.state.EXPECT().GetUnitNetNodeUUID(gomock.Any(), unitUUID).Return(netnodeUUID.String(), nil)
+	s.state.EXPECT().GetUnitMachineUUID(gomock.Any(), unitUUID.String()).Return(machineUUID.String(), nil)
 
 	err := s.service.AttachStorageToUnit(c.Context(), siUUID, unitUUID)
 	c.Assert(err, tc.ErrorIs, storageerrors.StorageInstanceNotFound)
@@ -3390,7 +3395,9 @@ func (s *providerServiceSuite) TestAttachStorageValidates(c *tc.C) {
 	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
 	defer ctrl.Finish()
 
+	machineUUID := tc.Must(c, coremachine.NewUUID)
 	unitUUID := tc.Must(c, coreunit.NewUUID)
+	netnodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
@@ -3402,6 +3409,8 @@ func (s *providerServiceSuite) TestAttachStorageValidates(c *tc.C) {
 			AlreadyAttachedCount: 66,
 			ProvisionedSizeMiB:   6,
 		}, nil)
+	s.state.EXPECT().GetUnitNetNodeUUID(gomock.Any(), unitUUID).Return(netnodeUUID.String(), nil)
+	s.state.EXPECT().GetUnitMachineUUID(gomock.Any(), unitUUID.String()).Return(machineUUID.String(), nil)
 	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
 		CountMin:    1,
@@ -3420,6 +3429,7 @@ func (s *providerServiceSuite) TestAttachStorageChecksMachineOwnerOk(c *tc.C) {
 
 	machineUUID := tc.Must(c, coremachine.NewUUID)
 	unitUUID := tc.Must(c, coreunit.NewUUID)
+	netnodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
@@ -3435,6 +3445,7 @@ func (s *providerServiceSuite) TestAttachStorageChecksMachineOwnerOk(c *tc.C) {
 				Name: "666",
 			},
 		}, nil)
+	s.state.EXPECT().GetUnitNetNodeUUID(gomock.Any(), unitUUID).Return(netnodeUUID.String(), nil)
 	s.state.EXPECT().GetUnitMachineUUID(gomock.Any(), unitUUID.String()).Return(machineUUID.String(), nil)
 	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
@@ -3455,6 +3466,7 @@ func (s *providerServiceSuite) TestAttachStorageChecksMachineOwnerInvalid(c *tc.
 	machineOwnerUUID := tc.Must(c, coremachine.NewUUID)
 	machineUUID := tc.Must(c, coremachine.NewUUID)
 	unitUUID := tc.Must(c, coreunit.NewUUID)
+	netnodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
@@ -3470,6 +3482,7 @@ func (s *providerServiceSuite) TestAttachStorageChecksMachineOwnerInvalid(c *tc.
 				Name: "666",
 			},
 		}, nil)
+	s.state.EXPECT().GetUnitNetNodeUUID(gomock.Any(), unitUUID).Return(netnodeUUID.String(), nil)
 	s.state.EXPECT().GetUnitMachineUUID(gomock.Any(), unitUUID.String()).Return(machineUUID.String(), nil)
 
 	err := s.service.AttachStorageToUnit(c.Context(), siUUID, unitUUID)
@@ -3485,6 +3498,8 @@ func (s *providerServiceSuite) TestAttachStorage(c *tc.C) {
 	defer ctrl.Finish()
 
 	unitUUID := tc.Must(c, coreunit.NewUUID)
+	machineUUID := tc.Must(c, coremachine.NewUUID)
+	netnodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
@@ -3498,6 +3513,8 @@ func (s *providerServiceSuite) TestAttachStorage(c *tc.C) {
 			AlreadyAttachedCount: 66,
 			ProvisionedSizeMiB:   6,
 		}, nil)
+	s.state.EXPECT().GetUnitNetNodeUUID(gomock.Any(), unitUUID).Return(netnodeUUID.String(), nil)
+	s.state.EXPECT().GetUnitMachineUUID(gomock.Any(), unitUUID.String()).Return(machineUUID.String(), nil)
 	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
 		CountMin:    1,
@@ -3515,7 +3532,7 @@ func (s *providerServiceSuite) TestAttachStorage(c *tc.C) {
 		StorageInstanceUUID: siUUID,
 	}
 
-	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), unitUUID, siUUID).
+	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), netnodeUUID.String(), siUUID).
 		Return(storageToAttach, nil)
 
 	unitStorageArgs := internal.AttachStorageToUnitArg{

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3423,7 +3423,7 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnitValidates(c *tc.C) {
 		CountMin:    1,
 		CountMax:    66,
 		MinimumSize: 10,
-	}, uint32(67), uint64(6)).
+	}, uint32(66), uint64(6)).
 		Return(applicationerrors.StorageCountLimitExceeded{})
 
 	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
@@ -3455,7 +3455,7 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 		CountMin:    1,
 		CountMax:    666,
 		MinimumSize: 10,
-	}, uint32(67), uint64(6)).
+	}, uint32(66), uint64(6)).
 		Return(nil)
 
 	storageToAttach := internal.CreateUnitStorageAttachmentArg{
@@ -3550,7 +3550,7 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnitValidates(c *tc.C) {
 		CountMin:    1,
 		CountMax:    66,
 		MinimumSize: 10,
-	}, uint32(67), uint64(6)).
+	}, uint32(66), uint64(6)).
 		Return(applicationerrors.StorageCountLimitExceeded{})
 
 	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
@@ -3581,7 +3581,7 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
 		CountMin:    1,
 		CountMax:    666,
 		MinimumSize: 10,
-	}, uint32(67), uint64(6)).
+	}, uint32(66), uint64(6)).
 		Return(nil)
 
 	storageToAttach := internal.CreateUnitStorageAttachmentArg{

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -1519,7 +1519,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationError(c *tc.C) {
 //						Name: "data",
 //					},
 //				},
-//				StorageToAttach: []application.CreateStorageAttachmentArg{
+//				NewStorageToAttach: []application.CreateStorageAttachmentArg{
 //					{},
 //				},
 //				StorageToOwn: []storage.StorageInstanceUUID{""},
@@ -1687,7 +1687,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationError(c *tc.C) {
 //						Name: "data",
 //					},
 //				},
-//				StorageToAttach: []application.CreateStorageAttachmentArg{
+//				NewStorageToAttach: []application.CreateStorageAttachmentArg{
 //					{}, {}, {},
 //				},
 //				StorageToOwn: []storage.StorageInstanceUUID{"", "", ""},
@@ -1846,7 +1846,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationError(c *tc.C) {
 //						Name: "data",
 //					},
 //				},
-//				StorageToAttach: []application.CreateStorageAttachmentArg{
+//				NewStorageToAttach: []application.CreateStorageAttachmentArg{
 //					{},
 //				},
 //				StorageToOwn: []storage.StorageInstanceUUID{""},
@@ -2010,7 +2010,7 @@ func (s *providerServiceSuite) TestCreateIAASApplicationError(c *tc.C) {
 //						Name: "data",
 //					},
 //				},
-//				StorageToAttach: []application.CreateStorageAttachmentArg{
+//				NewStorageToAttach: []application.CreateStorageAttachmentArg{
 //					{}, {},
 //				},
 //				StorageToOwn: []storage.StorageInstanceUUID{"", ""},
@@ -3523,24 +3523,31 @@ func (s *providerServiceSuite) TestAttachStorage(c *tc.C) {
 	}, uint32(66), uint64(6)).
 		Return(nil)
 
-	storageToAttach := internal.CreateUnitStorageAttachmentArg{
-		UUID: saUUID,
-		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
-			FilesystemUUID: fsUUID,
-			ProvisionScope: 1,
+	storageToAttach := internal.AttachExistingStorageToUnitArg{
+		AttachStorageToUnitArg: internal.AttachStorageToUnitArg{
+			UUID: saUUID,
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+				FilesystemUUID: fsUUID,
+				ProvisionScope: 1,
+			},
+			StorageInstanceUUID: siUUID,
 		},
-		StorageInstanceUUID: siUUID,
-	}
-
-	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), netnodeUUID.String(), siUUID).
-		Return(storageToAttach, nil)
-
-	unitStorageArgs := internal.AttachStorageToUnitArg{
-		StorageToAttach:    storageToAttach,
 		StorageName:        "pgdata",
 		CountLessThanEqual: 665,
 	}
-	s.state.EXPECT().AttachStorageToUnit(gomock.Any(), siUUID, unitUUID, unitStorageArgs)
+
+	storageAttachInfo := internal.StorageInfoForAttach{
+		CharmStorageName:     "pgdata",
+		CountMin:             1,
+		CountMax:             666,
+		MinimumSize:          10,
+		AlreadyAttachedCount: 66,
+		ProvisionedSizeMiB:   6,
+	}
+	s.storageService.EXPECT().MakeAttachExistingStorageArgs(gomock.Any(), netnodeUUID.String(), siUUID, storageAttachInfo).
+		Return(storageToAttach, nil)
+
+	s.state.EXPECT().AttachStorageToUnit(gomock.Any(), siUUID, unitUUID, storageToAttach)
 
 	err := s.service.AttachStorageToUnit(c.Context(), siUUID, unitUUID)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3115,7 +3115,7 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnitValidates(c *tc.C) {
 		}, nil)
 	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
 		Return(internal.StorageInfoForAdd{
-			Name:                 "pgdata",
+			CharmStorageName:     "pgdata",
 			Type:                 internalcharm.StorageFilesystem,
 			MinimumSize:          10,
 			CountMin:             1,
@@ -3161,7 +3161,7 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 		}, nil)
 	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
 		Return(internal.StorageInfoForAdd{
-			Name:                 "pgdata",
+			CharmStorageName:     "pgdata",
 			Type:                 internalcharm.StorageFilesystem,
 			MinimumSize:          10,
 			CountMin:             1,
@@ -3215,7 +3215,7 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			VolumesToOwn:     volToOwn,
 		}, nil)
 
-	s.state.EXPECT().AddStorageForIAASUnit(gomock.Any(), unitUUID, corestorage.Name("pgdata"), internal.IAASUnitAddStorageArg{
+	s.state.EXPECT().AddStorageForIAASUnit(gomock.Any(), unitUUID, corestorage.Name("pgdata"), internal.AddStorageToIAASUnitArg{
 		AddStorageToUnitArg: unitStorageArgs,
 		FilesystemsToOwn:    fsToOwn,
 		VolumesToOwn:        volToOwn,
@@ -3279,7 +3279,7 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnitValidates(c *tc.C) {
 		}, nil)
 	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
 		Return(internal.StorageInfoForAdd{
-			Name:                 "pgdata",
+			CharmStorageName:     "pgdata",
 			Type:                 internalcharm.StorageFilesystem,
 			MinimumSize:          10,
 			CountMin:             1,
@@ -3325,7 +3325,7 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnit(c *tc.C) {
 		}, nil)
 	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
 		Return(internal.StorageInfoForAdd{
-			Name:                 "pgdata",
+			CharmStorageName:     "pgdata",
 			Type:                 internalcharm.StorageFilesystem,
 			MinimumSize:          10,
 			CountMin:             1,
@@ -3411,12 +3411,12 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnitValidates(c *tc.C) {
 		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
-			Name:                 "pgdata",
+			CharmStorageName:     "pgdata",
 			CountMin:             1,
 			CountMax:             66,
 			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
-			SizeMiB:              6,
+			ProvisionedSizeMiB:   6,
 		}, nil)
 	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
@@ -3443,12 +3443,12 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
-			Name:                 "pgdata",
+			CharmStorageName:     "pgdata",
 			CountMin:             1,
 			CountMax:             666,
 			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
-			SizeMiB:              6,
+			ProvisionedSizeMiB:   6,
 		}, nil)
 	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
@@ -3489,7 +3489,7 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 		StorageName:        "pgdata",
 		CountLessThanEqual: 665,
 	}
-	s.state.EXPECT().AttachStorageToIAASUnit(gomock.Any(), siUUID, unitUUID, internal.IAASUnitAttachStorageArg{
+	s.state.EXPECT().AttachStorageToIAASUnit(gomock.Any(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
 		AttachStorageToUnitArg: unitStorageArgs,
 		FilesystemsToOwn:       fsToOwn,
 		VolumesToOwn:           volToOwn,
@@ -3538,12 +3538,12 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnitValidates(c *tc.C) {
 		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
-			Name:                 "pgdata",
+			CharmStorageName:     "pgdata",
 			CountMin:             1,
 			CountMax:             66,
 			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
-			SizeMiB:              6,
+			ProvisionedSizeMiB:   6,
 		}, nil)
 	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
@@ -3569,12 +3569,12 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
 		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
-			Name:                 "pgdata",
+			CharmStorageName:     "pgdata",
 			CountMin:             1,
 			CountMax:             666,
 			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
-			SizeMiB:              6,
+			ProvisionedSizeMiB:   6,
 		}, nil)
 	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/juju/collections/transform"
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
@@ -3119,7 +3120,7 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnitValidates(c *tc.C) {
 			CountMin:    1,
 			CountMax:    666,
 		}, 66, nil)
-	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internalcharm.Storage{
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.ValidateStorageArg{
 		"pgdata": {
 			Name:        "pgdata",
 			Type:        internalcharm.StorageFilesystem,
@@ -3164,7 +3165,7 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			CountMin:    1,
 			CountMax:    666,
 		}, 66, nil)
-	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internalcharm.Storage{
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.ValidateStorageArg{
 		"pgdata": {
 			Name:        "pgdata",
 			Type:        internalcharm.StorageFilesystem,
@@ -3197,7 +3198,15 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 		Size:             uint64(6),
 	}).
 		Return(unitStorageArgs, nil)
-	s.storageService.EXPECT().MakeIAASUnitStorageArgs(gomock.Any(), unitStorageArgs.StorageInstances).
+	storageInst := transform.Slice(unitStorageArgs.StorageInstances,
+		func(in internal.CreateUnitStorageInstanceArg) internal.UnitStorageInstanceArg {
+			return internal.UnitStorageInstanceArg{
+				Filesystem: in.Filesystem,
+				Volume:     in.Volume,
+				UUID:       in.UUID,
+			}
+		})
+	s.storageService.EXPECT().MakeIAASUnitStorageArgs(storageInst).
 		Return(internal.CreateIAASUnitStorageArg{
 			FilesystemsToOwn: fsToOwn,
 			VolumesToOwn:     volToOwn,
@@ -3273,7 +3282,7 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnitValidates(c *tc.C) {
 			CountMin:    1,
 			CountMax:    666,
 		}, 66, nil)
-	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internalcharm.Storage{
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.ValidateStorageArg{
 		"pgdata": {
 			Name:        "pgdata",
 			Type:        internalcharm.StorageFilesystem,
@@ -3318,7 +3327,7 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnit(c *tc.C) {
 			CountMin:    1,
 			CountMax:    666,
 		}, 66, nil)
-	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internalcharm.Storage{
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.ValidateStorageArg{
 		"pgdata": {
 			Name:        "pgdata",
 			Type:        internalcharm.StorageFilesystem,

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3414,6 +3414,72 @@ func (s *providerServiceSuite) TestAttachStorageValidates(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.StorageCountLimitExceeded{})
 }
 
+func (s *providerServiceSuite) TestAttachStorageChecksMachineOwnerOk(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	machineUUID := tc.Must(c, coremachine.NewUUID)
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internal.StorageInfoForAttach{
+			CharmStorageName:     "pgdata",
+			CountMin:             1,
+			CountMax:             66,
+			MinimumSize:          10,
+			AlreadyAttachedCount: 66,
+			ProvisionedSizeMiB:   6,
+			StorageMachineOwner: &internal.MachineIdentifier{
+				UUID: machineUUID.String(),
+				Name: "666",
+			},
+		}, nil)
+	s.state.EXPECT().GetUnitMachineUUID(gomock.Any(), unitUUID.String()).Return(machineUUID.String(), nil)
+	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
+		Name:        "pgdata",
+		CountMin:    1,
+		CountMax:    66,
+		MinimumSize: 10,
+	}, uint32(66), uint64(6)).
+		Return(applicationerrors.StorageCountLimitExceeded{})
+
+	err := s.service.AttachStorageToUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIs, applicationerrors.StorageCountLimitExceeded{})
+}
+
+func (s *providerServiceSuite) TestAttachStorageChecksMachineOwnerInvalid(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	machineOwnerUUID := tc.Must(c, coremachine.NewUUID)
+	machineUUID := tc.Must(c, coremachine.NewUUID)
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internal.StorageInfoForAttach{
+			CharmStorageName:     "pgdata",
+			CountMin:             1,
+			CountMax:             66,
+			MinimumSize:          10,
+			AlreadyAttachedCount: 66,
+			ProvisionedSizeMiB:   6,
+			StorageMachineOwner: &internal.MachineIdentifier{
+				UUID: machineOwnerUUID.String(),
+				Name: "666",
+			},
+		}, nil)
+	s.state.EXPECT().GetUnitMachineUUID(gomock.Any(), unitUUID.String()).Return(machineUUID.String(), nil)
+
+	err := s.service.AttachStorageToUnit(c.Context(), siUUID, unitUUID)
+	storageErr, ok := errors.AsType[applicationerrors.StorageAttachmentNotAllowed](err)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(storageErr, tc.DeepEquals, applicationerrors.StorageAttachmentNotAllowed{
+		ExistingStorageMachineOwner: ptr("666"),
+	})
+}
+
 func (s *providerServiceSuite) TestAttachStorage(c *tc.C) {
 	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
 	defer ctrl.Finish()

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3458,14 +3458,14 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 	}, uint32(67), uint64(6)).
 		Return(nil)
 
-	storageToAttach := []internal.CreateUnitStorageAttachmentArg{{
+	storageToAttach := internal.CreateUnitStorageAttachmentArg{
 		UUID: saUUID,
 		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: fsUUID,
 			ProvisionScope: 1,
 		},
 		StorageInstanceUUID: siUUID,
-	}}
+	}
 	fsToOwn := []domainstorage.FilesystemUUID{tc.Must(c, domainstorage.NewFilesystemUUID)}
 	volToOwn := []domainstorage.VolumeUUID{tc.Must(c, domainstorage.NewVolumeUUID)}
 
@@ -3584,13 +3584,13 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
 	}, uint32(67), uint64(6)).
 		Return(nil)
 
-	storageToAttach := []internal.CreateUnitStorageAttachmentArg{{
+	storageToAttach := internal.CreateUnitStorageAttachmentArg{
 		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: fsUUUID,
 			ProvisionScope: 1,
 		},
 		StorageInstanceUUID: siUUID,
-	}}
+	}
 	unitStorageArgs := internal.AttachStorageToUnitArg{
 		// UUID
 		StorageToAttach:    storageToAttach,

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -44,6 +44,7 @@ import (
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/status"
 	domainstorage "github.com/juju/juju/domain/storage"
+	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/errors"
 )
@@ -3365,4 +3366,256 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnit(c *tc.C) {
 		StoragePoolUUID: ptr(poolUUID),
 	})
 	c.Assert(err, tc.ErrorIs, nil)
+}
+
+func (s *providerServiceSuite) TestAttachStorageForIAASUnitNotFound(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
+		Return(false, applicationerrors.UnitNotFound)
+
+	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
+}
+
+func (s *providerServiceSuite) TestAttachStorageForIAASStorageNotFound(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
+		Return(false, storageerrors.StorageInstanceNotFound)
+
+	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIs, storageerrors.StorageInstanceNotFound)
+}
+
+func (s *providerServiceSuite) TestAttachStorageForIAASUnitValidates(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
+		Return(false, nil)
+	s.state.EXPECT().GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internalcharm.Storage{
+			Name:        "pgdata",
+			Type:        internalcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    66,
+			MinimumSize: 10,
+		}, internal.StorageInstanceInfo{
+			AlreadyAttachedCount: 66,
+			PoolUUID:             poolUUID,
+			SizeMiB:              6,
+		}, nil)
+	s.storageService.EXPECT().ValidateAttachStorage(gomock.Any(), internal.ValidateStorageArg{
+		Name:        "pgdata",
+		Type:        internalcharm.StorageFilesystem,
+		CountMin:    1,
+		CountMax:    66,
+		MinimumSize: 10,
+	}, uint32(67), uint64(6), poolUUID).
+		Return(applicationerrors.StorageCountLimitExceeded{})
+
+	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIs, applicationerrors.StorageCountLimitExceeded{})
+}
+
+func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
+	fsUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
+		Return(false, nil)
+	s.state.EXPECT().GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internalcharm.Storage{
+			Name:        "pgdata",
+			Type:        internalcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    666,
+			MinimumSize: 10,
+		}, internal.StorageInstanceInfo{
+			AlreadyAttachedCount: 66,
+			PoolUUID:             poolUUID,
+			SizeMiB:              6,
+		}, nil)
+	s.storageService.EXPECT().ValidateAttachStorage(gomock.Any(), internal.ValidateStorageArg{
+		Name:        "pgdata",
+		Type:        internalcharm.StorageFilesystem,
+		CountMin:    1,
+		CountMax:    666,
+		MinimumSize: 10,
+	}, uint32(67), uint64(6), poolUUID).
+		Return(nil)
+
+	unitStorageArgs := internal.UnitAttachStorageArg{
+		StorageToAttach: []internal.UnitStorageAttachmentArg{{
+			UUID: saUUID,
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+				FilesystemUUID: fsUUID,
+				ProvisionScope: 1,
+			},
+			StorageInstanceUUID: siUUID,
+		}},
+		StorageName:        "pgdata",
+		CountLessThanEqual: 665,
+	}
+	fsToOwn := []domainstorage.FilesystemUUID{tc.Must(c, domainstorage.NewFilesystemUUID)}
+	volToOwn := []domainstorage.VolumeUUID{tc.Must(c, domainstorage.NewVolumeUUID)}
+
+	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), unitUUID, siUUID).
+		Return(unitStorageArgs, nil)
+	storageInst := []internal.UnitStorageInstanceArg{{
+		Filesystem: &internal.UnitStorageFilesystemArg{
+			UUID:           fsUUID,
+			ProvisionScope: 1,
+		},
+		UUID: siUUID,
+	}}
+	s.storageService.EXPECT().MakeIAASUnitStorageArgs(storageInst).
+		Return(internal.IAASUnitStorageArg{
+			FilesystemsToOwn: fsToOwn,
+			VolumesToOwn:     volToOwn,
+		}, nil)
+
+	s.state.EXPECT().AttachStorageToIAASUnit(gomock.Any(), siUUID, unitUUID, internal.IAASUnitAttachStorageArg{
+		UnitAttachStorageArg: unitStorageArgs,
+		FilesystemsToOwn:     fsToOwn,
+		VolumesToOwn:         volToOwn,
+	})
+
+	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *providerServiceSuite) TestAttachStorageForCAASUnitNotFound(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
+		Return(false, applicationerrors.UnitNotFound)
+
+	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
+}
+
+func (s *providerServiceSuite) TestAttachStorageForCAASStorageNotFound(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
+		Return(false, storageerrors.StorageInstanceNotFound)
+
+	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIs, storageerrors.StorageInstanceNotFound)
+}
+
+func (s *providerServiceSuite) TestAttachStorageForCAASUnitValidates(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
+		Return(false, nil)
+	s.state.EXPECT().GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internalcharm.Storage{
+			Name:        "pgdata",
+			Type:        internalcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    66,
+			MinimumSize: 10,
+		}, internal.StorageInstanceInfo{
+			AlreadyAttachedCount: 66,
+			PoolUUID:             poolUUID,
+			SizeMiB:              6,
+		}, nil)
+	s.storageService.EXPECT().ValidateAttachStorage(gomock.Any(), internal.ValidateStorageArg{
+		Name:        "pgdata",
+		Type:        internalcharm.StorageFilesystem,
+		CountMin:    1,
+		CountMax:    66,
+		MinimumSize: 10,
+	}, uint32(67), uint64(6), poolUUID).
+		Return(applicationerrors.StorageCountLimitExceeded{})
+
+	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIs, applicationerrors.StorageCountLimitExceeded{})
+}
+
+func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
+	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	fsUUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
+		Return(false, nil)
+	s.state.EXPECT().GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internalcharm.Storage{
+			Name:        "pgdata",
+			Type:        internalcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    666,
+			MinimumSize: 10,
+		}, internal.StorageInstanceInfo{
+			AlreadyAttachedCount: 66,
+			PoolUUID:             poolUUID,
+			SizeMiB:              6,
+		}, nil)
+	s.storageService.EXPECT().ValidateAttachStorage(gomock.Any(), internal.ValidateStorageArg{
+		Name:        "pgdata",
+		Type:        internalcharm.StorageFilesystem,
+		CountMin:    1,
+		CountMax:    666,
+		MinimumSize: 10,
+	}, uint32(67), uint64(6), poolUUID).
+		Return(nil)
+
+	unitStorageArgs := internal.UnitAttachStorageArg{
+		// UUID
+		StorageToAttach: []internal.UnitStorageAttachmentArg{{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+				FilesystemUUID: fsUUUID,
+				ProvisionScope: 1,
+			},
+			StorageInstanceUUID: siUUID,
+		}},
+		StorageName:        "pgdata",
+		CountLessThanEqual: 665,
+	}
+
+	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), unitUUID, siUUID).
+		Return(unitStorageArgs, nil)
+	s.state.EXPECT().AttachStorageToCAASUnit(gomock.Any(), siUUID, unitUUID, unitStorageArgs)
+
+	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIsNil)
 }

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3406,28 +3406,24 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnitValidates(c *tc.C) {
 
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 
 	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
 		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
 			Name:                 "pgdata",
-			Type:                 internalcharm.StorageFilesystem,
 			CountMin:             1,
 			CountMax:             66,
 			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
-			PoolUUID:             poolUUID,
 			SizeMiB:              6,
 		}, nil)
-	s.storageService.EXPECT().ValidateAttachStorage(gomock.Any(), internal.ValidateStorageArg{
+	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
-		Type:        internalcharm.StorageFilesystem,
 		CountMin:    1,
 		CountMax:    66,
 		MinimumSize: 10,
-	}, uint32(67), uint64(6), poolUUID).
+	}, uint32(67), uint64(6)).
 		Return(applicationerrors.StorageCountLimitExceeded{})
 
 	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
@@ -3442,28 +3438,24 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
-	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 
 	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
 		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
 			Name:                 "pgdata",
-			Type:                 internalcharm.StorageFilesystem,
 			CountMin:             1,
 			CountMax:             666,
 			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
-			PoolUUID:             poolUUID,
 			SizeMiB:              6,
 		}, nil)
-	s.storageService.EXPECT().ValidateAttachStorage(gomock.Any(), internal.ValidateStorageArg{
+	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
-		Type:        internalcharm.StorageFilesystem,
 		CountMin:    1,
 		CountMax:    666,
 		MinimumSize: 10,
-	}, uint32(67), uint64(6), poolUUID).
+	}, uint32(67), uint64(6)).
 		Return(nil)
 
 	storageToAttach := []internal.CreateUnitStorageAttachmentArg{{
@@ -3541,28 +3533,24 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnitValidates(c *tc.C) {
 
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 
 	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
 		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
 			Name:                 "pgdata",
-			Type:                 internalcharm.StorageFilesystem,
 			CountMin:             1,
 			CountMax:             66,
 			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
-			PoolUUID:             poolUUID,
 			SizeMiB:              6,
 		}, nil)
-	s.storageService.EXPECT().ValidateAttachStorage(gomock.Any(), internal.ValidateStorageArg{
+	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
-		Type:        internalcharm.StorageFilesystem,
 		CountMin:    1,
 		CountMax:    66,
 		MinimumSize: 10,
-	}, uint32(67), uint64(6), poolUUID).
+	}, uint32(67), uint64(6)).
 		Return(applicationerrors.StorageCountLimitExceeded{})
 
 	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
@@ -3576,28 +3564,24 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	fsUUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
-	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 
 	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
 		Return(false, nil)
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{
 			Name:                 "pgdata",
-			Type:                 internalcharm.StorageFilesystem,
 			CountMin:             1,
 			CountMax:             666,
 			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
-			PoolUUID:             poolUUID,
 			SizeMiB:              6,
 		}, nil)
-	s.storageService.EXPECT().ValidateAttachStorage(gomock.Any(), internal.ValidateStorageArg{
+	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
 		Name:        "pgdata",
-		Type:        internalcharm.StorageFilesystem,
 		CountMin:    1,
 		CountMax:    666,
 		MinimumSize: 10,
-	}, uint32(67), uint64(6), poolUUID).
+	}, uint32(67), uint64(6)).
 		Return(nil)
 
 	storageToAttach := []internal.CreateUnitStorageAttachmentArg{{

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3113,14 +3113,15 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnitValidates(c *tc.C) {
 			Count:            1,
 			MaxCount:         666,
 		}, nil)
-	s.state.EXPECT().GetCharmStorageAndInstanceCountByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
-		Return(internalcharm.Storage{
-			Name:        "pgdata",
-			Type:        internalcharm.StorageFilesystem,
-			MinimumSize: 10,
-			CountMin:    1,
-			CountMax:    666,
-		}, 66, nil)
+	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageInfoForAdd{
+			Name:                 "pgdata",
+			Type:                 internalcharm.StorageFilesystem,
+			MinimumSize:          10,
+			CountMin:             1,
+			CountMax:             666,
+			AlreadyAttachedCount: 66,
+		}, nil)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.ValidateStorageArg{
 		"pgdata": {
 			Name:        "pgdata",
@@ -3158,14 +3159,15 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			Count:            1,
 			MaxCount:         666,
 		}, nil)
-	s.state.EXPECT().GetCharmStorageAndInstanceCountByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
-		Return(internalcharm.Storage{
-			Name:        "pgdata",
-			Type:        internalcharm.StorageFilesystem,
-			MinimumSize: 10,
-			CountMin:    1,
-			CountMax:    666,
-		}, 66, nil)
+	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageInfoForAdd{
+			Name:                 "pgdata",
+			Type:                 internalcharm.StorageFilesystem,
+			MinimumSize:          10,
+			CountMin:             1,
+			CountMax:             666,
+			AlreadyAttachedCount: 66,
+		}, nil)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.ValidateStorageArg{
 		"pgdata": {
 			Name:        "pgdata",
@@ -3275,14 +3277,15 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnitValidates(c *tc.C) {
 			Count:            1,
 			MaxCount:         666,
 		}, nil)
-	s.state.EXPECT().GetCharmStorageAndInstanceCountByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
-		Return(internalcharm.Storage{
-			Name:        "pgdata",
-			Type:        internalcharm.StorageFilesystem,
-			MinimumSize: 10,
-			CountMin:    1,
-			CountMax:    666,
-		}, 66, nil)
+	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageInfoForAdd{
+			Name:                 "pgdata",
+			Type:                 internalcharm.StorageFilesystem,
+			MinimumSize:          10,
+			CountMin:             1,
+			CountMax:             666,
+			AlreadyAttachedCount: 66,
+		}, nil)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.ValidateStorageArg{
 		"pgdata": {
 			Name:        "pgdata",
@@ -3320,14 +3323,15 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnit(c *tc.C) {
 			Count:            1,
 			MaxCount:         666,
 		}, nil)
-	s.state.EXPECT().GetCharmStorageAndInstanceCountByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
-		Return(internalcharm.Storage{
-			Name:        "pgdata",
-			Type:        internalcharm.StorageFilesystem,
-			MinimumSize: 10,
-			CountMin:    1,
-			CountMax:    666,
-		}, 66, nil)
+	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageInfoForAdd{
+			Name:                 "pgdata",
+			Type:                 internalcharm.StorageFilesystem,
+			MinimumSize:          10,
+			CountMin:             1,
+			CountMax:             666,
+			AlreadyAttachedCount: 66,
+		}, nil)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.ValidateStorageArg{
 		"pgdata": {
 			Name:        "pgdata",
@@ -3406,14 +3410,13 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnitValidates(c *tc.C) {
 
 	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
 		Return(false, nil)
-	s.state.EXPECT().GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
-		Return(internalcharm.Storage{
-			Name:        "pgdata",
-			Type:        internalcharm.StorageFilesystem,
-			CountMin:    1,
-			CountMax:    66,
-			MinimumSize: 10,
-		}, internal.StorageInstanceInfo{
+	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internal.StorageInfoForAttach{
+			Name:                 "pgdata",
+			Type:                 internalcharm.StorageFilesystem,
+			CountMin:             1,
+			CountMax:             66,
+			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
 			PoolUUID:             poolUUID,
 			SizeMiB:              6,
@@ -3443,14 +3446,13 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 
 	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
 		Return(false, nil)
-	s.state.EXPECT().GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
-		Return(internalcharm.Storage{
-			Name:        "pgdata",
-			Type:        internalcharm.StorageFilesystem,
-			CountMin:    1,
-			CountMax:    666,
-			MinimumSize: 10,
-		}, internal.StorageInstanceInfo{
+	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internal.StorageInfoForAttach{
+			Name:                 "pgdata",
+			Type:                 internalcharm.StorageFilesystem,
+			CountMin:             1,
+			CountMax:             666,
+			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
 			PoolUUID:             poolUUID,
 			SizeMiB:              6,
@@ -3543,14 +3545,13 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnitValidates(c *tc.C) {
 
 	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
 		Return(false, nil)
-	s.state.EXPECT().GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
-		Return(internalcharm.Storage{
-			Name:        "pgdata",
-			Type:        internalcharm.StorageFilesystem,
-			CountMin:    1,
-			CountMax:    66,
-			MinimumSize: 10,
-		}, internal.StorageInstanceInfo{
+	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internal.StorageInfoForAttach{
+			Name:                 "pgdata",
+			Type:                 internalcharm.StorageFilesystem,
+			CountMin:             1,
+			CountMax:             66,
+			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
 			PoolUUID:             poolUUID,
 			SizeMiB:              6,
@@ -3579,14 +3580,13 @@ func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
 
 	s.state.EXPECT().GetUnitStorageAttachmentExists(gomock.Any(), siUUID, unitUUID).
 		Return(false, nil)
-	s.state.EXPECT().GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
-		Return(internalcharm.Storage{
-			Name:        "pgdata",
-			Type:        internalcharm.StorageFilesystem,
-			CountMin:    1,
-			CountMax:    666,
-			MinimumSize: 10,
-		}, internal.StorageInstanceInfo{
+	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
+		Return(internal.StorageInfoForAttach{
+			Name:                 "pgdata",
+			Type:                 internalcharm.StorageFilesystem,
+			CountMin:             1,
+			CountMax:             666,
+			MinimumSize:          10,
 			AlreadyAttachedCount: 66,
 			PoolUUID:             poolUUID,
 			SizeMiB:              6,

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3202,8 +3202,8 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	}).
 		Return(unitStorageArgs, nil)
 	storageInst := transform.Slice(unitStorageArgs.StorageInstances,
-		func(in internal.CreateUnitStorageInstanceArg) internal.UnitStorageInstanceArg {
-			return internal.UnitStorageInstanceArg{
+		func(in internal.CreateUnitStorageInstanceArg) internal.AddStorageInstanceArg {
+			return internal.AddStorageInstanceArg{
 				Filesystem: in.Filesystem,
 				Volume:     in.Volume,
 				UUID:       in.UUID,
@@ -3372,7 +3372,7 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, nil)
 }
 
-func (s *providerServiceSuite) TestAttachStorageForIAASStorageNotFound(c *tc.C) {
+func (s *providerServiceSuite) TestAttachStorageNotFound(c *tc.C) {
 	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
 	defer ctrl.Finish()
 
@@ -3382,11 +3382,11 @@ func (s *providerServiceSuite) TestAttachStorageForIAASStorageNotFound(c *tc.C) 
 	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
 		Return(internal.StorageInfoForAttach{}, storageerrors.StorageInstanceNotFound)
 
-	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
+	err := s.service.AttachStorageToUnit(c.Context(), siUUID, unitUUID)
 	c.Assert(err, tc.ErrorIs, storageerrors.StorageInstanceNotFound)
 }
 
-func (s *providerServiceSuite) TestAttachStorageForIAASUnitValidates(c *tc.C) {
+func (s *providerServiceSuite) TestAttachStorageValidates(c *tc.C) {
 	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
 	defer ctrl.Finish()
 
@@ -3410,11 +3410,11 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnitValidates(c *tc.C) {
 	}, uint32(66), uint64(6)).
 		Return(applicationerrors.StorageCountLimitExceeded{})
 
-	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
+	err := s.service.AttachStorageToUnit(c.Context(), siUUID, unitUUID)
 	c.Assert(err, tc.ErrorIs, applicationerrors.StorageCountLimitExceeded{})
 }
 
-func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
+func (s *providerServiceSuite) TestAttachStorage(c *tc.C) {
 	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
 	defer ctrl.Finish()
 
@@ -3448,124 +3448,17 @@ func (s *providerServiceSuite) TestAttachStorageForIAASUnit(c *tc.C) {
 		},
 		StorageInstanceUUID: siUUID,
 	}
-	fsToOwn := []domainstorage.FilesystemUUID{tc.Must(c, domainstorage.NewFilesystemUUID)}
-	volToOwn := []domainstorage.VolumeUUID{tc.Must(c, domainstorage.NewVolumeUUID)}
 
 	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), unitUUID, siUUID).
 		Return(storageToAttach, nil)
-	storageInst := []internal.UnitStorageInstanceArg{{
-		Filesystem: &internal.CreateUnitStorageFilesystemArg{
-			UUID:           fsUUID,
-			ProvisionScope: 1,
-		},
-		UUID: siUUID,
-	}}
-	s.storageService.EXPECT().MakeIAASUnitStorageArgs(storageInst).
-		Return(internal.CreateIAASUnitStorageArg{
-			FilesystemsToOwn: fsToOwn,
-			VolumesToOwn:     volToOwn,
-		}, nil)
 
 	unitStorageArgs := internal.AttachStorageToUnitArg{
 		StorageToAttach:    storageToAttach,
 		StorageName:        "pgdata",
 		CountLessThanEqual: 665,
 	}
-	s.state.EXPECT().AttachStorageToIAASUnit(gomock.Any(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
-		AttachStorageToUnitArg: unitStorageArgs,
-		FilesystemsToOwn:       fsToOwn,
-		VolumesToOwn:           volToOwn,
-	})
+	s.state.EXPECT().AttachStorageToUnit(gomock.Any(), siUUID, unitUUID, unitStorageArgs)
 
-	err := s.service.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID)
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *providerServiceSuite) TestAttachStorageForCAASStorageNotFound(c *tc.C) {
-	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
-	defer ctrl.Finish()
-
-	unitUUID := tc.Must(c, coreunit.NewUUID)
-	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-
-	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
-		Return(internal.StorageInfoForAttach{}, storageerrors.StorageInstanceNotFound)
-
-	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
-	c.Assert(err, tc.ErrorIs, storageerrors.StorageInstanceNotFound)
-}
-
-func (s *providerServiceSuite) TestAttachStorageForCAASUnitValidates(c *tc.C) {
-	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
-	defer ctrl.Finish()
-
-	unitUUID := tc.Must(c, coreunit.NewUUID)
-	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-
-	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
-		Return(internal.StorageInfoForAttach{
-			CharmStorageName:     "pgdata",
-			CountMin:             1,
-			CountMax:             66,
-			MinimumSize:          10,
-			AlreadyAttachedCount: 66,
-			ProvisionedSizeMiB:   6,
-		}, nil)
-	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
-		Name:        "pgdata",
-		CountMin:    1,
-		CountMax:    66,
-		MinimumSize: 10,
-	}, uint32(66), uint64(6)).
-		Return(applicationerrors.StorageCountLimitExceeded{})
-
-	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
-	c.Assert(err, tc.ErrorIs, applicationerrors.StorageCountLimitExceeded{})
-}
-
-func (s *providerServiceSuite) TestAttachStorageForCAASUnit(c *tc.C) {
-	ctrl := s.setupMocksWithProvider(c, noProviderError, noProviderError)
-	defer ctrl.Finish()
-
-	unitUUID := tc.Must(c, coreunit.NewUUID)
-	siUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-	fsUUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
-
-	s.state.EXPECT().GetStorageAttachInfoByUnitUUIDAndStorageUUID(gomock.Any(), unitUUID, siUUID).
-		Return(internal.StorageInfoForAttach{
-			CharmStorageName:     "pgdata",
-			CountMin:             1,
-			CountMax:             666,
-			MinimumSize:          10,
-			AlreadyAttachedCount: 66,
-			ProvisionedSizeMiB:   6,
-		}, nil)
-	s.storageService.EXPECT().ValidateAttachStorage(internal.ValidateStorageArg{
-		Name:        "pgdata",
-		CountMin:    1,
-		CountMax:    666,
-		MinimumSize: 10,
-	}, uint32(66), uint64(6)).
-		Return(nil)
-
-	storageToAttach := internal.CreateUnitStorageAttachmentArg{
-		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
-			FilesystemUUID: fsUUUID,
-			ProvisionScope: 1,
-		},
-		StorageInstanceUUID: siUUID,
-	}
-	unitStorageArgs := internal.AttachStorageToUnitArg{
-		// UUID
-		StorageToAttach:    storageToAttach,
-		StorageName:        "pgdata",
-		CountLessThanEqual: 665,
-	}
-
-	s.storageService.EXPECT().MakeUnitAttachStorageArgs(gomock.Any(), unitUUID, siUUID).
-		Return(storageToAttach, nil)
-	s.state.EXPECT().AttachStorageToCAASUnit(gomock.Any(), siUUID, unitUUID, unitStorageArgs)
-
-	err := s.service.AttachStorageToCAASUnit(c.Context(), siUUID, unitUUID)
+	err := s.service.AttachStorageToUnit(c.Context(), siUUID, unitUUID)
 	c.Assert(err, tc.ErrorIsNil)
 }

--- a/domain/application/service/registerunit_test.go
+++ b/domain/application/service/registerunit_test.go
@@ -48,7 +48,7 @@ func (s *registerCAASUnitSuite) makeStorageArg(
 			StorageInstances: []internal.CreateUnitStorageInstanceArg{
 				{
 					CharmName: "foo",
-					Filesystem: &internal.CreateUnitStorageFilesystemArg{
+					Filesystem: &internal.UnitStorageFilesystemArg{
 						UUID:           fsUUID,
 						ProvisionScope: domainstorageprov.ProvisionScopeModel,
 					},
@@ -60,7 +60,7 @@ func (s *registerCAASUnitSuite) makeStorageArg(
 			},
 			StorageToAttach: []internal.UnitStorageAttachmentArg{
 				{
-					FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+					FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 						FilesystemUUID: fsUUID,
 						ProvisionScope: domainstorageprov.ProvisionScopeModel,
 						UUID:           tc.Must(c, domainstorage.NewFilesystemAttachmentUUID),

--- a/domain/application/service/registerunit_test.go
+++ b/domain/application/service/registerunit_test.go
@@ -115,6 +115,7 @@ func (s *registerCAASUnitSuite) TestRegisterNewCAASUnit(c *tc.C) {
 	).Return(storageArg, nil).AnyTimes()
 
 	arg := application.RegisterCAASUnitArg{
+		UnitUUID:               tc.Must(c, coreunit.NewUUID),
 		UnitName:               "foo/666",
 		PasswordHash:           "secret",
 		ProviderID:             "foo-666",
@@ -144,6 +145,7 @@ func (s *registerCAASUnitSuite) TestRegisterNewCAASUnit(c *tc.C) {
 
 	mc := tc.NewMultiChecker()
 	mc.AddExpr(`_.PasswordHash`, tc.Ignore)
+	mc.AddExpr(`_.UnitUUID`, tc.IsNonZeroUUID)
 	mc.AddExpr(`_.NetNodeUUID`, tc.IsNonZeroUUID)
 	mc.AddExpr(`_.RegisterUnitStorageArg`, s.storageChecker(), tc.ExpectedValue)
 	c.Assert(gotRCA, mc, arg)
@@ -189,6 +191,7 @@ func (s *registerCAASUnitSuite) TestRegisterExistingCAASUnit(c *tc.C) {
 	).Return(storageArg, nil).AnyTimes()
 
 	expectedArg := application.RegisterCAASUnitArg{
+		UnitUUID:               unitUUID,
 		Address:                ptr("10.6.6.6"),
 		NetNodeUUID:            unitNetNodeUUID,
 		OrderedId:              666,

--- a/domain/application/service/registerunit_test.go
+++ b/domain/application/service/registerunit_test.go
@@ -58,7 +58,7 @@ func (s *registerCAASUnitSuite) makeStorageArg(
 					UUID:            storageInstUUID,
 				},
 			},
-			StorageToAttach: []internal.CreateUnitStorageAttachmentArg{
+			StorageToAttach: []internal.UnitStorageAttachmentArg{
 				{
 					FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 						FilesystemUUID: fsUUID,

--- a/domain/application/service/registerunit_test.go
+++ b/domain/application/service/registerunit_test.go
@@ -48,7 +48,7 @@ func (s *registerCAASUnitSuite) makeStorageArg(
 			StorageInstances: []internal.CreateUnitStorageInstanceArg{
 				{
 					CharmName: "foo",
-					Filesystem: &internal.UnitStorageFilesystemArg{
+					Filesystem: &internal.CreateUnitStorageFilesystemArg{
 						UUID:           fsUUID,
 						ProvisionScope: domainstorageprov.ProvisionScopeModel,
 					},
@@ -58,9 +58,9 @@ func (s *registerCAASUnitSuite) makeStorageArg(
 					UUID:            storageInstUUID,
 				},
 			},
-			StorageToAttach: []internal.UnitStorageAttachmentArg{
+			StorageToAttach: []internal.CreateUnitStorageAttachmentArg{
 				{
-					FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+					FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 						FilesystemUUID: fsUUID,
 						ProvisionScope: domainstorageprov.ProvisionScopeModel,
 						UUID:           tc.Must(c, domainstorage.NewFilesystemAttachmentUUID),

--- a/domain/application/service/registerunit_test.go
+++ b/domain/application/service/registerunit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
-	caas "github.com/juju/juju/caas"
+	"github.com/juju/juju/caas"
 	coreapplication "github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
 	coreunit "github.com/juju/juju/core/unit"

--- a/domain/application/service/registerunit_test.go
+++ b/domain/application/service/registerunit_test.go
@@ -58,7 +58,7 @@ func (s *registerCAASUnitSuite) makeStorageArg(
 					UUID:            storageInstUUID,
 				},
 			},
-			StorageToAttach: []internal.CreateUnitStorageAttachmentArg{
+			NewStorageToAttach: []internal.AttachStorageToUnitArg{
 				{
 					FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 						FilesystemUUID: fsUUID,
@@ -81,7 +81,7 @@ func (s *registerCAASUnitSuite) makeStorageArg(
 
 func (*registerCAASUnitSuite) storageChecker() *tc.MultiChecker {
 	mc := tc.NewMultiChecker()
-	mc.AddExpr(`_.CreateUnitStorageArg.StorageToAttach[_].FilesystemAttachment.NetNodeUUID`, tc.Ignore)
+	mc.AddExpr(`_.CreateUnitStorageArg.NewStorageToAttach[_].FilesystemAttachment.NetNodeUUID`, tc.Ignore)
 	return mc
 }
 

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -111,11 +111,11 @@ type StorageService interface {
 		existingStorageAttachments []internal.StorageAttachmentComposition,
 	) (internal.CreateUnitStorageArg, error)
 
-	// MakeIAASUnitStorageArgs returns [internal.IAASUnitStorageArg] that
+	// MakeIAASUnitStorageArgs returns [internal.CreateIAASUnitStorageArg] that
 	// complement the unit storage arguments provided for IAAS units.
 	MakeIAASUnitStorageArgs(
 		storageInst []internal.UnitStorageInstanceArg,
-	) (internal.IAASUnitStorageArg, error)
+	) (internal.CreateIAASUnitStorageArg, error)
 
 	// MakeUnitAddStorageArgs creates the storage arguments required to
 	// add storage to a unit. This is similar to [MakeUnitStorageArgs]
@@ -127,7 +127,7 @@ type StorageService interface {
 		unitUUID coreunit.UUID,
 		addCount uint32,
 		storageDirectives application.StorageDirective,
-	) (internal.UnitAddStorageArg, error)
+	) (internal.AddStorageToUnitArg, error)
 
 	// ValidateApplicationStorageDirectiveOverrides checks a set of storage
 	// directive overrides to make sure they are valid with respect to the charms
@@ -197,5 +197,5 @@ type StorageService interface {
 		ctx context.Context,
 		unitUUID coreunit.UUID,
 		storageUUID domainstorage.StorageInstanceUUID,
-	) (internal.UnitAttachStorageArg, error)
+	) ([]internal.CreateUnitStorageAttachmentArg, error)
 }

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -193,7 +193,7 @@ type StorageService interface {
 	// falls outside of the bounds defined by the charm.
 	MakeUnitAttachStorageArgs(
 		ctx context.Context,
-		unitUUID coreunit.UUID,
+		netNodeUUID string,
 		storageUUID domainstorage.StorageInstanceUUID,
 	) (internal.CreateUnitStorageAttachmentArg, error)
 }

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -195,5 +195,5 @@ type StorageService interface {
 		ctx context.Context,
 		unitUUID coreunit.UUID,
 		storageUUID domainstorage.StorageInstanceUUID,
-	) ([]internal.CreateUnitStorageAttachmentArg, error)
+	) (internal.CreateUnitStorageAttachmentArg, error)
 }

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -182,7 +182,7 @@ type StorageService interface {
 	// falls outside of the bounds defined by the charm.
 	ValidateAttachStorage(
 		charmStorageDef internal.ValidateStorageArg,
-		wantCount uint32,
+		existingCount uint32,
 		storageSize uint64,
 	) error
 	

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -111,11 +111,11 @@ type StorageService interface {
 		existingStorageAttachments []internal.StorageAttachmentComposition,
 	) (internal.CreateUnitStorageArg, error)
 
-	// MakeIAASUnitStorageArgs returns [internal.CreateIAASUnitStorageArg] that
+	// MakeIAASUnitStorageArgs returns [internal.IAASUnitStorageArg] that
 	// complement the unit storage arguments provided for IAAS units.
 	MakeIAASUnitStorageArgs(
 		storageInst []internal.UnitStorageInstanceArg,
-	) (internal.CreateIAASUnitStorageArg, error)
+	) (internal.IAASUnitStorageArg, error)
 
 	// MakeUnitAddStorageArgs creates the storage arguments required to
 	// add storage to a unit. This is similar to [MakeUnitStorageArgs]

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -114,7 +114,7 @@ type StorageService interface {
 	// MakeIAASUnitStorageArgs returns [internal.CreateIAASUnitStorageArg] that
 	// complement the unit storage arguments provided for IAAS units.
 	MakeIAASUnitStorageArgs(
-		storageInst []internal.UnitStorageInstanceArg,
+		storageInst []internal.AddStorageInstanceArg,
 	) (internal.CreateIAASUnitStorageArg, error)
 
 	// MakeUnitAddStorageArgs creates the storage arguments required to

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -181,11 +181,9 @@ type StorageService interface {
 	// - [applicationerrors.StorageCountLimitExceeded] when the requested storage
 	// falls outside of the bounds defined by the charm.
 	ValidateAttachStorage(
-		ctx context.Context,
 		charmStorageDef internal.ValidateStorageArg,
 		wantCount uint32,
 		storageSize uint64,
-		poolUUID domainstorage.StoragePoolUUID,
 	) error
 	
 	// MakeUnitAttachStorageArgs creates the storage arguments required to

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/domain/application/service/storage"
 	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	domainnetwork "github.com/juju/juju/domain/network"
+	domainstorage "github.com/juju/juju/domain/storage"
 )
 
 // StorageDirectiveOverrides represents override instructions for application
@@ -113,8 +114,7 @@ type StorageService interface {
 	// MakeIAASUnitStorageArgs returns [internal.CreateIAASUnitStorageArg] that
 	// complement the unit storage arguments provided for IAAS units.
 	MakeIAASUnitStorageArgs(
-		ctx context.Context,
-		storageInst []internal.CreateUnitStorageInstanceArg,
+		storageInst []internal.UnitStorageInstanceArg,
 	) (internal.CreateIAASUnitStorageArg, error)
 
 	// MakeUnitAddStorageArgs creates the storage arguments required to
@@ -134,7 +134,7 @@ type StorageService interface {
 	// storage definitions.
 	ValidateApplicationStorageDirectiveOverrides(
 		ctx context.Context,
-		charmStorageDefs map[string]internalcharm.Storage,
+		charmStorageDefs map[string]internal.ValidateStorageArg,
 		overrides map[string]storage.StorageDirectiveOverride,
 	) error
 
@@ -172,4 +172,30 @@ type StorageService interface {
 		toUpdate []internal.UpdateApplicationStorageDirectiveArg,
 		err error,
 	)
+
+	// ValidateAttachStorage checks that a storage instance from the specified
+	// pool can be attached to a unit with respect to the unit's charm storage
+	// definition.
+	//
+	// The following errors may be expected:
+	// - [applicationerrors.StorageCountLimitExceeded] when the requested storage
+	// falls outside of the bounds defined by the charm.
+	ValidateAttachStorage(
+		ctx context.Context,
+		charmStorageDef internal.ValidateStorageArg,
+		wantCount uint32,
+		storageSize uint64,
+		poolUUID domainstorage.StoragePoolUUID,
+	) error
+	
+	// MakeUnitAttachStorageArgs creates the storage arguments required to
+	// attach existing storage to a unit.
+	// The following errors may be expected:
+	// - [applicationerrors.StorageCountLimitExceeded] when the requested storage
+	// falls outside of the bounds defined by the charm.
+	MakeUnitAttachStorageArgs(
+		ctx context.Context,
+		unitUUID coreunit.UUID,
+		storageUUID domainstorage.StorageInstanceUUID,
+	) (internal.UnitAttachStorageArg, error)
 }

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -172,10 +172,10 @@ type StorageService interface {
 		toUpdate []internal.UpdateApplicationStorageDirectiveArg,
 		err error,
 	)
-
-	// ValidateAttachStorage checks that a storage instance from the specified
-	// pool can be attached to a unit with respect to the unit's charm storage
-	// definition.
+	
+	// ValidateAttachStorage checks that a storage instance can be attached
+	// to a unit with respect to the unit's charm storage definition, checking
+	// the existing count of storage instances and the size of the new storage.
 	//
 	// The following errors may be expected:
 	// - [applicationerrors.StorageCountLimitExceeded] when the requested storage

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -172,7 +172,7 @@ type StorageService interface {
 		toUpdate []internal.UpdateApplicationStorageDirectiveArg,
 		err error,
 	)
-	
+
 	// ValidateAttachStorage checks that a storage instance can be attached
 	// to a unit with respect to the unit's charm storage definition, checking
 	// the existing count of storage instances and the size of the new storage.
@@ -185,15 +185,16 @@ type StorageService interface {
 		existingCount uint32,
 		storageSize uint64,
 	) error
-	
-	// MakeUnitAttachStorageArgs creates the storage arguments required to
+
+	// MakeAttachExistingStorageArgs creates the storage arguments required to
 	// attach existing storage to a unit.
 	// The following errors may be expected:
 	// - [applicationerrors.StorageCountLimitExceeded] when the requested storage
 	// falls outside of the bounds defined by the charm.
-	MakeUnitAttachStorageArgs(
+	MakeAttachExistingStorageArgs(
 		ctx context.Context,
 		netNodeUUID string,
 		storageUUID domainstorage.StorageInstanceUUID,
-	) (internal.CreateUnitStorageAttachmentArg, error)
+		storageAttachInfo internal.StorageInfoForAttach,
+	) (internal.AttachExistingStorageToUnitArg, error)
 }

--- a/domain/application/service/storage/checker_test.go
+++ b/domain/application/service/storage/checker_test.go
@@ -20,9 +20,7 @@ func createUnitStorageArgChecker() *tc.MultiChecker {
 	expectedStorageAttachmentChecker := tc.NewMultiChecker()
 	expectedStorageAttachmentChecker.AddExpr("_.UUID", tc.IsNonZeroUUID)
 	expectedStorageAttachmentChecker.AddExpr("_.FilesystemAttachment.UUID", tc.IsNonZeroUUID)
-	expectedStorageAttachmentChecker.AddExpr("_.FilesystemAttachment.FilesystemUUID", tc.IsNonZeroUUID)
 	expectedStorageAttachmentChecker.AddExpr("_.VolumeAttachment.UUID", tc.IsNonZeroUUID)
-	expectedStorageAttachmentChecker.AddExpr("_.VolumeAttachment.VolumeUUID", tc.IsNonZeroUUID)
 
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_.StorageDirectives", tc.SameContents, tc.ExpectedValue)

--- a/domain/application/service/storage/checker_test.go
+++ b/domain/application/service/storage/checker_test.go
@@ -32,8 +32,8 @@ func createUnitStorageArgChecker() *tc.MultiChecker {
 		tc.ExpectedValue,
 	)
 	mc.AddExpr(
-		"_.StorageToAttach",
-		tc.UnorderedMatch[[]internal.CreateUnitStorageAttachmentArg](
+		"_.NewStorageToAttach",
+		tc.UnorderedMatch[[]internal.AttachStorageToUnitArg](
 			expectedStorageAttachmentChecker,
 		),
 		tc.ExpectedValue,

--- a/domain/application/service/storage/checker_test.go
+++ b/domain/application/service/storage/checker_test.go
@@ -35,7 +35,7 @@ func createUnitStorageArgChecker() *tc.MultiChecker {
 	)
 	mc.AddExpr(
 		"_.StorageToAttach",
-		tc.UnorderedMatch[[]internal.UnitStorageAttachmentArg](
+		tc.UnorderedMatch[[]internal.CreateUnitStorageAttachmentArg](
 			expectedStorageAttachmentChecker,
 		),
 		tc.ExpectedValue,

--- a/domain/application/service/storage/checker_test.go
+++ b/domain/application/service/storage/checker_test.go
@@ -35,7 +35,7 @@ func createUnitStorageArgChecker() *tc.MultiChecker {
 	)
 	mc.AddExpr(
 		"_.StorageToAttach",
-		tc.UnorderedMatch[[]internal.CreateUnitStorageAttachmentArg](
+		tc.UnorderedMatch[[]internal.UnitStorageAttachmentArg](
 			expectedStorageAttachmentChecker,
 		),
 		tc.ExpectedValue,

--- a/domain/application/service/storage/checker_test.go
+++ b/domain/application/service/storage/checker_test.go
@@ -20,7 +20,9 @@ func createUnitStorageArgChecker() *tc.MultiChecker {
 	expectedStorageAttachmentChecker := tc.NewMultiChecker()
 	expectedStorageAttachmentChecker.AddExpr("_.UUID", tc.IsNonZeroUUID)
 	expectedStorageAttachmentChecker.AddExpr("_.FilesystemAttachment.UUID", tc.IsNonZeroUUID)
+	expectedStorageAttachmentChecker.AddExpr("_.FilesystemAttachment.FilesystemUUID", tc.IsNonZeroUUID)
 	expectedStorageAttachmentChecker.AddExpr("_.VolumeAttachment.UUID", tc.IsNonZeroUUID)
+	expectedStorageAttachmentChecker.AddExpr("_.VolumeAttachment.VolumeUUID", tc.IsNonZeroUUID)
 
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_.StorageDirectives", tc.SameContents, tc.ExpectedValue)

--- a/domain/application/service/storage/directive.go
+++ b/domain/application/service/storage/directive.go
@@ -323,11 +323,9 @@ func validateApplicationStorageDirectiveOverride(
 // pool can be attached to a unit with respect to the unit's charm storage
 // definition.
 func (s *Service) ValidateAttachStorage(
-	ctx context.Context,
 	charmStorageDef internal.ValidateStorageArg,
 	wantCount uint32,
 	storageSize uint64,
-	poolUUID domainstorage.StoragePoolUUID,
 ) error {
 	var (
 		// hasMaxCount is true when the charm storage definition has
@@ -358,25 +356,6 @@ func (s *Service) ValidateAttachStorage(
 			storageSize, charmStorageDef.Name, charmStorageDef.MinimumSize,
 		)
 	}
-
-	charmStorageType := charm.StorageType(charmStorageDef.Type)
-	supports, err := s.storagePoolProvider.CheckPoolSupportsCharmStorage(
-		ctx, poolUUID, charmStorageType,
-	)
-	if err != nil {
-		return errors.Errorf(
-			"checking storage directive pool %q supports charm storage %q",
-			poolUUID, charmStorageDef.Type,
-		)
-	}
-
-	if !supports {
-		return errors.Errorf(
-			"storage directive pool %q does not support charm storage %q",
-			poolUUID, charmStorageDef.Type,
-		)
-	}
-
 	return nil
 }
 

--- a/domain/application/service/storage/directive.go
+++ b/domain/application/service/storage/directive.go
@@ -319,9 +319,9 @@ func validateApplicationStorageDirectiveOverride(
 	return nil
 }
 
-// ValidateAttachStorage checks that a storage instance from the specified
-// pool can be attached to a unit with respect to the unit's charm storage
-// definition.
+// ValidateAttachStorage checks that a storage instance can be attached
+// to a unit with respect to the unit's charm storage definition, checking
+// the existing count of storage instances and the size of the new storage.
 func (s *Service) ValidateAttachStorage(
 	charmStorageDef internal.ValidateStorageArg,
 	existingCount uint32,

--- a/domain/application/service/storage/directive.go
+++ b/domain/application/service/storage/directive.go
@@ -324,7 +324,7 @@ func validateApplicationStorageDirectiveOverride(
 // definition.
 func (s *Service) ValidateAttachStorage(
 	charmStorageDef internal.ValidateStorageArg,
-	wantCount uint32,
+	existingCount uint32,
 	storageSize uint64,
 ) error {
 	var (
@@ -340,6 +340,7 @@ func (s *Service) ValidateAttachStorage(
 		hasMaxCount = true
 	}
 
+	wantCount := existingCount + 1
 	if hasMaxCount && wantCount > maxCount {
 		return applicationerrors.StorageCountLimitExceeded{
 			Maximum:     &charmStorageDef.CountMax,

--- a/domain/application/service/storage/directive.go
+++ b/domain/application/service/storage/directive.go
@@ -354,8 +354,8 @@ func (s *Service) ValidateAttachStorage(
 	if charmStorageDef.MinimumSize != 0 &&
 		storageSize < charmStorageDef.MinimumSize {
 		return errors.Errorf(
-			"storage directive size %d is less than the charm minimum requirement of %d",
-			storageSize, charmStorageDef.MinimumSize,
+			"storage instance size %d for charm storage %s does not meet minimum requirements of %d",
+			storageSize, charmStorageDef.Name, charmStorageDef.MinimumSize,
 		)
 	}
 

--- a/domain/application/service/storage/directive.go
+++ b/domain/application/service/storage/directive.go
@@ -329,17 +329,6 @@ func (s *Service) ValidateAttachStorage(
 	storageSize uint64,
 	poolUUID domainstorage.StoragePoolUUID,
 ) error {
-	return validateAttachStorage(ctx, charmStorageDef, wantCount, storageSize, poolUUID, s.storagePoolProvider)
-}
-
-func validateAttachStorage(
-	ctx context.Context,
-	charmStorageDef internal.ValidateStorageArg,
-	wantCount uint32,
-	storageSize uint64,
-	poolUUID domainstorage.StoragePoolUUID,
-	poolProvider StoragePoolProvider,
-) error {
 	var (
 		// hasMaxCount is true when the charm storage definition has
 		// indicated that there is a maximum value it will tolerate. When
@@ -371,7 +360,7 @@ func validateAttachStorage(
 	}
 
 	charmStorageType := charm.StorageType(charmStorageDef.Type)
-	supports, err := poolProvider.CheckPoolSupportsCharmStorage(
+	supports, err := s.storagePoolProvider.CheckPoolSupportsCharmStorage(
 		ctx, poolUUID, charmStorageType,
 	)
 	if err != nil {

--- a/domain/application/service/storage/directive.go
+++ b/domain/application/service/storage/directive.go
@@ -213,7 +213,7 @@ func MakeStorageDirectiveFromApplicationArg(
 // falls outside of the bounds defined by the charm.
 func (s *Service) ValidateApplicationStorageDirectiveOverrides(
 	ctx context.Context,
-	charmStorageDefs map[string]internalcharm.Storage,
+	charmStorageDefs map[string]internal.ValidateStorageArg,
 	overrides map[string]StorageDirectiveOverride,
 ) error {
 	for name, override := range overrides {
@@ -244,7 +244,7 @@ func (s *Service) ValidateApplicationStorageDirectiveOverrides(
 // falls outside of the bounds defined by the charm.
 func validateApplicationStorageDirectiveOverride(
 	ctx context.Context,
-	charmStorageDef internalcharm.Storage,
+	charmStorageDef internal.ValidateStorageArg,
 	override StorageDirectiveOverride,
 	poolProvider StoragePoolProvider,
 ) error {
@@ -314,6 +314,78 @@ func validateApplicationStorageDirectiveOverride(
 				*override.PoolUUID, charmStorageDef.Type,
 			)
 		}
+	}
+
+	return nil
+}
+
+// ValidateAttachStorage checks that a storage instance from the specified
+// pool can be attached to a unit with respect to the unit's charm storage
+// definition.
+func (s *Service) ValidateAttachStorage(
+	ctx context.Context,
+	charmStorageDef internal.ValidateStorageArg,
+	wantCount uint32,
+	storageSize uint64,
+	poolUUID domainstorage.StoragePoolUUID,
+) error {
+	return validateAttachStorage(ctx, charmStorageDef, wantCount, storageSize, poolUUID, s.storagePoolProvider)
+}
+
+func validateAttachStorage(
+	ctx context.Context,
+	charmStorageDef internal.ValidateStorageArg,
+	wantCount uint32,
+	storageSize uint64,
+	poolUUID domainstorage.StoragePoolUUID,
+	poolProvider StoragePoolProvider,
+) error {
+	var (
+		// hasMaxCount is true when the charm storage definition has
+		// indicated that there is a maximum value it will tolerate. When
+		// the charm specifies -1 the charm has no opinion what the maximum
+		// should be.
+		hasMaxCount bool
+		maxCount    uint32
+	)
+	if charmStorageDef.CountMax >= 0 {
+		maxCount = uint32(charmStorageDef.CountMax)
+		hasMaxCount = true
+	}
+
+	if hasMaxCount && wantCount > maxCount {
+		return applicationerrors.StorageCountLimitExceeded{
+			Maximum:     &charmStorageDef.CountMax,
+			Minimum:     charmStorageDef.CountMin,
+			Requested:   int(wantCount),
+			StorageName: charmStorageDef.Name,
+		}
+	}
+
+	if charmStorageDef.MinimumSize != 0 &&
+		storageSize < charmStorageDef.MinimumSize {
+		return errors.Errorf(
+			"storage directive size %d is less than the charm minimum requirement of %d",
+			storageSize, charmStorageDef.MinimumSize,
+		)
+	}
+
+	charmStorageType := charm.StorageType(charmStorageDef.Type)
+	supports, err := poolProvider.CheckPoolSupportsCharmStorage(
+		ctx, poolUUID, charmStorageType,
+	)
+	if err != nil {
+		return errors.Errorf(
+			"checking storage directive pool %q supports charm storage %q",
+			poolUUID, charmStorageDef.Type,
+		)
+	}
+
+	if !supports {
+		return errors.Errorf(
+			"storage directive pool %q does not support charm storage %q",
+			poolUUID, charmStorageDef.Type,
+		)
 	}
 
 	return nil

--- a/domain/application/service/storage/directive_test.go
+++ b/domain/application/service/storage/directive_test.go
@@ -355,11 +355,10 @@ func (s *directiveSuite) TestValidateAttachStorageExceedMax(c *tc.C) {
 		MinimumSize: 1024,
 		Type:        internalcharm.StorageBlock,
 	}
-	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 
 	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
 	err := svc.ValidateAttachStorage(
-		c.Context(), charmStorageDef, 3, 1024, poolUUID,
+		charmStorageDef, 3, 1024,
 	)
 
 	errVal, is := errors.AsType[applicationerrors.StorageCountLimitExceeded](err)
@@ -367,7 +366,7 @@ func (s *directiveSuite) TestValidateAttachStorageExceedMax(c *tc.C) {
 	c.Check(errVal, tc.DeepEquals, applicationerrors.StorageCountLimitExceeded{
 		Maximum:     ptr(2),
 		Minimum:     0,
-		Requested:   3,
+		Requested:   4,
 		StorageName: "st1",
 	})
 }

--- a/domain/application/service/storage/directive_test.go
+++ b/domain/application/service/storage/directive_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/juju/tc"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	coreapplication "github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
@@ -194,11 +194,10 @@ func (s *directiveSuite) TestMakeApplicationStorageDirectiveArgs(c *tc.C) {
 func (s *directiveSuite) TestValidateApplicationStorageDirectiveOverridesNoMaxLimit(c *tc.C) {
 	defer s.setupMocks(c.T).Finish()
 
-	charmStorageDefs := map[string]internalcharm.Storage{
+	charmStorageDefs := map[string]internal.ValidateStorageArg{
 		"st1": {
 			CountMin:    0,
 			CountMax:    -1, // -1 indicates no max limit
-			Description: "",
 			Name:        "st1",
 			MinimumSize: 1024,
 			Type:        internalcharm.StorageBlock,
@@ -252,11 +251,10 @@ func (s *directiveSuite) TestGetApplicationStorageDirectivesInfo(c *tc.C) {
 func (s *directiveSuite) TestValidateApplicationStorageDirectiveOverridesExceedMax(c *tc.C) {
 	defer s.setupMocks(c.T).Finish()
 
-	charmStorageDefs := map[string]internalcharm.Storage{
+	charmStorageDefs := map[string]internal.ValidateStorageArg{
 		"st1": {
 			CountMin:    0,
 			CountMax:    2,
-			Description: "",
 			Name:        "st1",
 			MinimumSize: 1024,
 			Type:        internalcharm.StorageBlock,
@@ -345,6 +343,33 @@ func (s *directiveSuite) TestMakeStorageDirectiveFromApplicationArg(c *tc.C) {
 		"kratos", charmStorage, createArgs,
 	)
 	c.Assert(gotDirectives, tc.SameContents, expected)
+}
+
+func (s *directiveSuite) TestValidateAttachStorageExceedMax(c *tc.C) {
+	defer s.setupMocks(c.T).Finish()
+
+	charmStorageDef := internal.ValidateStorageArg{
+		CountMin:    0,
+		CountMax:    2,
+		Name:        "st1",
+		MinimumSize: 1024,
+		Type:        internalcharm.StorageBlock,
+	}
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
+	err := svc.ValidateAttachStorage(
+		c.Context(), charmStorageDef, 3, 1024, poolUUID,
+	)
+
+	errVal, is := errors.AsType[applicationerrors.StorageCountLimitExceeded](err)
+	c.Check(is, tc.IsTrue)
+	c.Check(errVal, tc.DeepEquals, applicationerrors.StorageCountLimitExceeded{
+		Maximum:     ptr(2),
+		Minimum:     0,
+		Requested:   3,
+		StorageName: "st1",
+	})
 }
 
 // TestReconcileStorageDirectiveAgainstCharmStorageNoChanges tests that when existing

--- a/domain/application/service/storage/registercaas_test.go
+++ b/domain/application/service/storage/registercaas_test.go
@@ -131,7 +131,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitStorageArg(c *tc.C
 		},
 	}
 
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.AttachStorageToUnitArg{
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: arg.StorageInstances[0].Filesystem.UUID,
@@ -148,10 +148,10 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitStorageArg(c *tc.C
 
 	c.Check(arg, registerUnitStorageArgChecker(), internal.RegisterUnitStorageArg{
 		CreateUnitStorageArg: internal.CreateUnitStorageArg{
-			StorageDirectives: expectedStorageDirectives,
-			StorageInstances:  expectedStorageInstances,
-			StorageToAttach:   expectedStorageToAttach,
-			StorageToOwn:      expectedStorageToOwn,
+			StorageDirectives:  expectedStorageDirectives,
+			StorageInstances:   expectedStorageInstances,
+			NewStorageToAttach: expectedStorageToAttach,
+			StorageToOwn:       expectedStorageToOwn,
 		},
 		FilesystemProviderIDs: map[domainstorage.FilesystemUUID]string{
 			arg.StorageInstances[0].Filesystem.UUID: "fs-1",
@@ -273,7 +273,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArg(c 
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.AttachStorageToUnitArg{
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[0].Filesystem.UUID,
@@ -296,10 +296,10 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArg(c 
 
 	c.Check(arg, registerUnitStorageArgChecker(), internal.RegisterUnitStorageArg{
 		CreateUnitStorageArg: internal.CreateUnitStorageArg{
-			StorageDirectives: expectedStorageDirectives,
-			StorageInstances:  expectedStorageInstances,
-			StorageToAttach:   expectedStorageToAttach,
-			StorageToOwn:      expectedStorageToOwn,
+			StorageDirectives:  expectedStorageDirectives,
+			StorageInstances:   expectedStorageInstances,
+			NewStorageToAttach: expectedStorageToAttach,
+			StorageToOwn:       expectedStorageToOwn,
 		},
 	})
 }
@@ -423,7 +423,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArgeEx
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.AttachStorageToUnitArg{
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[0].Filesystem.UUID,
@@ -448,10 +448,10 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArgeEx
 
 	c.Check(arg, registerUnitStorageArgChecker(), internal.RegisterUnitStorageArg{
 		CreateUnitStorageArg: internal.CreateUnitStorageArg{
-			StorageDirectives: expectedStorageDirectives,
-			StorageInstances:  expectedStorageInstances,
-			StorageToAttach:   expectedStorageToAttach,
-			StorageToOwn:      expectedStorageToOwn,
+			StorageDirectives:  expectedStorageDirectives,
+			StorageInstances:   expectedStorageInstances,
+			NewStorageToAttach: expectedStorageToAttach,
+			StorageToOwn:       expectedStorageToOwn,
 		},
 	})
 }
@@ -570,7 +570,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitWithExistingStorag
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.AttachStorageToUnitArg{
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingProviderStorage[0].Filesystem.UUID,
@@ -596,10 +596,10 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitWithExistingStorag
 
 	c.Check(arg, registerUnitStorageArgChecker(), internal.RegisterUnitStorageArg{
 		CreateUnitStorageArg: internal.CreateUnitStorageArg{
-			StorageDirectives: expectedStorageDirectives,
-			StorageInstances:  expectedStorageInstances,
-			StorageToAttach:   expectedStorageToAttach,
-			StorageToOwn:      expectedStorageToOwn,
+			StorageDirectives:  expectedStorageDirectives,
+			StorageInstances:   expectedStorageInstances,
+			NewStorageToAttach: expectedStorageToAttach,
+			StorageToOwn:       expectedStorageToOwn,
 		},
 	})
 }

--- a/domain/application/service/storage/registercaas_test.go
+++ b/domain/application/service/storage/registercaas_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
-	caas "github.com/juju/juju/caas"
+	"github.com/juju/juju/caas"
 	coreapplication "github.com/juju/juju/core/application"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"

--- a/domain/application/service/storage/registercaas_test.go
+++ b/domain/application/service/storage/registercaas_test.go
@@ -121,7 +121,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitStorageArg(c *tc.C
 	expectedStorageInstances := []internal.CreateUnitStorageInstanceArg{
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -133,7 +133,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitStorageArg(c *tc.C
 
 	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: arg.StorageInstances[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -275,7 +275,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArg(c 
 	// is to make sure the storage is attached.
 	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -283,7 +283,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArg(c 
 			StorageInstanceUUID: unitOwnedStorage[0].UUID,
 		},
 		{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[1].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -425,7 +425,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArgeEx
 	// is to make sure the storage is attached.
 	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -433,7 +433,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArgeEx
 			StorageInstanceUUID: unitOwnedStorage[0].UUID,
 		},
 		{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingProviderStorage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -572,7 +572,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitWithExistingStorag
 	// is to make sure the storage is attached.
 	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingProviderStorage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -580,7 +580,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitWithExistingStorag
 			StorageInstanceUUID: existingProviderStorage[0].UUID,
 		},
 		{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingProviderStorage[1].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -673,13 +673,13 @@ func (*registerCAASStorageSuite) TestMakeCAASStorageInstanceProviderIDAssociatio
 	fs2UUID := tc.Must(c, domainstorage.NewFilesystemUUID)
 	unitStorageToCreate := []internal.CreateUnitStorageInstanceArg{
 		{
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				UUID: fs1UUID,
 			},
 			Name: "st1",
 		},
 		{
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				UUID: fs2UUID,
 			},
 			Name: "st2",

--- a/domain/application/service/storage/registercaas_test.go
+++ b/domain/application/service/storage/registercaas_test.go
@@ -131,7 +131,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitStorageArg(c *tc.C
 		},
 	}
 
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: arg.StorageInstances[0].Filesystem.UUID,
@@ -273,7 +273,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArg(c 
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[0].Filesystem.UUID,
@@ -423,7 +423,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArgeEx
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[0].Filesystem.UUID,
@@ -570,7 +570,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitWithExistingStorag
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingProviderStorage[0].Filesystem.UUID,

--- a/domain/application/service/storage/registercaas_test.go
+++ b/domain/application/service/storage/registercaas_test.go
@@ -121,7 +121,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitStorageArg(c *tc.C
 	expectedStorageInstances := []internal.CreateUnitStorageInstanceArg{
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -131,9 +131,9 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitStorageArg(c *tc.C
 		},
 	}
 
-	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
 		{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: arg.StorageInstances[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -273,9 +273,9 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArg(c 
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
 		{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -283,7 +283,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArg(c 
 			StorageInstanceUUID: unitOwnedStorage[0].UUID,
 		},
 		{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[1].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -423,9 +423,9 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArgeEx
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
 		{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: unitOwnedStorage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -433,7 +433,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterExistingCAASUnitStorageArgeEx
 			StorageInstanceUUID: unitOwnedStorage[0].UUID,
 		},
 		{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingProviderStorage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -570,9 +570,9 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitWithExistingStorag
 
 	// We expect to see the existing storage come back in the attachments. This
 	// is to make sure the storage is attached.
-	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
 		{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingProviderStorage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -580,7 +580,7 @@ func (s *registerCAASStorageSuite) TestMakeRegisterNewCAASUnitWithExistingStorag
 			StorageInstanceUUID: existingProviderStorage[0].UUID,
 		},
 		{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingProviderStorage[1].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -673,13 +673,13 @@ func (*registerCAASStorageSuite) TestMakeCAASStorageInstanceProviderIDAssociatio
 	fs2UUID := tc.Must(c, domainstorage.NewFilesystemUUID)
 	unitStorageToCreate := []internal.CreateUnitStorageInstanceArg{
 		{
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID: fs1UUID,
 			},
 			Name: "st1",
 		},
 		{
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID: fs2UUID,
 			},
 			Name: "st2",

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -583,7 +583,7 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 			)
 		}
 
-		rval.FilesystemAttachment = &internal.CreateUnitStorageFilesystemAttachmentArg{
+		rval.FilesystemAttachment = &internal.UnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: storageInstance.Filesystem.UUID,
 			NetNodeUUID:    netNodeUUID,
 			ProvisionScope: storageInstance.Filesystem.ProvisionScope,
@@ -599,7 +599,7 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 			)
 		}
 
-		rval.VolumeAttachment = &internal.CreateUnitStorageVolumeAttachmentArg{
+		rval.VolumeAttachment = &internal.UnitStorageVolumeAttachmentArg{
 			VolumeUUID:     storageInstance.Volume.UUID,
 			NetNodeUUID:    netNodeUUID,
 			ProvisionScope: storageInstance.Volume.ProvisionScope,
@@ -640,7 +640,7 @@ func makeStorageAttachmentArgFromNewStorageInstance(
 			)
 		}
 
-		rval.FilesystemAttachment = &internal.CreateUnitStorageFilesystemAttachmentArg{
+		rval.FilesystemAttachment = &internal.UnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: storageInstance.Filesystem.UUID,
 			NetNodeUUID:    netNodeUUID,
 			ProvisionScope: storageInstance.Filesystem.ProvisionScope,
@@ -656,7 +656,7 @@ func makeStorageAttachmentArgFromNewStorageInstance(
 			)
 		}
 
-		rval.VolumeAttachment = &internal.CreateUnitStorageVolumeAttachmentArg{
+		rval.VolumeAttachment = &internal.UnitStorageVolumeAttachmentArg{
 			VolumeUUID:     storageInstance.Volume.UUID,
 			NetNodeUUID:    netNodeUUID,
 			ProvisionScope: storageInstance.Volume.ProvisionScope,
@@ -996,7 +996,7 @@ func makeUnitStorageInstancesFromDirective(
 				)
 			}
 
-			instArg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
+			instArg.Filesystem = &internal.UnitStorageFilesystemArg{
 				UUID:           u,
 				ProvisionScope: composition.FilesystemProvisionScope,
 			}
@@ -1010,7 +1010,7 @@ func makeUnitStorageInstancesFromDirective(
 				)
 			}
 
-			instArg.Volume = &internal.CreateUnitStorageVolumeArg{
+			instArg.Volume = &internal.UnitStorageVolumeArg{
 				UUID:           u,
 				ProvisionScope: composition.VolumeProvisionScope,
 			}
@@ -1053,13 +1053,13 @@ func (s Service) MakeUnitAttachStorageArgs(
 			UUID: storageInstanceUUID,
 		}
 		if inst.Filesystem != nil {
-			instArg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
+			instArg.Filesystem = &internal.UnitStorageFilesystemArg{
 				UUID:           inst.Filesystem.UUID,
 				ProvisionScope: inst.Filesystem.ProvisionScope,
 			}
 		}
 		if inst.Volume != nil {
-			instArg.Volume = &internal.CreateUnitStorageVolumeArg{
+			instArg.Volume = &internal.UnitStorageVolumeArg{
 				UUID:           inst.Volume.UUID,
 				ProvisionScope: inst.Volume.ProvisionScope,
 			}

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -610,13 +610,13 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 	return rval, nil
 }
 
-// makeStorageAttachmentArgFromNewStorageInstance is responsible for taking the
-// arguments to create a new storage instance in the model and generating a
-// corresponding storage attachment creation argument.
+// makeStorageAttachmentArgFromStorageInstance is responsible generating a
+// storage attachment creation argument for either a new or existing
+// storage instance.
 //
 // The attachment of filesystem and volume will be done on to the supplied net
 // node and follow the information set on the storage instance.
-func makeStorageAttachmentArgFromNewStorageInstance(
+func makeStorageAttachmentArgFromStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
 	storageInstance internal.AttachStorageInstanceArg,
 ) (internal.CreateUnitStorageAttachmentArg, error) {
@@ -756,7 +756,7 @@ func (s Service) MakeUnitStorageArgs(
 		rvalInstances = slices.Grow(rvalInstances, len(instArgs))
 		rvalToOwn = slices.Grow(rvalToOwn, len(instArgs))
 		for _, inst := range instArgs {
-			storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
+			storageAttachArg, err := makeStorageAttachmentArgFromStorageInstance(
 				attachNetNodeUUID, internal.AttachStorageInstanceArg{
 					Filesystem: inst.Filesystem,
 					Volume:     inst.Volume,
@@ -903,7 +903,7 @@ func (s Service) MakeUnitAddStorageArgs(
 	rvalInstances = slices.Grow(rvalInstances, len(instArgs))
 	rvalToOwn = slices.Grow(rvalToOwn, len(instArgs))
 	for _, inst := range instArgs {
-		storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
+		storageAttachArg, err := makeStorageAttachmentArgFromStorageInstance(
 			domainnetwork.NetNodeUUID(attachNetNodeUUID), internal.AttachStorageInstanceArg{
 				Filesystem: inst.Filesystem,
 				Volume:     inst.Volume,
@@ -1054,7 +1054,7 @@ func (s Service) MakeUnitAttachStorageArgs(
 			ProvisionScope: instComposition.Volume.ProvisionScope,
 		}
 	}
-	storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
+	storageAttachArg, err := makeStorageAttachmentArgFromStorageInstance(
 		domainnetwork.NetNodeUUID(attachNetNodeUUID), instArg,
 	)
 	if err != nil {

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -155,7 +155,7 @@ type State interface {
 	GetStorageInstanceCompositionByUUID(
 		ctx context.Context,
 		storageInstanceUUID domainstorage.StorageInstanceUUID,
-	) ([]internal.StorageInstanceComposition, error)
+	) (internal.StorageInstanceComposition, error)
 }
 
 // NewService returns a new application storage service for the model.
@@ -1028,52 +1028,44 @@ func (s Service) MakeUnitAttachStorageArgs(
 	ctx context.Context,
 	unitUUID coreunit.UUID,
 	storageInstanceUUID domainstorage.StorageInstanceUUID,
-) ([]internal.CreateUnitStorageAttachmentArg, error) {
+) (internal.CreateUnitStorageAttachmentArg, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, 1)
-
 	instComposition, err := s.st.GetStorageInstanceCompositionByUUID(ctx, storageInstanceUUID)
 	if err != nil {
-		return nil, errors.Errorf(
+		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
 			"getting composition details for storage %q: %w", storageInstanceUUID, err,
 		)
 	}
 
 	attachNetNodeUUID, err := s.st.GetUnitNetNodeUUID(ctx, unitUUID)
 	if err != nil {
-		return nil, errors.Errorf("getting unit net node uuid: %w", err)
+		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf("getting unit net node uuid: %w", err)
 	}
 
-	// Allocate capacity we know we are going to need.
-	rvalToAttach = slices.Grow(rvalToAttach, len(instComposition))
-	for _, inst := range instComposition {
-		instArg := internal.UnitStorageInstanceArg{
-			UUID: storageInstanceUUID,
+	instArg := internal.UnitStorageInstanceArg{
+		UUID: storageInstanceUUID,
+	}
+	if instComposition.Filesystem != nil {
+		instArg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
+			UUID:           instComposition.Filesystem.UUID,
+			ProvisionScope: instComposition.Filesystem.ProvisionScope,
 		}
-		if inst.Filesystem != nil {
-			instArg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
-				UUID:           inst.Filesystem.UUID,
-				ProvisionScope: inst.Filesystem.ProvisionScope,
-			}
+	}
+	if instComposition.Volume != nil {
+		instArg.Volume = &internal.CreateUnitStorageVolumeArg{
+			UUID:           instComposition.Volume.UUID,
+			ProvisionScope: instComposition.Volume.ProvisionScope,
 		}
-		if inst.Volume != nil {
-			instArg.Volume = &internal.CreateUnitStorageVolumeArg{
-				UUID:           inst.Volume.UUID,
-				ProvisionScope: inst.Volume.ProvisionScope,
-			}
-		}
-		storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
-			domainnetwork.NetNodeUUID(attachNetNodeUUID), instArg,
+	}
+	storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
+		domainnetwork.NetNodeUUID(attachNetNodeUUID), instArg,
+	)
+	if err != nil {
+		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			"making storage attachment arguments for new storage instance: %w", err,
 		)
-		if err != nil {
-			return nil, errors.Errorf(
-				"making storage attachment arguments for new storage instance: %w", err,
-			)
-		}
-		rvalToAttach = append(rvalToAttach, storageAttachArg)
 	}
-
-	return rvalToAttach, nil
+	return storageAttachArg, nil
 }

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -810,12 +810,12 @@ func (s Service) MakeUnitStorageArgs(
 	}, nil
 }
 
-// MakeIAASUnitStorageArgs returns [internal.IAASUnitStorageArg] that
+// MakeIAASUnitStorageArgs returns [internal.CreateIAASUnitStorageArg] that
 // complement the unit storage arguments provided for IAAS units.
 func (s Service) MakeIAASUnitStorageArgs(
 	storageInst []internal.UnitStorageInstanceArg,
-) (internal.IAASUnitStorageArg, error) {
-	var arg internal.IAASUnitStorageArg
+) (internal.CreateIAASUnitStorageArg, error) {
+	var arg internal.CreateIAASUnitStorageArg
 	for _, v := range storageInst {
 		// TODO(storage): refactor this to use the storage instance composition
 		// calculated from the storageprovisioning domain.
@@ -831,7 +831,7 @@ func (s Service) MakeIAASUnitStorageArgs(
 		s, err := domainstorageprov.CalculateStorageInstanceOwnershipScope(
 			comp)
 		if err != nil {
-			return internal.IAASUnitStorageArg{}, errors.Errorf(
+			return internal.CreateIAASUnitStorageArg{}, errors.Errorf(
 				"calculating storage ownership for storage instance %q: %w",
 				v.UUID, err,
 			)
@@ -864,7 +864,7 @@ func (s Service) MakeUnitAddStorageArgs(
 	unitUUID coreunit.UUID,
 	addCount uint32,
 	sd application.StorageDirective,
-) (internal.UnitAddStorageArg, error) {
+) (internal.AddStorageToUnitArg, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -888,14 +888,14 @@ func (s Service) MakeUnitAddStorageArgs(
 		sd,
 	)
 	if err != nil {
-		return internal.UnitAddStorageArg{}, errors.Errorf(
+		return internal.AddStorageToUnitArg{}, errors.Errorf(
 			"making new storage %q instance args: %w", sd.Name, err,
 		)
 	}
 
 	attachNetNodeUUID, err := s.st.GetUnitNetNodeUUID(ctx, unitUUID)
 	if err != nil {
-		return internal.UnitAddStorageArg{}, errors.Errorf("getting unit net node uuid: %w", err)
+		return internal.AddStorageToUnitArg{}, errors.Errorf("getting unit net node uuid: %w", err)
 	}
 
 	// Allocate capacity we know we are going to need.
@@ -912,7 +912,7 @@ func (s Service) MakeUnitAddStorageArgs(
 		)
 
 		if err != nil {
-			return internal.UnitAddStorageArg{}, errors.Errorf(
+			return internal.AddStorageToUnitArg{}, errors.Errorf(
 				"making storage attachment arguments for new storage instance: %w", err,
 			)
 		}
@@ -922,7 +922,7 @@ func (s Service) MakeUnitAddStorageArgs(
 		rvalInstances = append(rvalInstances, inst)
 	}
 
-	return internal.UnitAddStorageArg{
+	return internal.AddStorageToUnitArg{
 		StorageInstances: rvalInstances,
 		StorageToAttach:  rvalToAttach,
 		StorageToOwn:     rvalToOwn,
@@ -1028,7 +1028,7 @@ func (s Service) MakeUnitAttachStorageArgs(
 	ctx context.Context,
 	unitUUID coreunit.UUID,
 	storageInstanceUUID domainstorage.StorageInstanceUUID,
-) (internal.UnitAttachStorageArg, error) {
+) ([]internal.CreateUnitStorageAttachmentArg, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1036,14 +1036,14 @@ func (s Service) MakeUnitAttachStorageArgs(
 
 	instComposition, err := s.st.GetStorageInstanceCompositionByUUID(ctx, storageInstanceUUID)
 	if err != nil {
-		return internal.UnitAttachStorageArg{}, errors.Errorf(
+		return nil, errors.Errorf(
 			"getting composition details for storage %q: %w", storageInstanceUUID, err,
 		)
 	}
 
 	attachNetNodeUUID, err := s.st.GetUnitNetNodeUUID(ctx, unitUUID)
 	if err != nil {
-		return internal.UnitAttachStorageArg{}, errors.Errorf("getting unit net node uuid: %w", err)
+		return nil, errors.Errorf("getting unit net node uuid: %w", err)
 	}
 
 	// Allocate capacity we know we are going to need.
@@ -1068,14 +1068,12 @@ func (s Service) MakeUnitAttachStorageArgs(
 			domainnetwork.NetNodeUUID(attachNetNodeUUID), instArg,
 		)
 		if err != nil {
-			return internal.UnitAttachStorageArg{}, errors.Errorf(
+			return nil, errors.Errorf(
 				"making storage attachment arguments for new storage instance: %w", err,
 			)
 		}
 		rvalToAttach = append(rvalToAttach, storageAttachArg)
 	}
 
-	return internal.UnitAttachStorageArg{
-		StorageToAttach: rvalToAttach,
-	}, nil
+	return rvalToAttach, nil
 }

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -1026,7 +1026,7 @@ func makeUnitStorageInstancesFromDirective(
 // attach existing storage to a unit.
 func (s Service) MakeUnitAttachStorageArgs(
 	ctx context.Context,
-	unitUUID coreunit.UUID,
+	attachNetNodeUUID string,
 	storageInstanceUUID domainstorage.StorageInstanceUUID,
 ) (internal.CreateUnitStorageAttachmentArg, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
@@ -1037,11 +1037,6 @@ func (s Service) MakeUnitAttachStorageArgs(
 		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
 			"getting composition details for storage %q: %w", storageInstanceUUID, err,
 		)
-	}
-
-	attachNetNodeUUID, err := s.st.GetUnitNetNodeUUID(ctx, unitUUID)
-	if err != nil {
-		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf("getting unit net node uuid: %w", err)
 	}
 
 	instArg := internal.AttachStorageInstanceArg{

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -319,7 +319,7 @@ func (s Service) makeRegisterCAASUnitStorageArg(
 	for _, storageInstance := range existingProviderStorage {
 		attachmentIndex := slices.IndexFunc(
 			unitStorageArgs.StorageToAttach,
-			func(e internal.UnitStorageAttachmentArg) bool {
+			func(e internal.CreateUnitStorageAttachmentArg) bool {
 				return e.StorageInstanceUUID == storageInstance.UUID
 			},
 		)
@@ -404,7 +404,7 @@ func makeCAASStorageInstanceProviderIDAssociations(
 	existingUnitOwnedStorage []internal.StorageInstanceComposition,
 	existingUnitAttachments []internal.StorageAttachmentComposition,
 	unitStorageToCreate []internal.CreateUnitStorageInstanceArg,
-	unitStorageToAttach []internal.UnitStorageAttachmentArg,
+	unitStorageToAttach []internal.CreateUnitStorageAttachmentArg,
 ) (
 	map[domainstorage.FilesystemUUID]string,
 	map[domainstorage.VolumeUUID]string,
@@ -562,15 +562,15 @@ volumeAttachmentLoop:
 func makeStorageAttachmentArgFromExistingStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
 	storageInstance internal.StorageInstanceComposition,
-) (internal.UnitStorageAttachmentArg, error) {
+) (internal.CreateUnitStorageAttachmentArg, error) {
 	uuid, err := domainstorage.NewStorageAttachmentUUID()
 	if err != nil {
-		return internal.UnitStorageAttachmentArg{}, errors.Errorf(
+		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
 			"generating new storage attachment uuid: %w", err,
 		)
 	}
 
-	rval := internal.UnitStorageAttachmentArg{
+	rval := internal.CreateUnitStorageAttachmentArg{
 		StorageInstanceUUID: storageInstance.UUID,
 		UUID:                uuid,
 	}
@@ -578,12 +578,12 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 	if storageInstance.Filesystem != nil {
 		uuid, err := domainstorage.NewFilesystemAttachmentUUID()
 		if err != nil {
-			return internal.UnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
 				"generating new filesystem attachment uuid: %w", err,
 			)
 		}
 
-		rval.FilesystemAttachment = &internal.UnitStorageFilesystemAttachmentArg{
+		rval.FilesystemAttachment = &internal.CreateUnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: storageInstance.Filesystem.UUID,
 			NetNodeUUID:    netNodeUUID,
 			ProvisionScope: storageInstance.Filesystem.ProvisionScope,
@@ -594,12 +594,12 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 	if storageInstance.Volume != nil {
 		uuid, err := domainstorage.NewVolumeAttachmentUUID()
 		if err != nil {
-			return internal.UnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
 				"generating new volume attachment uuid: %w", err,
 			)
 		}
 
-		rval.VolumeAttachment = &internal.UnitStorageVolumeAttachmentArg{
+		rval.VolumeAttachment = &internal.CreateUnitStorageVolumeAttachmentArg{
 			VolumeUUID:     storageInstance.Volume.UUID,
 			NetNodeUUID:    netNodeUUID,
 			ProvisionScope: storageInstance.Volume.ProvisionScope,
@@ -619,15 +619,15 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 func makeStorageAttachmentArgFromNewStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
 	storageInstance internal.UnitStorageInstanceArg,
-) (internal.UnitStorageAttachmentArg, error) {
+) (internal.CreateUnitStorageAttachmentArg, error) {
 	uuid, err := domainstorage.NewStorageAttachmentUUID()
 	if err != nil {
-		return internal.UnitStorageAttachmentArg{}, errors.Errorf(
+		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
 			"generating new storage attachment uuid: %w", err,
 		)
 	}
 
-	rval := internal.UnitStorageAttachmentArg{
+	rval := internal.CreateUnitStorageAttachmentArg{
 		StorageInstanceUUID: storageInstance.UUID,
 		UUID:                uuid,
 	}
@@ -635,12 +635,12 @@ func makeStorageAttachmentArgFromNewStorageInstance(
 	if storageInstance.Filesystem != nil {
 		uuid, err := domainstorage.NewFilesystemAttachmentUUID()
 		if err != nil {
-			return internal.UnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
 				"generating new filesystem attachment uuid: %w", err,
 			)
 		}
 
-		rval.FilesystemAttachment = &internal.UnitStorageFilesystemAttachmentArg{
+		rval.FilesystemAttachment = &internal.CreateUnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: storageInstance.Filesystem.UUID,
 			NetNodeUUID:    netNodeUUID,
 			ProvisionScope: storageInstance.Filesystem.ProvisionScope,
@@ -651,12 +651,12 @@ func makeStorageAttachmentArgFromNewStorageInstance(
 	if storageInstance.Volume != nil {
 		uuid, err := domainstorage.NewVolumeAttachmentUUID()
 		if err != nil {
-			return internal.UnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
 				"generating new volume attachment uuid: %w", err,
 			)
 		}
 
-		rval.VolumeAttachment = &internal.UnitStorageVolumeAttachmentArg{
+		rval.VolumeAttachment = &internal.CreateUnitStorageVolumeAttachmentArg{
 			VolumeUUID:     storageInstance.Volume.UUID,
 			NetNodeUUID:    netNodeUUID,
 			ProvisionScope: storageInstance.Volume.ProvisionScope,
@@ -696,7 +696,7 @@ func (s Service) MakeUnitStorageArgs(
 
 	rvalDirectives := make([]internal.CreateUnitStorageDirectiveArg, 0, len(storageDirectives))
 	rvalInstances := []internal.CreateUnitStorageInstanceArg{}
-	rvalToAttach := make([]internal.UnitStorageAttachmentArg, 0, len(storageDirectives))
+	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(storageDirectives))
 	// rvalToOwn is the list of storage instance uuid's that the unit must own.
 	rvalToOwn := make([]domainstorage.StorageInstanceUUID, 0, len(storageDirectives))
 
@@ -869,7 +869,7 @@ func (s Service) MakeUnitAddStorageArgs(
 	defer span.End()
 
 	var rvalInstances []internal.CreateUnitStorageInstanceArg
-	rvalToAttach := make([]internal.UnitStorageAttachmentArg, 0, 1)
+	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, 1)
 	// rvalToOwn is the list of storage instance UUIDs that the unit must own.
 	rvalToOwn := make([]domainstorage.StorageInstanceUUID, 0, 1)
 
@@ -996,7 +996,7 @@ func makeUnitStorageInstancesFromDirective(
 				)
 			}
 
-			instArg.Filesystem = &internal.UnitStorageFilesystemArg{
+			instArg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
 				UUID:           u,
 				ProvisionScope: composition.FilesystemProvisionScope,
 			}
@@ -1010,7 +1010,7 @@ func makeUnitStorageInstancesFromDirective(
 				)
 			}
 
-			instArg.Volume = &internal.UnitStorageVolumeArg{
+			instArg.Volume = &internal.CreateUnitStorageVolumeArg{
 				UUID:           u,
 				ProvisionScope: composition.VolumeProvisionScope,
 			}
@@ -1032,7 +1032,7 @@ func (s Service) MakeUnitAttachStorageArgs(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	rvalToAttach := make([]internal.UnitStorageAttachmentArg, 0, 1)
+	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, 1)
 
 	instComposition, err := s.st.GetStorageInstanceCompositionByUUID(ctx, storageInstanceUUID)
 	if err != nil {
@@ -1053,13 +1053,13 @@ func (s Service) MakeUnitAttachStorageArgs(
 			UUID: storageInstanceUUID,
 		}
 		if inst.Filesystem != nil {
-			instArg.Filesystem = &internal.UnitStorageFilesystemArg{
+			instArg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
 				UUID:           inst.Filesystem.UUID,
 				ProvisionScope: inst.Filesystem.ProvisionScope,
 			}
 		}
 		if inst.Volume != nil {
-			instArg.Volume = &internal.UnitStorageVolumeArg{
+			instArg.Volume = &internal.CreateUnitStorageVolumeArg{
 				UUID:           inst.Volume.UUID,
 				ProvisionScope: inst.Volume.ProvisionScope,
 			}

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -618,7 +618,7 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 // node and follow the information set on the storage instance.
 func makeStorageAttachmentArgFromNewStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
-	storageInstance internal.UnitStorageInstanceArg,
+	storageInstance internal.AttachStorageInstanceArg,
 ) (internal.CreateUnitStorageAttachmentArg, error) {
 	uuid, err := domainstorage.NewStorageAttachmentUUID()
 	if err != nil {
@@ -757,7 +757,7 @@ func (s Service) MakeUnitStorageArgs(
 		rvalToOwn = slices.Grow(rvalToOwn, len(instArgs))
 		for _, inst := range instArgs {
 			storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
-				attachNetNodeUUID, internal.UnitStorageInstanceArg{
+				attachNetNodeUUID, internal.AttachStorageInstanceArg{
 					Filesystem: inst.Filesystem,
 					Volume:     inst.Volume,
 					UUID:       inst.UUID,
@@ -813,7 +813,7 @@ func (s Service) MakeUnitStorageArgs(
 // MakeIAASUnitStorageArgs returns [internal.CreateIAASUnitStorageArg] that
 // complement the unit storage arguments provided for IAAS units.
 func (s Service) MakeIAASUnitStorageArgs(
-	storageInst []internal.UnitStorageInstanceArg,
+	storageInst []internal.AddStorageInstanceArg,
 ) (internal.CreateIAASUnitStorageArg, error) {
 	var arg internal.CreateIAASUnitStorageArg
 	for _, v := range storageInst {
@@ -904,7 +904,7 @@ func (s Service) MakeUnitAddStorageArgs(
 	rvalToOwn = slices.Grow(rvalToOwn, len(instArgs))
 	for _, inst := range instArgs {
 		storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
-			domainnetwork.NetNodeUUID(attachNetNodeUUID), internal.UnitStorageInstanceArg{
+			domainnetwork.NetNodeUUID(attachNetNodeUUID), internal.AttachStorageInstanceArg{
 				Filesystem: inst.Filesystem,
 				Volume:     inst.Volume,
 				UUID:       inst.UUID,
@@ -1044,7 +1044,7 @@ func (s Service) MakeUnitAttachStorageArgs(
 		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf("getting unit net node uuid: %w", err)
 	}
 
-	instArg := internal.UnitStorageInstanceArg{
+	instArg := internal.AttachStorageInstanceArg{
 		UUID: storageInstanceUUID,
 	}
 	if instComposition.Filesystem != nil {

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -48,19 +48,6 @@ type Service struct {
 // State describes retrieval and persistence methods for
 // storage related interactions.
 type State interface {
-	// AttachStorageToUnit attaches the specified storage to the specified unit.
-	// The following error types can be expected:
-	// - [github.com/juju/juju/domain/storage/errors.StorageNotFound] when the storage doesn't exist.
-	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the unit does not exist.
-	// - [github.com/juju/juju/domain/application/errors.StorageAlreadyAttached]: when the attachment already exists.
-	// - [github.com/juju/juju/domain/application/errors.FilesystemAlreadyAttached]: when the filesystem is already attached.
-	// - [github.com/juju/juju/domain/application/errors.VolumeAlreadyAttached]: when the volume is already attached.
-	// - [github.com/juju/juju/domain/application/errors.UnitNotAlive]: when the unit is not alive.
-	// - [github.com/juju/juju/domain/application/errors.StorageNotAlive]: when the storage is not alive.
-	// - [github.com/juju/juju/domain/application/errors.StorageNameNotSupported]: when storage name is not defined in charm metadata.
-	// - [github.com/juju/juju/domain/application/errors.InvalidStorageCount]: when the allowed attachment count would be violated.
-	AttachStorageToUnit(ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error
-
 	// DetachStorageForUnit detaches the specified storage from the specified unit.
 	// The following error types can be expected:
 	// - [github.com/juju/juju/domain/storage/errors.StorageNotFound] when the storage doesn't exist.
@@ -158,6 +145,17 @@ type State interface {
 	// The following error types can be expected:
 	// - [applicationerrors.UnitNotFound]: when the unit is not found.
 	GetUnitNetNodeUUID(ctx context.Context, uuid coreunit.UUID) (string, error)
+
+	// GetStorageInstanceCompositionByUUID returns the storage compositions for
+	// the specified storage instance.
+	//
+	// The following errors can be expected:
+	// - [github.com/juju/juju/domain/storage/errors.StorageInstanceNotFound]
+	// when the storage doesn't exist.
+	GetStorageInstanceCompositionByUUID(
+		ctx context.Context,
+		storageInstanceUUID domainstorage.StorageInstanceUUID,
+	) ([]internal.StorageInstanceComposition, error)
 }
 
 // NewService returns a new application storage service for the model.
@@ -620,7 +618,7 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 // node and follow the information set on the storage instance.
 func makeStorageAttachmentArgFromNewStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
-	storageInstance internal.CreateUnitStorageInstanceArg,
+	storageInstance internal.UnitStorageInstanceArg,
 ) (internal.CreateUnitStorageAttachmentArg, error) {
 	uuid, err := domainstorage.NewStorageAttachmentUUID()
 	if err != nil {
@@ -759,7 +757,11 @@ func (s Service) MakeUnitStorageArgs(
 		rvalToOwn = slices.Grow(rvalToOwn, len(instArgs))
 		for _, inst := range instArgs {
 			storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
-				attachNetNodeUUID, inst,
+				attachNetNodeUUID, internal.UnitStorageInstanceArg{
+					Filesystem: inst.Filesystem,
+					Volume:     inst.Volume,
+					UUID:       inst.UUID,
+				},
 			)
 
 			if err != nil {
@@ -811,8 +813,7 @@ func (s Service) MakeUnitStorageArgs(
 // MakeIAASUnitStorageArgs returns [internal.CreateIAASUnitStorageArg] that
 // complement the unit storage arguments provided for IAAS units.
 func (s Service) MakeIAASUnitStorageArgs(
-	ctx context.Context,
-	storageInst []internal.CreateUnitStorageInstanceArg,
+	storageInst []internal.UnitStorageInstanceArg,
 ) (internal.CreateIAASUnitStorageArg, error) {
 	var arg internal.CreateIAASUnitStorageArg
 	for _, v := range storageInst {
@@ -903,7 +904,11 @@ func (s Service) MakeUnitAddStorageArgs(
 	rvalToOwn = slices.Grow(rvalToOwn, len(instArgs))
 	for _, inst := range instArgs {
 		storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
-			domainnetwork.NetNodeUUID(attachNetNodeUUID), inst,
+			domainnetwork.NetNodeUUID(attachNetNodeUUID), internal.UnitStorageInstanceArg{
+				Filesystem: inst.Filesystem,
+				Volume:     inst.Volume,
+				UUID:       inst.UUID,
+			},
 		)
 
 		if err != nil {
@@ -1015,4 +1020,62 @@ func makeUnitStorageInstancesFromDirective(
 	}
 
 	return rval, nil
+}
+
+// MakeUnitAttachStorageArgs creates the storage arguments required to
+// attach existing storage to a unit.
+func (s Service) MakeUnitAttachStorageArgs(
+	ctx context.Context,
+	unitUUID coreunit.UUID,
+	storageInstanceUUID domainstorage.StorageInstanceUUID,
+) (internal.UnitAttachStorageArg, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, 1)
+
+	instComposition, err := s.st.GetStorageInstanceCompositionByUUID(ctx, storageInstanceUUID)
+	if err != nil {
+		return internal.UnitAttachStorageArg{}, errors.Errorf(
+			"getting composition details for storage %q: %w", storageInstanceUUID, err,
+		)
+	}
+
+	attachNetNodeUUID, err := s.st.GetUnitNetNodeUUID(ctx, unitUUID)
+	if err != nil {
+		return internal.UnitAttachStorageArg{}, errors.Errorf("getting unit net node uuid: %w", err)
+	}
+
+	// Allocate capacity we know we are going to need.
+	rvalToAttach = slices.Grow(rvalToAttach, len(instComposition))
+	for _, inst := range instComposition {
+		instArg := internal.UnitStorageInstanceArg{
+			UUID: storageInstanceUUID,
+		}
+		if inst.Filesystem != nil {
+			instArg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
+				UUID:           inst.Filesystem.UUID,
+				ProvisionScope: inst.Filesystem.ProvisionScope,
+			}
+		}
+		if inst.Volume != nil {
+			instArg.Volume = &internal.CreateUnitStorageVolumeArg{
+				UUID:           inst.Volume.UUID,
+				ProvisionScope: inst.Volume.ProvisionScope,
+			}
+		}
+		storageAttachArg, err := makeStorageAttachmentArgFromNewStorageInstance(
+			domainnetwork.NetNodeUUID(attachNetNodeUUID), instArg,
+		)
+		if err != nil {
+			return internal.UnitAttachStorageArg{}, errors.Errorf(
+				"making storage attachment arguments for new storage instance: %w", err,
+			)
+		}
+		rvalToAttach = append(rvalToAttach, storageAttachArg)
+	}
+
+	return internal.UnitAttachStorageArg{
+		StorageToAttach: rvalToAttach,
+	}, nil
 }

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -319,7 +319,7 @@ func (s Service) makeRegisterCAASUnitStorageArg(
 	for _, storageInstance := range existingProviderStorage {
 		attachmentIndex := slices.IndexFunc(
 			unitStorageArgs.StorageToAttach,
-			func(e internal.CreateUnitStorageAttachmentArg) bool {
+			func(e internal.UnitStorageAttachmentArg) bool {
 				return e.StorageInstanceUUID == storageInstance.UUID
 			},
 		)
@@ -404,7 +404,7 @@ func makeCAASStorageInstanceProviderIDAssociations(
 	existingUnitOwnedStorage []internal.StorageInstanceComposition,
 	existingUnitAttachments []internal.StorageAttachmentComposition,
 	unitStorageToCreate []internal.CreateUnitStorageInstanceArg,
-	unitStorageToAttach []internal.CreateUnitStorageAttachmentArg,
+	unitStorageToAttach []internal.UnitStorageAttachmentArg,
 ) (
 	map[domainstorage.FilesystemUUID]string,
 	map[domainstorage.VolumeUUID]string,
@@ -562,15 +562,15 @@ volumeAttachmentLoop:
 func makeStorageAttachmentArgFromExistingStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
 	storageInstance internal.StorageInstanceComposition,
-) (internal.CreateUnitStorageAttachmentArg, error) {
+) (internal.UnitStorageAttachmentArg, error) {
 	uuid, err := domainstorage.NewStorageAttachmentUUID()
 	if err != nil {
-		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+		return internal.UnitStorageAttachmentArg{}, errors.Errorf(
 			"generating new storage attachment uuid: %w", err,
 		)
 	}
 
-	rval := internal.CreateUnitStorageAttachmentArg{
+	rval := internal.UnitStorageAttachmentArg{
 		StorageInstanceUUID: storageInstance.UUID,
 		UUID:                uuid,
 	}
@@ -578,7 +578,7 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 	if storageInstance.Filesystem != nil {
 		uuid, err := domainstorage.NewFilesystemAttachmentUUID()
 		if err != nil {
-			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.UnitStorageAttachmentArg{}, errors.Errorf(
 				"generating new filesystem attachment uuid: %w", err,
 			)
 		}
@@ -594,7 +594,7 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 	if storageInstance.Volume != nil {
 		uuid, err := domainstorage.NewVolumeAttachmentUUID()
 		if err != nil {
-			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.UnitStorageAttachmentArg{}, errors.Errorf(
 				"generating new volume attachment uuid: %w", err,
 			)
 		}
@@ -619,15 +619,15 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 func makeStorageAttachmentArgFromNewStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
 	storageInstance internal.UnitStorageInstanceArg,
-) (internal.CreateUnitStorageAttachmentArg, error) {
+) (internal.UnitStorageAttachmentArg, error) {
 	uuid, err := domainstorage.NewStorageAttachmentUUID()
 	if err != nil {
-		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+		return internal.UnitStorageAttachmentArg{}, errors.Errorf(
 			"generating new storage attachment uuid: %w", err,
 		)
 	}
 
-	rval := internal.CreateUnitStorageAttachmentArg{
+	rval := internal.UnitStorageAttachmentArg{
 		StorageInstanceUUID: storageInstance.UUID,
 		UUID:                uuid,
 	}
@@ -635,7 +635,7 @@ func makeStorageAttachmentArgFromNewStorageInstance(
 	if storageInstance.Filesystem != nil {
 		uuid, err := domainstorage.NewFilesystemAttachmentUUID()
 		if err != nil {
-			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.UnitStorageAttachmentArg{}, errors.Errorf(
 				"generating new filesystem attachment uuid: %w", err,
 			)
 		}
@@ -651,7 +651,7 @@ func makeStorageAttachmentArgFromNewStorageInstance(
 	if storageInstance.Volume != nil {
 		uuid, err := domainstorage.NewVolumeAttachmentUUID()
 		if err != nil {
-			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.UnitStorageAttachmentArg{}, errors.Errorf(
 				"generating new volume attachment uuid: %w", err,
 			)
 		}
@@ -696,7 +696,7 @@ func (s Service) MakeUnitStorageArgs(
 
 	rvalDirectives := make([]internal.CreateUnitStorageDirectiveArg, 0, len(storageDirectives))
 	rvalInstances := []internal.CreateUnitStorageInstanceArg{}
-	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(storageDirectives))
+	rvalToAttach := make([]internal.UnitStorageAttachmentArg, 0, len(storageDirectives))
 	// rvalToOwn is the list of storage instance uuid's that the unit must own.
 	rvalToOwn := make([]domainstorage.StorageInstanceUUID, 0, len(storageDirectives))
 
@@ -810,12 +810,12 @@ func (s Service) MakeUnitStorageArgs(
 	}, nil
 }
 
-// MakeIAASUnitStorageArgs returns [internal.CreateIAASUnitStorageArg] that
+// MakeIAASUnitStorageArgs returns [internal.IAASUnitStorageArg] that
 // complement the unit storage arguments provided for IAAS units.
 func (s Service) MakeIAASUnitStorageArgs(
 	storageInst []internal.UnitStorageInstanceArg,
-) (internal.CreateIAASUnitStorageArg, error) {
-	var arg internal.CreateIAASUnitStorageArg
+) (internal.IAASUnitStorageArg, error) {
+	var arg internal.IAASUnitStorageArg
 	for _, v := range storageInst {
 		// TODO(storage): refactor this to use the storage instance composition
 		// calculated from the storageprovisioning domain.
@@ -831,7 +831,7 @@ func (s Service) MakeIAASUnitStorageArgs(
 		s, err := domainstorageprov.CalculateStorageInstanceOwnershipScope(
 			comp)
 		if err != nil {
-			return internal.CreateIAASUnitStorageArg{}, errors.Errorf(
+			return internal.IAASUnitStorageArg{}, errors.Errorf(
 				"calculating storage ownership for storage instance %q: %w",
 				v.UUID, err,
 			)
@@ -869,7 +869,7 @@ func (s Service) MakeUnitAddStorageArgs(
 	defer span.End()
 
 	var rvalInstances []internal.CreateUnitStorageInstanceArg
-	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, 1)
+	rvalToAttach := make([]internal.UnitStorageAttachmentArg, 0, 1)
 	// rvalToOwn is the list of storage instance UUIDs that the unit must own.
 	rvalToOwn := make([]domainstorage.StorageInstanceUUID, 0, 1)
 
@@ -1032,7 +1032,7 @@ func (s Service) MakeUnitAttachStorageArgs(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, 1)
+	rvalToAttach := make([]internal.UnitStorageAttachmentArg, 0, 1)
 
 	instComposition, err := s.st.GetStorageInstanceCompositionByUUID(ctx, storageInstanceUUID)
 	if err != nil {

--- a/domain/application/service/storage/service.go
+++ b/domain/application/service/storage/service.go
@@ -5,6 +5,8 @@ package storage
 
 import (
 	"context"
+	"maps"
+	"math"
 	"slices"
 
 	"github.com/juju/juju/caas"
@@ -318,8 +320,8 @@ func (s Service) makeRegisterCAASUnitStorageArg(
 	// attachment provider ID mapped if one exists.
 	for _, storageInstance := range existingProviderStorage {
 		attachmentIndex := slices.IndexFunc(
-			unitStorageArgs.StorageToAttach,
-			func(e internal.CreateUnitStorageAttachmentArg) bool {
+			unitStorageArgs.NewStorageToAttach,
+			func(e internal.AttachStorageToUnitArg) bool {
 				return e.StorageInstanceUUID == storageInstance.UUID
 			},
 		)
@@ -343,7 +345,7 @@ func (s Service) makeRegisterCAASUnitStorageArg(
 			existingUnitOwnedStorage,
 			existingUnitOwnedStorageAttachments,
 			unitStorageArgs.StorageInstances,
-			unitStorageArgs.StorageToAttach,
+			unitStorageArgs.NewStorageToAttach,
 		)
 	)
 
@@ -404,7 +406,7 @@ func makeCAASStorageInstanceProviderIDAssociations(
 	existingUnitOwnedStorage []internal.StorageInstanceComposition,
 	existingUnitAttachments []internal.StorageAttachmentComposition,
 	unitStorageToCreate []internal.CreateUnitStorageInstanceArg,
-	unitStorageToAttach []internal.CreateUnitStorageAttachmentArg,
+	unitStorageToAttach []internal.AttachStorageToUnitArg,
 ) (
 	map[domainstorage.FilesystemUUID]string,
 	map[domainstorage.VolumeUUID]string,
@@ -562,15 +564,15 @@ volumeAttachmentLoop:
 func makeStorageAttachmentArgFromExistingStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
 	storageInstance internal.StorageInstanceComposition,
-) (internal.CreateUnitStorageAttachmentArg, error) {
+) (internal.AttachStorageToUnitArg, error) {
 	uuid, err := domainstorage.NewStorageAttachmentUUID()
 	if err != nil {
-		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+		return internal.AttachStorageToUnitArg{}, errors.Errorf(
 			"generating new storage attachment uuid: %w", err,
 		)
 	}
 
-	rval := internal.CreateUnitStorageAttachmentArg{
+	rval := internal.AttachStorageToUnitArg{
 		StorageInstanceUUID: storageInstance.UUID,
 		UUID:                uuid,
 	}
@@ -578,7 +580,7 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 	if storageInstance.Filesystem != nil {
 		uuid, err := domainstorage.NewFilesystemAttachmentUUID()
 		if err != nil {
-			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.AttachStorageToUnitArg{}, errors.Errorf(
 				"generating new filesystem attachment uuid: %w", err,
 			)
 		}
@@ -594,7 +596,7 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 	if storageInstance.Volume != nil {
 		uuid, err := domainstorage.NewVolumeAttachmentUUID()
 		if err != nil {
-			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.AttachStorageToUnitArg{}, errors.Errorf(
 				"generating new volume attachment uuid: %w", err,
 			)
 		}
@@ -619,15 +621,15 @@ func makeStorageAttachmentArgFromExistingStorageInstance(
 func makeStorageAttachmentArgFromStorageInstance(
 	netNodeUUID domainnetwork.NetNodeUUID,
 	storageInstance internal.AttachStorageInstanceArg,
-) (internal.CreateUnitStorageAttachmentArg, error) {
+) (internal.AttachStorageToUnitArg, error) {
 	uuid, err := domainstorage.NewStorageAttachmentUUID()
 	if err != nil {
-		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+		return internal.AttachStorageToUnitArg{}, errors.Errorf(
 			"generating new storage attachment uuid: %w", err,
 		)
 	}
 
-	rval := internal.CreateUnitStorageAttachmentArg{
+	rval := internal.AttachStorageToUnitArg{
 		StorageInstanceUUID: storageInstance.UUID,
 		UUID:                uuid,
 	}
@@ -635,7 +637,7 @@ func makeStorageAttachmentArgFromStorageInstance(
 	if storageInstance.Filesystem != nil {
 		uuid, err := domainstorage.NewFilesystemAttachmentUUID()
 		if err != nil {
-			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.AttachStorageToUnitArg{}, errors.Errorf(
 				"generating new filesystem attachment uuid: %w", err,
 			)
 		}
@@ -651,7 +653,7 @@ func makeStorageAttachmentArgFromStorageInstance(
 	if storageInstance.Volume != nil {
 		uuid, err := domainstorage.NewVolumeAttachmentUUID()
 		if err != nil {
-			return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+			return internal.AttachStorageToUnitArg{}, errors.Errorf(
 				"generating new volume attachment uuid: %w", err,
 			)
 		}
@@ -680,7 +682,7 @@ func makeStorageAttachmentArgFromStorageInstance(
 // storage.
 //
 // No guarantee is made that existing storage supplied to this func will be used
-// in it's entirety. If a storage directive has less demand then what is
+// in its entirety. If a storage directive has less demand then what is
 // supplied it is possible that some existing storage will be unused. It is up
 // to the caller to validate what storage was and wasn't used by looking at the
 // storage attachments.
@@ -688,6 +690,14 @@ func (s Service) MakeUnitStorageArgs(
 	ctx context.Context,
 	attachNetNodeUUID domainnetwork.NetNodeUUID,
 	storageDirectives []application.StorageDirective,
+	// TODO - we only pass in non nil existing storage values for
+	//  CAAS unit registration. These are treated as new storage to
+	//  be attached in the downstream workflow, since the additional
+	//  checks for attaching existing storage to units as initiated by
+	//  a user are not currently relevant for CAAS unit registration.
+	//  We should consider if we want to split the MakeUnitStorageArgs func
+	//  into two separate funcs - one for CAAS unit registration and one
+	//  for adding new units in response to a scale operation.
 	existingStorage []internal.StorageInstanceComposition,
 	existingStorageAttachments []internal.StorageAttachmentComposition,
 ) (internal.CreateUnitStorageArg, error) {
@@ -696,7 +706,7 @@ func (s Service) MakeUnitStorageArgs(
 
 	rvalDirectives := make([]internal.CreateUnitStorageDirectiveArg, 0, len(storageDirectives))
 	rvalInstances := []internal.CreateUnitStorageInstanceArg{}
-	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(storageDirectives))
+	rvalToAttach := make([]internal.AttachStorageToUnitArg, 0, len(storageDirectives))
 	// rvalToOwn is the list of storage instance uuid's that the unit must own.
 	rvalToOwn := make([]domainstorage.StorageInstanceUUID, 0, len(storageDirectives))
 
@@ -803,10 +813,10 @@ func (s Service) MakeUnitStorageArgs(
 	}
 
 	return internal.CreateUnitStorageArg{
-		StorageDirectives: rvalDirectives,
-		StorageInstances:  rvalInstances,
-		StorageToAttach:   rvalToAttach,
-		StorageToOwn:      rvalToOwn,
+		StorageDirectives:  rvalDirectives,
+		StorageInstances:   rvalInstances,
+		NewStorageToAttach: rvalToAttach,
+		StorageToOwn:       rvalToOwn,
 	}, nil
 }
 
@@ -869,7 +879,7 @@ func (s Service) MakeUnitAddStorageArgs(
 	defer span.End()
 
 	var rvalInstances []internal.CreateUnitStorageInstanceArg
-	rvalToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, 1)
+	rvalToAttach := make([]internal.AttachStorageToUnitArg, 0, 1)
 	// rvalToOwn is the list of storage instance UUIDs that the unit must own.
 	rvalToOwn := make([]domainstorage.StorageInstanceUUID, 0, 1)
 
@@ -923,9 +933,9 @@ func (s Service) MakeUnitAddStorageArgs(
 	}
 
 	return internal.AddStorageToUnitArg{
-		StorageInstances: rvalInstances,
-		StorageToAttach:  rvalToAttach,
-		StorageToOwn:     rvalToOwn,
+		StorageInstances:   rvalInstances,
+		NewStorageToAttach: rvalToAttach,
+		StorageToOwn:       rvalToOwn,
 	}, nil
 }
 
@@ -1022,19 +1032,20 @@ func makeUnitStorageInstancesFromDirective(
 	return rval, nil
 }
 
-// MakeUnitAttachStorageArgs creates the storage arguments required to
+// MakeAttachExistingStorageArgs creates the storage arguments required to
 // attach existing storage to a unit.
-func (s Service) MakeUnitAttachStorageArgs(
+func (s Service) MakeAttachExistingStorageArgs(
 	ctx context.Context,
 	attachNetNodeUUID string,
 	storageInstanceUUID domainstorage.StorageInstanceUUID,
-) (internal.CreateUnitStorageAttachmentArg, error) {
+	storageAttachInfo internal.StorageInfoForAttach,
+) (internal.AttachExistingStorageToUnitArg, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	instComposition, err := s.st.GetStorageInstanceCompositionByUUID(ctx, storageInstanceUUID)
 	if err != nil {
-		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+		return internal.AttachExistingStorageToUnitArg{}, errors.Errorf(
 			"getting composition details for storage %q: %w", storageInstanceUUID, err,
 		)
 	}
@@ -1058,9 +1069,29 @@ func (s Service) MakeUnitAttachStorageArgs(
 		domainnetwork.NetNodeUUID(attachNetNodeUUID), instArg,
 	)
 	if err != nil {
-		return internal.CreateUnitStorageAttachmentArg{}, errors.Errorf(
+		return internal.AttachExistingStorageToUnitArg{}, errors.Errorf(
 			"making storage attachment arguments for new storage instance: %w", err,
 		)
 	}
-	return storageAttachArg, nil
+
+	allowedUUIDs := slices.Collect(maps.Keys(storageAttachInfo.AlreadyAttachedToUnits))
+	result := internal.AttachExistingStorageToUnitArg{
+		AttachStorageToUnitArg: internal.AttachStorageToUnitArg{
+			UUID:                 storageAttachArg.UUID,
+			FilesystemAttachment: storageAttachArg.FilesystemAttachment,
+			StorageInstanceUUID:  storageAttachArg.StorageInstanceUUID,
+			VolumeAttachment:     storageAttachArg.VolumeAttachment,
+		},
+		StorageName:                    storageAttachInfo.CharmStorageName,
+		CountLessThanEqual:             uint32(math.MaxUint32),
+		AllowedExistingUnitAttachments: allowedUUIDs,
+	}
+
+	// Record the max allowed count precondition.
+	// This will be checked inside the transaction.
+	if storageAttachInfo.CountMax > 0 {
+		result.CountLessThanEqual = uint32(storageAttachInfo.CountMax) - 1
+	}
+
+	return result, nil
 }

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -146,7 +146,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 	expectedStorageInstances := []internal.CreateUnitStorageInstanceArg{
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -156,7 +156,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		},
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -166,10 +166,10 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		},
 	}
 
-	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
 		// Existing st1 storage
 		{
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingSt1Storage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: existingSt1Storage[0].Filesystem.ProvisionScope,
@@ -180,7 +180,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		// Existing st2 storage
 		{
 			StorageInstanceUUID: existingSt2Storage[0].UUID,
-			VolumeAttachment: &internal.UnitStorageVolumeAttachmentArg{
+			VolumeAttachment: &internal.CreateUnitStorageVolumeAttachmentArg{
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: existingSt2Storage[0].Volume.ProvisionScope,
 				VolumeUUID:     existingSt2Storage[0].Volume.UUID,
@@ -188,7 +188,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		},
 		{
 			StorageInstanceUUID: existingSt2Storage[1].UUID,
-			VolumeAttachment: &internal.UnitStorageVolumeAttachmentArg{
+			VolumeAttachment: &internal.CreateUnitStorageVolumeAttachmentArg{
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: existingSt2Storage[1].Volume.ProvisionScope,
 				VolumeUUID:     existingSt2Storage[1].Volume.UUID,
@@ -199,13 +199,13 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 	// attachment expectations.
 	expectedStorageToAttach = slices.Grow(expectedStorageToAttach, len(arg.StorageInstances))
 	for _, si := range arg.StorageInstances {
-		attachArg := internal.UnitStorageAttachmentArg{
+		attachArg := internal.CreateUnitStorageAttachmentArg{
 			StorageInstanceUUID: si.UUID,
 		}
 
 		if si.Filesystem != nil {
 			attachArg.FilesystemAttachment =
-				&internal.UnitStorageFilesystemAttachmentArg{
+				&internal.CreateUnitStorageFilesystemAttachmentArg{
 					FilesystemUUID: si.Filesystem.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Filesystem.ProvisionScope,
@@ -213,7 +213,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		}
 		if si.Volume != nil {
 			attachArg.VolumeAttachment =
-				&internal.UnitStorageVolumeAttachmentArg{
+				&internal.CreateUnitStorageVolumeAttachmentArg{
 					VolumeUUID:     si.Volume.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Volume.ProvisionScope,
@@ -245,45 +245,45 @@ func (s *serviceSuite) TestMakeIAASUnitStorageArgs(c *tc.C) {
 
 	expectedStorageInstances := []internal.UnitStorageInstanceArg{
 		{
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
-			Volume: &internal.UnitStorageVolumeArg{
+			Volume: &internal.CreateUnitStorageVolumeArg{
 				UUID:           tc.Must(c, domainstorage.NewVolumeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
 			},
 		},
 		{
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
 			},
 		},
 		{
-			Volume: &internal.UnitStorageVolumeArg{
+			Volume: &internal.CreateUnitStorageVolumeArg{
 				UUID:           tc.Must(c, domainstorage.NewVolumeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
 			},
 		},
 		{
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID:           fsUUID1,
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 		},
 		{
-			Volume: &internal.UnitStorageVolumeArg{
+			Volume: &internal.CreateUnitStorageVolumeArg{
 				UUID:           volUUID1,
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 		},
 		{
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID:           fsUUID2,
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
-			Volume: &internal.UnitStorageVolumeArg{
+			Volume: &internal.CreateUnitStorageVolumeArg{
 				UUID:           volUUID2,
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
@@ -346,7 +346,7 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 	expectedStorageInstances := []internal.CreateUnitStorageInstanceArg{
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -356,7 +356,7 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		},
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -366,18 +366,18 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		},
 	}
 
-	expectedStorageToAttach := make([]internal.UnitStorageAttachmentArg, 0, len(arg.StorageInstances))
+	expectedStorageToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(arg.StorageInstances))
 	// Loop through the new storage instances being created and set their
 	// attachment expectations.
 	expectedStorageToAttach = slices.Grow(expectedStorageToAttach, len(arg.StorageInstances))
 	for _, si := range arg.StorageInstances {
-		attachArg := internal.UnitStorageAttachmentArg{
+		attachArg := internal.CreateUnitStorageAttachmentArg{
 			StorageInstanceUUID: si.UUID,
 		}
 
 		if si.Filesystem != nil {
 			attachArg.FilesystemAttachment =
-				&internal.UnitStorageFilesystemAttachmentArg{
+				&internal.CreateUnitStorageFilesystemAttachmentArg{
 					FilesystemUUID: si.Filesystem.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Filesystem.ProvisionScope,
@@ -385,7 +385,7 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		}
 		if si.Volume != nil {
 			attachArg.VolumeAttachment =
-				&internal.UnitStorageVolumeAttachmentArg{
+				&internal.CreateUnitStorageVolumeAttachmentArg{
 					VolumeUUID:     si.Volume.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Volume.ProvisionScope,
@@ -451,15 +451,15 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 	)
 	c.Check(err, tc.ErrorIsNil)
 
-	expectedStorageToAttach := make([]internal.UnitStorageAttachmentArg, 0, len(instComposition))
+	expectedStorageToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(instComposition))
 	for _, si := range instComposition {
-		attachArg := internal.UnitStorageAttachmentArg{
+		attachArg := internal.CreateUnitStorageAttachmentArg{
 			StorageInstanceUUID: si.UUID,
 		}
 
 		if si.Filesystem != nil {
 			attachArg.FilesystemAttachment =
-				&internal.UnitStorageFilesystemAttachmentArg{
+				&internal.CreateUnitStorageFilesystemAttachmentArg{
 					FilesystemUUID: si.Filesystem.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Filesystem.ProvisionScope,
@@ -467,7 +467,7 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 		}
 		if si.Volume != nil {
 			attachArg.VolumeAttachment =
-				&internal.UnitStorageVolumeAttachmentArg{
+				&internal.CreateUnitStorageVolumeAttachmentArg{
 					VolumeUUID:     si.Volume.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Volume.ProvisionScope,
@@ -480,14 +480,14 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 		}
 		if si.Filesystem != nil {
 			instArg.Filesystem =
-				&internal.UnitStorageFilesystemArg{
+				&internal.CreateUnitStorageFilesystemArg{
 					UUID:           si.Filesystem.UUID,
 					ProvisionScope: si.Filesystem.ProvisionScope,
 				}
 		}
 		if si.Volume != nil {
 			instArg.Volume =
-				&internal.UnitStorageVolumeArg{
+				&internal.CreateUnitStorageVolumeArg{
 					UUID:           si.Volume.UUID,
 					ProvisionScope: si.Volume.ProvisionScope,
 				}

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -516,11 +516,10 @@ func (s *serviceSuite) TestValidateAttachStorageExceedMax(c *tc.C) {
 		MinimumSize: 1024,
 		Type:        internalcharm.StorageBlock,
 	}
-	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 
 	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
 	err := svc.ValidateAttachStorage(
-		c.Context(), charmStorageDef, 3, 1024, poolUUID,
+		charmStorageDef, 3, 1024,
 	)
 
 	errVal, is := errors.AsType[applicationerrors.StorageCountLimitExceeded](err)

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -243,7 +243,7 @@ func (s *serviceSuite) TestMakeIAASUnitStorageArgs(c *tc.C) {
 	volUUID1 := tc.Must(c, domainstorage.NewVolumeUUID)
 	volUUID2 := tc.Must(c, domainstorage.NewVolumeUUID)
 
-	expectedStorageInstances := []internal.CreateUnitStorageInstanceArg{
+	expectedStorageInstances := []internal.UnitStorageInstanceArg{
 		{
 			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),
@@ -291,7 +291,7 @@ func (s *serviceSuite) TestMakeIAASUnitStorageArgs(c *tc.C) {
 	}
 
 	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
-	arg, err := svc.MakeIAASUnitStorageArgs(c.Context(), expectedStorageInstances)
+	arg, err := svc.MakeIAASUnitStorageArgs(expectedStorageInstances)
 	c.Assert(err, tc.IsNil)
 	c.Check(arg.FilesystemsToOwn, tc.SameContents,
 		[]domainstorage.FilesystemUUID{
@@ -403,5 +403,98 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		StorageInstances: expectedStorageInstances,
 		StorageToAttach:  expectedStorageToAttach,
 		StorageToOwn:     expectedStorageToOwn,
+	})
+}
+
+func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	attachNetNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
+	storageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	instComposition := []internal.StorageInstanceComposition{
+		{
+			UUID: storageUUID,
+			Filesystem: &internal.StorageInstanceCompositionFilesystem{
+				UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),
+				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
+			},
+		},
+		{
+			UUID: storageUUID,
+			Volume: &internal.StorageInstanceCompositionVolume{
+				UUID:           tc.Must(c, domainstorage.NewVolumeUUID),
+				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
+			},
+		},
+	}
+
+	provider := NewMockStorageProvider(ctrl)
+	provider.EXPECT().Scope().Return(internalstorage.ScopeMachine).AnyTimes()
+	provider.EXPECT().Supports(internalstorage.StorageKindFilesystem).Return(true).AnyTimes()
+	provider.EXPECT().Supports(internalstorage.StorageKindBlock).Return(true).AnyTimes()
+	s.poolProvider.EXPECT().GetProviderForPool(gomock.Any(), poolUUID).Return(
+		provider, nil,
+	).AnyTimes()
+
+	s.state.EXPECT().GetStorageInstanceCompositionByUUID(gomock.Any(), storageUUID).Return(instComposition, nil)
+	s.state.EXPECT().GetUnitNetNodeUUID(gomock.Any(), unitUUID).Return(attachNetNodeUUID.String(), nil)
+
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
+
+	arg, err := svc.MakeUnitAttachStorageArgs(
+		c.Context(),
+		unitUUID,
+		storageUUID,
+	)
+	c.Check(err, tc.ErrorIsNil)
+
+	expectedStorageToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(instComposition))
+	for _, si := range instComposition {
+		attachArg := internal.CreateUnitStorageAttachmentArg{
+			StorageInstanceUUID: si.UUID,
+		}
+
+		if si.Filesystem != nil {
+			attachArg.FilesystemAttachment =
+				&internal.CreateUnitStorageFilesystemAttachmentArg{
+					FilesystemUUID: si.Filesystem.UUID,
+					NetNodeUUID:    attachNetNodeUUID,
+					ProvisionScope: si.Filesystem.ProvisionScope,
+				}
+		}
+		if si.Volume != nil {
+			attachArg.VolumeAttachment =
+				&internal.CreateUnitStorageVolumeAttachmentArg{
+					VolumeUUID:     si.Volume.UUID,
+					NetNodeUUID:    attachNetNodeUUID,
+					ProvisionScope: si.Volume.ProvisionScope,
+				}
+		}
+		expectedStorageToAttach = append(expectedStorageToAttach, attachArg)
+
+		instArg := internal.UnitStorageInstanceArg{
+			UUID: si.UUID,
+		}
+		if si.Filesystem != nil {
+			instArg.Filesystem =
+				&internal.CreateUnitStorageFilesystemArg{
+					UUID:           si.Filesystem.UUID,
+					ProvisionScope: si.Filesystem.ProvisionScope,
+				}
+		}
+		if si.Volume != nil {
+			instArg.Volume =
+				&internal.CreateUnitStorageVolumeArg{
+					UUID:           si.Volume.UUID,
+					ProvisionScope: si.Volume.ProvisionScope,
+				}
+		}
+	}
+
+	c.Check(arg, createUnitStorageArgChecker(), internal.UnitAttachStorageArg{
+		StorageToAttach: expectedStorageToAttach,
 	})
 }

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -417,20 +417,15 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 	storageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 	unitUUID := tc.Must(c, coreunit.NewUUID)
-	instComposition := []internal.StorageInstanceComposition{
-		{
-			UUID: storageUUID,
-			Filesystem: &internal.StorageInstanceCompositionFilesystem{
-				UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),
-				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
-			},
+	instComposition := internal.StorageInstanceComposition{
+		UUID: storageUUID,
+		Filesystem: &internal.StorageInstanceCompositionFilesystem{
+			UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),
+			ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 		},
-		{
-			UUID: storageUUID,
-			Volume: &internal.StorageInstanceCompositionVolume{
-				UUID:           tc.Must(c, domainstorage.NewVolumeUUID),
-				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
-			},
+		Volume: &internal.StorageInstanceCompositionVolume{
+			UUID:           tc.Must(c, domainstorage.NewVolumeUUID),
+			ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 		},
 	}
 
@@ -454,53 +449,40 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 	)
 	c.Check(err, tc.ErrorIsNil)
 
-	expectedStorageToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(instComposition))
-	for _, si := range instComposition {
-		attachArg := internal.CreateUnitStorageAttachmentArg{
-			StorageInstanceUUID: si.UUID,
-		}
-
-		if si.Filesystem != nil {
-			attachArg.FilesystemAttachment =
-				&internal.CreateUnitStorageFilesystemAttachmentArg{
-					FilesystemUUID: si.Filesystem.UUID,
-					NetNodeUUID:    attachNetNodeUUID,
-					ProvisionScope: si.Filesystem.ProvisionScope,
-				}
-		}
-		if si.Volume != nil {
-			attachArg.VolumeAttachment =
-				&internal.CreateUnitStorageVolumeAttachmentArg{
-					VolumeUUID:     si.Volume.UUID,
-					NetNodeUUID:    attachNetNodeUUID,
-					ProvisionScope: si.Volume.ProvisionScope,
-				}
-		}
-		expectedStorageToAttach = append(expectedStorageToAttach, attachArg)
-
-		instArg := internal.UnitStorageInstanceArg{
-			UUID: si.UUID,
-		}
-		if si.Filesystem != nil {
-			instArg.Filesystem =
-				&internal.CreateUnitStorageFilesystemArg{
-					UUID:           si.Filesystem.UUID,
-					ProvisionScope: si.Filesystem.ProvisionScope,
-				}
-		}
-		if si.Volume != nil {
-			instArg.Volume =
-				&internal.CreateUnitStorageVolumeArg{
-					UUID:           si.Volume.UUID,
-					ProvisionScope: si.Volume.ProvisionScope,
-				}
-		}
+	expectedStorageToAttach := internal.CreateUnitStorageAttachmentArg{
+		StorageInstanceUUID: instComposition.UUID,
+	}
+	if instComposition.Filesystem != nil {
+		expectedStorageToAttach.FilesystemAttachment =
+			&internal.CreateUnitStorageFilesystemAttachmentArg{
+				FilesystemUUID: instComposition.Filesystem.UUID,
+				NetNodeUUID:    attachNetNodeUUID,
+				ProvisionScope: instComposition.Filesystem.ProvisionScope,
+			}
+	}
+	if instComposition.Volume != nil {
+		expectedStorageToAttach.VolumeAttachment =
+			&internal.CreateUnitStorageVolumeAttachmentArg{
+				VolumeUUID:     instComposition.Volume.UUID,
+				NetNodeUUID:    attachNetNodeUUID,
+				ProvisionScope: instComposition.Volume.ProvisionScope,
+			}
 	}
 
+	c.Assert(attachArg.UUID, tc.Not(tc.Equals), "")
+	attachArg.UUID = ""
+	if instComposition.Filesystem != nil {
+		c.Assert(attachArg.FilesystemAttachment.UUID, tc.Not(tc.Equals), "")
+		attachArg.FilesystemAttachment.UUID = ""
+	}
+	if instComposition.Volume != nil {
+		c.Assert(attachArg.VolumeAttachment.UUID, tc.Not(tc.Equals), "")
+		attachArg.VolumeAttachment.UUID = ""
+	}
 	arg := internal.AttachStorageToUnitArg{
 		StorageToAttach: attachArg,
 	}
-	c.Check(arg, createUnitStorageArgChecker(), internal.AttachStorageToUnitArg{
+	c.Check(arg, tc.DeepEquals, internal.AttachStorageToUnitArg{
 		StorageToAttach: expectedStorageToAttach,
 	})
 }

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -501,7 +501,7 @@ func (s *serviceSuite) TestValidateAttachStorageExceedMax(c *tc.C) {
 
 	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
 	err := svc.ValidateAttachStorage(
-		charmStorageDef, 3, 1024,
+		charmStorageDef, 2, 1024,
 	)
 
 	errVal, is := errors.AsType[applicationerrors.StorageCountLimitExceeded](err)

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -13,10 +13,13 @@ import (
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/application/internal"
+	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	domainnetwork "github.com/juju/juju/domain/network"
 	domainstorage "github.com/juju/juju/domain/storage"
 	domainstorageprov "github.com/juju/juju/domain/storageprovisioning"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	internalstorage "github.com/juju/juju/internal/storage"
 )
@@ -399,7 +402,7 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		expectedStorageToOwn = append(expectedStorageToOwn, si.UUID)
 	}
 
-	c.Check(arg, createUnitStorageArgChecker(), internal.UnitAddStorageArg{
+	c.Check(arg, createUnitStorageArgChecker(), internal.AddStorageToUnitArg{
 		StorageInstances: expectedStorageInstances,
 		StorageToAttach:  expectedStorageToAttach,
 		StorageToOwn:     expectedStorageToOwn,
@@ -444,7 +447,7 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 
 	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
 
-	arg, err := svc.MakeUnitAttachStorageArgs(
+	attachArg, err := svc.MakeUnitAttachStorageArgs(
 		c.Context(),
 		unitUUID,
 		storageUUID,
@@ -494,7 +497,38 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 		}
 	}
 
-	c.Check(arg, createUnitStorageArgChecker(), internal.UnitAttachStorageArg{
+	arg := internal.AttachStorageToUnitArg{
+		StorageToAttach: attachArg,
+	}
+	c.Check(arg, createUnitStorageArgChecker(), internal.AttachStorageToUnitArg{
 		StorageToAttach: expectedStorageToAttach,
+	})
+}
+
+func (s *serviceSuite) TestValidateAttachStorageExceedMax(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	charmStorageDef := internal.ValidateStorageArg{
+		CountMin:    0,
+		CountMax:    2,
+		Name:        "st1",
+		MinimumSize: 1024,
+		Type:        internalcharm.StorageBlock,
+	}
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
+	err := svc.ValidateAttachStorage(
+		c.Context(), charmStorageDef, 3, 1024, poolUUID,
+	)
+
+	errVal, is := errors.AsType[applicationerrors.StorageCountLimitExceeded](err)
+	c.Check(is, tc.IsTrue)
+	c.Check(errVal, tc.DeepEquals, applicationerrors.StorageCountLimitExceeded{
+		Maximum:     ptr(2),
+		Minimum:     0,
+		Requested:   3,
+		StorageName: "st1",
 	})
 }

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -169,7 +169,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		},
 	}
 
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.AttachStorageToUnitArg{
 		// Existing st1 storage
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
@@ -202,7 +202,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 	// attachment expectations.
 	expectedStorageToAttach = slices.Grow(expectedStorageToAttach, len(arg.StorageInstances))
 	for _, si := range arg.StorageInstances {
-		attachArg := internal.CreateUnitStorageAttachmentArg{
+		attachArg := internal.AttachStorageToUnitArg{
 			StorageInstanceUUID: si.UUID,
 		}
 
@@ -231,10 +231,10 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 	}
 
 	c.Check(arg, createUnitStorageArgChecker(), internal.CreateUnitStorageArg{
-		StorageDirectives: expectStorageDirectives,
-		StorageInstances:  expectedStorageInstances,
-		StorageToAttach:   expectedStorageToAttach,
-		StorageToOwn:      expectedStorageToOwn,
+		StorageDirectives:  expectStorageDirectives,
+		StorageInstances:   expectedStorageInstances,
+		NewStorageToAttach: expectedStorageToAttach,
+		StorageToOwn:       expectedStorageToOwn,
 	})
 }
 
@@ -369,12 +369,12 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		},
 	}
 
-	expectedStorageToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(arg.StorageInstances))
+	expectedStorageToAttach := make([]internal.AttachStorageToUnitArg, 0, len(arg.StorageInstances))
 	// Loop through the new storage instances being created and set their
 	// attachment expectations.
 	expectedStorageToAttach = slices.Grow(expectedStorageToAttach, len(arg.StorageInstances))
 	for _, si := range arg.StorageInstances {
-		attachArg := internal.CreateUnitStorageAttachmentArg{
+		attachArg := internal.AttachStorageToUnitArg{
 			StorageInstanceUUID: si.UUID,
 		}
 
@@ -403,13 +403,13 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 	}
 
 	c.Check(arg, createUnitStorageArgChecker(), internal.AddStorageToUnitArg{
-		StorageInstances: expectedStorageInstances,
-		StorageToAttach:  expectedStorageToAttach,
-		StorageToOwn:     expectedStorageToOwn,
+		StorageInstances:   expectedStorageInstances,
+		NewStorageToAttach: expectedStorageToAttach,
+		StorageToOwn:       expectedStorageToOwn,
 	})
 }
 
-func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
+func (s *serviceSuite) TestMakeAttachExistingStorageArgs(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
@@ -434,17 +434,27 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 
 	s.state.EXPECT().GetStorageInstanceCompositionByUUID(gomock.Any(), storageUUID).Return(instComposition, nil)
 
+	storageAttachInfo := internal.StorageInfoForAttach{
+		CharmStorageName: "pgdata",
+		CountMax:         667,
+	}
+
 	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
 
-	attachArg, err := svc.MakeUnitAttachStorageArgs(
+	attachArg, err := svc.MakeAttachExistingStorageArgs(
 		c.Context(),
 		attachNetNodeUUID.String(),
 		storageUUID,
+		storageAttachInfo,
 	)
 	c.Check(err, tc.ErrorIsNil)
 
-	expectedStorageToAttach := internal.CreateUnitStorageAttachmentArg{
-		StorageInstanceUUID: instComposition.UUID,
+	expectedStorageToAttach := internal.AttachExistingStorageToUnitArg{
+		AttachStorageToUnitArg: internal.AttachStorageToUnitArg{
+			StorageInstanceUUID: instComposition.UUID,
+		},
+		StorageName:        "pgdata",
+		CountLessThanEqual: 666,
 	}
 	if instComposition.Filesystem != nil {
 		expectedStorageToAttach.FilesystemAttachment =
@@ -473,12 +483,7 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 		c.Assert(attachArg.VolumeAttachment.UUID, tc.Not(tc.Equals), "")
 		attachArg.VolumeAttachment.UUID = ""
 	}
-	arg := internal.AttachStorageToUnitArg{
-		StorageToAttach: attachArg,
-	}
-	c.Check(arg, tc.DeepEquals, internal.AttachStorageToUnitArg{
-		StorageToAttach: expectedStorageToAttach,
-	})
+	c.Check(attachArg, tc.DeepEquals, expectedStorageToAttach)
 }
 
 func (s *serviceSuite) TestValidateAttachStorageExceedMax(c *tc.C) {

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -146,7 +146,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 	expectedStorageInstances := []internal.CreateUnitStorageInstanceArg{
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -156,7 +156,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		},
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -169,7 +169,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		// Existing st1 storage
 		{
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: existingSt1Storage[0].Filesystem.UUID,
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: existingSt1Storage[0].Filesystem.ProvisionScope,
@@ -180,7 +180,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		// Existing st2 storage
 		{
 			StorageInstanceUUID: existingSt2Storage[0].UUID,
-			VolumeAttachment: &internal.CreateUnitStorageVolumeAttachmentArg{
+			VolumeAttachment: &internal.UnitStorageVolumeAttachmentArg{
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: existingSt2Storage[0].Volume.ProvisionScope,
 				VolumeUUID:     existingSt2Storage[0].Volume.UUID,
@@ -188,7 +188,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		},
 		{
 			StorageInstanceUUID: existingSt2Storage[1].UUID,
-			VolumeAttachment: &internal.CreateUnitStorageVolumeAttachmentArg{
+			VolumeAttachment: &internal.UnitStorageVolumeAttachmentArg{
 				NetNodeUUID:    attachNetNodeUUID,
 				ProvisionScope: existingSt2Storage[1].Volume.ProvisionScope,
 				VolumeUUID:     existingSt2Storage[1].Volume.UUID,
@@ -205,7 +205,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 
 		if si.Filesystem != nil {
 			attachArg.FilesystemAttachment =
-				&internal.CreateUnitStorageFilesystemAttachmentArg{
+				&internal.UnitStorageFilesystemAttachmentArg{
 					FilesystemUUID: si.Filesystem.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Filesystem.ProvisionScope,
@@ -213,7 +213,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		}
 		if si.Volume != nil {
 			attachArg.VolumeAttachment =
-				&internal.CreateUnitStorageVolumeAttachmentArg{
+				&internal.UnitStorageVolumeAttachmentArg{
 					VolumeUUID:     si.Volume.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Volume.ProvisionScope,
@@ -245,45 +245,45 @@ func (s *serviceSuite) TestMakeIAASUnitStorageArgs(c *tc.C) {
 
 	expectedStorageInstances := []internal.UnitStorageInstanceArg{
 		{
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
-			Volume: &internal.CreateUnitStorageVolumeArg{
+			Volume: &internal.UnitStorageVolumeArg{
 				UUID:           tc.Must(c, domainstorage.NewVolumeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
 			},
 		},
 		{
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
 			},
 		},
 		{
-			Volume: &internal.CreateUnitStorageVolumeArg{
+			Volume: &internal.UnitStorageVolumeArg{
 				UUID:           tc.Must(c, domainstorage.NewVolumeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
 			},
 		},
 		{
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				UUID:           fsUUID1,
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 		},
 		{
-			Volume: &internal.CreateUnitStorageVolumeArg{
+			Volume: &internal.UnitStorageVolumeArg{
 				UUID:           volUUID1,
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 		},
 		{
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				UUID:           fsUUID2,
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
-			Volume: &internal.CreateUnitStorageVolumeArg{
+			Volume: &internal.UnitStorageVolumeArg{
 				UUID:           volUUID2,
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
@@ -346,7 +346,7 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 	expectedStorageInstances := []internal.CreateUnitStorageInstanceArg{
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -356,7 +356,7 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		},
 		{
 			CharmName: "big-beautiful-charm",
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
 			},
 			Kind:            domainstorage.StorageKindFilesystem,
@@ -377,7 +377,7 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 
 		if si.Filesystem != nil {
 			attachArg.FilesystemAttachment =
-				&internal.CreateUnitStorageFilesystemAttachmentArg{
+				&internal.UnitStorageFilesystemAttachmentArg{
 					FilesystemUUID: si.Filesystem.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Filesystem.ProvisionScope,
@@ -385,7 +385,7 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		}
 		if si.Volume != nil {
 			attachArg.VolumeAttachment =
-				&internal.CreateUnitStorageVolumeAttachmentArg{
+				&internal.UnitStorageVolumeAttachmentArg{
 					VolumeUUID:     si.Volume.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Volume.ProvisionScope,
@@ -459,7 +459,7 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 
 		if si.Filesystem != nil {
 			attachArg.FilesystemAttachment =
-				&internal.CreateUnitStorageFilesystemAttachmentArg{
+				&internal.UnitStorageFilesystemAttachmentArg{
 					FilesystemUUID: si.Filesystem.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Filesystem.ProvisionScope,
@@ -467,7 +467,7 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 		}
 		if si.Volume != nil {
 			attachArg.VolumeAttachment =
-				&internal.CreateUnitStorageVolumeAttachmentArg{
+				&internal.UnitStorageVolumeAttachmentArg{
 					VolumeUUID:     si.Volume.UUID,
 					NetNodeUUID:    attachNetNodeUUID,
 					ProvisionScope: si.Volume.ProvisionScope,
@@ -480,14 +480,14 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 		}
 		if si.Filesystem != nil {
 			instArg.Filesystem =
-				&internal.CreateUnitStorageFilesystemArg{
+				&internal.UnitStorageFilesystemArg{
 					UUID:           si.Filesystem.UUID,
 					ProvisionScope: si.Filesystem.ProvisionScope,
 				}
 		}
 		if si.Volume != nil {
 			instArg.Volume =
-				&internal.CreateUnitStorageVolumeArg{
+				&internal.UnitStorageVolumeArg{
 					UUID:           si.Volume.UUID,
 					ProvisionScope: si.Volume.ProvisionScope,
 				}

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -416,7 +416,6 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 	attachNetNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	storageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
-	unitUUID := tc.Must(c, coreunit.NewUUID)
 	instComposition := internal.StorageInstanceComposition{
 		UUID: storageUUID,
 		Filesystem: &internal.StorageInstanceCompositionFilesystem{
@@ -438,13 +437,12 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 	).AnyTimes()
 
 	s.state.EXPECT().GetStorageInstanceCompositionByUUID(gomock.Any(), storageUUID).Return(instComposition, nil)
-	s.state.EXPECT().GetUnitNetNodeUUID(gomock.Any(), unitUUID).Return(attachNetNodeUUID.String(), nil)
 
 	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
 
 	attachArg, err := svc.MakeUnitAttachStorageArgs(
 		c.Context(),
-		unitUUID,
+		attachNetNodeUUID.String(),
 		storageUUID,
 	)
 	c.Check(err, tc.ErrorIsNil)

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -246,7 +246,7 @@ func (s *serviceSuite) TestMakeIAASUnitStorageArgs(c *tc.C) {
 	volUUID1 := tc.Must(c, domainstorage.NewVolumeUUID)
 	volUUID2 := tc.Must(c, domainstorage.NewVolumeUUID)
 
-	expectedStorageInstances := []internal.UnitStorageInstanceArg{
+	expectedStorageInstances := []internal.AddStorageInstanceArg{
 		{
 			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID:           tc.Must(c, domainstorage.NewFilesystemUUID),

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -415,7 +415,6 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 
 	attachNetNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	storageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 	instComposition := internal.StorageInstanceComposition{
 		UUID: storageUUID,
 		Filesystem: &internal.StorageInstanceCompositionFilesystem{
@@ -432,9 +431,6 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 	provider.EXPECT().Scope().Return(internalstorage.ScopeMachine).AnyTimes()
 	provider.EXPECT().Supports(internalstorage.StorageKindFilesystem).Return(true).AnyTimes()
 	provider.EXPECT().Supports(internalstorage.StorageKindBlock).Return(true).AnyTimes()
-	s.poolProvider.EXPECT().GetProviderForPool(gomock.Any(), poolUUID).Return(
-		provider, nil,
-	).AnyTimes()
 
 	s.state.EXPECT().GetStorageInstanceCompositionByUUID(gomock.Any(), storageUUID).Return(instComposition, nil)
 

--- a/domain/application/service/storage/service_test.go
+++ b/domain/application/service/storage/service_test.go
@@ -166,7 +166,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 		},
 	}
 
-	expectedStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	expectedStorageToAttach := []internal.UnitStorageAttachmentArg{
 		// Existing st1 storage
 		{
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
@@ -199,7 +199,7 @@ func (s *serviceSuite) TestMakeUnitStorageArgs(c *tc.C) {
 	// attachment expectations.
 	expectedStorageToAttach = slices.Grow(expectedStorageToAttach, len(arg.StorageInstances))
 	for _, si := range arg.StorageInstances {
-		attachArg := internal.CreateUnitStorageAttachmentArg{
+		attachArg := internal.UnitStorageAttachmentArg{
 			StorageInstanceUUID: si.UUID,
 		}
 
@@ -366,12 +366,12 @@ func (s *serviceSuite) TestMakeUnitAddStorageArgs(c *tc.C) {
 		},
 	}
 
-	expectedStorageToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(arg.StorageInstances))
+	expectedStorageToAttach := make([]internal.UnitStorageAttachmentArg, 0, len(arg.StorageInstances))
 	// Loop through the new storage instances being created and set their
 	// attachment expectations.
 	expectedStorageToAttach = slices.Grow(expectedStorageToAttach, len(arg.StorageInstances))
 	for _, si := range arg.StorageInstances {
-		attachArg := internal.CreateUnitStorageAttachmentArg{
+		attachArg := internal.UnitStorageAttachmentArg{
 			StorageInstanceUUID: si.UUID,
 		}
 
@@ -451,9 +451,9 @@ func (s *serviceSuite) TestMakeUnitAttachStorageArgs(c *tc.C) {
 	)
 	c.Check(err, tc.ErrorIsNil)
 
-	expectedStorageToAttach := make([]internal.CreateUnitStorageAttachmentArg, 0, len(instComposition))
+	expectedStorageToAttach := make([]internal.UnitStorageAttachmentArg, 0, len(instComposition))
 	for _, si := range instComposition {
-		attachArg := internal.CreateUnitStorageAttachmentArg{
+		attachArg := internal.UnitStorageAttachmentArg{
 			StorageInstanceUUID: si.UUID,
 		}
 

--- a/domain/application/service/storage/storage_mock_test.go
+++ b/domain/application/service/storage/storage_mock_test.go
@@ -303,10 +303,10 @@ func (c *MockStateGetModelStoragePoolsCall) DoAndReturn(f func(context.Context) 
 }
 
 // GetStorageInstanceCompositionByUUID mocks base method.
-func (m *MockState) GetStorageInstanceCompositionByUUID(arg0 context.Context, arg1 storage0.StorageInstanceUUID) ([]internal.StorageInstanceComposition, error) {
+func (m *MockState) GetStorageInstanceCompositionByUUID(arg0 context.Context, arg1 storage0.StorageInstanceUUID) (internal.StorageInstanceComposition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStorageInstanceCompositionByUUID", arg0, arg1)
-	ret0, _ := ret[0].([]internal.StorageInstanceComposition)
+	ret0, _ := ret[0].(internal.StorageInstanceComposition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -324,19 +324,19 @@ type MockStateGetStorageInstanceCompositionByUUIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetStorageInstanceCompositionByUUIDCall) Return(arg0 []internal.StorageInstanceComposition, arg1 error) *MockStateGetStorageInstanceCompositionByUUIDCall {
+func (c *MockStateGetStorageInstanceCompositionByUUIDCall) Return(arg0 internal.StorageInstanceComposition, arg1 error) *MockStateGetStorageInstanceCompositionByUUIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetStorageInstanceCompositionByUUIDCall) Do(f func(context.Context, storage0.StorageInstanceUUID) ([]internal.StorageInstanceComposition, error)) *MockStateGetStorageInstanceCompositionByUUIDCall {
+func (c *MockStateGetStorageInstanceCompositionByUUIDCall) Do(f func(context.Context, storage0.StorageInstanceUUID) (internal.StorageInstanceComposition, error)) *MockStateGetStorageInstanceCompositionByUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetStorageInstanceCompositionByUUIDCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID) ([]internal.StorageInstanceComposition, error)) *MockStateGetStorageInstanceCompositionByUUIDCall {
+func (c *MockStateGetStorageInstanceCompositionByUUIDCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID) (internal.StorageInstanceComposition, error)) *MockStateGetStorageInstanceCompositionByUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/storage/storage_mock_test.go
+++ b/domain/application/service/storage/storage_mock_test.go
@@ -109,44 +109,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AttachStorageToUnit mocks base method.
-func (m *MockState) AttachStorageToUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachStorageToUnit", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AttachStorageToUnit indicates an expected call of AttachStorageToUnit.
-func (mr *MockStateMockRecorder) AttachStorageToUnit(arg0, arg1, arg2 any) *MockStateAttachStorageToUnitCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachStorageToUnit", reflect.TypeOf((*MockState)(nil).AttachStorageToUnit), arg0, arg1, arg2)
-	return &MockStateAttachStorageToUnitCall{Call: call}
-}
-
-// MockStateAttachStorageToUnitCall wrap *gomock.Call
-type MockStateAttachStorageToUnitCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateAttachStorageToUnitCall) Return(arg0 error) *MockStateAttachStorageToUnitCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateAttachStorageToUnitCall) Do(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID) error) *MockStateAttachStorageToUnitCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAttachStorageToUnitCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID, unit.UUID) error) *MockStateAttachStorageToUnitCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // DetachStorage mocks base method.
 func (m *MockState) DetachStorage(arg0 context.Context, arg1 storage0.StorageInstanceUUID) error {
 	m.ctrl.T.Helper()
@@ -336,6 +298,45 @@ func (c *MockStateGetModelStoragePoolsCall) Do(f func(context.Context) (internal
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetModelStoragePoolsCall) DoAndReturn(f func(context.Context) (internal.ModelStoragePools, error)) *MockStateGetModelStoragePoolsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetStorageInstanceCompositionByUUID mocks base method.
+func (m *MockState) GetStorageInstanceCompositionByUUID(arg0 context.Context, arg1 storage0.StorageInstanceUUID) ([]internal.StorageInstanceComposition, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageInstanceCompositionByUUID", arg0, arg1)
+	ret0, _ := ret[0].([]internal.StorageInstanceComposition)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStorageInstanceCompositionByUUID indicates an expected call of GetStorageInstanceCompositionByUUID.
+func (mr *MockStateMockRecorder) GetStorageInstanceCompositionByUUID(arg0, arg1 any) *MockStateGetStorageInstanceCompositionByUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageInstanceCompositionByUUID", reflect.TypeOf((*MockState)(nil).GetStorageInstanceCompositionByUUID), arg0, arg1)
+	return &MockStateGetStorageInstanceCompositionByUUIDCall{Call: call}
+}
+
+// MockStateGetStorageInstanceCompositionByUUIDCall wrap *gomock.Call
+type MockStateGetStorageInstanceCompositionByUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetStorageInstanceCompositionByUUIDCall) Return(arg0 []internal.StorageInstanceComposition, arg1 error) *MockStateGetStorageInstanceCompositionByUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetStorageInstanceCompositionByUUIDCall) Do(f func(context.Context, storage0.StorageInstanceUUID) ([]internal.StorageInstanceComposition, error)) *MockStateGetStorageInstanceCompositionByUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetStorageInstanceCompositionByUUIDCall) DoAndReturn(f func(context.Context, storage0.StorageInstanceUUID) ([]internal.StorageInstanceComposition, error)) *MockStateGetStorageInstanceCompositionByUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/storage_mock_test.go
+++ b/domain/application/service/storage_mock_test.go
@@ -21,6 +21,7 @@ import (
 	internal "github.com/juju/juju/domain/application/internal"
 	charm "github.com/juju/juju/domain/deployment/charm"
 	network "github.com/juju/juju/domain/network"
+	storage0 "github.com/juju/juju/domain/storage"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -204,18 +205,18 @@ func (c *MockStorageServiceMakeApplicationStorageDirectiveArgsCall) DoAndReturn(
 }
 
 // MakeIAASUnitStorageArgs mocks base method.
-func (m *MockStorageService) MakeIAASUnitStorageArgs(arg0 context.Context, arg1 []internal.CreateUnitStorageInstanceArg) (internal.CreateIAASUnitStorageArg, error) {
+func (m *MockStorageService) MakeIAASUnitStorageArgs(arg0 []internal.AddStorageInstanceArg) (internal.CreateIAASUnitStorageArg, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeIAASUnitStorageArgs", arg0, arg1)
+	ret := m.ctrl.Call(m, "MakeIAASUnitStorageArgs", arg0)
 	ret0, _ := ret[0].(internal.CreateIAASUnitStorageArg)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeIAASUnitStorageArgs indicates an expected call of MakeIAASUnitStorageArgs.
-func (mr *MockStorageServiceMockRecorder) MakeIAASUnitStorageArgs(arg0, arg1 any) *MockStorageServiceMakeIAASUnitStorageArgsCall {
+func (mr *MockStorageServiceMockRecorder) MakeIAASUnitStorageArgs(arg0 any) *MockStorageServiceMakeIAASUnitStorageArgsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeIAASUnitStorageArgs", reflect.TypeOf((*MockStorageService)(nil).MakeIAASUnitStorageArgs), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeIAASUnitStorageArgs", reflect.TypeOf((*MockStorageService)(nil).MakeIAASUnitStorageArgs), arg0)
 	return &MockStorageServiceMakeIAASUnitStorageArgsCall{Call: call}
 }
 
@@ -231,13 +232,13 @@ func (c *MockStorageServiceMakeIAASUnitStorageArgsCall) Return(arg0 internal.Cre
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceMakeIAASUnitStorageArgsCall) Do(f func(context.Context, []internal.CreateUnitStorageInstanceArg) (internal.CreateIAASUnitStorageArg, error)) *MockStorageServiceMakeIAASUnitStorageArgsCall {
+func (c *MockStorageServiceMakeIAASUnitStorageArgsCall) Do(f func([]internal.AddStorageInstanceArg) (internal.CreateIAASUnitStorageArg, error)) *MockStorageServiceMakeIAASUnitStorageArgsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceMakeIAASUnitStorageArgsCall) DoAndReturn(f func(context.Context, []internal.CreateUnitStorageInstanceArg) (internal.CreateIAASUnitStorageArg, error)) *MockStorageServiceMakeIAASUnitStorageArgsCall {
+func (c *MockStorageServiceMakeIAASUnitStorageArgsCall) DoAndReturn(f func([]internal.AddStorageInstanceArg) (internal.CreateIAASUnitStorageArg, error)) *MockStorageServiceMakeIAASUnitStorageArgsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -321,10 +322,10 @@ func (c *MockStorageServiceMakeRegisterNewCAASUnitStorageArgCall) DoAndReturn(f 
 }
 
 // MakeUnitAddStorageArgs mocks base method.
-func (m *MockStorageService) MakeUnitAddStorageArgs(arg0 context.Context, arg1 unit.UUID, arg2 uint32, arg3 application0.StorageDirective) (internal.UnitAddStorageArg, error) {
+func (m *MockStorageService) MakeUnitAddStorageArgs(arg0 context.Context, arg1 unit.UUID, arg2 uint32, arg3 application0.StorageDirective) (internal.AddStorageToUnitArg, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeUnitAddStorageArgs", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(internal.UnitAddStorageArg)
+	ret0, _ := ret[0].(internal.AddStorageToUnitArg)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -342,19 +343,58 @@ type MockStorageServiceMakeUnitAddStorageArgsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStorageServiceMakeUnitAddStorageArgsCall) Return(arg0 internal.UnitAddStorageArg, arg1 error) *MockStorageServiceMakeUnitAddStorageArgsCall {
+func (c *MockStorageServiceMakeUnitAddStorageArgsCall) Return(arg0 internal.AddStorageToUnitArg, arg1 error) *MockStorageServiceMakeUnitAddStorageArgsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceMakeUnitAddStorageArgsCall) Do(f func(context.Context, unit.UUID, uint32, application0.StorageDirective) (internal.UnitAddStorageArg, error)) *MockStorageServiceMakeUnitAddStorageArgsCall {
+func (c *MockStorageServiceMakeUnitAddStorageArgsCall) Do(f func(context.Context, unit.UUID, uint32, application0.StorageDirective) (internal.AddStorageToUnitArg, error)) *MockStorageServiceMakeUnitAddStorageArgsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceMakeUnitAddStorageArgsCall) DoAndReturn(f func(context.Context, unit.UUID, uint32, application0.StorageDirective) (internal.UnitAddStorageArg, error)) *MockStorageServiceMakeUnitAddStorageArgsCall {
+func (c *MockStorageServiceMakeUnitAddStorageArgsCall) DoAndReturn(f func(context.Context, unit.UUID, uint32, application0.StorageDirective) (internal.AddStorageToUnitArg, error)) *MockStorageServiceMakeUnitAddStorageArgsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// MakeUnitAttachStorageArgs mocks base method.
+func (m *MockStorageService) MakeUnitAttachStorageArgs(arg0 context.Context, arg1 string, arg2 storage0.StorageInstanceUUID) (internal.CreateUnitStorageAttachmentArg, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeUnitAttachStorageArgs", arg0, arg1, arg2)
+	ret0, _ := ret[0].(internal.CreateUnitStorageAttachmentArg)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MakeUnitAttachStorageArgs indicates an expected call of MakeUnitAttachStorageArgs.
+func (mr *MockStorageServiceMockRecorder) MakeUnitAttachStorageArgs(arg0, arg1, arg2 any) *MockStorageServiceMakeUnitAttachStorageArgsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeUnitAttachStorageArgs", reflect.TypeOf((*MockStorageService)(nil).MakeUnitAttachStorageArgs), arg0, arg1, arg2)
+	return &MockStorageServiceMakeUnitAttachStorageArgsCall{Call: call}
+}
+
+// MockStorageServiceMakeUnitAttachStorageArgsCall wrap *gomock.Call
+type MockStorageServiceMakeUnitAttachStorageArgsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStorageServiceMakeUnitAttachStorageArgsCall) Return(arg0 internal.CreateUnitStorageAttachmentArg, arg1 error) *MockStorageServiceMakeUnitAttachStorageArgsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStorageServiceMakeUnitAttachStorageArgsCall) Do(f func(context.Context, string, storage0.StorageInstanceUUID) (internal.CreateUnitStorageAttachmentArg, error)) *MockStorageServiceMakeUnitAttachStorageArgsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStorageServiceMakeUnitAttachStorageArgsCall) DoAndReturn(f func(context.Context, string, storage0.StorageInstanceUUID) (internal.CreateUnitStorageAttachmentArg, error)) *MockStorageServiceMakeUnitAttachStorageArgsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -439,7 +479,7 @@ func (c *MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall) Do
 }
 
 // ValidateApplicationStorageDirectiveOverrides mocks base method.
-func (m *MockStorageService) ValidateApplicationStorageDirectiveOverrides(arg0 context.Context, arg1 map[string]charm.Storage, arg2 map[string]application0.ApplicationStorageDirectiveOverride) error {
+func (m *MockStorageService) ValidateApplicationStorageDirectiveOverrides(arg0 context.Context, arg1 map[string]internal.ValidateStorageArg, arg2 map[string]application0.ApplicationStorageDirectiveOverride) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateApplicationStorageDirectiveOverrides", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -465,13 +505,51 @@ func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) Ret
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) Do(f func(context.Context, map[string]charm.Storage, map[string]application0.ApplicationStorageDirectiveOverride) error) *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall {
+func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) Do(f func(context.Context, map[string]internal.ValidateStorageArg, map[string]application0.ApplicationStorageDirectiveOverride) error) *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) DoAndReturn(f func(context.Context, map[string]charm.Storage, map[string]application0.ApplicationStorageDirectiveOverride) error) *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall {
+func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) DoAndReturn(f func(context.Context, map[string]internal.ValidateStorageArg, map[string]application0.ApplicationStorageDirectiveOverride) error) *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ValidateAttachStorage mocks base method.
+func (m *MockStorageService) ValidateAttachStorage(arg0 internal.ValidateStorageArg, arg1 uint32, arg2 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateAttachStorage", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateAttachStorage indicates an expected call of ValidateAttachStorage.
+func (mr *MockStorageServiceMockRecorder) ValidateAttachStorage(arg0, arg1, arg2 any) *MockStorageServiceValidateAttachStorageCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAttachStorage", reflect.TypeOf((*MockStorageService)(nil).ValidateAttachStorage), arg0, arg1, arg2)
+	return &MockStorageServiceValidateAttachStorageCall{Call: call}
+}
+
+// MockStorageServiceValidateAttachStorageCall wrap *gomock.Call
+type MockStorageServiceValidateAttachStorageCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStorageServiceValidateAttachStorageCall) Return(arg0 error) *MockStorageServiceValidateAttachStorageCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStorageServiceValidateAttachStorageCall) Do(f func(internal.ValidateStorageArg, uint32, uint64) error) *MockStorageServiceValidateAttachStorageCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStorageServiceValidateAttachStorageCall) DoAndReturn(f func(internal.ValidateStorageArg, uint32, uint64) error) *MockStorageServiceValidateAttachStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/storage_mock_test.go
+++ b/domain/application/service/storage_mock_test.go
@@ -204,6 +204,45 @@ func (c *MockStorageServiceMakeApplicationStorageDirectiveArgsCall) DoAndReturn(
 	return c
 }
 
+// MakeAttachExistingStorageArgs mocks base method.
+func (m *MockStorageService) MakeAttachExistingStorageArgs(arg0 context.Context, arg1 string, arg2 storage0.StorageInstanceUUID, arg3 internal.StorageInfoForAttach) (internal.AttachExistingStorageToUnitArg, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeAttachExistingStorageArgs", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(internal.AttachExistingStorageToUnitArg)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MakeAttachExistingStorageArgs indicates an expected call of MakeAttachExistingStorageArgs.
+func (mr *MockStorageServiceMockRecorder) MakeAttachExistingStorageArgs(arg0, arg1, arg2, arg3 any) *MockStorageServiceMakeAttachExistingStorageArgsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeAttachExistingStorageArgs", reflect.TypeOf((*MockStorageService)(nil).MakeAttachExistingStorageArgs), arg0, arg1, arg2, arg3)
+	return &MockStorageServiceMakeAttachExistingStorageArgsCall{Call: call}
+}
+
+// MockStorageServiceMakeAttachExistingStorageArgsCall wrap *gomock.Call
+type MockStorageServiceMakeAttachExistingStorageArgsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStorageServiceMakeAttachExistingStorageArgsCall) Return(arg0 internal.AttachExistingStorageToUnitArg, arg1 error) *MockStorageServiceMakeAttachExistingStorageArgsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStorageServiceMakeAttachExistingStorageArgsCall) Do(f func(context.Context, string, storage0.StorageInstanceUUID, internal.StorageInfoForAttach) (internal.AttachExistingStorageToUnitArg, error)) *MockStorageServiceMakeAttachExistingStorageArgsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStorageServiceMakeAttachExistingStorageArgsCall) DoAndReturn(f func(context.Context, string, storage0.StorageInstanceUUID, internal.StorageInfoForAttach) (internal.AttachExistingStorageToUnitArg, error)) *MockStorageServiceMakeAttachExistingStorageArgsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MakeIAASUnitStorageArgs mocks base method.
 func (m *MockStorageService) MakeIAASUnitStorageArgs(arg0 []internal.AddStorageInstanceArg) (internal.CreateIAASUnitStorageArg, error) {
 	m.ctrl.T.Helper()
@@ -356,45 +395,6 @@ func (c *MockStorageServiceMakeUnitAddStorageArgsCall) Do(f func(context.Context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStorageServiceMakeUnitAddStorageArgsCall) DoAndReturn(f func(context.Context, unit.UUID, uint32, application0.StorageDirective) (internal.AddStorageToUnitArg, error)) *MockStorageServiceMakeUnitAddStorageArgsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// MakeUnitAttachStorageArgs mocks base method.
-func (m *MockStorageService) MakeUnitAttachStorageArgs(arg0 context.Context, arg1 string, arg2 storage0.StorageInstanceUUID) (internal.CreateUnitStorageAttachmentArg, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeUnitAttachStorageArgs", arg0, arg1, arg2)
-	ret0, _ := ret[0].(internal.CreateUnitStorageAttachmentArg)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MakeUnitAttachStorageArgs indicates an expected call of MakeUnitAttachStorageArgs.
-func (mr *MockStorageServiceMockRecorder) MakeUnitAttachStorageArgs(arg0, arg1, arg2 any) *MockStorageServiceMakeUnitAttachStorageArgsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeUnitAttachStorageArgs", reflect.TypeOf((*MockStorageService)(nil).MakeUnitAttachStorageArgs), arg0, arg1, arg2)
-	return &MockStorageServiceMakeUnitAttachStorageArgsCall{Call: call}
-}
-
-// MockStorageServiceMakeUnitAttachStorageArgsCall wrap *gomock.Call
-type MockStorageServiceMakeUnitAttachStorageArgsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStorageServiceMakeUnitAttachStorageArgsCall) Return(arg0 internal.CreateUnitStorageAttachmentArg, arg1 error) *MockStorageServiceMakeUnitAttachStorageArgsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceMakeUnitAttachStorageArgsCall) Do(f func(context.Context, string, storage0.StorageInstanceUUID) (internal.CreateUnitStorageAttachmentArg, error)) *MockStorageServiceMakeUnitAttachStorageArgsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceMakeUnitAttachStorageArgsCall) DoAndReturn(f func(context.Context, string, storage0.StorageInstanceUUID) (internal.CreateUnitStorageAttachmentArg, error)) *MockStorageServiceMakeUnitAttachStorageArgsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/storage_test.go
+++ b/domain/application/service/storage_test.go
@@ -26,7 +26,7 @@ func setAddUnitNoopStorageExpects(
 	).Return(internal.CreateUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().MakeIAASUnitStorageArgs(
 		gomock.Any(),
-	).Return(internal.IAASUnitStorageArg{}, nil).AnyTimes()
+	).Return(internal.CreateIAASUnitStorageArg{}, nil).AnyTimes()
 }
 
 // setCreateApplicationNoopStorageExpects sets on the storage service mock a set
@@ -48,7 +48,7 @@ func setCreateApplicationNoopStorageExpects(
 	).Return(internal.CreateUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().MakeIAASUnitStorageArgs(
 		gomock.Any(),
-	).Return(internal.IAASUnitStorageArg{}, nil).AnyTimes()
+	).Return(internal.CreateIAASUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().ValidateCharmStorage(
 		gomock.Any(), gomock.Any(),
 	).Return(nil).AnyTimes()

--- a/domain/application/service/storage_test.go
+++ b/domain/application/service/storage_test.go
@@ -26,7 +26,7 @@ func setAddUnitNoopStorageExpects(
 	).Return(internal.CreateUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().MakeIAASUnitStorageArgs(
 		gomock.Any(),
-	).Return(internal.CreateIAASUnitStorageArg{}, nil).AnyTimes()
+	).Return(internal.IAASUnitStorageArg{}, nil).AnyTimes()
 }
 
 // setCreateApplicationNoopStorageExpects sets on the storage service mock a set
@@ -48,7 +48,7 @@ func setCreateApplicationNoopStorageExpects(
 	).Return(internal.CreateUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().MakeIAASUnitStorageArgs(
 		gomock.Any(),
-	).Return(internal.CreateIAASUnitStorageArg{}, nil).AnyTimes()
+	).Return(internal.IAASUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().ValidateCharmStorage(
 		gomock.Any(), gomock.Any(),
 	).Return(nil).AnyTimes()

--- a/domain/application/service/storage_test.go
+++ b/domain/application/service/storage_test.go
@@ -25,7 +25,7 @@ func setAddUnitNoopStorageExpects(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).Return(internal.CreateUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().MakeIAASUnitStorageArgs(
-		gomock.Any(), gomock.Any(),
+		gomock.Any(),
 	).Return(internal.CreateIAASUnitStorageArg{}, nil).AnyTimes()
 }
 
@@ -47,7 +47,7 @@ func setCreateApplicationNoopStorageExpects(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).Return(internal.CreateUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().MakeIAASUnitStorageArgs(
-		gomock.Any(), gomock.Any(),
+		gomock.Any(),
 	).Return(internal.CreateIAASUnitStorageArg{}, nil).AnyTimes()
 	storageService.EXPECT().ValidateCharmStorage(
 		gomock.Any(), gomock.Any(),

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/domain/application/internal"
 	"github.com/juju/juju/domain/constraints"
 	"github.com/juju/juju/domain/deployment"
-	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/status"
@@ -197,22 +196,22 @@ type UnitState interface {
 	//     is returned.
 	GetAllUnitCloudContainerIDsForApplication(context.Context, coreapplication.UUID) (map[coreunit.Name]string, error)
 
-	// GetCharmStorageAndInstanceCountByUnitUUID returns the metadata and how many
+	// GetStorageAddInfoByUnitUUID returns the deploy metadata and how many
 	// storage instances exist for the named storage on the specified unit.
 	// The following error types can be expected:
 	// - [github.com/juju/juju/domain/application/errors.StorageNameNotSupported]: when storage name is not defined in charm metadata.
-	GetCharmStorageAndInstanceCountByUnitUUID(ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name) (internalcharm.Storage, uint32, error)
+	GetStorageAddInfoByUnitUUID(ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name) (internal.StorageInfoForAdd, error)
 
-	// GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID returns the metadata
+	// GetStorageAttachInfoByUnitUUIDAndStorageUUID returns the metadata
 	// and select details for the storage instance on the specified unit.
 	// The details include how many existing instances of the same named storage
 	// already exist, the requested size, and the instance's storage pool.
 	// The following error types can be expected:
 	// - [applicationerrors.storageerrors.StorageInstanceNotFound]: when storage
 	// instance does not exist.
-	GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(
+	GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 		ctx context.Context, unitUUID coreunit.UUID, storageUUID domainstorage.StorageInstanceUUID,
-	) (internalcharm.Storage, internal.StorageInstanceInfo, error)
+	) (internal.StorageInfoForAttach, error)
 
 	// AddStorageForCAASUnit adds storage instances to given unit as specified.
 	// The specified storage name is used to retrieve existing storage instances.

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -6,6 +6,8 @@ package service
 import (
 	"context"
 
+	"github.com/juju/collections/transform"
+
 	coreapplication "github.com/juju/juju/core/application"
 	corecharm "github.com/juju/juju/core/charm"
 	corelife "github.com/juju/juju/core/life"
@@ -24,6 +26,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/status"
+	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -200,6 +203,17 @@ type UnitState interface {
 	// - [github.com/juju/juju/domain/application/errors.StorageNameNotSupported]: when storage name is not defined in charm metadata.
 	GetCharmStorageAndInstanceCountByUnitUUID(ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name) (internalcharm.Storage, uint32, error)
 
+	// GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID returns the metadata
+	// and select details for the storage instance on the specified unit.
+	// The details include how many existing instances of the same named storage
+	// already exist, the requested size, and the instance's storage pool.
+	// The following error types can be expected:
+	// - [applicationerrors.storageerrors.StorageInstanceNotFound]: when storage
+	// instance does not exist.
+	GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(
+		ctx context.Context, unitUUID coreunit.UUID, storageUUID domainstorage.StorageInstanceUUID,
+	) (internalcharm.Storage, internal.StorageInstanceInfo, error)
+
 	// AddStorageForCAASUnit adds storage instances to given unit as specified.
 	// The specified storage name is used to retrieve existing storage instances.
 	// Combination of existing storage instances and anticipated additional storage
@@ -235,6 +249,38 @@ type UnitState interface {
 		ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name,
 		storageArg internal.IAASUnitAddStorageArg,
 	) ([]corestorage.ID, error)
+
+	// AttachStorageToCAASUnit attaches the storage instance to a CAAS unit.
+	// The following error types can be expected:
+	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
+	// unit does not exist.
+	// - [github.com/juju/juju/domain/application/errors.UnitNotAlive]: when the
+	// unit is not alive.
+	// - [github.com/juju/juju/domain/application/errors.StorageInstanceNotFound]:
+	// when the storage instance does not exist.
+	// - [github.com/juju/juju/domain/application/errors.StorageNotAlive]: when
+	// the storage instance is not alive.
+	// - [github.com/juju/juju/domain/application/errors.StorageCountLimitExceeded]:
+	// when the requested storage falls outside of the bounds defined by the charm.
+	AttachStorageToCAASUnit(
+		ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
+		storageArg internal.UnitAttachStorageArg) error
+
+	// AttachStorageToIAASUnit attaches the storage instance to an IAAS unit.
+	// The following error types can be expected:
+	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
+	// unit does not exist.
+	// - [github.com/juju/juju/domain/application/errors.UnitNotAlive]: when the
+	// unit is not alive.
+	// - [github.com/juju/juju/domain/application/errors.StorageInstanceNotFound]:
+	// when the storage instance does not exist.
+	// - [github.com/juju/juju/domain/application/errors.StorageNotAlive]: when
+	// the storage instance is not alive.
+	// - [github.com/juju/juju/domain/application/errors.StorageCountLimitExceeded]:
+	// when the requested storage falls outside of the bounds defined by the charm.
+	AttachStorageToIAASUnit(
+		ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
+		storageArg internal.IAASUnitAttachStorageArg) error
 }
 
 func (s *ProviderService) makeIAASUnitArgs(
@@ -302,8 +348,15 @@ func (s *ProviderService) makeIAASUnitArgs(
 				"making storage arguments for IAAS unit: %w", err,
 			)
 		}
-		iassUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(
-			ctx, unitStorageArgs.StorageInstances)
+		storageInst := transform.Slice(unitStorageArgs.StorageInstances,
+			func(in internal.CreateUnitStorageInstanceArg) internal.UnitStorageInstanceArg {
+				return internal.UnitStorageInstanceArg{
+					Filesystem: in.Filesystem,
+					Volume:     in.Volume,
+					UUID:       in.UUID,
+				}
+			})
+		iassUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(storageInst)
 		if err != nil {
 			return nil, errors.Errorf(
 				"making IAAS storage arguments for IAAS unit: %w", err,

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -229,7 +229,7 @@ type UnitState interface {
 	// when the requested storage falls outside of the bounds defined by the charm.
 	AddStorageForCAASUnit(
 		ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name,
-		storageArg internal.UnitAddStorageArg,
+		storageArg internal.AddStorageToUnitArg,
 	) ([]corestorage.ID, error)
 
 	// AddStorageForIAASUnit adds storage instances to given IAAS unit as specified.
@@ -277,7 +277,7 @@ type UnitState interface {
 	// when the requested storage falls outside of the bounds defined by the charm.
 	AttachStorageToCAASUnit(
 		ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-		storageArg internal.UnitAttachStorageArg) error
+		storageArg internal.AttachStorageToUnitArg) error
 
 	// AttachStorageToIAASUnit attaches the storage instance to an IAAS unit.
 	// The following error types can be expected:
@@ -385,11 +385,11 @@ func (s *ProviderService) makeIAASUnitArgs(
 				NetNodeUUID:   machineNetNodeUUID,
 				UnitStatusArg: s.makeIAASUnitStatusArgs(),
 			},
-			IAASUnitStorageArg: iassUnitStorageArgs,
-			Platform:           platform,
-			Nonce:              u.Nonce,
-			MachineNetNodeUUID: machineNetNodeUUID,
-			MachineUUID:        machineUUID,
+			CreateIAASUnitStorageArg: iassUnitStorageArgs,
+			Platform:                 platform,
+			Nonce:                    u.Nonce,
+			MachineNetNodeUUID:       machineNetNodeUUID,
+			MachineUUID:              machineUUID,
 		}
 		args[i] = arg
 	}

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -248,7 +248,7 @@ type UnitState interface {
 	// when the requested storage falls outside of the bounds defined by the charm.
 	AddStorageForIAASUnit(
 		ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name,
-		storageArg internal.IAASUnitAddStorageArg,
+		storageArg internal.AddStorageToIAASUnitArg,
 	) ([]corestorage.ID, error)
 
 	// GetUnitStorageAttachmentExists returns true if the storage is
@@ -294,7 +294,7 @@ type UnitState interface {
 	// when the requested storage falls outside of the bounds defined by the charm.
 	AttachStorageToIAASUnit(
 		ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-		storageArg internal.IAASUnitAttachStorageArg) error
+		storageArg internal.AttachStorageToIAASUnitArg) error
 }
 
 func (s *ProviderService) makeIAASUnitArgs(

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -209,6 +209,8 @@ type UnitState interface {
 	// The following error types can be expected:
 	// - [applicationerrors.storageerrors.StorageInstanceNotFound]: when storage
 	// instance does not exist.
+	// - [applicationerrors.StorageNameNotSupported]: when the storage instance
+	//  name is not defined in charm metadata.
 	GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 		ctx context.Context, unitUUID coreunit.UUID, storageUUID domainstorage.StorageInstanceUUID,
 	) (internal.StorageInfoForAttach, error)

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -270,7 +270,7 @@ type UnitState interface {
 	// when the requested storage falls outside of the bounds defined by the charm.
 	AttachStorageToUnit(
 		ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-		storageArg internal.AttachStorageToUnitArg) error
+		storageArg internal.AttachExistingStorageToUnitArg) error
 }
 
 func (s *ProviderService) makeIAASUnitArgs(
@@ -375,7 +375,7 @@ func (s *ProviderService) makeIAASUnitArgs(
 					unitUUID, storageInstanceUUID, err,
 				)
 			}
-			attachArg, err := s.makeAttachStorageToUnitArgs(
+			attachArg, err := s.makeAttachExistingStorageToUnitArgs(
 				ctx, storageInstanceUUID, unitUUID, netNodeUUID.String(), placementMachineUUID, storageAttachInfo)
 			if err != nil {
 				return nil, errors.Capture(err)

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -251,7 +251,7 @@ type UnitState interface {
 		storageArg internal.AddStorageToIAASUnitArg,
 	) ([]corestorage.ID, error)
 
-	// AttachStorageToCAASUnit attaches the storage instance to a CAAS unit.
+	// AttachStorageToUnit attaches the storage instance to a CAAS unit.
 	// The following error types can be expected:
 	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
 	// unit does not exist.
@@ -263,25 +263,9 @@ type UnitState interface {
 	// the storage instance is not alive.
 	// - [github.com/juju/juju/domain/application/errors.StorageCountLimitExceeded]:
 	// when the requested storage falls outside of the bounds defined by the charm.
-	AttachStorageToCAASUnit(
+	AttachStorageToUnit(
 		ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
 		storageArg internal.AttachStorageToUnitArg) error
-
-	// AttachStorageToIAASUnit attaches the storage instance to an IAAS unit.
-	// The following error types can be expected:
-	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
-	// unit does not exist.
-	// - [github.com/juju/juju/domain/application/errors.UnitNotAlive]: when the
-	// unit is not alive.
-	// - [github.com/juju/juju/domain/application/errors.StorageInstanceNotFound]:
-	// when the storage instance does not exist.
-	// - [github.com/juju/juju/domain/application/errors.StorageNotAlive]: when
-	// the storage instance is not alive.
-	// - [github.com/juju/juju/domain/application/errors.StorageCountLimitExceeded]:
-	// when the requested storage falls outside of the bounds defined by the charm.
-	AttachStorageToIAASUnit(
-		ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-		storageArg internal.AttachStorageToIAASUnitArg) error
 }
 
 func (s *ProviderService) makeIAASUnitArgs(
@@ -350,8 +334,8 @@ func (s *ProviderService) makeIAASUnitArgs(
 			)
 		}
 		storageInst := transform.Slice(unitStorageArgs.StorageInstances,
-			func(in internal.CreateUnitStorageInstanceArg) internal.UnitStorageInstanceArg {
-				return internal.UnitStorageInstanceArg{
+			func(in internal.CreateUnitStorageInstanceArg) internal.AddStorageInstanceArg {
+				return internal.AddStorageInstanceArg{
 					Filesystem: in.Filesystem,
 					Volume:     in.Volume,
 					UUID:       in.UUID,

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -84,6 +84,11 @@ type UnitState interface {
 	// exist.
 	GetUnitUUIDByName(context.Context, coreunit.Name) (coreunit.UUID, error)
 
+	// GetUnitNetNodeUUID returns the net node UUID for the specified unit.
+	// The following error types can be expected:
+	// - [applicationerrors.UnitNotFound]: when the unit is not found.
+	GetUnitNetNodeUUID(ctx context.Context, uuid coreunit.UUID) (string, error)
+
 	// GetUnitUUIDAndNetNodeForName returns the unit uuid and net node uuid for a
 	// unit matching the supplied name.
 	//
@@ -283,8 +288,9 @@ func (s *ProviderService) makeIAASUnitArgs(
 		}
 
 		var (
-			machineUUID        coremachine.UUID
-			machineNetNodeUUID domainnetwork.NetNodeUUID
+			placementMachineUUID *string
+			machineUUID          coremachine.UUID
+			machineNetNodeUUID   domainnetwork.NetNodeUUID
 		)
 		// If the placement of the unit is on to an already established machine
 		// we need to resolve this to a machine uuid and netnode uuid.
@@ -300,6 +306,7 @@ func (s *ProviderService) makeIAASUnitArgs(
 			}
 			machineUUID = mUUID
 			machineNetNodeUUID = mNNUUID
+			placementMachineUUID = ptr(mUUID.String())
 		} else {
 			// If the placement is not on to an already established machine we need
 			// to generate a new machine uuid and netnode uuid for the unit.
@@ -348,14 +355,34 @@ func (s *ProviderService) makeIAASUnitArgs(
 			)
 		}
 
+		unitUUID, err := coreunit.NewUUID()
+		if err != nil {
+			return nil, errors.Errorf(
+				"generating new unit uuid for IAAS unit: %w", err,
+			)
+		}
+		// We use the same netnode uuid as the machine for the unit.
+		netNodeUUID := machineNetNodeUUID
+
+		// Compose the storage attachments for any existing storage instances
+		// that need to be attached to the unit.
+		for _, storageInstanceUUID := range u.StorageToAttach {
+			attachArg, err := s.makeAttachStorageToUnitArgs(
+				ctx, storageInstanceUUID, unitUUID, netNodeUUID.String(), placementMachineUUID)
+			if err != nil {
+				return nil, errors.Capture(err)
+			}
+			unitStorageArgs.ExistingStorageToAttach = append(unitStorageArgs.ExistingStorageToAttach, attachArg)
+		}
+
 		arg := application.AddIAASUnitArg{
 			AddUnitArg: application.AddUnitArg{
 				CreateUnitStorageArg: unitStorageArgs,
 				Constraints:          constraints,
 				Placement:            placement,
-				// We use the same netnode uuid as the machine for the unit.
-				NetNodeUUID:   machineNetNodeUUID,
-				UnitStatusArg: s.makeIAASUnitStatusArgs(),
+				NetNodeUUID:          netNodeUUID,
+				UnitUUID:             unitUUID,
+				UnitStatusArg:        s.makeIAASUnitStatusArgs(),
 			},
 			CreateIAASUnitStorageArg: iassUnitStorageArgs,
 			Platform:                 platform,
@@ -380,6 +407,13 @@ func (s *ProviderService) makeCAASUnitArgs(
 		placement, err := deployment.ParsePlacement(u.Placement)
 		if err != nil {
 			return nil, errors.Errorf("invalid placement: %w", err)
+		}
+
+		unitUUID, err := coreunit.NewUUID()
+		if err != nil {
+			return nil, errors.Errorf(
+				"generating new unit uuid for caas unit: %w", err,
+			)
 		}
 
 		netNodeUUID, err := domainnetwork.NewNetNodeUUID()
@@ -407,6 +441,7 @@ func (s *ProviderService) makeCAASUnitArgs(
 				CreateUnitStorageArg: unitStorageArgs,
 				Constraints:          constraints,
 				NetNodeUUID:          netNodeUUID,
+				UnitUUID:             unitUUID,
 				Placement:            placement,
 				UnitStatusArg:        s.makeCAASUnitStatusArgs(),
 			},

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -372,11 +372,11 @@ func (s *ProviderService) makeIAASUnitArgs(
 				NetNodeUUID:   machineNetNodeUUID,
 				UnitStatusArg: s.makeIAASUnitStatusArgs(),
 			},
-			CreateIAASUnitStorageArg: iassUnitStorageArgs,
-			Platform:                 platform,
-			Nonce:                    u.Nonce,
-			MachineNetNodeUUID:       machineNetNodeUUID,
-			MachineUUID:              machineUUID,
+			IAASUnitStorageArg: iassUnitStorageArgs,
+			Platform:           platform,
+			Nonce:              u.Nonce,
+			MachineNetNodeUUID: machineNetNodeUUID,
+			MachineUUID:        machineUUID,
 		}
 		args[i] = arg
 	}

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -251,19 +251,6 @@ type UnitState interface {
 		storageArg internal.AddStorageToIAASUnitArg,
 	) ([]corestorage.ID, error)
 
-	// GetUnitStorageAttachmentExists returns true if the storage is
-	// attached to the specified unit.
-	// The following error types can be expected:
-	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
-	// unit does not exist.
-	// - [github.com/juju/juju/domain/application/errors.StorageInstanceNotFound]:
-	// when the storage instance does not exist.
-	GetUnitStorageAttachmentExists(
-		ctx context.Context,
-		stUUID domainstorage.StorageInstanceUUID,
-		uUUID coreunit.UUID,
-	) (bool, error)
-
 	// AttachStorageToCAASUnit attaches the storage instance to a CAAS unit.
 	// The following error types can be expected:
 	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -250,6 +250,19 @@ type UnitState interface {
 		storageArg internal.IAASUnitAddStorageArg,
 	) ([]corestorage.ID, error)
 
+	// GetUnitStorageAttachmentExists returns true if the storage is
+	// attached to the specified unit.
+	// The following error types can be expected:
+	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the
+	// unit does not exist.
+	// - [github.com/juju/juju/domain/application/errors.StorageInstanceNotFound]:
+	// when the storage instance does not exist.
+	GetUnitStorageAttachmentExists(
+		ctx context.Context,
+		stUUID domainstorage.StorageInstanceUUID,
+		uUUID coreunit.UUID,
+	) (bool, error)
+
 	// AttachStorageToCAASUnit attaches the storage instance to a CAAS unit.
 	// The following error types can be expected:
 	// - [github.com/juju/juju/domain/application/errors.UnitNotFound]: when the

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -367,8 +367,16 @@ func (s *ProviderService) makeIAASUnitArgs(
 		// Compose the storage attachments for any existing storage instances
 		// that need to be attached to the unit.
 		for _, storageInstanceUUID := range u.StorageToAttach {
+			storageAttachInfo, err := s.st.GetStorageAttachInfoByUnitUUIDAndStorageUUID(
+				ctx, unitUUID, storageInstanceUUID)
+			if err != nil {
+				return nil, errors.Errorf(
+					"getting unit %q charm storage and attachment info for %q: %w",
+					unitUUID, storageInstanceUUID, err,
+				)
+			}
 			attachArg, err := s.makeAttachStorageToUnitArgs(
-				ctx, storageInstanceUUID, unitUUID, netNodeUUID.String(), placementMachineUUID)
+				ctx, storageInstanceUUID, unitUUID, netNodeUUID.String(), placementMachineUUID, storageAttachInfo)
 			if err != nil {
 				return nil, errors.Capture(err)
 			}

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -429,7 +429,7 @@ func (st *State) insertIAASApplicationUnits(
 ) ([]coremachine.Name, error) {
 	var machineNames []coremachine.Name
 	for i, unit := range units {
-		_, _, mNames, err := st.unitState.InsertIAASUnit(ctx, tx, appUUID, charmUUID, unit)
+		_, _, mNames, err := st.InsertIAASUnit(ctx, tx, appUUID, charmUUID, unit)
 		if err != nil {
 			return nil, errors.Errorf("inserting IAAS unit %d: %w", i, err)
 		}
@@ -1205,7 +1205,7 @@ func (st *State) insertCloudServiceAddresses(
 		return nil
 	}
 
-	subnetUUIDs, err := st.unitState.k8sSubnetUUIDsByAddressType(ctx, tx)
+	subnetUUIDs, err := st.k8sSubnetUUIDsByAddressType(ctx, tx)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -2525,7 +2525,7 @@ func (st *State) GetApplicationName(ctx context.Context, appID coreapplication.U
 	var name string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		name, err = st.unitState.getApplicationName(ctx, tx, appID.String())
+		name, err = st.getApplicationName(ctx, tx, appID.String())
 		return err
 	})
 	if err != nil {

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -375,6 +375,7 @@ func (s *applicationStateSuite) TestCreateApplicationWithUnits(c *tc.C) {
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		MachineNetNodeUUID: machineNetNodeUUID,
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    tc.Must(c, unit.NewUUID),
 			NetNodeUUID: machineNetNodeUUID,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{

--- a/domain/application/state/machine_placement_test.go
+++ b/domain/application/state/machine_placement_test.go
@@ -151,6 +151,7 @@ func (s *machinePlacementSuite) createUnit(c *tc.C) unit.Name {
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	unitNames, _, err := s.state.AddIAASUnits(c.Context(), appID, application.AddIAASUnitArg{
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    tc.Must(c, unit.NewUUID),
 			NetNodeUUID: netNodeUUID,
 		},
 		MachineNetNodeUUID: netNodeUUID,

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -267,7 +267,7 @@ func (st *State) importCAASUnit(
 		return errors.Errorf("generating new net node uuid for imported unit: %w", err)
 	}
 
-	err = st.unitState.insertUnit(
+	err = st.insertUnit(
 		ctx, tx, appUUID, unitUUID, netNodeUUID.String(),
 		insertUnitArg{
 			CharmUUID:       charmUUID,
@@ -364,7 +364,7 @@ func (st *State) importIAASUnit(
 		return errors.Errorf("getting charm for application %q: %w", appUUID, err)
 	}
 
-	if err := st.unitState.insertUnit(ctx, tx, appUUID, unitUUID, netNodeUUID, insertUnitArg{
+	if err := st.insertUnit(ctx, tx, appUUID, unitUUID, netNodeUUID, insertUnitArg{
 		CharmUUID:       charmUUID,
 		UnitName:        args.UnitName.String(),
 		Password:        args.Password,

--- a/domain/application/state/package_test.go
+++ b/domain/application/state/package_test.go
@@ -248,11 +248,15 @@ func (s *baseSuite) createIAASApplicationWithNUnitsAndStorage(
 
 	ctx := c.Context()
 	units := make([]application.AddIAASUnitArg, unitCount)
+	unitUUIDs := make([]coreunit.UUID, unitCount)
 	for i := range units {
+		unitUUID := tc.Must(c, coreunit.NewUUID)
+		unitUUIDs[i] = unitUUID
 		netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 		units[i].MachineUUID = coremachinetesting.GenUUID(c)
 		units[i].MachineNetNodeUUID = netNodeUUID
 		units[i].NetNodeUUID = netNodeUUID
+		units[i].UnitUUID = unitUUID
 	}
 
 	appUUID, _, err := state.CreateIAASApplication(ctx, name, application.AddIAASApplicationArg{
@@ -324,7 +328,6 @@ func (s *baseSuite) createIAASApplicationWithNUnitsAndStorage(
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	unitUUIDs := s.getApplicationUnits(c, appUUID)
 	return appUUID, unitUUIDs
 }
 
@@ -534,18 +537,21 @@ func (s *baseSuite) createSubnetForCAASModel(c *tc.C) {
 func (s *baseSuite) createCAASApplicationWithNUnits(
 	c *tc.C, name string, l life.Life, unitCount int,
 ) (coreapplication.UUID, []coreunit.UUID) {
-	units := make([]application.AddCAASUnitArg, 0, unitCount)
-	for range unitCount {
-		units = append(units, application.AddCAASUnitArg{
+	units := make([]application.AddCAASUnitArg, unitCount)
+	unitUUIDs := make([]coreunit.UUID, unitCount)
+	for i := range unitCount {
+		unitUUID := tc.Must(c, coreunit.NewUUID)
+		unitUUIDs[i] = unitUUID
+		units[i] = application.AddCAASUnitArg{
 			AddUnitArg: application.AddUnitArg{
+				UnitUUID:    unitUUID,
 				NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 			},
-		})
+		}
 	}
 	appUUID := s.createCAASApplication(
 		c, name, l, units...,
 	)
-	unitUUIDs := s.getApplicationUnits(c, appUUID)
 	return appUUID, unitUUIDs
 }
 

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -30,7 +30,6 @@ type State struct {
 	modelUUID model.UUID
 	clock     clock.Clock
 	logger    logger.Logger
-	unitState *InsertIAASUnitState
 }
 
 // NewState returns a new state reference.
@@ -41,11 +40,6 @@ func NewState(factory database.TxnRunnerFactory, modelUUID model.UUID, clock clo
 		modelUUID: modelUUID,
 		clock:     clock,
 		logger:    logger,
-		unitState: &InsertIAASUnitState{
-			StateBase: base,
-			clock:     clock,
-			logger:    logger,
-		},
 	}
 }
 
@@ -1370,14 +1364,6 @@ WHERE name = $applicationDetails.name
 		return applicationerrors.ApplicationAlreadyExists
 	}
 	return nil
-}
-
-// checkApplicationAlive checks if the application exists and is alive.
-//   - If the application is not alive, [applicationerrors.ApplicationNotAlive] is returned.
-//   - If the application is not found, [applicationerrors.ApplicationNotFound]
-//     is returned.
-func (st *State) checkApplicationAlive(ctx context.Context, tx *sqlair.TX, appUUID coreapplication.UUID) error {
-	return st.checkApplicationLife(ctx, tx, appUUID, domainlife.Alive)
 }
 
 // checkApplicationNotDead checks if the application exists and is not dead. It's

--- a/domain/application/state/state_test.go
+++ b/domain/application/state/state_test.go
@@ -130,25 +130,25 @@ func (s *stateSuite) TestCheckApplicationExistsDead(c *tc.C) {
 }
 
 func (s *stateSuite) TestCheckApplicationExistsAlive(c *tc.C) {
-	id := s.createIAASApplication(c, "foo", life.Dying)
+	appUUID := s.createIAASApplication(c, "foo", life.Dying)
 
 	st := NewState(s.TxnRunnerFactory(), s.modelUUID, clock.WallClock, loggertesting.WrapCheckLog(c))
 
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return st.checkApplicationAlive(ctx, tx, id)
+		return st.checkApplicationAlive(ctx, tx, appUUID.String())
 	})
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotAlive)
 }
 
 func (s *stateSuite) TestCheckApplicationExistsAliveSyntheticCMRApplication(c *tc.C) {
-	id := s.createIAASApplication(c, "foo", life.Dying)
+	appUUID := s.createIAASApplication(c, "foo", life.Dying)
 
 	// Switch the source_id of a charm to a synthetic CMR charm.
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
 UPDATE charm SET source_id = 2, architecture_id = NULL WHERE uuid = (
 SELECT charm_uuid FROM application WHERE uuid = ?
-)`, id)
+)`, appUUID)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -156,7 +156,7 @@ SELECT charm_uuid FROM application WHERE uuid = ?
 	st := NewState(s.TxnRunnerFactory(), s.modelUUID, clock.WallClock, loggertesting.WrapCheckLog(c))
 
 	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return st.checkApplicationAlive(ctx, tx, id)
+		return st.checkApplicationAlive(ctx, tx, appUUID.String())
 	})
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotAlive)
 }

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -8,6 +8,8 @@ import (
 	"database/sql"
 
 	"github.com/canonical/sqlair"
+	"github.com/juju/collections/set"
+	"github.com/juju/collections/transform"
 
 	coreapplication "github.com/juju/juju/core/application"
 	coremachine "github.com/juju/juju/core/machine"
@@ -537,33 +539,11 @@ FROM (
 	return retInstComp, retAttachmentComp, nil
 }
 
-// GetUnitStorageAttachmentExists returns true if the storage is
-// attached to the specified unit.
-func (st *State) GetUnitStorageAttachmentExists(
-	ctx context.Context,
-	stUUID domainstorage.StorageInstanceUUID,
-	uUUID coreunit.UUID,
-) (bool, error) {
-	db, err := st.DB(ctx)
-	if err != nil {
-		return false, errors.Capture(err)
-	}
-	var result bool
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		var err error
-		result, err = st.getUnitStorageAttachmentExists(ctx, tx, stUUID, uUUID)
-		return errors.Capture(err)
-	})
-	return result, errors.Capture(err)
-}
-
-func (st *State) getUnitStorageAttachmentExists(
+func (st *State) getStorageAttachmentUnits(
 	ctx context.Context,
 	tx *sqlair.TX,
 	stUUID domainstorage.StorageInstanceUUID,
-	uUUID coreunit.UUID,
-) (bool, error) {
-	unitUUID := unitUUID{UnitUUID: uUUID.String()}
+) ([]string, error) {
 	storageUUID := entityUUID{UUID: stUUID.String()}
 
 	storageExistsStmt, err := st.Prepare(`
@@ -572,46 +552,38 @@ FROM   storage_instance
 WHERE  uuid = $entityUUID.uuid
 `, storageUUID)
 	if err != nil {
-		return false, errors.Capture(err)
+		return nil, errors.Capture(err)
 	}
+
+	type unitUUID entityUUID
 
 	attachStmt, err := st.Prepare(`
-SELECT count(*) AS &count.count
+SELECT u.uuid AS &unitUUID.uuid
 FROM   storage_attachment sia
 JOIN   unit u ON sia.unit_uuid = u.uuid
-WHERE  u.uuid = $unitUUID.uuid
 AND    sia.storage_instance_uuid = $entityUUID.uuid
-`, unitUUID, storageUUID, count{})
+`, storageUUID, unitUUID{})
 	if err != nil {
-		return false, errors.Capture(err)
+		return nil, errors.Capture(err)
 	}
 
-	exists, err := st.checkUnitExists(ctx, tx, uUUID.String())
-	if err != nil {
-		return false, errors.Errorf(
-			"checking unit %q exists: %w", uUUID, err,
-		)
-	}
-	if !exists {
-		return false, errors.Errorf("unit %q does not exist", uUUID).Add(
-			applicationerrors.UnitNotFound,
-		)
-	}
 	err = tx.Query(ctx, storageExistsStmt, storageUUID).Get(&storageUUID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return false, errors.Errorf("storage %q does not exist", stUUID).
+		return nil, errors.Errorf("storage %q does not exist", stUUID).
 			Add(storageerrors.StorageInstanceNotFound)
 	}
 	if err != nil {
-		return false, errors.Errorf("checking storage %q exists: %w", stUUID, err)
+		return nil, errors.Errorf("checking storage %q exists: %w", stUUID, err)
 	}
 
-	var result count
-	err = tx.Query(ctx, attachStmt, unitUUID, storageUUID).Get(&result)
-	if err != nil {
-		return false, errors.Errorf("checking storage %q is attached to unit %q: %w", stUUID, uUUID, err)
+	var result []unitUUID
+	err = tx.Query(ctx, attachStmt, storageUUID).GetAll(&result)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Errorf("getting storage %q attachments: %w", stUUID, err)
 	}
-	return result.Count > 0, nil
+	return transform.Slice(result, func(u unitUUID) string { return u.UUID }), nil
 }
 
 // GetUnitStorageDirectives returns the storage directives that are set for
@@ -1108,13 +1080,20 @@ func (st *State) attachStorageForUnit(
 	ctx context.Context, tx *sqlair.TX, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
 	storageArg internal.AttachStorageToUnitArg,
 ) error {
-	// Already attached is a no-op.
-	attached, err := st.getUnitStorageAttachmentExists(ctx, tx, storageUUID, unitUUID)
+	// Check allowed attachments.
+	attachedToUnits, err := st.getStorageAttachmentUnits(ctx, tx, storageUUID)
 	if err != nil {
 		return errors.Capture(err)
 	}
-	if attached {
-		return nil
+	allowedAttachments := set.NewStrings(storageArg.AllowedExistingUnitAttachments...)
+	attachedTo := set.NewStrings(attachedToUnits...)
+	if attachedTo.Difference(allowedAttachments).Size() > 0 {
+		return internal.StorageAttachmentNotAllowed{
+			AttachedToUnits: attachedToUnits,
+		}
+	} else if attachedTo.Contains(unitUUID.String()) {
+		// The storage is already attached to the unit, so we can no-op.
+		return internal.StorageAlreadyAttached
 	}
 
 	// First to the basic life checks for the unit and storage.
@@ -1221,6 +1200,9 @@ func (st *State) AttachStorageToCAASUnit(
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.attachStorageForUnit(ctx, tx, storageUUID, unitUUID, storageArg)
+		if errors.Is(err, internal.StorageAlreadyAttached) {
+			return nil
+		}
 		return errors.Capture(err)
 	})
 	if err != nil {
@@ -1246,7 +1228,9 @@ func (st *State) AttachStorageToIAASUnit(
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.attachStorageForUnit(ctx, tx, storageUUID, unitUUID, storageArg.AttachStorageToUnitArg)
-		if err != nil {
+		if errors.Is(err, internal.StorageAlreadyAttached) {
+			return nil
+		} else if err != nil {
 			return errors.Capture(err)
 		}
 

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -921,7 +921,7 @@ WHERE  uuid = $storagePoolUUID.uuid
 func makeInsertUnitStorageAttachmentArgs(
 	_ context.Context,
 	unitUUID string,
-	storageToAttach []internal.CreateUnitStorageAttachmentArg,
+	storageToAttach []internal.UnitStorageAttachmentArg,
 ) []insertStorageInstanceAttachment {
 	rval := make([]insertStorageInstanceAttachment, 0, len(storageToAttach))
 	for _, sa := range storageToAttach {

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -9,7 +9,6 @@ import (
 	"github.com/canonical/sqlair"
 
 	coreapplication "github.com/juju/juju/core/application"
-	coreerrors "github.com/juju/juju/core/errors"
 	coremachine "github.com/juju/juju/core/machine"
 	corestorage "github.com/juju/juju/core/storage"
 	coreunit "github.com/juju/juju/core/unit"
@@ -185,6 +184,64 @@ SELECT &storageDirective.* FROM (
 	return rval, nil
 }
 
+// GetStorageInstanceCompositionByUUID returns the storage compositions for
+// the specified storage instance.
+func (st *State) GetStorageInstanceCompositionByUUID(
+	ctx context.Context,
+	storageInstanceUUID domainstorage.StorageInstanceUUID,
+) (
+	[]internal.StorageInstanceComposition,
+	error,
+) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	storageInstanceUUIDInput := entityUUID{UUID: storageInstanceUUID.String()}
+	compositionQ := `
+SELECT &storageInstanceComposition.*
+FROM (
+    SELECT    sf.uuid AS filesystem_uuid,
+              sf.provision_scope_id AS filesystem_provision_scope,
+              si.storage_name AS storage_name,
+              si.uuid AS uuid,
+              sv.uuid AS volume_uuid,
+              sv.provision_scope_id AS volume_provision_scope
+    FROM      storage_instance si
+    LEFT JOIN storage_instance_filesystem sif ON si.uuid = sif.storage_instance_uuid
+    LEFT JOIN storage_filesystem sf ON sif.storage_filesystem_uuid = sf.uuid
+    LEFT JOIN storage_instance_volume siv ON si.uuid = siv.storage_instance_uuid
+    LEFT JOIN storage_volume sv ON siv.storage_volume_uuid = sv.uuid
+    WHERE     si.uuid = $entityUUID.uuid
+)
+`
+
+	stmt, err := st.Prepare(
+		compositionQ,
+		storageInstanceUUIDInput,
+		storageInstanceComposition{},
+	)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var dbVals []storageInstanceComposition
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, storageInstanceUUIDInput).GetAll(&dbVals)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("storage instance %q not found", storageInstanceUUID).
+				Add(storageerrors.StorageInstanceNotFound)
+		}
+		return err
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	rval := makeStorageInstanceComposition(dbVals)
+	return rval, nil
+}
+
 // GetStorageInstancesForProviderIDs returns all of the storage instances
 // found in the model using one of the provider ids supplied. The storage
 // instance must also not be owned by a unit. If no storage instances are found
@@ -257,6 +314,11 @@ FROM (
 		return nil, errors.Capture(err)
 	}
 
+	rval := makeStorageInstanceComposition(dbVals)
+	return rval, nil
+}
+
+func makeStorageInstanceComposition(dbVals []storageInstanceComposition) []internal.StorageInstanceComposition {
 	rval := make([]internal.StorageInstanceComposition, 0, len(dbVals))
 	for _, dbVal := range dbVals {
 		v := internal.StorageInstanceComposition{
@@ -280,8 +342,7 @@ FROM (
 
 		rval = append(rval, v)
 	}
-
-	return rval, nil
+	return rval
 }
 
 // GetUnitOwnedStorageInstances returns the storage compositions for all
@@ -961,83 +1022,120 @@ WHERE  storage_id = $storageInstance.storage_id
 	return inst.StorageUUID, nil
 }
 
-// AttachStorageToUnit attaches the specified storage to the specified unit.
-// The following error types can be expected:
-// - [storageerrors.StorageInstanceNotFound] when the storage doesn't exist.
-// - [applicationerrors.UnitNotFound]: when the unit does not exist.
-// - [applicationerrors.StorageAlreadyAttached]: when the attachment already exists.
-// - [applicationerrors.FilesystemAlreadyAttached]: when the filesystem is already attached.
-// - [applicationerrors.VolumeAlreadyAttached]: when the volume is already attached.
-// - [applicationerrors.UnitNotAlive]: when the unit is not alive.
-// - [applicationerrors.StorageNotAlive]: when the storage is not alive.
-// - [applicationerrors.StorageNameNotSupported]: when storage name is not defined in charm metadata.
-// - [applicationerrors.InvalidStorageCount]: when the allowed attachment count would be violated.
-func (st *State) AttachStorageToUnit(ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID) error {
+func (st *State) attachStorageForUnit(
+	ctx context.Context, tx *sqlair.TX, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
+	storageArg internal.UnitAttachStorageArg,
+) error {
+	// First to the basic life checks for the unit and storage.
+	unitLifeID, _, err := st.getUnitLifeAndNetNode(ctx, tx, unitUUID.String())
+	if err != nil {
+		return err
+	}
+	if unitLifeID != life.Alive {
+		return errors.Errorf("unit %q is not alive", unitUUID).Add(applicationerrors.UnitNotAlive)
+	}
+
+	stor, err := st.getStorageDetails(ctx, tx, storageUUID)
+	if err != nil {
+		return err
+	}
+	if stor.LifeID != life.Alive {
+		return errors.Errorf("storage %q is not alive", unitUUID).Add(applicationerrors.StorageNotAlive)
+	}
+
+	// Ensure another update hasn't violated our preconditions.
+	currentCount, err := st.getUnitStorageCount(ctx, tx, unitUUID, stor.StorageName)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if currentCount > storageArg.CountLessThanEqual {
+		return internal.MaxStorageCountPreconditonFailed
+	}
+
+	err = st.unitState.insertUnitStorageAttachments(
+		ctx,
+		tx,
+		unitUUID.String(),
+		storageArg.StorageToAttach,
+	)
+	if err != nil {
+		return errors.Errorf(
+			"creating storage attachments for unit %q: %w", unitUUID, err,
+		)
+	}
+
+	err = st.unitState.insertUnitStorageOwnership(ctx, tx, unitUUID.String(), []domainstorage.StorageInstanceUUID{storageUUID})
+	if err != nil {
+		return errors.Errorf(
+			"inserting storage ownership for unit %q: %w", unitUUID, err,
+		)
+	}
+	return nil
+}
+
+// AttachStorageToCAASUnit attaches the storage instance to a CAAS unit.
+func (st *State) AttachStorageToCAASUnit(
+	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
+	storageArg internal.UnitAttachStorageArg,
+) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	countQuery, err := st.Prepare(`
-SELECT count(*) AS &storageCount.count
-FROM storage_instance si
-JOIN storage_unit_owner suo ON si.uuid = suo.storage_instance_uuid
-WHERE suo.unit_uuid = $storageCount.unit_uuid
-AND si.storage_name = $storageCount.storage_name
-AND si.uuid != $storageCount.uuid
-`, storageCount{})
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := st.attachStorageForUnit(ctx, tx, storageUUID, unitUUID, storageArg)
+		return errors.Capture(err)
+	})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return nil
+}
+
+// AttachStorageToIAASUnit attaches the storage instance to an IAAS unit.
+func (st *State) AttachStorageToIAASUnit(
+	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
+	storageArg internal.IAASUnitAttachStorageArg,
+) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	machineUUID, err := st.GetUnitMachineUUID(ctx, unitUUID.String())
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		// First to the basic life checks for the unit and storage.
-		unitLifeID, netNodeUUID, err := st.getUnitLifeAndNetNode(ctx, tx, unitUUID.String())
+		err := st.attachStorageForUnit(ctx, tx, storageUUID, unitUUID, storageArg.UnitAttachStorageArg)
 		if err != nil {
-			return err
-		}
-		if unitLifeID != life.Alive {
-			return errors.Errorf("unit %q is not alive", unitUUID).Add(applicationerrors.UnitNotAlive)
+			return errors.Capture(err)
 		}
 
-		stor, err := st.getStorageDetails(ctx, tx, storageUUID)
+		err = st.unitState.insertMachineVolumeOwnership(ctx, tx, coremachine.UUID(machineUUID),
+			storageArg.VolumesToOwn)
 		if err != nil {
-			return err
-		}
-		if stor.LifeID != life.Alive {
-			return errors.Errorf("storage %q is not alive", unitUUID).Add(applicationerrors.StorageNotAlive)
-		}
-
-		// See if the storage name is supported by the unit's current charm.
-		// We might be attaching a storage instance created for a previous charm version
-		// and no longer supported.
-		charmStorage, err := st.getUnitCharmStorageByName(ctx, tx, unitUUID, stor.StorageName)
-		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(
-				"charm for unit %q has no storage called %q",
-				unitUUID, stor.StorageName,
-			).Add(applicationerrors.StorageNameNotSupported)
-		} else if err != nil {
-			return errors.Errorf("getting charm storage metadata for storage name %q unit %q: %w", stor.StorageName, unitUUID, err)
+				"inserting volume ownership for machine %q: %w",
+				machineUUID, err,
+			)
 		}
 
-		// Check allowed storage attachment counts - will this attachment exceed the max allowed.
-		// First get the number of storage instances (excluding the one we are attaching)
-		// of the same name already owned by this unit.
-		storageCount := storageCount{StorageUUID: storageUUID, StorageName: stor.StorageName, UnitUUID: unitUUID}
-		err = tx.Query(ctx, countQuery, storageCount).Get(&storageCount)
-		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("querying storage count for storage %q on unit %q: %w", stor.StorageName, unitUUID, err)
-		}
-		// Ensure that the attachment count can increase by 1.
-		if err := ensureCharmStorageCountChange(charmStorage, storageCount.Count, 1); err != nil {
-			return err
+		err = st.unitState.insertMachineFilesystemOwnership(ctx, tx, coremachine.UUID(machineUUID),
+			storageArg.FilesystemsToOwn)
+		if err != nil {
+			return errors.Errorf(
+				"inserting volume ownership for machine %q: %w",
+				machineUUID, err,
+			)
 		}
 
-		return st.attachStorage(ctx, tx, stor, unitUUID, netNodeUUID, charmStorage)
+		return nil
 	})
 	if err != nil {
-		return errors.Errorf("attaching storage %q to unit %q: %w", storageUUID, unitUUID, err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -1335,244 +1433,3 @@ SELECT &modelStoragePools.* FROM (
 	}
 	return rval, nil
 }
-
-// ensureCharmStorageCountChange checks that the charm storage can change by
-// the specified (positive or negative) increment. This is a backstop - the service
-// should already have performed the necessary validation.
-func ensureCharmStorageCountChange(charmStorage charmStorage, current, n uint32) error {
-	action := "attach"
-	gerund := action + "ing"
-	pluralise := ""
-	if n != 1 {
-		pluralise = "s"
-	}
-
-	count := current + n
-	if charmStorage.CountMin == 1 && charmStorage.CountMax == 1 && count != 1 {
-		return errors.Errorf("cannot %s, storage is singular", action)
-	}
-	if count < uint32(charmStorage.CountMin) {
-		return errors.Errorf(
-			"%s %d storage instance%s brings the total to %d, "+
-				"which is less than the minimum of %d",
-			gerund, n, pluralise, count,
-			charmStorage.CountMin,
-		).Add(applicationerrors.InvalidStorageCount)
-	}
-	if charmStorage.CountMax >= 0 && count > uint32(charmStorage.CountMax) {
-		return errors.Errorf(
-			"%s %d storage instance%s brings the total to %d, "+
-				"exceeding the maximum of %d",
-			gerund, n, pluralise, count,
-			charmStorage.CountMax,
-		).Add(applicationerrors.InvalidStorageCount)
-	}
-	return nil
-}
-
-func (st *State) attachStorage(
-	ctx context.Context, tx *sqlair.TX, inst storageInstance, unitUUID coreunit.UUID, netNodeUUID string,
-	charmStorage charmStorage,
-) error {
-	// TODO (tlm) reimplement when we understand what attach storage looks like.
-	return coreerrors.NotImplemented
-	//	su := storageUnit{StorageUUID: inst.StorageUUID, UnitUUID: unitUUID}
-	//	updateStorageInstanceQuery, err := st.Prepare(`
-	//
-	// UPDATE storage_instance
-	// SET    charm_uuid = (SELECT charm_uuid FROM unit where uuid = $storageUnit.unit_uuid)
-	// WHERE  uuid = $storageUnit.storage_instance_uuid
-	// `, su)
-	//
-	//	if err != nil {
-	//		return errors.Capture(err)
-	//	}
-	//
-	//	err = st.attachStorageToUnit(ctx, tx, inst.StorageUUID, unitUUID)
-	//	if err != nil {
-	//		return errors.Errorf("attaching storage %q to unit %q: %w", inst.StorageUUID, unitUUID, err)
-	//	}
-	//
-	//	// TODO(storage) - insert data for the unit's assigned machine when that is implemented
-	//
-	//	// Attach volumes and filesystems for reattached storage on CAAS.
-	//	// This only occurs in corner cases where a new pod appears with storage
-	//	// that needs to be reconciled with the Juju model. It is part of the
-	//	// UnitIntroduction workflow when a pod appears with volumes already attached.
-	//	// TODO - this can be removed when ObservedAttachedVolumeIDs are processed.
-	//	modelType, err := st.getModelType(ctx, tx)
-	//	if err != nil {
-	//		return errors.Errorf("getting model type: %w", err)
-	//	}
-	//	if modelType == model.CAAS {
-	//		filesystem, volume, err := st.attachmentParamsForStorageInstance(ctx, tx, inst.StorageUUID, inst.StorageID, inst.StorageName, charmStorage)
-	//		if err != nil {
-	//			return errors.Errorf("creating storage attachment parameters: %w", err)
-	//		}
-	//		if filesystem != nil {
-	//			if err := st.attachFilesystemToNode(ctx, tx, netNodeUUID, *filesystem); err != nil {
-	//				return errors.Errorf("attaching filesystem %q to unit %q: %w", filesystem.filesystemUUID, unitUUID, err)
-	//			}
-	//		}
-	//		if volume != nil {
-	//			if err := st.attachVolumeToNode(ctx, tx, netNodeUUID, *volume); err != nil {
-	//				return errors.Errorf("attaching volume %q to unit %q: %w", volume.volumeUUID, unitUUID, err)
-	//			}
-	//		}
-	//	}
-	//
-	//	// Update the charm of the storage instance to match the unit to which it is being attached.
-	//	err = tx.Query(ctx, updateStorageInstanceQuery, su).Run()
-	//	if err != nil {
-	//		return errors.Errorf("updating storage instance %q charm: %w", inst.StorageUUID, err)
-	//	}
-	//	return nil
-}
-
-// type filesystemAttachmentParams struct {
-//	// locationAutoGenerated records whether or not the Location
-//	// field's value was automatically generated, and thus known
-//	// to be unique. This is used to optimise away mount point
-//	// conflict checks.
-//	locationAutoGenerated bool
-//	filesystemUUID        string
-//	location              string
-//	readOnly              bool
-// }
-
-// attachmentParamsForStorageInstance returns parameters for creating
-// volume and filesystem attachments for the specified storage.
-// func (st *State) attachmentParamsForStorageInstance(
-//	ctx context.Context,
-//	tx *sqlair.TX,
-//	storageUUID domainstorage.StorageInstanceUUID,
-//	storageID corestorage.ID,
-//	storageName corestorage.Name,
-//	charmStorage charmStorage,
-// ) (filesystemResult *filesystemAttachmentParams, volumeResult *volumeAttachmentParams, _ error) {
-//
-//	switch charm.StorageType(charmStorage.Kind) {
-//	case charm.StorageFilesystem:
-//		location, err := domainstorage.FilesystemMountPoint(charmStorage.Location, charmStorage.CountMax, storageID)
-//		if err != nil {
-//			return nil, nil, errors.Errorf(
-//				"getting filesystem mount point for storage %s: %w",
-//				storageName, err,
-//			).Add(applicationerrors.InvalidStorageMountPoint)
-//		}
-//
-//		filesystem, err := st.getStorageFilesystem(ctx, tx, storageUUID)
-//		if err != nil {
-//			return nil, nil, errors.Errorf("getting filesystem UUID for storage %q: %w", storageID, err)
-//		}
-//		// The filesystem already exists, so just attach it.
-//		// When creating ops to attach the storage to the
-//		// machine, we will check if the attachment already
-//		// exists, and whether the storage can be attached to
-//		// the machine.
-//		if !charmStorage.Shared {
-//			// The storage is not shared, so make sure that it is
-//			// not currently attached to any other host. If it
-//			// is, it should be in the process of being detached.
-//			if filesystem.AttachedTo != nil {
-//				return nil, nil, errors.Errorf(
-//					"filesystem %q is attached to %q", filesystem.UUID, *filesystem.AttachedTo).
-//					Add(applicationerrors.FilesystemAlreadyAttached)
-//			}
-//		}
-//		filesystemResult = &filesystemAttachmentParams{
-//			locationAutoGenerated: charmStorage.Location == "", // auto-generated location
-//			location:              location,
-//			readOnly:              charmStorage.ReadOnly,
-//			filesystemUUID:        filesystem.UUID,
-//		}
-//
-//		// Fall through to attach the volume that backs the filesystem (if any).
-//		fallthrough
-//
-//	case charm.StorageBlock:
-//		volume, err := st.getStorageVolume(ctx, tx, storageUUID)
-//		if errors.Is(err, storageerrors.VolumeNotFound) && charm.StorageType(charmStorage.Kind) == charm.StorageFilesystem {
-//			break
-//		}
-//		if err != nil {
-//			return nil, nil, errors.Errorf("getting volume UUID for storage %q: %w", storageID, err)
-//		}
-//
-//		// The volume already exists, so just attach it. When
-//		// creating ops to attach the storage to the machine,
-//		// we will check if the attachment already exists, and
-//		// whether the storage can be attached to the machine.
-//		if !charmStorage.Shared {
-//			// The storage is not shared, so make sure that it is
-//			// not currently attached to any other machine. If it
-//			// is, it should be in the process of being detached.
-//			if volume.AttachedTo != nil {
-//				return nil, nil, errors.Errorf("volume %q is attached to %q", volume.UUID, *volume.AttachedTo).
-//					Add(applicationerrors.VolumeAlreadyAttached)
-//			}
-//		}
-//		volumeResult = &volumeAttachmentParams{
-//			readOnly:   charmStorage.ReadOnly,
-//			volumeUUID: volume.UUID,
-//		}
-//	default:
-//		return nil, nil, errors.Errorf("invalid storage kind %v", charmStorage.Kind)
-//	}
-//	return filesystemResult, volumeResult, nil
-// }
-
-// func (st *State) attachFilesystemToNode(
-//	ctx context.Context, tx *sqlair.TX, netNodeUUID string, args filesystemAttachmentParams,
-// ) error {
-//	uuid, err := storageprovisioning.NewFilesystemAttachmentUUID()
-//	if err != nil {
-//		return errors.Capture(err)
-//	}
-//	fsa := filesystemAttachment{
-//		UUID:           uuid.String(),
-//		NetNodeUUID:    netNodeUUID,
-//		FilesystemUUID: args.filesystemUUID,
-//		LifeID:         life.Alive,
-//		MountPoint:     args.location,
-//		ReadOnly:       args.readOnly,
-//	}
-//	stmt, err := st.Prepare(`
-// INSERT INTO storage_filesystem_attachment (*) VALUES ($filesystemAttachment.*)
-// `, fsa)
-//	if err != nil {
-//		return errors.Capture(err)
-//	}
-//	err = tx.Query(ctx, stmt, fsa).Run()
-//	if err != nil {
-//		return errors.Errorf("creating filesystem attachment for %q on %q: %w", args.filesystemUUID, netNodeUUID, err)
-//	}
-//	return nil
-// }
-
-// func (st *State) attachVolumeToNode(
-//	ctx context.Context, tx *sqlair.TX, netNodeUUID string, args volumeAttachmentParams,//
-// ) error {
-//	uuid, err := storageprovisioning.NewVolumeAttachmentUUID()
-//	if err != nil {
-//		return errors.Capture(err)
-//	}
-//	fsa := volumeAttachment{
-//		UUID:        uuid.String(),
-//		NetNodeUUID: netNodeUUID,
-//		VolumeUUID:  args.volumeUUID,
-//		LifeID:      life.Alive,
-//		ReadOnly:    args.readOnly,
-//	}
-//	stmt, err := st.Prepare(`
-// INSERT INTO storage_volume_attachment (*) VALUES ($volumeAttachment.*)
-// `, fsa)
-//	if err != nil {
-//		return errors.Capture(err)
-//	}
-//	err = tx.Query(ctx, stmt, fsa).Run()
-//	if err != nil {
-//		return errors.Errorf("creating volume attachment for %q on %q: %w", args.volumeUUID, netNodeUUID, err)
-//	}
-//	return nil
-// }

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -973,7 +973,6 @@ WHERE  uuid = $storagePoolUUID.uuid
 // makeInsertUnitStorageAttachmentArgs is responsible for making the set of
 // storage instance attachment arguments that correspond to the storage uuids.
 func makeInsertUnitStorageAttachmentArgs(
-	_ context.Context,
 	unitUUID string,
 	storageToAttach []internal.CreateUnitStorageAttachmentArg,
 ) []insertStorageInstanceAttachment {
@@ -1188,8 +1187,8 @@ WHERE storage_instance.uuid = $storageInstance.uuid
 	return nil
 }
 
-// AttachStorageToCAASUnit attaches the storage instance to a CAAS unit.
-func (st *State) AttachStorageToCAASUnit(
+// AttachStorageToUnit attaches the storage instance to an unit.
+func (st *State) AttachStorageToUnit(
 	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
 	storageArg internal.AttachStorageToUnitArg,
 ) error {
@@ -1203,55 +1202,9 @@ func (st *State) AttachStorageToCAASUnit(
 		if errors.Is(err, internal.StorageAlreadyAttached) {
 			return nil
 		}
-		return errors.Capture(err)
-	})
-	if err != nil {
-		return errors.Capture(err)
-	}
-	return nil
-}
-
-// AttachStorageToIAASUnit attaches the storage instance to an IAAS unit.
-func (st *State) AttachStorageToIAASUnit(
-	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-	storageArg internal.AttachStorageToIAASUnitArg,
-) error {
-	db, err := st.DB(ctx)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	machineUUID, err := st.GetUnitMachineUUID(ctx, unitUUID.String())
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := st.attachStorageForUnit(ctx, tx, storageUUID, unitUUID, storageArg.AttachStorageToUnitArg)
-		if errors.Is(err, internal.StorageAlreadyAttached) {
-			return nil
-		} else if err != nil {
-			return errors.Capture(err)
-		}
-
-		err = st.unitState.insertMachineVolumeOwnership(ctx, tx, coremachine.UUID(machineUUID),
-			storageArg.VolumesToOwn)
 		if err != nil {
-			return errors.Errorf(
-				"inserting volume ownership for machine %q: %w",
-				machineUUID, err,
-			)
+			return errors.Errorf("attaching storage %q to unit %q: %w", storageUUID, unitUUID, err)
 		}
-
-		err = st.unitState.insertMachineFilesystemOwnership(ctx, tx, coremachine.UUID(machineUUID),
-			storageArg.FilesystemsToOwn)
-		if err != nil {
-			return errors.Errorf(
-				"inserting volume ownership for machine %q: %w",
-				machineUUID, err,
-			)
-		}
-
 		return nil
 	})
 	if err != nil {

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1151,12 +1151,57 @@ func (st *State) attachStorageForUnit(
 		)
 	}
 
+	err = st.updateStorageInstanceForUnit(ctx, tx, unitUUID, storageUUID)
+	if err != nil {
+		return errors.Errorf(
+			"updating storage instance %q for unit %q: %w", storageUUID, unitUUID, err,
+		)
+	}
+
 	err = st.unitState.insertUnitStorageOwnership(ctx, tx, unitUUID.String(), []domainstorage.StorageInstanceUUID{storageUUID})
 	if err != nil {
 		return errors.Errorf(
 			"inserting storage ownership for unit %q: %w", unitUUID, err,
 		)
 	}
+	return nil
+}
+
+// updateStorageInstanceForUnit updates the storage instance to reflect
+// that it's now attached to the specified unit.
+// Currently this just entails updating the storage instance
+// charm name to match that of the unit's charm.
+func (st *State) updateStorageInstanceForUnit(
+	ctx context.Context,
+	tx *sqlair.TX,
+	unitUUID coreunit.UUID,
+	storageUUID domainstorage.StorageInstanceUUID,
+) error {
+	uUUID := entityUUID{UUID: unitUUID.String()}
+	storageInst := storageInstance{StorageUUID: storageUUID}
+
+	updateStorageCharmStmt, err := st.Prepare(`
+UPDATE storage_instance
+SET charm_name = (
+    SELECT cm.name
+    FROM charm_metadata cm
+    JOIN UNIT u ON cm.charm_uuid = u.charm_uuid
+    WHERE u.uuid = $entityUUID.uuid
+)
+WHERE storage_instance.uuid = $storageInstance.uuid
+`,
+		uUUID, storageInst)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, updateStorageCharmStmt, uUUID, storageInst).Run()
+	if err != nil {
+		return errors.Errorf(
+			"setting storage instance charm name: %w", err,
+		)
+	}
+
 	return nil
 }
 

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -543,7 +543,7 @@ func (st *State) getStorageAttachmentUnits(
 	ctx context.Context,
 	tx *sqlair.TX,
 	stUUID domainstorage.StorageInstanceUUID,
-) ([]string, error) {
+) ([]storageAttachmentUnit, error) {
 	storageUUID := entityUUID{UUID: stUUID.String()}
 
 	storageExistsStmt, err := st.Prepare(`
@@ -555,14 +555,12 @@ WHERE  uuid = $entityUUID.uuid
 		return nil, errors.Capture(err)
 	}
 
-	type unitUUID entityUUID
-
 	attachStmt, err := st.Prepare(`
-SELECT u.uuid AS &unitUUID.uuid
+SELECT u.* AS &storageAttachmentUnit.*
 FROM   storage_attachment sia
 JOIN   unit u ON sia.unit_uuid = u.uuid
 AND    sia.storage_instance_uuid = $entityUUID.uuid
-`, storageUUID, unitUUID{})
+`, storageUUID, storageAttachmentUnit{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -576,14 +574,14 @@ AND    sia.storage_instance_uuid = $entityUUID.uuid
 		return nil, errors.Errorf("checking storage %q exists: %w", stUUID, err)
 	}
 
-	var result []unitUUID
+	var result []storageAttachmentUnit
 	err = tx.Query(ctx, attachStmt, storageUUID).GetAll(&result)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	} else if err != nil {
 		return nil, errors.Errorf("getting storage %q attachments: %w", stUUID, err)
 	}
-	return transform.Slice(result, func(u unitUUID) string { return u.UUID }), nil
+	return result, nil
 }
 
 // GetUnitStorageDirectives returns the storage directives that are set for
@@ -1085,12 +1083,12 @@ func (st *State) attachStorageForUnit(
 		return errors.Capture(err)
 	}
 	allowedAttachments := set.NewStrings(storageArg.AllowedExistingUnitAttachments...)
-	attachedTo := set.NewStrings(attachedToUnits...)
-	if attachedTo.Difference(allowedAttachments).Size() > 0 {
+	attachedUUIDs := set.NewStrings(transform.Slice(attachedToUnits, func(u storageAttachmentUnit) string { return u.UUID })...)
+	if attachedUUIDs.Difference(allowedAttachments).Size() > 0 {
 		return internal.StorageAttachmentNotAllowed{
-			AttachedToUnits: attachedToUnits,
+			AttachedToUnits: transform.Slice(attachedToUnits, func(u storageAttachmentUnit) string { return u.Name }),
 		}
-	} else if attachedTo.Contains(unitUUID.String()) {
+	} else if attachedUUIDs.Contains(unitUUID.String()) {
 		// The storage is already attached to the unit, so we can no-op.
 		return internal.StorageAlreadyAttached
 	}

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -191,12 +191,12 @@ func (st *State) GetStorageInstanceCompositionByUUID(
 	ctx context.Context,
 	storageInstanceUUID domainstorage.StorageInstanceUUID,
 ) (
-	[]internal.StorageInstanceComposition,
+	internal.StorageInstanceComposition,
 	error,
 ) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return nil, errors.Capture(err)
+		return internal.StorageInstanceComposition{}, errors.Capture(err)
 	}
 	storageInstanceUUIDInput := entityUUID{UUID: storageInstanceUUID.String()}
 	compositionQ := `
@@ -223,12 +223,12 @@ FROM (
 		storageInstanceComposition{},
 	)
 	if err != nil {
-		return nil, errors.Capture(err)
+		return internal.StorageInstanceComposition{}, errors.Capture(err)
 	}
 
-	var dbVals []storageInstanceComposition
+	var dbVal storageInstanceComposition
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, stmt, storageInstanceUUIDInput).GetAll(&dbVals)
+		err := tx.Query(ctx, stmt, storageInstanceUUIDInput).Get(&dbVal)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("storage instance %q not found", storageInstanceUUID).
 				Add(storageerrors.StorageInstanceNotFound)
@@ -236,10 +236,10 @@ FROM (
 		return err
 	})
 	if err != nil {
-		return nil, errors.Capture(err)
+		return internal.StorageInstanceComposition{}, errors.Capture(err)
 	}
 
-	rval := makeStorageInstanceComposition(dbVals)
+	rval := makeStorageInstanceComposition(dbVal)
 	return rval, nil
 }
 
@@ -315,35 +315,39 @@ FROM (
 		return nil, errors.Capture(err)
 	}
 
-	rval := makeStorageInstanceComposition(dbVals)
+	rval := makeStorageInstanceCompositions(dbVals)
 	return rval, nil
 }
 
-func makeStorageInstanceComposition(dbVals []storageInstanceComposition) []internal.StorageInstanceComposition {
+func makeStorageInstanceCompositions(dbVals []storageInstanceComposition) []internal.StorageInstanceComposition {
 	rval := make([]internal.StorageInstanceComposition, 0, len(dbVals))
 	for _, dbVal := range dbVals {
-		v := internal.StorageInstanceComposition{
-			StorageName: domainstorage.Name(dbVal.StorageName),
-			UUID:        domainstorage.StorageInstanceUUID(dbVal.UUID),
-		}
-
-		if dbVal.FilesystemUUID.Valid {
-			v.Filesystem = &internal.StorageInstanceCompositionFilesystem{
-				ProvisionScope: domainstorageprov.ProvisionScope(dbVal.FilesystemProvisionScope.V),
-				UUID:           domainstorage.FilesystemUUID(dbVal.FilesystemUUID.V),
-			}
-		}
-
-		if dbVal.VolumeUUID.Valid {
-			v.Volume = &internal.StorageInstanceCompositionVolume{
-				ProvisionScope: domainstorageprov.ProvisionScope(dbVal.VolumeProvisionScope.V),
-				UUID:           domainstorage.VolumeUUID(dbVal.VolumeUUID.V),
-			}
-		}
-
+		v := makeStorageInstanceComposition(dbVal)
 		rval = append(rval, v)
 	}
 	return rval
+}
+
+func makeStorageInstanceComposition(dbVal storageInstanceComposition) internal.StorageInstanceComposition {
+	v := internal.StorageInstanceComposition{
+		StorageName: domainstorage.Name(dbVal.StorageName),
+		UUID:        domainstorage.StorageInstanceUUID(dbVal.UUID),
+	}
+
+	if dbVal.FilesystemUUID.Valid {
+		v.Filesystem = &internal.StorageInstanceCompositionFilesystem{
+			ProvisionScope: domainstorageprov.ProvisionScope(dbVal.FilesystemProvisionScope.V),
+			UUID:           domainstorage.FilesystemUUID(dbVal.FilesystemUUID.V),
+		}
+	}
+
+	if dbVal.VolumeUUID.Valid {
+		v.Volume = &internal.StorageInstanceCompositionVolume{
+			ProvisionScope: domainstorageprov.ProvisionScope(dbVal.VolumeProvisionScope.V),
+			UUID:           domainstorage.VolumeUUID(dbVal.VolumeUUID.V),
+		}
+	}
+	return v
 }
 
 // GetUnitOwnedStorageInstances returns the storage compositions for all
@@ -1143,7 +1147,7 @@ func (st *State) attachStorageForUnit(
 		ctx,
 		tx,
 		unitUUID.String(),
-		storageArg.StorageToAttach,
+		[]internal.CreateUnitStorageAttachmentArg{storageArg.StorageToAttach},
 	)
 	if err != nil {
 		return errors.Errorf(

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1457,18 +1457,53 @@ WHERE  uuid = $storageInstance.uuid
 	return inst, nil
 }
 
+func (st *State) checkStorageInstanceExists(
+	ctx context.Context,
+	tx *sqlair.TX,
+	storageUUID string,
+) (bool, error) {
+	uuidInput := entityUUID{UUID: storageUUID}
+
+	checkStmt, err := st.Prepare(`
+SELECT &entityUUID.*
+FROM   storage_instance
+WHERE  uuid = $entityUUID.uuid
+	`,
+		uuidInput,
+	)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, checkStmt, uuidInput).Get(&uuidInput)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Capture(err)
+	}
+	return true, nil
+}
+
 func (st *State) getStorageInstanceInfoForAttach(
-	ctx context.Context, tx *sqlair.TX, uuid coreunit.UUID,
+	ctx context.Context, tx *sqlair.TX,
 	storageUUID domainstorage.StorageInstanceUUID,
 ) (storageInfoForAttach, error) {
-	inst := storageInstance{StorageUUID: storageUUID}
-	unit := unitUUID{
-		UnitUUID: uuid.String(),
+	exists, err := st.checkStorageInstanceExists(ctx, tx, storageUUID.String())
+	if err != nil {
+		return storageInfoForAttach{}, errors.Errorf(
+			"checking storage instance %q exists: %w", storageUUID, err,
+		)
 	}
+	if !exists {
+		return storageInfoForAttach{}, errors.Errorf("storage instance %q does not exist", storageUUID).Add(
+			storageerrors.StorageInstanceNotFound,
+		)
+	}
+
+	inst := storageInstance{StorageUUID: storageUUID}
 	query := `
 SELECT * AS &storageInfoForAttach.* FROM (
     SELECT    si.storage_name,
-              si.storage_pool_uuid,
               (CASE
                   WHEN sf.size_mib != 0 THEN sf.size_mib
                   WHEN sv.size_mib != 0 THEN sv.size_mib
@@ -1476,32 +1511,28 @@ SELECT * AS &storageInfoForAttach.* FROM (
               END) AS size_mib,
               cs.count_max,
               cs.count_min,
-              cs.kind,
               cs.minimum_size_mib
     FROM      storage_instance si
-    JOIN      storage_unit_owner suo ON si.uuid = suo.storage_instance_uuid
-    JOIN      unit ON suo.unit_uuid = unit.uuid
-    JOIN      v_charm_storage cs ON unit.charm_uuid = cs.charm_uuid
+    JOIN      v_charm_storage cs ON si.storage_name = cs.name
     LEFT JOIN storage_instance_filesystem sif ON si.uuid = sif.storage_instance_uuid
     LEFT JOIN storage_filesystem sf ON sif.storage_filesystem_uuid = sf.uuid
     LEFT JOIN storage_instance_volume siv ON si.uuid = siv.storage_instance_uuid
     LEFT JOIN storage_volume sv ON siv.storage_volume_uuid = sv.uuid
     WHERE     si.uuid = $storageInstance.uuid
-    AND       suo.unit_uuid = $unitUUID.uuid
 )
 `
-	queryStmt, err := st.Prepare(query, inst, unit, storageInfoForAttach{})
+	queryStmt, err := st.Prepare(query, inst, storageInfoForAttach{})
 	if err != nil {
 		return storageInfoForAttach{}, errors.Capture(err)
 	}
 
 	var result storageInfoForAttach
-	err = tx.Query(ctx, queryStmt, inst, unit).Get(&result)
+	err = tx.Query(ctx, queryStmt, inst).Get(&result)
 	if err != nil {
 		if !errors.Is(err, sqlair.ErrNoRows) {
 			return storageInfoForAttach{}, errors.Errorf("querying storage %q: %w", storageUUID, err)
 		}
-		return storageInfoForAttach{}, errors.Errorf("%w: %s", storageerrors.StorageInstanceNotFound, storageUUID)
+		return storageInfoForAttach{}, errors.Errorf("%w: %s", applicationerrors.StorageNameNotSupported, storageUUID)
 	}
 	return result, nil
 }

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1188,7 +1188,7 @@ func (st *State) attachExistingStorageForExistingUnit(
 		}
 	} else if attachedUUIDs.Contains(unitUUID.String()) {
 		// The storage is already attached to the unit, so we can no-op.
-		return internal.StorageAlreadyAttached
+		return nil
 	}
 
 	// First to the basic life checks for the unit and storage.
@@ -1295,9 +1295,6 @@ func (st *State) AttachStorageToUnit(
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.attachExistingStorageForExistingUnit(ctx, tx, storageUUID, unitUUID, storageArg)
-		if errors.Is(err, internal.StorageAlreadyAttached) {
-			return nil
-		}
 		if err != nil {
 			return errors.Errorf("attaching storage %q to unit %q: %w", storageUUID, unitUUID, err)
 		}

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1412,6 +1412,41 @@ WHERE  uuid = $storageInstance.uuid
 	return inst, nil
 }
 
+func (st *State) getStorageInstanceProvisionedInfo(ctx context.Context, tx *sqlair.TX, storageUUID domainstorage.StorageInstanceUUID) (storageInstanceProvisionedInfo, error) {
+	inst := storageInstance{StorageUUID: storageUUID}
+	query := `
+SELECT * AS &storageInstanceProvisionedInfo.* FROM (
+    SELECT    si.storage_name,
+              si.storage_pool_uuid,
+              (CASE
+                  WHEN sf.size_mib != 0 THEN sf.size_mib
+                  WHEN sv.size_mib != 0 THEN sv.size_mib
+                  WHEN sv.size_mib = 0 AND sf.size_mib = 0 THEN si.requested_size_mib
+              END) AS size_mib
+    FROM      storage_instance si
+    LEFT JOIN storage_instance_filesystem sif ON si.uuid = sif.storage_instance_uuid
+    LEFT JOIN storage_filesystem sf ON sif.storage_filesystem_uuid = sf.uuid
+    LEFT JOIN storage_instance_volume siv ON si.uuid = siv.storage_instance_uuid
+    LEFT JOIN storage_volume sv ON siv.storage_volume_uuid = sv.uuid
+    WHERE     si.uuid = $storageInstance.uuid
+)
+`
+	queryStmt, err := st.Prepare(query, inst, storageInstanceProvisionedInfo{})
+	if err != nil {
+		return storageInstanceProvisionedInfo{}, errors.Capture(err)
+	}
+
+	var result storageInstanceProvisionedInfo
+	err = tx.Query(ctx, queryStmt, inst).Get(&result)
+	if err != nil {
+		if !errors.Is(err, sqlair.ErrNoRows) {
+			return storageInstanceProvisionedInfo{}, errors.Errorf("querying storage %q: %w", storageUUID, err)
+		}
+		return storageInstanceProvisionedInfo{}, errors.Errorf("%w: %s", storageerrors.StorageInstanceNotFound, storageUUID)
+	}
+	return result, nil
+}
+
 func (st *State) getUnitCharmStorageByName(ctx context.Context, tx *sqlair.TX, uuid coreunit.UUID, name corestorage.Name) (charmStorage, error) {
 	storageSpec := unitCharmStorage{
 		UnitUUID:    uuid,

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1016,7 +1016,7 @@ WHERE  uuid = $storagePoolUUID.uuid
 // storage instance attachment arguments that correspond to the storage uuids.
 func makeInsertUnitStorageAttachmentArgs(
 	unitUUID string,
-	storageToAttach []internal.CreateUnitStorageAttachmentArg,
+	storageToAttach []internal.AttachStorageToUnitArg,
 ) []insertStorageInstanceAttachment {
 	rval := make([]insertStorageInstanceAttachment, 0, len(storageToAttach))
 	for _, sa := range storageToAttach {
@@ -1117,9 +1117,63 @@ WHERE  storage_id = $storageInstance.storage_id
 	return inst.StorageUUID, nil
 }
 
-func (st *State) attachStorageForUnit(
+func (st *State) attachExistingStorageForNewUnit(
 	ctx context.Context, tx *sqlair.TX, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-	storageArg internal.AttachStorageToUnitArg,
+	storageArg internal.AttachExistingStorageToUnitArg,
+) error {
+	// Check allowed attachments.
+	attachedToUnits, err := st.getStorageAttachmentUnits(ctx, tx, storageUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	allowedAttachments := set.NewStrings(storageArg.AllowedExistingUnitAttachments...)
+	attachedUUIDs := set.NewStrings(transform.Slice(attachedToUnits, func(u storageAttachmentUnit) string { return u.UUID })...)
+	if attachedUUIDs.Difference(allowedAttachments).Size() > 0 {
+		return applicationerrors.StorageAttachmentNotAllowed{
+			AttachedToUnits: transform.Slice(attachedToUnits, func(u storageAttachmentUnit) string { return u.Name }),
+		}
+	}
+
+	// First to the basic life checks for the storage.
+	stor, err := st.getStorageDetails(ctx, tx, storageUUID)
+	if err != nil {
+		return err
+	}
+	if stor.LifeID != life.Alive {
+		return errors.Errorf("storage %q is not alive", unitUUID).Add(applicationerrors.StorageNotAlive)
+	}
+
+	err = st.insertUnitStorageAttachments(
+		ctx,
+		tx,
+		unitUUID.String(),
+		[]internal.AttachStorageToUnitArg{storageArg.AttachStorageToUnitArg},
+	)
+	if err != nil {
+		return errors.Errorf(
+			"creating storage attachments for unit %q: %w", unitUUID, err,
+		)
+	}
+
+	err = st.updateStorageInstanceForUnit(ctx, tx, unitUUID, storageUUID)
+	if err != nil {
+		return errors.Errorf(
+			"updating storage instance %q for unit %q: %w", storageUUID, unitUUID, err,
+		)
+	}
+
+	err = st.insertUnitStorageOwnership(ctx, tx, unitUUID.String(), []domainstorage.StorageInstanceUUID{storageUUID})
+	if err != nil {
+		return errors.Errorf(
+			"inserting storage ownership for unit %q: %w", unitUUID, err,
+		)
+	}
+	return nil
+}
+
+func (st *State) attachExistingStorageForExistingUnit(
+	ctx context.Context, tx *sqlair.TX, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
+	storageArg internal.AttachExistingStorageToUnitArg,
 ) error {
 	// Check allowed attachments.
 	attachedToUnits, err := st.getStorageAttachmentUnits(ctx, tx, storageUUID)
@@ -1167,7 +1221,7 @@ func (st *State) attachStorageForUnit(
 		ctx,
 		tx,
 		unitUUID.String(),
-		[]internal.CreateUnitStorageAttachmentArg{storageArg.StorageToAttach},
+		[]internal.AttachStorageToUnitArg{storageArg.AttachStorageToUnitArg},
 	)
 	if err != nil {
 		return errors.Errorf(
@@ -1232,7 +1286,7 @@ WHERE storage_instance.uuid = $storageInstance.uuid
 // AttachStorageToUnit attaches the storage instance to an unit.
 func (st *State) AttachStorageToUnit(
 	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-	storageArg internal.AttachStorageToUnitArg,
+	storageArg internal.AttachExistingStorageToUnitArg,
 ) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -1240,7 +1294,7 @@ func (st *State) AttachStorageToUnit(
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := st.attachStorageForUnit(ctx, tx, storageUUID, unitUUID, storageArg)
+		err := st.attachExistingStorageForExistingUnit(ctx, tx, storageUUID, unitUUID, storageArg)
 		if errors.Is(err, internal.StorageAlreadyAttached) {
 			return nil
 		}
@@ -1290,7 +1344,7 @@ func (st *State) addStorageForUnit(
 		ctx,
 		tx,
 		unitUUID.String(),
-		storageArg.StorageToAttach,
+		storageArg.NewStorageToAttach,
 	)
 	if err != nil {
 		return nil, errors.Errorf(

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1232,7 +1232,7 @@ func (st *State) AttachStorageToCAASUnit(
 // AttachStorageToIAASUnit attaches the storage instance to an IAAS unit.
 func (st *State) AttachStorageToIAASUnit(
 	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-	storageArg internal.IAASUnitAttachStorageArg,
+	storageArg internal.AttachStorageToIAASUnitArg,
 ) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -1357,7 +1357,7 @@ func (st *State) AddStorageForCAASUnit(
 // AddStorageForIAASUnit adds storage instances to given IAAS unit as specified.
 func (st *State) AddStorageForIAASUnit(
 	ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name,
-	storageArg internal.IAASUnitAddStorageArg,
+	storageArg internal.AddStorageToIAASUnitArg,
 ) ([]corestorage.ID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -999,7 +999,7 @@ WHERE  uuid = $storagePoolUUID.uuid
 func makeInsertUnitStorageAttachmentArgs(
 	_ context.Context,
 	unitUUID string,
-	storageToAttach []internal.UnitStorageAttachmentArg,
+	storageToAttach []internal.CreateUnitStorageAttachmentArg,
 ) []insertStorageInstanceAttachment {
 	rval := make([]insertStorageInstanceAttachment, 0, len(storageToAttach))
 	for _, sa := range storageToAttach {

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/canonical/sqlair"
 
@@ -532,6 +533,83 @@ FROM (
 	return retInstComp, retAttachmentComp, nil
 }
 
+// GetUnitStorageAttachmentExists returns true if the storage is
+// attached to the specified unit.
+func (st *State) GetUnitStorageAttachmentExists(
+	ctx context.Context,
+	stUUID domainstorage.StorageInstanceUUID,
+	uUUID coreunit.UUID,
+) (bool, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+	var result bool
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		result, err = st.getUnitStorageAttachmentExists(ctx, tx, stUUID, uUUID)
+		return errors.Capture(err)
+	})
+	return result, errors.Capture(err)
+}
+
+func (st *State) getUnitStorageAttachmentExists(
+	ctx context.Context,
+	tx *sqlair.TX,
+	stUUID domainstorage.StorageInstanceUUID,
+	uUUID coreunit.UUID,
+) (bool, error) {
+	unitUUID := unitUUID{UnitUUID: uUUID.String()}
+	storageUUID := entityUUID{UUID: stUUID.String()}
+
+	storageExistsStmt, err := st.Prepare(`
+SELECT &entityUUID.uuid
+FROM   storage_instance
+WHERE  uuid = $entityUUID.uuid
+`, storageUUID)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	attachStmt, err := st.Prepare(`
+SELECT count(*) AS &count.count
+FROM   storage_attachment sia
+JOIN   unit u ON sia.unit_uuid = u.uuid
+WHERE  u.uuid = $unitUUID.uuid
+AND    sia.storage_instance_uuid = $entityUUID.uuid
+`, unitUUID, storageUUID, count{})
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	exists, err := st.checkUnitExists(ctx, tx, uUUID.String())
+	if err != nil {
+		return false, errors.Errorf(
+			"checking unit %q exists: %w", uUUID, err,
+		)
+	}
+	if !exists {
+		return false, errors.Errorf("unit %q does not exist", uUUID).Add(
+			applicationerrors.UnitNotFound,
+		)
+	}
+	err = tx.Query(ctx, storageExistsStmt, storageUUID).Get(&storageUUID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, errors.Errorf("storage %q does not exist", stUUID).
+			Add(storageerrors.StorageInstanceNotFound)
+	}
+	if err != nil {
+		return false, errors.Errorf("checking storage %q exists: %w", stUUID, err)
+	}
+
+	var result count
+	err = tx.Query(ctx, attachStmt, unitUUID, storageUUID).Get(&result)
+	if err != nil {
+		return false, errors.Errorf("checking storage %q is attached to unit %q: %w", stUUID, uUUID, err)
+	}
+	return result.Count > 0, nil
+}
+
 // GetUnitStorageDirectives returns the storage directives that are set for
 // a unit. If the unit does not have any storage directives set then an
 // empty result is returned.
@@ -1026,6 +1104,15 @@ func (st *State) attachStorageForUnit(
 	ctx context.Context, tx *sqlair.TX, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
 	storageArg internal.UnitAttachStorageArg,
 ) error {
+	// Already attached is a no-op.
+	attached, err := st.getUnitStorageAttachmentExists(ctx, tx, storageUUID, unitUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if attached {
+		return nil
+	}
+
 	// First to the basic life checks for the unit and storage.
 	unitLifeID, _, err := st.getUnitLifeAndNetNode(ctx, tx, unitUUID.String())
 	if err != nil {

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -584,6 +584,50 @@ AND    sia.storage_instance_uuid = $entityUUID.uuid
 	return result, nil
 }
 
+// getStorageMachineOwner returns the UUID and name of the machine that owns
+// the storage instance's underlying volume or filesystem. If the storage
+// instance has both a filesystem and a volume associated with a machine, the
+// filesystem association is preferred. Returns nil if no machine owns the
+// storage.
+func (st *State) getStorageMachineOwner(
+	ctx context.Context,
+	tx *sqlair.TX,
+	stUUID domainstorage.StorageInstanceUUID,
+) (*storageMachineOwner, error) {
+	storageUUID := entityUUID{UUID: stUUID.String()}
+
+	// Prefer the filesystem path; fall back to the volume path.
+	stmt, err := st.Prepare(`
+WITH machine_storage AS (
+	SELECT m.uuid, m.name
+	FROM   storage_instance_filesystem sif
+	JOIN   machine_filesystem mf ON sif.storage_filesystem_uuid = mf.filesystem_uuid
+	JOIN   machine m ON mf.machine_uuid = m.uuid
+	WHERE  sif.storage_instance_uuid = $entityUUID.uuid
+	UNION
+	SELECT m.uuid, m.name
+	FROM   storage_instance_volume siv
+	JOIN   machine_volume mv ON siv.storage_volume_uuid = mv.volume_uuid
+	JOIN   machine m ON mv.machine_uuid = m.uuid
+	WHERE  siv.storage_instance_uuid = $entityUUID.uuid
+	LIMIT 1
+)
+SELECT * AS &storageMachineOwner.* FROM machine_storage
+`, storageUUID, storageMachineOwner{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var result storageMachineOwner
+	err = tx.Query(ctx, stmt, storageUUID).Get(&result)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Errorf("getting machine owner for storage %q: %w", stUUID, err)
+	}
+	return &result, nil
+}
+
 // GetUnitStorageDirectives returns the storage directives that are set for
 // a unit. If the unit does not have any storage directives set then an
 // empty result is returned.
@@ -1085,7 +1129,7 @@ func (st *State) attachStorageForUnit(
 	allowedAttachments := set.NewStrings(storageArg.AllowedExistingUnitAttachments...)
 	attachedUUIDs := set.NewStrings(transform.Slice(attachedToUnits, func(u storageAttachmentUnit) string { return u.UUID })...)
 	if attachedUUIDs.Difference(allowedAttachments).Size() > 0 {
-		return internal.StorageAttachmentNotAllowed{
+		return applicationerrors.StorageAttachmentNotAllowed{
 			AttachedToUnits: transform.Slice(attachedToUnits, func(u storageAttachmentUnit) string { return u.Name }),
 		}
 	} else if attachedUUIDs.Contains(unitUUID.String()) {

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1102,7 +1102,7 @@ WHERE  storage_id = $storageInstance.storage_id
 
 func (st *State) attachStorageForUnit(
 	ctx context.Context, tx *sqlair.TX, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-	storageArg internal.UnitAttachStorageArg,
+	storageArg internal.AttachStorageToUnitArg,
 ) error {
 	// Already attached is a no-op.
 	attached, err := st.getUnitStorageAttachmentExists(ctx, tx, storageUUID, unitUUID)
@@ -1208,7 +1208,7 @@ WHERE storage_instance.uuid = $storageInstance.uuid
 // AttachStorageToCAASUnit attaches the storage instance to a CAAS unit.
 func (st *State) AttachStorageToCAASUnit(
 	ctx context.Context, storageUUID domainstorage.StorageInstanceUUID, unitUUID coreunit.UUID,
-	storageArg internal.UnitAttachStorageArg,
+	storageArg internal.AttachStorageToUnitArg,
 ) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -1241,7 +1241,7 @@ func (st *State) AttachStorageToIAASUnit(
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := st.attachStorageForUnit(ctx, tx, storageUUID, unitUUID, storageArg.UnitAttachStorageArg)
+		err := st.attachStorageForUnit(ctx, tx, storageUUID, unitUUID, storageArg.AttachStorageToUnitArg)
 		if err != nil {
 			return errors.Capture(err)
 		}
@@ -1274,7 +1274,7 @@ func (st *State) AttachStorageToIAASUnit(
 
 func (st *State) addStorageForUnit(
 	ctx context.Context, tx *sqlair.TX, unitUUID coreunit.UUID,
-	storageName corestorage.Name, storageArg internal.UnitAddStorageArg,
+	storageName corestorage.Name, storageArg internal.AddStorageToUnitArg,
 ) ([]string, error) {
 	// First to the basic life check for the unit.
 	unitLifeID, _, err := st.getUnitLifeAndNetNode(ctx, tx, unitUUID.String())
@@ -1327,7 +1327,7 @@ func (st *State) addStorageForUnit(
 // AddStorageForCAASUnit adds storage instances to given CAAS unit as specified.
 func (st *State) AddStorageForCAASUnit(
 	ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name,
-	storageArg internal.UnitAddStorageArg,
+	storageArg internal.AddStorageToUnitArg,
 ) ([]corestorage.ID, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -1367,7 +1367,7 @@ func (st *State) AddStorageForIAASUnit(
 
 	var storageIDs []string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		storageIDs, err = st.addStorageForUnit(ctx, tx, unitUUID, storageName, storageArg.UnitAddStorageArg)
+		storageIDs, err = st.addStorageForUnit(ctx, tx, unitUUID, storageName, storageArg.AddStorageToUnitArg)
 		if err != nil {
 			return errors.Capture(err)
 		}

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1163,7 +1163,7 @@ func (st *State) attachStorageForUnit(
 		return internal.MaxStorageCountPreconditonFailed
 	}
 
-	err = st.unitState.insertUnitStorageAttachments(
+	err = st.insertUnitStorageAttachments(
 		ctx,
 		tx,
 		unitUUID.String(),
@@ -1182,7 +1182,7 @@ func (st *State) attachStorageForUnit(
 		)
 	}
 
-	err = st.unitState.insertUnitStorageOwnership(ctx, tx, unitUUID.String(), []domainstorage.StorageInstanceUUID{storageUUID})
+	err = st.insertUnitStorageOwnership(ctx, tx, unitUUID.String(), []domainstorage.StorageInstanceUUID{storageUUID})
 	if err != nil {
 		return errors.Errorf(
 			"inserting storage ownership for unit %q: %w", unitUUID, err,
@@ -1277,7 +1277,7 @@ func (st *State) addStorageForUnit(
 		return nil, internal.MaxStorageCountPreconditonFailed
 	}
 
-	storageIDs, err := st.unitState.insertUnitStorageInstances(
+	storageIDs, err := st.insertUnitStorageInstances(
 		ctx, tx, storageArg.StorageInstances,
 	)
 	if err != nil {
@@ -1286,7 +1286,7 @@ func (st *State) addStorageForUnit(
 		)
 	}
 
-	err = st.unitState.insertUnitStorageAttachments(
+	err = st.insertUnitStorageAttachments(
 		ctx,
 		tx,
 		unitUUID.String(),
@@ -1298,7 +1298,7 @@ func (st *State) addStorageForUnit(
 		)
 	}
 
-	err = st.unitState.insertUnitStorageOwnership(ctx, tx, unitUUID.String(), storageArg.StorageToOwn)
+	err = st.insertUnitStorageOwnership(ctx, tx, unitUUID.String(), storageArg.StorageToOwn)
 	if err != nil {
 		return nil, errors.Errorf(
 			"inserting storage ownership for unit %q: %w", unitUUID, err,
@@ -1355,7 +1355,7 @@ func (st *State) AddStorageForIAASUnit(
 			return errors.Capture(err)
 		}
 
-		err = st.unitState.insertMachineVolumeOwnership(ctx, tx, coremachine.UUID(machineUUID),
+		err = st.insertMachineVolumeOwnership(ctx, tx, coremachine.UUID(machineUUID),
 			storageArg.VolumesToOwn)
 		if err != nil {
 			return errors.Errorf(
@@ -1364,7 +1364,7 @@ func (st *State) AddStorageForIAASUnit(
 			)
 		}
 
-		err = st.unitState.insertMachineFilesystemOwnership(ctx, tx, coremachine.UUID(machineUUID),
+		err = st.insertMachineFilesystemOwnership(ctx, tx, coremachine.UUID(machineUUID),
 			storageArg.FilesystemsToOwn)
 		if err != nil {
 			return errors.Errorf(

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1457,49 +1457,65 @@ WHERE  uuid = $storageInstance.uuid
 	return inst, nil
 }
 
-func (st *State) getStorageInstanceProvisionedInfo(ctx context.Context, tx *sqlair.TX, storageUUID domainstorage.StorageInstanceUUID) (storageInstanceProvisionedInfo, error) {
+func (st *State) getStorageInstanceInfoForAttach(
+	ctx context.Context, tx *sqlair.TX, uuid coreunit.UUID,
+	storageUUID domainstorage.StorageInstanceUUID,
+) (storageInfoForAttach, error) {
 	inst := storageInstance{StorageUUID: storageUUID}
+	unit := unitUUID{
+		UnitUUID: uuid.String(),
+	}
 	query := `
-SELECT * AS &storageInstanceProvisionedInfo.* FROM (
+SELECT * AS &storageInfoForAttach.* FROM (
     SELECT    si.storage_name,
               si.storage_pool_uuid,
               (CASE
                   WHEN sf.size_mib != 0 THEN sf.size_mib
                   WHEN sv.size_mib != 0 THEN sv.size_mib
                   WHEN sv.size_mib = 0 AND sf.size_mib = 0 THEN si.requested_size_mib
-              END) AS size_mib
+              END) AS size_mib,
+              cs.count_max,
+              cs.count_min,
+              cs.kind,
+              cs.minimum_size_mib
     FROM      storage_instance si
+    JOIN      storage_unit_owner suo ON si.uuid = suo.storage_instance_uuid
+    JOIN      unit ON suo.unit_uuid = unit.uuid
+    JOIN      v_charm_storage cs ON unit.charm_uuid = cs.charm_uuid
     LEFT JOIN storage_instance_filesystem sif ON si.uuid = sif.storage_instance_uuid
     LEFT JOIN storage_filesystem sf ON sif.storage_filesystem_uuid = sf.uuid
     LEFT JOIN storage_instance_volume siv ON si.uuid = siv.storage_instance_uuid
     LEFT JOIN storage_volume sv ON siv.storage_volume_uuid = sv.uuid
     WHERE     si.uuid = $storageInstance.uuid
+    AND       suo.unit_uuid = $unitUUID.uuid
 )
 `
-	queryStmt, err := st.Prepare(query, inst, storageInstanceProvisionedInfo{})
+	queryStmt, err := st.Prepare(query, inst, unit, storageInfoForAttach{})
 	if err != nil {
-		return storageInstanceProvisionedInfo{}, errors.Capture(err)
+		return storageInfoForAttach{}, errors.Capture(err)
 	}
 
-	var result storageInstanceProvisionedInfo
-	err = tx.Query(ctx, queryStmt, inst).Get(&result)
+	var result storageInfoForAttach
+	err = tx.Query(ctx, queryStmt, inst, unit).Get(&result)
 	if err != nil {
 		if !errors.Is(err, sqlair.ErrNoRows) {
-			return storageInstanceProvisionedInfo{}, errors.Errorf("querying storage %q: %w", storageUUID, err)
+			return storageInfoForAttach{}, errors.Errorf("querying storage %q: %w", storageUUID, err)
 		}
-		return storageInstanceProvisionedInfo{}, errors.Errorf("%w: %s", storageerrors.StorageInstanceNotFound, storageUUID)
+		return storageInfoForAttach{}, errors.Errorf("%w: %s", storageerrors.StorageInstanceNotFound, storageUUID)
 	}
 	return result, nil
 }
 
-func (st *State) getUnitCharmStorageByName(ctx context.Context, tx *sqlair.TX, uuid coreunit.UUID, name corestorage.Name) (charmStorage, error) {
+func (st *State) getStorageInstanceInfoForAdd(
+	ctx context.Context, tx *sqlair.TX, uuid coreunit.UUID, name corestorage.Name,
+) (storageInfoForAdd, error) {
 	storageSpec := unitCharmStorage{
 		UnitUUID:    uuid,
 		StorageName: name,
 	}
-	var result charmStorage
+	var result storageInfoForAdd
 	stmt, err := st.Prepare(`
-SELECT cs.* AS &charmStorage.*
+SELECT cs.* AS &storageInfoForAdd.*
 FROM   v_charm_storage cs
 JOIN   unit ON unit.charm_uuid = cs.charm_uuid
 WHERE  unit.uuid = $unitCharmStorage.uuid

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -908,8 +908,20 @@ type storageInstance struct {
 	RequestedSizeMIB uint64                            `db:"requested_size_mib"`
 }
 
-type storageInstanceProvisionedInfo struct {
+type storageInfoForAdd struct {
+	Name        string `db:"name"`
+	Kind        string `db:"kind"`
+	CountMin    int    `db:"count_min"`
+	CountMax    int    `db:"count_max"`
+	MinimumSize uint64 `db:"minimum_size_mib"`
+}
+
+type storageInfoForAttach struct {
 	StorageName     corestorage.Name `db:"storage_name"`
+	Kind            string           `db:"kind"`
+	CountMin        int              `db:"count_min"`
+	CountMax        int              `db:"count_max"`
+	MinimumSize     uint64           `db:"minimum_size_mib"`
 	StoragePoolUUID string           `db:"storage_pool_uuid"`
 	SizeMIB         uint64           `db:"size_mib"`
 }

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -908,6 +908,12 @@ type storageInstance struct {
 	RequestedSizeMIB uint64                            `db:"requested_size_mib"`
 }
 
+// storageAttachmentUnit holds the UUID and name of a unit attached to storage.
+type storageAttachmentUnit struct {
+	UUID string `db:"uuid"`
+	Name string `db:"name"`
+}
+
 type storageInfoForAdd struct {
 	Name        string `db:"name"`
 	Kind        string `db:"kind"`

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -917,13 +917,11 @@ type storageInfoForAdd struct {
 }
 
 type storageInfoForAttach struct {
-	StorageName     corestorage.Name `db:"storage_name"`
-	Kind            string           `db:"kind"`
-	CountMin        int              `db:"count_min"`
-	CountMax        int              `db:"count_max"`
-	MinimumSize     uint64           `db:"minimum_size_mib"`
-	StoragePoolUUID string           `db:"storage_pool_uuid"`
-	SizeMIB         uint64           `db:"size_mib"`
+	StorageName corestorage.Name `db:"storage_name"`
+	CountMin    int              `db:"count_min"`
+	CountMax    int              `db:"count_max"`
+	MinimumSize uint64           `db:"minimum_size_mib"`
+	SizeMIB     uint64           `db:"size_mib"`
 }
 
 type unitCharmStorage struct {

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -908,6 +908,12 @@ type storageInstance struct {
 	RequestedSizeMIB uint64                            `db:"requested_size_mib"`
 }
 
+type storageInstanceProvisionedInfo struct {
+	StorageName     corestorage.Name `db:"storage_name"`
+	StoragePoolUUID string           `db:"storage_pool_uuid"`
+	SizeMIB         uint64           `db:"size_mib"`
+}
+
 type unitCharmStorage struct {
 	UnitUUID    coreunit.UUID    `db:"uuid"`
 	StorageName corestorage.Name `db:"name"`

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -914,6 +914,11 @@ type storageAttachmentUnit struct {
 	Name string `db:"name"`
 }
 
+type storageMachineOwner struct {
+	UUID string `db:"uuid"`
+	Name string `db:"name"`
+}
+
 type storageInfoForAdd struct {
 	Name        string `db:"name"`
 	Kind        string `db:"kind"`

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1834,12 +1834,17 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 		return internal.StorageInfoForAttach{}, errors.Capture(err)
 	}
 	var (
-		attachInfo storageInfoForAttach
-		count      uint32
+		attachInfo      storageInfoForAttach
+		attachedToUnits []string
+		count           uint32
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		attachInfo, err = st.getStorageInstanceInfoForAttach(ctx, tx, storageUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		attachedToUnits, err = st.getStorageAttachmentUnits(ctx, tx, storageUUID)
 		if err != nil {
 			return errors.Capture(err)
 		}
@@ -1852,12 +1857,13 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 		return internal.StorageInfoForAttach{}, errors.Capture(err)
 	}
 	return internal.StorageInfoForAttach{
-		CharmStorageName:     attachInfo.StorageName.String(),
-		CountMin:             attachInfo.CountMin,
-		CountMax:             attachInfo.CountMax,
-		MinimumSize:          attachInfo.MinimumSize,
-		ProvisionedSizeMiB:   attachInfo.SizeMIB,
-		AlreadyAttachedCount: count,
+		CharmStorageName:       attachInfo.StorageName.String(),
+		CountMin:               attachInfo.CountMin,
+		CountMax:               attachInfo.CountMax,
+		MinimumSize:            attachInfo.MinimumSize,
+		ProvisionedSizeMiB:     attachInfo.SizeMIB,
+		AlreadyAttachedCount:   count,
+		AlreadyAttachedToUnits: attachedToUnits,
 	}, nil
 }
 

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1837,18 +1837,18 @@ func (st *State) GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(
 		return internalcharm.Storage{}, internal.StorageInstanceInfo{}, errors.Capture(err)
 	}
 	var (
-		chStorage        charmStorage
-		count            uint32
-		requestedSizeMiB uint64
-		poolUUID         string
+		chStorage charmStorage
+		count     uint32
+		sizeMiB   uint64
+		poolUUID  string
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		details, err := st.getStorageDetails(ctx, tx, storageUUID)
+		details, err := st.getStorageInstanceProvisionedInfo(ctx, tx, storageUUID)
 		if err != nil {
 			return errors.Capture(err)
 		}
 		poolUUID = details.StoragePoolUUID
-		requestedSizeMiB = details.RequestedSizeMIB
+		sizeMiB = details.SizeMIB
 		chStorage, err = st.getUnitCharmStorageByName(ctx, tx, unitUUID, details.StorageName)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			// Should never happen.
@@ -1877,7 +1877,7 @@ func (st *State) GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(
 			Location:    chStorage.Location,
 		}, internal.StorageInstanceInfo{
 			AlreadyAttachedCount: count,
-			SizeMiB:              requestedSizeMiB,
+			SizeMiB:              sizeMiB,
 			PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),
 		}, nil
 }

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1836,6 +1836,7 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 	var (
 		attachInfo      storageInfoForAttach
 		attachedToUnits []storageAttachmentUnit
+		ownedByMachine  *storageMachineOwner
 		count           uint32
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -1845,6 +1846,10 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 			return errors.Capture(err)
 		}
 		attachedToUnits, err = st.getStorageAttachmentUnits(ctx, tx, storageUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		ownedByMachine, err = st.getStorageMachineOwner(ctx, tx, storageUUID)
 		if err != nil {
 			return errors.Capture(err)
 		}
@@ -1861,6 +1866,13 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 	for _, u := range attachedToUnits {
 		attachedMap[u.UUID] = u.Name
 	}
+	var ownedByMachinePtr *internal.MachineIdentifier
+	if ownedByMachine != nil {
+		ownedByMachinePtr = &internal.MachineIdentifier{
+			UUID: ownedByMachine.UUID,
+			Name: ownedByMachine.Name,
+		}
+	}
 	return internal.StorageInfoForAttach{
 		CharmStorageName:       attachInfo.StorageName.String(),
 		CountMin:               attachInfo.CountMin,
@@ -1869,6 +1881,7 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 		ProvisionedSizeMiB:     attachInfo.SizeMIB,
 		AlreadyAttachedCount:   count,
 		AlreadyAttachedToUnits: attachedMap,
+		StorageMachineOwner:    ownedByMachinePtr,
 	}, nil
 }
 

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1813,7 +1813,7 @@ func (st *State) GetStorageAddInfoByUnitUUID(
 		return internal.StorageInfoForAdd{}, errors.Capture(err)
 	}
 	return internal.StorageInfoForAdd{
-		Name:                 addInfo.Name,
+		CharmStorageName:     addInfo.Name,
 		Type:                 internalcharm.StorageType(addInfo.Kind),
 		CountMin:             addInfo.CountMin,
 		CountMax:             addInfo.CountMax,
@@ -1852,11 +1852,11 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 		return internal.StorageInfoForAttach{}, errors.Capture(err)
 	}
 	return internal.StorageInfoForAttach{
-		Name:                 attachInfo.StorageName.String(),
+		CharmStorageName:     attachInfo.StorageName.String(),
 		CountMin:             attachInfo.CountMin,
 		CountMax:             attachInfo.CountMax,
 		MinimumSize:          attachInfo.MinimumSize,
-		SizeMiB:              attachInfo.SizeMIB,
+		ProvisionedSizeMiB:   attachInfo.SizeMIB,
 		AlreadyAttachedCount: count,
 	}, nil
 }

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -439,7 +439,7 @@ func (st *State) AddIAASUnits(
 		machineNames []coremachine.Name
 	)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if err := st.checkApplicationAlive(ctx, tx, appUUID); err != nil {
+		if err := st.checkApplicationAlive(ctx, tx, appUUID.String()); err != nil {
 			return errors.Capture(err)
 		}
 
@@ -449,7 +449,7 @@ func (st *State) AddIAASUnits(
 		}
 
 		for i, arg := range args {
-			uName, _, mNames, err := st.unitState.InsertIAASUnit(ctx, tx, appUUID.String(), charmUUID, arg)
+			uName, _, mNames, err := st.InsertIAASUnit(ctx, tx, appUUID.String(), charmUUID, arg)
 			if err != nil {
 				return errors.Errorf("inserting unit %d: %w ", i, err)
 			}
@@ -809,6 +809,7 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 	addUnitArg := application.AddCAASUnitArg{
 		AddUnitArg: application.AddUnitArg{
 			CreateUnitStorageArg: arg.CreateUnitStorageArg,
+			UnitUUID:             arg.UnitUUID,
 			NetNodeUUID:          arg.NetNodeUUID,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -880,7 +881,7 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 			return errors.Capture(err)
 		}
 
-		err = st.unitState.upsertUnitCloudContainer(ctx, tx, toUpdate.Name, toUpdate.UnitUUID, toUpdate.NetNodeID, cloudContainer)
+		err = st.upsertUnitCloudContainer(ctx, tx, toUpdate.Name, toUpdate.UnitUUID, toUpdate.NetNodeID, cloudContainer)
 		if err != nil {
 			return errors.Errorf("updating cloud container for unit %q: %w", arg.UnitName, err)
 		}
@@ -947,7 +948,7 @@ func (st *State) insertCAASUnit(
 	appUUID, charmUUID string,
 	args application.AddCAASUnitArg,
 ) (string, error) {
-	unitName, err := st.unitState.newUnitName(ctx, tx, appUUID)
+	unitName, err := st.newUnitName(ctx, tx, appUUID)
 	if err != nil {
 		return "", errors.Errorf("getting new unit name for application %q: %w", appUUID, err)
 	}
@@ -968,13 +969,9 @@ func (st *State) insertCAASUnitWithName(
 	appUUID, charmUUID, unitName string,
 	args application.AddCAASUnitArg,
 ) (string, error) {
-	u, err := coreunit.NewUUID()
-	if err != nil {
-		return "", errors.Capture(err)
-	}
-	unitUUID := u.String()
+	unitUUID := args.UnitUUID.String()
 
-	if err := st.unitState.insertUnit(ctx, tx, appUUID, unitUUID, args.NetNodeUUID.String(), insertUnitArg{
+	if err := st.insertUnit(ctx, tx, appUUID, unitUUID, args.NetNodeUUID.String(), insertUnitArg{
 		CharmUUID:      charmUUID,
 		UnitName:       unitName,
 		CloudContainer: args.CloudContainer,
@@ -984,7 +981,7 @@ func (st *State) insertCAASUnitWithName(
 		return "", errors.Errorf("inserting unit for CAAS application %q: %w", appUUID, err)
 	}
 
-	err = st.unitState.insertUnitStorageDirectives(
+	err := st.insertUnitStorageDirectives(
 		ctx, tx, unitUUID, charmUUID, args.StorageDirectives,
 	)
 	if err != nil {
@@ -993,7 +990,7 @@ func (st *State) insertCAASUnitWithName(
 		)
 	}
 
-	_, err = st.unitState.insertUnitStorageInstances(
+	_, err = st.insertUnitStorageInstances(
 		ctx, tx, args.StorageInstances,
 	)
 	if err != nil {
@@ -1002,7 +999,7 @@ func (st *State) insertCAASUnitWithName(
 		)
 	}
 
-	err = st.unitState.insertUnitStorageAttachments(
+	err = st.insertUnitStorageAttachments(
 		ctx,
 		tx,
 		unitUUID,
@@ -1014,7 +1011,7 @@ func (st *State) insertCAASUnitWithName(
 		)
 	}
 
-	err = st.unitState.insertUnitStorageOwnership(ctx, tx, unitUUID, args.StorageToOwn)
+	err = st.insertUnitStorageOwnership(ctx, tx, unitUUID, args.StorageToOwn)
 	if err != nil {
 		return "", errors.Errorf(
 			"inserting storage ownership for unit %q: %w", unitName, err,
@@ -1055,17 +1052,17 @@ func (st *State) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, par
 		}
 
 		if cloudContainer != nil {
-			err = st.unitState.upsertUnitCloudContainer(ctx, tx, toUpdate.Name, toUpdate.UnitUUID, toUpdate.NetNodeID, cloudContainer)
+			err = st.upsertUnitCloudContainer(ctx, tx, toUpdate.Name, toUpdate.UnitUUID, toUpdate.NetNodeID, cloudContainer)
 			if err != nil {
 				return errors.Errorf("updating cloud container for unit %q: %w", unitName, err)
 			}
 		}
 
-		if err := st.unitState.setUnitAgentStatus(ctx, tx, toUpdate.UnitUUID, params.AgentStatus); err != nil {
+		if err := st.setUnitAgentStatus(ctx, tx, toUpdate.UnitUUID, params.AgentStatus); err != nil {
 			return errors.Errorf("saving unit %q agent status: %w", unitName, err)
 		}
 
-		if err := st.unitState.setUnitWorkloadStatus(ctx, tx, toUpdate.UnitUUID, params.WorkloadStatus); err != nil {
+		if err := st.setUnitWorkloadStatus(ctx, tx, toUpdate.UnitUUID, params.WorkloadStatus); err != nil {
 			return errors.Errorf("saving unit %q workload status: %w", unitName, err)
 		}
 		if err := st.setK8sPodStatus(ctx, tx, toUpdate.UnitUUID, params.K8sPodStatus); err != nil {
@@ -1474,7 +1471,7 @@ func (st *State) SetUnitWorkloadVersion(ctx context.Context, unitName coreunit.N
 		if err != nil {
 			return errors.Errorf("getting uuid for unit %q: %w", unitName, err)
 		}
-		return st.unitState.setUnitWorkloadVersion(ctx, tx, unitUUID, version)
+		return st.setUnitWorkloadVersion(ctx, tx, unitUUID, version)
 	})
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1835,7 +1835,7 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 	}
 	var (
 		attachInfo      storageInfoForAttach
-		attachedToUnits []string
+		attachedToUnits []storageAttachmentUnit
 		count           uint32
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -1856,6 +1856,11 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 	}); err != nil {
 		return internal.StorageInfoForAttach{}, errors.Capture(err)
 	}
+
+	attachedMap := make(map[string]string, len(attachedToUnits))
+	for _, u := range attachedToUnits {
+		attachedMap[u.UUID] = u.Name
+	}
 	return internal.StorageInfoForAttach{
 		CharmStorageName:       attachInfo.StorageName.String(),
 		CountMin:               attachInfo.CountMin,
@@ -1863,7 +1868,7 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 		MinimumSize:            attachInfo.MinimumSize,
 		ProvisionedSizeMiB:     attachInfo.SizeMIB,
 		AlreadyAttachedCount:   count,
-		AlreadyAttachedToUnits: attachedToUnits,
+		AlreadyAttachedToUnits: attachedMap,
 	}, nil
 }
 

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1780,24 +1780,24 @@ WHERE  u.uuid = $unitUUID.uuid
 	return netNodeUUID.NetNodeUUID, nil
 }
 
-// GetCharmStorageAndInstanceCountByUnitUUID returns the metadata and how many
+// GetStorageAddInfoByUnitUUID returns the deploy metadata and how many
 // storage instances exist for the named storage on the specified unit.
 // The following error types can be expected:
 // - [applicationerrors.StorageNameNotSupported]: when storage name is not defined in charm metadata.
-func (st *State) GetCharmStorageAndInstanceCountByUnitUUID(
+func (st *State) GetStorageAddInfoByUnitUUID(
 	ctx context.Context, unitUUID coreunit.UUID, storageName corestorage.Name,
-) (internalcharm.Storage, uint32, error) {
+) (internal.StorageInfoForAdd, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return internalcharm.Storage{}, 0, errors.Capture(err)
+		return internal.StorageInfoForAdd{}, errors.Capture(err)
 	}
 
 	var (
-		chStorage charmStorage
+		chStorage storageInfoForAdd
 		count     uint32
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		chStorage, err = st.getUnitCharmStorageByName(ctx, tx, unitUUID, storageName)
+		chStorage, err = st.getStorageInstanceInfoForAdd(ctx, tx, unitUUID, storageName)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("storage %q is not found", storageName).Add(applicationerrors.StorageNameNotSupported)
 		}
@@ -1810,76 +1810,61 @@ func (st *State) GetCharmStorageAndInstanceCountByUnitUUID(
 		}
 		return nil
 	}); err != nil {
-		return internalcharm.Storage{}, 0, errors.Capture(err)
+		return internal.StorageInfoForAdd{}, errors.Capture(err)
 	}
-	return internalcharm.Storage{
-		Name:        chStorage.Name,
-		Description: chStorage.Description,
-		Type:        internalcharm.StorageType(chStorage.Kind),
-		Shared:      chStorage.Shared,
-		ReadOnly:    chStorage.ReadOnly,
-		CountMin:    chStorage.CountMin,
-		CountMax:    chStorage.CountMax,
-		MinimumSize: chStorage.MinimumSize,
-		Location:    chStorage.Location,
-	}, count, nil
+	return internal.StorageInfoForAdd{
+		Name:                 chStorage.Name,
+		Type:                 internalcharm.StorageType(chStorage.Kind),
+		CountMin:             chStorage.CountMin,
+		CountMax:             chStorage.CountMax,
+		MinimumSize:          chStorage.MinimumSize,
+		AlreadyAttachedCount: count,
+	}, nil
 }
 
-// GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID returns the metadata
+// GetStorageAttachInfoByUnitUUIDAndStorageUUID returns the metadata
 // and select details for the storage instance on the specified unit.
 // The details include how many existing instances of the same named storage
 // already exist, the requested size, and the instance's storage pool.
-func (st *State) GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(
+func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 	ctx context.Context, unitUUID coreunit.UUID, storageUUID domainstorage.StorageInstanceUUID,
-) (internalcharm.Storage, internal.StorageInstanceInfo, error) {
+) (internal.StorageInfoForAttach, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return internalcharm.Storage{}, internal.StorageInstanceInfo{}, errors.Capture(err)
+		return internal.StorageInfoForAttach{}, errors.Capture(err)
 	}
 	var (
-		chStorage charmStorage
+		chStorage storageInfoForAttach
 		count     uint32
 		sizeMiB   uint64
 		poolUUID  string
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		details, err := st.getStorageInstanceProvisionedInfo(ctx, tx, storageUUID)
+		var err error
+		chStorage, err = st.getStorageInstanceInfoForAttach(ctx, tx, unitUUID, storageUUID)
 		if err != nil {
 			return errors.Capture(err)
 		}
-		poolUUID = details.StoragePoolUUID
-		sizeMiB = details.SizeMIB
-		chStorage, err = st.getUnitCharmStorageByName(ctx, tx, unitUUID, details.StorageName)
-		if errors.Is(err, sqlair.ErrNoRows) {
-			// Should never happen.
-			return errors.Errorf("storage %q is not found", details.StorageName).Add(applicationerrors.StorageNameNotSupported)
-		}
+		poolUUID = chStorage.StoragePoolUUID
+		sizeMiB = chStorage.SizeMIB
+		count, err = st.getUnitStorageCount(ctx, tx, unitUUID, chStorage.StorageName)
 		if err != nil {
-			return errors.Errorf("getting charm storage metadata for unit %q: %w", unitUUID, err)
-		}
-		count, err = st.getUnitStorageCount(ctx, tx, unitUUID, details.StorageName)
-		if err != nil {
-			return errors.Errorf("getting storage count for unit %q storage %s: %w", unitUUID, details.StorageName, err)
+			return errors.Errorf("getting storage count for unit %q storage %s: %w", unitUUID, chStorage.StorageName, err)
 		}
 		return nil
 	}); err != nil {
-		return internalcharm.Storage{}, internal.StorageInstanceInfo{}, errors.Capture(err)
+		return internal.StorageInfoForAttach{}, errors.Capture(err)
 	}
-	return internalcharm.Storage{
-			Name:        chStorage.Name,
-			Description: chStorage.Description,
-			Type:        internalcharm.StorageType(chStorage.Kind),
-			Shared:      chStorage.Shared,
-			ReadOnly:    chStorage.ReadOnly,
-			CountMin:    chStorage.CountMin,
-			CountMax:    chStorage.CountMax,
-			MinimumSize: chStorage.MinimumSize,
-			Location:    chStorage.Location,
-		}, internal.StorageInstanceInfo{
-			AlreadyAttachedCount: count,
-			SizeMiB:              sizeMiB,
-			PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),
-		}, nil
+	return internal.StorageInfoForAttach{
+		Name:                 chStorage.StorageName.String(),
+		Type:                 internalcharm.StorageType(chStorage.Kind),
+		CountMin:             chStorage.CountMin,
+		CountMax:             chStorage.CountMax,
+		MinimumSize:          chStorage.MinimumSize,
+		AlreadyAttachedCount: count,
+		SizeMiB:              sizeMiB,
+		PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),
+	}, nil
 }
 
 // setK8sPodStatus saves the given k8s pod status, overwriting

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1793,11 +1793,11 @@ func (st *State) GetStorageAddInfoByUnitUUID(
 	}
 
 	var (
-		chStorage storageInfoForAdd
-		count     uint32
+		addInfo storageInfoForAdd
+		count   uint32
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		chStorage, err = st.getStorageInstanceInfoForAdd(ctx, tx, unitUUID, storageName)
+		addInfo, err = st.getStorageInstanceInfoForAdd(ctx, tx, unitUUID, storageName)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("storage %q is not found", storageName).Add(applicationerrors.StorageNameNotSupported)
 		}
@@ -1813,11 +1813,11 @@ func (st *State) GetStorageAddInfoByUnitUUID(
 		return internal.StorageInfoForAdd{}, errors.Capture(err)
 	}
 	return internal.StorageInfoForAdd{
-		Name:                 chStorage.Name,
-		Type:                 internalcharm.StorageType(chStorage.Kind),
-		CountMin:             chStorage.CountMin,
-		CountMax:             chStorage.CountMax,
-		MinimumSize:          chStorage.MinimumSize,
+		Name:                 addInfo.Name,
+		Type:                 internalcharm.StorageType(addInfo.Kind),
+		CountMin:             addInfo.CountMin,
+		CountMax:             addInfo.CountMax,
+		MinimumSize:          addInfo.MinimumSize,
 		AlreadyAttachedCount: count,
 	}, nil
 }
@@ -1834,33 +1834,33 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 		return internal.StorageInfoForAttach{}, errors.Capture(err)
 	}
 	var (
-		chStorage storageInfoForAttach
-		count     uint32
+		attachInfo storageInfoForAttach
+		count      uint32
 		sizeMiB   uint64
 		poolUUID  string
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		chStorage, err = st.getStorageInstanceInfoForAttach(ctx, tx, unitUUID, storageUUID)
+		attachInfo, err = st.getStorageInstanceInfoForAttach(ctx, tx, unitUUID, storageUUID)
 		if err != nil {
 			return errors.Capture(err)
 		}
-		poolUUID = chStorage.StoragePoolUUID
-		sizeMiB = chStorage.SizeMIB
-		count, err = st.getUnitStorageCount(ctx, tx, unitUUID, chStorage.StorageName)
+		poolUUID = attachInfo.StoragePoolUUID
+		sizeMiB = attachInfo.SizeMIB
+		count, err = st.getUnitStorageCount(ctx, tx, unitUUID, attachInfo.StorageName)
 		if err != nil {
-			return errors.Errorf("getting storage count for unit %q storage %s: %w", unitUUID, chStorage.StorageName, err)
+			return errors.Errorf("getting storage count for unit %q storage %s: %w", unitUUID, attachInfo.StorageName, err)
 		}
 		return nil
 	}); err != nil {
 		return internal.StorageInfoForAttach{}, errors.Capture(err)
 	}
 	return internal.StorageInfoForAttach{
-		Name:                 chStorage.StorageName.String(),
-		Type:                 internalcharm.StorageType(chStorage.Kind),
-		CountMin:             chStorage.CountMin,
-		CountMax:             chStorage.CountMax,
-		MinimumSize:          chStorage.MinimumSize,
+		Name:                 attachInfo.StorageName.String(),
+		Type:                 internalcharm.StorageType(attachInfo.Kind),
+		CountMin:             attachInfo.CountMin,
+		CountMax:             attachInfo.CountMax,
+		MinimumSize:          attachInfo.MinimumSize,
 		AlreadyAttachedCount: count,
 		SizeMiB:              sizeMiB,
 		PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1836,17 +1836,13 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 	var (
 		attachInfo storageInfoForAttach
 		count      uint32
-		sizeMiB   uint64
-		poolUUID  string
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		attachInfo, err = st.getStorageInstanceInfoForAttach(ctx, tx, unitUUID, storageUUID)
+		attachInfo, err = st.getStorageInstanceInfoForAttach(ctx, tx, storageUUID)
 		if err != nil {
 			return errors.Capture(err)
 		}
-		poolUUID = attachInfo.StoragePoolUUID
-		sizeMiB = attachInfo.SizeMIB
 		count, err = st.getUnitStorageCount(ctx, tx, unitUUID, attachInfo.StorageName)
 		if err != nil {
 			return errors.Errorf("getting storage count for unit %q storage %s: %w", unitUUID, attachInfo.StorageName, err)
@@ -1857,13 +1853,11 @@ func (st *State) GetStorageAttachInfoByUnitUUIDAndStorageUUID(
 	}
 	return internal.StorageInfoForAttach{
 		Name:                 attachInfo.StorageName.String(),
-		Type:                 internalcharm.StorageType(attachInfo.Kind),
 		CountMin:             attachInfo.CountMin,
 		CountMax:             attachInfo.CountMax,
 		MinimumSize:          attachInfo.MinimumSize,
+		SizeMiB:              attachInfo.SizeMIB,
 		AlreadyAttachedCount: count,
-		SizeMiB:              sizeMiB,
-		PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),
 	}, nil
 }
 

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1003,7 +1003,7 @@ func (st *State) insertCAASUnitWithName(
 		ctx,
 		tx,
 		unitUUID,
-		args.StorageToAttach,
+		args.NewStorageToAttach,
 	)
 	if err != nil {
 		return "", errors.Errorf(

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/application"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/application/internal"
 	"github.com/juju/juju/domain/constraints"
 	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/ipaddress"
@@ -33,6 +34,7 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/status"
+	domainstorage "github.com/juju/juju/domain/storage"
 	internaldatabase "github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
 )
@@ -1821,6 +1823,63 @@ func (st *State) GetCharmStorageAndInstanceCountByUnitUUID(
 		MinimumSize: chStorage.MinimumSize,
 		Location:    chStorage.Location,
 	}, count, nil
+}
+
+// GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID returns the metadata
+// and select details for the storage instance on the specified unit.
+// The details include how many existing instances of the same named storage
+// already exist, the requested size, and the instance's storage pool.
+func (st *State) GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(
+	ctx context.Context, unitUUID coreunit.UUID, storageUUID domainstorage.StorageInstanceUUID,
+) (internalcharm.Storage, internal.StorageInstanceInfo, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return internalcharm.Storage{}, internal.StorageInstanceInfo{}, errors.Capture(err)
+	}
+	var (
+		chStorage        charmStorage
+		count            uint32
+		requestedSizeMiB uint64
+		poolUUID         string
+	)
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		details, err := st.getStorageDetails(ctx, tx, storageUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		poolUUID = details.StoragePoolUUID
+		requestedSizeMiB = details.RequestedSizeMIB
+		chStorage, err = st.getUnitCharmStorageByName(ctx, tx, unitUUID, details.StorageName)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			// Should never happen.
+			return errors.Errorf("storage %q is not found", details.StorageName).Add(applicationerrors.StorageNameNotSupported)
+		}
+		if err != nil {
+			return errors.Errorf("getting charm storage metadata for unit %q: %w", unitUUID, err)
+		}
+		count, err = st.getUnitStorageCount(ctx, tx, unitUUID, details.StorageName)
+		if err != nil {
+			return errors.Errorf("getting storage count for unit %q storage %s: %w", unitUUID, details.StorageName, err)
+		}
+		return nil
+	}); err != nil {
+		return internalcharm.Storage{}, internal.StorageInstanceInfo{}, errors.Capture(err)
+	}
+	return internalcharm.Storage{
+			Name:        chStorage.Name,
+			Description: chStorage.Description,
+			Type:        internalcharm.StorageType(chStorage.Kind),
+			Shared:      chStorage.Shared,
+			ReadOnly:    chStorage.ReadOnly,
+			CountMin:    chStorage.CountMin,
+			CountMax:    chStorage.CountMax,
+			MinimumSize: chStorage.MinimumSize,
+			Location:    chStorage.Location,
+		}, internal.StorageInstanceInfo{
+			AlreadyAttachedCount: count,
+			SizeMiB:              requestedSizeMiB,
+			PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),
+		}, nil
 }
 
 // setK8sPodStatus saves the given k8s pod status, overwriting

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -238,6 +238,7 @@ func (s *unitStateSuite) TestRegisterCAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
 		UnitName:     "bar/0",
 		PasswordHash: "passwordhash",
 		ProviderID:   "some-id",
@@ -359,6 +360,7 @@ func (s *unitStateSuite) TestRegisterCAASUnitAlreadyExists(c *tc.C) {
 	unitName, _ := s.createNamedCAASUnit(c)
 
 	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
 		UnitName:     unitName,
 		PasswordHash: "passwordhash",
 		ProviderID:   "some-id",
@@ -401,6 +403,7 @@ func (s *unitStateSuite) TestRegisterCAASUnitReplaceDead(c *tc.C) {
 	s.setUnitLife(c, unitUUID, life.Dead)
 
 	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
 		UnitName:     unitName,
 		PasswordHash: "passwordhash",
 		ProviderID:   "foo-0",
@@ -416,6 +419,7 @@ func (s *unitStateSuite) TestRegisterCAASUnitReplaceDead(c *tc.C) {
 func (s *unitStateSuite) TestRegisterCAASUnitApplicationNotAlive(c *tc.C) {
 	s.createCAASApplication(c, "foo", life.Dying)
 	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
 		UnitName:     "foo/0",
 		PasswordHash: "passwordhash",
 		ProviderID:   "foo-0",
@@ -442,6 +446,7 @@ WHERE application_uuid = ?`, 1, 3, appUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
 		UnitName:     "foo/2",
 		PasswordHash: "passwordhash",
 		ProviderID:   "foo-2",
@@ -468,6 +473,7 @@ WHERE application_uuid = ?`, true, 1, 3, appUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
 		UnitName:     "foo/2",
 		PasswordHash: "passwordhash",
 		ProviderID:   "foo-2",
@@ -494,6 +500,7 @@ WHERE application_uuid = ?`, true, 3, 1, appUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
 		UnitName:     "foo/2",
 		PasswordHash: "passwordhash",
 		ProviderID:   "foo-2",
@@ -1047,6 +1054,7 @@ func (s *unitStateSuite) TestGetUnitNamesForNetNode(c *tc.C) {
 			MachineUUID:        machineUUID,
 			MachineNetNodeUUID: netNodeUUID,
 			AddUnitArg: application.AddUnitArg{
+				UnitUUID:    tc.Must(c, coreunit.NewUUID),
 				NetNodeUUID: netNodeUUID,
 				Placement: deployment.Placement{
 					Directive: "0",
@@ -1057,6 +1065,7 @@ func (s *unitStateSuite) TestGetUnitNamesForNetNode(c *tc.C) {
 			MachineUUID:        machineUUID,
 			MachineNetNodeUUID: netNodeUUID,
 			AddUnitArg: application.AddUnitArg{
+				UnitUUID:    tc.Must(c, coreunit.NewUUID),
 				NetNodeUUID: netNodeUUID,
 				Placement: deployment.Placement{
 					Type:      deployment.PlacementTypeMachine,
@@ -1068,6 +1077,7 @@ func (s *unitStateSuite) TestGetUnitNamesForNetNode(c *tc.C) {
 			MachineUUID:        machinetesting.GenUUID(c),
 			MachineNetNodeUUID: altNetNodeUUID,
 			AddUnitArg: application.AddUnitArg{
+				UnitUUID:    tc.Must(c, coreunit.NewUUID),
 				NetNodeUUID: altNetNodeUUID,
 				Placement: deployment.Placement{
 					Directive: "1",
@@ -1221,6 +1231,7 @@ func (s *unitStateSuite) TestGetUnitsK8sPodInfo(c *tc.C) {
 	// Arrange: 2 applications with 1 unit each, and a third application with a dead unit.
 	app1UUID := s.createCAASApplication(c, "foo", life.Alive, application.AddCAASUnitArg{
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    tc.Must(c, coreunit.NewUUID),
 			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 		},
 		CloudContainer: &application.CloudContainer{
@@ -1237,6 +1248,7 @@ func (s *unitStateSuite) TestGetUnitsK8sPodInfo(c *tc.C) {
 
 	app2UUID := s.createCAASApplication(c, "bar", life.Alive, application.AddCAASUnitArg{
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    tc.Must(c, coreunit.NewUUID),
 			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 		},
 		CloudContainer: &application.CloudContainer{
@@ -1254,6 +1266,7 @@ func (s *unitStateSuite) TestGetUnitsK8sPodInfo(c *tc.C) {
 
 	app3UUID := s.createCAASApplication(c, "zoo", life.Alive, application.AddCAASUnitArg{
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    tc.Must(c, coreunit.NewUUID),
 			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 		},
 		CloudContainer: &application.CloudContainer{

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -794,7 +794,7 @@ func (st *InsertIAASUnitState) insertUnitStorageAttachments(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID string,
-	storageToAttach []internal.CreateUnitStorageAttachmentArg,
+	storageToAttach []internal.UnitStorageAttachmentArg,
 ) error {
 	storageAttachmentArgs := makeInsertUnitStorageAttachmentArgs(
 		ctx, unitUUID, storageToAttach,
@@ -1252,7 +1252,7 @@ func (st *InsertIAASUnitState) makeInsertUnitFilesystemArgs(
 // [insertStorageFilesystemAttachment] for each filesystem attachment defined in
 // args.
 func (st *InsertIAASUnitState) makeInsertUnitFilesystemAttachmentArgs(
-	args []internal.CreateUnitStorageAttachmentArg,
+	args []internal.UnitStorageAttachmentArg,
 ) []insertStorageFilesystemAttachment {
 	rval := []insertStorageFilesystemAttachment{}
 	for _, arg := range args {
@@ -1386,7 +1386,7 @@ func (st *InsertIAASUnitState) makeInsertUnitVolumeArgs(
 // [insertStorageVolumeAttachment] values for each volume attachment argument
 // supplied.
 func (st *InsertIAASUnitState) makeInsertUnitVolumeAttachmentArgs(
-	args []internal.CreateUnitStorageAttachmentArg,
+	args []internal.UnitStorageAttachmentArg,
 ) []insertStorageVolumeAttachment {
 	rval := []insertStorageVolumeAttachment{}
 	for _, arg := range args {

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -797,7 +797,7 @@ func (st *InsertIAASUnitState) insertUnitStorageAttachments(
 	storageToAttach []internal.CreateUnitStorageAttachmentArg,
 ) error {
 	storageAttachmentArgs := makeInsertUnitStorageAttachmentArgs(
-		ctx, unitUUID, storageToAttach,
+		unitUUID, storageToAttach,
 	)
 
 	fsAttachmentArgs := st.makeInsertUnitFilesystemAttachmentArgs(

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -109,7 +109,7 @@ func (st *State) InsertIAASUnit(
 		ctx,
 		tx,
 		unitUUID,
-		args.StorageToAttach,
+		args.NewStorageToAttach,
 	)
 	if err != nil {
 		return "", "", nil, errors.Errorf(
@@ -143,11 +143,11 @@ func (st *State) InsertIAASUnit(
 	}
 
 	for _, extra := range args.ExistingStorageToAttach {
-		err = st.attachStorageForUnit(ctx, tx, extra.StorageToAttach.StorageInstanceUUID, args.UnitUUID, extra)
+		err = st.attachExistingStorageForNewUnit(ctx, tx, extra.StorageInstanceUUID, args.UnitUUID, extra)
 		if err != nil {
 			return "", "", nil, errors.Errorf(
 				"attaching existing storage instance %q to unit %q: %w",
-				extra.StorageToAttach.StorageInstanceUUID, unitName, err,
+				extra.StorageInstanceUUID, unitName, err,
 			)
 		}
 	}
@@ -802,7 +802,7 @@ func (st *State) insertUnitStorageAttachments(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID string,
-	storageToAttach []internal.CreateUnitStorageAttachmentArg,
+	storageToAttach []internal.AttachStorageToUnitArg,
 ) error {
 	storageAttachmentArgs := makeInsertUnitStorageAttachmentArgs(
 		unitUUID, storageToAttach,
@@ -1260,7 +1260,7 @@ func (st *State) makeInsertUnitFilesystemArgs(
 // [insertStorageFilesystemAttachment] for each filesystem attachment defined in
 // args.
 func (st *State) makeInsertUnitFilesystemAttachmentArgs(
-	args []internal.CreateUnitStorageAttachmentArg,
+	args []internal.AttachStorageToUnitArg,
 ) []insertStorageFilesystemAttachment {
 	rval := []insertStorageFilesystemAttachment{}
 	for _, arg := range args {
@@ -1394,7 +1394,7 @@ func (st *State) makeInsertUnitVolumeArgs(
 // [insertStorageVolumeAttachment] values for each volume attachment argument
 // supplied.
 func (st *State) makeInsertUnitVolumeAttachmentArgs(
-	args []internal.CreateUnitStorageAttachmentArg,
+	args []internal.AttachStorageToUnitArg,
 ) []insertStorageVolumeAttachment {
 	rval := []insertStorageVolumeAttachment{}
 	for _, arg := range args {

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -794,7 +794,7 @@ func (st *InsertIAASUnitState) insertUnitStorageAttachments(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID string,
-	storageToAttach []internal.UnitStorageAttachmentArg,
+	storageToAttach []internal.CreateUnitStorageAttachmentArg,
 ) error {
 	storageAttachmentArgs := makeInsertUnitStorageAttachmentArgs(
 		ctx, unitUUID, storageToAttach,
@@ -1252,7 +1252,7 @@ func (st *InsertIAASUnitState) makeInsertUnitFilesystemArgs(
 // [insertStorageFilesystemAttachment] for each filesystem attachment defined in
 // args.
 func (st *InsertIAASUnitState) makeInsertUnitFilesystemAttachmentArgs(
-	args []internal.UnitStorageAttachmentArg,
+	args []internal.CreateUnitStorageAttachmentArg,
 ) []insertStorageFilesystemAttachment {
 	rval := []insertStorageFilesystemAttachment{}
 	for _, arg := range args {
@@ -1386,7 +1386,7 @@ func (st *InsertIAASUnitState) makeInsertUnitVolumeArgs(
 // [insertStorageVolumeAttachment] values for each volume attachment argument
 // supplied.
 func (st *InsertIAASUnitState) makeInsertUnitVolumeAttachmentArgs(
-	args []internal.UnitStorageAttachmentArg,
+	args []internal.CreateUnitStorageAttachmentArg,
 ) []insertStorageVolumeAttachment {
 	rval := []insertStorageVolumeAttachment{}
 	for _, arg := range args {

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -36,18 +36,20 @@ import (
 	"github.com/juju/juju/internal/uuid"
 )
 
-// InsertIAASUnitState represents the minium state required to insert
-// an IAAS unit. Splitting this out, allows for sharing with the
-// relation domain to facilitate subordinate unit creation.
-type InsertIAASUnitState struct {
-	*domain.StateBase
-	clock  clock.Clock
-	logger logger.Logger
+// InsertIAASUnitState represents the application domain method which
+// inserts an IAAS unit.
+type InsertIAASUnitState interface {
+	InsertIAASUnit(
+		ctx context.Context,
+		tx *sqlair.TX,
+		appUUID, charmUUID string,
+		args application.AddIAASUnitArg,
+	) (coreunit.Name, coreunit.UUID, []coremachine.Name, error)
 }
 
 // NewInsertIAASUnitState returns a new insert IAAS unit state reference.
-func NewInsertIAASUnitState(factory database.TxnRunnerFactory, clock clock.Clock, logger logger.Logger) *InsertIAASUnitState {
-	return &InsertIAASUnitState{
+func NewInsertIAASUnitState(factory database.TxnRunnerFactory, clock clock.Clock, logger logger.Logger) InsertIAASUnitState {
+	return &State{
 		StateBase: domain.NewStateBase(factory),
 		clock:     clock,
 		logger:    logger,
@@ -57,7 +59,7 @@ func NewInsertIAASUnitState(factory database.TxnRunnerFactory, clock clock.Clock
 // InsertIAASUnit inserts an IAAS unit into state, handling the IAAS
 // specific details. It's a public method to share with the relation
 // domain for subordinate applications.
-func (st *InsertIAASUnitState) InsertIAASUnit(
+func (st *State) InsertIAASUnit(
 	ctx context.Context,
 	tx *sqlair.TX,
 	appUUID, charmUUID string,
@@ -68,11 +70,7 @@ func (st *InsertIAASUnitState) InsertIAASUnit(
 		return "", "", nil, errors.Errorf("getting new unit name for application %q: %w", appUUID, err)
 	}
 
-	unit, err := coreunit.NewUUID()
-	if err != nil {
-		return "", "", nil, errors.Capture(err)
-	}
-	unitUUID := unit.String()
+	unitUUID := args.UnitUUID.String()
 
 	machineNames, err := st.placeIAASUnitMachine(ctx, tx, args)
 	if err != nil {
@@ -144,6 +142,16 @@ func (st *InsertIAASUnitState) InsertIAASUnit(
 		)
 	}
 
+	for _, extra := range args.ExistingStorageToAttach {
+		err = st.attachStorageForUnit(ctx, tx, extra.StorageToAttach.StorageInstanceUUID, args.UnitUUID, extra)
+		if err != nil {
+			return "", "", nil, errors.Errorf(
+				"attaching existing storage instance %q to unit %q: %w",
+				extra.StorageToAttach.StorageInstanceUUID, unitName, err,
+			)
+		}
+	}
+
 	return coreunit.Name(unitName), coreunit.UUID(unitUUID), machineNames, nil
 }
 
@@ -159,7 +167,7 @@ type insertUnitArg struct {
 
 // insertUnit inserts a unit into state. IAAS or CAAS specific details
 // are handled by the callers, modulo CloudContainer functionality.
-func (st *InsertIAASUnitState) insertUnit(
+func (st *State) insertUnit(
 	ctx context.Context, tx *sqlair.TX,
 	appUUID, unitUUID, netNodeUUID string,
 	args insertUnitArg,
@@ -230,7 +238,7 @@ func (st *InsertIAASUnitState) insertUnit(
 
 // getApplicationName returns the application name. If no application is found,
 // an error satisfying [applicationerrors.ApplicationNotFound] is returned.
-func (st *InsertIAASUnitState) getApplicationName(
+func (st *State) getApplicationName(
 	ctx context.Context,
 	tx *sqlair.TX,
 	id string,
@@ -259,7 +267,7 @@ WHERE  a.uuid = $applicationUUIDAndName.uuid AND c.source_id < 2;
 }
 
 // checkApplicationAlive checks if the application exists and it is alive.
-func (st *InsertIAASUnitState) checkApplicationAlive(ctx context.Context, tx *sqlair.TX, appUUID string) error {
+func (st *State) checkApplicationAlive(ctx context.Context, tx *sqlair.TX, appUUID string) error {
 	type life struct {
 		LifeID corelife.Value `db:"value"`
 	}
@@ -296,7 +304,7 @@ WHERE  a.uuid = $entityUUID.uuid
 
 // newUnitName returns a new name for the unit. It increments the unit counter
 // on the application.
-func (st *InsertIAASUnitState) newUnitName(
+func (st *State) newUnitName(
 	ctx context.Context,
 	tx *sqlair.TX,
 	appUUID string,
@@ -317,7 +325,7 @@ func (st *InsertIAASUnitState) newUnitName(
 	return unitName.String(), errors.Capture(err)
 }
 
-func (st *InsertIAASUnitState) upsertUnitCloudContainer(
+func (st *State) upsertUnitCloudContainer(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitName, unitUUID, netNodeUUID string,
@@ -387,7 +395,7 @@ WHERE unit_uuid = $cloudContainer.unit_uuid
 	return nil
 }
 
-func (st *InsertIAASUnitState) upsertCloudContainerAddress(
+func (st *State) upsertCloudContainerAddress(
 	ctx context.Context, tx *sqlair.TX, unitName, netNodeUUID string, address application.ContainerAddress,
 ) error {
 	// First ensure the address link layer device is upserted.
@@ -505,7 +513,7 @@ ON CONFLICT(uuid) DO UPDATE SET
 	return nil
 }
 
-func (st *InsertIAASUnitState) upsertCloudContainerPorts(ctx context.Context, tx *sqlair.TX, unitUUID string, portValues []string) error {
+func (st *State) upsertCloudContainerPorts(ctx context.Context, tx *sqlair.TX, unitUUID string, portValues []string) error {
 	type ports []string
 
 	ccPort := unitK8sPodPort{
@@ -544,7 +552,7 @@ DO NOTHING
 	return nil
 }
 
-func (st *InsertIAASUnitState) k8sSubnetUUIDsByAddressType(ctx context.Context, tx *sqlair.TX) (map[network.AddressType]string, error) {
+func (st *State) k8sSubnetUUIDsByAddressType(ctx context.Context, tx *sqlair.TX) (map[network.AddressType]string, error) {
 	result := make(map[network.AddressType]string)
 	subnetStmt, err := st.Prepare(`SELECT &subnet.* FROM subnet`, subnet{})
 	if err != nil {
@@ -573,7 +581,7 @@ func (st *InsertIAASUnitState) k8sSubnetUUIDsByAddressType(ctx context.Context, 
 // be used for a machine exists. We do this because the business logic around if
 // netnode uuid for a unit is shared or already exists is outside the scope of
 // state.
-func (st *InsertIAASUnitState) ensureFutureUnitNetNode(
+func (st *State) ensureFutureUnitNetNode(
 	ctx context.Context, tx *sqlair.TX, uuid string,
 ) error {
 	netNodeUUID := netNodeUUID{NetNodeUUID: uuid}
@@ -594,7 +602,7 @@ func (st *InsertIAASUnitState) ensureFutureUnitNetNode(
 	return nil
 }
 
-func (st *InsertIAASUnitState) getUnitApplicationUUID(ctx context.Context, tx *sqlair.TX, uuid string) (string, error) {
+func (st *State) getUnitApplicationUUID(ctx context.Context, tx *sqlair.TX, uuid string) (string, error) {
 	unitUUID := unitUUID{UnitUUID: uuid}
 
 	query, err := st.Prepare(`
@@ -620,7 +628,7 @@ WHERE u.uuid = $unitUUID.uuid
 
 // placeIAASUnitMachine is responsible for making sure that the machine required
 // by the unit being added has been placed.
-func (st *InsertIAASUnitState) placeIAASUnitMachine(
+func (st *State) placeIAASUnitMachine(
 	ctx context.Context,
 	tx *sqlair.TX,
 	args application.AddIAASUnitArg,
@@ -651,7 +659,7 @@ func (st *InsertIAASUnitState) placeIAASUnitMachine(
 // so we need to do two separate queries. This prevents the workload version
 // from trigging a cascade of unwanted updates to the application and or unit
 // tables.
-func (st *InsertIAASUnitState) setUnitWorkloadVersion(
+func (st *State) setUnitWorkloadVersion(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID string,
@@ -700,7 +708,7 @@ ON CONFLICT (application_uuid) DO UPDATE SET
 
 // status data. If returns an error satisfying [applicationerrors.UnitNotFound]
 // if the unit doesn't exist.
-func (st *InsertIAASUnitState) setUnitAgentStatus(
+func (st *State) setUnitAgentStatus(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID string,
@@ -745,7 +753,7 @@ ON CONFLICT(unit_uuid) DO UPDATE SET
 // setUnitWorkloadStatus saves the given unit workload status, overwriting any
 // current status data. If returns an error satisfying
 // [applicationerrors.UnitNotFound] if the unit doesn't exist.
-func (st *InsertIAASUnitState) setUnitWorkloadStatus(
+func (st *State) setUnitWorkloadStatus(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID string,
@@ -790,7 +798,7 @@ ON CONFLICT(unit_uuid) DO UPDATE SET
 // insertUnitStorageAttachments is responsible for creating all of the unit
 // storage attachments for the supplied storage instance uuids. This func will
 // also create storage attachments for each filesystem and volume
-func (st *InsertIAASUnitState) insertUnitStorageAttachments(
+func (st *State) insertUnitStorageAttachments(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID string,
@@ -870,7 +878,7 @@ VALUES ($insertStorageVolumeAttachment.*)
 //
 // The storage directives supply must match the storage defined by the charm.
 // It is expected that the caller is satisfied this check has been performed.
-func (st *InsertIAASUnitState) insertUnitStorageDirectives(
+func (st *State) insertUnitStorageDirectives(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID, charmUUID string,
@@ -913,7 +921,7 @@ INSERT INTO unit_storage_directive (*) VALUES ($insertUnitStorageDirective.*)
 // insertUnitStorageInstances is responsible for creating all of the needed
 // storage instances to satisfy the storage instance arguments supplied.
 // The IDs of the new storage instances are returned.
-func (st *InsertIAASUnitState) insertUnitStorageInstances(
+func (st *State) insertUnitStorageInstances(
 	ctx context.Context,
 	tx *sqlair.TX,
 	stArgs []internal.CreateUnitStorageInstanceArg,
@@ -1086,7 +1094,7 @@ INSERT INTO storage_volume_status (*) VALUES ($insertStorageVolumeStatus.*)
 
 // insertUnitStorageOwnership is responsible setting unit ownership records for
 // the supplied storage instance uuids.
-func (st *InsertIAASUnitState) insertUnitStorageOwnership(
+func (st *State) insertUnitStorageOwnership(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitUUID string,
@@ -1117,7 +1125,7 @@ INSERT INTO storage_unit_owner (*) VALUES ($insertStorageUnitOwner.*)
 
 // insertMachineVolumeOwnership is responsible setting machine ownership records
 // for the supplied volume uuids.
-func (st *InsertIAASUnitState) insertMachineVolumeOwnership(
+func (st *State) insertMachineVolumeOwnership(
 	ctx context.Context,
 	tx *sqlair.TX,
 	machineUUID coremachine.UUID,
@@ -1147,7 +1155,7 @@ INSERT INTO machine_volume (*) VALUES ($insertVolumeMachineOwner.*)
 
 // insertMachineFilesystemOwnership is responsible setting machine ownership
 // records for the supplied filesystem uuids.
-func (st *InsertIAASUnitState) insertMachineFilesystemOwnership(
+func (st *State) insertMachineFilesystemOwnership(
 	ctx context.Context,
 	tx *sqlair.TX,
 	machineUUID coremachine.UUID,
@@ -1178,7 +1186,7 @@ INSERT INTO machine_filesystem (*) VALUES ($insertFilesystemMachineOwner.*)
 
 // makeInsertUnitFilesystemArgs is responsible for making the insert args to
 // establish new filesystems linked to a storage instance in the model.
-func (st *InsertIAASUnitState) makeInsertUnitFilesystemArgs(
+func (st *State) makeInsertUnitFilesystemArgs(
 	ctx context.Context,
 	tx *sqlair.TX,
 	args []internal.CreateUnitStorageInstanceArg,
@@ -1251,7 +1259,7 @@ func (st *InsertIAASUnitState) makeInsertUnitFilesystemArgs(
 // makeInsertUnitFilesystemAttachmentArgs will make a slice of
 // [insertStorageFilesystemAttachment] for each filesystem attachment defined in
 // args.
-func (st *InsertIAASUnitState) makeInsertUnitFilesystemAttachmentArgs(
+func (st *State) makeInsertUnitFilesystemAttachmentArgs(
 	args []internal.CreateUnitStorageAttachmentArg,
 ) []insertStorageFilesystemAttachment {
 	rval := []insertStorageFilesystemAttachment{}
@@ -1277,7 +1285,7 @@ func (st *InsertIAASUnitState) makeInsertUnitFilesystemAttachmentArgs(
 // directive Included in the return is the set of insert values required for
 // making the unit the owner of the new storage instance(s). Attachment records
 // are also returned for each of the storage instances.
-func (st *InsertIAASUnitState) makeInsertUnitStorageInstanceArgs(
+func (st *State) makeInsertUnitStorageInstanceArgs(
 	ctx context.Context,
 	tx *sqlair.TX,
 	args []internal.CreateUnitStorageInstanceArg,
@@ -1312,7 +1320,7 @@ func (st *InsertIAASUnitState) makeInsertUnitStorageInstanceArgs(
 
 // makeInsertUnitVolumeArgs is responsible for making the insert args to
 // establish new volumes linked to a storage instance in the model.
-func (st *InsertIAASUnitState) makeInsertUnitVolumeArgs(
+func (st *State) makeInsertUnitVolumeArgs(
 	ctx context.Context,
 	tx *sqlair.TX,
 	args []internal.CreateUnitStorageInstanceArg,
@@ -1385,7 +1393,7 @@ func (st *InsertIAASUnitState) makeInsertUnitVolumeArgs(
 // makeInsertUnitVolumeAttachmentArgs will make a slice of
 // [insertStorageVolumeAttachment] values for each volume attachment argument
 // supplied.
-func (st *InsertIAASUnitState) makeInsertUnitVolumeAttachmentArgs(
+func (st *State) makeInsertUnitVolumeAttachmentArgs(
 	args []internal.CreateUnitStorageAttachmentArg,
 ) []insertStorageVolumeAttachment {
 	rval := []insertStorageVolumeAttachment{}

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -92,8 +92,8 @@ VALUES (?, ?, 1, ?, ?, ?, 1024)
 	_, err = u.DB().ExecContext(
 		c.Context(),
 		`
-INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
-VALUES (?, ?, ?, 0)
+INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id, size_mib)
+VALUES (?, ?, ?, 0, 1024)
 	`,
 		filesystemUUID.String(),
 		filesystemUUID.String(),

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -696,24 +696,15 @@ func (u *unitStorageSuite) TestGetStorageAttachInfoByUnitUUIDAndStorageUUID(c *t
 	u.newStorageUnitOwner(c, st1UUID, unitUUID)
 	u.newStorageUnitOwner(c, st2UUID, unitUUID)
 
-	var poolUUID string
-	err := u.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT uuid FROM storage_pool WHERE name=?", st1UUID).Scan(&poolUUID)
-		return err
-	})
-	c.Assert(err, tc.ErrorIsNil)
-
 	storageInfo, err := u.state.GetStorageAttachInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, st1UUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Assert(storageInfo, tc.DeepEquals, internal.StorageInfoForAttach{
 		Name:                 "st1",
-		Type:                 "filesystem",
 		CountMin:             1,
 		CountMax:             10,
 		MinimumSize:          1024,
 		AlreadyAttachedCount: 2,
 		SizeMiB:              1024,
-		PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),
 	})
 }

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -468,7 +468,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	fsa1UUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 	sa2UUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsa2UUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
-	unitStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	unitStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
 			UUID: sa1UUID,
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
@@ -586,7 +586,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 
-	unitStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	unitStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
 			UUID: saUUID,
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -405,7 +405,7 @@ func (u *unitStorageSuite) TestGetStorageAddInfoByUnitUUID(c *tc.C) {
 	storageInfo, err := u.state.GetStorageAddInfoByUnitUUID(c.Context(), unitUUID, "st1")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(storageInfo, tc.DeepEquals, internal.StorageInfoForAdd{
-		Name:                 "st1",
+		CharmStorageName:     "st1",
 		Type:                 "filesystem",
 		CountMin:             1,
 		CountMax:             10,
@@ -423,7 +423,7 @@ func (u *unitStorageSuite) TestGetStorageAddInfoByUnitUUIDNotSupported(c *tc.C) 
 
 func (u *unitStorageSuite) TestAddStorageForIAASUnitNotFound(c *tc.C) {
 	uuid := tc.Must(c, coreunit.NewUUID)
-	_, err := u.state.AddStorageForIAASUnit(c.Context(), uuid, "st1", internal.IAASUnitAddStorageArg{})
+	_, err := u.state.AddStorageForIAASUnit(c.Context(), uuid, "st1", internal.AddStorageToIAASUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
@@ -436,7 +436,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnitNotAlive(c *tc.C) {
 	})
 	c.Assert(err, tc.IsNil)
 
-	_, err = u.state.AddStorageForIAASUnit(c.Context(), uuid, "st1", internal.IAASUnitAddStorageArg{})
+	_, err = u.state.AddStorageForIAASUnit(c.Context(), uuid, "st1", internal.AddStorageToIAASUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotAlive)
 }
 
@@ -498,7 +498,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 		},
 	}
 
-	gotIDs, err := u.state.AddStorageForIAASUnit(c.Context(), unitUUID, "st1", internal.IAASUnitAddStorageArg{
+	gotIDs, err := u.state.AddStorageForIAASUnit(c.Context(), unitUUID, "st1", internal.AddStorageToIAASUnitArg{
 		AddStorageToUnitArg: internal.AddStorageToUnitArg{
 			StorageInstances: unitStorageToCreate,
 			StorageToAttach:  unitStorageToAttach,
@@ -552,14 +552,14 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotFound(c *tc.C) {
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	stUUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
-	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
+	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToIAASUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotFound(c *tc.C) {
 	_, unitUUID := u.createNamedIAASUnit(c)
 	storageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-	err := u.state.AttachStorageToIAASUnit(c.Context(), storageUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
+	err := u.state.AttachStorageToIAASUnit(c.Context(), storageUUID, unitUUID, internal.AttachStorageToIAASUnitArg{})
 	c.Assert(err, tc.ErrorIs, errors.StorageInstanceNotFound)
 }
 
@@ -573,7 +573,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotAlive(c *tc.C) {
 	})
 	c.Assert(err, tc.IsNil)
 
-	err = u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
+	err = u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToIAASUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotAlive)
 }
 
@@ -581,7 +581,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotAlive(c *tc.C) {
 	_, unitUUID := u.createNamedIAASUnit(c)
 	stUUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
 
-	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
+	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToIAASUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.StorageNotAlive)
 }
 
@@ -609,7 +609,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(exists, tc.IsFalse)
 
-	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.IAASUnitAttachStorageArg{
+	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
 		AttachStorageToUnitArg: internal.AttachStorageToUnitArg{
 			StorageToAttach: unitStorageToAttach,
 		},
@@ -706,11 +706,11 @@ func (u *unitStorageSuite) TestGetStorageAttachInfoByUnitUUIDAndStorageUUID(c *t
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Assert(storageInfo, tc.DeepEquals, internal.StorageInfoForAttach{
-		Name:                 "st1",
+		CharmStorageName:     "st1",
 		CountMin:             1,
 		CountMax:             10,
 		MinimumSize:          1024,
 		AlreadyAttachedCount: 2,
-		SizeMiB:              1024,
+		ProvisionedSizeMiB:   1024,
 	})
 }

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"database/sql"
 	"testing"
-
+	
 	"github.com/juju/clock"
 	"github.com/juju/tc"
-
+	
 	corestorage "github.com/juju/juju/core/storage"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"
@@ -22,6 +22,7 @@ import (
 	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/domain/storage/errors"
 	domainstorageprov "github.com/juju/juju/domain/storageprovisioning"
+	internalerrors "github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -605,9 +606,9 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 		StorageInstanceUUID: siUUID,
 	}
 
-	exists, err := u.state.GetUnitStorageAttachmentExists(c.Context(), siUUID, unitUUID)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(exists, tc.IsFalse)
+	attachInfo, err := u.state.GetStorageAttachInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, siUUID)
+	c.Assert(err, tc.IsNil)
+	c.Assert(attachInfo.AlreadyAttachedToUnits, tc.HasLen, 0)
 
 	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
 		AttachStorageToUnitArg: internal.AttachStorageToUnitArg{
@@ -649,9 +650,88 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 		},
 	})
 
-	exists, err = u.state.GetUnitStorageAttachmentExists(c.Context(), siUUID, unitUUID)
+	attachInfo, err = u.state.GetStorageAttachInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, siUUID)
+	c.Assert(err, tc.IsNil)
+	c.Assert(attachInfo.AlreadyAttachedToUnits, tc.SameContents, []string{unitUUID.String()})
+}
+
+func (u *unitStorageSuite) TestAttachStorageMismatch(c *tc.C) {
+	unitUUID, _ := u.newUnitWithStorageDirectives(c)
+	netNodeUUID, err := u.state.GetUnitNetNodeUUID(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(exists, tc.IsTrue)
+
+	siUUID, fsUUID := u.newAliveStorageInstanceWithModelFilesystem(c)
+	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
+	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
+
+	unitStorageToAttach := internal.CreateUnitStorageAttachmentArg{
+		UUID: saUUID,
+		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemUUID: fsUUID,
+			NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
+			ProvisionScope: domainstorageprov.ProvisionScopeMachine,
+			UUID:           fsaUUID,
+		},
+		StorageInstanceUUID: siUUID,
+	}
+
+	arg := internal.AttachStorageToUnitArg{
+		StorageToAttach: unitStorageToAttach,
+	}
+	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
+		AttachStorageToUnitArg: arg,
+		FilesystemsToOwn:       []domainstorage.FilesystemUUID{fsUUID},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	arg.AllowedExistingUnitAttachments = []string{tc.Must(c, coreunit.NewUUID).String()}
+	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
+		AttachStorageToUnitArg: arg,
+		FilesystemsToOwn:       []domainstorage.FilesystemUUID{fsUUID},
+	})
+	rErr, ok := internalerrors.AsType[internal.StorageAttachmentNotAllowed](err)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(rErr, tc.DeepEquals, internal.StorageAttachmentNotAllowed{
+		AttachedToUnits: []string{unitUUID.String()},
+	})
+}
+
+func (u *unitStorageSuite) TestAttachStorageTwiceSameUnit(c *tc.C) {
+	unitUUID, _ := u.newUnitWithStorageDirectives(c)
+	netNodeUUID, err := u.state.GetUnitNetNodeUUID(c.Context(), unitUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	siUUID, fsUUID := u.newAliveStorageInstanceWithModelFilesystem(c)
+	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
+	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
+
+	unitStorageToAttach := internal.CreateUnitStorageAttachmentArg{
+		UUID: saUUID,
+		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemUUID: fsUUID,
+			NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
+			ProvisionScope: domainstorageprov.ProvisionScopeMachine,
+			UUID:           fsaUUID,
+		},
+		StorageInstanceUUID: siUUID,
+	}
+
+	arg := internal.AttachStorageToUnitArg{
+		StorageToAttach: unitStorageToAttach,
+	}
+	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
+		AttachStorageToUnitArg: arg,
+		FilesystemsToOwn:       []domainstorage.FilesystemUUID{fsUUID},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	arg.AllowedExistingUnitAttachments = []string{unitUUID.String()}
+	arg.CountLessThanEqual = 2
+	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
+		AttachStorageToUnitArg: arg,
+		FilesystemsToOwn:       []domainstorage.FilesystemUUID{fsUUID},
+	})
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (u *unitStorageSuite) TestGetStorageInstanceCompositionByUUIDNotFound(c *tc.C) {
@@ -706,11 +786,12 @@ func (u *unitStorageSuite) TestGetStorageAttachInfoByUnitUUIDAndStorageUUID(c *t
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Assert(storageInfo, tc.DeepEquals, internal.StorageInfoForAttach{
-		CharmStorageName:     "st1",
-		CountMin:             1,
-		CountMax:             10,
-		MinimumSize:          1024,
-		AlreadyAttachedCount: 2,
-		ProvisionedSizeMiB:   1024,
+		CharmStorageName:       "st1",
+		CountMin:               1,
+		CountMax:               10,
+		MinimumSize:            1024,
+		AlreadyAttachedCount:   2,
+		ProvisionedSizeMiB:     1024,
+		AlreadyAttachedToUnits: nil,
 	})
 }

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -443,7 +443,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	si2UUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	unitStorageToCreate := []internal.CreateUnitStorageInstanceArg{
 		{
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				UUID: fs1UUID,
 			},
 			Name:            "st1",
@@ -453,7 +453,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			RequestSizeMiB:  1024,
 		},
 		{
-			Filesystem: &internal.CreateUnitStorageFilesystemArg{
+			Filesystem: &internal.UnitStorageFilesystemArg{
 				UUID: fs2UUID,
 			},
 			Name:            "st2",
@@ -471,7 +471,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	unitStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
 			UUID: sa1UUID,
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: fs1UUID,
 				NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
@@ -480,7 +480,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			StorageInstanceUUID: si1UUID,
 		}, {
 			UUID: sa2UUID,
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: fs2UUID,
 				NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -589,7 +589,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 	unitStorageToAttach := []internal.UnitStorageAttachmentArg{
 		{
 			UUID: saUUID,
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: fsUUID,
 				NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
@@ -598,6 +598,10 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 			StorageInstanceUUID: siUUID,
 		},
 	}
+
+	exists, err := u.state.GetUnitStorageAttachmentExists(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(exists, tc.IsFalse)
 
 	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.IAASUnitAttachStorageArg{
 		UnitAttachStorageArg: internal.UnitAttachStorageArg{
@@ -630,6 +634,10 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 			},
 		},
 	})
+
+	exists, err = u.state.GetUnitStorageAttachmentExists(c.Context(), siUUID, unitUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(exists, tc.IsTrue)
 }
 
 func (u *unitStorageSuite) TestGetStorageInstanceCompositionByUUIDNotFound(c *tc.C) {

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -444,7 +444,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	si2UUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	unitStorageToCreate := []internal.CreateUnitStorageInstanceArg{
 		{
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID: fs1UUID,
 			},
 			Name:            "st1",
@@ -454,7 +454,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			RequestSizeMiB:  1024,
 		},
 		{
-			Filesystem: &internal.UnitStorageFilesystemArg{
+			Filesystem: &internal.CreateUnitStorageFilesystemArg{
 				UUID: fs2UUID,
 			},
 			Name:            "st2",
@@ -469,10 +469,10 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	fsa1UUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 	sa2UUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsa2UUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
-	unitStorageToAttach := []internal.UnitStorageAttachmentArg{
+	unitStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
 		{
 			UUID: sa1UUID,
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: fs1UUID,
 				NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
@@ -481,7 +481,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 			StorageInstanceUUID: si1UUID,
 		}, {
 			UUID: sa2UUID,
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: fs2UUID,
 				NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeModel,
@@ -587,10 +587,10 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 
-	unitStorageToAttach := []internal.UnitStorageAttachmentArg{
+	unitStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
 		{
 			UUID: saUUID,
-			FilesystemAttachment: &internal.UnitStorageFilesystemAttachmentArg{
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 				FilesystemUUID: fsUUID,
 				NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
 				ProvisionScope: domainstorageprov.ProvisionScopeMachine,

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -680,9 +680,9 @@ func (u *unitStorageSuite) TestAttachStorageAlreadyAttached(c *tc.C) {
 
 	arg.AllowedExistingUnitAttachments = []string{tc.Must(c, coreunit.NewUUID).String()}
 	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, arg)
-	rErr, ok := internalerrors.AsType[internal.StorageAttachmentNotAllowed](err)
+	rErr, ok := internalerrors.AsType[applicationerrors.StorageAttachmentNotAllowed](err)
 	c.Assert(ok, tc.IsTrue)
-	c.Assert(rErr, tc.DeepEquals, internal.StorageAttachmentNotAllowed{
+	c.Assert(rErr, tc.DeepEquals, applicationerrors.StorageAttachmentNotAllowed{
 		AttachedToUnits: []string{"foo/0"},
 	})
 }

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -53,13 +53,22 @@ func (u *unitStorageSuite) SetUpTest(c *tc.C) {
 	)
 }
 
-// newStorageInstanceWithModelFilesystem is a helper function to create a new
-// storage instance in the model with an associated model provisioned
-// filesystem.
-func (u *unitStorageSuite) newStorageInstanceWithModelFilesystem(
+// newDyingStorageInstanceWithModelFilesystem is a helper function to
+// create a new storage instance with life Dying in the model with an
+// associated model provisioned filesystem.
+func (u *unitStorageSuite) newDyingStorageInstanceWithModelFilesystem(
 	c *tc.C,
 ) (domainstorage.StorageInstanceUUID, domainstorage.FilesystemUUID) {
 	return u.newStorageInstanceWithLifeAndWithModelFilesystem(c, life.Dying)
+}
+
+// newAliveStorageInstanceWithModelFilesystem is a helper function to
+// create a new storage instance with life Dying in the model with an
+// associated model provisioned filesystem.
+func (u *unitStorageSuite) newAliveStorageInstanceWithModelFilesystem(
+	c *tc.C,
+) (domainstorage.StorageInstanceUUID, domainstorage.FilesystemUUID) {
+	return u.newStorageInstanceWithLifeAndWithModelFilesystem(c, life.Alive)
 }
 
 // newStorageInstanceWithModelFilesystem is a helper function to create a new
@@ -142,8 +151,8 @@ func (u *unitStorageSuite) TestGetUnitOwnedStorageInstances(c *tc.C) {
 	_, unitUUIDs := u.createIAASApplicationWithNUnits(c, "foo", life.Alive, 1)
 	unitUUID := unitUUIDs[0]
 
-	st1UUID, fs1UUID := u.newStorageInstanceWithModelFilesystem(c)
-	st2UUID, fs2UUID := u.newStorageInstanceWithModelFilesystem(c)
+	st1UUID, fs1UUID := u.newDyingStorageInstanceWithModelFilesystem(c)
+	st2UUID, fs2UUID := u.newDyingStorageInstanceWithModelFilesystem(c)
 	u.newStorageUnitOwner(c, st1UUID, unitUUID)
 	u.newStorageUnitOwner(c, st2UUID, unitUUID)
 
@@ -388,8 +397,8 @@ func (u *unitStorageSuite) TestGetUnitStorageDirectiveByName(c *tc.C) {
 func (u *unitStorageSuite) TestGetStorageAddInfoByUnitUUID(c *tc.C) {
 	unitUUID, _ := u.newUnitWithStorageDirectives(c)
 
-	st1UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
-	st2UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	st1UUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
+	st2UUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
 	u.newStorageUnitOwner(c, st1UUID, unitUUID)
 	u.newStorageUnitOwner(c, st2UUID, unitUUID)
 
@@ -542,7 +551,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotFound(c *tc.C) {
 	unitUUID := tc.Must(c, coreunit.NewUUID)
-	stUUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	stUUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
 	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
@@ -556,7 +565,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotFound(c *tc.C) {
 
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotAlive(c *tc.C) {
 	_, unitUUID := u.createNamedIAASUnit(c)
-	stUUID, _ := u.newStorageInstanceWithLifeAndWithModelFilesystem(c, life.Alive)
+	stUUID, _ := u.newAliveStorageInstanceWithModelFilesystem(c)
 
 	err := u.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "UPDATE unit SET life_id = 1 WHERE uuid = ?", unitUUID.String())
@@ -570,7 +579,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotAlive(c *tc.C) {
 
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotAlive(c *tc.C) {
 	_, unitUUID := u.createNamedIAASUnit(c)
-	stUUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	stUUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
 
 	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.StorageNotAlive)
@@ -581,7 +590,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 	netNodeUUID, err := u.state.GetUnitNetNodeUUID(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
-	siUUID, fsUUID := u.newStorageInstanceWithLifeAndWithModelFilesystem(c, life.Alive)
+	siUUID, fsUUID := u.newAliveStorageInstanceWithModelFilesystem(c)
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 
@@ -655,8 +664,8 @@ func (u *unitStorageSuite) TestGetStorageInstanceCompositionByUUID(c *tc.C) {
 	_, unitUUIDs := u.createIAASApplicationWithNUnits(c, "foo", life.Alive, 1)
 	unitUUID := unitUUIDs[0]
 
-	st1UUID, fs1UUID := u.newStorageInstanceWithModelFilesystem(c)
-	st2UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	st1UUID, fs1UUID := u.newDyingStorageInstanceWithModelFilesystem(c)
+	st2UUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
 	u.newStorageUnitOwner(c, st1UUID, unitUUID)
 	u.newStorageUnitOwner(c, st2UUID, unitUUID)
 
@@ -688,8 +697,8 @@ func (u *unitStorageSuite) TestGetStorageAttachInfoByUnitUUIDAndStorageUUIDNotFo
 func (u *unitStorageSuite) TestGetStorageAttachInfoByUnitUUIDAndStorageUUID(c *tc.C) {
 	unitUUID, _ := u.newUnitWithStorageDirectives(c)
 
-	st1UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
-	st2UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	st1UUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
+	st2UUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
 	u.newStorageUnitOwner(c, st1UUID, unitUUID)
 	u.newStorageUnitOwner(c, st2UUID, unitUUID)
 

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -477,7 +477,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	fsa1UUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 	sa2UUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsa2UUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
-	unitStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+	unitStorageToAttach := []internal.AttachStorageToUnitArg{
 		{
 			UUID: sa1UUID,
 			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
@@ -501,9 +501,9 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 
 	gotIDs, err := u.state.AddStorageForIAASUnit(c.Context(), unitUUID, "st1", internal.AddStorageToIAASUnitArg{
 		AddStorageToUnitArg: internal.AddStorageToUnitArg{
-			StorageInstances: unitStorageToCreate,
-			StorageToAttach:  unitStorageToAttach,
-			StorageToOwn:     []domainstorage.StorageInstanceUUID{si1UUID, si2UUID},
+			StorageInstances:   unitStorageToCreate,
+			NewStorageToAttach: unitStorageToAttach,
+			StorageToOwn:       []domainstorage.StorageInstanceUUID{si1UUID, si2UUID},
 		},
 		FilesystemsToOwn: []domainstorage.FilesystemUUID{fs1UUID, fs2UUID},
 	})
@@ -553,14 +553,14 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotFound(c *tc.C) {
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	stUUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
-	err := u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToUnitArg{})
+	err := u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachExistingStorageToUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotFound(c *tc.C) {
 	_, unitUUID := u.createNamedIAASUnit(c)
 	storageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-	err := u.state.AttachStorageToUnit(c.Context(), storageUUID, unitUUID, internal.AttachStorageToUnitArg{})
+	err := u.state.AttachStorageToUnit(c.Context(), storageUUID, unitUUID, internal.AttachExistingStorageToUnitArg{})
 	c.Assert(err, tc.ErrorIs, errors.StorageInstanceNotFound)
 }
 
@@ -574,7 +574,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotAlive(c *tc.C) {
 	})
 	c.Assert(err, tc.IsNil)
 
-	err = u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToUnitArg{})
+	err = u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachExistingStorageToUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotAlive)
 }
 
@@ -582,7 +582,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotAlive(c *tc.C) {
 	_, unitUUID := u.createNamedIAASUnit(c)
 	stUUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
 
-	err := u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToUnitArg{})
+	err := u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachExistingStorageToUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.StorageNotAlive)
 }
 
@@ -595,7 +595,7 @@ func (u *unitStorageSuite) TestAttachStorageToUnit(c *tc.C) {
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 
-	unitStorageToAttach := internal.CreateUnitStorageAttachmentArg{
+	unitStorageToAttach := internal.AttachStorageToUnitArg{
 		UUID: saUUID,
 		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: fsUUID,
@@ -610,8 +610,8 @@ func (u *unitStorageSuite) TestAttachStorageToUnit(c *tc.C) {
 	c.Assert(err, tc.IsNil)
 	c.Assert(attachInfo.AlreadyAttachedToUnits, tc.HasLen, 0)
 
-	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToUnitArg{
-		StorageToAttach: unitStorageToAttach,
+	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, internal.AttachExistingStorageToUnitArg{
+		AttachStorageToUnitArg: unitStorageToAttach,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -661,7 +661,7 @@ func (u *unitStorageSuite) TestAttachStorageAlreadyAttached(c *tc.C) {
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 
-	unitStorageToAttach := internal.CreateUnitStorageAttachmentArg{
+	unitStorageToAttach := internal.AttachStorageToUnitArg{
 		UUID: saUUID,
 		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: fsUUID,
@@ -672,8 +672,8 @@ func (u *unitStorageSuite) TestAttachStorageAlreadyAttached(c *tc.C) {
 		StorageInstanceUUID: siUUID,
 	}
 
-	arg := internal.AttachStorageToUnitArg{
-		StorageToAttach: unitStorageToAttach,
+	arg := internal.AttachExistingStorageToUnitArg{
+		AttachStorageToUnitArg: unitStorageToAttach,
 	}
 	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, arg)
 	c.Assert(err, tc.ErrorIsNil)
@@ -696,7 +696,7 @@ func (u *unitStorageSuite) TestAttachStorageTwiceSameUnit(c *tc.C) {
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 
-	unitStorageToAttach := internal.CreateUnitStorageAttachmentArg{
+	unitStorageToAttach := internal.AttachStorageToUnitArg{
 		UUID: saUUID,
 		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
 			FilesystemUUID: fsUUID,
@@ -707,8 +707,8 @@ func (u *unitStorageSuite) TestAttachStorageTwiceSameUnit(c *tc.C) {
 		StorageInstanceUUID: siUUID,
 	}
 
-	arg := internal.AttachStorageToUnitArg{
-		StorageToAttach: unitStorageToAttach,
+	arg := internal.AttachExistingStorageToUnitArg{
+		AttachStorageToUnitArg: unitStorageToAttach,
 	}
 	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, arg)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -649,10 +649,10 @@ func (u *unitStorageSuite) TestAttachStorageToUnit(c *tc.C) {
 
 	attachInfo, err = u.state.GetStorageAttachInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, siUUID)
 	c.Assert(err, tc.IsNil)
-	c.Assert(attachInfo.AlreadyAttachedToUnits, tc.SameContents, []string{unitUUID.String()})
+	c.Assert(attachInfo.AlreadyAttachedToUnits, tc.DeepEquals, map[string]string{unitUUID.String(): "foo/0"})
 }
 
-func (u *unitStorageSuite) TestAttachStorageMismatch(c *tc.C) {
+func (u *unitStorageSuite) TestAttachStorageAlreadyAttached(c *tc.C) {
 	unitUUID, _ := u.newUnitWithStorageDirectives(c)
 	netNodeUUID, err := u.state.GetUnitNetNodeUUID(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIsNil)
@@ -683,7 +683,7 @@ func (u *unitStorageSuite) TestAttachStorageMismatch(c *tc.C) {
 	rErr, ok := internalerrors.AsType[internal.StorageAttachmentNotAllowed](err)
 	c.Assert(ok, tc.IsTrue)
 	c.Assert(rErr, tc.DeepEquals, internal.StorageAttachmentNotAllowed{
-		AttachedToUnits: []string{unitUUID.String()},
+		AttachedToUnits: []string{"foo/0"},
 	})
 }
 

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -492,7 +492,7 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	}
 
 	gotIDs, err := u.state.AddStorageForIAASUnit(c.Context(), unitUUID, "st1", internal.IAASUnitAddStorageArg{
-		UnitAddStorageArg: internal.UnitAddStorageArg{
+		AddStorageToUnitArg: internal.AddStorageToUnitArg{
 			StorageInstances: unitStorageToCreate,
 			StorageToAttach:  unitStorageToAttach,
 			StorageToOwn:     []domainstorage.StorageInstanceUUID{si1UUID, si2UUID},
@@ -605,7 +605,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 	c.Assert(exists, tc.IsFalse)
 
 	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.IAASUnitAttachStorageArg{
-		UnitAttachStorageArg: internal.UnitAttachStorageArg{
+		AttachStorageToUnitArg: internal.AttachStorageToUnitArg{
 			StorageToAttach: unitStorageToAttach,
 		},
 		FilesystemsToOwn: []domainstorage.FilesystemUUID{fsUUID},

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -585,17 +585,15 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
 	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
 
-	unitStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
-		{
-			UUID: saUUID,
-			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
-				FilesystemUUID: fsUUID,
-				NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
-				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
-				UUID:           fsaUUID,
-			},
-			StorageInstanceUUID: siUUID,
+	unitStorageToAttach := internal.CreateUnitStorageAttachmentArg{
+		UUID: saUUID,
+		FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+			FilesystemUUID: fsUUID,
+			NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
+			ProvisionScope: domainstorageprov.ProvisionScopeMachine,
+			UUID:           fsaUUID,
 		},
+		StorageInstanceUUID: siUUID,
 	}
 
 	exists, err := u.state.GetUnitStorageAttachmentExists(c.Context(), siUUID, unitUUID)
@@ -665,14 +663,13 @@ func (u *unitStorageSuite) TestGetStorageInstanceCompositionByUUID(c *tc.C) {
 	result, err := u.state.GetStorageInstanceCompositionByUUID(c.Context(), st1UUID)
 	c.Assert(err, tc.ErrorIsNil)
 
-	expected := []internal.StorageInstanceComposition{
-		{
-			Filesystem: &internal.StorageInstanceCompositionFilesystem{
-				ProvisionScope: domainstorageprov.ProvisionScopeModel,
-				UUID:           fs1UUID,
-			},
-			UUID: st1UUID,
+	expected := internal.StorageInstanceComposition{
+		Filesystem: &internal.StorageInstanceCompositionFilesystem{
+			ProvisionScope: domainstorageprov.ProvisionScopeModel,
+			UUID:           fs1UUID,
 		},
+		StorageName: "st1",
+		UUID: st1UUID,
 	}
 
 	mc := tc.NewMultiChecker()

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"database/sql"
 	"testing"
-	
+
 	"github.com/juju/clock"
 	"github.com/juju/tc"
-	
+
 	corestorage "github.com/juju/juju/core/storage"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"
@@ -553,14 +553,14 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotFound(c *tc.C) {
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 	stUUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
-	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToIAASUnitArg{})
+	err := u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
 func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotFound(c *tc.C) {
 	_, unitUUID := u.createNamedIAASUnit(c)
 	storageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
-	err := u.state.AttachStorageToIAASUnit(c.Context(), storageUUID, unitUUID, internal.AttachStorageToIAASUnitArg{})
+	err := u.state.AttachStorageToUnit(c.Context(), storageUUID, unitUUID, internal.AttachStorageToUnitArg{})
 	c.Assert(err, tc.ErrorIs, errors.StorageInstanceNotFound)
 }
 
@@ -574,7 +574,7 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotAlive(c *tc.C) {
 	})
 	c.Assert(err, tc.IsNil)
 
-	err = u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToIAASUnitArg{})
+	err = u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotAlive)
 }
 
@@ -582,11 +582,11 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotAlive(c *tc.C) {
 	_, unitUUID := u.createNamedIAASUnit(c)
 	stUUID, _ := u.newDyingStorageInstanceWithModelFilesystem(c)
 
-	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToIAASUnitArg{})
+	err := u.state.AttachStorageToUnit(c.Context(), stUUID, unitUUID, internal.AttachStorageToUnitArg{})
 	c.Assert(err, tc.ErrorIs, applicationerrors.StorageNotAlive)
 }
 
-func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
+func (u *unitStorageSuite) TestAttachStorageToUnit(c *tc.C) {
 	unitUUID, _ := u.newUnitWithStorageDirectives(c)
 	netNodeUUID, err := u.state.GetUnitNetNodeUUID(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIsNil)
@@ -610,11 +610,8 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 	c.Assert(err, tc.IsNil)
 	c.Assert(attachInfo.AlreadyAttachedToUnits, tc.HasLen, 0)
 
-	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
-		AttachStorageToUnitArg: internal.AttachStorageToUnitArg{
-			StorageToAttach: unitStorageToAttach,
-		},
-		FilesystemsToOwn: []domainstorage.FilesystemUUID{fsUUID},
+	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToUnitArg{
+		StorageToAttach: unitStorageToAttach,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -678,17 +675,11 @@ func (u *unitStorageSuite) TestAttachStorageMismatch(c *tc.C) {
 	arg := internal.AttachStorageToUnitArg{
 		StorageToAttach: unitStorageToAttach,
 	}
-	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
-		AttachStorageToUnitArg: arg,
-		FilesystemsToOwn:       []domainstorage.FilesystemUUID{fsUUID},
-	})
+	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, arg)
 	c.Assert(err, tc.ErrorIsNil)
 
 	arg.AllowedExistingUnitAttachments = []string{tc.Must(c, coreunit.NewUUID).String()}
-	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
-		AttachStorageToUnitArg: arg,
-		FilesystemsToOwn:       []domainstorage.FilesystemUUID{fsUUID},
-	})
+	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, arg)
 	rErr, ok := internalerrors.AsType[internal.StorageAttachmentNotAllowed](err)
 	c.Assert(ok, tc.IsTrue)
 	c.Assert(rErr, tc.DeepEquals, internal.StorageAttachmentNotAllowed{
@@ -719,18 +710,12 @@ func (u *unitStorageSuite) TestAttachStorageTwiceSameUnit(c *tc.C) {
 	arg := internal.AttachStorageToUnitArg{
 		StorageToAttach: unitStorageToAttach,
 	}
-	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
-		AttachStorageToUnitArg: arg,
-		FilesystemsToOwn:       []domainstorage.FilesystemUUID{fsUUID},
-	})
+	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, arg)
 	c.Assert(err, tc.ErrorIsNil)
 
 	arg.AllowedExistingUnitAttachments = []string{unitUUID.String()}
 	arg.CountLessThanEqual = 2
-	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.AttachStorageToIAASUnitArg{
-		AttachStorageToUnitArg: arg,
-		FilesystemsToOwn:       []domainstorage.FilesystemUUID{fsUUID},
-	})
+	err = u.state.AttachStorageToUnit(c.Context(), siUUID, unitUUID, arg)
 	c.Assert(err, tc.ErrorIsNil)
 }
 

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -669,7 +669,7 @@ func (u *unitStorageSuite) TestGetStorageInstanceCompositionByUUID(c *tc.C) {
 			UUID:           fs1UUID,
 		},
 		StorageName: "st1",
-		UUID: st1UUID,
+		UUID:        st1UUID,
 	}
 
 	mc := tc.NewMultiChecker()

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
 	domainstorage "github.com/juju/juju/domain/storage"
+	"github.com/juju/juju/domain/storage/errors"
 	domainstorageprov "github.com/juju/juju/domain/storageprovisioning"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
@@ -59,6 +60,15 @@ func (u *unitStorageSuite) SetUpTest(c *tc.C) {
 func (u *unitStorageSuite) newStorageInstanceWithModelFilesystem(
 	c *tc.C,
 ) (domainstorage.StorageInstanceUUID, domainstorage.FilesystemUUID) {
+	return u.newStorageInstanceWithLifeAndWithModelFilesystem(c, life.Dying)
+}
+
+// newStorageInstanceWithModelFilesystem is a helper function to create a new
+// storage instance in the model with an associated model provisioned
+// filesystem.
+func (u *unitStorageSuite) newStorageInstanceWithLifeAndWithModelFilesystem(
+	c *tc.C, life life.Life,
+) (domainstorage.StorageInstanceUUID, domainstorage.FilesystemUUID) {
 	storageInstanceUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 	filesystemUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
 
@@ -69,11 +79,12 @@ func (u *unitStorageSuite) newStorageInstanceWithModelFilesystem(
 		`
 INSERT INTO storage_instance (uuid, storage_name, storage_kind_id, storage_id,
                               life_id, storage_pool_uuid, requested_size_mib)
-VALUES (?, ?, 1, ?, 1, ?, 1024)
+VALUES (?, ?, 1, ?, ?, ?, 1024)
 `,
 		storageInstanceUUID.String(),
 		"st1",
 		storageInstanceUUID.String(),
+		life,
 		storagePoolUUID.String(),
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -82,10 +93,11 @@ VALUES (?, ?, 1, ?, 1, ?, 1024)
 		c.Context(),
 		`
 INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
-VALUES (?, ?, 1, 0)
+VALUES (?, ?, ?, 0)
 	`,
 		filesystemUUID.String(),
 		filesystemUUID.String(),
+		life,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -526,5 +538,169 @@ func (u *unitStorageSuite) TestAddStorageForIAASUnit(c *tc.C) {
 				FilesystemUUID: fs2UUID,
 			},
 		},
+	})
+}
+
+func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotFound(c *tc.C) {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	stUUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
+	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
+}
+
+func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotFound(c *tc.C) {
+	_, unitUUID := u.createNamedIAASUnit(c)
+	storageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	err := u.state.AttachStorageToIAASUnit(c.Context(), storageUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
+	c.Assert(err, tc.ErrorIs, errors.StorageInstanceNotFound)
+}
+
+func (u *unitStorageSuite) TestAttachStorageToIAASUnitNotAlive(c *tc.C) {
+	_, unitUUID := u.createNamedIAASUnit(c)
+	stUUID, _ := u.newStorageInstanceWithLifeAndWithModelFilesystem(c, life.Alive)
+
+	err := u.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "UPDATE unit SET life_id = 1 WHERE uuid = ?", unitUUID.String())
+		return err
+	})
+	c.Assert(err, tc.IsNil)
+
+	err = u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
+	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotAlive)
+}
+
+func (u *unitStorageSuite) TestAttachStorageToIAASUnitStorageNotAlive(c *tc.C) {
+	_, unitUUID := u.createNamedIAASUnit(c)
+	stUUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+
+	err := u.state.AttachStorageToIAASUnit(c.Context(), stUUID, unitUUID, internal.IAASUnitAttachStorageArg{})
+	c.Assert(err, tc.ErrorIs, applicationerrors.StorageNotAlive)
+}
+
+func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
+	unitUUID, _ := u.newUnitWithStorageDirectives(c)
+	netNodeUUID, err := u.state.GetUnitNetNodeUUID(c.Context(), unitUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	siUUID, fsUUID := u.newStorageInstanceWithLifeAndWithModelFilesystem(c, life.Alive)
+	saUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
+	fsaUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
+
+	unitStorageToAttach := []internal.CreateUnitStorageAttachmentArg{
+		{
+			UUID: saUUID,
+			FilesystemAttachment: &internal.CreateUnitStorageFilesystemAttachmentArg{
+				FilesystemUUID: fsUUID,
+				NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
+				ProvisionScope: domainstorageprov.ProvisionScopeMachine,
+				UUID:           fsaUUID,
+			},
+			StorageInstanceUUID: siUUID,
+		},
+	}
+
+	err = u.state.AttachStorageToIAASUnit(c.Context(), siUUID, unitUUID, internal.IAASUnitAttachStorageArg{
+		UnitAttachStorageArg: internal.UnitAttachStorageArg{
+			StorageToAttach: unitStorageToAttach,
+		},
+		FilesystemsToOwn: []domainstorage.FilesystemUUID{fsUUID},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	inst, attach, err := u.state.GetUnitOwnedStorageInstances(c.Context(), unitUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(inst, tc.SameContents, []internal.StorageInstanceComposition{
+		{
+			Filesystem: &internal.StorageInstanceCompositionFilesystem{
+				ProvisionScope: 0,
+				UUID:           fsUUID,
+			},
+			StorageName: "st1",
+			UUID:        siUUID,
+		},
+	})
+	c.Assert(attach, tc.SameContents, []internal.StorageAttachmentComposition{
+		{
+			UUID:                saUUID,
+			StorageInstanceUUID: siUUID,
+			FilesystemAttachment: &internal.StorageInstanceCompositionFilesystemAttachment{
+				ProvisionScope: 1,
+				UUID:           fsaUUID,
+				FilesystemUUID: fsUUID,
+			},
+		},
+	})
+}
+
+func (u *unitStorageSuite) TestGetStorageInstanceCompositionByUUIDNotFound(c *tc.C) {
+	uuid := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	_, err := u.state.GetStorageInstanceCompositionByUUID(c.Context(), uuid)
+	c.Assert(err, tc.ErrorIs, errors.StorageInstanceNotFound)
+}
+
+func (u *unitStorageSuite) TestGetStorageInstanceCompositionByUUID(c *tc.C) {
+	_, unitUUIDs := u.createIAASApplicationWithNUnits(c, "foo", life.Alive, 1)
+	unitUUID := unitUUIDs[0]
+
+	st1UUID, fs1UUID := u.newStorageInstanceWithModelFilesystem(c)
+	st2UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	u.newStorageUnitOwner(c, st1UUID, unitUUID)
+	u.newStorageUnitOwner(c, st2UUID, unitUUID)
+
+	result, err := u.state.GetStorageInstanceCompositionByUUID(c.Context(), st1UUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	expected := []internal.StorageInstanceComposition{
+		{
+			Filesystem: &internal.StorageInstanceCompositionFilesystem{
+				ProvisionScope: domainstorageprov.ProvisionScopeModel,
+				UUID:           fs1UUID,
+			},
+			UUID: st1UUID,
+		},
+	}
+
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_[_].StorageName", tc.Ignore)
+	c.Check(result, mc, expected)
+}
+
+func (u *unitStorageSuite) TestGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDNotFound(c *tc.C) {
+	unitUUID, _ := u.newUnitWithStorageDirectives(c)
+	stUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	_, _, err := u.state.GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, stUUID)
+	c.Assert(err, tc.ErrorIs, errors.StorageInstanceNotFound)
+}
+
+func (u *unitStorageSuite) TestGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(c *tc.C) {
+	unitUUID, _ := u.newUnitWithStorageDirectives(c)
+
+	st1UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	st2UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
+	u.newStorageUnitOwner(c, st1UUID, unitUUID)
+	u.newStorageUnitOwner(c, st2UUID, unitUUID)
+
+	storageInfo, instInfo, err := u.state.GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, st1UUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(storageInfo, tc.DeepEquals, internalcharm.Storage{
+		Name:        "st1",
+		Description: "st1",
+		Type:        "filesystem",
+		CountMin:    1,
+		CountMax:    10,
+		MinimumSize: 1024,
+	})
+
+	var poolUUID string
+	err = u.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT uuid FROM storage_pool WHERE name=?", st1UUID).Scan(&poolUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(instInfo, tc.DeepEquals, internal.StorageInstanceInfo{
+		AlreadyAttachedCount: 2,
+		SizeMiB:              1024,
+		PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),
 	})
 }

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/application/internal"
-	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
 	domainstorage "github.com/juju/juju/domain/storage"
@@ -386,7 +385,7 @@ func (u *unitStorageSuite) TestGetUnitStorageDirectiveByName(c *tc.C) {
 	})
 }
 
-func (u *unitStorageSuite) TestGetCharmStorageAndInstanceCountByUnitUUID(c *tc.C) {
+func (u *unitStorageSuite) TestGetStorageAddInfoByUnitUUID(c *tc.C) {
 	unitUUID, _ := u.newUnitWithStorageDirectives(c)
 
 	st1UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
@@ -394,23 +393,22 @@ func (u *unitStorageSuite) TestGetCharmStorageAndInstanceCountByUnitUUID(c *tc.C
 	u.newStorageUnitOwner(c, st1UUID, unitUUID)
 	u.newStorageUnitOwner(c, st2UUID, unitUUID)
 
-	storageInfo, count, err := u.state.GetCharmStorageAndInstanceCountByUnitUUID(c.Context(), unitUUID, "st1")
+	storageInfo, err := u.state.GetStorageAddInfoByUnitUUID(c.Context(), unitUUID, "st1")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(count, tc.Equals, uint32(2))
-	c.Assert(storageInfo, tc.DeepEquals, internalcharm.Storage{
-		Name:        "st1",
-		Description: "st1",
-		Type:        "filesystem",
-		CountMin:    1,
-		CountMax:    10,
-		MinimumSize: 1024,
+	c.Assert(storageInfo, tc.DeepEquals, internal.StorageInfoForAdd{
+		Name:                 "st1",
+		Type:                 "filesystem",
+		CountMin:             1,
+		CountMax:             10,
+		MinimumSize:          1024,
+		AlreadyAttachedCount: uint32(2),
 	})
 }
 
-func (u *unitStorageSuite) TestGetCharmStorageAndInstanceCountByUnitUUIDNotSupported(c *tc.C) {
+func (u *unitStorageSuite) TestGetStorageAddInfoByUnitUUIDNotSupported(c *tc.C) {
 	unitUUID, _ := u.newUnitWithStorageDirectives(c)
 
-	_, _, err := u.state.GetCharmStorageAndInstanceCountByUnitUUID(c.Context(), unitUUID, "st666")
+	_, err := u.state.GetStorageAddInfoByUnitUUID(c.Context(), unitUUID, "st666")
 	c.Assert(err, tc.ErrorIs, applicationerrors.StorageNameNotSupported)
 }
 
@@ -682,15 +680,15 @@ func (u *unitStorageSuite) TestGetStorageInstanceCompositionByUUID(c *tc.C) {
 	c.Check(result, mc, expected)
 }
 
-func (u *unitStorageSuite) TestGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUIDNotFound(c *tc.C) {
+func (u *unitStorageSuite) TestGetStorageAttachInfoByUnitUUIDAndStorageUUIDNotFound(c *tc.C) {
 	unitUUID, _ := u.newUnitWithStorageDirectives(c)
 	stUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
 
-	_, _, err := u.state.GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, stUUID)
+	_, err := u.state.GetStorageAttachInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, stUUID)
 	c.Assert(err, tc.ErrorIs, errors.StorageInstanceNotFound)
 }
 
-func (u *unitStorageSuite) TestGetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(c *tc.C) {
+func (u *unitStorageSuite) TestGetStorageAttachInfoByUnitUUIDAndStorageUUID(c *tc.C) {
 	unitUUID, _ := u.newUnitWithStorageDirectives(c)
 
 	st1UUID, _ := u.newStorageInstanceWithModelFilesystem(c)
@@ -698,24 +696,22 @@ func (u *unitStorageSuite) TestGetCharmStorageAndInstanceInfoByUnitUUIDAndStorag
 	u.newStorageUnitOwner(c, st1UUID, unitUUID)
 	u.newStorageUnitOwner(c, st2UUID, unitUUID)
 
-	storageInfo, instInfo, err := u.state.GetCharmStorageAndInstanceInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, st1UUID)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(storageInfo, tc.DeepEquals, internalcharm.Storage{
-		Name:        "st1",
-		Description: "st1",
-		Type:        "filesystem",
-		CountMin:    1,
-		CountMax:    10,
-		MinimumSize: 1024,
-	})
-
 	var poolUUID string
-	err = u.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := u.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT uuid FROM storage_pool WHERE name=?", st1UUID).Scan(&poolUUID)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(instInfo, tc.DeepEquals, internal.StorageInstanceInfo{
+
+	storageInfo, err := u.state.GetStorageAttachInfoByUnitUUIDAndStorageUUID(c.Context(), unitUUID, st1UUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(storageInfo, tc.DeepEquals, internal.StorageInfoForAttach{
+		Name:                 "st1",
+		Type:                 "filesystem",
+		CountMin:             1,
+		CountMax:             10,
+		MinimumSize:          1024,
 		AlreadyAttachedCount: 2,
 		SizeMiB:              1024,
 		PoolUUID:             domainstorage.StoragePoolUUID(poolUUID),

--- a/domain/application/state/unitstorage_test.go
+++ b/domain/application/state/unitstorage_test.go
@@ -78,14 +78,15 @@ func (u *unitStorageSuite) newStorageInstanceWithLifeAndWithModelFilesystem(
 		c.Context(),
 		`
 INSERT INTO storage_instance (uuid, storage_name, storage_kind_id, storage_id,
-                              life_id, storage_pool_uuid, requested_size_mib)
-VALUES (?, ?, 1, ?, ?, ?, 1024)
+                              life_id, storage_pool_uuid, charm_name, requested_size_mib)
+VALUES (?, ?, 1, ?, ?, ?, ?, 1024)
 `,
 		storageInstanceUUID.String(),
 		"st1",
 		storageInstanceUUID.String(),
 		life,
 		storagePoolUUID.String(),
+		"bar",
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -610,6 +611,14 @@ func (u *unitStorageSuite) TestAttachStorageToIAASUnit(c *tc.C) {
 		FilesystemsToOwn: []domainstorage.FilesystemUUID{fsUUID},
 	})
 	c.Assert(err, tc.ErrorIsNil)
+
+	var siCharmName string
+	err = u.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT charm_name FROM storage_instance WHERE uuid=?", siUUID).Scan(&siCharmName)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(siCharmName, tc.Equals, "foo")
 
 	inst, attach, err := u.state.GetUnitOwnedStorageInstances(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -209,7 +209,7 @@ type AddUnitArg struct {
 
 // AddIAASUnitArg contains parameters for adding a IAAS unit to state.
 type AddIAASUnitArg struct {
-	internal.IAASUnitStorageArg
+	internal.CreateIAASUnitStorageArg
 	AddUnitArg
 	Platform deployment.Platform
 
@@ -272,7 +272,7 @@ type SubordinateUnitArg struct {
 
 type SubordinateIAASUnitArg struct {
 	SubordinateUnitArg
-	internal.IAASUnitStorageArg
+	internal.CreateIAASUnitStorageArg
 }
 
 // UpdateCAASUnitParams contains parameters for updating a CAAS unit.

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -209,7 +209,7 @@ type AddUnitArg struct {
 
 // AddIAASUnitArg contains parameters for adding a IAAS unit to state.
 type AddIAASUnitArg struct {
-	internal.CreateIAASUnitStorageArg
+	internal.IAASUnitStorageArg
 	AddUnitArg
 	Platform deployment.Platform
 
@@ -272,7 +272,7 @@ type SubordinateUnitArg struct {
 
 type SubordinateIAASUnitArg struct {
 	SubordinateUnitArg
-	internal.CreateIAASUnitStorageArg
+	internal.IAASUnitStorageArg
 }
 
 // UpdateCAASUnitParams contains parameters for updating a CAAS unit.

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -205,6 +205,8 @@ type AddUnitArg struct {
 
 	// NetNodeUUID is the new network node uuid to assign to this unit.
 	NetNodeUUID domainnetwork.NetNodeUUID
+	// UnitUUID is the new unit uuid to assign to this unit.
+	UnitUUID coreunit.UUID
 }
 
 // AddIAASUnitArg contains parameters for adding a IAAS unit to state.
@@ -241,6 +243,7 @@ type RegisterCAASUnitArg struct {
 	ProviderID   string
 	Address      *string
 	Ports        *[]string
+	UnitUUID     coreunit.UUID
 	NetNodeUUID  domainnetwork.NetNodeUUID
 	OrderedScale bool
 	OrderedId    int

--- a/domain/deployment/charm/meta.go
+++ b/domain/deployment/charm/meta.go
@@ -61,12 +61,12 @@ func (s StorageType) String() string {
 
 // Storage represents a charm's storage requirement.
 type Storage struct {
-	// Name is the name of the store.
+	// Name is the name of the storage.
 	//
 	// Name has no default, and must be specified.
 	Name string
 
-	// Description is a description of the store.
+	// Description is a description of the storage.
 	//
 	// Description has no default, and is optional.
 	Description string

--- a/domain/modelagent/state/model/state_test.go
+++ b/domain/modelagent/state/model/state_test.go
@@ -1669,21 +1669,17 @@ func (s *modelStateSuite) createTestingUnitForApplication(
 	appID, err := appState.GetApplicationUUIDByName(c.Context(), appName)
 	c.Assert(err, tc.ErrorIsNil)
 
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
-	unitNames, _, err := appState.AddIAASUnits(c.Context(), appID, application.AddIAASUnitArg{
+	_, _, err = appState.AddIAASUnits(c.Context(), appID, application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID,
 		MachineUUID:        tc.Must(c, machine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID,
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(unitNames, tc.HasLen, 1)
-	unitName := unitNames[0]
-
-	unitUUID, err := appState.GetUnitUUIDByName(c.Context(), unitName)
-	c.Assert(err, tc.ErrorIsNil)
-
 	return unitUUID
 }
 

--- a/domain/port/state/state_test.go
+++ b/domain/port/state/state_test.go
@@ -179,10 +179,12 @@ SELECT uuid, name FROM machine WHERE net_node_uuid = ?
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	unitNames, _, err := applicationSt.AddIAASUnits(c.Context(), appID, application.AddIAASUnitArg{
 		MachineNetNodeUUID: domainnetwork.NetNodeUUID(netNodeUUID),
 		MachineUUID:        machineUUID,
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: domainnetwork.NetNodeUUID(netNodeUUID),
 			Placement: deployment.Placement{
 				Type:      deployment.PlacementTypeMachine,
@@ -195,16 +197,6 @@ SELECT uuid, name FROM machine WHERE net_node_uuid = ?
 	unitName := unitNames[0]
 	s.unitCount++
 
-	var unitUUID coreunit.UUID
-	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name = ?", unitName).Scan(&unitUUID)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
 	return unitUUID, unitName
 }
 

--- a/domain/port/state/watcher_test.go
+++ b/domain/port/state/watcher_test.go
@@ -162,7 +162,7 @@ func (s *watcherSuite) createNetNode(c *tc.C) string {
 // createUnit creates a new unit in state and returns its UUID. The unit is assigned
 // to the net node with uuid `netNodeUUID` and application with name `appName`.
 func (s *watcherSuite) createUnitWithoutMachine(c *tc.C, netNodeUUID, appName, appUUID string) {
-	unitUUID := tc.Must0(c, coreunit.NewUUID).String()
+	unitUUID := tc.Must(c, coreunit.NewUUID).String()
 	unitName := appName + "/0"
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {

--- a/domain/port/watcher_test.go
+++ b/domain/port/watcher_test.go
@@ -174,10 +174,12 @@ func (s *watcherSuite) createUnit(c *tc.C, netNodeUUID, appName string) coreunit
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	unitNames, _, err := applicationSt.AddIAASUnits(ctx, appID, application.AddIAASUnitArg{
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	_, _, err = applicationSt.AddIAASUnits(ctx, appID, application.AddIAASUnitArg{
 		MachineNetNodeUUID: domainnetwork.NetNodeUUID(netNodeUUID),
 		MachineUUID:        machine.UUID(machineUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: domainnetwork.NetNodeUUID(netNodeUUID),
 			Placement: deployment.Placement{
 				Type:      deployment.PlacementTypeMachine,
@@ -186,16 +188,8 @@ func (s *watcherSuite) createUnit(c *tc.C, netNodeUUID, appName string) coreunit
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(unitNames, tc.HasLen, 1)
-	unitName := unitNames[0]
 	s.unitCount++
 
-	var unitUUID coreunit.UUID
-	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name = ?", unitName).Scan(&unitUUID)
-		return err
-	})
-	c.Assert(err, tc.ErrorIsNil)
 	return unitUUID
 }
 
@@ -214,7 +208,7 @@ func (s *watcherSuite) createNetNode(c *tc.C) string {
 // state and returns its UUID. The unit is assigned to the net node with uuid
 // `netNodeUUID` and application with name `appName`.
 func (s *watcherSuite) createUnitWithoutMachine(c *tc.C, netNodeUUID, appName, appUUID string) {
-	unitUUID := tc.Must0(c, coreunit.NewUUID).String()
+	unitUUID := tc.Must(c, coreunit.NewUUID).String()
 	unitName := appName + "/0"
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {

--- a/domain/relation/state/subordinateunit.go
+++ b/domain/relation/state/subordinateunit.go
@@ -70,6 +70,10 @@ func (st *State) addSubordinateUnit(
 	if err != nil {
 		return empty, errors.Errorf("getting principal unit net node uuid: %w", err)
 	}
+	unitUUID, err := unit.NewUUID()
+	if err != nil {
+		return empty, errors.Errorf("generating subordinate unit uuid: %w", err)
+	}
 
 	charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, subAppUUID)
 	if err != nil {
@@ -92,6 +96,7 @@ func (st *State) addSubordinateUnit(
 		MachineNetNodeUUID: network.NetNodeUUID(machineIdentifiers.NetNodeUUID),
 		MachineUUID:        machine.UUID(machineIdentifiers.UUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID: unitUUID,
 			// TODO: storage for subordinate units.
 			NetNodeUUID: principalNetNodeUUID,
 			Placement: deployment.Placement{

--- a/domain/relation/state/subordinateunit_test.go
+++ b/domain/relation/state/subordinateunit_test.go
@@ -426,6 +426,7 @@ func (m addIAASUnitArgMatcher) Matches(x interface{}) bool {
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_.AddUnitArg.UnitStatusArg.AgentStatus.Since", tc.Ignore)
 	mc.AddExpr("_.AddUnitArg.UnitStatusArg.WorkloadStatus.Since", tc.Ignore)
+	mc.AddExpr("_.AddUnitArg.UnitUUID", tc.NotNil)
 	m.c.Check(obtained, mc, m.expected)
 	return true
 }

--- a/domain/resolve/state/state_test.go
+++ b/domain/resolve/state/state_test.go
@@ -4,8 +4,6 @@
 package state
 
 import (
-	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/juju/clock"
@@ -43,9 +41,13 @@ func (s *stateSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *stateSuite) TestGetUnitUUID(c *tc.C) {
-	u1 := application.AddIAASUnitArg{}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	u1 := application.AddIAASUnitArg{
+		AddUnitArg: application.AddUnitArg{
+			UnitUUID: unitUUID,
+		},
+	}
+	s.createApplication(c, "foo", u1)
 
 	gotUUID, err := s.state.GetUnitUUID(c.Context(), "foo/0")
 	c.Assert(err, tc.ErrorIsNil)
@@ -63,9 +65,13 @@ func (s *stateSuite) TestUnitResolveModeNoUnit(c *tc.C) {
 }
 
 func (s *stateSuite) TestUnitResolveModeUnitNotResolved(c *tc.C) {
-	u1 := application.AddIAASUnitArg{}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	u1 := application.AddIAASUnitArg{
+		AddUnitArg: application.AddUnitArg{
+			UnitUUID: unitUUID,
+		},
+	}
+	s.createApplication(c, "foo", u1)
 
 	_, err := s.state.UnitResolveMode(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitNotResolved)
@@ -77,20 +83,26 @@ func (s *stateSuite) TestResolveUnitNoUnit(c *tc.C) {
 }
 
 func (s *stateSuite) TestResolveUnitNoStatus(c *tc.C) {
-	u1 := application.AddIAASUnitArg{}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	u1 := application.AddIAASUnitArg{
+		AddUnitArg: application.AddUnitArg{
+			UnitUUID: unitUUID,
+		},
+	}
+	s.createApplication(c, "foo", u1)
 
 	err := s.state.ResolveUnit(c.Context(), unitUUID, resolve.ResolveModeRetryHooks)
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitAgentStatusNotFound)
 }
 
 func (s *stateSuite) TestResolveUnitNotInError(c *tc.C) {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -99,19 +111,20 @@ func (s *stateSuite) TestResolveUnitNotInError(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	s.createApplication(c, "foo", u1)
 
 	err := s.state.ResolveUnit(c.Context(), unitUUID, resolve.ResolveModeRetryHooks)
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitNotInErrorState)
 }
 
 func (s *stateSuite) TestResolveUnitNoHooks(c *tc.C) {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -120,8 +133,7 @@ func (s *stateSuite) TestResolveUnitNoHooks(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	s.createApplication(c, "foo", u1)
 
 	err := s.state.ResolveUnit(c.Context(), unitUUID, resolve.ResolveModeNoHooks)
 	c.Assert(err, tc.ErrorIsNil)
@@ -132,11 +144,13 @@ func (s *stateSuite) TestResolveUnitNoHooks(c *tc.C) {
 }
 
 func (s *stateSuite) TestResolveUnitRetryHooks(c *tc.C) {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -145,8 +159,7 @@ func (s *stateSuite) TestResolveUnitRetryHooks(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	s.createApplication(c, "foo", u1)
 
 	err := s.state.ResolveUnit(c.Context(), unitUUID, resolve.ResolveModeRetryHooks)
 	c.Assert(err, tc.ErrorIsNil)
@@ -157,11 +170,13 @@ func (s *stateSuite) TestResolveUnitRetryHooks(c *tc.C) {
 }
 
 func (s *stateSuite) TestResolveUnitAlreadyResolved(c *tc.C) {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -170,8 +185,7 @@ func (s *stateSuite) TestResolveUnitAlreadyResolved(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	s.createApplication(c, "foo", u1)
 
 	err := s.state.ResolveUnit(c.Context(), unitUUID, resolve.ResolveModeRetryHooks)
 	c.Assert(err, tc.ErrorIsNil)
@@ -190,11 +204,13 @@ func (s *stateSuite) TestResolveAllUnitsNoUnits(c *tc.C) {
 }
 
 func (s *stateSuite) TestResolveAllUnitsNoUnitsInError(c *tc.C) {
+	unitUUID1 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID1 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID1,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID1,
 			NetNodeUUID: netNodeUUID1,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -204,11 +220,13 @@ func (s *stateSuite) TestResolveAllUnitsNoUnitsInError(c *tc.C) {
 		},
 	}
 
+	unitUUID2 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID2 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u2 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID2,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID2,
 			NetNodeUUID: netNodeUUID2,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -217,24 +235,26 @@ func (s *stateSuite) TestResolveAllUnitsNoUnitsInError(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1, u2)
+	s.createApplication(c, "foo", u1, u2)
 
 	err := s.state.ResolveAllUnits(c.Context(), resolve.ResolveModeRetryHooks)
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, err = s.state.UnitResolveMode(c.Context(), unitUUIDs[0])
+	_, err = s.state.UnitResolveMode(c.Context(), unitUUID1)
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitNotResolved)
 
-	_, err = s.state.UnitResolveMode(c.Context(), unitUUIDs[1])
+	_, err = s.state.UnitResolveMode(c.Context(), unitUUID2)
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitNotResolved)
 }
 
 func (s *stateSuite) TestResolveAllUnitsRetryHooks(c *tc.C) {
+	unitUUID1 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID1 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID1,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID1,
 			NetNodeUUID: netNodeUUID1,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -243,11 +263,13 @@ func (s *stateSuite) TestResolveAllUnitsRetryHooks(c *tc.C) {
 			},
 		},
 	}
+	unitUUID2 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID2 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u2 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID2,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID2,
 			NetNodeUUID: netNodeUUID2,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -256,11 +278,13 @@ func (s *stateSuite) TestResolveAllUnitsRetryHooks(c *tc.C) {
 			},
 		},
 	}
+	unitUUID3 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID3 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u3 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID3,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID3,
 			NetNodeUUID: netNodeUUID3,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -269,29 +293,31 @@ func (s *stateSuite) TestResolveAllUnitsRetryHooks(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1, u2, u3)
+	s.createApplication(c, "foo", u1, u2, u3)
 
 	err := s.state.ResolveAllUnits(c.Context(), resolve.ResolveModeRetryHooks)
 	c.Assert(err, tc.ErrorIsNil)
 
-	mode, err := s.state.UnitResolveMode(c.Context(), unitUUIDs[0])
+	mode, err := s.state.UnitResolveMode(c.Context(), unitUUID1)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(mode, tc.Equals, resolve.ResolveModeRetryHooks)
 
-	mode, err = s.state.UnitResolveMode(c.Context(), unitUUIDs[1])
+	mode, err = s.state.UnitResolveMode(c.Context(), unitUUID2)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(mode, tc.Equals, resolve.ResolveModeRetryHooks)
 
-	_, err = s.state.UnitResolveMode(c.Context(), unitUUIDs[2])
+	_, err = s.state.UnitResolveMode(c.Context(), unitUUID3)
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitNotResolved)
 }
 
 func (s *stateSuite) TestResolveAllUnitsNoHooks(c *tc.C) {
+	unitUUID1 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID1 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID1,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID1,
 			NetNodeUUID: netNodeUUID1,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -300,11 +326,13 @@ func (s *stateSuite) TestResolveAllUnitsNoHooks(c *tc.C) {
 			},
 		},
 	}
+	unitUUID2 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID2 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u2 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID2,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID2,
 			NetNodeUUID: netNodeUUID2,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -313,11 +341,13 @@ func (s *stateSuite) TestResolveAllUnitsNoHooks(c *tc.C) {
 			},
 		},
 	}
+	unitUUID3 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID3 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u3 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID3,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID3,
 			NetNodeUUID: netNodeUUID3,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -326,29 +356,31 @@ func (s *stateSuite) TestResolveAllUnitsNoHooks(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1, u2, u3)
+	s.createApplication(c, "foo", u1, u2, u3)
 
 	err := s.state.ResolveAllUnits(c.Context(), resolve.ResolveModeNoHooks)
 	c.Assert(err, tc.ErrorIsNil)
 
-	mode, err := s.state.UnitResolveMode(c.Context(), unitUUIDs[0])
+	mode, err := s.state.UnitResolveMode(c.Context(), unitUUID1)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(mode, tc.Equals, resolve.ResolveModeNoHooks)
 
-	mode, err = s.state.UnitResolveMode(c.Context(), unitUUIDs[1])
+	mode, err = s.state.UnitResolveMode(c.Context(), unitUUID2)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(mode, tc.Equals, resolve.ResolveModeNoHooks)
 
-	_, err = s.state.UnitResolveMode(c.Context(), unitUUIDs[2])
+	_, err = s.state.UnitResolveMode(c.Context(), unitUUID3)
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitNotResolved)
 }
 
 func (s *stateSuite) TestResolveAllUnitsAlreadyResolved(c *tc.C) {
+	unitUUID1 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID1 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID1,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID1,
 			NetNodeUUID: netNodeUUID1,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -357,11 +389,13 @@ func (s *stateSuite) TestResolveAllUnitsAlreadyResolved(c *tc.C) {
 			},
 		},
 	}
+	unitUUID2 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID2 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u2 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID2,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID2,
 			NetNodeUUID: netNodeUUID2,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -371,18 +405,18 @@ func (s *stateSuite) TestResolveAllUnitsAlreadyResolved(c *tc.C) {
 		},
 	}
 
-	unitUUIDs := s.createApplication(c, "foo", u1, u2)
-	err := s.state.ResolveUnit(c.Context(), unitUUIDs[0], resolve.ResolveModeRetryHooks)
+	s.createApplication(c, "foo", u1, u2)
+	err := s.state.ResolveUnit(c.Context(), unitUUID1, resolve.ResolveModeRetryHooks)
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = s.state.ResolveAllUnits(c.Context(), resolve.ResolveModeNoHooks)
 	c.Assert(err, tc.ErrorIsNil)
 
-	mode, err := s.state.UnitResolveMode(c.Context(), unitUUIDs[0])
+	mode, err := s.state.UnitResolveMode(c.Context(), unitUUID1)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(mode, tc.Equals, resolve.ResolveModeNoHooks)
 
-	mode, err = s.state.UnitResolveMode(c.Context(), unitUUIDs[1])
+	mode, err = s.state.UnitResolveMode(c.Context(), unitUUID2)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(mode, tc.Equals, resolve.ResolveModeNoHooks)
 }
@@ -393,20 +427,26 @@ func (s *stateSuite) TestClearResolvedNoUnit(c *tc.C) {
 }
 
 func (s *stateSuite) TestClearResolvedUnitNotResolved(c *tc.C) {
-	u1 := application.AddIAASUnitArg{}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	u1 := application.AddIAASUnitArg{
+		AddUnitArg: application.AddUnitArg{
+			UnitUUID: unitUUID,
+		},
+	}
+	s.createApplication(c, "foo", u1)
 
 	err := s.state.ClearResolved(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitNotResolved)
 }
 
 func (s *stateSuite) TestClearResolvedRetryHooks(c *tc.C) {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID1 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID1,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID1,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -415,8 +455,7 @@ func (s *stateSuite) TestClearResolvedRetryHooks(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	s.createApplication(c, "foo", u1)
 
 	err := s.state.ResolveUnit(c.Context(), unitUUID, resolve.ResolveModeRetryHooks)
 	c.Assert(err, tc.ErrorIsNil)
@@ -429,11 +468,13 @@ func (s *stateSuite) TestClearResolvedRetryHooks(c *tc.C) {
 }
 
 func (s *stateSuite) TestClearResolvedNoHooks(c *tc.C) {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID1 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID1,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID1,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -442,8 +483,7 @@ func (s *stateSuite) TestClearResolvedNoHooks(c *tc.C) {
 			},
 		},
 	}
-	unitUUIDs := s.createApplication(c, "foo", u1)
-	unitUUID := unitUUIDs[0]
+	s.createApplication(c, "foo", u1)
 
 	err := s.state.ResolveUnit(c.Context(), unitUUID, resolve.ResolveModeNoHooks)
 	c.Assert(err, tc.ErrorIsNil)
@@ -455,7 +495,7 @@ func (s *stateSuite) TestClearResolvedNoHooks(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, resolveerrors.UnitNotResolved)
 }
 
-func (s *stateSuite) createApplication(c *tc.C, name string, units ...application.AddIAASUnitArg) []coreunit.UUID {
+func (s *stateSuite) createApplication(c *tc.C, name string, units ...application.AddIAASUnitArg) {
 	appState := applicationstate.NewState(s.TxnRunnerFactory(), model.UUID(s.ModelUUID()), clock.WallClock, loggertesting.WrapCheckLog(c))
 
 	platform := deployment.Platform{
@@ -507,24 +547,8 @@ func (s *stateSuite) createApplication(c *tc.C, name string, units ...applicatio
 	}, nil)
 	c.Assert(err, tc.ErrorIsNil)
 
-	unitNames, _, err := appState.AddIAASUnits(ctx, appID, units...)
+	_, _, err = appState.AddIAASUnits(ctx, appID, units...)
 	c.Assert(err, tc.ErrorIsNil)
-
-	var unitUUIDs = make([]coreunit.UUID, len(units))
-	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		for i, unitName := range unitNames {
-			var uuid coreunit.UUID
-			err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name = ?", unitName).Scan(&uuid)
-			if err != nil {
-				return err
-			}
-			unitUUIDs[i] = uuid
-		}
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-
-	return unitUUIDs
 }
 
 func (s *stateSuite) minimalManifest(c *tc.C) charm.Manifest {

--- a/domain/status/state/model/modelstate_test.go
+++ b/domain/status/state/model/modelstate_test.go
@@ -1566,11 +1566,13 @@ func (s *modelStateSuite) TestGetApplicationAndUnitStatusesNoAppStatuses(c *tc.C
 func (s *modelStateSuite) TestGetApplicationAndUnitStatuses(c *tc.C) {
 	now := time.Now()
 
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID1 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u1 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID1,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID1,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
@@ -1588,11 +1590,13 @@ func (s *modelStateSuite) TestGetApplicationAndUnitStatuses(c *tc.C) {
 			},
 		},
 	}
+	unitUUID2 := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID2 := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	u2 := application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID2,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID2,
 			NetNodeUUID: netNodeUUID2,
 			UnitStatusArg: application.UnitStatusArg{
 				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{

--- a/domain/status/state/model/package_test.go
+++ b/domain/status/state/model/package_test.go
@@ -59,17 +59,20 @@ func (s *baseSuite) workloadStatus(now time.Time) *status.StatusInfo[status.Work
 func (s *baseSuite) createCAASUnitArg(c *tc.C) application.AddCAASUnitArg {
 	return application.AddCAASUnitArg{
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    tc.Must(c, coreunit.NewUUID),
 			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 		},
 	}
 }
 
 func (s *baseSuite) createIAASUnitArg(c *tc.C) application.AddIAASUnitArg {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 	return application.AddIAASUnitArg{
 		MachineNetNodeUUID: netNodeUUID,
 		MachineUUID:        tc.Must(c, coremachine.NewUUID),
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: netNodeUUID,
 		},
 	}
@@ -82,9 +85,11 @@ func (s *baseSuite) createIAASApplicationWithNUnits(
 ) (coreapplication.UUID, []coreunit.UUID) {
 	units := make([]application.AddIAASUnitArg, nUnits)
 	for i := range units {
+		unitUUID := tc.Must(c, coreunit.NewUUID)
 		netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 		units[i].MachineUUID = tc.Must(c, coremachine.NewUUID)
 		units[i].MachineNetNodeUUID = netNodeUUID
+		units[i].UnitUUID = unitUUID
 		units[i].NetNodeUUID = netNodeUUID
 	}
 

--- a/domain/status/watcher_test.go
+++ b/domain/status/watcher_test.go
@@ -4,7 +4,7 @@
 package status_test
 
 import (
-	context "context"
+	"context"
 	"database/sql"
 	stdtesting "testing"
 
@@ -117,9 +117,11 @@ func (s *watcherSuite) TestWatchOfferStatus(c *tc.C) {
 func (s *watcherSuite) TestWatchOfferStatusApplicationWithUnits(c *tc.C) {
 	units := make([]application.AddIAASUnitArg, 3)
 	for i := range units {
+		unitUUID := tc.Must(c, coreunit.NewUUID)
 		netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 		units[i].MachineUUID = tc.Must(c, coremachine.NewUUID)
 		units[i].MachineNetNodeUUID = netNodeUUID
+		units[i].UnitUUID = unitUUID
 		units[i].NetNodeUUID = netNodeUUID
 		units[i].WorkloadStatus = &domainstatus.StatusInfo[domainstatus.WorkloadStatusType]{
 			Status: domainstatus.WorkloadStatusActive,

--- a/domain/unitstate/state/updateunitports_test.go
+++ b/domain/unitstate/state/updateunitports_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
@@ -821,10 +822,12 @@ SELECT uuid, name FROM machine WHERE net_node_uuid = ?
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
+	unitUUID := tc.Must(c, coreunit.NewUUID)
 	unitNames, _, err := applicationSt.AddIAASUnits(c.Context(), appID, application.AddIAASUnitArg{
 		MachineNetNodeUUID: domainnetwork.NetNodeUUID(netNodeUUID),
 		MachineUUID:        machineUUID,
 		AddUnitArg: application.AddUnitArg{
+			UnitUUID:    unitUUID,
 			NetNodeUUID: domainnetwork.NetNodeUUID(netNodeUUID),
 			Placement: deployment.Placement{
 				Type:      deployment.PlacementTypeMachine,
@@ -837,17 +840,7 @@ SELECT uuid, name FROM machine WHERE net_node_uuid = ?
 	unitName := unitNames[0].String()
 	s.unitCount++
 
-	var unitUUID string
-	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name = ?", unitName).Scan(&unitUUID)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	return unitUUID, unitName
+	return unitUUID.String(), unitName
 }
 
 // endpointPortRange represents a range of ports for a give protocol for a


### PR DESCRIPTION
Add backend support for attaching storage to units.

[Commit 1](https://github.com/juju/juju/commit/706836d566d947c179628570800ede43acebc14d) updates the client storage facade to call separate IAAS and CAAS methods - this should have been done when it was wired up previously.

[Commit 2](https://github.com/juju/juju/commit/e43f2ac395e8213f7108f7bb1bc29a1371cd4c77) is the main implementation.

[Commit 5](https://github.com/juju/juju/pull/21718/commits/ff45b8404df92c24270c9aa891a60ba9a71b9c49) uses the actual provisioned storage size when validating the storage against the charm min size. falls back to the requested size if for some reason the provisioned size is not known

[Commit 6](https://github.com/juju/juju/pull/21718/commits/1129eaca3f2a6858712e472c5e23b30e1009da8e) updates the storage instance charm name to match that of the unit's charm

A similar implementation pattern is used as for add storage:
- validate preconditions
- compose the args
- update state, reusing existing methods already in place for create

The work is essentially the same as for add, but the instance creation is skipped - the other ops like attachment creations, ownership registration etc are the same.

Arg structs are optimised eg `charm.Storage` is replaced with a new `ValidateStorageArg` which only contains the subset of attrs we care about.

To implement support for attaching storage when deploying an app, an existing TODO needed to be fixed. We now generate the unit UUID in the service layer, not the state layer, when adding units.
We also use a single state receiver instead of "unitState" etc to allow the required method calls when creating units vs adding storage etc.

## QA steps

deploy and remove the dummy-storage charm 2 times so that we end up with 2 detached storage instances

```
juju deploy ~/charms/dummy-storage.charm --storage multi-fs=10M
juju remove-application dummy-storage
juju deploy ~/charms/dummy-storage.charm --storage multi-fs=10M
juju remove-application dummy-storage
juju status --storage

Model       Controller  Cloud/Region         Version  Timestamp
controller  test        localhost/localhost  4.0.2.1  10:32:48+10:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.0/stable  157  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.68.47.178

Machine  State    Address       Inst id        Base          AZ          Message
0        started  10.68.47.178  juju-911693-0  ubuntu@24.04  wallyworld  Running

Storage Unit  Storage ID  Type        Mountpoint  Size    Status    Message
              multi-fs/0  filesystem              10 MiB  detached
              multi-fs/1  filesystem              10 MiB  detached
```

deploy a 3rd time

```
juju deploy ~/charms/dummy-storage.charm --storage multi-fs=10M
juju status --storage

Model       Controller  Cloud/Region         Version  Timestamp
controller  test        localhost/localhost  4.0.2.1  10:34:24+10:00

App            Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller              active      1  juju-controller  4.0/stable  157  no
dummy-storage           active      1  dummy-storage                  2  no       Stored token: /tmp/status

Unit              Workload  Agent  Machine  Public address  Ports  Message
controller/0*     active    idle   0        10.68.47.178
dummy-storage/0*  active    idle   3        10.68.47.145           Stored token: /tmp/status

Machine  State    Address       Inst id        Base          AZ          Message
0        started  10.68.47.178  juju-911693-0  ubuntu@24.04  wallyworld  Running
3        started  10.68.47.145  juju-911693-3  ubuntu@24.04  wallyworld  Running

Storage Unit     Storage ID  Type        Mountpoint                                          Size    Status    Message
                 multi-fs/1  filesystem                                                      10 MiB  detached
dummy-storage/0  multi-fs/0  filesystem                                                      10 MiB  detached
dummy-storage/0  multi-fs/2  filesystem  /srv/multi-fs/a057418b-6a37-47c8-8a68-f308cbd7ae1f  10 MiB  attached
```

Attach the detached storage - do it for both detached instances, the 2nd time fails.

```
juju attach-storage dummy-storage/0 multi-fs/0
attaching multi-fs/0 to dummy-storage/0

juju attach-storage dummy-storage/0 multi-fs/0
failed to attach multi-fs/0 to dummy-storage/0: storage attachment "multi-fs" count 3 would exceed the charm's maximum count of 2

juju status --storage

Model       Controller  Cloud/Region         Version  Timestamp
controller  test        localhost/localhost  4.0.2.1  10:34:26+10:00

App            Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller              active      1  juju-controller  4.0/stable  157  no
dummy-storage           active      1  dummy-storage                  2  no       Started

Unit              Workload  Agent  Machine  Public address  Ports  Message
controller/0*     active    idle   0        10.68.47.178
dummy-storage/0*  active    idle   3        10.68.47.145           Started

Machine  State    Address       Inst id        Base          AZ          Message
0        started  10.68.47.178  juju-911693-0  ubuntu@24.04  wallyworld  Running
3        started  10.68.47.145  juju-911693-3  ubuntu@24.04  wallyworld  Running

Storage Unit     Storage ID  Type        Mountpoint                                          Size    Status    Message
                 multi-fs/1  filesystem                                                      10 MiB  detached
dummy-storage/0  multi-fs/0  filesystem  /srv/multi-fs/b3c56f2f-7990-4b32-81a4-74d4211b6afa  10 MiB  attached
dummy-storage/0  multi-fs/2  filesystem  /srv/multi-fs/a057418b-6a37-47c8-8a68-f308cbd7ae1f  10 MiB  attached
```

Attaching is idempotent
```
juju attach-storage dummy-storage/0 multi-fs/0
attaching multi-fs/0 to dummy-storage/0
```

Add a second unit and attempt to attach already attached storage
```
juju add-unit dummy-storage
juju attach-storage dummy-storage/1 multi-fs/0
failed to attach multi-fs/0 to dummy-storage/1: storage is already attached to other unit(s): [dummy-storage/0]
```

But we can detach and re-attach to another unit
```
juju detach-storage multi-fs/0
detaching multi-fs/0

juju attach-storage dummy-storage/1 multi-fs/0
```

We cannot attach machine scoped storage to a unit on a different machine
```
juju add-storage dummy-storage/0 multi-fs=10M,rootfs
added storage multi-fs/3 to dummy-storage/0

juju detach-storage multi-fs/3
detaching multi-fs/3

juju attach-storage dummy-storage/1 multi-fs/3 
failed to attach multi-fs/3 to dummy-storage/1: storage is attached to machine "1"
```

Test deploying and attaching storage.
First, deploy an app and create storage - one machine scoped, the other model scoped.
```
juju deploy ~/charms/dummy-storage.charm --storage multi-fs=10M,rootfs
juju add-storage dummy-storage/0 multi-fs=10M,lxd
```

Deploy a second app, storage is already attached, can't be re-used.
```
juju deploy ~/charms/dummy-storage.charm ds --attach-storage multi-fs/1
Located local charm "dummy-storage", revision 6

Deploying "ds" from local charm "dummy-storage", revision 6 on ubuntu@24.04/stable
ERROR cannot deploy "ds": storage is already attached to other unit(s): [dummy-storage/0]
```

Even if storage is detached, if it's on a different machine, can't be re-used.
```
juju detach-storage multi-fs/0
detaching multi-fs/0
juju deploy ~/charms/dummy-storage.charm ds --attach-storage multi-fs/0
Located local charm "dummy-storage", revision 5
Deploying "ds" from local charm "dummy-storage", revision 5 on ubuntu@24.04/stable
ERROR cannot deploy "ds": storage is attached to machine 1
```

It can be re-used with placement
```
juju deploy ~/charms/dummy-storage.charm ds --to 1 --attach-storage multi-fs/0

Located local charm "dummy-storage", revision 7
Deploying "ds" from local charm "dummy-storage", revision 7 on ubuntu@24.04/stable

juju status --storage
Model       Controller  Cloud/Region         Version  Timestamp
controller  test        localhost/localhost  4.0.3.4  10:47:07+10:00

App            Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller              active      1  juju-controller  4.0/stable  157  no       
ds                      active      1  dummy-storage                  7  no       Stored token: /tmp/status
dummy-storage           active      1  dummy-storage                  0  no       Started

Unit              Workload  Agent  Machine  Public address  Ports  Message
controller/0*     active    idle   0        10.68.47.208           
ds/0*             active    idle   1        10.68.47.198           Stored token: /tmp/status
dummy-storage/0*  active    idle   1        10.68.47.198           Started

Machine  State    Address       Inst id        Base          AZ          Message
0        started  10.68.47.208  juju-2fed54-0  ubuntu@24.04  wallyworld  Running
1        started  10.68.47.198  juju-2fed54-1  ubuntu@24.04  wallyworld  Running

Storage Unit     Storage ID  Type        Mountpoint                                          Size     Status    Message
ds/0             multi-fs/0  filesystem  /srv/multi-fs/16300fc7-6616-45cb-87a0-42c755ec67e6  1.7 TiB  attached  
dummy-storage/0  multi-fs/1  filesystem  /srv/multi-fs/528cfbc7-0f47-442f-85ff-dd8f7d338bfd  10 MiB   attached 
```

## Links

**Jira card:** [JUJU-8035](https://warthogs.atlassian.net/browse/JUJU-8035)


[JUJU-8035]: https://warthogs.atlassian.net/browse/JUJU-8035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ