### PR TITLE
fix(removal): reschedule application child removals on retries

### DIFF
--- a/domain/removal/service/application_test.go
+++ b/domain/removal/service/application_test.go
@@ -90,6 +90,118 @@ func (s *applicationSuite) TestRemoveApplicationForceWaitSuccess(c *tc.C) {
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
+func (s *applicationSuite) TestRemoveApplicationRetrySchedulesRemovalJobs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	cascaded := internal.CascadedApplicationLives{
+		RelationUUIDs: []string{"relation-1"},
+		UnitUUIDs:     []string{"unit-1"},
+		MachineUUIDs:  []string{"machine-1"},
+		CascadedStorageLives: internal.CascadedStorageLives{
+			CascadedStorageAttachmentLives: internal.CascadedStorageAttachmentLives{
+				StorageAttachmentUUIDs:    []string{"storage-attachment-1"},
+				FileSystemAttachmentUUIDs: []string{"filesystem-attachment-1"},
+				VolumeAttachmentUUIDs:     []string{"volume-attachment-1"},
+				VolumeAttachmentPlanUUIDs: []string{"volume-attachment-plan-1"},
+			},
+			CascadedStorageInstanceLives: internal.CascadedStorageInstanceLives{
+				StorageInstanceUUIDs: []string{"storage-instance-1"},
+				FileSystemUUIDs:      []string{"filesystem-1"},
+				VolumeUUIDs:          []string{"volume-1"},
+			},
+		},
+	}
+
+	exp := s.modelState.EXPECT()
+	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil).Times(2)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(cascaded, nil).Times(2)
+	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil).Times(2)
+	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "relation-1", false, when.UTC()).Return(nil).Times(2)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "unit-1", false, when.UTC()).Return(nil).Times(2)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", false, when.UTC()).Return(nil).Times(2)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", false, when.UTC()).Return(nil).Times(2)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", false, when.UTC()).Return(nil).Times(2)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", false, when.UTC()).Return(nil).Times(2)
+
+	jobUUID1, err := s.newService(c).RemoveApplication(c.Context(), appUUID, false, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID1.Validate(), tc.ErrorIsNil)
+
+	jobUUID2, err := s.newService(c).RemoveApplication(c.Context(), appUUID, false, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID2.Validate(), tc.ErrorIsNil)
+}
+
+func (s *applicationSuite) TestRemoveApplicationRetryWithForceSchedulesRemovalJobs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	cascaded := internal.CascadedApplicationLives{
+		RelationUUIDs: []string{"relation-1"},
+		UnitUUIDs:     []string{"unit-1"},
+		MachineUUIDs:  []string{"machine-1"},
+		CascadedStorageLives: internal.CascadedStorageLives{
+			CascadedStorageAttachmentLives: internal.CascadedStorageAttachmentLives{
+				StorageAttachmentUUIDs:    []string{"storage-attachment-1"},
+				FileSystemAttachmentUUIDs: []string{"filesystem-attachment-1"},
+				VolumeAttachmentUUIDs:     []string{"volume-attachment-1"},
+				VolumeAttachmentPlanUUIDs: []string{"volume-attachment-plan-1"},
+			},
+			CascadedStorageInstanceLives: internal.CascadedStorageInstanceLives{
+				StorageInstanceUUIDs: []string{"storage-instance-1"},
+				FileSystemUUIDs:      []string{"filesystem-1"},
+				VolumeUUIDs:          []string{"volume-1"},
+			},
+		},
+	}
+
+	exp := s.modelState.EXPECT()
+	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil).Times(2)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(cascaded, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, true).Return(cascaded, nil)
+	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
+	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), true, when.UTC()).Return(nil)
+	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "relation-1", false, when.UTC()).Return(nil)
+	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "relation-1", true, when.UTC()).Return(nil)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "unit-1", false, when.UTC()).Return(nil)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "unit-1", true, when.UTC()).Return(nil)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", false, when.UTC()).Return(nil)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", true, when.UTC()).Return(nil)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", false, when.UTC()).Return(nil)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", true, when.UTC()).Return(nil)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", false, when.UTC()).Return(nil)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", true, when.UTC()).Return(nil)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", false, when.UTC()).Return(nil)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", true, when.UTC()).Return(nil)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", false, when.UTC()).Return(nil)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", true, when.UTC()).Return(nil)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", false, when.UTC()).Return(nil)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", true, when.UTC()).Return(nil)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", false, when.UTC()).Return(nil)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", true, when.UTC()).Return(nil)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", false, when.UTC()).Return(nil)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", true, when.UTC()).Return(nil)
+
+	jobUUID1, err := s.newService(c).RemoveApplication(c.Context(), appUUID, false, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID1.Validate(), tc.ErrorIsNil)
+
+	jobUUID2, err := s.newService(c).RemoveApplication(c.Context(), appUUID, false, true, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID2.Validate(), tc.ErrorIsNil)
+}
+
 func (s *applicationSuite) TestRemoveApplicationNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/removal/service/machine_test.go
+++ b/domain/removal/service/machine_test.go
@@ -99,6 +99,113 @@ func (s *machineSuite) TestRemoveMachineForceWaitSuccess(c *tc.C) {
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
+func (s *machineSuite) TestRemoveMachineRetrySchedulesRemovalJobs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	mUUID := machinetesting.GenUUID(c)
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	cascaded := internal.CascadedMachineLives{
+		MachineUUIDs: []string{"machine-child-1"},
+		UnitUUIDs:    []string{"unit-1"},
+		CascadedStorageLives: internal.CascadedStorageLives{
+			CascadedStorageAttachmentLives: internal.CascadedStorageAttachmentLives{
+				StorageAttachmentUUIDs:    []string{"storage-attachment-1"},
+				FileSystemAttachmentUUIDs: []string{"filesystem-attachment-1"},
+				VolumeAttachmentUUIDs:     []string{"volume-attachment-1"},
+				VolumeAttachmentPlanUUIDs: []string{"volume-attachment-plan-1"},
+			},
+			CascadedStorageInstanceLives: internal.CascadedStorageInstanceLives{
+				StorageInstanceUUIDs: []string{"storage-instance-1"},
+				FileSystemUUIDs:      []string{"filesystem-1"},
+				VolumeUUIDs:          []string{"volume-1"},
+			},
+		},
+	}
+
+	exp := s.modelState.EXPECT()
+	exp.MachineExists(gomock.Any(), mUUID.String()).Return(true, nil).Times(2)
+	exp.EnsureMachineNotAliveCascade(gomock.Any(), mUUID.String(), false).Return(cascaded, nil).Times(2)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC()).Return(nil).Times(2)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-child-1", false, when.UTC()).Return(nil).Times(2)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "unit-1", false, when.UTC()).Return(nil).Times(2)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", false, when.UTC()).Return(nil).Times(2)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", false, when.UTC()).Return(nil).Times(2)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", false, when.UTC()).Return(nil).Times(2)
+
+	jobUUID1, err := s.newService(c).RemoveMachine(c.Context(), mUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID1.Validate(), tc.ErrorIsNil)
+
+	jobUUID2, err := s.newService(c).RemoveMachine(c.Context(), mUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID2.Validate(), tc.ErrorIsNil)
+}
+
+func (s *machineSuite) TestRemoveMachineRetryWithForceSchedulesRemovalJobs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	mUUID := machinetesting.GenUUID(c)
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	cascaded := internal.CascadedMachineLives{
+		MachineUUIDs: []string{"machine-child-1"},
+		UnitUUIDs:    []string{"unit-1"},
+		CascadedStorageLives: internal.CascadedStorageLives{
+			CascadedStorageAttachmentLives: internal.CascadedStorageAttachmentLives{
+				StorageAttachmentUUIDs:    []string{"storage-attachment-1"},
+				FileSystemAttachmentUUIDs: []string{"filesystem-attachment-1"},
+				VolumeAttachmentUUIDs:     []string{"volume-attachment-1"},
+				VolumeAttachmentPlanUUIDs: []string{"volume-attachment-plan-1"},
+			},
+			CascadedStorageInstanceLives: internal.CascadedStorageInstanceLives{
+				StorageInstanceUUIDs: []string{"storage-instance-1"},
+				FileSystemUUIDs:      []string{"filesystem-1"},
+				VolumeUUIDs:          []string{"volume-1"},
+			},
+		},
+	}
+
+	exp := s.modelState.EXPECT()
+	exp.MachineExists(gomock.Any(), mUUID.String()).Return(true, nil).Times(2)
+	exp.EnsureMachineNotAliveCascade(gomock.Any(), mUUID.String(), false).Return(cascaded, nil)
+	exp.EnsureMachineNotAliveCascade(gomock.Any(), mUUID.String(), true).Return(cascaded, nil)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC()).Return(nil)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), true, when.UTC()).Return(nil)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-child-1", false, when.UTC()).Return(nil)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-child-1", true, when.UTC()).Return(nil)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "unit-1", false, when.UTC()).Return(nil)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "unit-1", true, when.UTC()).Return(nil)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", false, when.UTC()).Return(nil)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", true, when.UTC()).Return(nil)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", false, when.UTC()).Return(nil)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", true, when.UTC()).Return(nil)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", false, when.UTC()).Return(nil)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", true, when.UTC()).Return(nil)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", false, when.UTC()).Return(nil)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", true, when.UTC()).Return(nil)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", false, when.UTC()).Return(nil)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", true, when.UTC()).Return(nil)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", false, when.UTC()).Return(nil)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", true, when.UTC()).Return(nil)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", false, when.UTC()).Return(nil)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", true, when.UTC()).Return(nil)
+
+	jobUUID1, err := s.newService(c).RemoveMachine(c.Context(), mUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID1.Validate(), tc.ErrorIsNil)
+
+	jobUUID2, err := s.newService(c).RemoveMachine(c.Context(), mUUID, true, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID2.Validate(), tc.ErrorIsNil)
+}
+
 func (s *machineSuite) TestRemoveMachineCascadeStorage(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/removal/service/unit_test.go
+++ b/domain/removal/service/unit_test.go
@@ -103,6 +103,109 @@ func (s *unitSuite) TestRemoveUnitForceWaitSuccess(c *tc.C) {
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
+func (s *unitSuite) TestRemoveUnitRetrySchedulesRemovalJobs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uUUID := unittesting.GenUnitUUID(c)
+	mUUID := "machine-1"
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	cascaded := internal.CascadedUnitLives{
+		MachineUUID: &mUUID,
+		CascadedStorageLives: internal.CascadedStorageLives{
+			CascadedStorageAttachmentLives: internal.CascadedStorageAttachmentLives{
+				StorageAttachmentUUIDs:    []string{"storage-attachment-1"},
+				FileSystemAttachmentUUIDs: []string{"filesystem-attachment-1"},
+				VolumeAttachmentUUIDs:     []string{"volume-attachment-1"},
+				VolumeAttachmentPlanUUIDs: []string{"volume-attachment-plan-1"},
+			},
+			CascadedStorageInstanceLives: internal.CascadedStorageInstanceLives{
+				StorageInstanceUUIDs: []string{"storage-instance-1"},
+				FileSystemUUIDs:      []string{"filesystem-1"},
+				VolumeUUIDs:          []string{"volume-1"},
+			},
+		},
+	}
+
+	exp := s.modelState.EXPECT()
+	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil).Times(2)
+	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(cascaded, nil).Times(2)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil).Times(2)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", false, when.UTC()).Return(nil).Times(2)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", false, when.UTC()).Return(nil).Times(2)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", false, when.UTC()).Return(nil).Times(2)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", false, when.UTC()).Return(nil).Times(2)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", false, when.UTC()).Return(nil).Times(2)
+
+	jobUUID1, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID1.Validate(), tc.ErrorIsNil)
+
+	jobUUID2, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID2.Validate(), tc.ErrorIsNil)
+}
+
+func (s *unitSuite) TestRemoveUnitRetryWithForceSchedulesRemovalJobs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uUUID := unittesting.GenUnitUUID(c)
+	mUUID := "machine-1"
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).AnyTimes()
+
+	cascaded := internal.CascadedUnitLives{
+		MachineUUID: &mUUID,
+		CascadedStorageLives: internal.CascadedStorageLives{
+			CascadedStorageAttachmentLives: internal.CascadedStorageAttachmentLives{
+				StorageAttachmentUUIDs:    []string{"storage-attachment-1"},
+				FileSystemAttachmentUUIDs: []string{"filesystem-attachment-1"},
+				VolumeAttachmentUUIDs:     []string{"volume-attachment-1"},
+				VolumeAttachmentPlanUUIDs: []string{"volume-attachment-plan-1"},
+			},
+			CascadedStorageInstanceLives: internal.CascadedStorageInstanceLives{
+				StorageInstanceUUIDs: []string{"storage-instance-1"},
+				FileSystemUUIDs:      []string{"filesystem-1"},
+				VolumeUUIDs:          []string{"volume-1"},
+			},
+		},
+	}
+
+	exp := s.modelState.EXPECT()
+	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil).Times(2)
+	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(cascaded, nil).Times(2)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), true, when.UTC()).Return(nil)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", false, when.UTC()).Return(nil)
+	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", true, when.UTC()).Return(nil)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", false, when.UTC()).Return(nil)
+	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", true, when.UTC()).Return(nil)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", false, when.UTC()).Return(nil)
+	exp.FilesystemAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-attachment-1", true, when.UTC()).Return(nil)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", false, when.UTC()).Return(nil)
+	exp.VolumeAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-1", true, when.UTC()).Return(nil)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", false, when.UTC()).Return(nil)
+	exp.VolumeAttachmentPlanScheduleRemoval(gomock.Any(), gomock.Any(), "volume-attachment-plan-1", true, when.UTC()).Return(nil)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", false, when.UTC()).Return(nil)
+	exp.FilesystemScheduleRemoval(gomock.Any(), gomock.Any(), "filesystem-1", true, when.UTC()).Return(nil)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", false, when.UTC()).Return(nil)
+	exp.VolumeScheduleRemoval(gomock.Any(), gomock.Any(), "volume-1", true, when.UTC()).Return(nil)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", false, when.UTC()).Return(nil)
+	exp.StorageInstanceScheduleRemoval(gomock.Any(), gomock.Any(), "storage-instance-1", true, when.UTC()).Return(nil)
+
+	jobUUID1, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID1.Validate(), tc.ErrorIsNil)
+
+	jobUUID2, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, true, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID2.Validate(), tc.ErrorIsNil)
+}
+
 func (s *unitSuite) TestRemoveUnitNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/canonical/sqlair"
@@ -81,7 +82,8 @@ WHERE  application_uuid = $entityUUID.uuid`, count{}, applicationUUID)
 // application has units, they are also guaranteed to be no longer alive,
 // cascading. The affected unit UUIDs are returned. If the units are also
 // the last ones on their machines, it will cascade and the machines are
-// also set to dying. The affected machine UUIDs are returned.
+// also set to dying. Non-dead cascaded entity UUIDs are returned so retries
+// can re-schedule child removals with updated intent.
 func (st *State) EnsureApplicationNotAliveCascade(
 	ctx context.Context, aUUID string, destroyStorage bool, force bool,
 ) (internal.CascadedApplicationLives, error) {
@@ -123,7 +125,7 @@ AND    life_id = 0`, applicationUUID)
 SELECT &entityUUID.uuid
 FROM   v_relation_endpoint AS re
 JOIN   relation AS r ON re.relation_uuid = r.uuid
-WHERE  r.life_id = 0
+WHERE  r.life_id < 2
 AND    re.application_uuid = $entityUUID.uuid
 `, applicationUUID)
 	if err != nil {
@@ -143,7 +145,7 @@ AND    life_id = 0`, uuids{})
 SELECT &entityUUID.uuid
 FROM   unit
 WHERE  application_uuid = $entityUUID.uuid
-AND    life_id = 0`, applicationUUID)
+AND    life_id < 2`, applicationUUID)
 	if err != nil {
 		return res, errors.Errorf("preparing unit uuids query: %w", err)
 	}
@@ -190,9 +192,12 @@ AND    life_id = 0`, applicationUUID)
 		}
 
 		const checkEmptyMachine = true
+		const includeDyingArtifacts = true
 		res.UnitUUIDs = transform.Slice(unitUUIDsRec, func(e entityUUID) string { return e.UUID })
 		for _, u := range res.UnitUUIDs {
-			cascaded, err := st.ensureUnitNotAliveCascade(ctx, tx, u, checkEmptyMachine, destroyStorage)
+			cascaded, err := st.ensureUnitNotAliveCascade(
+				ctx, tx, u, checkEmptyMachine, destroyStorage, includeDyingArtifacts,
+			)
 			if err != nil {
 				return errors.Errorf("cascading unit %q life advancement: %w", u, err)
 			}
@@ -209,7 +214,26 @@ AND    life_id = 0`, applicationUUID)
 		return res, errors.Capture(err)
 	}
 
+	res.RelationUUIDs = dedupeStrings(res.RelationUUIDs)
+	res.UnitUUIDs = dedupeStrings(res.UnitUUIDs)
+	res.MachineUUIDs = dedupeStrings(res.MachineUUIDs)
+	res.StorageAttachmentUUIDs = dedupeStrings(res.StorageAttachmentUUIDs)
+	res.FileSystemAttachmentUUIDs = dedupeStrings(res.FileSystemAttachmentUUIDs)
+	res.VolumeAttachmentUUIDs = dedupeStrings(res.VolumeAttachmentUUIDs)
+	res.VolumeAttachmentPlanUUIDs = dedupeStrings(res.VolumeAttachmentPlanUUIDs)
+	res.FileSystemUUIDs = dedupeStrings(res.FileSystemUUIDs)
+	res.VolumeUUIDs = dedupeStrings(res.VolumeUUIDs)
+	res.StorageInstanceUUIDs = dedupeStrings(res.StorageInstanceUUIDs)
+
 	return res, nil
+}
+
+func dedupeStrings(in []string) []string {
+	if len(in) < 2 {
+		return in
+	}
+	slices.Sort(in)
+	return slices.Compact(in)
 }
 
 // ApplicationScheduleRemoval schedules a removal job for the application with

--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -192,11 +192,10 @@ AND    life_id < 2`, applicationUUID)
 		}
 
 		const checkEmptyMachine = true
-		const includeDyingArtifacts = true
 		res.UnitUUIDs = transform.Slice(unitUUIDsRec, func(e entityUUID) string { return e.UUID })
 		for _, u := range res.UnitUUIDs {
 			cascaded, err := st.ensureUnitNotAliveCascade(
-				ctx, tx, u, checkEmptyMachine, destroyStorage, includeDyingArtifacts,
+				ctx, tx, u, checkEmptyMachine, destroyStorage,
 			)
 			if err != nil {
 				return errors.Errorf("cascading unit %q life advancement: %w", u, err)
@@ -229,9 +228,6 @@ AND    life_id < 2`, applicationUUID)
 }
 
 func dedupeStrings(in []string) []string {
-	if len(in) < 2 {
-		return in
-	}
 	slices.Sort(in)
 	return slices.Compact(in)
 }

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -175,6 +175,8 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 	_, err = s.DB().Exec(`UPDATE machine SET life_id = 1 WHERE uuid = ?`, allMachineUUIDs[0].String())
 	c.Assert(err, tc.ErrorIsNil)
 
+	aliveMachineUUIDs := allMachineUUIDs[1:]
+
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
@@ -183,11 +185,11 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 	c.Check(artifacts.RelationUUIDs, tc.HasLen, 0)
 	// Dying children should be returned too so retries can re-schedule them.
 	s.checkUnitContents(c, artifacts.UnitUUIDs, allUnitUUIDs)
-	s.checkMachineContents(c, artifacts.MachineUUIDs, allMachineUUIDs)
+	s.checkMachineContents(c, artifacts.MachineUUIDs, aliveMachineUUIDs)
 
 	s.checkApplicationDyingState(c, appUUID)
 	s.checkUnitDyingState(c, allUnitUUIDs)
-	s.checkMachineDyingState(c, allMachineUUIDs)
+	s.checkMachineDyingState(c, aliveMachineUUIDs)
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWithAliveAndDyingUnitsWithLastMachine(c *tc.C) {
@@ -356,7 +358,9 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeRetryReturnsDying
 
 	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(secondArtifacts, tc.DeepEquals, firstArtifacts)
+	c.Check(secondArtifacts.RelationUUIDs, tc.DeepEquals, firstArtifacts.RelationUUIDs)
+	c.Check(secondArtifacts.UnitUUIDs, tc.DeepEquals, firstArtifacts.UnitUUIDs)
+	c.Check(secondArtifacts.MachineUUIDs, tc.HasLen, 0)
 
 	s.checkApplicationDyingState(c, appUUID)
 	s.checkUnitDyingState(c, s.getAllUnitUUIDs(c, appUUID))
@@ -434,7 +438,10 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`, allUnitUUIDs[0])
 
 	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true, false)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(secondArtifacts, tc.DeepEquals, firstArtifacts)
+	c.Check(secondArtifacts.StorageAttachmentUUIDs, tc.DeepEquals, firstArtifacts.StorageAttachmentUUIDs)
+	c.Check(secondArtifacts.StorageInstanceUUIDs, tc.DeepEquals, firstArtifacts.StorageInstanceUUIDs)
+	c.Check(secondArtifacts.UnitUUIDs, tc.DeepEquals, firstArtifacts.UnitUUIDs)
+	c.Check(secondArtifacts.MachineUUIDs, tc.HasLen, 0)
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeOfferConnections(c *tc.C) {

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -175,21 +175,19 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 	_, err = s.DB().Exec(`UPDATE machine SET life_id = 1 WHERE uuid = ?`, allMachineUUIDs[0].String())
 	c.Assert(err, tc.ErrorIsNil)
 
-	aliveUnitUUIDs := allUnitUUIDs[1:]
-	aliveMachineUUIDs := allMachineUUIDs[1:]
-
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(artifacts.RelationUUIDs, tc.HasLen, 0)
-	s.checkUnitContents(c, artifacts.UnitUUIDs, aliveUnitUUIDs)
-	s.checkMachineContents(c, artifacts.MachineUUIDs, aliveMachineUUIDs)
+	// Dying children should be returned too so retries can re-schedule them.
+	s.checkUnitContents(c, artifacts.UnitUUIDs, allUnitUUIDs)
+	s.checkMachineContents(c, artifacts.MachineUUIDs, allMachineUUIDs)
 
 	s.checkApplicationDyingState(c, appUUID)
-	s.checkUnitDyingState(c, aliveUnitUUIDs)
-	s.checkMachineDyingState(c, aliveMachineUUIDs)
+	s.checkUnitDyingState(c, allUnitUUIDs)
+	s.checkMachineDyingState(c, allMachineUUIDs)
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWithAliveAndDyingUnitsWithLastMachine(c *tc.C) {
@@ -342,6 +340,101 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeDyingSuccess(c *t
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(lifeID, tc.Equals, 1)
+}
+
+func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeRetryReturnsDyingArtifacts(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(firstArtifacts.RelationUUIDs, tc.HasLen, 0)
+	c.Check(firstArtifacts.UnitUUIDs, tc.HasLen, 1)
+	c.Check(firstArtifacts.MachineUUIDs, tc.HasLen, 1)
+
+	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(secondArtifacts, tc.DeepEquals, firstArtifacts)
+
+	s.checkApplicationDyingState(c, appUUID)
+	s.checkUnitDyingState(c, s.getAllUnitUUIDs(c, appUUID))
+	_, allMachineUUIDs := s.getAllUnitAndMachineUUIDs(c)
+	s.checkMachineDyingState(c, allMachineUUIDs)
+}
+
+func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeRetryReturnsDyingRelations(c *tc.C) {
+	appSvc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, appSvc, "app1")
+	s.createIAASApplication(c, appSvc, "app2")
+
+	relSvc := s.setupRelationService(c)
+	_, _, err := relSvc.AddRelation(c.Context(), "app1:foo", "app2:bar")
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(firstArtifacts.RelationUUIDs, tc.HasLen, 1)
+	c.Check(firstArtifacts.UnitUUIDs, tc.HasLen, 0)
+	c.Check(firstArtifacts.MachineUUIDs, tc.HasLen, 0)
+
+	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(secondArtifacts, tc.DeepEquals, firstArtifacts)
+
+	row := s.DB().QueryRowContext(c.Context(), "SELECT life_id FROM relation WHERE uuid = ?", firstArtifacts.RelationUUIDs[0])
+	var relationLife life.Life
+	err = row.Scan(&relationLife)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(relationLife, tc.Equals, life.Dying)
+}
+
+func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeRetryReturnsDyingStorageArtifacts(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+
+	allUnitUUIDs := s.getAllUnitUUIDs(c, appUUID)
+	c.Assert(allUnitUUIDs, tc.HasLen, 1)
+
+	ctx := c.Context()
+	db := s.DB()
+
+	_, err := db.ExecContext(
+		ctx, "INSERT INTO storage_pool (uuid, name, type) VALUES ('pool-uuid', 'pool', 'whatever')",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = db.ExecContext(ctx, `
+INSERT INTO storage_instance (
+	uuid, storage_id, storage_pool_uuid, requested_size_mib, charm_name, storage_name, life_id, storage_kind_id
+)
+VALUES ('instance-uuid', 'does-not-matter', 'pool-uuid', 100, 'charm-name', 'storage-name', 0, 0)`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = db.ExecContext(ctx, `
+INSERT INTO storage_attachment (uuid, storage_instance_uuid, unit_uuid, life_id)
+VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`, allUnitUUIDs[0])
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO storage_unit_owner (storage_instance_uuid, unit_uuid) VALUES ('instance-uuid', ?)",
+		allUnitUUIDs[0],
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true, false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(firstArtifacts.StorageAttachmentUUIDs, tc.DeepEquals, []string{"storage-attachment-uuid"})
+	c.Check(firstArtifacts.StorageInstanceUUIDs, tc.DeepEquals, []string{"instance-uuid"})
+
+	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true, false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(secondArtifacts, tc.DeepEquals, firstArtifacts)
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeOfferConnections(c *tc.C) {

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -175,8 +175,6 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 	_, err = s.DB().Exec(`UPDATE machine SET life_id = 1 WHERE uuid = ?`, allMachineUUIDs[0].String())
 	c.Assert(err, tc.ErrorIsNil)
 
-	aliveMachineUUIDs := allMachineUUIDs[1:]
-
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
@@ -185,10 +183,14 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 	c.Check(artifacts.RelationUUIDs, tc.HasLen, 0)
 	// Dying children should be returned too so retries can re-schedule them.
 	s.checkUnitContents(c, artifacts.UnitUUIDs, allUnitUUIDs)
-	s.checkMachineContents(c, artifacts.MachineUUIDs, aliveMachineUUIDs)
+	// All machine UUIDs are returned, including the already-dying one,
+	// so retries can re-schedule child removal jobs.
+	s.checkMachineContents(c, artifacts.MachineUUIDs, allMachineUUIDs)
 
 	s.checkApplicationDyingState(c, appUUID)
 	s.checkUnitDyingState(c, allUnitUUIDs)
+	// Only the previously-alive machines were transitioned by this call.
+	aliveMachineUUIDs := allMachineUUIDs[1:]
 	s.checkMachineDyingState(c, aliveMachineUUIDs)
 }
 
@@ -360,7 +362,9 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeRetryReturnsDying
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(secondArtifacts.RelationUUIDs, tc.DeepEquals, firstArtifacts.RelationUUIDs)
 	c.Check(secondArtifacts.UnitUUIDs, tc.DeepEquals, firstArtifacts.UnitUUIDs)
-	c.Check(secondArtifacts.MachineUUIDs, tc.HasLen, 0)
+	// Machine UUIDs are still returned on retries so child removal
+	// jobs can be re-scheduled.
+	c.Check(secondArtifacts.MachineUUIDs, tc.SameContents, firstArtifacts.MachineUUIDs)
 
 	s.checkApplicationDyingState(c, appUUID)
 	s.checkUnitDyingState(c, s.getAllUnitUUIDs(c, appUUID))
@@ -441,7 +445,9 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`, allUnitUUIDs[0])
 	c.Check(secondArtifacts.StorageAttachmentUUIDs, tc.DeepEquals, firstArtifacts.StorageAttachmentUUIDs)
 	c.Check(secondArtifacts.StorageInstanceUUIDs, tc.DeepEquals, firstArtifacts.StorageInstanceUUIDs)
 	c.Check(secondArtifacts.UnitUUIDs, tc.DeepEquals, firstArtifacts.UnitUUIDs)
-	c.Check(secondArtifacts.MachineUUIDs, tc.HasLen, 0)
+	// Machine UUIDs are still returned on retries so child removal
+	// jobs can be re-scheduled.
+	c.Check(secondArtifacts.MachineUUIDs, tc.SameContents, firstArtifacts.MachineUUIDs)
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeOfferConnections(c *tc.C) {

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -93,9 +93,9 @@ AND    life_id = 0;`, machineUUID)
 	selectContainerMachines, err := st.Prepare(`
 SELECT    mp.machine_uuid AS &entityUUID.uuid
 FROM      machine_parent AS mp
-JOIN      machine AS m ON mp.parent_uuid = m.uuid
+JOIN      machine AS m ON mp.machine_uuid = m.uuid
 WHERE     mp.parent_uuid = $entityUUID.uuid
-AND       m.life_id = 0;`, machineUUID)
+AND       m.life_id < 2;`, machineUUID)
 	if err != nil {
 		return cascaded, errors.Errorf("preparing container machine selection query: %w", err)
 	}
@@ -124,7 +124,7 @@ SELECT u.uuid AS &entityUUID.uuid
 FROM   unit AS u
 JOIN   machine  AS m ON m.net_node_uuid = u.net_node_uuid
 WHERE  m.uuid IN ($uuids[:])
-AND    u.life_id = 0;`, machineUUID, uuids{})
+AND    u.life_id < 2;`, machineUUID, uuids{})
 	if err != nil {
 		return cascaded, errors.Errorf("preparing unit selection query: %w", err)
 	}
@@ -189,9 +189,8 @@ AND    u.life_id = 0;`, machineUUID, uuids{})
 			}
 		}
 
-		const includeDyingArtifacts = false
 		cascaded.CascadedStorageInstanceLives, err = st.ensureMachineStorageInstancesNotAliveCascade(
-			ctx, tx, mUUID, includeDyingArtifacts,
+			ctx, tx, mUUID,
 		)
 		if err != nil {
 			return errors.Errorf("advancing machine storage entity lives: %w", err)
@@ -216,7 +215,7 @@ AND    u.life_id = 0;`, machineUUID, uuids{})
 		})
 		for _, u := range cascaded.UnitUUIDs {
 			uc, err := st.ensureUnitNotAliveCascade(
-				ctx, tx, u, checkEmptyMachine, destroyStorage, includeDyingArtifacts,
+				ctx, tx, u, checkEmptyMachine, destroyStorage,
 			)
 			if err != nil {
 				return errors.Errorf("cascading unit %q life advancement: %w", u, err)
@@ -232,7 +231,7 @@ AND    u.life_id = 0;`, machineUUID, uuids{})
 	return cascaded, nil
 }
 
-// ensureMachineStorageInstancesNotAliveCascade transitions any "alive"
+// ensureMachineStorageInstancesNotAliveCascade transitions any non-dead
 // storage instances that are provisioned by the machine to "dying" and to be
 // obliterated.
 //
@@ -244,14 +243,10 @@ AND    u.life_id = 0;`, machineUUID, uuids{})
 // backed by a non-machine owned volume, it will not go to "dying", even if this
 // state is impossible, we protect against it.
 func (st *State) ensureMachineStorageInstancesNotAliveCascade(
-	ctx context.Context, tx *sqlair.TX, mUUID string, includeDying bool,
+	ctx context.Context, tx *sqlair.TX, mUUID string,
 ) (internal.CascadedStorageInstanceLives, error) {
 	var cascaded internal.CascadedStorageInstanceLives
 	machineUUID := entityUUID{UUID: mUUID}
-	storageInstanceLife := "= 0"
-	if includeDying {
-		storageInstanceLife = "< 2"
-	}
 
 	q := `
 WITH all_instances AS (
@@ -260,7 +255,7 @@ WITH all_instances AS (
     JOIN   storage_instance_volume iv ON i.uuid = iv.storage_instance_uuid
     JOIN   machine_volume mv ON iv.storage_volume_uuid = mv.volume_uuid
     WHERE  mv.machine_uuid = $entityUUID.uuid AND
-           i.life_id ` + storageInstanceLife + `
+           i.life_id < 2
     UNION
     SELECT if.storage_instance_uuid AS uuid
     FROM   storage_instance i
@@ -268,7 +263,7 @@ WITH all_instances AS (
     JOIN   machine_filesystem mf ON if.storage_filesystem_uuid = mf.filesystem_uuid
     LEFT JOIN storage_instance_volume iv ON i.uuid = iv.storage_instance_uuid
     WHERE  mf.machine_uuid = $entityUUID.uuid AND
-           i.life_id ` + storageInstanceLife + ` AND
+           i.life_id < 2 AND
            iv.storage_instance_uuid IS NULL
 )
 SELECT &entityUUID.* FROM all_instances`
@@ -294,7 +289,7 @@ SELECT &entityUUID.* FROM all_instances`
 	// machine will cease to exist too.
 	obliterate := true
 	cascaded, err = st.ensureStorageInstancesNotAliveCascade(
-		ctx, tx, sUUIDs, obliterate, includeDying,
+		ctx, tx, sUUIDs, obliterate,
 	)
 	if err != nil {
 		return cascaded, errors.Errorf(

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -189,7 +189,10 @@ AND    u.life_id = 0;`, machineUUID, uuids{})
 			}
 		}
 
-		cascaded.CascadedStorageInstanceLives, err = st.ensureMachineStorageInstancesNotAliveCascade(ctx, tx, mUUID)
+		const includeDyingArtifacts = false
+		cascaded.CascadedStorageInstanceLives, err = st.ensureMachineStorageInstancesNotAliveCascade(
+			ctx, tx, mUUID, includeDyingArtifacts,
+		)
 		if err != nil {
 			return errors.Errorf("advancing machine storage entity lives: %w", err)
 		}
@@ -212,7 +215,9 @@ AND    u.life_id = 0;`, machineUUID, uuids{})
 			return u.UUID
 		})
 		for _, u := range cascaded.UnitUUIDs {
-			uc, err := st.ensureUnitNotAliveCascade(ctx, tx, u, checkEmptyMachine, destroyStorage)
+			uc, err := st.ensureUnitNotAliveCascade(
+				ctx, tx, u, checkEmptyMachine, destroyStorage, includeDyingArtifacts,
+			)
 			if err != nil {
 				return errors.Errorf("cascading unit %q life advancement: %w", u, err)
 			}
@@ -239,10 +244,14 @@ AND    u.life_id = 0;`, machineUUID, uuids{})
 // backed by a non-machine owned volume, it will not go to "dying", even if this
 // state is impossible, we protect against it.
 func (st *State) ensureMachineStorageInstancesNotAliveCascade(
-	ctx context.Context, tx *sqlair.TX, mUUID string,
+	ctx context.Context, tx *sqlair.TX, mUUID string, includeDying bool,
 ) (internal.CascadedStorageInstanceLives, error) {
 	var cascaded internal.CascadedStorageInstanceLives
 	machineUUID := entityUUID{UUID: mUUID}
+	storageInstanceLife := "= 0"
+	if includeDying {
+		storageInstanceLife = "< 2"
+	}
 
 	q := `
 WITH all_instances AS (
@@ -251,7 +260,7 @@ WITH all_instances AS (
     JOIN   storage_instance_volume iv ON i.uuid = iv.storage_instance_uuid
     JOIN   machine_volume mv ON iv.storage_volume_uuid = mv.volume_uuid
     WHERE  mv.machine_uuid = $entityUUID.uuid AND
-           i.life_id = 0
+           i.life_id ` + storageInstanceLife + `
     UNION
     SELECT if.storage_instance_uuid AS uuid
     FROM   storage_instance i
@@ -259,7 +268,7 @@ WITH all_instances AS (
     JOIN   machine_filesystem mf ON if.storage_filesystem_uuid = mf.filesystem_uuid
     LEFT JOIN storage_instance_volume iv ON i.uuid = iv.storage_instance_uuid
     WHERE  mf.machine_uuid = $entityUUID.uuid AND
-           i.life_id = 0 AND
+           i.life_id ` + storageInstanceLife + ` AND
            iv.storage_instance_uuid IS NULL
 )
 SELECT &entityUUID.* FROM all_instances`
@@ -285,7 +294,8 @@ SELECT &entityUUID.* FROM all_instances`
 	// machine will cease to exist too.
 	obliterate := true
 	cascaded, err = st.ensureStorageInstancesNotAliveCascade(
-		ctx, tx, sUUIDs, obliterate)
+		ctx, tx, sUUIDs, obliterate, includeDying,
+	)
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"ensuring %d storage instances not alive: %w", len(sUUIDs), err,

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -93,7 +93,7 @@ AND    life_id = 0;`, machineUUID)
 	selectContainerMachines, err := st.Prepare(`
 SELECT    mp.machine_uuid AS &entityUUID.uuid
 FROM      machine_parent AS mp
-JOIN      machine AS m ON mp.machine_uuid = m.uuid
+JOIN      machine AS m ON mp.parent_uuid = m.uuid
 WHERE     mp.parent_uuid = $entityUUID.uuid
 AND       m.life_id < 2;`, machineUUID)
 	if err != nil {

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -888,6 +888,27 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeCoHostedUnits(c *tc.C) {
 	s.checkInstanceLife(c, parentMachineUUID.String(), life.Dying)
 }
 
+func (s *machineSuite) TestEnsureMachineNotAliveCascadeRetryReturnsDyingArtifacts(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	firstCascaded, err := st.EnsureMachineNotAliveCascade(c.Context(), machineUUID.String(), true)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(firstCascaded.UnitUUIDs, tc.HasLen, 1)
+	c.Check(firstCascaded.MachineUUIDs, tc.HasLen, 0)
+
+	secondCascaded, err := st.EnsureMachineNotAliveCascade(c.Context(), machineUUID.String(), true)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(secondCascaded, tc.DeepEquals, firstCascaded)
+
+	s.checkUnitLife(c, firstCascaded.UnitUUIDs[0], life.Dying)
+	s.checkMachineLife(c, machineUUID.String(), life.Dying)
+	s.checkInstanceLife(c, machineUUID.String(), life.Dying)
+}
+
 func (s *machineSuite) TestEnsureMachineNotAliveCascadeChildMachines(c *tc.C) {
 	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app",

--- a/domain/removal/state/model/storage.go
+++ b/domain/removal/state/model/storage.go
@@ -553,7 +553,7 @@ WHERE  siv.storage_instance_uuid = $entityUUID.uuid
 		}
 
 		result, err = st.ensureStorageInstancesNotAliveCascade(
-			ctx, tx, []entityUUID{input}, obliterate, false,
+			ctx, tx, []entityUUID{input}, obliterate,
 		)
 		if err != nil {
 			return err
@@ -2046,7 +2046,7 @@ INSERT INTO removal (*) VALUES ($removalJob.*)
 // ensured to be no longer alive. If a Filesystem or Volume id not attached,
 // then it goes straight to dead.
 func (st *State) ensureStorageInstancesNotAliveCascade(
-	ctx context.Context, tx *sqlair.TX, siUUIDs entityUUIDs, obliterate, includeDying bool,
+	ctx context.Context, tx *sqlair.TX, siUUIDs entityUUIDs, obliterate bool,
 ) (internal.CascadedStorageInstanceLives, error) {
 	var cascaded internal.CascadedStorageInstanceLives
 
@@ -2054,10 +2054,6 @@ func (st *State) ensureStorageInstancesNotAliveCascade(
 		Obliterate: obliterate,
 	}
 	input := siUUIDs.uuids()
-	liveFilter := "= 0"
-	if includeDying {
-		liveFilter = "< 2"
-	}
 
 	// First kill the storage instances.
 	stmt, err := st.Prepare(`
@@ -2108,7 +2104,7 @@ SELECT f.uuid AS &entityUUID.uuid
 FROM   storage_instance_filesystem i
 JOIN   storage_filesystem f ON i.storage_filesystem_uuid = f.uuid
 WHERE  i.storage_instance_uuid IN ($uuids[:])
-AND    f.life_id ` + liveFilter
+AND    f.life_id < 2`
 
 	del = `
 UPDATE storage_filesystem
@@ -2155,7 +2151,7 @@ SELECT &entityUUID.uuid
 FROM   storage_instance_volume i
 JOIN   storage_volume v ON i.storage_volume_uuid = v.uuid
 WHERE  i.storage_instance_uuid IN ($uuids[:])
-AND    v.life_id ` + liveFilter
+AND    v.life_id < 2`
 
 	del = `
 UPDATE storage_volume

--- a/domain/removal/state/model/storage.go
+++ b/domain/removal/state/model/storage.go
@@ -553,7 +553,8 @@ WHERE  siv.storage_instance_uuid = $entityUUID.uuid
 		}
 
 		result, err = st.ensureStorageInstancesNotAliveCascade(
-			ctx, tx, []entityUUID{input}, obliterate)
+			ctx, tx, []entityUUID{input}, obliterate, false,
+		)
 		if err != nil {
 			return err
 		}
@@ -2045,7 +2046,7 @@ INSERT INTO removal (*) VALUES ($removalJob.*)
 // ensured to be no longer alive. If a Filesystem or Volume id not attached,
 // then it goes straight to dead.
 func (st *State) ensureStorageInstancesNotAliveCascade(
-	ctx context.Context, tx *sqlair.TX, siUUIDs entityUUIDs, obliterate bool,
+	ctx context.Context, tx *sqlair.TX, siUUIDs entityUUIDs, obliterate, includeDying bool,
 ) (internal.CascadedStorageInstanceLives, error) {
 	var cascaded internal.CascadedStorageInstanceLives
 
@@ -2053,6 +2054,10 @@ func (st *State) ensureStorageInstancesNotAliveCascade(
 		Obliterate: obliterate,
 	}
 	input := siUUIDs.uuids()
+	liveFilter := "= 0"
+	if includeDying {
+		liveFilter = "< 2"
+	}
 
 	// First kill the storage instances.
 	stmt, err := st.Prepare(`
@@ -2103,7 +2108,7 @@ SELECT f.uuid AS &entityUUID.uuid
 FROM   storage_instance_filesystem i
 JOIN   storage_filesystem f ON i.storage_filesystem_uuid = f.uuid
 WHERE  i.storage_instance_uuid IN ($uuids[:])
-AND    f.life_id = 0`
+AND    f.life_id ` + liveFilter
 
 	del = `
 UPDATE storage_filesystem
@@ -2150,7 +2155,7 @@ SELECT &entityUUID.uuid
 FROM   storage_instance_volume i
 JOIN   storage_volume v ON i.storage_volume_uuid = v.uuid
 WHERE  i.storage_instance_uuid IN ($uuids[:])
-AND    v.life_id = 0`
+AND    v.life_id ` + liveFilter
 
 	del = `
 UPDATE storage_volume

--- a/domain/removal/state/model/storage_test.go
+++ b/domain/removal/state/model/storage_test.go
@@ -268,8 +268,7 @@ func (s *storageSuite) TestEnsureStorageInstanceNotAliveCascadeAttached(c *tc.C)
 }
 
 // TestEnsureStorageInstanceNotAliveCascadeAttachedWithSecondForce tests that
-// forcing returns the filesystem and volume uuids, even if they are already
-// Dying.
+// retries return filesystem and volume uuids even when already dying.
 func (s *storageSuite) TestEnsureStorageInstanceNotAliveCascadeAttachedWithSecondForce(c *tc.C) {
 	siUUID := s.addStorageInstance(c)
 	fsUUID, _ := s.addAttachedFilesystem(c)
@@ -293,7 +292,11 @@ func (s *storageSuite) TestEnsureStorageInstanceNotAliveCascadeAttachedWithSecon
 		c.Context(), siUUID, false, false)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(cascaded, tc.DeepEquals,
-		internal.CascadedStorageInstanceLifeChildren{})
+		internal.CascadedStorageInstanceLifeChildren{
+			FileSystemUUID: &fsUUID,
+			VolumeUUID:     &volUUID,
+		},
+	)
 
 	cascadeForce := true
 	cascaded, err = st.EnsureStorageInstanceNotAliveCascade(

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -369,7 +369,14 @@ AND    life_id = 0`, entityUUID{})
 	if affected, err := outcome.Result().RowsAffected(); err != nil {
 		return "", cascaded, errors.Errorf("getting affected rows: %w", err)
 	} else if affected == 0 {
-		return "", cascaded, nil
+		// The machine was already dying or dead.
+		// We still need to return cascaded storage information
+		// so retries can re-schedule child removal jobs.
+		cascaded, err = st.ensureMachineStorageInstancesNotAliveCascade(ctx, tx, result.UUID)
+		if err != nil {
+			return "", cascaded, errors.Errorf("advancing machine storage entity lives: %w", err)
+		}
+		return result.UUID, cascaded, nil
 	}
 
 	updateInstanceStmt, err := st.Prepare(`

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -52,8 +52,9 @@ WHERE  uuid = $entityUUID.uuid`, unitUUID)
 
 // EnsureUnitNotAliveCascade ensures that there is no unit identified by the
 // input unit UUID, that is still alive. If the unit is the last one on the
-// machine, it will cascade and the machine is also set to dying. The
-// affected machine UUID is returned.
+// machine, it will cascade and the machine is also set to dying.
+// Non-dead cascaded entity UUIDs are returned so retries can re-schedule
+// child removals with updated intent.
 func (st *State) EnsureUnitNotAliveCascade(
 	ctx context.Context, uUUID string, destroyStorage bool,
 ) (internal.CascadedUnitLives, error) {
@@ -66,9 +67,8 @@ func (st *State) EnsureUnitNotAliveCascade(
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		const includeDyingArtifacts = false
 		cascaded, err = st.ensureUnitNotAliveCascade(
-			ctx, tx, uUUID, true, destroyStorage, includeDyingArtifacts,
+			ctx, tx, uUUID, true, destroyStorage,
 		)
 		return errors.Capture(err)
 	})
@@ -76,7 +76,7 @@ func (st *State) EnsureUnitNotAliveCascade(
 }
 
 func (st *State) ensureUnitNotAliveCascade(
-	ctx context.Context, tx *sqlair.TX, uUUID string, checkMachine, destroyStorage, includeDyingArtifacts bool,
+	ctx context.Context, tx *sqlair.TX, uUUID string, checkMachine, destroyStorage bool,
 ) (internal.CascadedUnitLives, error) {
 	var cascaded internal.CascadedUnitLives
 
@@ -95,7 +95,7 @@ AND    life_id = 0`, unitUUID)
 	}
 
 	cascaded.CascadedStorageAttachmentLives, err = st.ensureUnitStorageAttachmentsNotAlive(
-		ctx, tx, uUUID, includeDyingArtifacts,
+		ctx, tx, uUUID,
 	)
 	if err != nil {
 		return cascaded, errors.Errorf("setting unit storage attachment lives to dying: %w", err)
@@ -104,7 +104,7 @@ AND    life_id = 0`, unitUUID)
 	if destroyStorage {
 		// TODO(storage): wire through obliterate separately from destroy.
 		cascaded.CascadedStorageInstanceLives, err = st.ensureUnitOwnedStorageInstancesNotAlive(
-			ctx, tx, uUUID, destroyStorage, includeDyingArtifacts,
+			ctx, tx, uUUID, destroyStorage,
 		)
 		if err != nil {
 			return cascaded, errors.Errorf("setting unit storage instance lives to dying: %w", err)
@@ -113,7 +113,7 @@ AND    life_id = 0`, unitUUID)
 
 	if checkMachine {
 		mUUID, machineStorageCascaded, err := st.markMachineAsDyingIfAllUnitsAreNotAlive(
-			ctx, tx, uUUID, includeDyingArtifacts,
+			ctx, tx, uUUID,
 		)
 		if err != nil {
 			return cascaded, errors.Errorf("setting unit machine life to dying: %w", err)
@@ -128,21 +128,17 @@ AND    life_id = 0`, unitUUID)
 }
 
 func (st *State) ensureUnitStorageAttachmentsNotAlive(
-	ctx context.Context, tx *sqlair.TX, uUUID string, includeDying bool,
+	ctx context.Context, tx *sqlair.TX, uUUID string,
 ) (internal.CascadedStorageAttachmentLives, error) {
 	var cascaded internal.CascadedStorageAttachmentLives
 
 	unitUUID := entityUUID{UUID: uUUID}
-	storageAttachmentLife := "= 0"
-	if includeDying {
-		storageAttachmentLife = "< 2"
-	}
 
 	stmt, err := st.Prepare(`
 SELECT &entityUUID.*
 FROM   storage_attachment
 WHERE  unit_uuid = $entityUUID.uuid
-AND    life_id `+storageAttachmentLife, unitUUID)
+AND    life_id < 2`, unitUUID)
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live storage attachments query: %w", err,
@@ -187,7 +183,7 @@ FROM   storage_attachment sa
        JOIN storage_instance_filesystem sif ON sa.storage_instance_uuid = sif.storage_instance_uuid
        JOIN storage_filesystem_attachment sfa ON sif.storage_filesystem_uuid = sfa.storage_filesystem_uuid
 WHERE  sa.unit_uuid = $entityUUID.uuid
-AND    sfa.life_id `+storageAttachmentLife, entityUUID{})
+AND    sfa.life_id < 2`, entityUUID{})
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live unit filesystem attachments query: %w", err,
@@ -213,7 +209,7 @@ FROM   storage_attachment sa
        JOIN storage_instance_volume siv ON sa.storage_instance_uuid = siv.storage_instance_uuid
        JOIN storage_volume_attachment sva ON siv.storage_volume_uuid = sva.storage_volume_uuid
 WHERE  sa.unit_uuid = $entityUUID.uuid
-AND    sva.life_id `+storageAttachmentLife, entityUUID{})
+AND    sva.life_id < 2`, entityUUID{})
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live unit volume attachments query: %w", err,
@@ -239,7 +235,7 @@ FROM   storage_attachment sa
        JOIN storage_instance_volume siv ON sa.storage_instance_uuid = siv.storage_instance_uuid
        JOIN storage_volume_attachment_plan svap ON siv.storage_volume_uuid = svap.storage_volume_uuid
 WHERE  sa.unit_uuid = $entityUUID.uuid
-AND    svap.life_id `+storageAttachmentLife, unitUUID)
+AND    svap.life_id < 2`, unitUUID)
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live unit volume attachment plans query: %w", err,
@@ -263,22 +259,18 @@ AND    svap.life_id `+storageAttachmentLife, unitUUID)
 }
 
 func (st *State) ensureUnitOwnedStorageInstancesNotAlive(
-	ctx context.Context, tx *sqlair.TX, uUUID string, obliterate, includeDying bool,
+	ctx context.Context, tx *sqlair.TX, uUUID string, obliterate bool,
 ) (internal.CascadedStorageInstanceLives, error) {
 	var cascaded internal.CascadedStorageInstanceLives
 
 	unitUUID := entityUUID{UUID: uUUID}
-	storageInstanceLife := "= 0"
-	if includeDying {
-		storageInstanceLife = "< 2"
-	}
 
 	stmt, err := st.Prepare(`
 SELECT si.uuid AS &entityUUID.uuid
 FROM   storage_unit_owner so 
 JOIN   storage_instance si ON so.storage_instance_uuid = si.uuid
 WHERE  so.unit_uuid = $entityUUID.uuid
-AND    si.life_id `+storageInstanceLife, entityUUID{})
+AND    si.life_id < 2`, entityUUID{})
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live storage instances query: %w", err,
@@ -295,13 +287,13 @@ AND    si.life_id `+storageInstanceLife, entityUUID{})
 		)
 	}
 
-	return st.ensureStorageInstancesNotAliveCascade(ctx, tx, instances, obliterate, includeDying)
+	return st.ensureStorageInstancesNotAliveCascade(ctx, tx, instances, obliterate)
 }
 
 // markMachineAsDyingIfAllUnitsAreNotAlive checks if all the units on the
 // machine are not alive. If this is the case, it marks the machine as dying.
 func (st *State) markMachineAsDyingIfAllUnitsAreNotAlive(
-	ctx context.Context, tx *sqlair.TX, uUUID string, includeDying bool,
+	ctx context.Context, tx *sqlair.TX, uUUID string,
 ) (string, internal.CascadedStorageInstanceLives, error) {
 	var cascaded internal.CascadedStorageInstanceLives
 	unitUUID := entityUUID{UUID: uUUID}
@@ -377,34 +369,7 @@ AND    life_id = 0`, entityUUID{})
 	if affected, err := outcome.Result().RowsAffected(); err != nil {
 		return "", cascaded, errors.Errorf("getting affected rows: %w", err)
 	} else if affected == 0 {
-		if !includeDying {
-			// The machine was already dying or dead.
-			return "", cascaded, nil
-		}
-
-		machineLifeStmt, err := st.Prepare(`
-SELECT life_id AS &entityLife.life_id
-FROM   machine
-WHERE  uuid = $entityUUID.uuid`, entityLife{}, entityUUID{})
-		if err != nil {
-			return "", cascaded, errors.Errorf("preparing machine life query: %w", err)
-		}
-
-		var machineLife entityLife
-		if err := tx.Query(ctx, machineLifeStmt, entityUUID{UUID: result.UUID}).Get(&machineLife); errors.Is(err, sqlair.ErrNoRows) {
-			return "", cascaded, nil
-		} else if err != nil {
-			return "", cascaded, errors.Errorf("getting machine life: %w", err)
-		} else if machineLife.Life == int(life.Dead) {
-			return "", cascaded, nil
-		}
-
-		cascaded, err = st.ensureMachineStorageInstancesNotAliveCascade(ctx, tx, result.UUID, includeDying)
-		if err != nil {
-			return "", cascaded, errors.Errorf("advancing machine storage entity lives: %w", err)
-		}
-
-		return result.UUID, cascaded, nil
+		return "", cascaded, nil
 	}
 
 	updateInstanceStmt, err := st.Prepare(`
@@ -420,7 +385,7 @@ AND    life_id = 0`, entityUUID{})
 		return "", cascaded, errors.Errorf("advancing machine cloud instance life: %w", err)
 	}
 
-	cascaded, err = st.ensureMachineStorageInstancesNotAliveCascade(ctx, tx, result.UUID, includeDying)
+	cascaded, err = st.ensureMachineStorageInstancesNotAliveCascade(ctx, tx, result.UUID)
 	if err != nil {
 		return "", cascaded, errors.Errorf("advancing machine storage entity lives: %w", err)
 	}

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -66,14 +66,17 @@ func (st *State) EnsureUnitNotAliveCascade(
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
-		cascaded, err = st.ensureUnitNotAliveCascade(ctx, tx, uUUID, true, destroyStorage)
+		const includeDyingArtifacts = false
+		cascaded, err = st.ensureUnitNotAliveCascade(
+			ctx, tx, uUUID, true, destroyStorage, includeDyingArtifacts,
+		)
 		return errors.Capture(err)
 	})
 	return cascaded, errors.Capture(err)
 }
 
 func (st *State) ensureUnitNotAliveCascade(
-	ctx context.Context, tx *sqlair.TX, uUUID string, checkMachine, destroyStorage bool,
+	ctx context.Context, tx *sqlair.TX, uUUID string, checkMachine, destroyStorage, includeDyingArtifacts bool,
 ) (internal.CascadedUnitLives, error) {
 	var cascaded internal.CascadedUnitLives
 
@@ -91,21 +94,27 @@ AND    life_id = 0`, unitUUID)
 		return cascaded, errors.Errorf("advancing unit life: %w", err)
 	}
 
-	cascaded.CascadedStorageAttachmentLives, err = st.ensureUnitStorageAttachmentsNotAlive(ctx, tx, uUUID)
+	cascaded.CascadedStorageAttachmentLives, err = st.ensureUnitStorageAttachmentsNotAlive(
+		ctx, tx, uUUID, includeDyingArtifacts,
+	)
 	if err != nil {
 		return cascaded, errors.Errorf("setting unit storage attachment lives to dying: %w", err)
 	}
 
 	if destroyStorage {
 		// TODO(storage): wire through obliterate separately from destroy.
-		cascaded.CascadedStorageInstanceLives, err = st.ensureUnitOwnedStorageInstancesNotAlive(ctx, tx, uUUID, destroyStorage)
+		cascaded.CascadedStorageInstanceLives, err = st.ensureUnitOwnedStorageInstancesNotAlive(
+			ctx, tx, uUUID, destroyStorage, includeDyingArtifacts,
+		)
 		if err != nil {
 			return cascaded, errors.Errorf("setting unit storage instance lives to dying: %w", err)
 		}
 	}
 
 	if checkMachine {
-		mUUID, machineStorageCascaded, err := st.markMachineAsDyingIfAllUnitsAreNotAlive(ctx, tx, uUUID)
+		mUUID, machineStorageCascaded, err := st.markMachineAsDyingIfAllUnitsAreNotAlive(
+			ctx, tx, uUUID, includeDyingArtifacts,
+		)
 		if err != nil {
 			return cascaded, errors.Errorf("setting unit machine life to dying: %w", err)
 		}
@@ -119,17 +128,21 @@ AND    life_id = 0`, unitUUID)
 }
 
 func (st *State) ensureUnitStorageAttachmentsNotAlive(
-	ctx context.Context, tx *sqlair.TX, uUUID string,
+	ctx context.Context, tx *sqlair.TX, uUUID string, includeDying bool,
 ) (internal.CascadedStorageAttachmentLives, error) {
 	var cascaded internal.CascadedStorageAttachmentLives
 
 	unitUUID := entityUUID{UUID: uUUID}
+	storageAttachmentLife := "= 0"
+	if includeDying {
+		storageAttachmentLife = "< 2"
+	}
 
 	stmt, err := st.Prepare(`
 SELECT &entityUUID.*
 FROM   storage_attachment
 WHERE  unit_uuid = $entityUUID.uuid
-AND    life_id = 0`, unitUUID)
+AND    life_id `+storageAttachmentLife, unitUUID)
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live storage attachments query: %w", err,
@@ -174,7 +187,7 @@ FROM   storage_attachment sa
        JOIN storage_instance_filesystem sif ON sa.storage_instance_uuid = sif.storage_instance_uuid
        JOIN storage_filesystem_attachment sfa ON sif.storage_filesystem_uuid = sfa.storage_filesystem_uuid
 WHERE  sa.unit_uuid = $entityUUID.uuid
-AND    sfa.life_id = 0`, entityUUID{})
+AND    sfa.life_id `+storageAttachmentLife, entityUUID{})
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live unit filesystem attachments query: %w", err,
@@ -200,7 +213,7 @@ FROM   storage_attachment sa
        JOIN storage_instance_volume siv ON sa.storage_instance_uuid = siv.storage_instance_uuid
        JOIN storage_volume_attachment sva ON siv.storage_volume_uuid = sva.storage_volume_uuid
 WHERE  sa.unit_uuid = $entityUUID.uuid
-AND    sva.life_id = 0`, entityUUID{})
+AND    sva.life_id `+storageAttachmentLife, entityUUID{})
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live unit volume attachments query: %w", err,
@@ -226,7 +239,7 @@ FROM   storage_attachment sa
        JOIN storage_instance_volume siv ON sa.storage_instance_uuid = siv.storage_instance_uuid
        JOIN storage_volume_attachment_plan svap ON siv.storage_volume_uuid = svap.storage_volume_uuid
 WHERE  sa.unit_uuid = $entityUUID.uuid
-AND    svap.life_id = 0`, unitUUID)
+AND    svap.life_id `+storageAttachmentLife, unitUUID)
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live unit volume attachment plans query: %w", err,
@@ -250,18 +263,22 @@ AND    svap.life_id = 0`, unitUUID)
 }
 
 func (st *State) ensureUnitOwnedStorageInstancesNotAlive(
-	ctx context.Context, tx *sqlair.TX, uUUID string, obliterate bool,
+	ctx context.Context, tx *sqlair.TX, uUUID string, obliterate, includeDying bool,
 ) (internal.CascadedStorageInstanceLives, error) {
 	var cascaded internal.CascadedStorageInstanceLives
 
 	unitUUID := entityUUID{UUID: uUUID}
+	storageInstanceLife := "= 0"
+	if includeDying {
+		storageInstanceLife = "< 2"
+	}
 
 	stmt, err := st.Prepare(`
 SELECT si.uuid AS &entityUUID.uuid
 FROM   storage_unit_owner so 
 JOIN   storage_instance si ON so.storage_instance_uuid = si.uuid
 WHERE  so.unit_uuid = $entityUUID.uuid
-AND    si.life_id = 0`, entityUUID{})
+AND    si.life_id `+storageInstanceLife, entityUUID{})
 	if err != nil {
 		return cascaded, errors.Errorf(
 			"preparing live storage instances query: %w", err,
@@ -278,13 +295,13 @@ AND    si.life_id = 0`, entityUUID{})
 		)
 	}
 
-	return st.ensureStorageInstancesNotAliveCascade(ctx, tx, instances, obliterate)
+	return st.ensureStorageInstancesNotAliveCascade(ctx, tx, instances, obliterate, includeDying)
 }
 
 // markMachineAsDyingIfAllUnitsAreNotAlive checks if all the units on the
 // machine are not alive. If this is the case, it marks the machine as dying.
 func (st *State) markMachineAsDyingIfAllUnitsAreNotAlive(
-	ctx context.Context, tx *sqlair.TX, uUUID string,
+	ctx context.Context, tx *sqlair.TX, uUUID string, includeDying bool,
 ) (string, internal.CascadedStorageInstanceLives, error) {
 	var cascaded internal.CascadedStorageInstanceLives
 	unitUUID := entityUUID{UUID: uUUID}
@@ -360,8 +377,34 @@ AND    life_id = 0`, entityUUID{})
 	if affected, err := outcome.Result().RowsAffected(); err != nil {
 		return "", cascaded, errors.Errorf("getting affected rows: %w", err)
 	} else if affected == 0 {
-		// The machine was already dying or dead.
-		return "", cascaded, nil
+		if !includeDying {
+			// The machine was already dying or dead.
+			return "", cascaded, nil
+		}
+
+		machineLifeStmt, err := st.Prepare(`
+SELECT life_id AS &entityLife.life_id
+FROM   machine
+WHERE  uuid = $entityUUID.uuid`, entityLife{}, entityUUID{})
+		if err != nil {
+			return "", cascaded, errors.Errorf("preparing machine life query: %w", err)
+		}
+
+		var machineLife entityLife
+		if err := tx.Query(ctx, machineLifeStmt, entityUUID{UUID: result.UUID}).Get(&machineLife); errors.Is(err, sqlair.ErrNoRows) {
+			return "", cascaded, nil
+		} else if err != nil {
+			return "", cascaded, errors.Errorf("getting machine life: %w", err)
+		} else if machineLife.Life == int(life.Dead) {
+			return "", cascaded, nil
+		}
+
+		cascaded, err = st.ensureMachineStorageInstancesNotAliveCascade(ctx, tx, result.UUID, includeDying)
+		if err != nil {
+			return "", cascaded, errors.Errorf("advancing machine storage entity lives: %w", err)
+		}
+
+		return result.UUID, cascaded, nil
 	}
 
 	updateInstanceStmt, err := st.Prepare(`
@@ -377,7 +420,7 @@ AND    life_id = 0`, entityUUID{})
 		return "", cascaded, errors.Errorf("advancing machine cloud instance life: %w", err)
 	}
 
-	cascaded, err = st.ensureMachineStorageInstancesNotAliveCascade(ctx, tx, result.UUID)
+	cascaded, err = st.ensureMachineStorageInstancesNotAliveCascade(ctx, tx, result.UUID, includeDying)
 	if err != nil {
 		return "", cascaded, errors.Errorf("advancing machine storage entity lives: %w", err)
 	}

--- a/domain/removal/state/model/unit_test.go
+++ b/domain/removal/state/model/unit_test.go
@@ -262,11 +262,99 @@ func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccessLastUnitMachineAlr
 	cascade, err := st.EnsureUnitNotAliveCascade(c.Context(), unitUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
-	// The machine was already "dying", so we don't expect a machine UUID.
-	c.Assert(cascade.MachineUUID, tc.IsNil)
+	// The machine was already "dying", but we still expect the machine UUID
+	// so retries can re-schedule child removal jobs.
+	c.Assert(cascade.MachineUUID, tc.NotNil)
+	c.Check(*cascade.MachineUUID, tc.Equals, unitMachineUUID.String())
 
 	// Unit had life "alive" and should now be "dying".
 	s.checkUnitLife(c, unitUUID.String(), life.Dying)
+}
+
+func (s *unitSuite) TestEnsureUnitNotAliveCascadeMachineAlreadyDyingReturnsStorageCascade(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, svc, "some-app",
+		applicationservice.AddIAASUnitArg{},
+	)
+
+	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
+	c.Assert(len(unitUUIDs), tc.Equals, 1)
+	unitUUID := unitUUIDs[0]
+
+	unitMachineUUID := s.getUnitMachineUUID(c, unitUUID)
+
+	// Create machine-owned storage: pool, instance, filesystem, and link them.
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		row := tx.QueryRowContext(
+			ctx, "SELECT net_node_uuid FROM unit WHERE uuid = ?", unitUUID.String())
+		if row.Err() != nil {
+			return row.Err()
+		}
+		var netNodeUUID string
+		if err := row.Scan(&netNodeUUID); err != nil {
+			return err
+		}
+
+		if _, err := tx.ExecContext(
+			ctx, "INSERT INTO storage_pool (uuid, name, type) VALUES ('pool-uuid', 'pool', 'whatever')",
+		); err != nil {
+			return err
+		}
+
+		inst := `
+INSERT INTO storage_instance (
+    uuid, storage_id, storage_pool_uuid, storage_kind_id, requested_size_mib, charm_name, storage_name, life_id
+)
+VALUES ('instance-uuid', 'does-not-matter', 'pool-uuid', 1, 100, 'charm-name', 'storage-name', 0)`
+		if _, err := tx.ExecContext(ctx, inst); err != nil {
+			return err
+		}
+
+		fs := `
+INSERT INTO storage_filesystem(uuid, filesystem_id, life_id, provision_scope_id)
+VALUES ('filesystem-uuid', 'filesystem-id', 0, 1)`
+		if _, err := tx.ExecContext(ctx, fs); err != nil {
+			return err
+		}
+
+		mfs := `
+INSERT INTO machine_filesystem(machine_uuid, filesystem_uuid)
+VALUES (?, 'filesystem-uuid')`
+		if _, err := tx.ExecContext(ctx, mfs, unitMachineUUID.String()); err != nil {
+			return err
+		}
+
+		fsi := `
+INSERT INTO storage_instance_filesystem (storage_instance_uuid, storage_filesystem_uuid)
+VALUES ('instance-uuid', 'filesystem-uuid')`
+		if _, err := tx.ExecContext(ctx, fsi); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Set the machine to "dying" manually before the cascade call.
+	s.advanceMachineLife(c, unitMachineUUID, life.Dying)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	cascade, err := st.EnsureUnitNotAliveCascade(c.Context(), unitUUID.String(), false)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Machine was already dying, but we still expect the machine UUID
+	// and the machine-owned storage cascade info.
+	c.Assert(cascade.MachineUUID, tc.NotNil)
+	c.Check(*cascade.MachineUUID, tc.Equals, unitMachineUUID.String())
+	c.Check(cascade.StorageInstanceUUIDs, tc.DeepEquals, []string{"instance-uuid"})
+	c.Check(cascade.FileSystemUUIDs, tc.DeepEquals, []string{"filesystem-uuid"})
+
+	s.checkUnitLife(c, unitUUID.String(), life.Dying)
+	s.checkMachineLife(c, unitMachineUUID.String(), life.Dying)
+	s.checkStorageInstanceLife(c, "instance-uuid", life.Dying)
+	// Filesystem has no attachment, so it goes directly to dead.
+	s.checkFileSystemLife(c, "filesystem-uuid", life.Dead)
 }
 
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccess(c *tc.C) {
@@ -345,7 +433,8 @@ func (s *unitSuite) TestEnsureUnitNotAliveCascadeRetryReturnsDyingArtifacts(c *t
 	secondCascade, err := st.EnsureUnitNotAliveCascade(c.Context(), unitUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(secondCascade.CascadedStorageLives, tc.DeepEquals, firstCascade.CascadedStorageLives)
-	c.Assert(secondCascade.MachineUUID, tc.IsNil)
+	c.Assert(secondCascade.MachineUUID, tc.NotNil)
+	c.Check(*secondCascade.MachineUUID, tc.Equals, unitMachineUUID.String())
 
 	s.checkUnitLife(c, unitUUID.String(), life.Dying)
 	s.checkMachineLife(c, unitMachineUUID.String(), life.Dying)

--- a/domain/removal/state/model/unit_test.go
+++ b/domain/removal/state/model/unit_test.go
@@ -326,6 +326,31 @@ func (s *unitSuite) TestEnsureUnitNotAliveCascadeDyingSuccess(c *tc.C) {
 	s.checkUnitLife(c, unitUUID.String(), life.Dying)
 }
 
+func (s *unitSuite) TestEnsureUnitNotAliveCascadeRetryReturnsDyingArtifacts(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+
+	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
+	c.Assert(len(unitUUIDs), tc.Equals, 1)
+	unitUUID := unitUUIDs[0]
+	unitMachineUUID := s.getUnitMachineUUID(c, unitUUID)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	firstCascade, err := st.EnsureUnitNotAliveCascade(c.Context(), unitUUID.String(), false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(firstCascade.MachineUUID, tc.NotNil)
+	c.Check(*firstCascade.MachineUUID, tc.Equals, unitMachineUUID.String())
+
+	secondCascade, err := st.EnsureUnitNotAliveCascade(c.Context(), unitUUID.String(), false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(secondCascade.CascadedStorageLives, tc.DeepEquals, firstCascade.CascadedStorageLives)
+	c.Assert(secondCascade.MachineUUID, tc.IsNil)
+
+	s.checkUnitLife(c, unitUUID.String(), life.Dying)
+	s.checkMachineLife(c, unitMachineUUID.String(), life.Dying)
+}
+
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeNotExistsSuccess(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 

--- a/domain/storage/service/instance_test.go
+++ b/domain/storage/service/instance_test.go
@@ -99,7 +99,7 @@ func (s *instanceSuite) TestGetStorageInstanceInfoNotFound(c *tc.C) {
 	)
 
 	svc := NewService(
-		s.state, loggertesting.WrapCheckLog(c), s.storageRegistryGetter,
+		s.state, loggertesting.WrapCheckLog(c), clock.WallClock, s.storageRegistryGetter,
 	)
 	_, err := svc.GetStorageInstanceInfo(c.Context(), notFoundUUID)
 	c.Check(err, tc.ErrorIs, domainstorageerrors.StorageInstanceNotFound)
@@ -114,7 +114,7 @@ func (s *instanceSuite) TestGetStorageInstanceInfoUUIDNotValid(c *tc.C) {
 	invalidUUID := domainstorage.StorageInstanceUUID("invalid")
 
 	svc := NewService(
-		s.state, loggertesting.WrapCheckLog(c), s.storageRegistryGetter,
+		s.state, loggertesting.WrapCheckLog(c), clock.WallClock, s.storageRegistryGetter,
 	)
 	_, err := svc.GetStorageInstanceInfo(c.Context(), invalidUUID)
 	c.Check(err, tc.ErrorIs, coreerrors.NotValid)
@@ -168,7 +168,7 @@ func (s *instanceSuite) TestGetStorageInstanceInfoFilesystem(c *tc.C) {
 	)
 
 	svc := NewService(
-		s.state, loggertesting.WrapCheckLog(c), s.storageRegistryGetter,
+		s.state, loggertesting.WrapCheckLog(c), clock.WallClock, s.storageRegistryGetter,
 	)
 	res, err := svc.GetStorageInstanceInfo(c.Context(), siUUID)
 	c.Check(err, tc.ErrorIsNil)
@@ -268,7 +268,7 @@ func (s *instanceSuite) TestGetStorageInstanceInfoFilesystemVolumeBacked(c *tc.C
 	)
 
 	svc := NewService(
-		s.state, loggertesting.WrapCheckLog(c), s.storageRegistryGetter,
+		s.state, loggertesting.WrapCheckLog(c), clock.WallClock, s.storageRegistryGetter,
 	)
 	res, err := svc.GetStorageInstanceInfo(c.Context(), siUUID)
 	c.Check(err, tc.ErrorIsNil)
@@ -375,7 +375,7 @@ func (s *instanceSuite) TestGetStorageInstanceInfoFilesystemMultipleUnits(c *tc.
 	)
 
 	svc := NewService(
-		s.state, loggertesting.WrapCheckLog(c), s.storageRegistryGetter,
+		s.state, loggertesting.WrapCheckLog(c), clock.WallClock, s.storageRegistryGetter,
 	)
 	res, err := svc.GetStorageInstanceInfo(c.Context(), siUUID)
 	c.Check(err, tc.ErrorIsNil)
@@ -470,7 +470,7 @@ func (s *instanceSuite) TestGetStorageInstanceInfoBlockVolume(c *tc.C) {
 	)
 
 	svc := NewService(
-		s.state, loggertesting.WrapCheckLog(c), s.storageRegistryGetter,
+		s.state, loggertesting.WrapCheckLog(c), clock.WallClock, s.storageRegistryGetter,
 	)
 	res, err := svc.GetStorageInstanceInfo(c.Context(), siUUID)
 	c.Check(err, tc.ErrorIsNil)


### PR DESCRIPTION
__Note: this is the second patch that fixes the (re-)schedule of removal jobs on child entities when retried. Prev. one was https://github.com/juju/juju/pull/21973.__

## Problem

While analyzing https://github.com/juju/juju/issues/21257 I discovered that we have an issue when removing applications after a first attempt failed. 
The actual problem was that when we run remove-application with --force *after* it had been run without it, and a unit removal job hangs, then the application is blocked for removal.
The reason for this can be found in `EnsureApplicationNotAliveCascade()` in the state layer:
https://github.com/juju/juju/blob/78529496d3f72768f173b51286421c0eed0b393a/domain/removal/state/model/application.go#L142-L146
In this case, we only select units that are alive and update them to dying, then return their UUIDs. But what happens if the unit had previously been updated already?: It's not returned.
And therefore we don't re-schedule any job for it: https://github.com/juju/juju/blob/7c5e8de23c37e0ce9061454fcaac818c53c2e7db/domain/removal/service/model.go#L226
This is of course problematic since the second run of `juju destroy-model --force` should be effective and "supersede" the previously scheduled/running removal jobs for that entity.

If we look at an example (subset) hierarchy of model destroy:
```
                   Model
                     |
                 Application
                     |
       ----------------------------
       |                          |
      Unit <-fails             Relation
       |
    Machine
```

A common operator flow is to escalate removal intent over multiple commands:

   juju remove-application ubuntu
   juju remove-application ubuntu --force --wait=60s
   juju remove-application ubuntu --force --wait=0s   # highest priority request

Before this fix, the previous executions would be hang because the unit job would not finish and so the application cannot be removed.

## The fix

Before this change, remove-application only re-collected children that were still alive.
If a previous removal attempt had already moved units, relations, machines, or storage
to dying, a retry (including --force) would not reschedule those child jobs. That made
retry escalation ineffective and could leave app removal wedged.

Now application removal returns all non-dead cascaded children on each retry and
reschedules their jobs with the latest intent (including no-force -> force escalation),
while still keeping life transitions monotonic (alive -> dying only).

## Fly-by

As a flyby, an unseen bug was fixed in the container removal path (we were selecting based on the life of the parent and not the machine):
https://github.com/juju/juju/pull/22008/changes#diff-84670fef638b2c8dbf568c3029af0906c2f2661d129020b20ac8bd1a8f8e5fe8R96


## QA steps
The scenario is basically to deploy an app on a model, and then stop the jujud service on the machine to simulate a broken state that will block graceful removal. Then destroy again with --force and check that it actually goes away.
```
$ juju add-model m
$ juju deploy ubuntu
$ juju add-ssh-key "$(cat ~/.ssh/id_ed25519.pub)"
$ juju ssh 0 "sudo systemctl stop jujud-machine-0.service"
```
Now the status should show the machine `down` and ubuntu app and unit as `unknown` status.

After a first graceful destroy (`juju remove-application ubuntu`) we'll see that it just hangs, and on the logs we have:
```
machine-0: 12:08:21 INFO juju.worker.removal scheduling application job "10442cf7-83cb-4f1a-8b57-2b731aa9cebc"
machine-0: 12:08:21 INFO juju.worker.removal scheduling unit job "24c15f0c-d84e-4536-8abc-d55d12e0ce16"
machine-0: 12:08:21 INFO juju.worker.removal scheduling machine job "2fe9cff7-63ed-4d86-8129-1a81c1ff76df"
machine-0: 12:08:21 INFO juju.worker.removal runner "removal" starting worker "24c15f0c-d84e-4536-8abc-d55d12e0ce16"
machine-0: 12:08:21 INFO juju.worker.removal runner "removal" starting worker "10442cf7-83cb-4f1a-8b57-2b731aa9cebc"
machine-0: 12:08:21 INFO juju.worker.removal runner "removal" starting worker "2fe9cff7-63ed-4d86-8129-1a81c1ff76df"
```
If we then force the app removal, the application will end up being removed:
```
$ juju remove-application ubuntu --force
```
Another scenario is similar but with a relation included:
```
$ juju add-model m
$ juju deploy juju-qa-dummy-source --base ubuntu@22.04
$ juju deploy juju-qa-dummy-sink --base ubuntu@22.04
$ juju relate dummy-sink dummy-source
# Now stop one of the machine services
$ juju add-ssh-key "$(cat ~/.ssh/id_ed25519.pub)"
$ juju ssh 0 "sudo systemctl stop jujud-machine-0.service"
```
This will bring the `dummy-source` application to an `unknown` state so we can now perform the removal without and with force (which will remove the application).

The last scenario regards storage. 
We deploy an application with storage attached, and then try to remove the app with a failing unit (exactly like the previous scenarios). 
- First without the `--destroy-storage` flag, only force: this time the app will be removed but the storage won't.
- Second with `--destroy-storage`. This time everything will go away.
(The dummy-storage charm must be packed first with charmcraft)
```
$ juju deploy ./testcharms/charms/dummy-storage/dummy-storage_amd64.charm --storage single-fs=100M
$ juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
mmm    ccc         localhost/localhost  4.0.4.1  12:57:22+01:00

App            Version  Status  Scale  Charm          Channel  Rev  Exposed  Message
dummy-storage           active      1  dummy-storage             0  no       Stored token: /tmp/status

Unit              Workload  Agent  Machine  Public address  Ports  Message
dummy-storage/0*  active    idle   0        10.134.1.182           Stored token: /tmp/status

Machine  State    Address       Inst id        Base          AZ                                Message
0        started  10.134.1.182  juju-fd968a-0  ubuntu@24.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Running
```
Now break the machine and try removing without --destroy-storage:
```
$ juju add-ssh-key "$(cat ~/.ssh/id_ed25519.pub)"
$ juju ssh 0 "sudo systemctl stop jujud-machine-0.service"
$ juju remove-application dummy-storage
# ...
$ juju remove-application dummy-storage --force
# ...
$ juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
mmm     ccc         localhost/localhost  4.0.4.1  13:02:35+01:00

Storage Unit  Storage ID   Type        Mountpoint  Size  Status    Message
              single-fs/0  filesystem                    attached  
```
If we do the same thing a second time, but this time we remove with `--destroy-storage`:
```
$ juju remove-application dummy-storage --destroy-storage
# ...
$ juju remove-application dummy-storage --destroy-storage --force
# ...
$ juju status --storage
Model  Controller  Cloud/Region         Version  Timestamp
mmm    ccc         localhost/localhost  4.0.4.1  13:03:44+01:00

Model "admin/mmm" is empty.
```
This shows that storage artifacts are correctly removed as well and it doesn't block the app removal.



## Links


<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21257.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-8783](https://warthogs.atlassian.net/browse/JUJU-8783)

[JUJU-8783]: https://warthogs.atlassian.net/browse/JUJU-8783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ