### PR TITLE
feat: handle firewaller duplicate changes

### DIFF
--- a/internal/worker/firewaller/firewaller.go
+++ b/internal/worker/firewaller/firewaller.go
@@ -1697,7 +1697,7 @@ func (fw *Firewaller) startConsumerRelationRequirer(
 			return nil, errors.Trace(err)
 		}
 		return data, nil
-	}); err != nil {
+	}); err != nil && !errors.Is(err, errors.AlreadyExists) {
 		return errors.Annotate(err, "error starting consumer relation requirer worker")
 	}
 
@@ -1734,7 +1734,7 @@ func (fw *Firewaller) startConsumerRelationProvider(
 			return nil, errors.Trace(err)
 		}
 		return data, nil
-	}); err != nil {
+	}); err != nil && !errors.Is(err, errors.AlreadyExists) {
 		return errors.Annotate(err, "error starting consumer relation provider worker")
 	}
 
@@ -1794,7 +1794,7 @@ func (fw *Firewaller) startOffererRelation(ctx context.Context, rel domainrelati
 			return nil, errors.Trace(err)
 		}
 		return data, nil
-	}); err != nil {
+	}); err != nil && !errors.Is(err, errors.AlreadyExists) {
 		return errors.Annotate(err, "error starting offerer relation worker")
 	}
 

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -1520,6 +1520,62 @@ func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSide(c *tc.C)
 	}
 }
 
+func (s *InstanceModeSuite) TestRemoteRelationRequirerRoleConsumingSideAlreadyExists(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	s.ensureMocks(c, ctrl)
+
+	// Create the firewaller facade on the consuming model.
+	fw := s.newFirewaller(c, ctrl)
+	defer workertest.CleanKill(c, fw)
+
+	published := make(chan bool)
+	app, _ := s.addApplication(ctrl, "wordpress", true)
+	_, _, m, _ := s.addUnit(c, ctrl, app)
+	s.machinesCh <- []string{m.Tag().Id()}
+	s.waitForMachineFlush(c)
+	relSubnetCh, mac := s.setupRemoteRelationRequirerRoleConsumingSide(c)
+
+	// Force the trigger of the worker again.
+	s.consumerRelCh <- []string{"rel-token"}
+
+	// Have a unit on the consuming app enter the relation scope.
+	// This will trigger the firewaller to publish the changes.
+	event := params.IngressNetworksChangeEvent{
+		RelationToken:   "rel-token",
+		Networks:        []string{"10.0.0.0/24"},
+		IngressRequired: true,
+		Macaroons:       macaroon.Slice{mac},
+		BakeryVersion:   bakery.LatestVersion,
+	}
+	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(gomock.Any(), event).DoAndReturn(func(_ context.Context, _ params.IngressNetworksChangeEvent) error {
+		published <- true
+		return nil
+	})
+
+	relSubnetCh <- []string{"10.0.0.0/24"}
+
+	select {
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("time out waiting for ingress change to be published on enter scope")
+	case <-published:
+	}
+
+	s.crossmodelFirewaller.EXPECT().PublishIngressNetworkChange(gomock.Any(), event).DoAndReturn(func(_ context.Context, _ params.IngressNetworksChangeEvent) error {
+		published <- true
+		return nil
+	})
+
+	relSubnetCh <- []string{"10.0.0.0/24"}
+
+	select {
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("time out waiting for ingress change to be published on enter scope")
+	case <-published:
+	}
+}
+
 func (s *InstanceModeSuite) TestRemoteRelationWorkerError(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
If the firewaller gets changes for the same tag, just ignore it, as we're already processing it.

This prevents the firewaller bouncing completely. The relation and remote model uuid should never change, so it's fine to handle this.


## QA steps

```sh
$ juju bootstrap localhost dst
```

Create a 3.6 model to migrate.

```sh
$ snap install juju --channel=3.6/stable
$ /snap/bin/juju bootstrap localhost src
$ /snap/bin/juju add-model offer && /snap/bin/juju deploy juju-qa-dummy-source && /snap/bin/juju offer dummy-source:sink
$ /snap/bin/juju add-model consume && /snap/bin/juju deploy juju-qa-dummy-sink sink1 &&  && /snap/bin/juju deploy juju-qa-dummy-sink sink2
$ /snap/bin/juju consume src:admin/offer.dummy-source && /snap/bin/juju relate dummy-source sink1 &&  && /snap/bin/juju relate dummy-source sink2
```

Now migrate the model

```sh
$ juju migrate src:to tgt
```

Watch the logs on the controller


## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/21858.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9267](https://warthogs.atlassian.net/browse/JUJU-9267)


[JUJU-9267]: https://warthogs.atlassian.net/browse/JUJU-9267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ