### PR TITLE
fix: clean-up of orphaned k8s resources after application removal

### DIFF
--- a/internal/secrets/provider/kubernetes/labels.go
+++ b/internal/secrets/provider/kubernetes/labels.go
@@ -27,6 +27,7 @@ func labelsForSecretRevision(modelName string, modelUUID string) labels.Set {
 func labelsForServiceAccount(modelName string, modelUUID string) labels.Set {
 	secretLabels := map[string]string{
 		constants.LabelJujuModelName: modelName,
+		constants.LabelJujuModelUUID: modelUUID,
 		labelJujuSecretModelName:     modelName,
 		labelJujuSecretModelUUID:     modelUUID,
 	}

--- a/internal/secrets/provider/kubernetes/labels_test.go
+++ b/internal/secrets/provider/kubernetes/labels_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/juju/juju/internal/provider/kubernetes/constants"
+	"github.com/juju/juju/internal/provider/kubernetes/utils"
+)
+
+// TestServiceAccountLabelsMatchAppCreatedSelector verifies that the labels
+// applied to secrets provider resources (service accounts, roles, rolebindings)
+// are a superset of the LabelsForAppCreated selector used by app.Delete() for
+// label-based K8s resource cleanup. If this test fails, removed applications
+// will leave orphaned secrets provider resources behind in the cluster.
+func TestServiceAccountLabelsMatchAppCreatedSelector(t *testing.T) {
+	const (
+		appName        = "zinc-k8s"
+		modelName      = "my-model"
+		modelUUID      = "deadbeef-0bad-400d-8000-4b1d0d06f00d"
+		controllerUUID = "deadbeef-1bad-500d-9000-4b1d0d06f00d"
+	)
+
+	// Build labels exactly as ensureSecretAccessToken does:
+	// 1. Start with labelsForServiceAccount (base labels)
+	// 2. Merge in app name labels including LabelJujuAppCreatedBy
+	resourceLabels := labelsForServiceAccount(modelName, modelUUID)
+	resourceLabels = utils.LabelsMerge(resourceLabels, map[string]string{
+		constants.LabelKubernetesAppName: appName,
+		constants.LabelJujuAppCreatedBy:  appName,
+	})
+
+	// Build the selector that app.Delete() uses to find resources to clean up.
+	cleanupSelector := utils.LabelsToSelector(
+		utils.LabelsForAppCreated(appName, modelName, modelUUID, controllerUUID, constants.LabelVersion2),
+	)
+
+	if !cleanupSelector.Matches(resourceLabels) {
+		t.Errorf("secrets provider resource labels do not match app.Delete() cleanup selector\n"+
+			"resource labels: %v\n"+
+			"cleanup selector: %v",
+			resourceLabels, cleanupSelector)
+	}
+}

--- a/internal/secrets/provider/kubernetes/provider.go
+++ b/internal/secrets/provider/kubernetes/provider.go
@@ -995,6 +995,7 @@ func (k *kubernetesClient) ensureSecretAccessToken(
 	labels = utils.LabelsMerge(labels,
 		map[string]string{
 			constants.LabelKubernetesAppName: appName,
+			constants.LabelJujuAppCreatedBy:  appName,
 		})
 
 	// Compose the name of the service account and role and role binding.

--- a/internal/secrets/provider/kubernetes/provider_test.go
+++ b/internal/secrets/provider/kubernetes/provider_test.go
@@ -117,7 +117,9 @@ func (s *providerSuite) expectEnsureSecretAccessToken(consumer, appNameLabel str
 		Labels: map[string]string{
 			"app.kubernetes.io/managed-by": "juju",
 			"app.kubernetes.io/name":       appNameLabel,
+			"app.juju.is/created-by":       appNameLabel,
 			"model.juju.is/name":           "fred",
+			"model.juju.is/id":             coretesting.ModelTag.Id(),
 			"secrets.juju.is/model-name":   "fred",
 			"secrets.juju.is/model-id":     coretesting.ModelTag.Id(),
 		},
@@ -211,7 +213,9 @@ func (s *providerSuite) expectEnsureControllerModelSecretAccessToken(unit string
 		Labels: map[string]string{
 			"app.kubernetes.io/managed-by": "juju",
 			"app.kubernetes.io/name":       "gitlab",
+			"app.juju.is/created-by":       "gitlab",
 			"model.juju.is/name":           "controller",
+			"model.juju.is/id":             coretesting.ModelTag.Id(),
 			"secrets.juju.is/model-name":   "controller",
 			"secrets.juju.is/model-id":     coretesting.ModelTag.Id(),
 		},
@@ -575,7 +579,9 @@ func (s *providerSuite) TestEnsureSecretAccessTokenUpdate(c *tc.C) {
 		Labels: map[string]string{
 			"app.kubernetes.io/managed-by": "juju",
 			"app.kubernetes.io/name":       "gitlab",
+			"app.juju.is/created-by":       "gitlab",
 			"model.juju.is/name":           "fred",
+			"model.juju.is/id":             coretesting.ModelTag.Id(),
 			"secrets.juju.is/model-name":   "fred",
 			"secrets.juju.is/model-id":     coretesting.ModelTag.Id(),
 		},

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -380,11 +380,11 @@ func appDying(
 ) (err error) {
 	logger.Debugf(ctx, "application %q dying", appName)
 	err = ensureScale(ctx, appName, appUUID, app, appLife, facade, applicationService, logger)
-	if err != nil {
+	if err != nil && !errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return errors.Annotate(err, "cannot scale dying application to 0")
 	}
 	err = reconcileDeadUnitScale(ctx, appName, appUUID, app, facade, applicationService, logger)
-	if err != nil {
+	if err != nil && !errors.Is(err, applicationerrors.ApplicationNotFound) {
 		return errors.Annotate(err, "cannot reconcile dead units in dying application")
 	}
 	return nil

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/unit"
 	applicationcharm "github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/deployment/charm"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
@@ -752,6 +753,31 @@ func (s *OpsSuite) TestAppDying(c *tc.C) {
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(nil, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.AppDying(c.Context(), "test", appUUID, app,
+		life.Dying, facade, applicationService, statusService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestAppDyingApplicationNotFound(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appUUID := tc.Must(c, application.NewUUID)
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+	statusService := mocks.NewMockStatusService(ctrl)
+
+	// GetApplicationScalingState returns ApplicationNotFound because the app
+	// has already been removed from the DB. appDying should tolerate this
+	// so that appDead can still run and clean up K8s resources.
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").
+			Return(applicationservice.ScalingState{}, applicationerrors.ApplicationNotFound),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).
+			Return(nil, applicationerrors.ApplicationNotFound),
 	)
 
 	err := caasapplicationprovisioner.AppOps.AppDying(c.Context(), "test", appUUID, app,


### PR DESCRIPTION
This patch fixes two distinct bugs which prevent the correct cleanup of k8s resources after an application was completely removed.

1) `ApplicationNotFound` returned during CAAS application provisioner `appDying()` would return with an error instead of advancing to `appDead` and correctly removing the resources.
This is fixed in the first commit.

This happens because in https://github.com/juju/juju/blob/d78cc51695ed0572366d7086d55a9577c0e81fc9/internal/worker/caasapplicationprovisioner/application.go#L236-L237 we only update `appLife` thus hiding the error, and then https://github.com/juju/juju/blob/d78cc51695ed0572366d7086d55a9577c0e81fc9/internal/worker/caasapplicationprovisioner/application.go#L327-L328 is where we'll return with an error and never advancing to `err = a.ops.AppDead(...`.

2) The secrets provider lacked two labels during creation (`app.juju.is/created-by` and `model.juju.is/id`). This prevented `app.Delete()` to correctly match the labels during cleanup. 
The required labels are https://github.com/juju/juju/blob/d78cc51695ed0572366d7086d55a9577c0e81fc9/internal/provider/kubernetes/utils/labels.go#L136-L149: 
- app.juju.is/created-by (missing)
- model.juju.is/name
- model.juju.is/id (missing)
- app.kubernetes.io/managed-by
This is fixed in the second commit.

## QA steps
Bootstrap on microk8s and deploy `zinc-k8s`:
```
$ make go-install
$ make microks8-operator-update
$ juju bootstrap microk8s c
$ juju add-model m
$ juju deploy zinc-k8s
```
Once the app is active, check the resources:
```
$ microk8s kubectl -n m get deployments.apps,svc,sa,roles,rolebindings,secrets,pvc
NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/modeloperator   1/1     1            1           87s

NAME                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
service/modeloperator        ClusterIP   10.152.183.241   <none>        17071/TCP   87s
service/zinc-k8s             ClusterIP   10.152.183.42    <none>        4080/TCP    80s
service/zinc-k8s-endpoints   ClusterIP   None             <none>        <none>      80s

NAME                             AGE
serviceaccount/default           94s
serviceaccount/model-exec        88s
serviceaccount/modeloperator     88s
serviceaccount/unit-zinc-k8s-0   58s
serviceaccount/zinc-k8s          79s

NAME                                             CREATED AT
role.rbac.authorization.k8s.io/model-exec        2026-02-25T11:33:10Z
role.rbac.authorization.k8s.io/modeloperator     2026-02-25T11:33:10Z
role.rbac.authorization.k8s.io/unit-zinc-k8s-0   2026-02-25T11:33:40Z
role.rbac.authorization.k8s.io/zinc-k8s          2026-02-25T11:33:19Z

NAME                                                    ROLE                   AGE
rolebinding.rbac.authorization.k8s.io/model-exec        Role/model-exec        88s
rolebinding.rbac.authorization.k8s.io/modeloperator     Role/modeloperator     88s
rolebinding.rbac.authorization.k8s.io/unit-zinc-k8s-0   Role/unit-zinc-k8s-0   58s
rolebinding.rbac.authorization.k8s.io/zinc-k8s          Role/zinc-k8s          79s

NAME                                 TYPE                                  DATA   AGE
secret/d6fds4vmp2500agfeef0-1        Opaque                                1      58s
secret/model-exec                    kubernetes.io/service-account-token   3      88s
secret/zinc-k8s-application-config   Opaque                                5      80s
secret/zinc-k8s-zinc-secret          kubernetes.io/dockerconfigjson        1      79s

NAME                                                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        VOLUMEATTRIBUTESCLASS   AGE
persistentvolumeclaim/zinc-k8s-data-e2ca24-zinc-k8s-0   Bound    pvc-be13a595-04fa-4172-b577-bd8ae2f6f0ae   1Gi        RWO            microk8s-hostpath   <unset>                 75s
```
Now we can remove the app and check that all resources related to the app are actually gone:
```
$ juju remove-application zinc-k8s
# wait until fully gone...
$ microk8s kubectl -n m get deployments.apps,svc,sa,roles,rolebindings,secrets,pvc
NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/modeloperator   1/1     1            1           3m3s

NAME                    TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
service/modeloperator   ClusterIP   10.152.183.241   <none>        17071/TCP   3m3s

NAME                           AGE
serviceaccount/default         3m10s
serviceaccount/model-exec      3m4s
serviceaccount/modeloperator   3m4s

NAME                                           CREATED AT
role.rbac.authorization.k8s.io/model-exec      2026-02-25T11:33:10Z
role.rbac.authorization.k8s.io/modeloperator   2026-02-25T11:33:10Z

NAME                                                  ROLE                 AGE
rolebinding.rbac.authorization.k8s.io/model-exec      Role/model-exec      3m4s
rolebinding.rbac.authorization.k8s.io/modeloperator   Role/modeloperator   3m4s

NAME                TYPE                                  DATA   AGE
secret/model-exec   kubernetes.io/service-account-token   3      3m4s
```
(`service/zinc-k8s` and `service/zinc-k8s-endpoints`, `serviceaccount/unit-zinc-k8s-0`, `serviceaccount/zinc-k8s`, `role.rbac.authorization.k8s.io/unit-zinc-k8s-0`, `role.rbac.authorization.k8s.io/zinc-k8s`, `rolebinding.rbac.authorization.k8s.io/unit-zinc-k8s-0`, `rolebinding.rbac.authorization.k8s.io/zinc-k8s`, `secret/zinc-k8s-application-config`, `secret/zinc-k8s-zinc-secret` and `persistentvolumeclaim/zinc-k8s-data-e2ca24-zinc-k8s-0` are all gone).

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9192](https://warthogs.atlassian.net/browse/JUJU-9192)


[JUJU-9192]: https://warthogs.atlassian.net/browse/JUJU-9192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ