### PR TITLE
fix: avoid blob retriever namespace race

### DIFF
--- a/internal/objectstore/factory.go
+++ b/internal/objectstore/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/worker/v4"
 
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/internal/errors"
@@ -184,8 +185,21 @@ func ObjectStoreFactory(ctx context.Context, backendType objectstore.BackendType
 	}
 }
 
+func newBlobRetriever(
+	apiRemoteCallers apiremotecaller.APIRemoteCallers,
+	namespace string,
+	newBlobsClient remote.NewBlobsClientFunc,
+	clock clock.Clock,
+	logger logger.Logger,
+) (*remote.BlobRetriever, error) {
+	if namespace == database.ControllerNS {
+		return remote.NewControllerBlobRetriever(apiRemoteCallers, newBlobsClient, clock, logger)
+	}
+	return remote.NewModelBlobRetriever(apiRemoteCallers, namespace, newBlobsClient, clock, logger)
+}
+
 func newFileObjectStore(ctx context.Context, namespace string, opts *options) (_ *remoteFileObjectStore, err error) {
-	blobRetriever, err := remote.NewBlobRetriever(
+	blobRetriever, err := newBlobRetriever(
 		opts.apiRemoteCallers,
 		namespace,
 		opts.newFileBlobsClient,

--- a/internal/objectstore/remote/retriever.go
+++ b/internal/objectstore/remote/retriever.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/clock"
 	jujuerrors "github.com/juju/errors"
+	"github.com/juju/names/v6"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/api"
@@ -37,6 +38,18 @@ const (
 	HTTPError = errors.ConstError("http error")
 )
 
+// ModelTagGetter is an interface for getting the model tag from an API
+// connection.
+type ModelTagGetter interface {
+	// ModelTag returns the model tag for the current connection, if available.
+	ModelTag() (names.ModelTag, bool)
+}
+
+// GetNamespaceFunc is a function that returns the namespace to use for
+// retrieving blobs from the remote API, given a ModelTagGetter to get the model
+// tag from the API connection.
+type GetNamespaceFunc func(ModelTagGetter) (string, error)
+
 // BlobsClient is an interface for retrieving objects from an object store.
 type BlobsClient interface {
 	// GetObject returns a reader for the object with the given key in the
@@ -51,7 +64,8 @@ type NewBlobsClientFunc func(url string, client s3client.HTTPClient, logger logg
 type BlobRetriever struct {
 	tomb tomb.Tomb
 
-	namespace string
+	namespace       string
+	namespaceGetter GetNamespaceFunc
 
 	apiRemoteCallers apiremotecaller.APIRemoteCallers
 	newBlobsClient   NewBlobsClientFunc
@@ -60,10 +74,35 @@ type BlobRetriever struct {
 	logger logger.Logger
 }
 
-// NewBlobRetriever creates a new BlobRetriever.
-func NewBlobRetriever(apiRemoteCallers apiremotecaller.APIRemoteCallers, namespace string, newBlobsClient NewBlobsClientFunc, clock clock.Clock, logger logger.Logger) (*BlobRetriever, error) {
+// NewControllerBlobRetriever creates a new BlobRetriever.
+func NewControllerBlobRetriever(apiRemoteCallers apiremotecaller.APIRemoteCallers, newBlobsClient NewBlobsClientFunc, clock clock.Clock, logger logger.Logger) (*BlobRetriever, error) {
 	w := &BlobRetriever{
-		namespace:        namespace,
+		namespace: database.ControllerNS,
+		namespaceGetter: func(mtg ModelTagGetter) (string, error) {
+			tag, ok := mtg.ModelTag()
+			if !ok {
+				return "", errors.Errorf("missing model tag when using controller namespace")
+			}
+			return tag.Id(), nil
+		},
+		newBlobsClient:   newBlobsClient,
+		apiRemoteCallers: apiRemoteCallers,
+		clock:            clock,
+		logger:           logger,
+	}
+
+	w.tomb.Go(w.loop)
+
+	return w, nil
+}
+
+// NewModelBlobRetriever creates a new BlobRetriever.
+func NewModelBlobRetriever(apiRemoteCallers apiremotecaller.APIRemoteCallers, namespace string, newBlobsClient NewBlobsClientFunc, clock clock.Clock, logger logger.Logger) (*BlobRetriever, error) {
+	w := &BlobRetriever{
+		namespace: namespace,
+		namespaceGetter: func(mtg ModelTagGetter) (string, error) {
+			return namespace, nil
+		},
 		newBlobsClient:   newBlobsClient,
 		apiRemoteCallers: apiRemoteCallers,
 		clock:            clock,
@@ -86,8 +125,6 @@ func (r *BlobRetriever) Report() map[string]any {
 
 // Retrieve returns a reader for the blob with the given SHA256.
 func (r *BlobRetriever) Retrieve(ctx context.Context, sha256 string, controllerIDHints []string) (io.ReadCloser, int64, error) {
-	controllerNamespace := r.namespace == database.ControllerNS
-
 	// Check if we're already dead or dying before we start to do anything.
 	select {
 	case <-r.tomb.Dying():
@@ -113,14 +150,14 @@ func (r *BlobRetriever) Retrieve(ctx context.Context, sha256 string, controllerI
 		remotes = shuffleRemotes(remotes)
 	}
 
-	return r.retrieveFromRemotes(ctx, remotes, sha256, controllerNamespace)
+	return r.retrieveFromRemotes(ctx, remotes, sha256)
 }
 
-func (r *BlobRetriever) retrieveFromRemotes(ctx context.Context, remotes []apiremotecaller.RemoteConnection, sha256 string, controllerNamespace bool) (io.ReadCloser, int64, error) {
+func (r *BlobRetriever) retrieveFromRemotes(ctx context.Context, remotes []apiremotecaller.RemoteConnection, sha256 string) (io.ReadCloser, int64, error) {
 	// Iterate over the remotes and try to retrieve the blob from each one.
 	var errs []string
 	for _, remote := range remotes {
-		reader, size, err := r.retrieve(ctx, remote, sha256, controllerNamespace)
+		reader, size, err := r.retrieve(ctx, remote, sha256)
 		if errors.Is(err, HTTPError) {
 			errs = append(errs, err.Error())
 			r.logger.Debugf(ctx, "failed to retrieve blob %q from remote: %v", sha256, err)
@@ -137,7 +174,7 @@ func (r *BlobRetriever) retrieveFromRemotes(ctx context.Context, remotes []apire
 	return nil, -1, errors.Errorf(`failed to retrieve %q: %s`, sha256, strings.Join(errs, ",")).Add(BlobNotFound)
 }
 
-func (r *BlobRetriever) retrieve(ctx context.Context, remote apiremotecaller.RemoteConnection, sha256 string, controllerNamespace bool) (io.ReadCloser, int64, error) {
+func (r *BlobRetriever) retrieve(ctx context.Context, remote apiremotecaller.RemoteConnection, sha256 string) (io.ReadCloser, int64, error) {
 	var reader io.ReadCloser
 	var size int64
 
@@ -152,13 +189,9 @@ func (r *BlobRetriever) retrieve(ctx context.Context, remote apiremotecaller.Rem
 			return errors.Errorf("failed to create object client: %w", err).Add(HTTPError)
 		}
 
-		ns := r.namespace
-		if controllerNamespace {
-			tag, ok := conn.ModelTag()
-			if !ok {
-				return errors.Errorf("missing model tag when using controller namespace")
-			}
-			ns = tag.Id()
+		ns, err := r.namespaceGetter(conn)
+		if err != nil {
+			return errors.Errorf("failed to get namespace: %w", err).Add(HTTPError)
 		}
 
 		ctx := &scopedContext{

--- a/internal/objectstore/remote/retriever_test.go
+++ b/internal/objectstore/remote/retriever_test.go
@@ -21,7 +21,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	api "github.com/juju/juju/api"
-	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/s3client"
@@ -79,7 +78,31 @@ func (s *retrieverSuite) TestRetrieveControllerNamespace(c *tc.C) {
 	s.simpleHTTPClient.EXPECT().BaseURL().Return("http://example.com/api")
 	s.client.EXPECT().GetObject(gomock.Any(), "f47ac10b-58cc-4372-a567-0e02b2c3d479", "sha256").Return(io.NopCloser(strings.NewReader("test data")), int64(9), nil)
 
-	ret, err := NewBlobRetriever(s.remoteCallers, database.ControllerNS, func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
+	ret, err := NewControllerBlobRetriever(s.remoteCallers, func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
+		return s.client, nil
+	}, s.clock, loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, ret)
+
+	reader, size, err := ret.Retrieve(c.Context(), "sha256", []string{"1"})
+	c.Assert(err, tc.ErrorIsNil)
+	s.checkReader(c, reader, size)
+
+	workertest.CleanKill(c, ret)
+}
+
+func (s *retrieverSuite) TestRetrieveModelNamespace(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.remoteCallers.EXPECT().GetAPIRemotes().Return([]apiremotecaller.RemoteConnection{s.remoteConnection1}, nil)
+	s.remoteConnection1.EXPECT().Connection(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, f func(context.Context, api.Connection) error) error {
+		return f(ctx, s.apiConnection)
+	})
+	s.apiConnection.EXPECT().SimpleHTTPClient().Return(s.simpleHTTPClient, nil)
+	s.simpleHTTPClient.EXPECT().BaseURL().Return("http://example.com/api")
+	s.client.EXPECT().GetObject(gomock.Any(), "f47ac10b-58cc-4372-a567-0e02b2c3d479", "sha256").Return(io.NopCloser(strings.NewReader("test data")), int64(9), nil)
+
+	ret, err := NewModelBlobRetriever(s.remoteCallers, "f47ac10b-58cc-4372-a567-0e02b2c3d479", func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
 		return s.client, nil
 	}, s.clock, loggertesting.WrapCheckLog(c))
 	c.Assert(err, tc.ErrorIsNil)
@@ -118,7 +141,7 @@ func (s *retrieverSuite) TestRetrieveControllerNamespacePerCall(c *tc.C) {
 		s.client.EXPECT().GetObject(gomock.Any(), tag2.Id(), "sha256").Return(io.NopCloser(strings.NewReader("test data")), int64(9), nil),
 	)
 
-	ret, err := NewBlobRetriever(s.remoteCallers, database.ControllerNS, func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
+	ret, err := NewControllerBlobRetriever(s.remoteCallers, func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
 		return s.client, nil
 	}, s.clock, loggertesting.WrapCheckLog(c))
 	c.Assert(err, tc.ErrorIsNil)
@@ -138,21 +161,21 @@ func (s *retrieverSuite) TestRetrieveControllerNamespacePerCall(c *tc.C) {
 func (s *retrieverSuite) TestRetrieveControllerNamespaceMissingModelTag(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.remoteCallers.EXPECT().GetAPIRemotes().Return([]apiremotecaller.RemoteConnection{s.remoteConnection}, nil)
-	s.remoteConnection.EXPECT().Connection(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, f func(context.Context, api.Connection) error) error {
+	s.remoteCallers.EXPECT().GetAPIRemotes().Return([]apiremotecaller.RemoteConnection{s.remoteConnection1}, nil)
+	s.remoteConnection1.EXPECT().Connection(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, f func(context.Context, api.Connection) error) error {
 		return f(ctx, s.apiConnection)
 	})
 	s.apiConnection.EXPECT().SimpleHTTPClient().Return(s.simpleHTTPClient, nil)
 	s.simpleHTTPClient.EXPECT().BaseURL().Return("http://example.com/api")
 	s.apiConnection.EXPECT().ModelTag().Return(names.NewModelTag("f47ac10b-58cc-4372-a567-0e02b2c3d479"), false)
 
-	ret, err := NewBlobRetriever(s.remoteCallers, database.ControllerNS, func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
+	ret, err := NewControllerBlobRetriever(s.remoteCallers, func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
 		return s.client, nil
 	}, s.clock, loggertesting.WrapCheckLog(c))
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.DirtyKill(c, ret)
 
-	_, _, err = ret.Retrieve(c.Context(), "sha256")
+	_, _, err = ret.Retrieve(c.Context(), "sha256", []string{"1"})
 	c.Assert(err, tc.ErrorMatches, ".*missing model tag.*")
 
 	workertest.CleanKill(c, ret)
@@ -537,7 +560,7 @@ func (s *retrieverSuite) TestScopedContextDoneIgnoresChildAfterIgnore(c *tc.C) {
 }
 
 func (s *retrieverSuite) newRetriever(c *tc.C) *BlobRetriever {
-	ret, err := NewBlobRetriever(s.remoteCallers, "namespace", func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
+	ret, err := NewModelBlobRetriever(s.remoteCallers, "namespace", func(url string, client s3client.HTTPClient, logger logger.Logger) (BlobsClient, error) {
 		return s.client, nil
 	}, s.clock, loggertesting.WrapCheckLog(c))
 	c.Assert(err, tc.ErrorIsNil)


### PR DESCRIPTION
Ensure the namespace for the retrieval call doesn't mutate the underlying namespace of the blob retriever.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-unit -m controller controller -n 2
$ juju add-model foo
$ juju deploy juju-qa-test
$ for i in {1..100} ; do juju exec -u juju-qa-test/0 --wait 30s "date" ; done
```

