### PR TITLE
tests: print extra debugging for the test_serviceaccount_credential test

### DIFF
--- a/tests/suites/cloud_gce/service_account.sh
+++ b/tests/suites/cloud_gce/service_account.sh
@@ -13,7 +13,17 @@ run_serviceaccount_credential() {
 		exit 1
 	fi
 	credServiceAccount=$(juju show-credential --controller "$BOOTSTRAPPED_JUJU_CTRL_NAME" | yq '.controller-credentials .google .default .content .service-account')
-	check_contains "$credServiceAccount" "$projectServiceAccount"
+	chk=$(echo "${credServiceAccount}" | grep "${projectServiceAccount}" || true)
+	if [[ -z ${chk} ]]; then
+		printf "Expected project service account \"%s\" not found in controller credential\n" "${projectServiceAccount}" >&2
+		accountInfo=$(gcloud compute project-info describe --format yaml)
+		printf "Google account info:\n%s\n" "${accountInfo}" >&2
+		credentialInfo=$(juju show-credential --controller "$BOOTSTRAPPED_JUJU_CTRL_NAME")
+		printf "Controller credential info:\n%s\n" "${credentialInfo}" >&2
+		return 1
+	else
+		echo "Success: \"${projectServiceAccount}\" found" >&2
+	fi
 
 	juju switch "test-serviceaccount-gce"
 	juju deploy ubuntu


### PR DESCRIPTION
When the test_serviceaccount_credential shell test fails checking the controller service account after bootstrap, we don't know why.

This PR adds some extra debugging. It's safe to print the controller credential because it contains a service account, not a password, eg
```
controller-credentials:
  google:
    default:
      content:
        auth-type: service-account
        validity-check: valid
        service-account: 471336811634-compute@developer.gserviceaccount.com
      models:
        controller: admin
        test-serviceaccount-gce: admin
```

## QA steps

`./main.sh -v -p gce cloud_gce`