### PR TITLE
fix: panic when charm has no actions

### DIFF
--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -231,6 +231,13 @@ func (c *debugHooksCommand) validateHooksOrActions() error {
 
 func (c *debugHooksCommand) getValidActions(ch charm.Charm) (set.Strings, error) {
 	validActions := set.NewStrings()
+
+	// A charm can have no actions defined, but that is not an error. In that
+	// case, return an empty set of actions.
+	if ch.Actions() == nil {
+		return validActions, nil
+	}
+
 	for name := range ch.Actions().ActionSpecs {
 		validActions.Add(name)
 	}

--- a/cmd/juju/ssh/debughooks_test.go
+++ b/cmd/juju/ssh/debughooks_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/charm/v12"
 	"github.com/juju/clock"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/retry"
@@ -17,6 +18,7 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	jujussh "github.com/juju/juju/network/ssh"
+	"github.com/juju/juju/testcharms"
 )
 
 var _ = gc.Suite(&DebugHooksSuite{})
@@ -167,4 +169,14 @@ func (s *DebugHooksSuite) TestDebugHooksArgFormatting(c *gc.C) {
 	c.Check(args, gc.DeepEquals, map[string]interface{}{
 		"hooks": []interface{}{"install", "start"},
 	})
+}
+
+func (s *DebugHooksSuite) TestGetValidActionsReturnsEmptySetWhenNoActions(c *gc.C) {
+	ch, err := charm.ReadCharmDir(testcharms.Repo.CharmDirPath("actionless"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	cmd := &debugHooksCommand{}
+	validActions, err := cmd.getValidActions(ch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(validActions.SortedValues(), gc.DeepEquals, []string{})
 }


### PR DESCRIPTION
There should always be actions, it's not 100% guaranteed. In that case we should just return an empty set, that way it is unioned with the valid hooks. It will then fail gracefully if it can't match the hook or the action.


## QA steps

```
$ juju boostrap microk8s k8s
$ juju add-model foo
$ juju deploy mysql-k8s --trust --model=testing --revision 255 --channel 8.0/stable -n 2
$ juju run mysql-k8s/leader pre-upgrade-check
$ juju refresh mysql-k8s --revision 346 --channel 8.0/stable
```

Immediately after, try juju debug-hooks mysql-k8s/$UNIT mysql-pebble-ready (set $UNIT to the non-primary one, about to restart)
See error




## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/22013.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9431](https://warthogs.atlassian.net/browse/JUJU-9431)


[JUJU-9431]: https://warthogs.atlassian.net/browse/JUJU-9431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ