### PR TITLE
fix(removal): add conditional lifecycle guards for storage attachment advancement

### DIFF
--- a/domain/removal/internal/types.go
+++ b/domain/removal/internal/types.go
@@ -253,6 +253,40 @@ type CascadedRelationWithRemoteConsumerLives struct {
 	SyntheticRelationUnitUUIDs []string
 }
 
+// StorageAttachmentHookInfo contains the information required to determine
+// if a dying storage attachment can be safely advanced to dead.
+type StorageAttachmentHookInfo struct {
+	// UnitDead is true when the unit the storage is attached to is dead.
+	UnitDead bool
+
+	// StorageID is the storage instance identifier (e.g. "data/0"),
+	// used to look up the hook state in StorageState.
+	StorageID string
+
+	// StorageState is the raw YAML-serialized map[string]bool from the
+	// unit_state.storage_state column, written by the uniter's storage
+	// worker when storage-attached hooks fire.
+	StorageState string
+}
+
+// ProvisionedAttachmentAdvanceInfo contains the information required to
+// determine if a dying filesystem or volume attachment can be safely
+// advanced to dead.
+type ProvisionedAttachmentAdvanceInfo struct {
+	// MachineScopeProvisioned is true when the filesystem/volume was
+	// provisioned with machine scope (provision_scope_id == 1).
+	MachineScopeProvisioned bool
+
+	// StorageAttachmentDeadOrGone is true when the associated storage
+	// attachment is dead or no longer exists.
+	StorageAttachmentDeadOrGone bool
+
+	// MachineGone is true when the machine owning the filesystem/volume
+	// via machine_filesystem/machine_volume is gone (no row or the
+	// machine itself no longer exists).
+	MachineGone bool
+}
+
 // StorageAttachmentDetachInfo contains the information required to establish
 // if a storage attachment in the model can be detached.
 type StorageAttachmentDetachInfo struct {

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -2376,6 +2376,45 @@ func (c *MockModelDBStateGetDetachInfoForStorageAttachmentCall) DoAndReturn(f fu
 	return c
 }
 
+// GetFilesystemAttachmentAdvanceInfo mocks base method.
+func (m *MockModelDBState) GetFilesystemAttachmentAdvanceInfo(arg0 context.Context, arg1 string) (internal.ProvisionedAttachmentAdvanceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFilesystemAttachmentAdvanceInfo", arg0, arg1)
+	ret0, _ := ret[0].(internal.ProvisionedAttachmentAdvanceInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFilesystemAttachmentAdvanceInfo indicates an expected call of GetFilesystemAttachmentAdvanceInfo.
+func (mr *MockModelDBStateMockRecorder) GetFilesystemAttachmentAdvanceInfo(arg0, arg1 any) *MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilesystemAttachmentAdvanceInfo", reflect.TypeOf((*MockModelDBState)(nil).GetFilesystemAttachmentAdvanceInfo), arg0, arg1)
+	return &MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall{Call: call}
+}
+
+// MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall wrap *gomock.Call
+type MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall) Return(arg0 internal.ProvisionedAttachmentAdvanceInfo, arg1 error) *MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall) Do(f func(context.Context, string) (internal.ProvisionedAttachmentAdvanceInfo, error)) *MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall) DoAndReturn(f func(context.Context, string) (internal.ProvisionedAttachmentAdvanceInfo, error)) *MockModelDBStateGetFilesystemAttachmentAdvanceInfoCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetFilesystemAttachmentLife mocks base method.
 func (m *MockModelDBState) GetFilesystemAttachmentLife(arg0 context.Context, arg1 string) (life.Life, error) {
 	m.ctrl.T.Helper()
@@ -2805,6 +2844,45 @@ func (c *MockModelDBStateGetRemoteApplicationOffererUUIDByApplicationUUIDCall) D
 	return c
 }
 
+// GetStorageAttachmentHookInfo mocks base method.
+func (m *MockModelDBState) GetStorageAttachmentHookInfo(arg0 context.Context, arg1 string) (internal.StorageAttachmentHookInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageAttachmentHookInfo", arg0, arg1)
+	ret0, _ := ret[0].(internal.StorageAttachmentHookInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStorageAttachmentHookInfo indicates an expected call of GetStorageAttachmentHookInfo.
+func (mr *MockModelDBStateMockRecorder) GetStorageAttachmentHookInfo(arg0, arg1 any) *MockModelDBStateGetStorageAttachmentHookInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageAttachmentHookInfo", reflect.TypeOf((*MockModelDBState)(nil).GetStorageAttachmentHookInfo), arg0, arg1)
+	return &MockModelDBStateGetStorageAttachmentHookInfoCall{Call: call}
+}
+
+// MockModelDBStateGetStorageAttachmentHookInfoCall wrap *gomock.Call
+type MockModelDBStateGetStorageAttachmentHookInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateGetStorageAttachmentHookInfoCall) Return(arg0 internal.StorageAttachmentHookInfo, arg1 error) *MockModelDBStateGetStorageAttachmentHookInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateGetStorageAttachmentHookInfoCall) Do(f func(context.Context, string) (internal.StorageAttachmentHookInfo, error)) *MockModelDBStateGetStorageAttachmentHookInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateGetStorageAttachmentHookInfoCall) DoAndReturn(f func(context.Context, string) (internal.StorageAttachmentHookInfo, error)) *MockModelDBStateGetStorageAttachmentHookInfoCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetStorageAttachmentLife mocks base method.
 func (m *MockModelDBState) GetStorageAttachmentLife(arg0 context.Context, arg1 string) (life.Life, error) {
 	m.ctrl.T.Helper()
@@ -2957,6 +3035,45 @@ func (c *MockModelDBStateGetUnitOwnedSecretRevisionRefsCall) Do(f func(context.C
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateGetUnitOwnedSecretRevisionRefsCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockModelDBStateGetUnitOwnedSecretRevisionRefsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetVolumeAttachmentAdvanceInfo mocks base method.
+func (m *MockModelDBState) GetVolumeAttachmentAdvanceInfo(arg0 context.Context, arg1 string) (internal.ProvisionedAttachmentAdvanceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAttachmentAdvanceInfo", arg0, arg1)
+	ret0, _ := ret[0].(internal.ProvisionedAttachmentAdvanceInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeAttachmentAdvanceInfo indicates an expected call of GetVolumeAttachmentAdvanceInfo.
+func (mr *MockModelDBStateMockRecorder) GetVolumeAttachmentAdvanceInfo(arg0, arg1 any) *MockModelDBStateGetVolumeAttachmentAdvanceInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAttachmentAdvanceInfo", reflect.TypeOf((*MockModelDBState)(nil).GetVolumeAttachmentAdvanceInfo), arg0, arg1)
+	return &MockModelDBStateGetVolumeAttachmentAdvanceInfoCall{Call: call}
+}
+
+// MockModelDBStateGetVolumeAttachmentAdvanceInfoCall wrap *gomock.Call
+type MockModelDBStateGetVolumeAttachmentAdvanceInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateGetVolumeAttachmentAdvanceInfoCall) Return(arg0 internal.ProvisionedAttachmentAdvanceInfo, arg1 error) *MockModelDBStateGetVolumeAttachmentAdvanceInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateGetVolumeAttachmentAdvanceInfoCall) Do(f func(context.Context, string) (internal.ProvisionedAttachmentAdvanceInfo, error)) *MockModelDBStateGetVolumeAttachmentAdvanceInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateGetVolumeAttachmentAdvanceInfoCall) DoAndReturn(f func(context.Context, string) (internal.ProvisionedAttachmentAdvanceInfo, error)) *MockModelDBStateGetVolumeAttachmentAdvanceInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/service/storage.go
+++ b/domain/removal/service/storage.go
@@ -19,6 +19,7 @@ import (
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	storageprovisioningerrors "github.com/juju/juju/domain/storageprovisioning/errors"
 	"github.com/juju/juju/internal/errors"
+	"gopkg.in/yaml.v3"
 )
 
 // StorageState describes retrieval and persistence
@@ -84,6 +85,26 @@ type StorageState interface {
 	// database completely. If the unit attached to the storage was its owner,
 	// then that record is deleted too.
 	DeleteStorageAttachment(ctx context.Context, rUUID string) error
+
+	// GetStorageAttachmentHookInfo returns the unit life status, storage ID,
+	// and raw storage state YAML for a storage attachment. Used by the
+	// service layer to determine if a dying storage attachment can safely
+	// advance to dead.
+	GetStorageAttachmentHookInfo(
+		ctx context.Context, saUUID string,
+	) (internal.StorageAttachmentHookInfo, error)
+
+	// GetFilesystemAttachmentAdvanceInfo returns provisioned attachment
+	// advance information for a filesystem attachment.
+	GetFilesystemAttachmentAdvanceInfo(
+		ctx context.Context, fsaUUID string,
+	) (internal.ProvisionedAttachmentAdvanceInfo, error)
+
+	// GetVolumeAttachmentAdvanceInfo returns provisioned attachment advance
+	// information for a volume attachment.
+	GetVolumeAttachmentAdvanceInfo(
+		ctx context.Context, vaUUID string,
+	) (internal.ProvisionedAttachmentAdvanceInfo, error)
 
 	// EnsureStorageInstanceNotAliveCascade ensures that there is no storage
 	// instance identified by the input UUID, that is still alive.
@@ -453,13 +474,34 @@ func (s *Service) processStorageAttachmentRemovalJob(ctx context.Context, job re
 		return errors.Errorf(
 			"storage attachment %q is alive", job.EntityUUID,
 		).Add(removalerrors.EntityStillAlive)
-	} else if !job.Force && l == life.Dying {
-		return errors.Errorf(
-			"storage attachment %q is not dead", job.EntityUUID,
-		).Add(removalerrors.EntityNotDead)
 	}
 
-	if job.Force && l == life.Dying {
+	if l == life.Dying {
+		// When not forced, only advance dying -> dead if the unit is
+		// dead or the storage-attached hook never fired. This prevents
+		// unconditionally advancing the lifecycle when the provisioner
+		// may still be responsible for it.
+		if !job.Force {
+			hookInfo, err := s.modelState.GetStorageAttachmentHookInfo(
+				ctx, job.EntityUUID)
+			if errors.Is(err, storageerrors.StorageAttachmentNotFound) {
+				return nil
+			} else if err != nil {
+				return errors.Errorf(
+					"getting storage attachment %q hook info: %w",
+					job.EntityUUID, err,
+				)
+			}
+
+			if !hookInfo.UnitDead && storageAttachedHookFired(hookInfo.StorageID, hookInfo.StorageState) {
+				return errors.Errorf(
+					"storage attachment %q is not dead", job.EntityUUID,
+				).Add(removalerrors.EntityNotDead)
+			}
+		}
+
+		// Mark the storage attachment as dead, cascading to any child
+		// filesystem/volume attachments.
 		cascade, err := s.modelState.EnsureStorageAttachmentDeadCascade(
 			ctx, job.EntityUUID)
 		if errors.Is(err, storageerrors.StorageAttachmentNotFound) {
@@ -1182,10 +1224,39 @@ func (s *Service) processStorageFilesystemAttachmentRemovalJob(
 		return errors.Errorf(
 			"filesystem attachment %q is alive", job.EntityUUID,
 		).Add(removalerrors.EntityStillAlive)
-	} else if !job.Force && l == life.Dying {
-		return errors.Errorf(
-			"filesystem attachment %q is not dead", job.EntityUUID,
-		).Add(removalerrors.EntityNotDead)
+	}
+
+	// If the filesystem attachment is dying, mark it as dead before
+	// deletion.
+	// NOTE: When not forced, ONLY ADVANCE IF CONDITIONS ARE SAFE.
+	if l == life.Dying {
+		if !job.Force {
+			info, err := s.modelState.GetFilesystemAttachmentAdvanceInfo(
+				ctx, job.EntityUUID)
+			if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
+				return nil
+			} else if err != nil {
+				return errors.Errorf(
+					"getting filesystem attachment %q advance info: %w",
+					job.EntityUUID, err,
+				)
+			}
+			if !canAdvanceProvisionedAttachment(info) {
+				return errors.Errorf(
+					"filesystem attachment %q is not dead",
+					job.EntityUUID,
+				).Add(removalerrors.EntityNotDead)
+			}
+		}
+
+		if err := s.modelState.MarkFilesystemAttachmentAsDead(
+			ctx, job.EntityUUID,
+		); err != nil {
+			return errors.Errorf(
+				"marking filesystem attachment %q as dead: %w",
+				job.EntityUUID, err,
+			)
+		}
 	}
 
 	err = s.modelState.DeleteFilesystemAttachment(ctx, job.EntityUUID)
@@ -1247,10 +1318,38 @@ func (s *Service) processStorageVolumeAttachmentRemovalJob(
 		return errors.Errorf(
 			"volume attachment %q is alive", job.EntityUUID,
 		).Add(removalerrors.EntityStillAlive)
-	} else if !job.Force && l == life.Dying {
-		return errors.Errorf(
-			"volume attachment %q is not dead", job.EntityUUID,
-		).Add(removalerrors.EntityNotDead)
+	}
+
+	// If the volume attachment is dying, mark it as dead before deletion.
+	// When not forced, only advance if conditions are safe.
+	if l == life.Dying {
+		if !job.Force {
+			info, err := s.modelState.GetVolumeAttachmentAdvanceInfo(
+				ctx, job.EntityUUID)
+			if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+				return nil
+			} else if err != nil {
+				return errors.Errorf(
+					"getting volume attachment %q advance info: %w",
+					job.EntityUUID, err,
+				)
+			}
+			if !canAdvanceProvisionedAttachment(info) {
+				return errors.Errorf(
+					"volume attachment %q is not dead",
+					job.EntityUUID,
+				).Add(removalerrors.EntityNotDead)
+			}
+		}
+
+		if err := s.modelState.MarkVolumeAttachmentAsDead(
+			ctx, job.EntityUUID,
+		); err != nil {
+			return errors.Errorf(
+				"marking volume attachment %q as dead: %w",
+				job.EntityUUID, err,
+			)
+		}
 	}
 
 	err = s.modelState.DeleteVolumeAttachment(ctx, job.EntityUUID)
@@ -1326,4 +1425,29 @@ func (s *Service) processStorageVolumeAttachmentPlanRemovalJob(
 	}
 
 	return nil
+}
+
+// storageAttachedHookFired returns true if the storage-attached hook has
+// been recorded as fired for the given storage ID. The storageStateYAML is
+// the YAML-serialized map[string]bool from the unit_state.storage_state
+// column, written by the uniter's storage worker on hook commit.
+func storageAttachedHookFired(storageID, storageStateYAML string) bool {
+	if storageStateYAML == "" {
+		return false
+	}
+	var state map[string]bool
+	if err := yaml.Unmarshal([]byte(storageStateYAML), &state); err != nil {
+		return false
+	}
+	attached, ok := state[storageID]
+	return ok && attached
+}
+
+// canAdvanceProvisionedAttachment returns true if a provisioned filesystem
+// or volume attachment can safely advance from dying to dead based on the
+// provided advance info.
+func canAdvanceProvisionedAttachment(info internal.ProvisionedAttachmentAdvanceInfo) bool {
+	return info.MachineScopeProvisioned &&
+		info.StorageAttachmentDeadOrGone &&
+		info.MachineGone
 }

--- a/domain/removal/service/storage_test.go
+++ b/domain/removal/service/storage_test.go
@@ -1264,9 +1264,37 @@ func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDying(c *tc.C) {
 
 	j := newFilesystemAttachmentJob(c)
 
-	s.modelState.EXPECT().GetFilesystemAttachmentLife(
+	exp := s.modelState.EXPECT()
+	exp.GetFilesystemAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
+	exp.GetFilesystemAttachmentAdvanceInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.ProvisionedAttachmentAdvanceInfo{
+		MachineScopeProvisioned:     true,
+		StorageAttachmentDeadOrGone: true,
+		MachineGone:                 true,
+	}, nil)
+	exp.MarkFilesystemAttachmentAsDead(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteFilesystemAttachment(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDyingCannotAdvance(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newFilesystemAttachmentJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetFilesystemAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.GetFilesystemAttachmentAdvanceInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.ProvisionedAttachmentAdvanceInfo{}, nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIs, removalerrors.EntityNotDead)
@@ -1281,6 +1309,9 @@ func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDyingForce(c *tc.C) 
 	s.modelState.EXPECT().GetFilesystemAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
+	s.modelState.EXPECT().MarkFilesystemAttachmentAsDead(
+		gomock.Any(), j.EntityUUID,
+	).Return(nil)
 	s.modelState.EXPECT().DeleteFilesystemAttachment(
 		gomock.Any(), j.EntityUUID,
 	).Return(nil)
@@ -1288,6 +1319,30 @@ func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDyingForce(c *tc.C) 
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDyingMarkAsDeadError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newFilesystemAttachmentJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetFilesystemAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.GetFilesystemAttachmentAdvanceInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.ProvisionedAttachmentAdvanceInfo{
+		MachineScopeProvisioned:     true,
+		StorageAttachmentDeadOrGone: true,
+		MachineGone:                 true,
+	}, nil)
+	exp.MarkFilesystemAttachmentAsDead(
+		gomock.Any(), j.EntityUUID,
+	).Return(errors.Errorf("the front fell off"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
 }
 
 func (s *storageSuite) TestExecuteJobForFilesystemAttachmentSuccess(c *tc.C) {
@@ -1351,9 +1406,37 @@ func (s *storageSuite) TestExecuteJobForVolumeAttachmentDying(c *tc.C) {
 
 	j := newVolumeAttachmentJob(c)
 
-	s.modelState.EXPECT().GetVolumeAttachmentLife(
+	exp := s.modelState.EXPECT()
+	exp.GetVolumeAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
+	exp.GetVolumeAttachmentAdvanceInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.ProvisionedAttachmentAdvanceInfo{
+		MachineScopeProvisioned:     true,
+		StorageAttachmentDeadOrGone: true,
+		MachineGone:                 true,
+	}, nil)
+	exp.MarkVolumeAttachmentAsDead(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteVolumeAttachment(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForVolumeAttachmentDyingCannotAdvance(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newVolumeAttachmentJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetVolumeAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.GetVolumeAttachmentAdvanceInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.ProvisionedAttachmentAdvanceInfo{}, nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIs, removalerrors.EntityNotDead)
@@ -1368,6 +1451,9 @@ func (s *storageSuite) TestExecuteJobForVolumeAttachmentDyingForce(c *tc.C) {
 	s.modelState.EXPECT().GetVolumeAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
+	s.modelState.EXPECT().MarkVolumeAttachmentAsDead(
+		gomock.Any(), j.EntityUUID,
+	).Return(nil)
 	s.modelState.EXPECT().DeleteVolumeAttachment(
 		gomock.Any(), j.EntityUUID,
 	).Return(nil)
@@ -1375,6 +1461,30 @@ func (s *storageSuite) TestExecuteJobForVolumeAttachmentDyingForce(c *tc.C) {
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForVolumeAttachmentDyingMarkAsDeadError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newVolumeAttachmentJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetVolumeAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.GetVolumeAttachmentAdvanceInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.ProvisionedAttachmentAdvanceInfo{
+		MachineScopeProvisioned:     true,
+		StorageAttachmentDeadOrGone: true,
+		MachineGone:                 true,
+	}, nil)
+	exp.MarkVolumeAttachmentAsDead(
+		gomock.Any(), j.EntityUUID,
+	).Return(errors.Errorf("the front fell off"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
 }
 
 func (s *storageSuite) TestExecuteJobForVolumeAttachmentSuccess(c *tc.C) {
@@ -1565,17 +1675,149 @@ func (s *storageSuite) TestExecuteJobForStorageAttachmentStillAlive(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, removalerrors.EntityStillAlive)
 }
 
-func (s *storageSuite) TestExecuteJobForStorageAttachmentDying(c *tc.C) {
+func (s *storageSuite) TestExecuteJobForStorageAttachmentDyingHookNeverFired(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	when := time.Now().UTC()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	j := newStorageAttachmentJob(c)
+
+	fsaUUID := tc.Must(c, storage.NewFilesystemAttachmentUUID)
+	vaUUID := tc.Must(c, storage.NewVolumeAttachmentUUID)
+	vapUUID := tc.Must(c, storage.NewVolumeAttachmentPlanUUID)
+
+	cascaded := internal.CascadedStorageProvisionedAttachmentLives{
+		FileSystemAttachmentUUIDs: []string{fsaUUID.String()},
+		VolumeAttachmentUUIDs:     []string{vaUUID.String()},
+		VolumeAttachmentPlanUUIDs: []string{vapUUID.String()},
+	}
+
+	exp := s.modelState.EXPECT()
+	exp.GetStorageAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.GetStorageAttachmentHookInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.StorageAttachmentHookInfo{
+		UnitDead:     false,
+		StorageID:    "data/0",
+		StorageState: "",
+	}, nil)
+	exp.EnsureStorageAttachmentDeadCascade(
+		gomock.Any(), j.EntityUUID,
+	).Return(cascaded, nil)
+	exp.FilesystemAttachmentScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), fsaUUID.String(), false, when,
+	).Return(nil)
+	exp.VolumeAttachmentScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), vaUUID.String(), false, when,
+	).Return(nil)
+	exp.VolumeAttachmentPlanScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), vapUUID.String(), false, when,
+	).Return(nil)
+	exp.DeleteStorageAttachment(
+		gomock.Any(), j.EntityUUID,
+	).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForStorageAttachmentDyingUnitDead(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	when := time.Now().UTC()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	j := newStorageAttachmentJob(c)
+
+	fsaUUID := tc.Must(c, storage.NewFilesystemAttachmentUUID)
+	vaUUID := tc.Must(c, storage.NewVolumeAttachmentUUID)
+	vapUUID := tc.Must(c, storage.NewVolumeAttachmentPlanUUID)
+
+	cascaded := internal.CascadedStorageProvisionedAttachmentLives{
+		FileSystemAttachmentUUIDs: []string{fsaUUID.String()},
+		VolumeAttachmentUUIDs:     []string{vaUUID.String()},
+		VolumeAttachmentPlanUUIDs: []string{vapUUID.String()},
+	}
+
+	exp := s.modelState.EXPECT()
+	exp.GetStorageAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.GetStorageAttachmentHookInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.StorageAttachmentHookInfo{
+		UnitDead:     true,
+		StorageID:    "data/0",
+		StorageState: "data/0: true\n",
+	}, nil)
+	exp.EnsureStorageAttachmentDeadCascade(
+		gomock.Any(), j.EntityUUID,
+	).Return(cascaded, nil)
+	exp.FilesystemAttachmentScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), fsaUUID.String(), false, when,
+	).Return(nil)
+	exp.VolumeAttachmentScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), vaUUID.String(), false, when,
+	).Return(nil)
+	exp.VolumeAttachmentPlanScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), vapUUID.String(), false, when,
+	).Return(nil)
+	exp.DeleteStorageAttachment(
+		gomock.Any(), j.EntityUUID,
+	).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForStorageAttachmentDyingHookFiredUnitNotDead(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	j := newStorageAttachmentJob(c)
 
-	s.modelState.EXPECT().GetStorageAttachmentLife(
+	exp := s.modelState.EXPECT()
+	exp.GetStorageAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
+	exp.GetStorageAttachmentHookInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.StorageAttachmentHookInfo{
+		UnitDead:     false,
+		StorageID:    "data/0",
+		StorageState: "data/0: true\n",
+	}, nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIs, removalerrors.EntityNotDead)
+}
+
+func (s *storageSuite) TestExecuteJobForStorageAttachmentDyingCascadeError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newStorageAttachmentJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetStorageAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.GetStorageAttachmentHookInfo(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.StorageAttachmentHookInfo{
+		UnitDead:     true,
+		StorageID:    "data/0",
+		StorageState: "",
+	}, nil)
+	exp.EnsureStorageAttachmentDeadCascade(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.CascadedStorageProvisionedAttachmentLives{}, errors.Errorf("cascade boom"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*cascade boom")
 }
 
 func (s *storageSuite) TestExecuteJobForStorageAttachmentDyingForce(c *tc.C) {

--- a/domain/removal/state/model/storage.go
+++ b/domain/removal/state/model/storage.go
@@ -271,6 +271,251 @@ SELECT &storageAttachmentDetachInfo.* FROM (
 	}, nil
 }
 
+// GetStorageAttachmentHookInfo returns the unit life status, storage ID,
+// and raw storage state YAML for a storage attachment. Used by the
+// service layer to determine if a dying storage attachment can safely
+// advance to dead.
+//
+// The following errors may be returned:
+// - [storageerrors.StorageAttachmentNotFound] if the storage attachment
+// no longer exists in the model.
+func (st *State) GetStorageAttachmentHookInfo(
+	ctx context.Context, saUUID string,
+) (internal.StorageAttachmentHookInfo, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return internal.StorageAttachmentHookInfo{}, errors.Capture(err)
+	}
+
+	var (
+		dbVal     storageAttachmentUnitInfo
+		uuidInput = entityUUID{UUID: saUUID}
+	)
+
+	q := `
+SELECT u.life_id AS &storageAttachmentUnitInfo.unit_life_id,
+       si.storage_id AS &storageAttachmentUnitInfo.storage_id,
+       COALESCE(us.storage_state, '') AS &storageAttachmentUnitInfo.storage_state
+FROM   storage_attachment sa
+JOIN   unit u ON sa.unit_uuid = u.uuid
+JOIN   storage_instance si ON sa.storage_instance_uuid = si.uuid
+LEFT JOIN unit_state us ON sa.unit_uuid = us.unit_uuid
+WHERE  sa.uuid = $entityUUID.uuid
+`
+
+	stmt, err := st.Prepare(q, uuidInput, dbVal)
+	if err != nil {
+		return internal.StorageAttachmentHookInfo{}, errors.Errorf(
+			"preparing storage attachment hook info query: %w", err,
+		)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		exists, err := st.checkStorageAttachmentExists(ctx, tx, saUUID)
+		if err != nil {
+			return errors.Errorf(
+				"checking if storage attachment exists: %w", err,
+			)
+		}
+		if !exists {
+			return errors.Errorf(
+				"storage attachment %q does not exist in the model", saUUID,
+			).Add(storageerrors.StorageAttachmentNotFound)
+		}
+
+		return tx.Query(ctx, stmt, uuidInput).Get(&dbVal)
+	})
+	if err != nil {
+		return internal.StorageAttachmentHookInfo{}, errors.Capture(err)
+	}
+
+	return internal.StorageAttachmentHookInfo{
+		UnitDead:     dbVal.UnitLifeID == int(life.Dead),
+		StorageID:    dbVal.StorageID,
+		StorageState: dbVal.StorageState,
+	}, nil
+}
+
+// GetFilesystemAttachmentAdvanceInfo returns the provisioned attachment
+// advance information for the filesystem attachment identified by the input
+// UUID. This information is used by the service layer to determine if
+// the attachment can safely advance from dying to dead.
+//
+// The following errors may be returned:
+// - [storageprovisioningerrors.FilesystemAttachmentNotFound] if the
+// filesystem attachment no longer exists in the model.
+func (st *State) GetFilesystemAttachmentAdvanceInfo(
+	ctx context.Context, fsaUUID string,
+) (internal.ProvisionedAttachmentAdvanceInfo, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return internal.ProvisionedAttachmentAdvanceInfo{}, errors.Capture(err)
+	}
+
+	var (
+		dbVal     provisionedAttachmentAdvanceInfo
+		uuidInput = entityUUID{UUID: fsaUUID}
+	)
+
+	existsStmt, err := st.Prepare(`
+SELECT &entityUUID.uuid
+FROM   storage_filesystem_attachment
+WHERE  uuid = $entityUUID.uuid`, uuidInput)
+	if err != nil {
+		return internal.ProvisionedAttachmentAdvanceInfo{}, errors.Errorf(
+			"preparing filesystem attachment exists query: %w", err,
+		)
+	}
+
+	q := `
+SELECT sf.provision_scope_id AS &provisionedAttachmentAdvanceInfo.provision_scope_id,
+       COALESCE(sa.life_id, -1) AS &provisionedAttachmentAdvanceInfo.storage_attachment_life_id,
+       CASE WHEN mf.machine_uuid IS NULL THEN 1
+            WHEN m.uuid IS NULL THEN 1
+            ELSE 0
+       END AS &provisionedAttachmentAdvanceInfo.machine_gone
+FROM   storage_filesystem_attachment sfa
+JOIN   storage_filesystem sf ON sfa.storage_filesystem_uuid = sf.uuid
+LEFT JOIN storage_instance_filesystem sif ON sf.uuid = sif.storage_filesystem_uuid
+LEFT JOIN storage_attachment sa ON sif.storage_instance_uuid = sa.storage_instance_uuid
+LEFT JOIN machine_filesystem mf ON sf.uuid = mf.filesystem_uuid
+LEFT JOIN machine m ON mf.machine_uuid = m.uuid
+WHERE  sfa.uuid = $entityUUID.uuid
+`
+
+	stmt, err := st.Prepare(q, uuidInput, dbVal)
+	if err != nil {
+		return internal.ProvisionedAttachmentAdvanceInfo{}, errors.Errorf(
+			"preparing filesystem attachment advance info query: %w", err,
+		)
+	}
+
+	var result internal.ProvisionedAttachmentAdvanceInfo
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, existsStmt, uuidInput).Get(&uuidInput)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf(
+				"filesystem attachment %q not found", fsaUUID,
+			).Add(storageprovisioningerrors.FilesystemAttachmentNotFound)
+		} else if err != nil {
+			return errors.Errorf(
+				"running filesystem attachment exists query: %w", err,
+			)
+		}
+
+		err = tx.Query(ctx, stmt, uuidInput).Get(&dbVal)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return errors.Errorf(
+				"running filesystem attachment advance info query: %w", err,
+			)
+		}
+
+		result = internal.ProvisionedAttachmentAdvanceInfo{
+			MachineScopeProvisioned:     dbVal.ProvisionScopeID == 1,
+			StorageAttachmentDeadOrGone: dbVal.StorageAttachmentLifeID == int(life.Dead) || dbVal.StorageAttachmentLifeID == -1,
+			MachineGone:                 dbVal.MachineGone == 1,
+		}
+		return nil
+	})
+	if err != nil {
+		return internal.ProvisionedAttachmentAdvanceInfo{}, errors.Capture(err)
+	}
+
+	return result, nil
+}
+
+// GetVolumeAttachmentAdvanceInfo returns the provisioned attachment advance
+// information for the volume attachment identified by the input UUID. This
+// information is used by the service layer to determine if the attachment
+// can safely advance from dying to dead.
+//
+// The following errors may be returned:
+// - [storageprovisioningerrors.VolumeAttachmentNotFound] if the volume
+// attachment no longer exists in the model.
+func (st *State) GetVolumeAttachmentAdvanceInfo(
+	ctx context.Context, vaUUID string,
+) (internal.ProvisionedAttachmentAdvanceInfo, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return internal.ProvisionedAttachmentAdvanceInfo{}, errors.Capture(err)
+	}
+
+	var (
+		dbVal     provisionedAttachmentAdvanceInfo
+		uuidInput = entityUUID{UUID: vaUUID}
+	)
+
+	existsStmt, err := st.Prepare(`
+SELECT &entityUUID.uuid
+FROM   storage_volume_attachment
+WHERE  uuid = $entityUUID.uuid`, uuidInput)
+	if err != nil {
+		return internal.ProvisionedAttachmentAdvanceInfo{}, errors.Errorf(
+			"preparing volume attachment exists query: %w", err,
+		)
+	}
+
+	q := `
+SELECT sv.provision_scope_id AS &provisionedAttachmentAdvanceInfo.provision_scope_id,
+       COALESCE(sa.life_id, -1) AS &provisionedAttachmentAdvanceInfo.storage_attachment_life_id,
+       CASE WHEN mv.machine_uuid IS NULL THEN 1
+            WHEN m.uuid IS NULL THEN 1
+            ELSE 0
+       END AS &provisionedAttachmentAdvanceInfo.machine_gone
+FROM   storage_volume_attachment sva
+JOIN   storage_volume sv ON sva.storage_volume_uuid = sv.uuid
+LEFT JOIN storage_instance_volume siv ON sv.uuid = siv.storage_volume_uuid
+LEFT JOIN storage_attachment sa ON siv.storage_instance_uuid = sa.storage_instance_uuid
+LEFT JOIN machine_volume mv ON sv.uuid = mv.volume_uuid
+LEFT JOIN machine m ON mv.machine_uuid = m.uuid
+WHERE  sva.uuid = $entityUUID.uuid
+`
+
+	stmt, err := st.Prepare(q, uuidInput, dbVal)
+	if err != nil {
+		return internal.ProvisionedAttachmentAdvanceInfo{}, errors.Errorf(
+			"preparing volume attachment advance info query: %w", err,
+		)
+	}
+
+	var result internal.ProvisionedAttachmentAdvanceInfo
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, existsStmt, uuidInput).Get(&uuidInput)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf(
+				"volume attachment %q not found", vaUUID,
+			).Add(storageprovisioningerrors.VolumeAttachmentNotFound)
+		} else if err != nil {
+			return errors.Errorf(
+				"running volume attachment exists query: %w", err,
+			)
+		}
+
+		err = tx.Query(ctx, stmt, uuidInput).Get(&dbVal)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return errors.Errorf(
+				"running volume attachment advance info query: %w", err,
+			)
+		}
+
+		result = internal.ProvisionedAttachmentAdvanceInfo{
+			MachineScopeProvisioned:     dbVal.ProvisionScopeID == 1,
+			StorageAttachmentDeadOrGone: dbVal.StorageAttachmentLifeID == int(life.Dead) || dbVal.StorageAttachmentLifeID == -1,
+			MachineGone:                 dbVal.MachineGone == 1,
+		}
+		return nil
+	})
+	if err != nil {
+		return internal.ProvisionedAttachmentAdvanceInfo{}, errors.Capture(err)
+	}
+
+	return result, nil
+}
+
 // StorageAttachmentScheduleRemoval schedules a removal job for the storage
 // attachment with the input UUID, qualified with the input force boolean.
 // We don't care if the attachment does not exist at this point because:

--- a/domain/removal/state/model/storage_test.go
+++ b/domain/removal/state/model/storage_test.go
@@ -1323,6 +1323,281 @@ func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDead(c *tc.C) {
 	c.Check(lifeID, tc.Equals, 2)
 }
 
+// TestGetStorageAttachmentHookInfoNotFound verifies that the method returns
+// StorageAttachmentNotFound when the storage attachment does not exist.
+func (s *storageSuite) TestGetStorageAttachmentHookInfoNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	_, err := st.GetStorageAttachmentHookInfo(c.Context(), "nonexistent-uuid")
+	c.Check(err, tc.ErrorIs, storageerrors.StorageAttachmentNotFound)
+}
+
+// TestGetStorageAttachmentHookInfoNoUnitState verifies that when no unit_state
+// row exists, StorageState is returned as empty string.
+func (s *storageSuite) TestGetStorageAttachmentHookInfoNoUnitState(c *tc.C) {
+	_, saUUID := s.addAppUnitStorage(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetStorageAttachmentHookInfo(c.Context(), saUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.UnitDead, tc.Equals, false) // unit is alive (life_id=0)
+	c.Check(info.StorageState, tc.Equals, "")
+	// storage_id is populated from storage_instance
+	c.Check(info.StorageID, tc.Not(tc.Equals), "")
+}
+
+// TestGetStorageAttachmentHookInfoWithStorageState verifies that when a
+// unit_state row has storage_state YAML, it is returned verbatim.
+func (s *storageSuite) TestGetStorageAttachmentHookInfoWithStorageState(c *tc.C) {
+	_, saUUID := s.addAppUnitStorage(c)
+
+	ctx := c.Context()
+	_, err := s.DB().ExecContext(ctx,
+		"INSERT INTO unit_state (unit_uuid, storage_state) VALUES ('some-unit-uuid', 'data/0: true\n')")
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetStorageAttachmentHookInfo(ctx, saUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.UnitDead, tc.Equals, false)
+	c.Check(info.StorageState, tc.Equals, "data/0: true\n")
+}
+
+// TestGetStorageAttachmentHookInfoUnitDead verifies that UnitDead is true
+// when the unit's life is dead.
+func (s *storageSuite) TestGetStorageAttachmentHookInfoUnitDead(c *tc.C) {
+	_, saUUID := s.addAppUnitStorage(c)
+
+	ctx := c.Context()
+	_, err := s.DB().ExecContext(ctx,
+		"UPDATE unit SET life_id = 2 WHERE uuid = 'some-unit-uuid'")
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetStorageAttachmentHookInfo(ctx, saUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.UnitDead, tc.Equals, true)
+}
+
+// TestGetFilesystemAttachmentAdvanceInfoNotFound verifies that the method
+// returns FilesystemAttachmentNotFound when the attachment doesn't exist.
+func (s *storageSuite) TestGetFilesystemAttachmentAdvanceInfoNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	_, err := st.GetFilesystemAttachmentAdvanceInfo(c.Context(), "nonexistent-uuid")
+	c.Check(err, tc.ErrorIs, storageprovisioningerrors.FilesystemAttachmentNotFound)
+}
+
+// TestGetFilesystemAttachmentAdvanceInfoAllConditionsMet verifies that when
+// the filesystem is machine-scoped, the storage attachment is dead, and the
+// machine is gone, all conditions are met.
+func (s *storageSuite) TestGetFilesystemAttachmentAdvanceInfoAllConditionsMet(c *tc.C) {
+	ctx := c.Context()
+
+	// Create a machine-scoped filesystem with attachment.
+	netNode := "advance-net-node"
+	_, err := s.DB().ExecContext(ctx, "INSERT INTO net_node (uuid) VALUES (?)", netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fsUUID := "advance-fs-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id) VALUES (?, ?, 0, 1)",
+		fsUUID, "advance-fs")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem_status (filesystem_uuid, status_id) VALUES (?, 0)", fsUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fsaUUID := "advance-fsa-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem_attachment (uuid, storage_filesystem_uuid, net_node_uuid, life_id, provision_scope_id) VALUES (?, ?, ?, 0, 1)",
+		fsaUUID, fsUUID, netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// No storage_instance_filesystem link (storage attachment gone),
+	// no machine_filesystem link (machine gone).
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetFilesystemAttachmentAdvanceInfo(ctx, fsaUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.MachineScopeProvisioned, tc.Equals, true)
+	c.Check(info.StorageAttachmentDeadOrGone, tc.Equals, true)
+	c.Check(info.MachineGone, tc.Equals, true)
+}
+
+// TestGetFilesystemAttachmentAdvanceInfoStorageAttachmentAlive verifies that
+// StorageAttachmentDeadOrGone is false when the storage attachment is alive.
+func (s *storageSuite) TestGetFilesystemAttachmentAdvanceInfoStorageAttachmentAlive(c *tc.C) {
+	ctx := c.Context()
+
+	// Use addAppUnitStorage to create a full storage setup with an alive
+	// storage attachment.
+	siUUID, _ := s.addAppUnitStorage(c)
+
+	// Create a machine-scoped filesystem linked to the storage instance.
+	fsUUID := "advance-fs-alive-uuid"
+	_, err := s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id) VALUES (?, ?, 0, 1)",
+		fsUUID, "advance-fs-alive")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem_status (filesystem_uuid, status_id) VALUES (?, 0)", fsUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.addStorageInstanceFilesystem(c, siUUID, fsUUID)
+
+	fsaUUID := "advance-fsa-alive-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem_attachment (uuid, storage_filesystem_uuid, net_node_uuid, life_id, provision_scope_id) VALUES (?, ?, 'some-net-node-uuid', 0, 1)",
+		fsaUUID, fsUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetFilesystemAttachmentAdvanceInfo(ctx, fsaUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.MachineScopeProvisioned, tc.Equals, true)
+	c.Check(info.StorageAttachmentDeadOrGone, tc.Equals, false) // alive
+	c.Check(info.MachineGone, tc.Equals, true)                  // no machine_filesystem
+}
+
+// TestGetFilesystemAttachmentAdvanceInfoModelScoped verifies that
+// MachineScopeProvisioned is false when the filesystem is model-scoped.
+func (s *storageSuite) TestGetFilesystemAttachmentAdvanceInfoModelScoped(c *tc.C) {
+	ctx := c.Context()
+
+	netNode := "advance-model-net-node"
+	_, err := s.DB().ExecContext(ctx, "INSERT INTO net_node (uuid) VALUES (?)", netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fsUUID := "advance-model-fs-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id) VALUES (?, ?, 0, 0)",
+		fsUUID, "advance-model-fs")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem_status (filesystem_uuid, status_id) VALUES (?, 0)", fsUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fsaUUID := "advance-model-fsa-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem_attachment (uuid, storage_filesystem_uuid, net_node_uuid, life_id, provision_scope_id) VALUES (?, ?, ?, 0, 0)",
+		fsaUUID, fsUUID, netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetFilesystemAttachmentAdvanceInfo(ctx, fsaUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.MachineScopeProvisioned, tc.Equals, false) // model-scoped
+}
+
+// TestGetFilesystemAttachmentAdvanceInfoMachineExists verifies that
+// MachineGone is false when the machine still exists.
+func (s *storageSuite) TestGetFilesystemAttachmentAdvanceInfoMachineExists(c *tc.C) {
+	ctx := c.Context()
+
+	netNode := "advance-machine-net-node"
+	_, err := s.DB().ExecContext(ctx, "INSERT INTO net_node (uuid) VALUES (?)", netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fsUUID := "advance-machine-fs-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id) VALUES (?, ?, 0, 1)",
+		fsUUID, "advance-machine-fs")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem_status (filesystem_uuid, status_id) VALUES (?, 0)", fsUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fsaUUID := "advance-machine-fsa-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_filesystem_attachment (uuid, storage_filesystem_uuid, net_node_uuid, life_id, provision_scope_id) VALUES (?, ?, ?, 0, 1)",
+		fsaUUID, fsUUID, netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	machineUUID := s.addMachine(c)
+	s.addMachineFilesystem(c, machineUUID, fsUUID)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetFilesystemAttachmentAdvanceInfo(ctx, fsaUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.MachineScopeProvisioned, tc.Equals, true)
+	c.Check(info.MachineGone, tc.Equals, false) // machine still exists
+}
+
+// TestGetVolumeAttachmentAdvanceInfoNotFound verifies that the method returns
+// VolumeAttachmentNotFound when the attachment doesn't exist.
+func (s *storageSuite) TestGetVolumeAttachmentAdvanceInfoNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	_, err := st.GetVolumeAttachmentAdvanceInfo(c.Context(), "nonexistent-uuid")
+	c.Check(err, tc.ErrorIs, storageprovisioningerrors.VolumeAttachmentNotFound)
+}
+
+// TestGetVolumeAttachmentAdvanceInfoAllConditionsMet verifies the case where
+// all conditions for advancement are met.
+func (s *storageSuite) TestGetVolumeAttachmentAdvanceInfoAllConditionsMet(c *tc.C) {
+	ctx := c.Context()
+
+	netNode := "advance-vol-net-node"
+	_, err := s.DB().ExecContext(ctx, "INSERT INTO net_node (uuid) VALUES (?)", netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	volUUID := "advance-vol-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id) VALUES (?, ?, 0, 1)",
+		volUUID, "advance-vol")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_volume_status (volume_uuid, status_id) VALUES (?, 0)", volUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	vaUUID := "advance-va-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_volume_attachment (uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id) VALUES (?, ?, ?, 0, 1)",
+		vaUUID, volUUID, netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// No storage_instance_volume link, no machine_volume link.
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetVolumeAttachmentAdvanceInfo(ctx, vaUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.MachineScopeProvisioned, tc.Equals, true)
+	c.Check(info.StorageAttachmentDeadOrGone, tc.Equals, true)
+	c.Check(info.MachineGone, tc.Equals, true)
+}
+
+// TestGetVolumeAttachmentAdvanceInfoMachineExists verifies that MachineGone
+// is false when the machine still exists.
+func (s *storageSuite) TestGetVolumeAttachmentAdvanceInfoMachineExists(c *tc.C) {
+	ctx := c.Context()
+
+	netNode := "advance-vol-machine-net-node"
+	_, err := s.DB().ExecContext(ctx, "INSERT INTO net_node (uuid) VALUES (?)", netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	volUUID := "advance-vol-machine-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id) VALUES (?, ?, 0, 1)",
+		volUUID, "advance-vol-machine")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_volume_status (volume_uuid, status_id) VALUES (?, 0)", volUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	vaUUID := "advance-va-machine-uuid"
+	_, err = s.DB().ExecContext(ctx,
+		"INSERT INTO storage_volume_attachment (uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id) VALUES (?, ?, ?, 0, 1)",
+		vaUUID, volUUID, netNode)
+	c.Assert(err, tc.ErrorIsNil)
+
+	machineUUID := s.addMachine(c)
+	s.addMachineVolume(c, machineUUID, volUUID)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	info, err := st.GetVolumeAttachmentAdvanceInfo(ctx, vaUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.MachineScopeProvisioned, tc.Equals, true)
+	c.Check(info.MachineGone, tc.Equals, false)
+}
+
 func (s *storageSuite) TestGetDetachInfoForStorageAttachmentNotFound(c *tc.C) {
 	saUUID := tc.Must(c, storage.NewStorageAttachmentUUID)
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))

--- a/domain/removal/state/model/types.go
+++ b/domain/removal/state/model/types.go
@@ -120,6 +120,18 @@ type linkLayerDevice struct {
 // decision if a given storage attachment can be detached from a unit safely.
 // This information assumes the case where the unit will continue to run after
 // the attachment is removed.
+type storageAttachmentUnitInfo struct {
+	UnitLifeID   int    `db:"unit_life_id"`
+	StorageID    string `db:"storage_id"`
+	StorageState string `db:"storage_state"`
+}
+
+type provisionedAttachmentAdvanceInfo struct {
+	ProvisionScopeID        int `db:"provision_scope_id"`
+	StorageAttachmentLifeID int `db:"storage_attachment_life_id"`
+	MachineGone             int `db:"machine_gone"`
+}
+
 type storageAttachmentDetachInfo struct {
 	CharmStorageName string `db:"charm_storage_name"`
 	CountFulfilment  int    `db:"count_fulfilment"`


### PR DESCRIPTION
This patch ensures we remove the storage attachments before attempting to remove the machine. This had to be done from the removal domain. Initially this was done in a separate patch (https://github.com/juju/juju/pull/21761).

Storage attachments, filesystem attachments, and volume attachments were
being unconditionally advanced from dying to dead in removal job
processors. This violates lifecycle rules when provisioners may still be
responsible for them.

Add guards so that:
- Storage attachment dying->dead: only if force, unit is dead, or the
  storage-attached hook never fired (checked via unit_state YAML)
- Filesystem/volume attachment dying->dead: only if force, or the
  storage attachment is dead/gone AND the filesystem/volume is
  machine-scoped AND the owning machine is gone
- Filesystem/volume attachments are now marked as dead before deletion
  when dying


The rules requested in https://github.com/juju/juju/pull/21761#issuecomment-3884122276 were taken into account to fulfill the storage attachment removal: new types were added and queries to ensure that the storage attachment hook was not fired, we query the state of the storage attachment before deciding to advance its life.

## QA steps

First pack the `dummy-storage` charm (from /testcharms). Then deploy it and remove the app before the machine reaches the RUNNING state:
```
juju deploy ./testcharms/charms/dummy-storage/dummy-storage_amd64.charm --storage multi-fs=10M
juju status # just to check that the app is deploying
juju remove-application dummy-storage
```

You shouldn't see any errors in the logs and the app/unit/machine should be removed (after a few moments).

## Links

**Issue:** Fixes #21717.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9147](https://warthogs.atlassian.net/browse/JUJU-9147)


[JUJU-9147]: https://warthogs.atlassian.net/browse/JUJU-9147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ