### PR TITLE
feat: update unit storage directives after refresh

### DIFF
--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/application"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/application/internal"
 	"github.com/juju/juju/domain/constraints"
 	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/ipaddress"
@@ -33,6 +34,8 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/status"
+	domainstorage "github.com/juju/juju/domain/storage"
+	domainstorageprov "github.com/juju/juju/domain/storageprovisioning"
 	internaldatabase "github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
 )
@@ -1158,6 +1161,10 @@ ON CONFLICT (unit_uuid, charm_uuid, storage_name) DO NOTHING
 		if err != nil {
 			return errors.Capture(err)
 		}
+		err = st.backfillUnitStorageInstancesForDirectives(ctx, tx, unitName, charmUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
 		return nil
 	})
 	if err != nil {
@@ -1165,6 +1172,196 @@ ON CONFLICT (unit_uuid, charm_uuid, storage_name) DO NOTHING
 	}
 
 	return nil
+}
+
+func (st *State) backfillUnitStorageInstancesForDirectives(
+	ctx context.Context,
+	tx *sqlair.TX,
+	unitName unitName,
+	charmUUID charmUUID,
+) error {
+	type unitStorageDirectiveBackfill struct {
+		UnitUUID      string `db:"unit_uuid"`
+		NetNodeUUID   string `db:"net_node_uuid"`
+		CharmName     string `db:"charm_name"`
+		StorageName   string `db:"storage_name"`
+		StorageKind   string `db:"storage_kind"`
+		StoragePoolID string `db:"storage_pool_uuid"`
+		SizeMiB       uint64 `db:"size_mib"`
+		DesiredCount  uint32 `db:"desired_count"`
+		CurrentCount  uint32 `db:"current_count"`
+	}
+
+	// Identify directive rows for this unit/charm where current instance count
+	// is below the directive count; each row maps to "instances still needed".
+	backfillQuery, err := st.Prepare(`
+SELECT u.uuid AS &unitStorageDirectiveBackfill.unit_uuid,
+       u.net_node_uuid AS &unitStorageDirectiveBackfill.net_node_uuid,
+       cm.name AS &unitStorageDirectiveBackfill.charm_name,
+       usd.storage_name AS &unitStorageDirectiveBackfill.storage_name,
+       csk.kind AS &unitStorageDirectiveBackfill.storage_kind,
+       usd.storage_pool_uuid AS &unitStorageDirectiveBackfill.storage_pool_uuid,
+       usd.size_mib AS &unitStorageDirectiveBackfill.size_mib,
+       usd.count AS &unitStorageDirectiveBackfill.desired_count,
+       CAST(COALESCE(existing.current_count, 0) AS INT) AS &unitStorageDirectiveBackfill.current_count
+FROM   unit u
+JOIN   unit_storage_directive usd
+       ON usd.unit_uuid = u.uuid
+JOIN   charm_metadata cm
+       ON cm.charm_uuid = usd.charm_uuid
+JOIN   charm_storage cs
+       ON cs.charm_uuid = usd.charm_uuid
+      AND cs.name = usd.storage_name
+JOIN   charm_storage_kind csk
+       ON csk.id = cs.storage_kind_id
+LEFT JOIN (
+    SELECT suo.unit_uuid,
+           si.storage_name,
+           COUNT(*) AS current_count
+    FROM   storage_unit_owner suo
+    JOIN   storage_instance si
+           ON si.uuid = suo.storage_instance_uuid
+    GROUP BY suo.unit_uuid, si.storage_name
+) existing
+       ON existing.unit_uuid = u.uuid
+      AND existing.storage_name = usd.storage_name
+WHERE  u.name = $unitName.name
+AND    usd.charm_uuid = $charmUUID.charm_uuid
+AND    CAST(COALESCE(existing.current_count, 0) AS INT) < usd.count
+`, unitStorageDirectiveBackfill{}, unitName, charmUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	var backfill []unitStorageDirectiveBackfill
+	err = tx.Query(ctx, backfillQuery, unitName, charmUUID).GetAll(&backfill)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if len(backfill) == 0 {
+		return nil
+	}
+
+	var (
+		instArgs      []internal.CreateUnitStorageInstanceArg
+		attachArgs    []internal.CreateUnitStorageAttachmentArg
+		ownershipArgs []domainstorage.StorageInstanceUUID
+	)
+
+	// Build create/attach/ownership args for each missing instance.
+	for _, row := range backfill {
+		toCreate := int(row.DesiredCount - row.CurrentCount)
+		for range toCreate {
+			storageUUID, err := domainstorage.NewStorageInstanceUUID()
+			if err != nil {
+				return errors.Errorf("generating storage instance uuid: %w", err)
+			}
+
+			kind, err := decodeStorageKind(row.StorageKind)
+			if err != nil {
+				return errors.Capture(err)
+			}
+
+			instanceArg := internal.CreateUnitStorageInstanceArg{
+				UUID:            storageUUID,
+				CharmName:       row.CharmName,
+				Name:            domainstorage.Name(row.StorageName),
+				Kind:            kind,
+				RequestSizeMiB:  row.SizeMiB,
+				StoragePoolUUID: domainstorage.StoragePoolUUID(row.StoragePoolID),
+			}
+
+			attachArg := internal.CreateUnitStorageAttachmentArg{
+				StorageInstanceUUID: storageUUID,
+			}
+			storageAttachmentUUID, err := domainstorage.NewStorageAttachmentUUID()
+			if err != nil {
+				return errors.Errorf("generating storage attachment uuid: %w", err)
+			}
+			attachArg.UUID = storageAttachmentUUID
+
+			switch kind {
+			case domainstorage.StorageKindFilesystem:
+				filesystemUUID, err := domainstorage.NewFilesystemUUID()
+				if err != nil {
+					return errors.Errorf("generating storage filesystem uuid: %w", err)
+				}
+				filesystemAttachmentUUID, err := domainstorage.NewFilesystemAttachmentUUID()
+				if err != nil {
+					return errors.Errorf("generating filesystem attachment uuid: %w", err)
+				}
+				instanceArg.Filesystem = &internal.CreateUnitStorageFilesystemArg{
+					UUID:           filesystemUUID,
+					ProvisionScope: domainstorageprov.ProvisionScopeModel,
+				}
+				attachArg.FilesystemAttachment = &internal.CreateUnitStorageFilesystemAttachmentArg{
+					FilesystemUUID: filesystemUUID,
+					NetNodeUUID:    domainnetwork.NetNodeUUID(row.NetNodeUUID),
+					ProvisionScope: domainstorageprov.ProvisionScopeModel,
+					UUID:           filesystemAttachmentUUID,
+				}
+			case domainstorage.StorageKindBlock:
+				volumeUUID, err := domainstorage.NewVolumeUUID()
+				if err != nil {
+					return errors.Errorf("generating storage volume uuid: %w", err)
+				}
+				volumeAttachmentUUID, err := domainstorage.NewVolumeAttachmentUUID()
+				if err != nil {
+					return errors.Errorf("generating volume attachment uuid: %w", err)
+				}
+				instanceArg.Volume = &internal.CreateUnitStorageVolumeArg{
+					UUID:           volumeUUID,
+					ProvisionScope: domainstorageprov.ProvisionScopeModel,
+				}
+				attachArg.VolumeAttachment = &internal.CreateUnitStorageVolumeAttachmentArg{
+					VolumeUUID:     volumeUUID,
+					NetNodeUUID:    domainnetwork.NetNodeUUID(row.NetNodeUUID),
+					ProvisionScope: domainstorageprov.ProvisionScopeModel,
+					UUID:           volumeAttachmentUUID,
+				}
+			default:
+				return errors.Errorf("unsupported storage kind %q", row.StorageKind)
+			}
+
+			instArgs = append(instArgs, instanceArg)
+			attachArgs = append(attachArgs, attachArg)
+			ownershipArgs = append(ownershipArgs, storageUUID)
+		}
+	}
+
+	// Insert instance rows first, then attachments, then ownership links.
+	storageIDs, err := st.unitState.insertUnitStorageInstances(ctx, tx, instArgs)
+	if err != nil {
+		return errors.Errorf("inserting backfilled storage instances for unit %q: %w", unitName.Name, err)
+	}
+	if len(storageIDs) != len(instArgs) {
+		return errors.Errorf("unexpected storage ids created for unit %q", unitName.Name)
+	}
+	err = st.unitState.insertUnitStorageAttachments(ctx, tx, backfill[0].UnitUUID, attachArgs)
+	if err != nil {
+		return errors.Errorf("inserting backfilled storage attachments for unit %q: %w", unitName.Name, err)
+	}
+	err = st.unitState.insertUnitStorageOwnership(ctx, tx, backfill[0].UnitUUID, ownershipArgs)
+	if err != nil {
+		return errors.Errorf("inserting backfilled storage ownership for unit %q: %w", unitName.Name, err)
+	}
+
+	return nil
+}
+
+func decodeStorageKind(kind string) (domainstorage.StorageKind, error) {
+	switch kind {
+	case string(internalcharm.StorageFilesystem):
+		return domainstorage.StorageKindFilesystem, nil
+	case string(internalcharm.StorageBlock):
+		return domainstorage.StorageKindBlock, nil
+	default:
+		return -1, errors.Errorf("unknown charm storage kind %q", kind)
+	}
 }
 
 // GetUnitRefreshAttributes returns the unit refresh attributes for the

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -1080,6 +1080,7 @@ func (s *unitStateSuite) TestUpdateUnitCharmAddsNewUnitStorageDirectives(c *tc.C
 		st2Name               string
 		st2Size               int
 		st2Count              int
+		st2InstanceCount      int
 	)
 
 	// Assert that the newly defined storage is inserted for the existing unit.
@@ -1102,10 +1103,23 @@ func (s *unitStateSuite) TestUpdateUnitCharmAddsNewUnitStorageDirectives(c *tc.C
 		).Scan(&st2Name, &st2Size, &st2Count)
 	})
 	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(
+			ctx,
+			`SELECT count(*)
+			 FROM storage_instance si
+			 JOIN storage_unit_owner suo ON suo.storage_instance_uuid = si.uuid
+			 WHERE suo.unit_uuid=? AND si.storage_name='st2'`,
+			unitUUID.String(),
+		).Scan(&st2InstanceCount)
+	})
+	c.Assert(err, tc.ErrorIsNil)
 	c.Check(storageDirectiveCount, tc.Equals, 2)
 	c.Check(st2Name, tc.Equals, "st2")
 	c.Check(st2Size, tc.Equals, 8192)
 	c.Check(st2Count, tc.Equals, 1)
+	c.Check(st2InstanceCount, tc.Equals, 1)
 }
 
 func (s *unitStateSuite) TestGetUnitRefreshAttributes(c *tc.C) {


### PR DESCRIPTION
This PR improves UpdateUnitCharm so existing unit storage directives and instances stays consistent when we refresh the application to a new charm revision, especially when the new charm introduces a new storage definition. Specifically, we do the following:

1. Update charmUUID for existing unit storage directives
2. Add any new storage definitions to existing unit storage directives
3. Create storage instances for these new storage definitions

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps - Checking if juju refresh still works normally
TBC

**Charm Description**
```
A test charm that validates juju refresh storage directive compatibility. Current Revision: 15

  Base Definition (Single-Instance):
  The base charm defines a filesystem storage "data" with minimum size 3G,
  single instance, and no storage-attached hook.

  storage:
  data:
    type: filesystem
    description: Storage for application data
    location: /srv/data
    minimum-size: 3G
  dummy:
    type: filesystem
    description: Dummy storage for testing
    location: /srv/dummy
    minimum-size: 1G

  Multi-Instance Base Definition:
  The multi-instance base defines a filesystem storage "data" with
  count min 3 and count max 6, and a valid storage-attached hook.

  storage:
  data:
    type: filesystem
    description: Storage for application data
    location: /srv/data
    minimum-size: 3G
    multiple:
      range: 3-6
  dummy:
    type: filesystem
    description: Dummy storage for testing
    location: /srv/dummy
    minimum-size: 1G  

  Revision 1 is identical to the base definition.

  Revision 2 is the same as the base definition but sets the minimum size of "data" to 7G.
  (Should fail)

  Revision 3 is the same as the base definition but sets the minimum size of "data" to 2G.
  Note that size of storage directive should not change and would still be 3G.
  (Should pass)

  Revision 4 is the same as the base definition but adds a new storage "logs".
  (Should pass)

  Revision 5 is the same as the base definition but removes storage "data".
  (Should fail)

  Revision 6 is the same as the base definition but sets count min to 2 and count max to 5 for "data".
  (Should fail)

  Revision 7 is the same as the base definition but sets the storage type of "data" from filesystem to block.
  (Should fail)

  Revision 8 is the same as the base definition but adds its storage-attached hook.
  (Should pass with no missing hook warning)

  Revision 9 is identical to the multi-instance base definition.

  Revision 10 is the same as the multi-instance base definition but sets count min to 4 for "data".
  (Should fail)

  Revision 11 is the same as the multi-instance base definition but sets count min to 1 for "data".
  Note that count of storage directive should not change and would still be 3.
  (Should pass)

  Revision 12 is the same as the multi-instance base definition but sets count max to 5 for "data".
  (Should fail)

  Revision 13 is the same as the multi-instance base definition but sets count max to 10 for "data".
  Note that count of storage directive should not change and would still be 3.
  (Should pass)

  Revision 14 is voided.

  Revision 15 is the same as the multi-instance base definition but sets minimum size for "data" to 2G.
  Note that count of storage directive should not change and would still be 3, 
  and minimum size should not change and would still be 3G.
  (Should pass)

  Revision 16 is voided.

  Revision 17 is voided.

  Revision 18 is the same as the multi-instance base definition but sets read-only to true for "data".
  Note that count of storage directive should not change and would still be 3, 
  and minimum size should not change and would still be 3G.
  (Should fail)

  Revision 19 is the same as the multi-instance base definition but sets shared to true for "data".
  Note that count of storage directive should not change and would still be 3, 
  and minimum size should not change and would still be 3G.
  (Should fail)   

  Revision 20 is the same as the multi-instance base definition but sets location to /srv/newdata for "data".
  Note that count of storage directive should not change and would still be 3, 
  and minimum size should not change and would still be 3G.
  (Should fail)
```

## Links
[JUJU-9270]: https://warthogs.atlassian.net/browse/JUJU-9270