### PR TITLE
fix(removal): reschedule child removals on destroy retries

### DIFF
--- a/domain/removal/service/model.go
+++ b/domain/removal/service/model.go
@@ -41,9 +41,8 @@ type ModelState interface {
 
 	// EnsureModelNotAliveCascade ensures that there is no model identified
 	// by the input model UUID, that is still alive. Returns the artifacts
-	// that were transitioned from alive to dying during setting the model to
-	// not alive.
-	EnsureModelNotAliveCascade(ctx context.Context, modelUUID string, force bool) (removal.ModelArtifacts, error)
+	// that are not dead while setting the model to not alive.
+	EnsureModelNotAliveCascade(ctx context.Context, modelUUID string) (removal.ModelArtifacts, error)
 
 	// ModelScheduleRemoval schedules a removal job for the model with the
 	// input UUID, qualified with the input force boolean.
@@ -148,11 +147,10 @@ func (s *Service) removeModel(
 	// 3. Check the model exists in the model database. If it does not, and
 	//    the controller model doesn't exist, then we can return early.
 	// 4. Ensure the model is not alive in the model database and return any
-	//    artifacts that were transitioned from alive to dying.
+	//    non-dead artifacts that should have removal jobs.
 	// 5. Schedule the model removal job in the model database.
 	// 6. If there are any relations, units, machines or applications that
-	//    were transitioned from alive to dying, schedule their removal
-	//    as well.
+	//    are not dead, schedule their removal as well.
 
 	controllerModelExists, err := s.controllerState.ModelExists(ctx, modelUUID.String())
 	if err != nil {
@@ -179,7 +177,7 @@ func (s *Service) removeModel(
 
 	// Either the model in the controller database or the model database exists,
 	// so we can proceed with the removal.
-	artifacts, err := s.modelState.EnsureModelNotAliveCascade(ctx, modelUUID.String(), force)
+	artifacts, err := s.modelState.EnsureModelNotAliveCascade(ctx, modelUUID.String())
 	if err != nil {
 		return "", errors.Errorf("model %q: %w", modelUUID, err)
 	}
@@ -213,8 +211,8 @@ func (s *Service) removeModel(
 	}
 
 	if len(artifacts.RelationUUIDs) > 0 {
-		// If there are any relations that transitioned from alive to dying or
-		// dead, we need to schedule their removal as well.
+		// If there are any relations that are not dead, we need to schedule
+		// their removal as well.
 		s.logger.Infof(ctx, "model has relations %v, scheduling removal", artifacts.RelationUUIDs)
 
 		s.removeRelations(ctx, artifacts.RelationUUIDs, force, wait)
@@ -224,24 +222,24 @@ func (s *Service) removeModel(
 	const destroyStorage = true
 
 	if len(artifacts.UnitUUIDs) > 0 {
-		// If there are any units that transitioned from alive to dying or
-		// dead, we need to schedule their removal as well.
+		// If there are any units that are not dead, we need to schedule their
+		// removal as well.
 		s.logger.Infof(ctx, "model has units %v, scheduling removal", artifacts.UnitUUIDs)
 
 		s.removeUnits(ctx, artifacts.UnitUUIDs, destroyStorage, force, wait)
 	}
 
 	if len(artifacts.MachineUUIDs) > 0 {
-		// If there are any machines that transitioned from alive to dying or
-		// dead, we need to schedule their removal as well.
+		// If there are any machines that are not dead, we need to schedule
+		// their removal as well.
 		s.logger.Infof(ctx, "model has machines %v, scheduling removal", artifacts.MachineUUIDs)
 
 		s.removeMachines(ctx, artifacts.MachineUUIDs, force, wait)
 	}
 
 	if len(artifacts.ApplicationUUIDs) > 0 {
-		// If there are any applications that transitioned from alive to dying
-		// or dead, we need to schedule their removal as well.
+		// If there are any applications that are not dead, we need to schedule
+		// their removal as well.
 		s.logger.Infof(ctx, "model has applications %v, scheduling removal", artifacts.ApplicationUUIDs)
 
 		s.removeApplications(ctx, artifacts.ApplicationUUIDs, destroyStorage, force, wait)

--- a/domain/removal/service/model_test.go
+++ b/domain/removal/service/model_test.go
@@ -15,6 +15,7 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/removal"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
+	removalinternal "github.com/juju/juju/domain/removal/internal"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -41,7 +42,7 @@ func (s *modelSuite) TestRemoveModelNoForceSuccess(c *tc.C) {
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
 	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String(), false).Return(removal.ModelArtifacts{
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(removal.ModelArtifacts{
 		RelationUUIDs:    []string{"some-relation-id"},
 		UnitUUIDs:        []string{"some-unit-id"},
 		MachineUUIDs:     []string{"some-machine-id"},
@@ -61,6 +62,117 @@ func (s *modelSuite) TestRemoveModelNoForceSuccess(c *tc.C) {
 	jobUUID, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *modelSuite) TestRemoveModelRetrySchedulesRemovalJobs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	mUUID := tc.Must0(c, coremodel.NewUUID)
+	when := time.Now()
+	artifacts := removal.ModelArtifacts{
+		RelationUUIDs:    []string{"some-relation-id"},
+		UnitUUIDs:        []string{"some-unit-id"},
+		MachineUUIDs:     []string{"some-machine-id"},
+		ApplicationUUIDs: []string{"some-application-id"},
+	}
+
+	// Each call schedules model + relation + unit + machine + application.
+	s.clock.EXPECT().Now().Return(when).Times(10)
+
+	cExp := s.controllerState.EXPECT()
+	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil).Times(2)
+	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil).Times(2)
+
+	mExp := s.modelState.EXPECT()
+	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil).Times(2)
+	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil).Times(2)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(artifacts, nil).Times(2)
+	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC()).Return(nil).Times(2)
+
+	mExp.RelationExists(gomock.Any(), "some-relation-id").Return(true, nil).Times(2)
+	mExp.EnsureRelationNotAlive(gomock.Any(), "some-relation-id").Return(nil).Times(2)
+	mExp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "some-relation-id", false, when.UTC()).Return(nil).Times(2)
+
+	mExp.UnitExists(gomock.Any(), "some-unit-id").Return(true, nil).Times(2)
+	mExp.EnsureUnitNotAliveCascade(gomock.Any(), "some-unit-id", true).Return(removalinternal.CascadedUnitLives{}, nil).Times(2)
+	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", false, when.UTC()).Return(nil).Times(2)
+
+	mExp.MachineExists(gomock.Any(), "some-machine-id").Return(true, nil).Times(2)
+	mExp.EnsureMachineNotAliveCascade(gomock.Any(), "some-machine-id", false).Return(removalinternal.CascadedMachineLives{}, nil).Times(2)
+	mExp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "some-machine-id", false, when.UTC()).Return(nil).Times(2)
+
+	mExp.ApplicationExists(gomock.Any(), "some-application-id").Return(true, nil).Times(2)
+	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true, false).Return(removalinternal.CascadedApplicationLives{}, nil).Times(2)
+	mExp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), "some-application-id", false, when.UTC()).Return(nil).Times(2)
+
+	jobUUID1, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID1.Validate(), tc.ErrorIsNil)
+
+	// Simulate a second identical call, should be idempotent.
+	jobUUID2, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID2.Validate(), tc.ErrorIsNil)
+}
+
+func (s *modelSuite) TestRemoveModelRetryWithForceSchedulesRemovalJobs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	mUUID := tc.Must0(c, coremodel.NewUUID)
+	when := time.Now()
+	artifacts := removal.ModelArtifacts{
+		RelationUUIDs:    []string{"some-relation-id"},
+		UnitUUIDs:        []string{"some-unit-id"},
+		MachineUUIDs:     []string{"some-machine-id"},
+		ApplicationUUIDs: []string{"some-application-id"},
+	}
+
+	// Each call schedules model + relation + unit + machine + application.
+	s.clock.EXPECT().Now().Return(when).Times(10)
+
+	cExp := s.controllerState.EXPECT()
+	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil).Times(2)
+	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), true).Return(nil)
+
+	mExp := s.modelState.EXPECT()
+	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil).Times(2)
+	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil).Times(2)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(artifacts, nil).Times(2)
+	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC()).Return(nil)
+	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), true, when.UTC()).Return(nil)
+
+	mExp.RelationExists(gomock.Any(), "some-relation-id").Return(true, nil).Times(2)
+	mExp.EnsureRelationNotAlive(gomock.Any(), "some-relation-id").Return(nil).Times(2)
+	mExp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "some-relation-id", false, when.UTC()).Return(nil)
+	mExp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "some-relation-id", true, when.UTC()).Return(nil)
+
+	mExp.UnitExists(gomock.Any(), "some-unit-id").Return(true, nil).Times(2)
+	mExp.EnsureUnitNotAliveCascade(gomock.Any(), "some-unit-id", true).Return(removalinternal.CascadedUnitLives{}, nil).Times(2)
+	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", false, when.UTC()).Return(nil)
+	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", true, when.UTC()).Return(nil)
+
+	mExp.MachineExists(gomock.Any(), "some-machine-id").Return(true, nil).Times(2)
+	mExp.EnsureMachineNotAliveCascade(gomock.Any(), "some-machine-id", false).Return(removalinternal.CascadedMachineLives{}, nil)
+	mExp.EnsureMachineNotAliveCascade(gomock.Any(), "some-machine-id", true).Return(removalinternal.CascadedMachineLives{}, nil)
+	mExp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "some-machine-id", false, when.UTC()).Return(nil)
+	mExp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "some-machine-id", true, when.UTC()).Return(nil)
+
+	mExp.ApplicationExists(gomock.Any(), "some-application-id").Return(true, nil).Times(2)
+	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true, false).Return(removalinternal.CascadedApplicationLives{}, nil)
+	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true, true).Return(removalinternal.CascadedApplicationLives{}, nil)
+	mExp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), "some-application-id", false, when.UTC()).Return(nil)
+	mExp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), "some-application-id", true, when.UTC()).Return(nil)
+
+	jobUUID1, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID1.Validate(), tc.ErrorIsNil)
+
+	// Simulate a second call with force, should also schedule the same removal
+	// jobs.
+	jobUUID2, err := s.newService(c).RemoveModel(c.Context(), mUUID, true, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID2.Validate(), tc.ErrorIsNil)
 }
 
 func (s *modelSuite) TestRemoveModelControllerModel(c *tc.C) {
@@ -90,7 +202,7 @@ func (s *modelSuite) TestRemoveModelNoForceSuccessControllerModel(c *tc.C) {
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(true, nil)
 	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String(), true).Return(removal.ModelArtifacts{
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(removal.ModelArtifacts{
 		RelationUUIDs:    []string{"some-relation-id"},
 		UnitUUIDs:        []string{"some-unit-id"},
 		MachineUUIDs:     []string{"some-machine-id"},
@@ -127,7 +239,7 @@ func (s *modelSuite) TestRemoveModelForceNoWaitSuccess(c *tc.C) {
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
 	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String(), true).Return(removal.ModelArtifacts{}, nil)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(removal.ModelArtifacts{}, nil)
 	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), true, when.UTC()).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveModel(c.Context(), mUUID, true, 0)
@@ -150,7 +262,7 @@ func (s *modelSuite) TestRemoveModelForceWaitSuccess(c *tc.C) {
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
 	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String(), true).Return(removal.ModelArtifacts{}, nil)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(removal.ModelArtifacts{}, nil)
 
 	// The first normal removal scheduled immediately.
 	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC()).Return(nil)
@@ -178,7 +290,7 @@ func (s *modelSuite) TestRemoveModelNotFoundInModelButInController(c *tc.C) {
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
 	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(false, nil)
-	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String(), false).Return(removal.ModelArtifacts{}, nil)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(removal.ModelArtifacts{}, nil)
 	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC()).Return(nil)
 
 	_, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)
@@ -200,7 +312,7 @@ func (s *modelSuite) TestRemoveModelNotFoundInControllerButInModel(c *tc.C) {
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
 	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String(), false).Return(removal.ModelArtifacts{}, nil)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(removal.ModelArtifacts{}, nil)
 	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC()).Return(nil)
 
 	_, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -1798,18 +1798,18 @@ func (c *MockModelDBStateEnsureModelNotAliveCall) DoAndReturn(f func(context.Con
 }
 
 // EnsureModelNotAliveCascade mocks base method.
-func (m *MockModelDBState) EnsureModelNotAliveCascade(arg0 context.Context, arg1 string, arg2 bool) (removal.ModelArtifacts, error) {
+func (m *MockModelDBState) EnsureModelNotAliveCascade(arg0 context.Context, arg1 string) (removal.ModelArtifacts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureModelNotAliveCascade", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureModelNotAliveCascade", arg0, arg1)
 	ret0, _ := ret[0].(removal.ModelArtifacts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureModelNotAliveCascade indicates an expected call of EnsureModelNotAliveCascade.
-func (mr *MockModelDBStateMockRecorder) EnsureModelNotAliveCascade(arg0, arg1, arg2 any) *MockModelDBStateEnsureModelNotAliveCascadeCall {
+func (mr *MockModelDBStateMockRecorder) EnsureModelNotAliveCascade(arg0, arg1 any) *MockModelDBStateEnsureModelNotAliveCascadeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureModelNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureModelNotAliveCascade), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureModelNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureModelNotAliveCascade), arg0, arg1)
 	return &MockModelDBStateEnsureModelNotAliveCascadeCall{Call: call}
 }
 
@@ -1825,13 +1825,13 @@ func (c *MockModelDBStateEnsureModelNotAliveCascadeCall) Return(arg0 removal.Mod
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateEnsureModelNotAliveCascadeCall) Do(f func(context.Context, string, bool) (removal.ModelArtifacts, error)) *MockModelDBStateEnsureModelNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureModelNotAliveCascadeCall) Do(f func(context.Context, string) (removal.ModelArtifacts, error)) *MockModelDBStateEnsureModelNotAliveCascadeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateEnsureModelNotAliveCascadeCall) DoAndReturn(f func(context.Context, string, bool) (removal.ModelArtifacts, error)) *MockModelDBStateEnsureModelNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureModelNotAliveCascadeCall) DoAndReturn(f func(context.Context, string) (removal.ModelArtifacts, error)) *MockModelDBStateEnsureModelNotAliveCascadeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/state/model/model.go
+++ b/domain/removal/state/model/model.go
@@ -87,8 +87,8 @@ func (st *State) EnsureModelNotAlive(ctx context.Context, modelUUID string, forc
 
 // EnsureModelNotAliveCascade ensures that there is no model identified by the
 // input model UUID, that is still alive. Returns the artifacts that were
-// transitioned from alive to dying during setting the model to not alive.
-func (st *State) EnsureModelNotAliveCascade(ctx context.Context, modelUUID string, force bool) (removal.ModelArtifacts, error) {
+// not dead while setting the model to not alive.
+func (st *State) EnsureModelNotAliveCascade(ctx context.Context, modelUUID string) (removal.ModelArtifacts, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Capture(err)
@@ -98,25 +98,25 @@ func (st *State) EnsureModelNotAliveCascade(ctx context.Context, modelUUID strin
 		UUID: modelUUID,
 	}
 
-	// Cascading of the dying state of the model means that we will also set the entities to dying all of the
-	// following:
+	// Cascading of the dying state of the model means that we will also set
+	// entities to dying for all of the following:
 	// - All units in the model.
 	// - All applications in the model.
 	// - All relations in the model.
 	// - All machines in the model.
-	selectUnits, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM unit WHERE life_id = 0`, eUUID)
+	selectUnits, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM unit WHERE life_id < 2`, eUUID)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Errorf("preparing select units query: %w", err)
 	}
-	selectApplications, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM application WHERE life_id = 0`, eUUID)
+	selectApplications, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM application WHERE life_id < 2`, eUUID)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Errorf("preparing select applications query: %w", err)
 	}
-	selectRelations, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM relation WHERE life_id = 0`, eUUID)
+	selectRelations, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM relation WHERE life_id < 2`, eUUID)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Errorf("preparing select relations query: %w", err)
 	}
-	selectMachines, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM machine WHERE life_id = 0`, eUUID)
+	selectMachines, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM machine WHERE life_id < 2`, eUUID)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Errorf("preparing select machines query: %w", err)
 	}

--- a/domain/removal/state/model/model_test.go
+++ b/domain/removal/state/model/model_test.go
@@ -99,7 +99,7 @@ func (s *modelSuite) TestEnsureModelNotAliveCascade(c *tc.C) {
 
 	modelUUID := s.getModelUUID(c)
 
-	artifacts, err := st.EnsureModelNotAliveCascade(c.Context(), modelUUID, false)
+	artifacts, err := st.EnsureModelNotAliveCascade(c.Context(), modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(len(artifacts.UnitUUIDs), tc.Equals, 1)
 	c.Check(len(artifacts.ApplicationUUIDs), tc.Equals, 1)
@@ -113,12 +113,70 @@ func (s *modelSuite) TestEnsureModelNotAliveCascade(c *tc.C) {
 	s.checkApplicationLife(c, artifacts.ApplicationUUIDs[0], life.Dying)
 }
 
+func (s *modelSuite) TestEnsureModelNotAliveCascadeRetryReturnsDyingArtifacts(c *tc.C) {
+	svc := s.setupApplicationService(c)
+
+	s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	modelUUID := s.getModelUUID(c)
+
+	firstArtifacts, err := st.EnsureModelNotAliveCascade(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(len(firstArtifacts.UnitUUIDs), tc.Equals, 1)
+	c.Check(len(firstArtifacts.ApplicationUUIDs), tc.Equals, 1)
+	c.Check(len(firstArtifacts.MachineUUIDs), tc.Equals, 1)
+	c.Check(len(firstArtifacts.RelationUUIDs), tc.Equals, 0)
+
+	// Simulate retrying (e.g. destroy-model --force) while dependent entity
+	// removal is still in progress. Dying entities must be returned again so
+	// new jobs can be scheduled.
+	secondArtifacts, err := st.EnsureModelNotAliveCascade(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(secondArtifacts, tc.DeepEquals, firstArtifacts)
+
+	s.checkModelLife(c, modelUUID, life.Dying)
+	s.checkUnitLife(c, secondArtifacts.UnitUUIDs[0], life.Dying)
+	s.checkMachineLife(c, secondArtifacts.MachineUUIDs[0], life.Dying)
+	s.checkInstanceLife(c, secondArtifacts.MachineUUIDs[0], life.Dying)
+	s.checkApplicationLife(c, secondArtifacts.ApplicationUUIDs[0], life.Dying)
+}
+
+func (s *modelSuite) TestEnsureModelNotAliveCascadeRetryReturnsDyingRelations(c *tc.C) {
+	relUUID := s.createRelation(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	modelUUID := s.getModelUUID(c)
+
+	firstArtifacts, err := st.EnsureModelNotAliveCascade(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(len(firstArtifacts.RelationUUIDs), tc.Equals, 1)
+	c.Check(len(firstArtifacts.ApplicationUUIDs), tc.Equals, 2)
+	c.Check(len(firstArtifacts.UnitUUIDs), tc.Equals, 0)
+	c.Check(len(firstArtifacts.MachineUUIDs), tc.Equals, 0)
+	c.Check(firstArtifacts.RelationUUIDs[0], tc.Equals, relUUID.String())
+
+	// Simulate retrying (e.g. destroy-model --force) while dependent entity
+	// removal is still in progress. Dying entities must be returned again so
+	// new jobs can be scheduled.
+	secondArtifacts, err := st.EnsureModelNotAliveCascade(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(secondArtifacts, tc.DeepEquals, firstArtifacts)
+
+	// The relation should still be in the dying state.
+	row := s.DB().QueryRowContext(c.Context(), "SELECT life_id FROM relation where uuid = ?", relUUID.String())
+	var relationLife life.Life
+	err = row.Scan(&relationLife)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(relationLife, tc.Equals, life.Dying)
+}
+
 func (s *modelSuite) TestEnsureModelNotAliveCascadeEmpty(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	modelUUID := s.getModelUUID(c)
 
-	artifacts, err := st.EnsureModelNotAliveCascade(c.Context(), modelUUID, false)
+	artifacts, err := st.EnsureModelNotAliveCascade(c.Context(), modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(artifacts.Empty(), tc.IsTrue)
 }


### PR DESCRIPTION
__Note: this is the first of a series of patches that will fix the (re-)schedule of removal jobs on child entities when retried. Next patch should be on applications.__

TLDR; This PR fixes retry semantics for juju destroy-model so that repeated requests actually re-schedule dependent removal jobs with the latest force/wait intent (if present).

## Problem

While analyzing https://github.com/juju/juju/issues/21257 I discovered that we have an issue when removing (in this case) applications after a first attempt failed. 
The actual problem was that when we run remove-application (or destroy-model in the case of this PR) with --force *after* it had been run without it, and a unit removal job hangs, then the application is blocked for removal.
The reason for this can be found in `EnsureModelNotAliveCascade()` in the state layer:
https://github.com/juju/juju/blob/7c5e8de23c37e0ce9061454fcaac818c53c2e7db/domain/removal/state/model/model.go#L107
In this case, we only select units that are alive and update them to dying, then return their UUIDs. But what happens if the unit had previously been updated already?: It's not returned.
And therefore we don't re-schedule any job for it: https://github.com/juju/juju/blob/7c5e8de23c37e0ce9061454fcaac818c53c2e7db/domain/removal/service/model.go#L226
This is of course problematic since the second run of `juju destroy-model --force` should be effective and "supersede" the previously scheduled/running removal jobs for that entity.

If we look at an example (subset) hierarchy of model destroy:
```
                   Model
                     |
                 Application
                     |
       ----------------------------
       |                          |
      Unit <-fails             Relation
       |
    Machine
```

A common operator flow is to escalate removal intent over multiple commands:

   juju destroy-model test-model
   juju destroy-model test-model --force --wait=60s
   juju destroy-model test-model --force --wait=0s   # highest priority request

Before this fix, the previous executions would be hang because the unit job would not finish and so the application cannot be removed and therefore the model.

## The fix

`EnsureModelNotAliveCascade()` only selected artifacts with life_id = alive.

What this PR changes

   - Make model cascade include non-dead entities (life_id < dead), not only alive ones.
   - Keep transitioning alive entities to dying as before, but return both alive/dying artifacts for scheduling.
   - Remove the unused force parameter from `EnsureModelNotAliveCascade()` and align service interfaces/mocks/comments.
   - Add regression coverage for:
    - repeated cascade calls returning dying artifacts (state layer),
    - repeated RemoveModel calls scheduling model + dependent jobs on each call (service layer),
    - mixed retry flow (normal -> force) scheduling dependent jobs again with updated intent.


## QA steps
The scenario is basically to deploy an app on a model, and then stop the jujud service on the machine to simulate a broken state that will block graceful removal. Then destroy again with --force and check that it actually goes away.
```
$ juju add-model m
$ juju deploy ubuntu
$ juju add-ssh-key "$(cat ~/.ssh/id_ed25519.pub)"
$ juju ssh 0 "sudo systemctl stop jujud-machine-0.service"
```
Now the status should show the machine `down` and ubuntu app and unit as `unknown` status.

After a first graceful destroy (`juju destroy-model m`) we'll see that it just hangs, and on the logs we have:
```
machine-0: 17:28:18 INFO juju.worker.removal scheduling model job "355127d1-6590-4ca0-838f-a88cad0d7afa"
machine-0: 17:28:18 INFO juju.worker.removal scheduling unit job "4a2a2d2c-b5a1-47b9-88ea-a0aea8428804"
machine-0: 17:28:18 INFO juju.worker.removal scheduling machine job "2bed4167-be2d-4ac4-88fa-2da0395c06ae"
machine-0: 17:28:18 INFO juju.worker.removal scheduling application job "14ce5ca8-4554-41b1-85fc-bd8937f9205b"
machine-0: 17:28:18 INFO juju.worker.removal runner "removal" starting worker "4a2a2d2c-b5a1-47b9-88ea-a0aea8428804"
machine-0: 17:28:18 INFO juju.worker.removal runner "removal" starting worker "355127d1-6590-4ca0-838f-a88cad0d7afa"
machine-0: 17:28:18 INFO juju.worker.removal runner "removal" starting worker "2bed4167-be2d-4ac4-88fa-2da0395c06ae"
machine-0: 17:28:18 INFO juju.worker.removal runner "removal" starting worker "14ce5ca8-4554-41b1-85fc-bd8937f9205b"
```
repeatedly.
But then if we force the removal `juju destroy-model m --force` we will see that the model does get destroyed and in the logs we can confirm:
```
machine-0: 17:28:25 INFO juju.services.removal scheduled removal job "c4c6b0dc-5d1b-47f1-884c-fce9f984bf08" for model "6147eb73-e2b6-4af2-82b7-8e4f216930d3"
machine-0: 17:28:25 INFO juju.services.removal model has units [4f20781f-3eb1-4f95-865f-db703f1d9d1c], scheduling removal
machine-0: 17:28:25 INFO juju.services.removal scheduled removal job "4f74359a-4936-411f-807d-4f91ad6ad050" for unit "4f20781f-3eb1-4f95-865f-db703f1d9d1c"
machine-0: 17:28:25 INFO juju.services.removal model has machines [77e19b85-51f2-4b66-897b-0c1b31842535], scheduling removal
machine-0: 17:28:25 INFO juju.services.removal scheduled removal job "74dc5935-0c2c-46d7-8752-c032aef86d66" for machine "77e19b85-51f2-4b66-897b-0c1b31842535"
machine-0: 17:28:25 INFO juju.services.removal model has applications [660f5f3c-e4be-40b4-843f-e0951e46c400], scheduling removal
machine-0: 17:28:25 INFO juju.services.removal scheduled removal job "c81a4ace-ff60-498c-80da-51fe7fc477b3" for application "660f5f3c-e4be-40b4-843f-e0951e46c400"
machine-0: 17:28:28 INFO juju.worker.removal scheduling model job "355127d1-6590-4ca0-838f-a88cad0d7afa"
machine-0: 17:28:28 INFO juju.worker.removal scheduling unit job "4a2a2d2c-b5a1-47b9-88ea-a0aea8428804"
machine-0: 17:28:28 INFO juju.worker.removal scheduling machine job "2bed4167-be2d-4ac4-88fa-2da0395c06ae"
machine-0: 17:28:28 INFO juju.worker.removal scheduling application job "14ce5ca8-4554-41b1-85fc-bd8937f9205b"
machine-0: 17:28:28 INFO juju.worker.removal runner "removal" starting worker "355127d1-6590-4ca0-838f-a88cad0d7afa"
machine-0: 17:28:28 INFO juju.worker.removal runner "removal" starting worker "14ce5ca8-4554-41b1-85fc-bd8937f9205b"
machine-0: 17:28:28 INFO juju.worker.removal scheduling model job "c4c6b0dc-5d1b-47f1-884c-fce9f984bf08"
machine-0: 17:28:28 INFO juju.worker.removal runner "removal" starting worker "2bed4167-be2d-4ac4-88fa-2da0395c06ae"
machine-0: 17:28:28 INFO juju.worker.removal scheduling unit job "4f74359a-4936-411f-807d-4f91ad6ad050"
machine-0: 17:28:28 INFO juju.worker.removal runner "removal" starting worker "4a2a2d2c-b5a1-47b9-88ea-a0aea8428804"
machine-0: 17:28:28 INFO juju.worker.removal runner "removal" starting worker "c4c6b0dc-5d1b-47f1-884c-fce9f984bf08"
machine-0: 17:28:28 INFO juju.worker.removal runner "removal" starting worker "4f74359a-4936-411f-807d-4f91ad6ad050"
machine-0: 17:28:28 INFO juju.worker.removal scheduling machine job "74dc5935-0c2c-46d7-8752-c032aef86d66"
machine-0: 17:28:28 INFO juju.worker.removal scheduling application job "c81a4ace-ff60-498c-80da-51fe7fc477b3"
machine-0: 17:28:28 INFO juju.worker.removal runner "removal" starting worker "74dc5935-0c2c-46d7-8752-c032aef86d66"
machine-0: 17:28:28 INFO juju.worker.removal runner "removal" starting worker "c81a4ace-ff60-498c-80da-51fe7fc477b3"
machine-0: 17:28:28 INFO juju.services.removal model "6147eb73-e2b6-4af2-82b7-8e4f216930d3" marked as dead
machine-0: 17:28:28 INFO juju.services.removal model "6147eb73-e2b6-4af2-82b7-8e4f216930d3" marked as dead
machine-0: 17:28:28 INFO juju.services.removal charm "7677ee4e-450d-4525-8f94-1c4bb33d80cb" is still used by 1 application(s), not deleting
machine-0: 17:28:29 INFO juju.worker.providertracker model "m" (6147eb73-e2b6-4af2-82b7-8e4f216930d3) is dead, stopping tracker worker
machine-0: 17:28:29 INFO juju.worker.providertracker model "m" (6147eb73-e2b6-4af2-82b7-8e4f216930d3) is dead, stopping tracker worker
```
But most importantly, check the db:
```
repl (model-m)> select * from unit
uuid					name		life_id	application_uuid			net_node_uuid				charm_uuid				password_hash_algorithm_id	password_hash			
4f9ea7ec-c9d1-4a8d-8cd3-199984e40e02	ubuntu/0	0	d6e132fb-9802-4391-8f4a-460193c0ad78	06b1e776-ff21-4483-84b8-df3a47eb8980	3677301d-9f26-4ea2-80ad-c41ad66b3efc	0	oQEWF2oqltK/sf5iudwUNRDP	

repl (model-m)> select * from removal
uuid					removal_type_id	entity_uuid				force	scheduled_for				arg	
3dbffc16-540a-4e8a-8006-d43232497218	4		df7d74b3-4341-48b0-8446-c01db661b883	0	2026-03-11 16:49:24.774279069 +0000 UTC	<nil>	
42777f5f-1cd2-42c2-8373-879385ec8d1b	1		4f9ea7ec-c9d1-4a8d-8cd3-199984e40e02	0	2026-03-11 16:49:24.781334744 +0000 UTC	<nil>	
65400569-3e55-42c8-81c9-a937822f3364	3		79720ea9-b359-4d8a-8c46-ce1e3317955f	0	2026-03-11 16:49:24.788352578 +0000 UTC	<nil>	
f269fb27-b295-4abf-81ab-14cbb3a52b29	2		d6e132fb-9802-4391-8f4a-460193c0ad78	0	2026-03-11 16:49:24.797606095 +0000 UTC	<nil>	
5e382656-6cf1-4df7-846f-36c57111c434	1		4f9ea7ec-c9d1-4a8d-8cd3-199984e40e02	1	2026-03-11 16:49:33.724739338 +0000 UTC	<nil>	
4c6a33cd-b051-4ddc-8010-314eeed43783	2		d6e132fb-9802-4391-8f4a-460193c0ad78	1	2026-03-11 16:49:33.736991789 +0000 UTC	<nil>	
```

If the same scenario was run without this patch, this would be the state after the second destroy (with force):
```
repl (model-m)> select * from unit
uuid					name		life_id	application_uuid			net_node_uuid				charm_uuid				password_hash_algorithm_id	password_hash			
9c9d1f34-393a-47e0-84ed-d4e5d2255edf	ubuntu/0	1	213cc336-84b9-40d9-8113-10fdbcfa5f1b	b9933506-5f1a-4a07-8f75-057da8fbf28b	086e4873-24de-4800-824b-bb443b4b2f19	0	GN5Hn5L5ap5PucYI89wkU1wh	

repl (model-m)> select * from removal
uuid					removal_type_id	entity_uuid				force	scheduled_for				arg	
eb7b0aac-ec48-45bc-8345-18d33c4ba3d9	4		0e4f1eeb-16cd-4026-8ac9-8535b58a015c	0	2026-03-11 16:45:46.170212821 +0000 UTC	<nil>	
f0f7d855-8675-4fab-8918-0d2e3b671bd3	1		9c9d1f34-393a-47e0-84ed-d4e5d2255edf	0	2026-03-11 16:45:46.177576039 +0000 UTC	<nil>	
4323aaf1-abb1-4d91-8939-2e12bc0c7580	3		14596cfa-2d1f-4533-8a6d-0a946d7d28a5	0	2026-03-11 16:45:46.184336187 +0000 UTC	<nil>	
7cf72d50-caaa-4fc1-828b-802f35a746e6	2		213cc336-84b9-40d9-8113-10fdbcfa5f1b	0	2026-03-11 16:45:46.190767003 +0000 UTC	<nil>	
```
Although in this case it will still be removed because of the undertaker picking it up. This won't happen with `remove-application` though.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21257.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8783](https://warthogs.atlassian.net/browse/JUJU-8783)


[JUJU-8783]: https://warthogs.atlassian.net/browse/JUJU-8783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ