### PR TITLE
fix: windows build

### DIFF
--- a/juju/sockets/sockets_unix.go
+++ b/juju/sockets/sockets_unix.go
@@ -2,6 +2,8 @@
 // Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+//go:build !windows
+
 package sockets
 
 import (


### PR DESCRIPTION
For windows builds we compiled in the sockets twice, one for windows and one for unix.


## QA steps

```sh
$ make juju juju-metadata
$ GOARCH=amd64 GOOS=windows make juju juju-metadata
```