### PR TITLE
feat: always log offending ops on transaction errors

### DIFF
--- a/state/txns.go
+++ b/state/txns.go
@@ -77,10 +77,11 @@ var txnOpLogger = logger.Child("txn.op")
 // collections will be modified to ensure correct interaction with
 // these collections.
 func (r *multiModelRunner) Run(transactions jujutxn.TransactionSource) error {
-	return r.rawRunner.Run(func(attempt int) ([]txn.Op, error) {
+	var lastOps []txn.Op
+	err := r.rawRunner.Run(func(attempt int) ([]txn.Op, error) {
 		ops, err := transactions(attempt)
 		if err != nil {
-			// Don't use Trace here as jujutxn doens't use juju/errors
+			// Don't use Trace here as jujutxn doesn't use juju/errors
 			// and won't deal correctly with some returned errors.
 			return nil, err
 		}
@@ -89,13 +90,17 @@ func (r *multiModelRunner) Run(transactions jujutxn.TransactionSource) error {
 			return nil, errors.Trace(err)
 		}
 
-		if txnOpLogger.IsTraceEnabled() {
-			txnOpLogger.Tracef(string(debug.Stack()))
-			txnOpLogger.Tracef(
-				strings.Join(transform.Slice(ops, func(op txn.Op) string { return fmt.Sprintf("%#v", op) }), "\n"))
-		}
+		lastOps = ops
 		return newOps, nil
 	})
+	if errors.Is(err, jujutxn.ErrExcessiveContention) {
+		txnOpLogger.Warningf(string(debug.Stack()))
+		if len(lastOps) > 0 {
+			txnOpLogger.Warningf(
+				strings.Join(transform.Slice(lastOps, func(op txn.Op) string { return fmt.Sprintf("%#v", op) }), "\n"))
+		}
+	}
+	return err
 }
 
 // ResumeTransactions is part of the jujutxn.Runner interface.


### PR DESCRIPTION
Previously we allowed the user to turn on trace level logging to get the operations of transactions. 

This is too noisy to be of use for large models, so instead we log them at warning whenever the runner returns the excessive contention error.

## QA steps

- Bootstrap to LXD, add a model and deploy ubuntu.
- Connect to Mongo and run `db.applications.updateOne({"name": "ubuntu"}, {$set: {unitcount: 0}})`.
- `juju remove-unit ubuntu/0`.
- Controller log will show:
```
machine-0: 12:27:46 WARNING juju.state.txn.op goroutine 35089 [running]:
runtime/debug.Stack()
        /home/joseph/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/runtime/debug/stack.go:26 +0x5e
github.com/juju/juju/state.(*multiModelRunner).Run(0xc0040fa600, 0xc004565ba8)
        /home/joseph/go/src/github.com/juju/juju/state/txns.go:97 +0xf4
github.com/juju/juju/state.(*database).Run(0xc0000c92b0?, 0xc004565ba8)
        /home/joseph/go/src/github.com/juju/juju/state/database.go:448 +0x42
github.com/juju/juju/state.(*State).ApplyOperation(0xc0040f5b90?, {0x8d5a6b0, 0xc00454f470})
        /home/joseph/go/src/github.com/juju/juju/state/modeloperation.go:106 +0x84
github.com/juju/juju/state.(*Unit).RemoveWithForce(0xc0039d4a50, 0x0, 0x0)
        /home/joseph/go/src/github.com/juju/juju/state/unit.go:1079 +0x12a
github.com/juju/juju/state.(*Unit).Remove(0x8da3b68?)
        /home/joseph/go/src/github.com/juju/juju/state/unit.go:1068 +0x17
github.com/juju/juju/apiserver/common.(*Remover).removeEntity(0xc004277530, {0x8da3b68, 0xc004606410})
        /home/joseph/go/src/github.com/juju/juju/apiserver/common/remove.go:65 +0x142
github.com/juju/juju/apiserver/common.(*Remover).Remove(0xc004277530, {{0xc0040ecb80?, 0x0?, 0x4852d3?}})
        /home/joseph/go/src/github.com/juju/juju/apiserver/common/remove.go:89 +0x159
reflect.Value.call({0x7db88c0?, 0xc003bfe4e0?, 0x41de05?}, {0x81f814d, 0x4}, {0xc0040c4bd0, 0x1, 0xb2d733?})
        /home/joseph/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/reflect/value.go:581 +0xcc6
reflect.Value.Call({0x7db88c0?, 0xc003bfe4e0?, 0x748dd40?}, {0xc0040c4bd0?, 0x0?, 0x0?})
        /home/joseph/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/reflect/value.go:365 +0xb9
github.com/juju/rpcreflect.newMethod.func8({0x8dc7788, 0xc0039e1d70}, {0x7db88c0?, 0xc003bfe4e0?, 0x40b885?}, {0x748dd40?, 0xc0040c4b28?, 0x0?})
        /home/joseph/go/pkg/mod/github.com/juju/rpcreflect@v1.2.0/type.go:365 +0xc8
github.com/juju/juju/apiserver.(*srvCaller).Call(0xc0039e1d10, {0x8dc7788, 0xc0039e1d70}, {0x0?, 0xc0040f4140?}, {0x748dd40?, 0xc0040c4b28?, 0x45d7a9?})
        /home/joseph/go/src/github.com/juju/juju/apiserver/root.go:205 +0x99
github.com/juju/juju/rpc.(*Conn).callRequest(0xc0028b8000, {0x8dc7788?, 0xc0039e1d70?}, {{0x8da5360, 0xc0039e1d10}, 0x84f7f00, {0xda, {{0xc0040f4128, 0x8}, 0x1, ...}, ...}}, ...)
        /home/joseph/go/src/github.com/juju/juju/rpc/server.go:607 +0xa2
github.com/juju/juju/rpc.(*Conn).runRequest.func2({0x8dc7788?, 0xc0039e1d70?})
        /home/joseph/go/src/github.com/juju/juju/rpc/server.go:596 +0x87
runtime/pprof.Do({0x8dc77c0?, 0xc0005ee960?}, {{0xc0039d94e0?, 0x2?, 0x2?}}, 0xc002c47e60)
        /home/joseph/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/runtime/pprof/runtime.go:51 +0x8c
github.com/juju/juju/rpc.(*Conn).runRequest(0xc0028b8000, {{0x8da5360, 0xc0039e1d10}, 0x84f7f00, {0xda, {{0xc0040f4128, 0x8}, 0x1, {0x0, 0x0}, ...}, ...}}, ...)
        /home/joseph/go/src/github.com/juju/juju/rpc/server.go:595 +0x2ef
created by github.com/juju/juju/rpc.(*Conn).handleRequest in goroutine 8193
        /home/joseph/go/src/github.com/juju/juju/rpc/server.go:498 +0x63f
machine-0: 12:27:46 WARNING juju.state.txn.op txn.Op{C:"units", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:ubuntu/0", Assert:bson.D{bson.DocElem{Name:"charmurl", Value:(*string)(0xc004ad15b0)}, bson.DocElem{Name:"machineid", Value:"0"}, bson.DocElem{Name:"life", Value:2}}, Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"statuses", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:u#ubuntu/0", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"statuses", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:u#ubuntu/0#charm", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"statuses", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:u#ubuntu/0#charm#sat#workload-version", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"unitstates", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:u#ubuntu/0#charm", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"statuses", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:u#ubuntu/0#charm#container", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"constraints", Id:"u#ubuntu/0", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"annotations", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:u#ubuntu/0#charm", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"cleanups", Id:"6992ff32ff3add1ff9982677", Assert:interface {}(nil), Insert:(*state.cleanupDoc)(0xc004af21e0), Update:interface {}(nil), Remove:false}
txn.Op{C:"containerRefs", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:0", Assert:bson.D{bson.DocElem{Name:"$or", Value:[]bson.D{bson.D{bson.DocElem{Name:"children", Value:bson.D{bson.DocElem{Name:"$size", Value:0}}}}, bson.D{bson.DocElem{Name:"children", Value:bson.D{bson.DocElem{Name:"$exists", Value:false}}}}}}}, Insert:interface {}(nil), Update:interface {}(nil), Remove:false}
txn.Op{C:"machines", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:0", Assert:bson.D{bson.DocElem{Name:"$and", Value:[]bson.D{bson.D{bson.DocElem{Name:"principals", Value:[]string{"ubuntu/0"}}}, bson.D{bson.DocElem{Name:"jobs", Value:bson.D{bson.DocElem{Name:"$nin", Value:[]state.MachineJob{2}}}}}}}}, Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$pull", Value:bson.D{bson.DocElem{Name:"principals", Value:"ubuntu/0"}}}, bson.DocElem{Name:"$set", Value:bson.D{bson.DocElem{Name:"life", Value:1}}}}, Remove:false}
txn.Op{C:"controllerNodes", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:0", Assert:"d-", Insert:interface {}(nil), Update:interface {}(nil), Remove:false}
txn.Op{C:"cleanups", Id:"6992ff32ff3add1ff9982676", Assert:interface {}(nil), Insert:(*state.cleanupDoc)(0xc004a8dbc0), Update:interface {}(nil), Remove:false}
txn.Op{C:"refcounts", Id:"c#ch:amd64/ubuntu-26", Assert:bson.D{bson.DocElem{Name:"refcount", Value:bson.D{bson.DocElem{Name:"$gt", Value:0}}}}, Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$inc", Value:bson.D{bson.DocElem{Name:"refcount", Value:-1}}}}, Remove:false}
txn.Op{C:"refcounts", Id:"a#ubuntu#ch:amd64/ubuntu-26", Assert:bson.D{bson.DocElem{Name:"refcount", Value:bson.D{bson.DocElem{Name:"$gt", Value:1}}}}, Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$inc", Value:bson.D{bson.DocElem{Name:"refcount", Value:-1}}}}, Remove:false}
txn.Op{C:"refcounts", Id:"asc#ubuntu#ch:amd64/ubuntu-26", Assert:bson.D{bson.DocElem{Name:"refcount", Value:bson.D{bson.DocElem{Name:"$gt", Value:1}}}}, Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$inc", Value:bson.D{bson.DocElem{Name:"refcount", Value:-1}}}}, Remove:false}
txn.Op{C:"applications", Id:"ea0f15bb-8030-4155-8659-fe5344cd25e1:ubuntu", Assert:bson.D{bson.DocElem{Name:"life", Value:0}, bson.DocElem{Name:"unitcount", Value:bson.D{bson.DocElem{Name:"$gt", Value:0}}}}, Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$inc", Value:bson.D{bson.DocElem{Name:"unitcount", Value:-1}}}}, Remove:false}
```
