### PR TITLE
chore: add applyTo headers to instructions files

### DIFF
--- a/.github/instructions/0-main.instructions.md
+++ b/.github/instructions/0-main.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "**/*"
+---
+
 # Main Instructions for GitHub Copilot Agents
 
 This document defines the global rules all Copilot agents MUST follow in this repository.

--- a/.github/instructions/agent-commit.instructions.md
+++ b/.github/instructions/agent-commit.instructions.md
@@ -1,4 +1,5 @@
 ---
+applyTo: "**/*"
 exclude-agent: "code-review"
 ---
 


### PR DESCRIPTION
Maybe I'm holding it wrong?

It seems the doc at https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot says that for instructions files under `.github/instructions`, the `applyTo` header is needed. This contrasts with `copilot-instructions.md` where it's optional.

Note the last line:

```
Create the .github/instructions directory if it does not already exist.

Optionally, create subdirectories of .github/instructions to organize your instruction files.

Create one or more NAME.instructions.md files, where NAME indicates the purpose of the instructions. The file name must end with .instructions.md.

At the start of the file, create a frontmatter block containing the applyTo keyword. Use glob syntax to specify what files or directories the instructions apply to.
```

Especially since the next line of doc does say "optionally" for an optional bit

```
Optionally, to prevent the file from being used by either Copilot coding agent or Copilot ...
```