### PR TITLE
fix(http): retry duration can be negative

### DIFF
--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -286,7 +286,7 @@ func (m retryMiddleware) defaultBackoff(resp *http.Response, backoff time.Durati
 		// Check for http-date.
 		date, err := time.Parse(time.RFC1123, header)
 		if err == nil {
-			return m.clampBackoff(m.clock.Now().Sub(date))
+			return m.clampBackoff(date.Sub(m.clock.Now()))
 		}
 		url := ""
 		if resp.Request != nil {
@@ -299,6 +299,9 @@ func (m retryMiddleware) defaultBackoff(resp *http.Response, backoff time.Durati
 }
 
 func (m retryMiddleware) clampBackoff(duration time.Duration) (time.Duration, error) {
+	if duration < 0 {
+		duration = 0
+	}
 	if m.policy.MaxDelay > 0 && duration > m.policy.MaxDelay {
 		future := m.clock.Now().Add(duration)
 		return duration, errors.Errorf("API request retry is not accepting further requests until %s", future.Format(time.RFC3339))

--- a/internal/http/middleware_test.go
+++ b/internal/http/middleware_test.go
@@ -226,6 +226,51 @@ func (s *RetrySuite) TestRetryRequiredUsingBackoff(c *tc.C) {
 	c.Assert(resp.StatusCode, tc.Equals, http.StatusOK)
 }
 
+func (s *RetrySuite) TestRetryRequiredUsingBackoffDate(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	req, err := http.NewRequest("GET", "http://meshuggah.rocks", nil)
+	c.Assert(err, tc.IsNil)
+
+	header := make(http.Header)
+	header.Add("Retry-After", "Wed, 21 Oct 2015 07:28:00 UTC")
+
+	transport := NewMockRoundTripper(ctrl)
+	transport.EXPECT().RoundTrip(req).Return(&http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     header,
+	}, nil).Times(2)
+	transport.EXPECT().RoundTrip(req).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	ch := make(chan time.Time)
+
+	clock := NewMockClock(ctrl)
+	now, err := time.Parse(time.RFC1123, "Wed, 21 Oct 2015 07:27:18 UTC")
+	c.Assert(err, tc.IsNil)
+	clock.EXPECT().Now().Return(now).AnyTimes()
+	clock.EXPECT().After(time.Second * 42).Return(ch).Times(2)
+
+	retries := 3
+	go func() {
+		for range retries {
+			ch <- now
+		}
+	}()
+
+	middleware := makeRetryMiddleware(transport, RetryPolicy{
+		Attempts: retries,
+		Delay:    time.Second,
+		MaxDelay: time.Minute,
+	}, clock, loggertesting.WrapCheckLog(c))
+
+	resp, err := middleware.RoundTrip(req) //nolint:bodyclose
+	c.Assert(err, tc.IsNil)
+	c.Assert(resp.StatusCode, tc.Equals, http.StatusOK)
+}
+
 func (s *RetrySuite) TestRetryRequiredUsingBackoffFailure(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
I have to credit copilot for noticing this. We have a project which reuses some of the Juju HTTP client machinery. If the server responds with a fixed date in Retry-After, the client should wait until that time before retrying. In other words, we should subtract the current time from the Retry-After time to get a (most likely) positive duration. I added a test to confirm this intuition; it fails without the fix because time.After is called with -42s instead of +42s.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Just run the new regression test (with or without the fixed code)

## Documentation changes

No behaviour changes, just a bugfix.