### PR TITLE
refactor: rename offer to create offer

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -173,7 +173,7 @@ func (api *OffersAPI) Offer(ctx context.Context, all params.AddApplicationOffers
 		return handleErr(err), nil
 	}
 
-	err = crossModelRelationService.Offer(ctx, applicationOfferArgs)
+	err = crossModelRelationService.CreateOffer(ctx, applicationOfferArgs)
 	if errors.Is(err, crossmodelrelationerrors.OfferAlreadyExists) {
 		// We don't support updating offers via this API, so return an
 		// appropriate error.

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -75,7 +75,7 @@ func (s *offerSuite) TestOffer(c *tc.C) {
 		Endpoints:       map[string]string{"db": "db"},
 		OwnerName:       user.NameFromTag(apiUserTag),
 	}
-	s.crossModelRelationService.EXPECT().Offer(gomock.Any(), createOfferArgs).Return(nil)
+	s.crossModelRelationService.EXPECT().CreateOffer(gomock.Any(), createOfferArgs).Return(nil)
 
 	one := params.AddApplicationOffer{
 		ModelTag:        modelTag.String(),
@@ -148,7 +148,7 @@ func (s *offerSuite) TestOfferOwnerViaArgs(c *tc.C) {
 		Endpoints:       map[string]string{"db": "db"},
 		OwnerName:       user.NameFromTag(offerOwnerTag),
 	}
-	s.crossModelRelationService.EXPECT().Offer(gomock.Any(), createOfferArgs).Return(nil)
+	s.crossModelRelationService.EXPECT().CreateOffer(gomock.Any(), createOfferArgs).Return(nil)
 
 	one := params.AddApplicationOffer{
 		ModelTag:        modelTag.String(),
@@ -197,7 +197,7 @@ func (s *offerSuite) TestOfferModelViaArgs(c *tc.C) {
 		Endpoints:       map[string]string{"db": "db"},
 		OwnerName:       user.NameFromTag(userTag),
 	}
-	s.crossModelRelationService.EXPECT().Offer(gomock.Any(), createOfferArgs).Return(nil)
+	s.crossModelRelationService.EXPECT().CreateOffer(gomock.Any(), createOfferArgs).Return(nil)
 
 	one := params.AddApplicationOffer{
 		ModelTag:        offerModelTag.String(),
@@ -234,7 +234,7 @@ func (s *offerSuite) TestOfferError(c *tc.C) {
 		Endpoints:       map[string]string{"db": "db"},
 		OwnerName:       user.NameFromTag(userTag),
 	}
-	s.crossModelRelationService.EXPECT().Offer(gomock.Any(), createOfferArgs).Return(errors.Errorf("boom"))
+	s.crossModelRelationService.EXPECT().CreateOffer(gomock.Any(), createOfferArgs).Return(errors.Errorf("boom"))
 
 	one := params.AddApplicationOffer{
 		ModelTag:        modelTag.String(),

--- a/apiserver/facades/client/applicationoffers/package_mock_test.go
+++ b/apiserver/facades/client/applicationoffers/package_mock_test.go
@@ -289,6 +289,44 @@ func (m *MockCrossModelRelationService) EXPECT() *MockCrossModelRelationServiceM
 	return m.recorder
 }
 
+// CreateOffer mocks base method.
+func (m *MockCrossModelRelationService) CreateOffer(arg0 context.Context, arg1 crossmodelrelation.ApplicationOfferArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOffer", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOffer indicates an expected call of CreateOffer.
+func (mr *MockCrossModelRelationServiceMockRecorder) CreateOffer(arg0, arg1 any) *MockCrossModelRelationServiceCreateOfferCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOffer", reflect.TypeOf((*MockCrossModelRelationService)(nil).CreateOffer), arg0, arg1)
+	return &MockCrossModelRelationServiceCreateOfferCall{Call: call}
+}
+
+// MockCrossModelRelationServiceCreateOfferCall wrap *gomock.Call
+type MockCrossModelRelationServiceCreateOfferCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelRelationServiceCreateOfferCall) Return(arg0 error) *MockCrossModelRelationServiceCreateOfferCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelRelationServiceCreateOfferCall) Do(f func(context.Context, crossmodelrelation.ApplicationOfferArgs) error) *MockCrossModelRelationServiceCreateOfferCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelRelationServiceCreateOfferCall) DoAndReturn(f func(context.Context, crossmodelrelation.ApplicationOfferArgs) error) *MockCrossModelRelationServiceCreateOfferCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetConsumeDetails mocks base method.
 func (m *MockCrossModelRelationService) GetConsumeDetails(arg0 context.Context, arg1 crossmodel.OfferURL) (crossmodelrelation.ConsumeDetails, error) {
 	m.ctrl.T.Helper()
@@ -402,44 +440,6 @@ func (c *MockCrossModelRelationServiceGetOffersCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelRelationServiceGetOffersCall) DoAndReturn(f func(context.Context, []service.OfferFilter) ([]*crossmodelrelation.OfferDetail, error)) *MockCrossModelRelationServiceGetOffersCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// Offer mocks base method.
-func (m *MockCrossModelRelationService) Offer(arg0 context.Context, arg1 crossmodelrelation.ApplicationOfferArgs) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Offer", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Offer indicates an expected call of Offer.
-func (mr *MockCrossModelRelationServiceMockRecorder) Offer(arg0, arg1 any) *MockCrossModelRelationServiceOfferCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Offer", reflect.TypeOf((*MockCrossModelRelationService)(nil).Offer), arg0, arg1)
-	return &MockCrossModelRelationServiceOfferCall{Call: call}
-}
-
-// MockCrossModelRelationServiceOfferCall wrap *gomock.Call
-type MockCrossModelRelationServiceOfferCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockCrossModelRelationServiceOfferCall) Return(arg0 error) *MockCrossModelRelationServiceOfferCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockCrossModelRelationServiceOfferCall) Do(f func(context.Context, crossmodelrelation.ApplicationOfferArgs) error) *MockCrossModelRelationServiceOfferCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCrossModelRelationServiceOfferCall) DoAndReturn(f func(context.Context, crossmodelrelation.ApplicationOfferArgs) error) *MockCrossModelRelationServiceOfferCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/applicationoffers/service.go
+++ b/apiserver/facades/client/applicationoffers/service.go
@@ -70,9 +70,9 @@ type CrossModelRelationService interface {
 		filters []crossmodelrelationservice.OfferFilter,
 	) ([]*crossmodelrelation.OfferDetail, error)
 
-	// Offer updates an existing offer, or creates a new offer if it does not
-	// exist. Permissions are created for a new offer only.
-	Offer(
+	// CreateOffer updates an existing offer, or creates a new offer if it does
+	// not exist. Permissions are created for a new offer only.
+	CreateOffer(
 		ctx context.Context,
 		args crossmodelrelation.ApplicationOfferArgs,
 	) error

--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -102,9 +102,9 @@ func (s *Service) GetOfferUUIDByRelationUUID(ctx context.Context, relationUUID c
 	return res, nil
 }
 
-// Offer updates an existing offer, or creates a new offer if it does not exist.
-// Permissions are created for a new offer only.
-func (s *Service) Offer(
+// CreateOffer updates an existing offer, or creates a new offer if it does not
+// exist. Permissions are created for a new offer only.
+func (s *Service) CreateOffer(
 	ctx context.Context,
 	args crossmodelrelation.ApplicationOfferArgs,
 ) error {

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -61,7 +61,7 @@ func (s *offerServiceSuite) TestOfferCreate(c *tc.C) {
 	).Return(nil)
 
 	// Act
-	err := s.service(c).Offer(c.Context(), args)
+	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -101,7 +101,7 @@ func (s *offerServiceSuite) TestOfferCreateAccessErr(c *tc.C) {
 	s.modelState.EXPECT().DeleteFailedOffer(gomock.Any(), gomock.AssignableToTypeOf(offer.UUID(""))).Return(nil)
 
 	// Act
-	err := s.service(c).Offer(c.Context(), args)
+	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
 	c.Assert(err, tc.ErrorMatches, `creating access for offer "test-offer": boom`)
@@ -132,7 +132,7 @@ func (s *offerServiceSuite) TestOfferCreateError(c *tc.C) {
 	s.modelState.EXPECT().CreateOffer(gomock.Any(), m).Return(errors.Errorf("boom"))
 
 	// Act
-	err := s.service(c).Offer(c.Context(), args)
+	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
 	c.Assert(err, tc.ErrorMatches, "create offer: boom")
@@ -159,7 +159,7 @@ func (s *offerServiceSuite) TestOfferAlreadyExists(c *tc.C) {
 	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return(existingOfferUUID, nil)
 
 	// Act
-	err := s.service(c).Offer(c.Context(), args)
+	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
 	c.Assert(err, tc.ErrorMatches, `create offer: offer "test-offer" already exists with UUID ".*"`)
@@ -186,7 +186,7 @@ func (s *offerServiceSuite) TestOfferGetOfferUUIDError(c *tc.C) {
 	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", errors.Errorf("database error"))
 
 	// Act
-	err := s.service(c).Offer(c.Context(), args)
+	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
 	c.Assert(err, tc.ErrorMatches, "create offer: database error")
@@ -214,7 +214,7 @@ func (s *offerServiceSuite) TestOfferOwnerNotFound(c *tc.C) {
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(uuid.UUID{}, errors.Errorf("user not found"))
 
 	// Act
-	err := s.service(c).Offer(c.Context(), args)
+	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
 	c.Assert(err, tc.ErrorMatches, "create offer: user not found")


### PR DESCRIPTION
Even though create offer can update an existing offer, I'd rather we didn't use UpsertOffer and this is a LOT better than just the name Offer for a method.

I found this whilst investigating why relation joined events weren't correctly being triggered.

## QA steps

```sh
$ juju bootstrap lxd src
$ juju add-model offer && juju deploy juju-qa-dummy-source
$ juju offer dummy-source:sink
$ juju offer dummy-source:sink foo
$ juju status
Model  Controller  Cloud/Region  Version  Timestamp
offer  src         lxd/default   4.0.2.1  11:29:09Z

App           Version  Status   Scale  Charm                 Channel        Rev  Exposed  Message
dummy-source           blocked      1  juju-qa-dummy-source  latest/stable    6  no       Set the token

Unit             Workload  Agent  Machine  Public address  Ports  Message
dummy-source/0*  blocked   idle   0        10.232.51.228          Set the token

Machine  State    Address        Inst id        Base          AZ          Message
0        started  10.232.51.228  juju-593c58-0  ubuntu@20.04  simon-work  Running

Offer         Application   Charm         Rev  Connected  Endpoint  Interface    Role
dummy-source  dummy-source  dummy-source  6    1/1        sink      dummy-token  requirer
foo           dummy-source  dummy-source  6    0/0        sink      dummy-token  requirer
```


## Links

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/21768

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
