### PR TITLE
docs: remove duplicate section and fix numbering

### DIFF
--- a/docs/howto/manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40.md
+++ b/docs/howto/manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40.md
@@ -315,22 +315,7 @@ juju add-machine kvm:1
 juju add-machine lxd:1 --constraints virt-type=virtual-machine
 ```
 
-### 11. `juju status --watch` is dropped
-
-`juju wait-for` and subcommands are removed in `4.0`. Use status polling and check readiness yourself.
-
-**Juju 3.6**
-```bash
-juju wait-for application myapp --timeout=10m
-```
-
-**Juju 4.0**
-```bash
-# poll JSON status, then evaluate readiness client-side
-juju status --format=json
-```
-
-### 12. `juju wait-for` removed (scripts/CI must change)
+### 11. `juju wait-for` removed (scripts/CI must change)
 
 `juju wait-for` and subcommands are removed in `4.0`. Use status polling and check readiness yourself.
 
@@ -345,7 +330,7 @@ juju wait-for application myapp --timeout=10m
 juju status --format=json
 ```
 
-### 13. `juju export-bundle` removed
+### 12. `juju export-bundle` removed
 
 The `juju status` command cannot be used to watch status anymore. Please use the third-party `watch`.
 
@@ -359,7 +344,7 @@ juju export-bundle > bundle.yaml
 # Command removed. Please use Juju Terraform Provider plans.
 ```
 
-### 14. `juju status --watch` flag is dropped
+### 13. `juju status --watch` flag is dropped
 
 Operators can’t use `juju status` to watch the changes (via polling) using this command in `4.0`.
 


### PR DESCRIPTION
The upgrade guide contained a duplicate section regarding 'juju wait-for' / 'status --watch'.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# checks should pass
```

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
