### PR TITLE
fix: prevent spin-lock in object store scoped context

### DIFF
--- a/internal/objectstore/remote/retriever.go
+++ b/internal/objectstore/remote/retriever.go
@@ -240,28 +240,36 @@ func (c *scopedContext) Done() <-chan struct{} {
 		close(d)
 	})
 
+	parentDone := c.parent.Done()
+	childDone := c.child.Done()
+
 	go func() {
 		for {
 			select {
-			case <-c.parent.Done():
+			case <-parentDone:
 				closeDone()
 				return
-			case <-c.child.Done():
+			case <-childDone:
 				// If the child context is ignored, we don't want to close
 				// the done channel, because we don't want to propagate the
 				// cancellation to the caller.
 				if c.IsChildIgnored() {
+					// The child channel is closed, disable this select arm to
+					// avoid a tight loop while we continue to wait on parent
+					// cancellation.
+					childDone = nil
 					continue
 				}
 
 				closeDone()
+				return
 			}
 		}
 	}()
 	return d
 }
 
-// If Done is not yet closed, Err returns nil.
+// Err returns nil if channel returned by Done() is not yet closed.
 func (c *scopedContext) Err() error {
 	if err := c.parent.Err(); err != nil {
 		return err

--- a/internal/objectstore/remote/retriever_test.go
+++ b/internal/objectstore/remote/retriever_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	io "io"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -257,6 +258,63 @@ func (s *retrieverSuite) TestRetrievePreventReaderCancelationPropagate(c *tc.C) 
 	s.checkReader(c, reader, size)
 
 	workertest.CleanKill(c, ret)
+}
+
+func (s *retrieverSuite) TestScopedContextDoneClosesOnChildDone(c *tc.C) {
+	parentCtx, parentCancel := context.WithCancel(c.Context())
+	defer parentCancel()
+
+	childCtx, childCancel := context.WithCancel(c.Context())
+	defer childCancel()
+
+	ctx := &scopedContext{
+		parent: parentCtx,
+		child:  childCtx,
+	}
+
+	done := ctx.Done()
+	childCancel()
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("done channel did not close when child context was cancelled: %v", c.Context().Err())
+	}
+}
+
+func (s *retrieverSuite) TestScopedContextDoneIgnoresChildAfterIgnore(c *tc.C) {
+	parentCtx, parentCancel := context.WithCancel(c.Context())
+	defer parentCancel()
+
+	childCtx, childCancel := context.WithCancel(c.Context())
+	defer childCancel()
+
+	ctx := &scopedContext{
+		parent: parentCtx,
+		child:  childCtx,
+	}
+
+	done := ctx.Done()
+	ctx.IgnoreChild()
+	childCancel()
+
+	// Give the goroutine behind Done a chance to process child cancellation.
+	for i := 0; i < 1000; i++ {
+		runtime.Gosched()
+	}
+
+	select {
+	case <-done:
+		c.Fatal("done channel closed while child context is ignored")
+	default:
+	}
+
+	parentCancel()
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("done channel did not close when parent context was cancelled: %v", c.Context().Err())
+	}
 }
 
 func (s *retrieverSuite) newRetriever(c *tc.C) *BlobRetriever {


### PR DESCRIPTION
In the object store worker's `scopedContext`, when ignoring done child contexts, we can create a spin lock where we keep re-reading the `child.Done()` case without doing anything.

Even when the parent is done, we have a 50% chance of selecting the child case on each pass through the loop.

This sets the channel to nil and continues so that the the loop blocks and exits as soon as the parent is done.


## Links

Helps with, but does not alone fix https://github.com/juju/juju/issues/21753.

**Jira card:** [JUJU-9183](https://warthogs.atlassian.net/browse/JUJU-9183)


[JUJU-9183]: https://warthogs.atlassian.net/browse/JUJU-9183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ