### PR TITLE
test: do not explicitly enable Microk8s dns

### DIFF
--- a/.github/microk8s-launch-config-aws.yaml
+++ b/.github/microk8s-launch-config-aws.yaml
@@ -4,7 +4,6 @@ extraKubeletArgs:
   --cluster-domain: cluster.local
   --cluster-dns: 10.152.183.10
 addons:
-  - name: dns
 containerdRegistryConfigs:
   docker.io: |
     [host."https://docker-cache.us-west-2.aws.jujuqa.com:443"]

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         channel: '${{ matrix.microk8s }}'
         # enable now to give microk8s more time to settle down.
-        addons: '["dns", "hostpath-storage", "dashboard", "ingress", "metallb:10.64.140.43-10.64.140.49"]'
+        addons: '["hostpath-storage", "dashboard", "ingress", "metallb:10.64.140.43-10.64.140.49"]'
         launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 
     - name: Install Dependencies

--- a/.github/workflows/postgresql-k8s.yml
+++ b/.github/workflows/postgresql-k8s.yml
@@ -38,7 +38,7 @@ jobs:
         uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9
         with:
           channel: "1.34-strict/stable"
-          addons: '["dns", "hostpath-storage", "rbac"]'
+          addons: '["hostpath-storage", "rbac"]'
           launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 
       - name: Set up Go

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -45,7 +45,7 @@ jobs:
         uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9
         with:
           channel: "1.34-strict/stable"
-          addons: '["dns", "hostpath-storage", "rbac"]'
+          addons: '["hostpath-storage", "rbac"]'
           launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 
       - name: Set up Go

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -108,7 +108,7 @@ jobs:
         uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9
         with:
           channel: "1.34-strict/stable"
-          addons: '["dns", "hostpath-storage"]'
+          addons: '["hostpath-storage"]'
           launch-configuration: "$GITHUB_WORKSPACE/.github/microk8s-launch-config-aws.yaml"
 
       - name: Install k8s Dependencies


### PR DESCRIPTION
CI workflows are spinning wheels like this:
```
20:29:05 + sudo microk8s enable dns
20:29:05 Infer repository core for addon dns
20:29:05 Addon core/dns is already enabled
20:29:05 + microk8s status --yaml
20:29:54 + grep -q 'dns: enabled'
20:29:54 + sleep 43
20:29:54 + '[' 44 -eq 30 ']'
20:29:54 + sudo microk8s enable dns
20:29:54 Infer repository core for addon dns
20:29:54 Addon core/dns is already enabled
20:29:55 + microk8s status --yaml
20:30:45 + grep -q 'dns: enabled'
20:30:45 + sleep 44
20:30:45 + '[' 45 -eq 30 ']'
20:30:45 + sudo microk8s enable dns
20:30:45 Infer repository core for addon dns
20:30:45 Addon core/dns is already enabled
20:30:45 + microk8s status --yaml
20:31:36 + grep -q 'dns: enabled'
20:31:36 + sleep 45
20:31:37 + '[' 46 -eq 30 ']'
```

The DNS add-on is enabled by default. This part of test composition is vestigial and not needed.