### PR TITLE
feat: S3 object store state backend

### DIFF
--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -799,6 +799,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		objectStoreServicesName: objectstoreservices.Manifold(objectstoreservices.ManifoldConfig{
 			ChangeStreamName:             changeStreamName,
+			Clock:                        config.Clock,
 			Logger:                       internallogger.GetLogger("juju.worker.objectstoreservices"),
 			NewWorker:                    objectstoreservices.NewWorker,
 			NewObjectStoreServices:       objectstoreservices.NewObjectStoreServices,

--- a/core/objectstore/phase.go
+++ b/core/objectstore/phase.go
@@ -9,6 +9,10 @@ const (
 	// ErrTerminalPhase is the error returned when the object store is already
 	// in a terminal phase.
 	ErrTerminalPhase = errors.ConstError("object store is already in a terminal phase")
+
+	// ErrInvalidTransition is the error returned when the object store cannot
+	// transition from the current phase to the new phase.
+	ErrInvalidTransition = errors.ConstError("invalid phase transition")
 )
 
 // Phase is the type to identify the phase of the object store.
@@ -84,7 +88,7 @@ func (p Phase) TransitionTo(newPhase Phase) (Phase, error) {
 			return p, ErrTerminalPhase
 		}
 	}
-	return "", errors.Errorf("invalid transition from %q to %q", p, newPhase)
+	return "", errors.Errorf("invalid transition from %q to %q", p, newPhase).Add(ErrInvalidTransition)
 }
 
 // IsValid returns true if the phase is a valid phase.

--- a/core/objectstore/phase.go
+++ b/core/objectstore/phase.go
@@ -117,3 +117,20 @@ func ParsePhase(value string) (Phase, error) {
 		return "", errors.Errorf("invalid phase %q", value)
 	}
 }
+
+// DrainingPhaseInfo represents the information about the draining process,
+// including the phase of the draining process, and the uuids of the backends
+// that are being drained from and to. This information can be used to correlate
+// with logs and other information about the draining process.
+type DrainingPhaseInfo struct {
+	// Phase is the phase of the draining process.
+	Phase Phase
+	// FromBackendUUID is the uuid of the backend that is being drained from.
+	// This is optional, as there might not be a draining process, so you'll
+	// get the current backend UUID only.
+	FromBackendUUID *UUID
+	// ActiveBackendUUID is the uuid of the backend that is currently active to.
+	// It will also indicate the backend that is being drained to, if there is a
+	// draining process.
+	ActiveBackendUUID UUID
+}

--- a/core/objectstore/phase_test.go
+++ b/core/objectstore/phase_test.go
@@ -168,9 +168,10 @@ func (s *phaseSuite) TestTransitionTo(c *tc.C) {
 		newPhase, err := pFrom.TransitionTo(pTo)
 		if test.err != "" {
 			c.Assert(err, tc.ErrorMatches, test.err)
+			c.Check(err, tc.ErrorIs, ErrInvalidTransition)
 			continue
 		}
 		c.Assert(err, tc.IsNil)
-		c.Assert(newPhase.String(), tc.Equals, test.expected)
+		c.Check(newPhase.String(), tc.Equals, test.expected)
 	}
 }

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -851,7 +851,7 @@ func (s *watcherSuite) setCharmObjectStoreMetadata(c *tc.C, appID string) {
 	}
 
 	uuid := tc.Must(c, uuid.NewUUID).String()
-	objectStoreUUID, err := objectstorestate.NewState(modelDB).PutMetadata(c.Context(), uuid, coreobjectstore.Metadata{
+	objectStoreUUID, err := objectstorestate.NewState(modelDB, clock.WallClock).PutMetadata(c.Context(), uuid, coreobjectstore.Metadata{
 		SHA256: fmt.Sprintf("%v-sha256", appID),
 		SHA384: fmt.Sprintf("%v-sha384", appID),
 		Path:   fmt.Sprintf("/path/to/%v", appID),

--- a/domain/objectstore/errors/errors.go
+++ b/domain/objectstore/errors/errors.go
@@ -47,4 +47,7 @@ const (
 
 	// ErrNoHints is returned when there are no hints for a given SHA384.
 	ErrNoHints = errors.ConstError("no hints for SHA384")
+
+	// ErrBackendNotFound is returned when the backend is not found.
+	ErrBackendNotFound = errors.ConstError("backend not found")
 )

--- a/domain/objectstore/errors/errors.go
+++ b/domain/objectstore/errors/errors.go
@@ -50,4 +50,7 @@ const (
 
 	// ErrBackendNotFound is returned when the backend is not found.
 	ErrBackendNotFound = errors.ConstError("backend not found")
+
+	// ErrBackendAlreadyExists is returned when the backend already exists.
+	ErrBackendAlreadyExists = errors.ConstError("backend already exists")
 )

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -428,16 +428,19 @@ func (s *WatchableDrainingService) SetDrainingPhase(ctx context.Context, phase o
 		return errors.Errorf("invalid phase %q", phase)
 	}
 
+	hasPhase := true
 	phaseInfo, err := s.st.GetActiveDrainingInfo(ctx)
-	if err != nil && !errors.Is(err, objectstoreerrors.ErrDrainingPhaseNotFound) {
+	if errors.Is(err, objectstoreerrors.ErrDrainingPhaseNotFound) {
+		hasPhase = false
+	} else if err != nil {
 		return errors.Errorf("getting active draining phase: %w", err)
 	}
 
 	// If there is no active draining phase, we consider the current phase to be
 	// unknown, otherwise we use the active draining phase.
-	current := objectstore.Phase(phaseInfo.Phase)
-	if errors.Is(err, objectstoreerrors.ErrDrainingPhaseNotFound) {
-		current = objectstore.PhaseUnknown
+	current := objectstore.PhaseUnknown
+	if hasPhase {
+		current = objectstore.Phase(phaseInfo.Phase)
 	}
 
 	if _, err := current.TransitionTo(phase); errors.Is(err, objectstore.ErrTerminalPhase) {

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -429,22 +429,32 @@ func (s *WatchableDrainingService) SetDrainingPhase(ctx context.Context, phase o
 	}
 
 	phaseInfo, err := s.st.GetActiveDrainingInfo(ctx)
+	if err != nil && !errors.Is(err, objectstoreerrors.ErrDrainingPhaseNotFound) {
+		return errors.Errorf("getting active draining phase: %w", err)
+	}
+
+	// If there is no active draining phase, we consider the current phase to be
+	// unknown, otherwise we use the active draining phase.
+	current := objectstore.Phase(phaseInfo.Phase)
 	if errors.Is(err, objectstoreerrors.ErrDrainingPhaseNotFound) {
+		current = objectstore.PhaseUnknown
+	}
+
+	if _, err := current.TransitionTo(phase); errors.Is(err, objectstore.ErrTerminalPhase) {
+		return nil
+	} else if err != nil {
+		return errors.Errorf("transitioning phase: %w", err)
+	}
+
+	// If the phase is draining, we need to start the draining process,
+	// otherwise we just update the phase in the state.
+	if phase.IsDraining() {
 		uuid, err := objectstore.NewUUID()
 		if err != nil {
 			return errors.Errorf("creating new uuid: %w", err)
 		}
 
 		return s.st.StartDraining(ctx, uuid.String())
-	} else if err != nil {
-		return errors.Errorf("getting active draining phase: %w", err)
-	}
-
-	current := objectstore.Phase(phaseInfo.Phase)
-	if _, err := current.TransitionTo(phase); errors.Is(err, objectstore.ErrTerminalPhase) {
-		return nil
-	} else if err != nil {
-		return errors.Errorf("transitioning phase: %w", err)
 	}
 
 	// Set the phase in the state.

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
+	domainobjectstore "github.com/juju/juju/domain/objectstore"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/errors"
 )
@@ -82,9 +83,13 @@ type State interface {
 // phase of the object store.
 type DrainingState interface {
 	State
-	// GetActiveDrainingPhase returns the active draining phase of the object
+
+	// GetActiveDrainingInfo returns the active draining info of the object
 	// store.
-	GetActiveDrainingPhase(ctx context.Context) (string, objectstore.Phase, error)
+	GetActiveDrainingInfo(ctx context.Context) (domainobjectstore.DrainingInfo, error)
+
+	// StartDraining initiates the draining process for the object store.
+	StartDraining(ctx context.Context, uuid string) error
 
 	// SetDrainingPhase sets the phase of the object store to draining.
 	SetDrainingPhase(ctx context.Context, uuid string, phase objectstore.Phase) error
@@ -423,18 +428,19 @@ func (s *WatchableDrainingService) SetDrainingPhase(ctx context.Context, phase o
 		return errors.Errorf("invalid phase %q", phase)
 	}
 
-	uuid, current, err := s.st.GetActiveDrainingPhase(ctx)
+	phaseInfo, err := s.st.GetActiveDrainingInfo(ctx)
 	if errors.Is(err, objectstoreerrors.ErrDrainingPhaseNotFound) {
 		uuid, err := objectstore.NewUUID()
 		if err != nil {
 			return errors.Errorf("creating new uuid: %w", err)
 		}
 
-		return s.st.SetDrainingPhase(ctx, uuid.String(), phase)
+		return s.st.StartDraining(ctx, uuid.String())
 	} else if err != nil {
 		return errors.Errorf("getting active draining phase: %w", err)
 	}
 
+	current := objectstore.Phase(phaseInfo.Phase)
 	if _, err := current.TransitionTo(phase); errors.Is(err, objectstore.ErrTerminalPhase) {
 		return nil
 	} else if err != nil {
@@ -442,7 +448,7 @@ func (s *WatchableDrainingService) SetDrainingPhase(ctx context.Context, phase o
 	}
 
 	// Set the phase in the state.
-	if err := s.st.SetDrainingPhase(ctx, uuid, phase); err != nil {
+	if err := s.st.SetDrainingPhase(ctx, phaseInfo.UUID, phase); err != nil {
 		return errors.Errorf("setting draining phase: %w", err)
 	}
 	return nil
@@ -453,13 +459,13 @@ func (s *WatchableDrainingService) GetDrainingPhase(ctx context.Context) (object
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	_, phase, err := s.st.GetActiveDrainingPhase(ctx)
+	info, err := s.st.GetActiveDrainingInfo(ctx)
 	if errors.Is(err, objectstoreerrors.ErrDrainingPhaseNotFound) {
 		return objectstore.PhaseUnknown, nil
 	} else if err != nil {
 		return "", errors.Errorf("getting draining phase: %w", err)
 	}
-	return phase, nil
+	return objectstore.Phase(info.Phase), nil
 }
 
 // WatchDraining returns a watcher that watches the draining phase of the

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
 	"github.com/juju/juju/core/watcher/watchertest"
+	domainobjectstore "github.com/juju/juju/domain/objectstore"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/testhelpers"
@@ -430,7 +431,10 @@ func (s *drainingServiceSuite) TestSetDrainingPhase(c *tc.C) {
 	newPhase := objectstore.PhaseDraining
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
-	s.state.EXPECT().GetActiveDrainingPhase(gomock.Any()).Return(uuid.String(), currentPhase, nil)
+	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).Return(domainobjectstore.DrainingInfo{
+		UUID:  uuid.String(),
+		Phase: currentPhase.String(),
+	}, nil)
 	s.state.EXPECT().SetDrainingPhase(gomock.Any(), uuid.String(), newPhase).Return(nil)
 
 	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
@@ -442,8 +446,9 @@ func (s *drainingServiceSuite) TestSetDrainingPhaseNoInitial(c *tc.C) {
 
 	newPhase := objectstore.PhaseDraining
 
-	s.state.EXPECT().GetActiveDrainingPhase(gomock.Any()).Return("", "", objectstoreerrors.ErrDrainingPhaseNotFound)
-	s.state.EXPECT().SetDrainingPhase(gomock.Any(), gomock.Any(), newPhase).Return(nil)
+	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).
+		Return(domainobjectstore.DrainingInfo{}, objectstoreerrors.ErrDrainingPhaseNotFound)
+	s.state.EXPECT().StartDraining(gomock.Any(), gomock.Any()).Return(nil)
 
 	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
 	c.Assert(err, tc.ErrorIsNil)
@@ -465,7 +470,10 @@ func (s *drainingServiceSuite) TestSetDrainingPhaseError(c *tc.C) {
 	newPhase := objectstore.PhaseDraining
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
-	s.state.EXPECT().GetActiveDrainingPhase(gomock.Any()).Return(uuid.String(), currentPhase, nil)
+	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).Return(domainobjectstore.DrainingInfo{
+		UUID:  uuid.String(),
+		Phase: currentPhase.String(),
+	}, nil)
 	s.state.EXPECT().SetDrainingPhase(gomock.Any(), uuid.String(), newPhase).Return(errors.Errorf("boom"))
 
 	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
@@ -478,7 +486,10 @@ func (s *drainingServiceSuite) TestGetDrainingPhase(c *tc.C) {
 	phase := objectstore.PhaseDraining
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
-	s.state.EXPECT().GetActiveDrainingPhase(gomock.Any()).Return(uuid.String(), phase, nil)
+	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).Return(domainobjectstore.DrainingInfo{
+		UUID:  uuid.String(),
+		Phase: phase.String(),
+	}, nil)
 
 	p, err := NewWatchableDrainingService(s.state, s.watcherFactory).GetDrainingPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -488,10 +499,8 @@ func (s *drainingServiceSuite) TestGetDrainingPhase(c *tc.C) {
 func (s *drainingServiceSuite) TestGetDrainingPhaseError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	phase := objectstore.PhaseDraining
-	uuid := objectstoretesting.GenObjectStoreUUID(c)
-
-	s.state.EXPECT().GetActiveDrainingPhase(gomock.Any()).Return(uuid.String(), phase, errors.Errorf("boom"))
+	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).
+		Return(domainobjectstore.DrainingInfo{}, errors.Errorf("boom"))
 
 	_, err := NewWatchableDrainingService(s.state, s.watcherFactory).GetDrainingPhase(c.Context())
 	c.Assert(err, tc.ErrorMatches, `.*boom`)

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -435,7 +435,7 @@ func (s *drainingServiceSuite) TestSetDrainingPhase(c *tc.C) {
 		UUID:  uuid.String(),
 		Phase: currentPhase.String(),
 	}, nil)
-	s.state.EXPECT().SetDrainingPhase(gomock.Any(), uuid.String(), newPhase).Return(nil)
+	s.state.EXPECT().StartDraining(gomock.Any(), tc.Bind(tc.IsNonZeroUUID)).Return(nil)
 
 	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
 	c.Assert(err, tc.ErrorIsNil)
@@ -454,6 +454,18 @@ func (s *drainingServiceSuite) TestSetDrainingPhaseNoInitial(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *drainingServiceSuite) TestSetDrainingPhaseNoInitialToCompleted(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	newPhase := objectstore.PhaseCompleted
+
+	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).
+		Return(domainobjectstore.DrainingInfo{}, objectstoreerrors.ErrDrainingPhaseNotFound)
+
+	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
+	c.Assert(err, tc.ErrorIs, objectstore.ErrInvalidTransition)
+}
+
 func (s *drainingServiceSuite) TestSetDrainingPhaseInvalid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -463,11 +475,27 @@ func (s *drainingServiceSuite) TestSetDrainingPhaseInvalid(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "invalid phase \"invalid\"")
 }
 
-func (s *drainingServiceSuite) TestSetDrainingPhaseError(c *tc.C) {
+func (s *drainingServiceSuite) TestSetDrainingPhaseInvalidTransition(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	currentPhase := objectstore.PhaseUnknown
-	newPhase := objectstore.PhaseDraining
+	newPhase := objectstore.PhaseError
+	uuid := objectstoretesting.GenObjectStoreUUID(c)
+
+	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).Return(domainobjectstore.DrainingInfo{
+		UUID:  uuid.String(),
+		Phase: currentPhase.String(),
+	}, nil)
+
+	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
+	c.Assert(err, tc.ErrorIs, objectstore.ErrInvalidTransition)
+}
+
+func (s *drainingServiceSuite) TestSetDrainingPhaseError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	currentPhase := objectstore.PhaseDraining
+	newPhase := objectstore.PhaseError
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).Return(domainobjectstore.DrainingInfo{

--- a/domain/objectstore/service/state_mock_test.go
+++ b/domain/objectstore/service/state_mock_test.go
@@ -16,6 +16,7 @@ import (
 	objectstore "github.com/juju/juju/core/objectstore"
 	watcher "github.com/juju/juju/core/watcher"
 	eventsource "github.com/juju/juju/core/watcher/eventsource"
+	objectstore0 "github.com/juju/juju/domain/objectstore"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -491,42 +492,41 @@ func (c *MockDrainingStateAddControllerIDHintCall) DoAndReturn(f func(context.Co
 	return c
 }
 
-// GetActiveDrainingPhase mocks base method.
-func (m *MockDrainingState) GetActiveDrainingPhase(arg0 context.Context) (string, objectstore.Phase, error) {
+// GetActiveDrainingInfo mocks base method.
+func (m *MockDrainingState) GetActiveDrainingInfo(arg0 context.Context) (objectstore0.DrainingInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetActiveDrainingPhase", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(objectstore.Phase)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "GetActiveDrainingInfo", arg0)
+	ret0, _ := ret[0].(objectstore0.DrainingInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// GetActiveDrainingPhase indicates an expected call of GetActiveDrainingPhase.
-func (mr *MockDrainingStateMockRecorder) GetActiveDrainingPhase(arg0 any) *MockDrainingStateGetActiveDrainingPhaseCall {
+// GetActiveDrainingInfo indicates an expected call of GetActiveDrainingInfo.
+func (mr *MockDrainingStateMockRecorder) GetActiveDrainingInfo(arg0 any) *MockDrainingStateGetActiveDrainingInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveDrainingPhase", reflect.TypeOf((*MockDrainingState)(nil).GetActiveDrainingPhase), arg0)
-	return &MockDrainingStateGetActiveDrainingPhaseCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveDrainingInfo", reflect.TypeOf((*MockDrainingState)(nil).GetActiveDrainingInfo), arg0)
+	return &MockDrainingStateGetActiveDrainingInfoCall{Call: call}
 }
 
-// MockDrainingStateGetActiveDrainingPhaseCall wrap *gomock.Call
-type MockDrainingStateGetActiveDrainingPhaseCall struct {
+// MockDrainingStateGetActiveDrainingInfoCall wrap *gomock.Call
+type MockDrainingStateGetActiveDrainingInfoCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockDrainingStateGetActiveDrainingPhaseCall) Return(arg0 string, arg1 objectstore.Phase, arg2 error) *MockDrainingStateGetActiveDrainingPhaseCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
+func (c *MockDrainingStateGetActiveDrainingInfoCall) Return(arg0 objectstore0.DrainingInfo, arg1 error) *MockDrainingStateGetActiveDrainingInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDrainingStateGetActiveDrainingPhaseCall) Do(f func(context.Context) (string, objectstore.Phase, error)) *MockDrainingStateGetActiveDrainingPhaseCall {
+func (c *MockDrainingStateGetActiveDrainingInfoCall) Do(f func(context.Context) (objectstore0.DrainingInfo, error)) *MockDrainingStateGetActiveDrainingInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDrainingStateGetActiveDrainingPhaseCall) DoAndReturn(f func(context.Context) (string, objectstore.Phase, error)) *MockDrainingStateGetActiveDrainingPhaseCall {
+func (c *MockDrainingStateGetActiveDrainingInfoCall) DoAndReturn(f func(context.Context) (objectstore0.DrainingInfo, error)) *MockDrainingStateGetActiveDrainingInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -953,6 +953,44 @@ func (c *MockDrainingStateSetDrainingPhaseCall) Do(f func(context.Context, strin
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockDrainingStateSetDrainingPhaseCall) DoAndReturn(f func(context.Context, string, objectstore.Phase) error) *MockDrainingStateSetDrainingPhaseCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// StartDraining mocks base method.
+func (m *MockDrainingState) StartDraining(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartDraining", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartDraining indicates an expected call of StartDraining.
+func (mr *MockDrainingStateMockRecorder) StartDraining(arg0, arg1 any) *MockDrainingStateStartDrainingCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartDraining", reflect.TypeOf((*MockDrainingState)(nil).StartDraining), arg0, arg1)
+	return &MockDrainingStateStartDrainingCall{Call: call}
+}
+
+// MockDrainingStateStartDrainingCall wrap *gomock.Call
+type MockDrainingStateStartDrainingCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDrainingStateStartDrainingCall) Return(arg0 error) *MockDrainingStateStartDrainingCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDrainingStateStartDrainingCall) Do(f func(context.Context, string) error) *MockDrainingStateStartDrainingCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDrainingStateStartDrainingCall) DoAndReturn(f func(context.Context, string) error) *MockDrainingStateStartDrainingCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
@@ -12,6 +13,8 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/life"
+	domainobjectstore "github.com/juju/juju/domain/objectstore"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
@@ -507,34 +510,69 @@ WHERE uuid = $dbMetadataPath.metadata_uuid`, dbMetadataPath)
 	return nil
 }
 
-// SetDrainingPhase sets the phase of the object store to draining.
-func (s *State) SetDrainingPhase(ctx context.Context, uuid string, phase coreobjectstore.Phase) error {
+// StartDraining initiates the draining process for the object store.
+func (s *State) StartDraining(ctx context.Context, uuid string) error {
 	db, err := s.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	phaseTypeID, err := encodePhaseTypeID(phase)
+	phaseTypeID, err := encodePhaseTypeID(coreobjectstore.PhaseDraining)
 	if err != nil {
 		return errors.Errorf("encoding phase type id: %w", err)
 	}
 
-	args := dbSetPhaseInfo{
-		UUID:        uuid,
-		PhaseTypeID: phaseTypeID,
+	fromBackendStmt, err := s.Prepare(`
+SELECT b.uuid AS &backendUUID.uuid
+FROM object_store_backend AS b
+WHERE b.life_id = 1`, backendUUID{})
+	if err != nil {
+		return errors.Errorf("preparing active object store backend statement: %w", err)
 	}
 
-	stmt, err := s.Prepare(`
-INSERT INTO object_store_drain_info (uuid, phase_type_id)
-VALUES ($dbSetPhaseInfo.*)
-ON CONFLICT (uuid) DO UPDATE SET
-	phase_type_id = $dbSetPhaseInfo.phase_type_id;
-	`, args)
+	toBackendStmt, err := s.Prepare(`
+SELECT b.uuid AS &backendUUID.uuid
+FROM object_store_backend AS b
+WHERE b.life_id = 0`, backendUUID{})
+	if err != nil {
+		return errors.Errorf("preparing to object store backend statement: %w", err)
+	}
+
+	insertStmt, err := s.Prepare(`
+INSERT INTO object_store_drain_info (uuid, phase_type_id, from_backend_uuid, to_backend_uuid)
+VALUES ($dbSetPhaseInfo.*);
+	`, dbSetPhaseInfo{})
 	if err != nil {
 		return errors.Errorf("preparing insert draining phase statement: %w", err)
 	}
+
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, stmt, args).Run()
+		// Find the active backend. We'll need to set this backend as dying
+		// if the phase is set to draining.
+		var fromBackend backendUUID
+		err := tx.Query(ctx, fromBackendStmt).Get(&fromBackend)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("migrating from: %v", objectstoreerrors.ErrBackendNotFound)
+		} else if err != nil {
+			return errors.Capture(err)
+		}
+
+		var toBackend backendUUID
+		err = tx.Query(ctx, toBackendStmt).Get(&toBackend)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("migrating to: %v", objectstoreerrors.ErrBackendNotFound)
+		} else if err != nil {
+			return errors.Capture(err)
+		}
+
+		args := dbSetPhaseInfo{
+			UUID:            uuid,
+			PhaseTypeID:     phaseTypeID,
+			FromBackendUUID: fromBackend.UUID,
+			ToBackendUUID:   toBackend.UUID,
+		}
+
+		err = tx.Query(ctx, insertStmt, args).Run()
 		if database.IsErrConstraintUnique(err) {
 			return objectstoreerrors.ErrDrainingAlreadyInProgress
 		} else if err != nil {
@@ -548,21 +586,72 @@ ON CONFLICT (uuid) DO UPDATE SET
 	return nil
 }
 
-// GetActiveDrainingPhase returns the phase of the object store.
-func (s *State) GetActiveDrainingPhase(ctx context.Context) (string, coreobjectstore.Phase, error) {
+// SetDrainingPhase sets the phase of the object store to draining. Returns an
+// error if it cannot find the active backend, the to backend, or if there is
+// already an active draining phase.
+func (s *State) SetDrainingPhase(ctx context.Context, uuid string, phase coreobjectstore.Phase) error {
 	db, err := s.DB(ctx)
 	if err != nil {
-		return "", "", errors.Capture(err)
+		return errors.Capture(err)
+	}
+
+	phaseTypeID, err := encodePhaseTypeID(phase)
+	if err != nil {
+		return errors.Errorf("encoding phase type id: %w", err)
+	}
+
+	insertStmt, err := s.Prepare(`
+UPDATE object_store_drain_info
+SET phase_type_id = $dbSetPhaseInfo.phase_type_id
+WHERE uuid = $dbSetPhaseInfo.uuid;
+	`, dbSetPhaseInfo{})
+	if err != nil {
+		return errors.Errorf("preparing insert draining phase statement: %w", err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		args := dbSetPhaseInfo{
+			UUID:        uuid,
+			PhaseTypeID: phaseTypeID,
+		}
+
+		err = tx.Query(ctx, insertStmt, args).Run()
+		if database.IsErrConstraintUnique(err) {
+			return objectstoreerrors.ErrDrainingAlreadyInProgress
+		} else if err != nil {
+			return errors.Errorf("inserting draining phase: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Errorf("setting draining phase: %w", err)
+	}
+	return nil
+}
+
+// GetActiveDrainingInfo returns the current draining information of the object
+// store. If there is no active draining phase, then this will return an error.
+// This is used to determine if the object store is currently in a draining
+// phase, and if so, which phase it is in, and the uuid of the draining
+// information, which can be used to correlate with logs and other information
+// about the draining process.
+func (s *State) GetActiveDrainingInfo(ctx context.Context) (domainobjectstore.DrainingInfo, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return domainobjectstore.DrainingInfo{}, errors.Capture(err)
 	}
 	stmt, err := s.Prepare(`
 SELECT di.uuid AS &dbGetPhaseInfo.uuid,
-	   pt.type AS &dbGetPhaseInfo.phase
+       pt.type AS &dbGetPhaseInfo.phase,
+       di.from_backend_uuid AS &dbGetPhaseInfo.from_backend_uuid,
+       di.to_backend_uuid AS &dbGetPhaseInfo.active_backend_uuid
 FROM object_store_drain_info AS di
 JOIN object_store_drain_phase_type AS pt ON di.phase_type_id=pt.id
 WHERE di.phase_type_id <= 1;
 `, dbGetPhaseInfo{})
 	if err != nil {
-		return "", "", errors.Errorf("preparing select draining phase statement: %w", err)
+		return domainobjectstore.DrainingInfo{}, errors.Errorf("preparing select draining phase statement: %w", err)
 	}
 
 	var phaseInfo dbGetPhaseInfo
@@ -576,10 +665,289 @@ WHERE di.phase_type_id <= 1;
 		return nil
 	})
 	if err != nil {
-		return "", "", errors.Errorf("getting draining phase: %w", err)
+		return domainobjectstore.DrainingInfo{}, errors.Errorf("getting draining phase: %w", err)
 	}
 
-	return phaseInfo.UUID, phaseInfo.Phase, nil
+	return domainobjectstore.DrainingInfo{
+		UUID:              phaseInfo.UUID,
+		Phase:             phaseInfo.Phase,
+		FromBackendUUID:   nullableOrNil(phaseInfo.FromBackendUUID),
+		ActiveBackendUUID: phaseInfo.ActiveBackendUUID,
+	}, nil
+}
+
+// GetObjectStoreBackend returns the current object store backend information. This is used to determine which backend the object store is currently using, and if it is using S3, then it will return the credentials for the S3 backend.
+func (s *State) GetObjectStoreBackend(ctx context.Context, uuid string) (domainobjectstore.BackendInfo, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return domainobjectstore.BackendInfo{}, errors.Capture(err)
+	}
+
+	type backendInfo struct {
+		UUID         string           `db:"uuid"`
+		TypeID       int              `db:"type_id"`
+		TypeValue    string           `db:"type"`
+		LifeID       life.Life        `db:"life_id"`
+		Endpoint     sql.Null[string] `db:"endpoint"`
+		AccessKey    sql.Null[string] `db:"static_key"`
+		SecretKey    sql.Null[string] `db:"static_secret"`
+		SessionToken sql.Null[string] `db:"session_token"`
+	}
+
+	stmt, err := s.Prepare(`
+SELECT &backendInfo.*
+FROM object_store_backend
+JOIN object_store_backend_type ON object_store_backend.type_id = object_store_backend_type.id
+LEFT JOIN object_store_backend_s3_credential ON object_store_backend.uuid = object_store_backend_s3_credential.object_store_backend_uuid
+WHERE uuid = $backendInfo.uuid`, backendInfo{})
+	if err != nil {
+		return domainobjectstore.BackendInfo{}, errors.Errorf("preparing select object store backend statement: %w", err)
+	}
+
+	var info backendInfo
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, backendInfo{UUID: uuid}).Get(&info)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return objectstoreerrors.ErrBackendNotFound
+		} else if err != nil {
+			return errors.Errorf("retrieving object store backend: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return domainobjectstore.BackendInfo{}, errors.Errorf("getting object store backend: %w", err)
+	}
+
+	return domainobjectstore.BackendInfo{
+		UUID:            info.UUID,
+		ObjectStoreType: info.TypeValue,
+		LifeID:          info.LifeID,
+		Endpoint:        nullableOrNil(info.Endpoint),
+		AccessKey:       nullableOrNil(info.AccessKey),
+		SecretKey:       nullableOrNil(info.SecretKey),
+		SessionToken:    nullableOrNil(info.SessionToken),
+	}, nil
+}
+
+// GetActiveObjectStoreBackend returns the current active object store backend
+// information. This is used to determine which backend the object store is
+// currently using, and if it is using S3, then it will return the credentials
+// for the S3 backend.
+func (s *State) GetActiveObjectStoreBackend(ctx context.Context) (domainobjectstore.BackendInfo, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return domainobjectstore.BackendInfo{}, errors.Capture(err)
+	}
+
+	type backendInfo struct {
+		UUID         string           `db:"uuid"`
+		TypeID       int              `db:"type_id"`
+		TypeValue    string           `db:"type"`
+		LifeID       life.Life        `db:"life_id"`
+		Endpoint     sql.Null[string] `db:"endpoint"`
+		AccessKey    sql.Null[string] `db:"static_key"`
+		SecretKey    sql.Null[string] `db:"static_secret"`
+		SessionToken sql.Null[string] `db:"session_token"`
+	}
+
+	stmt, err := s.Prepare(`
+SELECT &backendInfo.*
+FROM object_store_backend
+JOIN object_store_backend_type ON object_store_backend.type_id = object_store_backend_type.id
+LEFT JOIN object_store_backend_s3_credential ON object_store_backend.uuid = object_store_backend_s3_credential.object_store_backend_uuid
+WHERE life_id = 0`, backendInfo{})
+	if err != nil {
+		return domainobjectstore.BackendInfo{}, errors.Errorf("preparing select active object store backend statement: %w", err)
+	}
+
+	var info backendInfo
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt).Get(&info)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return objectstoreerrors.ErrBackendNotFound
+		} else if err != nil {
+			return errors.Errorf("retrieving active object store backend: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return domainobjectstore.BackendInfo{}, errors.Errorf("getting active object store backend: %w", err)
+	}
+
+	return domainobjectstore.BackendInfo{
+		UUID:            info.UUID,
+		ObjectStoreType: info.TypeValue,
+		LifeID:          info.LifeID,
+		Endpoint:        nullableOrNil(info.Endpoint),
+		AccessKey:       nullableOrNil(info.AccessKey),
+		SecretKey:       nullableOrNil(info.SecretKey),
+		SessionToken:    nullableOrNil(info.SessionToken),
+	}, nil
+}
+
+// SetObjectStoreBackendToS3 sets the object store to use S3 with the provided
+// credentials. This is used to update the object store information when the
+// object store is set to use S3 as the backend.
+func (s *State) SetObjectStoreBackendToS3(ctx context.Context, uuid string, credential domainobjectstore.S3Credentials) error {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	type s3Credentials struct {
+		UUID         string `db:"object_store_backend_uuid"`
+		Endpoint     string `db:"endpoint"`
+		AccessKey    string `db:"static_key"`
+		SecretKey    string `db:"static_secret"`
+		SessionToken string `db:"session_token"`
+	}
+	type uuidIdent struct {
+		UUID string `db:"uuid"`
+	}
+
+	s3Creds := s3Credentials{
+		UUID:         uuid,
+		Endpoint:     credential.Endpoint,
+		AccessKey:    credential.AccessKey,
+		SecretKey:    credential.SecretKey,
+		SessionToken: credential.SessionToken,
+	}
+	backendUUID := uuidIdent{UUID: uuid}
+
+	// Force the active backend to be marked as dying, this will ensure that
+	// we can ensure that there is only one active backend at a time, and that
+	// we can monitor the process of draining from on to another.
+
+	setBackendDyingStmt, err := s.Prepare(`
+UPDATE object_store_backend
+SET life_id = 1
+WHERE life_id = 0`)
+	if err != nil {
+		return errors.Errorf("preparing update object store backend statement: %w", err)
+	}
+
+	insertBackendInfoStmt, err := s.Prepare(`
+INSERT INTO object_store_backend (uuid, life_id, type_id)
+VALUES ($uuidIdent.uuid, 0, 1)`, backendUUID)
+	if err != nil {
+		return errors.Errorf("preparing insert object store backend statement: %w", err)
+	}
+
+	s3InsertStmt, err := s.Prepare(`
+INSERT INTO object_store_backend_s3_credential (object_store_backend_uuid, endpoint, static_key, static_secret, session_token)
+VALUES ($s3Credentials.*)
+`, s3Creds)
+	if err != nil {
+		return errors.Errorf("preparing insert object store information statement: %w", err)
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var outcome sqlair.Outcome
+		if err := tx.Query(ctx, setBackendDyingStmt).Get(&outcome); err != nil {
+			return errors.Errorf("updating object store backend: %w", err)
+		}
+		if rows, err := outcome.Result().RowsAffected(); err != nil {
+			return errors.Errorf("updating object store backend: %w", err)
+		} else if rows == 0 {
+			// If there are no active backends, then we can't trust the state
+			// of the object store, so we return an error.
+			return errors.Errorf("no object store backend active")
+		}
+
+		// Now activate the new backend by inserting the new backend
+		// information, and the credentials for the S3 backend.
+		if err := tx.Query(ctx, insertBackendInfoStmt, backendUUID).Get(&outcome); err != nil {
+			return errors.Errorf("inserting object store backend: %w", err)
+		}
+		if rows, err := outcome.Result().RowsAffected(); err != nil {
+			return errors.Errorf("inserting object store backend: %w", err)
+		} else if rows == 0 {
+			return errors.Errorf("activating s3 object store backend")
+		}
+
+		if err := tx.Query(ctx, s3InsertStmt, s3Creds).Run(); err != nil {
+			return errors.Errorf("inserting object store information: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Errorf("setting object store information: %w", err)
+	}
+	return nil
+}
+
+// MarkObjectStoreBackendAsDrained marks the object store backend as drained.
+// This is used to mark the object store backend as drained after the draining
+// process has completed. If the s3 backend has been drained, then this will
+// remove the credentials.
+func (s *State) MarkObjectStoreBackendAsDrained(ctx context.Context, uuid string) error {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	type backendType struct {
+		UUID   string    `db:"uuid"`
+		TypeID int       `db:"type_id"`
+		LifeID life.Life `db:"life_id"`
+	}
+
+	backend := backendType{UUID: uuid}
+
+	selectStmt, err := s.Prepare(`
+SELECT type_id AS &backendType.type_id,
+       life_id AS &backendType.life_id
+FROM object_store_backend
+WHERE uuid = $backendType.uuid`, backend)
+	if err != nil {
+		return errors.Errorf("preparing select object store backend statement: %w", err)
+	}
+
+	deleteStmt, err := s.Prepare(`
+DELETE FROM object_store_backend_s3_credential
+WHERE object_store_backend_uuid = $backendType.uuid`, backend)
+	if err != nil {
+		return errors.Errorf("preparing delete object store backend credentials statement: %w", err)
+	}
+
+	updateStmt, err := s.Prepare(`
+UPDATE object_store_backend
+SET life_id = 2
+WHERE uuid = $backendType.uuid AND life_id = 1`, backend)
+	if err != nil {
+		return errors.Errorf("preparing update object store backend statement: %w", err)
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, selectStmt, backend).Get(&backend); errors.Is(err, sqlair.ErrNoRows) {
+			return objectstoreerrors.ErrBackendNotFound
+		} else if err != nil {
+			return errors.Errorf("selecting object store backend: %w", err)
+		}
+
+		// If the backend is S3, then we want to remove the credentials for the
+		// backend, as the draining process has completed, and we want to ensure
+		// that the credentials are not left in the database.
+		if backend.TypeID == 1 {
+			if err := tx.Query(ctx, deleteStmt, backend).Run(); err != nil {
+				return errors.Errorf("deleting object store backend credentials: %w", err)
+			}
+		}
+
+		var outcome sqlair.Outcome
+		if err := tx.Query(ctx, updateStmt, backend).Get(&outcome); err != nil {
+			return errors.Errorf("updating object store backend: %w", err)
+		}
+		if rows, err := outcome.Result().RowsAffected(); err != nil {
+			return errors.Errorf("updating object store backend: %w", err)
+		} else if rows == 0 && backend.LifeID != life.Dead {
+			return errors.Errorf("no draining backend found")
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Errorf("marking object store backend as drained: %w", err)
+	}
+	return nil
 }
 
 // InitialWatchStatement returns the initial watch statement for the
@@ -591,6 +959,11 @@ func (s *State) InitialWatchStatement() (string, string) {
 // InitialWatchDrainingTable returns the table for the draining phase.
 func (s *State) InitialWatchDrainingTable() string {
 	return "object_store_drain_info"
+}
+
+// InitialWatchBackendTable returns the table for the object store backend.
+func (s *State) InitialWatchBackendTable() (string, string) {
+	return "object_store_backend", "SELECT uuid FROM object_store_backend WHERE life_id = 0"
 }
 
 func encodePhaseTypeID(phase coreobjectstore.Phase) (int, error) {
@@ -606,4 +979,11 @@ func encodePhaseTypeID(phase coreobjectstore.Phase) (int, error) {
 	default:
 		return -1, errors.Errorf("invalid phase %q", phase)
 	}
+}
+
+func nullableOrNil[T any](s sql.Null[T]) *T {
+	if s.Valid {
+		return &s.V
+	}
+	return nil
 }

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -6,8 +6,10 @@ package state
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/canonical/sqlair"
+	"github.com/juju/clock"
 	"github.com/juju/collections/transform"
 
 	coredatabase "github.com/juju/juju/core/database"
@@ -23,12 +25,15 @@ import (
 // State implements the domain objectstore state.
 type State struct {
 	*domain.StateBase
+
+	clock clock.Clock
 }
 
 // NewState returns a new State instance.
-func NewState(factory coredatabase.TxnRunnerFactory) *State {
+func NewState(factory coredatabase.TxnRunnerFactory, clock clock.Clock) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
+		clock:     clock,
 	}
 }
 
@@ -533,7 +538,8 @@ WHERE b.life_id = 1`, backendUUID{})
 	toBackendStmt, err := s.Prepare(`
 SELECT b.uuid AS &backendUUID.uuid
 FROM object_store_backend AS b
-WHERE b.life_id = 0`, backendUUID{})
+WHERE b.life_id = 0
+ORDER BY b.updated_at DESC`, backendUUID{})
 	if err != nil {
 		return errors.Errorf("preparing to object store backend statement: %w", err)
 	}
@@ -801,8 +807,12 @@ func (s *State) SetObjectStoreBackendToS3(ctx context.Context, uuid string, cred
 		SecretKey    string `db:"static_secret"`
 		SessionToken string `db:"session_token"`
 	}
-	type uuidIdent struct {
-		UUID string `db:"uuid"`
+	type newBackend struct {
+		UUID      string    `db:"uuid"`
+		UpdatedAt time.Time `db:"updated_at"`
+	}
+	type count struct {
+		Count int `db:"count"`
 	}
 
 	s3Creds := s3Credentials{
@@ -812,11 +822,22 @@ func (s *State) SetObjectStoreBackendToS3(ctx context.Context, uuid string, cred
 		SecretKey:    credential.SecretKey,
 		SessionToken: credential.SessionToken,
 	}
-	backendUUID := uuidIdent{UUID: uuid}
+	backend := newBackend{
+		UUID:      uuid,
+		UpdatedAt: s.clock.Now().UTC(),
+	}
 
 	// Force the active backend to be marked as dying, this will ensure that
 	// we can ensure that there is only one active backend at a time, and that
 	// we can monitor the process of draining from on to another.
+
+	getPhaseInfoStmt, err := s.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM object_store_drain_info AS di
+WHERE di.phase_type_id = 1`, count{})
+	if err != nil {
+		return errors.Errorf("preparing select draining phase statement: %w", err)
+	}
 
 	setBackendDyingStmt, err := s.Prepare(`
 UPDATE object_store_backend
@@ -827,20 +848,36 @@ WHERE life_id = 0`)
 	}
 
 	insertBackendInfoStmt, err := s.Prepare(`
-INSERT INTO object_store_backend (uuid, life_id, type_id)
-VALUES ($uuidIdent.uuid, 0, 1)`, backendUUID)
+INSERT INTO object_store_backend (uuid, life_id, type_id, updated_at)
+VALUES ($newBackend.uuid, 0, 1, $newBackend.updated_at)`, backend)
 	if err != nil {
 		return errors.Errorf("preparing insert object store backend statement: %w", err)
 	}
 
 	s3InsertStmt, err := s.Prepare(`
-INSERT INTO object_store_backend_s3_credential (object_store_backend_uuid, endpoint, static_key, static_secret, session_token)
+INSERT INTO object_store_backend_s3_credential (
+    object_store_backend_uuid, 
+    endpoint, 
+    static_key, 
+    static_secret, 
+    session_token
+)
 VALUES ($s3Credentials.*)
 `, s3Creds)
 	if err != nil {
 		return errors.Errorf("preparing insert object store information statement: %w", err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// Ensure that we're not currently in a draining phase, as we don't want
+		// to update the backend information while we're in the middle of a
+		// draining process.
+		var phaseCount count
+		if err := tx.Query(ctx, getPhaseInfoStmt).Get(&phaseCount); err != nil {
+			return errors.Errorf("checking draining phase: %w", err)
+		} else if phaseCount.Count > 0 {
+			return objectstoreerrors.ErrDrainingAlreadyInProgress
+		}
+
 		var outcome sqlair.Outcome
 		if err := tx.Query(ctx, setBackendDyingStmt).Get(&outcome); err != nil {
 			return errors.Errorf("updating object store backend: %w", err)
@@ -855,7 +892,9 @@ VALUES ($s3Credentials.*)
 
 		// Now activate the new backend by inserting the new backend
 		// information, and the credentials for the S3 backend.
-		if err := tx.Query(ctx, insertBackendInfoStmt, backendUUID).Get(&outcome); err != nil {
+		if err := tx.Query(ctx, insertBackendInfoStmt, backend).Get(&outcome); database.IsErrConstraintPrimaryKey(err) {
+			return objectstoreerrors.ErrBackendAlreadyExists
+		} else if err != nil {
 			return errors.Errorf("inserting object store backend: %w", err)
 		}
 		if rows, err := outcome.Result().RowsAffected(); err != nil {

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -516,6 +516,12 @@ WHERE uuid = $dbMetadataPath.metadata_uuid`, dbMetadataPath)
 }
 
 // StartDraining initiates the draining process for the object store.
+//
+// This method returns the following errors:
+//   - [objectstoreerrors.ErrBackendNotFound]: if it cannot find the active
+//     backend or the to backend.
+//   - [objectstoreerrors.ErrDrainingAlreadyInProgress]: if there is already an
+//     active draining phase.
 func (s *State) StartDraining(ctx context.Context, uuid string) error {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -525,6 +531,14 @@ func (s *State) StartDraining(ctx context.Context, uuid string) error {
 	phaseTypeID, err := encodePhaseTypeID(coreobjectstore.PhaseDraining)
 	if err != nil {
 		return errors.Errorf("encoding phase type id: %w", err)
+	}
+
+	checkStmt, err := s.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM object_store_drain_info
+WHERE phase_type_id <= 1`, count{})
+	if err != nil {
+		return errors.Errorf("preparing check active draining phase statement: %w", err)
 	}
 
 	fromBackendStmt, err := s.Prepare(`
@@ -538,8 +552,7 @@ WHERE b.life_id = 1`, backendUUID{})
 	toBackendStmt, err := s.Prepare(`
 SELECT b.uuid AS &backendUUID.uuid
 FROM object_store_backend AS b
-WHERE b.life_id = 0
-ORDER BY b.updated_at DESC`, backendUUID{})
+WHERE b.life_id = 0`, backendUUID{})
 	if err != nil {
 		return errors.Errorf("preparing to object store backend statement: %w", err)
 	}
@@ -553,10 +566,18 @@ VALUES ($dbSetPhaseInfo.*);
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var activeDrainingCount count
+		err := tx.Query(ctx, checkStmt).Get(&activeDrainingCount)
+		if err != nil {
+			return errors.Errorf("checking active draining phase: %w", err)
+		} else if activeDrainingCount.Count > 0 {
+			return objectstoreerrors.ErrDrainingAlreadyInProgress
+		}
+
 		// Find the active backend. We'll need to set this backend as dying
 		// if the phase is set to draining.
 		var fromBackend backendUUID
-		err := tx.Query(ctx, fromBackendStmt).Get(&fromBackend)
+		err = tx.Query(ctx, fromBackendStmt).Get(&fromBackend)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("migrating from: %w", objectstoreerrors.ErrBackendNotFound)
 		} else if err != nil {
@@ -579,9 +600,7 @@ VALUES ($dbSetPhaseInfo.*);
 		}
 
 		err = tx.Query(ctx, insertStmt, args).Run()
-		if database.IsErrConstraintUnique(err) {
-			return objectstoreerrors.ErrDrainingAlreadyInProgress
-		} else if err != nil {
+		if err != nil {
 			return errors.Errorf("inserting draining phase: %w", err)
 		}
 		return nil
@@ -595,6 +614,12 @@ VALUES ($dbSetPhaseInfo.*);
 // SetDrainingPhase sets the phase of the object store to draining. Returns an
 // error if it cannot find the active backend, the to backend, or if there is
 // already an active draining phase.
+//
+// This method returns the following errors:
+//   - [objectstoreerrors.ErrBackendNotFound]: if it cannot find the active
+//     backend or the to backend.
+//   - [objectstoreerrors.ErrDrainingAlreadyInProgress]: if there is already an
+//     active draining phase.
 func (s *State) SetDrainingPhase(ctx context.Context, uuid string, phase coreobjectstore.Phase) error {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -642,6 +667,10 @@ WHERE uuid = $dbSetPhaseInfo.uuid;
 // phase, and if so, which phase it is in, and the uuid of the draining
 // information, which can be used to correlate with logs and other information
 // about the draining process.
+//
+// This method returns the following errors:
+//   - [objectstoreerrors.ErrDrainingPhaseNotFound]: if there is no active
+//     draining phase.
 func (s *State) GetActiveDrainingInfo(ctx context.Context) (domainobjectstore.DrainingInfo, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -682,7 +711,14 @@ WHERE di.phase_type_id <= 1;
 	}, nil
 }
 
-// GetObjectStoreBackend returns the current object store backend information. This is used to determine which backend the object store is currently using, and if it is using S3, then it will return the credentials for the S3 backend.
+// GetObjectStoreBackend returns the current object store backend information.
+// This is used to determine which backend the object store is currently using,
+// and if it is using S3, then it will return the credentials for the S3
+// backend.
+//
+// This method returns the following errors:
+//   - [objectstoreerrors.ErrBackendNotFound]: if it cannot find the backend with
+//     the specified uuid.
 func (s *State) GetObjectStoreBackend(ctx context.Context, uuid string) (domainobjectstore.BackendInfo, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -739,6 +775,10 @@ WHERE uuid = $backendInfo.uuid`, backendInfo{})
 // information. This is used to determine which backend the object store is
 // currently using, and if it is using S3, then it will return the credentials
 // for the S3 backend.
+//
+// This method returns the following errors:
+//   - [objectstoreerrors.ErrBackendNotFound]: if it cannot find the active
+//     backend.
 func (s *State) GetActiveObjectStoreBackend(ctx context.Context) (domainobjectstore.BackendInfo, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -794,6 +834,13 @@ WHERE life_id = 0`, backendInfo{})
 // SetObjectStoreBackendToS3 sets the object store to use S3 with the provided
 // credentials. This is used to update the object store information when the
 // object store is set to use S3 as the backend.
+//
+// This method returns the following errors:
+//   - [objectstoreerrors.ErrDrainingAlreadyInProgress]: if there is already an
+//     active draining phase, as we don't want to update the backend information
+//     while we're in the middle of a draining process.
+//   - [objectstoreerrors.ErrBackendAlreadyExists]: if there is already a backend
+//     with the specified uuid.
 func (s *State) SetObjectStoreBackendToS3(ctx context.Context, uuid string, credential domainobjectstore.S3Credentials) error {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -918,6 +965,13 @@ VALUES ($s3Credentials.*)
 // This is used to mark the object store backend as drained after the draining
 // process has completed. If the s3 backend has been drained, then this will
 // remove the credentials.
+//
+// This method returns the following errors:
+//   - [objectstoreerrors.ErrBackendNotFound]: if it cannot find the backend with
+//     the specified uuid.
+//   - [objectstoreerrors.ErrNoDrainingBackendFound]: if there is no draining
+//     backend found with the specified uuid, which indicates that the draining
+//     process has not been initiated for the specified backend.
 func (s *State) MarkObjectStoreBackendAsDrained(ctx context.Context, uuid string) error {
 	db, err := s.DB(ctx)
 	if err != nil {

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -22,6 +22,14 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
+const (
+	// defaultFileBackendUUID is the default uuid for the file backend.
+	// Although, this is only used for testing, it's here to ensure that
+	// we have a consistent uuid for all file based backends. This must not be
+	// changed.
+	defaultFileBackendUUID = "f44ea516-22ad-4161-b2bd-cbae9d7a9412"
+)
+
 // State implements the domain objectstore state.
 type State struct {
 	*domain.StateBase

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -734,14 +734,13 @@ func (s *State) GetObjectStoreBackend(ctx context.Context, uuid string) (domaino
 	}
 
 	type backendInfo struct {
-		UUID         string           `db:"uuid"`
-		TypeID       int              `db:"type_id"`
-		TypeValue    string           `db:"type"`
-		LifeID       life.Life        `db:"life_id"`
-		Endpoint     sql.Null[string] `db:"endpoint"`
-		AccessKey    sql.Null[string] `db:"static_key"`
-		SecretKey    sql.Null[string] `db:"static_secret"`
-		SessionToken sql.Null[string] `db:"session_token"`
+		UUID      string           `db:"uuid"`
+		TypeID    int              `db:"type_id"`
+		TypeValue string           `db:"type"`
+		LifeID    life.Life        `db:"life_id"`
+		Endpoint  sql.Null[string] `db:"endpoint"`
+		AccessKey sql.Null[string] `db:"static_key"`
+		SecretKey sql.Null[string] `db:"static_secret"`
 	}
 
 	stmt, err := s.Prepare(`
@@ -775,7 +774,6 @@ WHERE uuid = $backendInfo.uuid`, backendInfo{})
 		Endpoint:        nullableOrNil(info.Endpoint),
 		AccessKey:       nullableOrNil(info.AccessKey),
 		SecretKey:       nullableOrNil(info.SecretKey),
-		SessionToken:    nullableOrNil(info.SessionToken),
 	}, nil
 }
 
@@ -794,14 +792,13 @@ func (s *State) GetActiveObjectStoreBackend(ctx context.Context) (domainobjectst
 	}
 
 	type backendInfo struct {
-		UUID         string           `db:"uuid"`
-		TypeID       int              `db:"type_id"`
-		TypeValue    string           `db:"type"`
-		LifeID       life.Life        `db:"life_id"`
-		Endpoint     sql.Null[string] `db:"endpoint"`
-		AccessKey    sql.Null[string] `db:"static_key"`
-		SecretKey    sql.Null[string] `db:"static_secret"`
-		SessionToken sql.Null[string] `db:"session_token"`
+		UUID      string           `db:"uuid"`
+		TypeID    int              `db:"type_id"`
+		TypeValue string           `db:"type"`
+		LifeID    life.Life        `db:"life_id"`
+		Endpoint  sql.Null[string] `db:"endpoint"`
+		AccessKey sql.Null[string] `db:"static_key"`
+		SecretKey sql.Null[string] `db:"static_secret"`
 	}
 
 	stmt, err := s.Prepare(`
@@ -835,7 +832,6 @@ WHERE life_id = 0`, backendInfo{})
 		Endpoint:        nullableOrNil(info.Endpoint),
 		AccessKey:       nullableOrNil(info.AccessKey),
 		SecretKey:       nullableOrNil(info.SecretKey),
-		SessionToken:    nullableOrNil(info.SessionToken),
 	}, nil
 }
 
@@ -856,11 +852,10 @@ func (s *State) SetObjectStoreBackendToS3(ctx context.Context, uuid string, cred
 	}
 
 	type s3Credentials struct {
-		UUID         string `db:"object_store_backend_uuid"`
-		Endpoint     string `db:"endpoint"`
-		AccessKey    string `db:"static_key"`
-		SecretKey    string `db:"static_secret"`
-		SessionToken string `db:"session_token"`
+		UUID      string `db:"object_store_backend_uuid"`
+		Endpoint  string `db:"endpoint"`
+		AccessKey string `db:"static_key"`
+		SecretKey string `db:"static_secret"`
 	}
 	type newBackend struct {
 		UUID      string    `db:"uuid"`
@@ -871,11 +866,10 @@ func (s *State) SetObjectStoreBackendToS3(ctx context.Context, uuid string, cred
 	}
 
 	s3Creds := s3Credentials{
-		UUID:         uuid,
-		Endpoint:     credential.Endpoint,
-		AccessKey:    credential.AccessKey,
-		SecretKey:    credential.SecretKey,
-		SessionToken: credential.SessionToken,
+		UUID:      uuid,
+		Endpoint:  credential.Endpoint,
+		AccessKey: credential.AccessKey,
+		SecretKey: credential.SecretKey,
 	}
 	backend := newBackend{
 		UUID:      uuid,
@@ -914,8 +908,7 @@ INSERT INTO object_store_backend_s3_credential (
     object_store_backend_uuid, 
     endpoint, 
     static_key, 
-    static_secret, 
-    session_token
+    static_secret
 )
 VALUES ($s3Credentials.*)
 `, s3Creds)

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -841,8 +841,8 @@ WHERE di.phase_type_id = 1`, count{})
 
 	setBackendDyingStmt, err := s.Prepare(`
 UPDATE object_store_backend
-SET life_id = 1
-WHERE life_id = 0`)
+SET life_id = 1, updated_at = $newBackend.updated_at
+WHERE life_id = 0`, backend)
 	if err != nil {
 		return errors.Errorf("preparing update object store backend statement: %w", err)
 	}
@@ -879,7 +879,7 @@ VALUES ($s3Credentials.*)
 		}
 
 		var outcome sqlair.Outcome
-		if err := tx.Query(ctx, setBackendDyingStmt).Get(&outcome); err != nil {
+		if err := tx.Query(ctx, setBackendDyingStmt, backend).Get(&outcome); err != nil {
 			return errors.Errorf("updating object store backend: %w", err)
 		}
 		if rows, err := outcome.Result().RowsAffected(); err != nil {

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -27,7 +27,7 @@ const (
 	// Although, this is only used for testing, it's here to ensure that
 	// we have a consistent uuid for all file based backends. This must not be
 	// changed.
-	defaultFileBackendUUID = "f44ea516-22ad-4161-b2bd-cbae9d7a9412"
+	defaultFileBackendUUID = "653813f9-2896-5332-8cbe-629a337a56a3"
 )
 
 // State implements the domain objectstore state.

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -552,7 +552,7 @@ VALUES ($dbSetPhaseInfo.*);
 		var fromBackend backendUUID
 		err := tx.Query(ctx, fromBackendStmt).Get(&fromBackend)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("migrating from: %v", objectstoreerrors.ErrBackendNotFound)
+			return errors.Errorf("migrating from: %w", objectstoreerrors.ErrBackendNotFound)
 		} else if err != nil {
 			return errors.Capture(err)
 		}
@@ -560,7 +560,7 @@ VALUES ($dbSetPhaseInfo.*);
 		var toBackend backendUUID
 		err = tx.Query(ctx, toBackendStmt).Get(&toBackend)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("migrating to: %v", objectstoreerrors.ErrBackendNotFound)
+			return errors.Errorf("migrating to: %w", objectstoreerrors.ErrBackendNotFound)
 		} else if err != nil {
 			return errors.Capture(err)
 		}

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/tc"
 
 	coreobjectstore "github.com/juju/juju/core/objectstore"
@@ -28,14 +29,14 @@ func TestStateSuite(t *testing.T) {
 }
 
 func (s *stateSuite) TestGetMetadataNotFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	_, err := st.GetMetadata(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrNotFound)
 }
 
 func (s *stateSuite) TestGetMetadataFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid := tc.Must(c, coreobjectstore.NewUUID).String()
 
@@ -55,7 +56,7 @@ func (s *stateSuite) TestGetMetadataFound(c *tc.C) {
 }
 
 func (s *stateSuite) TestGetMetadataBySHA256Found(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid1 := tc.Must(c, coreobjectstore.NewUUID).String()
 	uuid2 := tc.Must(c, coreobjectstore.NewUUID).String()
@@ -90,14 +91,14 @@ func (s *stateSuite) TestGetMetadataBySHA256Found(c *tc.C) {
 }
 
 func (s *stateSuite) TestGetMetadataBySHA256NotFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	_, err := st.GetMetadataBySHA256(c.Context(), "deadbeef")
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrNotFound)
 }
 
 func (s *stateSuite) TestGetMetadataBySHA256PrefixFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid1 := tc.Must(c, coreobjectstore.NewUUID).String()
 	uuid2 := tc.Must(c, coreobjectstore.NewUUID).String()
@@ -136,14 +137,14 @@ func (s *stateSuite) TestGetMetadataBySHA256PrefixFound(c *tc.C) {
 }
 
 func (s *stateSuite) TestGetMetadataBySHA256PrefixNotFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	_, err := st.GetMetadataBySHA256Prefix(c.Context(), "deadbeef")
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrNotFound)
 }
 
 func (s *stateSuite) TestListMetadataFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid := tc.Must(c, coreobjectstore.NewUUID).String()
 
@@ -163,7 +164,7 @@ func (s *stateSuite) TestListMetadataFound(c *tc.C) {
 }
 
 func (s *stateSuite) TestPutMetadata(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid := tc.Must(c, coreobjectstore.NewUUID).String()
 
@@ -177,11 +178,8 @@ func (s *stateSuite) TestPutMetadata(c *tc.C) {
 	uuid, err := st.PutMetadata(c.Context(), uuid, metadata)
 	c.Assert(err, tc.ErrorIsNil)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
 	var received coreobjectstore.Metadata
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT path, size, sha_256, sha_384 FROM v_object_store_metadata WHERE uuid = ?`, uuid)
 		return row.Scan(&received.Path, &received.Size, &received.SHA256, &received.SHA384)
@@ -191,7 +189,7 @@ SELECT path, size, sha_256, sha_384 FROM v_object_store_metadata WHERE uuid = ?`
 }
 
 func (s *stateSuite) TestPutMetadataConflict(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	// UUID does not matter in this test, because we are testing the conflict of
 	// the hash and size, which is independent of the UUID.
@@ -215,7 +213,7 @@ func (s *stateSuite) TestPutMetadataConflict(c *tc.C) {
 }
 
 func (s *stateSuite) TestPutMetadataConflictDifferentHash(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	// UUID does not matter in this test, because we are testing the conflict of
 	// the hash and size, which is independent of the UUID.
@@ -246,7 +244,7 @@ func (s *stateSuite) TestPutMetadataConflictDifferentHash(c *tc.C) {
 }
 
 func (s *stateSuite) TestPutMetadataWithSameHashesAndSize(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	// UUID does not matter in this test, because we are testing the conflict of
 	// the hash and size, which is independent of the UUID.
@@ -275,7 +273,7 @@ func (s *stateSuite) TestPutMetadataWithSameHashesAndSize(c *tc.C) {
 }
 
 func (s *stateSuite) TestPutMetadataWithSameSHA256AndSize(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	// UUID does not matter in this test, because we are testing the conflict of
 	// the hash and size, which is independent of the UUID.
@@ -306,7 +304,7 @@ func (s *stateSuite) TestPutMetadataWithSameSHA256AndSize(c *tc.C) {
 }
 
 func (s *stateSuite) TestPutMetadataWithSameSHA384AndSize(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	// UUID does not matter in this test, because we are testing the conflict of
 	// the hash and size, which is independent of the UUID.
@@ -337,7 +335,7 @@ func (s *stateSuite) TestPutMetadataWithSameSHA384AndSize(c *tc.C) {
 }
 
 func (s *stateSuite) TestPutMetadataWithSameHashDifferentSize(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	// Test if the hash is the same but the size is different. The root
 	// cause of this, is if the hash is the same, but the size is different.
@@ -367,7 +365,7 @@ func (s *stateSuite) TestPutMetadataWithSameHashDifferentSize(c *tc.C) {
 }
 
 func (s *stateSuite) TestPutMetadataMultipleTimes(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	// Ensure that we can add the same metadata multiple times.
 	metadatas := make([]coreobjectstore.Metadata, 10)
@@ -394,7 +392,7 @@ func (s *stateSuite) TestPutMetadataMultipleTimes(c *tc.C) {
 }
 
 func (s *stateSuite) TestPutMetadataWithControllerIDHint(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid := tc.Must(c, coreobjectstore.NewUUID).String()
 
@@ -408,11 +406,8 @@ func (s *stateSuite) TestPutMetadataWithControllerIDHint(c *tc.C) {
 	uuid, err := st.PutMetadataWithControllerIDHint(c.Context(), uuid, metadata, "1")
 	c.Assert(err, tc.ErrorIsNil)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
 	var nodeID string
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT node_id FROM object_store_placement WHERE uuid = ?`, uuid)
 		return row.Scan(&nodeID)
@@ -422,7 +417,7 @@ SELECT node_id FROM object_store_placement WHERE uuid = ?`, uuid)
 }
 
 func (s *stateSuite) TestPutMetadataWithControllerIDHintMultipleTimes(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	// Ensure that we can add the same metadata multiple times.
 	metadatas := make([]coreobjectstore.Metadata, 10)
@@ -449,7 +444,7 @@ func (s *stateSuite) TestPutMetadataWithControllerIDHintMultipleTimes(c *tc.C) {
 }
 
 func (s *stateSuite) TestAddControllerIDHint(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid := tc.Must(c, coreobjectstore.NewUUID).String()
 
@@ -466,11 +461,8 @@ func (s *stateSuite) TestAddControllerIDHint(c *tc.C) {
 	err = st.AddControllerIDHint(c.Context(), "sha384", "2")
 	c.Assert(err, tc.ErrorIsNil)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
 	var nodes []string
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, `
 SELECT p.node_id
 FROM object_store_placement AS p
@@ -494,14 +486,14 @@ WHERE m.sha_384 = ?`, "sha384")
 }
 
 func (s *stateSuite) TestAddControllerIDHintNotFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	err := st.AddControllerIDHint(c.Context(), "non-existent-sha384", "1")
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrNotFound)
 }
 
 func (s *stateSuite) TestGetControllerIDHints(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid := tc.Must(c, coreobjectstore.NewUUID).String()
 
@@ -525,7 +517,7 @@ func (s *stateSuite) TestGetControllerIDHints(c *tc.C) {
 }
 
 func (s *stateSuite) TestGetControllerIDHintsNoHints(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	hints, err := st.GetControllerIDHints(c.Context(), "sha384")
 	c.Assert(err, tc.ErrorIsNil)
@@ -533,14 +525,14 @@ func (s *stateSuite) TestGetControllerIDHintsNoHints(c *tc.C) {
 }
 
 func (s *stateSuite) TestRemoveMetadataNotExists(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	err := st.RemoveMetadata(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrNotFound)
 }
 
 func (s *stateSuite) TestRemoveMetadataDoesNotRemoveMetadataIfReferenced(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid1 := tc.Must(c, coreobjectstore.NewUUID).String()
 	uuid2 := tc.Must(c, coreobjectstore.NewUUID).String()
@@ -573,7 +565,7 @@ func (s *stateSuite) TestRemoveMetadataDoesNotRemoveMetadataIfReferenced(c *tc.C
 }
 
 func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid1 := tc.Must(c, coreobjectstore.NewUUID).String()
 	uuid2 := tc.Must(c, coreobjectstore.NewUUID).String()
@@ -629,7 +621,7 @@ func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *tc.C) {
 }
 
 func (s *stateSuite) TestRemoveMetadataThenAddAgain(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid1 := tc.Must(c, coreobjectstore.NewUUID).String()
 	uuid2 := tc.Must(c, coreobjectstore.NewUUID).String()
@@ -656,7 +648,7 @@ func (s *stateSuite) TestRemoveMetadataThenAddAgain(c *tc.C) {
 }
 
 func (s *stateSuite) TestListMetadata(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	uuid1 := tc.Must(c, coreobjectstore.NewUUID).String()
 
@@ -678,7 +670,7 @@ func (s *stateSuite) TestListMetadata(c *tc.C) {
 }
 
 func (s *stateSuite) TestListMetadataNoRows(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	metadatas, err := st.ListMetadata(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -686,7 +678,7 @@ func (s *stateSuite) TestListMetadataNoRows(c *tc.C) {
 }
 
 func (s *stateSuite) TestGetActiveDrainingInfo(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	_, err := st.GetActiveDrainingInfo(c.Context())
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingPhaseNotFound)
@@ -710,11 +702,8 @@ func (s *stateSuite) TestGetActiveDrainingInfo(c *tc.C) {
 	c.Check(info.UUID, tc.Equals, "foo")
 	c.Check(info.ActiveBackendUUID, tc.Equals, backendUUID)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
 	var fromBackendUUID string
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT uuid FROM object_store_backend
 WHERE life_id = 1`)
@@ -726,7 +715,7 @@ WHERE life_id = 1`)
 }
 
 func (s *stateSuite) TestSetDrainingPhase(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
@@ -753,19 +742,16 @@ func (s *stateSuite) TestSetDrainingPhase(c *tc.C) {
 }
 
 func (s *stateSuite) TestStartDrainingMissingFromBackend(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	err := st.StartDraining(c.Context(), "foo")
 	c.Assert(err, tc.ErrorMatches, ".*migrating from: backend not found")
 }
 
 func (s *stateSuite) TestStartDrainingMissingToBackend(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
 UPDATE object_store_backend
 SET life_id = 1`)
@@ -777,8 +763,8 @@ SET life_id = 1`)
 	c.Assert(err, tc.ErrorMatches, ".*migrating to: backend not found")
 }
 
-func (s *stateSuite) TestSetObjectStoreBackendToS3(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+func (s *stateSuite) TestStartDraining(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
@@ -791,13 +777,148 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3(c *tc.C) {
 	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
+	err = st.StartDraining(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.StartDraining(c.Context(), "bar")
+	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingAlreadyInProgress)
+}
+
+func (s *stateSuite) TestStartDrainingAndSetDrainingPhase(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
+
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:     "https://s3.example.com",
+		AccessKey:    "access-key",
+		SecretKey:    "secret-key",
+		SessionToken: "session-token",
+	}
+
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.StartDraining(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseCompleted)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *stateSuite) TestSetObjectStoreBackendToS3CalledTwice(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
+
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:     "https://s3.example.com",
+		AccessKey:    "access-key",
+		SecretKey:    "secret-key",
+		SessionToken: "session-token",
+	}
+
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Force the old backend to be marked as dead.
+	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+
+	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
+	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrBackendAlreadyExists)
+}
+
+func (s *stateSuite) TestSetObjectStoreBackendToS3MultipleTimes(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
+
+	backendUUID0 := tc.Must(c, coreobjectstore.NewUUID).String()
+	backendUUID1 := tc.Must(c, coreobjectstore.NewUUID).String()
+	backendUUID2 := tc.Must(c, coreobjectstore.NewUUID).String()
+
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:     "https://s3.example.com",
+		AccessKey:    "access-key",
+		SecretKey:    "secret-key",
+		SessionToken: "session-token",
+	}
+
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID0, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Force the file backend to be marked as dead.
+	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+
+	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID1, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.StartDraining(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Force the first backend to be marked as dead.
+	s.markBackendAsDead(c, backendUUID0)
+
+	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID2, creds)
+	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingAlreadyInProgress)
+
+	err = st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseCompleted)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID2, creds)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *stateSuite) TestSetObjectStoreBackendToS3WithActiveDrainingBackend(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
+
+	backendUUID0 := tc.Must(c, coreobjectstore.NewUUID).String()
+	backendUUID1 := tc.Must(c, coreobjectstore.NewUUID).String()
+
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:     "https://s3.example.com",
+		AccessKey:    "access-key",
+		SecretKey:    "secret-key",
+		SessionToken: "session-token",
+	}
+
+	// This backend is ignored, as the draining phase is not active.
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID0, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Force the file backend to be marked as dead.
+	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+
+	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID1, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.StartDraining(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIsNil)
+
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info, tc.DeepEquals, domainobjectstore.DrainingInfo{
+		Phase:             string(coreobjectstore.PhaseDraining),
+		UUID:              "foo",
+		FromBackendUUID:   new(backendUUID0),
+		ActiveBackendUUID: backendUUID1,
+	})
+}
+
+func (s *stateSuite) TestSetObjectStoreBackendToS3(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
+
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:     "https://s3.example.com",
+		AccessKey:    "access-key",
+		SecretKey:    "secret-key",
+		SessionToken: "session-token",
+	}
+
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
 	var lifeID, typeID int
 	var dyingTypeID int
 	var endpoint, accessKey, secretKey, sessionToken string
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT life_id, type_id FROM object_store_backend
 WHERE uuid = ?`, backendUUID)
@@ -836,7 +957,7 @@ WHERE object_store_backend_uuid = ?`, backendUUID)
 }
 
 func (s *stateSuite) TestMarkObjectStoreBackendAsDrained(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	drainingUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	activeUUID := tc.Must(c, coreobjectstore.NewUUID).String()
@@ -852,6 +973,9 @@ func (s *stateSuite) TestMarkObjectStoreBackendAsDrained(c *tc.C) {
 	err := st.SetObjectStoreBackendToS3(c.Context(), drainingUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
+	// Force the old backend to be marked as dead.
+	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+
 	// Second call marks the first S3 backend as dying and activates a new one.
 	err = st.SetObjectStoreBackendToS3(c.Context(), activeUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
@@ -859,12 +983,9 @@ func (s *stateSuite) TestMarkObjectStoreBackendAsDrained(c *tc.C) {
 	err = st.MarkObjectStoreBackendAsDrained(c.Context(), drainingUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
 	var drainingLifeID, activeLifeID int
 	var credsCount int
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT life_id FROM object_store_backend
 WHERE uuid = ?`, drainingUUID)
@@ -896,7 +1017,7 @@ WHERE uuid = ?`, activeUUID)
 }
 
 func (s *stateSuite) TestMarkObjectStoreBackendAsDrainedReentrant(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	drainingUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	activeUUID := tc.Must(c, coreobjectstore.NewUUID).String()
@@ -911,6 +1032,9 @@ func (s *stateSuite) TestMarkObjectStoreBackendAsDrainedReentrant(c *tc.C) {
 	err := st.SetObjectStoreBackendToS3(c.Context(), drainingUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
+	// Force the old backend to be marked as dead.
+	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+
 	// Second promotion marks the first S3 backend as dying and activates a new
 	// one.
 	err = st.SetObjectStoreBackendToS3(c.Context(), activeUUID, creds)
@@ -924,12 +1048,9 @@ func (s *stateSuite) TestMarkObjectStoreBackendAsDrainedReentrant(c *tc.C) {
 	err = st.MarkObjectStoreBackendAsDrained(c.Context(), drainingUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
 	var lifeID int
 	var credsCount int
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT life_id FROM object_store_backend
 WHERE uuid = ?`, drainingUUID)
@@ -953,13 +1074,10 @@ WHERE object_store_backend_uuid = ?`, drainingUUID)
 }
 
 func (s *stateSuite) TestGetActiveObjectStoreBackend(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
-
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	var activeUUID string
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT uuid FROM object_store_backend
 WHERE life_id = 0`)
@@ -979,7 +1097,7 @@ WHERE life_id = 0`)
 }
 
 func (s *stateSuite) TestGetActiveObjectStoreBackendS3(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
@@ -1008,12 +1126,9 @@ func (s *stateSuite) TestGetActiveObjectStoreBackendS3(c *tc.C) {
 }
 
 func (s *stateSuite) TestGetActiveObjectStoreBackendNotFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
 UPDATE object_store_backend
 SET life_id = 1`)
@@ -1026,13 +1141,10 @@ SET life_id = 1`)
 }
 
 func (s *stateSuite) TestGetObjectStoreBackend(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
-
-	runner, err := s.TxnRunnerFactory()(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	var backendUUID string
-	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT uuid FROM object_store_backend
 WHERE life_id = 0`)
@@ -1052,7 +1164,7 @@ WHERE life_id = 0`)
 }
 
 func (s *stateSuite) TestGetObjectStoreBackendS3(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
@@ -1082,10 +1194,21 @@ func (s *stateSuite) TestGetObjectStoreBackendS3(c *tc.C) {
 }
 
 func (s *stateSuite) TestGetObjectStoreBackendNotFound(c *tc.C) {
-	st := NewState(s.TxnRunnerFactory())
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
 
 	missingUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 
 	_, err := st.GetObjectStoreBackend(c.Context(), missingUUID)
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrBackendNotFound)
+}
+
+func (s *stateSuite) markBackendAsDead(c *tc.C, uuid string) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE object_store_backend
+SET life_id = 2
+WHERE uuid = ?`, uuid)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
 }

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 
@@ -817,7 +818,7 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3CalledTwice(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Force the old backend to be marked as dead.
-	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
 
 	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrBackendAlreadyExists)
@@ -840,7 +841,7 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3MultipleTimes(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Force the file backend to be marked as dead.
-	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
 
 	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID1, creds)
 	c.Assert(err, tc.ErrorIsNil)
@@ -878,7 +879,7 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3WithActiveDrainingBackend(c *t
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Force the file backend to be marked as dead.
-	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
 
 	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID1, creds)
 	c.Assert(err, tc.ErrorIsNil)
@@ -967,7 +968,7 @@ func (s *stateSuite) TestMarkObjectStoreBackendAsDrained(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Force the old backend to be marked as dead.
-	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
 
 	// Second call marks the first S3 backend as dying and activates a new one.
 	err = st.SetObjectStoreBackendToS3(c.Context(), activeUUID, creds)
@@ -1026,7 +1027,7 @@ func (s *stateSuite) TestMarkObjectStoreBackendAsDrainedReentrant(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Force the old backend to be marked as dead.
-	s.markBackendAsDead(c, "f44ea516-22ad-4161-b2bd-cbae9d7a9412")
+	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
 
 	// Second promotion marks the first S3 backend as dying and activates a new
 	// one.
@@ -1188,8 +1189,16 @@ func (s *stateSuite) TestGetObjectStoreBackendNotFound(c *tc.C) {
 }
 
 func (s *stateSuite) TestDefaultFileBackendUUID(c *tc.C) {
+	// Juju UUID namespace that we (should) use for all Juju well-known UUIDs.
+	jujuUUIDNamespace := "96bb15e6-8b85-448b-9fce-ede1a1700e64"
+	namespaceUUID, err := uuid.Parse(jujuUUIDNamespace)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fileObjectStoreUUID := uuid.NewSHA1(namespaceUUID, []byte("juju.objectstore.file.backend"))
+	c.Assert(fileObjectStoreUUID.String(), tc.Equals, defaultFileBackendUUID)
+
 	var backendUUID string
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT uuid FROM object_store_backend
 WHERE type_id = 0`)

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/juju/tc"
 
 	coreobjectstore "github.com/juju/juju/core/objectstore"
+	"github.com/juju/juju/domain/life"
+	domainobjectstore "github.com/juju/juju/domain/objectstore"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/errors"
@@ -683,47 +685,407 @@ func (s *stateSuite) TestListMetadataNoRows(c *tc.C) {
 	c.Assert(metadatas, tc.HasLen, 0)
 }
 
-func (s *stateSuite) TestGetActiveDrainingPhase(c *tc.C) {
+func (s *stateSuite) TestGetActiveDrainingInfo(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	_, _, err := st.GetActiveDrainingPhase(c.Context())
+	_, err := st.GetActiveDrainingInfo(c.Context())
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingPhaseNotFound)
 
-	err = st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseDraining)
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	}
+
+	err = st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, phase, err := st.GetActiveDrainingPhase(c.Context())
+	err = st.StartDraining(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(phase, tc.Equals, coreobjectstore.PhaseDraining)
+
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.Phase, tc.Equals, string(coreobjectstore.PhaseDraining))
+	c.Check(info.UUID, tc.Equals, "foo")
+	c.Check(info.ActiveBackendUUID, tc.Equals, backendUUID)
+
+	runner, err := s.TxnRunnerFactory()(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var fromBackendUUID string
+	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT uuid FROM object_store_backend
+WHERE life_id = 1`)
+		return row.Scan(&fromBackendUUID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(info.FromBackendUUID, tc.NotNil)
+	c.Check(*info.FromBackendUUID, tc.Equals, fromBackendUUID)
 }
 
 func (s *stateSuite) TestSetDrainingPhase(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	err := st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseDraining)
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	}
+
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, phase, err := st.GetActiveDrainingPhase(c.Context())
+	err = st.StartDraining(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(phase, tc.Equals, coreobjectstore.PhaseDraining)
+
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.Phase, tc.Equals, string(coreobjectstore.PhaseDraining))
 
 	err = st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseCompleted)
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, _, err = st.GetActiveDrainingPhase(c.Context())
+	_, err = st.GetActiveDrainingInfo(c.Context())
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingPhaseNotFound)
 }
 
-func (s *stateSuite) TestSetDrainingPhaseWithMultipleActive(c *tc.C) {
+func (s *stateSuite) TestStartDrainingMissingFromBackend(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	err := st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseDraining)
+	err := st.StartDraining(c.Context(), "foo")
+	c.Assert(err, tc.ErrorMatches, ".*migrating from: backend not found")
+}
+
+func (s *stateSuite) TestStartDrainingMissingToBackend(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	runner, err := s.TxnRunnerFactory()(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, phase, err := st.GetActiveDrainingPhase(c.Context())
+	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE object_store_backend
+SET life_id = 1`)
+		return err
+	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(phase, tc.Equals, coreobjectstore.PhaseDraining)
 
-	err = st.SetDrainingPhase(c.Context(), "bar", coreobjectstore.PhaseDraining)
-	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingAlreadyInProgress)
+	err = st.StartDraining(c.Context(), "foo")
+	c.Assert(err, tc.ErrorMatches, ".*migrating to: backend not found")
+}
+
+func (s *stateSuite) TestSetObjectStoreBackendToS3(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:     "https://s3.example.com",
+		AccessKey:    "access-key",
+		SecretKey:    "secret-key",
+		SessionToken: "session-token",
+	}
+
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	runner, err := s.TxnRunnerFactory()(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var lifeID, typeID int
+	var dyingTypeID int
+	var endpoint, accessKey, secretKey, sessionToken string
+	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT life_id, type_id FROM object_store_backend
+WHERE uuid = ?`, backendUUID)
+		if err := row.Scan(&lifeID, &typeID); err != nil {
+			return errors.Errorf("querying s3 backend: %w", err)
+		}
+
+		row = tx.QueryRowContext(ctx, `
+SELECT type_id FROM object_store_backend
+WHERE life_id = 1`)
+		if err := row.Scan(&dyingTypeID); err != nil {
+			return errors.Errorf("querying dying backend: %w", err)
+		}
+
+		row = tx.QueryRowContext(ctx, `
+SELECT endpoint, static_key, static_secret, session_token
+FROM object_store_backend_s3_credential
+WHERE object_store_backend_uuid = ?`, backendUUID)
+		if err := row.Scan(&endpoint, &accessKey, &secretKey, &sessionToken); err != nil {
+			return errors.Errorf("querying backend credentials: %w", err)
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(lifeID, tc.Equals, 0)
+	c.Check(typeID, tc.Equals, 1)
+
+	c.Check(dyingTypeID, tc.Equals, 0)
+
+	c.Check(endpoint, tc.Equals, creds.Endpoint)
+	c.Check(accessKey, tc.Equals, creds.AccessKey)
+	c.Check(secretKey, tc.Equals, creds.SecretKey)
+	c.Check(sessionToken, tc.Equals, creds.SessionToken)
+}
+
+func (s *stateSuite) TestMarkObjectStoreBackendAsDrained(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	drainingUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	activeUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	}
+
+	// First call promotes an S3 backend and marks the default file backend as
+	// dying.
+	err := st.SetObjectStoreBackendToS3(c.Context(), drainingUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Second call marks the first S3 backend as dying and activates a new one.
+	err = st.SetObjectStoreBackendToS3(c.Context(), activeUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), drainingUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	runner, err := s.TxnRunnerFactory()(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var drainingLifeID, activeLifeID int
+	var credsCount int
+	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT life_id FROM object_store_backend
+WHERE uuid = ?`, drainingUUID)
+		if err := row.Scan(&drainingLifeID); err != nil {
+			return errors.Errorf("querying drained backend: %w", err)
+		}
+
+		row = tx.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM object_store_backend_s3_credential
+WHERE object_store_backend_uuid = ?`, drainingUUID)
+		if err := row.Scan(&credsCount); err != nil {
+			return errors.Errorf("counting drained backend credentials: %w", err)
+		}
+
+		row = tx.QueryRowContext(ctx, `
+SELECT life_id FROM object_store_backend
+WHERE uuid = ?`, activeUUID)
+		if err := row.Scan(&activeLifeID); err != nil {
+			return errors.Errorf("querying active backend: %w", err)
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(drainingLifeID, tc.Equals, 2)
+	c.Check(credsCount, tc.Equals, 0)
+	c.Check(activeLifeID, tc.Equals, 0)
+}
+
+func (s *stateSuite) TestMarkObjectStoreBackendAsDrainedReentrant(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	drainingUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	activeUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	}
+
+	// First promotion marks the default file backend as dying.
+	err := st.SetObjectStoreBackendToS3(c.Context(), drainingUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Second promotion marks the first S3 backend as dying and activates a new
+	// one.
+	err = st.SetObjectStoreBackendToS3(c.Context(), activeUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// First call should mark the draining backend dead.
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), drainingUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Second call should be a no-op.
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), drainingUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	runner, err := s.TxnRunnerFactory()(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var lifeID int
+	var credsCount int
+	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT life_id FROM object_store_backend
+WHERE uuid = ?`, drainingUUID)
+		if err := row.Scan(&lifeID); err != nil {
+			return errors.Errorf("querying drained backend: %w", err)
+		}
+
+		row = tx.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM object_store_backend_s3_credential
+WHERE object_store_backend_uuid = ?`, drainingUUID)
+		if err := row.Scan(&credsCount); err != nil {
+			return errors.Errorf("counting drained backend credentials: %w", err)
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(lifeID, tc.Equals, 2)
+	c.Check(credsCount, tc.Equals, 0)
+}
+
+func (s *stateSuite) TestGetActiveObjectStoreBackend(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	runner, err := s.TxnRunnerFactory()(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var activeUUID string
+	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT uuid FROM object_store_backend
+WHERE life_id = 0`)
+		return row.Scan(&activeUUID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	info, err := st.GetActiveObjectStoreBackend(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.UUID, tc.Equals, activeUUID)
+	c.Check(info.ObjectStoreType, tc.Equals, "file")
+	c.Check(info.LifeID, tc.Equals, life.Alive)
+	c.Check(info.Endpoint, tc.IsNil)
+	c.Check(info.AccessKey, tc.IsNil)
+	c.Check(info.SecretKey, tc.IsNil)
+	c.Check(info.SessionToken, tc.IsNil)
+}
+
+func (s *stateSuite) TestGetActiveObjectStoreBackendS3(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:     "https://s3.example.com",
+		AccessKey:    "access-key",
+		SecretKey:    "secret-key",
+		SessionToken: "session-token",
+	}
+
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	info, err := st.GetActiveObjectStoreBackend(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.UUID, tc.Equals, backendUUID)
+	c.Check(info.ObjectStoreType, tc.Equals, "s3")
+	c.Check(info.LifeID, tc.Equals, life.Alive)
+	c.Assert(info.Endpoint, tc.NotNil)
+	c.Check(*info.Endpoint, tc.Equals, creds.Endpoint)
+	c.Assert(info.AccessKey, tc.NotNil)
+	c.Check(*info.AccessKey, tc.Equals, creds.AccessKey)
+	c.Assert(info.SecretKey, tc.NotNil)
+	c.Check(*info.SecretKey, tc.Equals, creds.SecretKey)
+	c.Assert(info.SessionToken, tc.NotNil)
+	c.Check(*info.SessionToken, tc.Equals, creds.SessionToken)
+}
+
+func (s *stateSuite) TestGetActiveObjectStoreBackendNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	runner, err := s.TxnRunnerFactory()(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE object_store_backend
+SET life_id = 1`)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = st.GetActiveObjectStoreBackend(c.Context())
+	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrBackendNotFound)
+}
+
+func (s *stateSuite) TestGetObjectStoreBackend(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	runner, err := s.TxnRunnerFactory()(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var backendUUID string
+	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT uuid FROM object_store_backend
+WHERE life_id = 0`)
+		return row.Scan(&backendUUID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	info, err := st.GetObjectStoreBackend(c.Context(), backendUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.UUID, tc.Equals, backendUUID)
+	c.Check(info.ObjectStoreType, tc.Equals, "file")
+	c.Check(info.LifeID, tc.Equals, life.Alive)
+	c.Check(info.Endpoint, tc.IsNil)
+	c.Check(info.AccessKey, tc.IsNil)
+	c.Check(info.SecretKey, tc.IsNil)
+	c.Check(info.SessionToken, tc.IsNil)
+}
+
+func (s *stateSuite) TestGetObjectStoreBackendS3(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:     "https://s3.example.com",
+		AccessKey:    "access-key",
+		SecretKey:    "secret-key",
+		SessionToken: "foo",
+	}
+
+	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	info, err := st.GetObjectStoreBackend(c.Context(), backendUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.UUID, tc.Equals, backendUUID)
+	c.Check(info.ObjectStoreType, tc.Equals, "s3")
+	c.Check(info.LifeID, tc.Equals, life.Alive)
+
+	c.Assert(info.Endpoint, tc.NotNil)
+	c.Check(*info.Endpoint, tc.Equals, creds.Endpoint)
+	c.Assert(info.AccessKey, tc.NotNil)
+	c.Check(*info.AccessKey, tc.Equals, creds.AccessKey)
+	c.Assert(info.SecretKey, tc.NotNil)
+	c.Check(*info.SecretKey, tc.Equals, creds.SecretKey)
+	c.Check(info.SessionToken, tc.NotNil)
+	c.Check(*info.SessionToken, tc.Equals, creds.SessionToken)
+}
+
+func (s *stateSuite) TestGetObjectStoreBackendNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	missingUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+
+	_, err := st.GetObjectStoreBackend(c.Context(), missingUUID)
+	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrBackendNotFound)
 }

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -1202,6 +1202,19 @@ func (s *stateSuite) TestGetObjectStoreBackendNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrBackendNotFound)
 }
 
+func (s *stateSuite) TestDefaultFileBackendUUID(c *tc.C) {
+	var backendUUID string
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT uuid FROM object_store_backend
+WHERE type_id = 0`)
+		return row.Scan(&backendUUID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(backendUUID, tc.Equals, defaultFileBackendUUID)
+}
+
 func (s *stateSuite) markBackendAsDead(c *tc.C, uuid string) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -768,10 +768,9 @@ func (s *stateSuite) TestStartDraining(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
-		Endpoint:     "https://s3.example.com",
-		AccessKey:    "access-key",
-		SecretKey:    "secret-key",
-		SessionToken: "session-token",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
 	}
 
 	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
@@ -789,10 +788,9 @@ func (s *stateSuite) TestStartDrainingAndSetDrainingPhase(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
-		Endpoint:     "https://s3.example.com",
-		AccessKey:    "access-key",
-		SecretKey:    "secret-key",
-		SessionToken: "session-token",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
 	}
 
 	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
@@ -810,10 +808,9 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3CalledTwice(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
-		Endpoint:     "https://s3.example.com",
-		AccessKey:    "access-key",
-		SecretKey:    "secret-key",
-		SessionToken: "session-token",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
 	}
 
 	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
@@ -834,10 +831,9 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3MultipleTimes(c *tc.C) {
 	backendUUID2 := tc.Must(c, coreobjectstore.NewUUID).String()
 
 	creds := domainobjectstore.S3Credentials{
-		Endpoint:     "https://s3.example.com",
-		AccessKey:    "access-key",
-		SecretKey:    "secret-key",
-		SessionToken: "session-token",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
 	}
 
 	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID0, creds)
@@ -872,10 +868,9 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3WithActiveDrainingBackend(c *t
 	backendUUID1 := tc.Must(c, coreobjectstore.NewUUID).String()
 
 	creds := domainobjectstore.S3Credentials{
-		Endpoint:     "https://s3.example.com",
-		AccessKey:    "access-key",
-		SecretKey:    "secret-key",
-		SessionToken: "session-token",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
 	}
 
 	// This backend is ignored, as the draining phase is not active.
@@ -906,10 +901,9 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
-		Endpoint:     "https://s3.example.com",
-		AccessKey:    "access-key",
-		SecretKey:    "secret-key",
-		SessionToken: "session-token",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
 	}
 
 	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
@@ -917,7 +911,7 @@ func (s *stateSuite) TestSetObjectStoreBackendToS3(c *tc.C) {
 
 	var lifeID, typeID int
 	var dyingTypeID int
-	var endpoint, accessKey, secretKey, sessionToken string
+	var endpoint, accessKey, secretKey string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT life_id, type_id FROM object_store_backend
@@ -934,10 +928,10 @@ WHERE life_id = 1`)
 		}
 
 		row = tx.QueryRowContext(ctx, `
-SELECT endpoint, static_key, static_secret, session_token
+SELECT endpoint, static_key, static_secret
 FROM object_store_backend_s3_credential
 WHERE object_store_backend_uuid = ?`, backendUUID)
-		if err := row.Scan(&endpoint, &accessKey, &secretKey, &sessionToken); err != nil {
+		if err := row.Scan(&endpoint, &accessKey, &secretKey); err != nil {
 			return errors.Errorf("querying backend credentials: %w", err)
 		}
 
@@ -953,7 +947,6 @@ WHERE object_store_backend_uuid = ?`, backendUUID)
 	c.Check(endpoint, tc.Equals, creds.Endpoint)
 	c.Check(accessKey, tc.Equals, creds.AccessKey)
 	c.Check(secretKey, tc.Equals, creds.SecretKey)
-	c.Check(sessionToken, tc.Equals, creds.SessionToken)
 }
 
 func (s *stateSuite) TestMarkObjectStoreBackendAsDrained(c *tc.C) {
@@ -1093,7 +1086,6 @@ WHERE life_id = 0`)
 	c.Check(info.Endpoint, tc.IsNil)
 	c.Check(info.AccessKey, tc.IsNil)
 	c.Check(info.SecretKey, tc.IsNil)
-	c.Check(info.SessionToken, tc.IsNil)
 }
 
 func (s *stateSuite) TestGetActiveObjectStoreBackendS3(c *tc.C) {
@@ -1101,10 +1093,9 @@ func (s *stateSuite) TestGetActiveObjectStoreBackendS3(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
-		Endpoint:     "https://s3.example.com",
-		AccessKey:    "access-key",
-		SecretKey:    "secret-key",
-		SessionToken: "session-token",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
 	}
 
 	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
@@ -1121,8 +1112,6 @@ func (s *stateSuite) TestGetActiveObjectStoreBackendS3(c *tc.C) {
 	c.Check(*info.AccessKey, tc.Equals, creds.AccessKey)
 	c.Assert(info.SecretKey, tc.NotNil)
 	c.Check(*info.SecretKey, tc.Equals, creds.SecretKey)
-	c.Assert(info.SessionToken, tc.NotNil)
-	c.Check(*info.SessionToken, tc.Equals, creds.SessionToken)
 }
 
 func (s *stateSuite) TestGetActiveObjectStoreBackendNotFound(c *tc.C) {
@@ -1160,7 +1149,6 @@ WHERE life_id = 0`)
 	c.Check(info.Endpoint, tc.IsNil)
 	c.Check(info.AccessKey, tc.IsNil)
 	c.Check(info.SecretKey, tc.IsNil)
-	c.Check(info.SessionToken, tc.IsNil)
 }
 
 func (s *stateSuite) TestGetObjectStoreBackendS3(c *tc.C) {
@@ -1168,10 +1156,9 @@ func (s *stateSuite) TestGetObjectStoreBackendS3(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
-		Endpoint:     "https://s3.example.com",
-		AccessKey:    "access-key",
-		SecretKey:    "secret-key",
-		SessionToken: "foo",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
 	}
 
 	err := st.SetObjectStoreBackendToS3(c.Context(), backendUUID, creds)
@@ -1189,8 +1176,6 @@ func (s *stateSuite) TestGetObjectStoreBackendS3(c *tc.C) {
 	c.Check(*info.AccessKey, tc.Equals, creds.AccessKey)
 	c.Assert(info.SecretKey, tc.NotNil)
 	c.Check(*info.SecretKey, tc.Equals, creds.SecretKey)
-	c.Check(info.SessionToken, tc.NotNil)
-	c.Check(*info.SessionToken, tc.Equals, creds.SessionToken)
 }
 
 func (s *stateSuite) TestGetObjectStoreBackendNotFound(c *tc.C) {

--- a/domain/objectstore/state/types.go
+++ b/domain/objectstore/state/types.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"database/sql"
+
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 )
 
@@ -55,7 +57,11 @@ type dbGetPhaseInfo struct {
 	// UUID is the uuid for the phase info.
 	UUID string `db:"uuid"`
 	// Phase is the phase of the object store.
-	Phase coreobjectstore.Phase `db:"phase"`
+	Phase string `db:"phase"`
+	// FromBackendUUID is the uuid of the backend that is being drained from.
+	FromBackendUUID sql.Null[string] `db:"from_backend_uuid"`
+	// ActiveBackendUUID is the uuid of the backend that is active.
+	ActiveBackendUUID string `db:"active_backend_uuid"`
 }
 
 type dbSetPhaseInfo struct {
@@ -63,4 +69,12 @@ type dbSetPhaseInfo struct {
 	UUID string `db:"uuid"`
 	// PhaseTypeID is the phase of the object store.
 	PhaseTypeID int `db:"phase_type_id"`
+	// FromBackendUUID is the backend uuid being drained from.
+	FromBackendUUID string `db:"from_backend_uuid"`
+	// ToBackendUUID is the backend uuid being drained to.
+	ToBackendUUID string `db:"to_backend_uuid"`
+}
+
+type backendUUID struct {
+	UUID string `db:"uuid"`
 }

--- a/domain/objectstore/state/types.go
+++ b/domain/objectstore/state/types.go
@@ -78,3 +78,7 @@ type dbSetPhaseInfo struct {
 type backendUUID struct {
 	UUID string `db:"uuid"`
 }
+
+type count struct {
+	Count int `db:"count"`
+}

--- a/domain/objectstore/types.go
+++ b/domain/objectstore/types.go
@@ -3,6 +3,12 @@
 
 package objectstore
 
+import (
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/internal/errors"
+)
+
 // Metadata represents the metadata for an object.
 type Metadata struct {
 	// UUID is the uuid for the metadata.
@@ -13,4 +19,75 @@ type Metadata struct {
 	Path string
 	// Size is the size of the object.
 	Size int64
+}
+
+// S3Credentials represents the credentials for the s3 object store.
+type S3Credentials struct {
+	// Endpoint is the endpoint for the object store.
+	Endpoint string
+	// AccessKey is the access key for the object store.
+	AccessKey string
+	// SecretKey is the secret key for the object store.
+	SecretKey string
+	// SessionToken is the session token for the object store.
+	SessionToken string
+}
+
+// Validate validates the S3Credentials.
+func (s S3Credentials) Validate() error {
+	if s.Endpoint == "" {
+		return errors.New("endpoint is required").Add(coreerrors.NotValid)
+	}
+	if s.AccessKey == "" {
+		return errors.New("access key is required").Add(coreerrors.NotValid)
+	}
+	if s.SecretKey == "" {
+		return errors.New("secret key is required").Add(coreerrors.NotValid)
+	}
+	return nil
+}
+
+// DrainingInfo represents the information about the draining process, including
+// the phase of the draining process, and the uuids of the backends that are
+// being drained from and to. This information can be used to correlate with
+// logs and other information about the draining process.
+type DrainingInfo struct {
+	// UUID is the uuid for the draining info.
+	UUID string
+	// Phase is the phase of the draining process.
+	Phase string
+	// FromBackendUUID is the uuid of the backend that is being drained from.
+	FromBackendUUID *string
+	// ActiveBackendUUID is the uuid of the backend that is the active backend.
+	ActiveBackendUUID string
+}
+
+// BackendInfo represents the information about an object store backend,
+// including the uuid and the type of the object store.
+type BackendInfo struct {
+	// UUID is the uuid for the backend.
+	UUID string
+	// LifeID is the life id for the backend, which indicates if the backend is
+	// active (life_id = 0) or not (life_id >= 1).
+	LifeID life.Life
+	// ObjectStoreType is the type of the object store.
+	ObjectStoreType string
+
+	// Endpoint, AccessKey, SecretKey, and Region are only used for S3 backend.
+	Endpoint *string
+
+	// AccessKey is not returned for security reasons, but it is expected to be
+	// set in the state when the backend is S3, and it will be used to create
+	// the S3 client for the draining process.
+	AccessKey *string
+
+	// SecretKey is not returned for security reasons, but it is expected to be
+	// set in the state when the backend is S3, and it will be used to create
+	// the S3 client for the draining process.
+	SecretKey *string
+
+	// SessionToken is not returned for security reasons, but it is expected to
+	// be set in the state when the backend is S3, and it will be used to create
+	// the S3 client for the draining process.
+	SessionToken *string
 }

--- a/domain/objectstore/types.go
+++ b/domain/objectstore/types.go
@@ -29,8 +29,6 @@ type S3Credentials struct {
 	AccessKey string
 	// SecretKey is the secret key for the object store.
 	SecretKey string
-	// SessionToken is the session token for the object store.
-	SessionToken string
 }
 
 // Validate validates the S3Credentials.
@@ -85,9 +83,4 @@ type BackendInfo struct {
 	// in the state when the backend is S3, and it will be used to create the
 	// S3 client for the draining process.
 	SecretKey *string
-
-	// SessionToken is the session token for the S3 backend. It is expected to be
-	// set in the state when the backend is S3, and it will be used to create
-	// the S3 client for the draining process
-	SessionToken *string
 }

--- a/domain/objectstore/types.go
+++ b/domain/objectstore/types.go
@@ -76,18 +76,18 @@ type BackendInfo struct {
 	// Endpoint, AccessKey, SecretKey, and Region are only used for S3 backend.
 	Endpoint *string
 
-	// AccessKey is not returned for security reasons, but it is expected to be
-	// set in the state when the backend is S3, and it will be used to create
-	// the S3 client for the draining process.
+	// AccessKey is the access key for the S3 backend. It is expected to be set
+	// in the state when the backend is S3, and it will be used to create the
+	// S3 client for the draining process.
 	AccessKey *string
 
-	// SecretKey is not returned for security reasons, but it is expected to be
-	// set in the state when the backend is S3, and it will be used to create
-	// the S3 client for the draining process.
+	// SecretKey is the secret key for the S3 backend. It is expected to be set
+	// in the state when the backend is S3, and it will be used to create the
+	// S3 client for the draining process.
 	SecretKey *string
 
-	// SessionToken is not returned for security reasons, but it is expected to
-	// be set in the state when the backend is S3, and it will be used to create
-	// the S3 client for the draining process.
+	// SessionToken is the session token for the S3 backend. It is expected to be
+	// set in the state when the backend is S3, and it will be used to create
+	// the S3 client for the draining process
 	SessionToken *string
 }

--- a/domain/objectstore/watcher_test.go
+++ b/domain/objectstore/watcher_test.go
@@ -8,6 +8,7 @@ import (
 	stdtesting "testing"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/changestream"
@@ -35,7 +36,7 @@ func (s *watcherSuite) TestWatchWithAdd(c *tc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "objectstore")
 
 	svc := service.NewWatchableService(
-		state.NewState(func(ctx context.Context) (database.TxnRunner, error) { return factory(ctx) }),
+		state.NewState(func(ctx context.Context) (database.TxnRunner, error) { return factory(ctx) }, clock.WallClock),
 		domain.NewWatcherFactory(factory,
 			loggertesting.WrapCheckLog(c),
 		),
@@ -73,7 +74,7 @@ func (s *watcherSuite) TestWatchWithDelete(c *tc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "objectstore")
 
 	svc := service.NewWatchableService(
-		state.NewState(func(ctx context.Context) (database.TxnRunner, error) { return factory(ctx) }),
+		state.NewState(func(ctx context.Context) (database.TxnRunner, error) { return factory(ctx) }, clock.WallClock),
 		domain.NewWatcherFactory(factory,
 			loggertesting.WrapCheckLog(c),
 		),
@@ -126,7 +127,7 @@ func (s *watcherSuite) TestWatchDraining(c *tc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "objectstore")
 
 	svc := service.NewWatchableDrainingService(
-		state.NewState(func(ctx context.Context) (database.TxnRunner, error) { return factory(ctx) }),
+		state.NewState(func(ctx context.Context) (database.TxnRunner, error) { return factory(ctx) }, clock.WallClock),
 		domain.NewWatcherFactory(factory,
 			loggertesting.WrapCheckLog(c),
 		),

--- a/domain/objectstore/watcher_test.go
+++ b/domain/objectstore/watcher_test.go
@@ -5,6 +5,7 @@ package objectstore_test
 
 import (
 	"context"
+	"database/sql"
 	stdtesting "testing"
 	"time"
 
@@ -138,7 +139,20 @@ func (s *watcherSuite) TestWatchDraining(c *tc.C) {
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
 
 	harness.AddTest(c, func(c *tc.C) {
-		err := svc.SetDrainingPhase(c.Context(), objectstore.PhaseDraining)
+		err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			if _, err := tx.ExecContext(ctx, `UPDATE object_store_backend SET life_id = 1`); err != nil {
+				return err
+			}
+
+			_, err := tx.ExecContext(ctx, `
+INSERT INTO object_store_backend (uuid, life_id, type_id, updated_at) 
+VALUES ('foo', 0, 1, CURRENT_TIMESTAMP)
+`)
+			return err
+		})
+		c.Assert(err, tc.ErrorIsNil)
+
+		err = svc.SetDrainingPhase(c.Context(), objectstore.PhaseDraining)
 		c.Assert(err, tc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[struct{}]) {
 		w.Check(watchertest.SliceAssert(struct{}{}))

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -648,7 +648,7 @@ func (s *baseSuite) setCharmObjectStoreMetadata(c *tc.C, appID coreapplication.U
 	}
 
 	uuid := tc.Must(c, uuid.NewUUID).String()
-	objectStoreUUID, err := objectstorestate.NewState(modelDB).PutMetadata(c.Context(), uuid, coreobjectstore.Metadata{
+	objectStoreUUID, err := objectstorestate.NewState(modelDB, clock.WallClock).PutMetadata(c.Context(), uuid, coreobjectstore.Metadata{
 		SHA256: fmt.Sprintf("%v-sha256", appID),
 		SHA384: fmt.Sprintf("%v-sha384", appID),
 		Path:   fmt.Sprintf("/path/to/%v", appID),

--- a/domain/removal/watcher_test.go
+++ b/domain/removal/watcher_test.go
@@ -264,7 +264,7 @@ func (s *watcherSuite) setCharmObjectStoreMetadata(c *tc.C, appID string) {
 	}
 
 	uuid := tc.Must(c, uuid.NewUUID).String()
-	objectStoreUUID, err := objectstorestate.NewState(modelDB).PutMetadata(c.Context(), uuid, coreobjectstore.Metadata{
+	objectStoreUUID, err := objectstorestate.NewState(modelDB, clock.WallClock).PutMetadata(c.Context(), uuid, coreobjectstore.Metadata{
 		SHA256: fmt.Sprintf("%v-sha256", appID),
 		SHA384: fmt.Sprintf("%v-sha384", appID),
 		Path:   fmt.Sprintf("/path/to/%v", appID),

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -16,7 +16,7 @@ import (
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/controller-triggers.gen.go -package=triggers -tables=controller_config,controller_node,external_controller,controller_api_address
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/migration-triggers.gen.go -package=triggers -tables=model_migration_status,model_migration_minion_sync
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/upgrade-triggers.gen.go -package=triggers -tables=upgrade_info,upgrade_info_controller_node
-//go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/objectstore-triggers.gen.go -package=triggers -tables=object_store_metadata_path,object_store_drain_info
+//go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/objectstore-triggers.gen.go -package=triggers -tables=object_store_metadata_path,object_store_drain_info,object_store_backend
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/secret-triggers.gen.go -package=triggers -tables=secret_backend_rotation,model_secret_backend
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/model-triggers.gen.go -package=triggers -tables=model
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/model-authorized-keys-triggers.gen.go -package=triggers -tables=model_authorized_keys
@@ -45,6 +45,7 @@ const (
 	tableModelMetadata
 	tableModelAuthorizedKeys
 	tableUserAuthentication
+	tableObjectStoreBackend
 )
 
 // controllerPostPatchFilesByVersion is used to categorise the post patch files
@@ -98,6 +99,7 @@ func ControllerDDLForVersion(version semversion.Number) *schema.Schema {
 		triggers.ChangeLogTriggersForModel("uuid", tableModelMetadata),
 		triggers.ChangeLogTriggersForModelAuthorizedKeys("model_uuid", tableModelAuthorizedKeys),
 		triggers.ChangeLogTriggersForUserAuthentication("user_uuid", tableUserAuthentication),
+		triggers.ChangeLogTriggersForObjectStoreBackend("uuid", tableObjectStoreBackend),
 	)
 
 	// Generic triggers.

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -51,6 +51,7 @@ CREATE TABLE object_store_backend (
     uuid TEXT NOT NULL PRIMARY KEY,
     life_id INT NOT NULL,
     type_id INT NOT NULL,
+    updated_at DATETIME NOT NULL,
     CONSTRAINT fk_object_store_backend_life_id
     FOREIGN KEY (life_id)
     REFERENCES life (id),
@@ -59,18 +60,19 @@ CREATE TABLE object_store_backend (
     REFERENCES object_store_backend_type (id)
 );
 
-INSERT INTO object_store_backend (uuid, life_id, type_id) VALUES
-('f44ea516-22ad-4161-b2bd-cbae9d7a9412', 0, 0);
+INSERT INTO object_store_backend (uuid, life_id, type_id, updated_at) VALUES
+('f44ea516-22ad-4161-b2bd-cbae9d7a9412', 0, 0, current_timestamp);
 
 -- A unique constraint over a constant index ensures only 1 entry matching the
 -- condition can exist. In this case only 1 object store backend of type file
 -- can exist, but multiple s3 backends can exist.
-CREATE UNIQUE INDEX idx_singleton_object_store_backend ON object_store_backend ((1)) WHERE type_id = 0;
+CREATE UNIQUE INDEX idx_singleton_object_store_backend_type_id ON object_store_backend ((1)) WHERE type_id = 0;
 
--- This index ensures only 1 object store backend can exist with a life_id of 0,
--- which is the life_id used for the file backend. This ensures only 1 file
--- backend can exist at a time.
-CREATE UNIQUE INDEX idx_object_store_backend_life_id ON object_store_backend (life_id) WHERE life_id = 0;
+-- This unique constraint ensures only 1 object store backend can exist with a
+-- life_id of 0, which is the life_id used for the file backend. This ensures
+-- only 1 file backend can exist at a time.
+CREATE UNIQUE INDEX idx_singleton_object_store_backend_life_id_alive ON object_store_backend ((1)) WHERE life_id = 0;
+CREATE UNIQUE INDEX idx_singleton_object_store_backend_life_id_dying ON object_store_backend ((1)) WHERE life_id = 1;
 
 CREATE TABLE object_store_backend_s3_credential (
     object_store_backend_uuid TEXT NOT NULL PRIMARY KEY,

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -73,7 +73,7 @@ CREATE UNIQUE INDEX idx_singleton_object_store_backend ON object_store_backend (
 CREATE UNIQUE INDEX idx_object_store_backend_life_id ON object_store_backend (life_id) WHERE life_id = 0;
 
 CREATE TABLE object_store_backend_s3_credential (
-    object_store_backend_uuid INT NOT NULL PRIMARY KEY,
+    object_store_backend_uuid TEXT NOT NULL PRIMARY KEY,
     endpoint TEXT NOT NULL,
     static_key TEXT NOT NULL,
     static_secret TEXT NOT NULL,

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -29,6 +29,60 @@ FROM object_store_metadata AS osm
 LEFT JOIN object_store_metadata_path AS osmp
     ON osm.uuid = osmp.metadata_uuid;
 
+CREATE TABLE object_store_placement (
+    uuid TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    CONSTRAINT fk_object_store_placement_uuid
+    FOREIGN KEY (uuid)
+    REFERENCES object_store_metadata (uuid),
+    PRIMARY KEY (uuid, node_id)
+);
+
+CREATE TABLE object_store_backend_type (
+    id INT NOT NULL PRIMARY KEY,
+    type TEXT NOT NULL UNIQUE
+);
+
+INSERT INTO object_store_backend_type (id, type) VALUES
+(0, 'file'),
+(1, 's3');
+
+CREATE TABLE object_store_backend (
+    uuid TEXT NOT NULL PRIMARY KEY,
+    life_id INT NOT NULL,
+    type_id INT NOT NULL,
+    CONSTRAINT fk_object_store_backend_life_id
+    FOREIGN KEY (life_id)
+    REFERENCES life (id),
+    CONSTRAINT fk_object_store_backend_type_id
+    FOREIGN KEY (type_id)
+    REFERENCES object_store_backend_type (id)
+);
+
+INSERT INTO object_store_backend (uuid, life_id, type_id) VALUES
+('f44ea516-22ad-4161-b2bd-cbae9d7a9412', 0, 0);
+
+-- A unique constraint over a constant index ensures only 1 entry matching the
+-- condition can exist. In this case only 1 object store backend of type file
+-- can exist, but multiple s3 backends can exist.
+CREATE UNIQUE INDEX idx_singleton_object_store_backend ON object_store_backend ((1)) WHERE type_id = 0;
+
+-- This index ensures only 1 object store backend can exist with a life_id of 0,
+-- which is the life_id used for the file backend. This ensures only 1 file
+-- backend can exist at a time.
+CREATE UNIQUE INDEX idx_object_store_backend_life_id ON object_store_backend (life_id) WHERE life_id = 0;
+
+CREATE TABLE object_store_backend_s3_credential (
+    object_store_backend_uuid INT NOT NULL PRIMARY KEY,
+    endpoint TEXT NOT NULL,
+    static_key TEXT NOT NULL,
+    static_secret TEXT NOT NULL,
+    session_token TEXT,
+    CONSTRAINT fk_object_store_backend_uuid_s3_credential_object_store_uuid
+    FOREIGN KEY (object_store_backend_uuid)
+    REFERENCES object_store_backend (uuid)
+);
+
 CREATE TABLE object_store_drain_phase_type (
     id INT PRIMARY KEY,
     type TEXT
@@ -46,21 +100,20 @@ INSERT INTO object_store_drain_phase_type VALUES
 CREATE TABLE object_store_drain_info (
     uuid TEXT NOT NULL PRIMARY KEY,
     phase_type_id INT NOT NULL,
+    from_backend_uuid TEXT,
+    to_backend_uuid TEXT NOT NULL,
     CONSTRAINT fk_object_store_drain_info_object_store_drain_phase_type
     FOREIGN KEY (phase_type_id)
-    REFERENCES object_store_drain_phase_type (id)
+    REFERENCES object_store_drain_phase_type (id),
+    CONSTRAINT fk_object_store_drain_info_from_object_store_backend_uuid
+    FOREIGN KEY (from_backend_uuid)
+    REFERENCES object_store_backend (uuid),
+    CONSTRAINT fk_object_store_drain_info_to_object_store_backend_uuid
+    FOREIGN KEY (to_backend_uuid)
+    REFERENCES object_store_backend (uuid)
 );
 
 -- A unique constraint over a constant index ensures only 1 entry matching the 
 -- condition can exist. This states, that multiple draining can exist if they're
 -- not active, but only one active drain can exist.
 CREATE UNIQUE INDEX idx_singleton_active_drain ON object_store_drain_info ((1)) WHERE phase_type_id < 2;
-
-CREATE TABLE object_store_placement (
-    uuid TEXT NOT NULL,
-    node_id TEXT NOT NULL,
-    CONSTRAINT fk_object_store_placement_uuid
-    FOREIGN KEY (uuid)
-    REFERENCES object_store_metadata (uuid),
-    PRIMARY KEY (uuid, node_id)
-);

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -61,7 +61,7 @@ CREATE TABLE object_store_backend (
 );
 
 INSERT INTO object_store_backend (uuid, life_id, type_id, updated_at) VALUES
-('f44ea516-22ad-4161-b2bd-cbae9d7a9412', 0, 0, current_timestamp);
+('653813f9-2896-5332-8cbe-629a337a56a3', 0, 0, current_timestamp);
 
 -- A unique constraint over a constant index ensures only 1 entry matching the
 -- condition can exist. In this case only 1 object store backend of type file

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -79,7 +79,6 @@ CREATE TABLE object_store_backend_s3_credential (
     endpoint TEXT NOT NULL,
     static_key TEXT NOT NULL,
     static_secret TEXT NOT NULL,
-    session_token TEXT,
     CONSTRAINT fk_object_store_backend_uuid_s3_credential_object_store_uuid
     FOREIGN KEY (object_store_backend_uuid)
     REFERENCES object_store_backend (uuid)

--- a/domain/schema/controller/triggers/objectstore-triggers.gen.go
+++ b/domain/schema/controller/triggers/objectstore-triggers.gen.go
@@ -9,6 +9,43 @@ import (
 )
 
 
+// ChangeLogTriggersForObjectStoreBackend generates the triggers for the
+// object_store_backend table.
+func ChangeLogTriggersForObjectStoreBackend(columnName string, namespaceID int) func() schema.Patch {
+	return func() schema.Patch {
+		return schema.MakePatch(fmt.Sprintf(`
+-- insert namespace for ObjectStoreBackend
+INSERT INTO change_log_namespace VALUES (%[2]d, 'object_store_backend', 'ObjectStoreBackend changes based on %[1]s');
+
+-- insert trigger for ObjectStoreBackend
+CREATE TRIGGER trg_log_object_store_backend_insert
+AFTER INSERT ON object_store_backend FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (1, %[2]d, NEW.%[1]s, DATETIME('now', 'utc'));
+END;
+
+-- update trigger for ObjectStoreBackend
+CREATE TRIGGER trg_log_object_store_backend_update
+AFTER UPDATE ON object_store_backend FOR EACH ROW
+WHEN 
+	NEW.uuid != OLD.uuid OR
+	NEW.life_id != OLD.life_id OR
+	NEW.type_id != OLD.type_id 
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;
+-- delete trigger for ObjectStoreBackend
+CREATE TRIGGER trg_log_object_store_backend_delete
+AFTER DELETE ON object_store_backend FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (4, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;`, columnName, namespaceID))
+	}
+}
+
 // ChangeLogTriggersForObjectStoreDrainInfo generates the triggers for the
 // object_store_drain_info table.
 func ChangeLogTriggersForObjectStoreDrainInfo(columnName string, namespaceID int) func() schema.Patch {

--- a/domain/schema/controller/triggers/objectstore-triggers.gen.go
+++ b/domain/schema/controller/triggers/objectstore-triggers.gen.go
@@ -30,7 +30,9 @@ CREATE TRIGGER trg_log_object_store_drain_info_update
 AFTER UPDATE ON object_store_drain_info FOR EACH ROW
 WHEN 
 	NEW.uuid != OLD.uuid OR
-	NEW.phase_type_id != OLD.phase_type_id 
+	NEW.phase_type_id != OLD.phase_type_id OR
+	(NEW.from_backend_uuid != OLD.from_backend_uuid OR (NEW.from_backend_uuid IS NOT NULL AND OLD.from_backend_uuid IS NULL) OR (NEW.from_backend_uuid IS NULL AND OLD.from_backend_uuid IS NOT NULL)) OR
+	NEW.to_backend_uuid != OLD.to_backend_uuid 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));

--- a/domain/schema/controller/triggers/objectstore-triggers.gen.go
+++ b/domain/schema/controller/triggers/objectstore-triggers.gen.go
@@ -31,7 +31,8 @@ AFTER UPDATE ON object_store_backend FOR EACH ROW
 WHEN 
 	NEW.uuid != OLD.uuid OR
 	NEW.life_id != OLD.life_id OR
-	NEW.type_id != OLD.type_id 
+	NEW.type_id != OLD.type_id OR
+	NEW.updated_at != OLD.updated_at 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -341,6 +341,10 @@ func (s *controllerSchemaSuite) TestControllerTriggers(c *tc.C) {
 		"trg_log_object_store_drain_info_insert",
 		"trg_log_object_store_drain_info_update",
 		"trg_log_object_store_drain_info_delete",
+
+		"trg_log_object_store_backend_delete",
+		"trg_log_object_store_backend_insert",
+		"trg_log_object_store_backend_update",
 	)
 
 	// These are additional triggers that are not change log triggers, but

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -155,10 +155,13 @@ func (s *controllerSchemaSuite) TestControllerTables(c *tc.C) {
 		"upgrade_state_type",
 
 		// Object store metadata
-		"object_store_metadata",
-		"object_store_metadata_path",
+		"object_store_backend_s3_credential",
+		"object_store_backend_type",
+		"object_store_backend",
 		"object_store_drain_info",
 		"object_store_drain_phase_type",
+		"object_store_metadata_path",
+		"object_store_metadata",
 		"object_store_placement",
 
 		// SSH Keys

--- a/domain/services/objectstore.go
+++ b/domain/services/objectstore.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"github.com/juju/clock"
+
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/logger"
 	controllerservice "github.com/juju/juju/domain/controller/service"

--- a/domain/services/objectstore.go
+++ b/domain/services/objectstore.go
@@ -4,6 +4,7 @@
 package services
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/logger"
 	controllerservice "github.com/juju/juju/domain/controller/service"
@@ -22,6 +23,8 @@ import (
 // apiserver.
 type ObjectStoreServices struct {
 	modelServiceFactoryBase
+
+	clock clock.Clock
 }
 
 // NewObjectStoreServices returns a new set of services for the usage of the
@@ -29,6 +32,7 @@ type ObjectStoreServices struct {
 func NewObjectStoreServices(
 	controllerDB changestream.WatchableDBFactory,
 	modelDB changestream.WatchableDBFactory,
+	clock clock.Clock,
 	logger logger.Logger,
 ) *ObjectStoreServices {
 	return &ObjectStoreServices{
@@ -39,6 +43,7 @@ func NewObjectStoreServices(
 			},
 			modelDB: modelDB,
 		},
+		clock: clock,
 	}
 }
 
@@ -69,7 +74,7 @@ func (s *ObjectStoreServices) ControllerNode() *controllernodeservice.WatchableS
 // AgentObjectStore returns the object store service.
 func (s *ObjectStoreServices) AgentObjectStore() *objectstoreservice.WatchableDrainingService {
 	return objectstoreservice.NewWatchableDrainingService(
-		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
+		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.clock),
 		s.controllerWatcherFactory("objectstore"),
 	)
 }
@@ -77,7 +82,7 @@ func (s *ObjectStoreServices) AgentObjectStore() *objectstoreservice.WatchableDr
 // ObjectStore returns the model's object store service.
 func (s *ObjectStoreServices) ObjectStore() *objectstoreservice.WatchableService {
 	return objectstoreservice.NewWatchableService(
-		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
+		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.modelDB), s.clock),
 		s.modelWatcherFactory("objectstore"),
 	)
 }

--- a/domain/services/testing/suite.go
+++ b/domain/services/testing/suite.go
@@ -324,6 +324,7 @@ func (s *DomainServicesSuite) ObjectStoreServicesGetter(c *tc.C) ObjectStoreServ
 		return domainservices.NewObjectStoreServices(
 			databasetesting.ConstFactory(s.TxnRunner()),
 			databasetesting.ConstFactory(s.ModelTxnRunner(c, modelUUID.String())),
+			clock.WallClock,
 			loggertesting.WrapCheckLog(c),
 		)
 	}

--- a/internal/worker/objectstoreservices/manifold.go
+++ b/internal/worker/objectstoreservices/manifold.go
@@ -6,6 +6,7 @@ package objectstoreservices
 import (
 	"context"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
@@ -23,6 +24,7 @@ import (
 // worker in a dependency.Engine.
 type ManifoldConfig struct {
 	ChangeStreamName string
+	Clock            clock.Clock
 	Logger           logger.Logger
 	NewWorker        func(Config) (worker.Worker, error)
 
@@ -40,6 +42,7 @@ type ManifoldConfig struct {
 type ObjectStoreServicesGetterFn func(
 	ObjectStoreServicesFn,
 	changestream.WatchableDBGetter,
+	clock.Clock,
 	logger.Logger,
 ) services.ObjectStoreServicesGetter
 
@@ -47,6 +50,7 @@ type ObjectStoreServicesGetterFn func(
 type ObjectStoreServicesFn func(
 	coremodel.UUID,
 	changestream.WatchableDBGetter,
+	clock.Clock,
 	logger.Logger,
 ) services.ObjectStoreServices
 
@@ -63,6 +67,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.NewObjectStoreServices == nil {
 		return errors.NotValidf("nil NewObjectStoreServices")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
@@ -93,6 +100,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 
 	return config.NewWorker(Config{
 		DBGetter:                     dbGetter,
+		Clock:                        config.Clock,
 		Logger:                       config.Logger,
 		NewObjectStoreServicesGetter: config.NewObjectStoreServicesGetter,
 		NewObjectStoreServices:       config.NewObjectStoreServices,
@@ -125,11 +133,13 @@ func (config ManifoldConfig) output(in worker.Worker, out any) error {
 func NewObjectStoreServicesGetter(
 	newObjectStoreServices ObjectStoreServicesFn,
 	dbGetter changestream.WatchableDBGetter,
+	clock clock.Clock,
 	logger logger.Logger,
 ) services.ObjectStoreServicesGetter {
 	return &domainServicesGetter{
 		newObjectStoreServices: newObjectStoreServices,
 		dbGetter:               dbGetter,
+		clock:                  clock,
 		logger:                 logger,
 	}
 }
@@ -138,11 +148,13 @@ func NewObjectStoreServicesGetter(
 func NewObjectStoreServices(
 	modelUUID coremodel.UUID,
 	dbGetter changestream.WatchableDBGetter,
+	clock clock.Clock,
 	logger logger.Logger,
 ) services.ObjectStoreServices {
 	return domainservicefactory.NewObjectStoreServices(
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, coredatabase.ControllerNS),
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, modelUUID.String()),
+		clock,
 		logger,
 	)
 }

--- a/internal/worker/objectstoreservices/manifold_test.go
+++ b/internal/worker/objectstoreservices/manifold_test.go
@@ -6,6 +6,7 @@ package objectstoreservices
 import (
 	"testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v4"
@@ -31,6 +32,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 
 	cfg := s.getConfig()
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
+
+	cfg = s.getConfig()
+	cfg.Clock = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
 	cfg.Logger = nil
@@ -62,6 +67,7 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 
 	manifold := Manifold(ManifoldConfig{
 		ChangeStreamName:             "changestream",
+		Clock:                        clock.WallClock,
 		Logger:                       s.logger,
 		NewWorker:                    NewWorker,
 		NewObjectStoreServices:       NewObjectStoreServices,
@@ -79,6 +85,7 @@ func (s *manifoldSuite) TestOutputObjectStoreServicesGetter(c *tc.C) {
 
 	w, err := NewWorker(Config{
 		DBGetter:                     s.dbGetter,
+		Clock:                        clock.WallClock,
 		Logger:                       s.logger,
 		NewObjectStoreServices:       NewObjectStoreServices,
 		NewObjectStoreServicesGetter: NewObjectStoreServicesGetter,
@@ -98,6 +105,7 @@ func (s *manifoldSuite) TestOutputInvalid(c *tc.C) {
 
 	w, err := NewWorker(Config{
 		DBGetter:                     s.dbGetter,
+		Clock:                        clock.WallClock,
 		Logger:                       s.logger,
 		NewObjectStoreServices:       NewObjectStoreServices,
 		NewObjectStoreServicesGetter: NewObjectStoreServicesGetter,
@@ -115,14 +123,15 @@ func (s *manifoldSuite) TestOutputInvalid(c *tc.C) {
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
 		ChangeStreamName: "changestream",
+		Clock:            clock.WallClock,
 		Logger:           s.logger,
 		NewWorker: func(Config) (worker.Worker, error) {
 			return nil, nil
 		},
-		NewObjectStoreServices: func(model.UUID, changestream.WatchableDBGetter, logger.Logger) services.ObjectStoreServices {
+		NewObjectStoreServices: func(model.UUID, changestream.WatchableDBGetter, clock.Clock, logger.Logger) services.ObjectStoreServices {
 			return nil
 		},
-		NewObjectStoreServicesGetter: func(ObjectStoreServicesFn, changestream.WatchableDBGetter, logger.Logger) services.ObjectStoreServicesGetter {
+		NewObjectStoreServicesGetter: func(ObjectStoreServicesFn, changestream.WatchableDBGetter, clock.Clock, logger.Logger) services.ObjectStoreServicesGetter {
 			return nil
 		},
 	}

--- a/internal/worker/objectstoreservices/worker.go
+++ b/internal/worker/objectstoreservices/worker.go
@@ -4,6 +4,7 @@
 package objectstoreservices
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"gopkg.in/tomb.v2"
@@ -19,6 +20,7 @@ type Config struct {
 	// DBGetter supplies WatchableDB implementations by namespace.
 	DBGetter changestream.WatchableDBGetter
 
+	Clock  clock.Clock
 	Logger logger.Logger
 
 	NewObjectStoreServicesGetter ObjectStoreServicesGetterFn
@@ -29,6 +31,9 @@ type Config struct {
 func (config Config) Validate() error {
 	if config.DBGetter == nil {
 		return errors.NotValidf("nil DBGetter")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
@@ -52,6 +57,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		servicesGetter: config.NewObjectStoreServicesGetter(
 			config.NewObjectStoreServices,
 			config.DBGetter,
+			config.Clock,
 			config.Logger,
 		),
 	}
@@ -104,6 +110,7 @@ type objectStoreServices struct {
 type domainServicesGetter struct {
 	newObjectStoreServices ObjectStoreServicesFn
 	dbGetter               changestream.WatchableDBGetter
+	clock                  clock.Clock
 	logger                 logger.Logger
 }
 
@@ -113,7 +120,7 @@ type domainServicesGetter struct {
 func (s *domainServicesGetter) ServicesForModel(modelUUID coremodel.UUID) services.ObjectStoreServices {
 	return &objectStoreServices{
 		ObjectStoreServices: s.newObjectStoreServices(
-			modelUUID, s.dbGetter, s.logger,
+			modelUUID, s.dbGetter, s.clock, s.logger,
 		),
 	}
 }

--- a/internal/worker/objectstoreservices/worker_test.go
+++ b/internal/worker/objectstoreservices/worker_test.go
@@ -6,6 +6,7 @@ package objectstoreservices
 import (
 	"testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v4"
@@ -32,6 +33,10 @@ func (s *workerSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
 	cfg = s.getConfig()
+	cfg.Clock = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
 	cfg.Logger = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -51,11 +56,12 @@ func (s *workerSuite) TestValidateConfig(c *tc.C) {
 func (s *workerSuite) getConfig() Config {
 	return Config{
 		DBGetter: s.dbGetter,
+		Clock:    clock.WallClock,
 		Logger:   s.logger,
-		NewObjectStoreServices: func(coremodel.UUID, changestream.WatchableDBGetter, logger.Logger) services.ObjectStoreServices {
+		NewObjectStoreServices: func(coremodel.UUID, changestream.WatchableDBGetter, clock.Clock, logger.Logger) services.ObjectStoreServices {
 			return s.objectStoreServices
 		},
-		NewObjectStoreServicesGetter: func(ObjectStoreServicesFn, changestream.WatchableDBGetter, logger.Logger) services.ObjectStoreServicesGetter {
+		NewObjectStoreServicesGetter: func(ObjectStoreServicesFn, changestream.WatchableDBGetter, clock.Clock, logger.Logger) services.ObjectStoreServicesGetter {
 			return s.objectStoreServicesGetter
 		},
 	}


### PR DESCRIPTION
This set of changes is snapped off from https://github.com/juju/juju/pull/21938, where it introduces a way to relate to an s3 relation and get the correct credentials instead of using the ones on controller config. By utilising the [juju-controller charm](https://github.com/juju/juju-controller/pull/107) to drive the changes, we'll be able to ensure that we benefit from the latest charm infrastructure. 

The changes only target the state code at the moment, with services coming in a later patch.

## QA steps

This breaks s3 charm integration, as we require all service changes to be in place. 

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
