### PR TITLE
fix: deduplicate DNS in container fallback path

### DIFF
--- a/container/broker/broker.go
+++ b/container/broker/broker.go
@@ -135,6 +135,9 @@ func associateDNSConfig(nics corenetwork.InterfaceInfos, dns *corenetwork.DNSCon
 				if ipNet.Contains(dnsIP) {
 					// Make sure we only add the nameserver to this device once.
 					nsAddr := dns.Nameservers[j].Value
+					// Either we've already seen this nameserver,
+					// or we're adding it now
+					dnsUsed[j] = true
 					if nameservers.Contains(nsAddr) {
 						continue
 					}
@@ -142,7 +145,6 @@ func associateDNSConfig(nics corenetwork.InterfaceInfos, dns *corenetwork.DNSCon
 					logger.Infof("setting DNS address %q for interface %q", nsAddr, nic.InterfaceName)
 					nic.DNSServers = append(nic.DNSServers, dns.Nameservers[j])
 					nameservers.Add(nsAddr)
-					dnsUsed[j] = true
 				}
 			}
 		}
@@ -157,12 +159,34 @@ func associateDNSConfig(nics corenetwork.InterfaceInfos, dns *corenetwork.DNSCon
 		if used {
 			continue
 		}
-		for j := range results {
-			results[j].DNSServers = append(results[j].DNSServers, dns.Nameservers[i])
-		}
+		addFallbackDNS(results, dns.Nameservers[i])
 	}
 
 	return results
+}
+
+// Apply fallback DNS for any unused nameservers
+func addFallbackDNS(results corenetwork.InterfaceInfos, dnsServer corenetwork.ProviderAddress) {
+	for j := range results {
+		// Skip adding this DNS server if it’s already configured.
+		alreadyPresent := false
+		for _, nameserver := range results[j].DNSServers {
+			if nameserver.Value == dnsServer.Value {
+				alreadyPresent = true
+				logger.Debugf(
+					"nameserver %q already present for interface %q during fallback; skipping",
+					nameserver.Value,
+					results[j].InterfaceName,
+				)
+				break
+			}
+		}
+		if alreadyPresent {
+			continue
+		}
+		results[j].DNSServers = append(results[j].DNSServers, dnsServer)
+		logger.Debugf("Fallback DNS added: %q to NIC %q", dnsServer.Value, results[j].InterfaceName)
+	}
 }
 
 // findDNSServerConfig is a heuristic method to find an adequate DNS

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -49,3 +49,43 @@ func (s *brokerSuite) TestAssociateDNSConfigSetsDomainsAndServers(c *gc.C) {
 	c.Assert(results[1].DNSSearchDomains, gc.DeepEquals, []string{"example.com"})
 	c.Assert(results[1].DNSServers.Values(), gc.DeepEquals, []string{"192.168.20.2", "8.8.8.8", "1.1.1.1"})
 }
+
+func (s *brokerSuite) TestAssociateDNSConfigFallbackDedupes(c *gc.C) {
+	nics := network.InterfaceInfos{
+		{
+			InterfaceName: "eth0",
+			Addresses: network.ProviderAddresses{
+				network.NewMachineAddress("10.0.0.5", network.WithCIDR("10.0.0.0/24")).AsProviderAddress(),
+			},
+		},
+	}
+
+	dnsCfg := &network.DNSConfig{
+		Nameservers: []network.ProviderAddress{
+			// This matches the subnet and will be added during main association.
+			network.NewMachineAddress("10.0.0.2").AsProviderAddress(),
+
+			// Duplicate of the above — if dedupe fails, it will appear twice.
+			network.NewMachineAddress("10.0.0.2").AsProviderAddress(),
+
+			// Fallback DNS
+			network.NewMachineAddress("8.8.8.8").AsProviderAddress(),
+
+			// Duplicate fallback DNS
+			network.NewMachineAddress("8.8.8.8").AsProviderAddress(),
+		},
+	}
+
+	results := associateDNSConfig(nics, dnsCfg)
+	c.Assert(results, gc.HasLen, 1)
+
+	values := results[0].DNSServers.Values()
+
+	// If dedupe is broken, we would get:
+	// ["10.0.0.2", "10.0.0.2", "8.8.8.8"]
+	// We expect only one instance of 10.0.0.2
+	c.Assert(values, gc.DeepEquals, []string{
+		"10.0.0.2",
+		"8.8.8.8",
+	})
+}


### PR DESCRIPTION
## Description

Running an LXD container on a Juju machine (provisioned via MAAS) can result in duplicate DNS entries in the container’s netplan.


This PR achieves the following:
- Prevent duplicate DNS entries on Juju container NICs when nameservers aren't associated with any subnet. 
- Adds checks to avoid appending a nameserver if it already exists on the interface
- Adds logging for skipped and added DNS entries in the fallback for debugging purposes.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
~Go unit tests, with comments saying what you're testing~
~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

### Environment
- Juju 3.6.14
- Cloud: MAAS

### Reproduce the issue

**Host Machine Setup**
- Create two networks (e.g. with virt manager)
- OAM (e.g. subnet 172.16.17.0/24), no DHCP
- INTERNAL (e.g. subnet 172.16.18.0/24), no DHCP

**MAAS Setup**
- Create two spaces and attach them to the subnets of the OAM and INTERNAL networks respectively. 
- Attach DNS servers to the OAM space.

OAM-SPACE
- Subnet: 172.16.17.0/24
- Gateway: 172.16.17.1
- DNS servers: 8.8.8.8, 8.8.4.4

INTERNAL-SPACE
- Subnet: 172.16.18.0/24
- Gateway: 172.16.18.1
- DNS servers: none

Both of these subnets are in the same fabric

**Juju Setup**
1. Bootstrap Juju on MAAS
2. Create a Juju model and set the default space to be OAM-SPACE
3. Deploy an application and pass `--constraints "spaces=oam-space,internal-space"`

For example, deploy the ubuntu application:
```
juju deploy ubuntu --series jammy \
  --constraints "spaces=oam-space,internal-space" \
  --to <maas-machine>
```

4. Add an LXD container to the (e.g. ubuntu) charm
5. Get console access to the LXD container once it is done setting itself up
6. View the `/etc/netplan/99-juju.yaml` file and notice duplicate DNS entries
```
nameservers:
    search: [maas]
     addresses: [8.8.8.8, 8.8.4.4, 172.16.17.2, 8.8.8.8, 8.8.4.4, 172.16.17.2, 8.8.8.8, 8.8.4.4]
```

### After applying the fix:
1. Add a new LXD container to the (e.g. ubuntu) charm
2. Get console access to the LXD container once it is done setting itself up
3. View the `/etc/netplan/99-juju.yaml` file and notice DNS entries are not duplicated anymore

```
nameservers:
    search: [maas]
     addresses: [8.8.8.8, 8.8.4.4, 172.16.17.2]
```
## Documentation changes

CLI/API behavior remains the same. This is an internal fix to prevent duplicate DNS entries.

## Links
- Addresses Issue #20764