### PR TITLE
test(deploy): skip export-overlay subtest setup

### DIFF
--- a/tests/suites/deploy/export_overlay.sh
+++ b/tests/suites/deploy/export_overlay.sh
@@ -1,35 +1,6 @@
-run_cmr_bundles_export_overlay() {
-	echo
-
-	file="${TEST_DIR}/test-cmr-bundles-export-overlay.log"
-
-	ensure "cmr-bundles-test-export-overlay" "${file}"
-
-	juju add-user bar
-	juju deploy ./tests/suites/deploy/bundles/bundle-with-overlays/easyrsa.yaml
-
-	# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
-	got=$(juju export-bundle 2>&1 1>/dev/null)
-	if [[ $got != *"not implemented"* ]]; then
-		echo "ERROR: export-bundle should return 'not implemented'."
-		exit 1
-	fi
-
-	juju deploy ./tests/suites/deploy/bundles/bundle-with-overlays/easyrsa-etcd.yaml --overlay overlay.yaml
-	# TODO(gfouillet) - recover from 3.6, delete whenever export bundle is restored or deleted
-	got=$(juju export-bundle 2>&1 1>/dev/null)
-	if [[ $got != *"not implemented"* ]]; then
-		echo "ERROR: export-bundle should return 'not implemented'."
-		exit 1
-	fi
-
-	destroy_model "cmr-bundles-test-export-overlay"
-	destroy_model "test1"
-}
-
 test_cmr_bundles_export_overlay() {
-	if [ "$(skip 'test_cmr_bundles_export_overlay')" ]; then
-		echo "==> TEST SKIPPED: CMR bundle deploy tests"
+	if true; then
+		echo "==> TEST SKIPPED: CMR bundle deploy tests, as 'export-bundle' command is not supported in the current Juju Major version."
 		return
 	fi
 
@@ -37,7 +8,5 @@ test_cmr_bundles_export_overlay() {
 		set_verbosity
 
 		cd .. || exit
-
-		run "run_cmr_bundles_export_overlay"
 	)
 }

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -11,7 +11,15 @@ test_deploy() {
 
 	file="${TEST_DIR}/test-deploy-ctl.log"
 
-	bootstrap "test-deploy-ctl" "${file}"
+	# When running only this subtest, don't create/destroy a controller.
+	skip_bootstrap=false
+	if [[ ${RUN_LIST:-} =~ ^[^,]+,test_cmr_bundles_export_overlay$ ]] ; then
+		skip_bootstrap=true
+	fi
+
+	if [[ ${skip_bootstrap} != "true" ]]; then
+		bootstrap "test-deploy-ctl" "${file}"
+	fi
 
 	test_deploy_charms
 	test_deploy_bundles
@@ -19,5 +27,7 @@ test_deploy() {
 	test_deploy_revision
 	test_deploy_default_series
 
-	destroy_controller "test-deploy-ctl"
+	if [[ ${skip_bootstrap} != "true" ]]; then
+		destroy_controller "test-deploy-ctl"
+	fi
 }


### PR DESCRIPTION
This PR skips `test_cmr_bundles_export_overlay` unconditionally while `export-bundle` is not supported in the current Juju major version.

Also, avoid controller bootstrap/destroy in `test_deploy` when running only that subtest, so targeted runs do not perform unnecessary setup.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
cd tests
./main.sh -v deploy test_cmr_bundles_export_overlay
```

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
