### PR TITLE
docs: set up llms dot txt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -294,6 +294,7 @@ extensions = [
     "sphinx_config_options",
     "sphinx_contributor_listing",
     "sphinx_filtered_toctree",
+    "sphinx_llm.txt",
     "sphinx_related_links",
     "sphinx_roles",
     "sphinx_terminal",

--- a/docs/reference/configuration/list-of-controller-configuration-keys.md
+++ b/docs/reference/configuration/list-of-controller-configuration-keys.md
@@ -371,7 +371,7 @@ snaps for focal or later. The value is ignored for older releases.
 
 **Type:** string
 
-**Default value:** 4.4/stable
+**Default value:** 4.4.30/stable
 
 **Can be changed after bootstrap:** no
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,7 @@ sphinxext-opengraph
 sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
+sphinx-llm
 sphinx-related-links>=0.1.1
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ sphinxext-opengraph
 sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
-sphinx-llm
+sphinx-llm>=0.3.0
 sphinx-related-links>=0.1.1
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2


### PR DESCRIPTION
## Changes

Our docs need to be AI-friendly. A simple strategy suggested by our PM, Massi, and a TA that has looked into this, Robert,  is to update our Sphinx setup so that we generate an `llms.txt` for each docs page and an `llms-full.txt` for the docs as a whole. This PR sets this up for version 3.6.

PS While building the docs I noticed an update to our configs file that hadn't been pushed to the Markdown, so this PR catches that as well.

## QA steps

### Using the PR preview

Inspect https://canonical-ubuntu-documentation-library--22019.com.readthedocs.build/juju/22019/llms-full.txt

### Using your local build

1. Build the docs:

```
cd docs
make clean && make run
```

2. In the browser preview, append `llms.txt` and `llms-full.txt` at the end of the index page URL (e.g., http://127.0.0.1:8000/llms-full.txt ) 

## Forward merge

The PR should be forward merged into `4.0`. (And we should maybe recreate it in `2.9` too.)