### PR TITLE
fix(ssh): force PTY allocation for debug-hooks and debug-code

### DIFF
--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -278,6 +278,13 @@ func (c *debugHooksCommand) commonRun(
 	innercmd := fmt.Sprintf(`F=$(mktemp); echo %s | base64 -d > $F; chmod +x $F; exec $F`, b64Script)
 	args := []string{fmt.Sprintf(c.decideEntryPoint(ctx), innercmd)}
 	c.provider.setArgs(args)
+
+	// debug-hooks and debug-code always need a PTY because they launch a
+	// tmux session on the remote side. Force PTY allocation so that the
+	// enablePty heuristic (which disables PTY when args are present) does
+	// not prevent it.
+	_ = c.pty.Set("true")
+
 	return c.sshCommand.Run(ctx)
 }
 

--- a/cmd/juju/ssh/debughooks_test.go
+++ b/cmd/juju/ssh/debughooks_test.go
@@ -44,6 +44,7 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
+		enablePty:       true,
 		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
 	},
 }, {
@@ -53,12 +54,23 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
+		enablePty:       true,
 		withProxy:       true,
 		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
 	},
 }, {
 	info:        "pty enabled",
 	args:        []string{"--pty=true", "mysql/0"},
+	hostChecker: validAddresses("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
+	expected: &argsSpec{
+		hostKeyChecking: "yes",
+		knownHosts:      "0",
+		enablePty:       true,
+		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
+	},
+}, {
+	info:        "pty=false overridden by debug-hooks",
+	args:        []string{"--pty=false", "mysql/0"},
 	hostChecker: validAddresses("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
 	expected: &argsSpec{
 		hostKeyChecking: "yes",


### PR DESCRIPTION
Fixes #21984

PR #21716 added a heuristic to `enablePty()` in `cmd/juju/ssh/ssh.go` that disables PTY allocation when remote command args are present. This inadvertently broke `juju debug-hooks` and `juju debug-code`. Both commands always pass args (a base64-encoded tmux debug script), so the heuristic prevented PTY allocation, causing tmux to fail with:

- `no server running on /tmp/tmux-0/default` (first attempt)
- `open terminal failed: not a terminal` (subsequent attempts)

The fix forces PTY allocation via `c.pty.Set("true")` in `commonRun()` before calling `sshCommand.Run`, ensuring tmux gets the terminal it requires. This also means an explicit `--pty=false` flag is overridden for debug-hooks and debug-code, since tmux cannot function without a PTY.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Bootstrap a Juju controller on microk8s (or any k8s cloud):

    juju bootstrap microk8s micro
    juju add-model k
    juju deploy postgresql-k8s --channel 14/stable

Wait for the unit to become active, then verify:

    # debug-hooks on k8s charm (was broken):
    juju debug-hooks postgresql-k8s/0
    # Expected: tmux session opens

    # debug-code on k8s charm (was broken):
    juju debug-code postgresql-k8s/0
    # Expected: tmux session opens

    # Non-interactive ssh on k8s (no regression):
    juju ssh postgresql-k8s/0 -- "echo hello && tty"
    # Expected: prints "hello" and "not a tty"

## Links

**Caused by:** #21716