### PR TITLE
fix: do not add subnets for IPv6 loopback

### DIFF
--- a/domain/network/state/netconfig.go
+++ b/domain/network/state/netconfig.go
@@ -419,7 +419,7 @@ func (st *State) reconcileNetConfigAddresses(
 				return nil, nil, errors.Errorf("invalid IP address %q", a.AddressValue)
 			}
 			ones, bits := cidr.Mask.Size()
-			isSingleHostCIDR := ones == bits && !ip.IsLoopback()
+			isDiscoverableSingleHostCIDR := ones == bits && a.ConfigType != corenetwork.ConfigLoopback
 
 			var (
 				subnetUUID  string
@@ -434,7 +434,7 @@ func (st *State) reconcileNetConfigAddresses(
 			// If we found no match and are not adding discovered subnets
 			// progressively, there's nothing more we can do, unless the
 			// address is a /32 or /128, which always gets its subnet added.
-			if errors.Is(subMatchErr, errAddrSubnetMatchNone) && !addMissingSubnets && !isSingleHostCIDR {
+			if errors.Is(subMatchErr, errAddrSubnetMatchNone) && !addMissingSubnets && !isDiscoverableSingleHostCIDR {
 				// TODO (manadart 2025-04-29): Figure out what to do with
 				// loopback addresses before making
 				// ip_address.subnet_uuid NOT NULL.

--- a/domain/network/state/netconfig_test.go
+++ b/domain/network/state/netconfig_test.go
@@ -236,7 +236,16 @@ func (s *netConfigSuite) TestSetMachineNetConfigAddsSingleHostSubnet(c *tc.C) {
 				InterfaceName: devName,
 				AddressValue:  "::1/128",
 				AddressType:   corenetwork.IPv4Address,
-				ConfigType:    corenetwork.ConfigStatic,
+				ConfigType:    corenetwork.ConfigLoopback,
+				Origin:        corenetwork.OriginMachine,
+				Scope:         corenetwork.ScopeMachineLocal,
+			},
+			// We never add IPv4 loopback addresses either.
+			{
+				InterfaceName: devName,
+				AddressValue:  "127.0.0.1/8",
+				AddressType:   corenetwork.IPv4Address,
+				ConfigType:    corenetwork.ConfigLoopback,
 				Origin:        corenetwork.OriginMachine,
 				Scope:         corenetwork.ScopeMachineLocal,
 			},


### PR DESCRIPTION
In a prior patch, we added logic to create single address subnets during machine network discovery.

IPv6 loopback addresses have a /128 mask, but should not be treated like single subnet addresses. 

Such subnets are not added.

## QA steps

- Make sure your LXD bridge supports both IPv4 and IPv6 addresses.
- Bootstrap, switch to the controller, then run `juju spaces` we should not have the IPv6 /128 subnet listed in the alpha space.
