### PR TITLE
feat: implement facade method CheckCredentialsModels

### DIFF
--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -60,4 +60,5 @@ type CredentialService interface {
 	WatchCredential(ctx context.Context, key credential.Key) (watcher.NotifyWatcher, error)
 	CheckAndUpdateCredential(ctx context.Context, key credential.Key, cred cloud.Credential, force bool) ([]credentialservice.UpdateCredentialModelResult, error)
 	CheckAndRevokeCredential(ctx context.Context, key credential.Key, force bool) error
+	CheckCredentialModels(ctx context.Context, key credential.Key, cred cloud.Credential) ([]credentialservice.CheckCredentialModelResult, error)
 }

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -6,6 +6,7 @@ package cloud
 import (
 	"context"
 
+	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/juju/juju/domain/access"
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	clouderrors "github.com/juju/juju/domain/cloud/errors"
+	credentialerrors "github.com/juju/juju/domain/credential/errors"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/environs"
 	internalerrors "github.com/juju/juju/internal/errors"
@@ -31,6 +33,7 @@ import (
 type CloudV7 interface {
 	AddCloud(ctx context.Context, cloudArgs params.AddCloudArgs) error
 	AddCredentials(ctx context.Context, args params.TaggedCredentials) (params.ErrorResults, error)
+	CheckCredentialsModels(ctx context.Context, args params.TaggedCredentials) (params.UpdateCredentialResults, error)
 	Cloud(ctx context.Context, args params.Entities) (params.CloudResults, error)
 	Clouds(ctx context.Context) (params.CloudsResult, error)
 	Credential(ctx context.Context, args params.Entities) (params.CloudCredentialResults, error)
@@ -400,6 +403,64 @@ func (api *CloudAPI) AddCredentials(ctx context.Context, args params.TaggedCrede
 		}
 	}
 	return results, nil
+}
+
+// CheckCredentialsModels validates supplied cloud credentials' content against
+// models that currently use these credentials.
+// If there are any models that are using a credential and these models or their
+// cloud instances are not going to be accessible with corresponding credential,
+// there will be detailed validation errors per model.
+func (api *CloudAPI) CheckCredentialsModels(ctx context.Context, args params.TaggedCredentials) (params.UpdateCredentialResults, error) {
+	authFunc, err := api.getCredentialsAuthFunc(ctx)
+	if err != nil {
+		return params.UpdateCredentialResults{}, err
+	}
+
+	results := make([]params.UpdateCredentialResult, len(args.Credentials))
+	for i, arg := range args.Credentials {
+		results[i].CredentialTag = arg.Tag
+		tag, err := names.ParseCloudCredentialTag(arg.Tag)
+		if err != nil {
+			results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		// NOTE(axw) if we add ACLs for cloud credentials, we'll need
+		// to change this auth check.
+		if !authFunc(tag.Owner()) {
+			results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
+			continue
+		}
+
+		in := cloud.NewCredential(
+			cloud.AuthType(arg.Credential.AuthType),
+			arg.Credential.Attributes,
+		)
+
+		checkResults, err := api.credentialService.CheckCredentialModels(ctx, credential.KeyFromTag(tag), in)
+		if err != nil && !errors.Is(err, credentialerrors.CredentialModelValidation) {
+			results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		if len(checkResults) == 0 {
+			continue
+		}
+
+		var modelsResult []params.UpdateCredentialModelResult
+		for _, r := range checkResults {
+			model := params.UpdateCredentialModelResult{
+				ModelUUID: r.ModelUUID.String(),
+				ModelName: r.ModelName,
+			}
+			model.Errors = transform.Slice(r.Errors, func(e error) params.ErrorResult {
+				return params.ErrorResult{
+					Error: apiservererrors.ServerError(e),
+				}
+			})
+			modelsResult = append(modelsResult, model)
+		}
+		results[i].Models = modelsResult
+	}
+	return params.UpdateCredentialResults{Results: results}, nil
 }
 
 // UpdateCredentialsCheckModels updates a set of cloud credentials' content.

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/core/user"
 	usertesting "github.com/juju/juju/core/user/testing"
 	"github.com/juju/juju/domain/access"
+	credentialerrors "github.com/juju/juju/domain/credential/errors"
 	credentialservice "github.com/juju/juju/domain/credential/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	_ "github.com/juju/juju/internal/provider/dummy"
@@ -755,6 +756,138 @@ func (s *cloudSuite) TestUpdateCredentialsOneModelSuccess(c *tc.C) {
 				{
 					ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 					ModelName: "testModel1",
+				},
+			},
+		}},
+	})
+}
+
+func (s *cloudSuite) TestCheckCredentialModelsErrors(c *tc.C) {
+	bruceTag := names.NewUserTag("bruce")
+	defer s.setup(c, bruceTag).Finish()
+
+	_, tagOne := cloudCredentialTag(credParams{name: "three", owner: "bruce", cloudName: "meep", authType: jujucloud.EmptyAuthType,
+		attrs: map[string]string{}})
+	_, tagTwo := cloudCredentialTag(credParams{name: "three", owner: "bruce", cloudName: "badcloud", authType: jujucloud.EmptyAuthType,
+		attrs: map[string]string{}})
+
+	cred := jujucloud.NewCredential(
+		jujucloud.OAuth1AuthType,
+		map[string]string{"token": "foo:bar:baz"},
+	)
+	s.credService.EXPECT().CheckCredentialModels(gomock.Any(), credential.KeyFromTag(tagTwo), cred).Return(
+		nil, errors.New("cannot update credential \"three\": controller does not manage cloud \"badcloud\""))
+	s.credService.EXPECT().CheckCredentialModels(gomock.Any(), credential.KeyFromTag(tagOne), cred).Return(
+		[]credentialservice.CheckCredentialModelResult{}, nil)
+
+	results, err := s.api.CheckCredentialsModels(c.Context(), params.TaggedCredentials{
+		Credentials: []params.TaggedCredential{{
+			Tag: "machine-0",
+		}, {
+			Tag: "cloudcred-meep_admin_whatever",
+		}, {
+			Tag: "cloudcred-meep_bruce_three",
+			Credential: params.CloudCredential{
+				AuthType:   "oauth1",
+				Attributes: map[string]string{"token": "foo:bar:baz"},
+			},
+		}, {
+			Tag: "cloudcred-badcloud_bruce_three",
+			Credential: params.CloudCredential{
+				AuthType:   "oauth1",
+				Attributes: map[string]string{"token": "foo:bar:baz"},
+			},
+		}}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{
+			{
+				CredentialTag: "machine-0",
+				Error:         &params.Error{Message: `"machine-0" is not a valid cloudcred tag`},
+			},
+			{
+				CredentialTag: "cloudcred-meep_admin_whatever",
+				Error:         &params.Error{Message: "permission denied", Code: params.CodeUnauthorized},
+			},
+			{CredentialTag: "cloudcred-meep_bruce_three"},
+			{
+				CredentialTag: "cloudcred-badcloud_bruce_three",
+				Error:         &params.Error{Message: `cannot update credential "three": controller does not manage cloud "badcloud"`},
+			},
+		},
+	})
+}
+
+func (s *cloudSuite) TestCheckCredentialModelsOneModelSuccess(c *tc.C) {
+	adminTag := names.NewUserTag("admin")
+	defer s.setup(c, adminTag).Finish()
+
+	_, tag := cloudCredentialTag(credParams{name: "three", owner: "julia", cloudName: "meep", authType: jujucloud.EmptyAuthType,
+		attrs: map[string]string{}})
+
+	cred := jujucloud.Credential{}
+	s.credService.EXPECT().CheckCredentialModels(gomock.Any(), credential.KeyFromTag(tag), cred).Return(
+		[]credentialservice.CheckCredentialModelResult{{
+			ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+			ModelName: "testModel1",
+		}}, nil)
+
+	results, err := s.api.CheckCredentialsModels(c.Context(), params.TaggedCredentials{
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{{
+			CredentialTag: "cloudcred-meep_julia_three",
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+					ModelName: "testModel1",
+				},
+			},
+		}},
+	})
+}
+
+func (s *cloudSuite) TestCheckCredentialModelsValidationError(c *tc.C) {
+	adminTag := names.NewUserTag("admin")
+	defer s.setup(c, adminTag).Finish()
+
+	_, tag := cloudCredentialTag(credParams{name: "three", owner: "julia", cloudName: "meep", authType: jujucloud.EmptyAuthType,
+		attrs: map[string]string{}})
+
+	cred := jujucloud.Credential{}
+	s.credService.EXPECT().CheckCredentialModels(gomock.Any(), credential.KeyFromTag(tag), cred).Return(
+		[]credentialservice.CheckCredentialModelResult{{
+			ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+			ModelName: "testModel1",
+		}, {
+			ModelUUID: "deadbeef-0bad-400d-8000-5b1d0d06f00d",
+			ModelName: "testModel2",
+			Errors:    []error{errors.New("boom")},
+		}}, credentialerrors.CredentialModelValidation)
+
+	results, err := s.api.CheckCredentialsModels(c.Context(), params.TaggedCredentials{
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{{
+			CredentialTag: "cloudcred-meep_julia_three",
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+					ModelName: "testModel1",
+				}, {
+					ModelUUID: "deadbeef-0bad-400d-8000-5b1d0d06f00d",
+					ModelName: "testModel2",
+					Errors: []params.ErrorResult{{
+						Error: &params.Error{Message: "boom"},
+					}},
 				},
 			},
 		}},

--- a/apiserver/facades/client/cloud/mocks/cloud_mock.go
+++ b/apiserver/facades/client/cloud/mocks/cloud_mock.go
@@ -162,6 +162,45 @@ func (c *MockCredentialServiceCheckAndUpdateCredentialCall) DoAndReturn(f func(c
 	return c
 }
 
+// CheckCredentialModels mocks base method.
+func (m *MockCredentialService) CheckCredentialModels(arg0 context.Context, arg1 credential.Key, arg2 cloud.Credential) ([]service.CheckCredentialModelResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckCredentialModels", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]service.CheckCredentialModelResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckCredentialModels indicates an expected call of CheckCredentialModels.
+func (mr *MockCredentialServiceMockRecorder) CheckCredentialModels(arg0, arg1, arg2 any) *MockCredentialServiceCheckCredentialModelsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCredentialModels", reflect.TypeOf((*MockCredentialService)(nil).CheckCredentialModels), arg0, arg1, arg2)
+	return &MockCredentialServiceCheckCredentialModelsCall{Call: call}
+}
+
+// MockCredentialServiceCheckCredentialModelsCall wrap *gomock.Call
+type MockCredentialServiceCheckCredentialModelsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCredentialServiceCheckCredentialModelsCall) Return(arg0 []service.CheckCredentialModelResult, arg1 error) *MockCredentialServiceCheckCredentialModelsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCredentialServiceCheckCredentialModelsCall) Do(f func(context.Context, credential.Key, cloud.Credential) ([]service.CheckCredentialModelResult, error)) *MockCredentialServiceCheckCredentialModelsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCredentialServiceCheckCredentialModelsCall) DoAndReturn(f func(context.Context, credential.Key, cloud.Credential) ([]service.CheckCredentialModelResult, error)) *MockCredentialServiceCheckCredentialModelsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CloudCredential mocks base method.
 func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.Key) (cloud.Credential, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6880,6 +6880,17 @@
                         }
                     }
                 },
+                "CheckCredentialsModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/TaggedCredentials"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UpdateCredentialResults"
+                        }
+                    }
+                },
                 "Cloud": {
                     "type": "object",
                     "properties": {

--- a/domain/credential/service/service.go
+++ b/domain/credential/service/service.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/juju/collections/transform"
+
 	"github.com/juju/juju/cloud"
 	corecredential "github.com/juju/juju/core/credential"
 	coreerrors "github.com/juju/juju/core/errors"
@@ -190,6 +192,30 @@ func (s *Service) UpdateCloudCredential(ctx context.Context, key corecredential.
 	return s.st.UpsertCloudCredential(ctx, key, credentialInfoFromCloudCredential(cred))
 }
 
+// CheckCredentialModels checks the credential for the given tag is valid for
+// any models which use this credential and returns the models using the
+// credential and any errors encountered.
+// TODO(wallyworld) - we need a strategy to handle changes which occur after the
+// affected models have been read but before validation can complete.
+func (s *Service) CheckCredentialModels(ctx context.Context, key corecredential.Key, cred cloud.Credential) ([]CheckCredentialModelResult, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := key.Validate(); err != nil {
+		return nil, errors.Errorf("invalid id checking cloud credential: %w", err)
+	}
+
+	modelsResult, modelsErred, err := s.validateCredential(ctx, key, cred)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	if modelsErred {
+		return modelsResult, credentialerrors.CredentialModelValidation
+	}
+
+	return modelsResult, nil
+}
+
 // RemoveCloudCredential removes a cloud credential with the given tag.
 func (s *Service) RemoveCloudCredential(ctx context.Context, key corecredential.Key) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
@@ -253,8 +279,8 @@ func (s *Service) modelsUsingCredential(ctx context.Context, key corecredential.
 // CheckAndUpdateCredential updates the credential after first checking that any models which use the credential
 // can still access the cloud resources. If force is true, update the credential even if there are issues
 // validating the credential.
-// TODO(wallyworld) - we need a strategy to handle changes which occur after the affected models have been read
-// but before validation can complete.
+// TODO(wallyworld) - we need a strategy to handle changes which occur after the
+// affected models have been read but before validation can complete.
 func (s *Service) CheckAndUpdateCredential(ctx context.Context, key corecredential.Key, cred cloud.Credential, force bool) ([]UpdateCredentialModelResult, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -263,30 +289,16 @@ func (s *Service) CheckAndUpdateCredential(ctx context.Context, key corecredenti
 		return nil, errors.Errorf("invalid id updating cloud credential: %w", err)
 	}
 
-	models, err := s.modelsUsingCredential(ctx, key)
-	if err != nil && !errors.Is(err, credentialerrors.NotFound) {
+	modelsCheckResult, modelsErred, err := s.validateCredential(ctx, key, cred)
+	if err != nil {
 		return nil, errors.Capture(err)
 	}
-
-	var (
-		modelsErred  bool
-		modelsResult []UpdateCredentialModelResult
-	)
-	for uuid, name := range models {
-		result := UpdateCredentialModelResult{
-			ModelUUID: uuid,
-			ModelName: name,
+	modelsResult := transform.Slice(modelsCheckResult, func(checkResult CheckCredentialModelResult) UpdateCredentialModelResult {
+		return UpdateCredentialModelResult{
+			ModelUUID: checkResult.ModelUUID,
+			ModelName: checkResult.ModelName,
+			Errors:    checkResult.Errors,
 		}
-		result.Errors = s.validateModelCredential(ctx, uuid, cred)
-		modelsResult = append(modelsResult, result)
-		if len(result.Errors) > 0 {
-			modelsErred = true
-		}
-	}
-	// Since we get a map above, for consistency ensure that models are added
-	// sorted by model uuid.
-	sort.Slice(modelsResult, func(i, j int) bool {
-		return modelsResult[i].ModelUUID < modelsResult[j].ModelUUID
 	})
 
 	if modelsErred && !force {
@@ -303,6 +315,35 @@ func (s *Service) CheckAndUpdateCredential(ctx context.Context, key corecredenti
 	return modelsResult, nil
 }
 
+func (s *Service) validateCredential(ctx context.Context, key corecredential.Key, cred cloud.Credential) ([]CheckCredentialModelResult, bool, error) {
+	models, err := s.modelsUsingCredential(ctx, key)
+	if err != nil && !errors.Is(err, credentialerrors.NotFound) {
+		return nil, false, errors.Capture(err)
+	}
+
+	var (
+		modelsErred  bool
+		modelsResult []CheckCredentialModelResult
+	)
+	for uuid, name := range models {
+		result := CheckCredentialModelResult{
+			ModelUUID: uuid,
+			ModelName: name,
+		}
+		result.Errors = s.validateModelCredential(ctx, uuid, cred)
+		modelsResult = append(modelsResult, result)
+		if len(result.Errors) > 0 {
+			modelsErred = true
+		}
+	}
+	// Since we get a map above, for consistency ensure that models are added
+	// sorted by model uuid.
+	sort.Slice(modelsResult, func(i, j int) bool {
+		return modelsResult[i].ModelUUID < modelsResult[j].ModelUUID
+	})
+	return modelsResult, modelsErred, nil
+}
+
 // validateModelCredential attempts to ensure the credential is valid for the
 // specified model and returns any errors encountered.
 func (s *Service) validateModelCredential(ctx context.Context, modelUUID coremodel.UUID, cred cloud.Credential) []error {
@@ -313,8 +354,8 @@ func (s *Service) validateModelCredential(ctx context.Context, modelUUID coremod
 // CheckAndRevokeCredential removes the credential after first checking that any models which use the credential
 // can still access the cloud resources. If force is true, update the credential even if there are issues
 // validating the credential.
-// TODO(wallyworld) - we need a strategy to handle changes which occur after the affected models have been read
-// but before validation can complete.
+// TODO(wallyworld) - we need a strategy to handle changes which occur after the
+// affected models have been read but before validation can complete.
 func (s *Service) CheckAndRevokeCredential(ctx context.Context, key corecredential.Key, force bool) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/credential/service/service_test.go
+++ b/domain/credential/service/service_test.go
@@ -572,3 +572,72 @@ func (s *serviceSuite) TestModelCredentialStatusNotSet(c *tc.C) {
 	_, _, err := s.service(c).GetModelCredentialStatus(c.Context(), modelUUID)
 	c.Check(err, tc.ErrorIs, credentialerrors.ModelCredentialNotSet)
 }
+
+func (s *serviceSuite) TestCheckCredentialModelsInvalidKey(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	key := corecredential.Key{Cloud: "cirrus", Owner: usertesting.GenNewName(c, "fred")}
+	_, err := s.service(c).CheckCredentialModels(c.Context(), key, cloud.Credential{})
+	c.Assert(err, tc.ErrorMatches, "invalid id checking cloud credential.*")
+}
+
+func (s *serviceSuite) TestCheckCredentialModelsError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cred := cloud.Credential{}
+	key := corecredential.Key{
+		Cloud: "cirrus",
+		Owner: usertesting.GenNewName(c, "bob"),
+		Name:  "foobar",
+	}
+
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, errors.New("cannot get models"))
+
+	service := s.service(c)
+
+	results, err := service.CheckCredentialModels(c.Context(), key, cred)
+	c.Assert(err, tc.ErrorMatches, "cannot get models")
+	c.Assert(results, tc.HasLen, 0)
+}
+
+func (s *serviceSuite) TestCheckCredentialModels(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cred := cloud.Credential{}
+	key := corecredential.Key{
+		Cloud: "cirrus",
+		Owner: usertesting.GenNewName(c, "bob"),
+		Name:  "foobar",
+	}
+
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
+		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
+	}, nil)
+
+	service := s.service(c)
+
+	results, err := service.CheckCredentialModels(c.Context(), key, cred)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.DeepEquals, []CheckCredentialModelResult{{
+		ModelUUID: coremodel.UUID(jujutesting.ModelTag.Id()), ModelName: "mymodel",
+	}})
+}
+
+func (s *serviceSuite) TestCheckCredentialModelsNewCredential(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cred := cloud.Credential{}
+	key := corecredential.Key{
+		Cloud: "cirrus",
+		Owner: usertesting.GenNewName(c, "bob"),
+		Name:  "foobar",
+	}
+
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, credentialerrors.NotFound)
+
+	service := s.service(c)
+
+	results, err := service.CheckCredentialModels(c.Context(), key, cred)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.HasLen, 0)
+}

--- a/domain/credential/service/types.go
+++ b/domain/credential/service/types.go
@@ -18,3 +18,16 @@ type UpdateCredentialModelResult struct {
 	// Errors contains the errors accumulated while trying to update a credential.
 	Errors []error
 }
+
+// CheckCredentialModelResult holds details of any errors
+// encountered validating a credential for a model.
+type CheckCredentialModelResult struct {
+	// ModelUUID contains model's UUID.
+	ModelUUID coremodel.UUID
+
+	// ModelName contains model name.
+	ModelName string
+
+	// Errors contains the errors accumulated while validating a credential.
+	Errors []error
+}


### PR DESCRIPTION
Implement the client facade method CheckCredentialsModels. The facade code brings back the code from 3.6 but changes it to call the new domain service apis instead. The auth and param marshalling are as things were in 3.6.

On the credential service we already have a CheckAndUpdateCredential method. This does exactly the validation we need prior to updating the credential. This PR splits out the validation code so it can be used in the new method as well.

Note: the existing TODOs remain. This PR doesn't fix those, just wires things up.

## QA steps

juju doesn't use this, just unit tests

## Links

**Issue:** Fixes #21799.

**Jira card:** [JUJU-9284](https://warthogs.atlassian.net/browse/JUJU-9284)


[JUJU-9284]: https://warthogs.atlassian.net/browse/JUJU-9284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ