### PR TITLE
test(resource): remove commented-out placeholders in test

### DIFF
--- a/domain/resource/state/resource_test.go
+++ b/domain/resource/state/resource_test.go
@@ -635,9 +635,6 @@ func (s *resourceSuite) TestGetResource(c *tc.C) {
 			},
 			Revision: 42,
 			Origin:   charmresource.OriginUpload,
-			// todo(gfouillet): handle size/fingerprint
-			//Fingerprint: charmresource.Fingerprint{},
-			//Size:        0,
 		},
 		ID:              resID.String(),
 		ApplicationName: s.constants.fakeApplicationName1,


### PR DESCRIPTION
The removed placeholder are not needed since there are already dedicated tests for those:

* TestGetResourceWithStoredFile
* TestGetResourceWithStoredImage

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unit tests pass
