### PR TITLE
fix(offer): use charm reference_name instead of metadata name in v_offer_detail view

### DIFF
--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -518,7 +518,6 @@ func (s *modelOfferSuite) TestGetConsumeDetailsNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferNotFound)
 }
 
-// setupForGetOfferDetails
 func (s *modelOfferSuite) setupForGetOfferDetails(c *tc.C) []*crossmodelrelation.OfferDetail {
 	// Create an offer with one endpoint.
 	// Use a distinct reference_name vs charm_metadata.name to ensure
@@ -582,7 +581,6 @@ func (s *modelOfferSuite) setupForGetOfferDetails(c *tc.C) []*crossmodelrelation
 	}
 }
 
-// setupOfferWithInterface
 func (s *modelOfferSuite) setupOfferWithInterface(c *tc.C, interfaceName string) []*crossmodelrelation.OfferDetail {
 	// Create an offer with one endpoint.
 	// Use a distinct reference_name vs charm_metadata.name to ensure

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -520,8 +520,11 @@ func (s *modelOfferSuite) TestGetConsumeDetailsNotFound(c *tc.C) {
 
 // setupForGetOfferDetails
 func (s *modelOfferSuite) setupForGetOfferDetails(c *tc.C) []*crossmodelrelation.OfferDetail {
-	// Create an offer with one endpoint
-	charmUUID := s.addCharm(c)
+	// Create an offer with one endpoint.
+	// Use a distinct reference_name vs charm_metadata.name to ensure
+	// the view returns reference_name (the correct charm name).
+	charmReferenceName := "test-charm"
+	charmUUID := s.addCharmWithReferenceName(c, charmReferenceName)
 	description := "testing application"
 	s.addCharmMetadataWithDescription(c, charmUUID, description)
 	relation := charm.Relation{
@@ -560,7 +563,7 @@ func (s *modelOfferSuite) setupForGetOfferDetails(c *tc.C) []*crossmodelrelation
 			ApplicationName:        appName,
 			ApplicationDescription: description,
 			CharmLocator: domaincharm.CharmLocator{
-				Name:         charmUUID.String(),
+				Name:         charmReferenceName,
 				Revision:     42,
 				Source:       domaincharm.CharmHubSource,
 				Architecture: architecture.AMD64,
@@ -579,10 +582,13 @@ func (s *modelOfferSuite) setupForGetOfferDetails(c *tc.C) []*crossmodelrelation
 	}
 }
 
-// setupForGetOfferDetails
+// setupOfferWithInterface
 func (s *modelOfferSuite) setupOfferWithInterface(c *tc.C, interfaceName string) []*crossmodelrelation.OfferDetail {
-	// Create an offer with one endpoint
-	charmUUID := s.addCharm(c)
+	// Create an offer with one endpoint.
+	// Use a distinct reference_name vs charm_metadata.name to ensure
+	// the view returns reference_name (the correct charm name).
+	charmReferenceName := "second-charm"
+	charmUUID := s.addCharmWithReferenceName(c, charmReferenceName)
 	description := "second testing application"
 	s.addCharmMetadataWithDescription(c, charmUUID, description)
 	relation := charm.Relation{
@@ -606,7 +612,7 @@ func (s *modelOfferSuite) setupOfferWithInterface(c *tc.C, interfaceName string)
 			ApplicationName:        appName,
 			ApplicationDescription: description,
 			CharmLocator: domaincharm.CharmLocator{
-				Name:         charmUUID.String(),
+				Name:         charmReferenceName,
 				Revision:     42,
 				Source:       domaincharm.CharmHubSource,
 				Architecture: architecture.AMD64,

--- a/domain/crossmodelrelation/state/model/package_test.go
+++ b/domain/crossmodelrelation/state/model/package_test.go
@@ -116,13 +116,17 @@ VALUES (?, ?, ?, ?)
 
 // addCharm inserts a new charm into the database and returns the UUID.
 func (s *baseSuite) addCharm(c *tc.C) corecharm.ID {
+	return s.addCharmWithReferenceName(c, corecharmtesting.GenCharmID(c).String())
+}
+
+// addCharmWithReferenceName inserts a new charm into the database with the
+// specified reference name and returns the UUID.
+func (s *baseSuite) addCharmWithReferenceName(c *tc.C, referenceName string) corecharm.ID {
 	charmUUID := corecharmtesting.GenCharmID(c)
-	// The UUID is also used as the reference_name as there is a unique
-	// constraint on the reference_name, revision.
 	s.query(c, `
 INSERT INTO charm (uuid, reference_name, revision)
 VALUES (?, ?, 42)
-`, charmUUID, charmUUID)
+`, charmUUID, referenceName)
 	return charmUUID
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -148,6 +148,7 @@ var modelPostPatchFilesByVersion = []struct {
 		"0045-veth-nic-type.PATCH.sql",
 		"0046-relation.PATCH.sql",
 		"0047-secret.PATCH.sql",
+		"0048-offer.PATCH.sql",
 	},
 }}
 

--- a/domain/schema/model/sql/0032-offer.sql
+++ b/domain/schema/model/sql/0032-offer.sql
@@ -36,7 +36,7 @@ SELECT
     o.name AS offer_name,
     a.name AS application_name,
     cm.description AS application_description,
-    c.reference_name AS charm_name,
+    cm.name AS charm_name,
     c.revision AS charm_revision,
     cs.name AS charm_source,
     c.architecture_id AS charm_architecture,

--- a/domain/schema/model/sql/0048-offer.PATCH.sql
+++ b/domain/schema/model/sql/0048-offer.PATCH.sql
@@ -1,12 +1,12 @@
 -- Add indexes for efficient view queries.
 CREATE INDEX IF NOT EXISTS idx_offer_connection_offer_uuid
-    ON offer_connection (offer_uuid);
+ON offer_connection (offer_uuid);
 
 CREATE INDEX IF NOT EXISTS idx_offer_connection_remote_relation_offer
-    ON offer_connection (remote_relation_uuid, offer_uuid);
+ON offer_connection (remote_relation_uuid, offer_uuid);
 
 CREATE INDEX IF NOT EXISTS idx_relation_status_type_relation
-    ON relation_status (relation_status_type_id, relation_uuid);
+ON relation_status (relation_status_type_id, relation_uuid);
 
 DROP VIEW v_offer_detail;
 
@@ -18,16 +18,18 @@ WITH total_conn AS (
     FROM offer_connection
     GROUP BY offer_uuid
 ),
+
 active_conn AS (
     SELECT
         oc.offer_uuid,
         COUNT(*) AS total_active_connections
     FROM offer_connection AS oc
     JOIN relation_status AS rs
-      ON rs.relation_uuid = oc.remote_relation_uuid
-     AND rs.relation_status_type_id = 1
+        ON oc.remote_relation_uuid = rs.relation_uuid
+        AND rs.relation_status_type_id = 1
     GROUP BY oc.offer_uuid
 )
+
 SELECT
     o.uuid AS offer_uuid,
     o.name AS offer_name,
@@ -47,9 +49,9 @@ FROM offer AS o
 JOIN offer_endpoint AS oe ON o.uuid = oe.offer_uuid
 JOIN application_endpoint AS ae ON oe.endpoint_uuid = ae.uuid
 JOIN application AS a ON ae.application_uuid = a.uuid
+JOIN charm AS c ON a.charm_uuid = c.uuid
 JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
 JOIN charm_relation_role AS crr ON cr.role_id = crr.id
-JOIN charm AS c ON a.charm_uuid = c.uuid
 JOIN charm_source AS cs ON c.source_id = cs.id
 JOIN charm_metadata AS cm ON c.uuid = cm.charm_uuid
 LEFT JOIN total_conn AS tc ON tc.offer_uuid = o.uuid

--- a/domain/schema/model/sql/0048-offer.PATCH.sql
+++ b/domain/schema/model/sql/0048-offer.PATCH.sql
@@ -1,24 +1,4 @@
-CREATE TABLE offer (
-    uuid TEXT NOT NULL PRIMARY KEY,
-    name TEXT NOT NULL
-);
-
--- The offer_endpoint table is a join table to indicate which application
--- endpoints are included in the offer.
---
--- Note: trg_ensure_single_app_per_offer ensures that for every offer,
--- each endpoint_uuid is for the same application.
-CREATE TABLE offer_endpoint (
-    offer_uuid TEXT NOT NULL,
-    endpoint_uuid TEXT NOT NULL,
-    PRIMARY KEY (offer_uuid, endpoint_uuid),
-    CONSTRAINT fk_endpoint_uuid
-    FOREIGN KEY (endpoint_uuid)
-    REFERENCES application_endpoint (uuid),
-    CONSTRAINT fk_offer_uuid
-    FOREIGN KEY (offer_uuid)
-    REFERENCES offer (uuid)
-);
+DROP VIEW v_offer_detail;
 
 CREATE VIEW v_offer_detail AS
 WITH conn AS (
@@ -43,6 +23,7 @@ SELECT
     cr.name AS endpoint_name,
     crr.name AS endpoint_role,
     cr.interface AS endpoint_interface,
+    cr.capacity AS endpoint_limit,
     (SELECT COUNT(*) FROM conn AS c WHERE o.uuid = c.offer_uuid) AS total_connections,
     (SELECT COUNT(*) FROM active_conn AS ac WHERE o.uuid = ac.offer_uuid) AS total_active_connections
 FROM offer AS o

--- a/domain/schema/model/sql/0048-offer.PATCH.sql
+++ b/domain/schema/model/sql/0048-offer.PATCH.sql
@@ -54,5 +54,5 @@ JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
 JOIN charm_relation_role AS crr ON cr.role_id = crr.id
 JOIN charm_source AS cs ON c.source_id = cs.id
 JOIN charm_metadata AS cm ON c.uuid = cm.charm_uuid
-LEFT JOIN total_conn AS tc ON tc.offer_uuid = o.uuid
-LEFT JOIN active_conn AS ac ON ac.offer_uuid = o.uuid;
+LEFT JOIN total_conn AS tc ON o.uuid = tc.offer_uuid
+LEFT JOIN active_conn AS ac ON o.uuid = ac.offer_uuid

--- a/domain/schema/model/sql/0048-offer.PATCH.sql
+++ b/domain/schema/model/sql/0048-offer.PATCH.sql
@@ -1,16 +1,33 @@
+-- Add indexes for efficient view queries.
+CREATE INDEX IF NOT EXISTS idx_offer_connection_offer_uuid
+    ON offer_connection (offer_uuid);
+
+CREATE INDEX IF NOT EXISTS idx_offer_connection_remote_relation_offer
+    ON offer_connection (remote_relation_uuid, offer_uuid);
+
+CREATE INDEX IF NOT EXISTS idx_relation_status_type_relation
+    ON relation_status (relation_status_type_id, relation_uuid);
+
 DROP VIEW v_offer_detail;
 
 CREATE VIEW v_offer_detail AS
-WITH conn AS (
-    SELECT offer_uuid FROM offer_connection
+WITH total_conn AS (
+    SELECT
+        offer_uuid,
+        COUNT(*) AS total_connections
+    FROM offer_connection
+    GROUP BY offer_uuid
 ),
-
 active_conn AS (
-    SELECT oc.offer_uuid FROM offer_connection AS oc
-    JOIN relation_status AS rs ON oc.remote_relation_uuid = rs.relation_uuid
-    WHERE rs.relation_status_type_id = 1
+    SELECT
+        oc.offer_uuid,
+        COUNT(*) AS total_active_connections
+    FROM offer_connection AS oc
+    JOIN relation_status AS rs
+      ON rs.relation_uuid = oc.remote_relation_uuid
+     AND rs.relation_status_type_id = 1
+    GROUP BY oc.offer_uuid
 )
-
 SELECT
     o.uuid AS offer_uuid,
     o.name AS offer_name,
@@ -24,8 +41,8 @@ SELECT
     crr.name AS endpoint_role,
     cr.interface AS endpoint_interface,
     cr.capacity AS endpoint_limit,
-    (SELECT COUNT(*) FROM conn AS c WHERE o.uuid = c.offer_uuid) AS total_connections,
-    (SELECT COUNT(*) FROM active_conn AS ac WHERE o.uuid = ac.offer_uuid) AS total_active_connections
+    COALESCE(tc.total_connections, 0) AS total_connections,
+    COALESCE(ac.total_active_connections, 0) AS total_active_connections
 FROM offer AS o
 JOIN offer_endpoint AS oe ON o.uuid = oe.offer_uuid
 JOIN application_endpoint AS ae ON oe.endpoint_uuid = ae.uuid
@@ -34,4 +51,6 @@ JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
 JOIN charm_relation_role AS crr ON cr.role_id = crr.id
 JOIN charm AS c ON a.charm_uuid = c.uuid
 JOIN charm_source AS cs ON c.source_id = cs.id
-JOIN charm_metadata AS cm ON c.uuid = cm.charm_uuid;
+JOIN charm_metadata AS cm ON c.uuid = cm.charm_uuid
+LEFT JOIN total_conn AS tc ON tc.offer_uuid = o.uuid
+LEFT JOIN active_conn AS ac ON ac.offer_uuid = o.uuid;


### PR DESCRIPTION
The v_offer_detail SQL view was selecting charm_metadata.name (the internal metadata name from metadata.yaml) instead of charm.reference_name (the canonical charm name). 

This caused `juju status` to show the application name in the Offer "Charm" column rather than the actual charm name (e.g. "dummy-source" instead of "juju-qa-dummy-source").

Fix by patching the (already patched) view.

__Note: There already was a patch on that exact same view, introduced in https://github.com/juju/juju/pull/21542. But since that patch corresponds to a relased version (4.0.1) we cannot reuse it.__

## QA steps

QA steps exactly as in the GH issue:
```
$ juju bootstrap lxd src
$ juju add-model m && juju deploy juju-qa-dummy-source && juju offer dummy-source:sink
$ juju status
```
Correct status:
```
Model  Controller  Cloud/Region         Version  Timestamp
m      c           localhost/localhost  4.0.2.1  13:19:43+01:00

App           Version  Status   Scale  Charm                 Channel        Rev  Exposed  Message
dummy-source           waiting    0/1  juju-qa-dummy-source  latest/stable    6  no       waiting for machine

Unit            Workload  Agent       Machine  Public address  Ports  Message
dummy-source/0  waiting   allocating  0                               waiting for machine

Machine  State    Address  Inst id  Base          AZ  Message
0        pending           pending  ubuntu@20.04

Offer         Application   Charm                 Rev  Connected  Endpoint  Interface    Role
dummy-source  dummy-source  juju-qa-dummy-source  6    0/0        sink      dummy-token  requirer
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21765.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9190](https://warthogs.atlassian.net/browse/JUJU-9190)


[JUJU-9190]: https://warthogs.atlassian.net/browse/JUJU-9190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ