### PR TITLE
feat: update storage directives during setcharm call useroverride and state

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -56,6 +57,7 @@ import (
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/domain/resolve"
 	resolveerrors "github.com/juju/juju/domain/resolve/errors"
+	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/charmhub"
 	"github.com/juju/juju/internal/configschema"
@@ -705,20 +707,150 @@ func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetChar
 		return errors.Trace(err)
 	}
 
-	err = api.applicationService.SetApplicationCharm(ctx, args.ApplicationName, newCharmLocator, application.SetCharmParams{
-		CharmOrigin:         charmOrigin,
-		CharmUpgradeOnError: args.Force,
-		EndpointBindings:    transform.Map(args.EndpointBindings, func(k, v string) (string, network.SpaceName) { return k, network.SpaceName(v) }),
-	})
-	if errors.Is(err, applicationerrors.ApplicationNotFound) {
-		return errors.NotFoundf("application %q", args.ApplicationName)
-	} else if errors.Is(err, applicationerrors.CharmNotFound) {
-		return errors.NotFoundf("charm %q", args.CharmURL)
-	} else if err != nil {
+	storageDirectiveOverrides, err := convertToApplicationStorageDirectiveOverrides(ctx, api.storageService, args.StorageDirectives)
+	if err != nil {
 		return errors.Trace(err)
 	}
 
+	err = api.applicationService.SetApplicationCharm(ctx, args.ApplicationName, newCharmLocator, application.SetCharmParams{
+		CharmOrigin:               charmOrigin,
+		CharmUpgradeOnError:       args.Force,
+		EndpointBindings:          transform.Map(args.EndpointBindings, func(k, v string) (string, network.SpaceName) { return k, network.SpaceName(v) }),
+		StorageDirectiveOverrides: storageDirectiveOverrides,
+	})
+	switch {
+	case errors.Is(err, applicationerrors.ApplicationNotFound):
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotFound, "application %q not found", args.ApplicationName,
+		)
+	case errors.Is(err, applicationerrors.CharmNotFound):
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotFound, "charm %q not found", args.CharmURL,
+		)
+	case errors.HasType[applicationerrors.CharmStorageDefinitionRemoved](err):
+		defErr, _ := errors.AsType[applicationerrors.CharmStorageDefinitionRemoved](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, defErr.Error(),
+		)
+	case errors.HasType[applicationerrors.CharmStorageDefinitionMinSizeViolation](err):
+		sizeErr, _ := errors.AsType[applicationerrors.CharmStorageDefinitionMinSizeViolation](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, sizeErr.Error(),
+		)
+	case errors.HasType[applicationerrors.CharmStorageDefinitionMinCountViolation](err):
+		minErr, _ := errors.AsType[applicationerrors.CharmStorageDefinitionMinCountViolation](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, minErr.Error(),
+		)
+	case errors.HasType[applicationerrors.CharmStorageDefinitionMaxCountViolation](err):
+		maxErr, _ := errors.AsType[applicationerrors.CharmStorageDefinitionMaxCountViolation](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, maxErr.Error(),
+		)
+	case errors.HasType[applicationerrors.CharmStorageDefinitionSingleToMultipleViolation](err):
+		multiErr, _ := errors.AsType[applicationerrors.CharmStorageDefinitionSingleToMultipleViolation](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, multiErr.Error(),
+		)
+	case errors.HasType[applicationerrors.CharmStorageDefinitionSharedChanged](err):
+		sharedErr, _ := errors.AsType[applicationerrors.CharmStorageDefinitionSharedChanged](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, sharedErr.Error(),
+		)
+	case errors.HasType[applicationerrors.CharmStorageDefinitionReadOnlyChanged](err):
+		readOnlyErr, _ := errors.AsType[applicationerrors.CharmStorageDefinitionReadOnlyChanged](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, readOnlyErr.Error(),
+		)
+	case errors.HasType[applicationerrors.CharmStorageDefinitionLocationChanged](err):
+		locationErr, _ := errors.AsType[applicationerrors.CharmStorageDefinitionLocationChanged](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, locationErr.Error(),
+		)
+	case errors.HasType[applicationerrors.CharmStorageTypeChanged](err):
+		typeErr, _ := errors.AsType[applicationerrors.CharmStorageTypeChanged](err)
+		return apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"cannot set charm %q because %s", args.CharmURL, typeErr.Error(),
+		)
+	case err != nil:
+		return err
+	}
+
 	return nil
+}
+
+func convertToApplicationStorageDirectiveOverrides(
+	ctx context.Context,
+	storageService StorageService,
+	in map[string]params.StorageDirectives,
+) (map[string]application.ApplicationStorageDirectiveOverride, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+
+	storagePoolNamesMap := make(map[string]struct{})
+	for name, sd := range in {
+		// Pool is not a required field in the storage directive override, so only validate if it's provided.
+		if len(sd.Pool) == 0 {
+			continue
+		}
+		if isValidPoolName := domainstorage.IsValidStoragePoolName(sd.Pool); !isValidPoolName {
+			return nil, apiservererrors.ParamsErrorf(params.CodeNotValid,
+				"storage directive %q references an invalid pool", name)
+		}
+		storagePoolNamesMap[sd.Pool] = struct{}{}
+	}
+	storagePoolNames := make([]string, 0, len(storagePoolNamesMap))
+	for name := range storagePoolNamesMap {
+		storagePoolNames = append(storagePoolNames, name)
+	}
+	storagePoolUUIDs, err := storageService.GetStoragePoolUUIDsByName(ctx, storagePoolNames)
+	if err != nil {
+		return nil, apiservererrors.ParamsErrorf(params.CodeNotValid,
+			"getting storage pool uuids for user supplied storage directive overrides: %v", err)
+	}
+
+	out := make(map[string]application.ApplicationStorageDirectiveOverride, len(in))
+	for name, dir := range in {
+		override := application.ApplicationStorageDirectiveOverride{}
+		// Validate count before we assign it to the override, as the domain expects uint32, but the user input is uint64.
+		// This is to prevent overflow when the count is assigned to the override.
+		if dir.Count != nil {
+			if *dir.Count > math.MaxUint32 {
+				return nil, apiservererrors.ParamsErrorf(params.CodeNotValid,
+					"storage directive %q override count %d exceeds maximum %d",
+					name,
+					*dir.Count,
+					math.MaxUint32,
+				)
+			}
+			count := uint32(*dir.Count)
+			override.Count = &count
+		}
+		// Validate pool name is not empty and exists before we assign the pool UUID to the override.
+		if dir.Pool != "" {
+			poolUUID, exists := storagePoolUUIDs[dir.Pool]
+			if !exists {
+				return nil, apiservererrors.ParamsErrorf(params.CodeNotFound,
+					"storage directive %q references unknown storage pool %q", name, dir.Pool)
+			}
+			override.PoolUUID = &poolUUID
+		}
+
+		override.Size = dir.SizeMiB
+		out[name] = override
+	}
+
+	return out, nil
 }
 
 // GetCharmURLOrigin returns the charm URL and charm origin the given

--- a/apiserver/facades/client/application/application_perm_test.go
+++ b/apiserver/facades/client/application/application_perm_test.go
@@ -146,7 +146,7 @@ func (s *permBaseSuite) TestSetCharmValidOrigin(c *tc.C) {
 		},
 	})
 
-	c.Assert(err, tc.ErrorIs, errors.NotFound)
+	c.Assert(err, tc.Satisfies, params.IsCodeNotFound)
 }
 
 func (s *permBaseSuite) TestGetCharmURLOriginPermission(c *tc.C) {

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -431,6 +431,10 @@ type ResourceService interface {
 type StorageService interface {
 	// GetStoragePoolUUID returns the UUID of the storage pool for the specified name.
 	GetStoragePoolUUID(context.Context, string) (domainstorage.StoragePoolUUID, error)
+
+	// GetStoragePoolUUIDsByName returns pool UUIDs keyed by pool name for
+	// the supplied names. Unknown names are omitted.
+	GetStoragePoolUUIDsByName(ctx context.Context, names []string) (map[string]domainstorage.StoragePoolUUID, error)
 }
 
 // StatusService provides access to the status service.

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -2393,6 +2393,45 @@ func (c *MockStorageServiceGetStoragePoolUUIDCall) DoAndReturn(f func(context.Co
 	return c
 }
 
+// GetStoragePoolUUIDsByName mocks base method.
+func (m *MockStorageService) GetStoragePoolUUIDsByName(arg0 context.Context, arg1 []string) (map[string]storage.StoragePoolUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStoragePoolUUIDsByName", arg0, arg1)
+	ret0, _ := ret[0].(map[string]storage.StoragePoolUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStoragePoolUUIDsByName indicates an expected call of GetStoragePoolUUIDsByName.
+func (mr *MockStorageServiceMockRecorder) GetStoragePoolUUIDsByName(arg0, arg1 any) *MockStorageServiceGetStoragePoolUUIDsByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolUUIDsByName", reflect.TypeOf((*MockStorageService)(nil).GetStoragePoolUUIDsByName), arg0, arg1)
+	return &MockStorageServiceGetStoragePoolUUIDsByNameCall{Call: call}
+}
+
+// MockStorageServiceGetStoragePoolUUIDsByNameCall wrap *gomock.Call
+type MockStorageServiceGetStoragePoolUUIDsByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStorageServiceGetStoragePoolUUIDsByNameCall) Return(arg0 map[string]storage.StoragePoolUUID, arg1 error) *MockStorageServiceGetStoragePoolUUIDsByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStorageServiceGetStoragePoolUUIDsByNameCall) Do(f func(context.Context, []string) (map[string]storage.StoragePoolUUID, error)) *MockStorageServiceGetStoragePoolUUIDsByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStorageServiceGetStoragePoolUUIDsByNameCall) DoAndReturn(f func(context.Context, []string) (map[string]storage.StoragePoolUUID, error)) *MockStorageServiceGetStoragePoolUUIDsByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockRelationService is a mock of RelationService interface.
 type MockRelationService struct {
 	ctrl     *gomock.Controller

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -394,6 +394,25 @@ func (u UnitStorageMinViolation) Error() string {
 	)
 }
 
+// CharmStorageDefinitionRemoved describes an error that occurs when a charm's
+// storage definition is removed during a refresh for a named storage definition.
+// Example of this would be the previous charm's storage `foo` being removed
+// in the new charm.
+type CharmStorageDefinitionRemoved struct {
+	// StorageName is the name of the storage which was removed in the new charm,
+	// but exists in the old charm.
+	StorageName string
+}
+
+// Error returns a string representation of the [CharmStorageDefinitionRemoved] error
+// providing context of the storage name for the violation.
+// This func implements the [error] interface.
+func (s CharmStorageDefinitionRemoved) Error() string {
+	return fmt.Sprintf(
+		"storage definition %q removed", s.StorageName,
+	)
+}
+
 // CharmStorageTypeChanged describes an error that occurs when a charm's
 // storage type changes during a refresh for a named storage definition.
 // Example of this would be the previous charm's storage `foo` changing from
@@ -413,7 +432,153 @@ type CharmStorageTypeChanged struct {
 // This func implements the [error] interface.
 func (s CharmStorageTypeChanged) Error() string {
 	return fmt.Sprintf(
-		"existing storage %q type changed from %q to %q",
+		"storage definition %q type changed from %q to %q",
 		s.StorageName, s.OldType, s.NewType,
+	)
+}
+
+// CharmStorageDefinitionMinSizeViolation describes an error that occurs when a charm's
+// storage minimum size increases during a refresh for a named storage definition.
+type CharmStorageDefinitionMinSizeViolation struct {
+	// ExistingMin defines the minimum storage size required by the existing charm.
+	ExistingMin uint64
+
+	// NewMin defines the minimum storage size required by the new charm.
+	NewMin uint64
+
+	// StorageName is the name of the storage whose
+	// minimum size check fails.
+	StorageName string
+}
+
+// Error returns a string representation of the [CharmStorageDefinitionMinSizeViolation] error
+// providing context for the violation. This func implements the [error]
+// interface.
+func (s CharmStorageDefinitionMinSizeViolation) Error() string {
+	return fmt.Sprintf(
+		"storage definition %q new minimum size %d MiB exceeds existing minimum size %d MiB",
+		s.StorageName, s.NewMin, s.ExistingMin,
+	)
+}
+
+// CharmStorageDefinitionMinCountViolation describes an error that occurs when a charm's
+// storage minimum count increases during a refresh for a named storage definition.
+type CharmStorageDefinitionMinCountViolation struct {
+	// ExistingMin defines the minimum storage count required by the existing charm.
+	ExistingMin int
+
+	// NewMin defines the minimum storage count required by the new charm.
+	NewMin int
+
+	// StorageName is the name of the storage whose
+	// minimum count check fails.
+	StorageName string
+}
+
+// Error returns a string representation of the [CharmStorageDefinitionMinCountViolation] error
+// providing context for the violation. This func implements the [error]
+// interface.
+func (s CharmStorageDefinitionMinCountViolation) Error() string {
+	return fmt.Sprintf(
+		"storage definition %q new minimum count %d exceeds existing minimum count %d",
+		s.StorageName, s.NewMin, s.ExistingMin,
+	)
+}
+
+// CharmStorageDefinitionMaxCountViolation describes an error that occurs when a charm's
+// storage maximum count decreases during a refresh for a named storage definition.
+type CharmStorageDefinitionMaxCountViolation struct {
+	// ExistingMax defines the maximum storage count required by the existing charm.
+	ExistingMax int
+
+	// NewMax defines the maximum storage count required by the new charm.
+	NewMax int
+
+	// StorageName is the name of the storage whose
+	// maximum count check fails.
+	StorageName string
+}
+
+// Error returns a string representation of the [CharmStorageDefinitionMaxCountViolation] error
+// providing context for the violation. This func implements the [error]
+// interface.
+func (s CharmStorageDefinitionMaxCountViolation) Error() string {
+	if s.ExistingMax < 0 {
+		return fmt.Sprintf(
+			"storage definition %q new maximum count %d is less than existing maximum count (unbounded)",
+			s.StorageName, s.NewMax,
+		)
+	}
+	return fmt.Sprintf(
+		"storage definition %q new maximum count %d is less than existing maximum count %d",
+		s.StorageName, s.NewMax, s.ExistingMax,
+	)
+}
+
+// CharmStorageDefinitionSingleToMultipleViolation describes an error that occurs
+// when a charm's singleton storage definition with a fixed location changes to
+// a multiple storage definition during refresh.
+type CharmStorageDefinitionSingleToMultipleViolation struct {
+	// ExistingMax defines the existing maximum storage count.
+	ExistingMax int
+
+	// NewMax defines the new maximum storage count.
+	NewMax int
+
+	// StorageName is the storage whose single-to-multiple check fails.
+	StorageName string
+}
+
+// Error returns a string representation of the
+// [CharmStorageDefinitionSingleToMultipleViolation] error.
+func (s CharmStorageDefinitionSingleToMultipleViolation) Error() string {
+	return fmt.Sprintf(
+		"storage definition %q cannot change from single to multiple when location is set (maximum count %d -> %d)",
+		s.StorageName, s.ExistingMax, s.NewMax,
+	)
+}
+
+// CharmStorageDefinitionSharedChanged describes an error that occurs when a
+// charm storage definition shared value changes during refresh.
+type CharmStorageDefinitionSharedChanged struct {
+	StorageName   string
+	ExistingValue bool
+	NewValue      bool
+}
+
+func (s CharmStorageDefinitionSharedChanged) Error() string {
+	return fmt.Sprintf(
+		"storage definition %q shared changed from %v to %v",
+		s.StorageName, s.ExistingValue, s.NewValue,
+	)
+}
+
+// CharmStorageDefinitionReadOnlyChanged describes an error that occurs when a
+// charm storage definition read-only value changes during refresh.
+type CharmStorageDefinitionReadOnlyChanged struct {
+	StorageName   string
+	ExistingValue bool
+	NewValue      bool
+}
+
+func (s CharmStorageDefinitionReadOnlyChanged) Error() string {
+	return fmt.Sprintf(
+		"storage definition %q read-only changed from %v to %v",
+		s.StorageName, s.ExistingValue, s.NewValue,
+	)
+}
+
+// CharmStorageDefinitionLocationChanged describes an error that occurs when a
+// charm storage definition location changes during refresh.
+type CharmStorageDefinitionLocationChanged struct {
+	StorageName      string
+	ExistingLocation string
+	NewLocation      string
+}
+
+func (s CharmStorageDefinitionLocationChanged) Error() string {
+	return fmt.Sprintf(
+		"storage definition %q location changed from %q to %q",
+		s.StorageName, s.ExistingLocation, s.NewLocation,
 	)
 }

--- a/domain/application/internal/storage.go
+++ b/domain/application/internal/storage.go
@@ -14,9 +14,9 @@ import (
 // associated with an application.
 type CreateApplicationStorageDirectiveArg = CreateStorageDirectiveArg
 
-// ApplyApplicationStorageDirectiveArg defines the arguments required to
-// apply an existing storage directive associated with an application.
-type ApplyApplicationStorageDirectiveArg = CreateStorageDirectiveArg
+// UpdateApplicationStorageDirectiveArg defines the arguments required to
+// update an existing storage directive associated with an application.
+type UpdateApplicationStorageDirectiveArg = CreateStorageDirectiveArg
 
 // CreateStorageDirectiveArg defines the arguments required to add a storage
 // directive to the model.

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"context"
-	"math"
 	"strconv"
 
 	"github.com/juju/collections/set"
@@ -512,15 +511,15 @@ func validateCharmStorage(charmStorage map[string]internalcharm.Storage) error {
 
 		if storage.CountMin < 0 {
 			return errors.Errorf(
-				"charm storage %q has a minimum count less than zero, negative storage count cannot be achieved",
-				name,
+				"charm storage %q has a minimum count %d less than zero, negative storage count cannot be achieved",
+				name, storage.CountMin,
 			)
 		}
 
 		if storage.CountMax >= 0 && storage.CountMin > storage.CountMax {
 			return errors.Errorf(
-				"charm storage %q has a minimum count greater than maximum count, this is can't be achieved",
-				name,
+				"charm storage %q has a minimum count %d greater than maximum count %d, this can't be achieved",
+				name, storage.CountMin, storage.CountMax,
 			)
 		}
 	}
@@ -636,107 +635,6 @@ func validateDeviceConstraints(cons map[string]devices.Constraints, charmMeta *i
 			return errors.Errorf("no constraints specified for device %q", name)
 		}
 	}
-	return nil
-}
-
-// validateApplicationStorageDirectives performs a sanity check on the
-// directives for the application to make sure they are in a sane state to be
-// persisted to the state layer.
-//
-// The following errors may be returned:
-// - [applicationerrors.MissingStorageDirective] when one or more storage
-// directives are missing that are required by the charm.
-func validateApplicationStorageDirectives(
-	charmStorageDefs map[string]internalcharm.Storage,
-	directives []internal.CreateApplicationStorageDirectiveArg,
-) error {
-	// seenDirectives acts as a sanity check to see if a directive by a name has
-	// been witnessed.
-	seenDirectives := map[string]struct{}{}
-	for _, directive := range directives {
-		charmStorageDef, exists := charmStorageDefs[directive.Name.String()]
-		if !exists {
-			return errors.Errorf(
-				"invalid storage directive, charm has no storage %q",
-				directive.Name,
-			)
-		}
-
-		if _, seen := seenDirectives[directive.Name.String()]; seen {
-			return errors.Errorf(
-				"duplicate storage directive for %q exists", directive.Name,
-			)
-		}
-		seenDirectives[directive.Name.String()] = struct{}{}
-
-		err := validateApplicationStorageDirective(charmStorageDef, directive)
-		if err != nil {
-			return errors.Capture(err)
-		}
-	}
-
-	// This is a sanity to check to make sure that for each required storage in
-	// the charm there exists a directive for it.
-	for charmStorageName, charmStorageDef := range charmStorageDefs {
-		if charmStorageDef.CountMin == 0 {
-			// We skip storage definitions that don't require at least one
-			// storage instance. If the directive is missing that is fine.
-			continue
-		}
-
-		if _, seen := seenDirectives[charmStorageName]; !seen {
-			return errors.Errorf(
-				"missing storage directive for charm storage %q",
-				charmStorageName,
-			).Add(applicationerrors.MissingStorageDirective)
-		}
-	}
-	return nil
-}
-
-// validateApplicationStorageDirective checks a single storage directive against
-// a charm storage definition. This checks the definition is inline with the
-// expectations of the charm storage definition.
-func validateApplicationStorageDirective(
-	charmStorageDef internalcharm.Storage,
-	directive internal.CreateApplicationStorageDirectiveArg,
-) error {
-	minCount := uint32(0)
-	if charmStorageDef.CountMin > 0 {
-		minCount = uint32(charmStorageDef.CountMin)
-	}
-	maxCount := uint32(math.MaxUint32)
-	if charmStorageDef.CountMax > 0 {
-		maxCount = uint32(charmStorageDef.CountMax)
-	}
-
-	if directive.Count < minCount {
-		return errors.Errorf(
-			"charm requires min %q storage %q instances, %d specified",
-			minCount, directive.Name, directive.Count,
-		)
-	}
-	if directive.Count > maxCount {
-		return errors.Errorf(
-			"charm requires at most %d instances of storage %q, %d specified",
-			maxCount, directive.Name, directive.Count,
-		)
-	}
-
-	if directive.Size < charmStorageDef.MinimumSize {
-		return errors.Errorf(
-			"storage directive %q must be at least of size %d defined by the charm",
-			directive.Name, charmStorageDef.MinimumSize,
-		)
-	}
-
-	if err := directive.PoolUUID.Validate(); err != nil {
-		return errors.Errorf(
-			"storage directive %q pool uuid is not valid: %w",
-			directive.Name, err,
-		)
-	}
-
 	return nil
 }
 
@@ -1671,6 +1569,47 @@ func (s *Service) GetMachinesForApplication(ctx context.Context, appName string)
 	}), nil
 }
 
+func overrideStorageDirectives(
+	toCreate []internal.CreateApplicationStorageDirectiveArg,
+	toUpdate []internal.UpdateApplicationStorageDirectiveArg,
+	overrides map[string]storage.StorageDirectiveOverride,
+) ([]internal.CreateApplicationStorageDirectiveArg, []internal.UpdateApplicationStorageDirectiveArg) {
+	created := append([]internal.CreateApplicationStorageDirectiveArg{}, toCreate...)
+	updated := append([]internal.UpdateApplicationStorageDirectiveArg{}, toUpdate...)
+
+	for i, dir := range created {
+		override, exists := overrides[dir.Name.String()]
+		if !exists {
+			continue
+		}
+		if override.PoolUUID != nil {
+			created[i].PoolUUID = *override.PoolUUID
+		}
+		if override.Count != nil {
+			created[i].Count = *override.Count
+		}
+		if override.Size != nil {
+			created[i].Size = *override.Size
+		}
+	}
+	for i, dir := range updated {
+		override, exists := overrides[dir.Name.String()]
+		if !exists {
+			continue
+		}
+		if override.PoolUUID != nil {
+			updated[i].PoolUUID = *override.PoolUUID
+		}
+		if override.Count != nil {
+			updated[i].Count = *override.Count
+		}
+		if override.Size != nil {
+			updated[i].Size = *override.Size
+		}
+	}
+	return created, updated
+}
+
 // SetApplicationCharm sets a new charm for the application, validating that aspects such
 // as storage are still viable with the new charm. It reconciles existing application
 // storage directives with the new charm's storage requirements.
@@ -1686,18 +1625,18 @@ func (s *ProviderService) SetApplicationCharm(ctx context.Context, appName strin
 	if err != nil {
 		return errors.Errorf("getting charm ID: %w", err)
 	}
-	// Retrieve the current storage directives for the application.
-	storageDirectives, err := s.storageService.GetApplicationStorageDirectives(ctx, appUUID)
-	if err != nil {
-		return errors.Errorf("getting application storage directives: %w", err)
-	}
+
+	// 1. Validate storage requirements between the existing and new charm.
+	// Prevent refresh if the new charm’s storage configuration is incompatible.
+	// For example, removing previously defined storage names is disallowed,
+	// as it may cause important hooks (e.g., storage-attached) to be skipped.
+
 	// Get new charm's storage requirements.
-	charmMetadataStorage, err := s.st.GetCharmMetadataStorage(ctx, charmID)
+	newCharmMetadataStorage, err := s.st.GetCharmMetadataStorage(ctx, charmID)
 	if err != nil {
 		return errors.Errorf("getting charm storage metadata: %w", err)
 	}
-	// Decode charm storage to internal charm format.
-	newCharmStorage, err := decodeMetadataStorage(charmMetadataStorage)
+	newCharmStorage, err := decodeMetadataStorage(newCharmMetadataStorage)
 	if err != nil {
 		return errors.Errorf("decoding charm storage: %w", err)
 	}
@@ -1705,26 +1644,61 @@ func (s *ProviderService) SetApplicationCharm(ctx context.Context, appName strin
 	if err := validateCharmStorage(newCharmStorage); err != nil {
 		return errors.Errorf("validating charm storage: %w", err)
 	}
-	// Reconcile storage directives between existing and new charm storage.
-	modelStoragePools, err := s.st.GetModelStoragePools(ctx)
+	// Retrieve the current charm storage metadata.
+	currentCharm, err := s.st.GetCharmByApplicationUUID(ctx, appUUID)
 	if err != nil {
-		return errors.Errorf("getting default storage provisioners for model: %w", err)
+		return errors.Errorf("getting current application charm ID: %w", err)
 	}
-	toApply, toDelete, err := storage.ReconcileUpdatedCharmStorageDirective(newCharmStorage, storageDirectives, modelStoragePools)
+	currentCharmMetadataStorage := currentCharm.Metadata.Storage
+	currentCharmStorage, err := decodeMetadataStorage(currentCharmMetadataStorage)
+	if err != nil {
+		return errors.Errorf("decoding current charm storage: %w", err)
+	}
+	// Validate new charm storage against existing charm storage.
+	err = storage.ValidateNewCharmStorageAgainstExistingCharmStorage(newCharmStorage, currentCharmStorage)
+	if err != nil {
+		return errors.Errorf("validating new charm storage against existing charm storage: %w", err)
+	}
+
+	// 2. Reconcile existing storage directives with the new charm’s storage definitions
+	// and handle any newly added storage definitions.
+
+	// Retrieve the current storage directives for the application.
+	storageDirectives, err := s.storageService.GetApplicationStorageDirectives(ctx, appUUID)
+	if err != nil {
+		return errors.Errorf("getting application storage directives: %w", err)
+	}
+	// Reconcile storage directives between existing and new charm storage.
+	toCreate, toUpdate, err := s.storageService.ReconcileStorageDirectivesAgainstCharmStorage(ctx, storageDirectives, newCharmStorage)
 	if err != nil {
 		return errors.Errorf("reconciling storage directives: %w", err)
 	}
 
-	// TODO: Override toApply with user provided storage directives in params.
+	// 3. Validate and apply any user provided storage directive overrides.
 
-	// TODO: Validate storage directives in toApply against new charm requirements again.
+	// Validate that the user provided storage directive overrides are valid
+	// against the new charm storage requirements.
+	userStorageDirectiveOverrides := params.StorageDirectiveOverrides
+	if err := s.storageService.ValidateApplicationStorageDirectiveOverrides(
+		ctx, newCharmStorage, userStorageDirectiveOverrides,
+	); err != nil {
+		return errors.Errorf("validating storage directives: %w", err)
+	}
+	// Apply user-provided overrides to the reconciled directives.
+	toCreate, toUpdate = overrideStorageDirectives(
+		toCreate, toUpdate, params.StorageDirectiveOverrides,
+	)
 
-	paramsState, err := makeSetCharmStateArg(params)
+	// 4. Do a final sanity validation to ensure that the final storage directives are valid against the new charm storage requirements.
+	finalStorageDirectives := append(toCreate, toUpdate...)
+	if err := storage.ValidateApplicationStorageDirectives(newCharmStorage, finalStorageDirectives); err != nil {
+		return errors.Errorf("validating final storage directives against charm storage: %w", err)
+	}
+
+	paramsState, err := makeSetCharmStateArg(params, toCreate, toUpdate)
 	if err != nil {
 		return errors.Capture(err)
 	}
-	paramsState.StorageDirectivesToApply = toApply
-	paramsState.StorageDirectivesToDelete = toDelete
 
 	err = s.st.SetApplicationCharm(ctx, appUUID, charmID, paramsState)
 	if err != nil {
@@ -1946,14 +1920,18 @@ func coerceValue(t charm.OptionType, value string) (interface{}, error) {
 
 }
 
-func makeSetCharmStateArg(setCharmParams application.SetCharmParams) (application.SetCharmStateParams, error) {
+func makeSetCharmStateArg(setCharmParams application.SetCharmParams,
+	toCreate []internal.CreateApplicationStorageDirectiveArg,
+	toUpdate []internal.UpdateApplicationStorageDirectiveArg) (application.SetCharmStateParams, error) {
 	channel, err := encodeChannel(setCharmParams.CharmOrigin.Channel)
 	if err != nil {
 		return application.SetCharmStateParams{}, errors.Errorf("encoding charm channel: %w", err)
 	}
 
 	return application.SetCharmStateParams{
-		Channel:          channel,
-		EndpointBindings: setCharmParams.EndpointBindings,
+		Channel:                   channel,
+		EndpointBindings:          setCharmParams.EndpointBindings,
+		StorageDirectivesToCreate: toCreate,
+		StorageDirectivesToUpdate: toUpdate,
 	}, nil
 }

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"math"
 	"math/rand/v2"
 	"testing"
 	"time"
@@ -37,6 +38,7 @@ import (
 	"github.com/juju/juju/domain/application/charm/store"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/application/internal"
+	"github.com/juju/juju/domain/application/service/storage"
 	"github.com/juju/juju/domain/deployment"
 	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/life"
@@ -1597,7 +1599,9 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithChannel(c *tc.C) {
 	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
 	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]application.StorageDirective{}, nil)
 	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(map[string]applicationcharm.Storage{}, nil)
-	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(internal.ModelStoragePools{}, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(nil), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).
 		Do(func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
 			c.Assert(params.Channel, tc.DeepEquals, channel)
@@ -1625,14 +1629,874 @@ func (s *applicationServiceSuite) TestSetApplicationCharmEmptyChannel(c *tc.C) {
 	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
 	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]application.StorageDirective{}, nil)
 	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(map[string]applicationcharm.Storage{}, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(nil), nil)
 	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
-	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(internal.ModelStoragePools{}, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *applicationServiceSuite) TestSetApplicationCharmWithStorage(c *tc.C) {
+// TestSetApplicationCharmWithStorageNameAdded tests that adding a new
+// storage name in the new charm is allowed.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageNameAdded(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			PoolUUID:         tc.Must(c, domainstorage.NewStoragePoolUUID),
+			Count:            1,
+			Size:             1024,
+		},
+	}
+
+	// Current charm has only "data" storage.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm adds "logs" storage - this should be allowed.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+		"logs": {
+			Type:        applicationcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 512,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		[]internal.CreateApplicationStorageDirectiveArg{{
+			Name:     "logs",
+			PoolUUID: tc.Must(c, domainstorage.NewStoragePoolUUID),
+			Count:    1,
+			Size:     512,
+		}},
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: existingStorageDirectives[0].PoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestSetApplicationCharmWithStorageNameRemoved tests that removing a storage
+// name from the new charm is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageNameRemoved(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	// Current charm has "data" storage.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+		"logs": {
+			Type:        applicationcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 512,
+		},
+	}
+
+	// New charm removes "logs" storage - this should be rejected.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var storageNameRemovedErr applicationerrors.CharmStorageDefinitionRemoved
+	c.Assert(errors.As(err, &storageNameRemovedErr), tc.IsTrue)
+	c.Assert(storageNameRemovedErr.StorageName, tc.Equals, "logs")
+}
+
+// TestSetApplicationCharmWithStorageTypeChanged tests that changing a storage
+// type from the old charm to the new charm is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageTypeChanged(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	// Current charm has "data" as block storage.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm changes "data" to filesystem storage - this should be rejected.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var storageTypeChangedErr applicationerrors.CharmStorageTypeChanged
+	c.Assert(errors.As(err, &storageTypeChangedErr), tc.IsTrue)
+	c.Assert(storageTypeChangedErr.StorageName, tc.Equals, "data")
+	c.Assert(storageTypeChangedErr.OldType, tc.Equals, "block")
+	c.Assert(storageTypeChangedErr.NewType, tc.Equals, "filesystem")
+}
+
+// TestSetApplicationCharmWithStorageSizeMinimumIncreased tests that increasing
+// the minimum size requirement in the new charm is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageSizeMinimumIncreased(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	// Current charm requires minimum 1024MB.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm requires minimum 2048MB - this should be rejected.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 2048,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var sizeMinViolationErr applicationerrors.CharmStorageDefinitionMinSizeViolation
+	c.Assert(errors.As(err, &sizeMinViolationErr), tc.IsTrue)
+	c.Assert(sizeMinViolationErr.StorageName, tc.Equals, "data")
+	c.Assert(sizeMinViolationErr.ExistingMin, tc.Equals, uint64(1024))
+	c.Assert(sizeMinViolationErr.NewMin, tc.Equals, uint64(2048))
+}
+
+// TestSetApplicationCharmStorageSizeMinimumDecreased tests that decreasing
+// the minimum size requirement in the new charm is allowed.
+func (s *applicationServiceSuite) TestSetApplicationCharmStorageSizeMinimumDecreased(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			PoolUUID:         tc.Must(c, domainstorage.NewStoragePoolUUID),
+			Count:            1,
+			Size:             8192,
+		},
+	}
+
+	// Current charm requires minimum 2048MB.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 4096,
+		},
+	}
+
+	// New charm requires only 1024MB - this should be allowed.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: existingStorageDirectives[0].PoolUUID,
+			Count:    1,
+			Size:     8192,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestSetApplicationCharmWithStorageCountMinimumIncreased tests that increasing
+// the minimum count requirement in the new charm is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountMinimumIncreased(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	// Current charm requires minimum count of 1.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm requires minimum count of 3 - this should be rejected.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    3,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var countMinViolationErr applicationerrors.CharmStorageDefinitionMinCountViolation
+	c.Assert(errors.As(err, &countMinViolationErr), tc.IsTrue)
+	c.Assert(countMinViolationErr.StorageName, tc.Equals, "data")
+	c.Assert(countMinViolationErr.ExistingMin, tc.Equals, 1)
+	c.Assert(countMinViolationErr.NewMin, tc.Equals, 3)
+}
+
+// TestSetApplicationCharmWithStorageCountMinimumDecreased tests that decreasing
+// the minimum count requirement in the new charm is allowed.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountMinimumDecreased(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			PoolUUID:         tc.Must(c, domainstorage.NewStoragePoolUUID),
+			Count:            3,
+			Size:             1024,
+		},
+	}
+
+	// Current charm requires minimum count of 3.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    3,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm requires minimum count of 1 - this should be allowed.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: existingStorageDirectives[0].PoolUUID,
+			Count:    5,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestSetApplicationCharmWithStorageCountMaximumIncreasedBounded tests that
+// increasing the maximum count from a bounded value to a higher bounded value
+// is allowed.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountMaximumIncreasedBounded(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			PoolUUID:         tc.Must(c, domainstorage.NewStoragePoolUUID),
+			Count:            3,
+			Size:             1024,
+		},
+	}
+
+	// Current charm allows maximum count of 5.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm allows maximum count of 10 - this should be allowed.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    10,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: existingStorageDirectives[0].PoolUUID,
+			Count:    5,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestSetApplicationCharmWithStorageCountMaximumDecreasedBounded tests that
+// decreasing the maximum count from a bounded value to a lower bounded value
+// is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountMaximumDecreasedBounded(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	// Current charm allows maximum count of 5.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm allows maximum count of 3 - this should be rejected.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    3,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var countMaxViolationErr applicationerrors.CharmStorageDefinitionMaxCountViolation
+	c.Assert(errors.As(err, &countMaxViolationErr), tc.IsTrue)
+	c.Assert(countMaxViolationErr.StorageName, tc.Equals, "data")
+	c.Assert(countMaxViolationErr.ExistingMax, tc.Equals, 5)
+	c.Assert(countMaxViolationErr.NewMax, tc.Equals, 3)
+}
+
+// TestSetApplicationCharmWithStorageCountMaximumUnboundedToBounded tests that
+// changing from unbounded (-1) to bounded maximum count is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountMaximumUnboundedToBounded(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	// Current charm has unbounded maximum count (-1).
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    -1,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm has bounded maximum count - this should be rejected.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    100,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorMatches, `validating new charm storage against existing charm storage: storage definition "data" new maximum count 100 is less than existing maximum count \(unbounded\)`)
+	var countMaxViolationErr applicationerrors.CharmStorageDefinitionMaxCountViolation
+	c.Assert(errors.As(err, &countMaxViolationErr), tc.IsTrue)
+	c.Assert(countMaxViolationErr.StorageName, tc.Equals, "data")
+	c.Assert(countMaxViolationErr.ExistingMax, tc.Equals, -1)
+	c.Assert(countMaxViolationErr.NewMax, tc.Equals, 100)
+}
+
+// TestSetApplicationCharmWithStorageCountMaximumBoundedToUnbounded tests that
+// changing from bounded to unbounded (-1) maximum count is allowed.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountMaximumBoundedToUnbounded(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			PoolUUID:         tc.Must(c, domainstorage.NewStoragePoolUUID),
+			Count:            5,
+			Size:             1024,
+		},
+	}
+
+	// Current charm has bounded maximum count of 10.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    10,
+			MinimumSize: 1024,
+		},
+	}
+
+	// New charm has unbounded maximum count - this should be allowed.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    -1,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: existingStorageDirectives[0].PoolUUID,
+			Count:    5,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestSetApplicationCharmWithStorageCountMaximumBothUnbounded tests that
+// both charms having unbounded maximum count is allowed.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountMaximumBothUnbounded(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			PoolUUID:         tc.Must(c, domainstorage.NewStoragePoolUUID),
+			Count:            5,
+			Size:             1024,
+		},
+	}
+
+	// Both current and new charm have unbounded maximum count.
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    -1,
+			MinimumSize: 1024,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    -1,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: existingStorageDirectives[0].PoolUUID,
+			Count:    5,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestSetApplicationCharmWithStorageCountInvalidMinMaxCount tests that if the new charm has invalid storage configuration
+// (minimum count greater than maximum count), the SetApplicationCharm call is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountInvalidMinMaxCount(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	// New charm storage count min is higher than max, this is invalid.
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    5,
+			CountMax:    3,
+			MinimumSize: 1024,
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorMatches, `.*minimum count 5 greater than maximum count 3.*`)
+}
+
+// TestSetApplicationCharmWithStorageCountMaximumSingletonToMultipleWithLocation
+// tests that a storage with a fixed location cannot change from singleton to
+// multiple.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageCountMaximumSingletonToMultipleWithLocation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+			Location:    "/var/lib/data",
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    3,
+			MinimumSize: 1024,
+			Location:    "/var/lib/data",
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var singleToMultipleErr applicationerrors.CharmStorageDefinitionSingleToMultipleViolation
+	c.Assert(errors.As(err, &singleToMultipleErr), tc.IsTrue)
+	c.Assert(singleToMultipleErr.StorageName, tc.Equals, "data")
+	c.Assert(singleToMultipleErr.ExistingMax, tc.Equals, 1)
+	c.Assert(singleToMultipleErr.NewMax, tc.Equals, 3)
+}
+
+// TestSetApplicationCharmWithStorageSingletonWithLocationRangeEqualsSingleton
+// tests that a singleton storage with a fixed location remains allowed when
+// the new charm keeps the same effective singleton definition.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageSingletonWithLocationRangeEqualsSingleton(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageFilesystem,
+			Name:             "data",
+			PoolUUID:         tc.Must(c, domainstorage.NewStoragePoolUUID),
+			Count:            1,
+			Size:             1024,
+		},
+	}
+
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+			Location:    "/var/lib/data",
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageFilesystem,
+			CountMin:    1,
+			CountMax:    1,
+			MinimumSize: 1024,
+			Location:    "/var/lib/data",
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: existingStorageDirectives[0].PoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestSetApplicationCharmWithStorageSharedChanged tests that if the new charm has a storage with a different shared setting
+// than the current charm, the SetApplicationCharm call is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageSharedChanged(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {Type: applicationcharm.StorageFilesystem, CountMin: 0, CountMax: 1, MinimumSize: 1024, Shared: false},
+	}
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {Type: applicationcharm.StorageFilesystem, CountMin: 0, CountMax: 1, MinimumSize: 1024, Shared: true},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var got applicationerrors.CharmStorageDefinitionSharedChanged
+	c.Assert(errors.As(err, &got), tc.IsTrue)
+	c.Assert(got.StorageName, tc.Equals, "data")
+	c.Assert(got.ExistingValue, tc.Equals, false)
+	c.Assert(got.NewValue, tc.Equals, true)
+}
+
+// TestSetApplicationCharmWithStorageReadOnlyChanged tests that if the new charm has a storage with a different read-only setting
+// than the current charm, the SetApplicationCharm call is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageReadOnlyChanged(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {Type: applicationcharm.StorageFilesystem, CountMin: 1, CountMax: 1, MinimumSize: 1024, ReadOnly: false},
+	}
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {Type: applicationcharm.StorageFilesystem, CountMin: 1, CountMax: 1, MinimumSize: 1024, ReadOnly: true},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var got applicationerrors.CharmStorageDefinitionReadOnlyChanged
+	c.Assert(errors.As(err, &got), tc.IsTrue)
+	c.Assert(got.StorageName, tc.Equals, "data")
+	c.Assert(got.ExistingValue, tc.Equals, false)
+	c.Assert(got.NewValue, tc.Equals, true)
+}
+
+// TestSetApplicationCharmWithStorageLocationChanged tests that if the new charm has a storage with a different location
+// than the current charm, the SetApplicationCharm call is rejected.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageLocationChanged(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {Type: applicationcharm.StorageFilesystem, CountMin: 1, CountMax: 1, MinimumSize: 1024, Location: "/a"},
+	}
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {Type: applicationcharm.StorageFilesystem, CountMin: 1, CountMax: 1, MinimumSize: 1024, Location: "/b"},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
+	var got applicationerrors.CharmStorageDefinitionLocationChanged
+	c.Assert(errors.As(err, &got), tc.IsTrue)
+	c.Assert(got.StorageName, tc.Equals, "data")
+	c.Assert(got.ExistingLocation, tc.Equals, "/a")
+	c.Assert(got.NewLocation, tc.Equals, "/b")
+}
+
+// TestSetApplicationCharmWithStorageDirectivesChanges tests that when storage directives
+// are changed in the new charm, they are correctly reconciled and passed to the state.
+// While existingStorageDirectives does not adhere to current charm storage requirements,
+// we want to test that even if the existing directives have been manually updated to a "bad" state,
+// the new directives will still be correctly calculated and passed to the state.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesChanges(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	appName := "foo"
@@ -1640,7 +2504,8 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorage(c *tc.C) {
 	charmID := charmtesting.GenCharmID(c)
 	modelStoragePools := makeModelStoragePools(c)
 
-	// Combination of: update storage count, update storage size, delete old storage, add new storage.
+	// Combination of: update storage count, update storage size, and add new storage.
+	// Note that existing storage directives do not adhere to current charm storage requirements.
 	existingStorageDirectives := []application.StorageDirective{
 		// storage "data" size and count will be updated.
 		{
@@ -1650,13 +2515,14 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorage(c *tc.C) {
 			Size:             512, // Will be updated to 1024
 			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
 		},
-		// storage "cache" will be deleted.
-		{
-			CharmStorageType: applicationcharm.StorageBlock,
-			Name:             "cache",
-			Count:            1,
-			Size:             256,
-			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+	}
+
+	currentCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    2,
+			CountMax:    5,
+			MinimumSize: 1024,
 		},
 	}
 
@@ -1680,33 +2546,39 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorage(c *tc.C) {
 	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
 	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
 	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
-	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(currentCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		[]internal.CreateApplicationStorageDirectiveArg{{
+			Name:     "logs",
+			PoolUUID: *modelStoragePools.FilesystemPoolUUID,
+			Count:    1,
+			Size:     512,
+		}},
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    2,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	// Expect complex changes: update data count, delete cache, add logs
 	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).
 		Do(func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
-			c.Assert(params.StorageDirectivesToApply, tc.HasLen, 2)
-			c.Assert(params.StorageDirectivesToDelete, tc.HasLen, 1)
-			c.Assert(params.StorageDirectivesToDelete[0], tc.Equals, "cache")
+			c.Assert(params.StorageDirectivesToCreate, tc.HasLen, 1)
+			c.Assert(params.StorageDirectivesToUpdate, tc.HasLen, 1)
 
-			// Check that we have both updated and new storage
-			var dataUpdate, logsCreate *internal.ApplyApplicationStorageDirectiveArg
-			for i := range params.StorageDirectivesToApply {
-				if string(params.StorageDirectivesToApply[i].Name) == "data" {
-					dataUpdate = &params.StorageDirectivesToApply[i]
-				} else if string(params.StorageDirectivesToApply[i].Name) == "logs" {
-					logsCreate = &params.StorageDirectivesToApply[i]
-				}
-			}
+			c.Assert(params.StorageDirectivesToCreate[0].Name.String(), tc.Equals, "logs")
+			c.Assert(params.StorageDirectivesToCreate[0].PoolUUID, tc.Equals, *modelStoragePools.FilesystemPoolUUID)
+			c.Assert(params.StorageDirectivesToCreate[0].Count, tc.Equals, uint32(1))
+			c.Assert(params.StorageDirectivesToCreate[0].Size, tc.Equals, uint64(512))
 
-			c.Assert(dataUpdate, tc.Not(tc.IsNil))
-			c.Assert(dataUpdate.Count, tc.Equals, uint32(2))
-			c.Assert(dataUpdate.Size, tc.Equals, uint64(1024))
-			c.Assert(dataUpdate.PoolUUID, tc.Equals, *modelStoragePools.BlockDevicePoolUUID)
+			c.Assert(params.StorageDirectivesToUpdate[0].Name.String(), tc.Equals, "data")
+			c.Assert(params.StorageDirectivesToUpdate[0].PoolUUID, tc.Equals, *modelStoragePools.BlockDevicePoolUUID)
+			c.Assert(params.StorageDirectivesToUpdate[0].Count, tc.Equals, uint32(2))
+			c.Assert(params.StorageDirectivesToUpdate[0].Size, tc.Equals, uint64(1024))
 
-			c.Assert(logsCreate, tc.Not(tc.IsNil))
-			c.Assert(logsCreate.Count, tc.Equals, uint32(1))
-			c.Assert(logsCreate.Size, tc.Equals, uint64(512))
-			c.Assert(logsCreate.PoolUUID, tc.Equals, *modelStoragePools.FilesystemPoolUUID)
 			return nil
 		})
 
@@ -1714,29 +2586,41 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorage(c *tc.C) {
 	c.Assert(err, tc.IsNil)
 }
 
-func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageInvalidMinMaxCount(c *tc.C) {
+// TestSetApplicationCharmWithStorageDirectivesOverrideCountOverflow tests that
+// when a storage directive override sets a very large count, an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideCountOverflow(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	appName := "foo"
 	appUUID := tc.Must(c, coreapplication.NewUUID)
 	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+	count := uint32(math.MaxUint32)
 
 	existingStorageDirectives := []application.StorageDirective{
 		{
 			CharmStorageType: applicationcharm.StorageBlock,
 			Name:             "data",
-			Count:            5,
-			Size:             1024,
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
 		},
 	}
 
-	// New charm storage count min is higher than max, this is invalid.
 	newCharmStorages := map[string]applicationcharm.Storage{
 		"data": {
 			Type:        applicationcharm.StorageBlock,
-			CountMin:    5,
+			CountMin:    1,
 			CountMax:    3,
-			MinimumSize: 1024,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Count: ptr(count),
+			},
 		},
 	}
 
@@ -1744,9 +2628,914 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageInvalidMinMa
 	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
 	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
 	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    1,
+			Size:     512,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		applicationerrors.StorageCountLimitExceeded{
+			Maximum:     ptr(3),
+			Minimum:     1,
+			Requested:   int(count),
+			StorageName: "data",
+		},
+	)
 
-	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, application.SetCharmParams{})
-	c.Assert(err, tc.ErrorMatches, `.*minimum count greater than maximum count.*`)
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage "data" cannot exceed 3 storage instances`)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverridePoolChange tests that
+// when a storage directive override changes the pool, the change is applied
+// correctly.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverridePoolChange(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    2,
+			CountMax:    5,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				PoolUUID: &poolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    2,
+			Size:     512,
+		}},
+		nil,
+	)
+	// Expect the override pool UUID validation to succeed.
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			override, exists := overrides["data"]
+			c.Assert(exists, tc.IsTrue)
+			c.Assert(override.PoolUUID, tc.NotNil)
+			c.Assert(*override.PoolUUID, tc.Equals, poolUUID)
+			return nil
+		},
+	)
+	// Expect the pool change to be applied in the update directives.
+	// Count should still be updated to the new charm minimum, but size should remain unchanged as there is no override for it.
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Do(
+		func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
+			c.Assert(params.StorageDirectivesToCreate, tc.HasLen, 0)
+			c.Assert(params.StorageDirectivesToUpdate, tc.HasLen, 1)
+
+			c.Assert(params.StorageDirectivesToUpdate[0].Name.String(), tc.Equals, "data")
+			c.Assert(params.StorageDirectivesToUpdate[0].PoolUUID, tc.Equals, poolUUID)
+			c.Assert(params.StorageDirectivesToUpdate[0].Count, tc.Equals, uint32(2))
+			return nil
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.IsNil)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverridePoolChangeUnsupported tests that
+// when a storage directive override changes the pool to one that does not support
+// the new charm storage type (i.e pool does not support filesystem), an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverridePoolChangeUnsupported(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    2,
+			CountMax:    5,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				PoolUUID: &poolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    2,
+			Size:     512,
+		}},
+		nil,
+	)
+	// Expect the override pool UUID validation to fail.
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			override, exists := overrides["data"]
+			c.Assert(exists, tc.IsTrue)
+			c.Assert(override.PoolUUID, tc.NotNil)
+			c.Assert(*override.PoolUUID, tc.Equals, poolUUID)
+			return errors.Errorf("storage directive pool %q does not support charm storage type filesystem", poolUUID.String())
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, "validating storage directives: storage directive pool .* does not support charm storage type filesystem")
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverridePoolChangeUnknownPool tests that
+// when a storage directive override changes the pool to one that does not exist in the model,
+// an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverridePoolChangeUnknownPool(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+	unknownPoolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    3,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				PoolUUID: &unknownPoolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		errors.Errorf(`storage directive data references unknown pool %q`, unknownPoolUUID),
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage directive data references unknown pool ".*"`)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideCountWithinRange tests that
+// when a storage directive override changes the count, the count is applied
+// correctly within the range of the new minimum and maximum.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideCountWithinRange(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    2,
+			CountMax:    5,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Count: ptr(uint32(4)),
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			override, exists := overrides["data"]
+			c.Assert(exists, tc.IsTrue)
+			c.Assert(override.Count, tc.NotNil)
+			c.Assert(*override.Count, tc.Equals, uint32(4))
+			return nil
+		},
+	)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Do(
+		func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
+			c.Assert(params.StorageDirectivesToUpdate, tc.HasLen, 1)
+			c.Assert(params.StorageDirectivesToUpdate[0].Name.String(), tc.Equals, "data")
+			c.Assert(params.StorageDirectivesToUpdate[0].PoolUUID, tc.Equals, *modelStoragePools.BlockDevicePoolUUID)
+			c.Assert(params.StorageDirectivesToUpdate[0].Count, tc.Equals, uint32(4))
+			return nil
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.IsNil)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideCountBelowMinimum tests that
+// when a storage directive override changes the count below the new charm minimum count,
+// an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideCountBelowMinimum(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	countMax := 8
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    3,
+			CountMax:    countMax,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Count: ptr(uint32(2)),
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			override, exists := overrides["data"]
+			c.Assert(exists, tc.IsTrue)
+			c.Assert(override.Count, tc.NotNil)
+			c.Assert(*override.Count, tc.Equals, uint32(2))
+
+			return applicationerrors.StorageCountLimitExceeded{
+				Maximum:     &countMax,
+				Minimum:     3,
+				Requested:   2,
+				StorageName: "data",
+			}
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage "data" cannot have less than 3 storage instances`)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideCountAboveMaximum tests that
+// when a storage directive override changes the count above the new charm maximum count,
+// an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideCountAboveMaximum(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	countMax := 5
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    2,
+			CountMax:    countMax,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Count: ptr(uint32(6)),
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			override, exists := overrides["data"]
+			c.Assert(exists, tc.IsTrue)
+			c.Assert(override.Count, tc.NotNil)
+			c.Assert(*override.Count, tc.Equals, uint32(6))
+			return applicationerrors.StorageCountLimitExceeded{
+				Maximum:     &countMax,
+				Minimum:     2,
+				Requested:   6,
+				StorageName: "data",
+			}
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage "data" cannot exceed 5 storage instances`)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideSizeAboveMinimum tests that
+// when a storage directive override changes the size above the new charm minimum size,
+// the size is applied correctly.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideSizeAboveMinimum(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    3,
+			MinimumSize: 1024,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Size:     ptr(uint64(2048)),
+				PoolUUID: modelStoragePools.BlockDevicePoolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			override, exists := overrides["data"]
+			c.Assert(exists, tc.IsTrue)
+			c.Assert(override.Size, tc.NotNil)
+			c.Assert(*override.Size, tc.Equals, uint64(2048))
+			return nil
+		},
+	)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Do(
+		func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
+			c.Assert(params.StorageDirectivesToUpdate, tc.HasLen, 1)
+			c.Assert(params.StorageDirectivesToUpdate[0].Name.String(), tc.Equals, "data")
+			c.Assert(params.StorageDirectivesToUpdate[0].Size, tc.Equals, uint64(2048))
+			return nil
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.IsNil)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideSizeBelowMinimum tests that
+// when a storage directive override changes the size below the new charm minimum size,
+// an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideSizeBelowMinimum(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    3,
+			MinimumSize: 1024,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Size:     ptr(uint64(512)),
+				PoolUUID: modelStoragePools.BlockDevicePoolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			override, exists := overrides["data"]
+			c.Assert(exists, tc.IsTrue)
+			c.Assert(override.Size, tc.NotNil)
+			c.Assert(*override.Size, tc.Equals, uint64(512))
+			return errors.Errorf(
+				"storage directive size %d is less than the charm minimum requirement of %d",
+				*override.Size,
+				uint64(1024),
+			)
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage directive size 512 is less than the charm minimum requirement of 1024`)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideSizeEqualsMinimum tests that
+// when a storage directive override changes the size to the new charm minimum size,
+// the size is applied correctly.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideSizeEqualsMinimum(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    3,
+			MinimumSize: 1024,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Size:     ptr(uint64(1024)),
+				PoolUUID: modelStoragePools.BlockDevicePoolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil,
+		[]internal.UpdateApplicationStorageDirectiveArg{{
+			Name:     "data",
+			PoolUUID: *modelStoragePools.BlockDevicePoolUUID,
+			Count:    1,
+			Size:     1024,
+		}},
+		nil,
+	)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			override, exists := overrides["data"]
+			c.Assert(exists, tc.IsTrue)
+			c.Assert(override.Size, tc.NotNil)
+			c.Assert(*override.Size, tc.Equals, uint64(1024))
+			return nil
+		},
+	)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Do(
+		func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
+			c.Assert(params.StorageDirectivesToUpdate, tc.HasLen, 1)
+			c.Assert(params.StorageDirectivesToUpdate[0].Name.String(), tc.Equals, "data")
+			c.Assert(params.StorageDirectivesToUpdate[0].Size, tc.Equals, uint64(1024))
+			return nil
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.IsNil)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideNonExistentDirective tests that
+// when a storage directive override does not exist in the new charm, an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideNonExistentDirective(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"not-data": {
+				Size:     ptr(uint64(1024)),
+				PoolUUID: modelStoragePools.BlockDevicePoolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			_, exists := overrides["data"]
+			c.Assert(exists, tc.IsFalse)
+			return errors.New("storage directive not-data does not exist in the application")
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage directive not-data does not exist in the application`)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideInvalidPool tests that
+// when a storage directive override specifies an invalid pool, an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideInvalidPool(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+	invalidPoolUUID := domainstorage.StoragePoolUUID("")
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"not-data": {
+				Size:     ptr(uint64(1024)),
+				PoolUUID: &invalidPoolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		errors.New(`storage directive "not-data" references an invalid pool uuid ""`),
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage directive "not-data" references an invalid pool uuid ""`)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideMissingPool tests that
+// when a storage directive override specifies a pool that is not found in the model, an error is returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideMissingPool(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+	missingPoolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Size:     ptr(uint64(2048)),
+				PoolUUID: &missingPoolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		errors.Errorf(`storage directive data references unknown pool %q`, missingPoolUUID),
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage directive data references unknown pool ".*"`)
+}
+
+// TestSetApplicationCharmWithStorageDirectivesOverrideValidAndInvalid tests that
+// when both a valid and invalid storage directive is supplied, an error will still be returned.
+func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageDirectivesOverrideValidAndInvalid(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	modelStoragePools := makeModelStoragePools(c)
+
+	existingStorageDirectives := []application.StorageDirective{
+		{
+			CharmStorageType: applicationcharm.StorageBlock,
+			Name:             "data",
+			Count:            1,
+			Size:             512,
+			PoolUUID:         *modelStoragePools.BlockDevicePoolUUID,
+		},
+	}
+
+	newCharmStorages := map[string]applicationcharm.Storage{
+		"data": {
+			Type:        applicationcharm.StorageBlock,
+			CountMin:    1,
+			CountMax:    5,
+			MinimumSize: 512,
+		},
+	}
+
+	params := application.SetCharmParams{
+		StorageDirectiveOverrides: map[string]application.ApplicationStorageDirectiveOverride{
+			"data": {
+				Size:     ptr(uint64(2048)),
+				PoolUUID: modelStoragePools.BlockDevicePoolUUID,
+			},
+			"not-data": {
+				Size:     ptr(uint64(1024)),
+				PoolUUID: modelStoragePools.BlockDevicePoolUUID,
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return(existingStorageDirectives, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(newCharmStorages, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(newCharmStorages), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ map[string]internalcharm.Storage, overrides map[string]storage.StorageDirectiveOverride) error {
+			c.Assert(len(overrides), tc.Equals, 2)
+			c.Assert(overrides["data"].Size, tc.NotNil)
+			c.Assert(*overrides["data"].Size, tc.Equals, uint64(2048))
+			c.Assert(overrides["not-data"].Size, tc.NotNil)
+			c.Assert(*overrides["not-data"].Size, tc.Equals, uint64(1024))
+
+			return errors.New("storage directive not-data does not exist in the application")
+		},
+	)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorMatches, `validating storage directives: storage directive not-data does not exist in the application`)
 }
 
 func (s *applicationServiceSuite) TestGetApplicationLife(c *tc.C) {
@@ -1799,5 +3588,15 @@ func makeModelStoragePools(c *tc.C) internal.ModelStoragePools {
 	return internal.ModelStoragePools{
 		FilesystemPoolUUID:  &fakeFilesytemPoolUUID,
 		BlockDevicePoolUUID: &fakeBlockdevicePoolUUID,
+	}
+}
+
+// makeCharmWithStorage creates a minimal charm with the given storage map for testing
+func makeCharmWithStorage(storage map[string]applicationcharm.Storage) applicationcharm.Charm {
+	return applicationcharm.Charm{
+		Metadata: applicationcharm.Metadata{
+			Storage: storage,
+			RunAs:   "default",
+		},
 	}
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -931,7 +931,7 @@ func makeCreateApplicationArgs(
 		)
 	}
 
-	err = validateApplicationStorageDirectives(charmMeta.Storage, storageDirectiveArgs)
+	err = storage.ValidateApplicationStorageDirectives(charmMeta.Storage, storageDirectiveArgs)
 	if err != nil {
 		return application.BaseAddApplicationArg{}, errors.Errorf(
 			"invalid application storage directives: %w", err,

--- a/domain/application/service/storage.go
+++ b/domain/application/service/storage.go
@@ -160,4 +160,16 @@ type StorageService interface {
 		uuid coreunit.UUID,
 		storageName corestorage.Name,
 	) (application.StorageDirective, error)
+
+	// ReconcileStorageDirectivesAgainstCharmStorage reconciles existing application storage directives
+	// and adds any new storage definitions.
+	ReconcileStorageDirectivesAgainstCharmStorage(
+		ctx context.Context,
+		existingStorageDirectives []application.StorageDirective,
+		newCharmStorages map[string]internalcharm.Storage,
+	) (
+		toCreate []internal.CreateApplicationStorageDirectiveArg,
+		toUpdate []internal.UpdateApplicationStorageDirectiveArg,
+		err error,
+	)
 }

--- a/domain/application/service/storage/charm.go
+++ b/domain/application/service/storage/charm.go
@@ -46,3 +46,124 @@ func (s *Service) ValidateCharmStorage(
 
 	return nil
 }
+
+// ValidateNewCharmStorageAgainstExistingCharmStorage ensures that the new charm's
+// storage requirements are compatible with the existing charm's storage requirements.
+// It validates the following rules from the existing charm to the new charm:
+//   - No storage has been removed.
+//   - Storage type must not change.
+//   - Minimum storage size must not increase.
+//   - Minimum storage count must not increase.
+//   - Maximum storage count must not decrease (unbounded cannot become bounded).
+//
+// The following errors can be expected:
+//   - [domainapplicationerrors.CharmStorageDefinitionRemoved] when storage is removed in new charm.
+//   - [domainapplicationerrors.CharmStorageTypeChanged] when type of a storage in new charm changes.
+//   - [domainapplicationerrors.CharmStorageDefinitionMinSizeViolation] when minimum size increased in new charm.
+//   - [domainapplicationerrors.CharmStorageDefinitionMinCountViolation] when minimum count increased in new charm.
+//   - [domainapplicationerrors.CharmStorageDefinitionMaxCountViolation] when maximum count decreased or became bounded from unbounded in new charm.
+//   - [domainapplicationerrors.CharmStorageDefinitionSingleToMultipleViolation] when a singleton storage with a fixed location changes to multiple.
+//   - [domainapplicationerrors.CharmStorageDefinitionSharedChanged] when shared changes.
+//   - [domainapplicationerrors.CharmStorageDefinitionReadOnlyChanged] when read-only changes.
+//   - [domainapplicationerrors.CharmStorageDefinitionLocationChanged] when location changes.
+func ValidateNewCharmStorageAgainstExistingCharmStorage(
+	newCharmStorageReqs map[string]internalcharm.Storage,
+	existingCharmStorageReqs map[string]internalcharm.Storage,
+) error {
+	for storageName, existingStorageReq := range existingCharmStorageReqs {
+		newCharmStorageReq, existsInNewCharm := newCharmStorageReqs[storageName]
+		if !existsInNewCharm {
+			// Storage no longer in new charm, return an error.
+			return domainapplicationerrors.CharmStorageDefinitionRemoved{
+				StorageName: storageName,
+			}
+		}
+		// Condition 1: Minimum storage size of new charm must not be more than existing charm minimum storage size.
+		if newCharmStorageReq.MinimumSize > existingStorageReq.MinimumSize {
+			return domainapplicationerrors.CharmStorageDefinitionMinSizeViolation{
+				StorageName: storageName,
+				ExistingMin: existingStorageReq.MinimumSize,
+				NewMin:      newCharmStorageReq.MinimumSize,
+			}
+		}
+
+		// Condition 2: Storage type of new charm must match existing charm storage type.
+		if newCharmStorageReq.Type != existingStorageReq.Type {
+			return domainapplicationerrors.CharmStorageTypeChanged{
+				StorageName: storageName,
+				OldType:     existingStorageReq.Type.String(),
+				NewType:     newCharmStorageReq.Type.String(),
+			}
+		}
+
+		// Condition 3a: Count min of new charm must not be more than existing charm minimum count.
+		if newCharmStorageReq.CountMin > existingStorageReq.CountMin {
+			return domainapplicationerrors.CharmStorageDefinitionMinCountViolation{
+				StorageName: storageName,
+				ExistingMin: existingStorageReq.CountMin,
+				NewMin:      newCharmStorageReq.CountMin,
+			}
+		}
+
+		// Condition 3b: Count max of new charm must not tighten count max.
+		oldMax := existingStorageReq.CountMax
+		newMax := newCharmStorageReq.CountMax
+
+		// Unbounded to bounded is a violation.
+		if oldMax < 0 && newMax >= 0 {
+			return domainapplicationerrors.CharmStorageDefinitionMaxCountViolation{
+				StorageName: storageName,
+				ExistingMax: oldMax,
+				NewMax:      newMax,
+			}
+		}
+
+		// Bounded to bounded, ensure new max is not less than old max.
+		if newMax >= 0 && oldMax >= 0 && newMax < oldMax {
+			return domainapplicationerrors.CharmStorageDefinitionMaxCountViolation{
+				StorageName: storageName,
+				ExistingMax: oldMax,
+				NewMax:      newMax,
+			}
+		}
+
+		// Condition 4: A singleton storage with a fixed location cannot change to multiple,
+		// as the location semantics become incompatible.
+		if existingStorageReq.Location != "" && oldMax == 1 && newMax != 1 {
+			return domainapplicationerrors.CharmStorageDefinitionSingleToMultipleViolation{
+				StorageName: storageName,
+				ExistingMax: oldMax,
+				NewMax:      newMax,
+			}
+		}
+
+		// Condition 5: Shared property must not change.
+		if newCharmStorageReq.Shared != existingStorageReq.Shared {
+			return domainapplicationerrors.CharmStorageDefinitionSharedChanged{
+				StorageName:   storageName,
+				ExistingValue: existingStorageReq.Shared,
+				NewValue:      newCharmStorageReq.Shared,
+			}
+		}
+
+		// Condition 6: Read-only property must not change.
+		if newCharmStorageReq.ReadOnly != existingStorageReq.ReadOnly {
+			return domainapplicationerrors.CharmStorageDefinitionReadOnlyChanged{
+				StorageName:   storageName,
+				ExistingValue: existingStorageReq.ReadOnly,
+				NewValue:      newCharmStorageReq.ReadOnly,
+			}
+		}
+
+		// Condition 7: Location must not change.
+		if newCharmStorageReq.Location != existingStorageReq.Location {
+			return domainapplicationerrors.CharmStorageDefinitionLocationChanged{
+				StorageName:      storageName,
+				ExistingLocation: existingStorageReq.Location,
+				NewLocation:      newCharmStorageReq.Location,
+			}
+		}
+
+	}
+	return nil
+}

--- a/domain/application/service/storage/directive.go
+++ b/domain/application/service/storage/directive.go
@@ -5,8 +5,7 @@ package storage
 
 import (
 	"context"
-
-	"github.com/juju/collections/transform"
+	"math"
 
 	coreapplication "github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
@@ -21,35 +20,15 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
-// StorageDirectiveOverride defines a single set of overrides for a
-// storage directive to accompany an application when it is being added.
-// Typically, this is supplied by the caller when the user whishes to set
-// explicitly storage directive parameters of the application.
-//
-// Each value in this struct is optional and only when a value that is non nil
-// has been supplied will it be used to override the defaults.
-type StorageDirectiveOverride struct {
-	// Count is the number of storage instances to create for each unit. This
-	// value must be greater or equal to the minimum defined by the charm. This
-	// value must also be less or equal to the maximum defined by the charm.
-	Count *uint32
-
-	// PoolUUID defines the storage pool to use when provisioning storage for
-	// this directive.
-	PoolUUID *domainstorage.StoragePoolUUID
-
-	// Size defines the size of the storage to provision as a minimum value in
-	// MiB. What gets provisioned by the provider for each unit may be larger
-	// then this value.
-	Size *uint64
-}
-
 const (
 	// defaultStorageDirectiveSize is the default size used for application
 	// storage directives when no other size value can be used. This value
 	// is in MiB.
 	defaultStorageDirectiveSize = 1024 // 1 GiB
 )
+
+// StorageDirectiveOverride is a type alias for the domain type.
+type StorageDirectiveOverride = application.ApplicationStorageDirectiveOverride
 
 // GetApplicationStorageDirectives returns the storage directives that are
 // set for an application. If the application does not have any storage
@@ -340,57 +319,42 @@ func validateApplicationStorageDirectiveOverride(
 	return nil
 }
 
-// ReconcileUpdatedCharmStorageDirective merges existing application storage directives with
-// new charm storage requirements.
-func ReconcileUpdatedCharmStorageDirective(
-	newCharmStorages map[string]internalcharm.Storage,
+// ReconcileStorageDirectivesAgainstCharmStorage reconciles existing application storage directives
+// and adds any new storage definitions.
+func (s *Service) ReconcileStorageDirectivesAgainstCharmStorage(
+	ctx context.Context,
 	existingStorageDirectives []application.StorageDirective,
-	modelStoragePools internal.ModelStoragePools,
+	newCharmStorages map[string]internalcharm.Storage,
 ) (
-	toApply []internal.ApplyApplicationStorageDirectiveArg,
-	toDelete []string,
+	toCreate []internal.CreateApplicationStorageDirectiveArg,
+	toUpdate []internal.UpdateApplicationStorageDirectiveArg,
 	err error,
 ) {
-	toApply = []internal.ApplyApplicationStorageDirectiveArg{}
-	toDelete = []string{}
-
 	// To check later on which new storage should be created.
 	processedNewCharmStorage := make(map[string]bool)
 
-	existingStorageDirectivesMap := transform.SliceToMap(existingStorageDirectives, func(d application.StorageDirective) (string, application.StorageDirective) {
-		return d.Name.String(), d
-	})
-
-	// Process existing directives against new charm storage.
-	// We process only overlapping storage names here for update.
-	for storageName, existingStorageDirective := range existingStorageDirectivesMap {
-		newCharmStorage, existsInCharm := newCharmStorages[storageName]
-
-		// Storage no longer in charm, mark for deletion.
-		if !existsInCharm {
-			toDelete = append(toDelete, storageName)
-			continue
+	// Reconcile storage names that already exist on the application.
+	for _, existingStorageDirective := range existingStorageDirectives {
+		storageName := existingStorageDirective.Name.String()
+		newCharmStorage, exists := newCharmStorages[storageName]
+		// This should not happen.
+		// Removal of storage definition in the charm should be blocked in charm compatibility check before this point.
+		if !exists {
+			return nil, nil, errors.Errorf("existing storage directive %q does not exist in the new charm", storageName)
 		}
 
-		// We return an error if the storage type has changed for the same storage name,
-		// preserving the behaviour and err message we had in 3.6.
-		if existingStorageDirective.CharmStorageType.String() != newCharmStorage.Type.String() {
-			return nil, nil, &applicationerrors.CharmStorageTypeChanged{
-				StorageName: storageName,
-				OldType:     existingStorageDirective.CharmStorageType.String(),
-				NewType:     newCharmStorage.Type.String(),
-			}
-		}
+		// Reconcile after compatibility validation succeeds.
+		// This ensures that min size, min count and max count changes in the existing storage directive are
+		// reconciled with the new charm storage requirements.
+		reconciledArg := ReconcileStorageDirective(existingStorageDirective, newCharmStorage)
 
-		// Reconcile this directive.
-		reconciledArg := reconcileStorageDirective(existingStorageDirective, storageName, newCharmStorage)
-
-		// Only include in toApply if something changed.
-		if hasStorageDirectiveChanged(existingStorageDirective, reconciledArg) {
-			toApply = append(toApply, reconciledArg)
-		}
-
+		// Include in toUpdate regardless of any value change. We have to update charmUUID regardless.
+		toUpdate = append(toUpdate, reconciledArg)
 		processedNewCharmStorage[storageName] = true
+	}
+	modelStoragePools, err := s.st.GetModelStoragePools(ctx)
+	if err != nil {
+		return nil, nil, errors.Errorf("getting model storage pools: %w", err)
 	}
 
 	// Process creating new charm storage that are not in existing directives.
@@ -404,20 +368,19 @@ func ReconcileUpdatedCharmStorageDirective(
 			newCharmStorage,
 			modelStoragePools,
 		)
-		toApply = append(toApply, arg)
+		toCreate = append(toCreate, arg)
 	}
 
-	return toApply, toDelete, nil
+	return toCreate, toUpdate, nil
 }
 
-// reconcileStorageDirective reconciles an existing directive with new charm requirements.
-func reconcileStorageDirective(
+// ReconcileStorageDirective reconciles an existing directive with new charm requirements.
+func ReconcileStorageDirective(
 	existingStorageDirective application.StorageDirective,
-	storageName string,
 	newCharmStorage internalcharm.Storage,
-) internal.ApplyApplicationStorageDirectiveArg {
-	arg := internal.ApplyApplicationStorageDirectiveArg{
-		Name: domainstorage.Name(storageName),
+) internal.UpdateApplicationStorageDirectiveArg {
+	arg := internal.UpdateApplicationStorageDirectiveArg{
+		Name: existingStorageDirective.Name,
 	}
 
 	// Increase count if below new minimum.
@@ -433,9 +396,12 @@ func reconcileStorageDirective(
 	}
 
 	// Reconcile storage count.
+	// We do not change the storage directive count if the count
+	// is already within the new min and max count defined by the new charm.
 	arg.Count = count
 
 	// Reconcile storage size.
+	// We do not decrease storage directive size if the new charm storage has a smaller minimum size.
 	arg.Size = max(existingStorageDirective.Size, newCharmStorage.MinimumSize)
 
 	// Preserve the existing pool UUID.
@@ -444,27 +410,15 @@ func reconcileStorageDirective(
 	return arg
 }
 
-// hasStorageDirectiveChanged checks if a directive needs updating.
-func hasStorageDirectiveChanged(
-	existing application.StorageDirective,
-	proposed internal.ApplyApplicationStorageDirectiveArg,
-) bool {
-	storageCountChanged := proposed.Count != existing.Count
-	storageSizeChanged := proposed.Size != existing.Size
-	storagePoolChanged := proposed.PoolUUID != existing.PoolUUID
-
-	return storageCountChanged || storageSizeChanged || storagePoolChanged
-}
-
 // createApplyApplicationStorageDirectiveArg creates a directive for new storage in the charm.
 // This is intended to be used for charm refresh.
 func createApplyApplicationStorageDirectiveArg(
 	storageName string,
 	charmStorage internalcharm.Storage,
 	modelStoragePools internal.ModelStoragePools,
-) internal.ApplyApplicationStorageDirectiveArg {
+) internal.CreateApplicationStorageDirectiveArg {
 
-	arg := internal.ApplyApplicationStorageDirectiveArg{
+	arg := internal.CreateApplicationStorageDirectiveArg{
 		Name: domainstorage.Name(storageName),
 	}
 	// Set count.
@@ -485,4 +439,105 @@ func createApplyApplicationStorageDirectiveArg(
 		arg.PoolUUID = *modelStoragePools.FilesystemPoolUUID
 	}
 	return arg
+}
+
+// ValidateApplicationStorageDirectives performs a sanity check on the
+// directives for the application to make sure they are in a sane state to be
+// persisted to the state layer.
+//
+// The following errors may be returned:
+// - [applicationerrors.MissingStorageDirective] when one or more storage
+// directives are missing that are required by the charm.
+func ValidateApplicationStorageDirectives(
+	charmStorageDefs map[string]internalcharm.Storage,
+	directives []internal.CreateApplicationStorageDirectiveArg,
+) error {
+	// seenDirectives acts as a sanity check to see if a directive by a name has
+	// been witnessed.
+	seenDirectives := map[string]struct{}{}
+	for _, directive := range directives {
+		charmStorageDef, exists := charmStorageDefs[directive.Name.String()]
+		if !exists {
+			return errors.Errorf(
+				"invalid storage directive, charm has no storage %q",
+				directive.Name,
+			)
+		}
+
+		if _, seen := seenDirectives[directive.Name.String()]; seen {
+			return errors.Errorf(
+				"duplicate storage directive for %q exists", directive.Name,
+			)
+		}
+		seenDirectives[directive.Name.String()] = struct{}{}
+
+		err := validateApplicationStorageDirective(charmStorageDef, directive)
+		if err != nil {
+			return errors.Capture(err)
+		}
+	}
+
+	// This is a sanity to check to make sure that for each required storage in
+	// the charm there exists a directive for it.
+	for charmStorageName, charmStorageDef := range charmStorageDefs {
+		if charmStorageDef.CountMin == 0 {
+			// We skip storage definitions that don't require at least one
+			// storage instance. If the directive is missing that is fine.
+			continue
+		}
+
+		if _, seen := seenDirectives[charmStorageName]; !seen {
+			return errors.Errorf(
+				"missing storage directive for charm storage %q",
+				charmStorageName,
+			).Add(applicationerrors.MissingStorageDirective)
+		}
+	}
+	return nil
+}
+
+// validateApplicationStorageDirective checks a single storage directive against
+// a charm storage definition. This checks the definition is inline with the
+// expectations of the charm storage definition.
+func validateApplicationStorageDirective(
+	charmStorageDef internalcharm.Storage,
+	directive internal.CreateApplicationStorageDirectiveArg,
+) error {
+	minCount := uint32(0)
+	if charmStorageDef.CountMin > 0 {
+		minCount = uint32(charmStorageDef.CountMin)
+	}
+	maxCount := uint32(math.MaxUint32)
+	if charmStorageDef.CountMax > 0 {
+		maxCount = uint32(charmStorageDef.CountMax)
+	}
+
+	if directive.Count < minCount {
+		return errors.Errorf(
+			"charm requires min %q storage %q instances, %d specified",
+			minCount, directive.Name, directive.Count,
+		)
+	}
+	if directive.Count > maxCount {
+		return errors.Errorf(
+			"charm requires at most %d instances of storage %q, %d specified",
+			maxCount, directive.Name, directive.Count,
+		)
+	}
+
+	if directive.Size < charmStorageDef.MinimumSize {
+		return errors.Errorf(
+			"storage directive %q must be at least of size %d defined by the charm",
+			directive.Name, charmStorageDef.MinimumSize,
+		)
+	}
+
+	if err := directive.PoolUUID.Validate(); err != nil {
+		return errors.Errorf(
+			"storage directive %q pool uuid is not valid: %w",
+			directive.Name, err,
+		)
+	}
+
+	return nil
 }

--- a/domain/application/service/storage/directive_test.go
+++ b/domain/application/service/storage/directive_test.go
@@ -347,10 +347,12 @@ func (s *directiveSuite) TestMakeStorageDirectiveFromApplicationArg(c *tc.C) {
 	c.Assert(gotDirectives, tc.SameContents, expected)
 }
 
-// TestReconcileUpdatedCharmStorageDirectiveNoChanges tests that when existing
+// TestReconcileStorageDirectiveAgainstCharmStorageNoChanges tests that when existing
 // storage directives match new charm storage exactly, no changes are proposed.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveNoChanges(c *tc.C) {
-	modelStoragePools := makeModelStoragePools(c)
+func (s *directiveSuite) TestReconcileStorageDirectiveAgainstCharmStorageNoChanges(c *tc.C) {
+	defer s.setupMocks(c.T).Finish()
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
+
 	existingStorageDirectives := []domainapplication.StorageDirective{
 		{
 			CharmStorageType: domainapplicationcharm.StorageFilesystem,
@@ -369,19 +371,32 @@ func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveNoChanges(c *t
 		},
 	}
 
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	modelStoragePools := makeModelStoragePools(c)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
+
+	toCreate, toUpdate, err := svc.ReconcileStorageDirectivesAgainstCharmStorage(
+		c.Context(), existingStorageDirectives, newCharmStorages,
 	)
 
 	c.Assert(err, tc.IsNil)
-	c.Assert(toApply, tc.HasLen, 0)
-	c.Assert(toDelete, tc.HasLen, 0)
+	c.Assert(toCreate, tc.HasLen, 0)
+
+	// There should be an update to refresh the charmID even no directive value has changed.
+	c.Assert(toUpdate, tc.SameContents, []internal.UpdateApplicationStorageDirectiveArg{
+		{
+			Name:  "data",
+			Size:  1024,
+			Count: 1,
+		},
+	})
 }
 
-// TestReconcileUpdatedCharmStorageDirectiveIncreaseSize tests that when new
+// TestReconcileStorageDirectiveAgainstCharmStorageIncreaseSize tests that when new
 // charm storage minimum size is higher than existing, the size is increased.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveIncreaseSize(c *tc.C) {
-	modelStoragePools := makeModelStoragePools(c)
+func (s *directiveSuite) TestReconcileStorageDirectiveAgainstCharmStorageIncreaseSize(c *tc.C) {
+	defer s.setupMocks(c.T).Finish()
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
+
 	existingStorageDirectives := []domainapplication.StorageDirective{
 		{
 			CharmStorageType: domainapplicationcharm.StorageBlock,
@@ -400,21 +415,31 @@ func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveIncreaseSize(c
 		},
 	}
 
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	modelStoragePools := makeModelStoragePools(c)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
+
+	toCreate, toUpdate, err := svc.ReconcileStorageDirectivesAgainstCharmStorage(
+		c.Context(), existingStorageDirectives, newCharmStorages,
 	)
 
 	c.Assert(err, tc.IsNil)
-	c.Assert(toApply, tc.HasLen, 1)
-	c.Assert(toApply[0].Size, tc.Equals, uint64(2048))
-	c.Assert(toApply[0].Name, tc.Equals, domainstorage.Name("data"))
-	c.Assert(toDelete, tc.HasLen, 0)
+	c.Assert(toCreate, tc.HasLen, 0)
+	c.Assert(toUpdate, tc.SameContents, []internal.UpdateApplicationStorageDirectiveArg{
+		{
+			Name:  "data",
+			Size:  2048,
+			Count: 1,
+		},
+	})
 }
 
-// TestReconcileUpdatedCharmStorageDirectiveNoSizeChange tests that when existing
-// storage size is already above new charm minimum, no size change occurs.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveNoSizeChange(c *tc.C) {
-	modelStoragePools := makeModelStoragePools(c)
+// TestReconcileStorageDirectiveAgainstCharmStorageNoSizeChange tests that when existing
+// storage size is already above new charm minimum, no size change occurs. However,
+// there will still be an update to the charmID.
+func (s *directiveSuite) TestReconcileStorageDirectiveAgainstCharmStorageNoSizeChange(c *tc.C) {
+	defer s.setupMocks(c.T).Finish()
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
+
 	existingStorageDirectives := []domainapplication.StorageDirective{
 		{
 			CharmStorageType: domainapplicationcharm.StorageBlock,
@@ -433,19 +458,32 @@ func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveNoSizeChange(c
 		},
 	}
 
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	modelStoragePools := makeModelStoragePools(c)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
+
+	toCreate, toUpdate, err := svc.ReconcileStorageDirectivesAgainstCharmStorage(
+		c.Context(), existingStorageDirectives, newCharmStorages,
 	)
 
 	c.Assert(err, tc.IsNil)
-	c.Assert(toApply, tc.HasLen, 0)
-	c.Assert(toDelete, tc.HasLen, 0)
+	c.Assert(toCreate, tc.HasLen, 0)
+
+	// There should be an update to refresh the charmID even no directive value has changed.
+	c.Assert(toUpdate, tc.SameContents, []internal.UpdateApplicationStorageDirectiveArg{
+		{
+			Name:  "data",
+			Size:  4096,
+			Count: 1,
+		},
+	})
 }
 
-// TestReconcileUpdatedCharmStorageDirectiveIncreaseCount tests that when new
+// TestReconcileStorageDirectiveAgainstCharmStorageIncreaseCount tests that when new
 // charm storage minimum count is higher than existing, the count is increased.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveIncreaseCount(c *tc.C) {
-	modelStoragePools := makeModelStoragePools(c)
+func (s *directiveSuite) TestReconcileStorageDirectiveAgainstCharmStorageIncreaseCount(c *tc.C) {
+	defer s.setupMocks(c.T).Finish()
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
+
 	existingStorageDirectives := []domainapplication.StorageDirective{
 		{
 			CharmStorageType: domainapplicationcharm.StorageBlock,
@@ -464,21 +502,30 @@ func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveIncreaseCount(
 		},
 	}
 
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	modelStoragePools := makeModelStoragePools(c)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
+
+	toCreate, toUpdate, err := svc.ReconcileStorageDirectivesAgainstCharmStorage(
+		c.Context(), existingStorageDirectives, newCharmStorages,
 	)
 
 	c.Assert(err, tc.IsNil)
-	c.Assert(toApply, tc.HasLen, 1)
-	c.Assert(toApply[0].Count, tc.Equals, uint32(3))
-	c.Assert(toApply[0].Name, tc.Equals, domainstorage.Name("data"))
-	c.Assert(toDelete, tc.HasLen, 0)
+	c.Assert(toCreate, tc.HasLen, 0)
+	c.Assert(toUpdate, tc.SameContents, []internal.UpdateApplicationStorageDirectiveArg{
+		{
+			Name:  "data",
+			Size:  1024,
+			Count: 3,
+		},
+	})
 }
 
-// TestReconcileUpdatedCharmStorageDirectiveDecreaseCount tests that when new
+// TestReconcileStorageDirectiveAgainstCharmStorageDecreaseCount tests that when new
 // charm storage maximum count is lower than existing, the count is decreased.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveDecreaseCount(c *tc.C) {
-	modelStoragePools := makeModelStoragePools(c)
+func (s *directiveSuite) TestReconcileStorageDirectiveAgainstCharmStorageDecreaseCount(c *tc.C) {
+	defer s.setupMocks(c.T).Finish()
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
+
 	existingStorageDirectives := []domainapplication.StorageDirective{
 		{
 			CharmStorageType: domainapplicationcharm.StorageBlock,
@@ -497,59 +544,29 @@ func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveDecreaseCount(
 		},
 	}
 
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
-	)
-
-	c.Assert(err, tc.IsNil)
-	c.Assert(toApply, tc.HasLen, 1)
-	c.Assert(toApply[0].Count, tc.Equals, uint32(4))
-	c.Assert(toApply[0].Name, tc.Equals, domainstorage.Name("data"))
-	c.Assert(toDelete, tc.HasLen, 0)
-}
-
-// TestReconcileUpdatedCharmStorageDirectiveDeleteOldStorage tests that storage
-// present in existing directives but not in new charm is marked for deletion.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveDeleteOldStorage(c *tc.C) {
 	modelStoragePools := makeModelStoragePools(c)
-	existingStorageDirectives := []domainapplication.StorageDirective{
-		{
-			CharmStorageType: domainapplicationcharm.StorageBlock,
-			Name:             "data",
-			Count:            1,
-			Size:             1024,
-		},
-		{
-			CharmStorageType: domainapplicationcharm.StorageBlock,
-			Name:             "logs",
-			Count:            1,
-			Size:             512,
-		},
-	}
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
 
-	newCharmStorages := map[string]internalcharm.Storage{
-		"data": {
-			Type:        internalcharm.StorageBlock,
-			CountMin:    1,
-			CountMax:    1,
-			MinimumSize: 1024,
-		},
-	}
-
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	toCreate, toUpdate, err := svc.ReconcileStorageDirectivesAgainstCharmStorage(
+		c.Context(), existingStorageDirectives, newCharmStorages,
 	)
 
 	c.Assert(err, tc.IsNil)
-	c.Assert(toApply, tc.HasLen, 0)
-	c.Assert(toDelete, tc.HasLen, 1)
-	c.Assert(toDelete[0], tc.Equals, "logs")
+	c.Assert(toCreate, tc.HasLen, 0)
+	c.Assert(toUpdate, tc.SameContents, []internal.UpdateApplicationStorageDirectiveArg{
+		{
+			Name:  "data",
+			Size:  1024,
+			Count: 4,
+		},
+	})
 }
 
-// TestReconcileUpdatedCharmStorageDirectiveAddNewStorage tests that storage
+// TestReconcileStorageDirectiveAgainstCharmStorageAddNewStorage tests that storage
 // present in new charm but not in existing directives is added.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveAddNewStorage(c *tc.C) {
-	modelStoragePools := makeModelStoragePools(c)
+func (s *directiveSuite) TestReconcileStorageDirectiveAgainstCharmStorageAddNewStorage(c *tc.C) {
+	defer s.setupMocks(c.T).Finish()
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
 
 	existingStorageDirectives := []domainapplication.StorageDirective{
 		{
@@ -575,60 +592,32 @@ func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveAddNewStorage(
 		},
 	}
 
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	modelStoragePools := makeModelStoragePools(c)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
+
+	toCreate, toUpdate, err := svc.ReconcileStorageDirectivesAgainstCharmStorage(
+		c.Context(), existingStorageDirectives, newCharmStorages,
 	)
 
 	c.Assert(err, tc.IsNil)
-	c.Assert(toApply, tc.HasLen, 1)
-	c.Assert(string(toApply[0].Name), tc.Equals, "logs")
-	c.Assert(toApply[0].Count, tc.Equals, uint32(2))
-	c.Assert(toApply[0].Size, tc.Equals, uint64(512))
-	c.Assert(toApply[0].PoolUUID, tc.Equals, *modelStoragePools.FilesystemPoolUUID)
-	c.Assert(toDelete, tc.HasLen, 0)
-}
-
-// TestReconcileUpdatedCharmStorageDirectiveIncompatibleType tests that when
-// storage type changes between existing and new charm, an error is returned.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveIncompatibleType(c *tc.C) {
-	modelStoragePools := makeModelStoragePools(c)
-	existingStorageDirectives := []domainapplication.StorageDirective{
+	c.Assert(toCreate, tc.SameContents, []internal.CreateApplicationStorageDirectiveArg{
 		{
-			Name:             "data",
-			Count:            1,
-			CharmStorageType: domainapplicationcharm.StorageBlock,
-			Size:             1024,
+			Name:     domainstorage.Name("logs"),
+			Count:    2,
+			Size:     512,
+			PoolUUID: *modelStoragePools.FilesystemPoolUUID,
 		},
-	}
+	})
 
-	newCharmStorages := map[string]internalcharm.Storage{
-		"data": {
-			Type:        internalcharm.StorageFilesystem,
-			CountMin:    1,
-			CountMax:    1,
-			MinimumSize: 1024,
-		},
-	}
-
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
-	)
-
-	c.Assert(toApply, tc.IsNil)
-	c.Assert(toDelete, tc.IsNil)
-	c.Assert(err, tc.ErrorMatches, `.*existing storage "data" type changed from "block" to "filesystem".*`)
-	var incompatibleErr *applicationerrors.CharmStorageTypeChanged
-	c.Assert(errors.As(err, &incompatibleErr), tc.Equals, true)
-	c.Assert(incompatibleErr.StorageName, tc.Equals, "data")
-	c.Assert(incompatibleErr.OldType, tc.Equals, "block")
-	c.Assert(incompatibleErr.NewType, tc.Equals, "filesystem")
+	// Update of charmID even though no value changed.
+	c.Assert(toUpdate, tc.HasLen, 1)
 }
 
-// TestReconcileUpdatedCharmStorageDirectiveComplexReconciliation tests a
-// combination of operations: update storage count and size, delete old storage,
-// and add new storage.
-func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveComplexReconciliation(c *tc.C) {
-	modelStoragePools := makeModelStoragePools(c)
+// TestReconcileStorageDirectiveAgainstCharmStorageComplexReconciliation tests a
+// combination of operations: update storage count and size and add new storage.
+func (s *directiveSuite) TestReconcileStorageDirectiveAgainstCharmStorageComplexReconciliation(c *tc.C) {
+	defer s.setupMocks(c.T).Finish()
+	svc := NewService(s.state, s.poolProvider, loggertesting.WrapCheckLog(c))
 
 	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
 
@@ -639,12 +628,6 @@ func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveComplexReconci
 			Count:            1,
 			Size:             512,
 			PoolUUID:         poolUUID,
-		},
-		{
-			CharmStorageType: domainapplicationcharm.StorageBlock,
-			Name:             "cache",
-			Count:            1,
-			Size:             256,
 		},
 	}
 
@@ -663,32 +646,28 @@ func (s *directiveSuite) TestReconcileUpdatedCharmStorageDirectiveComplexReconci
 		},
 	}
 
-	toApply, toDelete, err := ReconcileUpdatedCharmStorageDirective(
-		newCharmStorages, existingStorageDirectives, modelStoragePools,
+	modelStoragePools := makeModelStoragePools(c)
+	s.state.EXPECT().GetModelStoragePools(gomock.Any()).Return(modelStoragePools, nil)
+
+	toCreate, toUpdate, err := svc.ReconcileStorageDirectivesAgainstCharmStorage(
+		c.Context(), existingStorageDirectives, newCharmStorages,
 	)
 
 	c.Assert(err, tc.IsNil)
-	c.Assert(toApply, tc.HasLen, 2)
-	c.Assert(toDelete, tc.HasLen, 1)
-	c.Assert(toDelete[0], tc.Equals, "cache")
-
-	// Check for updated "data" storage
-	var dataUpdate, logsCreate *internal.ApplyApplicationStorageDirectiveArg
-	for i := range toApply {
-		if string(toApply[i].Name) == "data" {
-			dataUpdate = &toApply[i]
-		} else if string(toApply[i].Name) == "logs" {
-			logsCreate = &toApply[i]
-		}
-	}
-
-	c.Assert(dataUpdate, tc.Not(tc.IsNil))
-	c.Assert(dataUpdate.Count, tc.Equals, uint32(2))
-	c.Assert(dataUpdate.Size, tc.Equals, uint64(1024))
-	c.Assert(dataUpdate.PoolUUID, tc.Equals, poolUUID)
-
-	c.Assert(logsCreate, tc.Not(tc.IsNil))
-	c.Assert(logsCreate.Count, tc.Equals, uint32(1))
-	c.Assert(logsCreate.Size, tc.Equals, uint64(512))
-	c.Assert(logsCreate.PoolUUID, tc.Equals, *modelStoragePools.FilesystemPoolUUID)
+	c.Assert(toCreate, tc.SameContents, []internal.CreateApplicationStorageDirectiveArg{
+		{
+			Name:     domainstorage.Name("logs"),
+			Count:    1,
+			Size:     512,
+			PoolUUID: *modelStoragePools.FilesystemPoolUUID,
+		},
+	})
+	c.Assert(toUpdate, tc.SameContents, []internal.UpdateApplicationStorageDirectiveArg{
+		{
+			Name:     "data",
+			Count:    2,
+			Size:     1024,
+			PoolUUID: poolUUID,
+		},
+	})
 }

--- a/domain/application/service/storage_mock_test.go
+++ b/domain/application/service/storage_mock_test.go
@@ -19,7 +19,6 @@ import (
 	unit "github.com/juju/juju/core/unit"
 	application0 "github.com/juju/juju/domain/application"
 	internal "github.com/juju/juju/domain/application/internal"
-	storage0 "github.com/juju/juju/domain/application/service/storage"
 	charm "github.com/juju/juju/domain/deployment/charm"
 	network "github.com/juju/juju/domain/network"
 	gomock "go.uber.org/mock/gomock"
@@ -166,7 +165,7 @@ func (c *MockStorageServiceGetUnitStorageDirectiveByNameCall) DoAndReturn(f func
 }
 
 // MakeApplicationStorageDirectiveArgs mocks base method.
-func (m *MockStorageService) MakeApplicationStorageDirectiveArgs(arg0 context.Context, arg1 map[string]storage0.StorageDirectiveOverride, arg2 map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, error) {
+func (m *MockStorageService) MakeApplicationStorageDirectiveArgs(arg0 context.Context, arg1 map[string]application0.ApplicationStorageDirectiveOverride, arg2 map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeApplicationStorageDirectiveArgs", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]internal.CreateStorageDirectiveArg)
@@ -193,13 +192,13 @@ func (c *MockStorageServiceMakeApplicationStorageDirectiveArgsCall) Return(arg0 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceMakeApplicationStorageDirectiveArgsCall) Do(f func(context.Context, map[string]storage0.StorageDirectiveOverride, map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, error)) *MockStorageServiceMakeApplicationStorageDirectiveArgsCall {
+func (c *MockStorageServiceMakeApplicationStorageDirectiveArgsCall) Do(f func(context.Context, map[string]application0.ApplicationStorageDirectiveOverride, map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, error)) *MockStorageServiceMakeApplicationStorageDirectiveArgsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceMakeApplicationStorageDirectiveArgsCall) DoAndReturn(f func(context.Context, map[string]storage0.StorageDirectiveOverride, map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, error)) *MockStorageServiceMakeApplicationStorageDirectiveArgsCall {
+func (c *MockStorageServiceMakeApplicationStorageDirectiveArgsCall) DoAndReturn(f func(context.Context, map[string]application0.ApplicationStorageDirectiveOverride, map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, error)) *MockStorageServiceMakeApplicationStorageDirectiveArgsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -399,8 +398,48 @@ func (c *MockStorageServiceMakeUnitStorageArgsCall) DoAndReturn(f func(context.C
 	return c
 }
 
+// ReconcileStorageDirectivesAgainstCharmStorage mocks base method.
+func (m *MockStorageService) ReconcileStorageDirectivesAgainstCharmStorage(arg0 context.Context, arg1 []application0.StorageDirective, arg2 map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, []internal.CreateStorageDirectiveArg, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileStorageDirectivesAgainstCharmStorage", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]internal.CreateStorageDirectiveArg)
+	ret1, _ := ret[1].([]internal.CreateStorageDirectiveArg)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ReconcileStorageDirectivesAgainstCharmStorage indicates an expected call of ReconcileStorageDirectivesAgainstCharmStorage.
+func (mr *MockStorageServiceMockRecorder) ReconcileStorageDirectivesAgainstCharmStorage(arg0, arg1, arg2 any) *MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileStorageDirectivesAgainstCharmStorage", reflect.TypeOf((*MockStorageService)(nil).ReconcileStorageDirectivesAgainstCharmStorage), arg0, arg1, arg2)
+	return &MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall{Call: call}
+}
+
+// MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall wrap *gomock.Call
+type MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall) Return(arg0, arg1 []internal.CreateStorageDirectiveArg, arg2 error) *MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall) Do(f func(context.Context, []application0.StorageDirective, map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, []internal.CreateStorageDirectiveArg, error)) *MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall) DoAndReturn(f func(context.Context, []application0.StorageDirective, map[string]charm.Storage) ([]internal.CreateStorageDirectiveArg, []internal.CreateStorageDirectiveArg, error)) *MockStorageServiceReconcileStorageDirectivesAgainstCharmStorageCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ValidateApplicationStorageDirectiveOverrides mocks base method.
-func (m *MockStorageService) ValidateApplicationStorageDirectiveOverrides(arg0 context.Context, arg1 map[string]charm.Storage, arg2 map[string]storage0.StorageDirectiveOverride) error {
+func (m *MockStorageService) ValidateApplicationStorageDirectiveOverrides(arg0 context.Context, arg1 map[string]charm.Storage, arg2 map[string]application0.ApplicationStorageDirectiveOverride) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateApplicationStorageDirectiveOverrides", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -426,13 +465,13 @@ func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) Ret
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) Do(f func(context.Context, map[string]charm.Storage, map[string]storage0.StorageDirectiveOverride) error) *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall {
+func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) Do(f func(context.Context, map[string]charm.Storage, map[string]application0.ApplicationStorageDirectiveOverride) error) *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) DoAndReturn(f func(context.Context, map[string]charm.Storage, map[string]storage0.StorageDirectiveOverride) error) *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall {
+func (c *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall) DoAndReturn(f func(context.Context, map[string]charm.Storage, map[string]application0.ApplicationStorageDirectiveOverride) error) *MockStorageServiceValidateApplicationStorageDirectiveOverridesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1696,7 +1696,15 @@ WHERE  uuid = $entityUUID.uuid
 			return errors.Capture(err)
 		}
 
-		//TODO(storage) - upsert storage directive for app
+		// Update storage directives for the new charm.
+		if err := st.updateApplicationStorageDirectives(ctx, tx, appID, chID.String(), params.StorageDirectivesToUpdate); err != nil {
+			return errors.Errorf("updating storage directives: %w", err)
+		}
+
+		// Insert storage directives for the new charm.
+		if err := st.insertApplicationStorageDirectives(ctx, tx, appID.String(), chID.String(), params.StorageDirectivesToCreate); err != nil {
+			return errors.Errorf("inserting storage directives: %w", err)
+		}
 
 		bindings := transform.Map(params.EndpointBindings, func(k string, v network.SpaceName) (string, string) {
 			return k, v.String()

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -669,6 +669,64 @@ VALUES ($insertApplicationStorageDirective.*)
 	return nil
 }
 
+// updateApplicationStorageDirectives updates the storage directives and charmUUID
+// for an application based on the provided overrides.
+// This is used during charm refresh to reconcile storage requirements.
+func (st *State) updateApplicationStorageDirectives(
+	ctx context.Context,
+	tx *sqlair.TX,
+	appUUID coreapplication.UUID,
+	charmUUID string,
+	updates []internal.UpdateApplicationStorageDirectiveArg,
+) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	updateStmt, err := st.Prepare(`
+UPDATE application_storage_directive
+SET    count = $updateApplicationStorageDirective.count,
+       size_mib = $updateApplicationStorageDirective.size_mib,
+	   storage_pool_uuid = $updateApplicationStorageDirective.storage_pool_uuid,
+	   charm_uuid = $updateApplicationStorageDirective.charm_uuid
+WHERE  application_uuid = $updateApplicationStorageDirective.application_uuid
+AND    storage_name = $updateApplicationStorageDirective.storage_name
+`, updateApplicationStorageDirective{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	for _, override := range updates {
+		input := updateApplicationStorageDirective{
+			ApplicationUUID: appUUID.String(),
+			CharmUUID:       charmUUID,
+			Count:           override.Count,
+			SizeMiB:         override.Size,
+			StorageName:     override.Name.String(),
+			StoragePoolUUID: override.PoolUUID.String(),
+		}
+		var outcome sqlair.Outcome
+		if err := tx.Query(ctx, updateStmt, input).Get(&outcome); err != nil {
+			return errors.Errorf("updating storage directives for application: %w", err)
+		}
+		result := outcome.Result()
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return errors.Errorf("getting number of affected rows: %w", err)
+		}
+		// We should always have an update if the storage directive is present,
+		// since charmUUID should always be updated.
+		if affected == 0 {
+			return errors.Errorf(
+				"missing storage directive for charm storage %q",
+				input.StorageName,
+			).Add(applicationerrors.MissingStorageDirective)
+		}
+	}
+
+	return nil
+}
+
 func (st *State) setFilesystemProviderIDs(
 	ctx context.Context, tx *sqlair.TX,
 	providerIDs map[domainstorage.FilesystemUUID]string,

--- a/domain/application/state/storage_test.go
+++ b/domain/application/state/storage_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	stdtesting "testing"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 
@@ -281,6 +282,195 @@ WHERE application_uuid = ? AND charm_uuid = ?`, appUUID, charmUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(foundCharmStorage, tc.SameContents, chStorage)
 	c.Check(foundAppStorage, tc.SameContents, directives)
+}
+
+func (s *applicationStateSuite) TestUpdateApplicationStorageDirectives(c *tc.C) {
+	ctx := c.Context()
+
+	poolUUID1 := s.createStoragePool(c, "pool-a", "lxd")
+	poolUUID2 := s.createStoragePool(c, "pool-b", "ebs")
+
+	// Setup charm with 2 storages.
+	chStorage := []charm.Storage{{
+		Name:        "database",
+		Type:        "block",
+		CountMin:    1,
+		CountMax:    3,
+		MinimumSize: 10,
+	}, {
+		Name:        "logs",
+		Type:        "filesystem",
+		CountMin:    1,
+		CountMax:    2,
+		MinimumSize: 5,
+	}}
+
+	// Setup application with 2 storage directives.
+	directives := []internal.CreateApplicationStorageDirectiveArg{
+		{
+			Name:     "database",
+			PoolUUID: poolUUID1,
+			Size:     10,
+			Count:    1,
+		},
+		{
+			Name:     "logs",
+			PoolUUID: poolUUID2,
+			Size:     20,
+			Count:    2,
+		},
+	}
+
+	// Create application with the above directives and charm storages.
+	appUUID, _, err := s.state.CreateIAASApplication(
+		ctx,
+		"charm-name",
+		s.addIAASApplicationArgForStorage(c, "charm-name", chStorage, directives),
+		nil,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Get charmUUID for the application.
+	var charmUUID string
+	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		charmUUID, err = s.state.getCharmIDByApplicationUUID(c.Context(), tx, appUUID.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Update storage directives for the application.
+	overrides := []internal.UpdateApplicationStorageDirectiveArg{
+		{
+			Name:     "database",
+			PoolUUID: poolUUID2,
+			Size:     99,
+			Count:    3,
+		},
+		{
+			Name:     "logs",
+			PoolUUID: poolUUID1,
+			Size:     5,
+			Count:    1,
+		},
+	}
+	err = s.TxnRunner().Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return s.state.updateApplicationStorageDirectives(ctx, tx, appUUID, charmUUID, overrides)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Verify that the storage directives have been updated.
+	applicationStorageDirectives, err := s.state.GetApplicationStorageDirectives(ctx, appUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(applicationStorageDirectives, tc.SameContents, []application.StorageDirective{
+		{
+			CharmMetadataName: "charm-name",
+			CharmStorageType:  charm.StorageBlock,
+			Name:              "database",
+			PoolUUID:          poolUUID2,
+			Size:              99,
+			Count:             3,
+			MaxCount:          3,
+		},
+		{
+			CharmMetadataName: "charm-name",
+			CharmStorageType:  charm.StorageFilesystem,
+			Name:              "logs",
+			PoolUUID:          poolUUID1,
+			Size:              5,
+			Count:             1,
+			MaxCount:          2,
+		},
+	})
+}
+
+func (s *applicationStateSuite) TestUpdateApplicationStorageDirectivesMissingStorage(c *tc.C) {
+	ctx := c.Context()
+
+	poolUUID1 := s.createStoragePool(c, "pool-a", "lxd")
+	poolUUID2 := s.createStoragePool(c, "pool-b", "ebs")
+
+	// Setup charm with 3 storages.
+	chStorage := []charm.Storage{{
+		Name:        "database",
+		Type:        "block",
+		CountMin:    1,
+		CountMax:    3,
+		MinimumSize: 10,
+	}, {
+		Name:        "logs",
+		Type:        "filesystem",
+		CountMin:    1,
+		CountMax:    2,
+		MinimumSize: 5,
+	}, {
+		Name:        "cache",
+		Type:        "block",
+		CountMin:    1,
+		CountMax:    1,
+		MinimumSize: 1,
+	}}
+
+	// Setup application with 2 storage directives.
+	directives := []internal.CreateApplicationStorageDirectiveArg{
+		{
+			Name:     "database",
+			PoolUUID: poolUUID1,
+			Size:     10,
+			Count:    1,
+		},
+		{
+			Name:     "logs",
+			PoolUUID: poolUUID2,
+			Size:     20,
+			Count:    2,
+		},
+	}
+
+	// Create application with the above directives and charm storages.
+	appUUID, _, err := s.state.CreateIAASApplication(
+		ctx,
+		"charm-name",
+		s.addIAASApplicationArgForStorage(c, "charm-name", chStorage, directives),
+		nil,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Get charmUUID for the application.
+	var charmUUID string
+	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		charmUUID, err = s.state.getCharmIDByApplicationUUID(c.Context(), tx, appUUID.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Attempt to update 3 storage directives for the application, even though the application currently only has 2.
+	// This provides the situation where a storage directive is manually removed.
+	overrides := []internal.UpdateApplicationStorageDirectiveArg{
+		{
+			Name:     "database",
+			PoolUUID: poolUUID2,
+			Size:     99,
+			Count:    3,
+		},
+		{
+			Name:     "logs",
+			PoolUUID: poolUUID1,
+			Size:     5,
+			Count:    1,
+		},
+		{
+			Name:     "cache",
+			PoolUUID: poolUUID2,
+			Size:     1,
+			Count:    1,
+		},
+	}
+	err = s.TxnRunner().Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return s.state.updateApplicationStorageDirectives(ctx, tx, appUUID, charmUUID, overrides)
+	})
+	c.Assert(err, tc.ErrorMatches, `missing storage directive for charm storage "cache"`)
 }
 
 // TestGetProviderTypeOfPoolNotFound tests that trying to get the provider type

--- a/domain/application/state/storagetypes.go
+++ b/domain/application/state/storagetypes.go
@@ -174,3 +174,14 @@ type modelStoragePools struct {
 	StorageKindID   int    `db:"storage_kind_id"`
 	StoragePoolUUID string `db:"storage_pool_uuid"`
 }
+
+// updateApplicationStorageDirective represents the data needed to update
+// an application storage directive during charm refresh.
+type updateApplicationStorageDirective struct {
+	ApplicationUUID string `db:"application_uuid"`
+	CharmUUID       string `db:"charm_uuid"`
+	Count           uint32 `db:"count"`
+	SizeMiB         uint64 `db:"size_mib"`
+	StorageName     string `db:"storage_name"`
+	StoragePoolUUID string `db:"storage_pool_uuid"`
+}

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/status"
+	domainstorage "github.com/juju/juju/domain/storage"
 	internalstorage "github.com/juju/juju/internal/storage"
 )
 
@@ -475,6 +476,10 @@ type SetCharmParams struct {
 	// EndpointBindings is an operator-defined map of endpoint names to
 	// space names that should be merged with any existing bindings.
 	EndpointBindings map[string]network.SpaceName
+
+	// StorageDirectiveOverrides is a map of storage names to storage directives to
+	// update during the upgrade.
+	StorageDirectiveOverrides map[string]ApplicationStorageDirectiveOverride
 }
 
 // SetCharmParams contains the parameters for updating
@@ -488,17 +493,13 @@ type SetCharmStateParams struct {
 	// space names that should be merged with any existing bindings.
 	EndpointBindings map[string]network.SpaceName
 
-	// StorageDirectivesToApply contains storage directives that need to be
-	// applied based on the new charm's storage requirements.
-	StorageDirectivesToApply []internal.ApplyApplicationStorageDirectiveArg
+	// StorageDirectivesToCreate contains storage directives that need to be
+	// created based on the new charm's storage requirements.
+	StorageDirectivesToCreate []internal.CreateApplicationStorageDirectiveArg
 
-	// StorageDirectivesToDelete contains the names of storage directives that
-	// should be removed because the storage is no longer in the charm.
-	// These are tracked separately from StorageDirectivesToApply because the
-	// apply list may not contain the complete set of storage directives.
-	// Splitting them this way avoids unnecessary database churn and watcher
-	// events that would occur if we replaced all directives on every update.
-	StorageDirectivesToDelete []string
+	// StorageDirectivesToUpdate contains storage directives that need to be
+	// applied based on the new charm's storage requirements.
+	StorageDirectivesToUpdate []internal.UpdateApplicationStorageDirectiveArg
 }
 
 // ApplicationDetails contains details about an application.
@@ -507,4 +508,23 @@ type ApplicationDetails struct {
 	Life                   life.Life
 	Name                   string
 	IsApplicationSynthetic bool
+}
+
+// ApplicationStorageDirectiveOverride represents override instructions in the application
+// domain for application storage directives to alter the default
+// values a new application will receive.
+type ApplicationStorageDirectiveOverride struct {
+	// Count is the number of storage instances to create for each unit. This
+	// value must be greater or equal to the minimum defined by the charm. This
+	// value must also be less or equal to the maximum defined by the charm.
+	Count *uint32
+
+	// PoolUUID defines the storage pool to use when provisioning storage for
+	// this directive.
+	PoolUUID *domainstorage.StoragePoolUUID
+
+	// Size defines the size of the storage to provision as a minimum value in
+	// MiB. What gets provisioned by the provider for each unit may be larger
+	// then this value.
+	Size *uint64
 }

--- a/domain/storage/service/state_mock_test.go
+++ b/domain/storage/service/state_mock_test.go
@@ -431,6 +431,45 @@ func (c *MockStateGetStoragePoolUUIDCall) DoAndReturn(f func(context.Context, st
 	return c
 }
 
+// GetStoragePoolUUIDsByName mocks base method.
+func (m *MockState) GetStoragePoolUUIDsByName(arg0 context.Context, arg1 []string) ([]storage.StoragePoolNameUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStoragePoolUUIDsByName", arg0, arg1)
+	ret0, _ := ret[0].([]storage.StoragePoolNameUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStoragePoolUUIDsByName indicates an expected call of GetStoragePoolUUIDsByName.
+func (mr *MockStateMockRecorder) GetStoragePoolUUIDsByName(arg0, arg1 any) *MockStateGetStoragePoolUUIDsByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolUUIDsByName", reflect.TypeOf((*MockState)(nil).GetStoragePoolUUIDsByName), arg0, arg1)
+	return &MockStateGetStoragePoolUUIDsByNameCall{Call: call}
+}
+
+// MockStateGetStoragePoolUUIDsByNameCall wrap *gomock.Call
+type MockStateGetStoragePoolUUIDsByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetStoragePoolUUIDsByNameCall) Return(arg0 []storage.StoragePoolNameUUID, arg1 error) *MockStateGetStoragePoolUUIDsByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetStoragePoolUUIDsByNameCall) Do(f func(context.Context, []string) ([]storage.StoragePoolNameUUID, error)) *MockStateGetStoragePoolUUIDsByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetStoragePoolUUIDsByNameCall) DoAndReturn(f func(context.Context, []string) ([]storage.StoragePoolNameUUID, error)) *MockStateGetStoragePoolUUIDsByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ImportFilesystemsIAAS mocks base method.
 func (m *MockState) ImportFilesystemsIAAS(arg0 context.Context, arg1 []internal.ImportFilesystemIAASArgs, arg2 []internal.ImportFilesystemAttachmentIAASArgs) error {
 	m.ctrl.T.Helper()
@@ -950,6 +989,45 @@ func (c *MockStoragePoolStateGetStoragePoolUUIDCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStoragePoolStateGetStoragePoolUUIDCall) DoAndReturn(f func(context.Context, string) (storage.StoragePoolUUID, error)) *MockStoragePoolStateGetStoragePoolUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetStoragePoolUUIDsByName mocks base method.
+func (m *MockStoragePoolState) GetStoragePoolUUIDsByName(arg0 context.Context, arg1 []string) ([]storage.StoragePoolNameUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStoragePoolUUIDsByName", arg0, arg1)
+	ret0, _ := ret[0].([]storage.StoragePoolNameUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStoragePoolUUIDsByName indicates an expected call of GetStoragePoolUUIDsByName.
+func (mr *MockStoragePoolStateMockRecorder) GetStoragePoolUUIDsByName(arg0, arg1 any) *MockStoragePoolStateGetStoragePoolUUIDsByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolUUIDsByName", reflect.TypeOf((*MockStoragePoolState)(nil).GetStoragePoolUUIDsByName), arg0, arg1)
+	return &MockStoragePoolStateGetStoragePoolUUIDsByNameCall{Call: call}
+}
+
+// MockStoragePoolStateGetStoragePoolUUIDsByNameCall wrap *gomock.Call
+type MockStoragePoolStateGetStoragePoolUUIDsByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStoragePoolStateGetStoragePoolUUIDsByNameCall) Return(arg0 []storage.StoragePoolNameUUID, arg1 error) *MockStoragePoolStateGetStoragePoolUUIDsByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStoragePoolStateGetStoragePoolUUIDsByNameCall) Do(f func(context.Context, []string) ([]storage.StoragePoolNameUUID, error)) *MockStoragePoolStateGetStoragePoolUUIDsByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStoragePoolStateGetStoragePoolUUIDsByNameCall) DoAndReturn(f func(context.Context, []string) ([]storage.StoragePoolNameUUID, error)) *MockStoragePoolStateGetStoragePoolUUIDsByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/storage/service/storagepool.go
+++ b/domain/storage/service/storagepool.go
@@ -87,6 +87,11 @@ type StoragePoolState interface {
 	// returns [domainstorageerrors.StoragePoolNotFound]. Supplying an empty slice
 	// results in a no-op.
 	SetModelStoragePools(ctx context.Context, pools []domainstorage.RecommendedStoragePoolArg) error
+
+	// GetStoragePoolUUIDsByName returns storage pool UUIDs keyed by pool name for
+	// the supplied names. Unknown names are omitted.
+	// If no names are specified, an empty map is returned without error.
+	GetStoragePoolUUIDsByName(ctx context.Context, names []string) ([]domainstorage.StoragePoolNameUUID, error)
 }
 
 // StoragePoolService defines a service for interacting with the underlying state.
@@ -527,6 +532,37 @@ func (s *StoragePoolService) GetStoragePoolUUID(ctx context.Context, name string
 		return "", errors.Capture(err)
 	}
 	return poolUUID, nil
+}
+
+// GetStoragePoolUUIDsByName returns storage pool UUIDs keyed by pool name for
+// the supplied names. Unknown names are omitted.
+// If no names are specified, an empty map is returned without error.
+func (s *StoragePoolService) GetStoragePoolUUIDsByName(
+	ctx context.Context,
+	names []string,
+) (map[string]domainstorage.StoragePoolUUID, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if len(names) == 0 {
+		return map[string]domainstorage.StoragePoolUUID{}, nil
+	}
+
+	if err := s.validateNameCriteria(names); err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	pools, err := s.st.GetStoragePoolUUIDsByName(ctx, names)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	result := make(map[string]domainstorage.StoragePoolUUID, len(pools))
+	for _, pool := range pools {
+		result[pool.Name] = domainstorage.StoragePoolUUID(pool.UUID)
+	}
+
+	return result, nil
 }
 
 // GetStoragePoolByName returns the storage pool with the specified name.

--- a/domain/storage/service/storagepool_test.go
+++ b/domain/storage/service/storagepool_test.go
@@ -443,6 +443,52 @@ func (s *storagePoolServiceSuite) TestListStoragePoolsByNamesInvalidNames(c *tc.
 	c.Assert(err, tc.ErrorMatches, `pool name "666invalid" not valid`)
 }
 
+func (s *storagePoolServiceSuite) TestGetStoragePoolUUIDsByName(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	sp := domainstorage.StoragePoolNameUUID{
+		UUID: "pool-uuid-1",
+		Name: "ebs-fast",
+	}
+
+	s.state.EXPECT().GetStoragePoolUUIDsByName(gomock.Any(), []string{"ebs-fast"}).
+		Return([]domainstorage.StoragePoolNameUUID{sp}, nil)
+
+	svc := StoragePoolService{
+		registryGetter: registryGetter{s.registry},
+		st:             s.state,
+	}
+	got, err := svc.GetStoragePoolUUIDsByName(c.Context(), []string{"ebs-fast"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(got, tc.DeepEquals, map[string]domainstorage.StoragePoolUUID{
+		sp.Name: domainstorage.StoragePoolUUID(sp.UUID),
+	})
+}
+
+func (s *storagePoolServiceSuite) TestGetStoragePoolUUIDsByNameEmptyArgs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	svc := StoragePoolService{
+		registryGetter: registryGetter{s.registry},
+		st:             s.state,
+	}
+	got, err := svc.GetStoragePoolUUIDsByName(c.Context(), []string{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(got, tc.DeepEquals, map[string]domainstorage.StoragePoolUUID{})
+}
+
+func (s *storagePoolServiceSuite) TestGetStoragePoolUUIDsByNameInvalidNames(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	svc := StoragePoolService{
+		registryGetter: registryGetter{s.registry},
+		st:             s.state,
+	}
+	_, err := svc.GetStoragePoolUUIDsByName(c.Context(), []string{"666invalid"})
+	c.Assert(err, tc.ErrorIs, domainstorageerrors.StoragePoolNameInvalid)
+	c.Assert(err, tc.ErrorMatches, `pool name "666invalid" not valid`)
+}
+
 func (s *storagePoolServiceSuite) TestListStoragePoolsByProviders(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	ctrl.Finish()

--- a/domain/storage/state/storagepool.go
+++ b/domain/storage/state/storagepool.go
@@ -821,3 +821,55 @@ WHERE  uuid IN ($poolUUIDs[:])
 
 	return len(storagePoolUUIDs) == dbVal.Count, nil
 }
+
+// GetStoragePoolUUIDsByName returns name/UUID pairs for storage pools matching
+// the supplied names.
+// If no names are specified, or no storage pools match the criteria,
+// an empty slice is returned without an error.
+func (st *State) GetStoragePoolUUIDsByName(
+	ctx context.Context,
+	names []string,
+) ([]domainstorage.StoragePoolNameUUID, error) {
+	if len(names) == 0 {
+		return []domainstorage.StoragePoolNameUUID{}, nil
+	}
+	spNames := storagePoolNames(names)
+
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	stmt, err := st.Prepare(`
+SELECT sp.name AS &StoragePoolNameUUID.name,
+       sp.uuid AS &StoragePoolNameUUID.uuid
+FROM   storage_pool sp
+WHERE  sp.name IN ($storagePoolNames[:])
+`, spNames, domainstorage.StoragePoolNameUUID{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var dbRows []domainstorage.StoragePoolNameUUID
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		qerr := tx.Query(ctx, stmt, spNames).GetAll(&dbRows)
+		if errors.Is(qerr, sqlair.ErrNoRows) {
+			return nil
+		}
+		return qerr
+	})
+	if err != nil {
+		return nil, errors.Errorf("getting storage pool UUIDs by name: %w", err)
+	}
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	result := make([]domainstorage.StoragePoolNameUUID, 0, len(dbRows))
+	for _, row := range dbRows {
+		result = append(result, domainstorage.StoragePoolNameUUID{
+			UUID: row.UUID,
+			Name: row.Name,
+		})
+	}
+	return result, nil
+}

--- a/domain/storage/state/storagepool_test.go
+++ b/domain/storage/state/storagepool_test.go
@@ -512,6 +512,54 @@ FROM model_storage_pool
 	return result
 }
 
+func (s *storagePoolStateSuite) TestListStoragePoolNameUUIDs(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := c.Context()
+	poolUUID1 := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	poolUUID2 := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	err := st.CreateStoragePool(ctx, domainstorageinternal.CreateStoragePool{
+		Name:         "pool-a",
+		ProviderType: "lxd",
+		Origin:       domainstorage.StoragePoolOriginUser,
+		UUID:         poolUUID1,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.CreateStoragePool(ctx, domainstorageinternal.CreateStoragePool{
+		Name:         "pool-b",
+		ProviderType: "ec2",
+		Origin:       domainstorage.StoragePoolOriginUser,
+		UUID:         poolUUID2,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, err := st.GetStoragePoolUUIDsByName(ctx, []string{"pool-b", "pool-a"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.SameContents, []domainstorage.StoragePoolNameUUID{
+		{
+			Name: "pool-a",
+			UUID: poolUUID1.String(),
+		},
+		{
+			Name: "pool-b",
+			UUID: poolUUID2.String(),
+		},
+	})
+}
+
+func (s *storagePoolStateSuite) TestListStoragePoolNameUUIDsEmpty(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	got, err := st.GetStoragePoolUUIDsByName(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.HasLen, 0)
+}
+
+func (s *storagePoolStateSuite) TestListStoragePoolNameUUIDsNoMatch(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	got, err := st.GetStoragePoolUUIDsByName(c.Context(), []string{"unknown"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.HasLen, 0)
+}
+
 //func (s *storagePoolStateSuite) TestDeleteStoragePool(c *tc.C) {
 //	st := newStoragePoolState(s.TxnRunnerFactory())
 //

--- a/domain/storage/types.go
+++ b/domain/storage/types.go
@@ -231,3 +231,9 @@ func (i ImportVolumeParams) Validate() error {
 
 	return nil
 }
+
+// StoragePoolNameUUID represents a storage pool name and uuid pair.
+type StoragePoolNameUUID struct {
+	Name string `db:"name"`
+	UUID string `db:"uuid"`
+}


### PR DESCRIPTION
This PR adds support for handling updated charm storage requirements when an application’s charm is refreshed. A charm refresh updates the charm revision, and during this process the charm’s declared storage requirements may change. This work focuses on overriding the reconciled storage directives with the user defined storage directives. It also handle the state changes (insert/update/delete) for the final storage directivies.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps - Checking if juju refresh still works normally


1. Bootstrap a lxd controller and add a model.
```sh
juju bootstrap lxd lxd40new2 --debug && juju add-model test
```

2. Deploy alvin-storage-charm2 revision 1 on test model
```sh
juju deploy alvin-storage-charm2 --revision 1 --channel latest/stable
```

3. Check juju status storage to make sure the storage are attached
```sh
juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
test   alvinlxd40  localhost/localhost  4.0.2.1  13:38:41+08:00

App                   Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
alvin-storage-charm2           active      1  alvin-storage-charm2  latest/stable    1  no       Ready (rev 2)

Unit                     Workload  Agent  Machine  Public address  Ports  Message
alvin-storage-charm2/0*  active    idle   0        10.43.69.51            Ready (rev 2)

Machine  State    Address      Inst id        Base          AZ                    Message
0        started  10.43.69.51  juju-2acd24-0  ubuntu@22.04  alvinchee98-Adder-WS  Running

Storage Unit            Storage ID  Type        Mountpoint  Size     Status    Message
alvin-storage-charm2/0  data/1      filesystem  /srv/data   3.0 GiB  attached  
alvin-storage-charm2/0  dummy/0     filesystem  /srv/dummy  1.0 GiB  attached
```

Note: To verify storage directives values, should see these in db repl 
```
repl (model-test)> select * from application_storage_directive
application_uuid                        charm_uuid          storage_name     storage_pool_uuid                       size_mib     count
520ebb87-c42d-445c-8c5d-9bf43f75d808    4d793225-1608-4ae1-8442-734598b1516a dummy           16d8c090-8ef4-59b4-8e88-0bc64a0598a3 1024            1
520ebb87-c42d-445c-8c5d-9bf43f75d808    4d793225-1608-4ae1-8442-734598b1516a data            16d8c090-8ef4-59b4-8e88-0bc64a0598a3 3072            1
```

4. Refresh to all revisions that should fail (refer to below for charm revisions description)
```sh
juju refresh alvin-storage-charm2 --channel latest/stable --revision 2
Added charm-hub charm "alvin-storage-charm2", revision 2 in channel latest/stable, to the model
ERROR validating new charm storage against existing charm storage: storage "data" new minimum size 7168 MiB exceeds existing minimum size 3072 MiB

juju refresh alvin-storage-charm2 --channel latest/stable --revision 5
Added charm-hub charm "alvin-storage-charm2", revision 5 in channel latest/stable, to the model
ERROR validating new charm storage against existing charm storage: storage name "data" removed

juju refresh alvin-storage-charm2 --channel latest/stable --revision 6
Added charm-hub charm "alvin-storage-charm2", revision 6 in channel latest/stable, to the model
ERROR validating new charm storage against existing charm storage: storage "data" new minimum count 2 exceeds existing minimum count 1

juju refresh alvin-storage-charm2 --channel latest/stable --revision 7
Added charm-hub charm "alvin-storage-charm2", revision 7 in channel latest/stable, to the model
ERROR validating new charm storage against existing charm storage: storage "data" type changed from "filesystem" to "block"
```

Note: To verify storage directives values, should still see these in db repl 
```
repl (model-test)> select * from application_storage_directive
application_uuid                        charm_uuid          storage_name     storage_pool_uuid                       size_mib     count
520ebb87-c42d-445c-8c5d-9bf43f75d808    4d793225-1608-4ae1-8442-734598b1516a dummy           16d8c090-8ef4-59b4-8e88-0bc64a0598a3 1024            1
520ebb87-c42d-445c-8c5d-9bf43f75d808    4d793225-1608-4ae1-8442-734598b1516a data            16d8c090-8ef4-59b4-8e88-0bc64a0598a3 3072            1
```

5. Refresh to all revisions that should pass (refer to below for charm revisions description)
```sh
juju refresh alvin-storage-charm2 --channel latest/stable --revision 3
Added charm-hub charm "alvin-storage-charm2", revision 3 in channel latest/stable, to the model

OR 

(This would change the table in step 7 to 2G in size_mib column)
juju refresh alvin-storage-charm2 --channel latest/stable --revision 3 --storage "data=2G"
Added charm-hub charm "alvin-storage-charm2", revision 3 in channel latest/stable, to the model
no change to endpoint in space "alpha": juju-info
```

6. Refresh to revision 4
```sh
juju refresh alvin-storage-charm2 --channel latest/stable --revision 4
Added charm-hub charm "alvin-storage-charm2", revision 4 in channel latest/stable, to the model
no change to endpoint in space "
```

7. Note: To verify storage directives values, should see these in db repl. Storage size for storage directive "data" should still be at 3G even though we reduced the minimum size requirement for the charm.
```
repl (model-test)> select * from application_storage_directive
application_uuid                        charm_uuid   storage_name     storage_pool_uuid                    size_mib count
520ebb87-c42d-445c-8c5d-9bf43f75d808    c1b0fdcf-8132-45d2-8060-d0122fdf80d0  dummy       16d8c090-8ef4-59b4-8e88-0bc64a0598a3  1024            1
520ebb87-c42d-445c-8c5d-9bf43f75d808    c1b0fdcf-8132-45d2-8060-d0122fdf80d0  data       16d8c090-8ef4-59b4-8e88-0bc64a0598a3  3072            1
520ebb87-c42d-445c-8c5d-9bf43f75d808    c1b0fdcf-8132-45d2-8060-d0122fdf80d0  logs       16d8c090-8ef4-59b4-8e88-0bc64a0598a3  3072
```

8. Add a unit so we can have a new unit of which unit_directive contains "logs"
```sh
juju add-unit alvin-storage-charm2
```

9. Run juju status --storage to see "logs" storage attached
```sh
juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
test   alvinlxd40  localhost/localhost  4.0.2.1  19:44:37+08:00

App                   Version  Status   Scale  Charm                 Channel        Rev  Exposed  Message
alvin-storage-charm2           waiting    1/2  alvin-storage-charm2  latest/stable    4  no       waiting for machine

Unit                     Workload  Agent       Machine  Public address  Ports  Message
alvin-storage-charm2/0*  active    idle        0        10.43.69.51            Ready (rev 2) - Hi this is a charm for testing charm storage and storage directives.
alvin-storage-charm2/1   waiting   allocating  1                               waiting for machine

Machine  State    Address      Inst id        Base          AZ                    Message
0        started  10.43.69.51  juju-2acd24-0  ubuntu@22.04  alvinchee98-Adder-WS  Running
1        pending               juju-2acd24-1  ubuntu@22.04  alvinchee98-Adder-WS  Running

Storage Unit            Storage ID  Type        Mountpoint  Size     Status    Message
alvin-storage-charm2/0  data/1      filesystem  /srv/data   3.0 GiB  attached  
alvin-storage-charm2/0  dummy/0     filesystem  /srv/dummy  1.0 GiB  attached  
alvin-storage-charm2/1  data/3      filesystem  /srv/data   3.0 GiB  attached  
alvin-storage-charm2/1  dummy/2     filesystem  /srv/dummy  1.0 GiB  attached  
alvin-storage-charm2/1  logs/4      filesystem  /srv/logs   3.0 GiB  attached
```

10. Add a model test2
```sh
juju add-model test2
```

11. Deploy alvin-storage-charm2 revision 9 on test2 model. We can check storage status when it's ready.
```sh
juju deploy alvin-storage-charm2 --revision 9 --channel latest/stable
```

```sh
juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
test2  alvinlxd40  localhost/localhost  4.0.2.1  13:54:34+08:00

App                   Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
alvin-storage-charm2           active      1  alvin-storage-charm2  latest/stable   11  no       Ready (rev 2) - Hi this is a charm for testing charm storage and storage directives.

Unit                     Workload  Agent  Machine  Public address  Ports  Message
alvin-storage-charm2/0*  active    idle   0        10.43.69.2             Ready (rev 2) - Hi this is a charm for testing charm storage and storage directives.

Machine  State    Address     Inst id        Base          AZ                    Message
0        started  10.43.69.2  juju-681cf5-0  ubuntu@22.04  alvinchee98-Adder-WS  Running

Storage Unit            Storage ID  Type        Mountpoint                                      Size     Status    Message
alvin-storage-charm2/0  data/0      filesystem  /srv/data/837c82dc-b699-403c-8d02-1f46fb151c4f  3.0 GiB  attached  
alvin-storage-charm2/0  data/1      filesystem  /srv/data/f53a085e-8c26-420b-84ba-7c40582056ff  3.0 GiB  attached  
alvin-storage-charm2/0  data/2      filesystem  /srv/data/45a7d5a8-3e6b-4e64-8815-c394172a8c68  3.0 GiB  attached  
alvin-storage-charm2/0  dummy/3     filesystem  /srv/dummy                                      1.0 GiB  attached
```

Note: To verify storage directives values, should see these in db repl. Also note that we should change to "test2" model now.
```
repl (model-test2)> select * from application_storage_directive
application_uuid                        charm_uuid                            storage_name storage_pool_uuid                size_mib      count
e91ce5d9-8f7f-44a1-8c74-3a41a64dd027    e6004b9d-ea32-4ce1-8d97-afbbbe679934  data         16d8c090-8ef4-59b4-8e88-0bc64a0598a3     3072 3
e91ce5d9-8f7f-44a1-8c74-3a41a64dd027    e6004b9d-ea32-4ce1-8d97-afbbbe679934  dummy        16d8c090-8ef4-59b4-8e88-0bc64a0598a3     1024 1
```

12. Refresh to all revisions that should fail (refer to below for charm revisions description)
```sh
juju refresh alvin-storage-charm2 --channel latest/stable --revision 10
Added charm-hub charm "alvin-storage-charm2", revision 10 in channel latest/stable, to the model
ERROR validating new charm storage against existing charm storage: storage "data" new minimum count 4 exceeds existing minimum count 3

juju refresh alvin-storage-charm2 --channel latest/stable --revision 12
Added charm-hub charm "alvin-storage-charm2", revision 12 in channel latest/stable, to the model
ERROR validating new charm storage against existing charm storage: storage "data" new maximum count 5 is less than existing maximum count 6

juju refresh alvin-storage-charm2 --channel late
st/stable --revision 18
Added charm-hub charm "alvin-storage-charm2", revision 18 in channel latest/stable, to the model
ERROR cannot set charm "ch:amd64/alvin-storage-charm2-18" because storage definition "data" read-only changed from false to true (not supported)

juju refresh alvin-storage-charm2 --channel latest/stable --revision 19
Added charm-hub charm "alvin-storage-charm2", revision 19 in channel latest/stable, to the model
ERROR validating charm storage: charm storage "data" requires shared storage which is not implemented

juju refresh alvin-storage-charm2 --channel latest/stable --revision 20
Added charm-hub charm "alvin-storage-charm2", revision 20 in channel latest/stable, to the model
ERROR cannot set charm "ch:amd64/alvin-storage-charm2-20" because storage definition "data" location changed from "/srv/data" to "/srv/newdata" (not supported)
```


Note: To verify storage directives values, should still see these in db repl. 
```
repl (model-test2)> select * from application_storage_directive
application_uuid                        charm_uuid              storage_name     storage_pool_uuid                       size_mibcount
e91ce5d9-8f7f-44a1-8c74-3a41a64dd027    e6004b9d-ea32-4ce1-8d97-afbbbe679934     data            16d8c090-8ef4-59b4-8e88-0bc64a0598a3     3072            3
e91ce5d9-8f7f-44a1-8c74-3a41a64dd027    e6004b9d-ea32-4ce1-8d97-afbbbe679934     dummy           16d8c090-8ef4-59b4-8e88-0bc64a0598a3     1024            1
```

13. Attempt to detach storage
```sh
juju detach-storage data/2
failed to detach data/2: detaching storage "data/2" attachment 0: removing storage from unit would violate charm storage "data" requirements of having minimum 3 storage instances
```

14. Refresh to revision 11 from 9 that should pass (refer to below for charm revisions description)
```sh
juju refresh alvin-storage-charm2 --channel latest/stable --revision 11
Added charm-hub charm "alvin-storage-charm2", revision 11 in channel latest/stable, to the model
no change to endpoint in space "alpha": juju-info
```

Note: To verify storage directives values, should still see these in db repl. Storage directive count does not change even if minimum count requirement for new charm decreases.
```
repl (model-test2)> select * from application_storage_directive
application_uuid                        charm_uuid              storage_name     storage_pool_uuid                       size_mibcount
e91ce5d9-8f7f-44a1-8c74-3a41a64dd027    81c2b17e-8b1c-4e47-8327-f975c466e073     data            16d8c090-8ef4-59b4-8e88-0bc64a0598a3     3072            3
e91ce5d9-8f7f-44a1-8c74-3a41a64dd027    81c2b17e-8b1c-4e47-8327-f975c466e073     dummy           16d8c090-8ef4-59b4-8e88-0bc64a0598a3     1024            1
```

15. Detach storage to reduce storage instance. We should be able to reduce storage instances to less than 3 now. This is because storage detachment info is based off info from charm_storage, and the updated info reflects that of the new count min. Refer to https://github.com/juju/juju/blob/4.0/domain/removal/state/model/storage.go#L199.
```sh
test@alvinchee98-Adder-WS:~/Desktop/repos/juju$ juju detach-storage data/2
detaching data/2
test@alvinchee98-Adder-WS:~/Desktop/repos/juju$ juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
test2  alvinlxd40  localhost/localhost  4.0.2.1  16:48:37+08:00

App                   Version  Status       Scale  Charm                 Channel        Rev  Exposed  Message
alvin-storage-charm2           maintenance      1  alvin-storage-charm2  latest/stable   11  no       Storage detaching

Unit                     Workload     Agent  Machine  Public address  Ports  Message
alvin-storage-charm2/0*  maintenance  idle   0        10.43.69.2             Storage detaching

Machine  State    Address     Inst id        Base          AZ                    Message
0        started  10.43.69.2  juju-681cf5-0  ubuntu@22.04  alvinchee98-Adder-WS  Running

Storage Unit            Storage ID  Type        Mountpoint                                      Size     Status    Message
                        data/2      filesystem                                                  3.0 GiB  detached  
alvin-storage-charm2/0  data/0      filesystem  /srv/data/837c82dc-b699-403c-8d02-1f46fb151c4f  3.0 GiB  attached  
alvin-storage-charm2/0  data/1      filesystem  /srv/data/f53a085e-8c26-420b-84ba-7c40582056ff  3.0 GiB  attached  
alvin-storage-charm2/0  dummy/3     filesystem  /srv/dummy                                      1.0 GiB  attached
```

16. Add a model test3
```sh
juju add-model test3
```

17. Deploy alvin-storage-charm2 revision 9 on test3 model. We can check storage status when it's ready.
```sh
juju deploy alvin-storage-charm2 --revision 9 --channel latest/stable
```

```sh
Model  Controller  Cloud/Region         Version  Timestamp
test3  alvinlxd40  localhost/localhost  4.0.2.1  13:55:45+08:00

App                   Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
alvin-storage-charm2           active      1  alvin-storage-charm2  latest/stable    9  no       Ready (rev 2)

Unit                     Workload  Agent  Machine  Public address  Ports  Message
alvin-storage-charm2/0*  active    idle   0        10.43.69.46            Ready (rev 2)

Machine  State    Address      Inst id        Base          AZ                    Message
0        started  10.43.69.46  juju-8754ee-0  ubuntu@22.04  alvinchee98-Adder-WS  Running

Storage Unit            Storage ID  Type        Mountpoint                                      Size     Status    Message
alvin-storage-charm2/0  data/0      filesystem  /srv/data/dea85caa-d5f6-43ae-869d-899f049cce6f  3.0 GiB  attached  
alvin-storage-charm2/0  data/1      filesystem  /srv/data/afec26be-3fa6-450b-8263-fca1031124c9  3.0 GiB  attached  
alvin-storage-charm2/0  data/2      filesystem  /srv/data/7ae418da-9819-4105-8bda-89ed3894ee0a  3.0 GiB  attached  
alvin-storage-charm2/0  dummy/3     filesystem  /srv/dummy                                      1.0 GiB  attached
```

18. Attempt to add more than 7 storage for data in total (We currently have 3). This should fail.
```sh
juju add-storage alvin-storage-charm2/0 data=4G,7
failed to add storage "data" to alvin-storage-charm2/0: storage directive "data" request count 10 exceeds the charm's maximum count of 6
```

19. Refresh to revision 13 from 9 that should pass (refer to below for charm revisions description)
```
juju refresh alvin-storage-charm2 --channel latest/stable --revision 13 --storage data=4G,7
Added charm-hub charm "alvin-storage-charm2", revision 13 in channel latest/stable, to the model
no change to endpoint in space "alpha": juju-info
```

20. Attempt to add 7 more 4GiB storage for data to get 10 instances in total (We currently have 3). We should see that the 7 new storage instances should have 4GiB in size.
```sh
juju add-storage alvin-storage-charm2/0 data=4G,7
added storage data/4 to alvin-storage-charm2/0
added storage data/5 to alvin-storage-charm2/0
added storage data/6 to alvin-storage-charm2/0
added storage data/7 to alvin-storage-charm2/0
added storage data/8 to alvin-storage-charm2/0
added storage data/9 to alvin-storage-charm2/0
added storage data/10 to alvin-storage-charm2/0
```

Check status storage
```sh
juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
test3  alvinlxd40  localhost/localhost  4.0.2.1  14:30:19+08:00

App                   Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
alvin-storage-charm2           active      1  alvin-storage-charm2  latest/stable   13  no       Storage attached (rev 8)

Unit                     Workload  Agent  Machine  Public address  Ports  Message
alvin-storage-charm2/0*  active    idle   0        10.43.69.46            Storage attached (rev 8)

Machine  State    Address      Inst id        Base          AZ                    Message
0        started  10.43.69.46  juju-8754ee-0  ubuntu@22.04  alvinchee98-Adder-WS  Running

Storage Unit            Storage ID  Type        Mountpoint                                      Size     Status    Message
alvin-storage-charm2/0  data/0      filesystem  /srv/data/dea85caa-d5f6-43ae-869d-899f049cce6f  3.0 GiB  attached  
alvin-storage-charm2/0  data/1      filesystem  /srv/data/afec26be-3fa6-450b-8263-fca1031124c9  3.0 GiB  attached  
alvin-storage-charm2/0  data/10     filesystem  /srv/data/482788b3-3544-4435-8359-76bf9ff9a825  4.0 GiB  attached  
alvin-storage-charm2/0  data/2      filesystem  /srv/data/7ae418da-9819-4105-8bda-89ed3894ee0a  3.0 GiB  attached  
alvin-storage-charm2/0  data/4      filesystem  /srv/data/e302e182-fa6b-439e-888c-19cb92d246a6  4.0 GiB  attached  
alvin-storage-charm2/0  data/5      filesystem  /srv/data/c1395630-6096-4513-88c6-76d39959ee70  4.0 GiB  attached  
alvin-storage-charm2/0  data/6      filesystem  /srv/data/aeaf55b2-2c72-45df-8ae4-9c2575542f43  4.0 GiB  attached  
alvin-storage-charm2/0  data/7      filesystem  /srv/data/076a2d03-0123-4091-8cf1-5d6fe4e1859f  4.0 GiB  attached  
alvin-storage-charm2/0  data/8      filesystem  /srv/data/8c22d8c3-4ed0-41f4-8e20-3f9763d61535  4.0 GiB  attached  
alvin-storage-charm2/0  data/9      filesystem  /srv/data/2a928006-f663-4b7f-8c1d-6bcaadf8d07d  4.0 GiB  attached  
alvin-storage-charm2/0  dummy/3     filesystem  /srv/dummy                                      1.0 GiB  attached
```

Note: To verify storage directives values, should see these in db repl. Also note that we should change to "test3" model now.
```sh
repl (model-test3)> select * from application_storage_directive
application_uuid                        charm_uuid              storage_name     storage_pool_uuid                       size_mibcount
75c591d7-00e1-4bf9-8682-6c3cbbb7a947    dfead2e5-b6fd-4ed0-85d6-ed7a72e6f8ec     data            16d8c090-8ef4-59b4-8e88-0bc64a0598a3     3072            3
75c591d7-00e1-4bf9-8682-6c3cbbb7a947    dfead2e5-b6fd-4ed0-85d6-ed7a72e6f8ec     dummy           16d8c090-8ef4-59b4-8e88-0bc64a0598a3     1024            1
```

21. Add a new model "test4"
```sh
juju add-model test4
```

22. Deploy alvin-storage-charm2 revision 9 on test4 model.
```sh
juju deploy alvin-storage-charm2 --revision 9 --channel latest/stable
```

23. Attempt to refresh to revision 15 with overrides that are lesser than minimum size or not within the count range. They should all fail.
```sh
juju refresh alvin-storage-charm2 --channel latest/stable --revision 15 --storage "data=4,1G"
Added charm-hub charm "alvin-storage-charm2", revision 15 in channel latest/stable, to the model
ERROR validating storage directives: storage directive size 1024 is less than the charm minimum requirement of 2048

juju refresh alvin-storage-charm2 --channel latest/stable --revision 15 --storage "data=7,2G"
Added charm-hub charm "alvin-storage-charm2", revision 15 in channel latest/stable, to the model
ERROR validating storage directives: storage "data" cannot exceed 6 storage instances

juju refresh alvin-storage-charm2 --channel latest/stable --revision 15 --storage "data=2,2G"
Added charm-hub charm "alvin-storage-charm2", revision 15 in channel latest/stable, to the model
ERROR validating storage directives: storage "data" cannot have less than 3 storage instances
```

24. Refresh to revision 15 that allows for minimum size of 2G and 4 instances which we are overriding the storage directives with. This should be successful.
```sh
juju refresh alvin-storage-charm2 --channel latest/stable --revision 15 --storage "data=4,2G"
Added charm-hub charm "alvin-storage-charm2", revision 15 in channel latest/stable, to the model
no change to endpoint in space "alpha": juju-info
```

25.  We can check storage status to see the before and after, ensure that before and after juju refresh, these storage details are the same before we do juju add-unit. The --storage override should only affect directives and not set off actual change in storage instances.
```sh
Model  Controller  Cloud/Region         Version  Timestamp
test4  alvinlxd40  localhost/localhost  4.0.2.1  20:03:12+08:00

App                   Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
alvin-storage-charm2           active      1  alvin-storage-charm2  latest/stable   15  no       Ready (rev 2) - Hi this is a charm for testing charm storage and storage directives.

Unit                     Workload  Agent  Machine  Public address  Ports  Message
alvin-storage-charm2/0*  active    idle   0        10.43.69.138           Ready (rev 2) - Hi this is a charm for testing charm storage and storage directives.

Machine  State    Address       Inst id        Base          AZ                    Message
0        started  10.43.69.138  juju-66f670-0  ubuntu@22.04  alvinchee98-Adder-WS  Running

Storage Unit            Storage ID  Type        Mountpoint                                      Size     Status    Message
alvin-storage-charm2/0  data/1      filesystem  /srv/data/26e6e282-b58a-498a-8544-2be7548b682f  3.0 GiB  attached  
alvin-storage-charm2/0  data/2      filesystem  /srv/data/72982815-de7d-48ee-8682-916353eee5d5  3.0 GiB  attached  
alvin-storage-charm2/0  data/3      filesystem  /srv/data/085bc3ee-67e5-46ab-8c50-d078be221ef2  3.0 GiB  attached  
alvin-storage-charm2/0  dummy/0     filesystem  /srv/dummy                                      1.0 GiB  attached
```

26. Add a unit to application.
```sh
juju add-unit alvin-storage-charm2
```

27. Check juju status storage again. We should now see 4 more instances with 2GiB storage.
```sh
juju status --storage
test4  alvinlxd40  localhost/localhost  4.0.2.1  20:07:28+08:00

App                   Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
alvin-storage-charm2           active      2  alvin-storage-charm2  latest/stable   15  no       Ready (rev 2) - Hi this is a charm for testing charm storage and storage directives.

Unit                     Workload  Agent  Machine  Public address  Ports  Message
alvin-storage-charm2/0*  active    idle   0        10.43.69.138           Ready (rev 2) - Hi this is a charm for testing charm storage and storage directives.
alvin-storage-charm2/1   active    idle   1        10.43.69.110           Ready (rev 2)

Machine  State    Address       Inst id        Base          AZ                    Message
0        started  10.43.69.138  juju-66f670-0  ubuntu@22.04  alvinchee98-Adder-WS  Running
1        started  10.43.69.110  juju-66f670-1  ubuntu@22.04  alvinchee98-Adder-WS  Running

Storage Unit            Storage ID  Type        Mountpoint                                      Size     Status    Message
alvin-storage-charm2/0  data/1      filesystem  /srv/data/26e6e282-b58a-498a-8544-2be7548b682f  3.0 GiB  attached  
alvin-storage-charm2/0  data/2      filesystem  /srv/data/72982815-de7d-48ee-8682-916353eee5d5  3.0 GiB  attached  
alvin-storage-charm2/0  data/3      filesystem  /srv/data/085bc3ee-67e5-46ab-8c50-d078be221ef2  3.0 GiB  attached  
alvin-storage-charm2/0  dummy/0     filesystem  /srv/dummy                                      1.0 GiB  attached  
alvin-storage-charm2/1  data/5      filesystem  /srv/data/7c4ed2bf-4863-4e54-8899-daee2c7b9538  2.0 GiB  attached  
alvin-storage-charm2/1  data/6      filesystem  /srv/data/60586fc7-f7e9-4336-81b5-6fb6d2c1e17a  2.0 GiB  attached  
alvin-storage-charm2/1  data/7      filesystem  /srv/data/dd3b03ed-81eb-45f2-8eca-315bcd4bb56d  2.0 GiB  attached  
alvin-storage-charm2/1  data/8      filesystem  /srv/data/6ce510ed-1043-4462-8a91-26275ba87795  2.0 GiB  attached  
alvin-storage-charm2/1  dummy/4     filesystem  /srv/dummy                                      1.0 GiB  attached
```

**Charm Description**
```
A test charm that validates juju refresh storage directive compatibility. Current Revision: 15

  Base Definition (Single-Instance):
  The base charm defines a filesystem storage "data" with minimum size 3G,
  single instance, and no storage-attached hook.

  storage:
  data:
    type: filesystem
    description: Storage for application data
    location: /srv/data
    minimum-size: 3G
  dummy:
    type: filesystem
    description: Dummy storage for testing
    location: /srv/dummy
    minimum-size: 1G

  Multi-Instance Base Definition:
  The multi-instance base defines a filesystem storage "data" with
  count min 3 and count max 6, and a valid storage-attached hook.

  storage:
  data:
    type: filesystem
    description: Storage for application data
    location: /srv/data
    minimum-size: 3G
    multiple:
      range: 3-6
  dummy:
    type: filesystem
    description: Dummy storage for testing
    location: /srv/dummy
    minimum-size: 1G  

  Revision 1 is identical to the base definition.

  Revision 2 is the same as the base definition but sets the minimum size of "data" to 7G.
  (Should fail)

  Revision 3 is the same as the base definition but sets the minimum size of "data" to 2G.
  Note that size of storage directive should not change and would still be 3G.
  (Should pass)

  Revision 4 is the same as the base definition but adds a new storage "logs".
  (Should pass)

  Revision 5 is the same as the base definition but removes storage "data".
  (Should fail)

  Revision 6 is the same as the base definition but sets count min to 2 and count max to 5 for "data".
  (Should fail)

  Revision 7 is the same as the base definition but sets the storage type of "data" from filesystem to block.
  (Should fail)

  Revision 8 is the same as the base definition but adds its storage-attached hook.
  (Should pass with no missing hook warning)

  Revision 9 is identical to the multi-instance base definition.

  Revision 10 is the same as the multi-instance base definition but sets count min to 4 for "data".
  (Should fail)

  Revision 11 is the same as the multi-instance base definition but sets count min to 1 for "data".
  Note that count of storage directive should not change and would still be 3.
  (Should pass)

  Revision 12 is the same as the multi-instance base definition but sets count max to 5 for "data".
  (Should fail)

  Revision 13 is the same as the multi-instance base definition but sets count max to 10 for "data".
  Note that count of storage directive should not change and would still be 3.
  (Should pass)

  Revision 14 is voided.

  Revision 15 is the same as the multi-instance base definition but sets minimum size for "data" to 2G.
  Note that count of storage directive should not change and would still be 3, 
  and minimum size should not change and would still be 3G.
  (Should pass)

  Revision 16 is voided.

  Revision 17 is voided.

  Revision 18 is the same as the multi-instance base definition but sets read-only to true for "data".
  Note that count of storage directive should not change and would still be 3, 
  and minimum size should not change and would still be 3G.
  (Should fail)

  Revision 19 is the same as the multi-instance base definition but sets shared to true for "data".
  Note that count of storage directive should not change and would still be 3, 
  and minimum size should not change and would still be 3G.
  (Should fail)   

  Revision 20 is the same as the multi-instance base definition but sets location to /srv/newdata for "data".
  Note that count of storage directive should not change and would still be 3, 
  and minimum size should not change and would still be 3G.
  (Should fail)
```

## Links
[JUJU-9112]: https://warthogs.atlassian.net/browse/JUJU-9112