### PR TITLE
test: fix remote relations worker kill test

### DIFF
--- a/internal/worker/remoterelationconsumer/worker_test.go
+++ b/internal/worker/remoterelationconsumer/worker_test.go
@@ -38,14 +38,14 @@ type workerSuite struct {
 func (s *workerSuite) TestWorkerKilled(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	done := make(chan struct{})
+	started := make(chan struct{})
 	s.crossModelService.EXPECT().WatchRemoteApplicationOfferers(gomock.Any()).
 		DoAndReturn(func(ctx context.Context) (watcher.NotifyWatcher, error) {
-			defer close(done)
 			return watchertest.NewMockNotifyWatcher(make(chan struct{})), nil
 		})
 	s.crossModelService.EXPECT().WatchDyingModel(gomock.Any()).
 		DoAndReturn(func(ctx context.Context) (watcher.NotifyWatcher, error) {
+			defer close(started)
 			return watchertest.NewMockNotifyWatcher(make(chan struct{})), nil
 		})
 
@@ -53,9 +53,9 @@ func (s *workerSuite) TestWorkerKilled(c *tc.C) {
 	defer workertest.DirtyKill(c, w)
 
 	select {
-	case <-done:
+	case <-started:
 	case <-c.Context().Done():
-		c.Fatalf("timed out waiting for WatchRemoteApplications to be called")
+		c.Fatalf("timed out waiting for worker startup to complete")
 	}
 
 	workertest.CleanKill(c, w)


### PR DESCRIPTION
Observed in CI:
```
20:06:29 --- FAIL: TestWorkerSuite (0.05s)
20:06:29     --- FAIL: TestWorkerSuite/TestWorkerKilled (0.00s)
20:06:29         /home/jenkins/workspace/unit-tests-arm64/src/github.com/juju/juju/internal/worker/remoterelationconsumer/worker_test.go:38
20:06:29         runner.go:314: DEBUG: killing runner "remote-relations"
20:06:29         runner.go:436: INFO: runner "remote-relations" is dying
20:06:29         controller.go:243: missing call(s) to *remoterelationconsumer.MockCrossModelService.WatchDyingModel(is anything) /home/jenkins/workspace/unit-tests-arm64/src/github.com/juju/juju/internal/worker/remoterelationconsumer/worker_test.go:47
20:06:29         controller.go:243: aborting test due to missing call(s)
```

The test was treating the first watcher call as startup complete, then immediately calling `CleanKill`. If shutdown landed in that gap, `WatchDyingModel` was never called.

Now we don't kill until `WatchDyingModel` is called.