### PR TITLE
feat(storage): import filesystem attachments for IAAS during model migration

### DIFF
--- a/domain/storage/internal/types.go
+++ b/domain/storage/internal/types.go
@@ -21,8 +21,8 @@ type ImportStorageInstanceArgs struct {
 	UnitName         string
 }
 
-// ImportFilesystemArgs represents data to import a filesystem.
-type ImportFilesystemArgs struct {
+// ImportFilesystemIAASArgs represents data to import a filesystem.
+type ImportFilesystemIAASArgs struct {
 	UUID                string
 	ID                  string
 	Life                life.Life
@@ -30,4 +30,15 @@ type ImportFilesystemArgs struct {
 	ProviderID          string
 	StorageInstanceUUID string
 	Scope               storageprovisioning.ProvisionScope
+}
+
+// ImportFilesystemAttachmentIAASArgs represents data to import filesystem attachments.
+type ImportFilesystemAttachmentIAASArgs struct {
+	UUID           string
+	FilesystemUUID string
+	NetNodeUUID    string
+	Scope          storageprovisioning.ProvisionScope
+	Life           life.Life
+	MountPoint     string
+	ReadOnly       bool
 }

--- a/domain/storage/modelmigration/import.go
+++ b/domain/storage/modelmigration/import.go
@@ -56,8 +56,8 @@ type ImportService interface {
 	// unit owners if the unit name is provided.
 	ImportStorageInstances(ctx context.Context, params []domainstorage.ImportStorageInstanceParams) error
 
-	// ImportFilesystems imports filesystems from the provided parameters.
-	ImportFilesystems(ctx context.Context, args []domainstorage.ImportFilesystemParams) error
+	// ImportFilesystemsIAAS imports filesystems from the provided parameters.
+	ImportFilesystemsIAAS(ctx context.Context, args []domainstorage.ImportFilesystemParams) error
 }
 
 type importOperation struct {
@@ -107,7 +107,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	// Filesystems need to be handled differently for CAAS models. So until
 	// this is implemented skip the import step.
 	if model.Type() == coremodel.IAAS.String() {
-		if err := i.importFilesystems(ctx, model.Filesystems()); err != nil {
+		if err := i.importFilesystemsIAAS(ctx, model.Filesystems()); err != nil {
 			return errors.Errorf("importing filesystems: %w", err)
 		}
 	}
@@ -149,7 +149,7 @@ func (i *importOperation) importStorageInstances(ctx context.Context, instances 
 	return i.service.ImportStorageInstances(ctx, args)
 }
 
-func (i *importOperation) importFilesystems(ctx context.Context, filesystems []description.Filesystem) error {
+func (i *importOperation) importFilesystemsIAAS(ctx context.Context, filesystems []description.Filesystem) error {
 	if len(filesystems) == 0 {
 		return nil
 	}
@@ -161,8 +161,21 @@ func (i *importOperation) importFilesystems(ctx context.Context, filesystems []d
 			ProviderID:        in.FilesystemID(),
 			PoolName:          in.Pool(),
 			StorageInstanceID: in.Storage(),
+			Attachments: transform.Slice(
+				in.Attachments(),
+				func(a description.FilesystemAttachment) domainstorage.ImportFilesystemAttachmentsParams {
+					hostMachine, _ := a.HostMachine()
+					hostUnit, _ := a.HostUnit()
+					return domainstorage.ImportFilesystemAttachmentsParams{
+						HostMachineName: hostMachine,
+						HostUnitName:    hostUnit,
+						MountPoint:      a.MountPoint(),
+						ReadOnly:        a.ReadOnly(),
+					}
+				},
+			),
 		}
 	})
 
-	return i.service.ImportFilesystems(ctx, args)
+	return i.service.ImportFilesystemsIAAS(ctx, args)
 }

--- a/domain/storage/modelmigration/import_test.go
+++ b/domain/storage/modelmigration/import_test.go
@@ -384,14 +384,14 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
 	})
-	model.AddFilesystem(description.FilesystemArgs{
+	fs1 := model.AddFilesystem(description.FilesystemArgs{
 		ID:           "fs-1",
 		Size:         2048,
 		Storage:      "multi-fs/1",
 		Pool:         "testpool",
 		FilesystemID: "provider-fs-1",
 	})
-	model.AddFilesystem(description.FilesystemArgs{
+	fs2 := model.AddFilesystem(description.FilesystemArgs{
 		ID:           "fs-2",
 		Size:         4096,
 		Storage:      "multi-fs/2",
@@ -399,19 +399,40 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 		FilesystemID: "provider-fs-2",
 	})
 
+	fs1.AddAttachment(description.FilesystemAttachmentArgs{
+		HostMachine: "1",
+		ReadOnly:    false,
+		MountPoint:  "/data",
+	})
+	fs2.AddAttachment(description.FilesystemAttachmentArgs{
+		HostUnit:   "unit/1",
+		ReadOnly:   true,
+		MountPoint: "/opt",
+	})
+
 	s.noopStoragePoolImport()
-	s.service.EXPECT().ImportFilesystems(gomock.Any(), tc.Bind(tc.SameContents, []domainstorage.ImportFilesystemParams{{
+	s.service.EXPECT().ImportFilesystemsIAAS(gomock.Any(), tc.Bind(tc.SameContents, []domainstorage.ImportFilesystemParams{{
 		ID:                "fs-1",
 		SizeInMiB:         2048,
 		StorageInstanceID: "multi-fs/1",
 		PoolName:          "testpool",
 		ProviderID:        "provider-fs-1",
+		Attachments: []domainstorage.ImportFilesystemAttachmentsParams{{
+			HostMachineName: "1",
+			ReadOnly:        false,
+			MountPoint:      "/data",
+		}},
 	}, {
 		ID:                "fs-2",
 		SizeInMiB:         4096,
 		StorageInstanceID: "multi-fs/2",
 		PoolName:          "testpool",
 		ProviderID:        "provider-fs-2",
+		Attachments: []domainstorage.ImportFilesystemAttachmentsParams{{
+			HostUnitName: "unit/1",
+			ReadOnly:     true,
+			MountPoint:   "/opt",
+		}},
 	}})).Return(nil)
 
 	// Act

--- a/domain/storage/modelmigration/migrations_mock_test.go
+++ b/domain/storage/modelmigration/migrations_mock_test.go
@@ -141,40 +141,40 @@ func (c *MockImportServiceGetStoragePoolsToImportCall) DoAndReturn(f func(contex
 	return c
 }
 
-// ImportFilesystems mocks base method.
-func (m *MockImportService) ImportFilesystems(arg0 context.Context, arg1 []storage.ImportFilesystemParams) error {
+// ImportFilesystemsIAAS mocks base method.
+func (m *MockImportService) ImportFilesystemsIAAS(arg0 context.Context, arg1 []storage.ImportFilesystemParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ImportFilesystems", arg0, arg1)
+	ret := m.ctrl.Call(m, "ImportFilesystemsIAAS", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ImportFilesystems indicates an expected call of ImportFilesystems.
-func (mr *MockImportServiceMockRecorder) ImportFilesystems(arg0, arg1 any) *MockImportServiceImportFilesystemsCall {
+// ImportFilesystemsIAAS indicates an expected call of ImportFilesystemsIAAS.
+func (mr *MockImportServiceMockRecorder) ImportFilesystemsIAAS(arg0, arg1 any) *MockImportServiceImportFilesystemsIAASCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportFilesystems", reflect.TypeOf((*MockImportService)(nil).ImportFilesystems), arg0, arg1)
-	return &MockImportServiceImportFilesystemsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportFilesystemsIAAS", reflect.TypeOf((*MockImportService)(nil).ImportFilesystemsIAAS), arg0, arg1)
+	return &MockImportServiceImportFilesystemsIAASCall{Call: call}
 }
 
-// MockImportServiceImportFilesystemsCall wrap *gomock.Call
-type MockImportServiceImportFilesystemsCall struct {
+// MockImportServiceImportFilesystemsIAASCall wrap *gomock.Call
+type MockImportServiceImportFilesystemsIAASCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockImportServiceImportFilesystemsCall) Return(arg0 error) *MockImportServiceImportFilesystemsCall {
+func (c *MockImportServiceImportFilesystemsIAASCall) Return(arg0 error) *MockImportServiceImportFilesystemsIAASCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceImportFilesystemsCall) Do(f func(context.Context, []storage.ImportFilesystemParams) error) *MockImportServiceImportFilesystemsCall {
+func (c *MockImportServiceImportFilesystemsIAASCall) Do(f func(context.Context, []storage.ImportFilesystemParams) error) *MockImportServiceImportFilesystemsIAASCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceImportFilesystemsCall) DoAndReturn(f func(context.Context, []storage.ImportFilesystemParams) error) *MockImportServiceImportFilesystemsCall {
+func (c *MockImportServiceImportFilesystemsIAASCall) DoAndReturn(f func(context.Context, []storage.ImportFilesystemParams) error) *MockImportServiceImportFilesystemsIAASCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/storage/service/import.go
+++ b/domain/storage/service/import.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
 
 	coreerrors "github.com/juju/juju/core/errors"
@@ -24,12 +25,26 @@ import (
 // StorageImportState defines an interface for interacting with the underlying
 // state for storage import operations.
 type StorageImportState interface {
+	// GetNetNodeUUIDsByMachineOrUnitID returns net node UUIDs for all machine or
+	// and unit names provided. If a machine name or unit name is not found then it
+	// is excluded from the result.
+	GetNetNodeUUIDsByMachineOrUnitName(
+		ctx context.Context,
+		machines []string,
+		units []string,
+	) (map[string]string, map[string]string, error)
+
 	// ImportStorageInstances imports storage instances and storage unit
 	// unit owners if the unit name is provided.
 	ImportStorageInstances(ctx context.Context, args []internal.ImportStorageInstanceArgs) error
 
-	// ImportFilesystems imports filesystems from the provided parameters.
-	ImportFilesystems(ctx context.Context, args []internal.ImportFilesystemArgs) error
+	// ImportFilesystemsIAAS imports filesystems from the provided parameters
+	// for IAAS models.
+	ImportFilesystemsIAAS(
+		ctx context.Context,
+		fsArgs []internal.ImportFilesystemIAASArgs,
+		attachmentArgs []internal.ImportFilesystemAttachmentIAASArgs,
+	) error
 
 	// GetStoragePoolProvidersByNames returns a map of storage pool names to their
 	// provider types for the specified storage pool names.
@@ -93,7 +108,8 @@ func (s *StorageImportService) ImportStorageInstances(ctx context.Context, param
 	return s.st.ImportStorageInstances(ctx, args)
 }
 
-// ImportFilesystems imports filesystems from the provided parameters.
+// ImportFilesystemsIAAS imports filesystems from the provided parameters for
+// IAAS models.
 //
 // The following errors may be returned:
 // - [coreerrors.NotValid] when any of the params did not pass validation.
@@ -103,7 +119,7 @@ func (s *StorageImportService) ImportStorageInstances(ctx context.Context, param
 // of the specified storage pools cannot be found in the storage registry.
 // - [domainstorageerrors.StorageInstanceNotFound] when any of the
 // provided IDs do not have a corresponding storage instance.
-func (s *StorageImportService) ImportFilesystems(ctx context.Context, params []domainstorage.ImportFilesystemParams) error {
+func (s *StorageImportService) ImportFilesystemsIAAS(ctx context.Context, params []domainstorage.ImportFilesystemParams) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -111,32 +127,52 @@ func (s *StorageImportService) ImportFilesystems(ctx context.Context, params []d
 		return nil
 	}
 
+	var (
+		poolNames = make([]string, len(params))
+		// The vast majority of the time, storageInstanceIDs will be full length
+		storageInstanceIDs = make([]string, 0, len(params))
+		units              = set.NewStrings()
+		machines           = set.NewStrings()
+	)
 	for i, arg := range params {
 		if err := arg.Validate(); err != nil {
 			return errors.Errorf("validating import filesystem params %d: %w", i, err)
 		}
+
+		poolNames[i] = arg.PoolName
+		if arg.StorageInstanceID != "" {
+			storageInstanceIDs = append(storageInstanceIDs, arg.StorageInstanceID)
+		}
+
+		for _, attachment := range arg.Attachments {
+			if attachment.HostUnitName != "" {
+				units.Add(attachment.HostUnitName)
+			} else {
+				machines.Add(attachment.HostMachineName)
+			}
+		}
 	}
 
-	poolNames := transform.Slice(params, func(arg domainstorage.ImportFilesystemParams) string { return arg.PoolName })
 	poolScopes, err := s.retrieveFilesystemProviderScopesForPools(ctx, poolNames)
 	if err != nil {
 		return errors.Errorf("getting provider scopes of filesystems: %w", err)
 	}
 
-	// storage instance ID can be empty, which indicates the filesystem is not
-	// associated with any storage instance.
-	storageInstanceIDs := make([]string, 0, len(params))
-	for _, arg := range params {
-		if arg.StorageInstanceID != "" {
-			storageInstanceIDs = append(storageInstanceIDs, arg.StorageInstanceID)
-		}
-	}
 	storageInstanceUUIDsByID, err := s.st.GetStorageInstanceUUIDsByIDs(ctx, storageInstanceIDs)
 	if err != nil {
 		return errors.Errorf("retrieving storage instance UUIDs by IDs: %w", err)
 	}
 
-	fullArgs := make([]internal.ImportFilesystemArgs, len(params))
+	var machineNodes, unitNodes map[string]string
+	if len(machines)+len(units) > 0 {
+		machineNodes, unitNodes, err = s.st.GetNetNodeUUIDsByMachineOrUnitName(ctx, machines.Values(), units.Values())
+		if err != nil {
+			return errors.Errorf("retrieving net node UUIDs by machine or unit names: %w", err)
+		}
+	}
+
+	fsArgs := make([]internal.ImportFilesystemIAASArgs, len(params))
+	attachmentArgs := make([]internal.ImportFilesystemAttachmentIAASArgs, 0)
 	for i, arg := range params {
 		providerScope, ok := poolScopes[arg.PoolName]
 		if !ok {
@@ -156,13 +192,13 @@ func (s *StorageImportService) ImportFilesystems(ctx context.Context, params []d
 			}
 		}
 
-		uuid, err := domainstorage.NewFilesystemUUID()
+		fsUUID, err := domainstorage.NewFilesystemUUID()
 		if err != nil {
 			return errors.Errorf("generating UUID for filesystem %q: %w", arg.ID, err)
 		}
 
-		fullArgs[i] = internal.ImportFilesystemArgs{
-			UUID:                uuid.String(),
+		fsArgs[i] = internal.ImportFilesystemIAASArgs{
+			UUID:                fsUUID.String(),
 			ID:                  arg.ID,
 			Life:                life.Alive,
 			SizeInMiB:           arg.SizeInMiB,
@@ -170,9 +206,43 @@ func (s *StorageImportService) ImportFilesystems(ctx context.Context, params []d
 			StorageInstanceUUID: storageInstanceUUID,
 			Scope:               providerScope,
 		}
+
+		for _, attachment := range arg.Attachments {
+			attachmentUUID, err := domainstorage.NewFilesystemAttachmentUUID()
+			if err != nil {
+				return errors.Errorf("generating UUID for filesystem attachment of filesystem %q: %w", arg.ID, err)
+			}
+
+			var netNodeUUID string
+			if attachment.HostUnitName != "" {
+				var ok bool
+				netNodeUUID, ok = unitNodes[attachment.HostUnitName]
+				if !ok {
+					return errors.Errorf("net node for host unit %q not found", attachment.HostUnitName).
+						Add(coreerrors.NotFound)
+				}
+			} else {
+				var ok bool
+				netNodeUUID, ok = machineNodes[attachment.HostMachineName]
+				if !ok {
+					return errors.Errorf("net node for host machine %q not found", attachment.HostMachineName).
+						Add(coreerrors.NotFound)
+				}
+			}
+
+			attachmentArgs = append(attachmentArgs, internal.ImportFilesystemAttachmentIAASArgs{
+				UUID:           attachmentUUID.String(),
+				FilesystemUUID: fsUUID.String(),
+				NetNodeUUID:    netNodeUUID,
+				Scope:          providerScope,
+				Life:           life.Alive,
+				MountPoint:     attachment.MountPoint,
+				ReadOnly:       attachment.ReadOnly,
+			})
+		}
 	}
 
-	return s.st.ImportFilesystems(ctx, fullArgs)
+	return s.st.ImportFilesystemsIAAS(ctx, fsArgs, attachmentArgs)
 }
 
 func (s *StorageImportService) retrieveFilesystemProviderScopesForPools(

--- a/domain/storage/service/import_test.go
+++ b/domain/storage/service/import_test.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/tc"
@@ -60,10 +61,10 @@ func (s *importSuite) TestImportStorageInstances(c *tc.C) {
 			PoolName:         "ebs",
 		},
 	}
-	s.state.EXPECT().ImportStorageInstances(gomock.Any(), ignoreUUIDArgsMatcher[internal.ImportStorageInstanceArgs]{
-		c:        c,
-		expected: expected,
-	}).Return(nil)
+
+	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_[_].UUID`, tc.IsNonZeroUUID)
+	s.state.EXPECT().ImportStorageInstances(gomock.Any(), tc.Bind(mc, expected)).Return(nil)
 
 	args := []domainstorage.ImportStorageInstanceParams{
 		{
@@ -112,11 +113,11 @@ func (s *importSuite) TestImportStorageInstancesValidate(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
 }
 
-func (s *importSuite) TestImportFilesystems(c *tc.C) {
+func (s *importSuite) TestImportFilesystemsIAAS(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	args := []domainstorage.ImportFilesystemParams{{
+	params := []domainstorage.ImportFilesystemParams{{
 		ID:                "test-1/0",
 		PoolName:          "ebs",
 		SizeInMiB:         1024,
@@ -137,7 +138,7 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 		StorageInstanceID: "",
 	}}
 
-	s.state.EXPECT().GetStoragePoolProvidersByNames(gomock.Any(), []string{"ebs", "ebs-ssd", "tmpfs"}).Return(map[string]string{
+	s.state.EXPECT().GetStoragePoolProvidersByNames(gomock.Any(), tc.Bind(tc.SameContents, []string{"ebs", "ebs-ssd", "tmpfs"})).Return(map[string]string{
 		"ebs":     "ebs",
 		"ebs-ssd": "ebs",
 		"tmpfs":   "tmpfs",
@@ -161,7 +162,101 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 			"storageinstance/2": "storageinstance-uuid-2",
 		}, nil)
 
-	expected := []internal.ImportFilesystemArgs{{
+	expectedFS := []internal.ImportFilesystemIAASArgs{{
+		ID:                  "test-2/1",
+		Life:                life.Alive,
+		SizeInMiB:           2048,
+		ProviderID:          "provider-test-2/1",
+		StorageInstanceUUID: "storageinstance-uuid-2",
+		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
+	}, {
+		ID:                  "test-1/0",
+		Life:                life.Alive,
+		SizeInMiB:           1024,
+		ProviderID:          "provider-test-1/0",
+		StorageInstanceUUID: "storageinstance-uuid-1",
+		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
+	}, {
+		ID:         "test-3/2",
+		Life:       life.Alive,
+		SizeInMiB:  4096,
+		ProviderID: "provider-test-3/2",
+		Scope:      domainstorageprovisioning.ProvisionScopeMachine,
+	}}
+
+	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_.UUID`, tc.IsNonZeroUUID)
+
+	s.state.EXPECT().ImportFilesystemsIAAS(gomock.Any(),
+		tc.Bind(tc.UnorderedMatch[[]internal.ImportFilesystemIAASArgs](mc), expectedFS),
+		tc.Bind(tc.HasLen, 0),
+	).Return(nil)
+
+	err := s.service.ImportFilesystemsIAAS(c.Context(), params)
+
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportFilesystemsIAASWithAttachments(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	// Arrange
+	params := []domainstorage.ImportFilesystemParams{{
+		ID:                "test-1/0",
+		PoolName:          "ebs",
+		SizeInMiB:         1024,
+		ProviderID:        "provider-test-1/0",
+		StorageInstanceID: "storageinstance/1",
+		Attachments: []domainstorage.ImportFilesystemAttachmentsParams{{
+			HostUnitName: "unit/0",
+			MountPoint:   "/mnt/test1-0",
+			ReadOnly:     false,
+		}, {
+			HostUnitName: "unit/1",
+			MountPoint:   "/mnt/test1-0-ro",
+			ReadOnly:     true,
+		}},
+	}, {
+		ID:                "test-2/1",
+		PoolName:          "ebs-ssd",
+		SizeInMiB:         2048,
+		ProviderID:        "provider-test-2/1",
+		StorageInstanceID: "storageinstance/2",
+		Attachments: []domainstorage.ImportFilesystemAttachmentsParams{{
+			HostMachineName: "0",
+			MountPoint:      "/mnt/test2-1",
+			ReadOnly:        false,
+		}},
+	}}
+
+	s.state.EXPECT().GetStoragePoolProvidersByNames(gomock.Any(), tc.Bind(tc.SameContents, []string{"ebs", "ebs-ssd"})).Return(map[string]string{
+		"ebs":     "ebs",
+		"ebs-ssd": "ebs",
+	}, nil)
+
+	ebsProvider := NewMockProvider(ctrl)
+	ebsProvider.EXPECT().Scope().Return(internalstorage.ScopeEnviron).AnyTimes()
+	ebsProvider.EXPECT().Supports(internalstorage.StorageKindBlock).Return(true).AnyTimes()
+	ebsProvider.EXPECT().Supports(internalstorage.StorageKindFilesystem).Return(false).AnyTimes()
+	s.registry.Providers["ebs"] = ebsProvider
+
+	s.state.EXPECT().GetStorageInstanceUUIDsByIDs(gomock.Any(), []string{"storageinstance/1", "storageinstance/2"}).
+		Return(map[string]string{
+			"storageinstance/1": "storageinstance-uuid-1",
+			"storageinstance/2": "storageinstance-uuid-2",
+		}, nil)
+
+	s.state.EXPECT().GetNetNodeUUIDsByMachineOrUnitName(gomock.Any(),
+		tc.Bind(tc.SameContents, []string{"0"}),
+		tc.Bind(tc.SameContents, []string{"unit/0", "unit/1"}),
+	).Return(
+		map[string]string{"0": "netnode-uuid-0"},
+		map[string]string{"unit/0": "netnode-uuid-unit-0", "unit/1": "netnode-uuid-unit-1"},
+		nil,
+	)
+
+	expectedFS := []internal.ImportFilesystemIAASArgs{{
 		ID:                  "test-1/0",
 		Life:                life.Alive,
 		SizeInMiB:           1024,
@@ -175,28 +270,82 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 		ProviderID:          "provider-test-2/1",
 		StorageInstanceUUID: "storageinstance-uuid-2",
 		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
-	}, {
-		ID:         "test-3/2",
-		Life:       life.Alive,
-		SizeInMiB:  4096,
-		ProviderID: "provider-test-3/2",
-		Scope:      domainstorageprovisioning.ProvisionScopeMachine,
 	}}
-	s.state.EXPECT().ImportFilesystems(gomock.Any(), ignoreUUIDArgsMatcher[internal.ImportFilesystemArgs]{
-		c:        c,
-		expected: expected,
-	}).Return(nil)
+	expectedAttachments := []internal.ImportFilesystemAttachmentIAASArgs{{
+		MountPoint:  "/mnt/test1-0",
+		ReadOnly:    false,
+		NetNodeUUID: "netnode-uuid-unit-0",
+		Life:        life.Alive,
+		Scope:       domainstorageprovisioning.ProvisionScopeMachine,
+	}, {
+		MountPoint:  "/mnt/test1-0-ro",
+		ReadOnly:    true,
+		NetNodeUUID: "netnode-uuid-unit-1",
+		Life:        life.Alive,
+		Scope:       domainstorageprovisioning.ProvisionScopeMachine,
+	}, {
+		MountPoint:  "/mnt/test2-1",
+		ReadOnly:    false,
+		NetNodeUUID: "netnode-uuid-0",
+		Life:        life.Alive,
+		Scope:       domainstorageprovisioning.ProvisionScopeMachine,
+	}}
 
-	err := s.service.ImportFilesystems(c.Context(), args)
+	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_.UUID`, tc.IsNonZeroUUID)
+	mc.AddExpr(`_.FilesystemUUID`, tc.IsNonZeroUUID)
 
+	var (
+		gotFS          []internal.ImportFilesystemIAASArgs
+		gotAttachments []internal.ImportFilesystemAttachmentIAASArgs
+	)
+	s.state.EXPECT().ImportFilesystemsIAAS(gomock.Any(),
+		tc.Bind(tc.UnorderedMatch[[]internal.ImportFilesystemIAASArgs](mc), expectedFS),
+		tc.Bind(tc.UnorderedMatch[[]internal.ImportFilesystemAttachmentIAASArgs](mc), expectedAttachments),
+	).DoAndReturn(func(_ context.Context, fsArgs []internal.ImportFilesystemIAASArgs, attachmentArgs []internal.ImportFilesystemAttachmentIAASArgs) error {
+		gotFS = fsArgs
+		gotAttachments = attachmentArgs
+		return nil
+	})
+
+	// Act
+	err := s.service.ImportFilesystemsIAAS(c.Context(), params)
+
+	// Assert
 	c.Assert(err, tc.ErrorIsNil)
+
+	var (
+		fs1UUID, fs2UUID string
+	)
+	for _, fs := range gotFS {
+		switch fs.ID {
+		case "test-1/0":
+			fs1UUID = fs.UUID
+		case "test-2/1":
+			fs2UUID = fs.UUID
+		default:
+			c.Fatalf("unexpected filesystem ID %q", fs.ID)
+		}
+	}
+	for _, a := range gotAttachments {
+		switch a.MountPoint {
+		case "/mnt/test1-0":
+			c.Assert(a.FilesystemUUID, tc.Equals, fs1UUID)
+		case "/mnt/test1-0-ro":
+			c.Assert(a.FilesystemUUID, tc.Equals, fs1UUID)
+		case "/mnt/test2-1":
+			c.Assert(a.FilesystemUUID, tc.Equals, fs2UUID)
+		default:
+			c.Fatalf("unexpected attachment mount point %q", a.MountPoint)
+		}
+	}
 }
 
 func (s *importSuite) TestImportFilesystemsValidate(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	args := []domainstorage.ImportFilesystemParams{{}}
-	err := s.service.ImportFilesystems(c.Context(), args)
+	err := s.service.ImportFilesystemsIAAS(c.Context(), args)
 
 	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
 }
@@ -219,23 +368,4 @@ func (s *importSuite) setupMocks(c *tc.C) *gomock.Controller {
 	})
 
 	return ctrl
-}
-
-type ignoreUUIDArgsMatcher[T any] struct {
-	c        *tc.C
-	expected []T
-}
-
-func (m ignoreUUIDArgsMatcher[T]) Matches(arg any) bool {
-	obtained, ok := arg.([]T)
-	if !ok {
-		return false
-	}
-	mc := tc.NewMultiChecker()
-	mc.AddExpr(`_.UUID`, tc.IsNonZeroUUID)
-	return m.c.Check(obtained, tc.UnorderedMatch[[]T](mc), m.expected)
-}
-
-func (m ignoreUUIDArgsMatcher[T]) String() string {
-	return "matches if the input slice matches expectation."
 }

--- a/domain/storage/service/state_mock_test.go
+++ b/domain/storage/service/state_mock_test.go
@@ -119,6 +119,46 @@ func (c *MockStateDeleteStoragePoolCall) DoAndReturn(f func(context.Context, str
 	return c
 }
 
+// GetNetNodeUUIDsByMachineOrUnitName mocks base method.
+func (m *MockState) GetNetNodeUUIDsByMachineOrUnitName(arg0 context.Context, arg1, arg2 []string) (map[string]string, map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetNodeUUIDsByMachineOrUnitName", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(map[string]string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetNetNodeUUIDsByMachineOrUnitName indicates an expected call of GetNetNodeUUIDsByMachineOrUnitName.
+func (mr *MockStateMockRecorder) GetNetNodeUUIDsByMachineOrUnitName(arg0, arg1, arg2 any) *MockStateGetNetNodeUUIDsByMachineOrUnitNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetNodeUUIDsByMachineOrUnitName", reflect.TypeOf((*MockState)(nil).GetNetNodeUUIDsByMachineOrUnitName), arg0, arg1, arg2)
+	return &MockStateGetNetNodeUUIDsByMachineOrUnitNameCall{Call: call}
+}
+
+// MockStateGetNetNodeUUIDsByMachineOrUnitNameCall wrap *gomock.Call
+type MockStateGetNetNodeUUIDsByMachineOrUnitNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetNetNodeUUIDsByMachineOrUnitNameCall) Return(arg0, arg1 map[string]string, arg2 error) *MockStateGetNetNodeUUIDsByMachineOrUnitNameCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetNetNodeUUIDsByMachineOrUnitNameCall) Do(f func(context.Context, []string, []string) (map[string]string, map[string]string, error)) *MockStateGetNetNodeUUIDsByMachineOrUnitNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetNetNodeUUIDsByMachineOrUnitNameCall) DoAndReturn(f func(context.Context, []string, []string) (map[string]string, map[string]string, error)) *MockStateGetNetNodeUUIDsByMachineOrUnitNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetStorageAttachmentUUIDForStorageInstanceAndUnit mocks base method.
 func (m *MockState) GetStorageAttachmentUUIDForStorageInstanceAndUnit(arg0 context.Context, arg1 storage0.StorageInstanceUUID, arg2 unit.UUID) (storage0.StorageAttachmentUUID, error) {
 	m.ctrl.T.Helper()
@@ -431,40 +471,40 @@ func (c *MockStateImportFilesystemCall) DoAndReturn(f func(context.Context, stor
 	return c
 }
 
-// ImportFilesystems mocks base method.
-func (m *MockState) ImportFilesystems(arg0 context.Context, arg1 []internal.ImportFilesystemArgs) error {
+// ImportFilesystemsIAAS mocks base method.
+func (m *MockState) ImportFilesystemsIAAS(arg0 context.Context, arg1 []internal.ImportFilesystemIAASArgs, arg2 []internal.ImportFilesystemAttachmentIAASArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ImportFilesystems", arg0, arg1)
+	ret := m.ctrl.Call(m, "ImportFilesystemsIAAS", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ImportFilesystems indicates an expected call of ImportFilesystems.
-func (mr *MockStateMockRecorder) ImportFilesystems(arg0, arg1 any) *MockStateImportFilesystemsCall {
+// ImportFilesystemsIAAS indicates an expected call of ImportFilesystemsIAAS.
+func (mr *MockStateMockRecorder) ImportFilesystemsIAAS(arg0, arg1, arg2 any) *MockStateImportFilesystemsIAASCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportFilesystems", reflect.TypeOf((*MockState)(nil).ImportFilesystems), arg0, arg1)
-	return &MockStateImportFilesystemsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportFilesystemsIAAS", reflect.TypeOf((*MockState)(nil).ImportFilesystemsIAAS), arg0, arg1, arg2)
+	return &MockStateImportFilesystemsIAASCall{Call: call}
 }
 
-// MockStateImportFilesystemsCall wrap *gomock.Call
-type MockStateImportFilesystemsCall struct {
+// MockStateImportFilesystemsIAASCall wrap *gomock.Call
+type MockStateImportFilesystemsIAASCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateImportFilesystemsCall) Return(arg0 error) *MockStateImportFilesystemsCall {
+func (c *MockStateImportFilesystemsIAASCall) Return(arg0 error) *MockStateImportFilesystemsIAASCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateImportFilesystemsCall) Do(f func(context.Context, []internal.ImportFilesystemArgs) error) *MockStateImportFilesystemsCall {
+func (c *MockStateImportFilesystemsIAASCall) Do(f func(context.Context, []internal.ImportFilesystemIAASArgs, []internal.ImportFilesystemAttachmentIAASArgs) error) *MockStateImportFilesystemsIAASCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateImportFilesystemsCall) DoAndReturn(f func(context.Context, []internal.ImportFilesystemArgs) error) *MockStateImportFilesystemsCall {
+func (c *MockStateImportFilesystemsIAASCall) DoAndReturn(f func(context.Context, []internal.ImportFilesystemIAASArgs, []internal.ImportFilesystemAttachmentIAASArgs) error) *MockStateImportFilesystemsIAASCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/storage/state/import.go
+++ b/domain/storage/state/import.go
@@ -60,9 +60,14 @@ INSERT INTO storage_unit_owner (*) VALUES ($importStorageUnitOwner.*)`, importSt
 	return nil
 }
 
-// ImportFilesystems imports filesystems from the provided parameters.
-func (st *State) ImportFilesystems(ctx context.Context, args []internal.ImportFilesystemArgs) error {
-	if len(args) == 0 {
+// ImportFilesystemsIAAS imports filesystems from the provided parameters for
+// IAAS models.
+func (st *State) ImportFilesystemsIAAS(
+	ctx context.Context,
+	fsArgs []internal.ImportFilesystemIAASArgs,
+	attachmentArgs []internal.ImportFilesystemAttachmentIAASArgs,
+) error {
+	if len(fsArgs)+len(attachmentArgs) == 0 {
 		return nil
 	}
 
@@ -72,21 +77,27 @@ func (st *State) ImportFilesystems(ctx context.Context, args []internal.ImportFi
 	}
 
 	insertStorageFilesystemStmt, err := st.Prepare(`
-	INSERT INTO storage_filesystem (*) VALUES ($importStorageFilesystem.*)`, importStorageFilesystem{})
+INSERT INTO storage_filesystem (*) VALUES ($importStorageFilesystem.*)`, importStorageFilesystem{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	insertStorageInstanceFilesystemStmt, err := st.Prepare(`
-	INSERT INTO storage_instance_filesystem (*) VALUES ($importStorageInstanceFilesystem.*)`, importStorageInstanceFilesystem{})
+INSERT INTO storage_instance_filesystem (*) VALUES ($importStorageInstanceFilesystem.*)`, importStorageInstanceFilesystem{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	fsArgs := make([]importStorageFilesystem, len(args))
-	fsInstanceArgs := make([]importStorageInstanceFilesystem, 0, len(args))
-	for i, arg := range args {
-		fsArgs[i] = importStorageFilesystem{
+	insertFilesystemAttachmentStmt, err := st.Prepare(`
+INSERT INTO storage_filesystem_attachment (*) VALUES ($importStorageFilesystemAttachment.*)`, importStorageFilesystemAttachment{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	fsDBArgs := make([]importStorageFilesystem, len(fsArgs))
+	fsDBInstanceArgs := make([]importStorageInstanceFilesystem, 0, len(fsArgs))
+	for i, arg := range fsArgs {
+		fsDBArgs[i] = importStorageFilesystem{
 			UUID:       arg.UUID,
 			ID:         arg.ID,
 			LifeID:     int(arg.Life),
@@ -95,23 +106,45 @@ func (st *State) ImportFilesystems(ctx context.Context, args []internal.ImportFi
 			SizeInMiB:  arg.SizeInMiB,
 		}
 		if arg.StorageInstanceUUID != "" {
-			fsInstanceArgs = append(fsInstanceArgs, importStorageInstanceFilesystem{
+			fsDBInstanceArgs = append(fsDBInstanceArgs, importStorageInstanceFilesystem{
 				StorageInstanceUUID: arg.StorageInstanceUUID,
 				FilesystemUUID:      arg.UUID,
 			})
 		}
 	}
 
+	fsAttachmentDBArgs := make([]importStorageFilesystemAttachment, len(attachmentArgs))
+	for i, arg := range attachmentArgs {
+		fsAttachmentDBArgs[i] = importStorageFilesystemAttachment{
+			UUID:           arg.UUID,
+			FilesystemUUID: arg.FilesystemUUID,
+			NetNodeUUID:    arg.NetNodeUUID,
+			ScopeID:        int(arg.Scope),
+			LifeID:         int(arg.Life),
+			MountPoint:     arg.MountPoint,
+			ReadOnly:       arg.ReadOnly,
+		}
+	}
+
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, insertStorageFilesystemStmt, fsArgs).Run()
-		if err != nil {
-			return errors.Errorf("inserting storage filesystem rows: %w", err)
+		if len(fsDBArgs) > 0 {
+			err := tx.Query(ctx, insertStorageFilesystemStmt, fsDBArgs).Run()
+			if err != nil {
+				return errors.Errorf("inserting storage filesystem rows: %w", err)
+			}
 		}
 
-		if len(fsInstanceArgs) > 0 {
-			err := tx.Query(ctx, insertStorageInstanceFilesystemStmt, fsInstanceArgs).Run()
+		if len(fsDBInstanceArgs) > 0 {
+			err := tx.Query(ctx, insertStorageInstanceFilesystemStmt, fsDBInstanceArgs).Run()
 			if err != nil {
 				return errors.Errorf("inserting storage instance filesystem rows: %w", err)
+			}
+		}
+
+		if len(fsAttachmentDBArgs) > 0 {
+			err := tx.Query(ctx, insertFilesystemAttachmentStmt, fsAttachmentDBArgs).Run()
+			if err != nil {
+				return errors.Errorf("inserting storage filesystem attachment rows: %w", err)
 			}
 		}
 
@@ -200,7 +233,7 @@ WHERE  u.name = $name.name`, name{}, nameAndUUID{})
 	return output.Name, output.UUID, nil
 }
 
-// GetNetNodeUUIDsByMachineOrUnitID returns net node UUIDs for all machine or
+// GetNetNodeUUIDsByMachineOrUnitName returns net node UUIDs for all machine or
 // and unit names provided. If a machine name or unit name is not found then it
 // is excluded from the result.
 func (st *State) GetNetNodeUUIDsByMachineOrUnitName(ctx context.Context, machines []string, units []string) (map[string]string, map[string]string, error) {

--- a/domain/storage/state/import_test.go
+++ b/domain/storage/state/import_test.go
@@ -113,7 +113,7 @@ func (s *importSuite) TestImportStorageInstances(c *tc.C) {
 	s.checkStorageUnitOwner(c, unit, 2)
 }
 
-func (s *importSuite) TestImportFilesystems(c *tc.C) {
+func (s *importSuite) TestImportFilesystemsIAAS(c *tc.C) {
 	// Arrange
 	ebsPoolUUID := s.newStoragePool(c, "ebs", "fspool")
 	gcePoolUUID := s.newStoragePool(c, "gce", "testme")
@@ -125,7 +125,7 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 	gceFsUUID := tc.Must(c, storage.NewFilesystemUUID)
 	azureFsUUID := tc.Must(c, storage.NewFilesystemUUID)
 
-	args := []internal.ImportFilesystemArgs{{
+	args := []internal.ImportFilesystemIAASArgs{{
 		UUID:                ebsFsUUID.String(),
 		ID:                  "ebs-fs-1",
 		SizeInMiB:           1024,
@@ -155,7 +155,7 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	// Act
-	err := st.ImportFilesystems(c.Context(), args)
+	err := st.ImportFilesystemsIAAS(c.Context(), args, nil)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -188,6 +188,101 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 	}, {
 		StorageInstanceUUID: gceInstanceUUID.String(),
 		FilesystemUUID:      gceFsUUID.String(),
+	}})
+}
+
+func (s *importSuite) TestImportFilesystemsIAASWithAttachments(c *tc.C) {
+	// Arrange
+	ebsPoolUUID := s.newStoragePool(c, "ebs", "fspool")
+	gcePoolUUID := s.newStoragePool(c, "gce", "testme")
+
+	ebsInstanceUUID := s.newStorageInstance(c, "ebs", "1", ebsPoolUUID)
+	gceInstanceUUID := s.newStorageInstance(c, "gce", "1", gcePoolUUID)
+
+	netNodeUUID1 := s.newNetNode(c)
+	netNodeUUID2 := s.newNetNode(c)
+	netNodeUUID3 := s.newNetNode(c)
+
+	ebsFsUUID := tc.Must(c, storage.NewFilesystemUUID)
+	gceFsUUID := tc.Must(c, storage.NewFilesystemUUID)
+
+	ebsAttachment1UUID := tc.Must(c, storage.NewFilesystemAttachmentUUID)
+	ebsAttachment2UUID := tc.Must(c, storage.NewFilesystemAttachmentUUID)
+	gceAttachmentUUID := tc.Must(c, storage.NewFilesystemAttachmentUUID)
+
+	fsArgs := []internal.ImportFilesystemIAASArgs{{
+		UUID:                ebsFsUUID.String(),
+		ID:                  "ebs-fs-1",
+		SizeInMiB:           1024,
+		ProviderID:          "provider-ebs-fs-1",
+		StorageInstanceUUID: ebsInstanceUUID.String(),
+		Life:                life.Alive,
+		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
+	}, {
+		UUID:                gceFsUUID.String(),
+		ID:                  "gce-fs-1",
+		SizeInMiB:           2048,
+		ProviderID:          "provider-gce-fs-1",
+		StorageInstanceUUID: gceInstanceUUID.String(),
+		Life:                life.Alive,
+		Scope:               domainstorageprovisioning.ProvisionScopeModel,
+	}}
+
+	attachmentArgs := []internal.ImportFilesystemAttachmentIAASArgs{{
+		UUID:           ebsAttachment1UUID.String(),
+		FilesystemUUID: ebsFsUUID.String(),
+		Scope:          domainstorageprovisioning.ProvisionScopeMachine,
+		NetNodeUUID:    netNodeUUID1,
+		MountPoint:     "/mnt/ebs1",
+		ReadOnly:       false,
+	}, {
+		UUID:           ebsAttachment2UUID.String(),
+		FilesystemUUID: ebsFsUUID.String(),
+		Scope:          domainstorageprovisioning.ProvisionScopeMachine,
+		NetNodeUUID:    netNodeUUID2,
+		MountPoint:     "/mnt/ebs2",
+		ReadOnly:       true,
+	}, {
+		UUID:           gceAttachmentUUID.String(),
+		FilesystemUUID: gceFsUUID.String(),
+		Scope:          domainstorageprovisioning.ProvisionScopeModel,
+		NetNodeUUID:    netNodeUUID3,
+		MountPoint:     "/mnt/gce",
+		ReadOnly:       false,
+	}}
+
+	st := NewState(s.TxnRunnerFactory())
+
+	// Act
+	err := st.ImportFilesystemsIAAS(c.Context(), fsArgs, attachmentArgs)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	obtainedAttachments := s.getFilesystemAttachments(c)
+	c.Check(obtainedAttachments, tc.SameContents, []importStorageFilesystemAttachment{{
+		UUID:           ebsAttachment1UUID.String(),
+		FilesystemUUID: ebsFsUUID.String(),
+		NetNodeUUID:    netNodeUUID1,
+		ScopeID:        int(domainstorageprovisioning.ProvisionScopeMachine),
+		LifeID:         int(life.Alive),
+		MountPoint:     "/mnt/ebs1",
+		ReadOnly:       false,
+	}, {
+		UUID:           ebsAttachment2UUID.String(),
+		FilesystemUUID: ebsFsUUID.String(),
+		NetNodeUUID:    netNodeUUID2,
+		ScopeID:        int(domainstorageprovisioning.ProvisionScopeMachine),
+		LifeID:         int(life.Alive),
+		MountPoint:     "/mnt/ebs2",
+		ReadOnly:       true,
+	}, {
+		UUID:           gceAttachmentUUID.String(),
+		FilesystemUUID: gceFsUUID.String(),
+		NetNodeUUID:    netNodeUUID3,
+		ScopeID:        int(domainstorageprovisioning.ProvisionScopeModel),
+		LifeID:         int(life.Alive),
+		MountPoint:     "/mnt/gce",
+		ReadOnly:       false,
 	}})
 }
 
@@ -487,6 +582,41 @@ FROM storage_instance_filesystem`)
 	c.Assert(err, tc.ErrorIsNil)
 
 	return filesystems, instanceFilesystems
+}
+
+func (s *importSuite) getFilesystemAttachments(c *tc.C) []importStorageFilesystemAttachment {
+	var attachments []importStorageFilesystemAttachment
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		rows, err := tx.QueryContext(c.Context(), `
+SELECT uuid, storage_filesystem_uuid, net_node_uuid, provision_scope_id, life_id, mount_point, read_only
+FROM storage_filesystem_attachment`)
+		if err != nil {
+			return err
+		}
+
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var uuid, fsUUID, netNodeUUID, mountPoint string
+			var scopeID, lifeID int
+			var readOnly bool
+			if err := rows.Scan(&uuid, &fsUUID, &netNodeUUID, &scopeID, &lifeID, &mountPoint, &readOnly); err != nil {
+				return err
+			}
+			attachments = append(attachments, importStorageFilesystemAttachment{
+				UUID:           uuid,
+				FilesystemUUID: fsUUID,
+				NetNodeUUID:    netNodeUUID,
+				ScopeID:        scopeID,
+				LifeID:         lifeID,
+				MountPoint:     mountPoint,
+				ReadOnly:       readOnly,
+			})
+		}
+
+		return rows.Err()
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return attachments
 }
 
 func (s *importSuite) newStorageInstance(c *tc.C, name, id string, poolUUID storage.StoragePoolUUID) storage.StorageInstanceUUID {

--- a/domain/storage/state/types.go
+++ b/domain/storage/state/types.go
@@ -92,6 +92,16 @@ type importStorageInstanceFilesystem struct {
 	FilesystemUUID      string `db:"storage_filesystem_uuid"`
 }
 
+type importStorageFilesystemAttachment struct {
+	UUID           string `db:"uuid"`
+	FilesystemUUID string `db:"storage_filesystem_uuid"`
+	NetNodeUUID    string `db:"net_node_uuid"`
+	ScopeID        int    `db:"provision_scope_id"`
+	LifeID         int    `db:"life_id"`
+	MountPoint     string `db:"mount_point"`
+	ReadOnly       bool   `db:"read_only"`
+}
+
 // machineAndUnitNetNodeUUID represents names and net node uuid
 // for machine or unit combinations where the data is gathered in
 // a single query.

--- a/domain/storage/types.go
+++ b/domain/storage/types.go
@@ -7,7 +7,9 @@ import (
 	"github.com/juju/collections/set"
 
 	coreerrors "github.com/juju/juju/core/errors"
+	coremachine "github.com/juju/juju/core/machine"
 	corestorage "github.com/juju/juju/core/storage"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/storage"
 )
@@ -107,6 +109,17 @@ func (i ImportStorageInstanceParams) Validate() error {
 	if i.PoolName == "" || i.RequestedSizeMiB == 0 || i.StorageID == "" {
 		return errors.New("empty PoolName, RequestedSizeMiB, or StorageID not valid").Add(coreerrors.NotValid)
 	}
+
+	if i.UnitName != "" {
+		if err := coreunit.Name(i.UnitName).Validate(); err != nil {
+			return err
+		}
+	}
+
+	if !IsValidStoragePoolNameWithLegacy(i.PoolName) {
+		return errors.Errorf("invalid PoolName %q", i.PoolName).Add(coreerrors.NotValid)
+	}
+
 	return nil
 }
 
@@ -117,6 +130,7 @@ type ImportFilesystemParams struct {
 	ProviderID        string
 	PoolName          string
 	StorageInstanceID string
+	Attachments       []ImportFilesystemAttachmentsParams
 }
 
 // Validate returns NotValid if the params are not valid
@@ -133,6 +147,48 @@ func (p ImportFilesystemParams) Validate() error {
 		if err := corestorage.ID(p.StorageInstanceID).Validate(); err != nil {
 			return errors.Errorf("invalid StorageInstanceID %q: %w", p.StorageInstanceID, err).Add(coreerrors.NotValid)
 		}
+	}
+
+	for i, attachment := range p.Attachments {
+		if err := attachment.Validate(); err != nil {
+			return errors.Errorf("invalid attachment %d: %w", i, err).Add(coreerrors.NotValid)
+		}
+	}
+
+	return nil
+}
+
+// ImportFilesystemAttachmentsParams represents data to import filesystem
+// attachments.
+type ImportFilesystemAttachmentsParams struct {
+	HostMachineName string
+	HostUnitName    string
+	MountPoint      string
+	ReadOnly        bool
+}
+
+func (p ImportFilesystemAttachmentsParams) Validate() error {
+	if p.HostMachineName == "" && p.HostUnitName == "" {
+		return errors.New("either HostMachineName or HostUnitName must be provided").Add(coreerrors.NotValid)
+	}
+	if p.HostUnitName != "" && p.HostMachineName != "" {
+		return errors.New("only one of HostMachineName or HostUnitName can be provided").Add(coreerrors.NotValid)
+	}
+
+	if p.HostUnitName != "" {
+		if err := coreunit.Name(p.HostUnitName).Validate(); err != nil {
+			return err
+		}
+	}
+
+	if p.HostMachineName != "" {
+		if err := coremachine.Name(p.HostMachineName).Validate(); err != nil {
+			return err
+		}
+	}
+
+	if p.MountPoint == "" {
+		return errors.New("MountPoint cannot be empty").Add(coreerrors.NotValid)
 	}
 
 	return nil

--- a/domain/storage/types_test.go
+++ b/domain/storage/types_test.go
@@ -29,3 +29,248 @@ func (s *typesSuite) TestProvidersValues(c *tc.C) {
 	p := storage.Providers{"x", "y", "z", "x", ""}
 	c.Assert(p.Values(), tc.SameContents, []string{"x", "y", "z"})
 }
+
+func (s *typesSuite) TestImportStorageInstanceParamsValidate(c *tc.C) {
+	for _, test := range []struct {
+		name   string
+		params storage.ImportStorageInstanceParams
+		valid  bool
+	}{
+		{
+			name: "valid params",
+			params: storage.ImportStorageInstanceParams{
+				StorageName:      "foo",
+				StorageKind:      "block",
+				StorageID:        "foo/0",
+				RequestedSizeMiB: 1024,
+				PoolName:         "default",
+				UnitName:         "unit/0",
+			},
+			valid: true,
+		},
+		{
+			name: "invalid params with empty pool name",
+			params: storage.ImportStorageInstanceParams{
+				StorageName:      "foop",
+				StorageKind:      "block",
+				StorageID:        "foo/0",
+				RequestedSizeMiB: 1024,
+				PoolName:         "",
+				UnitName:         "unit/0",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid params with zero requested size",
+			params: storage.ImportStorageInstanceParams{
+				StorageName:      "foo",
+				StorageKind:      "block",
+				StorageID:        "foo/0",
+				RequestedSizeMiB: 0,
+				PoolName:         "default",
+				UnitName:         "unit/0",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid params with empty storage ID",
+			params: storage.ImportStorageInstanceParams{
+				StorageName:      "foo",
+				StorageKind:      "block",
+				StorageID:        "",
+				RequestedSizeMiB: 1024,
+				PoolName:         "default",
+				UnitName:         "unit/0",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid params with invalid unit name",
+			params: storage.ImportStorageInstanceParams{
+				StorageName:      "foo",
+				StorageKind:      "block",
+				StorageID:        "foo/0",
+				RequestedSizeMiB: 1024,
+				PoolName:         "default",
+				UnitName:         "invalid unit name",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid params with invalid pool name",
+			params: storage.ImportStorageInstanceParams{
+				StorageName:      "foo",
+				StorageKind:      "block",
+				StorageID:        "foo/0",
+				RequestedSizeMiB: 1024,
+				PoolName:         "invalid pool name",
+				UnitName:         "unit/0",
+			},
+			valid: false,
+		},
+	} {
+		c.Logf("testing: %s", test.name)
+		err := test.params.Validate()
+		if test.valid {
+			c.Assert(err, tc.ErrorIsNil)
+		} else {
+			c.Assert(err, tc.NotNil)
+		}
+	}
+}
+
+func (s *typesSuite) TestImportFilesystemParamsValidate(c *tc.C) {
+	for _, test := range []struct {
+		name   string
+		params storage.ImportFilesystemParams
+		valid  bool
+	}{
+		{
+			name: "valid params",
+			params: storage.ImportFilesystemParams{
+				ID:                "fs-0",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "default",
+				StorageInstanceID: "foo/0",
+				Attachments: []storage.ImportFilesystemAttachmentsParams{
+					{
+						HostMachineName: "0",
+						MountPoint:      "/mnt/fs-0",
+						ReadOnly:        false,
+					},
+					{
+						HostUnitName: "unit/0",
+						MountPoint:   "/mnt/fs-0",
+						ReadOnly:     true,
+					},
+				},
+			},
+			valid: true,
+		}, {
+			name: "invalid params with empty ID",
+			params: storage.ImportFilesystemParams{
+				ID:                "",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "default",
+				StorageInstanceID: "foo/0",
+			},
+			valid: false,
+		}, {
+			name: "invalid params with invalid pool name",
+			params: storage.ImportFilesystemParams{
+				ID:                "fs-0",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "invalid pool name",
+				StorageInstanceID: "foo/0",
+			},
+			valid: false,
+		}, {
+			name: "invalid params with invalid storage instance ID",
+			params: storage.ImportFilesystemParams{
+				ID:                "fs-0",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "default",
+				StorageInstanceID: "invalid storage instance id",
+			},
+			valid: false,
+		}, {
+			name: "invalid params attachment host machine and unit",
+			params: storage.ImportFilesystemParams{
+				ID:                "fs-0",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "default",
+				StorageInstanceID: "foo/0",
+				Attachments: []storage.ImportFilesystemAttachmentsParams{
+					{
+						HostMachineName: "0",
+						HostUnitName:    "unit/0",
+						MountPoint:      "/mnt/fs-0",
+						ReadOnly:        false,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid params attachment no host",
+			params: storage.ImportFilesystemParams{
+				ID:                "fs-0",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "default",
+				StorageInstanceID: "foo/0",
+				Attachments: []storage.ImportFilesystemAttachmentsParams{
+					{
+						MountPoint: "/mnt/fs-0",
+						ReadOnly:   false,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid params attachment host unit invalid",
+			params: storage.ImportFilesystemParams{
+				ID:                "fs-0",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "default",
+				StorageInstanceID: "foo/0",
+				Attachments: []storage.ImportFilesystemAttachmentsParams{
+					{
+						HostUnitName: "invalid host unit name",
+						MountPoint:   "/mnt/fs-0",
+						ReadOnly:     false,
+					},
+				},
+			},
+			valid: false,
+		}, {
+			name: "invalid params attachment host machine invalid",
+			params: storage.ImportFilesystemParams{
+				ID:                "fs-0",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "default",
+				StorageInstanceID: "foo/0",
+				Attachments: []storage.ImportFilesystemAttachmentsParams{
+					{
+						HostMachineName: "invalid host machine name",
+						MountPoint:      "/mnt/fs-0",
+						ReadOnly:        false,
+					},
+				},
+			},
+			valid: false,
+		}, {
+			name: "invalid params attachment empty mount point",
+			params: storage.ImportFilesystemParams{
+				ID:                "fs-0",
+				SizeInMiB:         1024,
+				ProviderID:        "provider-id",
+				PoolName:          "default",
+				StorageInstanceID: "foo/0",
+				Attachments: []storage.ImportFilesystemAttachmentsParams{
+					{
+						HostMachineName: "0",
+						ReadOnly:        false,
+					},
+				},
+			},
+			valid: false,
+		},
+	} {
+		c.Logf("testing: %s", test.name)
+		err := test.params.Validate()
+		if test.valid {
+			c.Assert(err, tc.ErrorIsNil)
+		} else {
+			c.Assert(err, tc.NotNil)
+		}
+	}
+}


### PR DESCRIPTION
Recently, import of filesystems was added. However, filesystem
attachments needed to be imported as well.

Amend ImportFilesystems (now ImportFilesystemsIAAS) to import filesystem
attachments as well

NOTE: this PR includes two commits, one authored by @hmlanigan I have pulled from https://github.com/juju/juju/pull/21787, since I need `GetNetNodeUUIDsByMachineOrUnitName`. Another including my work is based on top

## QA steps

```
$ juju_40 bootstrap localhost 40
$ juju_36 bootstrap localhost 36
$ juju add-model m
$ juju deploy  ./testcharms/charms/dummy-storage --storage multi-fs=10M
$ juju migrate m 40
$ juju switch 40:m
$ juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
m      40          localhost/localhost  4.0.3.1  14:35:33Z

App            Version  Status  Scale  Charm          Channel  Rev  Exposed  Message
dummy-storage           active      1  dummy-storage             0  no       Started

Unit              Workload  Agent  Machine  Public address  Ports  Message
dummy-storage/0*  active    idle   0        10.51.45.34            Started

Machine  State    Address      Inst id        Base          AZ    Message
0        started  10.51.45.34  juju-556dc4-0  ubuntu@24.04  jack  Running

Storage Unit     Storage ID  Type        Mountpoint                Size    Status    Message
                 multi-fs/0  filesystem  /srv/multi-fs/multi-fs/0  10 MiB  attached  
```
^ NOTE Storage Unit will not show, since regular storage attachments are not yet imported