### PR TITLE
feat: handle edge case where a filesystem is missing a storage instances on import

### DIFF
--- a/cmd/juju/common/format.go
+++ b/cmd/juju/common/format.go
@@ -90,6 +90,9 @@ func HumaniseInterval(interval time.Duration) string {
 // in an arbitrary format used for status or and localized tz
 // or in UTC timezone and format RFC3339 if u is specified.
 func FormatTime(t *time.Time, formatISO bool) string {
+	if t == nil {
+		return ""
+	}
 	if formatISO {
 		// If requested, use ISO time format.
 		// The format we use is RFC3339 without the "T". From the spec:

--- a/domain/storage/modelmigration/import.go
+++ b/domain/storage/modelmigration/import.go
@@ -110,15 +110,13 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	// Filesystems and Volumes need to be handled differently for CAAS models. Until
 	// this is implemented skip the import step.
 	if model.Type() == coremodel.IAAS.String() {
+		if err := i.importVolumes(ctx, model.Volumes()); err != nil {
+			return errors.Errorf("setting volumes: %w", err)
+		}
+
 		if err := i.importFilesystemsIAAS(ctx, model.Filesystems()); err != nil {
 			return errors.Errorf("importing filesystems: %w", err)
 		}
-
-		if err := i.importVolumes(ctx, model.Volumes()); err != nil {
-			return errors.Errorf("setting volumes: %w", err)
-
-		}
-
 	}
 	return nil
 }
@@ -170,6 +168,7 @@ func (i *importOperation) importFilesystemsIAAS(ctx context.Context, filesystems
 			ProviderID:        in.FilesystemID(),
 			PoolName:          in.Pool(),
 			StorageInstanceID: in.Storage(),
+			VolumeID:          in.Volume(),
 			Attachments: transform.Slice(
 				in.Attachments(),
 				func(a description.FilesystemAttachment) domainstorage.ImportFilesystemAttachmentsParams {

--- a/domain/storage/modelmigration/import_test.go
+++ b/domain/storage/modelmigration/import_test.go
@@ -444,6 +444,37 @@ func (s *importSuite) TestImportFilesystems(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *importSuite) TestImportFilesystemsWithVolumeReference(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	model := description.NewModel(description.ModelArgs{
+		Type: coremodel.IAAS.String(),
+	})
+	model.AddFilesystem(description.FilesystemArgs{
+		ID:           "fs-1",
+		Size:         2048,
+		Volume:       "0",
+		Pool:         "testpool",
+		FilesystemID: "provider-fs-1",
+	})
+
+	s.noopStoragePoolImport()
+	s.service.EXPECT().ImportFilesystemsIAAS(gomock.Any(), tc.Bind(tc.SameContents, []domainstorage.ImportFilesystemParams{{
+		ID:                "fs-1",
+		SizeInMiB:         2048,
+		StorageInstanceID: "",
+		VolumeID:          "0",
+		PoolName:          "testpool",
+		ProviderID:        "provider-fs-1",
+		Attachments:       []domainstorage.ImportFilesystemAttachmentsParams{},
+	}})).Return(nil)
+
+	op := s.newImportOperation()
+	err := op.Execute(c.Context(), model)
+
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *importSuite) TestImportVolumes(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/storage/service/import.go
+++ b/domain/storage/service/import.go
@@ -5,6 +5,8 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
@@ -22,6 +24,7 @@ import (
 	domainstorageprovisioning "github.com/juju/juju/domain/storageprovisioning"
 	"github.com/juju/juju/internal/errors"
 	internalstorage "github.com/juju/juju/internal/storage"
+	"github.com/juju/juju/internal/uuid"
 )
 
 // StorageImportState defines an interface for interacting with the underlying
@@ -39,6 +42,10 @@ type StorageImportState interface {
 	// GetStorageInstanceUUIDsByIDs retrieves the UUIDs of storage instances by
 	// their IDs.
 	GetStorageInstanceUUIDsByIDs(ctx context.Context, storageIDs []string) (map[string]string, error)
+
+	// GetStorageInstanceUUIDsByVolumeIDs retrieves the UUIDs of storage
+	// instances by their linked volume IDs.
+	GetStorageInstanceUUIDsByVolumeIDs(ctx context.Context, volumeIDs []string) (map[string]string, error)
 
 	// GetStoragePoolProvidersByNames returns a map of storage pool names to their
 	// provider types for the specified storage pool names.
@@ -169,6 +176,24 @@ func (s *StorageImportService) ImportStorageInstances(ctx context.Context, param
 	return s.st.ImportStorageInstances(ctx, instanceArgs, attachmentArgs)
 }
 
+type filesystemImportPartition struct {
+	poolNames          []string
+	storageInstanceIDs []string
+	volumeIDs          []string
+	orphanIndexes      []int
+	machines           []string
+	units              []string
+}
+
+type filesystemImportLookups struct {
+	poolScopes                             map[string]domainstorageprovisioning.ProvisionScope
+	storageInstanceUUIDsByID               map[string]string
+	storageInstanceUUIDsByVolumeID         map[string]string
+	orphanStorageInstanceUUIDsByFilesystem map[int]string
+	machineNodes                           map[string]string
+	unitNodes                              map[string]string
+}
+
 // ImportFilesystemsIAAS imports filesystems from the provided parameters for
 // IAAS models.
 //
@@ -192,21 +217,49 @@ func (s *StorageImportService) ImportFilesystemsIAAS(ctx context.Context, params
 		return nil
 	}
 
-	var (
-		poolNames = make([]string, len(params))
-		// The vast majority of the time, storageInstanceIDs will be full length
-		storageInstanceIDs = make([]string, 0, len(params))
-		units              = set.NewStrings()
-		machines           = set.NewStrings()
-	)
+	partition, err := s.partitionFilesystemImportParams(params)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	lookups, err := s.resolveFilesystemImportLookups(ctx, params, partition)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	fsArgs, attachmentArgs, err := s.makeImportFilesystemIAASArgs(params, lookups)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return s.st.ImportFilesystemsIAAS(ctx, fsArgs, attachmentArgs)
+}
+
+func (s *StorageImportService) partitionFilesystemImportParams(
+	params []domainstorage.ImportFilesystemParams,
+) (filesystemImportPartition, error) {
+	partition := filesystemImportPartition{
+		poolNames:          make([]string, len(params)),
+		storageInstanceIDs: make([]string, 0, len(params)),
+		volumeIDs:          make([]string, 0, len(params)),
+		orphanIndexes:      make([]int, 0, len(params)),
+	}
+
+	units := set.NewStrings()
+	machines := set.NewStrings()
 	for i, arg := range params {
 		if err := arg.Validate(); err != nil {
-			return errors.Errorf("validating import filesystem params %d: %w", i, err)
+			return filesystemImportPartition{}, errors.Errorf("validating import filesystem params %d: %w", i, err)
 		}
 
-		poolNames[i] = arg.PoolName
-		if arg.StorageInstanceID != "" {
-			storageInstanceIDs = append(storageInstanceIDs, arg.StorageInstanceID)
+		partition.poolNames[i] = arg.PoolName
+		switch {
+		case arg.StorageInstanceID != "":
+			partition.storageInstanceIDs = append(partition.storageInstanceIDs, arg.StorageInstanceID)
+		case arg.VolumeID != "":
+			partition.volumeIDs = append(partition.volumeIDs, arg.VolumeID)
+		default:
+			partition.orphanIndexes = append(partition.orphanIndexes, i)
 		}
 
 		for _, attachment := range arg.Attachments {
@@ -218,46 +271,87 @@ func (s *StorageImportService) ImportFilesystemsIAAS(ctx context.Context, params
 		}
 	}
 
-	poolScopes, err := s.retrieveProviderScopesForPools(ctx, domainstorage.StorageKindFilesystem, poolNames)
+	partition.machines = machines.Values()
+	partition.units = units.Values()
+	return partition, nil
+}
+
+func (s *StorageImportService) resolveFilesystemImportLookups(
+	ctx context.Context,
+	params []domainstorage.ImportFilesystemParams,
+	partition filesystemImportPartition,
+) (filesystemImportLookups, error) {
+	poolScopes, err := s.retrieveProviderScopesForPools(ctx, domainstorage.StorageKindFilesystem, partition.poolNames)
 	if err != nil {
-		return errors.Errorf("getting provider scopes of filesystems: %w", err)
+		return filesystemImportLookups{}, errors.Errorf("getting provider scopes of filesystems: %w", err)
 	}
 
-	storageInstanceUUIDsByID, err := s.st.GetStorageInstanceUUIDsByIDs(ctx, storageInstanceIDs)
-	if err != nil {
-		return errors.Errorf("retrieving storage instance UUIDs by IDs: %w", err)
-	}
-
-	var machineNodes, unitNodes map[string]string
-	if len(machines)+len(units) > 0 {
-		machineNodes, unitNodes, err = s.st.GetNetNodeUUIDsByMachineOrUnitName(ctx, machines.Values(), units.Values())
+	storageInstanceUUIDsByID := map[string]string{}
+	if len(partition.storageInstanceIDs) > 0 {
+		storageInstanceUUIDsByID, err = s.st.GetStorageInstanceUUIDsByIDs(ctx, partition.storageInstanceIDs)
 		if err != nil {
-			return errors.Errorf("retrieving net node UUIDs by machine or unit names: %w", err)
+			return filesystemImportLookups{}, errors.Errorf("retrieving storage instance UUIDs by IDs: %w", err)
 		}
 	}
 
+	storageInstanceUUIDsByVolumeID := map[string]string{}
+	if len(partition.volumeIDs) > 0 {
+		storageInstanceUUIDsByVolumeID, err = s.st.GetStorageInstanceUUIDsByVolumeIDs(ctx, partition.volumeIDs)
+		if err != nil {
+			return filesystemImportLookups{}, errors.Errorf("retrieving storage instance UUIDs by volume IDs: %w", err)
+		}
+	}
+
+	orphanStorageInstanceUUIDsByFilesystem := map[int]string{}
+	if len(partition.orphanIndexes) > 0 {
+		orphanStorageInstanceUUIDsByFilesystem, err = s.importOrphanedFilesystemStorageInstances(ctx, params, partition.orphanIndexes)
+		if err != nil {
+			return filesystemImportLookups{}, errors.Errorf("importing orphaned storage instances: %w", err)
+		}
+	}
+
+	lookups := filesystemImportLookups{
+		poolScopes:                             poolScopes,
+		storageInstanceUUIDsByID:               storageInstanceUUIDsByID,
+		storageInstanceUUIDsByVolumeID:         storageInstanceUUIDsByVolumeID,
+		orphanStorageInstanceUUIDsByFilesystem: orphanStorageInstanceUUIDsByFilesystem,
+	}
+
+	if len(partition.machines)+len(partition.units) == 0 {
+		return lookups, nil
+	}
+
+	lookups.machineNodes, lookups.unitNodes, err = s.st.GetNetNodeUUIDsByMachineOrUnitName(
+		ctx, partition.machines, partition.units,
+	)
+	if err != nil {
+		return filesystemImportLookups{}, errors.Errorf("retrieving net node UUIDs by machine or unit names: %w", err)
+	}
+
+	return lookups, nil
+}
+
+func (s *StorageImportService) makeImportFilesystemIAASArgs(
+	params []domainstorage.ImportFilesystemParams,
+	lookups filesystemImportLookups,
+) ([]internal.ImportFilesystemIAASArgs, []internal.ImportFilesystemAttachmentIAASArgs, error) {
 	fsArgs := make([]internal.ImportFilesystemIAASArgs, len(params))
 	attachmentArgs := make([]internal.ImportFilesystemAttachmentIAASArgs, 0)
 	for i, arg := range params {
-		providerScope, ok := poolScopes[arg.PoolName]
+		providerScope, ok := lookups.poolScopes[arg.PoolName]
 		if !ok {
-			return errors.Errorf("storage pool %q not found for filesystem %q", arg.PoolName, arg.ID).
+			return nil, nil, errors.Errorf("storage pool %q not found for filesystem %q", arg.PoolName, arg.ID).
 				Add(domainstorageerrors.StoragePoolNotFound)
 		}
 
-		var storageInstanceUUID string
-		if arg.StorageInstanceID != "" {
-			var ok bool
-			storageInstanceUUID, ok = storageInstanceUUIDsByID[arg.StorageInstanceID]
-			if !ok {
-				return errors.Errorf("storage instance with ID %q not found for filesystem %q", arg.StorageInstanceID, arg.ID).
-					Add(domainstorageerrors.StorageInstanceNotFound)
-			}
+		storageInstanceUUID, err := s.resolveFilesystemStorageInstanceUUID(i, arg, lookups)
+		if err != nil {
+			return nil, nil, errors.Capture(err)
 		}
 
 		fsUUID, err := domainstorage.NewFilesystemUUID()
 		if err != nil {
-			return errors.Errorf("generating UUID for filesystem %q: %w", arg.ID, err)
+			return nil, nil, errors.Errorf("generating UUID for filesystem %q: %w", arg.ID, err)
 		}
 
 		fsArgs[i] = internal.ImportFilesystemIAASArgs{
@@ -273,24 +367,12 @@ func (s *StorageImportService) ImportFilesystemsIAAS(ctx context.Context, params
 		for _, attachment := range arg.Attachments {
 			attachmentUUID, err := domainstorage.NewFilesystemAttachmentUUID()
 			if err != nil {
-				return errors.Errorf("generating UUID for filesystem attachment of filesystem %q: %w", arg.ID, err)
+				return nil, nil, errors.Errorf("generating UUID for filesystem attachment of filesystem %q: %w", arg.ID, err)
 			}
 
-			var netNodeUUID string
-			if attachment.HostUnitName != "" {
-				var ok bool
-				netNodeUUID, ok = unitNodes[attachment.HostUnitName]
-				if !ok {
-					return errors.Errorf("net node for host unit %q not found", attachment.HostUnitName).
-						Add(applicationerrors.UnitNotFound)
-				}
-			} else {
-				var ok bool
-				netNodeUUID, ok = machineNodes[attachment.HostMachineName]
-				if !ok {
-					return errors.Errorf("net node for host machine %q not found", attachment.HostMachineName).
-						Add(machineerrors.MachineNotFound)
-				}
+			netNodeUUID, err := s.resolveFilesystemAttachmentNetNodeUUID(attachment, lookups)
+			if err != nil {
+				return nil, nil, errors.Capture(err)
 			}
 
 			attachmentArgs = append(attachmentArgs, internal.ImportFilesystemAttachmentIAASArgs{
@@ -305,7 +387,109 @@ func (s *StorageImportService) ImportFilesystemsIAAS(ctx context.Context, params
 		}
 	}
 
-	return s.st.ImportFilesystemsIAAS(ctx, fsArgs, attachmentArgs)
+	return fsArgs, attachmentArgs, nil
+}
+
+func (s *StorageImportService) resolveFilesystemStorageInstanceUUID(
+	filesystemIndex int,
+	arg domainstorage.ImportFilesystemParams,
+	lookups filesystemImportLookups,
+) (string, error) {
+	switch {
+	case arg.StorageInstanceID != "":
+		storageInstanceUUID, ok := lookups.storageInstanceUUIDsByID[arg.StorageInstanceID]
+		if !ok {
+			return "", errors.Errorf("storage instance with ID %q not found for filesystem %q", arg.StorageInstanceID, arg.ID).
+				Add(domainstorageerrors.StorageInstanceNotFound)
+		}
+		return storageInstanceUUID, nil
+	case arg.VolumeID != "":
+		storageInstanceUUID, ok := lookups.storageInstanceUUIDsByVolumeID[arg.VolumeID]
+		if !ok {
+			return "", errors.Errorf("storage instance for volume %q not found for filesystem %q", arg.VolumeID, arg.ID).
+				Add(domainstorageerrors.StorageInstanceNotFound)
+		}
+		return storageInstanceUUID, nil
+	default:
+		storageInstanceUUID, ok := lookups.orphanStorageInstanceUUIDsByFilesystem[filesystemIndex]
+		if !ok {
+			return "", errors.Errorf("orphaned storage instance for filesystem %q not found", arg.ID).
+				Add(domainstorageerrors.StorageInstanceNotFound)
+		}
+		return storageInstanceUUID, nil
+	}
+}
+
+func (s *StorageImportService) resolveFilesystemAttachmentNetNodeUUID(
+	attachment domainstorage.ImportFilesystemAttachmentsParams,
+	lookups filesystemImportLookups,
+) (string, error) {
+	if attachment.HostUnitName != "" {
+		netNodeUUID, ok := lookups.unitNodes[attachment.HostUnitName]
+		if !ok {
+			return "", errors.Errorf("net node for host unit %q not found", attachment.HostUnitName).
+				Add(applicationerrors.UnitNotFound)
+		}
+		return netNodeUUID, nil
+	}
+
+	netNodeUUID, ok := lookups.machineNodes[attachment.HostMachineName]
+	if !ok {
+		return "", errors.Errorf("net node for host machine %q not found", attachment.HostMachineName).
+			Add(machineerrors.MachineNotFound)
+	}
+	return netNodeUUID, nil
+}
+
+func (s *StorageImportService) importOrphanedFilesystemStorageInstances(
+	ctx context.Context,
+	params []domainstorage.ImportFilesystemParams,
+	orphanIndexes []int,
+) (map[int]string, error) {
+	if len(orphanIndexes) == 0 {
+		return map[int]string{}, nil
+	}
+
+	// Include a dashless UUID in the name to be defensive against storage_id
+	// collisions. Dashless guarantees the storage name is valid.
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	orphanedStorageName := fmt.Sprintf("orphaned%s", strings.ReplaceAll(uuid.String(), "-", ""))
+
+	orphanedStorageIDs := make([]string, len(orphanIndexes))
+	for i := range orphanedStorageIDs {
+		orphanedStorageIDs[i] = fmt.Sprintf("%s/%d", orphanedStorageName, i)
+	}
+
+	instanceArgs := make([]internal.ImportStorageInstanceArgs, len(orphanIndexes))
+	orphanStorageUUIDsByFilesystemIndex := make(map[int]string, len(orphanIndexes))
+	for i, filesystemIndex := range orphanIndexes {
+		filesystem := params[filesystemIndex]
+
+		storageUUID, err := domainstorage.NewStorageInstanceUUID()
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+
+		instanceArgs[i] = internal.ImportStorageInstanceArgs{
+			UUID:              storageUUID.String(),
+			Life:              life.Alive,
+			PoolName:          filesystem.PoolName,
+			RequestedSizeMiB:  filesystem.SizeInMiB,
+			StorageInstanceID: orphanedStorageIDs[i],
+			StorageName:       orphanedStorageName,
+			StorageKind:       "filesystem",
+		}
+		orphanStorageUUIDsByFilesystemIndex[filesystemIndex] = storageUUID.String()
+	}
+
+	if err := s.st.ImportStorageInstances(ctx, instanceArgs, nil); err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return orphanStorageUUIDsByFilesystemIndex, nil
 }
 
 // retrieveProviderScopesForPools gets the provider scopes for the given

--- a/domain/storage/service/import_test.go
+++ b/domain/storage/service/import_test.go
@@ -336,19 +336,11 @@ func (s *importSuite) TestImportFilesystemsIAAS(c *tc.C) {
 		SizeInMiB:         2048,
 		ProviderID:        "provider-test-2/1",
 		StorageInstanceID: "storageinstance/2",
-	}, {
-		ID:         "test-3/2",
-		PoolName:   "tmpfs",
-		SizeInMiB:  4096,
-		ProviderID: "provider-test-3/2",
-		// sometimes filesystems are not associated with a storage instance
-		StorageInstanceID: "",
 	}}
 
-	s.state.EXPECT().GetStoragePoolProvidersByNames(gomock.Any(), tc.Bind(tc.SameContents, []string{"ebs", "ebs-ssd", "tmpfs"})).Return(map[string]string{
+	s.state.EXPECT().GetStoragePoolProvidersByNames(gomock.Any(), tc.Bind(tc.SameContents, []string{"ebs", "ebs-ssd"})).Return(map[string]string{
 		"ebs":     "ebs",
 		"ebs-ssd": "ebs",
-		"tmpfs":   "tmpfs",
 	}, nil)
 
 	ebsProvider := NewMockProvider(ctrl)
@@ -356,12 +348,6 @@ func (s *importSuite) TestImportFilesystemsIAAS(c *tc.C) {
 	ebsProvider.EXPECT().Supports(internalstorage.StorageKindBlock).Return(true).AnyTimes()
 	ebsProvider.EXPECT().Supports(internalstorage.StorageKindFilesystem).Return(false).AnyTimes()
 	s.registry.Providers["ebs"] = ebsProvider
-
-	tmpfsProvider := NewMockProvider(ctrl)
-	tmpfsProvider.EXPECT().Scope().Return(internalstorage.ScopeMachine).AnyTimes()
-	tmpfsProvider.EXPECT().Supports(internalstorage.StorageKindBlock).Return(false).AnyTimes()
-	tmpfsProvider.EXPECT().Supports(internalstorage.StorageKindFilesystem).Return(true).AnyTimes()
-	s.registry.Providers["tmpfs"] = tmpfsProvider
 
 	s.state.EXPECT().GetStorageInstanceUUIDsByIDs(gomock.Any(), []string{"storageinstance/1", "storageinstance/2"}).
 		Return(map[string]string{
@@ -383,12 +369,6 @@ func (s *importSuite) TestImportFilesystemsIAAS(c *tc.C) {
 		ProviderID:          "provider-test-1/0",
 		StorageInstanceUUID: "storageinstance-uuid-1",
 		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
-	}, {
-		ID:         "test-3/2",
-		Life:       life.Alive,
-		SizeInMiB:  4096,
-		ProviderID: "provider-test-3/2",
-		Scope:      domainstorageprovisioning.ProvisionScopeMachine,
 	}}
 
 	mc := tc.NewMultiChecker()
@@ -398,6 +378,225 @@ func (s *importSuite) TestImportFilesystemsIAAS(c *tc.C) {
 		tc.Bind(tc.UnorderedMatch[[]internal.ImportFilesystemIAASArgs](mc), expectedFS),
 		tc.Bind(tc.HasLen, 0),
 	).Return(nil)
+
+	err := s.service.ImportFilesystemsIAAS(c.Context(), params)
+
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportFilesystemsIAASResolveStorageInstanceFromVolume(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	params := []domainstorage.ImportFilesystemParams{{
+		ID:         "test-1/0",
+		PoolName:   "ebs",
+		SizeInMiB:  1024,
+		ProviderID: "provider-test-1/0",
+		VolumeID:   "volume-1",
+	}, {
+		ID:                "test-2/1",
+		PoolName:          "ebs-ssd",
+		SizeInMiB:         2048,
+		ProviderID:        "provider-test-2/1",
+		StorageInstanceID: "storageinstance/2",
+	}}
+
+	s.state.EXPECT().GetStoragePoolProvidersByNames(gomock.Any(), tc.Bind(tc.SameContents, []string{"ebs", "ebs-ssd"})).Return(map[string]string{
+		"ebs":     "ebs",
+		"ebs-ssd": "ebs",
+	}, nil)
+
+	ebsProvider := NewMockProvider(ctrl)
+	ebsProvider.EXPECT().Scope().Return(internalstorage.ScopeEnviron).AnyTimes()
+	ebsProvider.EXPECT().Supports(internalstorage.StorageKindBlock).Return(true).AnyTimes()
+	ebsProvider.EXPECT().Supports(internalstorage.StorageKindFilesystem).Return(false).AnyTimes()
+	s.registry.Providers["ebs"] = ebsProvider
+
+	s.state.EXPECT().GetStorageInstanceUUIDsByIDs(gomock.Any(), []string{"storageinstance/2"}).
+		Return(map[string]string{
+			"storageinstance/2": "storageinstance-uuid-2",
+		}, nil)
+
+	s.state.EXPECT().GetStorageInstanceUUIDsByVolumeIDs(gomock.Any(), []string{"volume-1"}).
+		Return(map[string]string{
+			"volume-1": "storageinstance-uuid-1",
+		}, nil)
+
+	expectedFS := []internal.ImportFilesystemIAASArgs{{
+		ID:                  "test-1/0",
+		Life:                life.Alive,
+		SizeInMiB:           1024,
+		ProviderID:          "provider-test-1/0",
+		StorageInstanceUUID: "storageinstance-uuid-1",
+		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
+	}, {
+		ID:                  "test-2/1",
+		Life:                life.Alive,
+		SizeInMiB:           2048,
+		ProviderID:          "provider-test-2/1",
+		StorageInstanceUUID: "storageinstance-uuid-2",
+		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
+	}}
+
+	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_.UUID`, tc.IsNonZeroUUID)
+
+	s.state.EXPECT().ImportFilesystemsIAAS(gomock.Any(),
+		tc.Bind(tc.UnorderedMatch[[]internal.ImportFilesystemIAASArgs](mc), expectedFS),
+		tc.Bind(tc.HasLen, 0),
+	).Return(nil)
+
+	err := s.service.ImportFilesystemsIAAS(c.Context(), params)
+
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportFilesystemsIAASStorageIDTakesPrecedenceOverVolume(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	params := []domainstorage.ImportFilesystemParams{{
+		ID:                "test-1/0",
+		PoolName:          "ebs",
+		SizeInMiB:         1024,
+		ProviderID:        "provider-test-1/0",
+		StorageInstanceID: "storageinstance/1",
+		VolumeID:          "volume-1",
+	}, {
+		ID:                "test-2/1",
+		PoolName:          "ebs-ssd",
+		SizeInMiB:         2048,
+		ProviderID:        "provider-test-2/1",
+		StorageInstanceID: "storageinstance/2",
+	}}
+
+	s.state.EXPECT().GetStoragePoolProvidersByNames(gomock.Any(), tc.Bind(tc.SameContents, []string{"ebs", "ebs-ssd"})).Return(map[string]string{
+		"ebs":     "ebs",
+		"ebs-ssd": "ebs",
+	}, nil)
+
+	ebsProvider := NewMockProvider(ctrl)
+	ebsProvider.EXPECT().Scope().Return(internalstorage.ScopeEnviron).AnyTimes()
+	ebsProvider.EXPECT().Supports(internalstorage.StorageKindBlock).Return(true).AnyTimes()
+	ebsProvider.EXPECT().Supports(internalstorage.StorageKindFilesystem).Return(false).AnyTimes()
+	s.registry.Providers["ebs"] = ebsProvider
+
+	// Both filesystems have storage IDs, so volume lookup should not happen.
+	s.state.EXPECT().GetStorageInstanceUUIDsByIDs(gomock.Any(), []string{"storageinstance/1", "storageinstance/2"}).
+		Return(map[string]string{
+			"storageinstance/1": "storageinstance-uuid-1",
+			"storageinstance/2": "storageinstance-uuid-2",
+		}, nil)
+
+	expectedFS := []internal.ImportFilesystemIAASArgs{{
+		ID:                  "test-1/0",
+		Life:                life.Alive,
+		SizeInMiB:           1024,
+		ProviderID:          "provider-test-1/0",
+		StorageInstanceUUID: "storageinstance-uuid-1",
+		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
+	}, {
+		ID:                  "test-2/1",
+		Life:                life.Alive,
+		SizeInMiB:           2048,
+		ProviderID:          "provider-test-2/1",
+		StorageInstanceUUID: "storageinstance-uuid-2",
+		Scope:               domainstorageprovisioning.ProvisionScopeMachine,
+	}}
+
+	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_.UUID`, tc.IsNonZeroUUID)
+
+	s.state.EXPECT().ImportFilesystemsIAAS(gomock.Any(),
+		tc.Bind(tc.UnorderedMatch[[]internal.ImportFilesystemIAASArgs](mc), expectedFS),
+		tc.Bind(tc.HasLen, 0),
+	).Return(nil)
+
+	err := s.service.ImportFilesystemsIAAS(c.Context(), params)
+
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportFilesystemsIAASCreateOrphanedStorageInstance(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	params := []domainstorage.ImportFilesystemParams{{
+		ID:         "test-1/0",
+		PoolName:   "tmpfs",
+		SizeInMiB:  1024,
+		ProviderID: "provider-test-1/0",
+	}, {
+		ID:         "test-2/1",
+		PoolName:   "tmpfs-alt",
+		SizeInMiB:  2048,
+		ProviderID: "provider-test-2/1",
+	}}
+
+	s.state.EXPECT().GetStoragePoolProvidersByNames(gomock.Any(), tc.Bind(tc.SameContents, []string{"tmpfs", "tmpfs-alt"})).Return(map[string]string{
+		"tmpfs":     "tmpfs",
+		"tmpfs-alt": "tmpfs",
+	}, nil)
+
+	tmpfsProvider := NewMockProvider(ctrl)
+	tmpfsProvider.EXPECT().Scope().Return(internalstorage.ScopeMachine).AnyTimes()
+	tmpfsProvider.EXPECT().Supports(internalstorage.StorageKindBlock).Return(false).AnyTimes()
+	tmpfsProvider.EXPECT().Supports(internalstorage.StorageKindFilesystem).Return(true).AnyTimes()
+	s.registry.Providers["tmpfs"] = tmpfsProvider
+
+	var gotInstances []internal.ImportStorageInstanceArgs
+	expectedInstances := []internal.ImportStorageInstanceArgs{{
+		Life:             life.Alive,
+		StorageKind:      "filesystem",
+		PoolName:         "tmpfs",
+		RequestedSizeMiB: 1024,
+	}, {
+		Life:             life.Alive,
+		StorageKind:      "filesystem",
+		PoolName:         "tmpfs-alt",
+		RequestedSizeMiB: 2048,
+	}}
+	instanceChecker := tc.NewMultiChecker()
+	instanceChecker.AddExpr(`_[_].UUID`, tc.IsNonZeroUUID)
+	instanceChecker.AddExpr(`_[_].StorageName`, tc.Matches, `orphaned[a-f0-9]{32}`)
+	instanceChecker.AddExpr(`_[_].StorageInstanceID`, tc.Matches, `orphaned[a-f0-9]{32}/[0-9]+`)
+	s.state.EXPECT().ImportStorageInstances(
+		gomock.Any(),
+		tc.Bind(instanceChecker, expectedInstances),
+		tc.Bind(tc.HasLen, 0),
+	).DoAndReturn(func(_ context.Context, importArgs []internal.ImportStorageInstanceArgs, _ []internal.ImportStorageInstanceAttachmentArgs) error {
+		c.Assert(importArgs, tc.HasLen, 2)
+		gotInstances = make([]internal.ImportStorageInstanceArgs, len(importArgs))
+		copy(gotInstances, importArgs)
+		return nil
+	})
+
+	expectedFS := []internal.ImportFilesystemIAASArgs{{
+		ID:         "test-1/0",
+		Life:       life.Alive,
+		SizeInMiB:  1024,
+		ProviderID: "provider-test-1/0",
+		Scope:      domainstorageprovisioning.ProvisionScopeMachine,
+	}, {
+		ID:         "test-2/1",
+		Life:       life.Alive,
+		SizeInMiB:  2048,
+		ProviderID: "provider-test-2/1",
+		Scope:      domainstorageprovisioning.ProvisionScopeMachine,
+	}}
+	fsChecker := tc.NewMultiChecker()
+	fsChecker.AddExpr(`_[_].UUID`, tc.IsNonZeroUUID)
+	fsChecker.AddExpr(`_[_].StorageInstanceUUID`, tc.IsNonZeroUUID)
+	s.state.EXPECT().ImportFilesystemsIAAS(gomock.Any(),
+		tc.Bind(fsChecker, expectedFS),
+		tc.Bind(tc.HasLen, 0),
+	).DoAndReturn(func(_ context.Context, fsArgs []internal.ImportFilesystemIAASArgs, _ []internal.ImportFilesystemAttachmentIAASArgs) error {
+		c.Assert(fsArgs, tc.HasLen, 2)
+		c.Check(fsArgs[0].StorageInstanceUUID, tc.Equals, gotInstances[0].UUID)
+		c.Check(fsArgs[1].StorageInstanceUUID, tc.Equals, gotInstances[1].UUID)
+		return nil
+	})
 
 	err := s.service.ImportFilesystemsIAAS(c.Context(), params)
 

--- a/domain/storage/service/state_mock_test.go
+++ b/domain/storage/service/state_mock_test.go
@@ -354,6 +354,45 @@ func (c *MockStateGetStorageInstanceUUIDsByIDsCall) DoAndReturn(f func(context.C
 	return c
 }
 
+// GetStorageInstanceUUIDsByVolumeIDs mocks base method.
+func (m *MockState) GetStorageInstanceUUIDsByVolumeIDs(arg0 context.Context, arg1 []string) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageInstanceUUIDsByVolumeIDs", arg0, arg1)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStorageInstanceUUIDsByVolumeIDs indicates an expected call of GetStorageInstanceUUIDsByVolumeIDs.
+func (mr *MockStateMockRecorder) GetStorageInstanceUUIDsByVolumeIDs(arg0, arg1 any) *MockStateGetStorageInstanceUUIDsByVolumeIDsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageInstanceUUIDsByVolumeIDs", reflect.TypeOf((*MockState)(nil).GetStorageInstanceUUIDsByVolumeIDs), arg0, arg1)
+	return &MockStateGetStorageInstanceUUIDsByVolumeIDsCall{Call: call}
+}
+
+// MockStateGetStorageInstanceUUIDsByVolumeIDsCall wrap *gomock.Call
+type MockStateGetStorageInstanceUUIDsByVolumeIDsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetStorageInstanceUUIDsByVolumeIDsCall) Return(arg0 map[string]string, arg1 error) *MockStateGetStorageInstanceUUIDsByVolumeIDsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetStorageInstanceUUIDsByVolumeIDsCall) Do(f func(context.Context, []string) (map[string]string, error)) *MockStateGetStorageInstanceUUIDsByVolumeIDsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetStorageInstanceUUIDsByVolumeIDsCall) DoAndReturn(f func(context.Context, []string) (map[string]string, error)) *MockStateGetStorageInstanceUUIDsByVolumeIDsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetStoragePool mocks base method.
 func (m *MockState) GetStoragePool(arg0 context.Context, arg1 storage.StoragePoolUUID) (storage.StoragePool, error) {
 	m.ctrl.T.Helper()

--- a/domain/storage/state/base_test.go
+++ b/domain/storage/state/base_test.go
@@ -69,6 +69,41 @@ VALUES (?, ?, ?, 1)
 	return saUUID
 }
 
+// newStorageVolume is responsible for establishing a new storage volume in the
+// model and returning the volume uuid.
+func (s *baseSuite) newStorageVolume(
+	c *tc.C,
+	volumeID string,
+) domainstorage.VolumeUUID {
+	volumeUUID := tc.Must(c, domainstorage.NewVolumeUUID)
+
+	_, err := s.DB().Exec(`
+INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, 0)
+`,
+		volumeUUID.String(), volumeID,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return volumeUUID
+}
+
+// newStorageInstanceVolume is responsible for establishing a relationship
+// between a storage instance and a storage volume.
+func (s *baseSuite) newStorageInstanceVolume(
+	c *tc.C,
+	storageInstanceUUID domainstorage.StorageInstanceUUID,
+	volumeUUID domainstorage.VolumeUUID,
+) {
+	_, err := s.DB().Exec(`
+INSERT INTO storage_instance_volume (storage_instance_uuid, storage_volume_uuid)
+VALUES (?, ?)
+`,
+		storageInstanceUUID.String(), volumeUUID.String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 // newStorageInstanceForCharmWithPool is responsible for establishing a new
 // storage instance in the model using the supplied storage pool. Returned is
 // the new uuid for the storage instance and the storage id.

--- a/domain/storage/state/instance.go
+++ b/domain/storage/state/instance.go
@@ -103,3 +103,49 @@ WHERE  storage_id IN ($storageInstanceIDs[:])`,
 
 	return result, nil
 }
+
+// GetStorageInstanceUUIDsByVolumeIDs retrieves the UUIDs of storage instances
+// by their linked volume IDs.
+func (s *State) GetStorageInstanceUUIDsByVolumeIDs(
+	ctx context.Context, volumeIDs []string,
+) (map[string]string, error) {
+	if len(volumeIDs) == 0 {
+		return map[string]string{}, nil
+	}
+
+	db, err := s.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	storageVolumeIDs := storageVolumeIDs(set.NewStrings(volumeIDs...).Values())
+
+	stmt, err := s.Prepare(`
+SELECT &storageInstanceUUIDAndVolumeID.*
+FROM   storage_volume sv
+JOIN   storage_instance_volume siv ON sv.uuid = siv.storage_volume_uuid
+WHERE  sv.volume_id IN ($storageVolumeIDs[:])`,
+		storageInstanceUUIDAndVolumeID{}, storageVolumeIDs,
+	)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var dbVals []storageInstanceUUIDAndVolumeID
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, storageVolumeIDs).GetAll(&dbVals)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	result := make(map[string]string, len(dbVals))
+	for _, val := range dbVals {
+		result[val.VolumeID] = val.UUID
+	}
+
+	return result, nil
+}

--- a/domain/storage/state/instance_test.go
+++ b/domain/storage/state/instance_test.go
@@ -98,3 +98,61 @@ func (s *instanceSuite) TestGetStorageInstanceUUIDsByIDsMiss(c *tc.C) {
 		id2: uuid2.String(),
 	})
 }
+
+func (s *instanceSuite) TestGetStorageInstanceUUIDsByVolumeIDs(c *tc.C) {
+	poolUUID := s.newStoragePool(c, "pool1", "myprovider", nil)
+	storage1UUID, _ := s.newStorageInstanceForCharmWithPool(
+		c, "foo", poolUUID, "token1",
+	)
+	storage2UUID, _ := s.newStorageInstanceForCharmWithPool(
+		c, "bar", poolUUID, "token2",
+	)
+
+	volume1UUID := s.newStorageVolume(c, "vol-1")
+	s.newStorageInstanceVolume(c, storage1UUID, volume1UUID)
+
+	volume2UUID := s.newStorageVolume(c, "vol-2")
+	s.newStorageInstanceVolume(c, storage2UUID, volume2UUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	uuidMap, err := st.GetStorageInstanceUUIDsByVolumeIDs(c.Context(), []string{"vol-1", "vol-2"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(uuidMap, tc.DeepEquals, map[string]string{
+		"vol-1": storage1UUID.String(),
+		"vol-2": storage2UUID.String(),
+	})
+}
+
+func (s *instanceSuite) TestGetStorageInstanceUUIDsByVolumeIDsDuplicateIDs(c *tc.C) {
+	poolUUID := s.newStoragePool(c, "pool1", "myprovider", nil)
+	storageUUID, _ := s.newStorageInstanceForCharmWithPool(
+		c, "foo", poolUUID, "token1",
+	)
+
+	volumeUUID := s.newStorageVolume(c, "vol-1")
+	s.newStorageInstanceVolume(c, storageUUID, volumeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	uuidMap, err := st.GetStorageInstanceUUIDsByVolumeIDs(c.Context(), []string{"vol-1", "vol-1"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(uuidMap, tc.DeepEquals, map[string]string{
+		"vol-1": storageUUID.String(),
+	})
+}
+
+func (s *instanceSuite) TestGetStorageInstanceUUIDsByVolumeIDsMiss(c *tc.C) {
+	poolUUID := s.newStoragePool(c, "pool1", "myprovider", nil)
+	storageUUID, _ := s.newStorageInstanceForCharmWithPool(
+		c, "foo", poolUUID, "token1",
+	)
+
+	volumeUUID := s.newStorageVolume(c, "vol-1")
+	s.newStorageInstanceVolume(c, storageUUID, volumeUUID)
+
+	st := NewState(s.TxnRunnerFactory())
+	uuidMap, err := st.GetStorageInstanceUUIDsByVolumeIDs(c.Context(), []string{"vol-1", "vol-missing"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(uuidMap, tc.DeepEquals, map[string]string{
+		"vol-1": storageUUID.String(),
+	})
+}

--- a/domain/storage/state/types.go
+++ b/domain/storage/state/types.go
@@ -62,6 +62,13 @@ type storageInstanceUUIDAndID struct {
 
 type storageInstanceIDs []string
 
+type storageInstanceUUIDAndVolumeID struct {
+	UUID     string `db:"storage_instance_uuid"`
+	VolumeID string `db:"volume_id"`
+}
+
+type storageVolumeIDs []string
+
 // dbModelStoragePool represents a single row from the model_storage_pool table.
 type dbModelStoragePool struct {
 	StoragePoolUUID string `db:"storage_pool_uuid"`

--- a/domain/storage/types.go
+++ b/domain/storage/types.go
@@ -137,6 +137,7 @@ type ImportFilesystemParams struct {
 	ProviderID        string
 	PoolName          string
 	StorageInstanceID string
+	VolumeID          string
 	Attachments       []ImportFilesystemAttachmentsParams
 }
 


### PR DESCRIPTION
There is a slim possibility that filesystems can be exported with an empty storage instance reference. In this case:

- First fall back to the volume id. This may be included, and we may be able to use this to deduce what the storage instance should be

- Failing this, create an 'orphaned' storage instance with dud data. This allows the migration to succeed and puts the resulting model in a usable state so the filesystem can be removed

## QA steps

### First check usual migrations are uneffected

using an aws controller
```
$ juju switch aws-src # running 3.6 
$ juju add-model m
$ juju model-config container-networking-method=""
$ juju model-config fan-config=""
$ juju deploy ./testcharms/charms/dummy-storage/dummy-storage_amd64.charm  --storage multi-fs=10G -n 2
$ juju migrate m aws-dst # aws-dst runs 4.0
$ juju switch aws-dst:m
$ juju status --storage
Model  Controller  Cloud/Region   Version  Timestamp
m      aws-dst     aws/eu-west-2  4.0.4.1  13:47:30Z

App            Version  Status  Scale  Charm          Channel  Rev  Exposed  Message
dummy-storage           active      2  dummy-storage             0  no       Stored token: /tmp/status

Unit              Workload  Agent  Machine  Public address  Ports  Message
dummy-storage/0*  active    idle   0        18.170.114.108         Stored token: /tmp/status
dummy-storage/1   active    idle   1        18.171.176.6           Stored token: /tmp/status

Machine  State    Address         Inst id              Base          AZ          Message
0        started  18.170.114.108  i-0c93ced6c149d9921  ubuntu@24.04  eu-west-2c  running
1        started  18.171.176.6    i-0dfbd7a5aca9480bb  ubuntu@24.04  eu-west-2a  running

Storage Unit     Storage ID  Type        Mountpoint  Size  Status    Message
dummy-storage/0  multi-fs/0  filesystem                    attached  
dummy-storage/1  multi-fs/1  filesystem                    attached  
```

### Check a volume-backed fs can restore the instance via the volume

using an aws controller (where filesystems are volume backed)
```
$ juju switch aws-src # running 3.6 
$ juju add-model m2
$ juju model-config container-networking-method=""
$ juju model-config fan-config=""
$ juju deploy ./testcharms/charms/dummy-storage/dummy-storage_amd64.charm  --storage multi-fs=10G -n 2
```
then in mongo run:
```
juju:PRIMARY> db.filesystems.updateMany(
...   {},
...   { $set: { storageid: "" } }
... )
{ "acknowledged" : true, "matchedCount" : 2, "modifiedCount" : 2 }
```
back to bash:
```
$ juju migrate m2 aws-dst # aws-dst runs 4.0
$ juju switch aws-dst:m2
$ juju status --storage
Model  Controller  Cloud/Region   Version  Timestamp
m2     aws-dst     aws/eu-west-2  4.0.4.1  13:49:03Z

App            Version  Status  Scale  Charm          Channel  Rev  Exposed  Message
dummy-storage           active      2  dummy-storage             0  no       Stored token: /tmp/status

Unit              Workload  Agent  Machine  Public address  Ports  Message
dummy-storage/0   active    idle   0        35.176.101.161         Stored token: /tmp/status
dummy-storage/1*  active    idle   1        13.40.135.75           Stored token: /tmp/status

Machine  State    Address         Inst id              Base          AZ          Message
0        started  35.176.101.161  i-05ee16fe2dc1f85e0  ubuntu@24.04  eu-west-2a  running
1        started  13.40.135.75    i-0cd17b40f327a9625  ubuntu@24.04  eu-west-2c  running

Storage Unit     Storage ID  Type        Mountpoint  Size  Status    Message
dummy-storage/0  multi-fs/0  filesystem                    attached  
dummy-storage/1  multi-fs/1  filesystem                    attached  
```

### Check a non-volume-backed filesystem becomes orphaned

using an lxd controller (where filesystems are NOT volume backed)
```
$ juju switch aws-src # running 3.6 
$ juju add-model m3
$ juju model-config container-networking-method=""
$ juju model-config fan-config=""
$ juju deploy ./testcharms/charms/dummy-storage/dummy-storage_amd64.charm  --storage multi-fs=10G -n 2
```
then in mongo run:
```
juju:PRIMARY> db.filesystems.updateMany(
...   {},
...   { $set: { storageid: "" } }
... )
{ "acknowledged" : true, "matchedCount" : 2, "modifiedCount" : 2 }
```
back to bash:
```
$ juju migrate m3 lxd-dst # lxd-dst runs 4.0
$ juju switch lxd-dst:m3
$ juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
m3     lxd-dst     localhost/localhost  4.0.4.1  14:28:48Z

App            Version  Status  Scale  Charm          Channel  Rev  Exposed  Message
dummy-storage           active      2  dummy-storage             0  no       Stored token: /tmp/status

Unit              Workload  Agent  Machine  Public address  Ports  Message
dummy-storage/0   active    idle   0        10.51.45.133           Stored token: /tmp/status
dummy-storage/1*  active    idle   1        10.51.45.229           Stored token: /tmp/status

Machine  State    Address       Inst id        Base          AZ    Message
0        started  10.51.45.133  juju-724343-0  ubuntu@24.04  jack  Running
1        started  10.51.45.229  juju-724343-1  ubuntu@24.04  jack  Running

Storage Unit     Storage ID                                  Type        Mountpoint  Size  Status    Message
                 orphaned8d0853a58a134dbc85eb1c100d94eaef/0  filesystem                    attached  
                 orphaned8d0853a58a134dbc85eb1c100d94eaef/1  filesystem                    attached  
dummy-storage/0  multi-fs/0                                  filesystem                    pending   
dummy-storage/1  multi-fs/1                                  filesystem                    pending   
```