### PR TITLE
fix: ensure we watch all relation units

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -484,6 +484,7 @@ type RelationService interface {
 	// if the operation fails.
 	GetRelationUnitChanges(
 		ctx context.Context,
+		relationUUID corerelation.UUID,
 		unitUUIDs []coreunit.UUID,
 		appUUIDs []coreapplication.UUID,
 	) (relation.RelationUnitsChange, error)

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -1727,18 +1727,18 @@ func (c *MockRelationServiceGetRelationUUIDByKeyCall) DoAndReturn(f func(context
 }
 
 // GetRelationUnitChanges mocks base method.
-func (m *MockRelationService) GetRelationUnitChanges(arg0 context.Context, arg1 []unit.UUID, arg2 []application.UUID) (relation0.RelationUnitsChange, error) {
+func (m *MockRelationService) GetRelationUnitChanges(arg0 context.Context, arg1 relation.UUID, arg2 []unit.UUID, arg3 []application.UUID) (relation0.RelationUnitsChange, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelationUnitChanges", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetRelationUnitChanges", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(relation0.RelationUnitsChange)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRelationUnitChanges indicates an expected call of GetRelationUnitChanges.
-func (mr *MockRelationServiceMockRecorder) GetRelationUnitChanges(arg0, arg1, arg2 any) *MockRelationServiceGetRelationUnitChangesCall {
+func (mr *MockRelationServiceMockRecorder) GetRelationUnitChanges(arg0, arg1, arg2, arg3 any) *MockRelationServiceGetRelationUnitChangesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitChanges", reflect.TypeOf((*MockRelationService)(nil).GetRelationUnitChanges), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitChanges", reflect.TypeOf((*MockRelationService)(nil).GetRelationUnitChanges), arg0, arg1, arg2, arg3)
 	return &MockRelationServiceGetRelationUnitChangesCall{Call: call}
 }
 
@@ -1754,13 +1754,13 @@ func (c *MockRelationServiceGetRelationUnitChangesCall) Return(arg0 relation0.Re
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationUnitChangesCall) Do(f func(context.Context, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockRelationServiceGetRelationUnitChangesCall {
+func (c *MockRelationServiceGetRelationUnitChangesCall) Do(f func(context.Context, relation.UUID, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockRelationServiceGetRelationUnitChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationUnitChangesCall) DoAndReturn(f func(context.Context, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockRelationServiceGetRelationUnitChangesCall {
+func (c *MockRelationServiceGetRelationUnitChangesCall) DoAndReturn(f func(context.Context, relation.UUID, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockRelationServiceGetRelationUnitChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3007,7 +3007,7 @@ func (s *uniterRelationSuite) expectWatchRelatedUnitsChange(
 
 	s.relationService.EXPECT().WatchRelatedUnits(gomock.Any(), watchedUnitUUID, relUUID).Return(mockWatcher, nil)
 	s.watcherRegistry.EXPECT().Register(gomock.Any(), gomock.Any()).Return(watcherID, nil)
-	s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), unitUUIDs, appUUIDS).Return(changes, nil)
+	s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), relUUID, unitUUIDs, appUUIDS).Return(changes, nil)
 }
 
 func encodeUnitFromUUID(uuid coreunit.UUID) string {

--- a/apiserver/facades/agent/uniter/watcherrelationunit.go
+++ b/apiserver/facades/agent/uniter/watcherrelationunit.go
@@ -83,7 +83,7 @@ func (w *relationUnitsWatcher) fetchRelationUnitChanges(ctx context.Context,
 		}
 	}
 
-	fetched, err := w.relation.GetRelationUnitChanges(ctx, changedUnitUUIDs, changedAppUUIDs)
+	fetched, err := w.relation.GetRelationUnitChanges(ctx, w.relationUUID, changedUnitUUIDs, changedAppUUIDs)
 	if err != nil {
 		return params.RelationUnitsChange{}, internalerrors.Errorf("fetching related units watcher changes: %w", err)
 	}

--- a/apiserver/facades/agent/uniter/watcherrelationunit.go
+++ b/apiserver/facades/agent/uniter/watcherrelationunit.go
@@ -92,13 +92,6 @@ func (w *relationUnitsWatcher) fetchRelationUnitChanges(ctx context.Context,
 }
 
 func convertRelationUnitsChange(changes relation.RelationUnitsChange) params.RelationUnitsChange {
-	var changed map[string]params.UnitSettings
-	if changes.Changed != nil {
-		changed = make(map[string]params.UnitSettings, len(changes.Changed))
-		for key, val := range changes.Changed {
-			changed[key.String()] = params.UnitSettings{Version: val}
-		}
-	}
 	return params.RelationUnitsChange{
 		Changed: transform.Map(changes.Changed, func(k coreunit.Name, v int64) (string, params.UnitSettings) {
 			return k.String(), params.UnitSettings{Version: v}

--- a/apiserver/facades/agent/uniter/watcherrelationunit_test.go
+++ b/apiserver/facades/agent/uniter/watcherrelationunit_test.go
@@ -212,7 +212,7 @@ func (s *watcherRelationUnitSuite) TestWatchOneRelationUnit(c *tc.C) {
 			return f, 1
 		}),
 	}
-	s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), unitUUIDs, nil).Return(initialChange, nil)
+	s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), relationUUID, unitUUIDs, nil).Return(initialChange, nil)
 
 	s.applicationService.EXPECT().GetUnitUUID(gomock.Any(), unit.Name("app1/0")).Return(watchedUUID, nil)
 
@@ -307,7 +307,7 @@ func (s *watcherRelationUnitSuite) TestRelationUnitsWatcher(c *tc.C) {
 			return f, 1
 		}),
 	}
-	initial := s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), unitUUIDs,
+	initial := s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), relationUUID, unitUUIDs,
 		nil).Return(initialChange, nil)
 	// Second change: all units and applications.
 	withAppsChange := domainrelation.RelationUnitsChange{
@@ -318,7 +318,7 @@ func (s *watcherRelationUnitSuite) TestRelationUnitsWatcher(c *tc.C) {
 			return f, 1
 		}),
 	}
-	withApps := s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), unitUUIDs,
+	withApps := s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), relationUUID, unitUUIDs,
 		appUUIDs).Return(withAppsChange,
 		nil)
 	// Third change: all applications (unit departed).
@@ -328,7 +328,7 @@ func (s *watcherRelationUnitSuite) TestRelationUnitsWatcher(c *tc.C) {
 		}),
 		Departed: unitNames,
 	}
-	unitDeparted := s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), nil, appUUIDs).Return(unitDepartedChange,
+	unitDeparted := s.relationService.EXPECT().GetRelationUnitChanges(gomock.Any(), relationUUID, nil, appUUIDs).Return(unitDepartedChange,
 		nil)
 	gomock.InOrder(initial, withApps, unitDeparted)
 	expectedEvents := []domainrelation.RelationUnitsChange{initialChange, withAppsChange, unitDepartedChange}

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -1169,18 +1169,18 @@ func (c *MockStateGetRelationUUIDByIDCall) DoAndReturn(f func(context.Context, i
 }
 
 // GetRelationUnitChanges mocks base method.
-func (m *MockState) GetRelationUnitChanges(arg0 context.Context, arg1 []unit.UUID, arg2 []application.UUID) (relation0.RelationUnitsChange, error) {
+func (m *MockState) GetRelationUnitChanges(arg0 context.Context, arg1 string, arg2 []unit.UUID, arg3 []application.UUID) (relation0.RelationUnitsChange, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelationUnitChanges", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetRelationUnitChanges", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(relation0.RelationUnitsChange)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRelationUnitChanges indicates an expected call of GetRelationUnitChanges.
-func (mr *MockStateMockRecorder) GetRelationUnitChanges(arg0, arg1, arg2 any) *MockStateGetRelationUnitChangesCall {
+func (mr *MockStateMockRecorder) GetRelationUnitChanges(arg0, arg1, arg2, arg3 any) *MockStateGetRelationUnitChangesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitChanges", reflect.TypeOf((*MockState)(nil).GetRelationUnitChanges), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitChanges", reflect.TypeOf((*MockState)(nil).GetRelationUnitChanges), arg0, arg1, arg2, arg3)
 	return &MockStateGetRelationUnitChangesCall{Call: call}
 }
 
@@ -1196,13 +1196,13 @@ func (c *MockStateGetRelationUnitChangesCall) Return(arg0 relation0.RelationUnit
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetRelationUnitChangesCall) Do(f func(context.Context, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockStateGetRelationUnitChangesCall {
+func (c *MockStateGetRelationUnitChangesCall) Do(f func(context.Context, string, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockStateGetRelationUnitChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetRelationUnitChangesCall) DoAndReturn(f func(context.Context, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockStateGetRelationUnitChangesCall {
+func (c *MockStateGetRelationUnitChangesCall) DoAndReturn(f func(context.Context, string, []unit.UUID, []application.UUID) (relation0.RelationUnitsChange, error)) *MockStateGetRelationUnitChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -185,7 +185,7 @@ type State interface {
 	// It takes a list of unit UUIDs and application UUIDs, returning the
 	// current setting version for each one, or departed if any unit is not
 	// found
-	GetRelationUnitChanges(ctx context.Context, unitUUIDs []unit.UUID, appUUIDs []application.UUID) (relation.RelationUnitsChange, error)
+	GetRelationUnitChanges(ctx context.Context, relationUUID string, unitUUIDs []unit.UUID, appUUIDs []application.UUID) (relation.RelationUnitsChange, error)
 
 	// GetRelationUnitUUID retrieves the UUID of a relation unit based on the
 	// given relation UUID and unit name.
@@ -809,9 +809,14 @@ func (s *Service) getRelationUnitByID(
 // GetRelationUnitChanges validates the given unit and application UUIDs,
 // and retrieves related unit changes.
 // If any UUID is invalid, an appropriate error is returned.
-func (s *Service) GetRelationUnitChanges(ctx context.Context, unitUUIDs []unit.UUID, appUUIDs []application.UUID) (relation.RelationUnitsChange, error) {
+func (s *Service) GetRelationUnitChanges(ctx context.Context, relUUID corerelation.UUID, unitUUIDs []unit.UUID, appUUIDs []application.UUID) (relation.RelationUnitsChange, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
+
+	if err := relUUID.Validate(); err != nil {
+		return relation.RelationUnitsChange{}, errors.Errorf(
+			"%w: %w", relationerrors.RelationUUIDNotValid, err)
+	}
 
 	for _, uuid := range unitUUIDs {
 		if err := uuid.Validate(); err != nil {
@@ -824,7 +829,7 @@ func (s *Service) GetRelationUnitChanges(ctx context.Context, unitUUIDs []unit.U
 		}
 	}
 
-	return s.st.GetRelationUnitChanges(ctx, unitUUIDs, appUUIDs)
+	return s.st.GetRelationUnitChanges(ctx, relUUID.String(), unitUUIDs, appUUIDs)
 }
 
 // GetRelationUnitSettings returns the relation settings for the input unit in

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -443,6 +443,7 @@ func (s *relationServiceSuite) TestGetRelationUnitByIDUnitStateError(c *tc.C) {
 func (s *relationServiceSuite) TestGetRelationUnitChanges(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
+	relationUUID := corerelationtesting.GenRelationUUID(c)
 	appUUIDs := []coreapplication.UUID{
 		tc.Must(c, coreapplication.NewUUID),
 		tc.Must(c, coreapplication.NewUUID),
@@ -463,10 +464,10 @@ func (s *relationServiceSuite) TestGetRelationUnitChanges(c *tc.C) {
 		},
 		Departed: []coreunit.Name{"bar/0"},
 	}
-	s.state.EXPECT().GetRelationUnitChanges(gomock.Any(), unitUUIDS, appUUIDs).Return(expectedResult, nil)
+	s.state.EXPECT().GetRelationUnitChanges(gomock.Any(), relationUUID.String(), unitUUIDS, appUUIDs).Return(expectedResult, nil)
 
 	// Act
-	result, err := s.service.GetRelationUnitChanges(c.Context(), unitUUIDS, appUUIDs)
+	result, err := s.service.GetRelationUnitChanges(c.Context(), relationUUID, unitUUIDS, appUUIDs)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -476,6 +477,7 @@ func (s *relationServiceSuite) TestGetRelationUnitChanges(c *tc.C) {
 func (s *relationServiceSuite) TestGetRelationUnitChangesUnitUUIDNotValid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
+	relationUUID := corerelationtesting.GenRelationUUID(c)
 	unitUUIDS := []coreunit.UUID{
 		coreunittesting.GenUnitUUID(c),
 		coreunit.UUID("not-valid-uuid"),
@@ -483,7 +485,7 @@ func (s *relationServiceSuite) TestGetRelationUnitChangesUnitUUIDNotValid(c *tc.
 	}
 
 	// Act
-	_, err := s.service.GetRelationUnitChanges(c.Context(), unitUUIDS, nil)
+	_, err := s.service.GetRelationUnitChanges(c.Context(), relationUUID, unitUUIDS, nil)
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitUUIDNotValid)
@@ -492,6 +494,7 @@ func (s *relationServiceSuite) TestGetRelationUnitChangesUnitUUIDNotValid(c *tc.
 func (s *relationServiceSuite) TestGetRelationUnitChangesAppUUIDNotValid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
+	relationUUID := corerelationtesting.GenRelationUUID(c)
 	appUUIDs := []coreapplication.UUID{
 		tc.Must(c, coreapplication.NewUUID),
 		coreapplication.UUID("not-valid-uuid"),
@@ -499,7 +502,7 @@ func (s *relationServiceSuite) TestGetRelationUnitChangesAppUUIDNotValid(c *tc.C
 	}
 
 	// Act
-	_, err := s.service.GetRelationUnitChanges(c.Context(), nil, appUUIDs)
+	_, err := s.service.GetRelationUnitChanges(c.Context(), relationUUID, nil, appUUIDs)
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationUUIDNotValid)
@@ -508,12 +511,13 @@ func (s *relationServiceSuite) TestGetRelationUnitChangesAppUUIDNotValid(c *tc.C
 func (s *relationServiceSuite) TestGetRelationUnitChangesUnitStateError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	// Arrange
+	relationUUID := corerelationtesting.GenRelationUUID(c)
 	boom := errors.Errorf("boom")
-	s.state.EXPECT().GetRelationUnitChanges(gomock.Any(), gomock.Any(),
+	s.state.EXPECT().GetRelationUnitChanges(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any()).Return(relation.RelationUnitsChange{}, boom)
 
 	// Act
-	_, err := s.service.GetRelationUnitChanges(c.Context(), nil, nil)
+	_, err := s.service.GetRelationUnitChanges(c.Context(), relationUUID, nil, nil)
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, boom)

--- a/domain/relation/service/watcher.go
+++ b/domain/relation/service/watcher.go
@@ -356,6 +356,7 @@ func (s *WatchableService) WatchRelationUnits(
 
 			if wantEvent {
 				out = append(out, e.Changed())
+				s.logger.Tracef(ctx, "relation unit changed: ", relationUUID, applicationUUID, relationUnitUUIDs)
 			}
 		}
 		return out, nil

--- a/domain/relation/service/watcher.go
+++ b/domain/relation/service/watcher.go
@@ -298,27 +298,62 @@ func (s *WatchableService) WatchRelationUnits(
 		return nil, errors.Capture(err)
 	}
 
+	getRelationUnitUUIDs := func(ctx context.Context) (set.Strings, error) {
+		relUnitUUIDs, err := s.st.GetRelationUnitUUIDsByEndpointUUID(ctx, watcherRelationUnitsData.RelationEndpointUUID)
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		return set.NewStrings(relUnitUUIDs...), nil
+	}
+
 	relationUnitUUIDs := set.NewStrings()
+
+	// relationSync is used to determine if the watcher has seen all the
+	// possible relation units. This is needed because there is a small window
+	// between when the initial relation units are queried and when the change
+	// stream watcher is setup. It might be possible that the relation units
+	// are created in that window. If that happens, we need to get the relation
+	// units again until we're 100% sure that we haven't missed any changes.
+	//
+	// This is a warning about caches serving stale data.
+	var relationSync bool
 	mapper := func(ctx context.Context, events []changestream.ChangeEvent) ([]string, error) {
 		var out []string
 		for _, e := range events {
 			var wantEvent bool
 			switch e.Namespace() {
 			case watcherRelationUnitsData.UnitSettingsHashNS:
+				// We're not officially in sync, because we've not witnessed the
+				// relation unit namespace yet, but we don't want to miss any
+				// relation unit setting changes.
+				//
+				// Either, we've seen it via the relation unit namespace, or we
+				// need to check it manually before making the decision about
+				// whether to emit the event.
+				if !relationSync {
+					relationUnitUUIDs, err = getRelationUnitUUIDs(ctx)
+					if err != nil {
+						return nil, errors.Capture(err)
+					}
+					relationSync = true
+				}
+
 				if relationUnitUUIDs.Contains(e.Changed()) {
 					wantEvent = true
 				}
+
 			case watcherRelationUnitsData.ApplicationSettingsHashNS:
 				wantEvent = true
+
 			case watcherRelationUnitsData.RelationUnitNS:
-				relUnitUUIDs, err := s.st.GetRelationUnitUUIDsByEndpointUUID(ctx, watcherRelationUnitsData.RelationEndpointUUID)
+				relationUnitUUIDs, err = getRelationUnitUUIDs(ctx)
 				if err != nil {
 					return nil, errors.Capture(err)
 				}
-				relationUnitUUIDs = set.NewStrings(relUnitUUIDs...)
-
+				relationSync = true
 				wantEvent = true
 			}
+
 			if wantEvent {
 				out = append(out, e.Changed())
 			}

--- a/domain/relation/state/related_unit_watcher.go
+++ b/domain/relation/state/related_unit_watcher.go
@@ -89,19 +89,24 @@ func (st *State) InitialWatchRelatedUnits(
 				return nil, errors.Errorf("fetching units for relation %q: %w", relationUUID, err)
 			}
 
+			// Always include the application UUID for the initial settings,
+			// as this is the base line, so we don't want to miss it.
+			entityUUIDs := []string{domainrelation.EncodeApplicationUUID(appUUID)}
+
 			// Exclude the input unit from the list of related units.
-			otherUnits := make([]string, 0, len(units)-1)
 			for _, u := range units {
 				if u.UnitUUID == unitUUID {
 					continue
 				}
-				// If we are not in a peer relation, we want to watch the remote side, so we exclude the local side too.
+				// If we are not in a peer relation, we want to watch the remote
+				// side, so we exclude the local side too.
 				if !isPeerRelation && appUUID == appByEndpoint[u.RelationEndpointUUID] {
 					continue
 				}
-				otherUnits = append(otherUnits, domainrelation.EncodeUnitUUID(u.UnitUUID))
+				entityUUIDs = append(entityUUIDs, domainrelation.EncodeUnitUUID(u.UnitUUID))
 			}
-			return otherUnits, nil
+
+			return entityUUIDs, nil
 		},
 		// Mapper.
 		func(ctx context.Context, events []changestream.ChangeEvent) ([]string, error) {

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -1136,29 +1136,35 @@ func (st *State) GetRelationDetails(ctx context.Context, relationUUID corerelati
 // the relation_unit table is that the unit has departed, and thus, the related
 // row has been deleted.
 func (st *State) GetRelationUnitChanges(
-	ctx context.Context, unitUUIDs []unit.UUID, appUUIDs []application.UUID,
+	ctx context.Context, relUUID string, unitUUIDs []unit.UUID, appUUIDs []application.UUID,
 ) (domainrelation.RelationUnitsChange, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return domainrelation.RelationUnitsChange{}, errors.Capture(err)
 	}
 
-	type uuids []string
-	type change struct {
-		UUID string `db:"uuid"`
-		Name string `db:"name"`
-		Hash string `db:"sha256"`
-	}
+	type (
+		uuids  []string
+		change struct {
+			UUID string `db:"uuid"`
+			Name string `db:"name"`
+			Hash string `db:"sha256"`
+		}
+	)
+
+	rel := relationUUID{UUID: relUUID}
 
 	unitStmt, err := st.Prepare(`
 SELECT 
     ru.unit_uuid AS &change.uuid,
     u.name AS &change.name,
     rush.sha256 AS &change.sha256
-FROM relation_unit AS ru
+FROM relation as r
+JOIN relation_endpoint AS re ON r.uuid = re.relation_uuid
+JOIN relation_unit AS ru ON re.uuid = ru.relation_endpoint_uuid
 JOIN unit AS u ON ru.unit_uuid = u.uuid
-LEFT JOIN  relation_unit_settings_hash AS rush ON ru.uuid = rush.relation_unit_uuid
-WHERE ru.unit_uuid IN ($uuids[:])`, change{}, uuids{})
+LEFT JOIN relation_unit_settings_hash AS rush ON ru.uuid = rush.relation_unit_uuid
+WHERE r.uuid = $relationUUID.uuid AND ru.unit_uuid IN ($uuids[:])`, change{}, rel, uuids{})
 	if err != nil {
 		return domainrelation.RelationUnitsChange{}, errors.Capture(err)
 	}
@@ -1171,8 +1177,9 @@ SELECT
 FROM application_endpoint AS ae
 JOIN application AS a ON ae.application_uuid = a.uuid
 JOIN relation_endpoint AS re ON ae.uuid = re.endpoint_uuid 
+JOIN relation AS r ON re.relation_uuid = r.uuid
 LEFT JOIN relation_application_settings_hash AS rash ON re.uuid = rash.relation_endpoint_uuid
-WHERE ae.application_uuid IN ($uuids[:])`, change{}, uuids{})
+WHERE r.uuid = $relationUUID.uuid AND ae.application_uuid IN ($uuids[:])`, change{}, rel, uuids{})
 	if err != nil {
 		return domainrelation.RelationUnitsChange{}, errors.Capture(err)
 	}
@@ -1190,13 +1197,13 @@ WHERE u.uuid IN ($uuids[:])`, getUnit{}, uuids{})
 	apps := transform.Slice(appUUIDs, application.UUID.String)
 	units := transform.Slice(unitUUIDs, unit.UUID.String)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err = tx.Query(ctx, unitStmt, uuids(units)).GetAll(&unitChanges)
+		err = tx.Query(ctx, unitStmt, rel, uuids(units)).GetAll(&unitChanges)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("failed to get relation unit changes: %w", err)
+			return errors.Errorf("getting relation unit changes: %w", err)
 		}
-		err = tx.Query(ctx, appStmt, uuids(apps)).GetAll(&appChanges)
+		err = tx.Query(ctx, appStmt, rel, uuids(apps)).GetAll(&appChanges)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("failed to get relation application changes: %w", err)
+			return errors.Errorf("getting relation application changes: %w", err)
 		}
 
 		// Compute departed units, which are requested units not found into the unitChanges
@@ -1208,7 +1215,7 @@ WHERE u.uuid IN ($uuids[:])`, getUnit{}, uuids{})
 
 		err = tx.Query(ctx, departedStmt, uuids(requested.Values())).GetAll(&departedUnits)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("failed to get relation application changes: %w", err)
+			return errors.Errorf("getting relation application changes: %w", err)
 		}
 
 		return nil

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -2998,6 +2998,7 @@ func (s *relationSuite) TestGetRelationUnitChanges(c *tc.C) {
 	var changes domainrelation.RelationUnitsChange
 	err = db.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
 		changes, err = s.state.GetRelationUnitChanges(ctx,
+			relationUUID.String(),
 			[]coreunit.UUID{noSettingUnitUUID, withSettingUnitUUID, departedUnitUUID},
 			[]coreapplication.UUID{noSettingAppUUID, withSettingAppUUID},
 		)
@@ -3017,6 +3018,47 @@ func (s *relationSuite) TestGetRelationUnitChanges(c *tc.C) {
 	c.Assert(changes.Departed, tc.SameContents, []coreunit.Name{"noSetting/1"})
 }
 
+func (s *relationSuite) TestGetRelationUnitChangesForDifferentRelationUUID(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	charmRelationUUID := s.addCharmRelationWithDefaults(c, charmUUID)
+	noSettingAppUUID := s.addApplication(c, charmUUID, "noSetting")
+	withSettingAppUUID := s.addApplication(c, charmUUID, "withSetting")
+	noSettingAppEndpointUUID := s.addApplicationEndpoint(c, noSettingAppUUID, charmRelationUUID)
+	withSettingAppEndpointUUID := s.addApplicationEndpoint(c, withSettingAppUUID, charmRelationUUID)
+	relationUUID := s.addRelation(c)
+	departedUnitUUID := s.addUnit(c, "noSetting/1", noSettingAppUUID, charmUUID)
+	noSettingUnitUUID := s.addUnit(c, "noSetting/0", noSettingAppUUID, charmUUID)
+	withSettingUnitUUID := s.addUnit(c, "withSetting/0", withSettingAppUUID, charmUUID)
+	noSettingRelationEndpointUUID := s.addRelationEndpoint(c, relationUUID, noSettingAppEndpointUUID)
+	withSettingRelationEndpointUUID := s.addRelationEndpoint(c, relationUUID, withSettingAppEndpointUUID)
+	s.addRelationUnit(c, noSettingUnitUUID, noSettingRelationEndpointUUID)
+	relUnitUUID := s.addRelationUnit(c, withSettingUnitUUID, withSettingRelationEndpointUUID)
+	s.addRelationUnitSettingsHash(c, relUnitUUID, "42")
+	s.addRelationApplicationSettingsHash(c, withSettingRelationEndpointUUID, "84")
+
+	db, err := s.state.DB(c.Context())
+	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Arrange) cannot get the DB: %s", errors.ErrorStack(err)))
+
+	relationUUID2 := s.addRelation(c)
+
+	// Act
+	var changes domainrelation.RelationUnitsChange
+	err = db.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		changes, err = s.state.GetRelationUnitChanges(ctx,
+			relationUUID2.String(),
+			[]coreunit.UUID{noSettingUnitUUID, withSettingUnitUUID, departedUnitUUID},
+			[]coreapplication.UUID{noSettingAppUUID, withSettingAppUUID},
+		)
+		return err
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil, tc.Commentf("(Assert) unexpected error: %s", errors.ErrorStack(err)))
+	c.Assert(changes.Changed, tc.HasLen, 0)
+	c.Assert(changes.AppChanged, tc.HasLen, 0)
+}
+
 func (s *relationSuite) TestGetRelationUnitChangesEmptyArgs(c *tc.C) {
 
 	// Arrange
@@ -3026,7 +3068,7 @@ func (s *relationSuite) TestGetRelationUnitChangesEmptyArgs(c *tc.C) {
 	// Act
 	var changes domainrelation.RelationUnitsChange
 	err = db.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		changes, err = s.state.GetRelationUnitChanges(ctx, nil, nil)
+		changes, err = s.state.GetRelationUnitChanges(ctx, "", nil, nil)
 		return err
 	})
 

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -573,9 +573,7 @@ func (s *watcherSuite) TestWatchRelatedUnitsUnitScope(c *tc.C) {
 
 	// Act: run test harness.
 	// Assert: initial events are related units
-	harness.Run(c, transform.Slice(config.initialEvents, func(uuid coreunit.UUID) string {
-		return domainrelation.EncodeUnitUUID(uuid.String())
-	}))
+	harness.Run(c, initialEvents(config.initialAppUUID, config.initialUnitUUIDs))
 }
 func (s *watcherSuite) TestWatchRelatedUnitsSettings(c *tc.C) {
 	// Arrange:
@@ -672,9 +670,7 @@ VALUES (?,?,?),
 
 	// Act: run test harness.
 	// Assert: initial events are related units
-	harness.Run(c, transform.Slice(config.initialEvents, func(uuid coreunit.UUID) string {
-		return domainrelation.EncodeUnitUUID(uuid.String())
-	}))
+	harness.Run(c, initialEvents(config.initialAppUUID, config.initialUnitUUIDs))
 }
 
 func (s *watcherSuite) TestWatchRelatedUnitsSettingsNoRemoteUnits(c *tc.C) {
@@ -772,9 +768,7 @@ VALUES (?,?,?),
 
 	// Act: run test harness.
 	// Assert: initial events are related units
-	harness.Run(c, transform.Slice(config.initialEvents, func(uuid coreunit.UUID) string {
-		return domainrelation.EncodeUnitUUID(uuid.String())
-	}))
+	harness.Run(c, initialEvents(config.initialAppUUID, config.initialUnitUUIDs))
 }
 
 func (s *watcherSuite) TestWatchRelatedUnitsPeerEnterScope(c *tc.C) {
@@ -824,9 +818,7 @@ func (s *watcherSuite) TestWatchRelatedUnitsPeerEnterScope(c *tc.C) {
 
 	// Act: run test harness.
 	// Assert: initial events are related units
-	harness.Run(c, transform.Slice(config.initialEvents, func(uuid coreunit.UUID) string {
-		return domainrelation.EncodeUnitUUID(uuid.String())
-	}))
+	harness.Run(c, initialEvents(config.initialAppUUID, config.initialUnitUUIDs))
 }
 
 func (s *watcherSuite) TestWatchRelationUnits(c *tc.C) {
@@ -994,7 +986,9 @@ type testWatchRelationUnit struct {
 	watched0UUID, watched1UUID             coreunit.UUID
 	otherRelationUUID, watchedRelationUUID relation.EndpointUUID
 	otherUUID                              coreapplication.UUID
-	initialEvents                          []coreunit.UUID
+
+	initialAppUUID   coreapplication.UUID
+	initialUnitUUIDs []coreunit.UUID
 }
 
 func (s *watcherSuite) setupTestWatchRelationUnit(c *tc.C) testWatchRelationUnit {
@@ -1037,8 +1031,9 @@ func (s *watcherSuite) setupTestWatchRelationUnit(c *tc.C) testWatchRelationUnit
 	s.addRelationEndpoint(c, config.watchedRelationUUID, config.relationUUID, watchedEndpointUUID)
 	s.addRelationEndpoint(c, config.otherRelationUUID, config.relationUUID, otherEndpointUUID)
 
-	config.initialEvents = []coreunit.UUID{config.other0UUID, config.other1UUID}
-	sort.Slice(config.initialEvents, func(i, j int) bool { return config.initialEvents[i] < config.initialEvents[j] })
+	config.initialAppUUID = watchedUUID
+	config.initialUnitUUIDs = []coreunit.UUID{config.other0UUID, config.other1UUID}
+	slices.Sort(config.initialUnitUUIDs)
 
 	return config
 }
@@ -1086,7 +1081,9 @@ type testWatchPeerRelationUnit struct {
 	watched0UUID, watched1UUID coreunit.UUID
 	watchedRelationUUID        relation.EndpointUUID
 	watchedUUID                coreapplication.UUID
-	initialEvents              []coreunit.UUID
+
+	initialAppUUID   coreapplication.UUID
+	initialUnitUUIDs []coreunit.UUID
 }
 
 func (s *watcherSuite) setupTestWatchPeerRelationUnit(c *tc.C) testWatchPeerRelationUnit {
@@ -1114,7 +1111,8 @@ func (s *watcherSuite) setupTestWatchPeerRelationUnit(c *tc.C) testWatchPeerRela
 	s.addRelation(c, config.relationUUID)
 	s.addRelationEndpoint(c, config.watchedRelationUUID, config.relationUUID, watchedEndpointUUID)
 
-	config.initialEvents = []coreunit.UUID{config.watched1UUID}
+	config.initialAppUUID = config.watchedUUID
+	config.initialUnitUUIDs = []coreunit.UUID{config.watched1UUID}
 
 	return config
 }
@@ -1268,4 +1266,11 @@ func (s *watcherSuite) query(c *tc.C, comment func(error) tc.CommentInterface, q
 		return nil
 	})
 	c.Assert(err, tc.ErrorIsNil, comment(err))
+}
+
+func initialEvents(appUUID coreapplication.UUID, initialEvents []coreunit.UUID) []string {
+	units := transform.Slice(initialEvents, func(uuid coreunit.UUID) string {
+		return domainrelation.EncodeUnitUUID(uuid.String())
+	})
+	return append([]string{domainrelation.EncodeApplicationUUID(appUUID.String())}, units...)
 }

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -899,6 +899,45 @@ VALUES (?,?,?)`,
 	harness.Run(c, struct{}{})
 }
 
+func (s *watcherSuite) TestWatchRelationUnitsInitial(c *tc.C) {
+	// Arrange:
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "relation_unit_settings_hash")
+
+	config := s.setupTestWatchRelationUnits(c)
+
+	svc := s.setupService(c, factory)
+
+	// Ensure that if we start the watcher after the relation units are created,
+	// we still get the events for them.
+	relationUnitUUID := uuid.MustNewUUID().String()
+	s.arrange(c, `
+INSERT INTO relation_unit (uuid, relation_endpoint_uuid, unit_uuid)
+VALUES (?,?,?),
+       (?,?,?)`,
+		relationUnitUUID, config.watchedRelationEndpointUUID, config.watched0UUID,
+		uuid.MustNewUUID().String(), config.watchedRelationEndpointUUID, config.watched1UUID)
+
+	s.AssertChangeStreamIdle(c)
+
+	watcher, err := svc.WatchRelationUnits(c.Context(), config.relationUUID, config.watchedAppUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
+
+	// Act: update the unit settings hash.
+	// Assert: change seen
+	harness.AddTest(c, func(c *tc.C) {
+		s.act(c, "INSERT INTO relation_unit_settings_hash (relation_unit_uuid, sha256) VALUES (?, 'hash')",
+			relationUnitUUID)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	// Act: run test harness.
+	// Assert: initial events are related units
+	harness.Run(c, struct{}{})
+}
+
 type testWatchRelationUnits struct {
 	relationUUID                relation.UUID
 	watchedAppUUID              coreapplication.UUID

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -702,7 +702,7 @@ func (s *watcherSuite) TestWatchRelatedUnitsSettingsNoRemoteUnits(c *tc.C) {
 		w.AssertNoChange()
 	})
 
-	harness.Run(c, []string{})
+	harness.Run(c, initialEvents(config.initialAppUUID, config.initialUnitUUIDs))
 }
 
 func (s *watcherSuite) TestWatchRelatedUnitsPeerSettings(c *tc.C) {
@@ -1071,7 +1071,8 @@ func (s *watcherSuite) setupTestWatchRelationUnitNoRemoteUnits(c *tc.C) testWatc
 	s.addRelationEndpoint(c, config.watchedRelationUUID, config.relationUUID, watchedEndpointUUID)
 	s.addRelationEndpoint(c, config.otherRelationUUID, config.relationUUID, otherEndpointUUID)
 
-	config.initialEvents = nil
+	config.initialAppUUID = watchedUUID
+	config.initialUnitUUIDs = nil
 	return config
 }
 


### PR DESCRIPTION
If watching for relation units is started **AFTER** the relation unit been created, and no other relation unit events have been dispatched, we'll get no unit setting hash changes. We've got a localized cache that is serving stale data. The solution is to get the relation units during the first call to unit settings hash check. We can do it before the call to the mapper, *but* there is a small window when you might not get the relation unit uuids, as we don't guarantee when your watcher is run. We need to be **really** careful about caching watcher information for the sake of performance (correct over performance every-time).

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model offer
$ juju add-model consume
$ juju switch offer
$ juju deploy juju-qa-dummy-source --config token=abc
$ juju offer dummy-source:sink
$ juju switch consume
$ juju deploy juju-qa-dummy-sink a
$ juju deploy juju-qa-dummy-sink b
$ juju relate a admin/offer.dummy-source
$ juju relate b admin/offer.dummy-source
```

Watch the status and keep changing the token.

```sh
$ juju config -m test:offer dummy-source token=jjj
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/21796.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9235](https://warthogs.atlassian.net/browse/JUJU-9235)


[JUJU-9235]: https://warthogs.atlassian.net/browse/JUJU-9235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ