### PR TITLE
docs: update llms implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ operators called ‘charms’.
 [![build](https://github.com/juju/juju/actions/workflows/build.yml/badge.svg)](https://github.com/juju/juju/actions/workflows/build.yml)
 
 - [Give it a try!](https://documentation.ubuntu.com/juju/latest/tutorial/)
-- Read the [docs](https://canonical-juju.readthedocs-hosted.com).
+- Read the [docs](https://documentation.ubuntu.com/juju/).
 - Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and join our [chat](https://matrix.to/#/#charmhub-juju:ubuntu.com) and [forum](https://discourse.charmhub.io/) or [open an issue](https://github.com/juju/juju/issues).
 - Read our [CONTRIBUTING guide](./CONTRIBUTING.md) and contribute!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -310,6 +310,16 @@ extensions = [
     'ibnote',
 ]
 
+# Customize sphinx_llm.txt
+llms_txt_description = (
+    "Juju is an open source orchestration engine for deploying, integrating, "
+    "and managing applications across Kubernetes, VMs, and bare metal using "
+    "software operators called charms."
+)
+llms_txt_full_build = False
+llms_txt_suffix_mode = "url-suffix"
+
+
 # Excludes files or directories from processing
 
 exclude_patterns = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -311,12 +311,15 @@ extensions = [
 ]
 
 # Customize sphinx_llm.txt
+## Add project summary:
 llms_txt_description = (
     "Juju is an open source orchestration engine for deploying, integrating, "
     "and managing applications across Kubernetes, VMs, and bare metal using "
     "software operators called charms."
 )
+## Disable concatenated file generation (because file counterproductively large):
 llms_txt_full_build = False
+## Get cleaner markdown URLs (e.g., `page.md` instead of `page/index.html.md`):
 llms_txt_suffix_mode = "url-suffix"
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ sphinxext-opengraph
 sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
-sphinx-llm>=0.3.0
+sphinx-llm @ git+https://github.com/NVIDIA/sphinx-llm
 sphinx-related-links>=0.1.1
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2


### PR DESCRIPTION
## Changes

Our `llms.txt` implementation needs refinements (see Massi's suggested fix: https://github.com/juju/juju/pull/22019#issuecomment-4076335835, where implementation is affected by a bug, cf. Robert's related issue https://github.com/NVIDIA/sphinx-llm/issues/90). This PR adds them.

## QA steps

### Using the PR preview

Inspect https://canonical-ubuntu-documentation-library--22026.com.readthedocs.build/juju/22026/llms.txt

Inspect, e.g., https://canonical-ubuntu-documentation-library--22026.com.readthedocs.build/juju/22026/howto/manage-clouds.md

### Using your local build

1. Build the docs:

```
cd docs
make clean && make run
```

2. In the browser preview:

2a. Append `llms.txt` at the end of the index page URL (e.g., http://127.0.0.1:8000/llms.txt ). (Note: `llms-full.txt` should no longer be there -- we've turned it off because, due to the high token content, it's likely to make things worse rather  than better.) 
2b. Append .md at the end of the URL for any other page, e.g.,  http://127.0.0.1:8000/howto/manage-clouds.md

## Forward merge

The PR should be forward merged into `4.0`. (And we should maybe recreate it in `2.9` too.)