### PR TITLE
feat: add apiclient for checkcredentialsmodels

### DIFF
--- a/api/client/cloud/cloud.go
+++ b/api/client/cloud/cloud.go
@@ -152,7 +152,7 @@ func (c *Client) UserCredentials(user names.UserTag, cloud names.CloudTag) ([]na
 // there will be detailed validation errors per model.
 func (c *Client) CheckCredentialsModels(args params.TaggedCredentials) ([]params.UpdateCredentialResult, error) {
 	var results params.UpdateCredentialResults
-	if err := c.facade.FacadeCall("UpdateCredentialsCheckModels", args, &results); err != nil {
+	if err := c.facade.FacadeCall("CheckCredentialsModels", args, &results); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return results.Results, nil

--- a/api/client/cloud/cloud_test.go
+++ b/api/client/cloud/cloud_test.go
@@ -226,8 +226,8 @@ func (s *cloudSuite) TestCheckCredentialsModels(c *gc.C) {
 
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
 	gomock.InOrder(
-		mockFacadeCaller.EXPECT().FacadeCall("UpdateCredentialsCheckModels", args, res).Return(errors.New("boom")),
-		mockFacadeCaller.EXPECT().FacadeCall("UpdateCredentialsCheckModels", args, resSuccess).SetArg(2, results).Return(nil),
+		mockFacadeCaller.EXPECT().FacadeCall("CheckCredentialsModels", args, res).Return(errors.New("boom")),
+		mockFacadeCaller.EXPECT().FacadeCall("CheckCredentialsModels", args, resSuccess).SetArg(2, results).Return(nil),
 	)
 	client := cloudapi.NewClientFromCaller(mockFacadeCaller)
 


### PR DESCRIPTION
This is required because we are moving over to the API client in JAAS, and want to call the client on a versioned basis. I noticed this wasn't added because the godoc for the facade states:

```go
// CheckCredentialsModels validates supplied cloud credentials' content against
// models that currently use these credentials.
// If there are any models that are using a credential and these models or their
// cloud instances are not going to be accessible with corresponding credential,
// there will be detailed validation errors per model.
// There's no Juju API client which uses this, but JAAS does,
func (api *CloudAPI) CheckCredentialsModels(args params.TaggedCredentials) (params.UpdateCredentialResults, error) {
	return api.commonUpdateCredentials(false, false, true, args)
}
```

Whilst incomplete, it appears that it is just stating JAAS has it's own client, but again, we're moving away from it to use Juju's. 

Side note:
I noticed this facade isn't present in 4.0. So we shouldn't merge this PR forward yet and perhaps just reimplement it at a later date once the facade is reimplemented.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

