### PR TITLE
docs: add explicit spaces note

### DIFF
--- a/docs/howto/manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40.md
+++ b/docs/howto/manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40.md
@@ -368,11 +368,16 @@ watch --color -n 1 juju status --color
 viddy juju status
 ```
 
-### 15. Importing orphaned volumes or file systems creates new storage instances
+### 15. Spaces are explicit
 
-If a storage volume or file system with no associated storage instance is migrated to `4.0`, a storage instance will be
-created. These will be of the form `orphaned/x`. The purpose of such storage instances is to allow the operator to 
-delete the linked volume or file system and its cloud resources should they desire.
+Juju `3.6` and prior treated the `alpha` space as a space agnostic request in some cases.
+
+Juju `4.0` treats spaces used for relation endpoint bindings of configuration settings as explicit requests in all 
+cases. This means that any time there is a space _other_ than the `alpha` space, care should be taken to set an 
+appropriate value for `default_space` in model configuration or choose a suitable space for all bindings.
+
+This is most relevant to MAAS, where Juju detects spaces on the cloud. This invariably means that (default) `alpha` 
+spaces does not contain any subnets.
 
 ### 16. Cross-model integration offers can only be consumed once
 

--- a/docs/releasenotes/juju_4.0.x/juju_4.0.3.md
+++ b/docs/releasenotes/juju_4.0.x/juju_4.0.3.md
@@ -14,7 +14,7 @@
 
 N/A.
 
-* **Upgrade note**: transition behavior for storage and offers is now explicitly documented; migrating models with multiple SAAS entries for one offer may collapse to a single SAAS entry, and orphaned storage may appear as storage instances to support cleanup flows.
+* **Upgrade note**: transition behavior for storage and offers is now explicitly documented; migrating models with multiple SAAS entries for one offer may collapse to a single SAAS entry.
   [feat: add transition information for storage and offers](https://github.com/juju/juju/pull/21832#top)
 
 ## 🚀 Features (key changes)


### PR DESCRIPTION
Adds a note on space requests implied by configuration or bindings, being explicit. This was highlighted in recent QA runs, where model `default-space` or explicit bindings needed to be set in order for deployments to work on MAAS.  

Since we changed tack on importing orphaned storage, the note added for this in https://github.com/juju/juju/pull/21832 is removed from the transition guide and the latest release notes.