### PR TITLE
docs: fix documentation reference labels for transition guide

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -57,7 +57,7 @@ Get a quick sense of how to do things in Juju, from preparing your deployment en
 - {ref}`Harden your deployment <harden-your-deployment>`
 - {ref}`Troubleshoot your deployment <troubleshoot-your-deployment>`
 - {ref}`Upgrade your deployment <upgrade-your-deployment>`
-- {ref}`Upgrade your deployment from 3.6 to 4.0 <upgrade-your-deployment-from-3.5-to-4.0>`
+- {ref}`Upgrade your deployment from 3.6 to 4.0 <upgrade-your-deployment-from-36-to-40>`
 - {ref}`Tear down your deployment -- local testing and development <tear-things-down>`
 
 ## Set up Juju

--- a/docs/howto/manage-your-deployment.md
+++ b/docs/howto/manage-your-deployment.md
@@ -20,7 +20,7 @@ manage-your-juju-deployment/set-up-your-juju-deployment-offline
 manage-your-juju-deployment/harden-your-juju-deployment
 manage-your-juju-deployment/troubleshoot-your-juju-deployment
 manage-your-juju-deployment/upgrade-your-juju-deployment
-manage-your-juju-deployment/upgrade-juju-36-to-40
+manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40
 manage-your-juju-deployment/tear-down-your-juju-deployment-local-testing-and-development
 
 ```

--- a/docs/howto/manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40.md
+++ b/docs/howto/manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40.md
@@ -5,7 +5,6 @@ myst:
 ---
 
 (upgrade-your-deployment-from-36-to-40)=
-
 # Upgrade your Juju deployment from `3.6` to `4.0`
 
 > **Disclaimer:** this is v1 of the document. We will update it with more details and examples over time.


### PR DESCRIPTION
Fix incorrect reference labels in the documentation sidebar menu and index file.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
cd docs
make clean
make run

# open http://127.0.0.1:8000/
# you sound see the new point in side menu
```

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
