### PR TITLE
fix(actions): preserve newlines in exec JSON output

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -620,10 +620,10 @@ func printPlainOutput(writer io.Writer, forceColor bool, value any) error {
 			w.Println(output.GoodHighlight, task[fieldOutput])
 		}
 		if stdout != "" {
-			_, _ = fmt.Fprintln(writer, stdout)
+			_, _ = fmt.Fprintln(writer, strings.Trim(stdout, "\n"))
 		}
 		if stderr != "" {
-			_, _ = fmt.Fprintln(writer, stderr)
+			_, _ = fmt.Fprintln(writer, strings.Trim(stderr, "\n"))
 		}
 	}
 
@@ -759,13 +759,13 @@ func convertActionOutput(output map[string]any) (map[string]any, int) {
 	// code and error if they are there.
 	res, ok := output[fieldStdout].(string)
 	if ok && len(res) > 0 {
-		values[fieldStdout] = strings.Trim(strings.ReplaceAll(res, "\r\n", "\n"), "\n")
+		values[fieldStdout] = strings.ReplaceAll(res, "\r\n", "\n")
 	} else {
 		delete(values, fieldStdout)
 	}
 	res, ok = output[fieldStderr].(string)
 	if ok && len(res) > 0 {
-		values[fieldStderr] = strings.Trim(strings.ReplaceAll(res, "\r\n", "\n"), "\n")
+		values[fieldStderr] = strings.ReplaceAll(res, "\r\n", "\n")
 	} else {
 		delete(values, fieldStderr)
 	}


### PR DESCRIPTION
Commit 42ab32a1ce introduced `strings.Trim(..., "\n")` around stdout and stderr in convertActionOutput, which strips all leading and trailing newlines from exec results. This causes JSON and YAML output to lose legitimate newlines (e.g., "foo\n" becomes "foo").

Restore the previous behaviour of only normalising `\r\n` to `\n`.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Bootstrap Juju
2. `juju deploy ubuntu` (any charm should work)
3. `juju exec --machine 0 --format=json 'echo foo'`

With `3.6.14-genericlinux-amd64`:

```
$ juju exec --machine 0 --format=json 'echo foo'
{"0":{"id":"18","machine":"0","results":{"return-code":0,"stdout":"foo\n"},"status":"completed","timing":{"completed":"2026-03-06 13:12:00 +1300 NZDT","enqueued":"2026-03-06 13:12:00 +1300 NZDT","started":"2026-03-06 13:12:00 +1300 NZDT"}}}
```

Verify that the stdout is `foo\n` (including the newline).

## Documentation changes

N/A

## Links

**Issue:** Fixes #21927