### PR TITLE
feat(cmr): migrate secret on consumer side

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -452,6 +452,13 @@ func (s *SecretsManagerAPI) getRemoteSecretContent(ctx context.Context, uri *cor
 	}
 	var wantRevision int
 	if err == nil {
+		// When a model consuming a secret through a cross-model relation is
+		// migrated, the owner application uuid for the secret cannot be set
+		// during migration.
+		// However, the secret reference is flagged as "migrated", to allow
+		// the secret to be updated during the next access. This is why we need
+		// to refresh the secret if we detect that it has been migrated.
+		refresh = refresh || consumerInfo.Migrated
 		wantRevision = consumerInfo.CurrentRevision
 	} else {
 		// Not found so need to create a new record and populate

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -1310,3 +1310,83 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 		}},
 	})
 }
+
+func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerMigrated(c *tc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	anotherUUID := "deadbeef-0bad-0666-8000-4b1d0d06f66d"
+	uri := coresecrets.NewURI().WithSource(anotherUUID)
+
+	consumer := unittesting.GenNewName(c, "mariadb/0")
+	appUUID := tc.Must(c, application.NewUUID)
+	relUUID := relationtesting.GenRelationUUID(c)
+	mac := apitesting.MustNewMacaroon("id")
+
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), consumer, uri, "").
+		Return(uri, nil, nil)
+
+	s.remoteClient.EXPECT().Close()
+
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "mariadb").Return(appUUID, nil)
+	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, consumer).Return(&coresecrets.SecretConsumerMetadata{
+		CurrentRevision: 665,
+		Migrated:        true,
+	}, nil)
+
+	s.remoteClient.EXPECT().GetSecretAccessScope(gomock.Any(), uri, appUUID, 0).Return(relUUID, nil)
+	s.crossModelRelationService.EXPECT().GetMacaroonForRelation(gomock.Any(), relUUID).Return(mac, nil)
+
+	// Note that even if Refresh is false in GetSecretContentArg,
+	// GetRemoteSecretContentInfo is called with refresh=true
+	// because consumerInfo.Migrated is true.
+	s.remoteClient.EXPECT().GetRemoteSecretContentInfo(
+		gomock.Any(), uri, 665, true, false, coretesting.ControllerTag.Id(),
+		appUUID, 0, macaroon.Slice{mac}).Return(
+		&secrets.ContentParams{
+			ValueRef: &coresecrets.ValueRef{
+				BackendID:  "backend-id",
+				RevisionID: "rev-id",
+			},
+		}, &provider.ModelBackendConfig{
+			ControllerUUID: coretesting.ControllerTag.Id(),
+			ModelUUID:      coretesting.ModelTag.Id(),
+			ModelName:      "fred",
+			BackendConfig: provider.BackendConfig{
+				BackendType: "vault",
+				Config:      map[string]interface{}{"foo": "bar"},
+			},
+		}, 666, true, nil)
+
+	s.crossModelRelationService.EXPECT().SaveRemoteSecretConsumer(gomock.Any(), uri, consumer, coresecrets.SecretConsumerMetadata{
+		CurrentRevision: 666,
+		Migrated:        true,
+	}, appUUID, relUUID)
+
+	results, err := s.facade.GetSecretContentInfo(c.Context(), params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{URI: uri.String(), Refresh: false},
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.DeepEquals, params.SecretContentResults{
+		Results: []params.SecretContentResult{{
+			Content: params.SecretContentParams{
+				ValueRef: &params.SecretValueRef{
+					BackendID:  "backend-id",
+					RevisionID: "rev-id",
+				},
+			},
+			BackendConfig: &params.SecretBackendConfigResult{
+				ControllerUUID: coretesting.ControllerTag.Id(),
+				ModelUUID:      coretesting.ModelTag.Id(),
+				ModelName:      "fred",
+				Draining:       true,
+				Config: params.SecretBackendConfig{
+					BackendType: "vault",
+					Params:      map[string]interface{}{"foo": "bar"},
+				},
+			},
+		}},
+	})
+}

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -286,6 +286,13 @@ type SecretConsumerMetadata struct {
 	// CurrentRevision is current revision the
 	// consumer wants to read.
 	CurrentRevision int
+
+	// Migrated indicates whether the secret has been migrated to a new model,
+	// which implies it may not have all information populated and requires
+	// override.
+	// It can only be true for secrets that are consumed by an application
+	// on a consumer model through a cross-model relation
+	Migrated bool
 }
 
 // SecretRevisionInfo holds info used to read a secret vale.

--- a/domain/crossmodelrelation/state/model/import.go
+++ b/domain/crossmodelrelation/state/model/import.go
@@ -404,53 +404,62 @@ func (st *State) ImportRemoteSecretConsumers(ctx context.Context,
 
 // ImportRemoteSecret imports a remote secret on the consumer model.
 func (st *State) ImportRemoteSecret(ctx context.Context, secret internal.RemoteSecret) error {
-	// TODO(gfouillet): reimplement remote secret import.
-	//   By default there is no need to implement it, since those information will be populated again whenever the
-	//   secret will be fetched again by the unit through a secret-get.
-	//   Non imported date belongs to both table secret_unit_consumer and secret_reference, but can't be completely
-	//   populated during the migration process: we don't have any solution to figure out the value of
-	//   secret_reference.owner_application_uuid from the model description.
-	//   I need to figure out if those data really need to be populated during migration process, and if it is
-	//   acceptable to have an empty value for secret_reference.owner_application_uuid, at least until the next
-	//   retrieval of the data by a unit.
-	//   This will be done in a follow up PR.
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
 
-	//	db, err := st.DB(ctx)
-	//	if err != nil {
-	//		return errors.Capture(err)
-	//	}
-	//
-	//	// Remote secrets doesn't have a reference yet.
-	//	secretRef := secretRef{ID: secret.SecretID}
-	//	insertRemoteSecretStmt, err := st.Prepare(`
-	//INSERT INTO secret (id)
-	//VALUES ($secretRef.secret_id)`, secretRef)
-	//	if err != nil {
-	//		return errors.Capture(err)
-	//	}
-	//
-	//	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-	//		err = tx.Query(ctx, insertRemoteSecretStmt, secretRef).Run()
-	//		if err != nil {
-	//			return errors.Errorf("inserting remote secret reference: %w", err)
-	//		}
-	//
-	//		err = st.saveSecretConsumer(ctx, tx, &coresecrets.URI{
-	//			SourceUUID: secret.SourceModelUUID,
-	//			ID:         secret.SecretID,
-	//		}, secret.UnitUUID, coresecrets.SecretConsumerMetadata{
-	//			Label:           secret.Label,
-	//			CurrentRevision: secret.CurrentRevision,
-	//		})
-	//		if err != nil {
-	//			return errors.Errorf("saving remote secret consumer info: %w", err)
-	//		}
-	//
-	//		return nil
-	//	})
-	//	if err != nil {
-	//		return errors.Capture(err)
-	//	}
+	// Remote secrets doesn't have a reference yet.
+	secretRef := secretLatestRevision{
+		ID:             secret.SecretID,
+		LatestRevision: secret.LatestRevision,
+		UpdatedAt:      st.clock.Now().UTC(),
+	}
+	insertRemoteSecretStmt, err := st.Prepare(`
+	INSERT INTO secret (id)
+	VALUES ($secretLatestRevision.secret_id)
+	ON CONFLICT DO NOTHING`, secretRef)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	insertReferenceQuery := `
+INSERT INTO secret_reference (secret_id, latest_revision, updated_at, migrated)
+VALUES ($secretLatestRevision.secret_id, $secretLatestRevision.latest_revision, $secretLatestRevision.updated_at, true)
+ON CONFLICT DO NOTHING` // Secret reference can be imported multiple times if there is more than one unit consuming it.
+
+	insertReferenceStmt, err := st.Prepare(insertReferenceQuery, secretLatestRevision{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, insertRemoteSecretStmt, secretRef).Run()
+		if err != nil {
+			return errors.Errorf("inserting remote secret reference: %w", err)
+		}
+
+		err = st.saveSecretConsumer(ctx, tx, &coresecrets.URI{
+			SourceUUID: secret.SourceModelUUID,
+			ID:         secret.SecretID,
+		}, secret.UnitUUID, coresecrets.SecretConsumerMetadata{
+			Label:           secret.Label,
+			CurrentRevision: secret.CurrentRevision,
+		})
+		if err != nil {
+			return errors.Errorf("saving remote secret consumer info: %w", err)
+		}
+
+		err = tx.Query(ctx, insertReferenceStmt, secretRef).Run()
+		if err != nil {
+			return errors.Errorf("inserting remote secret reference: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Capture(err)
+	}
 
 	return nil
 }

--- a/domain/crossmodelrelation/state/model/import_test.go
+++ b/domain/crossmodelrelation/state/model/import_test.go
@@ -612,7 +612,6 @@ func (s *importSecretSuite) TestImportRemoteSecretConsumers(c *tc.C) {
 }
 
 func (s *importSecretSuite) TestImportRemoteSecret(c *tc.C) {
-	c.Skip("Will be fixed in follow up PR when import remote will be implemented again")
 	// Arrange
 	secretID := "remote-secret-id"
 	sourceModelUUID := tc.Must(c, internaluuid.NewUUID).String()
@@ -629,6 +628,7 @@ func (s *importSecretSuite) TestImportRemoteSecret(c *tc.C) {
 		UnitUUID:        unitUUID,
 		Label:           "test-label",
 		CurrentRevision: 1,
+		LatestRevision:  2,
 	}
 
 	// Act
@@ -664,6 +664,108 @@ func (s *importSecretSuite) TestImportRemoteSecret(c *tc.C) {
 	c.Check(obtainedSourceModel, tc.Equals, sourceModelUUID)
 	c.Check(obtainedLabel, tc.Equals, "test-label")
 	c.Check(obtainedRev, tc.Equals, 1)
+
+	// Verify secret_reference exists
+	var (
+		obtainedRefSecretID       string
+		obtainedRefLatestRevision int
+		obtainedRefMigrated       bool
+	)
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT secret_id, latest_revision, migrated
+			FROM secret_reference
+			WHERE secret_id = ?
+		`, secretID).Scan(&obtainedRefSecretID, &obtainedRefLatestRevision, &obtainedRefMigrated)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(obtainedRefSecretID, tc.Equals, secretID)
+	c.Check(obtainedRefLatestRevision, tc.Equals, 2)
+	c.Check(obtainedRefMigrated, tc.Equals, true)
+}
+
+func (s *importSecretSuite) TestImportRemoteSecretTwoConsumerUnit(c *tc.C) {
+	// Arrange
+	secretID := "remote-secret-id"
+	sourceModelUUID := tc.Must(c, internaluuid.NewUUID).String()
+	unitUUID1 := tc.Must(c, internaluuid.NewUUID).String()
+	unitUUID2 := tc.Must(c, internaluuid.NewUUID).String()
+
+	// Unit must exist for saveSecretConsumer to work.
+	charmUUID := s.addCharm(c)
+	appUUID := s.addApplication(c, charmUUID, "app")
+	s.addUnitWithUUID(c, unitUUID1, "app/0", appUUID.String(), charmUUID.String())
+	s.addUnitWithUUID(c, unitUUID2, "app/1", appUUID.String(), charmUUID.String())
+
+	secret1 := internal.RemoteSecret{
+		SecretID:        secretID,
+		SourceModelUUID: sourceModelUUID,
+		UnitUUID:        unitUUID1,
+		Label:           "test-label",
+		CurrentRevision: 1,
+		LatestRevision:  2,
+	}
+	secret2 := internal.RemoteSecret{
+		SecretID:        secretID,
+		SourceModelUUID: sourceModelUUID,
+		UnitUUID:        unitUUID2,
+		Label:           "test-label",
+		CurrentRevision: 2,
+		LatestRevision:  2,
+	}
+
+	// Act
+	tc.Must2_0(c, s.state.ImportRemoteSecret, c.Context(), secret1)
+
+	err := s.state.ImportRemoteSecret(c.Context(), secret2)
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+
+	// Verify secret exists
+	var obtainedSecretID string
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT id FROM secret WHERE id = ?", secretID).Scan(&obtainedSecretID)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(obtainedSecretID, tc.Equals, secretID)
+
+	// Verify expected consumer exists
+	var (
+		obtainedSourceModel string
+		obtainedLabel       string
+		obtainedRev         int
+	)
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT source_model_uuid, label, current_revision
+			FROM secret_unit_consumer
+			WHERE secret_id = ?
+			AND unit_uuid = ?
+		`, secretID, unitUUID2).Scan(&obtainedSourceModel, &obtainedLabel, &obtainedRev)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(obtainedSourceModel, tc.Equals, sourceModelUUID)
+	c.Check(obtainedLabel, tc.Equals, "test-label")
+	c.Check(obtainedRev, tc.Equals, 2)
+
+	// Verify secret_reference exists
+	var (
+		obtainedRefSecretID       string
+		obtainedRefLatestRevision int
+		obtainedRefMigrated       bool
+	)
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT secret_id, latest_revision, migrated
+			FROM secret_reference
+			WHERE secret_id = ?
+		`, secretID).Scan(&obtainedRefSecretID, &obtainedRefLatestRevision, &obtainedRefMigrated)
+	})
+	c.Assert(err, tc.IsNil)
+	c.Check(obtainedRefSecretID, tc.Equals, secretID)
+	c.Check(obtainedRefLatestRevision, tc.Equals, 2)
+	c.Check(obtainedRefMigrated, tc.Equals, true)
 }
 
 func (s *importSecretSuite) createSecretWithMetadata(c *tc.C, secretID string) {

--- a/domain/crossmodelrelation/state/model/secrets.go
+++ b/domain/crossmodelrelation/state/model/secrets.go
@@ -344,11 +344,22 @@ ON CONFLICT(id) DO NOTHING`
 		return errors.Capture(err)
 	}
 
+	// When a model consuming a secret through a cross-model relation is
+	// migrated, the owner application uuid for the secret cannot be set
+	// during migration.
+	// This is why we may have a conflict on secret ID even if the
+	// latest_revision as not changed. The first purpose of this query is
+	// to update latest_revision, but we also update the owner_application_uuid
+	// (just in case), and set the migrated to false (missing piece of information
+	// are known at this point.
 	insertLatestQuery := `
 INSERT INTO secret_reference (*)
 VALUES ($secretLatestRevision.*)
 ON CONFLICT(secret_id) DO UPDATE SET
-    latest_revision=excluded.latest_revision`
+    latest_revision=excluded.latest_revision,
+    owner_application_uuid=excluded.owner_application_uuid,
+    updated_at=excluded.updated_at,
+    migrated=false`
 
 	insertLatestStmt, err := st.Prepare(insertLatestQuery, secretLatestRevision{})
 	if err != nil {
@@ -359,6 +370,7 @@ ON CONFLICT(secret_id) DO UPDATE SET
 		ID:              uri.ID,
 		LatestRevision:  latestRevision,
 		ApplicationUUID: applicationUUID,
+		UpdatedAt:       st.clock.Now().UTC(),
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, insertStmt, secretRef{ID: uri.ID}).Run()
@@ -407,7 +419,9 @@ ON CONFLICT DO NOTHING`
 	rUUID := remoteRelationUUID{UUID: relUUID}
 	aUUID := applicationUUID{UUID: appUUID}
 	remoteRef := secretLatestRevision{
-		ID: uri.ID, LatestRevision: md.CurrentRevision,
+		ID:             uri.ID,
+		LatestRevision: md.CurrentRevision,
+		UpdatedAt:      st.clock.Now().UTC(),
 	}
 
 	offerAppUUIDQuery, err := st.Prepare(`
@@ -422,10 +436,23 @@ AND    ae.application_uuid <> $applicationUUID.uuid
 		return errors.Capture(err)
 	}
 
+	// When a model consuming a secret through a cross-model relation is
+	// migrated, the owner application uuid for the secret cannot be set
+	// during migration.
+	// The insertion below doesn't need to do anything if the secret already
+	// exists.
+	// However, due to this migration workaround, we need to use this opportunity
+	// to setup the owner_application_uuid if the secret was imported.
+	// This why we don't do nothing in case of conflict, but instead do update
+	// if the reference has been migrated.
 	insertRemoteSecretReferenceQuery := `
-INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid)
+INSERT INTO secret_reference (*)
 VALUES ($secretLatestRevision.*)
-ON CONFLICT DO NOTHING`
+ON CONFLICT (secret_id) DO UPDATE SET
+    owner_application_uuid=excluded.owner_application_uuid,
+    updated_at=excluded.updated_at,
+    migrated=false
+WHERE secret_reference.migrated IS TRUE`
 
 	insertRemoteSecretReferenceStmt, err := st.Prepare(insertRemoteSecretReferenceQuery, remoteRef)
 	if err != nil {

--- a/domain/crossmodelrelation/state/model/secrets_test.go
+++ b/domain/crossmodelrelation/state/model/secrets_test.go
@@ -480,14 +480,57 @@ func (s *modelSecretsSuite) TestUpdateRemoteSecretRevision(c *tc.C) {
 	}
 
 	appUUID := s.setupRemoteApp(c, "mediawiki")
-	err := s.state.UpdateRemoteSecretRevision(c.Context(), uri, 666, appUUID)
+
+	// Create secret with 3 revisions (1, 2, 3).
+	s.createSecret(c, uri, map[string]string{"foo": "bar"}, nil)
+	s.addRevision(c, uri, map[string]string{"foo": "bar2"})
+	s.addRevision(c, uri, map[string]string{"foo": "bar3"})
+
+	// Initially revisions are not obsolete.
+	for i := 1; i <= 3; i++ {
+		obsolete, _ := s.getObsolete(c, uri, i)
+		c.Check(obsolete, tc.IsFalse)
+	}
+
+	// Update to latest revision 3.
+	err := s.state.UpdateRemoteSecretRevision(c.Context(), uri, 3, appUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	got := getLatest()
-	c.Assert(got, tc.Equals, 666)
-	err = s.state.UpdateRemoteSecretRevision(c.Context(), uri, 667, appUUID)
+	c.Assert(got, tc.Equals, 3)
+
+	// Revisions 1 and 2 are now obsolete because they are not the latest and have no consumers.
+	obsolete, _ := s.getObsolete(c, uri, 1)
+	c.Check(obsolete, tc.IsTrue)
+	obsolete, _ = s.getObsolete(c, uri, 2)
+	c.Check(obsolete, tc.IsTrue)
+
+	// Revision 3 is NOT obsolete because it's the latest in secret_revision table.
+	obsolete, _ = s.getObsolete(c, uri, 3)
+	c.Check(obsolete, tc.IsFalse)
+
+	// Add revision 4.
+	s.addRevision(c, uri, map[string]string{"foo": "bar4"})
+
+	// Add a consumer for revision 3.
+	consumer := coresecrets.SecretConsumerMetadata{
+		CurrentRevision: 3,
+	}
+	err = s.state.SaveSecretRemoteConsumer(c.Context(), uri, "remote-app/0", consumer)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Update to latest revision 4.
+	err = s.state.UpdateRemoteSecretRevision(c.Context(), uri, 4, appUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	got = getLatest()
-	c.Assert(got, tc.Equals, 667)
+	c.Assert(got, tc.Equals, 4)
+
+	// Revision 3 should NOT be obsolete because it has a consumer.
+	obsolete, _ = s.getObsolete(c, uri, 3)
+	c.Check(obsolete, tc.IsFalse)
+
+	// Revision 4 should NOT be obsolete because it's the latest in secret_revision table.
+	obsolete, _ = s.getObsolete(c, uri, 4)
+	c.Check(obsolete, tc.IsFalse)
 }
 
 func (s *modelSecretsSuite) setupSecretAccess(c *tc.C, uri *coresecrets.URI, unitName coreunit.Name) {

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -338,9 +338,10 @@ type secretRef struct {
 }
 
 type secretLatestRevision struct {
-	ID              string `db:"secret_id"`
-	LatestRevision  int    `db:"latest_revision"`
-	ApplicationUUID string `db:"owner_application_uuid"`
+	ID              string    `db:"secret_id"`
+	LatestRevision  int       `db:"latest_revision"`
+	ApplicationUUID string    `db:"owner_application_uuid"`
+	UpdatedAt       time.Time `db:"updated_at"`
 }
 
 type secretUnitConsumer struct {

--- a/domain/export/types/v4_0_4/model.go
+++ b/domain/export/types/v4_0_4/model.go
@@ -1243,9 +1243,11 @@ type SecretPermission struct {
 }
 
 type SecretReference struct {
-	SecretID             string `db:"secret_id"`
-	LatestRevision       int64  `db:"latest_revision"`
-	OwnerApplicationUUID string `db:"owner_application_uuid"`
+	SecretID             string    `db:"secret_id"`
+	LatestRevision       int64     `db:"latest_revision"`
+	OwnerApplicationUUID *string   `db:"owner_application_uuid"`
+	UpdatedAt            time.Time `db:"updated_at"`
+	Migrated             bool      `db:"migrated"`
 }
 
 type SecretRemoteUnitConsumer struct {

--- a/domain/removal/state/model/secret_test.go
+++ b/domain/removal/state/model/secret_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/juju/tc"
 
@@ -123,7 +124,9 @@ func (s *secretSuite) addSecretWithRevisionsAndContent(c *tc.C, appUUID string) 
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.DB().ExecContext(
-		ctx, "INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid) VALUES (?, ?, ?)", sec, 0, appUUID)
+		ctx, `
+INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid, updated_at) 
+VALUES (?, ?, ?, ?)`, sec, 0, appUUID, time.Now().UTC())
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.DB().ExecContext(

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -16,7 +16,7 @@ import (
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/blockdevice-triggers.gen.go -package=triggers -tables=block_device
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/model-triggers.gen.go -package=triggers -tables=model_config
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/objectstore-triggers.gen.go -package=triggers -tables=object_store_metadata_path
-//go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/secret-triggers.gen.go -package=triggers -tables=secret_metadata,secret_rotation,secret_revision_expire,secret_revision_obsolete,secret_reference,secret_deleted_value_ref
+//go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/secret-triggers.gen.go -package=triggers -tables=secret_metadata,secret_rotation,secret_revision_expire,secret_revision_obsolete,secret_deleted_value_ref
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/network-triggers.gen.go -package=triggers -tables=subnet,ip_address
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/machine-triggers.gen.go -package=triggers -tables=machine,machine_lxd_profile
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/machine-cloud-instance-triggers.gen.go -package=triggers -tables=machine_cloud_instance
@@ -154,6 +154,7 @@ var modelPostPatchFilesByVersion = []struct {
 	version: semversion.MustParse("4.0.4"),
 	files: []string{
 		"0049-object-store-node-id.PATCH.sql",
+		"0050-secret.PATCH.sql",
 	},
 }}
 
@@ -184,7 +185,7 @@ func ModelDDLForVersion(version semversion.Number) *schema.Schema {
 		triggers.ChangeLogTriggersForSecretRevisionObsolete("revision_uuid", tableSecretRevisionObsolete),
 		triggers.ChangeLogTriggersForSecretRevisionExpire("revision_uuid", tableSecretRevisionExpire),
 		changeLogTriggersForSecretRevision("uuid", tableSecretRevision),
-		triggers.ChangeLogTriggersForSecretReference("secret_id", tableSecretReference),
+		changeLogTriggersForSecretReference("secret_id", tableSecretReference),
 		triggers.ChangeLogTriggersForSubnet("uuid", tableSubnet),
 		triggers.ChangeLogTriggersForMachine("uuid", tableMachine),
 		triggers.ChangeLogTriggersForMachineLxdProfile("machine_uuid", tableMachineLxdProfile),

--- a/domain/schema/model/sql/0050-secret.PATCH.sql
+++ b/domain/schema/model/sql/0050-secret.PATCH.sql
@@ -1,0 +1,96 @@
+/*
+ This patch helps to mitigate the issue when migrating a consumer model where
+ few units consume secrets from an application on the offerer model (through a
+ cross-model relation).
+
+ The issue is that the secret_reference table contains an owner_application_uuid
+ column, which is used to determine which remote application the secret belongs
+ to. Through this reference, if the remote application is deleted, the owned
+ secrets can be from the local model. However, the model description which is
+ provided during a migration doesn't contain this information.
+ This patch updates the secret_reference table to allow delaying the retrieval
+ of the remote application information to the next secret update.
+
+ TODO <<<<< TO MERGE THIS >>>>>
+  you need to restore the trigger generation in domain/schema/model.go:
+  - model/triggers/secret-triggers.gen.go : should also contains secret_reference
+  - regenerate the triggers
+  - replace changeLogTriggersForSecretReference by
+    triggers.ChangeLogTriggersForSecretReference in the trigger declaration.
+ */
+
+CREATE TABLE secret_reference_new (
+    secret_id TEXT NOT NULL PRIMARY KEY,
+    latest_revision INT NOT NULL,
+
+    -- owner_application_uuid is the application that owns the secret.
+    -- It is used to determine which remote (offerer) application the secret
+    -- belongs to. It is leveraged when the remote application is deleted from
+    -- the point of view of the local model (consumer), in order to delete the
+    -- secret from the local model.
+    owner_application_uuid TEXT,
+
+    -- updated_at is either the creation time of the reference, or the time it
+    -- was migrated, or the last time it was fetched from a unit, and thus
+    -- when the owner_application_uuid was defined.
+    updated_at DATETIME NOT NULL,
+
+    -- migrated is true if the reference was migrated from the old table.
+    -- In this case, owner_application_uuid may be empty.
+    migrated BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT fk_secret_id
+    FOREIGN KEY (secret_id)
+    REFERENCES secret (id),
+    CONSTRAINT fk_secret_reference_application_uuid
+    FOREIGN KEY (owner_application_uuid)
+    REFERENCES application (uuid),
+    CONSTRAINT chk_owned_or_migrated
+    CHECK ((owner_application_uuid IS NOT null AND owner_application_uuid != '') OR migrated)
+);
+
+INSERT INTO secret_reference_new
+SELECT
+    secret_id,
+    latest_revision,
+    owner_application_uuid,
+    (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')) AS updated_at,
+    false AS migrated
+FROM secret_reference;
+
+-- Code after this point doesn't need to be merged, as long as the triggers are regenerated
+
+-- sqlfluff doesn't support TRIGGER statements
+-- noqa: disable=all
+DROP TABLE secret_reference;
+ALTER TABLE secret_reference_new RENAME TO secret_reference;
+
+-- insert trigger for SecretReference
+CREATE TRIGGER trg_log_secret_reference_insert
+AFTER INSERT ON secret_reference FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (1, 10008, NEW.secret_id, DATETIME('now', 'utc'));
+END;
+
+-- update trigger for SecretReference
+CREATE TRIGGER trg_log_secret_reference_update
+AFTER UPDATE ON secret_reference FOR EACH ROW
+WHEN
+	NEW.secret_id != OLD.secret_id OR
+	NEW.latest_revision != OLD.latest_revision OR
+	(NEW.owner_application_uuid != OLD.owner_application_uuid OR (NEW.owner_application_uuid IS NOT NULL AND OLD.owner_application_uuid IS NULL) OR (NEW.owner_application_uuid IS NULL AND OLD.owner_application_uuid IS NOT NULL)) OR
+	NEW.updated_at != OLD.updated_at OR
+	NEW.migrated != OLD.migrated
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (2, 10008, OLD.secret_id, DATETIME('now', 'utc'));
+END;
+
+-- delete trigger for SecretReference
+CREATE TRIGGER trg_log_secret_reference_delete
+AFTER DELETE ON secret_reference FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (4, 10008, OLD.secret_id, DATETIME('now', 'utc'));
+END;
+-- noqa: enable=all

--- a/domain/schema/model/triggers/secret-triggers.gen.go
+++ b/domain/schema/model/triggers/secret-triggers.gen.go
@@ -88,43 +88,6 @@ END;`, columnName, namespaceID))
 	}
 }
 
-// ChangeLogTriggersForSecretReference generates the triggers for the
-// secret_reference table.
-func ChangeLogTriggersForSecretReference(columnName string, namespaceID int) func() schema.Patch {
-	return func() schema.Patch {
-		return schema.MakePatch(fmt.Sprintf(`
--- insert namespace for SecretReference
-INSERT INTO change_log_namespace VALUES (%[2]d, 'secret_reference', 'SecretReference changes based on %[1]s');
-
--- insert trigger for SecretReference
-CREATE TRIGGER trg_log_secret_reference_insert
-AFTER INSERT ON secret_reference FOR EACH ROW
-BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
-    VALUES (1, %[2]d, NEW.%[1]s, DATETIME('now', 'utc'));
-END;
-
--- update trigger for SecretReference
-CREATE TRIGGER trg_log_secret_reference_update
-AFTER UPDATE ON secret_reference FOR EACH ROW
-WHEN 
-	NEW.secret_id != OLD.secret_id OR
-	NEW.latest_revision != OLD.latest_revision OR
-	NEW.owner_application_uuid != OLD.owner_application_uuid 
-BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
-    VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
-END;
--- delete trigger for SecretReference
-CREATE TRIGGER trg_log_secret_reference_delete
-AFTER DELETE ON secret_reference FOR EACH ROW
-BEGIN
-    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
-    VALUES (4, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
-END;`, columnName, namespaceID))
-	}
-}
-
 // ChangeLogTriggersForSecretRevisionExpire generates the triggers for the
 // secret_revision_expire table.
 func ChangeLogTriggersForSecretRevisionExpire(columnName string, namespaceID int) func() schema.Patch {

--- a/domain/schema/modeltriggers.go
+++ b/domain/schema/modeltriggers.go
@@ -903,3 +903,38 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+
+func changeLogTriggersForSecretReference(columnName string, namespaceID int) func() schema.Patch {
+	return func() schema.Patch {
+		return schema.MakePatch(fmt.Sprintf(`
+-- insert namespace for SecretReference
+INSERT INTO change_log_namespace VALUES (%[2]d, 'secret_reference', 'SecretReference changes based on %[1]s');
+
+-- insert trigger for SecretReference
+CREATE TRIGGER trg_log_secret_reference_insert
+AFTER INSERT ON secret_reference FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (1, %[2]d, NEW.%[1]s, DATETIME('now', 'utc'));
+END;
+
+-- update trigger for SecretReference
+CREATE TRIGGER trg_log_secret_reference_update
+AFTER UPDATE ON secret_reference FOR EACH ROW
+WHEN 
+	NEW.secret_id != OLD.secret_id OR
+	NEW.latest_revision != OLD.latest_revision OR
+	NEW.owner_application_uuid != OLD.owner_application_uuid 
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;
+-- delete trigger for SecretReference
+CREATE TRIGGER trg_log_secret_reference_delete
+AFTER DELETE ON secret_reference FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (4, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;`, columnName, namespaceID))
+	}
+}

--- a/domain/schema/secret_schema_test.go
+++ b/domain/schema/secret_schema_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/juju/tc"
 	"github.com/juju/utils/v4"
@@ -131,7 +132,7 @@ func (s *secretSchemaSuite) TestModelChangeLogTriggersForSecretTables(c *tc.C) {
 INSERT INTO application (uuid, charm_uuid, name, life_id, space_uuid)
 VALUES (?, ?, 'mysql', 0, ?);`, appUUID, charmUUID, network.AlphaSpaceId)
 
-	s.assertExecSQL(c, `INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid) VALUES (?, 1, ?);`, secretURI.ID, appUUID)
+	s.assertExecSQL(c, `INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid, updated_at) VALUES (?, 1, ?, ?);`, secretURI.ID, appUUID, time.Now().UTC())
 	s.assertExecSQL(c, `UPDATE secret_reference SET latest_revision = 2 WHERE secret_id = ?;`, secretURI.ID)
 	s.assertExecSQL(c, `DELETE FROM secret_reference WHERE secret_id = ?;`, secretURI.ID)
 

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -2281,7 +2281,7 @@ FROM (SELECT * FROM local UNION SELECT * FROM remote)`
 }
 
 // GetSecretConsumer returns the secret consumer info for the specified unit
-// and secret, along withthe latest revision for the secret.
+// and secret, along with the latest revision for the secret.
 // If the unit does not exist, an error satisfying [applicationerrors.UnitNotFound] is
 // returned.If the secret does not exist, an error satisfying
 // [secreterrors.SecretNotFound] is returned.
@@ -2322,7 +2322,9 @@ WHERE  rev.secret_id = $secretRef.secret_id`
 	}
 
 	selectLatestRemoteRevision := `
-SELECT latest_revision AS &secretRef.revision
+SELECT 
+    latest_revision AS &secretRef.revision,
+	migrated AS &secretRef.migrated
 FROM   secret_reference ref
 WHERE  ref.secret_id = $secretRef.secret_id`
 	selectLatestRemoteRevisionStmt, err := st.Prepare(selectLatestRemoteRevision, secretRef{})
@@ -2333,6 +2335,7 @@ WHERE  ref.secret_id = $secretRef.secret_id`
 	var (
 		dbSecretConsumers secretUnitConsumers
 		latestRevision    int
+		migrated          bool
 	)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		isLocal, err := st.checkExistsIfLocal(ctx, tx, uri)
@@ -2365,6 +2368,7 @@ WHERE  ref.secret_id = $secretRef.secret_id`
 			return errors.Errorf("looking up latest revision for %q: %w", uri.ID, err)
 		}
 		latestRevision = latest.Revision
+		migrated = latest.Migrated
 
 		return nil
 	})
@@ -2375,6 +2379,7 @@ WHERE  ref.secret_id = $secretRef.secret_id`
 		return nil, latestRevision, errors.Errorf("secret consumer for %q and unit %q %w", uri.ID, unitName, secreterrors.SecretConsumerNotFound)
 	}
 	consumers := dbSecretConsumers.toSecretConsumers()
+	consumers[0].Migrated = migrated
 	return consumers[0], latestRevision, nil
 }
 

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -1850,10 +1850,10 @@ func (s *stateSuite) updateRemoteSecretRevision(c *tc.C, uri *coresecrets.URI, l
 			return err
 		}
 		_, err = tx.ExecContext(ctx, `
-INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid) VALUES (?, ?, ?)
+INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid, updated_at) VALUES (?, ?, ?, ?)
 ON CONFLICT(secret_id) DO UPDATE SET
     latest_revision=excluded.latest_revision
-`, uri.ID, latestRevision, appUUID)
+`, uri.ID, latestRevision, appUUID, time.Now().UTC())
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -62,6 +62,7 @@ type secretRef struct {
 	ID         string `db:"secret_id"`
 	SourceUUID string `db:"source_uuid"`
 	Revision   int    `db:"revision"`
+	Migrated   bool   `db:"migrated"`
 }
 
 type secretMetadata struct {

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -652,11 +652,11 @@ func (s *watcherSuite) updateRemoteSecretRevisionInConsumingModel(c *tc.C, uri *
 			return err
 		}
 		_, err = tx.ExecContext(ctx, `
-INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid) VALUES (?, ?, ?)
+INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid, updated_at) VALUES (?, ?, ?, ?)
 ON CONFLICT(secret_id) DO UPDATE SET
     latest_revision=excluded.latest_revision
 `,
-			uri.ID, latestRevision, appUUID)
+			uri.ID, latestRevision, appUUID, time.Now().UTC())
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -680,10 +680,10 @@ func (s *watcherSuite) TestWatchConsumedRemoteSecretsChanges(c *tc.C) {
 				return err
 			}
 			_, err = tx.ExecContext(ctx, `
-INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid) VALUES (?, ?, ?)
+INSERT INTO secret_reference (secret_id, latest_revision, owner_application_uuid, updated_at) VALUES (?, ?, ?, ?)
 ON CONFLICT(secret_id) DO UPDATE SET
     latest_revision=excluded.latest_revision
-`, uri.ID, revision, appUUID)
+`, uri.ID, revision, appUUID, time.Now().UTC())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR updates the cross-model secret (CMR) migration path by importing the consumer-side secrets, which rely on two tables: `secret_reference` and `secret_unit_consumer`.

The challenge here is that we don't have enough information in model description to retrieve the application owner uuid required into `secret_reference`.

As a workaround, we introduce a column which specify if the secret has just been migrated which allows to not fill the application_owner_uuid until some update of the secret.

The application_owner_uuid will be populated later, if one of these situation occurs:

* A unit try to get the secret from the remote offerer application
* The remote offerer application update the secret (new revision), causing an update on the latest revision in the reference table.

Until that point, if the relation break or the remote application die, this may result in a leak in the database: the secret will remains because purge code path won't be able to delete it.

However this can be mitigated in the future through a dedicated worker which try to detect such leak, by checking "migrated" field and with the help of the newly introduced field `updated_at`. This part is not covered by this PR.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


## QA steps

Download script: [setup_secrets_cmr.sh](https://github.com/user-attachments/files/25443072/setup_secrets_cmr.sh)

Setup usecase (`juju_36` is a snap version of juju 3.6  and `juju` the current branch version)
```sh
juju bootstrap lxd tgt && juju_36 bootstrap lxd src && bash setup_cmr_merge.sh
```

The script should print two secret url:
```sh
All units are active.
Creating app-owned secrets...
secret created: secret://11a626e9-fccf-4787-8bee-ab861b8c80ce/d6c2gkl4jp0djds5ng90
Creating unit-owned secrets...
secret created: secret://11a626e9-fccf-4787-8bee-ab861b8c80ce/d6c2gkl4jp0djds5ng9g
```

Use those secret url to check that you have access to the secrets through sink/0 unit:

```
juju exec -m to --unit sink/0 -- secret-get <URL>
```

Then migrate `from` model

```sh
juju migrate from tgt
```

Verify that you still have access to the secrets from sink/0:

```
juju exec -m to --unit sink/0 -- secret-get <URL>
```

Migrate `to` model

```
juju migrate to tgt
juju switch tgt:to
```

Look at the database in `model-to` through juju_db_repl

* Verify that both table `secret_reference` and `secret_unit_consumer` are populated with the correct revision
* the secrets should be marked as "migrated"

Verify that you still have access to the secrets from sink/0:

```
juju exec -m to --unit sink/0 -- secret-get <URL>
```
Look again at the database in `model-to` through juju_db_repl

* the secret you just got shouldn't be marked as "migrated" and its application_owner_uuid should be populated.

Update the revision of both secret on offerer model:

```
juju exec -m tgt:from --unit src/leader -- secret-set <URL 1> updated=foo
juju exec -m tgt:from --unit src/leader -- secret-set <URL 2> updated=bar
```
Look again at the database in `model-to` through juju_db_repl

* Both secret shouldn't be marked as "migrated" and both application_owner_uuid should be populated.
* Latest revision should have been updated.



## Links

**Jira card:** [JUJU-9909](https://warthogs.atlassian.net/browse/JUJU-9909)
