### PR TITLE
refactor(api): adds a providers package to api

### DIFF
--- a/api/providers/doc.go
+++ b/api/providers/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package providers registers all the available cloud providers with the environs package.
+// This is JAAS to determine which providers are available and the schema of their credentials.
+// The providers themselves are implemented in the internal/provider/* packages, and this
+// package imports those packages to trigger their init() functions, which performs the
+// provider registration.
+package providers

--- a/api/providers/init.go
+++ b/api/providers/init.go
@@ -1,0 +1,8 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package providers
+
+import (
+	_ "github.com/juju/juju/internal/provider/all"
+)


### PR DESCRIPTION
Adds a `providers` package to api, which is used by JAAS to determine which providers are available and the schema of their credentials. 

The `providers` package contains only one file `init.go`, which imports all providers to trigger `init()` functions in each of the provider packages.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

N/A

## Documentation changes

N/A


