### PR TITLE
fix(client): use base.APICallCloser instead of api.Connection

### DIFF
--- a/api/client/client/client.go
+++ b/api/client/client/client.go
@@ -33,13 +33,13 @@ type Logger interface {
 type Client struct {
 	base.ClientFacade
 	facade base.FacadeCaller
-	conn   api.Connection
+	conn   base.APICallCloser
 	logger Logger
 }
 
 // NewClient returns an object that can be used to access client-specific
 // functionality.
-func NewClient(c api.Connection, logger Logger) *Client {
+func NewClient(c base.APICallCloser, logger Logger) *Client {
 	frontend, backend := base.NewClientFacade(c, "Client")
 	return &Client{
 		ClientFacade: frontend,


### PR DESCRIPTION
# Description

in JAAS we are using the client from the juju pkg, and I've noticed this one client constructor is the only one requiring api.Connection, which is a broader interface then base.APICallCloser. 
All the others just use `base.APICallCloser` which is a smaller interface.

Here the interface:
https://github.com/SimoneDutto/juju/blob/fix-new-client-client/api/interface.go#L325-L403

Since in the JAAS we don't implement the full `api.Connection` interface,  I've switched this client to use  base.APICallCloser.

# QA
If it compiles is fine, and i've QAed it against JAAS to see it solving the issue.