### PR TITLE
fix(actions): show correct message when task has error outcome

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -121,7 +121,6 @@ func (c *runCommandBase) ensureAPI(ctx context.Context) (err error) {
 }
 
 func (c *runCommandBase) operationResults(ctx *cmd.Context, results *actionapi.EnqueuedActions) error {
-
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
 		return c.processOperationResults(ctx, false, results)
 	}
@@ -171,7 +170,7 @@ func (c *runCommandBase) processOperationResults(ctx *cmd.Context, forceColor bo
 	}
 
 	var actionID string
-	info := make(map[string]interface{}, numTasks)
+	info := make(map[string]any, numTasks)
 	for _, result := range runningTasks {
 		actionID = result.task
 
@@ -205,7 +204,7 @@ func (c *runCommandBase) processOperationResults(ctx *cmd.Context, forceColor bo
 		}
 		ctx.Infof("")
 	}
-	printInfo := func(opID, actionId, nTasks interface{}) {
+	printInfo := func(opID, actionId, nTasks any) {
 		if numTasks == 1 {
 			ctx.Infof("Scheduled operation %s with task %s", opID, actionId)
 			ctx.Infof("Check operation status with 'juju show-operation %s'", opID)
@@ -258,7 +257,7 @@ use 'juju show-task' to inspect the failure%s
 	return nil
 }
 
-func (c *runCommandBase) waitForTasks(ctx *cmd.Context, runningTasks []enqueuedAction, info map[string]interface{}) (map[string]int, error) {
+func (c *runCommandBase) waitForTasks(ctx *cmd.Context, runningTasks []enqueuedAction, info map[string]any) (map[string]int, error) {
 	var wait clock.Timer
 	if c.wait < 0 {
 		// Indefinite wait. Discard the tick.
@@ -375,7 +374,7 @@ func (c *runCommandBase) handleTimeout(tasks []enqueuedAction, got set.Strings) 
 //
 // By setting the hideProgress field, commands can choose whether these
 // messages are logged or sent to console by default.
-func (c *runCommandBase) progressf(ctx *cmd.Context, format string, params ...interface{}) {
+func (c *runCommandBase) progressf(ctx *cmd.Context, format string, params ...any) {
 	if c.hideProgress {
 		ctx.Verbosef(format, params...)
 	} else {
@@ -383,19 +382,20 @@ func (c *runCommandBase) progressf(ctx *cmd.Context, format string, params ...in
 	}
 }
 
-func (c *runCommandBase) printRunOutput(writer io.Writer, value interface{}) error {
+func (c *runCommandBase) printRunOutput(writer io.Writer, value any) error {
 	if c.noColor {
 		if _, ok := os.LookupEnv("NO_COLOR"); !ok {
-			defer os.Unsetenv("NO_COLOR")
-			os.Setenv("NO_COLOR", "")
+			defer func() {
+				_ = os.Unsetenv("NO_COLOR")
+			}()
+			_ = os.Setenv("NO_COLOR", "")
 		}
 	}
 
 	return printPlainOutput(writer, c.color, value)
 }
 
-func (c *runCommandBase) formatYaml(writer io.Writer, value interface{}) error {
-
+func (c *runCommandBase) formatYaml(writer io.Writer, value any) error {
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
 		return cmd.FormatYaml(writer, value)
 	}
@@ -415,8 +415,7 @@ func (c *runCommandBase) formatYaml(writer io.Writer, value interface{}) error {
 	return cmd.FormatYaml(writer, value)
 }
 
-func (c *runCommandBase) formatJson(writer io.Writer, value interface{}) error {
-
+func (c *runCommandBase) formatJson(writer io.Writer, value any) error {
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
 		return cmd.FormatJson(writer, value)
 	}
@@ -515,7 +514,7 @@ func fetchResult(ctx context.Context, api APIClient, requestedId string) (action
 }
 
 // colorVal appends ansi color codes to the given value
-func colorVal(ctx *ansiterm.Context, val interface{}) string {
+func colorVal(ctx *ansiterm.Context, val any) string {
 	buff := &bytes.Buffer{}
 	coloredWriter := ansiterm.NewWriter(buff)
 	coloredWriter.SetColorCapable(true)
@@ -557,17 +556,28 @@ func (a *enqueuedAction) GoString() string {
 	return tag.Kind() + " " + tag.Id()
 }
 
+const (
+	fieldStdout     = "stdout"
+	fieldStderr     = "stderr"
+	fieldOutput     = "output"
+	fieldResults    = "results"
+	fieldReturnCode = "return-code"
+	fieldMessage    = "message"
+	fieldStatus     = "status"
+	fieldID         = "id"
+)
+
 // filteredOutputKeys are those we don't want to display as part of the
 // results map for plain output.
-var filteredOutputKeys = set.NewStrings("return-code", "stdout", "stderr", "stdout-encoding", "stderr-encoding")
+var filteredOutputKeys = set.NewStrings(fieldReturnCode, fieldStdout, fieldStderr, "stdout-encoding", "stderr-encoding")
 
 // invoked by showtask.go
-func printOutput(writer io.Writer, value interface{}) error {
+func printOutput(writer io.Writer, value any) error {
 	return printPlainOutput(writer, false, value)
 }
 
-func printPlainOutput(writer io.Writer, forceColor bool, value interface{}) error {
-	info, ok := value.(map[string]interface{})
+func printPlainOutput(writer io.Writer, forceColor bool, value any) error {
+	info, ok := value.(map[string]any)
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", info, value)
 	}
@@ -577,8 +587,55 @@ func printPlainOutput(writer io.Writer, forceColor bool, value interface{}) erro
 		w.SetColorCapable(forceColor)
 	}
 
-	// actionInfo contains relevant information for each action result.
-	var actionInfo = make(map[string]map[string]interface{})
+	// print yaml format if there are more than one tasks
+	if len(info) > 1 {
+		// actionInfo contains relevant information for each action result
+		// stdout and stderr are excluded in yaml
+		actionInfo := make(map[string]map[string]any)
+		for k := range info {
+			_, _, res, err := extractSingleTask(info[k])
+			if err != nil {
+				return errors.Trace(err)
+			}
+			actionInfo[k] = res
+		}
+
+		return cmd.FormatYaml(writer, actionInfo)
+	}
+
+	// print stdout and stderr along with output if there's only a single task
+	for _, v := range info {
+		stdout, stderr, task, err := extractSingleTask(v)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		switch task[fieldStatus] {
+		case params.ActionFailed:
+			w.Printf(output.ErrorHighlight, "Action id %v failed: %v\n", task[fieldID], task[fieldMessage])
+			w.Println(output.ErrorHighlight, task[fieldOutput])
+		case params.ActionError:
+			w.Printf(output.ErrorHighlight, "Action id %v failed: %v\n", task[fieldID], task[fieldMessage])
+		default:
+			w.Println(output.GoodHighlight, task[fieldOutput])
+		}
+		if stdout != "" {
+			_, _ = fmt.Fprintln(writer, stdout)
+		}
+		if stderr != "" {
+			_, _ = fmt.Fprintln(writer, stderr)
+		}
+	}
+
+	return nil
+}
+
+func extractSingleTask(info any) (string, string, map[string]any, error) {
+	var stdout, stderr string
+	resultMetadata, ok := info.(map[string]any)
+	if !ok {
+		return "", "", nil, errors.Errorf("expected value of type %T, got %T", resultMetadata, info)
+	}
 
 	/*
 		Parse action YAML data that looks like this:
@@ -589,78 +646,63 @@ func printPlainOutput(writer io.Writer, forceColor bool, value interface{}) erro
 		    <action data here>
 		  status: completed
 	*/
-	var resultMetadata map[string]interface{}
-	var stdout, stderr string
-	for k := range info {
-		resultMetadata, ok = info[k].(map[string]interface{})
+
+	resultData, ok := resultMetadata[fieldResults].(map[string]any)
+	var out string
+	if ok {
+		stdout, stderr, out = extractTaskOutput(resultData)
+	} else {
+		status, ok := resultMetadata[fieldStatus].(string)
 		if !ok {
-			return errors.Errorf("expected value of type %T, got %T", resultMetadata, info[k])
+			status = "has unknown status"
 		}
-		resultData, ok := resultMetadata["results"].(map[string]interface{})
-		var output string
-		if ok {
-			resultDataCopy := make(map[string]interface{})
-			for k, v := range resultData {
-				k = strings.ToLower(k)
-				if k == "stdout" && v != "" {
-					stdout = fmt.Sprint(v)
-				}
-				if k == "stderr" && v != "" {
-					stderr = fmt.Sprint(v)
-				}
-				if !filteredOutputKeys.Contains(k) {
-					resultDataCopy[k] = v
-				}
-			}
-			if len(resultDataCopy) > 0 {
-				data, err := yaml.Marshal(resultDataCopy)
-				if err == nil {
-					output = string(data)
-				} else {
-					output = fmt.Sprintf("%v", resultDataCopy)
-				}
-			}
-		} else {
-			status, ok := resultMetadata["status"].(string)
-			if !ok {
-				status = "has unknown status"
-			}
-			output = fmt.Sprintf("Task %v %v\n", resultMetadata["id"], status)
+		out = fmt.Sprintf("Task %v %v", resultMetadata[fieldID], status)
+	}
+	res := map[string]any{
+		fieldID:     resultMetadata[fieldID],
+		fieldOutput: out,
+		fieldStatus: resultMetadata[fieldStatus],
+	}
+	if msg, ok := resultMetadata[fieldMessage]; ok {
+		res[fieldMessage] = msg
+	}
+	return stdout, stderr, res, nil
+}
+
+// extractTaskOutput splits stdout and stderr from the rest of the result data so that they can be printed separately in
+// plain format. The remaining data, except the filtered keys, is returned as a YAML string to be printed in the results
+// section of the output.
+func extractTaskOutput(resultData map[string]any) (string, string, string) {
+	var stdout, stderr string
+	resultDataCopy := make(map[string]any)
+	for k, v := range resultData {
+		k = strings.ToLower(k)
+
+		if k == fieldStdout && v != "" {
+			stdout = fmt.Sprint(v)
 		}
-		actionInfo[k] = map[string]interface{}{
-			"id":     resultMetadata["id"],
-			"output": output,
-			"status": resultMetadata["status"],
+		if k == fieldStderr && v != "" {
+			stderr = fmt.Sprint(v)
 		}
-		if msg, ok := resultMetadata["message"]; ok {
-			actionInfo[k]["message"] = msg
+		if !filteredOutputKeys.Contains(k) {
+			resultDataCopy[k] = v
 		}
 	}
-	if len(actionInfo) > 1 {
-		return cmd.FormatYaml(writer, actionInfo)
+	if len(resultDataCopy) == 0 {
+		return stdout, stderr, ""
 	}
-	for _, info := range actionInfo {
-		if info["status"] == params.ActionFailed {
-			w.Printf(output.ErrorHighlight, "Action id %v failed: %v\n", info["id"], info["message"])
-			w.Println(output.ErrorHighlight, info["output"])
-		} else {
-			w.Println(output.GoodHighlight, info["output"])
-		}
+	data, err := yaml.Marshal(resultDataCopy)
+	if err != nil {
+		return stdout, stderr, fmt.Sprintf("%v", resultDataCopy)
 	}
-	if stdout != "" {
-		fmt.Fprintln(writer, strings.Trim(stdout, "\n"))
-	}
-	if stderr != "" {
-		fmt.Fprintln(writer, strings.Trim(stderr, "\n"))
-	}
-	return nil
+	return stdout, stderr, string(data)
 }
 
 // formatActionResult removes empty values from the given ActionResult and
-// inserts the remaining ones in a map[string]interface{} for cmd.Output to
+// inserts the remaining ones in a map[string]any for cmd.Output to
 // write in an easy-to-read format.
-func formatActionResult(id string, result actionapi.ActionResult, utc bool) (map[string]interface{}, int) {
-	response := map[string]interface{}{"id": id, "status": result.Status}
+func formatActionResult(id string, result actionapi.ActionResult, utc bool) (map[string]any, int) {
+	response := map[string]any{fieldID: id, fieldStatus: result.Status}
 	if result.Error != nil {
 		response["error"] = result.Error.Error()
 	}
@@ -671,11 +713,11 @@ func formatActionResult(id string, result actionapi.ActionResult, utc bool) (map
 		}
 	}
 	if result.Message != "" {
-		response["message"] = result.Message
+		response[fieldMessage] = result.Message
 	}
-	output, exitCode := convertActionOutput(result.Output)
+	out, exitCode := convertActionOutput(result.Output)
 	if len(result.Output) != 0 {
-		response["results"] = output
+		response[fieldResults] = out
 	}
 	if len(result.Log) > 0 {
 		var logs []string
@@ -708,38 +750,38 @@ func formatActionResult(id string, result actionapi.ActionResult, utc bool) (map
 }
 
 // convertActionOutput returns result data with stdout, stderr etc correctly formatted.
-func convertActionOutput(output map[string]interface{}) (map[string]interface{}, int) {
+func convertActionOutput(output map[string]any) (map[string]any, int) {
 	if output == nil {
 		return nil, -1
 	}
 	values := output
 	// We always want to have a string for stdout, but only show stderr,
 	// code and error if they are there.
-	res, ok := output["stdout"].(string)
+	res, ok := output[fieldStdout].(string)
 	if ok && len(res) > 0 {
-		values["stdout"] = strings.Replace(res, "\r\n", "\n", -1)
+		values[fieldStdout] = strings.Trim(strings.ReplaceAll(res, "\r\n", "\n"), "\n")
 	} else {
-		delete(values, "stdout")
+		delete(values, fieldStdout)
 	}
-	res, ok = output["stderr"].(string)
+	res, ok = output[fieldStderr].(string)
 	if ok && len(res) > 0 {
-		values["stderr"] = strings.Replace(res, "\r\n", "\n", -1)
+		values[fieldStderr] = strings.Trim(strings.ReplaceAll(res, "\r\n", "\n"), "\n")
 	} else {
-		delete(values, "stderr")
+		delete(values, fieldStderr)
 	}
 	// return-code may come in as a float64 due to serialisation.
-	var v interface{}
-	if v, ok = output["return-code"]; ok && v != nil {
+	var v any
+	if v, ok = output[fieldReturnCode]; ok && v != nil {
 		res = fmt.Sprintf("%v", v)
 	}
 	code := -1
 	if ok && len(res) > 0 {
 		var err error
 		if code, err = strconv.Atoi(res); err == nil {
-			values["return-code"] = code
+			values[fieldReturnCode] = code
 		}
 	} else {
-		delete(values, "return-code")
+		delete(values, fieldReturnCode)
 	}
 	return values, code
 }
@@ -747,7 +789,7 @@ func convertActionOutput(output map[string]interface{}) (map[string]interface{},
 // addValueToMap adds the given value to the map on which the method is run.
 // This allows us to merge maps such as {foo: {bar: baz}} and {foo: {baz: faz}}
 // into {foo: {bar: baz, baz: faz}}.
-func addValueToMap(keys []string, value interface{}, target map[string]interface{}) {
+func addValueToMap(keys []string, value any, target map[string]any) {
 	next := target
 
 	for i := range keys {
@@ -759,14 +801,14 @@ func addValueToMap(keys []string, value interface{}, target map[string]interface
 
 		if iface, ok := next[keys[i]]; ok {
 			switch typed := iface.(type) {
-			case map[string]interface{}:
+			case map[string]any:
 				// If we already had a map inside, keep
 				// stepping through.
 				next = typed
 			default:
 				// If we didn't, then overwrite value
 				// with a map and iterate with that.
-				m := map[string]interface{}{}
+				m := map[string]any{}
 				next[keys[i]] = m
 				next = m
 			}
@@ -775,7 +817,7 @@ func addValueToMap(keys []string, value interface{}, target map[string]interface
 
 		// Otherwise, it wasn't present, so make it and step
 		// into.
-		m := map[string]interface{}{}
+		m := map[string]any{}
 		next[keys[i]] = m
 		next = m
 	}

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -22,9 +22,9 @@ import (
 	actionapi "github.com/juju/juju/api/client/action"
 	"github.com/juju/juju/cmd/juju/action"
 	coreoperation "github.com/juju/juju/core/operation"
+	"github.com/juju/juju/core/testing"
 	"github.com/juju/juju/internal/cmd"
 	"github.com/juju/juju/internal/cmd/cmdtesting"
-	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -229,25 +229,27 @@ func (s *RunSuite) TestInit(c *tc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			wrappedCommand, command := action.NewRunCommandForTest(s.store, testClock(), nil)
-			c.Logf("test %d: should %s:\n$ juju run (action) %s\n", i,
-				t.should, strings.Join(t.args, " "))
-			args := append([]string{modelFlag, "admin"}, t.args...)
-			err := cmdtesting.InitCommand(wrappedCommand, args)
-			if t.expectError == "" {
-				c.Check(command.UnitNames(), tc.DeepEquals, t.expectUnits)
-				c.Check(command.ActionName(), tc.Equals, t.expectAction)
-				c.Check(command.ParamsYAML().Path, tc.Equals, t.expectParamsYamlPath)
-				c.Check(command.Args(), tc.DeepEquals, t.expectKVArgs)
-				c.Check(command.ParseStrings(), tc.Equals, t.expectParseStrings)
-				if t.expectWait != 0 {
-					c.Check(command.Wait(), tc.Equals, t.expectWait)
+			c.T.Run(t.should, func(_ *stdtesting.T) {
+				wrappedCommand, command := action.NewRunCommandForTest(s.store, testClock(), nil)
+				c.Logf("test %d: should %s:\n$ juju run (action) %s\n", i,
+					t.should, strings.Join(t.args, " "))
+				args := append([]string{modelFlag, "admin"}, t.args...)
+				err := cmdtesting.InitCommand(wrappedCommand, args)
+				if t.expectError == "" {
+					c.Check(command.UnitNames(), tc.DeepEquals, t.expectUnits)
+					c.Check(command.ActionName(), tc.Equals, t.expectAction)
+					c.Check(command.ParamsYAML().Path, tc.Equals, t.expectParamsYamlPath)
+					c.Check(command.Args(), tc.DeepEquals, t.expectKVArgs)
+					c.Check(command.ParseStrings(), tc.Equals, t.expectParseStrings)
+					if t.expectWait != 0 {
+						c.Check(command.Wait(), tc.Equals, t.expectWait)
+					} else {
+						c.Check(command.Wait(), tc.Equals, 60*time.Second)
+					}
 				} else {
-					c.Check(command.Wait(), tc.Equals, 60*time.Second)
+					c.Check(err, tc.ErrorMatches, t.expectError)
 				}
-			} else {
-				c.Check(err, tc.ErrorMatches, t.expectError)
-			}
+			})
 		}
 	}
 }
@@ -274,8 +276,10 @@ func (s *RunSuite) TestRun(c *tc.C) {
 	}, {
 		should:   "fail with API error",
 		withArgs: []string{validUnitId, "some-action"},
-		withActionResults: []actionapi.ActionResult{{
-			Action: &actionapi.Action{ID: validActionId}},
+		withActionResults: []actionapi.ActionResult{
+			{
+				Action: &actionapi.Action{ID: validActionId},
+			},
 		},
 		withAPIErr:  errors.New("something wrong in API"),
 		expectedErr: "something wrong in API",
@@ -291,19 +295,22 @@ Operation 1 failed to schedule any tasks:
 database error`[1:],
 	}, {
 		should: "fail with missing file passed",
-		withArgs: []string{validUnitId, "some-action",
+		withArgs: []string{
+			validUnitId, "some-action",
 			"--params", s.dir + "/" + "missing.yml",
 		},
 		expectedErr: "open .*missing.yml: " + utils.NoSuchFileErrRegexp,
 	}, {
 		should: "fail with invalid yaml in file",
-		withArgs: []string{validUnitId, "some-action",
+		withArgs: []string{
+			validUnitId, "some-action",
 			"--params", s.dir + "/" + "invalidParams.yml",
 		},
 		expectedErr: "yaml: line 4: mapping values are not allowed in this context",
 	}, {
 		should: "fail with invalid UTF in file",
-		withArgs: []string{validUnitId, "some-action",
+		withArgs: []string{
+			validUnitId, "some-action",
 			"--params", s.dir + "/" + "invalidUTF.yml",
 		},
 		expectedErr: "yaml: invalid leading UTF-8 octet",
@@ -322,7 +329,7 @@ database error`[1:],
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 	}, {
@@ -335,9 +342,9 @@ database error`[1:],
 				Name:     "some-action",
 			},
 			Status: "completed",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello",
 				},
 			},
@@ -347,7 +354,7 @@ database error`[1:],
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 		expectedOutput: `
@@ -364,14 +371,14 @@ result-map:
 				Name:     "some-action",
 			},
 			Status: "completed",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"return-code":     0,
 				"stdout":          "hello",
 				"stderr":          "world",
 				"stdout-encoding": "utf-8",
 				"stderr-encoding": "utf-8",
 				"outcome":         "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello",
 				},
 			},
@@ -381,7 +388,7 @@ result-map:
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 		expectedOutput: `
@@ -401,14 +408,14 @@ world`[1:],
 				Name:     "some-action",
 			},
 			Status: "completed",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"return-code":     0,
 				"stdout":          "hello",
 				"stderr":          "world",
 				"stdout-encoding": "utf-8",
 				"stderr-encoding": "utf-8",
 				"outcome":         "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello",
 				},
 			},
@@ -418,7 +425,7 @@ world`[1:],
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 		expectedOutput: `
@@ -449,14 +456,14 @@ mysql/0:
 				Name:     "some-action",
 			},
 			Status: "completed",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"return-code":     0,
 				"stdout":          "hello",
 				"stderr":          "world",
 				"stdout-encoding": "utf-8",
 				"stderr-encoding": "utf-8",
 				"outcome":         "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello",
 				},
 			},
@@ -466,7 +473,7 @@ mysql/0:
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 		expectedLogs: []string{"log line 1", "log line 2"},
@@ -494,14 +501,14 @@ world`[1:],
 				Message:   "log line 2",
 			}},
 			Status: "completed",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"return-code":     0,
 				"stdout":          "hello",
 				"stderr":          "world",
 				"stdout-encoding": "utf-8",
 				"stderr-encoding": "utf-8",
 				"outcome":         "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello",
 				},
 			},
@@ -511,7 +518,7 @@ world`[1:],
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 		expectedLogs: []string{"log line 1", "log line 2"},
@@ -547,16 +554,16 @@ mysql/0:
 			},
 			Status:  params.ActionFailed,
 			Message: "action failed msg",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "fail",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "failed :'(",
 				},
 			},
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 		expectedOutput: `
@@ -574,9 +581,9 @@ result-map:
 				Name:     "some-action",
 			},
 			Status: "completed",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello",
 				},
 			},
@@ -590,9 +597,9 @@ result-map:
 				Name:     "some-action",
 			},
 			Status: "completed",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello2",
 				},
 			},
@@ -602,11 +609,11 @@ result-map:
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}, {
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId2).String(),
 		}},
 		expectedOutput: `
@@ -644,9 +651,9 @@ mysql/1:
 				Name:     "some-action",
 			},
 			Status: "completed",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello",
 				},
 			},
@@ -657,20 +664,20 @@ mysql/1:
 				Name:     "some-action",
 			},
 			Status: params.ActionCompleted,
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "hello2",
 				},
 			},
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}, {
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId2).String(),
 		}},
 		expectedOutput: `
@@ -699,9 +706,9 @@ mysql/1:
 			},
 			Status:  params.ActionFailed,
 			Message: "action failed msg",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "fail",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "failed :'(",
 				},
 			},
@@ -713,20 +720,20 @@ mysql/1:
 			},
 			Status:  params.ActionFailed,
 			Message: "action failed msg 2",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "fail",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "failed2 :'(",
 				},
 			},
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}, {
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId2).String(),
 		}},
 		expectedOutput: `
@@ -757,9 +764,9 @@ mysql/1:
 			},
 			Status:  params.ActionFailed,
 			Message: "action failed msg",
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "fail",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "failed :'(",
 				},
 			},
@@ -770,20 +777,20 @@ mysql/1:
 				Name:     "some-action",
 			},
 			Status: params.ActionCompleted,
-			Output: map[string]interface{}{
+			Output: map[string]any{
 				"outcome": "success",
-				"result-map": map[string]interface{}{
+				"result-map": map[string]any{
 					"message": "pass",
 				},
 			},
 		}},
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}, {
 			Name:       "some-action",
-			Parameters: map[string]interface{}{},
+			Parameters: map[string]any{},
 			Receiver:   names.NewUnitTag(validUnitId2).String(),
 		}},
 		expectedOutput: `
@@ -804,7 +811,8 @@ mysql/1:
   status: completed`[1:],
 	}, {
 		should: "enqueue an action with some explicit params",
-		withArgs: []string{validUnitId, "some-action", "--background",
+		withArgs: []string{
+			validUnitId, "some-action", "--background",
 			"out.name=bar",
 			"out.kind=tmpfs",
 			"out.num=3",
@@ -819,8 +827,8 @@ mysql/1:
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:     "some-action",
 			Receiver: names.NewUnitTag(validUnitId).String(),
-			Parameters: map[string]interface{}{
-				"out": map[string]interface{}{
+			Parameters: map[string]any{
+				"out": map[string]any{
 					"name":    "bar",
 					"kind":    "tmpfs",
 					"num":     3,
@@ -830,7 +838,8 @@ mysql/1:
 		}},
 	}, {
 		should: "enqueue an action with some raw string params",
-		withArgs: []string{validUnitId, "some-action", "--background", "--string-args",
+		withArgs: []string{
+			validUnitId, "some-action", "--background", "--string-args",
 			"out.name=bar",
 			"out.kind=tmpfs",
 			"out.num=3",
@@ -845,8 +854,8 @@ mysql/1:
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:     "some-action",
 			Receiver: names.NewUnitTag(validUnitId).String(),
-			Parameters: map[string]interface{}{
-				"out": map[string]interface{}{
+			Parameters: map[string]any{
+				"out": map[string]any{
 					"name":    "bar",
 					"kind":    "tmpfs",
 					"num":     "3",
@@ -856,7 +865,8 @@ mysql/1:
 		}},
 	}, {
 		should: "enqueue an action with file params plus CLI args",
-		withArgs: []string{validUnitId, "some-action", "--background",
+		withArgs: []string{
+			validUnitId, "some-action", "--background",
 			"--params", s.dir + "/" + "validParams.yml",
 			"compression.kind=gz",
 			"compression.fast=true",
@@ -870,9 +880,9 @@ mysql/1:
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:     "some-action",
 			Receiver: names.NewUnitTag(validUnitId).String(),
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"out": "name",
-				"compression": map[string]interface{}{
+				"compression": map[string]any{
 					"kind":    "gz",
 					"quality": "high",
 					"fast":    true,
@@ -881,7 +891,8 @@ mysql/1:
 		}},
 	}, {
 		should: "enqueue an action with file params and explicit params",
-		withArgs: []string{validUnitId, "some-action", "--background",
+		withArgs: []string{
+			validUnitId, "some-action", "--background",
 			"out.name=bar",
 			"out.kind=tmpfs",
 			"compression.quality.speed=high",
@@ -897,20 +908,40 @@ mysql/1:
 		expectedActionEnqueued: []actionapi.Action{{
 			Name:     "some-action",
 			Receiver: names.NewUnitTag(validUnitId).String(),
-			Parameters: map[string]interface{}{
-				"out": map[string]interface{}{
+			Parameters: map[string]any{
+				"out": map[string]any{
 					"name": "bar",
 					"kind": "tmpfs",
 				},
-				"compression": map[string]interface{}{
+				"compression": map[string]any{
 					"kind": "xz",
-					"quality": map[string]interface{}{
+					"quality": map[string]any{
 						"speed": "high",
 						"size":  "small",
 					},
 				},
 			},
 		}},
+	}, {
+		should:   "enqueue action fails with incorrect params",
+		withArgs: []string{validUnitId, "some-action", "dry-run=abc"},
+		withActionResults: []actionapi.ActionResult{{
+			Action: &actionapi.Action{
+				ID:         validActionId,
+				Receiver:   names.NewUnitTag(validUnitId).String(),
+				Name:       "some-action",
+				Parameters: map[string]any{},
+			},
+			Status:  params.ActionError,
+			Message: "cannot run some-action action: validation failed",
+			Output:  nil,
+		}},
+		expectedActionEnqueued: []actionapi.Action{{
+			Name:       "some-action",
+			Parameters: map[string]any{"dry-run": "abc"},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		}},
+		expectedOutput: "Action id 1 failed: cannot run some-action action: validation failed",
 	}, {
 		should:   "enqueue a basic action on the leader",
 		withArgs: []string{"mysql/leader", "some-action", "--background"},
@@ -920,41 +951,44 @@ mysql/1:
 				Receiver: names.NewUnitTag(validUnitId).String(),
 			},
 		}},
-		expectedActionEnqueued: []actionapi.Action{{
-			Name:       "some-action",
-			Parameters: map[string]interface{}{},
-			Receiver:   "mysql/leader",
+		expectedActionEnqueued: []actionapi.Action{
+			{
+				Name:       "some-action",
+				Parameters: map[string]any{},
+				Receiver:   "mysql/leader",
+			},
 		},
-		}},
-	}
+	}}
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			c.Logf("test %d: should %s:\n$ juju actions do %s\n", i, t.should, strings.Join(t.withArgs, " "))
-			s.clock = testClock()
+			c.T.Run(t.should, func(_ *stdtesting.T) {
+				c.Logf("test %d: should %s:\n$ juju actions do %s\n", i, t.should, strings.Join(t.withArgs, " "))
+				s.clock = testClock()
 
-			fakeClient := &fakeAPIClient{
-				actionResults: t.withActionResults,
-				logMessageCh:  make(chan []string, len(t.expectedLogs)),
-			}
+				fakeClient := &fakeAPIClient{
+					actionResults: t.withActionResults,
+					logMessageCh:  make(chan []string, len(t.expectedLogs)),
+				}
 
-			if len(t.expectedLogs) > 0 {
-				fakeClient.waitForResults = make(chan bool)
-			}
-			if t.clientSetup != nil {
-				t.clientSetup(fakeClient)
-			}
-			fakeClient.apiErr = t.withAPIErr
-			fakeClient.actionResults = t.withActionResults
+				if len(t.expectedLogs) > 0 {
+					fakeClient.waitForResults = make(chan bool)
+				}
+				if t.clientSetup != nil {
+					t.clientSetup(fakeClient)
+				}
+				fakeClient.apiErr = t.withAPIErr
+				fakeClient.actionResults = t.withActionResults
 
-			s.testRunHelper(c,
-				fakeClient,
-				t.expectedErr,
-				t.expectedOutput,
-				modelFlag,
-				t.withArgs,
-				t.expectedActionEnqueued,
-				t.expectedLogs)
+				s.testRunHelper(c,
+					fakeClient,
+					t.expectedErr,
+					t.expectedOutput,
+					modelFlag,
+					t.withArgs,
+					t.expectedActionEnqueued,
+					t.expectedLogs)
+			})
 		}
 	}
 }
@@ -1003,34 +1037,36 @@ hello
 			Receiver: names.NewUnitTag(validUnitId).String(),
 			Name:     "some-action",
 		},
-		Output: map[string]interface{}{
+		Output: map[string]any{
 			"stdout": "hello",
 		},
 	}}
 
 	for i, t := range tests {
-		c.Logf("test %d: %s", i, t.about)
+		c.T.Run(t.about, func(_ *stdtesting.T) {
+			c.Logf("test %d: %s", i, t.about)
 
-		// Set up context
-		output := bytes.Buffer{}
-		ctx := &cmd.Context{
-			Context: c.Context(),
-			Stdout:  &output,
-			Stderr:  &output,
-		}
-		log := cmd.Log{
-			Verbose: t.verbose,
-			Quiet:   t.quiet,
-		}
-		log.Start(ctx) // sets the verbose/quiet options in `ctx`
+			// Set up context
+			output := bytes.Buffer{}
+			ctx := &cmd.Context{
+				Context: c.Context(),
+				Stdout:  &output,
+				Stderr:  &output,
+			}
+			log := cmd.Log{
+				Verbose: t.verbose,
+				Quiet:   t.quiet,
+			}
+			_ = log.Start(ctx) // sets the verbose/quiet options in `ctx`
 
-		// Run command
-		runCmd, _ := action.NewRunCommandForTest(s.store, s.clock, nil)
-		err := cmdtesting.InitCommand(runCmd, []string{"-m", "admin", validUnitId, "some-action"})
-		c.Assert(err, tc.ErrorIsNil)
-		err = runCmd.Run(ctx)
-		c.Assert(err, tc.ErrorIsNil)
-		c.Check(output.String(), tc.Equals, t.output)
+			// Run command
+			runCmd, _ := action.NewRunCommandForTest(s.store, s.clock, nil)
+			err := cmdtesting.InitCommand(runCmd, []string{"-m", "admin", validUnitId, "some-action"})
+			c.Assert(err, tc.ErrorIsNil)
+			err = runCmd.Run(ctx)
+			c.Assert(err, tc.ErrorIsNil)
+			c.Check(output.String(), tc.Equals, t.output)
+		})
 	}
 }
 

--- a/tests/suites/actions/run_actions.sh
+++ b/tests/suites/actions/run_actions.sh
@@ -27,11 +27,16 @@ run_actions_params() {
 	juju show-task 3 --format=json | jq '.status' | check 'failed'
 
 	# Run an action with misspelled parameters.
-	juju run juju-qa-action/0 fortune length="long" misspelledparam="ok"
+	juju run juju-qa-action/0 fortune length="long" misspelledparam="ok" |
+	  check 'additional property \"misspelledparam\" is not allowed'
 	# Check the action was rejected.
 	juju show-operation 4 --format=json | jq '.status' | check 'error'
+	juju show-operation 4 --format=json | jq '.tasks."5".message' |
+	 check 'additional property \\"misspelledparam\\" is not allowed'
 	# Check the task did not run and has status error.
 	juju show-task 5 --format=json | jq '.status' | check 'error'
+	juju show-task 5 --format=json | jq '.message' |
+	  check 'additional property \\"misspelledparam\\" is not allowed'
 
 	# Run an action that returns all the parameters passed to it.
 	juju run juju-qa-action/0 list-my-params string="my string" array="[1,2]" bool=true
@@ -41,6 +46,18 @@ run_actions_params() {
 	juju show-task 7 --format=json | jq '.results | .["string"]' | check 'my string'
 	juju show-task 7 --format=json | jq '.results | .["array"]' | check '[1, 2]'
 	juju show-task 7 --format=json | jq '.results | .["bool"]' | check 'True'
+
+  # Run an action that will return error status.
+	juju run juju-qa-action/0 fortune length=false |
+	  check 'validation failed: \(root\).length : must be of type string, given false'
+	# Check the the operation failed as expected.
+	juju show-operation 8 --format=json | jq '.status' | check 'error'
+	juju show-operation 8 --format=json | jq '.tasks."9".message' |
+	  check 'validation failed: \(root\).length : must be of type string, given false'
+	# Check the task failed as expected.
+	juju show-task 9 --format=json | jq '.status' | check 'error'
+	juju show-task 9 --format=json | jq '.message' |
+	  check 'validation failed: \(root\).length : must be of type string, given false'
 
 	destroy_model "actions_test"
 }


### PR DESCRIPTION
The core issue was that while `failed` outcomes (runtime errors) were properly
reported, `error` outcomes (often validation errors for action parameters) were
being swallowed by the CLI.

### Key Changes

- **Surfacing Error Status:** Updated `printPlainOutput` to handle the
  `params.ActionError` case.
- **Code Modernization:** Replaced `interface{}` with the more modern Go `any`
  alias across `common.go`.
- **Refactoring:** Extracted `extractTaskOutput` to clean up the logic in the
  main output loop.
- **Testing:** Improved unit test readability by using subtests (`c.T.Run`) and
  added a specific case for validation errors. Extend bash test to cover these
  cases.

Note: in `3.6` output were shown correctly because:

- validation of action parameters is done before queuing the task.
- validation failure means no tasks are created
- error message about task creation failure is shown, not task outcome.
- Same problem with the error outcome exists in `3.6` but was not noticed
  because it doesn't happen normally because validation is done before task
  creation.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. Setup controller v4.0 and deploy `kafka-k8s` for testing

```sh
juju bootstrap microk8s local-k8s-40
juju add-model test-40
juju deploy kafka-k8s --channel 3/stable
```

2. Setup controller v3.6 and deploy `kafka-k8s` for testing

```sh
juju_36 bootstrap microk8s local-k8s-36
juju_36 add-model test-36
juju_36 deploy kafka-k8s --channel 3/stable
```

3. Run action with incorrect parameter - error case
```sh
$ juju switch local-k8s-40:test-40
$ juju run kafka-k8s/0 rebalance brokerid=0 dryrun=abc mode=full
Running operation 0 with 1 task
  - task 1 on unit-kafka-k8s-0

Waiting for task 1...
Action id 1 failed: cannot run "rebalance" action: validation failed: (root).dryrun : must be of type boolean, given "abc"  

$ juju show-operation 0
summary: action "rebalance"
status: error
action:
  name: rebalance
  parameters:
    brokerid: 0
    dryrun: abc
    mode: full
timing:
  enqueued: 2026-02-10 13:56:23.297757676 +0100 CET
  completed: 2026-02-10 13:56:28.907390804 +0100 CET
tasks:
  "1":
    host: kafka-k8s/0
    status: error
    timing:
      enqueued: 2026-02-10 13:56:23.299012901 +0100 CET
    message: 'cannot run "rebalance" action: validation failed: (root).dryrun : must
      be of type boolean, given "abc"'

$ juju show-task 1
Action id 1 failed: cannot run "rebalance" action: validation failed: (root).dryrun : must be of type boolean, given "abc"
```

3. Run the same with current `4.0` without the fix
```sh
$ juju_40 run kafka-k8s/0 rebalance brokerid=0 dryrun=abc mode=full
Running operation 2 with 1 task
  - task 3 on unit-kafka-k8s-0

Waiting for task 3...
Task 3 error

$ juju_40 show-operation 2
summary: action "rebalance"
status: error
action:
  name: rebalance
  parameters:
    brokerid: 0
    dryrun: abc
    mode: full
timing:
  enqueued: 2026-02-10 13:58:27.57696025 +0100 CET
  completed: 2026-02-10 13:58:36.369897501 +0100 CET
tasks:
  "3":
    host: kafka-k8s/0
    status: error
    timing:
      enqueued: 2026-02-10 13:58:27.578155338 +0100 CET
    message: 'cannot run "rebalance" action: validation failed: (root).dryrun : must
      be of type boolean, given "abc"'

$ juju_40 show-task 3
Task 3 error
```

5. Run action with correct parameter - failed case

```sh
$ juju run kafka-k8s/0 rebalance brokerid=0 dryrun=false mode=full
Running operation 4 with 1 task
  - task 5 on unit-kafka-k8s-0

Waiting for task 5...
Action id 5 failed: Action must be ran on an application with balancer role
error: Action must be ran on an application with balancer role

$ juju show-task 5
Action id 5 failed: Action must be ran on an application with balancer role
error: Action must be ran on an application with balancer role

```


6. Run the same with current `4.0` without the fix
```sh
$ juju_40 run kafka-k8s/0 rebalance brokerid=0 dryrun=false mode=full
Running operation 6 with 1 task
  - task 7 on unit-kafka-k8s-0

Waiting for task 7...
Action id 7 failed: Action must be ran on an application with balancer role
error: Action must be ran on an application with balancer role


$ juju_40 show-task 7
Action id 7 failed: Action must be ran on an application with balancer role
error: Action must be ran on an application with balancer role

```


7. Run the fixed version against `3.6`
```sh
$ juju switch local-k8s-36:test-36
$ juju run kafka-k8s/0 rebalance brokerid=0 dryrun=false mode=full
Running operation 1 with 1 task
  - task 2 on unit-kafka-k8s-0

Waiting for task 2...
Action id 2 failed: Action must be ran on an application with balancer role
error: Action must be ran on an application with balancer role

$ juju show-task 2
Action id 2 failed: Action must be ran on an application with balancer role
error: Action must be ran on an application with balancer role

$ juju run kafka-k8s/0 rebalance brokerid=0 dryrun=abc mode=full
Operation 3 failed to schedule any tasks:
validation failed: (root).dryrun : must be of type boolean, given "abc"

$ juju show-operation 3
summary: rebalance run on unit-kafka-k8s-0
status: error
fail: 'error(s) enqueueing action(s): validation failed: (root).dryrun : must be of
  type boolean, given "abc"'
action:
  name: rebalance
  parameters: {}
timing:
  enqueued: 2026-02-10 14:05:59 +0100 CET
tasks:
  "4":
    host: kafka-k8s/0
    status: error
    timing:
      enqueued: 2026-02-10 14:05:59 +0100 CET
    message: 'validation failed: (root).dryrun : must be of type boolean, given "abc"'
    
```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

- Jira ticket: [JUJU-8827](https://warthogs.atlassian.net/browse/JUJU-8827)
- GitHub Issue: https://github.com/juju/juju/issues/21295


[JUJU-8827]: https://warthogs.atlassian.net/browse/JUJU-8827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ