### PR TITLE
fix(watcher): add AssertChangeStreamIdle before watcher creation

### DIFF
--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -632,7 +632,6 @@ func (s *watcherSuite) TestWatchApplicationBadName(c *tc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "application")
 	svc := s.setupService(c, factory)
 
-	s.AssertChangeStreamIdle(c)
 	_, err := svc.WatchApplication(c.Context(), "bad-name")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
 }

--- a/domain/credential/watcher_test.go
+++ b/domain/credential/watcher_test.go
@@ -70,6 +70,8 @@ func (s *watcherSuite) TestWatchCloud(c *tc.C) {
 	}
 	s.createCloudCredential(c, st, key)
 
+	s.AssertChangeStreamIdle(c)
+
 	watcher, err := service.WatchCredential(c.Context(), key)
 	c.Assert(err, tc.ErrorIsNil)
 

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -162,6 +162,8 @@ func (s *watcherSuite) TestWatchModelMachinesInitialEventMachine(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
+	s.AssertChangeStreamIdle(c)
+
 	watcher, err := s.svc.WatchModelMachines(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -189,6 +191,8 @@ func (s *watcherSuite) TestWatchModelMachinesInitialEventContainer(c *tc.C) {
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
+
+	s.AssertChangeStreamIdle(c)
 
 	watcher, err := s.svc.WatchModelMachines(c.Context())
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/model/watcher_test.go
+++ b/domain/model/watcher_test.go
@@ -312,6 +312,8 @@ func (s *watcherSuite) TestWatchModelCloudCredential(c *tc.C) {
 	err = st.Activate(c.Context(), modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
+	s.AssertChangeStreamIdle(c)
+
 	modelService := service.NewWatchableService(
 		st,
 		watcherFactory,

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -78,6 +78,8 @@ func (s *watcherSuite) TestWatchRelationUnitApplicationLifeSuspendedStatusPrinci
 	unitUUID := unittesting.GenUnitUUID(c)
 	s.addUnit(c, unitUUID, "my-application/0", s.appUUID, s.charmUUID)
 
+	s.AssertChangeStreamIdle(c)
+
 	svc := s.setupService(c, factory)
 	watcher, err := svc.WatchRelationUnitApplicationLifeSuspendedStatus(c.Context(), unitUUID)
 	c.Assert(err, tc.ErrorIsNil)
@@ -182,6 +184,8 @@ func (s *watcherSuite) TestWatchRelationUnitApplicationLifeSuspendedStatusSubord
 	s.addUnit(c, subordinateUnitUUID, "my-application/0", s.appUUID, s.charmUUID)
 	s.addUnit(c, principalUnitUUID, "two/0", appTwoUUID, charmTwoUUID)
 	s.setUnitSubordinate(c, subordinateUnitUUID, principalUnitUUID)
+
+	s.AssertChangeStreamIdle(c)
 
 	svc := s.setupService(c, factory)
 	watcher, err := svc.WatchRelationUnitApplicationLifeSuspendedStatus(c.Context(), subordinateUnitUUID)
@@ -291,6 +295,8 @@ func (s *watcherSuite) TestWatchRelationsLifeSuspendedStatusForApplication(c *tc
 	unitUUID := unittesting.GenUnitUUID(c)
 	s.addUnit(c, unitUUID, "my-application/0", s.appUUID, s.charmUUID)
 
+	s.AssertChangeStreamIdle(c)
+
 	svc := s.setupService(c, factory)
 	watcher, err := svc.WatchRelationsLifeSuspendedStatusForApplication(c.Context(), applicationUUID)
 	c.Assert(err, tc.ErrorIsNil)
@@ -388,6 +394,8 @@ func (s *watcherSuite) TestWatchRelationLifeSuspendedStatus(c *tc.C) {
 
 	relationUUID := tc.Must(c, relation.NewUUID)
 	s.addRelation(c, relationUUID)
+
+	s.AssertChangeStreamIdle(c)
 
 	svc := s.setupService(c, factory)
 	watcher, err := svc.WatchRelationLifeSuspendedStatus(c.Context(), relationUUID)

--- a/domain/status/watcher_test.go
+++ b/domain/status/watcher_test.go
@@ -134,6 +134,8 @@ func (s *watcherSuite) TestWatchOfferStatusApplicationWithUnits(c *tc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "status")
 	svc := s.setupService(c, factory)
 
+	s.AssertChangeStreamIdle(c)
+
 	watcher, err := svc.WatchOfferStatus(c.Context(), offerUUID)
 	c.Assert(err, tc.ErrorIsNil)
 


### PR DESCRIPTION
Fixes several possible flakyness in watcher test.

## Links

Authored by Copilot in PR : https://github.com/gfouillet/juju/pull/9

> [!NOTE]
>
> I discarded the change about the rule A (single transaction by harness test) since it doesn't cause flakyness and the suggested changes was incorrect (see [Tom comment](https://github.com/juju/juju/pull/22022#issuecomment-4078834730) below). If the test causes any issue, we should review it, maybe we need another approach.