### PR TITLE
fix(remoterelationconsumer): clean up orphaned offer_connection when local relation is removed during registration

### DIFF
--- a/domain/crossmodelrelation/service/service.go
+++ b/domain/crossmodelrelation/service/service.go
@@ -197,6 +197,20 @@ func (w *WatchableService) WatchRemoteApplicationOfferers(ctx context.Context) (
 	)
 }
 
+// WatchDyingModel returns a watcher that emits when the model lifecycle
+// changes. This is used to notify the offering model that the consuming model
+// is going away.
+func (w *WatchableService) WatchDyingModel(ctx context.Context) (watcher.NotifyWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return w.watcherFactory.NewNotifyWatcher(
+		ctx,
+		"watch model dying",
+		eventsource.NamespaceFilter("model_life", changestream.All),
+	)
+}
+
 // WatchRemoteConsumedSecretsChanges watches secrets remotely consumed by any
 // unit of the specified app and returns a watcher which notifies of secret URIs
 // that have had a new revision added.

--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -6,6 +6,7 @@ package remoterelationconsumer
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
@@ -145,12 +146,6 @@ type localConsumerWorker struct {
 	// consume the remote application to which this worker pertains.
 	offerMacaroon *macaroon.Macaroon
 
-	// relationMacaroons caches relation-specific macaroons obtained from
-	// registerConsumerRelation. These are used in handleRelationRemoved to
-	// notify the offering model when the consuming model's relation has
-	// already been deleted by the removal worker (race condition).
-	relationMacaroons map[corerelation.UUID]*macaroon.Macaroon
-
 	consumerRelationUnitChanges chan consumerunitrelations.RelationUnitChange
 	offererRelationUnitChanges  chan offererunitrelations.RelationUnitChange
 	offererRelationChanges      chan offererrelations.RelationChange
@@ -196,8 +191,6 @@ func NewLocalConsumerWorker(config LocalConsumerWorkerConfig) (ReportableWorker,
 		offererModelUUID:  config.OffererModelUUID,
 		consumeVersion:    config.ConsumeVersion,
 		offerMacaroon:     config.Macaroon,
-
-		relationMacaroons: make(map[corerelation.UUID]*macaroon.Macaroon),
 
 		remoteRelationClientGetter: config.RemoteRelationClientGetter,
 
@@ -258,6 +251,44 @@ func (w *localConsumerWorker) Report() map[string]interface{} {
 	return result
 }
 
+// PublishModelDying notifies the offering model that the consuming model is
+// dying, so that it can mark all relations to the remote application as dying.
+// This is a best-effort notification: errors are logged but not propagated.
+// Uses a fresh context since the catacomb context may be cancelled.
+func (w *localConsumerWorker) PublishModelDying(ctx context.Context) error {
+	for _, workerName := range w.runner.WorkerNames() {
+		if !isOffererUnitRelationWorker(workerName) {
+			continue
+		}
+
+		rw, err := w.runner.Worker(workerName, ctx.Done())
+		if errors.Is(err, errors.NotFound) {
+			continue
+		} else if err != nil {
+			return err
+		}
+
+		type RelationMacaroonGetter interface {
+			RelationUUID() corerelation.UUID
+			Macaroon() *macaroon.Macaroon
+		}
+
+		relationWorker, ok := rw.(RelationMacaroonGetter)
+		if !ok {
+			return errors.Errorf("worker %q is not a RelationMacaroonGetter", workerName)
+		}
+
+		w.publishRelationDyingChange(
+			relationWorker.RelationUUID(),
+			relationWorker.Macaroon(),
+			"model is dying",
+			"model dying",
+		)
+	}
+
+	return nil
+}
+
 func (w *localConsumerWorker) loop() (err error) {
 	ctx := w.catacomb.Context(context.Background())
 
@@ -292,7 +323,6 @@ func (w *localConsumerWorker) loop() (err error) {
 	for {
 		select {
 		case <-w.catacomb.Dying():
-			w.notifyOfferingModelOnShutdown()
 			return w.catacomb.ErrDying()
 
 		case changes, ok := <-relationsWatcher.Changes():
@@ -321,18 +351,9 @@ func (w *localConsumerWorker) loop() (err error) {
 				// change appropriately.
 				details, err := w.crossModelService.GetRelationDetails(ctx, relationUUID)
 				if errors.Is(err, relationerrors.RelationNotFound) {
-					// The relation has been removed from the local
-					// (consuming) model. Notify the offering model so
-					// it can clean up the offer_connection and
-					// associated data. This covers the race where the
-					// local removal worker deletes the relation before
-					// we can send the dying notification via the normal
-					// handleRelationConsumption path.
-					w.publishRelationDyingForRemovedRelation(ctx, relationUUID)
-
-					// Ensure that we don't have any workers still
-					// running for the removed relation.
-					if err := w.handleRelationRemoved(ctx, relationUUID, 0); err != nil {
+					// Ensure that we don't have any workers still running for
+					// the removed relation.
+					if err := w.handleRelationNotFound(ctx, relationUUID); err != nil {
 						// If we fail to remove the relation, we must kill the
 						// worker, as nothing will come around and try again.
 						// Thus, kill it and force the application worker to
@@ -495,6 +516,19 @@ func (w *localConsumerWorker) remoteOfferRemoved(ctx context.Context) error {
 	return nil
 }
 
+func (w *localConsumerWorker) handleRelationNotFound(ctx context.Context, relationUUID corerelation.UUID) error {
+	// The relation has been removed from the local (consuming) model. Notify
+	// the offering model so it can clean up the offer_connection and associated
+	// data. This covers the race where the local removal worker deletes the
+	// relation before we can send the dying notification via the normal
+	// handleRelationConsumption path.
+	if err := w.publishRelationDyingForRemovedRelation(ctx, relationUUID); err != nil {
+		return errors.Annotatef(err, "notifying offering model of removed relation %q", relationUUID)
+	}
+
+	return w.handleRelationRemoved(ctx, relationUUID, 0)
+}
+
 func (w *localConsumerWorker) handleRelationRemoved(ctx context.Context, relationUUID corerelation.UUID, inScopeUnits int) error {
 	w.logger.Debugf(ctx, "relation %q removed", relationUUID)
 
@@ -523,12 +557,6 @@ func (w *localConsumerWorker) handleRelationRemoved(ctx context.Context, relatio
 	return nil
 }
 
-// publishRelationDyingForRemovedRelation notifies the offering model that a
-// relation has been removed from the consuming model. This handles the race
-// condition where the local removal worker deletes the relation before the
-// localConsumerWorker can send the dying notification via the normal
-// handleRelationConsumption → handleRelationDying path.
-// This is a best-effort notification: errors are logged but not propagated.
 // publishRelationDyingChange sends a ForceCleanup notification to the offering
 // model for a relation. This is a best-effort notification: errors are logged
 // but not propagated. Uses a fresh context since the catacomb context may be
@@ -563,12 +591,22 @@ func (w *localConsumerWorker) publishRelationDyingChange(
 	}
 }
 
-func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(_ context.Context, relationUUID corerelation.UUID) {
-	mac, ok := w.relationMacaroons[relationUUID]
-	if !ok {
-		return
+func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(ctx context.Context, relationUUID corerelation.UUID) error {
+	offererUnitRelationWorker, err := w.runner.Worker(offererUnitRelationWorkerName(relationUUID), ctx.Done())
+	if errors.Is(err, errors.NotFound) {
+		// If the worker doesn't exist, then it either hasn't been created yet,
+		// or has already been removed, in either case, we can skip sending the
+		// notification.
+		return nil
+	} else if err != nil {
+		return errors.Annotatef(err, "stopping offerer unit relation worker for %q", relationUUID)
 	}
-	defer delete(w.relationMacaroons, relationUUID)
+
+	type MacaroonGetter interface {
+		Macaroon() *macaroon.Macaroon
+	}
+
+	mac := offererUnitRelationWorker.(MacaroonGetter).Macaroon()
 
 	w.publishRelationDyingChange(
 		relationUUID,
@@ -576,6 +614,8 @@ func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(_ context.C
 		"relation %q removed locally, notifying offering model",
 		"removal",
 	)
+
+	return nil
 }
 
 // publishRelationDyingWithMacaroon sends a ForceCleanup notification to the
@@ -592,26 +632,6 @@ func (w *localConsumerWorker) publishRelationDyingWithMacaroon(relationUUID core
 		"relation %q removed locally during registration, notifying offering model",
 		"removal during registration",
 	)
-}
-
-// notifyOfferingModelOnShutdown sends ForceCleanup notifications for all
-// relations that still have cached macaroons when the worker is shutting down.
-// Relations that had their dying notification sent successfully via the normal
-// path will have had their macaroons removed from the cache already.
-// This uses a fresh context since the catacomb context is cancelled on shutdown.
-func (w *localConsumerWorker) notifyOfferingModelOnShutdown() {
-	if len(w.relationMacaroons) == 0 || w.remoteModelClient == nil {
-		return
-	}
-
-	for relationUUID, mac := range w.relationMacaroons {
-		w.publishRelationDyingChange(
-			relationUUID,
-			mac,
-			"worker shutting down, notifying offering model about relation %q",
-			"on shutdown",
-		)
-	}
 }
 
 // handleConsumerRelationChange processes changes to the relation as recorded in
@@ -706,12 +726,6 @@ func (w *localConsumerWorker) handleRelationConsumption(
 
 	w.logger.Debugf(ctx, "consumer relation registered for %q: %v", details.UUID, result)
 
-	// Cache the relation-specific macaroon so that it can be used to notify
-	// the offering model if the relation is removed locally before the
-	// localConsumerWorker can process the dying event (race with the removal
-	// worker).
-	w.relationMacaroons[details.UUID] = result.macaroon
-
 	// Start the remote relation worker to watch for offerer relation changes.
 	// The aim is to ensure that we can track the suspended status of the
 	// relation so we can correctly react to that.
@@ -738,10 +752,6 @@ func (w *localConsumerWorker) handleRelationConsumption(
 		if err := w.handleRelationDying(ctx, details.UUID, result.macaroon, !relationKnown); err != nil {
 			return err
 		}
-		// Clean up the cached macaroon since the offering model has been
-		// successfully notified via the normal path. This avoids sending
-		// a duplicate forced notification from handleRelationRemoved later.
-		delete(w.relationMacaroons, details.UUID)
 		return nil
 	}
 
@@ -1248,6 +1258,10 @@ func consumerUnitRelationWorkerName(relationUUID corerelation.UUID) string {
 
 func offererUnitRelationWorkerName(relationUUID corerelation.UUID) string {
 	return fmt.Sprintf("offerer-unit-relation:%s", relationUUID)
+}
+
+func isOffererUnitRelationWorker(name string) bool {
+	return strings.HasPrefix(name, "offerer-unit-relation:")
 }
 
 func offererRelationWorkerName(relationUUID corerelation.UUID) string {

--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -145,6 +145,12 @@ type localConsumerWorker struct {
 	// consume the remote application to which this worker pertains.
 	offerMacaroon *macaroon.Macaroon
 
+	// relationMacaroons caches relation-specific macaroons obtained from
+	// registerConsumerRelation. These are used in handleRelationRemoved to
+	// notify the offering model when the consuming model's relation has
+	// already been deleted by the removal worker (race condition).
+	relationMacaroons map[corerelation.UUID]*macaroon.Macaroon
+
 	consumerRelationUnitChanges chan consumerunitrelations.RelationUnitChange
 	offererRelationUnitChanges  chan offererunitrelations.RelationUnitChange
 	offererRelationChanges      chan offererrelations.RelationChange
@@ -190,6 +196,8 @@ func NewLocalConsumerWorker(config LocalConsumerWorkerConfig) (ReportableWorker,
 		offererModelUUID:  config.OffererModelUUID,
 		consumeVersion:    config.ConsumeVersion,
 		offerMacaroon:     config.Macaroon,
+
+		relationMacaroons: make(map[corerelation.UUID]*macaroon.Macaroon),
 
 		remoteRelationClientGetter: config.RemoteRelationClientGetter,
 
@@ -284,6 +292,7 @@ func (w *localConsumerWorker) loop() (err error) {
 	for {
 		select {
 		case <-w.catacomb.Dying():
+			w.notifyOfferingModelOnShutdown()
 			return w.catacomb.ErrDying()
 
 		case changes, ok := <-relationsWatcher.Changes():
@@ -312,8 +321,17 @@ func (w *localConsumerWorker) loop() (err error) {
 				// change appropriately.
 				details, err := w.crossModelService.GetRelationDetails(ctx, relationUUID)
 				if errors.Is(err, relationerrors.RelationNotFound) {
-					// Relation has been removed, ensure that we don't have
-					// any workers still running for it.
+					// The relation has been removed from the local
+					// (consuming) model. Notify the offering model so
+					// it can clean up the offer_connection and
+					// associated data. This covers the race where the
+					// local removal worker deletes the relation before
+					// we can send the dying notification via the normal
+					// handleRelationConsumption path.
+					w.publishRelationDyingForRemovedRelation(ctx, relationUUID)
+
+					// Ensure that we don't have any workers still
+					// running for the removed relation.
 					if err := w.handleRelationRemoved(ctx, relationUUID, 0); err != nil {
 						// If we fail to remove the relation, we must kill the
 						// worker, as nothing will come around and try again.
@@ -505,6 +523,97 @@ func (w *localConsumerWorker) handleRelationRemoved(ctx context.Context, relatio
 	return nil
 }
 
+// publishRelationDyingForRemovedRelation notifies the offering model that a
+// relation has been removed from the consuming model. This handles the race
+// condition where the local removal worker deletes the relation before the
+// localConsumerWorker can send the dying notification via the normal
+// handleRelationConsumption → handleRelationDying path.
+// This is a best-effort notification: errors are logged but not propagated.
+// publishRelationDyingChange sends a ForceCleanup notification to the offering
+// model for a relation. This is a best-effort notification: errors are logged
+// but not propagated. Uses a fresh context since the catacomb context may be
+// cancelled.
+func (w *localConsumerWorker) publishRelationDyingChange(
+	relationUUID corerelation.UUID,
+	mac *macaroon.Macaroon,
+	debugMsg string,
+	errorMsgContext string,
+) {
+	if w.remoteModelClient == nil {
+		return
+	}
+
+	publishCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	w.logger.Debugf(publishCtx, debugMsg, relationUUID)
+
+	change := params.RemoteRelationChangeEvent{
+		RelationToken:           relationUUID.String(),
+		Life:                    life.Dying,
+		ApplicationOrOfferToken: w.offerUUID,
+		Macaroons:               macaroon.Slice{mac},
+		BakeryVersion:           defaultBakeryVersion,
+		ForceCleanup:            ptr(true),
+	}
+	if err := w.remoteModelClient.PublishRelationChange(publishCtx, change); err != nil {
+		if !isNotFound(err) {
+			w.logger.Warningf(publishCtx, "notifying offering model of relation %q %s: %v", relationUUID, errorMsgContext, err)
+		}
+	}
+}
+
+func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(_ context.Context, relationUUID corerelation.UUID) {
+	mac, ok := w.relationMacaroons[relationUUID]
+	if !ok {
+		return
+	}
+	defer delete(w.relationMacaroons, relationUUID)
+
+	w.publishRelationDyingChange(
+		relationUUID,
+		mac,
+		"relation %q removed locally, notifying offering model",
+		"removal",
+	)
+}
+
+// publishRelationDyingWithMacaroon sends a ForceCleanup notification to the
+// offering model for a relation using the given macaroon. This handles the case
+// where RegisterRemoteRelations succeeded (creating the offer_connection) but a
+// subsequent local operation failed because the relation was already removed by
+// the removal worker. Uses a fresh context since the catacomb context may be
+// cancelled. This is a best-effort notification: errors are logged but not
+// propagated.
+func (w *localConsumerWorker) publishRelationDyingWithMacaroon(relationUUID corerelation.UUID, mac *macaroon.Macaroon) {
+	w.publishRelationDyingChange(
+		relationUUID,
+		mac,
+		"relation %q removed locally during registration, notifying offering model",
+		"removal during registration",
+	)
+}
+
+// notifyOfferingModelOnShutdown sends ForceCleanup notifications for all
+// relations that still have cached macaroons when the worker is shutting down.
+// Relations that had their dying notification sent successfully via the normal
+// path will have had their macaroons removed from the cache already.
+// This uses a fresh context since the catacomb context is cancelled on shutdown.
+func (w *localConsumerWorker) notifyOfferingModelOnShutdown() {
+	if len(w.relationMacaroons) == 0 || w.remoteModelClient == nil {
+		return
+	}
+
+	for relationUUID, mac := range w.relationMacaroons {
+		w.publishRelationDyingChange(
+			relationUUID,
+			mac,
+			"worker shutting down, notifying offering model about relation %q",
+			"on shutdown",
+		)
+	}
+}
+
 // handleConsumerRelationChange processes changes to the relation as recorded in
 // the local model when a change event arrives from the remote model.
 func (w *localConsumerWorker) handleConsumerRelationChange(ctx context.Context, details relation.RelationDetails) error {
@@ -597,6 +706,12 @@ func (w *localConsumerWorker) handleRelationConsumption(
 
 	w.logger.Debugf(ctx, "consumer relation registered for %q: %v", details.UUID, result)
 
+	// Cache the relation-specific macaroon so that it can be used to notify
+	// the offering model if the relation is removed locally before the
+	// localConsumerWorker can process the dying event (race with the removal
+	// worker).
+	w.relationMacaroons[details.UUID] = result.macaroon
+
 	// Start the remote relation worker to watch for offerer relation changes.
 	// The aim is to ensure that we can track the suspended status of the
 	// relation so we can correctly react to that.
@@ -620,7 +735,14 @@ func (w *localConsumerWorker) handleRelationConsumption(
 	// Handle the case where the relation is dying, and ensure we have no
 	// workers still running for it.
 	if life.IsNotAlive(details.Life) {
-		return w.handleRelationDying(ctx, details.UUID, result.macaroon, !relationKnown)
+		if err := w.handleRelationDying(ctx, details.UUID, result.macaroon, !relationKnown); err != nil {
+			return err
+		}
+		// Clean up the cached macaroon since the offering model has been
+		// successfully notified via the normal path. This avoids sending
+		// a duplicate forced notification from handleRelationRemoved later.
+		delete(w.relationMacaroons, details.UUID)
+		return nil
 	}
 
 	return nil
@@ -827,6 +949,12 @@ func (w *localConsumerWorker) registerConsumerRelation(
 	// We have a new macaroon attenuated to the relation.
 	// Save for the firewaller.
 	if err := w.crossModelService.SaveMacaroonForRelation(ctx, relationUUID, registerResult.Macaroon); err != nil {
+		// If saving the macaroon fails because the local relation was deleted
+		// by the removal worker (FK constraint), the offer_connection was
+		// already created on the offering side by RegisterRemoteRelations
+		// above. Immediately notify the offering model to clean it up,
+		// using the macaroon we just received.
+		w.publishRelationDyingWithMacaroon(relationUUID, registerResult.Macaroon)
 		return consumerRelationResult{}, errors.Annotatef(err, "saving macaroon for %q", relationUUID)
 	}
 

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -389,6 +389,14 @@ func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChangedNotFound(c *
 			return domainrelation.RelationDetails{}, relationerrors.RelationNotFound
 		})
 
+	// Expect the notification to the offering model when the relation is found
+	// to be removed and the offerer unit worker has a macaroon.
+	mac := newMacaroon(c, "relation-mac")
+	s.remoteModelRelationClient.EXPECT().
+		PublishRelationChange(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
 	w := s.newLocalConsumerWorker(c)
 	defer workertest.DirtyKill(c, w)
 
@@ -398,7 +406,7 @@ func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChangedNotFound(c *
 		return newErrWorker(nil), nil
 	})
 	w.runner.StartWorker(c.Context(), offererUnitRelationWorkerName(relationUUID), func(ctx context.Context) (worker.Worker, error) {
-		return newErrWorker(nil), nil
+		return newMacaroonErrWorker(mac, relationUUID), nil
 	})
 
 	s.waitForWorkerStarted(c, w.runner,
@@ -588,7 +596,6 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerRelationChange(c *tc.C) {
 
 	s.waitForAllWorkersStarted(c)
 
-	s.allowShutdownPublish()
 }
 
 func (s *localConsumerWorkerSuite) TestHandleConsumerRelationChangeApplicationNotFound(c *tc.C) {
@@ -1225,7 +1232,6 @@ func (s *localConsumerWorkerSuite) TestHandleRelationConsumption(c *tc.C) {
 		"consumer-unit-relation:" + consumingRelationUUID.String(),
 	})
 
-	s.allowShutdownPublish()
 	workertest.CleanKill(c, w)
 }
 
@@ -1307,7 +1313,6 @@ func (s *localConsumerWorkerSuite) TestHandleRelationConsumptionEnsureSingular(c
 		"consumer-unit-relation:" + consumingRelationUUID.String(),
 	})
 
-	s.allowShutdownPublish()
 	workertest.CleanKill(c, w)
 }
 
@@ -1582,7 +1587,6 @@ func (s *localConsumerWorkerSuite) TestHandleSecretRevisionChange(c *tc.C) {
 		c.Fatalf("timed out waiting for secret to be updated")
 	}
 
-	s.allowShutdownPublish()
 	workertest.CleanKill(c, w)
 }
 
@@ -1943,7 +1947,6 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeAlreadyDeadWithNo
 	names = w.runner.WorkerNames()
 	c.Assert(names, tc.HasLen, 0)
 
-	s.allowShutdownPublish()
 	workertest.CleanKill(c, w)
 }
 
@@ -2849,7 +2852,7 @@ func (s *localConsumerWorkerSuite) newLocalConsumerWorkerConfig(c *tc.C) LocalCo
 			}()
 			return newErrWorker(nil), nil
 		},
-		NewOffererUnitRelationsWorker: func(offererunitrelations.Config) (offererunitrelations.ReportableWorker, error) {
+		NewOffererUnitRelationsWorker: func(cfg offererunitrelations.Config) (offererunitrelations.ReportableWorker, error) {
 			defer func() {
 				select {
 				case s.offererUnitRelationsWorkerStarted <- struct{}{}:
@@ -2857,7 +2860,7 @@ func (s *localConsumerWorkerSuite) newLocalConsumerWorkerConfig(c *tc.C) LocalCo
 					c.Fatalf("timed out trying to send on offererUnitRelationsWorkerStarted channel")
 				}
 			}()
-			return newErrWorker(nil), nil
+			return newMacaroonErrWorker(cfg.Macaroon, cfg.ConsumerRelationUUID), nil
 		},
 		NewOffererRelationsWorker: func(offererrelations.Config) (offererrelations.ReportableWorker, error) {
 			defer func() {
@@ -2910,18 +2913,6 @@ func (s *localConsumerWorkerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.secretRevisionWatcherStarted = make(chan struct{}, 1)
 
 	return ctrl
-}
-
-// allowShutdownPublish registers a catch-all PublishRelationChange expectation
-// so that the notifyOfferingModelOnShutdown cleanup during worker kill doesn't
-// cause unexpected mock call failures. Must be called AFTER all test-specific
-// PublishRelationChange expectations have been registered so that gomock matches
-// specific expectations first (FIFO order).
-func (s *localConsumerWorkerSuite) allowShutdownPublish() {
-	s.remoteModelRelationClient.EXPECT().
-		PublishRelationChange(gomock.Any(), gomock.Any()).
-		Return(nil).
-		AnyTimes()
 }
 
 func (s *localConsumerWorkerSuite) waitForAllWorkersStarted(c *tc.C) {
@@ -3073,10 +3064,11 @@ func (s *localConsumerWorkerSuite) TestRelationRemovedNotifiesOfferingModel(c *t
 	workertest.CleanKill(c, w)
 }
 
-// TestRelationRemovedWithoutCachedMacaroon tests that when a relation is
-// removed and no macaroon was cached (e.g. worker restarted), the worker
-// gracefully handles the situation without trying to notify the offering model.
-func (s *localConsumerWorkerSuite) TestRelationRemovedWithoutCachedMacaroon(c *tc.C) {
+// TestRelationRemovedWithoutOffererUnitWorker tests that when a relation is
+// removed and no offerer unit relation worker exists (e.g. worker restarted),
+// the worker gracefully handles the situation without trying to notify the
+// offering model.
+func (s *localConsumerWorkerSuite) TestRelationRemovedWithoutOffererUnitWorker(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	relationUUID := tc.Must(c, relation.NewUUID)
@@ -3104,7 +3096,7 @@ func (s *localConsumerWorkerSuite) TestRelationRemovedWithoutCachedMacaroon(c *t
 		})
 
 	// Relation is already gone. No PublishRelationChange expected because
-	// no macaroon was cached.
+	// no offerer unit worker exists.
 	s.crossModelService.EXPECT().
 		GetRelationDetails(gomock.Any(), relationUUID).
 		DoAndReturn(func(ctx context.Context, u relation.UUID) (domainrelation.RelationDetails, error) {
@@ -3115,18 +3107,15 @@ func (s *localConsumerWorkerSuite) TestRelationRemovedWithoutCachedMacaroon(c *t
 	w := s.newLocalConsumerWorker(c)
 	defer workertest.DirtyKill(c, w)
 
-	// Force the creation of the workers so handleRelationRemoved has
-	// something to clean up.
+	// Force the creation of only the consumer unit worker (no offerer unit
+	// worker). This simulates a restart where the offerer unit worker was
+	// never created for this relation.
 	w.runner.StartWorker(c.Context(), consumerUnitRelationWorkerName(relationUUID), func(ctx context.Context) (worker.Worker, error) {
-		return newErrWorker(nil), nil
-	})
-	w.runner.StartWorker(c.Context(), offererUnitRelationWorkerName(relationUUID), func(ctx context.Context) (worker.Worker, error) {
 		return newErrWorker(nil), nil
 	})
 
 	s.waitForWorkerStarted(c, w.runner,
 		consumerUnitRelationWorkerName(relationUUID),
-		offererUnitRelationWorkerName(relationUUID),
 	)
 
 	select {
@@ -3141,28 +3130,27 @@ func (s *localConsumerWorkerSuite) TestRelationRemovedWithoutCachedMacaroon(c *t
 		c.Fatalf("timed out waiting for GetRelationDetails to be called")
 	}
 
-	// Workers should be cleaned up.
+	// Consumer unit worker should be cleaned up.
 	s.waitUntilWorkerIsGone(c, w.runner,
 		consumerUnitRelationWorkerName(relationUUID),
-		offererUnitRelationWorkerName(relationUUID),
 	)
 
 	err := workertest.CheckKill(c, w)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-// TestWorkerShutdownNotifiesOfferingModel tests that when the worker is
-// killed (e.g. during model destruction), it sends ForceCleanup notifications
-// for all relations that still have cached macaroons.
+// TestPublishModelDying tests that when PublishModelDying is called
+// (e.g. during model destruction), it sends ForceCleanup notifications
+// for all relations that have offerer unit relation workers.
 // This is the main fix for https://github.com/juju/juju/issues/21771.
-func (s *localConsumerWorkerSuite) TestWorkerShutdownNotifiesOfferingModel(c *tc.C) {
+func (s *localConsumerWorkerSuite) TestPublishModelDying(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	done := s.expectWorkerStartup()
 	consumingRelationUUID := s.expectRegisterRemoteRelation(c)
 
 	// Relation is alive. This triggers registerConsumerRelation which
-	// caches the macaroon.
+	// starts the offerer unit relation worker with the macaroon.
 	s.crossModelService.EXPECT().GetRelationDetails(gomock.Any(), consumingRelationUUID).Return(domainrelation.RelationDetails{
 		UUID: consumingRelationUUID,
 		Life: life.Alive,
@@ -3186,8 +3174,7 @@ func (s *localConsumerWorkerSuite) TestWorkerShutdownNotifiesOfferingModel(c *tc
 		Suspended: false,
 	}, nil)
 
-	// Expect the shutdown notification with ForceCleanup=true when the
-	// worker is killed.
+	// Expect the model dying notification with ForceCleanup=true.
 	publishDone := make(chan struct{})
 	s.remoteModelRelationClient.EXPECT().
 		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
@@ -3211,7 +3198,7 @@ func (s *localConsumerWorkerSuite) TestWorkerShutdownNotifiesOfferingModel(c *tc
 		c.Fatalf("timed out waiting for worker to be started")
 	}
 
-	// Send the alive event to cache the macaroon.
+	// Send the alive event to start the offerer unit workers.
 	select {
 	case s.relationLifeChanges <- []string{consumingRelationUUID.String()}:
 	case <-c.Context().Done():
@@ -3220,17 +3207,16 @@ func (s *localConsumerWorkerSuite) TestWorkerShutdownNotifiesOfferingModel(c *tc
 
 	s.waitForAllWorkersStarted(c)
 
-	// Kill the worker (simulating model destruction).
-	// The shutdown path should notify the offering model.
-	w.Kill()
+	// Call PublishModelDying directly (simulating model destruction).
+	err := w.PublishModelDying(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
 
-	// Verify PublishRelationChange was called with ForceCleanup on shutdown.
+	// Verify PublishRelationChange was called with ForceCleanup.
 	select {
 	case <-publishDone:
 	case <-c.Context().Done():
-		c.Fatalf("timed out waiting for shutdown PublishRelationChange to be called")
+		c.Fatalf("timed out waiting for PublishModelDying PublishRelationChange to be called")
 	}
 
-	err := workertest.CheckKill(c, w)
-	c.Assert(err, tc.ErrorIsNil)
+	workertest.CleanKill(c, w)
 }

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -587,6 +587,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerRelationChange(c *tc.C) {
 	}
 
 	s.waitForAllWorkersStarted(c)
+
+	s.allowShutdownPublish()
 }
 
 func (s *localConsumerWorkerSuite) TestHandleConsumerRelationChangeApplicationNotFound(c *tc.C) {
@@ -1014,6 +1016,19 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationFailedToSaveMacar
 		SaveMacaroonForRelation(gomock.Any(), consumingRelationUUID, mac).
 		Return(internalerrors.Errorf("front fell off"))
 
+	// When SaveMacaroonForRelation fails, the worker should immediately
+	// notify the offering model to clean up the offer_connection that was
+	// just created by RegisterRemoteRelations.
+	s.remoteModelRelationClient.EXPECT().
+		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
+			RelationToken:           consumingRelationUUID.String(),
+			Life:                    life.Dying,
+			ApplicationOrOfferToken: s.offerUUID,
+			Macaroons:               macaroon.Slice{mac},
+			BakeryVersion:           bakery.LatestVersion,
+			ForceCleanup:            ptr(true),
+		}).Return(nil)
+
 	w := s.newLocalConsumerWorker(c)
 	defer workertest.DirtyKill(c, w)
 
@@ -1038,6 +1053,121 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationFailedToSaveMacar
 		"db",
 	)
 	c.Assert(err, tc.ErrorMatches, `.*front fell off.*`)
+}
+
+// TestRegisterConsumerRelationSaveMacaroonFailsNotifiesOfferingModel tests the
+// main fix for https://github.com/juju/juju/issues/21771.
+// When the local removal worker deletes a relation WHILE the localConsumerWorker
+// is registering it on the offering side, RegisterRemoteRelations succeeds
+// (creating the offer_connection) but SaveMacaroonForRelation fails (FK
+// constraint). The worker must immediately notify the offering model to clean up
+// the orphaned offer_connection.
+func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationSaveMacaroonFailsNotifiesOfferingModel(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	done := s.expectWorkerStartup()
+
+	consumingRelationUUID := tc.Must(c, relation.NewUUID)
+	consumingApplicationUUID := tc.Must(c, application.NewUUID)
+	offeredAppToken := tc.Must(c, uuid.NewUUID).String()
+	mac := newMacaroon(c, "test")
+
+	s.crossModelService.EXPECT().
+		GetApplicationUUIDByName(gomock.Any(), "bar").
+		Return(consumingApplicationUUID, nil)
+
+	s.remoteModelRelationClient.EXPECT().
+		RegisterRemoteRelations(gomock.Any(), params.RegisterConsumingRelationArg{
+			ConsumerApplicationToken: consumingApplicationUUID.String(),
+			SourceModelTag:           names.NewModelTag(s.consumerModelUUID.String()).String(),
+			RelationToken:            consumingRelationUUID.String(),
+			OfferUUID:                s.offerUUID,
+			Macaroons:                macaroon.Slice{s.macaroon},
+			ConsumerApplicationEndpoint: params.RemoteEndpoint{
+				Name:      "blog",
+				Role:      charm.RoleRequirer,
+				Interface: "blog",
+			},
+			OfferEndpointName: "db",
+			ConsumeVersion:    1,
+			BakeryVersion:     bakery.LatestVersion,
+		}).
+		Return([]params.RegisterConsumingRelationResult{{
+			Result: &params.ConsumingRelationDetails{
+				Token:         offeredAppToken,
+				Macaroon:      mac,
+				BakeryVersion: bakery.LatestVersion,
+			},
+		}}, nil)
+
+	// SaveMacaroonForRelation fails with FK constraint because the relation
+	// has been deleted by the removal worker during registration.
+	s.crossModelService.EXPECT().
+		SaveMacaroonForRelation(gomock.Any(), consumingRelationUUID, mac).
+		Return(internalerrors.Errorf("FOREIGN KEY constraint failed"))
+
+	// Expect the worker to immediately notify the offering model to clean
+	// up the offer_connection that was just created.
+	publishDone := make(chan struct{})
+	s.remoteModelRelationClient.EXPECT().
+		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
+			RelationToken:           consumingRelationUUID.String(),
+			Life:                    life.Dying,
+			ApplicationOrOfferToken: s.offerUUID,
+			Macaroons:               macaroon.Slice{mac},
+			BakeryVersion:           bakery.LatestVersion,
+			ForceCleanup:            ptr(true),
+		}).DoAndReturn(func(ctx context.Context, evt params.RemoteRelationChangeEvent) error {
+		defer close(publishDone)
+		return nil
+	})
+
+	s.crossModelService.EXPECT().GetRelationDetails(gomock.Any(), consumingRelationUUID).Return(domainrelation.RelationDetails{
+		UUID: consumingRelationUUID,
+		Life: life.Alive,
+		ID:   1,
+		Key:  corerelationtesting.GenNewKey(c, "blog:blog foo:db"),
+		Endpoints: []domainrelation.Endpoint{{
+			ApplicationName: "foo",
+			Relation: charm.Relation{
+				Name:      "db",
+				Role:      charm.RoleProvider,
+				Interface: "db",
+			},
+		}, {
+			ApplicationName: "bar",
+			Relation: charm.Relation{
+				Name:      "blog",
+				Role:      charm.RoleRequirer,
+				Interface: "blog",
+			},
+		}},
+		Suspended: false,
+	}, nil)
+
+	w := s.newLocalConsumerWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for worker to be started")
+	}
+
+	// Send the alive event. The worker will register the relation on the
+	// offering side, but SaveMacaroonForRelation will fail.
+	select {
+	case s.relationLifeChanges <- []string{consumingRelationUUID.String()}:
+	case <-c.Context().Done():
+		c.Fatalf("timed out sending relation change")
+	}
+
+	// Verify PublishRelationChange was called with ForceCleanup.
+	select {
+	case <-publishDone:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for PublishRelationChange to be called")
+	}
 }
 
 func (s *localConsumerWorkerSuite) TestHandleRelationConsumption(c *tc.C) {
@@ -1095,6 +1225,7 @@ func (s *localConsumerWorkerSuite) TestHandleRelationConsumption(c *tc.C) {
 		"consumer-unit-relation:" + consumingRelationUUID.String(),
 	})
 
+	s.allowShutdownPublish()
 	workertest.CleanKill(c, w)
 }
 
@@ -1176,6 +1307,7 @@ func (s *localConsumerWorkerSuite) TestHandleRelationConsumptionEnsureSingular(c
 		"consumer-unit-relation:" + consumingRelationUUID.String(),
 	})
 
+	s.allowShutdownPublish()
 	workertest.CleanKill(c, w)
 }
 
@@ -1449,6 +1581,8 @@ func (s *localConsumerWorkerSuite) TestHandleSecretRevisionChange(c *tc.C) {
 	case <-c.Context().Done():
 		c.Fatalf("timed out waiting for secret to be updated")
 	}
+
+	s.allowShutdownPublish()
 	workertest.CleanKill(c, w)
 }
 
@@ -1809,6 +1943,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeAlreadyDeadWithNo
 	names = w.runner.WorkerNames()
 	c.Assert(names, tc.HasLen, 0)
 
+	s.allowShutdownPublish()
 	workertest.CleanKill(c, w)
 }
 
@@ -2777,6 +2912,18 @@ func (s *localConsumerWorkerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	return ctrl
 }
 
+// allowShutdownPublish registers a catch-all PublishRelationChange expectation
+// so that the notifyOfferingModelOnShutdown cleanup during worker kill doesn't
+// cause unexpected mock call failures. Must be called AFTER all test-specific
+// PublishRelationChange expectations have been registered so that gomock matches
+// specific expectations first (FIFO order).
+func (s *localConsumerWorkerSuite) allowShutdownPublish() {
+	s.remoteModelRelationClient.EXPECT().
+		PublishRelationChange(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+}
+
 func (s *localConsumerWorkerSuite) waitForAllWorkersStarted(c *tc.C) {
 	select {
 	case <-s.consumerUnitRelationsWorkerStarted:
@@ -2833,4 +2980,257 @@ func (s *localConsumerWorkerSuite) waitForWorkerStarted(c *tc.C, runner *worker.
 			c.Fatalf("timed out waiting for worker %q to be gone", names)
 		}
 	}
+}
+
+// TestRelationRemovedNotifiesOfferingModel tests the fix for
+// https://github.com/juju/juju/issues/21771.
+// When the local removal worker deletes a CMR relation before the
+// localConsumerWorker can send the dying notification via the normal path,
+// the worker should use the cached macaroon to notify the offering model.
+func (s *localConsumerWorkerSuite) TestRelationRemovedNotifiesOfferingModel(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	done := s.expectWorkerStartup()
+	consumingRelationUUID := s.expectRegisterRemoteRelation(c)
+
+	// First event: relation is alive. This triggers registerConsumerRelation
+	// which caches the macaroon.
+	s.crossModelService.EXPECT().GetRelationDetails(gomock.Any(), consumingRelationUUID).Return(domainrelation.RelationDetails{
+		UUID: consumingRelationUUID,
+		Life: life.Alive,
+		ID:   1,
+		Key:  corerelationtesting.GenNewKey(c, "blog:blog foo:db"),
+		Endpoints: []domainrelation.Endpoint{{
+			ApplicationName: "foo",
+			Relation: charm.Relation{
+				Name:      "db",
+				Role:      charm.RoleProvider,
+				Interface: "db",
+			},
+		}, {
+			ApplicationName: "bar",
+			Relation: charm.Relation{
+				Name:      "blog",
+				Role:      charm.RoleRequirer,
+				Interface: "blog",
+			},
+		}},
+		Suspended: false,
+	}, nil)
+
+	// Second event: relation is gone (removal worker won the race).
+	// Expect the worker to publish dying with ForceCleanup to the offering model.
+	publishDone := make(chan struct{})
+	s.remoteModelRelationClient.EXPECT().
+		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
+			RelationToken:           consumingRelationUUID.String(),
+			Life:                    life.Dying,
+			ApplicationOrOfferToken: s.offerUUID,
+			Macaroons:               macaroon.Slice{newMacaroon(c, "test")},
+			BakeryVersion:           bakery.LatestVersion,
+			ForceCleanup:            ptr(true),
+		}).DoAndReturn(func(ctx context.Context, evt params.RemoteRelationChangeEvent) error {
+		defer close(publishDone)
+		return nil
+	})
+
+	s.crossModelService.EXPECT().GetRelationDetails(gomock.Any(), consumingRelationUUID).Return(
+		domainrelation.RelationDetails{}, relationerrors.RelationNotFound,
+	)
+
+	w := s.newLocalConsumerWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for worker to be started")
+	}
+
+	// Send the first event (relation alive) to cache the macaroon.
+	select {
+	case s.relationLifeChanges <- []string{consumingRelationUUID.String()}:
+	case <-c.Context().Done():
+		c.Fatalf("timed out sending first relation change")
+	}
+
+	s.waitForAllWorkersStarted(c)
+
+	// Send the second event (relation gone) to trigger the notification.
+	select {
+	case s.relationLifeChanges <- []string{consumingRelationUUID.String()}:
+	case <-c.Context().Done():
+		c.Fatalf("timed out sending second relation change")
+	}
+
+	// Verify that PublishRelationChange was called with ForceCleanup.
+	select {
+	case <-publishDone:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for PublishRelationChange to be called")
+	}
+
+	workertest.CleanKill(c, w)
+}
+
+// TestRelationRemovedWithoutCachedMacaroon tests that when a relation is
+// removed and no macaroon was cached (e.g. worker restarted), the worker
+// gracefully handles the situation without trying to notify the offering model.
+func (s *localConsumerWorkerSuite) TestRelationRemovedWithoutCachedMacaroon(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relationUUID := tc.Must(c, relation.NewUUID)
+	done := make(chan struct{})
+
+	ch := make(chan []string)
+	s.crossModelService.EXPECT().
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
+		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
+			return watchertest.NewMockStringsWatcher(ch), nil
+		})
+	s.remoteRelationClientGetter.EXPECT().
+		GetRemoteRelationClient(gomock.Any(), s.offererModelUUID).
+		Return(s.remoteModelRelationClient, nil)
+
+	s.remoteModelRelationClient.EXPECT().
+		WatchOfferStatus(gomock.Any(), params.OfferArg{
+			OfferUUID:     s.offerUUID,
+			Macaroons:     macaroon.Slice{s.macaroon},
+			BakeryVersion: bakery.LatestVersion,
+		}).
+		DoAndReturn(func(ctx context.Context, oa params.OfferArg) (watcher.OfferStatusWatcher, error) {
+			ch := make(chan []watcher.OfferStatusChange)
+			return watchertest.NewMockWatcher(ch), nil
+		})
+
+	// Relation is already gone. No PublishRelationChange expected because
+	// no macaroon was cached.
+	s.crossModelService.EXPECT().
+		GetRelationDetails(gomock.Any(), relationUUID).
+		DoAndReturn(func(ctx context.Context, u relation.UUID) (domainrelation.RelationDetails, error) {
+			close(done)
+			return domainrelation.RelationDetails{}, relationerrors.RelationNotFound
+		})
+
+	w := s.newLocalConsumerWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	// Force the creation of the workers so handleRelationRemoved has
+	// something to clean up.
+	w.runner.StartWorker(c.Context(), consumerUnitRelationWorkerName(relationUUID), func(ctx context.Context) (worker.Worker, error) {
+		return newErrWorker(nil), nil
+	})
+	w.runner.StartWorker(c.Context(), offererUnitRelationWorkerName(relationUUID), func(ctx context.Context) (worker.Worker, error) {
+		return newErrWorker(nil), nil
+	})
+
+	s.waitForWorkerStarted(c, w.runner,
+		consumerUnitRelationWorkerName(relationUUID),
+		offererUnitRelationWorkerName(relationUUID),
+	)
+
+	select {
+	case ch <- []string{relationUUID.String()}:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting to send on application status channel")
+	}
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for GetRelationDetails to be called")
+	}
+
+	// Workers should be cleaned up.
+	s.waitUntilWorkerIsGone(c, w.runner,
+		consumerUnitRelationWorkerName(relationUUID),
+		offererUnitRelationWorkerName(relationUUID),
+	)
+
+	err := workertest.CheckKill(c, w)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestWorkerShutdownNotifiesOfferingModel tests that when the worker is
+// killed (e.g. during model destruction), it sends ForceCleanup notifications
+// for all relations that still have cached macaroons.
+// This is the main fix for https://github.com/juju/juju/issues/21771.
+func (s *localConsumerWorkerSuite) TestWorkerShutdownNotifiesOfferingModel(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	done := s.expectWorkerStartup()
+	consumingRelationUUID := s.expectRegisterRemoteRelation(c)
+
+	// Relation is alive. This triggers registerConsumerRelation which
+	// caches the macaroon.
+	s.crossModelService.EXPECT().GetRelationDetails(gomock.Any(), consumingRelationUUID).Return(domainrelation.RelationDetails{
+		UUID: consumingRelationUUID,
+		Life: life.Alive,
+		ID:   1,
+		Key:  corerelationtesting.GenNewKey(c, "blog:blog foo:db"),
+		Endpoints: []domainrelation.Endpoint{{
+			ApplicationName: "foo",
+			Relation: charm.Relation{
+				Name:      "db",
+				Role:      charm.RoleProvider,
+				Interface: "db",
+			},
+		}, {
+			ApplicationName: "bar",
+			Relation: charm.Relation{
+				Name:      "blog",
+				Role:      charm.RoleRequirer,
+				Interface: "blog",
+			},
+		}},
+		Suspended: false,
+	}, nil)
+
+	// Expect the shutdown notification with ForceCleanup=true when the
+	// worker is killed.
+	publishDone := make(chan struct{})
+	s.remoteModelRelationClient.EXPECT().
+		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
+			RelationToken:           consumingRelationUUID.String(),
+			Life:                    life.Dying,
+			ApplicationOrOfferToken: s.offerUUID,
+			Macaroons:               macaroon.Slice{newMacaroon(c, "test")},
+			BakeryVersion:           bakery.LatestVersion,
+			ForceCleanup:            ptr(true),
+		}).DoAndReturn(func(ctx context.Context, evt params.RemoteRelationChangeEvent) error {
+		defer close(publishDone)
+		return nil
+	})
+
+	w := s.newLocalConsumerWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for worker to be started")
+	}
+
+	// Send the alive event to cache the macaroon.
+	select {
+	case s.relationLifeChanges <- []string{consumingRelationUUID.String()}:
+	case <-c.Context().Done():
+		c.Fatalf("timed out sending relation change")
+	}
+
+	s.waitForAllWorkersStarted(c)
+
+	// Kill the worker (simulating model destruction).
+	// The shutdown path should notify the offering model.
+	w.Kill()
+
+	// Verify PublishRelationChange was called with ForceCleanup on shutdown.
+	select {
+	case <-publishDone:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for shutdown PublishRelationChange to be called")
+	}
+
+	err := workertest.CheckKill(c, w)
+	c.Assert(err, tc.ErrorIsNil)
 }

--- a/internal/worker/remoterelationconsumer/offererunitrelations/worker.go
+++ b/internal/worker/remoterelationconsumer/offererunitrelations/worker.go
@@ -185,6 +185,17 @@ func (w *remoteWorker) Wait() error {
 	return w.catacomb.Wait()
 }
 
+// Macaroon returns the macaroon used by this worker to authenticate with the
+// remote model.
+func (w *remoteWorker) Macaroon() *macaroon.Macaroon {
+	return w.macaroon
+}
+
+// RelationUUID returns the consumer relation UUID for this worker.
+func (w *remoteWorker) RelationUUID() corerelation.UUID {
+	return w.consumerRelationUUID
+}
+
 func (w *remoteWorker) loop() error {
 	ctx := w.catacomb.Context(context.Background())
 

--- a/internal/worker/remoterelationconsumer/package_test.go
+++ b/internal/worker/remoterelationconsumer/package_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
+	corerelation "github.com/juju/juju/core/relation"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
 )
@@ -70,6 +71,34 @@ func (w *errWorker) Kill() {
 
 func (w *errWorker) Wait() error {
 	return w.tomb.Wait()
+}
+
+// macaroonErrWorker extends errWorker with Macaroon() and RelationUUID()
+// methods, so it can be used as an offerer unit relation worker in tests.
+type macaroonErrWorker struct {
+	errWorker
+	macaroon     *macaroon.Macaroon
+	relationUUID corerelation.UUID
+}
+
+func newMacaroonErrWorker(mac *macaroon.Macaroon, relationUUID corerelation.UUID) *macaroonErrWorker {
+	w := &macaroonErrWorker{
+		macaroon:     mac,
+		relationUUID: relationUUID,
+	}
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
+		return nil
+	})
+	return w
+}
+
+func (w *macaroonErrWorker) Macaroon() *macaroon.Macaroon {
+	return w.macaroon
+}
+
+func (w *macaroonErrWorker) RelationUUID() corerelation.UUID {
+	return w.relationUUID
 }
 
 type reportableWorker struct {

--- a/internal/worker/remoterelationconsumer/service_mock_test.go
+++ b/internal/worker/remoterelationconsumer/service_mock_test.go
@@ -225,6 +225,44 @@ func (c *MockOffererApplicationWorkerConsumeVersionCall) DoAndReturn(f func() in
 	return c
 }
 
+// PublishModelDying mocks base method.
+func (m *MockOffererApplicationWorker) PublishModelDying(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishModelDying", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PublishModelDying indicates an expected call of PublishModelDying.
+func (mr *MockOffererApplicationWorkerMockRecorder) PublishModelDying(ctx any) *MockOffererApplicationWorkerPublishModelDyingCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishModelDying", reflect.TypeOf((*MockOffererApplicationWorker)(nil).PublishModelDying), ctx)
+	return &MockOffererApplicationWorkerPublishModelDyingCall{Call: call}
+}
+
+// MockOffererApplicationWorkerPublishModelDyingCall wrap *gomock.Call
+type MockOffererApplicationWorkerPublishModelDyingCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOffererApplicationWorkerPublishModelDyingCall) Return(arg0 error) *MockOffererApplicationWorkerPublishModelDyingCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOffererApplicationWorkerPublishModelDyingCall) Do(f func(context.Context) error) *MockOffererApplicationWorkerPublishModelDyingCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOffererApplicationWorkerPublishModelDyingCall) DoAndReturn(f func(context.Context) error) *MockOffererApplicationWorkerPublishModelDyingCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockRemoteModelRelationsClient is a mock of RemoteModelRelationsClient interface.
 type MockRemoteModelRelationsClient struct {
 	ctrl     *gomock.Controller
@@ -1048,6 +1086,45 @@ func (c *MockCrossModelServiceUpdateRemoteSecretRevisionCall) DoAndReturn(f func
 	return c
 }
 
+// WatchDyingModel mocks base method.
+func (m *MockCrossModelService) WatchDyingModel(ctx context.Context) (watcher0.NotifyWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchDyingModel", ctx)
+	ret0, _ := ret[0].(watcher0.NotifyWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchDyingModel indicates an expected call of WatchDyingModel.
+func (mr *MockCrossModelServiceMockRecorder) WatchDyingModel(ctx any) *MockCrossModelServiceWatchDyingModelCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDyingModel", reflect.TypeOf((*MockCrossModelService)(nil).WatchDyingModel), ctx)
+	return &MockCrossModelServiceWatchDyingModelCall{Call: call}
+}
+
+// MockCrossModelServiceWatchDyingModelCall wrap *gomock.Call
+type MockCrossModelServiceWatchDyingModelCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelServiceWatchDyingModelCall) Return(arg0 watcher0.NotifyWatcher, arg1 error) *MockCrossModelServiceWatchDyingModelCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelServiceWatchDyingModelCall) Do(f func(context.Context) (watcher0.NotifyWatcher, error)) *MockCrossModelServiceWatchDyingModelCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelServiceWatchDyingModelCall) DoAndReturn(f func(context.Context) (watcher0.NotifyWatcher, error)) *MockCrossModelServiceWatchDyingModelCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // WatchRelationUnits mocks base method.
 func (m *MockCrossModelService) WatchRelationUnits(arg0 context.Context, arg1 relation.UUID, arg2 application.UUID) (watcher0.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
@@ -1693,6 +1770,45 @@ func (c *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall) Do(f func(
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, int, application.UUID) error) *MockCrossModelRelationServiceUpdateRemoteSecretRevisionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// WatchDyingModel mocks base method.
+func (m *MockCrossModelRelationService) WatchDyingModel(ctx context.Context) (watcher0.NotifyWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchDyingModel", ctx)
+	ret0, _ := ret[0].(watcher0.NotifyWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchDyingModel indicates an expected call of WatchDyingModel.
+func (mr *MockCrossModelRelationServiceMockRecorder) WatchDyingModel(ctx any) *MockCrossModelRelationServiceWatchDyingModelCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDyingModel", reflect.TypeOf((*MockCrossModelRelationService)(nil).WatchDyingModel), ctx)
+	return &MockCrossModelRelationServiceWatchDyingModelCall{Call: call}
+}
+
+// MockCrossModelRelationServiceWatchDyingModelCall wrap *gomock.Call
+type MockCrossModelRelationServiceWatchDyingModelCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelRelationServiceWatchDyingModelCall) Return(arg0 watcher0.NotifyWatcher, arg1 error) *MockCrossModelRelationServiceWatchDyingModelCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelRelationServiceWatchDyingModelCall) Do(f func(context.Context) (watcher0.NotifyWatcher, error)) *MockCrossModelRelationServiceWatchDyingModelCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelRelationServiceWatchDyingModelCall) DoAndReturn(f func(context.Context) (watcher0.NotifyWatcher, error)) *MockCrossModelRelationServiceWatchDyingModelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/remoterelationconsumer/worker.go
+++ b/internal/worker/remoterelationconsumer/worker.go
@@ -49,6 +49,10 @@ type OffererApplicationWorker interface {
 	// ConsumeVersion returns the consume version for the remote application
 	// worker.
 	ConsumeVersion() int
+
+	// PublishModelDying notifies the worker that the model is dying, so it can
+	// perform any necessary cleanup.
+	PublishModelDying(ctx context.Context) error
 }
 
 // RemoteModelRelationsClient instances publish local relation changes to the
@@ -153,6 +157,11 @@ type CrossModelRelationService interface {
 	// WatchRemoteApplicationOfferers watches the changes to remote
 	// application consumers and notifies the worker of any changes.
 	WatchRemoteApplicationOfferers(ctx context.Context) (watcher.NotifyWatcher, error)
+
+	// WatchDyingModel returns a watcher that emits when the model transitions
+	// to a dying state. This is used to notify the offering model that the
+	// consuming model is going away.
+	WatchDyingModel(ctx context.Context) (watcher.NotifyWatcher, error)
 
 	// GetRemoteApplicationOfferers returns the current state of all remote
 	// application consumers in the local model.
@@ -323,11 +332,19 @@ func (w *Worker) loop() (err error) {
 
 	// Watch for new remote application offerers. This is the consuming side,
 	// so the consumer model has received an offer from another model.
-	watcher, err := w.crossModelService.WatchRemoteApplicationOfferers(ctx)
+	offersWatcher, err := w.crossModelService.WatchRemoteApplicationOfferers(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := w.catacomb.Add(watcher); err != nil {
+	if err := w.catacomb.Add(offersWatcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	modelWatcher, err := w.crossModelService.WatchDyingModel(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := w.catacomb.Add(modelWatcher); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -335,7 +352,13 @@ func (w *Worker) loop() (err error) {
 		select {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
-		case _, ok := <-watcher.Changes():
+
+		case <-modelWatcher.Changes():
+			if err := w.handleModelDying(ctx); err != nil {
+				return errors.Trace(err)
+			}
+
+		case _, ok := <-offersWatcher.Changes():
 			if !ok {
 				return errors.New("change channel closed")
 			}
@@ -437,6 +460,30 @@ func (w *Worker) hasRemoteAppChanged(remoteApp crossmodelrelation.RemoteApplicat
 	}
 
 	return appWorker.ConsumeVersion() != 0, nil
+}
+
+func (w *Worker) handleModelDying(ctx context.Context) error {
+	w.logger.Debugf(ctx, "model is dying, stopping all offerer application workers")
+
+	for _, appUUID := range w.runner.WorkerNames() {
+		worker, err := w.runner.Worker(appUUID, ctx.Done())
+		if errors.Is(err, errors.NotFound) {
+			continue
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+
+		appWorker, ok := worker.(OffererApplicationWorker)
+		if !ok {
+			return errors.Errorf("worker %q is not a OffererApplicationWorker", appUUID)
+		}
+
+		if err := appWorker.PublishModelDying(ctx); err != nil {
+			w.logger.Warningf(ctx, "error publishing model dying for worker %q: %v", appUUID, err)
+		}
+	}
+
+	return nil
 }
 
 // Report provides information for the engine report.

--- a/internal/worker/remoterelationconsumer/worker_test.go
+++ b/internal/worker/remoterelationconsumer/worker_test.go
@@ -44,6 +44,10 @@ func (s *workerSuite) TestWorkerKilled(c *tc.C) {
 			defer close(done)
 			return watchertest.NewMockNotifyWatcher(make(chan struct{})), nil
 		})
+	s.crossModelService.EXPECT().WatchDyingModel(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) (watcher.NotifyWatcher, error) {
+			return watchertest.NewMockNotifyWatcher(make(chan struct{})), nil
+		})
 
 	w := s.newWorker(c, nil)
 	defer workertest.DirtyKill(c, w)
@@ -68,6 +72,10 @@ func (s *workerSuite) TestRemoteApplications(c *tc.C) {
 	exp.WatchRemoteApplicationOfferers(gomock.Any()).
 		DoAndReturn(func(ctx context.Context) (watcher.NotifyWatcher, error) {
 			return watchertest.NewMockNotifyWatcher(ch), nil
+		})
+	exp.WatchDyingModel(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) (watcher.NotifyWatcher, error) {
+			return watchertest.NewMockNotifyWatcher(make(chan struct{})), nil
 		})
 
 	exp.GetRemoteApplicationOfferers(gomock.Any()).
@@ -114,6 +122,10 @@ func (s *workerSuite) TestRemoteApplicationsGone(c *tc.C) {
 	exp.WatchRemoteApplicationOfferers(gomock.Any()).
 		DoAndReturn(func(ctx context.Context) (watcher.NotifyWatcher, error) {
 			return watchertest.NewMockNotifyWatcher(ch), nil
+		})
+	exp.WatchDyingModel(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) (watcher.NotifyWatcher, error) {
+			return watchertest.NewMockNotifyWatcher(make(chan struct{})), nil
 		})
 
 	exp.GetRemoteApplicationOfferers(gomock.Any()).
@@ -213,4 +225,8 @@ var _ OffererApplicationWorker = (*testOffererApplicationWorker)(nil)
 
 func (w *testOffererApplicationWorker) ConsumeVersion() int {
 	return w.consumeVersion
+}
+
+func (w *testOffererApplicationWorker) PublishModelDying(ctx context.Context) error {
+	return nil
 }


### PR DESCRIPTION
When a consuming model is destroyed, the removal worker may delete a CMR relation while the localConsumerWorker is registering it on the offering side. RegisterRemoteRelations succeeds (creating the offer_connection), but SaveMacaroonForRelation then fails with an FK constraint error because the local relation is gone. The macaroon is never cached, so no cleanup notification is ever sent, leaving the offer_connection permanently orphaned and the connection count stuck at 1/1.

Fix by immediately notifying the offering model with ForceCleanup when SaveMacaroonForRelation fails after a successful registration. Also add a shutdown notification path for relations with cached macaroons, and use background contexts in best-effort notification methods to avoid failures from cancelled catacomb contexts.


## QA steps

Bootstrap and add `offering` and `consuming` model with a CMR, then remove the consumer model before the unit reaches a idle status:

```
$ juju add-model offering
$ juju deploy juju-qa-dummy-source --config token=abc
$ juju offer dummy-source:sink
$ juju add-model consuming
$ juju deploy juju-qa-dummy-sink
$ juju relate dummy-sink admin/offering.dummy-source
# Don't wait until the unit gets to idle to:
$ juju destroy-model consuming
```
When you switch to the offering model, after a few moments you should see this status:
```
juju status --relations
Model     Controller  Cloud/Region         Version  Timestamp
offering  c           localhost/localhost  4.0.2.1  15:16:44+01:00

App           Version  Status       Scale  Charm                 Channel        Rev  Exposed  Message
dummy-source           maintenance      1  juju-qa-dummy-source  latest/stable    6  no       Started

Unit             Workload     Agent  Machine  Public address  Ports  Message
dummy-source/0*  maintenance  idle   0        10.42.73.62            Started

Machine  State    Address      Inst id        Base          AZ        Message
0        started  10.42.73.62  juju-4ee384-0  ubuntu@20.04  thinkpad  Running

Offer         Application   Charm         Rev  Connected  Endpoint  Interface    Role
dummy-source  dummy-source  dummy-source  6    0/0        sink      dummy-token  requirer
```
(see the `Connected` tab in the offer)
and also check the db:
```
repl (controller)> .switch model-offering
repl (model-offering)> select * from offer_connection
uuid	offer_uuid	remote_relation_uuid	username	

```


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21771.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9194](https://warthogs.atlassian.net/browse/JUJU-9194)


[JUJU-9194]: https://warthogs.atlassian.net/browse/JUJU-9194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ