### PR TITLE
fix: resource bug for CAAS

### DIFF
--- a/apiserver/internal/handlers/resources/resources.go
+++ b/apiserver/internal/handlers/resources/resources.go
@@ -142,14 +142,10 @@ func (h *ResourceHandler) download(service ResourceService, req *http.Request) (
 	}
 
 	appDetails, err := appService.GetApplicationDetailsByName(req.Context(), application)
-	if errors.Is(err, applicationerrors.ApplicationNotFound) {
-		return nil, 0, jujuerrors.NotFoundf("application %s", application)
-	} else if err != nil {
+	if err != nil && !errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return nil, 0, jujuerrors.Trace(err)
-	}
-
-	// Reject synthetic (SAAS) applications - they don't support resource operations
-	if appDetails.IsApplicationSynthetic {
+	} else if appDetails.IsApplicationSynthetic {
+		// Reject synthetic (SAAS) applications - they don't support resource operations
 		return nil, 0, jujuerrors.NotFoundf("application %s", application)
 	}
 
@@ -184,15 +180,11 @@ func (h *ResourceHandler) upload(service ResourceService, req *http.Request, use
 	}
 
 	appDetails, err := appService.GetApplicationDetailsByName(req.Context(), application)
-	if errors.Is(err, applicationerrors.ApplicationNotFound) {
-		return nil, jujuerrors.NotFoundf("application %s", application)
-	} else if err != nil {
+	if err != nil && !errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return nil, jujuerrors.Trace(err)
-	}
-
-	// Reject synthetic (SAAS) applications - they don't support resource operations
-	if appDetails.IsApplicationSynthetic {
-		return nil, jujuerrors.NotFoundf("application %s", application)
+	} else if appDetails.IsApplicationSynthetic {
+		// Reject synthetic (SAAS) applications - they don't support resource operations
+		return nil, jujuerrors.NotFoundf("application %q", application)
 	}
 
 	reader, uploaded, err := h.getUploadedResource(service, req)

--- a/apiserver/internal/handlers/resources/resources_test.go
+++ b/apiserver/internal/handlers/resources/resources_test.go
@@ -26,6 +26,7 @@ import (
 	coreresource "github.com/juju/juju/core/resource"
 	coreresourcetesting "github.com/juju/juju/core/resource/testing"
 	"github.com/juju/juju/domain/application"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
 	domainlife "github.com/juju/juju/domain/life"
 	domainresource "github.com/juju/juju/domain/resource"
@@ -244,6 +245,33 @@ func (s *ResourcesHandlerSuite) TestGetSuccess(c *tc.C) {
 	s.checkResp(c, http.StatusOK, "application/octet-stream", s.resourceContent)
 }
 
+func (s *ResourcesHandlerSuite) TestGetApplicationNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	req := s.newDownloadRequest(c)
+
+	s.applicationServiceGetter.EXPECT().Application(gomock.Any()).Return(s.applicationService, nil)
+	s.applicationService.EXPECT().GetApplicationDetailsByName(gomock.Any(), s.applicationName).Return(
+		application.ApplicationDetails{}, applicationerrors.ApplicationNotFound)
+	s.resourceService.EXPECT().GetResourceUUIDByApplicationAndResourceName(
+		gomock.Any(),
+		s.applicationName,
+		s.resourceName,
+	).Return(s.resourceUUID, nil)
+
+	s.resourceService.EXPECT().OpenResource(
+		gomock.Any(),
+		s.resourceUUID,
+	).Return(s.resource, s.resourceReader, nil)
+
+	// Act:
+	s.serveHTTP(req)
+
+	// Assert:
+	s.checkResp(c, http.StatusOK, "application/octet-stream", s.resourceContent)
+}
+
 func (s *ResourcesHandlerSuite) TestGetNotFoundError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange:
@@ -282,6 +310,62 @@ func (s *ResourcesHandlerSuite) TestPutSuccessAttachResource(c *tc.C) {
 			Name:                   s.applicationName,
 			IsApplicationSynthetic: false,
 		}, nil)
+	s.resourceService.EXPECT().GetResourceUUIDByApplicationAndResourceName(gomock.Any(), s.applicationName, s.resourceName).Return(s.resourceUUID, nil)
+	newResourceUUID := coreresourcetesting.GenResourceUUID(c)
+	s.resourceService.EXPECT().UpdateUploadResource(gomock.Any(), s.resourceUUID).Return(newResourceUUID, nil)
+	s.resource.ID = newResourceUUID.String()
+	s.resourceService.EXPECT().GetResource(gomock.Any(), newResourceUUID).Return(
+		s.resource, nil,
+	)
+
+	s.downloader.EXPECT().Download(
+		gomock.Any(),
+		s.resourceReader,
+		s.resource.Fingerprint.String(),
+		s.resource.Size,
+	).Return(s.resourceReader, nil)
+
+	s.resourceService.EXPECT().StoreResourceAndIncrementCharmModifiedVersion(gomock.Any(), domainresource.StoreResourceArgs{
+		ResourceUUID:    newResourceUUID,
+		Reader:          s.resourceReader,
+		RetrievedBy:     s.username,
+		RetrievedByType: coreresource.User,
+		Size:            s.resource.Size,
+		Fingerprint:     s.resource.Fingerprint,
+	})
+
+	// Second call to GetResource gets resource details after upload.
+	expectedResource := s.resource
+	expectedResource.Origin = charmresource.OriginUpload
+	expectedResource.Revision = -1
+	s.resourceService.EXPECT().GetResource(gomock.Any(), newResourceUUID).Return(
+		expectedResource, nil,
+	)
+
+	req := s.newUploadRequest(c)
+
+	// Act:
+	s.serveHTTP(req)
+
+	// Assert: Check that the uploaded resources details are returned:
+	expected := mustMarshalJSON(&params.UploadResult{
+		Resource: params.Resource{
+			CharmResource: api.CharmResource2API(expectedResource.Resource),
+			ID:            expectedResource.ID,
+			Username:      expectedResource.RetrievedBy,
+			Timestamp:     expectedResource.Timestamp,
+		},
+	})
+	s.checkResp(c, http.StatusOK, "application/json", string(expected))
+}
+
+func (s *ResourcesHandlerSuite) TestPutSuccessForApplicationNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	s.applicationServiceGetter.EXPECT().Application(gomock.Any()).Return(s.applicationService, nil)
+	s.applicationService.EXPECT().GetApplicationDetailsByName(gomock.Any(), s.applicationName).Return(
+		application.ApplicationDetails{}, applicationerrors.ApplicationNotFound)
 	s.resourceService.EXPECT().GetResourceUUIDByApplicationAndResourceName(gomock.Any(), s.applicationName, s.resourceName).Return(s.resourceUUID, nil)
 	newResourceUUID := coreresourcetesting.GenResourceUUID(c)
 	s.resourceService.EXPECT().UpdateUploadResource(gomock.Any(), s.resourceUUID).Return(newResourceUUID, nil)


### PR DESCRIPTION
We disallow uploading resources to synthetic application. We have an explicit check for this.

However, we do not know for sure that an application exists when we upload the resource. This leads to bugs under certain circumstances.

Handle ApplicationNotFound errors properly

Fixes: https://github.com/juju/juju/issues/21456

## QA steps

```
$ juju bootstrap microk8s mk8s
$ juju add-model test
$ juju download postgresql-k8s --channel 14/edge/juju4 --base ubuntu@22.04
Fetching charm "postgresql-k8s" revision 727 using "14/edge/juju4" channel and base "amd64/ubuntu/22.04"
Install the "postgresql-k8s" charm with:
    juju deploy ./postgresql-k8s_r727.charm

$ juju deploy ./postgresql-k8s_r727.charm --trust --resource postgresql-image=ghcr.io/canonical/charmed-postgresql@sha256:e2283194f7f8d9997fb06f0fd1ab0ec3938ce73ac001133bd8fd393ebe83acc7

$ juju status
Model  Controller  Cloud/Region        Version  Timestamp
test   mk8s        microk8s/localhost  4.0.2    15:04:38Z

App             Version  Status  Scale  Charm           Channel  Rev  Address  Exposed  Message
postgresql-k8s  14.19    active      1  postgresql-k8s             0           no       

Unit               Workload  Agent  Address       Ports          Message
postgresql-k8s/0*  active    idle   10.1.170.164  5432,8008/tcp  Primary
```