### PR TITLE
fix: close all file object store readers

### DIFF
--- a/internal/objectstore/fileobjectstore.go
+++ b/internal/objectstore/fileobjectstore.go
@@ -38,7 +38,7 @@ const (
 	remoteTimeout = time.Second * 30
 )
 
-// FallBackStrategy is the strategy to use when there is no local file to
+// FallbackStrategy is the strategy to use when there is no local file to
 // retrieve.
 type FallbackStrategy string
 
@@ -539,7 +539,9 @@ func (t *fileObjectStore) loop() error {
 	}
 }
 
-func (t *fileObjectStore) get(ctx context.Context, path string, fallbackStrategy FallbackStrategy) (io.ReadCloser, int64, error) {
+func (t *fileObjectStore) get(
+	ctx context.Context, path string, fallbackStrategy FallbackStrategy,
+) (io.ReadCloser, int64, error) {
 	t.logger.Debugf(ctx, "getting object %q from file storage", path)
 
 	metadata, err := t.metadataService.GetMetadata(ctx, path)
@@ -578,7 +580,9 @@ func (t *fileObjectStore) getBySHA256(ctx context.Context, sha256 string) (io.Re
 	return t.getWithMetadata(ctx, metadata, NoFallback)
 }
 
-func (t *fileObjectStore) getBySHA256Prefix(ctx context.Context, sha256 string, fallbackStrategy FallbackStrategy) (io.ReadCloser, int64, error) {
+func (t *fileObjectStore) getBySHA256Prefix(
+	ctx context.Context, sha256 string, fallbackStrategy FallbackStrategy,
+) (io.ReadCloser, int64, error) {
 	t.logger.Debugf(ctx, "getting object with SHA256 %q from file storage", sha256)
 
 	metadata, err := t.metadataService.GetMetadataBySHA256Prefix(ctx, sha256)
@@ -595,7 +599,9 @@ func (t *fileObjectStore) getBySHA256Prefix(ctx context.Context, sha256 string, 
 	return t.getWithMetadata(ctx, metadata, fallbackStrategy)
 }
 
-func (t *fileObjectStore) getWithMetadata(ctx context.Context, metadata objectstore.Metadata, fallbackStrategy FallbackStrategy) (io.ReadCloser, int64, error) {
+func (t *fileObjectStore) getWithMetadata(
+	ctx context.Context, metadata objectstore.Metadata, fallbackStrategy FallbackStrategy,
+) (io.ReadCloser, int64, error) {
 	hash := SelectFileHash(metadata)
 
 	file, err := t.fs.Open(hash)
@@ -627,14 +633,19 @@ func (t *fileObjectStore) getWithMetadata(ctx context.Context, metadata objectst
 	return file, size, nil
 }
 
-func (t *fileObjectStore) remoteGetWithMetadata(ctx context.Context, metadata objectstore.Metadata) (io.ReadCloser, int64, error) {
+func (t *fileObjectStore) remoteGetWithMetadata(
+	ctx context.Context, metadata objectstore.Metadata,
+) (io.ReadCloser, int64, error) {
 	// Retrieve the file from the remote source.
 	reader, size, err := t.remoteRetriever.Retrieve(ctx, metadata.SHA256)
 	if errors.Is(err, jujuerrors.NotFound) {
 		return nil, -1, errors.Errorf("%w: %w", err, objectstoreerrors.ObjectNotFound)
 	} else if err != nil {
 		return nil, -1, errors.Errorf("remote get: %w", err)
-	} else if size != metadata.Size {
+	}
+	defer func() { _ = reader.Close() }()
+
+	if size != metadata.Size {
 		return nil, -1, errors.Errorf("size mismatch for %q: expected %d, got %d", metadata.Path, metadata.Size, size)
 	}
 
@@ -657,7 +668,8 @@ func (t *fileObjectStore) remoteGetWithMetadata(ctx context.Context, metadata ob
 	encoded384 := hex.EncodeToString(hash384.Sum(nil))
 
 	if encoded384 != metadata.SHA384 {
-		return nil, -1, errors.Errorf("hash mismatch for %q: expected %q, got %q: %w", metadata.Path, metadata.SHA256, encoded384, objectstore.ErrHashMismatch)
+		return nil, -1, errors.Errorf("hash mismatch for %q: expected %q, got %q: %w",
+			metadata.Path, metadata.SHA256, encoded384, objectstore.ErrHashMismatch)
 	}
 
 	// Lock the file with the given hash, so that we can't remove the file
@@ -686,7 +698,9 @@ func (t *fileObjectStore) remoteGetWithMetadata(ctx context.Context, metadata ob
 	return file, size, nil
 }
 
-func (t *fileObjectStore) put(ctx context.Context, path string, r io.Reader, size int64, validator hashValidator) (objectstore.UUID, error) {
+func (t *fileObjectStore) put(
+	ctx context.Context, path string, r io.Reader, size int64, validator hashValidator,
+) (objectstore.UUID, error) {
 	t.logger.Debugf(ctx, "putting object %q to file storage", path)
 
 	// Charms and resources are coded to use the SHA384 hash. It is possible
@@ -719,7 +733,8 @@ func (t *fileObjectStore) put(ctx context.Context, path string, r io.Reader, siz
 
 	// Ensure that the hash of the file matches the expected hash.
 	if expected, ok := validator(encoded384); !ok {
-		return "", errors.Errorf("hash mismatch for %q: expected %q, got %q: %w", path, expected, encoded384, objectstore.ErrHashMismatch)
+		return "", errors.Errorf("hash mismatch for %q: expected %q, got %q: %w",
+			path, expected, encoded384, objectstore.ErrHashMismatch)
 	}
 
 	// Lock the file with the given hash, so that we can't remove the file
@@ -850,7 +865,9 @@ func basePath(rootDir, namespace string) string {
 
 // getFromRemote fetches the object from the remote API server, writes it to
 // the file store, and then retrieves the object from the file store.
-func (t *fileObjectStore) getFromRemote(ctx context.Context, metadata objectstore.Metadata) (io.ReadCloser, int64, error) {
+func (t *fileObjectStore) getFromRemote(
+	ctx context.Context, metadata objectstore.Metadata,
+) (io.ReadCloser, int64, error) {
 	ctx, cancel := context.WithTimeout(ctx, remoteTimeout)
 	defer cancel()
 
@@ -858,6 +875,7 @@ func (t *fileObjectStore) getFromRemote(ctx context.Context, metadata objectstor
 	if err != nil {
 		return nil, -1, errors.Errorf("fetching blob from remote: %w", err)
 	}
+	defer func() { _ = reader.Close() }()
 
 	// We need to now put the blob into the file store, so that we can
 	// retrieve it from the file store next time.
@@ -934,7 +952,9 @@ func (t *fileObjectStore) handleMetadataChange(ctx context.Context, path string)
 	return nil
 }
 
-func (t *fileObjectStore) fetchReaderFromRemote(ctx context.Context, metadata objectstore.Metadata) (io.ReadCloser, int64, error) {
+func (t *fileObjectStore) fetchReaderFromRemote(
+	ctx context.Context, metadata objectstore.Metadata,
+) (io.ReadCloser, int64, error) {
 	t.logger.Tracef(ctx, "fetching object %q from remote %q", metadata.Path, metadata.SHA256)
 
 	reader, size, err := t.remoteRetriever.Retrieve(ctx, metadata.SHA256)
@@ -946,6 +966,7 @@ func (t *fileObjectStore) fetchReaderFromRemote(ctx context.Context, metadata ob
 	}
 
 	if size != metadata.Size {
+		_ = reader.Close()
 		return nil, -1, errors.Errorf("size mismatch for %q: expected %d, got %d", metadata.Path, metadata.Size, size)
 	}
 
@@ -1006,7 +1027,7 @@ func (w *fetchWorker) loop() error {
 	}); err != nil {
 		return errors.Errorf("retrieving blob from remote: %w", err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	tmpFileName, tmpFileCleanup, err := w.t.writeToTmpFile(w.t.path, reader, size)
 	if err != nil {

--- a/internal/objectstore/fileobjectstore_test.go
+++ b/internal/objectstore/fileobjectstore_test.go
@@ -4,13 +4,13 @@
 package objectstore
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -205,8 +205,8 @@ func (s *fileObjectStoreSuite) TestGetMetadataFoundNoFileRemoteFallback(c *tc.C)
 
 	ch := s.expectWatch()
 
-	content := bytes.NewBufferString("some content")
-	size := int64(content.Len())
+	reader := newCloseTrackingReader("some content")
+	size := int64(len("some content"))
 
 	hash384 := "66b3707eaed3f7f4c6f084e4ba7aaa95f0412c3d9fd91475fc454b93ed8b7cd9d33cc1821e517b52d338f8d8d6908cb9"
 	hash256 := "290f493c44f5d63d06b374d0a5abd292fae38b92cab2fae5efefe1b0e9347f56"
@@ -219,7 +219,7 @@ func (s *fileObjectStoreSuite) TestGetMetadataFoundNoFileRemoteFallback(c *tc.C)
 	}, nil).Times(2)
 
 	s.remote.EXPECT().Retrieve(gomock.Any(), hash256).
-		Return(io.NopCloser(content), size, nil)
+		Return(reader, size, nil)
 
 	store := s.newFileObjectStore(c, path)
 	defer workertest.DirtyKill(c, store)
@@ -234,10 +234,50 @@ func (s *fileObjectStoreSuite) TestGetMetadataFoundNoFileRemoteFallback(c *tc.C)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(size, tc.Equals, fileSize)
 	c.Check(s.readFile(c, file), tc.Equals, "some content")
+	s.expectRemoteReaderClosed(c, reader)
 
 	// The file has been claimed and released.
 	s.expectFileDoesExist(c, path, hash384)
 
+	workertest.CleanKill(c, store)
+}
+
+func (s *fileObjectStoreSuite) TestGetMetadataNotFoundRemoteFallbackClosesReader(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	path := c.MkDir()
+	ch := s.expectWatch()
+
+	reader := newCloseTrackingReader("some content")
+	size := int64(len("some content"))
+
+	hash384 := "66b3707eaed3f7f4c6f084e4ba7aaa95f0412c3d9fd91475fc454b93ed8b7cd9d33cc1821e517b52d338f8d8d6908cb9"
+	hash256 := "290f493c44f5d63d06b374d0a5abd292fae38b92cab2fae5efefe1b0e9347f56"
+
+	s.service.EXPECT().GetMetadata(gomock.Any(), "foo").Return(objectstore.Metadata{
+		SHA384: hash384,
+		SHA256: hash256,
+		Path:   "foo",
+		Size:   12,
+	}, domainobjectstoreerrors.ErrNotFound).Times(2)
+
+	s.remote.EXPECT().Retrieve(gomock.Any(), hash256).
+		Return(reader, size, nil)
+
+	store := s.newFileObjectStore(c, path)
+	defer workertest.DirtyKill(c, store)
+
+	s.expectStartup(c, ch)
+	s.expectClaim(hash384, 1)
+	s.expectRelease(hash384, 1)
+
+	file, fileSize, err := store.Get(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(size, tc.Equals, fileSize)
+	c.Check(s.readFile(c, file), tc.Equals, "some content")
+	s.expectRemoteReaderClosed(c, reader)
+
+	s.expectFileDoesExist(c, path, hash384)
 	workertest.CleanKill(c, store)
 }
 
@@ -311,8 +351,8 @@ func (s *fileObjectStoreSuite) TestGetMetadataBySHA256PrefixFoundNoFileRemoteFal
 
 	ch := s.expectWatch()
 
-	content := bytes.NewBufferString("some content")
-	size := int64(content.Len())
+	reader := newCloseTrackingReader("some content")
+	size := int64(len("some content"))
 
 	hash384 := "66b3707eaed3f7f4c6f084e4ba7aaa95f0412c3d9fd91475fc454b93ed8b7cd9d33cc1821e517b52d338f8d8d6908cb9"
 	hash256 := "290f493c44f5d63d06b374d0a5abd292fae38b92cab2fae5efefe1b0e9347f56"
@@ -326,7 +366,7 @@ func (s *fileObjectStoreSuite) TestGetMetadataBySHA256PrefixFoundNoFileRemoteFal
 	}, nil).Times(2)
 
 	s.remote.EXPECT().Retrieve(gomock.Any(), hash256).
-		Return(io.NopCloser(content), size, nil)
+		Return(reader, size, nil)
 
 	store := s.newFileObjectStore(c, path)
 	defer workertest.DirtyKill(c, store)
@@ -341,6 +381,7 @@ func (s *fileObjectStoreSuite) TestGetMetadataBySHA256PrefixFoundNoFileRemoteFal
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(size, tc.Equals, fileSize)
 	c.Check(s.readFile(c, file), tc.Equals, "some content")
+	s.expectRemoteReaderClosed(c, reader)
 
 	// The file has been claimed and released.
 	s.expectFileDoesExist(c, path, hash384)
@@ -1069,6 +1110,38 @@ func (s *fileObjectStoreSuite) setupMocks(c *tc.C) *gomock.Controller {
 	})
 
 	return ctrl
+}
+
+type closeTrackingReader struct {
+	reader io.Reader
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newCloseTrackingReader(content string) *closeTrackingReader {
+	return &closeTrackingReader{
+		reader: strings.NewReader(content),
+		closed: make(chan struct{}),
+	}
+}
+
+func (r *closeTrackingReader) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *closeTrackingReader) Close() error {
+	r.once.Do(func() {
+		close(r.closed)
+	})
+	return nil
+}
+
+func (s *fileObjectStoreSuite) expectRemoteReaderClosed(c *tc.C, reader *closeTrackingReader) {
+	select {
+	case <-reader.closed:
+	case <-c.Context().Done():
+		c.Fatalf("expected remote reader to be closed: %v", c.Context().Err())
+	}
 }
 
 func (s *fileObjectStoreSuite) expectFileDoesNotExist(c *tc.C, path, hash string) {


### PR DESCRIPTION
Tidies up a few paths where we did not close readers from the file-based object store implementation.

## Links

This is one of a cluster of patches in service of addressing https://github.com/juju/juju/issues/21753.

**Jira card:** [JUJU-9183](https://warthogs.atlassian.net/browse/JUJU-9183)

[JUJU-9183]: https://warthogs.atlassian.net/browse/JUJU-9183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ