### PR TITLE
fix: external user offers

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -740,6 +740,29 @@ func (s *applicationOffersSuite) TestFindPermission(c *gc.C) {
 	s.assertFind(c, expected)
 }
 
+func (s *applicationOffersSuite) TestFindExternalUserWithoutLocalStateUser(c *gc.C) {
+	offerUUID := s.setupOffers(c, "", true)
+	user := names.NewUserTag("someone@external")
+	s.authorizer.Tag = user
+	s.authorizer.HasReadTag = user
+	expected := []params.ApplicationOfferAdminDetailsV5{
+		{
+			ApplicationName: "test",
+			ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
+				SourceModelTag:         testing.ModelTag.String(),
+				ApplicationDescription: "description",
+				OfferName:              "hosted-db2",
+				OfferUUID:              offerUUID,
+				OfferURL:               "fred@external/prod.hosted-db2",
+				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
+				Users: []params.OfferUserDetails{
+					{UserName: "someone@external", DisplayName: "", Access: "read"},
+				}},
+		},
+	}
+	s.assertFind(c, expected)
+}
+
 func (s *applicationOffersSuite) TestFindFiltersRequireModel(c *gc.C) {
 	s.setupOffers(c, "", true)
 	filter := params.OfferFilters{
@@ -1109,6 +1132,33 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 			return ""
 		},
 	)
+}
+
+func (s *consumeSuite) TestConsumeDetailsExternalUserWithoutLocalStateUser(c *gc.C) {
+	offerUUID := s.setupOffer()
+	apiUser := names.NewUserTag("someone@external")
+	s.authorizer.Tag = apiUser
+	s.authorizer.HasConsumeTag = apiUser
+
+	results, err := s.api.GetConsumeDetails(params.ConsumeOfferDetailsArg{
+		OfferURLs: params.OfferURLs{
+			OfferURLs: []string{"fred@external/prod.hosted-mysql"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+	c.Assert(results.Results[0].Offer, jc.DeepEquals, &params.ApplicationOfferDetailsV5{
+		SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		OfferURL:               "fred@external/prod.hosted-mysql",
+		OfferName:              "hosted-mysql",
+		OfferUUID:              offerUUID,
+		ApplicationDescription: "a database",
+		Endpoints:              []params.RemoteEndpoint{{Name: "server", Role: "provider", Interface: "mysql"}},
+		Users: []params.OfferUserDetails{
+			{UserName: "someone@external", DisplayName: "", Access: "consume"},
+		},
+	})
 }
 
 func (s *consumeSuite) TestConsumeDetailsSpecifiedUserHasPermission(c *gc.C) {

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -72,6 +72,17 @@ func (api *BaseAPI) modelForName(modelName, ownerName string) (Model, string, bo
 	return model, modelPath, model != nil, nil
 }
 
+func (api *BaseAPI) userDisplayName(backend Backend, userTag names.UserTag) (string, error) {
+	user, err := backend.User(userTag)
+	if errors.Is(err, errors.NotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return user.DisplayName(), nil
+}
+
 // applicationOffersFromModel gets details about remote applications that match given filters.
 func (api *BaseAPI) applicationOffersFromModel(
 	modelUUID string,
@@ -103,7 +114,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 		return nil, errors.Trace(err)
 	}
 
-	u, err := backend.User(user)
+	displayName, err := api.userDisplayName(backend, user)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -131,7 +142,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 		}
 		offerParams.Users = []params.OfferUserDetails{{
 			UserName:    user.Id(),
-			DisplayName: u.DisplayName(),
+			DisplayName: displayName,
 			Access:      string(userAccess),
 		}}
 		offer := params.ApplicationOfferAdminDetailsV5{


### PR DESCRIPTION
Patch #21763 broke offer finding and consumption for external users. 

The only fix it actually needed was the permission removal, but adding an unqualified call to `state.User` meant that `NotFound` errors we returned for offers owned by external users.

This restores the prior qualified user querying to the API. The other changes from that patch remain.

## QA steps

- Reproduction steps from https://github.com/juju/juju/issues/21932.
- QA steps from the original patch #21763.

## Links

**Issue:** Fixes #21932.

**Jira card:** [JUJU-9291](https://warthogs.atlassian.net/browse/JUJU-9291)


[JUJU-9291]: https://warthogs.atlassian.net/browse/JUJU-9291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ