### PR TITLE
fix(connection): fix Proxy() not to return an interface from `internal/proxy`

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -37,7 +37,6 @@ import (
 	internalerrors "github.com/juju/juju/internal/errors"
 	jujuhttp "github.com/juju/juju/internal/http"
 	internallogger "github.com/juju/juju/internal/logger"
-	jujuproxy "github.com/juju/juju/internal/proxy"
 	proxy "github.com/juju/juju/internal/proxy/config"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
@@ -518,7 +517,7 @@ type dialResult struct {
 	dialAddr *url.URL
 	// ipAddr represents the IP address that was dialed.
 	ipAddr    string
-	proxier   jujuproxy.Proxier
+	proxier   Proxier
 	tlsConfig *tls.Config
 }
 
@@ -590,7 +589,7 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 		logger.Debugf(ctx, "starting proxier for connection")
 
 		switch p := info.Proxier.(type) {
-		case jujuproxy.TunnelProxier:
+		case TunnelProxier:
 			logger.Debugf(ctx, "tunnel proxy in use at %s on port %s", p.Host(), p.Port())
 			addrs = []*url.URL{{
 				Scheme: apiScheme,
@@ -1352,7 +1351,7 @@ func (c *conn) IsProxied() bool {
 }
 
 // Proxy returns the proxy being used with this connection if one is being used.
-func (c *conn) Proxy() jujuproxy.Proxier {
+func (c *conn) Proxy() Proxier {
 	return c.proxier
 }
 

--- a/api/connection.go
+++ b/api/connection.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/api/agent/keyupdater"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/semversion"
-	jujuproxy "github.com/juju/juju/internal/proxy"
 	"github.com/juju/juju/rpc/jsoncodec"
 )
 
@@ -114,7 +113,7 @@ type conn struct {
 	// proxier is the proxier used for this connection when not nil. If's expected
 	// the proxy has already been started when placing in this var. This struct
 	// will take the responsibility of closing the proxy.
-	proxier jujuproxy.Proxier
+	proxier Proxier
 }
 
 // Login implements the Login method of the Connection interface providing authentication

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/network"
-	jujuproxy "github.com/juju/juju/internal/proxy"
 	"github.com/juju/juju/rpc/jsoncodec"
 )
 
@@ -60,7 +59,7 @@ type TestingConnectionParams struct {
 	RPCConnection  RPCConnection
 	Clock          clock.Clock
 	Broken, Closed chan struct{}
-	Proxier        jujuproxy.Proxier
+	Proxier        Proxier
 }
 
 // NewTestingConnection creates an api.Connection object that can be used for testing.

--- a/api/interface.go
+++ b/api/interface.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/semversion"
-	"github.com/juju/juju/internal/proxy"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/rpc/params"
 )
@@ -89,7 +88,7 @@ type Info struct {
 
 	// Proxier describes a proxier to use to for establing an API connection
 	// A nil proxier means that it will not be used.
-	Proxier proxy.Proxier
+	Proxier Proxier
 }
 
 // Ports returns the unique ports for the api addresses.
@@ -374,7 +373,7 @@ type Connection interface {
 	// Proxy returns the Proxier used to establish the connection if one was
 	// used at all. If no Proxier was used then it's expected that returned
 	// Proxier will be nil. Use IsProxied() to test for the presence of a proxy.
-	Proxy() proxy.Proxier
+	Proxy() Proxier
 
 	// PublicDNSName returns the host name for which an officially
 	// signed certificate will be used for TLS connection to the server.

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import "context"
+
+// Proxier describes an implementation of an object that is capable of performing
+// connection proxying. Typically an implementation will support this interface
+// and one of the more specific types of proxy's below. Proxy's should be
+// considered single use with regards to their Start  and Stop methods and not
+// thead safe.
+type Proxier interface {
+	// Start starts the lifecycle of the proxy. Proxy's should have their start
+	// method called before operating with the proxy.
+	Start(ctx context.Context) error
+
+	// Stop stops the proxy after a call to Start(). Proxy's should be
+	// considered single use. This call should only ever be made once.
+	Stop()
+
+	// RawConfig is responsible for providing a raw configuration representation
+	// of the proxier for serialising over the wire.
+	RawConfig() (map[string]interface{}, error)
+
+	// Type is the unique key identifying the type of proxying for configuration
+	// purposes.
+	Type() string
+
+	// MarshalYAML implements marshalling method for yaml.
+	MarshalYAML() (interface{}, error)
+
+	// Insecure sets the proxy to be insecure.
+	Insecure()
+}
+
+// TunnelProxier describes an implementation that can provide tunneled proxy
+// services. The interface provides the connection details for connecting to the
+// proxy
+type TunnelProxier interface {
+	Proxier
+
+	// Host returns the host string for establishing a tunneled connection.
+	Host() string
+
+	// Port returns the host port to connect to for tunneling connections.
+	Port() string
+}

--- a/cmd/modelcmd/mocks/api_mock.go
+++ b/cmd/modelcmd/mocks/api_mock.go
@@ -15,10 +15,10 @@ import (
 	url "net/url"
 	reflect "reflect"
 
+	api "github.com/juju/juju/api"
 	base "github.com/juju/juju/api/base"
 	network "github.com/juju/juju/core/network"
 	semversion "github.com/juju/juju/core/semversion"
-	proxy "github.com/juju/juju/internal/proxy"
 	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
 	httprequest "gopkg.in/httprequest.v1"
@@ -775,10 +775,10 @@ func (c *MockConnectionModelTagCall) DoAndReturn(f func() (names.ModelTag, bool)
 }
 
 // Proxy mocks base method.
-func (m *MockConnection) Proxy() proxy.Proxier {
+func (m *MockConnection) Proxy() api.Proxier {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Proxy")
-	ret0, _ := ret[0].(proxy.Proxier)
+	ret0, _ := ret[0].(api.Proxier)
 	return ret0
 }
 
@@ -795,19 +795,19 @@ type MockConnectionProxyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockConnectionProxyCall) Return(arg0 proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Return(arg0 api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockConnectionProxyCall) Do(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Do(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConnectionProxyCall) DoAndReturn(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) DoAndReturn(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/objectstore/remote/connection_mock_test.go
+++ b/internal/objectstore/remote/connection_mock_test.go
@@ -15,10 +15,10 @@ import (
 	url "net/url"
 	reflect "reflect"
 
+	api "github.com/juju/juju/api"
 	base "github.com/juju/juju/api/base"
 	network "github.com/juju/juju/core/network"
 	semversion "github.com/juju/juju/core/semversion"
-	proxy "github.com/juju/juju/internal/proxy"
 	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
 	httprequest "gopkg.in/httprequest.v1"
@@ -775,10 +775,10 @@ func (c *MockConnectionModelTagCall) DoAndReturn(f func() (names.ModelTag, bool)
 }
 
 // Proxy mocks base method.
-func (m *MockConnection) Proxy() proxy.Proxier {
+func (m *MockConnection) Proxy() api.Proxier {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Proxy")
-	ret0, _ := ret[0].(proxy.Proxier)
+	ret0, _ := ret[0].(api.Proxier)
 	return ret0
 }
 
@@ -795,19 +795,19 @@ type MockConnectionProxyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockConnectionProxyCall) Return(arg0 proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Return(arg0 api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockConnectionProxyCall) Do(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Do(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConnectionProxyCall) DoAndReturn(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) DoAndReturn(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/apiremotecaller/connection_mocks_test.go
+++ b/internal/worker/apiremotecaller/connection_mocks_test.go
@@ -15,10 +15,10 @@ import (
 	url "net/url"
 	reflect "reflect"
 
+	api "github.com/juju/juju/api"
 	base "github.com/juju/juju/api/base"
 	network "github.com/juju/juju/core/network"
 	semversion "github.com/juju/juju/core/semversion"
-	proxy "github.com/juju/juju/internal/proxy"
 	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
 	httprequest "gopkg.in/httprequest.v1"
@@ -775,10 +775,10 @@ func (c *MockConnectionModelTagCall) DoAndReturn(f func() (names.ModelTag, bool)
 }
 
 // Proxy mocks base method.
-func (m *MockConnection) Proxy() proxy.Proxier {
+func (m *MockConnection) Proxy() api.Proxier {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Proxy")
-	ret0, _ := ret[0].(proxy.Proxier)
+	ret0, _ := ret[0].(api.Proxier)
 	return ret0
 }
 
@@ -795,19 +795,19 @@ type MockConnectionProxyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockConnectionProxyCall) Return(arg0 proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Return(arg0 api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockConnectionProxyCall) Do(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Do(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConnectionProxyCall) DoAndReturn(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) DoAndReturn(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/apiremoterelationcaller/api_mock_test.go
+++ b/internal/worker/apiremoterelationcaller/api_mock_test.go
@@ -15,10 +15,10 @@ import (
 	url "net/url"
 	reflect "reflect"
 
+	api "github.com/juju/juju/api"
 	base "github.com/juju/juju/api/base"
 	network "github.com/juju/juju/core/network"
 	semversion "github.com/juju/juju/core/semversion"
-	proxy "github.com/juju/juju/internal/proxy"
 	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
 	httprequest "gopkg.in/httprequest.v1"
@@ -775,10 +775,10 @@ func (c *MockConnectionModelTagCall) DoAndReturn(f func() (names.ModelTag, bool)
 }
 
 // Proxy mocks base method.
-func (m *MockConnection) Proxy() proxy.Proxier {
+func (m *MockConnection) Proxy() api.Proxier {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Proxy")
-	ret0, _ := ret[0].(proxy.Proxier)
+	ret0, _ := ret[0].(api.Proxier)
 	return ret0
 }
 
@@ -795,19 +795,19 @@ type MockConnectionProxyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockConnectionProxyCall) Return(arg0 proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Return(arg0 api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockConnectionProxyCall) Do(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Do(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConnectionProxyCall) DoAndReturn(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) DoAndReturn(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/controllerpresence/api_mocks_test.go
+++ b/internal/worker/controllerpresence/api_mocks_test.go
@@ -15,10 +15,10 @@ import (
 	url "net/url"
 	reflect "reflect"
 
+	api "github.com/juju/juju/api"
 	base "github.com/juju/juju/api/base"
 	network "github.com/juju/juju/core/network"
 	semversion "github.com/juju/juju/core/semversion"
-	proxy "github.com/juju/juju/internal/proxy"
 	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
 	httprequest "gopkg.in/httprequest.v1"
@@ -775,10 +775,10 @@ func (c *MockConnectionModelTagCall) DoAndReturn(f func() (names.ModelTag, bool)
 }
 
 // Proxy mocks base method.
-func (m *MockConnection) Proxy() proxy.Proxier {
+func (m *MockConnection) Proxy() api.Proxier {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Proxy")
-	ret0, _ := ret[0].(proxy.Proxier)
+	ret0, _ := ret[0].(api.Proxier)
 	return ret0
 }
 
@@ -795,19 +795,19 @@ type MockConnectionProxyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockConnectionProxyCall) Return(arg0 proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Return(arg0 api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockConnectionProxyCall) Do(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Do(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConnectionProxyCall) DoAndReturn(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) DoAndReturn(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/units3caller/api_mocks_test.go
+++ b/internal/worker/units3caller/api_mocks_test.go
@@ -15,10 +15,10 @@ import (
 	url "net/url"
 	reflect "reflect"
 
+	api "github.com/juju/juju/api"
 	base "github.com/juju/juju/api/base"
 	network "github.com/juju/juju/core/network"
 	semversion "github.com/juju/juju/core/semversion"
-	proxy "github.com/juju/juju/internal/proxy"
 	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
 	httprequest "gopkg.in/httprequest.v1"
@@ -775,10 +775,10 @@ func (c *MockConnectionModelTagCall) DoAndReturn(f func() (names.ModelTag, bool)
 }
 
 // Proxy mocks base method.
-func (m *MockConnection) Proxy() proxy.Proxier {
+func (m *MockConnection) Proxy() api.Proxier {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Proxy")
-	ret0, _ := ret[0].(proxy.Proxier)
+	ret0, _ := ret[0].(api.Proxier)
 	return ret0
 }
 
@@ -795,19 +795,19 @@ type MockConnectionProxyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockConnectionProxyCall) Return(arg0 proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Return(arg0 api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockConnectionProxyCall) Do(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) Do(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConnectionProxyCall) DoAndReturn(f func() proxy.Proxier) *MockConnectionProxyCall {
+func (c *MockConnectionProxyCall) DoAndReturn(f func() api.Proxier) *MockConnectionProxyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
# Description

Proxy() was returning an interface coming from `internal`, this was causing troubles in terraform mock tests because mockgen was generating methods with types coming from an internal package. I've copy/pasted the interface definition.
