### PR TITLE
fix: sshserver check watcher closure and port changes

### DIFF
--- a/internal/worker/sshserver/worker.go
+++ b/internal/worker/sshserver/worker.go
@@ -175,13 +175,18 @@ func (ssw *serverWrapperWorker) loop() error {
 		select {
 		case <-ssw.catacomb.Dying():
 			return ssw.catacomb.ErrDying()
-		case <-changesChan:
+		case _, ok := <-changesChan:
+			if !ok {
+				return errors.New("controller config watcher closed")
+			}
+
 			config, err := ssw.config.ControllerConfigService.ControllerConfig(ctx)
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if maxConns == config.SSHMaxConcurrentConnections() {
-				ssw.config.Logger.Debugf(context.Background(), "controller configuration changed, but nothing changed for the ssh server.")
+			if maxConns == config.SSHMaxConcurrentConnections() &&
+				port == config.SSHServerPort() {
+				ssw.config.Logger.Debugf(ctx, "controller configuration changed, but nothing changed for the ssh server")
 				continue
 			}
 			return errors.New("changes detected, stopping SSH server worker")

--- a/internal/worker/sshserver/worker_test.go
+++ b/internal/worker/sshserver/worker_test.go
@@ -216,6 +216,118 @@ func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorker(c *tc.C) {
 	c.Check(workertest.CheckKilled(c, controllerConfigWatcher), tc.ErrorIsNil)
 }
 
+func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorkerOnPortChange(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	serverWorker := workertest.NewErrorWorker(nil)
+	defer workertest.DirtyKill(c, serverWorker)
+
+	ch := make(chan []string)
+	controllerConfigWatcher := watchertest.NewMockStringsWatcher(ch)
+	defer workertest.DirtyKill(c, controllerConfigWatcher)
+
+	controllerConfigService := NewMockControllerConfigService(ctrl)
+	controllerConfigService.EXPECT().WatchControllerConfig(gomock.Any()).Return(controllerConfigWatcher, nil)
+
+	// First call on startup.
+	controllerConfigService.EXPECT().
+		ControllerConfig(gomock.Any()).
+		Return(
+			controller.Config{
+				controller.SSHServerPort:               22,
+				controller.SSHMaxConcurrentConnections: 10,
+			},
+			nil,
+		).
+		Times(1)
+	// Second call after first watcher event: unchanged.
+	controllerConfigService.EXPECT().
+		ControllerConfig(gomock.Any()).
+		Return(
+			controller.Config{
+				controller.SSHServerPort:               22,
+				controller.SSHMaxConcurrentConnections: 10,
+			},
+			nil,
+		).
+		Times(1)
+	// Third call after second watcher event: port changed.
+	controllerConfigService.EXPECT().
+		ControllerConfig(gomock.Any()).
+		Return(
+			controller.Config{
+				controller.SSHServerPort:               23,
+				controller.SSHMaxConcurrentConnections: 10,
+			},
+			nil,
+		).
+		Times(1)
+
+	cfg := ServerWrapperWorkerConfig{
+		ControllerConfigService: controllerConfigService,
+		Logger:                  loggertesting.WrapCheckLog(c),
+		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
+			c.Check(swc.Port, tc.Equals, 22)
+			return serverWorker, nil
+		},
+		SessionHandler: &stubSessionHandler{},
+	}
+	w, err := NewServerWrapperWorker(cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	workertest.CheckAlive(c, w)
+	workertest.CheckAlive(c, serverWorker)
+	workertest.CheckAlive(c, controllerConfigWatcher)
+
+	// First change: no restart expected.
+	ch <- nil
+	workertest.CheckAlive(c, w)
+
+	// Second change: port changed, restart expected.
+	ch <- nil
+	err = workertest.CheckKilled(c, w)
+	c.Check(err, tc.ErrorMatches, "changes detected, stopping SSH server worker")
+}
+
+func (s *workerSuite) TestSSHServerWrapperWorkerConfigWatcherClosed(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	serverWorker := workertest.NewErrorWorker(nil)
+	defer workertest.DirtyKill(c, serverWorker)
+
+	ch := make(chan []string)
+	controllerConfigWatcher := watchertest.NewMockStringsWatcher(ch)
+	defer workertest.DirtyKill(c, controllerConfigWatcher)
+
+	controllerConfigService := NewMockControllerConfigService(ctrl)
+	controllerConfigService.EXPECT().WatchControllerConfig(gomock.Any()).Return(controllerConfigWatcher, nil)
+	controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controller.Config{
+		controller.SSHServerPort:               22,
+		controller.SSHMaxConcurrentConnections: 10,
+	}, nil).Times(1)
+
+	cfg := ServerWrapperWorkerConfig{
+		ControllerConfigService: controllerConfigService,
+		Logger:                  loggertesting.WrapCheckLog(c),
+		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
+			return serverWorker, nil
+		},
+		SessionHandler: &stubSessionHandler{},
+	}
+	w, err := NewServerWrapperWorker(cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	workertest.CheckAlive(c, w)
+	close(ch)
+
+	err = workertest.CheckKilled(c, w)
+	c.Check(err, tc.ErrorMatches, "controller config watcher closed")
+}
+
 func (s *workerSuite) TestWrapperWorkerReport(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
Two fixes:
- When we got a change to SSH port, we were not treating it as a change requiring action - we only looked at the max connections article. This change is now handled.
- We were not checking if the watcher channel is closed, which could cause case re-entrance and loop thrashing. This too is addressed.