### PR TITLE
fix(cmr): handle deleted users in show-offer

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -415,6 +415,7 @@ func (s *applicationOffersSuite) TestShow(c *gc.C) {
 	s.assertShow(c, "fred@external/prod.hosted-db2", offerUUID, expected)
 	// Again with an unqualified model path.
 	s.mockState.AdminTag = names.NewUserTag("fred@external")
+	s.mockState.users["fred@external"] = &mockUser{""}
 	s.authorizer.AdminTag = s.mockState.AdminTag
 	s.authorizer.Tag = s.mockState.AdminTag
 	expected[0].Result.Users[0].UserName = "fred@external"
@@ -516,6 +517,7 @@ func (s *applicationOffersSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
 	s.mockStatePool.st["uuid2"] = &mockState{
 		modelUUID: "uuid2",
 		model:     anotherModel,
+		users:     s.mockState.users,
 	}
 	s.mockState.allmodels = []applicationoffers.Model{s.mockState.model, anotherModel}
 
@@ -1326,17 +1328,14 @@ func (s *consumeSuite) TestRemoteApplicationInfo(c *gc.C) {
 }
 
 func (s *consumeSuite) TestDestroyOffersNoForceV2(c *gc.C) {
-	s.assertDestroyOffersNoForce(c, s.api)
+	s.assertDestroyOffersNoForce(c)
 }
 
-type destroyOffers interface {
-	DestroyOffers(args params.DestroyApplicationOffers) (params.ErrorResults, error)
-}
-
-func (s *consumeSuite) assertDestroyOffersNoForce(c *gc.C, api destroyOffers) {
+func (s *consumeSuite) assertDestroyOffersNoForce(c *gc.C) {
 	s.setupOffer()
 	st := s.mockStatePool.st[testing.ModelTag.Id()]
 	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
+	st.(*mockState).users["admin"] = &mockUser{"admin"}
 	st.(*mockState).connections = []applicationoffers.OfferConnection{
 		&mockOfferConnection{
 			username:    "fred@external",
@@ -1371,6 +1370,7 @@ func (s *consumeSuite) TestDestroyOffersForce(c *gc.C) {
 	s.setupOffer()
 	st := s.mockStatePool.st[testing.ModelTag.Id()]
 	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
+	st.(*mockState).users["admin"] = &mockUser{"admin"}
 	st.(*mockState).connections = []applicationoffers.OfferConnection{
 		&mockOfferConnection{
 			username:    "fred@external",

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -72,17 +72,6 @@ func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, string, bo
 	return model, modelPath, model != nil, nil
 }
 
-func (api *BaseAPI) userDisplayName(backend Backend, userTag names.UserTag) (string, error) {
-	var displayName string
-	user, err := backend.User(userTag)
-	if err != nil && !errors.IsNotFound(err) {
-		return "", errors.Trace(err)
-	} else if err == nil {
-		displayName = user.DisplayName()
-	}
-	return displayName, nil
-}
-
 // applicationOffersFromModel gets details about remote applications that match given filters.
 func (api *BaseAPI) applicationOffersFromModel(
 	modelUUID string,
@@ -114,7 +103,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 		return nil, errors.Trace(err)
 	}
 
-	apiUserDisplayName, err := api.userDisplayName(backend, user)
+	u, err := backend.User(user)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -142,7 +131,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 		}
 		offerParams.Users = []params.OfferUserDetails{{
 			UserName:    user.Id(),
-			DisplayName: apiUserDisplayName,
+			DisplayName: u.DisplayName(),
 			Access:      string(userAccess),
 		}}
 		offer := params.ApplicationOfferAdminDetailsV5{
@@ -194,7 +183,7 @@ func (api *BaseAPI) getOfferAdminDetails(user names.UserTag, backend Backend, ap
 			Since:  relStatus.Since,
 		}
 		relIngress, err := backend.IngressNetworks(oc.RelationKey())
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !errors.Is(err, errors.NotFound) {
 			return errors.Trace(err)
 		}
 		if err == nil {
@@ -208,18 +197,14 @@ func (api *BaseAPI) getOfferAdminDetails(user names.UserTag, backend Backend, ap
 		return errors.Trace(err)
 	}
 
-	for userName, access := range offerUsers {
+	for userName, userAccess := range offerUsers {
 		if userName == user.Id() {
 			continue
 		}
-		displayName, err := api.userDisplayName(backend, names.NewUserTag(userName))
-		if err != nil {
-			return errors.Trace(err)
-		}
 		offer.Users = append(offer.Users, params.OfferUserDetails{
 			UserName:    userName,
-			DisplayName: displayName,
-			Access:      string(access),
+			DisplayName: userAccess.DisplayName,
+			Access:      string(userAccess.Access),
 		})
 	}
 	return nil

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -62,6 +62,8 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 		relationNetworks:  &mockRelationNetworks{},
 	}
 	s.mockStatePool = &mockStatePool{map[string]applicationoffers.Backend{s.mockState.modelUUID: s.mockState}}
+	s.mockState.users["admin"] = &mockUser{""}
+	s.mockState.users["read"] = &mockUser{""}
 }
 
 func (s *baseSuite) addApplication(c *gc.C, name string) jujucrossmodel.ApplicationOffer {

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -357,7 +357,7 @@ func (m *mockState) KeyRelation(key string) (crossmodel.Relation, error) {
 	return rel, nil
 }
 
-func (m *mockState) OfferConnections(offerUUID string) ([]applicationoffers.OfferConnection, error) {
+func (m *mockState) OfferConnections(_ string) ([]applicationoffers.OfferConnection, error) {
 	return m.connections, nil
 }
 
@@ -434,13 +434,17 @@ func (m *mockState) RemoveOfferAccess(offer names.ApplicationOfferTag, user name
 	return nil
 }
 
-func (m *mockState) GetOfferUsers(offerUUID string) (map[string]permission.Access, error) {
-	result := make(map[string]permission.Access)
+func (m *mockState) GetOfferUsers(offerUUID string) (map[string]state.OfferUserAccess, error) {
+	result := make(map[string]state.OfferUserAccess)
 	for offerAccess, access := range m.accessPerms {
 		if offerAccess.offerUUID != offerUUID {
 			continue
 		}
-		result[offerAccess.user.Id()] = access
+		userAccess := state.OfferUserAccess{
+			Access:      access,
+			DisplayName: m.users[offerAccess.user.Id()].DisplayName(),
+		}
+		result[offerAccess.user.Id()] = userAccess
 	}
 	return result, nil
 }

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -65,7 +65,7 @@ type Backend interface {
 	CreateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error
 	UpdateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error
 	RemoveOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) error
-	GetOfferUsers(offerUUID string) (map[string]permission.Access, error)
+	GetOfferUsers(offerUUID string) (map[string]state.OfferUserAccess, error)
 
 	// GetModelCallContext gets everything that is needed to make cloud calls on behalf of the state current model.
 	GetModelCallContext() context.ProviderCallContext
@@ -101,7 +101,7 @@ func (s stateShim) RemoveOfferAccess(offer names.ApplicationOfferTag, user names
 	return s.st.RemoveOfferAccess(offer, user)
 }
 
-func (s stateShim) GetOfferUsers(offerUUID string) (map[string]permission.Access, error) {
+func (s stateShim) GetOfferUsers(offerUUID string) (map[string]state.OfferUserAccess, error) {
 	return s.st.GetOfferUsers(offerUUID)
 }
 

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -918,7 +918,8 @@ func (s *applicationOffers) filterOffersByAllowedConsumer(
 			return nil, errors.Trace(err)
 		}
 		for _, username := range users {
-			if offerUsers[username].EqualOrGreaterOfferAccessThan(permission.ConsumeAccess) {
+			userAccess, ok := offerUsers[username]
+			if ok && userAccess.Access.EqualOrGreaterOfferAccessThan(permission.ConsumeAccess) {
 				out = append(out, doc)
 				break
 			}

--- a/state/applicationofferuser.go
+++ b/state/applicationofferuser.go
@@ -13,6 +13,15 @@ import (
 	"github.com/juju/juju/core/permission"
 )
 
+// OfferUserAccess represents the access details for a user on an offer.
+type OfferUserAccess struct {
+	// Access represents the level of access subject has over the object.
+	Access permission.Access
+
+	// DisplayName is the name we are showing for this user.
+	DisplayName string
+}
+
 // GetOfferAccess gets the access permission for the specified user on an offer.
 func (st *State) GetOfferAccess(offerUUID string, user names.UserTag) (permission.Access, error) {
 	perm, err := st.userPermission(applicationOfferKey(offerUUID), userGlobalKey(userAccessID(user)))
@@ -22,15 +31,29 @@ func (st *State) GetOfferAccess(offerUUID string, user names.UserTag) (permissio
 	return perm.access(), nil
 }
 
-// GetOfferUsers gets the access permissions on an offer.
-func (st *State) GetOfferUsers(offerUUID string) (map[string]permission.Access, error) {
+// GetOfferUsers gets the access permissions on an offer and filters out
+// deleted users.
+func (st *State) GetOfferUsers(offerUUID string) (map[string]OfferUserAccess, error) {
 	perms, err := st.usersPermissions(applicationOfferKey(offerUUID))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	result := make(map[string]permission.Access)
+	result := make(map[string]OfferUserAccess)
 	for _, p := range perms {
-		result[userIDFromGlobalKey(p.doc.SubjectGlobalKey)] = p.access()
+		u := userIDFromGlobalKey(p.doc.SubjectGlobalKey)
+		var udoc userDoc
+		err := st.getUser(u, &udoc)
+		if err != nil && !errors.Is(err, errors.NotFound) {
+			return nil, errors.Annotatef(err, "fetching user %q for offer", u)
+		}
+		if udoc.Deleted {
+			continue
+		}
+		userAccess := OfferUserAccess{
+			Access:      p.access(),
+			DisplayName: udoc.DisplayName,
+		}
+		result[u] = userAccess
 	}
 	return result, nil
 }

--- a/state/applicationofferuser_test.go
+++ b/state/applicationofferuser_test.go
@@ -79,11 +79,10 @@ func (s *ApplicationOfferUserSuite) TestGetOfferAccess(c *gc.C) {
 	offerUUID := s.assertAddOffer(c, permission.ConsumeAccess)
 	users, err := s.State.GetOfferUsers(offerUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(users, jc.DeepEquals, map[string]permission.Access{
-		"everyone@external": permission.ReadAccess,
-		"test-admin":        permission.AdminAccess,
-		"validusername":     permission.ConsumeAccess,
-	})
+	c.Assert(users, gc.HasLen, 3)
+	c.Assert(users["everyone@external"].Access, gc.Equals, permission.ReadAccess)
+	c.Assert(users["test-admin"].Access, gc.Equals, permission.AdminAccess)
+	c.Assert(users["validusername"].Access, gc.Equals, permission.ConsumeAccess)
 }
 
 func (s *ApplicationOfferUserSuite) TestAddAdminModelUser(c *gc.C) {
@@ -187,6 +186,38 @@ func (s *ApplicationOfferUserSuite) TestCreateOfferAccessNoUserFails(c *gc.C) {
 		names.NewApplicationOfferTag("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
 		names.NewUserTag("validusername"), permission.ReadAccess)
 	c.Assert(err, gc.ErrorMatches, `user "validusername" does not exist locally: user "validusername" not found`)
+}
+
+func (s *ApplicationOfferUserSuite) TestGetOfferAccessWithDeletedUser(c *gc.C) {
+	offer, _ := s.makeOffer(c, permission.ConsumeAccess)
+
+	user := s.Factory.MakeUser(c,
+		&factory.UserParams{
+			Name:   "deleted-user",
+			Access: permission.ReadAccess,
+		})
+	err := s.State.CreateOfferAccess(names.NewApplicationOfferTag(offer.OfferUUID), user.UserTag(), permission.ReadAccess)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// validate before user removal
+	users, err := s.State.GetOfferUsers(offer.OfferUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(users, gc.HasLen, 4)
+	c.Assert(users["everyone@external"].Access, gc.Equals, permission.ReadAccess)
+	c.Assert(users["test-admin"].Access, gc.Equals, permission.AdminAccess)
+	c.Assert(users["validusername"].Access, gc.Equals, permission.ConsumeAccess)
+	c.Assert(users["deleted-user"].Access, gc.Equals, permission.ReadAccess)
+
+	err = s.State.RemoveUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// validate after user removal
+	users, err = s.State.GetOfferUsers(offer.OfferUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(users, gc.HasLen, 3)
+	c.Assert(users["everyone@external"].Access, gc.Equals, permission.ReadAccess)
+	c.Assert(users["test-admin"].Access, gc.Equals, permission.AdminAccess)
+	c.Assert(users["validusername"].Access, gc.Equals, permission.ConsumeAccess)
 }
 
 func (s *ApplicationOfferUserSuite) TestRemoveOfferAccess(c *gc.C) {

--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -95,8 +95,8 @@ type externalControllers struct {
 }
 
 // NewExternalControllers creates an external controllers instance backed by a state.
-func (s *State) NewExternalControllers() ExternalControllers {
-	return NewExternalControllers(s)
+func (st *State) NewExternalControllers() ExternalControllers {
+	return NewExternalControllers(st)
 }
 
 // NewExternalControllers creates an external controllers instance backed by a state.

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -934,8 +934,8 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		var acl map[string]string
 		if len(userMap) != 0 {
 			acl = make(map[string]string, len(userMap))
-			for user, access := range userMap {
-				acl[user] = accessToString(access)
+			for user, userAccess := range userMap {
+				acl[user] = accessToString(userAccess.Access)
 			}
 		}
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1111,10 +1111,8 @@ func (s *MigrationImportSuite) TestApplicationsWithExposedOffers(c *gc.C) {
 	users, err := newSt.GetOfferUsers(stOffer.OfferUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(users, gc.HasLen, 2)
-	c.Assert(users, gc.DeepEquals, map[string]permission.Access{
-		"admin": "admin",
-		"foo":   "consume",
-	})
+	c.Assert(users["admin"].Access, gc.Equals, permission.Access("admin"))
+	c.Assert(users["foo"].Access, gc.Equals, permission.Access("consume"))
 }
 
 func (s *MigrationImportSuite) TestExternalControllers(c *gc.C) {

--- a/state/querytracker.go
+++ b/state/querytracker.go
@@ -34,9 +34,9 @@ type QueryDetails struct {
 // just using a string.Contains check. We may want to extend this
 // functionality at some state to use regex, or support multiple
 // matches.
-func (s *State) TrackQueries(method string) QueryTracker {
+func (st *State) TrackQueries(method string) QueryTracker {
 	tracker := &queryTracker{method: method}
-	s.database.(*database).setTracker(tracker)
+	st.database.(*database).setTracker(tracker)
 	return tracker
 }
 

--- a/state/user.go
+++ b/state/user.go
@@ -71,7 +71,6 @@ func (st *State) AddUserWithSecretKey(name, displayName, creator string) (*User,
 }
 
 func (st *State) addUser(name, displayName, password, creator string, secretKey []byte) (*User, error) {
-
 	if !names.IsValidUserName(name) {
 		return nil, errors.Errorf("invalid user name %q", name)
 	}
@@ -275,6 +274,9 @@ func (st *State) RemoveUser(tag names.UserTag) error {
 
 		// remove the user from the controller
 		ops = append(ops, removeControllerUserOps(st.ControllerUUID(), tag)...)
+
+		// remove the all user permissions
+		ops = append(ops, removeAllSubjectPermissionsOp(userGlobalKey(userAccessID(tag))))
 
 		// new entry in the removal log
 		newRemovalLogEntry := userRemovedLogEntry{

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -156,7 +157,8 @@ func (s *UserSuite) TestAllUsersSkipsDeletedUsers(c *gc.C) {
 	}
 	c.Check(got, jc.SameContents, []string{"test-admin", "one", "two", "three"})
 
-	s.State.RemoveUser(user.UserTag())
+	err = s.State.RemoveUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
 
 	all, err = s.State.AllUsers(true)
 	got = nil
@@ -166,7 +168,6 @@ func (s *UserSuite) TestAllUsersSkipsDeletedUsers(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(len(all), jc.DeepEquals, 3)
 	c.Check(got, jc.SameContents, []string{"test-admin", "two", "three"})
-
 }
 
 func (s *UserSuite) TestRemoveUser(c *gc.C) {
@@ -284,6 +285,33 @@ func (s *UserSuite) TestRemoveUserRemovesUserAccess(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("user %q is permanently deleted", user.UserTag().Name()))
 }
 
+func (s *UserSuite) TestRemoveUserRemovesUserPermissions(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "so sekrit"})
+
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	offers := state.NewApplicationOffers(s.State)
+	offer, err := offers.AddOffer(crossmodel.AddApplicationOfferArgs{
+		OfferName:       "someoffer",
+		ApplicationName: "mysql",
+		Owner:           "test-admin",
+		HasRead:         []string{"everyone@external"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.CreateOfferAccess(names.NewApplicationOfferTag(offer.OfferUUID), user.UserTag(), permission.ReadAccess)
+	c.Assert(err, jc.ErrorIsNil)
+
+	oa, err := s.State.GetOfferAccess(offer.OfferUUID, user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(oa, gc.Equals, permission.ReadAccess)
+
+	// Remove the user.
+	err = s.State.RemoveUser(user.UserTag())
+	c.Check(err, jc.ErrorIsNil)
+
+	_, err = s.State.GetOfferAccess(offer.OfferUUID, user.UserTag())
+	c.Check(err, gc.ErrorMatches, fmt.Sprintf("user permission for \"us#%s\" on \"ao#%s\" not found", user.UserTag().Id(), offer.OfferUUID))
+}
+
 func (s *UserSuite) TestRecreatedUsersResetPermissions(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Password: "so sekrit"})
 
@@ -313,7 +341,8 @@ func (s *UserSuite) TestRecreatedUsersResetPermissions(c *gc.C) {
 	// Add the user again with other password and access
 	userRecreated := s.Factory.MakeUser(c, &factory.UserParams{
 		Password: "otherpassword",
-		Access:   permission.ReadAccess})
+		Access:   permission.ReadAccess,
+	})
 
 	// Assert user exists and can authenticate.
 	c.Assert(userRecreated.PasswordValid("otherpassword"), jc.IsTrue)

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -111,8 +111,18 @@ func removePermissionOp(objectGlobalKey, subjectGlobalKey string) txn.Op {
 		Assert: txn.DocExists,
 		Remove: true,
 	}
-
 }
+
+func removeAllSubjectPermissionsOp(subjectGlobalKey string) txn.Op {
+	findExpr := fmt.Sprintf(".*#%s$", subjectGlobalKey)
+	return txn.Op{
+		C:      permissionsC,
+		Id:     bson.D{{"$regex", findExpr}},
+		Assert: txn.DocExists,
+		Remove: true,
+	}
+}
+
 func createPermissionOp(objectGlobalKey, subjectGlobalKey string, access permission.Access) txn.Op {
 	doc := makePermissionDoc(objectGlobalKey, subjectGlobalKey, access)
 	return txn.Op{


### PR DESCRIPTION
When displaying application offers with `show-offer`, the API retrieves the
display name of each user that has access to the offer. Retrieving display
names accounts for missing user, but not deleted ones. If the list of users
include a deleted user, the error causes the users list to be incomplete.

**Solution:**

- Remove all user permissions (including offer access) when a user is deleted. This removes the root cause of the problem.
- Modified GetOfferUsers in the state layer to filter out deleted users and return user access details (including display names) directly. Filtering deleted users is needed for the users which were deleted before this change is implemented.
- Removed redundant userDisplayName API calls that could fail on deleted users.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. Setup offer and delete a user

```sh
juju bootstrap microk8s local-k8s
juju add-model test
juju deploy juju-qa-dummy-source src

## create offer and grant permissions to users
juju offer src:sink dummy-offer
for i in `seq 0 30`; do juju add-user  se-$i-pl-doc-prod ; done
for i in `seq 0 30`; do juju grant se-$i-pl-doc-prod consume admin/test.dummy-offer; done

## remove user
juju remove-user se-7-pl-doc-prod

## all users must be shown every time
for seq in {1..5}; do juju show-offer admin/test.dummy-offer --format yaml | grep access | wc -l ; sleep 1; done

for seq in {1..5}; do juju show-offer admin/test.dummy-offer --format json | jq '."local-k8s:admin/test.dummy-offer".users | length'; sleep 1; done
```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

- Jira ticket: [JUJU-9117](https://warthogs.atlassian.net/browse/JUJU-9117)
- GitHub Issue: https://github.com/juju/juju/issues/21681


[JUJU-9117]: https://warthogs.atlassian.net/browse/JUJU-9117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ