### PR TITLE
chore: bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.25.8
+go 1.26.1
 
 require (
 	cloud.google.com/go/compute v1.44.0


### PR DESCRIPTION
Go 1.25.7 had some vulnerabilities are checks was catching. Bump the  version to 1.25.8

## QA steps

Juju compiles