### PR TITLE
fix(cloudimagemetadata): add parentheses to SQL OR clause in FindMetadata query

### DIFF
--- a/domain/cloudimagemetadata/state/state.go
+++ b/domain/cloudimagemetadata/state/state.go
@@ -5,10 +5,8 @@ package state
 
 import (
 	"context"
-	"fmt"
 	"maps"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/canonical/sqlair"
@@ -259,65 +257,40 @@ func (s *State) FindMetadata(ctx context.Context, criteria cloudimagemetadata.Me
 		RootStorageType: criteria.RootStorageType,
 	}
 
-	// Injection of the expiration time
 	expirationTime := ttl{
 		ExpiresAt: s.clock.Now().Add(-ExpirationDelay),
 	}
 	customSource := inputMetadata{
 		Source: cloudimagemetadata.CustomSource,
 	}
-	inputArgs := []any{expirationTime, customSource}
-
-	// clauses will collect all required clauses to build the final WHERE ... AND ... clause
-	clauses := []string{
-		// Ignores expired metadata in case of non custom source.
-		// The parentheses are critical: without them, SQL operator
-		// precedence causes custom-source rows to bypass all subsequent filter
-		// clauses (version, region, etc).
-		`(source = $inputMetadata.source OR cloud_image_metadata.created_at >= $ttl.expires_at)`,
-	}
-
-	// declareEqualsClause is an helper function to add a sqlair clause with the format cloud_image_metadata.<field> = $metadataFilter.<field>,
-	// only if the corresponding field isn't empty
-	hasFilter := false
-	declareEqualsClause := func(field, value string) {
-		if value != "" {
-			hasFilter = true
-			clauses = append(clauses, fmt.Sprintf(`cloud_image_metadata.%s = $metadataFilter.%s`, field, field))
-		}
-	}
-	declareEqualsClause("region", filter.Region)
-	declareEqualsClause("stream", filter.Stream)
-	declareEqualsClause("virt_type", filter.VirtType)
-	declareEqualsClause("root_storage_type", filter.RootStorageType)
-
-	if hasFilter {
-		inputArgs = append(inputArgs, filter)
-	}
-
-	// Handle  IN clauses, which is are bit different than equals clauses.
+	flags := findFlags{}
 	if len(filter.Versions) > 0 {
-		clauses = append(clauses, `cloud_image_metadata.version IN ($versions[:])`)
-		inputArgs = append(inputArgs, filter.Versions)
+		flags.HasVersions = 1
 	}
 	if len(filter.Arches) > 0 {
-		clauses = append(clauses, `arch.architecture_name IN ($arches[:])`)
-		inputArgs = append(inputArgs, filter.Arches)
+		flags.HasArches = 1
 	}
 
-	findMetadataQuery := fmt.Sprintf(`
+	findMetadataStmt, err := sqlair.Prepare(`
 WITH arch(id, architecture_name) AS (
 	SELECT id, name FROM architecture
 )
-SELECT &outputMetadata.* 
+SELECT &outputMetadata.*
 FROM cloud_image_metadata
 JOIN arch ON cloud_image_metadata.architecture_id = arch.id
-WHERE %s;`, strings.Join(clauses, ` AND `))
-
-	findMetadataStmt, err := sqlair.Prepare(findMetadataQuery, append([]any{outputMetadata{}}, inputArgs...)...)
+WHERE (source = $inputMetadata.source OR cloud_image_metadata.created_at >= $ttl.expires_at)
+AND ($metadataFilter.region = '' OR cloud_image_metadata.region = $metadataFilter.region)
+AND ($metadataFilter.stream = '' OR cloud_image_metadata.stream = $metadataFilter.stream)
+AND ($metadataFilter.virt_type = '' OR cloud_image_metadata.virt_type = $metadataFilter.virt_type)
+AND ($metadataFilter.root_storage_type = '' OR cloud_image_metadata.root_storage_type = $metadataFilter.root_storage_type)
+AND ($findFlags.has_versions = 0 OR cloud_image_metadata.version IN ($versions[:]))
+AND ($findFlags.has_arches = 0 OR arch.architecture_name IN ($arches[:]));
+`, outputMetadata{}, inputMetadata{}, ttl{}, metadataFilter{}, findFlags{}, versions{}, arches{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
+
+	inputArgs := []any{expirationTime, customSource, filter, flags, filter.Versions, filter.Arches}
 
 	var metadata []outputMetadata
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {

--- a/domain/cloudimagemetadata/state/state.go
+++ b/domain/cloudimagemetadata/state/state.go
@@ -271,7 +271,10 @@ func (s *State) FindMetadata(ctx context.Context, criteria cloudimagemetadata.Me
 	// clauses will collect all required clauses to build the final WHERE ... AND ... clause
 	clauses := []string{
 		// Ignores expired metadata in case of non custom source.
-		`source = $inputMetadata.source OR cloud_image_metadata.created_at >=  $ttl.expires_at`,
+		// The parentheses are critical: without them, SQL operator
+		// precedence causes custom-source rows to bypass all subsequent filter
+		// clauses (version, region, etc).
+		`(source = $inputMetadata.source OR cloud_image_metadata.created_at >= $ttl.expires_at)`,
 	}
 
 	// declareEqualsClause is an helper function to add a sqlair clause with the format cloud_image_metadata.<field> = $metadataFilter.<field>,

--- a/domain/cloudimagemetadata/state/state_test.go
+++ b/domain/cloudimagemetadata/state/state_test.go
@@ -434,6 +434,58 @@ VALUES
 	})
 }
 
+// TestFindMetadataCustomSourceFilteredByVersion verifies that custom-source
+// metadata is correctly filtered by version. This is a regression test for a
+// SQL operator precedence bug where the OR in
+// "source = 'custom' OR created_at >= ..." was not parenthesised, causing
+// all custom-source rows to bypass subsequent AND filters (version, region, etc).
+func (s *stateSuite) TestFindMetadataCustomSourceFilteredByVersion(c *tc.C) {
+	// Arrange: insert custom metadata for multiple versions.
+	err := s.runQuery(c, `
+INSERT INTO cloud_image_metadata (uuid,created_at,source,stream,region,version,architecture_id,virt_type,root_storage_type,priority,image_id)
+VALUES
+('a',datetime('now','localtime'), 'custom', 'released', 'region1', '20.04', 0, 'kvm', 'ssd', 50, 'img-focal'),
+('b',datetime('now','localtime'), 'custom', 'released', 'region1', '22.04', 0, 'kvm', 'ssd', 50, 'img-jammy'),
+('c',datetime('now','localtime'), 'custom', 'released', 'region1', '24.04', 0, 'kvm', 'ssd', 50, 'img-noble');
+`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act: query for version 24.04 only.
+	obtained, err := s.state.FindMetadata(c.Context(), cloudimagemetadata.MetadataFilter{
+		Versions: []string{"24.04"},
+	})
+
+	// Assert: only the 24.04 entry should be returned.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained, tc.HasLen, 1)
+	c.Check(obtained[0].Version, tc.Equals, "24.04")
+	c.Check(obtained[0].ImageID, tc.Equals, "img-noble")
+}
+
+// TestFindMetadataCustomSourceFilteredByRegion verifies that custom-source
+// metadata is correctly filtered by region.
+func (s *stateSuite) TestFindMetadataCustomSourceFilteredByRegion(c *tc.C) {
+	// Arrange: insert custom metadata for multiple regions.
+	err := s.runQuery(c, `
+INSERT INTO cloud_image_metadata (uuid,created_at,source,stream,region,version,architecture_id,virt_type,root_storage_type,priority,image_id)
+VALUES
+('a',datetime('now','localtime'), 'custom', 'released', 'us-east-1', '24.04', 0, 'kvm', 'ssd', 50, 'img-us-east'),
+('b',datetime('now','localtime'), 'custom', 'released', 'eu-west-1', '24.04', 0, 'kvm', 'ssd', 50, 'img-eu-west');
+`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act: query for region eu-west-1 only.
+	obtained, err := s.state.FindMetadata(c.Context(), cloudimagemetadata.MetadataFilter{
+		Region: "eu-west-1",
+	})
+
+	// Assert: only the eu-west-1 entry should be returned.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained, tc.HasLen, 1)
+	c.Check(obtained[0].Region, tc.Equals, "eu-west-1")
+	c.Check(obtained[0].ImageID, tc.Equals, "img-eu-west")
+}
+
 // TestAllCloudImageMetadata tests the retrieval of all cloud image metadata from the database,
 // except expired one.
 func (s *stateSuite) TestAllCloudImageMetadata(c *tc.C) {

--- a/domain/cloudimagemetadata/state/types.go
+++ b/domain/cloudimagemetadata/state/types.go
@@ -74,3 +74,10 @@ type versions []string
 
 // arches represents a list of architecture names in the metadataFilter struct.
 type arches []string
+
+// findFlags holds boolean flags (as ints for SQL) that indicate whether
+// optional IN-clause filters should be applied in the FindMetadata query.
+type findFlags struct {
+	HasVersions int `db:"has_versions"`
+	HasArches   int `db:"has_arches"`
+}


### PR DESCRIPTION
The WHERE clause in FindMetadata joined conditions with AND, but the first clause "source = 'custom' OR created_at >= ..." lacked parentheses. Due to SQL operator precedence (AND before OR), all custom-source rows bypassed every subsequent filter (version, region, stream, etc.).

When custom image metadata was provided at bootstrap via --metadata-source, entries for all Ubuntu versions (20.04, 22.04, 24.04) were stored with source='custom'. The provisioner querying for version 24.04 would get back all versions, and since the Image struct used for selection carries no version field, it could pick the wrong image ID, resulting in HA controller machines running the wrong Ubuntu release while Juju reported them as 24.04.


## QA steps

There is a new unit test that tests this fix so it should pass. 
For the QA scenario, as it's run on prodstack, you'll need to bootstrap passing image metadata containing more than one ubuntu version (for example:
```
{
    "index": {
        "com.ubuntu.cloud:custom": {
            "updated": "Thu, 12 Feb 2026 10:04:07 +0000",
            "format": "products:1.0",
            "datatype": "image-ids",
            "cloudname": "custom",
            "clouds": [
                {
                    "region": "RegionOne",
                    "endpoint": "http://x.x.x.x/openstack-keystone/v3"
                }
            ],
            "path": "streams/v1/com.ubuntu.cloud-released-imagemetadata.json",
            "products": [
                "com.ubuntu.cloud:server:20.04:amd64",
                "com.ubuntu.cloud:server:22.04:amd64",
                "com.ubuntu.cloud:server:24.04:amd64"
            ]
        }
    },
    "updated": "Thu, 12 Feb 2026 10:04:07 +0000",
    "format": "index:1.0"
}
```
And then add 2 units to turn the controller HA. 

The three units should be 24.04 *and* the actual ubuntu version in the machine should be 24.04:
```
ubuntu@juju-486071-controller-0:~$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.4 LTS"
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21655.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9103](https://warthogs.atlassian.net/browse/JUJU-9103)


[JUJU-9103]: https://warthogs.atlassian.net/browse/JUJU-9103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ