### PR TITLE
fix(upgrade-controller): improve error message for unsupported version upgrades

### DIFF
--- a/apiserver/facades/client/modelupgrader/findagents.go
+++ b/apiserver/facades/client/modelupgrader/findagents.go
@@ -19,15 +19,22 @@ import (
 	coretools "github.com/juju/juju/tools"
 )
 
-var errUpToDate = errors.AlreadyExistsf("no upgrades available")
+var (
+	errUpToDate  = errors.AlreadyExistsf("no upgrades available")
+	errDowngrade = errors.NotSupportedf("downgrade")
+)
 
 func (m *ModelUpgraderAPI) decideVersion(
 	currentVersion version.Number, args common.FindAgentsParams,
 ) (_ version.Number, err error) {
-
 	// Short circuit expensive agent look up if we are already up-to-date.
-	if args.Number != version.Zero && args.Number.Compare(currentVersion.ToPatch()) <= 0 {
+	if args.Number != version.Zero && args.Number.Compare(currentVersion.ToPatch()) == 0 {
 		return version.Zero, errUpToDate
+	}
+
+	// Short circuit expensive agent look up if target version is lower.
+	if args.Number != version.Zero && args.Number.Compare(currentVersion.ToPatch()) < 0 {
+		return version.Zero, errDowngrade
 	}
 
 	streamVersions, err := m.findAgents(args, currentVersion)

--- a/apiserver/facades/client/modelupgrader/upgrader.go
+++ b/apiserver/facades/client/modelupgrader/upgrader.go
@@ -208,11 +208,13 @@ func (m *ModelUpgraderAPI) UpgradeModel(arg params.UpgradeModelParams) (result p
 			args.Number = targetVersion
 		}
 		targetVersion, err = m.decideVersion(currentVersion, args)
-		if errors.Is(errors.Cause(err), errors.NotFound) || errors.Is(errors.Cause(err), errors.AlreadyExists) {
+		switch {
+		case errors.Is(err, errors.NotFound),
+			errors.Is(err, errors.AlreadyExists),
+			errors.Is(err, errors.NotSupported):
 			result.Error = apiservererrors.ServerError(err)
 			return result, nil
-		}
-		if err != nil {
+		case err != nil:
 			return result, errors.Trace(err)
 		}
 	}

--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -535,14 +535,14 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 	c.Assert(result.Error.Error(), gc.Equals, `
 cannot upgrade to "3.9.99" due to issues with these models:
 "admin/controller":
-- upgrading a controller to a newer major.minor version 3.9 not supported
+- upgrading a controller only supports patch upgrades within the same major.minor series (e.g. 2.9.x -> 2.9.y); to upgrade to 3.9.x, bootstrap a new controller and migrate models
 - unable to upgrade, database node 1 (1.1.1.1) has state FATAL, node 2 (2.2.2.2) has state ARBITER, node 3 (3.3.3.3) has state RECOVERING
 - mongo version has to be "4.4" at least, but current version is "4.3"
 - the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): xenial(2)
 - LXD version has to be at least "5.0.0", but current version is only "4.0.0"
 "admin/model-1":
-- current model ("2.9.0") has to be upgraded to "2.9.2" at least
+- current model "2.9.0" must be at least "2.9.2" before upgrading to "3.9.99"
 - model is under "exporting" mode, upgrade blocked
 - the model hosts deprecated windows machine(s): win10(1) win7(3)
 - the model hosts deprecated ubuntu machine(s): artful(1) cosmic(2) disco(3) eoan(4) groovy(5) hirsute(6) impish(7) precise(8) quantal(9) raring(10) saucy(11) trusty(12) utopic(13) vivid(14) wily(15) xenial(16) yakkety(17) zesty(18)

--- a/upgrades/upgradevalidation/upgrade.go
+++ b/upgrades/upgradevalidation/upgrade.go
@@ -36,7 +36,7 @@ func ModelValidatorsForControllerModelUpgrade(
 	targetVersion version.Number, cloudspec environscloudspec.CloudSpec,
 ) []Validator {
 	validators := []Validator{
-		getCheckTargetVersionForModel(targetVersion, UpgradeControllerAllowed),
+		getCheckTargetVersionForModel(targetVersion),
 		checkModelMigrationModeForControllerUpgrade,
 		checkNoWinMachinesForModel,
 		checkForDeprecatedUbuntuSeriesForModel,

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -248,10 +248,8 @@ func checkForCharmStoreCharms(_ string, _ StatePool, st State, _ Model) (*Blocke
 	return nil, nil
 }
 
-func getCheckTargetVersionForControllerModel(
-	targetVersion version.Number,
-) Validator {
-	return func(modelUUID string, pool StatePool, st State, model Model) (*Blocker, error) {
+func getCheckTargetVersionForControllerModel(targetVersion version.Number) Validator {
+	return func(_ string, _ StatePool, _ State, model Model) (*Blocker, error) {
 		agentVersion, err := model.AgentVersion()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -262,31 +260,36 @@ func getCheckTargetVersionForControllerModel(
 		}
 
 		return NewBlocker(
-			"upgrading a controller to a newer major.minor version %d.%d not supported", targetVersion.Major, targetVersion.Minor,
+			"upgrading a controller only supports patch upgrades within the same major.minor series"+
+				" (e.g. %d.%d.x -> %[1]d.%d.y); to upgrade to %d.%d.x, bootstrap a new controller and migrate models",
+			agentVersion.Major, agentVersion.Minor, targetVersion.Major, targetVersion.Minor,
 		), nil
 	}
 }
 
-func getCheckTargetVersionForModel(
-	targetVersion version.Number,
-	versionChecker func(from, to version.Number) (bool, version.Number, error),
-) Validator {
+func getCheckTargetVersionForModel(targetVersion version.Number) Validator {
 	return func(modelUUID string, pool StatePool, st State, model Model) (*Blocker, error) {
 		agentVersion, err := model.AgentVersion()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 
-		allowed, minVer, err := versionChecker(agentVersion, targetVersion)
-		if err != nil {
-			return nil, errors.Trace(err)
+		// Downgrades not allowed.
+		if targetVersion.Compare(agentVersion) < 0 {
+			logger.Debugf("downgrade from %q to %q is not allowed", agentVersion, targetVersion)
+			return NewBlocker("downgrade is not allowed"), nil
 		}
-		if allowed {
-			return nil, nil
+
+		minVer, ok := MinAgentVersions[targetVersion.Major]
+		logger.Debugf("from %q, to %q, versionMap %#v", agentVersion, targetVersion, MinAgentVersions)
+		if !ok {
+			return NewBlocker("upgrading model from %q to %q is not supported", agentVersion, targetVersion), nil
 		}
-		return NewBlocker(
-			"current model (%q) has to be upgraded to %q at least", agentVersion, minVer,
-		), nil
+		if agentVersion.Compare(minVer) < 0 {
+			return NewBlocker("current model %q must be at least %q before upgrading to %q", agentVersion, minVer, targetVersion), nil
+		}
+
+		return nil, nil
 	}
 }
 

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -183,31 +183,27 @@ func (s *upgradeValidationSuite) TestGetCheckTargetVersionForControllerModel(c *
 
 	blocker, err := upgradevalidation.GetCheckTargetVersionForModel(
 		version.MustParse("3.0.0"),
-		upgradevalidation.UpgradeControllerAllowed,
 	)("", nil, nil, model)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blocker, gc.ErrorMatches, `current model \("2.9.29"\) has to be upgraded to "2.9.30" at least`)
+	c.Assert(blocker, gc.ErrorMatches, `current model "2.9.29" must be at least "2.9.30" before upgrading to "3.0.0"`)
 
 	blocker, err = upgradevalidation.GetCheckTargetVersionForModel(
 		version.MustParse("3.0.0"),
-		upgradevalidation.UpgradeControllerAllowed,
 	)("", nil, nil, model)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 
 	blocker, err = upgradevalidation.GetCheckTargetVersionForModel(
 		version.MustParse("1.1.1"),
-		upgradevalidation.UpgradeControllerAllowed,
 	)("", nil, nil, model)
-	c.Assert(err, gc.ErrorMatches, `downgrade is not allowed`)
-	c.Assert(blocker, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocker, gc.ErrorMatches, `downgrade is not allowed`)
 
 	blocker, err = upgradevalidation.GetCheckTargetVersionForModel(
 		version.MustParse("4.1.1"),
-		upgradevalidation.UpgradeControllerAllowed,
 	)("", nil, nil, model)
-	c.Assert(err, gc.ErrorMatches, `upgrading controller to "4.1.1" is not supported from "2.9.31"`)
-	c.Assert(blocker, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocker, gc.ErrorMatches, `upgrading model from "2.9.31" to "4.1.1" is not supported`)
 }
 
 func (s *upgradeValidationSuite) TestCheckModelMigrationModeForControllerUpgrade(c *gc.C) {

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -17,52 +17,28 @@ var MinAgentVersions = map[int]version.Number{
 	3: version.MustParse("2.9.43"),
 }
 
-// MinClientVersions defines the minimum user client version
-// allowed to make a call to a controller with the major version,
-// or the minimum controller version needed to accept a call from a
-// client with the major version.
-var MinClientVersions = map[int]version.Number{
-	3: version.MustParse("2.9.42"),
-}
-
 // MinMajorMigrateVersions defines the minimum version the model
 // must be running before migrating to the target controller.
 var MinMajorMigrateVersions = MinAgentVersions
 
 // MigrateToAllowed checks if the model can be migrated to the target controller.
 func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (bool, version.Number, error) {
-	return versionCheck(
-		modelVersion, targetControllerVersion, MinMajorMigrateVersions, "migrate",
-	)
-}
-
-// UpgradeControllerAllowed returns true if a controller upgrade is allowed
-// when it hosts a model with the specified version.
-func UpgradeControllerAllowed(modelVersion, targetControllerVersion version.Number) (bool, version.Number, error) {
-	return versionCheck(
-		modelVersion, targetControllerVersion, MinAgentVersions, "upgrading controller",
-	)
-}
-
-func versionCheck(
-	from, to version.Number, versionMap map[int]version.Number, operation string,
-) (bool, version.Number, error) {
 	// If the major version is the same then we will allow the upgrade.
-	if from.Major == to.Major {
+	if modelVersion.Major == targetControllerVersion.Major {
 		return true, version.Number{}, nil
 	}
 	// Downgrades not allowed.
-	if from.Major > to.Major {
-		logger.Debugf("downgrade from %q to %q is not allowed", from, to)
+	if modelVersion.Major > targetControllerVersion.Major {
+		logger.Debugf("downgrade from %q to %q is not allowed", modelVersion, targetControllerVersion)
 		return false, version.Number{}, errors.Errorf("downgrade is not allowed")
 	}
 
-	minVer, ok := versionMap[to.Major]
-	logger.Debugf("from %q, to %q, versionMap %#v", from, to, versionMap)
+	minVer, ok := MinMajorMigrateVersions[targetControllerVersion.Major]
+	logger.Debugf("from %q, to %q, versionMap %#v", modelVersion, targetControllerVersion, MinMajorMigrateVersions)
 	if !ok {
-		return false, version.Number{}, errors.Errorf("%s to %q is not supported from %q", operation, to, from)
+		return false, version.Number{}, errors.Errorf("%s to %q is not supported from %q", "migrate", targetControllerVersion, modelVersion)
 	}
 	// Allow upgrades from rc etc.
-	from.Tag = ""
-	return from.Compare(minVer) >= 0, minVer, nil
+	modelVersion.Tag = ""
+	return modelVersion.Compare(minVer) >= 0, minVer, nil
 }

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -26,62 +26,6 @@ type versionCheckTC struct {
 	err     string
 }
 
-func (s *versionSuite) TestUpgradeControllerAllowed(c *gc.C) {
-	for i, t := range []versionCheckTC{
-		{
-			from:    "2.8.0",
-			to:      "3.0.0",
-			allowed: false,
-			minVers: "2.9.36",
-		}, {
-			from:    "2.9.65",
-			to:      "3.0.0",
-			allowed: true,
-			minVers: "2.9.36",
-		}, {
-			from:    "2.9.37",
-			to:      "3.0.0",
-			allowed: true,
-			minVers: "2.9.36",
-		}, {
-			from:    "2.9.0",
-			to:      "4.0.0",
-			allowed: false,
-			minVers: "0.0.0",
-			err:     `upgrading controller to "4.0.0" is not supported from "2.9.0"`,
-		}, {
-			from:    "3.0.0",
-			to:      "2.0.0",
-			allowed: false,
-			minVers: "0.0.0",
-			err:     `downgrade is not allowed`,
-		},
-	} {
-		s.assertUpgradeControllerAllowed(c, i, t)
-	}
-}
-
-func (s *versionSuite) assertUpgradeControllerAllowed(c *gc.C, i int, t versionCheckTC) {
-	c.Logf("testing %d", i)
-
-	restore := jujutesting.PatchValue(&upgradevalidation.MinAgentVersions, map[int]version.Number{
-		3: version.MustParse("2.9.36"),
-	})
-	defer restore()
-
-	from := version.MustParse(t.from)
-	to := version.MustParse(t.to)
-	minVers := version.MustParse(t.minVers)
-	allowed, vers, err := upgradevalidation.UpgradeControllerAllowed(from, to)
-	c.Check(allowed, gc.Equals, t.allowed)
-	c.Check(vers, gc.DeepEquals, minVers)
-	if t.err == "" {
-		c.Check(err, jc.ErrorIsNil)
-	} else {
-		c.Check(err, gc.ErrorMatches, t.err)
-	}
-}
-
 func (s *versionSuite) TestMigrateToAllowed(c *gc.C) {
 	for i, t := range []versionCheckTC{
 		{


### PR DESCRIPTION
Upgrade checks are outdated and assumes upgrading minor and major versions are still possible. There's one particular check for minimum allowed model version, (i.e. version before `2.9.43` cannot migrate to `3.x`) which is not only checked for model migrations but also model upgrades that throws a plain Go error (not a `*Blocker`) and overrides the intended error message. This PR removes that check from model upgrades, and replaces it with the same condition used for controller upgrade version check.

Additionally, it also shortcuts the checks after finding blockers for controller, i.e. skips checking model related issues if controller cannot be upgraded.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ juju bootstrap lxd src
❯ juju add-model m
❯ juju models --format=json | jq '.models[] | {name,"agent-version"}'
{
  "name": "admin/controller",
  "agent-version": "3.6.16.13"
}
{
  "name": "admin/m",
  "agent-version": "3.6.16.5"
}
```


```sh
❯ juju upgrade-controller --agent-version=3.6.18 --dry-run --agent-stream=proposed
best version:
    3.6.18
upgrade to this version by running
    juju upgrade-controller
```

```sh
❯ juju upgrade-controller --agent-version=4.0.3 --dry-run --agent-stream=proposed
ERROR cannot upgrade to "4.0.3" due to issues with these models:
"admin/controller":
- upgrading a controller only supports patch upgrades within the same major.minor series (e.g. 3.6.x -> 3.6.y); to upgrade to 4.0.x, bootstrap a new controller and migrate models
"admin/m":
- upgrading model from "3.6.16.5" to "4.0.3" is not supported
```

```sh
❯ juju upgrade-controller --agent-version=3.6.14
ERROR downgrade not supported
```

```sh
❯ juju upgrade-controller --agent-version=3.6.16.13
no upgrades available
```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Issue:** Fixes 

**Jira card:** [JUJU-9178](https://warthogs.atlassian.net/browse/JUJU-9178)


[JUJU-9178]: https://warthogs.atlassian.net/browse/JUJU-9178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ