### PR TITLE
fix: prevent getting empty resources

### DIFF
--- a/apiserver/internal/handlers/resources/unitresources.go
+++ b/apiserver/internal/handlers/resources/unitresources.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
@@ -61,12 +62,18 @@ func (h *UnitResourcesHandler) ServeHTTP(resp http.ResponseWriter, req *http.Req
 }
 
 func (h *UnitResourcesHandler) serveGet(resp http.ResponseWriter, req *http.Request) error {
+	name := req.URL.Query().Get(":resource")
+
+	// If the name is empty, don't perform the lookup, just return a bad request
+	// error. We need some sort of name
+	if strings.TrimSpace(name) == "" {
+		return errors.BadRequestf("missing resource name")
+	}
+
 	opener, err := h.resourceOpenerGetter.Opener(req, names.UnitTagKind, names.ApplicationTagKind)
 	if err != nil {
 		return err
 	}
-
-	name := req.URL.Query().Get(":resource")
 	opened, err := opener.OpenResource(req.Context(), name)
 	if err != nil {
 		h.logger.Errorf(req.Context(), "cannot fetch resource reader: %v", err)

--- a/apiserver/internal/handlers/resources/unitresources_test.go
+++ b/apiserver/internal/handlers/resources/unitresources_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -29,18 +30,25 @@ type UnitResourcesHandlerSuite struct {
 	opener       *MockOpener
 	openerGetter *MockResourceOpenerGetter
 
-	urlStr   string
-	recorder *httptest.ResponseRecorder
+	urlStr      string
+	urlEmptyStr string
+	recorder    *httptest.ResponseRecorder
 }
 
 func TestUnitResourcesHandlerSuite(t *testing.T) {
 	tc.Run(t, &UnitResourcesHandlerSuite{})
 }
+
 func (s *UnitResourcesHandlerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.opener = NewMockOpener(ctrl)
 	s.openerGetter = NewMockResourceOpenerGetter(ctrl)
+
+	c.Cleanup(func() {
+		s.opener = nil
+		s.openerGetter = nil
+	})
 
 	return ctrl
 }
@@ -50,14 +58,20 @@ func (s *UnitResourcesHandlerSuite) SetUpTest(c *tc.C) {
 
 	args := url.Values{}
 	args.Add(":unit", "foo/0")
+	args.Add(":resource", "")
+	s.urlEmptyStr = "https://api:17017/?" + args.Encode()
+
+	args = url.Values{}
+	args.Add(":unit", "foo/0")
 	args.Add(":resource", "blob")
 	s.urlStr = "https://api:17017/?" + args.Encode()
+
+	fmt.Println(s.urlEmptyStr, s.urlStr)
 
 	s.recorder = httptest.NewRecorder()
 }
 
-func (s *UnitResourcesHandlerSuite) newUnitResourceHander(c *tc.C) *UnitResourcesHandler {
-	s.openerGetter.EXPECT().Opener(gomock.Any(), names.UnitTagKind, names.ApplicationTagKind).Return(s.opener, nil)
+func (s *UnitResourcesHandlerSuite) newUnitResourceHandler(c *tc.C) *UnitResourcesHandler {
 	return NewUnitResourcesHandler(
 		s.openerGetter,
 		loggertesting.WrapCheckLog(c),
@@ -81,8 +95,11 @@ func (s *UnitResourcesHandlerSuite) TestWrongMethod(c *tc.C) {
 
 func (s *UnitResourcesHandlerSuite) TestOpenerCreationError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
+
 	failure, expectedBody := apiFailure("boom", "")
+
 	s.openerGetter.EXPECT().Opener(gomock.Any(), names.UnitTagKind, names.ApplicationTagKind).Return(nil, failure)
+
 	handler := NewUnitResourcesHandler(
 		s.openerGetter,
 		loggertesting.WrapCheckLog(c),
@@ -102,8 +119,12 @@ func (s *UnitResourcesHandlerSuite) TestOpenerCreationError(c *tc.C) {
 
 func (s *UnitResourcesHandlerSuite) TestOpenResourceError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
+
 	failure, expectedBody := apiFailure("boom", "")
-	handler := s.newUnitResourceHander(c)
+
+	handler := s.newUnitResourceHandler(c)
+
+	s.openerGetter.EXPECT().Opener(gomock.Any(), names.UnitTagKind, names.ApplicationTagKind).Return(s.opener, nil)
 	s.opener.EXPECT().OpenResource(gomock.Any(), "blob").Return(coreresource.Opened{}, failure)
 
 	req, err := http.NewRequest("GET", s.urlStr, nil)
@@ -116,11 +137,14 @@ func (s *UnitResourcesHandlerSuite) TestOpenResourceError(c *tc.C) {
 
 func (s *UnitResourcesHandlerSuite) TestSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
+
 	const body = "some data"
+
 	fp, err := charmresource.GenerateFingerprint(strings.NewReader(body))
 	c.Assert(err, tc.ErrorIsNil)
+
 	size := int64(len(body))
-	handler := s.newUnitResourceHander(c)
+	handler := s.newUnitResourceHandler(c)
 
 	resourceUUID := uuid.MustNewUUID().String()
 	opened := coreresource.Opened{
@@ -133,6 +157,8 @@ func (s *UnitResourcesHandlerSuite) TestSuccess(c *tc.C) {
 		},
 		ReadCloser: io.NopCloser(strings.NewReader(body)),
 	}
+
+	s.openerGetter.EXPECT().Opener(gomock.Any(), names.UnitTagKind, names.ApplicationTagKind).Return(s.opener, nil)
 	s.opener.EXPECT().OpenResource(gomock.Any(), "blob").Return(opened, nil)
 	s.opener.EXPECT().SetResourceUsed(gomock.Any(), coreresource.UUID(resourceUUID)).Return(nil)
 
@@ -142,6 +168,19 @@ func (s *UnitResourcesHandlerSuite) TestSuccess(c *tc.C) {
 	handler.ServeHTTP(s.recorder, req)
 
 	s.checkResp(c, http.StatusOK, "application/octet-stream", body)
+}
+
+func (s *UnitResourcesHandlerSuite) TestEmptyName(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	handler := s.newUnitResourceHandler(c)
+
+	req, err := http.NewRequest("GET", s.urlEmptyStr, nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	handler.ServeHTTP(s.recorder, req)
+
+	c.Assert(s.recorder.Code, tc.Equals, http.StatusBadRequest)
 }
 
 func (s *UnitResourcesHandlerSuite) checkResp(c *tc.C, status int, ctype, body string) {

--- a/cmd/juju/resource/validation.go
+++ b/cmd/juju/resource/validation.go
@@ -109,7 +109,7 @@ func OpenResource(resValue string, resType charmresource.Type, osOpen osOpenFunc
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return noopCloser{bytes.NewReader(data)}, nil
+		return noopCloser{ReadSeeker: bytes.NewReader(data)}, nil
 	default:
 		return nil, errors.Errorf("unknown resource type %q", resType)
 	}

--- a/internal/resource/opener.go
+++ b/internal/resource/opener.go
@@ -154,6 +154,10 @@ func (ro ResourceOpener) getResource(
 	resName string,
 	done func(),
 ) (opened coreresource.Opened, err error) {
+	if resName == "" {
+		return coreresource.Opened{}, errors.Errorf("resource name cannot be empty")
+	}
+
 	defer func() {
 		// Call done if not returning a ReadCloser that calls done on Close.
 		if err != nil {

--- a/internal/resource/opener_test.go
+++ b/internal/resource/opener_test.go
@@ -62,8 +62,53 @@ func TestOpenerSuite(t *stdtesting.T) {
 // exists in the controllers object store. This is a regression test where we
 // were not correctly passing back the resource information including the
 // resource uuid.
+func (s *OpenerSuite) TestOpenUnitResourceEmptyResource(c *tc.C) {
+	defer s.setupMocks(c, false).Finish()
+
+	appName := "postgresql"
+	unitName := tc.Must1(c, coreunit.NewName, "postgresql/0")
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+
+	charmOrigin := charm.Origin{
+		Source: charm.CharmHub,
+	}
+
+	appSvcExp := s.applicationService.EXPECT()
+	appSvcExp.GetApplicationUUIDByUnitName(c.Context(), unitName).Return(
+		appUUID, nil,
+	)
+	appSvcExp.GetUnitUUID(gomock.Any(), unitName).Return(unitUUID, nil)
+	appSvcExp.GetApplicationCharmOrigin(
+		gomock.Any(),
+		appName,
+	).Return(charmOrigin, nil)
+
+	opener, err := NewResourceOpenerForUnit(
+		c.Context(),
+		ResourceOpenerArgs{
+			ResourceService:      s.resourceService,
+			ApplicationService:   s.applicationService,
+			CharmhubClientGetter: s.resourceClientGetter,
+		},
+		func() ResourceDownloadLock {
+			return noopDownloadResourceLocker{}
+		},
+		unitName,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = opener.OpenResource(c.Context(), "")
+	c.Assert(err, tc.ErrorMatches, "resource name cannot be empty")
+}
+
+// TestOpenUnitResource is a happy path test for opening a unit resource that
+// exists in the controllers object store. This is a regression test where we
+// were not correctly passing back the resource information including the
+// resource uuid.
 func (s *OpenerSuite) TestOpenUnitResource(c *tc.C) {
-	s.setupMocks(c, false)
+	defer s.setupMocks(c, false).Finish()
+
 	resourceUUID := tc.Must(c, coreresource.NewUUID)
 	appName := "postgresql"
 	appUUID := tc.Must(c, coreapplication.NewUUID)
@@ -158,7 +203,8 @@ func (s *OpenerSuite) TestOpenUnitResource(c *tc.C) {
 // This also acts as a regression test to show that the resource uuid is
 // correctly returned as in the original implementation it was not.
 func (s *OpenerSuite) TestOpenUnitResourceCacheMiss(c *tc.C) {
-	s.setupMocks(c, false)
+	defer s.setupMocks(c, false).Finish()
+
 	resourceUUID := tc.Must(c, coreresource.NewUUID)
 	appName := "postgresql"
 	appUUID := tc.Must(c, coreapplication.NewUUID)

--- a/internal/worker/uniter/runner/context/resources/resource.go
+++ b/internal/worker/uniter/runner/context/resources/resource.go
@@ -56,7 +56,7 @@ func OpenResource(ctx context.Context, name string, client OpenedResourceClient)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		reader = httprequest.BytesReaderCloser{bytes.NewReader(yamlOut)}
+		reader = httprequest.BytesReaderCloser{Reader: bytes.NewReader(yamlOut)}
 		info.Size = int64(len(yamlOut))
 	}
 	or := &OpenedResource{


### PR DESCRIPTION
A charm can request via resource-get with an empty string, which will go and create a lot of resources for selecting nothing. This will stop the object store from attempting to do a query to remotes if in a HA setup.

## QA steps

Ensure that deploying k8s still works.

```sh
$ juju bootstrap lxd src
$ juju add-model k8s
$ juju deploy  k8s --channel=1.33/stable   --base="ubuntu@24.04"   --constraints='cores=4 mem=16G root-disk=40G virt-type=virtual-machine'
```

Alternatively, deploying kubeflow.


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Work towards https://github.com/juju/juju/issues/21851

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9265](https://warthogs.atlassian.net/browse/JUJU-9265)


[JUJU-9265]: https://warthogs.atlassian.net/browse/JUJU-9265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ