### PR TITLE
fix: retry caas provisoning if charm not ready

### DIFF
--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -42,6 +42,8 @@ type appWorker struct {
 	lastApplied caas.ApplicationConfig
 	life        life.Value
 	statusOnly  bool
+
+	engineReportRequest chan chan<- map[string]any
 }
 
 type AppWorkerConfig struct {
@@ -69,16 +71,17 @@ func NewAppWorker(config AppWorkerConfig) func() (worker.Worker, error) {
 		changes := make(chan struct{}, 1)
 		changes <- struct{}{}
 		a := &appWorker{
-			name:       config.Name,
-			facade:     config.Facade,
-			broker:     config.Broker,
-			modelTag:   config.ModelTag,
-			clock:      config.Clock,
-			logger:     config.Logger,
-			changes:    changes,
-			unitFacade: config.UnitFacade,
-			ops:        ops,
-			statusOnly: config.StatusOnly,
+			name:                config.Name,
+			facade:              config.Facade,
+			broker:              config.Broker,
+			modelTag:            config.ModelTag,
+			clock:               config.Clock,
+			logger:              config.Logger,
+			changes:             changes,
+			unitFacade:          config.UnitFacade,
+			ops:                 ops,
+			statusOnly:          config.StatusOnly,
+			engineReportRequest: make(chan chan<- map[string]any),
 		}
 		err := catacomb.Invoke(catacomb.Plan{
 			Site: &a.catacomb,
@@ -187,9 +190,9 @@ func (a *appWorker) loop() error {
 		return errors.Annotatef(err, "failed to watch for application %q units changes", a.name)
 	}
 
-	done := false
-
 	var (
+		done                = false // done is true when the app is dead and cleaned up.
+		ready               = false // ready is true when the k8s resources are created.
 		initial             = true
 		scaleChan           <-chan time.Time
 		scaleTries          int
@@ -273,6 +276,8 @@ func (a *appWorker) loop() error {
 				}
 				replicaChanges = replicaWatcher.Changes()
 			}
+			a.logger.Debugf("application %q is ready", a.name)
+			ready = true
 		case life.Dying:
 			if !a.statusOnly {
 				err = a.ops.AppDying(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
@@ -280,6 +285,7 @@ func (a *appWorker) loop() error {
 					return errors.Trace(err)
 				}
 			}
+			ready = false
 		case life.Dead:
 			if !a.statusOnly {
 				err = a.ops.AppDying(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
@@ -292,6 +298,7 @@ func (a *appWorker) loop() error {
 				}
 			}
 			done = true
+			ready = false
 			return nil
 		default:
 			return errors.NotImplementedf("unknown life %q", a.life)
@@ -299,6 +306,8 @@ func (a *appWorker) loop() error {
 		return nil
 	}
 
+	refreshTimer := a.clock.NewTimer(10 * time.Second)
+	defer refreshTimer.Stop()
 	for {
 		shouldRefresh := true
 		select {
@@ -314,6 +323,11 @@ func (a *appWorker) loop() error {
 		case <-scaleChan:
 			if a.statusOnly {
 				scaleChan = nil
+				break
+			}
+			if !ready {
+				scaleChan = a.clock.After(retryDelay)
+				shouldRefresh = false
 				break
 			}
 			err := a.ops.EnsureScale(a.name, app, a.life, a.facade, a.unitFacade, a.logger)
@@ -344,6 +358,11 @@ func (a *appWorker) loop() error {
 		case <-trustChan:
 			if a.statusOnly {
 				trustChan = nil
+				break
+			}
+			if !ready {
+				trustChan = a.clock.After(retryDelay)
+				shouldRefresh = false
 				break
 			}
 			err := a.ops.EnsureTrust(a.name, app, a.unitFacade, a.logger)
@@ -419,8 +438,32 @@ func (a *appWorker) loop() error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-		case <-a.clock.After(10 * time.Second):
+		case <-refreshTimer.Chan():
 			// Force refresh of application status.
+		case reportChan := <-a.engineReportRequest:
+			// Respond to engine reports.
+			var reportErrors []string
+			ps, err := a.facade.ProvisioningState(a.name)
+			if err != nil {
+				reportErrors = append(reportErrors, err.Error())
+			}
+			if ps == nil {
+				ps = &params.CAASApplicationProvisioningState{}
+			}
+			report := map[string]any{
+				"application-name": a.name,
+				"status-only":      a.statusOnly,
+				"application-life": a.life,
+				"scale-target":     ps.ScaleTarget,
+				"scaling":          ps.Scaling,
+				"report-error":     reportErrors,
+			}
+			select {
+			case reportChan <- report:
+			case <-a.catacomb.Dying():
+				return a.catacomb.ErrDying()
+			}
+			shouldRefresh = false
 		}
 		if done {
 			return nil
@@ -430,5 +473,21 @@ func (a *appWorker) loop() error {
 				return errors.Annotatef(err, "refreshing application status for %q", a.name)
 			}
 		}
+	}
+}
+
+// Report returns a report about this application provisioner.
+func (a *appWorker) Report() map[string]any {
+	reportChan := make(chan map[string]any)
+	select {
+	case a.engineReportRequest <- reportChan:
+	case <-a.catacomb.Dying():
+		return nil
+	}
+	select {
+	case report := <-reportChan:
+		return report
+	case <-a.catacomb.Dying():
+		return nil
 	}
 }

--- a/internal/worker/caasapplicationprovisioner/application_test.go
+++ b/internal/worker/caasapplicationprovisioner/application_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/workertest"
@@ -340,6 +341,111 @@ func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *gc.C) {
 	)
 
 	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, true)
+	s.waitDone(c, done)
+	workertest.CheckKill(c, appWorker)
+}
+
+func (s *ApplicationWorkerSuite) TestWorkerScaleNotReadyRetry(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	broker := mocks.NewMockCAASBroker(ctrl)
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	unitFacade := mocks.NewMockCAASUnitProvisionerFacade(ctrl)
+	ops := mocks.NewMockApplicationOps(ctrl)
+	done := make(chan struct{})
+
+	clk := testclock.NewDilatedWallClock(time.Millisecond)
+
+	scaleChan := make(chan struct{}, 1)
+	trustChan := make(chan []string, 1)
+	provisioningInfoChan := make(chan struct{}, 1)
+	appUnitsChan := make(chan []string, 1)
+	appChan := make(chan struct{}, 1)
+	appReplicasChan := make(chan struct{}, 1)
+
+	ops.EXPECT().RefreshApplicationStatus("test", app, gomock.Any(), facade, s.logger).Return(nil).AnyTimes()
+
+	gomock.InOrder(
+		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
+		facade.EXPECT().Life("test").Return(life.Alive, nil),
+
+		ops.EXPECT().VerifyCharmUpgraded("test", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil),
+		ops.EXPECT().UpgradePodSpec("test", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+
+		facade.EXPECT().SetPassword("test", gomock.Any()).Return(nil),
+
+		unitFacade.EXPECT().WatchApplicationScale("test").Return(watchertest.NewMockNotifyWatcher(scaleChan), nil),
+		unitFacade.EXPECT().WatchApplicationTrustHash("test").Return(watchertest.NewMockStringsWatcher(trustChan), nil),
+		facade.EXPECT().WatchUnits("test").Return(watchertest.NewMockStringsWatcher(appUnitsChan), nil),
+
+		// Initially not provisioned.
+		facade.EXPECT().Life("test").Return(life.Alive, nil),
+		facade.EXPECT().ProvisioningState("test").Return(nil, nil),
+		facade.EXPECT().WatchProvisioningInfo("test").Return(watchertest.NewMockNotifyWatcher(provisioningInfoChan), nil),
+		ops.EXPECT().AppAlive("test", app, gomock.Any(), gomock.Any(), facade, clk, s.logger).DoAndReturn(func(_, _, _, _, _, _, _ any) error {
+			scaleChan <- struct{}{}
+			return errors.NotProvisioned
+		}),
+	)
+
+	select {
+	case provisioningInfoChan <- struct{}{}:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("sending provisioning change")
+	}
+
+	ops.EXPECT().EnsureScale("test", app, life.Alive, facade, unitFacade, s.logger).Return(nil)
+
+	gomock.InOrder(
+		// handleChange
+		facade.EXPECT().Life("test").Return(life.Alive, nil),
+		ops.EXPECT().AppAlive("test", app, gomock.Any(), gomock.Any(), facade, clk, s.logger).Return(nil),
+		app.EXPECT().Watch().Return(watchertest.NewMockNotifyWatcher(appChan), nil),
+		app.EXPECT().WatchReplicas().DoAndReturn(func() (watcher.NotifyWatcher, error) {
+			appUnitsChan <- nil
+			return watchertest.NewMockNotifyWatcher(appReplicasChan), nil
+		}),
+
+		// appUnitsChan fired
+		ops.EXPECT().ReconcileDeadUnitScale("test", app, facade, s.logger).Return(errors.NotFound),
+		ops.EXPECT().ReconcileDeadUnitScale("test", app, facade, s.logger).Return(errors.ConstError("try again")),
+		ops.EXPECT().ReconcileDeadUnitScale("test", app, facade, s.logger).DoAndReturn(func(_, _, _, _ any) error {
+			appChan <- struct{}{}
+			return nil
+		}),
+
+		// appChan fired
+		ops.EXPECT().UpdateState("test", app, gomock.Any(), broker, facade, unitFacade, s.logger).DoAndReturn(func(_, _, _, _, _, _, _ any) (map[string]status.StatusInfo, error) {
+			appReplicasChan <- struct{}{}
+			return nil, nil
+		}),
+		// appReplicasChan fired
+		ops.EXPECT().UpdateState("test", app, gomock.Any(), broker, facade, unitFacade, s.logger).DoAndReturn(func(_, _, _, _, _, _, _ any) (map[string]status.StatusInfo, error) {
+			provisioningInfoChan <- struct{}{}
+			return nil, nil
+		}),
+		// provisioningInfoChan fired
+		facade.EXPECT().Life("test").Return(life.Alive, nil),
+		ops.EXPECT().AppAlive("test", app, gomock.Any(), gomock.Any(), facade, clk, s.logger).DoAndReturn(func(_, _, _, _, _, _, _ any) error {
+			provisioningInfoChan <- struct{}{}
+			return nil
+		}),
+		facade.EXPECT().Life("test").Return(life.Dying, nil),
+		ops.EXPECT().AppDying("test", app, life.Dying, facade, unitFacade, s.logger).DoAndReturn(func(_, _, _, _, _, _ any) error {
+			provisioningInfoChan <- struct{}{}
+			return nil
+		}),
+		facade.EXPECT().Life("test").Return(life.Dead, nil),
+		ops.EXPECT().AppDying("test", app, life.Dead, facade, unitFacade, s.logger).Return(nil),
+		ops.EXPECT().AppDead("test", app, broker, facade, unitFacade, clk, s.logger).DoAndReturn(func(_, _, _, _, _, _, _ any) error {
+			close(done)
+			return nil
+		}),
+	)
+
+	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, false)
 	s.waitDone(c, done)
 	workertest.CheckKill(c, appWorker)
 }

--- a/internal/worker/caasapplicationprovisioner/mocks/runner_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/runner_mock.go
@@ -51,6 +51,20 @@ func (mr *MockRunnerMockRecorder) Kill() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockRunner)(nil).Kill))
 }
 
+// Report mocks base method.
+func (m *MockRunner) Report() map[string]any {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Report")
+	ret0, _ := ret[0].(map[string]any)
+	return ret0
+}
+
+// Report indicates an expected call of Report.
+func (mr *MockRunnerMockRecorder) Report() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockRunner)(nil).Report))
+}
+
 // StartWorker mocks base method.
 func (m *MockRunner) StartWorker(arg0 string, arg1 func() (worker.Worker, error)) error {
 	m.ctrl.T.Helper()

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -85,6 +85,7 @@ type Runner interface {
 	Worker(id string, abort <-chan struct{}) (worker.Worker, error)
 	StartWorker(id string, startFunc func() (worker.Worker, error)) error
 	StopAndRemoveWorker(id string, abort <-chan struct{}) error
+	Report() map[string]any
 	worker.Worker
 }
 
@@ -229,4 +230,10 @@ func (p *provisioner) loop() error {
 			}
 		}
 	}
+}
+
+// Report calls onto the runner give back information about each application
+// worker for an engine report.
+func (p *provisioner) Report() map[string]any {
+	return p.runner.Report()
 }


### PR DESCRIPTION
This backports the key fix from #19203 and adds a unit test.
If a scale notification is received before the app is marked as provisioned, it never retries.

As a drive by, also add the engine report from #20007

## QA steps

bootstrap k8s
```
juju deploy snappass-test && juju scale-application snappass-test 3
```

## Links

**Issue:** Fixes #21735.

**Jira card:** [JUJU-9177](https://warthogs.atlassian.net/browse/JUJU-9177)


[JUJU-9177]: https://warthogs.atlassian.net/browse/JUJU-9177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ