### PR TITLE
test: fix brittle storage provisioner test

### DIFF
--- a/internal/worker/storageprovisioner/storageprovisioner_test.go
+++ b/internal/worker/storageprovisioner/storageprovisioner_test.go
@@ -4,6 +4,7 @@
 package storageprovisioner_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -2354,18 +2355,24 @@ func (s *caasStorageProvisionerSuite) TestRemoveFilesystems(c *tc.C) {
 	}
 
 	detached := make(chan interface{})
+	var detachedOnce sync.Once
 	fsLife := life.Dying
 	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
 		c.Check(ids, tc.DeepEquals, expectedAttachmentIds)
-		close(detached)
+		detachedOnce.Do(func() {
+			close(detached)
+		})
 		fsLife = life.Dead
 		return make([]params.ErrorResult, len(ids)), nil
 	}
 
 	removed := make(chan interface{})
+	var removedOnce sync.Once
 	remove := func(t []names.Tag) ([]params.ErrorResult, error) {
 		c.Check(t, tc.DeepEquals, expectedFilesystems)
-		close(removed)
+		removedOnce.Do(func() {
+			close(removed)
+		})
 		return make([]params.ErrorResult, len(t)), nil
 	}
 	life := func(t []names.Tag) ([]params.LifeResult, error) {


### PR DESCRIPTION
Observed in CI:
```
  --- FAIL: TestCaasStorageProvisionerSuite (0.02s)
      --- FAIL: TestCaasStorageProvisionerSuite/TestRemoveFilesystems (0.02s)
          /home/jenkins/go/src/github.com/juju/juju/internal/worker/storageprovisioner/storageprovisioner_test.go:2340
          blockdevices.go:137: TRACE: no pending volume block devices
          storageprovisioner.go:306: TRACE: loop: incomplete: fs=0 fsa=0 v=0 va=0 complete: fs=0 fsa=0 v=0 va=0
          filesystem_events.go:74: TRACE: filesystemAttachmentsChanged: []watcher.MachineStorageID{watcher.MachineStorageID{MachineTag:"unit-mariadb-1",
  AttachmentTag:"filesystem-1"}}
          filesystem_events.go:80: DEBUG: filesystem attachment alive: [], dying: [{unit-mariadb-1 filesystem-1}], dead: []
          filesystem_events.go:300: TRACE: processDyingFilesystemAttachments: []params.MachineStorageId{params.MachineStorageId{MachineTag:"unit-mariadb-1",
  AttachmentTag:"filesystem-1"}} []params.FilesystemAttachmentResult{params.FilesystemAttachmentResult{Result:params.FilesystemAttachment{FilesystemTag:"", MachineTag:"",
  Info:params.FilesystemAttachmentInfo{MountPoint:"", ReadOnly:false}}, Error:&params.Error{Message: "filesystem attachment {unit-mariadb-1 filesystem-1} not
  provisioned", Code: "not provisioned"}}}
          filesystem_events.go:241: DEBUG: pending filesystem attachment {unit-mariadb-1 filesystem-1} removed
          filesystem_events.go:398: TRACE: processAliveFilesystemAttachments: []params.MachineStorageId(nil) []params.FilesystemAttachmentResult{}
          blockdevices.go:137: TRACE: no pending volume block devices
          storageprovisioner.go:306: TRACE: loop: incomplete: fs=0 fsa=0 v=0 va=0 complete: fs=0 fsa=0 v=0 va=0
          filesystem_events.go:21: TRACE: filesystemsChange: []string{"1"}
          filesystem_events.go:30: DEBUG: filesystems alive: [], dying: [], dead: [filesystem-1]
          filesystem_events.go:250: TRACE: processDeadFilesystems: []names.FilesystemTag{names.FilesystemTag{id:"1"}}
  []params.FilesystemResult{params.FilesystemResult{Result:params.Filesystem{FilesystemTag:"", VolumeTag:"", Info:params.FilesystemInfo{ProviderId:"", Pool:"",
  SizeMiB:0x0}}, Error:&params.Error{Message: "filesystem \"1\" not provisioned", Code: "not provisioned"}}}
          filesystem_events.go:167: DEBUG: pending filesystem filesystem-1 removed
          filesystem_events.go:273: DEBUG: filesystem 1 is not provisioned, queuing for removal
          common.go:88: DEBUG: removing entities: [filesystem-1]
          filesystem_events.go:120: TRACE: processDyingFilesystems: []names.FilesystemTag{} []params.FilesystemResult{}
          filesystem_events.go:338: TRACE: processAliveFilesystems: []names.FilesystemTag{} []params.FilesystemResult{}
          blockdevices.go:137: TRACE: no pending volume block devices
          storageprovisioner.go:306: TRACE: loop: incomplete: fs=0 fsa=0 v=0 va=0 complete: fs=0 fsa=0 v=0 va=0
          filesystem_events.go:21: TRACE: filesystemsChange: []string{"1"}
          filesystem_events.go:30: DEBUG: filesystems alive: [], dying: [], dead: [filesystem-1]
          filesystem_events.go:250: TRACE: processDeadFilesystems: []names.FilesystemTag{names.FilesystemTag{id:"1"}}
  []params.FilesystemResult{params.FilesystemResult{Result:params.Filesystem{FilesystemTag:"", VolumeTag:"", Info:params.FilesystemInfo{ProviderId:"", Pool:"",
  SizeMiB:0x0}}, Error:&params.Error{Message: "filesystem \"1\" not provisioned", Code: "not provisioned"}}}
          filesystem_events.go:167: DEBUG: pending filesystem filesystem-1 removed
          filesystem_events.go:273: DEBUG: filesystem 1 is not provisioned, queuing for removal
          common.go:88: DEBUG: removing entities: [filesystem-1]
          storageprovisioner_test.go:2389:
                  defer func() { c.Assert(w.Wait(), tc.IsNil) }()
              ... value *catacomb.errWithStackTrace = &catacomb.errWithStackTrace{error:(*errors.Err)(0xc000428d20), stackTrace:"goroutine 548 [running]:\nruntime/debug.
  Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:26 +0x68\ngithub.com/juju/worker/v4/catacomb.runSafely.func1()\n\t/home/jenkins/go/pkg/mod/github.com/juju/worker/v
  4@v4.3.0/catacomb/catacomb.go:322 +0xda\npanic({0x29518e0?, 0x2f40aa0?})\n\t/usr/local/go/src/runtime/panic.go:783 +0x132\ngithub.com/juju/juju/internal/worker/storage
  provisioner_test.(*caasStorageProvisionerSuite).TestRemoveFilesystems.func3({0xc0002a2b80, 0x1, 0x1})\n\t/home/jenkins/go/src/github.com/juju/juju/internal/worker/stor
  ageprovisioner/storageprovisioner_test.go:2368 +0x11b\ngithub.com/juju/juju/internal/worker/storageprovisioner_test.(*mockLifecycleManager).Remove(0xc000713b60, {0x2f6
  5148?, 0xc000428500?}, {0xc0002a2b80, 0x1, 0x1})\n\t/home/jenkins/go/src/github.com/juju/juju/internal/worker/storageprovisioner/mock_test.go:518 +0x8b\ngithub.com/juj
  u/juju/internal/worker/storageprovisioner.removeEntities({0x2f65148, 0xc000428500}, 0xc0001ba280, {0xc0002a2b80, 0x1, 0x1})\n\t/home/jenkins/go/src/github.com/juju/juj
  u/internal/worker/storageprovisioner/common.go:89 +0x19a\ngithub.com/juju/juju/internal/worker/storageprovisioner.processDeadFilesystems({0x2f65148, 0xc000428500}, 0xc
  0001ba280, {0xc0002a29f0, 0x1, 0x1}, {0xc000428820, 0x1, 0x1})\n\t/home/jenkins/go/src/github.com/juju/juju/internal/worker/storageprovisioner/filesystem_events.go:286
  +0xc6b\ngithub.com/juju/juju/internal/worker/storageprovisioner.filesystemsChanged({0x2f65148, 0xc000428500}, 0xc0001ba280, {0xc00021e670, 0x1, 0x1})\n\t/home/jenkins/
  go/src/github.com/juju/juju/internal/worker/storageprovisioner/filesystem_events.go:59 +0xbf9\ngithub.com/juju/juju/internal/worker/storageprovisioner.(*storageProvisi
  oner).loop(0xc0002ebc20)\n\t/home/jenkins/go/src/github.com/juju/juju/internal/worker/storageprovisioner/storageprovisioner.go:348 +0x1bd1\ngithub.com/juju/worker/v4/c
  atacomb.runSafely(0xc00021e5f0)\n\t/home/jenkins/go/pkg/mod/github.com/juju/worker/v4@v4.3.0/catacomb/catacomb.go:325 +0x79\ngithub.com/juju/worker/v4/catacomb.Invoke.
  func3.1()\n\t/home/jenkins/go/pkg/mod/github.com/juju/worker/v4@v4.3.0/catacomb/catacomb.go:129 +0xa5\ngopkg.in/tomb%2ev2.(*Tomb).run(0xc0002ebc20, 0xc000315040)\n\t/h
  ome/jenkins/go/pkg/mod/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637/tomb.go:163 +0x3c\ncreated by gopkg.in/tomb%2ev2.(*Tomb).Go in goroutine 546\n\t/home/jenkin
  s/go/pkg/mod/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637/tomb.go:159 +0x19d\n"} ("panic resulted in: close of closed channel")
  FAIL
 ```

The test has patched removal methods that close signalling channels. This practice inherently assumes a single call, but the logic allows multiple calls. The worker behaviour appears correct.

This change just makes the methods idempotent, avoiding test panics.