### PR TITLE
fix: panic in ModelConfigAPI.ModelUnset error handling

### DIFF
--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -303,7 +303,7 @@ func (c *ModelConfigAPI) ModelUnset(ctx context.Context, args params.ModelUnset)
 		return errors.Trace(err)
 	}
 
-	var validationError config.ValidationError
+	var validationError *config.ValidationError
 	err := c.modelConfigService.UpdateModelConfig(ctx, nil, args.Keys)
 	if errors.As(err, &validationError) {
 		return fmt.Errorf("removing config key %q %w: %s",

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -403,6 +403,28 @@ func (s *modelconfigSuite) TestModelUnset(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *modelconfigSuite) TestModelUnsetValidation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	api := s.getAPI(c)
+
+	s.expectModelWriteAccess()
+	s.expectNoBlocks()
+
+	s.mockModelConfigService.EXPECT().UpdateModelConfig(
+		gomock.Any(),
+		nil,
+		[]string{"abc"},
+		gomock.Any(),
+	).Return(&config.ValidationError{
+		InvalidAttrs: []string{"abc"},
+		Reason:       "some reason",
+	})
+
+	args := params.ModelUnset{Keys: []string{"abc"}}
+	err := api.ModelUnset(c.Context(), args)
+	c.Assert(err, tc.ErrorIs, errors.NotValid)
+}
+
 func (s *modelconfigSuite) TestBlockModelUnset(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	api := s.getAPI(c)


### PR DESCRIPTION
Fix ModelUnset of ModelConfigAPI facade crashing on non-nil errors from UpdateModelConfig

Found with [`errortype`](https://github.com/fillmore-labs/errortype#errortype)

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

A unit test added, which crashes without the fix.

## Documentation changes

None, since it's the same API as before.

## Links

[`errors.As`](https://pkg.go.dev/errors#As): As panics if target is not a non-nil pointer to [...] a type that implements error [...]
