### PR TITLE
feat: add offer UUID to crossmodel.ApplicationOfferDetails

### DIFF
--- a/api/client/applicationoffers/client.go
+++ b/api/client/applicationoffers/client.go
@@ -117,6 +117,7 @@ func offerParamsToDetails(offer params.ApplicationOfferAdminDetailsV5) (*crossmo
 		OfferName:              offer.OfferName,
 		CharmURL:               offer.CharmURL,
 		OfferURL:               offer.OfferURL,
+		OfferUUID:              offer.OfferUUID,
 		Endpoints:              eps,
 	}
 	for _, oc := range offer.Connections {

--- a/api/client/applicationoffers/client_test.go
+++ b/api/client/applicationoffers/client_test.go
@@ -165,6 +165,7 @@ func (s *crossmodelMockSuite) TestList(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []*jujucrossmodel.ApplicationOfferDetails{{
 		OfferURL:        url,
+		OfferUUID:       offerName + "-uuid",
 		OfferName:       offerName,
 		Endpoints:       []charm.Relation{{Name: "endPointA"}},
 		ApplicationName: "db2-app",
@@ -227,6 +228,7 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 	offerName := "hosted-db2"
 	access := "consume"
 	since := time.Now()
+	offerUUID := "offer-uuid"
 
 	args := params.OfferURLs{OfferURLs: []string{url}, BakeryVersion: bakery.LatestVersion}
 
@@ -238,6 +240,7 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 					ApplicationDescription: desc,
 					Endpoints:              endpoints,
 					OfferURL:               url,
+					OfferUUID:              offerUUID,
 					OfferName:              offerName,
 					Users: []params.OfferUserDetails{
 						{UserName: "fred", DisplayName: "Fred", Access: access},
@@ -263,6 +266,7 @@ func (s *crossmodelMockSuite) TestShow(c *gc.C) {
 
 	c.Assert(results, jc.DeepEquals, &jujucrossmodel.ApplicationOfferDetails{
 		OfferURL:  url,
+		OfferUUID: offerUUID,
 		OfferName: offerName,
 		Endpoints: []charm.Relation{
 			{Name: "db2", Role: "provider", Interface: "db2", Optional: false, Limit: 0, Scope: ""},
@@ -319,6 +323,8 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 	}
 	offerName := "hosted-db2"
 	args := params.OfferURLs{OfferURLs: []string{url}, BakeryVersion: bakery.LatestVersion}
+	offerUUID1 := "offer-uuid-1"
+	offerUUID2 := "offer-uuid-2"
 
 	res := new(params.ApplicationOffersResults)
 	ress := params.ApplicationOffersResults{
@@ -329,6 +335,7 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 					Endpoints:              endpoints,
 					OfferURL:               url,
 					OfferName:              offerName,
+					OfferUUID:              offerUUID1,
 				},
 			}},
 			{Result: &params.ApplicationOfferAdminDetailsV5{
@@ -337,6 +344,7 @@ func (s *crossmodelMockSuite) TestShowMultiple(c *gc.C) {
 					Endpoints:              endpoints,
 					OfferURL:               url,
 					OfferName:              offerName,
+					OfferUUID:              offerUUID2,
 				},
 			}}},
 	}

--- a/core/crossmodel/params.go
+++ b/core/crossmodel/params.go
@@ -41,6 +41,9 @@ type ApplicationOfferDetails struct {
 
 	// Users are the users able to access the offer.
 	Users []OfferUserDetails
+
+	// OfferUUID is the UUID of the offer.
+	OfferUUID string
 }
 
 // OfferUserDetails holds the details about a user's access to an offer.


### PR DESCRIPTION
This PR adds a field `OfferUUID` to the ApplicationOfferDetails struct. API client methods that fetch an `params.ApplicationOfferDetailsV5` object convert it to a `crossmodel.ApplicationOfferDetails`. The former has an OfferUUID field but the latter does not.

In JIMM we are trying to switch from direct facade calls to usage of the Juju api client package. JIMM uses the offer UUID and so switching to the api package, I noticed it was missing.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
