### PR TITLE
feat: merging duplicate remote applications

### DIFF
--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -97,7 +97,7 @@ func (sf *statusFormatter) Format() (formattedStatus, error) {
 		out.Applications[name] = sf.formatApplication(name, app)
 	}
 	for name, app := range sf.status.RemoteApplicationOfferers {
-		out.RemoteApplications[name] = sf.formatRemoteApplication(name, app)
+		out.RemoteApplications[name] = sf.formatRemoteApplication(app)
 	}
 	for name, offer := range sf.status.Offers {
 		out.Offers[name] = sf.formatOffer(name, offer)
@@ -295,7 +295,7 @@ func (sf *statusFormatter) findRelationStatus(appName, relName, theOtherSideAppN
 			}
 			return &rel
 		} else {
-			if endpointsMactch(appName, relName, theOtherSideAppName, rel.Endpoints) {
+			if endpointsMatch(appName, relName, theOtherSideAppName, rel.Endpoints) {
 				return &rel
 			}
 		}
@@ -303,7 +303,7 @@ func (sf *statusFormatter) findRelationStatus(appName, relName, theOtherSideAppN
 	return nil
 }
 
-func endpointsMactch(appName, relName, theOtherSideAppName string, eps []params.EndpointStatus) (equal bool) {
+func endpointsMatch(appName, relName, theOtherSideAppName string, eps []params.EndpointStatus) (equal bool) {
 	if len(eps) != 2 {
 		return false
 	}
@@ -318,7 +318,7 @@ func endpointsMactch(appName, relName, theOtherSideAppName string, eps []params.
 	return false
 }
 
-func (sf *statusFormatter) formatRemoteApplication(name string, application params.RemoteApplicationStatus) remoteApplicationStatus {
+func (sf *statusFormatter) formatRemoteApplication(application params.RemoteApplicationStatus) remoteApplicationStatus {
 	out := remoteApplicationStatus{
 		Err:        typedNilCheck(application.Err),
 		OfferURL:   application.OfferURL,

--- a/domain/crossmodelrelation/modelmigration/import.go
+++ b/domain/crossmodelrelation/modelmigration/import.go
@@ -223,26 +223,26 @@ func (i *importOperation) importRemoteApplicationOfferers(
 	}
 
 	input := make([]service.RemoteApplicationOffererImport, 0, len(uniqueRemoteApps))
-	for _, remoteApps := range uniqueRemoteApps {
-		if len(remoteApps) == 0 {
+	for _, duplicatedRemoteApps := range uniqueRemoteApps {
+		if duplicatedRemoteApps.IsEmpty() {
 			continue
 		}
 
-		remoteApp := remoteApps[0]
-		endpoints, err := extractRemoteEndpoints(remoteApp)
+		primaryRemoteApp := duplicatedRemoteApps.Primary
+		endpoints, err := extractRemoteEndpoints(primaryRemoteApp)
 		if err != nil {
 			return errors.Errorf("extracting endpoints for remote application %q: %w",
-				remoteApp.Name(), err)
+				primaryRemoteApp.Name(), err)
 		}
 
 		input = append(input, service.RemoteApplicationOffererImport{
 			RemoteApplicationImport: service.RemoteApplicationImport{
-				Name:            remoteApp.Name(),
-				OfferUUID:       remoteApp.OfferUUID(),
-				URL:             remoteApp.URL(),
-				SourceModelUUID: remoteApp.SourceModelUUID(),
-				Macaroon:        remoteApp.Macaroon(),
-				Units:           remoteAppUnits[remoteApp.Name()],
+				Name:            primaryRemoteApp.Name(),
+				OfferUUID:       primaryRemoteApp.OfferUUID(),
+				URL:             primaryRemoteApp.URL(),
+				SourceModelUUID: primaryRemoteApp.SourceModelUUID(),
+				Macaroon:        primaryRemoteApp.Macaroon(),
+				Units:           remoteAppUnits[primaryRemoteApp.Name()],
 				Endpoints:       endpoints,
 			},
 		})

--- a/domain/crossmodelrelation/modelmigration/import.go
+++ b/domain/crossmodelrelation/modelmigration/import.go
@@ -5,7 +5,6 @@ package modelmigration
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/domain/crossmodelrelation/service"
 	modelstate "github.com/juju/juju/domain/crossmodelrelation/state/model"
 	deploymentcharm "github.com/juju/juju/domain/deployment/charm"
+	domainmodelmigration "github.com/juju/juju/domain/modelmigration/modelmigration"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -215,13 +215,16 @@ func (i *importOperation) importRemoteApplicationOfferers(
 	relations []description.Relation,
 	remoteAppUnits map[string][]string,
 ) error {
-	unique, err := UniqueRemoteOfferApplications(remoteApps, relations)
+	// Import remote application offerers. These are remote applications that
+	// life in the consuming model, but represent applications in the offering
+	// model.
+	uniqueRemoteApps, err := domainmodelmigration.UniqueRemoteOfferApplications(remoteApps, relations)
 	if err != nil {
 		return err
 	}
 
-	input := make([]service.RemoteApplicationOffererImport, 0, len(remoteApps))
-	for _, remoteApp := range unique {
+	input := make([]service.RemoteApplicationOffererImport, 0, len(uniqueRemoteApps))
+	for _, remoteApp := range uniqueRemoteApps {
 		endpoints, err := extractRemoteEndpoints(remoteApp)
 		if err != nil {
 			return errors.Errorf("extracting endpoints for remote application %q: %w",
@@ -517,94 +520,4 @@ func parseRelationRole(role string) (charm.RelationRole, error) {
 	default:
 		return "", errors.Errorf("unknown relation role %q", role)
 	}
-}
-
-// UniqueRemoteOfferApplications de-duplicates remote applications based on
-// offer UUID and endpoints, and verifies that there are no conflicting remote
-// applications with the same offer UUID.
-func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, relations []description.Relation) (map[string]description.RemoteApplication, error) {
-	// In 3.x it's possible to have multiple remote applications with the same
-	// offer UUID and endpoints, but have different names. In this case, we need
-	// to merge and de-duplicate these remote applications when importing them.
-	// 4.x doesn't allow to have multiple remote applications with the same
-	// offer UUID.
-	unique := map[string]description.RemoteApplication{}
-	for _, remoteApp := range remoteApps {
-		// We don't care about remove application consumers, so duplications
-		// here don't matter.
-		if remoteApp.IsConsumerProxy() {
-			continue
-		}
-
-		// If the remote application is not used by a relation, then we can
-		// ignore it as well.
-		if !remoteAppUsedByRelation(remoteApp, relations) {
-			continue
-		}
-
-		// Verify that if there are multiple remote application offerers with
-		// the same offer UUID, they also have the same source model UUID and
-		// endpoints, otherwise the import would be ambiguous.
-		offerUUID := remoteApp.OfferUUID()
-		if existing, ok := unique[offerUUID]; ok {
-			if existing.SourceModelUUID() != remoteApp.SourceModelUUID() {
-				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different source model UUIDs: %q and %q",
-					offerUUID, existing.SourceModelUUID(), remoteApp.SourceModelUUID())
-			}
-			if !remoteEndpointsEqual(existing.Endpoints(), remoteApp.Endpoints()) {
-				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different endpoints: %v and %v",
-					offerUUID, remoteEndpointString(existing.Endpoints()), remoteEndpointString(remoteApp.Endpoints()))
-			}
-		}
-
-		unique[offerUUID] = remoteApp
-	}
-
-	return unique, nil
-}
-
-func remoteAppUsedByRelation(remoteApp description.RemoteApplication, relations []description.Relation) bool {
-	for _, rel := range relations {
-		for _, ep := range rel.Endpoints() {
-			if ep.ApplicationName() == remoteApp.Name() {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func remoteEndpointsEqual(a, b []description.RemoteEndpoint) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	aCopy := append([]description.RemoteEndpoint(nil), a...)
-	bCopy := append([]description.RemoteEndpoint(nil), b...)
-
-	sort.Slice(aCopy, func(i, j int) bool {
-		return aCopy[i].Name() < aCopy[j].Name()
-	})
-	sort.Slice(bCopy, func(i, j int) bool {
-		return bCopy[i].Name() < bCopy[j].Name()
-	})
-
-	for i := range aCopy {
-		if aCopy[i].Name() != bCopy[i].Name() ||
-			aCopy[i].Role() != bCopy[i].Role() ||
-			aCopy[i].Interface() != bCopy[i].Interface() {
-			return false
-		}
-	}
-
-	return true
-}
-
-func remoteEndpointString(eps []description.RemoteEndpoint) string {
-	var parts []string
-	for _, ep := range eps {
-		parts = append(parts, fmt.Sprintf("%s:%s", ep.Interface(), ep.Name()))
-	}
-	return strings.Join(parts, " ")
 }

--- a/domain/crossmodelrelation/modelmigration/import.go
+++ b/domain/crossmodelrelation/modelmigration/import.go
@@ -96,7 +96,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 	// Import remote application offerers, this will create the synthetic
 	// applications and units needed for relations.
-	if err := i.importRemoteApplicationOfferers(ctx, remoteApplications, model.Relations(), remoteAppUnits); err != nil {
+	if err := i.importRemoteApplicationOfferers(ctx, remoteApplications, remoteAppUnits); err != nil {
 		return errors.Errorf("importing remote applications: %w", err)
 	}
 
@@ -212,13 +212,12 @@ func (i *importOperation) importOffers(ctx context.Context, apps []description.A
 func (i *importOperation) importRemoteApplicationOfferers(
 	ctx context.Context,
 	remoteApps []description.RemoteApplication,
-	relations []description.Relation,
 	remoteAppUnits map[string][]string,
 ) error {
 	// Import remote application offerers. These are remote applications that
 	// life in the consuming model, but represent applications in the offering
 	// model.
-	uniqueRemoteApps, err := domainmodelmigration.UniqueRemoteOfferApplications(remoteApps, relations)
+	uniqueRemoteApps, err := domainmodelmigration.UniqueRemoteOfferApplications(remoteApps)
 	if err != nil {
 		return err
 	}

--- a/domain/crossmodelrelation/modelmigration/import.go
+++ b/domain/crossmodelrelation/modelmigration/import.go
@@ -5,6 +5,7 @@ package modelmigration
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -95,7 +96,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 	// Import remote application offerers, this will create the synthetic
 	// applications and units needed for relations.
-	if err := i.importRemoteApplicationOfferers(ctx, remoteApplications, remoteAppUnits); err != nil {
+	if err := i.importRemoteApplicationOfferers(ctx, remoteApplications, model.Relations(), remoteAppUnits); err != nil {
 		return errors.Errorf("importing remote applications: %w", err)
 	}
 
@@ -211,15 +212,16 @@ func (i *importOperation) importOffers(ctx context.Context, apps []description.A
 func (i *importOperation) importRemoteApplicationOfferers(
 	ctx context.Context,
 	remoteApps []description.RemoteApplication,
+	relations []description.Relation,
 	remoteAppUnits map[string][]string,
 ) error {
-	input := make([]service.RemoteApplicationOffererImport, 0, len(remoteApps))
-	for _, remoteApp := range remoteApps {
-		// Ignore remote application consumers.
-		if remoteApp.IsConsumerProxy() {
-			continue
-		}
+	unique, err := UniqueRemoteOfferApplications(remoteApps, relations)
+	if err != nil {
+		return err
+	}
 
+	input := make([]service.RemoteApplicationOffererImport, 0, len(remoteApps))
+	for _, remoteApp := range unique {
 		endpoints, err := extractRemoteEndpoints(remoteApp)
 		if err != nil {
 			return errors.Errorf("extracting endpoints for remote application %q: %w",
@@ -515,4 +517,94 @@ func parseRelationRole(role string) (charm.RelationRole, error) {
 	default:
 		return "", errors.Errorf("unknown relation role %q", role)
 	}
+}
+
+// UniqueRemoteOfferApplications de-duplicates remote applications based on
+// offer UUID and endpoints, and verifies that there are no conflicting remote
+// applications with the same offer UUID.
+func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, relations []description.Relation) (map[string]description.RemoteApplication, error) {
+	// In 3.x it's possible to have multiple remote applications with the same
+	// offer UUID and endpoints, but have different names. In this case, we need
+	// to merge and de-duplicate these remote applications when importing them.
+	// 4.x doesn't allow to have multiple remote applications with the same
+	// offer UUID.
+	unique := map[string]description.RemoteApplication{}
+	for _, remoteApp := range remoteApps {
+		// We don't care about remove application consumers, so duplications
+		// here don't matter.
+		if remoteApp.IsConsumerProxy() {
+			continue
+		}
+
+		// If the remote application is not used by a relation, then we can
+		// ignore it as well.
+		if !remoteAppUsedByRelation(remoteApp, relations) {
+			continue
+		}
+
+		// Verify that if there are multiple remote application offerers with
+		// the same offer UUID, they also have the same source model UUID and
+		// endpoints, otherwise the import would be ambiguous.
+		offerUUID := remoteApp.OfferUUID()
+		if existing, ok := unique[offerUUID]; ok {
+			if existing.SourceModelUUID() != remoteApp.SourceModelUUID() {
+				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different source model UUIDs: %q and %q",
+					offerUUID, existing.SourceModelUUID(), remoteApp.SourceModelUUID())
+			}
+			if !remoteEndpointsEqual(existing.Endpoints(), remoteApp.Endpoints()) {
+				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different endpoints: %v and %v",
+					offerUUID, remoteEndpointString(existing.Endpoints()), remoteEndpointString(remoteApp.Endpoints()))
+			}
+		}
+
+		unique[offerUUID] = remoteApp
+	}
+
+	return unique, nil
+}
+
+func remoteAppUsedByRelation(remoteApp description.RemoteApplication, relations []description.Relation) bool {
+	for _, rel := range relations {
+		for _, ep := range rel.Endpoints() {
+			if ep.ApplicationName() == remoteApp.Name() {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func remoteEndpointsEqual(a, b []description.RemoteEndpoint) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	aCopy := append([]description.RemoteEndpoint(nil), a...)
+	bCopy := append([]description.RemoteEndpoint(nil), b...)
+
+	sort.Slice(aCopy, func(i, j int) bool {
+		return aCopy[i].Name() < aCopy[j].Name()
+	})
+	sort.Slice(bCopy, func(i, j int) bool {
+		return bCopy[i].Name() < bCopy[j].Name()
+	})
+
+	for i := range aCopy {
+		if aCopy[i].Name() != bCopy[i].Name() ||
+			aCopy[i].Role() != bCopy[i].Role() ||
+			aCopy[i].Interface() != bCopy[i].Interface() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func remoteEndpointString(eps []description.RemoteEndpoint) string {
+	var parts []string
+	for _, ep := range eps {
+		parts = append(parts, fmt.Sprintf("%s:%s", ep.Interface(), ep.Name()))
+	}
+	return strings.Join(parts, " ")
 }

--- a/domain/crossmodelrelation/modelmigration/import.go
+++ b/domain/crossmodelrelation/modelmigration/import.go
@@ -224,7 +224,12 @@ func (i *importOperation) importRemoteApplicationOfferers(
 	}
 
 	input := make([]service.RemoteApplicationOffererImport, 0, len(uniqueRemoteApps))
-	for _, remoteApp := range uniqueRemoteApps {
+	for _, remoteApps := range uniqueRemoteApps {
+		if len(remoteApps) == 0 {
+			continue
+		}
+
+		remoteApp := remoteApps[0]
 		endpoints, err := extractRemoteEndpoints(remoteApp)
 		if err != nil {
 			return errors.Errorf("extracting endpoints for remote application %q: %w",

--- a/domain/crossmodelrelation/modelmigration/import_test.go
+++ b/domain/crossmodelrelation/modelmigration/import_test.go
@@ -132,7 +132,7 @@ func (s *importSuite) TestImportRemoteApplicationOfferers(c *tc.C) {
 	// Act - no relations, so no units to extract
 	remoteAppUnits := make(map[string][]string)
 	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(),
-		model.RemoteApplications(), model.Relations(), remoteAppUnits)
+		model.RemoteApplications(), remoteAppUnits)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -145,7 +145,7 @@ func (s *importSuite) TestImportRemoteApplicationOfferersEmpty(c *tc.C) {
 
 	remoteAppUnits := make(map[string][]string)
 	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(),
-		model.RemoteApplications(), model.Relations(), remoteAppUnits)
+		model.RemoteApplications(), remoteAppUnits)
 
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -250,7 +250,7 @@ func (s *importSuite) TestImportRemoteApplicationOfferersMultiple(c *tc.C) {
 
 	remoteAppUnits := make(map[string][]string)
 	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(),
-		model.RemoteApplications(), model.Relations(), remoteAppUnits)
+		model.RemoteApplications(), remoteAppUnits)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -322,7 +322,7 @@ func (s *importSuite) TestImportRemoteApplicationsWithUnitsFromRelations(c *tc.C
 	// Act - use Execute which extracts units from relations
 	op := s.newImportOperation(c)
 	remoteAppUnits := op.extractRemoteAppUnits(model)
-	err := op.importRemoteApplicationOfferers(c.Context(), model.RemoteApplications(), model.Relations(), remoteAppUnits)
+	err := op.importRemoteApplicationOfferers(c.Context(), model.RemoteApplications(), remoteAppUnits)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/crossmodelrelation/modelmigration/import_test.go
+++ b/domain/crossmodelrelation/modelmigration/import_test.go
@@ -121,7 +121,8 @@ func (s *importSuite) TestImportRemoteApplicationOfferers(c *tc.C) {
 
 	// Act - no relations, so no units to extract
 	remoteAppUnits := make(map[string][]string)
-	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(), model.RemoteApplications(), remoteAppUnits)
+	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(),
+		model.RemoteApplications(), model.Relations(), remoteAppUnits)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -133,7 +134,8 @@ func (s *importSuite) TestImportRemoteApplicationOfferersEmpty(c *tc.C) {
 	model := description.NewModel(description.ModelArgs{})
 
 	remoteAppUnits := make(map[string][]string)
-	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(), model.RemoteApplications(), remoteAppUnits)
+	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(),
+		model.RemoteApplications(), model.Relations(), remoteAppUnits)
 
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -215,7 +217,8 @@ func (s *importSuite) TestImportRemoteApplicationOfferersMultiple(c *tc.C) {
 	).Return(nil)
 
 	remoteAppUnits := make(map[string][]string)
-	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(), model.RemoteApplications(), remoteAppUnits)
+	err := s.newImportOperation(c).importRemoteApplicationOfferers(c.Context(),
+		model.RemoteApplications(), model.Relations(), remoteAppUnits)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -287,7 +290,7 @@ func (s *importSuite) TestImportRemoteApplicationsWithUnitsFromRelations(c *tc.C
 	// Act - use Execute which extracts units from relations
 	op := s.newImportOperation(c)
 	remoteAppUnits := op.extractRemoteAppUnits(model)
-	err := op.importRemoteApplicationOfferers(c.Context(), model.RemoteApplications(), remoteAppUnits)
+	err := op.importRemoteApplicationOfferers(c.Context(), model.RemoteApplications(), model.Relations(), remoteAppUnits)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/crossmodelrelation/modelmigration/import_test.go
+++ b/domain/crossmodelrelation/modelmigration/import_test.go
@@ -94,6 +94,16 @@ func (s *importSuite) TestImportRemoteApplicationOfferers(c *tc.C) {
 		Role:      "provider",
 		Interface: "mysql",
 	})
+	relation := model.AddRelation(description.RelationArgs{
+		Id:  0,
+		Key: "remote-mysql:db foo:db",
+	})
+	relation.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "remote-mysql",
+	})
+	relation.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+	})
 
 	expected := []service.RemoteApplicationOffererImport{
 		{
@@ -157,6 +167,17 @@ func (s *importSuite) TestImportRemoteApplicationOfferersMultiple(c *tc.C) {
 		Interface: "mysql",
 	})
 
+	relation1 := model.AddRelation(description.RelationArgs{
+		Id:  0,
+		Key: "remote-mysql:db foo:db",
+	})
+	relation1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "remote-mysql",
+	})
+	relation1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+	})
+
 	remoteApp2 := model.AddRemoteApplication(description.RemoteApplicationArgs{
 		Name:            "remote-postgresql",
 		OfferUUID:       "offer-uuid-2",
@@ -172,6 +193,17 @@ func (s *importSuite) TestImportRemoteApplicationOfferersMultiple(c *tc.C) {
 		Name:      "admin",
 		Role:      "requirer",
 		Interface: "admin",
+	})
+
+	relation2 := model.AddRelation(description.RelationArgs{
+		Id:  0,
+		Key: "remote-postgresql:db foo:db",
+	})
+	relation2.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "remote-postgresql",
+	})
+	relation2.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
 	})
 
 	expected := []service.RemoteApplicationOffererImport{

--- a/domain/modelmigration/modelmigration/relation.go
+++ b/domain/modelmigration/modelmigration/relation.go
@@ -61,6 +61,13 @@ func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, r
 	// to merge and de-duplicate these remote applications when importing them.
 	// 4.x doesn't allow to have multiple remote applications with the same
 	// offer UUID.
+	relByAppName := map[string]struct{}{}
+	for _, rel := range relations {
+		for _, ep := range rel.Endpoints() {
+			relByAppName[ep.ApplicationName()] = struct{}{}
+		}
+	}
+
 	unique := map[string][]description.RemoteApplication{}
 	for _, remoteApp := range remoteApps {
 		// We don't care about remove application consumers, so duplications
@@ -71,7 +78,7 @@ func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, r
 
 		// If the remote application is not used by a relation, then we can
 		// ignore it as well.
-		if !remoteAppUsedByRelation(remoteApp, relations) {
+		if _, ok := relByAppName[remoteApp.Name()]; !ok {
 			continue
 		}
 
@@ -96,18 +103,6 @@ func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, r
 	}
 
 	return unique, nil
-}
-
-func remoteAppUsedByRelation(remoteApp description.RemoteApplication, relations []description.Relation) bool {
-	for _, rel := range relations {
-		for _, ep := range rel.Endpoints() {
-			if ep.ApplicationName() == remoteApp.Name() {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 func remoteEndpointsEqual(a, b []description.RemoteEndpoint) bool {

--- a/domain/modelmigration/modelmigration/relation.go
+++ b/domain/modelmigration/modelmigration/relation.go
@@ -55,30 +55,12 @@ func GetUniqueRemoteConsumersNames(remoteApps []description.RemoteApplication) s
 // UniqueRemoteOfferApplications de-duplicates remote applications based on
 // offer UUID and endpoints, and verifies that there are no conflicting remote
 // applications with the same offer UUID.
-func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, relations []description.Relation) (map[string][]description.RemoteApplication, error) {
-	// In 3.x it's possible to have multiple remote applications with the same
-	// offer UUID and endpoints, but have different names. In this case, we need
-	// to merge and de-duplicate these remote applications when importing them.
-	// 4.x doesn't allow to have multiple remote applications with the same
-	// offer UUID.
-	relByAppName := map[string]struct{}{}
-	for _, rel := range relations {
-		for _, ep := range rel.Endpoints() {
-			relByAppName[ep.ApplicationName()] = struct{}{}
-		}
-	}
-
+func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication) (map[string][]description.RemoteApplication, error) {
 	unique := map[string][]description.RemoteApplication{}
 	for _, remoteApp := range remoteApps {
 		// We don't care about remove application consumers, so duplications
 		// here don't matter.
 		if remoteApp.IsConsumerProxy() {
-			continue
-		}
-
-		// If the remote application is not used by a relation, then we can
-		// ignore it as well.
-		if _, ok := relByAppName[remoteApp.Name()]; !ok {
 			continue
 		}
 

--- a/domain/modelmigration/modelmigration/relation.go
+++ b/domain/modelmigration/modelmigration/relation.go
@@ -55,13 +55,13 @@ func GetUniqueRemoteConsumersNames(remoteApps []description.RemoteApplication) s
 // UniqueRemoteOfferApplications de-duplicates remote applications based on
 // offer UUID and endpoints, and verifies that there are no conflicting remote
 // applications with the same offer UUID.
-func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, relations []description.Relation) (map[string]description.RemoteApplication, error) {
+func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, relations []description.Relation) (map[string][]description.RemoteApplication, error) {
 	// In 3.x it's possible to have multiple remote applications with the same
 	// offer UUID and endpoints, but have different names. In this case, we need
 	// to merge and de-duplicate these remote applications when importing them.
 	// 4.x doesn't allow to have multiple remote applications with the same
 	// offer UUID.
-	unique := map[string]description.RemoteApplication{}
+	unique := map[string][]description.RemoteApplication{}
 	for _, remoteApp := range remoteApps {
 		// We don't care about remove application consumers, so duplications
 		// here don't matter.
@@ -80,17 +80,19 @@ func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, r
 		// endpoints, otherwise the import would be ambiguous.
 		offerUUID := remoteApp.OfferUUID()
 		if existing, ok := unique[offerUUID]; ok {
-			if existing.SourceModelUUID() != remoteApp.SourceModelUUID() {
-				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different source model UUIDs: %q and %q",
-					offerUUID, existing.SourceModelUUID(), remoteApp.SourceModelUUID())
-			}
-			if !remoteEndpointsEqual(existing.Endpoints(), remoteApp.Endpoints()) {
-				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different endpoints: %v and %v",
-					offerUUID, remoteEndpointString(existing.Endpoints()), remoteEndpointString(remoteApp.Endpoints()))
+			for _, existingApp := range existing {
+				if existingApp.SourceModelUUID() != remoteApp.SourceModelUUID() {
+					return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different source model UUIDs: %q and %q",
+						offerUUID, existingApp.SourceModelUUID(), remoteApp.SourceModelUUID())
+				}
+				if !remoteEndpointsEqual(existingApp.Endpoints(), remoteApp.Endpoints()) {
+					return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different endpoints: %v and %v",
+						offerUUID, remoteEndpointString(existingApp.Endpoints()), remoteEndpointString(remoteApp.Endpoints()))
+				}
 			}
 		}
 
-		unique[offerUUID] = remoteApp
+		unique[offerUUID] = append(unique[offerUUID], remoteApp)
 	}
 
 	return unique, nil

--- a/domain/modelmigration/modelmigration/relation.go
+++ b/domain/modelmigration/modelmigration/relation.go
@@ -4,13 +4,19 @@
 package modelmigration
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/description/v11"
+
+	"github.com/juju/juju/internal/errors"
 )
 
-// IsRelationInApplicationsName returns true if any of the relation endpoints
-// match any of the given application names.
-func IsRelationInApplicationsName(rel description.Relation, applications set.Strings) bool {
+// ContainsRelationEndpointApplicationName returns true if any of the relation
+// endpoints match any of the given application names.
+func ContainsRelationEndpointApplicationName(rel description.Relation, applications set.Strings) bool {
 	for _, endpoint := range rel.Endpoints() {
 		appName := endpoint.ApplicationName()
 		if _, ok := applications[appName]; ok {
@@ -44,4 +50,94 @@ func GetUniqueRemoteConsumersNames(remoteApps []description.RemoteApplication) s
 	}
 
 	return remoteConsumers
+}
+
+// UniqueRemoteOfferApplications de-duplicates remote applications based on
+// offer UUID and endpoints, and verifies that there are no conflicting remote
+// applications with the same offer UUID.
+func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication, relations []description.Relation) (map[string]description.RemoteApplication, error) {
+	// In 3.x it's possible to have multiple remote applications with the same
+	// offer UUID and endpoints, but have different names. In this case, we need
+	// to merge and de-duplicate these remote applications when importing them.
+	// 4.x doesn't allow to have multiple remote applications with the same
+	// offer UUID.
+	unique := map[string]description.RemoteApplication{}
+	for _, remoteApp := range remoteApps {
+		// We don't care about remove application consumers, so duplications
+		// here don't matter.
+		if remoteApp.IsConsumerProxy() {
+			continue
+		}
+
+		// If the remote application is not used by a relation, then we can
+		// ignore it as well.
+		if !remoteAppUsedByRelation(remoteApp, relations) {
+			continue
+		}
+
+		// Verify that if there are multiple remote application offerers with
+		// the same offer UUID, they also have the same source model UUID and
+		// endpoints, otherwise the import would be ambiguous.
+		offerUUID := remoteApp.OfferUUID()
+		if existing, ok := unique[offerUUID]; ok {
+			if existing.SourceModelUUID() != remoteApp.SourceModelUUID() {
+				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different source model UUIDs: %q and %q",
+					offerUUID, existing.SourceModelUUID(), remoteApp.SourceModelUUID())
+			}
+			if !remoteEndpointsEqual(existing.Endpoints(), remoteApp.Endpoints()) {
+				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different endpoints: %v and %v",
+					offerUUID, remoteEndpointString(existing.Endpoints()), remoteEndpointString(remoteApp.Endpoints()))
+			}
+		}
+
+		unique[offerUUID] = remoteApp
+	}
+
+	return unique, nil
+}
+
+func remoteAppUsedByRelation(remoteApp description.RemoteApplication, relations []description.Relation) bool {
+	for _, rel := range relations {
+		for _, ep := range rel.Endpoints() {
+			if ep.ApplicationName() == remoteApp.Name() {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func remoteEndpointsEqual(a, b []description.RemoteEndpoint) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	aCopy := append([]description.RemoteEndpoint(nil), a...)
+	bCopy := append([]description.RemoteEndpoint(nil), b...)
+
+	sort.Slice(aCopy, func(i, j int) bool {
+		return aCopy[i].Name() < aCopy[j].Name()
+	})
+	sort.Slice(bCopy, func(i, j int) bool {
+		return bCopy[i].Name() < bCopy[j].Name()
+	})
+
+	for i := range aCopy {
+		if aCopy[i].Name() != bCopy[i].Name() ||
+			aCopy[i].Role() != bCopy[i].Role() ||
+			aCopy[i].Interface() != bCopy[i].Interface() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func remoteEndpointString(eps []description.RemoteEndpoint) string {
+	var parts []string
+	for _, ep := range eps {
+		parts = append(parts, fmt.Sprintf("%s:%s", ep.Interface(), ep.Name()))
+	}
+	return strings.Join(parts, " ")
 }

--- a/domain/modelmigration/modelmigration/relation.go
+++ b/domain/modelmigration/modelmigration/relation.go
@@ -52,11 +52,47 @@ func GetUniqueRemoteConsumersNames(remoteApps []description.RemoteApplication) s
 	return remoteConsumers
 }
 
+// RemoteApplicationOfferer represents a remote application that offers an
+// application, and any duplicate remote applications with the same offer UUID
+// and endpoints.
+type RemoteApplicationOfferer struct {
+	Primary    description.RemoteApplication
+	Duplicates []description.RemoteApplication
+}
+
+// MatchesSourceModelUUID returns true if the source model UUID of the primary
+// remote application does not match the given source model UUID.
+func (o RemoteApplicationOfferer) MatchesSourceModelUUID(sourceModelUUID string) bool {
+	return o.Primary.SourceModelUUID() != sourceModelUUID
+}
+
+// MatchesEndpoints returns true if the endpoints of the primary remote
+// application do not match the given endpoints.
+func (o RemoteApplicationOfferer) MatchesEndpoints(endpoints []description.RemoteEndpoint) bool {
+	return remoteEndpointsEqual(o.Primary.Endpoints(), endpoints)
+}
+
+// SourceModelUUID returns the source model UUID of the primary remote
+// application.
+func (o RemoteApplicationOfferer) SourceModelUUID() string {
+	return o.Primary.SourceModelUUID()
+}
+
+// Endpoints returns the endpoints of the primary remote application.
+func (o RemoteApplicationOfferer) Endpoints() []description.RemoteEndpoint {
+	return o.Primary.Endpoints()
+}
+
+// IsEmpty returns true if there is no primary remote application.
+func (o RemoteApplicationOfferer) IsEmpty() bool {
+	return o.Primary == nil
+}
+
 // UniqueRemoteOfferApplications de-duplicates remote applications based on
 // offer UUID and endpoints, and verifies that there are no conflicting remote
 // applications with the same offer UUID.
-func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication) (map[string][]description.RemoteApplication, error) {
-	unique := map[string][]description.RemoteApplication{}
+func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication) (map[string]RemoteApplicationOfferer, error) {
+	unique := map[string]RemoteApplicationOfferer{}
 	for _, remoteApp := range remoteApps {
 		// We don't care about remove application consumers, so duplications
 		// here don't matter.
@@ -69,19 +105,23 @@ func UniqueRemoteOfferApplications(remoteApps []description.RemoteApplication) (
 		// endpoints, otherwise the import would be ambiguous.
 		offerUUID := remoteApp.OfferUUID()
 		if existing, ok := unique[offerUUID]; ok {
-			for _, existingApp := range existing {
-				if existingApp.SourceModelUUID() != remoteApp.SourceModelUUID() {
-					return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different source model UUIDs: %q and %q",
-						offerUUID, existingApp.SourceModelUUID(), remoteApp.SourceModelUUID())
-				}
-				if !remoteEndpointsEqual(existingApp.Endpoints(), remoteApp.Endpoints()) {
-					return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different endpoints: %v and %v",
-						offerUUID, remoteEndpointString(existingApp.Endpoints()), remoteEndpointString(remoteApp.Endpoints()))
-				}
+			if existing.MatchesSourceModelUUID(remoteApp.SourceModelUUID()) {
+				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different source model UUIDs: %q and %q",
+					offerUUID, existing.SourceModelUUID(), remoteApp.SourceModelUUID())
 			}
+			if !existing.MatchesEndpoints(remoteApp.Endpoints()) {
+				return nil, errors.Errorf("multiple remote application offerers with the same offer UUID %q, but different endpoints: %v and %v",
+					offerUUID, remoteEndpointString(existing.Endpoints()), remoteEndpointString(remoteApp.Endpoints()))
+			}
+
+			existing.Duplicates = append(existing.Duplicates, remoteApp)
+			unique[offerUUID] = existing
+			continue
 		}
 
-		unique[offerUUID] = append(unique[offerUUID], remoteApp)
+		unique[offerUUID] = RemoteApplicationOfferer{
+			Primary: remoteApp,
+		}
 	}
 
 	return unique, nil

--- a/domain/modelmigration/modelmigration/relation_test.go
+++ b/domain/modelmigration/modelmigration/relation_test.go
@@ -91,14 +91,14 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 	tests := []struct {
 		name     string
 		setup    func() []description.RemoteApplication
-		expected func(c *tc.C, remoteApps map[string][]description.RemoteApplication)
+		expected func(c *tc.C, remoteApps map[string]RemoteApplicationOfferer)
 	}{
 		{
 			name: "no remote applications",
 			setup: func() []description.RemoteApplication {
 				return nil
 			},
-			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+			expected: func(c *tc.C, remoteApps map[string]RemoteApplicationOfferer) {
 				c.Check(remoteApps, tc.HasLen, 0)
 			},
 		},
@@ -114,7 +114,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 				})
 				return []description.RemoteApplication{remoteApp}
 			},
-			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+			expected: func(c *tc.C, remoteApps map[string]RemoteApplicationOfferer) {
 				c.Check(remoteApps, tc.HasLen, 0)
 			},
 		},
@@ -132,7 +132,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 
 				return []description.RemoteApplication{remoteApp0}
 			},
-			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+			expected: func(c *tc.C, remoteApps map[string]RemoteApplicationOfferer) {
 				c.Check(remoteApps, tc.HasLen, 0)
 			},
 		},
@@ -154,15 +154,15 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 
 				return []description.RemoteApplication{remoteApp0}
 			},
-			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+			expected: func(c *tc.C, remoteApps map[string]RemoteApplicationOfferer) {
 				c.Assert(remoteApps, tc.HasLen, 1)
 
 				remoteApp, ok := remoteApps["deadbeef"]
 				c.Assert(ok, tc.IsTrue)
-				c.Assert(remoteApp, tc.HasLen, 1)
+				c.Assert(remoteApp.IsEmpty(), tc.IsFalse)
 
-				c.Check(remoteApp[0].Name(), tc.Equals, "dummy-source")
-				c.Check(remoteApp[0].SourceModelUUID(), tc.Equals, "bar")
+				c.Check(remoteApp.Primary.Name(), tc.Equals, "dummy-source")
+				c.Check(remoteApp.Primary.SourceModelUUID(), tc.Equals, "bar")
 			},
 		},
 		{
@@ -194,18 +194,20 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 
 				return []description.RemoteApplication{remoteApp0, remoteApp1}
 			},
-			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+			expected: func(c *tc.C, remoteApps map[string]RemoteApplicationOfferer) {
 				c.Assert(remoteApps, tc.HasLen, 1)
 
 				remoteApp, ok := remoteApps["deadbeef"]
 				c.Assert(ok, tc.IsTrue)
-				c.Assert(remoteApp, tc.HasLen, 2)
+				c.Assert(remoteApp.IsEmpty(), tc.IsFalse)
 
-				c.Check(remoteApp[0].Name(), tc.Equals, "foo")
-				c.Check(remoteApp[0].SourceModelUUID(), tc.Equals, "bar")
+				c.Check(remoteApp.Primary.Name(), tc.Equals, "foo")
+				c.Check(remoteApp.Primary.SourceModelUUID(), tc.Equals, "bar")
 
-				c.Check(remoteApp[1].Name(), tc.Equals, "baz")
-				c.Check(remoteApp[1].SourceModelUUID(), tc.Equals, "bar")
+				c.Assert(remoteApp.Duplicates, tc.HasLen, 1)
+
+				c.Check(remoteApp.Duplicates[0].Name(), tc.Equals, "baz")
+				c.Check(remoteApp.Duplicates[0].SourceModelUUID(), tc.Equals, "bar")
 			},
 		},
 		{
@@ -237,18 +239,20 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 
 				return []description.RemoteApplication{remoteApp0, remoteApp1}
 			},
-			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+			expected: func(c *tc.C, remoteApps map[string]RemoteApplicationOfferer) {
 				c.Assert(remoteApps, tc.HasLen, 1)
 
 				remoteApp, ok := remoteApps["deadbeef"]
 				c.Assert(ok, tc.IsTrue)
-				c.Assert(remoteApp, tc.HasLen, 2)
+				c.Assert(remoteApp.IsEmpty(), tc.IsFalse)
 
-				c.Check(remoteApp[0].Name(), tc.Equals, "foo")
-				c.Check(remoteApp[0].SourceModelUUID(), tc.Equals, "bar")
+				c.Check(remoteApp.Primary.Name(), tc.Equals, "foo")
+				c.Check(remoteApp.Primary.SourceModelUUID(), tc.Equals, "bar")
 
-				c.Check(remoteApp[1].Name(), tc.Equals, "baz")
-				c.Check(remoteApp[1].SourceModelUUID(), tc.Equals, "bar")
+				c.Assert(remoteApp.Duplicates, tc.HasLen, 1)
+
+				c.Check(remoteApp.Duplicates[0].Name(), tc.Equals, "baz")
+				c.Check(remoteApp.Duplicates[0].SourceModelUUID(), tc.Equals, "bar")
 			},
 		},
 	}

--- a/domain/modelmigration/modelmigration/relation_test.go
+++ b/domain/modelmigration/modelmigration/relation_test.go
@@ -21,7 +21,6 @@ func TestRelationSuite(t *testing.T) {
 }
 
 func (s *relationSuite) TestMatchRelationEndpointByApplications(c *tc.C) {
-
 	tests := []struct {
 		name     string
 		setup    func() (description.Relation, []description.RemoteApplication)
@@ -86,6 +85,417 @@ func (s *relationSuite) TestMatchRelationEndpointByApplications(c *tc.C) {
 
 		c.Assert(result, tc.Equals, test.expected)
 	}
+}
+
+func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
+	tests := []struct {
+		name     string
+		setup    func() ([]description.RemoteApplication, []description.Relation)
+		expected func(c *tc.C, remoteApps map[string][]description.RemoteApplication)
+	}{
+		{
+			name: "no remote applications",
+			setup: func() ([]description.RemoteApplication, []description.Relation) {
+				return nil, nil
+			},
+			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+				c.Check(remoteApps, tc.HasLen, 0)
+			},
+		},
+		{
+			name: "no relations",
+			setup: func() ([]description.RemoteApplication, []description.Relation) {
+				m := description.NewModel(description.ModelArgs{})
+				remoteApp := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "remote-consumer-1",
+					IsConsumerProxy: true,
+					OfferUUID:       "foo",
+					SourceModelUUID: "bar",
+				})
+				return []description.RemoteApplication{remoteApp}, nil
+			},
+			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+				c.Check(remoteApps, tc.HasLen, 0)
+			},
+		},
+		{
+			name: "consumer proxy remote application",
+			setup: func() ([]description.RemoteApplication, []description.Relation) {
+				m := description.NewModel(description.ModelArgs{})
+				relation := m.AddRelation(description.RelationArgs{
+					Id:  0,
+					Key: "foo:sink",
+				})
+				relation.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "remote-consumer",
+					Name:            "endpoint",
+				})
+
+				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "remote-consumer",
+					IsConsumerProxy: true,
+					OfferUUID:       "foo",
+					SourceModelUUID: "bar",
+				})
+
+				return []description.RemoteApplication{remoteApp0},
+					[]description.Relation{relation}
+			},
+			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+				c.Check(remoteApps, tc.HasLen, 0)
+			},
+		},
+		{
+			name: "remote application",
+			setup: func() ([]description.RemoteApplication, []description.Relation) {
+				m := description.NewModel(description.ModelArgs{})
+				relation := m.AddRelation(description.RelationArgs{
+					Id:  0,
+					Key: "dummy-source:sink dummy-sink:source",
+				})
+				relation.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "dummy-source",
+					Name:            "sink",
+				})
+
+				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "dummy-source",
+					OfferUUID:       "deadbeef",
+					SourceModelUUID: "bar",
+				})
+				remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+					Name:      "dummy-source",
+					Interface: "dummy-token",
+					Role:      "requirer",
+				})
+
+				return []description.RemoteApplication{remoteApp0},
+					[]description.Relation{relation}
+			},
+			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+				c.Assert(remoteApps, tc.HasLen, 1)
+
+				remoteApp, ok := remoteApps["deadbeef"]
+				c.Assert(ok, tc.IsTrue)
+				c.Assert(remoteApp, tc.HasLen, 1)
+
+				c.Check(remoteApp[0].Name(), tc.Equals, "dummy-source")
+				c.Check(remoteApp[0].SourceModelUUID(), tc.Equals, "bar")
+			},
+		},
+		{
+			name: "duplicate remote application with one linked to a relation",
+			setup: func() ([]description.RemoteApplication, []description.Relation) {
+				m := description.NewModel(description.ModelArgs{})
+				relation := m.AddRelation(description.RelationArgs{
+					Id:  0,
+					Key: "foo:sink dummy-sink:source",
+				})
+				relation.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "foo",
+					Name:            "sink",
+				})
+				relation.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "dummy-sink",
+					Name:            "source",
+				})
+
+				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "foo",
+					OfferUUID:       "deadbeef",
+					SourceModelUUID: "bar",
+				})
+				remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+					Name:      "dummy-source",
+					Interface: "dummy-token",
+					Role:      "requirer",
+				})
+
+				remoteApp1 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "bar",
+					OfferUUID:       "deadbeef",
+					SourceModelUUID: "bar",
+				})
+				remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+					Name:      "dummy-source",
+					Interface: "dummy-token",
+					Role:      "requirer",
+				})
+
+				return []description.RemoteApplication{remoteApp0, remoteApp1},
+					[]description.Relation{relation}
+			},
+			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+				c.Assert(remoteApps, tc.HasLen, 1)
+
+				remoteApp, ok := remoteApps["deadbeef"]
+				c.Assert(ok, tc.IsTrue)
+				c.Assert(remoteApp, tc.HasLen, 1)
+
+				c.Check(remoteApp[0].Name(), tc.Equals, "foo")
+				c.Check(remoteApp[0].SourceModelUUID(), tc.Equals, "bar")
+			},
+		},
+		{
+			name: "duplicate remote application with relations",
+			setup: func() ([]description.RemoteApplication, []description.Relation) {
+				m := description.NewModel(description.ModelArgs{})
+				relation0 := m.AddRelation(description.RelationArgs{
+					Id:  0,
+					Key: "foo:sink dummy-sink:source",
+				})
+				relation0.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "foo",
+					Name:            "sink",
+				})
+				relation0.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "dummy-sink",
+					Name:            "source",
+				})
+
+				relation1 := m.AddRelation(description.RelationArgs{
+					Id:  1,
+					Key: "baz:sink dummy-sink:source",
+				})
+				relation1.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "baz",
+					Name:            "sink",
+				})
+				relation1.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "dummy-sink",
+					Name:            "source",
+				})
+
+				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "foo",
+					OfferUUID:       "deadbeef",
+					SourceModelUUID: "bar",
+				})
+				remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+					Name:      "dummy-source",
+					Interface: "dummy-token",
+					Role:      "requirer",
+				})
+
+				remoteApp1 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "baz",
+					OfferUUID:       "deadbeef",
+					SourceModelUUID: "bar",
+				})
+				remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+					Name:      "dummy-source",
+					Interface: "dummy-token",
+					Role:      "requirer",
+				})
+
+				return []description.RemoteApplication{remoteApp0, remoteApp1},
+					[]description.Relation{relation0, relation1}
+			},
+			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+				c.Assert(remoteApps, tc.HasLen, 1)
+
+				remoteApp, ok := remoteApps["deadbeef"]
+				c.Assert(ok, tc.IsTrue)
+				c.Assert(remoteApp, tc.HasLen, 2)
+
+				c.Check(remoteApp[0].Name(), tc.Equals, "foo")
+				c.Check(remoteApp[0].SourceModelUUID(), tc.Equals, "bar")
+
+				c.Check(remoteApp[1].Name(), tc.Equals, "baz")
+				c.Check(remoteApp[1].SourceModelUUID(), tc.Equals, "bar")
+			},
+		},
+		{
+			name: "duplicate remote application with relations - inverted endpoints",
+			setup: func() ([]description.RemoteApplication, []description.Relation) {
+				m := description.NewModel(description.ModelArgs{})
+				relation0 := m.AddRelation(description.RelationArgs{
+					Id:  0,
+					Key: "foo:sink dummy-sink:source",
+				})
+				relation0.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "dummy-sink",
+					Name:            "source",
+				})
+				relation0.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "foo",
+					Name:            "sink",
+				})
+
+				relation1 := m.AddRelation(description.RelationArgs{
+					Id:  1,
+					Key: "baz:sink dummy-sink:source",
+				})
+
+				relation1.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "dummy-sink",
+					Name:            "source",
+				})
+				relation1.AddEndpoint(description.EndpointArgs{
+					ApplicationName: "baz",
+					Name:            "sink",
+				})
+
+				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "foo",
+					OfferUUID:       "deadbeef",
+					SourceModelUUID: "bar",
+				})
+				remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+					Name:      "dummy-source",
+					Interface: "dummy-token",
+					Role:      "requirer",
+				})
+
+				remoteApp1 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+					Name:            "baz",
+					OfferUUID:       "deadbeef",
+					SourceModelUUID: "bar",
+				})
+				remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+					Name:      "dummy-source",
+					Interface: "dummy-token",
+					Role:      "requirer",
+				})
+
+				return []description.RemoteApplication{remoteApp0, remoteApp1},
+					[]description.Relation{relation0, relation1}
+			},
+			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
+				c.Assert(remoteApps, tc.HasLen, 1)
+
+				remoteApp, ok := remoteApps["deadbeef"]
+				c.Assert(ok, tc.IsTrue)
+				c.Assert(remoteApp, tc.HasLen, 2)
+
+				c.Check(remoteApp[0].Name(), tc.Equals, "foo")
+				c.Check(remoteApp[0].SourceModelUUID(), tc.Equals, "bar")
+
+				c.Check(remoteApp[1].Name(), tc.Equals, "baz")
+				c.Check(remoteApp[1].SourceModelUUID(), tc.Equals, "bar")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("Test case: %s", test.name)
+
+		remoteApps, relations := test.setup()
+		result, err := UniqueRemoteOfferApplications(remoteApps, relations)
+
+		c.Assert(err, tc.IsNil)
+		test.expected(c, result)
+	}
+}
+
+func (s *relationSuite) TestUniqueRemoteOfferApplicationsInvalidSourceModelUUID(c *tc.C) {
+	m := description.NewModel(description.ModelArgs{})
+	relation0 := m.AddRelation(description.RelationArgs{
+		Id:  0,
+		Key: "foo:sink dummy-sink:source",
+	})
+	relation0.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+	})
+	relation0.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+		Name:            "sink",
+	})
+
+	relation1 := m.AddRelation(description.RelationArgs{
+		Id:  1,
+		Key: "baz:sink dummy-sink:source",
+	})
+
+	relation1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+	})
+	relation1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "baz",
+		Name:            "sink",
+	})
+
+	remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "foo",
+		OfferUUID:       "deadbeef",
+		SourceModelUUID: "bar",
+	})
+	remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "dummy-source",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	remoteApp1 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "baz",
+		OfferUUID:       "deadbeef",
+		SourceModelUUID: "blah",
+	})
+	remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "dummy-source",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	_, err := UniqueRemoteOfferApplications([]description.RemoteApplication{remoteApp0, remoteApp1}, []description.Relation{relation0, relation1})
+	c.Assert(err, tc.ErrorMatches, "multiple remote application offerers with the same offer UUID.*but different source model UUIDs.*")
+}
+
+func (s *relationSuite) TestUniqueRemoteOfferApplicationsInvalidEndpoints(c *tc.C) {
+	m := description.NewModel(description.ModelArgs{})
+	relation0 := m.AddRelation(description.RelationArgs{
+		Id:  0,
+		Key: "foo:sink dummy-sink:source",
+	})
+	relation0.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+	})
+	relation0.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+		Name:            "sink",
+	})
+
+	relation1 := m.AddRelation(description.RelationArgs{
+		Id:  1,
+		Key: "baz:sink dummy-sink:source",
+	})
+
+	relation1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+	})
+	relation1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "baz",
+		Name:            "sink",
+	})
+
+	remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "foo",
+		OfferUUID:       "deadbeef",
+		SourceModelUUID: "bar",
+	})
+	remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "dummy-source",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	remoteApp1 := m.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "baz",
+		OfferUUID:       "deadbeef",
+		SourceModelUUID: "bar",
+	})
+	remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "dummy-source",
+		Interface: "dummy-token",
+		Role:      "foo",
+	})
+
+	_, err := UniqueRemoteOfferApplications([]description.RemoteApplication{remoteApp0, remoteApp1}, []description.Relation{relation0, relation1})
+	c.Assert(err, tc.ErrorMatches, "multiple remote application offerers with the same offer UUID.*but different endpoints.*")
 }
 
 func newModel() description.Model {

--- a/domain/modelmigration/modelmigration/relation_test.go
+++ b/domain/modelmigration/modelmigration/relation_test.go
@@ -90,13 +90,13 @@ func (s *relationSuite) TestMatchRelationEndpointByApplications(c *tc.C) {
 func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 	tests := []struct {
 		name     string
-		setup    func() ([]description.RemoteApplication, []description.Relation)
+		setup    func() []description.RemoteApplication
 		expected func(c *tc.C, remoteApps map[string][]description.RemoteApplication)
 	}{
 		{
 			name: "no remote applications",
-			setup: func() ([]description.RemoteApplication, []description.Relation) {
-				return nil, nil
+			setup: func() []description.RemoteApplication {
+				return nil
 			},
 			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
 				c.Check(remoteApps, tc.HasLen, 0)
@@ -104,7 +104,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 		},
 		{
 			name: "no relations",
-			setup: func() ([]description.RemoteApplication, []description.Relation) {
+			setup: func() []description.RemoteApplication {
 				m := description.NewModel(description.ModelArgs{})
 				remoteApp := m.AddRemoteApplication(description.RemoteApplicationArgs{
 					Name:            "remote-consumer-1",
@@ -112,7 +112,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 					OfferUUID:       "foo",
 					SourceModelUUID: "bar",
 				})
-				return []description.RemoteApplication{remoteApp}, nil
+				return []description.RemoteApplication{remoteApp}
 			},
 			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
 				c.Check(remoteApps, tc.HasLen, 0)
@@ -120,16 +120,8 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 		},
 		{
 			name: "consumer proxy remote application",
-			setup: func() ([]description.RemoteApplication, []description.Relation) {
+			setup: func() []description.RemoteApplication {
 				m := description.NewModel(description.ModelArgs{})
-				relation := m.AddRelation(description.RelationArgs{
-					Id:  0,
-					Key: "foo:sink",
-				})
-				relation.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "remote-consumer",
-					Name:            "endpoint",
-				})
 
 				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
 					Name:            "remote-consumer",
@@ -138,8 +130,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 					SourceModelUUID: "bar",
 				})
 
-				return []description.RemoteApplication{remoteApp0},
-					[]description.Relation{relation}
+				return []description.RemoteApplication{remoteApp0}
 			},
 			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
 				c.Check(remoteApps, tc.HasLen, 0)
@@ -147,16 +138,8 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 		},
 		{
 			name: "remote application",
-			setup: func() ([]description.RemoteApplication, []description.Relation) {
+			setup: func() []description.RemoteApplication {
 				m := description.NewModel(description.ModelArgs{})
-				relation := m.AddRelation(description.RelationArgs{
-					Id:  0,
-					Key: "dummy-source:sink dummy-sink:source",
-				})
-				relation.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "dummy-source",
-					Name:            "sink",
-				})
 
 				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
 					Name:            "dummy-source",
@@ -169,8 +152,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 					Role:      "requirer",
 				})
 
-				return []description.RemoteApplication{remoteApp0},
-					[]description.Relation{relation}
+				return []description.RemoteApplication{remoteApp0}
 			},
 			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
 				c.Assert(remoteApps, tc.HasLen, 1)
@@ -184,87 +166,9 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 			},
 		},
 		{
-			name: "duplicate remote application with one linked to a relation",
-			setup: func() ([]description.RemoteApplication, []description.Relation) {
-				m := description.NewModel(description.ModelArgs{})
-				relation := m.AddRelation(description.RelationArgs{
-					Id:  0,
-					Key: "foo:sink dummy-sink:source",
-				})
-				relation.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "foo",
-					Name:            "sink",
-				})
-				relation.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "dummy-sink",
-					Name:            "source",
-				})
-
-				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
-					Name:            "foo",
-					OfferUUID:       "deadbeef",
-					SourceModelUUID: "bar",
-				})
-				remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
-					Name:      "dummy-source",
-					Interface: "dummy-token",
-					Role:      "requirer",
-				})
-
-				remoteApp1 := m.AddRemoteApplication(description.RemoteApplicationArgs{
-					Name:            "bar",
-					OfferUUID:       "deadbeef",
-					SourceModelUUID: "bar",
-				})
-				remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
-					Name:      "dummy-source",
-					Interface: "dummy-token",
-					Role:      "requirer",
-				})
-
-				return []description.RemoteApplication{remoteApp0, remoteApp1},
-					[]description.Relation{relation}
-			},
-			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
-				c.Assert(remoteApps, tc.HasLen, 1)
-
-				remoteApp, ok := remoteApps["deadbeef"]
-				c.Assert(ok, tc.IsTrue)
-				c.Assert(remoteApp, tc.HasLen, 1)
-
-				c.Check(remoteApp[0].Name(), tc.Equals, "foo")
-				c.Check(remoteApp[0].SourceModelUUID(), tc.Equals, "bar")
-			},
-		},
-		{
 			name: "duplicate remote application with relations",
-			setup: func() ([]description.RemoteApplication, []description.Relation) {
+			setup: func() []description.RemoteApplication {
 				m := description.NewModel(description.ModelArgs{})
-				relation0 := m.AddRelation(description.RelationArgs{
-					Id:  0,
-					Key: "foo:sink dummy-sink:source",
-				})
-				relation0.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "foo",
-					Name:            "sink",
-				})
-				relation0.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "dummy-sink",
-					Name:            "source",
-				})
-
-				relation1 := m.AddRelation(description.RelationArgs{
-					Id:  1,
-					Key: "baz:sink dummy-sink:source",
-				})
-				relation1.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "baz",
-					Name:            "sink",
-				})
-				relation1.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "dummy-sink",
-					Name:            "source",
-				})
 
 				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
 					Name:            "foo",
@@ -288,8 +192,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 					Role:      "requirer",
 				})
 
-				return []description.RemoteApplication{remoteApp0, remoteApp1},
-					[]description.Relation{relation0, relation1}
+				return []description.RemoteApplication{remoteApp0, remoteApp1}
 			},
 			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
 				c.Assert(remoteApps, tc.HasLen, 1)
@@ -307,34 +210,8 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 		},
 		{
 			name: "duplicate remote application with relations - inverted endpoints",
-			setup: func() ([]description.RemoteApplication, []description.Relation) {
+			setup: func() []description.RemoteApplication {
 				m := description.NewModel(description.ModelArgs{})
-				relation0 := m.AddRelation(description.RelationArgs{
-					Id:  0,
-					Key: "foo:sink dummy-sink:source",
-				})
-				relation0.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "dummy-sink",
-					Name:            "source",
-				})
-				relation0.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "foo",
-					Name:            "sink",
-				})
-
-				relation1 := m.AddRelation(description.RelationArgs{
-					Id:  1,
-					Key: "baz:sink dummy-sink:source",
-				})
-
-				relation1.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "dummy-sink",
-					Name:            "source",
-				})
-				relation1.AddEndpoint(description.EndpointArgs{
-					ApplicationName: "baz",
-					Name:            "sink",
-				})
 
 				remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
 					Name:            "foo",
@@ -358,8 +235,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 					Role:      "requirer",
 				})
 
-				return []description.RemoteApplication{remoteApp0, remoteApp1},
-					[]description.Relation{relation0, relation1}
+				return []description.RemoteApplication{remoteApp0, remoteApp1}
 			},
 			expected: func(c *tc.C, remoteApps map[string][]description.RemoteApplication) {
 				c.Assert(remoteApps, tc.HasLen, 1)
@@ -380,8 +256,8 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 	for _, test := range tests {
 		c.Logf("Test case: %s", test.name)
 
-		remoteApps, relations := test.setup()
-		result, err := UniqueRemoteOfferApplications(remoteApps, relations)
+		remoteApps := test.setup()
+		result, err := UniqueRemoteOfferApplications(remoteApps)
 
 		c.Assert(err, tc.IsNil)
 		test.expected(c, result)
@@ -390,32 +266,6 @@ func (s *relationSuite) TestUniqueRemoteOfferApplications(c *tc.C) {
 
 func (s *relationSuite) TestUniqueRemoteOfferApplicationsInvalidSourceModelUUID(c *tc.C) {
 	m := description.NewModel(description.ModelArgs{})
-	relation0 := m.AddRelation(description.RelationArgs{
-		Id:  0,
-		Key: "foo:sink dummy-sink:source",
-	})
-	relation0.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "dummy-sink",
-		Name:            "source",
-	})
-	relation0.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "foo",
-		Name:            "sink",
-	})
-
-	relation1 := m.AddRelation(description.RelationArgs{
-		Id:  1,
-		Key: "baz:sink dummy-sink:source",
-	})
-
-	relation1.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "dummy-sink",
-		Name:            "source",
-	})
-	relation1.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "baz",
-		Name:            "sink",
-	})
 
 	remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
 		Name:            "foo",
@@ -439,38 +289,12 @@ func (s *relationSuite) TestUniqueRemoteOfferApplicationsInvalidSourceModelUUID(
 		Role:      "requirer",
 	})
 
-	_, err := UniqueRemoteOfferApplications([]description.RemoteApplication{remoteApp0, remoteApp1}, []description.Relation{relation0, relation1})
+	_, err := UniqueRemoteOfferApplications([]description.RemoteApplication{remoteApp0, remoteApp1})
 	c.Assert(err, tc.ErrorMatches, "multiple remote application offerers with the same offer UUID.*but different source model UUIDs.*")
 }
 
 func (s *relationSuite) TestUniqueRemoteOfferApplicationsInvalidEndpoints(c *tc.C) {
 	m := description.NewModel(description.ModelArgs{})
-	relation0 := m.AddRelation(description.RelationArgs{
-		Id:  0,
-		Key: "foo:sink dummy-sink:source",
-	})
-	relation0.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "dummy-sink",
-		Name:            "source",
-	})
-	relation0.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "foo",
-		Name:            "sink",
-	})
-
-	relation1 := m.AddRelation(description.RelationArgs{
-		Id:  1,
-		Key: "baz:sink dummy-sink:source",
-	})
-
-	relation1.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "dummy-sink",
-		Name:            "source",
-	})
-	relation1.AddEndpoint(description.EndpointArgs{
-		ApplicationName: "baz",
-		Name:            "sink",
-	})
 
 	remoteApp0 := m.AddRemoteApplication(description.RemoteApplicationArgs{
 		Name:            "foo",
@@ -494,7 +318,7 @@ func (s *relationSuite) TestUniqueRemoteOfferApplicationsInvalidEndpoints(c *tc.
 		Role:      "foo",
 	})
 
-	_, err := UniqueRemoteOfferApplications([]description.RemoteApplication{remoteApp0, remoteApp1}, []description.Relation{relation0, relation1})
+	_, err := UniqueRemoteOfferApplications([]description.RemoteApplication{remoteApp0, remoteApp1})
 	c.Assert(err, tc.ErrorMatches, "multiple remote application offerers with the same offer UUID.*but different endpoints.*")
 }
 

--- a/domain/modelmigration/modelmigration/relation_test.go
+++ b/domain/modelmigration/modelmigration/relation_test.go
@@ -82,7 +82,7 @@ func (s *relationSuite) TestMatchRelationEndpointByApplications(c *tc.C) {
 		c.Logf("Test case: %s", test.name)
 
 		relation, remoteApps := test.setup()
-		result := IsRelationInApplicationsName(relation, GetUniqueRemoteConsumersNames(remoteApps))
+		result := ContainsRelationEndpointApplicationName(relation, GetUniqueRemoteConsumersNames(remoteApps))
 
 		c.Assert(result, tc.Equals, test.expected)
 	}

--- a/domain/relation/errors/errors.go
+++ b/domain/relation/errors/errors.go
@@ -10,16 +10,16 @@ const (
 	// to relate two application
 	AmbiguousRelation = errors.ConstError("ambiguous relation")
 
-	// ApplicationNotFoundForRelation indicates that the application is not part of
-	// the relation.
+	// ApplicationNotFoundForRelation indicates that the application is not part
+	// of the relation.
 	ApplicationNotFoundForRelation = errors.ConstError("application not found in relation")
 
 	// BothEndpointsRemote describes an error that occurs when attempting to
 	// create a relation where both endpoints are remote (CMR) applications.
 	BothEndpointsRemote = errors.ConstError("both endpoints are remote applications")
 
-	// CompatibleEndpointsNotFound is returned when no matching relation is found when trying
-	// to relate two application
+	// CompatibleEndpointsNotFound is returned when no matching relation is
+	// found when trying to relate two application
 	CompatibleEndpointsNotFound = errors.ConstError("no compatible endpoints found between applications")
 
 	// EndpointQuotaLimitExceeded is returned when an operation fails due to
@@ -56,8 +56,8 @@ const (
 	// relation endpoint does not exist.
 	RelationEndpointNotFound = errors.ConstError("relation endpoint not found")
 
-	// RelationAlreadyExists indicates an error when attempting to create a relation
-	// that already exists between applications.
+	// RelationAlreadyExists indicates an error when attempting to create a
+	// relation that already exists between applications.
 	RelationAlreadyExists = errors.ConstError("already exists")
 
 	// RelationNotAlive describes an error that occurs when trying to update a
@@ -95,4 +95,8 @@ const (
 	// UnitNotInRelation describes an error when the unit specified is not in
 	// the relation specified.
 	UnitNotInRelation = errors.ConstError("unit not in relation")
+
+	// ApplicationEndpointNotFound describes an error that occurs when the
+	// specified application endpoint does not exist.
+	ApplicationEndpointNotFound = errors.ConstError("application endpoint not found")
 )

--- a/domain/relation/modelmigration/import.go
+++ b/domain/relation/modelmigration/import.go
@@ -76,17 +76,43 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 
 // Execute the import of application resources.
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
+	var (
+		relations          = model.Relations()
+		remoteApplications = model.RemoteApplications()
+
+		consumerRemoteApplications = domainmodelmigration.GetUniqueRemoteConsumersNames(remoteApplications)
+	)
+
 	// Get the remote applications so that we can filter out any remote consumer
 	// relations, which are not imported as part of the relation domain, but
 	// rather as part of the crossmodelrelation domain.
-	remoteApplications := domainmodelmigration.GetUniqueRemoteConsumersNames(model.RemoteApplications())
+	unique, err := domainmodelmigration.UniqueRemoteOfferApplications(remoteApplications, relations)
+	if err != nil {
+		return err
+	}
 
 	var args relation.ImportRelationsArgs
 	for _, rel := range model.Relations() {
-		if domainmodelmigration.IsRelationInApplicationsName(rel, remoteApplications) {
+		// If the relation is a remote consumer relation we skip it.
+		if domainmodelmigration.ContainsRelationEndpointApplicationName(rel, consumerRemoteApplications) {
 			continue
 		}
 
+		// If the relation is a remote offer relation, we need to work out
+		// if we need to re-write the relation endpoints, along with the
+		// relation key, to ensure that the relation is correctly imported if
+		// it has any remote applications that have be de-duplicated as part of
+		// the import in cross model relation domain.
+		if remoteApp, ok := matchesRemoteAppEndpoint(rel, unique); ok {
+			arg, err := i.createRemoteImportArg(rel, remoteApp)
+			if err != nil {
+				return errors.Errorf("setting up remote relation data for import %d: %w", rel.Id(), err)
+			}
+			args = append(args, arg)
+			continue
+		}
+
+		// This is a standard relation that we can import as is.
 		arg, err := i.createImportArg(rel)
 		if err != nil {
 			return errors.Errorf("setting up relation data for import %d: %w", rel.Id(), err)
@@ -100,8 +126,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		return nil
 	}
 
-	err := i.service.ImportRelations(ctx, args)
-	if err != nil {
+	if err := i.service.ImportRelations(ctx, args); err != nil {
 		return errors.Errorf("importing relations: %w", err)
 	}
 	return nil
@@ -131,4 +156,20 @@ func (i *importOperation) createImportArg(rel description.Relation) (relation.Im
 		})
 	}
 	return arg, nil
+}
+
+func (i *importOperation) createRemoteImportArg(rel description.Relation, remoteApp description.RemoteApplication) (relation.ImportRelationArg, error) {
+
+}
+
+func matchesRemoteAppEndpoint(rel description.Relation, remoteApps map[string]description.RemoteApplication) (description.RemoteApplication, bool) {
+	for _, endpoint := range rel.Endpoints() {
+		appName := endpoint.ApplicationName()
+		for _, remoteApp := range remoteApps {
+			if remoteApp.Name() == appName {
+				return remoteApp, true
+			}
+		}
+	}
+	return nil, false
 }

--- a/domain/relation/modelmigration/import.go
+++ b/domain/relation/modelmigration/import.go
@@ -126,7 +126,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	}
 
 	if err := i.service.ImportRelations(ctx, args); err != nil {
-		return errors.Errorf("importing relations: %w", err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -183,7 +183,7 @@ func (i *importOperation) createRemoteImportArg(rel description.Relation, remote
 	// unique across the model, instead of the original application names, which
 	// may not be unique if there are multiple remote applications with the same
 	// offer UUID that have been de-duplicated.
-	for _, ident := range key.EndpointIdentifiers() {
+	for i, ident := range key.EndpointIdentifiers() {
 		for _, remoteApp := range remoteApps {
 			if ident.ApplicationName == remoteApp.Name() {
 				// Re-write the relation key to use the remote application name,
@@ -192,6 +192,7 @@ func (i *importOperation) createRemoteImportArg(rel description.Relation, remote
 				// multiple remote applications with the same offer UUID that
 				// have been de-duplicated.
 				ident.ApplicationName = primaryApplicationName
+				key[i] = ident
 				break
 			}
 		}

--- a/domain/relation/modelmigration/import.go
+++ b/domain/relation/modelmigration/import.go
@@ -77,7 +77,6 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 // Execute the import of application resources.
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
 	var (
-		relations          = model.Relations()
 		remoteApplications = model.RemoteApplications()
 
 		consumerRemoteApplications = domainmodelmigration.GetUniqueRemoteConsumersNames(remoteApplications)
@@ -86,7 +85,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	// Get the remote applications so that we can filter out any remote consumer
 	// relations, which are not imported as part of the relation domain, but
 	// rather as part of the crossmodelrelation domain.
-	unique, err := domainmodelmigration.UniqueRemoteOfferApplications(remoteApplications, relations)
+	unique, err := domainmodelmigration.UniqueRemoteOfferApplications(remoteApplications)
 	if err != nil {
 		return err
 	}

--- a/domain/relation/modelmigration/import.go
+++ b/domain/relation/modelmigration/import.go
@@ -163,8 +163,8 @@ func (i *importOperation) createImportArg(rel description.Relation) (relation.Im
 // the remote application names, and also re-writing the relation key to ensure
 // that it is unique across the model if there are multiple relations with
 // remote applications that have been de-duplicated to have the same offer UUID.
-func (i *importOperation) createRemoteImportArg(rel description.Relation, remoteApps []description.RemoteApplication) (relation.ImportRelationArg, error) {
-	if len(remoteApps) == 0 {
+func (i *importOperation) createRemoteImportArg(rel description.Relation, remoteApps domainmodelmigration.RemoteApplicationOfferer) (relation.ImportRelationArg, error) {
+	if remoteApps.IsEmpty() {
 		// This is a programmatic error, as this function should only be called
 		// for relations that have remote applications, so we return an error if
 		// there are no remote applications provided.
@@ -172,7 +172,7 @@ func (i *importOperation) createRemoteImportArg(rel description.Relation, remote
 	}
 
 	// The first remote application name is the primary name.
-	primaryApplicationName := remoteApps[0].Name()
+	primaryApplicationName := remoteApps.Primary.Name()
 
 	key, err := corerelation.NewKeyFromString(rel.Key())
 	if err != nil {
@@ -184,13 +184,12 @@ func (i *importOperation) createRemoteImportArg(rel description.Relation, remote
 	// may not be unique if there are multiple remote applications with the same
 	// offer UUID that have been de-duplicated.
 	for i, ident := range key.EndpointIdentifiers() {
-		for _, remoteApp := range remoteApps {
+		if ident.ApplicationName == primaryApplicationName {
+			continue
+		}
+
+		for _, remoteApp := range remoteApps.Duplicates {
 			if ident.ApplicationName == remoteApp.Name() {
-				// Re-write the relation key to use the remote application name,
-				// which is unique across the model, instead of the original
-				// application name, which may not be unique if there are
-				// multiple remote applications with the same offer UUID that
-				// have been de-duplicated.
 				ident.ApplicationName = primaryApplicationName
 				key[i] = ident
 				break
@@ -215,10 +214,12 @@ func (i *importOperation) createRemoteImportArg(rel description.Relation, remote
 		// application names, which may not be unique if there are multiple
 		// remote applications with the same offer UUID that have been
 		// de-duplicated.
-		for _, remoteApp := range remoteApps {
-			if v.ApplicationName() == remoteApp.Name() {
-				applicationName = primaryApplicationName
-				break
+		if applicationName != primaryApplicationName {
+			for _, remoteApp := range remoteApps.Duplicates {
+				if v.ApplicationName() == remoteApp.Name() {
+					applicationName = primaryApplicationName
+					break
+				}
 			}
 		}
 
@@ -233,16 +234,20 @@ func (i *importOperation) createRemoteImportArg(rel description.Relation, remote
 	return arg, nil
 }
 
-func getRemoteRelation(rel description.Relation, remoteApps map[string][]description.RemoteApplication) ([]description.RemoteApplication, bool) {
+func getRemoteRelation(rel description.Relation, remoteApps map[string]domainmodelmigration.RemoteApplicationOfferer) (domainmodelmigration.RemoteApplicationOfferer, bool) {
 	for _, endpoint := range rel.Endpoints() {
 		appName := endpoint.ApplicationName()
 		for _, remoteApp := range remoteApps {
-			for _, app := range remoteApp {
+			if remoteApp.Primary.Name() == appName {
+				return remoteApp, true
+			}
+
+			for _, app := range remoteApp.Duplicates {
 				if app.Name() == appName {
 					return remoteApp, true
 				}
 			}
 		}
 	}
-	return nil, false
+	return domainmodelmigration.RemoteApplicationOfferer{}, false
 }

--- a/domain/relation/modelmigration/import.go
+++ b/domain/relation/modelmigration/import.go
@@ -103,8 +103,8 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		// relation key, to ensure that the relation is correctly imported if
 		// it has any remote applications that have be de-duplicated as part of
 		// the import in cross model relation domain.
-		if remoteApp, ok := matchesRemoteAppEndpoint(rel, unique); ok {
-			arg, err := i.createRemoteImportArg(rel, remoteApp)
+		if remoteApps, ok := getRemoteRelation(rel, unique); ok {
+			arg, err := i.createRemoteImportArg(rel, remoteApps)
 			if err != nil {
 				return errors.Errorf("setting up remote relation data for import %d: %w", rel.Id(), err)
 			}
@@ -158,16 +158,89 @@ func (i *importOperation) createImportArg(rel description.Relation) (relation.Im
 	return arg, nil
 }
 
-func (i *importOperation) createRemoteImportArg(rel description.Relation, remoteApp description.RemoteApplication) (relation.ImportRelationArg, error) {
+// createRemoteImportArg creates the import argument for a relation that has
+// remote applications, which may have been de-duplicated as part of the cross
+// model relation import. This involves re-writing the relation endpoints to use
+// the remote application names, and also re-writing the relation key to ensure
+// that it is unique across the model if there are multiple relations with
+// remote applications that have been de-duplicated to have the same offer UUID.
+func (i *importOperation) createRemoteImportArg(rel description.Relation, remoteApps []description.RemoteApplication) (relation.ImportRelationArg, error) {
+	if len(remoteApps) == 0 {
+		// This is a programmatic error, as this function should only be called
+		// for relations that have remote applications, so we return an error if
+		// there are no remote applications provided.
+		return relation.ImportRelationArg{}, errors.New("no remote applications provided for remote relation")
+	}
 
+	// The first remote application name is the primary name.
+	primaryApplicationName := remoteApps[0].Name()
+
+	key, err := corerelation.NewKeyFromString(rel.Key())
+	if err != nil {
+		return relation.ImportRelationArg{}, err
+	}
+
+	// Re-write the relation key to use the remote application names, which are
+	// unique across the model, instead of the original application names, which
+	// may not be unique if there are multiple remote applications with the same
+	// offer UUID that have been de-duplicated.
+	for _, ident := range key.EndpointIdentifiers() {
+		for _, remoteApp := range remoteApps {
+			if ident.ApplicationName == remoteApp.Name() {
+				// Re-write the relation key to use the remote application name,
+				// which is unique across the model, instead of the original
+				// application name, which may not be unique if there are
+				// multiple remote applications with the same offer UUID that
+				// have been de-duplicated.
+				ident.ApplicationName = primaryApplicationName
+				break
+			}
+		}
+	}
+
+	arg := relation.ImportRelationArg{
+		ID:    rel.Id(),
+		Key:   key,
+		Scope: charm.ScopeGlobal,
+	}
+
+	for _, v := range rel.Endpoints() {
+		if v.Scope() == string(charm.ScopeContainer) {
+			arg.Scope = charm.ScopeContainer
+		}
+
+		applicationName := v.ApplicationName()
+		// Re-write the relation endpoints to use the remote application names,
+		// which are unique across the model, instead of the original
+		// application names, which may not be unique if there are multiple
+		// remote applications with the same offer UUID that have been
+		// de-duplicated.
+		for _, remoteApp := range remoteApps {
+			if v.ApplicationName() == remoteApp.Name() {
+				applicationName = primaryApplicationName
+				break
+			}
+		}
+
+		arg.Endpoints = append(arg.Endpoints, relation.ImportEndpoint{
+			ApplicationName:     applicationName,
+			EndpointName:        v.Name(),
+			ApplicationSettings: v.ApplicationSettings(),
+			UnitSettings:        v.AllSettings(),
+		})
+	}
+
+	return arg, nil
 }
 
-func matchesRemoteAppEndpoint(rel description.Relation, remoteApps map[string]description.RemoteApplication) (description.RemoteApplication, bool) {
+func getRemoteRelation(rel description.Relation, remoteApps map[string][]description.RemoteApplication) ([]description.RemoteApplication, bool) {
 	for _, endpoint := range rel.Endpoints() {
 		appName := endpoint.ApplicationName()
 		for _, remoteApp := range remoteApps {
-			if remoteApp.Name() == appName {
-				return remoteApp, true
+			for _, app := range remoteApp {
+				if app.Name() == appName {
+					return remoteApp, true
+				}
 			}
 		}
 	}

--- a/domain/relation/modelmigration/import_test.go
+++ b/domain/relation/modelmigration/import_test.go
@@ -164,13 +164,13 @@ func (s *importSuite) TestImportSkipsConsumerRemoteRelationsWithOtherRelations(c
 		Endpoints: []relation.ImportEndpoint{{
 			ApplicationName:     "mysql",
 			EndpointName:        "db",
-			ApplicationSettings: map[string]interface{}{},
-			UnitSettings:        map[string]map[string]interface{}{},
+			ApplicationSettings: map[string]any{},
+			UnitSettings:        map[string]map[string]any{},
 		}, {
 			ApplicationName:     "ntp",
 			EndpointName:        "juju-info",
-			ApplicationSettings: map[string]interface{}{},
-			UnitSettings:        map[string]map[string]interface{}{},
+			ApplicationSettings: map[string]any{},
+			UnitSettings:        map[string]map[string]any{},
 		}},
 		Scope: charm.ScopeGlobal,
 	}}).Return(nil)
@@ -231,6 +231,333 @@ func (s *importSuite) TestImportBadKey(c *tc.C) {
 	c.Assert(err, tc.Not(tc.ErrorIsNil))
 }
 
+// Ignore consumer proxies when matching remote applications for a relation, as
+// these are not imported as part of the relation domain, but rather as part of
+// the crossmodelrelation domain.
+func (s *importSuite) TestImportConsumerRemoteRelation(c *tc.C) {
+	defer s.setupMocks(c)
+
+	model := description.NewModel(description.ModelArgs{
+		Type: coremodel.IAAS.String(),
+	})
+
+	rel := model.AddRelation(description.RelationArgs{
+		Id:  32,
+		Key: "foo:sink dummy-sink:source",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+		Name:            "sink",
+		Interface:       "dummy-token",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+		Interface:       "dummy-token",
+	})
+
+	model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "foo",
+		IsConsumerProxy: true,
+	})
+
+	importOp := importOperation{
+		service: s.service,
+		logger:  loggertesting.WrapCheckLog(c),
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.IsNil)
+}
+
+// Ignore consumer proxies when matching remote applications for a relation for
+// any endpoint application name. We can't guarantee the order of relation
+// endpoints, so we need to check all endpoints for a relation for any consumer
+// proxy remote application, and ignore the relation.
+func (s *importSuite) TestImportConsumerRemoteRelationOtherEndpoint(c *tc.C) {
+	defer s.setupMocks(c)
+
+	model := description.NewModel(description.ModelArgs{
+		Type: coremodel.IAAS.String(),
+	})
+
+	rel := model.AddRelation(description.RelationArgs{
+		Id:  32,
+		Key: "foo:sink dummy-sink:source",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+		Name:            "sink",
+		Interface:       "dummy-token",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+		Interface:       "dummy-token",
+	})
+
+	model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "dummy-sink",
+		IsConsumerProxy: true,
+	})
+
+	importOp := importOperation{
+		service: s.service,
+		logger:  loggertesting.WrapCheckLog(c),
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.IsNil)
+}
+
+func (s *importSuite) TestImportOffererRemoteRelation(c *tc.C) {
+	defer s.setupMocks(c)
+
+	model := description.NewModel(description.ModelArgs{
+		Type: coremodel.IAAS.String(),
+	})
+
+	rel := model.AddRelation(description.RelationArgs{
+		Id:  32,
+		Key: "foo:sink dummy-sink:source",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+		Name:            "sink",
+		Interface:       "dummy-token",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+		Interface:       "dummy-token",
+	})
+
+	model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name: "foo",
+	})
+
+	s.service.EXPECT().ImportRelations(gomock.Any(), relation.ImportRelationsArgs{
+		{
+			ID:  32,
+			Key: relationtesting.GenNewKey(c, "foo:sink dummy-sink:source"),
+			Endpoints: []relation.ImportEndpoint{
+				{
+					ApplicationName:     "foo",
+					EndpointName:        "sink",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+				{
+					ApplicationName:     "dummy-sink",
+					EndpointName:        "source",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+			},
+			Scope: charm.ScopeGlobal,
+		},
+	}).Return(nil)
+
+	importOp := importOperation{
+		service: s.service,
+		logger:  loggertesting.WrapCheckLog(c),
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.IsNil)
+}
+
+// If there are multiple remote applications with the same offer UUID and
+// endpoints, but different names, we should de-duplicate these remote
+// applications and import the relation using one of these remote applications,
+// as they are effectively the same offerer application.
+func (s *importSuite) TestImportOffererRemoteRelationMultipleMatchingRemoteApplications(c *tc.C) {
+	defer s.setupMocks(c)
+
+	model := description.NewModel(description.ModelArgs{
+		Type: coremodel.IAAS.String(),
+	})
+
+	rel := model.AddRelation(description.RelationArgs{
+		Id:  32,
+		Key: "foo:sink dummy-sink:source",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+		Name:            "sink",
+		Interface:       "dummy-token",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+		Interface:       "dummy-token",
+	})
+
+	remoteApp0 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "foo",
+		OfferUUID:       "b9424bc3-1053-43a8-8386-c2faf56c4e9a",
+		SourceModelUUID: "7e2421b5-4605-42d8-8636-bfcf7c35129f",
+	})
+	remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "sink",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	remoteApp1 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "bar",
+		OfferUUID:       "b9424bc3-1053-43a8-8386-c2faf56c4e9a",
+		SourceModelUUID: "7e2421b5-4605-42d8-8636-bfcf7c35129f",
+	})
+	remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "sink",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	s.service.EXPECT().ImportRelations(gomock.Any(), relation.ImportRelationsArgs{
+		{
+			ID:  32,
+			Key: relationtesting.GenNewKey(c, "foo:sink dummy-sink:source"),
+			Endpoints: []relation.ImportEndpoint{
+				{
+					ApplicationName:     "foo",
+					EndpointName:        "sink",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+				{
+					ApplicationName:     "dummy-sink",
+					EndpointName:        "source",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+			},
+			Scope: charm.ScopeGlobal,
+		},
+	}).Return(nil)
+
+	importOp := importOperation{
+		service: s.service,
+		logger:  loggertesting.WrapCheckLog(c),
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.IsNil)
+}
+
+// Test to ensure that relations that refer to the same application with a
+// different name, that are not remote do not interfere with the import of
+// remote relations.
+func (s *importSuite) TestImportRemoteRelations(c *tc.C) {
+	defer s.setupMocks(c)
+
+	model := description.NewModel(description.ModelArgs{
+		Type: coremodel.IAAS.String(),
+	})
+
+	rel0 := model.AddRelation(description.RelationArgs{
+		Id:  32,
+		Key: "foo:sink dummy-sink:source",
+	})
+	rel0.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+		Name:            "sink",
+		Interface:       "dummy-token",
+	})
+	rel0.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+		Interface:       "dummy-token",
+	})
+
+	rel1 := model.AddRelation(description.RelationArgs{
+		Id:  33,
+		Key: "dummy-source:sink dummy-sink:source",
+	})
+	rel1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-source",
+		Name:            "sink",
+		Interface:       "dummy-token",
+	})
+	rel1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+		Interface:       "dummy-token",
+	})
+
+	remoteApp0 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "foo",
+		OfferUUID:       "b9424bc3-1053-43a8-8386-c2faf56c4e9a",
+		SourceModelUUID: "7e2421b5-4605-42d8-8636-bfcf7c35129f",
+	})
+	remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "sink",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	remoteApp1 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "bar",
+		OfferUUID:       "b9424bc3-1053-43a8-8386-c2faf56c4e9a",
+		SourceModelUUID: "7e2421b5-4605-42d8-8636-bfcf7c35129f",
+	})
+	remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "sink",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	s.service.EXPECT().ImportRelations(gomock.Any(), relation.ImportRelationsArgs{
+		{
+			ID:  32,
+			Key: relationtesting.GenNewKey(c, "foo:sink dummy-sink:source"),
+			Endpoints: []relation.ImportEndpoint{
+				{
+					ApplicationName:     "foo",
+					EndpointName:        "sink",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+				{
+					ApplicationName:     "dummy-sink",
+					EndpointName:        "source",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+			},
+			Scope: charm.ScopeGlobal,
+		},
+		{
+			ID:  33,
+			Key: relationtesting.GenNewKey(c, "dummy-source:sink dummy-sink:source"),
+			Endpoints: []relation.ImportEndpoint{
+				{
+					ApplicationName:     "dummy-source",
+					EndpointName:        "sink",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+				{
+					ApplicationName:     "dummy-sink",
+					EndpointName:        "source",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+			},
+			Scope: charm.ScopeGlobal,
+		},
+	}).Return(nil)
+
+	importOp := importOperation{
+		service: s.service,
+		logger:  loggertesting.WrapCheckLog(c),
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.IsNil)
+}
+
 func (s *importSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.service = NewMockImportService(ctrl)
@@ -265,8 +592,8 @@ func (s *importSuite) expectImportRelations(c *tc.C, data map[int]corerelation.K
 			arg.Endpoints[j] = relation.ImportEndpoint{
 				ApplicationName:     ep.ApplicationName,
 				EndpointName:        ep.EndpointName,
-				ApplicationSettings: map[string]interface{}{},
-				UnitSettings:        map[string]map[string]interface{}{},
+				ApplicationSettings: map[string]any{},
+				UnitSettings:        map[string]map[string]any{},
 			}
 		}
 		args = append(args, arg)
@@ -281,7 +608,7 @@ type relationArgMatcher struct {
 	expected relation.ImportRelationsArgs
 }
 
-func (m relationArgMatcher) Matches(x interface{}) bool {
+func (m relationArgMatcher) Matches(x any) bool {
 	obtained, ok := x.(relation.ImportRelationsArgs)
 	if !ok {
 		return false

--- a/domain/relation/modelmigration/import_test.go
+++ b/domain/relation/modelmigration/import_test.go
@@ -189,7 +189,7 @@ func (s *importSuite) TestImportSkipsConsumerRemoteRelationsWithOtherRelations(c
 
 func (s *importSuite) TestImportNoRelations(c *tc.C) {
 	// Arrange
-	defer s.setupMocks(c)
+	defer s.setupMocks(c).Finish()
 
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
@@ -209,7 +209,7 @@ func (s *importSuite) TestImportNoRelations(c *tc.C) {
 
 func (s *importSuite) TestImportBadKey(c *tc.C) {
 	// Arrange
-	defer s.setupMocks(c)
+	defer s.setupMocks(c).Finish()
 
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
@@ -235,7 +235,7 @@ func (s *importSuite) TestImportBadKey(c *tc.C) {
 // these are not imported as part of the relation domain, but rather as part of
 // the crossmodelrelation domain.
 func (s *importSuite) TestImportConsumerRemoteRelation(c *tc.C) {
-	defer s.setupMocks(c)
+	defer s.setupMocks(c).Finish()
 
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
@@ -275,7 +275,7 @@ func (s *importSuite) TestImportConsumerRemoteRelation(c *tc.C) {
 // endpoints, so we need to check all endpoints for a relation for any consumer
 // proxy remote application, and ignore the relation.
 func (s *importSuite) TestImportConsumerRemoteRelationOtherEndpoint(c *tc.C) {
-	defer s.setupMocks(c)
+	defer s.setupMocks(c).Finish()
 
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
@@ -311,7 +311,7 @@ func (s *importSuite) TestImportConsumerRemoteRelationOtherEndpoint(c *tc.C) {
 }
 
 func (s *importSuite) TestImportOffererRemoteRelation(c *tc.C) {
-	defer s.setupMocks(c)
+	defer s.setupMocks(c).Finish()
 
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
@@ -372,7 +372,7 @@ func (s *importSuite) TestImportOffererRemoteRelation(c *tc.C) {
 // applications and import the relation using one of these remote applications,
 // as they are effectively the same offerer application.
 func (s *importSuite) TestImportOffererRemoteRelationMultipleMatchingRemoteApplications(c *tc.C) {
-	defer s.setupMocks(c)
+	defer s.setupMocks(c).Finish()
 
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
@@ -446,11 +446,86 @@ func (s *importSuite) TestImportOffererRemoteRelationMultipleMatchingRemoteAppli
 	c.Assert(err, tc.IsNil)
 }
 
+func (s *importSuite) TestImportOffererRemoteRelationMultipleMatchingRemoteApplicationsSwapOrder(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	model := description.NewModel(description.ModelArgs{
+		Type: coremodel.IAAS.String(),
+	})
+
+	rel := model.AddRelation(description.RelationArgs{
+		Id:  32,
+		Key: "foo:sink dummy-sink:source",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "foo",
+		Name:            "sink",
+		Interface:       "dummy-token",
+	})
+	rel.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "dummy-sink",
+		Name:            "source",
+		Interface:       "dummy-token",
+	})
+
+	remoteApp0 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "bar",
+		OfferUUID:       "b9424bc3-1053-43a8-8386-c2faf56c4e9a",
+		SourceModelUUID: "7e2421b5-4605-42d8-8636-bfcf7c35129f",
+	})
+	remoteApp0.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "sink",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	remoteApp1 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:            "foo",
+		OfferUUID:       "b9424bc3-1053-43a8-8386-c2faf56c4e9a",
+		SourceModelUUID: "7e2421b5-4605-42d8-8636-bfcf7c35129f",
+	})
+	remoteApp1.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "sink",
+		Interface: "dummy-token",
+		Role:      "requirer",
+	})
+
+	s.service.EXPECT().ImportRelations(gomock.Any(), relation.ImportRelationsArgs{
+		{
+			ID:  32,
+			Key: relationtesting.GenNewKey(c, "bar:sink dummy-sink:source"),
+			Endpoints: []relation.ImportEndpoint{
+				{
+					ApplicationName:     "bar",
+					EndpointName:        "sink",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+				{
+					ApplicationName:     "dummy-sink",
+					EndpointName:        "source",
+					ApplicationSettings: map[string]any{},
+					UnitSettings:        map[string]map[string]any{},
+				},
+			},
+			Scope: charm.ScopeGlobal,
+		},
+	}).Return(nil)
+
+	importOp := importOperation{
+		service: s.service,
+		logger:  loggertesting.WrapCheckLog(c),
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.IsNil)
+}
+
 // Test to ensure that relations that refer to the same application with a
 // different name, that are not remote do not interfere with the import of
 // remote relations.
 func (s *importSuite) TestImportRemoteRelations(c *tc.C) {
-	defer s.setupMocks(c)
+	defer s.setupMocks(c).Finish()
 
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
@@ -561,6 +636,11 @@ func (s *importSuite) TestImportRemoteRelations(c *tc.C) {
 func (s *importSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.service = NewMockImportService(ctrl)
+
+	c.Cleanup(func() {
+		s.service = nil
+	})
+
 	return ctrl
 }
 

--- a/domain/relation/modelmigration/import_test.go
+++ b/domain/relation/modelmigration/import_test.go
@@ -52,7 +52,7 @@ func (s *importSuite) TestImport(c *tc.C) {
 
 func (s *importSuite) TestImportRelationsWithContainerScope(c *tc.C) {
 	// Arrange
-	defer s.setupMocks(c)
+	defer s.setupMocks(c).Finish()
 
 	model := s.expectImportRelations(c, map[int]corerelation.Key{
 		3: relationtesting.GenNewKey(c, "ubuntu:peer"),

--- a/domain/relation/state/migration_test.go
+++ b/domain/relation/state/migration_test.go
@@ -88,6 +88,41 @@ func (s *migrationSuite) TestImportRelation(c *tc.C) {
 	c.Assert(obtainedRelUUID, tc.Equals, foundRelUUID)
 }
 
+func (s *migrationSuite) TestImportRelationNotFound(c *tc.C) {
+	// Arrange
+	relProvider := charm.Relation{
+		Name:  "prov",
+		Role:  charm.RoleProvider,
+		Scope: charm.ScopeGlobal,
+	}
+	relRequirer := charm.Relation{
+		Name:  "req",
+		Role:  charm.RoleRequirer,
+		Scope: charm.ScopeGlobal,
+	}
+
+	charm1 := s.addCharm(c)
+	charm2 := s.addCharm(c)
+
+	appUUID1 := s.addApplication(c, charm1, "application-1")
+	appUUID2 := s.addApplication(c, charm2, "application-2")
+	_ = s.addApplicationEndpointFromRelation(c, charm1, appUUID1, relProvider)
+	_ = s.addApplicationEndpointFromRelation(c, charm1, appUUID2, relRequirer)
+	expectedRelID := uint64(42)
+
+	// Act
+	_, err := s.state.ImportRelation(c.Context(), corerelation.EndpointIdentifier{
+		ApplicationName: "application-1",
+		EndpointName:    "req",
+	}, corerelation.EndpointIdentifier{
+		ApplicationName: "application-2",
+		EndpointName:    "prov",
+	}, expectedRelID, charm.ScopeGlobal)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationEndpointNotFound)
+}
+
 func (s *migrationSuite) TestImportPeerRelation(c *tc.C) {
 	// Arrange
 	relPeer := charm.Relation{
@@ -112,6 +147,21 @@ func (s *migrationSuite) TestImportPeerRelation(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	foundRelUUID := s.fetchRelationUUIDByRelationID(c, expectedRelID)
 	c.Assert(obtainedRelUUID, tc.Equals, foundRelUUID)
+}
+
+func (s *migrationSuite) TestImportPeerRelationNotFound(c *tc.C) {
+	charm1 := s.addCharm(c)
+
+	s.addApplication(c, charm1, "application-1")
+
+	expectedRelID := uint64(43)
+
+	_, err := s.state.ImportPeerRelation(c.Context(), corerelation.EndpointIdentifier{
+		ApplicationName: "application-1",
+		EndpointName:    "peer",
+	}, expectedRelID, charm.ScopeGlobal)
+
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationEndpointNotFound)
 }
 
 func (s *migrationSuite) TestGetApplicationUUIDByName(c *tc.C) {

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -3368,7 +3368,9 @@ AND    ae.application_name = $endpointIdentifier.application_name
 	}
 	var endpoint applicationEndpointUUID
 	err = tx.Query(ctx, stmt, epIdentifier).Get(&endpoint)
-	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return "", relationerrors.ApplicationEndpointNotFound
+	} else if err != nil {
 		return "", errors.Errorf("getting application endpoint uuid for %q:%q : %w", applicationName, endpointName, err)
 	}
 

--- a/domain/status/modelmigration/import.go
+++ b/domain/status/modelmigration/import.go
@@ -243,11 +243,11 @@ func (i *importOperation) importRemoteApplicationOffererStatus(
 		// We only need the first of the remote offer applications as the rest
 		// are de-duplicated copies of the same remote application, and will
 		// have the same status.
-		if len(remoteApps) == 0 {
+		if remoteApps.IsEmpty() {
 			continue
 		}
 
-		remoteApp := remoteApps[0]
+		remoteApp := remoteApps.Primary
 		offererStatus := i.importStatus(remoteApp.Status())
 		if err := service.SetRemoteApplicationOffererStatus(ctx, remoteApp.Name(), offererStatus); err != nil {
 			return errors.Errorf("setting offerer status for remote application %q: %w", remoteApp.Name(), err)

--- a/domain/status/modelmigration/import.go
+++ b/domain/status/modelmigration/import.go
@@ -216,9 +216,9 @@ func (i *importOperation) importRelationStatus(
 ) error {
 	remoteApplications := domainmodelmigration.GetUniqueRemoteConsumersNames(model.RemoteApplications())
 	for _, relation := range model.Relations() {
-		if domainmodelmigration.IsRelationInApplicationsName(relation, remoteApplications) {
-			// Remote consumer relations are imported as part of the
-			// crossmodelrelation domain, so we skip them here.
+		// Remote consumer relations are imported as part of the
+		// crossmodelrelation domain, so we skip them here.
+		if domainmodelmigration.ContainsRelationEndpointApplicationName(relation, remoteApplications) {
 			continue
 		}
 

--- a/domain/status/modelmigration/import.go
+++ b/domain/status/modelmigration/import.go
@@ -235,7 +235,7 @@ func (i *importOperation) importRemoteApplicationOffererStatus(
 	service ImportService,
 	model description.Model,
 ) error {
-	remoteOfferApps, err := domainmodelmigration.UniqueRemoteOfferApplications(model.RemoteApplications(), model.Relations())
+	remoteOfferApps, err := domainmodelmigration.UniqueRemoteOfferApplications(model.RemoteApplications())
 	if err != nil {
 		return errors.Errorf("getting unique remote offer applications: %w", err)
 	}

--- a/domain/status/modelmigration/import.go
+++ b/domain/status/modelmigration/import.go
@@ -235,12 +235,19 @@ func (i *importOperation) importRemoteApplicationOffererStatus(
 	service ImportService,
 	model description.Model,
 ) error {
-	for _, remoteApp := range model.RemoteApplications() {
-		// Skip remote applications, we only want offerers here.
-		if remoteApp.IsConsumerProxy() {
+	remoteOfferApps, err := domainmodelmigration.UniqueRemoteOfferApplications(model.RemoteApplications(), model.Relations())
+	if err != nil {
+		return errors.Errorf("getting unique remote offer applications: %w", err)
+	}
+	for _, remoteApps := range remoteOfferApps {
+		// We only need the first of the remote offer applications as the rest
+		// are de-duplicated copies of the same remote application, and will
+		// have the same status.
+		if len(remoteApps) == 0 {
 			continue
 		}
 
+		remoteApp := remoteApps[0]
 		offererStatus := i.importStatus(remoteApp.Status())
 		if err := service.SetRemoteApplicationOffererStatus(ctx, remoteApp.Name(), offererStatus); err != nil {
 			return errors.Errorf("setting offerer status for remote application %q: %w", remoteApp.Name(), err)

--- a/domain/status/modelmigration/import_test.go
+++ b/domain/status/modelmigration/import_test.go
@@ -308,7 +308,13 @@ func (s *importSuite) TestImportRemoteApplicationOffererStatus(c *tc.C) {
 	})
 
 	remoteApp2 := model.AddRemoteApplication(description.RemoteApplicationArgs{
-		Name: "remote-app-2",
+		Name:      "remote-app-2",
+		OfferUUID: "deadbeef",
+	})
+	remoteApp2.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "foo",
+		Role:      "blah",
+		Interface: "requirer",
 	})
 	remoteApp2.SetStatus(description.StatusArgs{
 		Value:   "blocked",
@@ -318,15 +324,52 @@ func (s *importSuite) TestImportRemoteApplicationOffererStatus(c *tc.C) {
 	})
 
 	remoteApp3 := model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Name:      "remote-app-3",
+		OfferUUID: "deadbeef",
+	})
+	remoteApp3.AddEndpoint(description.RemoteEndpointArgs{
+		Name:      "foo",
+		Role:      "blah",
+		Interface: "requirer",
+	})
+	remoteApp3.SetStatus(description.StatusArgs{
+		Value:   "stopped",
+		Message: "bar3",
+		Data:    map[string]any{"bar3": "qux3"},
+		Updated: now,
+	})
+
+	remoteApp4 := model.AddRemoteApplication(description.RemoteApplicationArgs{
 		Name:            "remote-123e4567e89b12d3a456426655440000",
 		IsConsumerProxy: true,
 	})
-	remoteApp3.SetStatus(description.StatusArgs{
-		Value:   "blocked",
-		Message: "bar2",
-		Data:    map[string]any{"baz2": "qux2"},
+	remoteApp4.SetStatus(description.StatusArgs{
+		Value:   "running",
+		Message: "bar4",
+		Data:    map[string]any{"foo": "baz"},
 		Updated: now,
 	})
+
+	rel1 := model.AddRelation(description.RelationArgs{
+		Id:  1,
+		Key: "remote-app:sink dummy-sink:source",
+	})
+	rel1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "remote-app",
+	})
+	rel2 := model.AddRelation(description.RelationArgs{
+		Id:  2,
+		Key: "remote-app-2:sink dummy-sink:source",
+	})
+	rel2.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "remote-app-2",
+	})
+
+	// We require a relation to be able to validate the flow, even though we're
+	// not interested in the relation status itself
+
+	s.importService.EXPECT().ImportRelationStatus(gomock.Any(), 1, gomock.Any())
+	s.importService.EXPECT().ImportRelationStatus(gomock.Any(), 2, gomock.Any())
 
 	s.importService.EXPECT().SetRemoteApplicationOffererStatus(gomock.Any(), "remote-app", corestatus.StatusInfo{
 		Status:  corestatus.Active,


### PR DESCRIPTION
In 3.6 it's possible to have multiple SAAS applications (remote applications) for CMR (cross model relations), that use the same offer UUID and the same endpoints, but that have a different name. The idea was that you could have the same or different endpoints for the same offer UUID. This wasn't migrated to the 4.x data model. Instead, if you wanted different endpoints you would have a different offer, which resulted in a different offer UUID. This leads to a much cleaner model with regards to immutable synthetic applications, charms and units, along with simpler table construction. The data model thus becomes immutable.

There is a sticky problem though, that you can have that setup in 3.6 so we should try our best to migrate from a 3.6 model to a 4.0 where possible. This allows a model to migrate with the same endpoints for a given remote application that has the same offer UUID and source model.

When selecting a remote application to use, they're keyed on the offer UUID and the first remote application in the slice from the description package will be used as the primary one. This ensures consistency between domains if required.

> [!NOTE]
> Relating one application to the same SAAS application even though there are multiple, breaks in 3.6 where it's not possible to differentiate between the two offers, as the underlying offer UUID is the same. This is why we removed this in 4.0 as it's not possible to differentiate the two relations.
> i.e. it's kinda broken in 3.6

-----

There are a few sticky issues:

 1. Endpoints keys aren't guaranteed to be ordered. The endpoints themselves could be ordered if we always assert that the requirer comes before the provider (or some other strategy). Thus ensuring that an relation is a remote application is somewhat fragile.
 2. Building on point 1, if the endpoints differ yet the offer UUID is the same then its unlike with the current endpoint situation that we can import the SAAS/remote application easily.
 3. Lastly, importing remote applications logic is over a couple of domains, which makes this less than ideal. Consumer proxies are always in crossmodelrelation, but non-consumer proxies are in relation and status, whilst also ensuring they're not imported in crossmodelrelation. 

Having said that, it works nicely!

## QA steps

Use 3.6 (from a snap)

```sh
$ /snap/bin/juju bootstrap localhost src
$ /snap/bin/juju add-model offer && /snap/bin/juju deploy juju-qa-dummy-source && /snap/bin/juju offer dummy-source:sink
$ /snap/bin/juju add-model consume 
$ /snap/bin/juju deploy juju-qa-dummy-sink ds0
$ /snap/bin/juju deploy juju-qa-dummy-sink ds1
$ /snap/bin/juju consume src:admin/offer.dummy-source foo
$ /snap/bin/juju consume src:admin/offer.dummy-source bar
$ /snap/bin/juju relate foo ds0
$ /snap/bin/juju relate bar ds1
```

There should be two models, one offer and one consume. The consume should have two SAAS applications; foo and bar.

Ensure that the SAAS is in the blocked state!

Bootstrap 4.0

```sh
$ juju bootstrap localhost dst
$ juju migrate src:consume dst
```

Migration should work, and it should select one of the relations.

```
$ juju config -m src:offer dummy-source token=iii
$ juju status
Model    Controller  Cloud/Region       Version  Timestamp
consume  dst         localhost/default  4.0.2.3  13:30:16Z

SAAS  Status   Store  URL
foo   blocked  src    admin/offer.dummy-source

App  Version  Status   Scale  Charm               Channel        Rev  Exposed  Message
ds0           waiting      1  juju-qa-dummy-sink  latest/stable    7  no       Waiting for token
ds1           waiting      1  juju-qa-dummy-sink  latest/stable    7  no       Waiting for token

Unit    Workload  Agent  Machine  Public address  Ports  Message
ds0/0*  waiting   idle   0        10.232.51.129          Waiting for token
ds1/0   waiting   idle   1        10.232.51.215          Waiting for token

Machine  State    Address        Inst id        Base          AZ          Message
0        started  10.232.51.129  juju-ce103d-0  ubuntu@20.04  simon-work  Running
1        started  10.232.51.215  juju-ce103d-1  ubuntu@20.04  simon-work  Running
```

Ensure the model reacts to the config:

```sh
$ juju config -m src:offer dummy-source token=iii
$ juju status
Model    Controller  Cloud/Region       Version  Timestamp
consume  dst         localhost/default  4.0.3.1  14:59:13Z

SAAS  Status  Store  URL
foo   active  src    admin/offer.dummy-source

App  Version  Status  Scale  Charm               Channel        Rev  Exposed  Message
ds0           active      1  juju-qa-dummy-sink  latest/stable    7  no       Token is iii
ds1           active      1  juju-qa-dummy-sink  latest/stable    7  no       Token is iii

Unit    Workload  Agent  Machine  Public address  Ports  Message
ds0/0*  active    idle   0        10.232.51.206          Token is iii
ds1/0*  active    idle   1        10.232.51.242          Token is iii

Machine  State    Address        Inst id        Base          AZ          Message
0        started  10.232.51.206  juju-816a9c-0  ubuntu@20.04  simon-work  Running
1        started  10.232.51.242  juju-816a9c-1  ubuntu@20.04  simon-work  Running
```

### Bonus

Migrate without relations should still migrate the model and de-duplicate it:

```sh
$ /snap/bin/juju add-model consume1
$ /snap/bin/juju deploy juju-qa-dummy-sink ds0
$ /snap/bin/juju deploy juju-qa-dummy-sink ds1
$ /snap/bin/juju consume src:admin/offer.dummy-source foo
$ /snap/bin/juju consume src:admin/offer.dummy-source bar
```

Migrate it.

```
$ juju migrate src:consume1 dst
$ juju status
Model     Controller  Cloud/Region       Version  Timestamp
consume1  dst         localhost/default  4.0.3.1  15:02:01Z

SAAS  Status  Store  URL
foo   active  src    admin/offer.dummy-source

App  Version  Status       Scale  Charm               Channel        Rev  Exposed  Message
ds0           maintenance      1  juju-qa-dummy-sink  latest/stable    7  no       Started
ds1           maintenance      1  juju-qa-dummy-sink  latest/stable    7  no       Started

Unit    Workload     Agent  Machine  Public address  Ports  Message
ds0/0*  maintenance  idle   0        10.232.51.72           Started
ds1/0*  maintenance  idle   1        10.232.51.207          Started

Machine  State    Address        Inst id        Base          AZ          Message
0        started  10.232.51.72   juju-a958c1-0  ubuntu@20.04  simon-work  Running
1        started  10.232.51.207  juju-a958c1-1  ubuntu@20.04  simon-work  Running
```


## Links


**Issue:** Fixes https://github.com/juju/juju/issues/21768

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
