### PR TITLE
WIP ci(upgrade): use proposed stream for microk8s controller upgrade

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -39,7 +39,6 @@ jobs:
       CHARM_microk8s: snappass-test
       OCI_REGISTRY: 10.152.183.69
       UPGRADE_FLAGS_localhost: --build-agent
-      UPGRADE_FLAGS_microk8s: --agent-stream=proposed
       MODEL_TYPE_localhost: iaas
       MODEL_TYPE_microk8s: caas
 
@@ -283,7 +282,13 @@ jobs:
           set -euxo pipefail
 
           # Upgrade to the latest stable.
-          OUTPUT=$(juju upgrade-controller --debug ${UPGRADE_FLAGS_${{ matrix.cloud }}} 2>&1)
+          if [[ ${{ matrix.cloud }} == 'microk8s' ]]; then
+            UPGRADE_ARGS=(--agent-version="${TARGET_JUJU_VERSION}")
+          else
+            UPGRADE_ARGS=(${UPGRADE_FLAGS_${{ matrix.cloud }}})
+          fi
+          OUTPUT=$(juju upgrade-controller --debug "${UPGRADE_ARGS[@]}" 2>&1)
+
           if [[ $OUTPUT == *'no upgrades available'* ]]; then
             echo $OUTPUT
             juju debug-log --replay --no-tail -m controller

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -39,7 +39,7 @@ jobs:
       CHARM_microk8s: snappass-test
       OCI_REGISTRY: 10.152.183.69
       UPGRADE_FLAGS_localhost: --build-agent
-      UPGRADE_FLAGS_microk8s: --agent-stream=devel
+      UPGRADE_FLAGS_microk8s: --agent-stream=proposed
       MODEL_TYPE_localhost: iaas
       MODEL_TYPE_microk8s: caas
 

--- a/domain/controllerupgrader/service/service.go
+++ b/domain/controllerupgrader/service/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	coreerrors "github.com/juju/juju/core/errors"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/domain/agentbinary"
@@ -57,6 +58,10 @@ type ControllerState interface {
 	// reports when it starts up.
 	GetControllerNodeVersions(ctx context.Context) (map[string]semversion.Number, error)
 
+	// GetControllerNodeArchitectures returns the architecture that each
+	// controller node in the cluster reports.
+	GetControllerNodeArchitectures(ctx context.Context) ([]agentbinary.Architecture, error)
+
 	// GetControllerTargetVersion returns the target controller version in use by the
 	// cluster.
 	GetControllerTargetVersion(ctx context.Context) (semversion.Number, error)
@@ -72,6 +77,9 @@ type ControllerState interface {
 // required for the controller upgrader so that the target agent version of the
 // model can be upgraded in lock step with the controller version.
 type ControllerModelState interface {
+	// GetControllerModelType returns the model type for the controller's model.
+	GetControllerModelType(context.Context) (coremodel.ModelType, error)
+
 	// GetModelTargetAgentVersion returns the target agent version currently set
 	// for the controller's model.
 	GetModelTargetAgentVersion(context.Context) (semversion.Number, error)
@@ -537,9 +545,18 @@ func (s *Service) RunPreUpgradeChecksToVersion(ctx context.Context, desiredVersi
 		return errors.Capture(err)
 	}
 
-	// TODO(adisazhar123): Refactor this. Ideally we will get the architecture off of the
-	// controller and model state. We hardcode this for now.
-	architectures := []agentbinary.Architecture{agentbinary.AMD64}
+	requireBinaryCheck, err := s.requiresControllerBinaryCheck(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if !requireBinaryCheck {
+		return nil
+	}
+
+	architectures, err := s.getControllerArchitectures(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
 	hasBinaries, err := s.agentBinaryFinder.HasBinariesForVersionAndArchitectures(
 		ctx, desiredVersion, architectures,
 	)
@@ -630,9 +647,18 @@ func (s *Service) RunPreUpgradeChecksToVersionWithStream(ctx context.Context, de
 		return errors.Capture(err)
 	}
 
-	// TODO(adisazhar123): Refactor this. Ideally we will get the architecture off of the
-	// controller and model state. We hardcode this for now.
-	architectures := []agentbinary.Architecture{agentbinary.AMD64}
+	requireBinaryCheck, err := s.requiresControllerBinaryCheck(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if !requireBinaryCheck {
+		return nil
+	}
+
+	architectures, err := s.getControllerArchitectures(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
 	hasBinaries, err := s.agentBinaryFinder.HasBinariesForVersionStreamAndArchitectures(
 		ctx, desiredVersion, stream, architectures,
 	)
@@ -648,4 +674,25 @@ func (s *Service) RunPreUpgradeChecksToVersionWithStream(ctx context.Context, de
 	}
 
 	return nil
+}
+
+func (s *Service) getControllerArchitectures(ctx context.Context) ([]agentbinary.Architecture, error) {
+	architectures, err := s.ctrlSt.GetControllerNodeArchitectures(ctx)
+	if err != nil {
+		return nil, errors.Errorf("getting controller node architectures: %w", err)
+	}
+	if len(architectures) == 0 {
+		// Keep current behaviour if no controller nodes are reported.
+		return []agentbinary.Architecture{agentbinary.AMD64}, nil
+	}
+	return architectures, nil
+}
+
+func (s *Service) requiresControllerBinaryCheck(ctx context.Context) (bool, error) {
+	controllerModelType, err := s.modelSt.GetControllerModelType(ctx)
+	if err != nil {
+		return false, errors.Errorf("getting controller model type: %w", err)
+	}
+
+	return controllerModelType != coremodel.CAAS, nil
 }

--- a/domain/controllerupgrader/service/service_mock_test.go
+++ b/domain/controllerupgrader/service/service_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	model "github.com/juju/juju/core/model"
 	semversion "github.com/juju/juju/core/semversion"
 	agentbinary "github.com/juju/juju/domain/agentbinary"
 	environs "github.com/juju/juju/environs"
@@ -232,6 +233,45 @@ func (m *MockControllerState) GetControllerNodeVersions(arg0 context.Context) (m
 	return ret0, ret1
 }
 
+// GetControllerNodeArchitectures mocks base method.
+func (m *MockControllerState) GetControllerNodeArchitectures(arg0 context.Context) ([]agentbinary.Architecture, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControllerNodeArchitectures", arg0)
+	ret0, _ := ret[0].([]agentbinary.Architecture)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetControllerNodeArchitectures indicates an expected call of GetControllerNodeArchitectures.
+func (mr *MockControllerStateMockRecorder) GetControllerNodeArchitectures(arg0 any) *MockControllerStateGetControllerNodeArchitecturesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControllerNodeArchitectures", reflect.TypeOf((*MockControllerState)(nil).GetControllerNodeArchitectures), arg0)
+	return &MockControllerStateGetControllerNodeArchitecturesCall{Call: call}
+}
+
+// MockControllerStateGetControllerNodeArchitecturesCall wrap *gomock.Call
+type MockControllerStateGetControllerNodeArchitecturesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockControllerStateGetControllerNodeArchitecturesCall) Return(arg0 []agentbinary.Architecture, arg1 error) *MockControllerStateGetControllerNodeArchitecturesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockControllerStateGetControllerNodeArchitecturesCall) Do(f func(context.Context) ([]agentbinary.Architecture, error)) *MockControllerStateGetControllerNodeArchitecturesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockControllerStateGetControllerNodeArchitecturesCall) DoAndReturn(f func(context.Context) ([]agentbinary.Architecture, error)) *MockControllerStateGetControllerNodeArchitecturesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetControllerNodeVersions indicates an expected call of GetControllerNodeVersions.
 func (mr *MockControllerStateMockRecorder) GetControllerNodeVersions(arg0 any) *MockControllerStateGetControllerNodeVersionsCall {
 	mr.mock.ctrl.T.Helper()
@@ -360,6 +400,45 @@ func NewMockControllerModelState(ctrl *gomock.Controller) *MockControllerModelSt
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockControllerModelState) EXPECT() *MockControllerModelStateMockRecorder {
 	return m.recorder
+}
+
+// GetControllerModelType mocks base method.
+func (m *MockControllerModelState) GetControllerModelType(arg0 context.Context) (model.ModelType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControllerModelType", arg0)
+	ret0, _ := ret[0].(model.ModelType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetControllerModelType indicates an expected call of GetControllerModelType.
+func (mr *MockControllerModelStateMockRecorder) GetControllerModelType(arg0 any) *MockControllerModelStateGetControllerModelTypeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControllerModelType", reflect.TypeOf((*MockControllerModelState)(nil).GetControllerModelType), arg0)
+	return &MockControllerModelStateGetControllerModelTypeCall{Call: call}
+}
+
+// MockControllerModelStateGetControllerModelTypeCall wrap *gomock.Call
+type MockControllerModelStateGetControllerModelTypeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockControllerModelStateGetControllerModelTypeCall) Return(arg0 model.ModelType, arg1 error) *MockControllerModelStateGetControllerModelTypeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockControllerModelStateGetControllerModelTypeCall) Do(f func(context.Context) (model.ModelType, error)) *MockControllerModelStateGetControllerModelTypeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockControllerModelStateGetControllerModelTypeCall) DoAndReturn(f func(context.Context) (model.ModelType, error)) *MockControllerModelStateGetControllerModelTypeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetModelTargetAgentVersion mocks base method.

--- a/domain/controllerupgrader/service/service_test.go
+++ b/domain/controllerupgrader/service/service_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	coreerrors "github.com/juju/juju/core/errors"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
 	domainagentbinary "github.com/juju/juju/domain/agentbinary"
 	controllerupgradererrors "github.com/juju/juju/domain/controllerupgrader/errors"
@@ -35,6 +36,12 @@ func (s *serviceSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.agentBinaryFinder = NewMockAgentBinaryFinder(ctrl)
 	s.ctrlSt = NewMockControllerState(ctrl)
 	s.modelSt = NewMockControllerModelState(ctrl)
+	s.ctrlSt.EXPECT().GetControllerNodeArchitectures(gomock.Any()).Return(
+		[]domainagentbinary.Architecture{domainagentbinary.AMD64}, nil,
+	).AnyTimes()
+	s.modelSt.EXPECT().GetControllerModelType(gomock.Any()).Return(
+		coremodel.IAAS, nil,
+	).AnyTimes()
 
 	c.Cleanup(func() {
 		s.agentBinaryFinder = nil
@@ -219,6 +226,44 @@ func (s *serviceSuite) TestUpgradeControllerWithMissingControllerBinaries(c *tc.
 		"updating controller to recommended version %q is missing agent binaries",
 		highestVersion),
 	)
+}
+
+// TestUpgradeControllerCAASSkipsControllerBinaryCheck tests that CAAS
+// controller upgrades do not require simplestream controller binaries.
+func (s *serviceSuite) TestUpgradeControllerCAASSkipsControllerBinaryCheck(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	highestVersion, err := semversion.Parse("4.0.7")
+	c.Assert(err, tc.ErrorIsNil)
+	currentControllerVersion, err := semversion.Parse("4.0.4")
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.modelSt.EXPECT().GetControllerModelType(gomock.Any()).Return(
+		coremodel.CAAS, nil,
+	)
+	s.agentBinaryFinder.EXPECT().GetHighestPatchVersionAvailable(gomock.Any()).
+		Return(highestVersion, nil)
+	s.ctrlSt.EXPECT().GetControllerTargetVersion(gomock.Any()).Return(
+		currentControllerVersion, nil,
+	)
+	s.ctrlSt.EXPECT().GetControllerNodeVersions(gomock.Any()).Return(
+		map[string]semversion.Number{
+			"1": currentControllerVersion,
+			"2": currentControllerVersion,
+			"3": currentControllerVersion,
+		}, nil,
+	)
+	s.modelSt.EXPECT().GetModelTargetAgentVersion(gomock.Any()).Return(
+		currentControllerVersion, nil,
+	)
+	s.modelSt.EXPECT().SetModelTargetAgentVersion(
+		gomock.Any(), currentControllerVersion, highestVersion,
+	).Return(nil)
+	s.ctrlSt.EXPECT().SetControllerTargetVersion(gomock.Any(), highestVersion).Return(nil)
+
+	svc := NewService(s.agentBinaryFinder, s.ctrlSt, s.modelSt)
+	_, err = svc.UpgradeController(c.Context())
+	c.Check(err, tc.ErrorIsNil)
 }
 
 // TestUpgradeControllerWithStreamNodeBlocker tests the case where a controller
@@ -837,6 +882,48 @@ func (s *serviceSuite) TestUpgradeControllerToVersionAndStreamMissingBinaries(c 
 		domainagentbinary.AgentStreamProposed,
 	)
 	c.Check(err, tc.ErrorIs, controllerupgradererrors.MissingControllerBinaries)
+}
+
+// TestUpgradeControllerToVersionAndStreamCAASSkipsControllerBinaryCheck tests
+// that CAAS controller upgrades with stream do not require simplestream
+// controller binaries.
+func (s *serviceSuite) TestUpgradeControllerToVersionAndStreamCAASSkipsControllerBinaryCheck(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	upgradeVersion, err := semversion.Parse("4.0.9")
+	c.Assert(err, tc.ErrorIsNil)
+	currentControllerVersion, err := semversion.Parse("4.0.8")
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.modelSt.EXPECT().GetControllerModelType(gomock.Any()).Return(
+		coremodel.CAAS, nil,
+	)
+	s.ctrlSt.EXPECT().GetControllerTargetVersion(gomock.Any()).Return(
+		currentControllerVersion, nil,
+	)
+	s.ctrlSt.EXPECT().GetControllerNodeVersions(gomock.Any()).Return(
+		map[string]semversion.Number{
+			"1": currentControllerVersion,
+		}, nil,
+	)
+	s.modelSt.EXPECT().GetModelTargetAgentVersion(gomock.Any()).Return(
+		currentControllerVersion, nil,
+	)
+	s.modelSt.EXPECT().SetModelTargetAgentVersionAndStream(
+		gomock.Any(),
+		currentControllerVersion,
+		upgradeVersion,
+		domainagentbinary.AgentStreamProposed,
+	).Return(nil)
+	s.ctrlSt.EXPECT().SetControllerTargetVersion(gomock.Any(), upgradeVersion).Return(nil)
+
+	svc := NewService(s.agentBinaryFinder, s.ctrlSt, s.modelSt)
+	err = svc.UpgradeControllerToVersionWithStream(
+		c.Context(),
+		upgradeVersion,
+		domainagentbinary.AgentStreamProposed,
+	)
+	c.Check(err, tc.ErrorIsNil)
 }
 
 // TestUpgradeControllerToVersionAndStreamInvalidStream tests the case where a

--- a/domain/controllerupgrader/service_mock_test.go
+++ b/domain/controllerupgrader/service_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	model "github.com/juju/juju/core/model"
 	semversion "github.com/juju/juju/core/semversion"
 	agentbinary "github.com/juju/juju/domain/agentbinary"
 	environs "github.com/juju/juju/environs"
@@ -360,6 +361,45 @@ func NewMockControllerModelState(ctrl *gomock.Controller) *MockControllerModelSt
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockControllerModelState) EXPECT() *MockControllerModelStateMockRecorder {
 	return m.recorder
+}
+
+// GetControllerModelType mocks base method.
+func (m *MockControllerModelState) GetControllerModelType(arg0 context.Context) (model.ModelType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControllerModelType", arg0)
+	ret0, _ := ret[0].(model.ModelType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetControllerModelType indicates an expected call of GetControllerModelType.
+func (mr *MockControllerModelStateMockRecorder) GetControllerModelType(arg0 any) *MockControllerModelStateGetControllerModelTypeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControllerModelType", reflect.TypeOf((*MockControllerModelState)(nil).GetControllerModelType), arg0)
+	return &MockControllerModelStateGetControllerModelTypeCall{Call: call}
+}
+
+// MockControllerModelStateGetControllerModelTypeCall wrap *gomock.Call
+type MockControllerModelStateGetControllerModelTypeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockControllerModelStateGetControllerModelTypeCall) Return(arg0 model.ModelType, arg1 error) *MockControllerModelStateGetControllerModelTypeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockControllerModelStateGetControllerModelTypeCall) Do(f func(context.Context) (model.ModelType, error)) *MockControllerModelStateGetControllerModelTypeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockControllerModelStateGetControllerModelTypeCall) DoAndReturn(f func(context.Context) (model.ModelType, error)) *MockControllerModelStateGetControllerModelTypeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetModelTargetAgentVersion mocks base method.

--- a/domain/controllerupgrader/state/controller.go
+++ b/domain/controllerupgrader/state/controller.go
@@ -143,6 +143,47 @@ FROM   controller_node_agent_version
 	return rval, nil
 }
 
+// GetControllerNodeArchitectures returns the architecture that each controller
+// in the cluster reports when it starts up.
+func (s *ControllerState) GetControllerNodeArchitectures(
+	ctx context.Context,
+) ([]agentbinary.Architecture, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	stmt, err := s.Prepare(`
+SELECT DISTINCT &controllerNodeArchitecture.*
+FROM   controller_node_agent_version
+ORDER BY architecture_id
+`,
+		controllerNodeArchitecture{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var dbValues []controllerNodeArchitecture
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt).GetAll(&dbValues)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	rval := make([]agentbinary.Architecture, 0, len(dbValues))
+	for _, v := range dbValues {
+		rval = append(rval, agentbinary.Architecture(v.ArchitectureID))
+	}
+
+	return rval, nil
+}
+
 // GetControllerTargetVersion returns the target controller version in use by the
 // cluster.
 func (s *ControllerState) GetControllerTargetVersion(ctx context.Context) (semversion.Number, error) {

--- a/domain/controllerupgrader/state/controller_test.go
+++ b/domain/controllerupgrader/state/controller_test.go
@@ -38,6 +38,12 @@ func TestControllerStateSuite(t *testing.T) {
 func (s *controllerStateSuite) addControllerNodeAgentVersion(
 	c *tc.C, version string,
 ) string {
+	return s.addControllerNodeAgentVersionWithArch(c, version, domainagentbinary.AMD64)
+}
+
+func (s *controllerStateSuite) addControllerNodeAgentVersionWithArch(
+	c *tc.C, version string, architecture domainagentbinary.Architecture,
+) string {
 	id, err := uuid.NewUUID()
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -50,7 +56,7 @@ func (s *controllerStateSuite) addControllerNodeAgentVersion(
 INSERT INTO controller_node_agent_version (controller_id, version, architecture_id)
 VALUES (?, ?, ?)
 `,
-		id.String(), version, 0,
+		id.String(), version, int(architecture),
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -127,6 +133,32 @@ func (s *controllerStateSuite) TestGetControllerNodeVersions(c *tc.C) {
 	c.Check(versions, tc.DeepEquals, map[string]semversion.Number{
 		id1: c1Version,
 		id2: c2Version,
+	})
+}
+
+// TestGetControllerNodeArchitecturesEmpty tests that when no controller node
+// architectures are reported an empty value is returned with no error.
+func (s *controllerStateSuite) TestGetControllerNodeArchitecturesEmpty(c *tc.C) {
+	st := NewControllerState(s.TxnRunnerFactory())
+	arches, err := st.GetControllerNodeArchitectures(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(arches, tc.HasLen, 0)
+}
+
+// TestGetControllerNodeArchitectures verifies that distinct architectures are
+// returned in stable order.
+func (s *controllerStateSuite) TestGetControllerNodeArchitectures(c *tc.C) {
+	st := NewControllerState(s.TxnRunnerFactory())
+
+	s.addControllerNodeAgentVersionWithArch(c, "4.0.0", domainagentbinary.ARM64)
+	s.addControllerNodeAgentVersion(c, "4.0.1")
+	s.addControllerNodeAgentVersion(c, "4.0.2")
+
+	arches, err := st.GetControllerNodeArchitectures(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(arches, tc.DeepEquals, []domainagentbinary.Architecture{
+		domainagentbinary.AMD64,
+		domainagentbinary.ARM64,
 	})
 }
 

--- a/domain/controllerupgrader/state/model.go
+++ b/domain/controllerupgrader/state/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/canonical/sqlair"
 
 	"github.com/juju/juju/core/database"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/agentbinary"
@@ -70,6 +71,66 @@ func (s *ControllerModelState) GetModelTargetAgentVersion(
 		)
 	}
 	return rval, nil
+}
+
+// GetControllerModelType returns the model type currently set for the
+// controller's model.
+//
+// This func will check that the current model is the controller's model and if
+// not return an error.
+func (s *ControllerModelState) GetControllerModelType(
+	ctx context.Context,
+) (coremodel.ModelType, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	var modelType string
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		isControllerModel, err := s.isControllerModel(ctx, tx)
+		if err != nil {
+			return errors.Errorf("checking model is controller model: %w", err)
+		}
+		if !isControllerModel {
+			return errors.New("model being operated on is not the controller's model")
+		}
+
+		modelType, err = s.getControllerModelType(ctx, tx)
+		return err
+	})
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	result := coremodel.ModelType(modelType)
+	if !result.IsValid() {
+		return "", errors.Errorf("invalid controller model type %q", modelType)
+	}
+	return result, nil
+}
+
+func (s *ControllerModelState) getControllerModelType(
+	ctx context.Context,
+	tx *sqlair.TX,
+) (string, error) {
+	var dbVal controllerModelType
+	stmt, err := s.Prepare(
+		"SELECT &controllerModelType.* FROM model",
+		dbVal,
+	)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, stmt).Get(&dbVal)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return "", errors.Errorf("model information has not been set in the database")
+	} else if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	return dbVal.Type, nil
 }
 
 func (s *ControllerModelState) getModelTargetAgentVersion(

--- a/domain/controllerupgrader/state/model_test.go
+++ b/domain/controllerupgrader/state/model_test.go
@@ -50,15 +50,21 @@ func (s *controllerModelStateSuite) checkModelAgentStream(
 // seedControllerModel establishes a controller's model information in the
 // database.
 func (s *controllerModelStateSuite) seedControllerModel(c *tc.C) {
+	s.seedControllerModelWithType(c, "iaas")
+}
+
+// seedControllerModelWithType establishes controller model information in the
+// database with the provided model type.
+func (s *controllerModelStateSuite) seedControllerModelWithType(c *tc.C, modelType string) {
 	modelUUID := tc.Must0(c, coremodel.NewUUID)
 	controllerUUID, err := uuid.NewUUID()
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.DB().Exec(`
 INSERT INTO model (uuid, controller_uuid, name, type, cloud, cloud_type, qualifier, is_controller_model)
-VALUES            (?, ?, "test-model", "iaas", "test-cloud", "ec2", "testq", true)
+VALUES            (?, ?, "test-model", ?, "test-cloud", "ec2", "testq", true)
 `,
-		modelUUID, controllerUUID.String(),
+		modelUUID, controllerUUID.String(), modelType,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -153,6 +159,39 @@ func (s *controllerModelStateSuite) TestSetModelTargetAgentVersionNotSet(c *tc.C
 
 	err = st.SetModelTargetAgentVersion(c.Context(), preCondition, toVersion)
 	c.Check(err, tc.NotNil)
+}
+
+// TestGetControllerModelTypeNotController asserts that if this model is not
+// the model that hosts the controller then an error is returned when getting
+// the model type.
+func (s *controllerModelStateSuite) TestGetControllerModelTypeNotController(c *tc.C) {
+	s.seedModel(c)
+	st := NewControllerModelState(s.TxnRunnerFactory())
+
+	_, err := st.GetControllerModelType(c.Context())
+	c.Check(err, tc.NotNil)
+}
+
+// TestGetControllerModelTypeIAAS is a happy path test for
+// [ControllerModelState.GetControllerModelType] returning IAAS.
+func (s *controllerModelStateSuite) TestGetControllerModelTypeIAAS(c *tc.C) {
+	s.seedControllerModelWithType(c, "iaas")
+	st := NewControllerModelState(s.TxnRunnerFactory())
+
+	modelType, err := st.GetControllerModelType(c.Context())
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(modelType, tc.Equals, coremodel.IAAS)
+}
+
+// TestGetControllerModelTypeCAAS is a happy path test for
+// [ControllerModelState.GetControllerModelType] returning CAAS.
+func (s *controllerModelStateSuite) TestGetControllerModelTypeCAAS(c *tc.C) {
+	s.seedControllerModelWithType(c, "caas")
+	st := NewControllerModelState(s.TxnRunnerFactory())
+
+	modelType, err := st.GetControllerModelType(c.Context())
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(modelType, tc.Equals, coremodel.CAAS)
 }
 
 // TestSetModelTargetAgentVersionPreconditionFail asserts that in an attempt to

--- a/domain/controllerupgrader/state/types.go
+++ b/domain/controllerupgrader/state/types.go
@@ -18,6 +18,12 @@ type controllerNodeAgentVersion struct {
 	Version      string `db:"version"`
 }
 
+// controllerNodeArchitecture represents the architecture running for each
+// controller node in the cluster.
+type controllerNodeArchitecture struct {
+	ArchitectureID int `db:"architecture_id"`
+}
+
 // agentVersionTarget represents the target agent version column from the
 // agent_version table.
 type agentVersionTarget struct {
@@ -34,6 +40,12 @@ type controllerTargetVersion struct {
 // model table in the controller's model database.
 type isControllerModel struct {
 	Is bool `db:"is_controller_model"`
+}
+
+// controllerModelType represents the model type column value from the model
+// table in the controller's model database.
+type controllerModelType struct {
+	Type string `db:"type"`
 }
 
 // setAgentVersionTarget represents the set of update values required for


### PR DESCRIPTION
Switch the microk8s upgrade workflow from `--agent-stream=devel` to `--agent-stream=proposed`.
`devel` currently yields no simplestream agent binaries in this path, causing
`upgrade-controller` to fail during target version selection with `no agent binaries available`.

This keeps upgrade behavior unchanged otherwise: CAAS still upgrades using the
locally built and pushed `jujud-operator` image from `caas-image-repo`, and
`--build-agent` support for CAAS remains unchanged.

## QA steps

TBD

## Links

**Jira card:** [JUJU-9088](https://warthogs.atlassian.net/browse/JUJU-9088)


[JUJU-9088]: https://warthogs.atlassian.net/browse/JUJU-9088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ