### PR TITLE
feat: import block devices found in volume attachments and plans

### DIFF
--- a/domain/blockdevice/modelmigration/import.go
+++ b/domain/blockdevice/modelmigration/import.go
@@ -5,6 +5,7 @@ package modelmigration
 
 import (
 	"context"
+	"slices"
 
 	"github.com/juju/description/v11"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/modelmigration"
+	domainblockdevice "github.com/juju/juju/domain/blockdevice"
 	"github.com/juju/juju/domain/blockdevice/service"
 	"github.com/juju/juju/domain/blockdevice/state"
 	"github.com/juju/juju/internal/errors"
@@ -64,8 +66,42 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 
 // Execute the import on the block devices contained in the model.
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
-	machines := model.Machines()
+	machinesToBlockDevices := i.getMachineBlockDevices(model.Machines())
+	volumeBlockDevices := i.getMachineBlockDevicesFromVolumeAttachments(model.Volumes())
 
+	// Prefer block devices defined for machines as they will have more data
+	// filled out usually. Only add block devices from volumeBlockDevices which
+	// have not been found with the machine.
+	for machineName, blockDevices := range volumeBlockDevices {
+		unique := slices.DeleteFunc(blockDevices, func(bd blockdevice.BlockDevice) bool {
+			return slices.ContainsFunc(
+				machinesToBlockDevices[machineName],
+				func(machineBD blockdevice.BlockDevice) bool {
+					return domainblockdevice.SameDevice(bd, machineBD)
+				})
+		})
+		machinesToBlockDevices[machineName] = append(machinesToBlockDevices[machineName], unique...)
+	}
+
+	for machineName, blockDevices := range machinesToBlockDevices {
+		err := i.service.SetBlockDevicesForMachineByName(
+			ctx, machine.Name(machineName), blockDevices)
+		if err != nil {
+			return errors.Errorf(
+				"importing block devices for machine %q: %w",
+				machineName, err,
+			)
+		}
+	}
+
+	return nil
+}
+
+// getMachineBlockDevices returns the block devices found for each machine.
+func (i *importOperation) getMachineBlockDevices(
+	machines []description.Machine,
+) map[string][]blockdevice.BlockDevice {
+	machinesToBlockDevices := make(map[string][]blockdevice.BlockDevice)
 	for _, m := range machines {
 		modelBlockDevices := m.BlockDevices()
 		if len(modelBlockDevices) == 0 {
@@ -90,14 +126,84 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			}
 		}
 
-		err := i.service.SetBlockDevicesForMachineByName(
-			ctx, machine.Name(m.Id()), machineBlockDevices)
-		if err != nil {
-			return errors.Errorf(
-				"importing block devices for machine %q: %w",
-				m.Id(), err,
-			)
+		machinesToBlockDevices[m.Id()] = machineBlockDevices
+	}
+
+	return machinesToBlockDevices
+}
+
+// getMachineBlockDevicesFromVolumeAttachments returns block devices found in
+// volume attachment plans for volume attachments. Partial block devices will
+// be resolved by the storage provisioner or registry workers.
+func (i *importOperation) getMachineBlockDevicesFromVolumeAttachments(
+	volumes []description.Volume,
+) map[string][]blockdevice.BlockDevice {
+	if len(volumes) == 0 {
+		return nil
+	}
+
+	machineVolumeBlockDevices := map[string][]blockdevice.BlockDevice{}
+	for _, v := range volumes {
+		for _, p := range v.AttachmentPlans() {
+			planBlockDevice := p.BlockDevice()
+			if planBlockDevice == nil {
+				continue
+			}
+			blockDevice := transformPlanToBlockDeviceStruct(planBlockDevice)
+			if domainblockdevice.IsEmpty(blockDevice) {
+				continue
+			}
+			machineVolumeBlockDevices[p.Machine()] = append(
+				machineVolumeBlockDevices[p.Machine()], blockDevice)
+		}
+
+		for _, attach := range v.Attachments() {
+			machineName, ok := attach.HostMachine()
+			if !ok {
+				continue
+			}
+			blockDevice := transformAttachmentToBlockDevice(attach)
+			if domainblockdevice.IsEmpty(blockDevice) {
+				continue
+			}
+			// Check to see if already been added via attachment plans.
+			// If not, add.
+			machineBDs, _ := machineVolumeBlockDevices[machineName]
+			contains := slices.ContainsFunc(machineBDs, func(bd blockdevice.BlockDevice) bool {
+				return domainblockdevice.SameDevice(bd, blockDevice)
+			})
+			if !contains {
+				machineVolumeBlockDevices[machineName] = append(machineBDs, blockDevice)
+			}
 		}
 	}
-	return nil
+
+	return machineVolumeBlockDevices
+}
+
+func transformPlanToBlockDeviceStruct(bd description.BlockDevice) blockdevice.BlockDevice {
+	return blockdevice.BlockDevice{
+		DeviceName:      bd.Name(),
+		DeviceLinks:     bd.Links(),
+		FilesystemLabel: bd.Label(),
+		FilesystemUUID:  bd.UUID(),
+		HardwareId:      bd.HardwareID(),
+		SerialId:        bd.SerialID(),
+		WWN:             bd.WWN(),
+		BusAddress:      bd.BusAddress(),
+	}
+}
+
+func transformAttachmentToBlockDevice(attach description.VolumeAttachment) blockdevice.BlockDevice {
+	var links []string
+
+	if attach.DeviceLink() != "" {
+		links = []string{attach.DeviceLink()}
+	}
+
+	return blockdevice.BlockDevice{
+		DeviceName:  attach.DeviceName(),
+		DeviceLinks: links,
+		BusAddress:  attach.BusAddress(),
+	}
 }

--- a/domain/blockdevice/modelmigration/import_test.go
+++ b/domain/blockdevice/modelmigration/import_test.go
@@ -106,3 +106,79 @@ func (s *importSuite) TestImport(c *tc.C) {
 	err = op.Execute(c.Context(), model)
 	c.Assert(err, tc.ErrorIsNil)
 }
+
+func (s *importSuite) TestImportVolumeAttachmentPlan(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: Add machines
+	model := description.NewModel(description.ModelArgs{})
+	model.AddMachine(description.MachineArgs{
+		Id: "666",
+	})
+	model.AddMachine(description.MachineArgs{
+		Id: "667",
+	})
+
+	// Arrange: Add a block device to one.
+	err := model.AddBlockDevice("666", description.BlockDeviceArgs{
+		Name:           "foo",
+		Links:          []string{"/dev/disk/by-id/a-link"},
+		Label:          "label",
+		UUID:           "device-uuid",
+		HardwareID:     "hardware-id",
+		WWN:            "wwn",
+		BusAddress:     "bus-address",
+		SerialID:       "serial-id",
+		Size:           100,
+		FilesystemType: "ext4",
+		InUse:          true,
+		MountPoint:     "/path/to/here",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Arrange: Add a volume with an attachment block device matching
+	// the machine's above, and with a attachment plan which does not.
+	vol := model.AddVolume(description.VolumeArgs{})
+	vol.AddAttachment(description.VolumeAttachmentArgs{
+		HostMachine: "666",
+		BusAddress:  "bus-address",
+		DeviceLink:  "/dev/disk/by-id/a-link",
+		DeviceName:  "foo",
+	})
+	vol.AddAttachmentPlan(description.VolumeAttachmentPlanArgs{
+		Machine:     "666",
+		DeviceName:  "baz",
+		DeviceLinks: []string{"/dev/disk/by-id/d-link"},
+	})
+
+	// Arrange: expected mock call. Where a block device is found in all
+	// three locations, the order of preference is: the machine's block
+	// device, the volume attachment plan's block device, lastly the
+	// volume attachment's block device.
+	expectedBlockDevices := []blockdevice.BlockDevice{{
+		DeviceName:      "foo",
+		DeviceLinks:     []string{"/dev/disk/by-id/a-link"},
+		FilesystemLabel: "label",
+		FilesystemUUID:  "device-uuid",
+		HardwareId:      "hardware-id",
+		WWN:             "wwn",
+		BusAddress:      "bus-address",
+		SerialId:        "serial-id",
+		SizeMiB:         100,
+		FilesystemType:  "ext4",
+		InUse:           true,
+		MountPoint:      "/path/to/here",
+	}, {
+		DeviceName:  "baz",
+		DeviceLinks: []string{"/dev/disk/by-id/d-link"},
+	}}
+	s.service.EXPECT().SetBlockDevicesForMachineByName(
+		gomock.Any(), machine.Name("666"), expectedBlockDevices).Return(nil)
+
+	// Act
+	op := s.newImportOperation()
+
+	// Assert
+	err = op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}


### PR DESCRIPTION
Split from PR #21841, moving creation of missing block devices to `blockdevice` domain.

Import non empty block devices created from data gathered from volume attachments and volume attachment plans if they have not already been imported from machine.BlockDevices().

Prefer data gathered from volume attachment plans over volume attachments. A volume attachment is the promise of a block device. A plan is real.

Done to allow all to be found when volume attachments are imported later. The attachments must have a block device. Storage workers will resolve any missing data later.

## Checklistx
- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

This data is not used yet. It is unclear how this scenario would be encountered to attempt testing. Should not impact existing block import functionality.

## Links

**Jira card:** [JUJU-9204](https://warthogs.atlassian.net/browse/JUJU-9204)


[JUJU-9204]: https://warthogs.atlassian.net/browse/JUJU-9204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ