### PR TITLE
fix(eventmultiplexer): add timeout for report request response

### DIFF
--- a/internal/changestream/eventmultiplexer/eventmultiplexer.go
+++ b/internal/changestream/eventmultiplexer/eventmultiplexer.go
@@ -169,6 +169,12 @@ func (e *EventMultiplexer) Report() map[string]any {
 		return nil
 	case <-e.stream.Dying():
 		return nil
+	// We can't block the engine report, so we time out after a second.
+	// This can happen if the stream supports reporting and have a slow report
+	// generation.
+	case <-e.clock.After(time.Second):
+		e.logger.Errorf(ctx, "waiting for report request response timed out")
+		return nil
 	case <-r.done:
 		return r.data
 	}


### PR DESCRIPTION
Added a 1-second timeout to handle slow report generation in stream reporting, logging an error when the timeout occurs. Prevents indefinite blocking of the engine report.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

stress the test 
```sh
go test ./internal/changestream/eventmultiplexer/ -c 
stress ./eventmultiplexer.test -test.run TestEventMultiplexerSuite/TestReportWithMultipleTopicSubscriptions
```
