### PR TITLE
fix: 4.0 fix ssh key comments

### DIFF
--- a/domain/keymanager/state/state.go
+++ b/domain/keymanager/state/state.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/model"
@@ -110,6 +111,30 @@ AND removed = false
 	return nil
 }
 
+// extractCleanPublicKey extracts the clean SSH public key without comment.
+// SSH key format: <type> <base64-key> [optional-comment]
+// Uses ssh.ParseAuthorizedKey to properly parse the key and MarshalAuthorizedKey to reconstruct it.
+func extractCleanPublicKey(fullKey string) (string, error) {
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(fullKey))
+	if err != nil {
+		return "", err
+	}
+
+	// MarshalAuthorizedKey returns "<type> <base64>\n"
+	clean := ssh.MarshalAuthorizedKey(pubKey)
+
+	// Trim the newline that MarshalAuthorizedKey adds
+	return string(clean[:len(clean)-1]), nil
+}
+
+// addCommentToKey reconstructs an SSH key with an optional comment appended.
+func addCommentToKey(cleanKey, comment string) string {
+	if comment == "" {
+		return cleanKey
+	}
+	return cleanKey + " " + comment
+}
+
 // ensureUserPublicKey ensures that a public key exists for a user returning the
 // unique id to represent that key within the database.
 func (s *State) ensureUserPublicKey(
@@ -117,14 +142,22 @@ func (s *State) ensureUserPublicKey(
 	key userPublicKeyInsert,
 	tx *sqlair.TX,
 ) (int64, error) {
+	// Store only the clean key without comment
+	cleanKey, err := extractCleanPublicKey(key.PublicKey)
+	if err != nil {
+		return 0, errors.Errorf(
+			"parsing public key for user %q: %w",
+			key.UserId, err,
+		)
+	}
+	key.PublicKey = cleanKey
+
 	insertStmt, err := s.Prepare(`
-INSERT INTO user_public_ssh_key (comment,
-                                 fingerprint,
+INSERT INTO user_public_ssh_key (fingerprint,
 						         public_key,
                                  user_uuid,
                                  fingerprint_hash_algorithm_id)
-SELECT $userPublicKeyInsert.comment,
-       $userPublicKeyInsert.fingerprint,
+SELECT $userPublicKeyInsert.fingerprint,
        $userPublicKeyInsert.public_key,
        $userPublicKeyInsert.user_uuid,
        s.id	
@@ -240,7 +273,6 @@ INSERT INTO model_authorized_keys (*) VALUES ($modelAuthorizedKey.*)
 		keyIds := []int64{}
 		for i, publicKey := range publicKeys {
 			row := userPublicKeyInsert{
-				Comment:                  publicKey.Comment,
 				FingerprintHashAlgorithm: publicKey.FingerprintHash.String(),
 				Fingerprint:              publicKey.Fingerprint,
 				PublicKey:                publicKey.Key,
@@ -262,9 +294,10 @@ INSERT INTO model_authorized_keys (*) VALUES ($modelAuthorizedKey.*)
 			row := modelAuthorizedKey{
 				UserPublicSSHKeyId: keyId,
 				ModelUUID:          modelUUID.String(),
+				Comment:            publicKeys[i].Comment,
 			}
 			err := tx.Query(ctx, insertModelAuthorisedKeyStmt, row).Run()
-			if jujudb.IsErrConstraintPrimaryKey(err) {
+			if jujudb.IsErrConstraintPrimaryKey(err) || jujudb.IsErrConstraintUnique(err) {
 				return errors.Errorf(
 					"adding key %d for user %q to model %q, key already exists",
 					i, userUUID, modelUUID,
@@ -342,7 +375,6 @@ ON CONFLICT DO NOTHING
 		// considered a hot path.
 		for i, publicKey := range publicKeys {
 			row := userPublicKeyInsert{
-				Comment:                  publicKey.Comment,
 				FingerprintHashAlgorithm: publicKey.FingerprintHash.String(),
 				Fingerprint:              publicKey.Fingerprint,
 				PublicKey:                publicKey.Key,
@@ -363,6 +395,7 @@ ON CONFLICT DO NOTHING
 			row := modelAuthorizedKey{
 				UserPublicSSHKeyId: keyId,
 				ModelUUID:          modelUUID.String(),
+				Comment:            publicKeys[i].Comment,
 			}
 
 			err := tx.Query(ctx, insertModelAuthorisedKeyStmt, row).Run()
@@ -463,7 +496,7 @@ func (s *State) GetPublicKeysForUser(
 	userUUIDVal := userUUIDValue{UUID: userUUID.String()}
 
 	stmt, err := s.Prepare(`
-SELECT &publicKey.*
+SELECT (upsk.fingerprint, upsk.public_key, m.comment) AS (&publicKey.*)
 FROM user_public_ssh_key AS upsk
 JOIN model_authorized_keys AS m ON upsk.id = m.user_public_ssh_key_id
 WHERE user_uuid = $userUUIDValue.user_uuid
@@ -510,9 +543,11 @@ AND model_uuid = $modelUUIDValue.model_uuid
 
 	rval := make([]coressh.PublicKey, 0, len(publicKeys))
 	for _, pk := range publicKeys {
+		// Reconstruct full key with model-specific comment
+		fullKey := addCommentToKey(pk.PublicKey, pk.Comment)
 		rval = append(rval, coressh.PublicKey{
 			Fingerprint: pk.Fingerprint,
-			Key:         pk.PublicKey,
+			Key:         fullKey,
 		})
 	}
 	return rval, nil
@@ -537,7 +572,7 @@ func (s *State) GetPublicKeysDataForUser(
 	modelUUIDVal := modelUUIDValue{modelUUID.String()}
 
 	stmt, err := s.Prepare(`
-SELECT &publicKeyData.public_key
+SELECT (upsk.public_key, m.comment) AS (&publicKeyData.*)
 FROM user_public_ssh_key AS upsk
 JOIN model_authorized_keys AS m ON upsk.id = m.user_public_ssh_key_id
 WHERE user_uuid = $userUUIDValue.user_uuid
@@ -585,7 +620,9 @@ AND model_uuid = $modelUUIDValue.model_uuid
 
 	rval := make([]string, 0, len(publicKeys))
 	for _, pk := range publicKeys {
-		rval = append(rval, pk.PublicKey)
+		// Reconstruct full key with model-specific comment
+		fullKey := addCommentToKey(pk.PublicKey, pk.Comment)
+		rval = append(rval, fullKey)
 	}
 	return rval, nil
 }
@@ -610,6 +647,19 @@ func (s *State) DeletePublicKeysForUser(
 	userUUIDVal := userUUIDValue{UUID: userUUID.String()}
 	modelUUIDVal := modelUUIDValue{UUID: modelUUID.String()}
 
+	// Clean public keys before searching, since we store only the key part without comment
+	cleanedKeyIds := make(sqlair.S, 0, len(keyIds))
+	for _, keyId := range keyIds {
+		clean, err := extractCleanPublicKey(keyId)
+		if err != nil {
+			// If parsing fails, still add original for comment/fingerprint fallback
+			cleanedKeyIds = append(cleanedKeyIds, keyId)
+			continue
+		}
+		cleanedKeyIds = append(cleanedKeyIds, clean)
+	}
+
+	// Also keep original for fingerprint and comment searches
 	input := make(sqlair.S, 0, len(keyIds))
 	for _, keyId := range keyIds {
 		input = append(input, keyId)
@@ -619,13 +669,36 @@ func (s *State) DeletePublicKeysForUser(
 SELECT &userPublicKeyId.*
 FROM user_public_ssh_key
 WHERE user_uuid = $userUUIDValue.user_uuid
-AND (comment IN ($S[:])
-  OR fingerprint IN ($S[:])
-  OR public_key IN ($S[:]))
+AND fingerprint IN ($S[:])
 `, userUUIDVal, userPublicKeyId{}, input)
 	if err != nil {
 		return errors.Errorf(
-			"preparing find keys statement when deleting public keys for user %q on model %q: %w",
+			"preparing find keys by fingerprint statement when deleting public keys for user %q on model %q: %w",
+			userUUID, modelUUID, err,
+		)
+	}
+
+	findKeysPublicKeyStmt, err := s.Prepare(`
+SELECT &userPublicKeyId.*
+FROM user_public_ssh_key
+WHERE user_uuid = $userUUIDValue.user_uuid
+AND public_key IN ($S[:])
+`, userUUIDVal, userPublicKeyId{}, cleanedKeyIds)
+	if err != nil {
+		return errors.Errorf(
+			"preparing find keys by public key statement when deleting public keys for user %q on model %q: %w",
+			userUUID, modelUUID, err,
+		)
+	}
+
+	deleteByCommentStmt, err := s.Prepare(`
+DELETE FROM model_authorized_keys
+WHERE model_uuid = $modelUUIDValue.model_uuid
+AND comment IN ($S[:])
+`, modelUUIDVal, input)
+	if err != nil {
+		return errors.Errorf(
+			"preparing delete by comment statement when deleting public keys for user %q on model %q: %w",
 			userUUID, modelUUID, err,
 		)
 	}
@@ -661,7 +734,6 @@ AND id IN (SELECT id
 		)
 	}
 
-	foundKeyIds := userPublicKeyIds{}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := s.checkUserExists(ctx, userUUID, tx)
 		if err != nil {
@@ -679,17 +751,48 @@ AND id IN (SELECT id
 			)
 		}
 
-		err = tx.Query(ctx, findKeysStmt, userUUIDVal, input).GetAll(&foundKeyIds)
-		if errors.Is(err, sqlair.ErrNoRows) {
-			// Nothing was found so we can safely bail out and give this
-			// transaction back to the pool early.
-			return nil
-		}
-		if err != nil {
+		// First, delete by comment directly from model_authorized_keys
+		err = tx.Query(ctx, deleteByCommentStmt, modelUUIDVal, input).Run()
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(
-				"finding public keys to delete for user %q on model %q: %w",
+				"deleting public keys by comment for user %q on model %q: %w",
 				userUUID, modelUUID, err,
 			)
+		}
+
+		// Then find keys by fingerprint
+		foundKeyIdsByFingerprint := userPublicKeyIds{}
+		err = tx.Query(ctx, findKeysStmt, userUUIDVal, input).GetAll(&foundKeyIdsByFingerprint)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf(
+				"finding public keys by fingerprint to delete for user %q on model %q: %w",
+				userUUID, modelUUID, err,
+			)
+		}
+
+		// Find keys by public key
+		foundKeyIdsByPublicKey := userPublicKeyIds{}
+		err = tx.Query(ctx, findKeysPublicKeyStmt, userUUIDVal, cleanedKeyIds).GetAll(&foundKeyIdsByPublicKey)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf(
+				"finding public keys by public key to delete for user %q on model %q: %w",
+				userUUID, modelUUID, err,
+			)
+		}
+
+		// Combine the results
+		foundKeyIds := append(foundKeyIdsByFingerprint, foundKeyIdsByPublicKey...)
+
+		if len(foundKeyIds) == 0 {
+			// Nothing was found, proceed to cleanup
+			err = tx.Query(ctx, deleteUnusedUserKeys, userUUIDVal).Run()
+			if err != nil {
+				return errors.Errorf(
+					"deleting unused public keys for user %q: %w",
+					userUUID, err,
+				)
+			}
+			return nil
 		}
 
 		err = tx.Query(ctx, deleteFromModelStmt, modelUUIDVal, foundKeyIds).Run()

--- a/domain/keymanager/state/state_test.go
+++ b/domain/keymanager/state/state_test.go
@@ -685,3 +685,186 @@ func (s *stateSuite) TestGetAllUsersPublicKeysOnNonActivatedModel(c *tc.C) {
 	c.Check(len(allKeys), tc.Equals, 1)
 	c.Check(allKeys[s.userName], tc.HasLen, len(testingPublicKeys))
 }
+
+// TestSameKeyDifferentModelsWithDifferentComments is asserting that the same SSH
+// key can be added to multiple models with different comments.
+func (s *stateSuite) TestSameKeyDifferentModelsWithDifferentComments(c *tc.C) {
+	state := NewState(s.TxnRunnerFactory())
+
+	parsedKey, err := ssh.ParsePublicKey(testingPublicKeys[0])
+	c.Assert(err, tc.ErrorIsNil)
+
+	keyWithCommentA := keymanager.PublicKey{
+		Comment:         "comment-a",
+		FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+		Fingerprint:     parsedKey.Fingerprint(),
+		Key:             testingPublicKeys[0],
+	}
+
+	keyWithCommentB := keymanager.PublicKey{
+		Comment:         "comment-b",
+		FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+		Fingerprint:     parsedKey.Fingerprint(),
+		Key:             testingPublicKeys[0],
+	}
+
+	// Add key with comment A to model 1.
+	err = state.AddPublicKeysForUser(c.Context(), s.modelId, s.userId, []keymanager.PublicKey{keyWithCommentA})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Create a second model.
+	modelId2 := statemodeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "keys2")
+
+	// Add the same key with comment B to model 2.
+	err = state.AddPublicKeysForUser(c.Context(), modelId2, s.userId, []keymanager.PublicKey{keyWithCommentB})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Verify model 1 has the key with comment A.
+	keys1, err := state.GetPublicKeysDataForUser(c.Context(), s.modelId, s.userId)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(keys1, tc.HasLen, 1)
+	c.Check(strings.HasSuffix(keys1[0], "comment-a"), tc.IsTrue, tc.Commentf("Expected key to end with 'comment-a', got: %s", keys1[0]))
+
+	// Verify model 2 has the key with comment B.
+	keys2, err := state.GetPublicKeysDataForUser(c.Context(), modelId2, s.userId)
+	c.Assert(err, tc.ErrorIsNil)
+	// Expect len 1.
+	c.Assert(keys2, tc.HasLen, 1)
+	c.Check(strings.HasSuffix(keys2[0], "comment-b"), tc.IsTrue, tc.Commentf("Expected key to end with 'comment-b', got: %s", keys2[0]))
+}
+
+// TestSameKeyDifferentModelsWithAndWithoutComment is asserting that the same SSH
+// key can be added to one model with a comment and another model without a comment.
+func (s *stateSuite) TestSameKeyDifferentModelsWithAndWithoutComment(c *tc.C) {
+	state := NewState(s.TxnRunnerFactory())
+
+	parsedKey, err := ssh.ParsePublicKey(testingPublicKeys[0])
+	c.Assert(err, tc.ErrorIsNil)
+
+	keyWithComment := keymanager.PublicKey{
+		Comment:         "my-comment",
+		FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+		Fingerprint:     parsedKey.Fingerprint(),
+		Key:             testingPublicKeys[0],
+	}
+
+	keyWithoutComment := keymanager.PublicKey{
+		Comment:         "",
+		FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+		Fingerprint:     parsedKey.Fingerprint(),
+		Key:             testingPublicKeys[0],
+	}
+
+	// Add key with comment to model 1.
+	err = state.AddPublicKeysForUser(c.Context(), s.modelId, s.userId, []keymanager.PublicKey{keyWithComment})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Create a second model.
+	modelId2 := statemodeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "keys2")
+
+	// Add the same key without comment to model 2.
+	err = state.AddPublicKeysForUser(c.Context(), modelId2, s.userId, []keymanager.PublicKey{keyWithoutComment})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Verify model 1 has the key with comment.
+	keys1, err := state.GetPublicKeysDataForUser(c.Context(), s.modelId, s.userId)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(keys1, tc.HasLen, 1)
+	c.Check(strings.HasSuffix(keys1[0], "my-comment"), tc.IsTrue)
+
+	// Verify model 2 has the key without comment (should just be the clean key).
+	keys2, err := state.GetPublicKeysDataForUser(c.Context(), modelId2, s.userId)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(keys2, tc.HasLen, 1)
+	c.Check(strings.HasSuffix(keys2[0], "my-comment"), tc.IsFalse)
+}
+
+// TestSameKeyNoComment is asserting that a key can be added without any comment.
+func (s *stateSuite) TestSameKeyNoComment(c *tc.C) {
+	state := NewState(s.TxnRunnerFactory())
+
+	parsedKey, err := ssh.ParsePublicKey(testingPublicKeys[0])
+	c.Assert(err, tc.ErrorIsNil)
+
+	keyWithoutComment := keymanager.PublicKey{
+		Comment:         "",
+		FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+		Fingerprint:     parsedKey.Fingerprint(),
+		Key:             testingPublicKeys[0],
+	}
+
+	err = state.AddPublicKeysForUser(c.Context(), s.modelId, s.userId, []keymanager.PublicKey{keyWithoutComment})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Verify the key was added without comment.
+	keys, err := state.GetPublicKeysDataForUser(c.Context(), s.modelId, s.userId)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(keys, tc.HasLen, 1)
+	// The key should not have any extra comment appended.
+	c.Check(strings.Contains(keys[0], "ecdsa-sha2-nistp256"), tc.IsTrue)
+}
+
+// TestSameKeySameModelSameCommentTwice is asserting that adding the same key
+// with the same comment to the same model twice results in a
+// PublicKeyAlreadyExists error.
+func (s *stateSuite) TestSameKeySameModelSameCommentTwice(c *tc.C) {
+	state := NewState(s.TxnRunnerFactory())
+
+	parsedKey, err := ssh.ParsePublicKey(testingPublicKeys[0])
+	c.Assert(err, tc.ErrorIsNil)
+
+	keyWithComment := keymanager.PublicKey{
+		Comment:         "my-comment",
+		FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+		Fingerprint:     parsedKey.Fingerprint(),
+		Key:             testingPublicKeys[0],
+	}
+
+	// Add key first time.
+	err = state.AddPublicKeysForUser(c.Context(), s.modelId, s.userId, []keymanager.PublicKey{keyWithComment})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Try to add the same key with same comment again.
+	err = state.AddPublicKeysForUser(c.Context(), s.modelId, s.userId, []keymanager.PublicKey{keyWithComment})
+	c.Check(err, tc.ErrorIs, keyerrors.PublicKeyAlreadyExists)
+}
+
+// TestSameKeySameModelDifferentComments is asserting that adding the same key
+// with different comments to the same model results in a PublicKeyAlreadyExists error.
+// This is the critical test: comments are per-model metadata, not part of the key identity.
+func (s *stateSuite) TestSameKeySameModelDifferentComments(c *tc.C) {
+	state := NewState(s.TxnRunnerFactory())
+
+	parsedKey, err := ssh.ParsePublicKey(testingPublicKeys[0])
+	c.Assert(err, tc.ErrorIsNil)
+
+	keyWithCommentA := keymanager.PublicKey{
+		Comment:         "comment-a",
+		FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+		Fingerprint:     parsedKey.Fingerprint(),
+		Key:             testingPublicKeys[0],
+	}
+
+	keyWithCommentB := keymanager.PublicKey{
+		Comment:         "comment-b",
+		FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+		Fingerprint:     parsedKey.Fingerprint(),
+		Key:             testingPublicKeys[0],
+	}
+
+	// Add key with comment A.
+	err = state.AddPublicKeysForUser(c.Context(), s.modelId, s.userId, []keymanager.PublicKey{keyWithCommentA})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Try to add the same key with comment B to the same model.
+	err = state.AddPublicKeysForUser(c.Context(), s.modelId, s.userId, []keymanager.PublicKey{keyWithCommentB})
+	// Expect this to fail as we don't wanna allow adding the same key twice
+	// even if the comment id different.
+	c.Check(err, tc.ErrorIs, keyerrors.PublicKeyAlreadyExists)
+
+	// Verify the original comment A is still there.
+	keys, err := state.GetPublicKeysDataForUser(c.Context(), s.modelId, s.userId)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(keys, tc.HasLen, 1)
+	c.Check(strings.HasSuffix(keys[0], "comment-a"), tc.IsTrue)
+}

--- a/domain/keymanager/state/types.go
+++ b/domain/keymanager/state/types.go
@@ -5,16 +5,19 @@ package state
 
 import "database/sql/driver"
 
-// publicKey represents a single row from the user public key table.
+// publicKey represents the result of selecting a public key with its per-model comment.
+// Data comes from joining user_public_ssh_key with model_authorized_keys.
 type publicKey struct {
 	Fingerprint string `db:"fingerprint"`
 	PublicKey   string `db:"public_key"`
+	Comment     string `db:"comment"`
 }
 
-// publicKeyData represents a single raw public key from the user public key
-// table.
+// publicKeyData represents public key data with its per-model comment.
+// Data comes from joining user_public_ssh_key with model_authorized_keys.
 type publicKeyData struct {
 	PublicKey string `db:"public_key"`
+	Comment   string `db:"comment"`
 }
 
 // modelAuthorizedKey represents a single row from the model_authorized_keys
@@ -22,6 +25,7 @@ type publicKeyData struct {
 type modelAuthorizedKey struct {
 	UserPublicSSHKeyId int64  `db:"user_public_ssh_key_id"`
 	ModelUUID          string `db:"model_uuid"`
+	Comment            string `db:"comment"`
 }
 
 // modelUUIDValue represents a model id for associating public keys with.
@@ -47,7 +51,6 @@ type userPublicKeyIds []userPublicKeyId
 // userPublicKeyInsert describes the data input needed for inserting new public
 // keys for a user.
 type userPublicKeyInsert struct {
-	Comment                  string `db:"comment"`
 	FingerprintHashAlgorithm string `db:"algorithm"`
 	Fingerprint              string `db:"fingerprint"`
 	PublicKey                string `db:"public_key"`

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -64,6 +64,11 @@ var controllerPostPatchFilesByVersion = []struct {
 		"0026-secret-backend.PATCH.sql",
 		"0027-model-migration-import.PATCH.sql",
 	},
+}, {
+	version: semversion.MustParse("4.0.2"),
+	files: []string{
+		"0028-user-ssh-keys.PATCH.sql",
+	},
 }}
 
 // ControllerDDL is used to create the controller database schema at bootstrap.

--- a/domain/schema/controller/sql/0028-user-ssh-keys.PATCH.sql
+++ b/domain/schema/controller/sql/0028-user-ssh-keys.PATCH.sql
@@ -1,0 +1,64 @@
+-- Move SSH key comments from global storage (user_public_ssh_key.comment)
+-- to per-model storage (model_authorized_keys.comment).
+--
+-- This allows the same SSH key to be added to multiple models with different comments,
+-- fixing the issue where Terraform would detect diffs simply due to the comment
+-- when the same key is used in different models.
+
+-- Add comment column to model_authorized_keys.
+ALTER TABLE model_authorized_keys
+ADD COLUMN comment TEXT;
+
+-- Migrate existing comments from user_public_ssh_key to model_authorized_keys.
+UPDATE model_authorized_keys
+SET comment = (
+    SELECT comment FROM user_public_ssh_key
+    WHERE user_public_ssh_key.id = model_authorized_keys.user_public_ssh_key_id
+)
+WHERE comment IS NULL;
+
+-- Clean up public_key values by removing comments from the end, as we're
+-- storing them on the model_authorized_keys table now there's no
+-- need to ever store the key with the comment.
+UPDATE user_public_ssh_key
+SET public_key = (
+    SUBSTR(public_key, 1, 
+        CASE 
+            WHEN INSTR(SUBSTR(public_key, INSTR(public_key, ' ') + 1), ' ') > 0
+            THEN INSTR(public_key, ' ') + INSTR(SUBSTR(public_key, INSTR(public_key, ' ') + 1), ' ') - 1
+            ELSE LENGTH(public_key)
+        END
+    )
+)
+WHERE comment IS NOT NULL;
+
+-- Remove the comment column from user_public_ssh_key as it's no longer needed.
+DROP INDEX IF EXISTS idx_user_public_ssh_key_user_comment;
+ALTER TABLE user_public_ssh_key
+DROP COLUMN comment;
+
+-- Drop the old view..
+DROP VIEW IF EXISTS v_model_authorized_keys;
+
+-- Create unique constraint as it was because we don't want 
+-- to allow the same key with a new comment adding to the model again.
+CREATE UNIQUE INDEX idx_model_authorized_keys_composite
+ON model_authorized_keys (model_uuid, user_public_ssh_key_id);
+
+-- Recreate the view with per-model comments.
+CREATE VIEW v_model_authorized_keys AS
+SELECT
+    mak.model_uuid,
+    CASE
+        WHEN mak.comment IS NOT NULL AND mak.comment != ''
+        THEN upsk.public_key || ' ' || mak.comment
+        ELSE upsk.public_key
+    END AS public_key,
+    upsk.user_uuid
+FROM model_authorized_keys AS mak
+JOIN user_public_ssh_key AS upsk ON mak.user_public_ssh_key_id = upsk.id
+JOIN user AS u ON upsk.user_uuid = u.uuid
+JOIN user_authentication AS ua ON u.uuid = ua.user_uuid
+WHERE
+    u.removed = FALSE
+    AND ua.disabled = FALSE;


### PR DESCRIPTION
# Support per-model SSH key comments

## Problem

SSH key comments were stored globally in `user_public_ssh_key.comment`, which meant:
- The same SSH key could only have **one comment** across all models.
- When the same key was added to Model A with "comment-a" and Model B with "comment-b", only one comment would persist, that is, if you listed the key with "--full" in model B, it'd show the initially set comment for this key.
- This caused the Terraform provider's SSH key resource tests to fail with spurious diffs when the same key was used across multiple models despite setting a different comment.

## Solution
After a discussion with @manadart and @SimonRichardson, it was agreed that we will allow a new comment to be set with adding the key to a new model, i.e., move comment storage from global to per-model scope.

It was additionally discussed to upsert the keys, but I've left that out as I fear that may introduce a different behaviour that may or may not affect Terraform (giving it would silently update) and wanted the least intrusive change without needing to modify any existing tests. 

**Before:**
```
juju add-model a
juju add-model b
juju switch a
juju add-ssh-key "ssh-rsa key a1"
juju switch b
juju add-ssh-key "ssh-rsa key a2"
juju list-ssh-keys --full # Returns the comment with a1, and forever will until removed entirely.
```
Now with this change it will return "a2" when listed in "full".

To build the response back, I've opted to do it programatically over querying again as we've already queried the model _authorized_keys and user_public_ssh_keys tables at each point - so I thought it would be safer to just concatenate them.

## Model Migration Safety
I've recreated the `v_model_authorized_keys` and it adds the comment if possible. AFAICT, this appears to be OK?

## Fixes
Terraform provider SSH key resource tests on Juju 4.0

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Setup a controller with two models.
```bash
juju bootstrap lxd 40; juju add-model a; juju add-model b; juju add-model c;
```

In another terminal run the following to get the repl (stay in controller db). 
```bash
lxc shell $(juju switch controller; juju status --format json | jq -r '.machines."0"."instance-id"')
juju_db_repl
```

Get some valid SSH key and fill in <key> for the next steps.

Expect an error when the same comment is added twice AND if we change the comment in the SAME model.
Also expect the listing to show "a1".
```bash
juju switch a
juju list-ssh-keys --full # expect no keys.
juju add-ssh-key "ssh-rsa <key> a1"
juju add-ssh-key "ssh-rsa <key> a1"
juju add-ssh-key "ssh-rsa <key> a2"
juju list-ssh-keys --full
```

Now we'll switch and expect to add the same key, but a new comment, and list keys should show the comment as "a1".
```bash
juju switch b
juju list-ssh-keys --full # expect no keys.
juju add-ssh-key "ssh-rsa <key> a1"
juju list-ssh-keys --full
```

Now we'll go to the final model and add the same key again, but with a new comment. When we list the keys in c, we should see a2 as the comment.
```bash
juju switch c
juju list-ssh-keys --full # expect no keys.
juju add-ssh-key "ssh-rsa <key> a2"
juju list-ssh-keys --full
```

Finally, in the REPL run:
```bash
select * from model_authorized_keys
```

And our state of the world should look like:
```
model_uuid                              user_public_ssh_key_id  comment
ed3db1b8-a041-447e-80e4-5440fdd9bd80    1                       juju-client-key
49ad0e61-374b-4fd1-825d-e8334b4bee22    2                       a1
0912fdbd-5a1e-4690-81f6-4afa2b516da1    2                       a1
4df9ad56-352f-4fc7-8e5a-bc11a9a9c7c5    2                       a2
```
Where the same user created the same key.

Jjust to verify that the comment isn't stored with the key itself run
```
select public_key from user_public_ssh_key
```
And verify the keys don't have a comment appended.


Next we'll delete the keys slowly one by one, checking the REPL each time to verify it is gone:
```
juju switch c 
juju list-ssh-keys 
juju remove-ssh-key
# Check repl that key with comment "a2" is gone & verify select * from user_public_ssh_key where id = 2 still exists.
juju list-ssh-keys  # expect empty.

juju switch b 
juju list-ssh-keys 
juju remove-ssh-key
# Check repl that key with comment "a1" is gone and one remains & verify select * from user_public_ssh_key where id = 2 still exists.
juju list-ssh-keys  # expect empty.

juju switch a 
juju list-ssh-keys 
juju remove-ssh-key
# Check repl that only juju-client-key remains in both model_authorized_keys and user_public_keys table

# And for a final sanity check add a key back into model a and verify repl (id should be 3 for this key now as it is technically a brand new key)
juju add-ssh-key "ssh-rsa <key> a1"

```