### PR TITLE
fix: treat dying consumer worker death as not found.

### DIFF
--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -1088,10 +1088,10 @@ func (w *localConsumerWorker) processDischargeRequiredError(ctx context.Context,
 
 func (w *localConsumerWorker) isRelationWorkerDead(ctx context.Context, relationUUID corerelation.UUID) (bool, error) {
 	_, err := w.runner.Worker(offererRelationWorkerName(relationUUID), ctx.Done())
-	if err != nil && !errors.Is(err, errors.NotFound) {
-		return false, errors.Annotatef(err, "querying offerer relation worker for %q", relationUUID)
-	} else if errors.Is(err, errors.NotFound) {
+	if errors.Is(err, errors.NotFound) || errors.Is(err, worker.ErrDead) {
 		return true, nil
+	} else if err != nil {
+		return false, errors.Annotatef(err, "querying offerer relation worker for %q", relationUUID)
 	}
 	return false, nil
 }

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -3064,6 +3064,26 @@ func (s *localConsumerWorkerSuite) TestRelationRemovedNotifiesOfferingModel(c *t
 	workertest.CleanKill(c, w)
 }
 
+func (s *localConsumerWorkerSuite) TestIsRelationWorkerDeadWhenRunnerDeadAndWorkerDying(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	done := s.expectWorkerStartup()
+
+	w := s.newLocalConsumerWorker(c)
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for worker to be started")
+	}
+
+	workertest.CleanKill(c, w)
+
+	dead, err := w.isRelationWorkerDead(c.Context(), tc.Must(c, relation.NewUUID))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(dead, tc.IsTrue)
+}
+
 // TestRelationRemovedWithoutOffererUnitWorker tests that when a relation is
 // removed and no offerer unit relation worker exists (e.g. worker restarted),
 // the worker gracefully handles the situation without trying to notify the


### PR DESCRIPTION
When checking the runner for dead relation workers, we can get `NotFound`, but we can also get `ErrDead` if the runner is shutting down.

Instead of crashing the parent worker, treat both errors as a dead relation worker.

This fixes intermittent failures observed in CI.
