### PR TITLE
fix: remove charm annotations only when empty string is provided

### DIFF
--- a/domain/annotation/service/service.go
+++ b/domain/annotation/service/service.go
@@ -34,9 +34,9 @@ type State interface {
 	// SetCharmAnnotations associates key/value annotation pairs with a given ID.
 	// If an annotation already exists for the given ID, then it will be updated
 	// with the given value.
-	// First all annotations are deleted, then the given
-	// pairs are inserted, so unsetting an annotation is implicit.
-	SetCharmAnnotations(ctx context.Context, ID annotation.GetCharmArgs, annotations map[string]string) error
+	// Annotation keys not included will be left unchanged.
+	// Annotation keys in the deletions slice will be deleted.
+	SetCharmAnnotations(ctx context.Context, ID annotation.GetCharmArgs, upserts map[string]string, deletions []string) error
 }
 
 // Service provides the API for working with annotations.
@@ -115,6 +115,8 @@ func (s *Service) SetAnnotations(ctx context.Context, id annotations.ID, annotat
 // SetCharmAnnotations associates key/value annotation pairs with a given charm
 // argument. If an annotation already exists for the given ID, then it will be
 // updated with the given value.
+// Annotation keys not included will be left unchanged.
+// Annotation keys with an empty string value will be removed.
 func (s *Service) SetCharmAnnotations(ctx context.Context, id annotation.GetCharmArgs, annotations map[string]string) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -127,7 +129,18 @@ func (s *Service) SetCharmAnnotations(ctx context.Context, id annotation.GetChar
 		return errors.Capture(err)
 	}
 
-	if err := s.st.SetCharmAnnotations(ctx, id, annotations); err != nil {
+	// To maintain API compatibility with the 3.x series, treat empty string values as deletions
+	upserts := make(map[string]string)
+	deletions := make([]string, 0)
+	for key, value := range annotations {
+		if value != "" {
+			upserts[key] = value
+		} else {
+			deletions = append(deletions, key)
+		}
+	}
+
+	if err := s.st.SetCharmAnnotations(ctx, id, upserts, deletions); err != nil {
 		return errors.Errorf("updating annotations for %q: %w", id.Name, err)
 	}
 	return nil

--- a/domain/annotation/service/service_test.go
+++ b/domain/annotation/service/service_test.go
@@ -156,8 +156,7 @@ func (s *serviceSuite) TestSetCharmAnnotations(c *tc.C) {
 		Revision: 1,
 	}, map[string]string{
 		"annotationKey1": "annotationValue1",
-		"annotationKey2": "annotationValue2",
-	}).Return(nil)
+	}, []string{"annotationKey2"}).Return(nil)
 
 	err := s.service().SetCharmAnnotations(c.Context(), annotation.GetCharmArgs{
 		Source:   "ch",
@@ -165,9 +164,63 @@ func (s *serviceSuite) TestSetCharmAnnotations(c *tc.C) {
 		Revision: 1,
 	}, map[string]string{
 		"annotationKey1": "annotationValue1",
-		"annotationKey2": "annotationValue2",
+		"annotationKey2": "",
 	})
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestSetCharmAnnotationsUpsertAndDelete(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	id1 := annotation.GetCharmArgs{Source: "ch", Name: "foo", Revision: 1}
+	id2 := annotation.GetCharmArgs{Source: "ch", Name: "bar", Revision: 2}
+
+	type stateCharmAnnotationKey struct {
+		ID  annotation.GetCharmArgs
+		key string
+	}
+	mockState := map[stateCharmAnnotationKey]string{
+		{ID: id1, key: "annotationKey1"}: "annotationValue1",
+		{ID: id1, key: "annotationKey2"}: "annotationValue2",
+		{ID: id2, key: "annotationKey4"}: "annotationValue4",
+	}
+
+	s.state.EXPECT().SetCharmAnnotations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, id annotation.GetCharmArgs, upserts map[string]string, deletions []string) error {
+			for annKey, annVal := range upserts {
+				mockState[stateCharmAnnotationKey{ID: id, key: annKey}] = annVal
+			}
+			for _, annKey := range deletions {
+				delete(mockState, stateCharmAnnotationKey{ID: id, key: annKey})
+			}
+			return nil
+		},
+	).AnyTimes()
+
+	// Upsert new key and update an existing one.
+	err := s.service().SetCharmAnnotations(c.Context(), id1, map[string]string{
+		"annotationKey5": "annotationValue5",
+		"annotationKey1": "annotationValue1Updated",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(mockState), tc.Equals, 4)
+	c.Assert(mockState[stateCharmAnnotationKey{ID: id1, key: "annotationKey5"}], tc.Equals, "annotationValue5")
+	c.Assert(mockState[stateCharmAnnotationKey{ID: id1, key: "annotationKey1"}], tc.Equals, "annotationValue1Updated")
+
+	// Unset a key.
+	err = s.service().SetCharmAnnotations(c.Context(), id2, map[string]string{
+		"annotationKey4": "",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(mockState), tc.Equals, 3)
+
+	// Upsert and unset in a single call.
+	err = s.service().SetCharmAnnotations(c.Context(), id1, map[string]string{
+		"annotationKey1": "annotationValue1Final",
+		"annotationKey5": "",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(mockState), tc.Equals, 2)
+	c.Assert(mockState[stateCharmAnnotationKey{ID: id1, key: "annotationKey1"}], tc.Equals, "annotationValue1Final")
 }
 
 func (s *serviceSuite) TestSetAnnotationsWithInvalidKeys(c *tc.C) {

--- a/domain/annotation/service/state_mock_test.go
+++ b/domain/annotation/service/state_mock_test.go
@@ -158,17 +158,17 @@ func (c *MockStateSetAnnotationsCall) DoAndReturn(f func(context.Context, annota
 }
 
 // SetCharmAnnotations mocks base method.
-func (m *MockState) SetCharmAnnotations(arg0 context.Context, arg1 annotation.GetCharmArgs, arg2 map[string]string) error {
+func (m *MockState) SetCharmAnnotations(arg0 context.Context, arg1 annotation.GetCharmArgs, arg2 map[string]string, arg3 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmAnnotations", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetCharmAnnotations", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCharmAnnotations indicates an expected call of SetCharmAnnotations.
-func (mr *MockStateMockRecorder) SetCharmAnnotations(arg0, arg1, arg2 any) *MockStateSetCharmAnnotationsCall {
+func (mr *MockStateMockRecorder) SetCharmAnnotations(arg0, arg1, arg2, arg3 any) *MockStateSetCharmAnnotationsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmAnnotations", reflect.TypeOf((*MockState)(nil).SetCharmAnnotations), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmAnnotations", reflect.TypeOf((*MockState)(nil).SetCharmAnnotations), arg0, arg1, arg2, arg3)
 	return &MockStateSetCharmAnnotationsCall{Call: call}
 }
 
@@ -184,13 +184,13 @@ func (c *MockStateSetCharmAnnotationsCall) Return(arg0 error) *MockStateSetCharm
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetCharmAnnotationsCall) Do(f func(context.Context, annotation.GetCharmArgs, map[string]string) error) *MockStateSetCharmAnnotationsCall {
+func (c *MockStateSetCharmAnnotationsCall) Do(f func(context.Context, annotation.GetCharmArgs, map[string]string, []string) error) *MockStateSetCharmAnnotationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetCharmAnnotationsCall) DoAndReturn(f func(context.Context, annotation.GetCharmArgs, map[string]string) error) *MockStateSetCharmAnnotationsCall {
+func (c *MockStateSetCharmAnnotationsCall) DoAndReturn(f func(context.Context, annotation.GetCharmArgs, map[string]string, []string) error) *MockStateSetCharmAnnotationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/annotation/state/state.go
+++ b/domain/annotation/state/state.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
-	"github.com/juju/juju/domain/annotation"
+	domainannotation "github.com/juju/juju/domain/annotation"
 	annotationerrors "github.com/juju/juju/domain/annotation/errors"
 	"github.com/juju/juju/internal/errors"
 )
@@ -44,7 +44,7 @@ func (st *State) GetAnnotations(ctx context.Context, id annotations.ID) (map[str
 // GetCharmAnnotations will retrieve all the annotations associated with the
 // given ID from the database.
 // If no annotations are found, an empty map is returned.
-func (st *State) GetCharmAnnotations(ctx context.Context, id annotation.GetCharmArgs) (map[string]string, error) {
+func (st *State) GetCharmAnnotations(ctx context.Context, id domainannotation.GetCharmArgs) (map[string]string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -55,13 +55,13 @@ func (st *State) GetCharmAnnotations(ctx context.Context, id annotation.GetCharm
 		Revision: id.Revision,
 	}
 
-	var results []Annotation
+	var results []annotation
 	query, err := st.Prepare(`
-SELECT (key, value) AS (&Annotation.*)
+SELECT (key, value) AS (&annotation.*)
 FROM annotation_charm AS ac
 JOIN v_charm_annotation_index AS c ON ac.uuid = c.uuid
 WHERE c.name = $charmArgs.name AND c.revision = $charmArgs.revision;
-`, args, Annotation{})
+`, args, annotation{})
 	if err != nil {
 		return nil, errors.Errorf("preparing get charm annotations query: %w", err)
 	}
@@ -77,7 +77,7 @@ WHERE c.name = $charmArgs.name AND c.revision = $charmArgs.revision;
 		return nil, errors.Errorf("loading annotations for charm %q: %w", id.Name, err)
 	}
 
-	annotations := transform.SliceToMap(results, func(a Annotation) (string, string) {
+	annotations := transform.SliceToMap(results, func(a annotation) (string, string) {
 		return a.Key, a.Value
 	})
 
@@ -97,13 +97,13 @@ func (st *State) getAnnotationsForModel(ctx context.Context) (map[string]string,
 	}
 
 	getAnnotationsStmt, err := st.Prepare(`
-SELECT (key, value) AS (&Annotation.*) 
-FROM   annotation_model`, Annotation{})
+SELECT (key, value) AS (&annotation.*)
+FROM   annotation_model`, annotation{})
 	if err != nil {
 		return nil, errors.Errorf("preparing get annotations query for model: %w", err)
 	}
 
-	var annotationsResults []Annotation
+	var annotationsResults []annotation
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, getAnnotationsStmt).GetAll(&annotationsResults)
 		if errors.Is(err, sqlair.ErrNoRows) {
@@ -115,7 +115,7 @@ FROM   annotation_model`, Annotation{})
 		return nil, errors.Errorf("loading annotations for model: %w", err)
 	}
 
-	annotations := transform.SliceToMap(annotationsResults, func(a Annotation) (string, string) { return a.Key, a.Value })
+	annotations := transform.SliceToMap(annotationsResults, func(a annotation) (string, string) { return a.Key, a.Value })
 
 	return annotations, nil
 }
@@ -137,11 +137,11 @@ func (st *State) getAnnotationsForID(ctx context.Context, id annotations.ID) (ma
 		return nil, errors.Capture(err)
 	}
 	getAnnotationsQuery := fmt.Sprintf(`
-SELECT (key, value) AS (&Annotation.*)
+SELECT (key, value) AS (&annotation.*)
 FROM %s
 WHERE uuid = $annotationUUID.uuid`, tableName)
 
-	getAnnotationsStmt, err := st.Prepare(getAnnotationsQuery, Annotation{}, annotationUUID{})
+	getAnnotationsStmt, err := st.Prepare(getAnnotationsQuery, annotation{}, annotationUUID{})
 	if err != nil {
 		return nil, errors.Errorf("preparing get annotations query for ID: %q: %w", id.Name, err)
 	}
@@ -156,7 +156,7 @@ WHERE uuid = $annotationUUID.uuid`, tableName)
 		return nil, errors.Errorf("preparing get annotations query for ID: %q: %w", id.Name, err)
 	}
 
-	var annotationsResults []Annotation
+	var annotationsResults []annotation
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, kindQueryStmt, kindQueryParam).Get(&annotationUUIDParam)
 		if errors.Is(err, sqlair.ErrNoRows) {
@@ -176,7 +176,7 @@ WHERE uuid = $annotationUUID.uuid`, tableName)
 		return nil, errors.Errorf("loading annotations for ID: %q: %w", id.Name, err)
 	}
 
-	annotations := transform.SliceToMap(annotationsResults, func(a Annotation) (string, string) {
+	annotations := transform.SliceToMap(annotationsResults, func(a annotation) (string, string) {
 		return a.Key, a.Value
 	})
 
@@ -218,10 +218,10 @@ func (st *State) setAnnotationsForID(ctx context.Context, id annotations.ID,
 	}
 	insertQuery := fmt.Sprintf(`
 INSERT INTO %s (uuid, key, value)
-VALUES ($annotationUUID.uuid, $Annotation.key, $Annotation.value)
-	ON CONFLICT(uuid, key) DO UPDATE SET value=$Annotation.value`, tableName)
+VALUES ($annotationUUID.uuid, $annotation.key, $annotation.value)
+	ON CONFLICT(uuid, key) DO UPDATE SET value=$annotation.value`, tableName)
 
-	setAnnotationsStmt, err := st.Prepare(insertQuery, Annotation{}, annotationUUID{})
+	setAnnotationsStmt, err := st.Prepare(insertQuery, annotation{}, annotationUUID{})
 	if err != nil {
 		return errors.Errorf("preparing set annotations query for ID: %q: %w", id.Name, err)
 	}
@@ -259,7 +259,7 @@ WHERE uuid = $annotationUUID.uuid AND key IN ($deleteInput[:])`, tableName)
 			return errors.Errorf("unsetting annotations for ID: %s: %w", id.Name, err)
 		}
 
-		var annotationParam Annotation
+		var annotationParam annotation
 		for key, value := range upserts {
 			annotationParam.Key = key
 			annotationParam.Value = value
@@ -291,8 +291,8 @@ func (st *State) setAnnotationsForModel(ctx context.Context,
 
 	setAnnotationsStmt, err := st.Prepare(`
 INSERT INTO annotation_model (key, value)
-VALUES ($Annotation.*)
-	ON CONFLICT(key) DO UPDATE SET value=$Annotation.value`, Annotation{})
+VALUES ($annotation.*)
+	ON CONFLICT(key) DO UPDATE SET value=$annotation.value`, annotation{})
 	if err != nil {
 		return errors.Errorf("preparing set annotations query for model: %w", err)
 	}
@@ -310,7 +310,7 @@ WHERE key IN ($deleteInput[:])`, deleteInput{})
 			return errors.Errorf("unsetting annotations for model: %w", err)
 		}
 
-		var annotationParam Annotation
+		var annotationParam annotation
 		for key, value := range upserts {
 			annotationParam.Key = key
 			annotationParam.Value = value
@@ -328,12 +328,14 @@ WHERE key IN ($deleteInput[:])`, deleteInput{})
 
 // SetCharmAnnotations associates key/value annotation pairs with a given ID.
 // If an annotation already exists for the given ID, then it will be updated
-// with the given value. First all annotations are deleted, then the given pairs
-// are inserted, so unsetting an annotation is implicit.
+// with the given value.
+// Annotation keys not included will be left unchanged.
+// Annotation keys in the deletions slice will be deleted.
 func (st *State) SetCharmAnnotations(
 	ctx context.Context,
-	id annotation.GetCharmArgs,
-	values map[string]string,
+	id domainannotation.GetCharmArgs,
+	upserts map[string]string,
+	deletions []string,
 ) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -353,18 +355,21 @@ WHERE name = $charmArgs.name AND revision = $charmArgs.revision;
 		return errors.Errorf("preparing get charm annotations query: %w", err)
 	}
 
+	type deleteInput []string
 	deleteStmt, err := st.Prepare(`
 DELETE FROM annotation_charm
 WHERE uuid = $annotationUUID.uuid
-`, annotationUUID{})
+AND key IN ($deleteInput[:])
+`, annotationUUID{}, deleteInput{})
 	if err != nil {
 		return errors.Errorf("preparing delete charm annotations query: %w", err)
 	}
 
 	insertStmt, err := st.Prepare(`
-INSERT INTO annotation_charm (*)
-VALUES ($annotationUUID.*, $Annotation.*)
-`, Annotation{}, annotationUUID{})
+INSERT INTO annotation_charm (uuid, key, value)
+VALUES ($annotationUUID.uuid, $annotation.key, $annotation.value)
+ON CONFLICT(uuid, key) DO UPDATE SET value=excluded.value
+`, annotation{}, annotationUUID{})
 	if err != nil {
 		return errors.Errorf("preparing set charm annotations query: %w", err)
 	}
@@ -378,12 +383,12 @@ VALUES ($annotationUUID.*, $Annotation.*)
 			return errors.Errorf("looking up UUID for ID: %s: %w", id.Name, err)
 		}
 
-		if err := tx.Query(ctx, deleteStmt, annotationUUID).Run(); err != nil {
+		if err := tx.Query(ctx, deleteStmt, annotationUUID, deleteInput(deletions)).Run(); err != nil {
 			return errors.Errorf("unsetting annotations for ID: %s: %w", id.Name, err)
 		}
 
-		var annotationParam Annotation
-		for key, value := range values {
+		var annotationParam annotation
+		for key, value := range upserts {
 			annotationParam.Key = key
 			annotationParam.Value = value
 			if err := tx.Query(ctx, insertStmt, annotationUUID, annotationParam).Run(); err != nil {

--- a/domain/annotation/state/state_test.go
+++ b/domain/annotation/state/state_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/domain/annotation"
+	domainannotation "github.com/juju/juju/domain/annotation"
 	annotationerrors "github.com/juju/juju/domain/annotation/errors"
 	"github.com/juju/juju/domain/deployment/charm"
 	schematesting "github.com/juju/juju/domain/schema/testing"
@@ -52,7 +52,7 @@ func (s *stateSuite) TestGetCharmAnnotations(c *tc.C) {
 	s.ensureAnnotation(c, "charm", "123", "foo", "5")
 	s.ensureAnnotation(c, "charm", "123", "bar", "6")
 
-	annotations, err := st.GetCharmAnnotations(c.Context(), annotation.GetCharmArgs{
+	annotations, err := st.GetCharmAnnotations(c.Context(), domainannotation.GetCharmArgs{
 		Source:   "local",
 		Name:     "mycharmurl",
 		Revision: 5,
@@ -107,14 +107,14 @@ func (s *stateSuite) TestSetCharmAnnotations(c *tc.C) {
 
 	s.ensureCharm(c, "local:mycharmurl-5", "mystorage", "123")
 
-	args := annotation.GetCharmArgs{
+	args := domainannotation.GetCharmArgs{
 		Source:   "local",
 		Name:     "mycharmurl",
 		Revision: 5,
 	}
 
 	// Set annotations bar:6 and foo:15
-	err := st.SetCharmAnnotations(c.Context(), args, map[string]string{"bar": "6", "foo": "15"})
+	err := st.SetCharmAnnotations(c.Context(), args, map[string]string{"bar": "6", "foo": "15"}, []string{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Check the final annotation set
@@ -122,8 +122,8 @@ func (s *stateSuite) TestSetCharmAnnotations(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(annotations, tc.DeepEquals, map[string]string{"bar": "6", "foo": "15"})
 
-	// Set annotations bar:6 and foo:15
-	err = st.SetCharmAnnotations(c.Context(), args, map[string]string{"bar": "6", "baz": "7"})
+	// Set annotations bar:6 and baz:7 and unset foo.
+	err = st.SetCharmAnnotations(c.Context(), args, map[string]string{"bar": "6", "baz": "7"}, []string{"foo"})
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Check the final annotation set

--- a/domain/annotation/state/types.go
+++ b/domain/annotation/state/types.go
@@ -3,9 +3,9 @@
 
 package state
 
-// Annotation represents an annotation in the state layer that we read/write
+// annotation represents an annotation in the state layer that we read/write
 // to/from DB.
-type Annotation struct {
+type annotation struct {
 	Key   string `db:"key"`
 	Value string `db:"value"`
 }


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

Removing/unsetting charm annotations by sending empty string as their value. This is to regain compatibility with 3.6.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

