### PR TITLE
fix(removal): advance dying storage attachments when provisioner is absent

### DIFF
--- a/domain/removal/service/storage.go
+++ b/domain/removal/service/storage.go
@@ -453,13 +453,13 @@ func (s *Service) processStorageAttachmentRemovalJob(ctx context.Context, job re
 		return errors.Errorf(
 			"storage attachment %q is alive", job.EntityUUID,
 		).Add(removalerrors.EntityStillAlive)
-	} else if !job.Force && l == life.Dying {
-		return errors.Errorf(
-			"storage attachment %q is not dead", job.EntityUUID,
-		).Add(removalerrors.EntityNotDead)
 	}
 
-	if job.Force && l == life.Dying {
+	if l == life.Dying {
+		// Mark the storage attachment as dead, cascading to any child
+		// filesystem/volume attachments. This handles the case where the
+		// storage provisioner is not running (e.g. the machine never
+		// reached a running status) and cannot advance the lifecycle.
 		cascade, err := s.modelState.EnsureStorageAttachmentDeadCascade(
 			ctx, job.EntityUUID)
 		if errors.Is(err, storageerrors.StorageAttachmentNotFound) {
@@ -473,14 +473,12 @@ func (s *Service) processStorageAttachmentRemovalJob(ctx context.Context, job re
 			)
 		}
 
-		// NOTE: filesystem attachments, volume attachments and volume attachment
-		// plans have their removal jobs already scheduled when the storage
-		// attachment goes to Dying.
-		//
-		// Since these entities do not go to Dying when the storage attachment
-		// goes to Dying, it is within the removal domain's pattern to schedule
-		// them here, since these entities just went to Dying.
-
+		// Schedule removal jobs for any child entities that were
+		// cascaded to dying. When force is used, the children may not
+		// have had removal jobs scheduled yet. For non-force removals,
+		// the children already have removal jobs from the initial
+		// application/unit removal cascade, but scheduling again is
+		// safe (idempotent).
 		for _, fsaUUID := range cascade.FileSystemAttachmentUUIDs {
 			uuid := storage.FilesystemAttachmentUUID(fsaUUID)
 			_, err := s.filesystemAttachmentScheduleRemoval(ctx, uuid, false, 0)
@@ -1182,10 +1180,21 @@ func (s *Service) processStorageFilesystemAttachmentRemovalJob(
 		return errors.Errorf(
 			"filesystem attachment %q is alive", job.EntityUUID,
 		).Add(removalerrors.EntityStillAlive)
-	} else if !job.Force && l == life.Dying {
-		return errors.Errorf(
-			"filesystem attachment %q is not dead", job.EntityUUID,
-		).Add(removalerrors.EntityNotDead)
+	}
+
+	// If the filesystem attachment is dying, mark it as dead before
+	// deletion. This handles the case where the storage provisioner is not
+	// running (e.g. the machine never reached a running status) and cannot
+	// advance the lifecycle itself.
+	if l == life.Dying {
+		if err := s.modelState.MarkFilesystemAttachmentAsDead(
+			ctx, job.EntityUUID,
+		); err != nil {
+			return errors.Errorf(
+				"marking filesystem attachment %q as dead: %w",
+				job.EntityUUID, err,
+			)
+		}
 	}
 
 	err = s.modelState.DeleteFilesystemAttachment(ctx, job.EntityUUID)
@@ -1247,10 +1256,21 @@ func (s *Service) processStorageVolumeAttachmentRemovalJob(
 		return errors.Errorf(
 			"volume attachment %q is alive", job.EntityUUID,
 		).Add(removalerrors.EntityStillAlive)
-	} else if !job.Force && l == life.Dying {
-		return errors.Errorf(
-			"volume attachment %q is not dead", job.EntityUUID,
-		).Add(removalerrors.EntityNotDead)
+	}
+
+	// If the volume attachment is dying, mark it as dead before deletion.
+	// This handles the case where the storage provisioner is not running
+	// (e.g. the machine never reached a running status) and cannot advance
+	// the lifecycle itself.
+	if l == life.Dying {
+		if err := s.modelState.MarkVolumeAttachmentAsDead(
+			ctx, job.EntityUUID,
+		); err != nil {
+			return errors.Errorf(
+				"marking volume attachment %q as dead: %w",
+				job.EntityUUID, err,
+			)
+		}
 	}
 
 	err = s.modelState.DeleteVolumeAttachment(ctx, job.EntityUUID)

--- a/domain/removal/service/storage_test.go
+++ b/domain/removal/service/storage_test.go
@@ -1264,12 +1264,18 @@ func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDying(c *tc.C) {
 
 	j := newFilesystemAttachmentJob(c)
 
-	s.modelState.EXPECT().GetFilesystemAttachmentLife(
+	exp := s.modelState.EXPECT()
+	exp.GetFilesystemAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
+	// The removal job marks the attachment as dead and then deletes it,
+	// handling the case where the storage provisioner is not running.
+	exp.MarkFilesystemAttachmentAsDead(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteFilesystemAttachment(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
-	c.Assert(err, tc.ErrorIs, removalerrors.EntityNotDead)
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDyingForce(c *tc.C) {
@@ -1278,16 +1284,35 @@ func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDyingForce(c *tc.C) 
 	j := newFilesystemAttachmentJob(c)
 	j.Force = true
 
-	s.modelState.EXPECT().GetFilesystemAttachmentLife(
+	exp := s.modelState.EXPECT()
+	exp.GetFilesystemAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
-	s.modelState.EXPECT().DeleteFilesystemAttachment(
+	exp.MarkFilesystemAttachmentAsDead(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteFilesystemAttachment(
 		gomock.Any(), j.EntityUUID,
 	).Return(nil)
-	s.modelState.EXPECT().DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForFilesystemAttachmentDyingMarkAsDeadError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newFilesystemAttachmentJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetFilesystemAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.MarkFilesystemAttachmentAsDead(
+		gomock.Any(), j.EntityUUID,
+	).Return(errors.Errorf("the front fell off"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
 }
 
 func (s *storageSuite) TestExecuteJobForFilesystemAttachmentSuccess(c *tc.C) {
@@ -1351,12 +1376,18 @@ func (s *storageSuite) TestExecuteJobForVolumeAttachmentDying(c *tc.C) {
 
 	j := newVolumeAttachmentJob(c)
 
-	s.modelState.EXPECT().GetVolumeAttachmentLife(
+	exp := s.modelState.EXPECT()
+	exp.GetVolumeAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
+	// The removal job marks the attachment as dead and then deletes it,
+	// handling the case where the storage provisioner is not running.
+	exp.MarkVolumeAttachmentAsDead(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteVolumeAttachment(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
-	c.Assert(err, tc.ErrorIs, removalerrors.EntityNotDead)
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *storageSuite) TestExecuteJobForVolumeAttachmentDyingForce(c *tc.C) {
@@ -1365,16 +1396,35 @@ func (s *storageSuite) TestExecuteJobForVolumeAttachmentDyingForce(c *tc.C) {
 	j := newVolumeAttachmentJob(c)
 	j.Force = true
 
-	s.modelState.EXPECT().GetVolumeAttachmentLife(
+	exp := s.modelState.EXPECT()
+	exp.GetVolumeAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
-	s.modelState.EXPECT().DeleteVolumeAttachment(
+	exp.MarkVolumeAttachmentAsDead(gomock.Any(), j.EntityUUID).Return(nil)
+	exp.DeleteVolumeAttachment(
 		gomock.Any(), j.EntityUUID,
 	).Return(nil)
-	s.modelState.EXPECT().DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForVolumeAttachmentDyingMarkAsDeadError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	j := newVolumeAttachmentJob(c)
+
+	exp := s.modelState.EXPECT()
+	exp.GetVolumeAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	exp.MarkVolumeAttachmentAsDead(
+		gomock.Any(), j.EntityUUID,
+	).Return(errors.Errorf("the front fell off"))
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
 }
 
 func (s *storageSuite) TestExecuteJobForVolumeAttachmentSuccess(c *tc.C) {
@@ -1568,14 +1618,58 @@ func (s *storageSuite) TestExecuteJobForStorageAttachmentStillAlive(c *tc.C) {
 func (s *storageSuite) TestExecuteJobForStorageAttachmentDying(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	when := time.Now().UTC()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	j := newStorageAttachmentJob(c)
+
+	fsaUUID := tc.Must(c, storage.NewFilesystemAttachmentUUID)
+	vaUUID := tc.Must(c, storage.NewVolumeAttachmentUUID)
+	vapUUID := tc.Must(c, storage.NewVolumeAttachmentPlanUUID)
+
+	cascaded := internal.CascadedStorageProvisionedAttachmentLives{
+		FileSystemAttachmentUUIDs: []string{fsaUUID.String()},
+		VolumeAttachmentUUIDs:     []string{vaUUID.String()},
+		VolumeAttachmentPlanUUIDs: []string{vapUUID.String()},
+	}
+	s.modelState.EXPECT().GetStorageAttachmentLife(
+		gomock.Any(), j.EntityUUID,
+	).Return(life.Dying, nil)
+	s.modelState.EXPECT().EnsureStorageAttachmentDeadCascade(
+		gomock.Any(), j.EntityUUID,
+	).Return(cascaded, nil)
+	s.modelState.EXPECT().FilesystemAttachmentScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), fsaUUID.String(), false, when,
+	).Return(nil)
+	s.modelState.EXPECT().VolumeAttachmentScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), vaUUID.String(), false, when,
+	).Return(nil)
+	s.modelState.EXPECT().VolumeAttachmentPlanScheduleRemoval(
+		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), vapUUID.String(), false, when,
+	).Return(nil)
+	s.modelState.EXPECT().DeleteStorageAttachment(
+		gomock.Any(), j.EntityUUID,
+	).Return(nil)
+	s.modelState.EXPECT().DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
+
+	err := s.newService(c).ExecuteJob(c.Context(), j)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storageSuite) TestExecuteJobForStorageAttachmentDyingCascadeError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
 	j := newStorageAttachmentJob(c)
 
 	s.modelState.EXPECT().GetStorageAttachmentLife(
 		gomock.Any(), j.EntityUUID,
 	).Return(life.Dying, nil)
+	s.modelState.EXPECT().EnsureStorageAttachmentDeadCascade(
+		gomock.Any(), j.EntityUUID,
+	).Return(internal.CascadedStorageProvisionedAttachmentLives{}, errors.New("boom"))
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
-	c.Assert(err, tc.ErrorIs, removalerrors.EntityNotDead)
+	c.Assert(err, tc.ErrorMatches, `.*ensuring storage attachment.*is dead.*boom.*`)
 }
 
 func (s *storageSuite) TestExecuteJobForStorageAttachmentDyingForce(c *tc.C) {


### PR DESCRIPTION
_Note: Although this fix is independent, for QA we'll need https://github.com/juju/juju/pull/21750 to land first (otherwise removing an app before the machine is RUNNING will not be possible)._

When a machine never reaches RUNNING status, the storage provisioner never starts, so it cannot advance storage attachments through their lifecycle. The removal job handlers for storage, filesystem, and volume attachments returned EntityNotDead for dying entities without force, creating a deadlock: storage attachments block the unit from being marked dead, which blocks the machine from being marked dead.

Fix by having the removal job handlers self-advance dying attachments to dead before deletion, rather than waiting for a provisioner that may never run. This applies the same cascade logic already used for forced removals to all dying attachment removals.



## QA steps

The QA is the same as in https://github.com/juju/juju/pull/21750, with the difference that we want to check that the machine is actually removed after the app (and double check that the storage is not removed unless --destroy-storage is passed:

First pack the `dummy-storage` charm (from /testcharms). Then deploy it and remove the app before the machine reaches the RUNNING state:
```
juju deploy ./testcharms/charms/dummy-storage/dummy-storage_amd64.charm --storage multi-fs=10M
juju status # just to check that the app is deploying
juju remove-application dummy-storage
```

After a few moments the app, unit and machine should be removed and no errors appear in the logs.

Also, you should double check that the storage is still present in the db, and the attachment is gone:
```
repl (model-m)> select * from storage_filesystem
uuid					filesystem_id	life_id	provision_scope_id	provider_id			size_mib	obliterate_on_cleanup	
18c7dfe0-1df9-4eef-8243-f350d42d432f	2		0	0			juju:juju-f5793b-filesystem-210		false			

repl (model-m)> select * from storage_filesystem_attachment
uuid	storage_filesystem_uuid	net_node_uuid	provision_scope_id	provider_id	life_id	mount_point	read_only	
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21717.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9147](https://warthogs.atlassian.net/browse/JUJU-9147)


[JUJU-9147]: https://warthogs.atlassian.net/browse/JUJU-9147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ