### PR TITLE
fix: sort before compact

### DIFF
--- a/domain/agentbinary/types.go
+++ b/domain/agentbinary/types.go
@@ -71,6 +71,12 @@ func AgentBinaryCompactOnVersion(a, b AgentBinary) bool {
 	return a.Version.Compare(b.Version) == 0
 }
 
+// AgentBinaryCompareOnVersion provides a comparison func for comparing
+// [AgentBinary] against their [AgentBinary.Version] field.
+func AgentBinaryCompareOnVersion(a, b AgentBinary) int {
+	return a.Version.Compare(b.Version)
+}
+
 // AgentBinaryNotMatchingVersion provides a helper closure to use with the
 // slices package for filtering agent binaries that do match the supplied
 // version.

--- a/domain/agentbinary/types_test.go
+++ b/domain/agentbinary/types_test.go
@@ -38,6 +38,11 @@ func (_ *typesSuite) TestAgentBinaryCompactOnVersion(c *tc.C) {
 			Version:      version1,
 		},
 		{
+			Architecture: AMD64,
+			Stream:       AgentStreamDevel,
+			Version:      version3,
+		},
+		{
 			Architecture: ARM64,
 			Stream:       AgentStreamReleased,
 			Version:      version1,
@@ -58,14 +63,15 @@ func (_ *typesSuite) TestAgentBinaryCompactOnVersion(c *tc.C) {
 			Version:      version3,
 		},
 	}
+	slices.SortFunc(agentBinaries, AgentBinaryCompareOnVersion)
 	agentBinaries = slices.CompactFunc(agentBinaries, AgentBinaryCompactOnVersion)
 
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_[_].Architecture", tc.Ignore)
 	mc.AddExpr("_[_].Stream", tc.Ignore)
 	c.Check(agentBinaries, mc, []AgentBinary{
-		{Version: version1},
 		{Version: version2},
+		{Version: version1},
 		{Version: version3},
 	})
 }

--- a/domain/controllerupgrader/service/agentfinder.go
+++ b/domain/controllerupgrader/service/agentfinder.go
@@ -304,6 +304,7 @@ func (a *StreamAgentBinaryFinder) HasBinariesForVersionStreamAndArchitectures(
 		return false, nil
 	}
 	// Dedupe architectures.
+	slices.Sort(architectures)
 	architectures = slices.Compact(architectures)
 
 	modelBinaries, err := a.modelSt.GetAllAgentStoreBinariesForStream(ctx, stream)
@@ -438,9 +439,11 @@ func (a *StreamAgentBinaryFinder) GetHighestPatchVersionAvailableForStream(
 		)
 	}
 
+	slices.SortFunc(storeBinaries, agentbinary.AgentBinaryCompareOnVersion)
 	storeBinaries = slices.CompactFunc(
 		storeBinaries, agentbinary.AgentBinaryCompactOnVersion,
 	)
+	slices.SortFunc(ssBinaries, agentbinary.AgentBinaryCompareOnVersion)
 	ssBinaries = slices.CompactFunc(
 		ssBinaries, agentbinary.AgentBinaryCompactOnVersion,
 	)


### PR DESCRIPTION
The agent binary domain had a few slices.Compact that were not being sorted before compacting.

I don't believe there would have been any major fall out from this that I can see. In any event this fixes the problem and they are now safe. Updated existing unit test to now be correct.

Identified by @manadart 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests and code review show this problem. I believe they are enough for the this PR.

## Documentation changes

N/A
