### PR TITLE
fix: ignore profile nics on lxd when space constraints are used

### DIFF
--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -223,7 +223,8 @@ func (env *environ) getContainerSpec(
 		return cSpec, errors.Trace(err)
 	}
 
-	if !(len(nics) == 1 && nics["eth0"] != nil) {
+	nonDefaultNic := !(len(nics) == 1 && nics["eth0"] != nil)
+	if len(args.SubnetsToZones) > 0 || nonDefaultNic {
 		logger.Debugf("generating custom cloud-init networking")
 
 		cSpec.Config[lxd.NetworkConfigKey] = cloudinit.CloudInitNetworkConfigDisabled
@@ -267,33 +268,24 @@ func (env *environ) getContainerSpec(
 }
 
 func (env *environ) assignContainerNICs(instStartParams environs.StartInstanceParams) (map[string]map[string]string, error) {
-	// First, include any nics explicitly requested by the default profile.
-	assignedNICs, err := env.server().GetNICsFromProfile("default")
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// No additional NICs required.
 	if len(instStartParams.SubnetsToZones) == 0 {
+		// No space requirements, just use the default profile NICs.
+		assignedNICs, err := env.server().GetNICsFromProfile("default")
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		return assignedNICs, nil
-	}
-
-	if assignedNICs == nil {
-		assignedNICs = make(map[string]map[string]string)
 	}
 
 	// We use two sets to de-dup the required NICs and ensure that each
 	// additional NIC gets assigned a sequential ethX name.
 	requestedHostBridges := set.NewStrings()
 	requestedNICNames := set.NewStrings()
-	for nicName, details := range assignedNICs {
-		requestedNICNames.Add(nicName)
-		netName := lxd.NetworkName(details)
-		requestedHostBridges.Add(netName)
-	}
 
-	// Assign any extra NICs required to satisfy the subnet requirements
+	// Assign any NICs required to satisfy the subnet requirements
 	// for this instance.
+	assignedNICs := make(map[string]map[string]string)
+
 	var nextIndex int
 	for _, subnetList := range instStartParams.SubnetsToZones {
 		for providerSubnetID := range subnetList {

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -184,28 +184,73 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	c.Assert(*res.Hardware.AvailabilityZone, jc.DeepEquals, "node01")
 }
 
-func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
+// TestStartInstanceWithSingleSubnetsInSpace tests that if there is one space-related
+// constraint, then none of the NICs from the default profile are used, and
+// instead we generate NICs based only on the subnets to zone mapping.
+func (s *environBrokerSuite) TestStartInstanceWithSingleSubnetsInSpace(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
 
-	profileNICs := map[string]map[string]string{
-		"eno9": {
-			"name":    "eno9",
-			"mtu":     "9000",
-			"nictype": "bridged",
-			"parent":  "lxdbr0",
-			"hwaddr":  "00:00:00:00:00",
+	// Check that the non-standard devices were passed explicitly,
+	// And that we have disabled the standard network config.
+	check := func(spec containerlxd.ContainerSpec) bool {
+		details, ok := spec.Devices["eth0"]
+		c.Assert(ok, jc.IsTrue)
+		hwaddr := details["hwaddr"]
+		c.Assert(hwaddr, jc.HasPrefix, "00:16:3e:")
+		delete(details, "hwaddr")
+		spec.Devices["eth0"] = details
+		matchedNICs := reflect.DeepEqual(spec.Devices, map[string]map[string]string{
+			"eth0": {
+				"name":    "eth0",
+				"type":    "nic",
+				"nictype": "bridged",
+				"parent":  "virbr0",
+			},
+		})
+		c.Assert(matchedNICs, jc.IsTrue, gc.Commentf("the expected NICs for space-related subnets were not injected; got %v", spec.Devices))
+
+		return spec.Config[containerlxd.NetworkConfigKey] == cloudinit.CloudInitNetworkConfigDisabled
+	}
+
+	exp := svr.EXPECT()
+	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
+		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
+			Instance: api.Instance{Location: "node01"},
+		}, nil),
+		exp.HostArch().Return(arch.AMD64),
+	)
+
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
+	startArgs := s.GetStartInstanceArgs(c)
+	startArgs.SubnetsToZones = []map[network.Id][]string{
+		{
+			"subnet-virbr0-10.42.0.0/24": {"locutus"},
 		},
 	}
+	res, err := env.StartInstance(s.callCtx, startArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+	c.Assert(*res.Hardware.AvailabilityZone, jc.DeepEquals, "node01")
+}
+
+// TestStartInstanceWithManySubnetsInSpace tests that if there are space-related
+// constraints, then none of the NICs from the default profile are used, and
+// instead we generate NICs based only on the subnets to zone mapping.
+func (s *environBrokerSuite) TestStartInstanceWithManySubnetsInSpace(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
 
 	// Check that the non-standard devices were passed explicitly,
 	// And that we have disabled the standard network config.
 	check := func(spec containerlxd.ContainerSpec) bool {
-		c.Assert(spec.Devices["eno9"], gc.DeepEquals, profileNICs["eno9"], gc.Commentf("expected NIC from profile to be included"))
-
-		// As the subnet IDs are map keys, the additional generated NIC
-		// indices depend on the key iteration order so we need to test
+		// As the subnet IDs are map keys, the generated NIC indices
+		// depend on the key iteration order so we need to test
 		// both possible variants here.
 		// First check the hwaddr values. These are random with
 		// a fixed prefix.
@@ -219,7 +264,6 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 			spec.Devices[name] = details
 		}
 		matchedNICs := reflect.DeepEqual(spec.Devices, map[string]map[string]string{
-			"eno9": profileNICs["eno9"],
 			"eth0": {
 				"name":    "eth0",
 				"type":    "nic",
@@ -233,7 +277,6 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 				"parent":  "virbr0",
 			},
 		}) || reflect.DeepEqual(spec.Devices, map[string]map[string]string{
-			"eno9": profileNICs["eno9"],
 			"eth0": {
 				"name":    "eth0",
 				"type":    "nic",
@@ -257,7 +300,6 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 		exp.HostArch().Return(arch.AMD64),
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
-		exp.GetNICsFromProfile("default").Return(profileNICs, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 			Instance: api.Instance{Location: "node01"},
 		}, nil),
@@ -279,9 +321,6 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 			"subnet-virbr0-10.42.0.0/24": {"locutus"},
 			// Bridge name with dashes
 			"subnet-ovs-br0-10.0.0.0/24": {"locutus"},
-			// Should be ignored as the default profile already
-			// specifies a device bridged to lxdbr0
-			"subnet-lxdbr0-10.99.0.0/24": {"locutus"},
 		},
 	}
 	res, err := env.StartInstance(s.callCtx, startArgs)


### PR DESCRIPTION
**WIP**

On LXD, when creating the NICS to be attached to an instance, we were always loading the NICs from the default profile, and then adding to those NICs created from the subnet to zones mapping derived from space constraints. This leads to an error 

```
"ERROR juju.worker.provisioner cannot start instance for machine "0": Failed start validation for device "eth0": Instance DNS name "juju-8554ac-0" conflict between "eth0" and "eth1" because both are connected to same network" 
```

The fix implemented here is to ignore any default profile NICs if space constraints have been specified.

**Note**: is it correct to leave off the profile nic(s) in this case? Should the fix be to query the subnets of the nics in the profile and exclude them if there's a space binding that would attach to that network and include any remaining profile nics without the subnet clash

## QA steps

```
configure lxd with 3 networks
| lxdbr0          | bridge   | 10.68.47.1/24
| lxdbr1          | bridge   | 10.68.48.1/24
| lxdbr2          | bridge   | 10.68.49.1/24
--
default profile:
devices:
  eth0:
    nictype: bridged
    parent: lxdbr0
    type: nic
```
```
juju bootstrap lxd
juju add-space clients 10.68.49.0/24
juju add-space peers 10.68.48.0/24 
```

Scenario 1
model with no default space

```
# no space constraints
juju deploy postgresql db1 --channel 1.16
lxc info juju-95c61f-1
Network usage:
    eth0:
      Type: broadcast
      State: UP
      Host interface: vethe6ac2f0a
      MAC address: 00:16:3e:95:09:ab
      IP addresses:
        inet:  10.68.47.158/24 (global)
--
lxc network list-allocations
| /1.0/instances/juju-95c61f-1 | 10.68.47.158/32 | lxdbr0
```

```
# space constraints for 2 of the endpoints, others use alpha space
juju deploy postgresql db1 --channel 16 --bind="database-peers=peers database=clients"
lxc info juju-95c61f-2
Network usage:
    eth0:
      Type: broadcast
      State: UP
      Host interface: veth28dae732
      MAC address: 00:16:3e:4f:36:8a
      IP addresses:
        inet:  10.68.47.102/24 (global)
    eth1:
      Type: broadcast
      State: UP
      Host interface: veth89d937e2
      MAC address: 00:16:3e:95:8c:cc
      IP addresses:
        inet:  10.68.48.47/24 (global)
    eth2:
      Type: broadcast
      State: UP
      Host interface: veth871801de
      MAC address: 00:16:3e:cb:60:4c
      IP addresses:
        inet:  10.68.49.9/24 (global)
--
lxc network list-allocations
/1.0/instances/juju-95c61f-2 | 10.68.47.102/32 | lxdbr0
/1.0/instances/juju-95c61f-2 | 10.68.48.47/32  | lxdbr1
/1.0/instances/juju-95c61f-2 | 10.68.49.9/32   | lxdbr2
```

Scenario 2
model with default space
`juju model-config default-space=clients`

```
# no space constraints, uses model default
juju deploy postgresql db1 --channel 1.16
lxc info juju-95c61f-1
Network usage:
    eth0:
      Type: broadcast
      State: UP
      Host interface: vethb87258a8
      MAC address: 00:16:3e:2c:f8:c2
      IP addresses:
        inet:  10.68.49.4/24 (global)
--
lxc network list-allocations
/1.0/instances/juju-95c61f-3 | 10.68.49.4/32 | lxdbr2
```

```
# space constraints for 2 of the endpoints
juju deploy postgresql db1 --channel 16 --bind="database-peers=peers database=clients"
lxc info juju-95c61f-2
Network usage:
    eth0:
      Type: broadcast
      State: UP
      Host interface: veth09f061ef
      MAC address: 00:16:3e:c5:09:8a
      IP addresses:
        inet:  10.68.49.165/24 (global)
    eth1:
      Type: broadcast
      State: UP
      Host interface: veth7a74240d
      MAC address: 00:16:3e:c8:b3:e9
      IP addresses:
        inet:  10.68.48.232/24 (global)
--
lxc network list-allocations
/1.0/instances/juju-95c61f-4 | 10.68.48.232/32 | lxdbr1 
/1.0/instances/juju-95c61f-4 | 10.68.49.165/32 | lxdbr2
```

## Links

**Issue:** Fixes #20440.

**Jira card:** [JUJU-8421](https://warthogs.atlassian.net/browse/JUJU-8421)


[JUJU-8421]: https://warthogs.atlassian.net/browse/JUJU-8421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ