### PR TITLE
fix(enable-ha): reinstanciate the enable ha client method

### DIFF
--- a/api/client/highavailability/client.go
+++ b/api/client/highavailability/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -62,4 +63,31 @@ func (c *Client) ControllerDetails(ctx context.Context) (map[string]ControllerDe
 		}
 	}
 	return result, nil
+}
+
+// EnableHA ensures the availability of Juju controllers.
+func (c *Client) EnableHA(
+	ctx context.Context, numControllers int, cons constraints.Value, placement []string,
+) (params.ControllersChanges, error) {
+
+	var results params.ControllersChangeResults
+	arg := params.ControllersSpecs{
+		Specs: []params.ControllersSpec{{
+			NumControllers: numControllers,
+			Constraints:    cons,
+			Placement:      placement,
+		}}}
+
+	err := c.facade.FacadeCall(ctx, "EnableHA", arg, &results)
+	if err != nil {
+		return params.ControllersChanges{}, apiservererrors.RestoreError(err)
+	}
+	if len(results.Results) != 1 {
+		return params.ControllersChanges{}, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return params.ControllersChanges{}, apiservererrors.RestoreError(result.Error)
+	}
+	return result.Result, nil
 }

--- a/api/client/highavailability/client_test.go
+++ b/api/client/highavailability/client_test.go
@@ -12,6 +12,7 @@ import (
 
 	basemocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/highavailability"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -68,4 +69,31 @@ func (s *clientSuite) TestControllerDetailsNotSupported(c *tc.C) {
 
 	_, err := client.ControllerDetails(c.Context())
 	c.Assert(err, tc.ErrorIs, errors.NotSupported)
+}
+
+func (s *clientSuite) TestEnableHa(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	res := new(params.ControllersChangeResults)
+	results := params.ControllersChangeResults{
+		Results: []params.ControllersChangeResult{{
+			Result: params.ControllersChanges{
+				Added:   []string{"machine1"},
+				Removed: []string{"machine2"},
+			},
+		}},
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "EnableHA", gomock.Any(), res).SetArg(3, results).Return(nil)
+
+	mockClient := basemocks.NewMockClientFacade(ctrl)
+	client := highavailability.NewClientFromCaller(mockFacadeCaller, mockClient)
+	changes, err := client.EnableHA(c.Context(), 3, constraints.Value{}, []string{"region"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(changes, tc.DeepEquals, params.ControllersChanges{
+		Added:   []string{"machine1"},
+		Removed: []string{"machine2"},
+	})
 }


### PR DESCRIPTION
# Description

Copy/Paste from Juju 3.6 plus apiservererrors.RestoreError on the return errors.
The terraform provider needs the method to use the Juju 4 client to enable ha on a juju 3 controller.

# QA

Easiest QA step is to run the terraform integration test `TestAcc_ResourceControllerWithJujuBinary`.
Since it's not committed yet, hit me up and i can show you the test to qa this.

