### PR TITLE
feat: delete object store placement

### DIFF
--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -910,6 +910,14 @@ WHERE metadata_uuid = $entityUUID.uuid
 		return errors.Capture(err)
 	}
 
+	deleteObjectStorePlacementStmt, err := st.Prepare(`
+DELETE FROM object_store_placement
+WHERE uuid = $entityUUID.uuid
+	`, ident)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
 	// Delete the associated object store entry.
 	deleteObjectStoreStmt, err := st.Prepare(`
 DELETE FROM object_store_metadata
@@ -921,6 +929,10 @@ WHERE uuid = $entityUUID.uuid
 
 	if err := tx.Query(ctx, deleteObjectStorePathStmt, ident).Run(); err != nil {
 		return errors.Errorf("deleting object store path: %w", err)
+	}
+
+	if err := tx.Query(ctx, deleteObjectStorePlacementStmt, ident).Run(); err != nil {
+		return errors.Errorf("deleting object store placement: %w", err)
 	}
 
 	if err := tx.Query(ctx, deleteObjectStoreStmt, ident).Run(); err != nil {

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -823,6 +823,9 @@ func (s *applicationSuite) TestDeleteApplicationWithObjectstoreResource(c *tc.C)
 		objectStoreUUID.String(), "/path/to/resource")
 	c.Assert(err, tc.ErrorIsNil)
 
+	_, err = s.DB().Exec("INSERT INTO object_store_placement (uuid, node_id) VALUES (?, 0)", objectStoreUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
 	_, err = s.DB().Exec("INSERT INTO resource_file_store (resource_uuid, store_uuid, size, sha384) VALUES (?, ?, ?, ?)",
 		resourceUUID, objectStoreUUID.String(), 42, "sha_384")
 	c.Assert(err, tc.ErrorIsNil)
@@ -837,9 +840,14 @@ func (s *applicationSuite) TestDeleteApplicationWithObjectstoreResource(c *tc.C)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(exists, tc.Equals, false)
 
-	// Assert: The resource object store entry is deleted
-	row := s.DB().QueryRow("SELECT COUNT(*) FROM object_store_metadata WHERE uuid = ?", objectStoreUUID.String())
 	var count int
+	row := s.DB().QueryRow("SELECT COUNT(*) FROM object_store_placement WHERE uuid = ?", objectStoreUUID.String())
+	err = row.Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+
+	// Assert: The resource object store entry is deleted
+	row = s.DB().QueryRow("SELECT COUNT(*) FROM object_store_metadata WHERE uuid = ?", objectStoreUUID.String())
 	err = row.Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 0)


### PR DESCRIPTION
Now that we have object store placement for HA setups, we also need to ensure that we delete that information when we delete a blob. Either that's a charm or a resource.

This is the last piece of improvements to the object store in HA setups. The next set of changes will be around draining.

## QA steps

```sh
$ juju bootstrap lxd src
$ juju add-unit -m controller controller -n 2
$ juju add-model m
$ juju deploy juju-qa-test
```

Wait till it's started:

```sh
$ juju remove-application juju-qa-test
```

Deploy it again, but this time remove the model, once it's installed.

```sh
$ juju deploy juju-qa-test
$ juju remove-model m
```

## Links

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/21753.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9183](https://warthogs.atlassian.net/browse/JUJU-9183)


[JUJU-9183]: https://warthogs.atlassian.net/browse/JUJU-9183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ