### PR TITLE
fix(secretbackend): migration for secret in builtin CaaS backend

### DIFF
--- a/domain/secret/import_integration_test.go
+++ b/domain/secret/import_integration_test.go
@@ -105,6 +105,7 @@ func (s *importSuite) prepareModel(c *tc.C) description.Model {
 
 	// Add a secret backend to handle secrets.
 	s.addSecretBackend(c, "internal", "controller")
+	s.addSecretBackend(c, "kubernetes", "kubernetes")
 
 	return description.NewModel(description.ModelArgs{
 		Type:  string(model.IAAS),

--- a/domain/secret/modelmigration/import.go
+++ b/domain/secret/modelmigration/import.go
@@ -48,6 +48,7 @@ type ImportService interface {
 // SecretBackendService provides a subset of the secret backend
 // domain service methods needed for secret import.
 type SecretBackendService interface {
+	GetBuiltInKubernetesBackendID(ctx context.Context) (string, error)
 	ListBackendIDs(ctx context.Context) ([]string, error)
 }
 
@@ -60,6 +61,7 @@ type importOperation struct {
 
 	knownSecretBackends set.Strings
 	seenBackendIds      set.Strings
+	migrateBackendID    func(backendID string) (string, error)
 }
 
 // Name returns the name of this operation.
@@ -142,6 +144,41 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		return errors.Errorf("loading secret backend IDs: %w", err)
 	}
 	i.knownSecretBackends = set.NewStrings(backendIDs...)
+	i.seenBackendIds = set.NewStrings()
+	builtInCaaSBackendID, err := i.backendService.GetBuiltInKubernetesBackendID(ctx)
+	if err != nil {
+		// This should never happen, except for DB error,
+		// since this backend is always present
+		return errors.Errorf("getting built-in CaaS backend ID: %w", err)
+	}
+	modelUUID := model.UUID()
+	i.migrateBackendID = func(backendID string) (string, error) {
+		// Set the backend ID to the built-in CaaS backend ID
+		// if it matches the model's UUID.
+		// - On IaaS models, exported secrets from the builtin backend are
+		//   by value (so we won't pass into this code).
+		// - On CaaS models, exported secrets from the builtin backend are
+		//   by reference, with a backend ID of the model's UUID. However,
+		//   those secrets are stored in the model namespace in k8s, so we just
+		//   need to change the backend ID to the built-in CaaS backend ID which
+		//   would store the secret in the model namespace.
+		if backendID == modelUUID {
+			return builtInCaaSBackendID, nil
+		}
+
+		// If the backend id is not the CaaS builtin, check it exists in the
+		// target controller.
+		if !i.seenBackendIds.Contains(backendID) {
+			if !i.knownSecretBackends.Contains(backendID) {
+				return "", errors.Errorf(
+					"target controller does not have all required secret backends set up, missing %q",
+					backendID).Add(secreterrors.MissingSecretBackendID)
+
+			}
+		}
+		i.seenBackendIds.Add(backendID)
+		return backendID, nil
+	}
 
 	modelSecrets := model.Secrets()
 	allSecrets := service.SecretImport{
@@ -151,8 +188,6 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		Access:    make(map[string][]service.SecretAccess),
 		Consumers: make(map[string][]service.ConsumerInfo),
 	}
-
-	i.seenBackendIds = set.NewStrings()
 	for j, secret := range modelSecrets {
 		ownerTag, err := secret.Owner()
 		if err != nil {
@@ -182,7 +217,6 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			nextRotateTime := secret.NextRotateTime()
 			allSecrets.Secrets[j].NextRotateTime = nextRotateTime
 		}
-
 		secretRevisions, secretContent, err := i.collateRevisionInfo(secret.Revisions())
 		if err != nil {
 			return errors.Errorf("collating revisions for secret %q: %w", secret.Id(), err)
@@ -227,19 +261,14 @@ func (i *importOperation) collateRevisionInfo(revisions []description.SecretRevi
 					return nil, nil, errors.Errorf("missing content for secret revision %d", rev.Number())
 				}
 			}
+			destBackendID, err := i.migrateBackendID(rev.ValueRef().BackendID())
+			if err != nil {
+				return nil, nil, errors.Capture(err)
+			}
 			valueRef = &secrets.ValueRef{
-				BackendID:  rev.ValueRef().BackendID(),
+				BackendID:  destBackendID,
 				RevisionID: rev.ValueRef().RevisionID(),
 			}
-			if !secrets.IsInternalSecretBackendID(valueRef.BackendID) && !i.seenBackendIds.Contains(valueRef.BackendID) {
-				if !i.knownSecretBackends.Contains(valueRef.BackendID) {
-					return nil, nil, errors.Errorf(
-						"target controller does not have all required secret backends set up, missing %q",
-						valueRef.BackendID).Add(secreterrors.MissingSecretBackendID)
-
-				}
-			}
-			i.seenBackendIds.Add(valueRef.BackendID)
 		} else {
 			secretContent[rev.Number()] = dataCopy
 		}

--- a/domain/secret/modelmigration/import_test.go
+++ b/domain/secret/modelmigration/import_test.go
@@ -60,9 +60,10 @@ func serialisedModel(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, ti
 	return fmt.Sprintf(`
 version: 11
 agent-version: "6.6.6"
-type: "iaas"
+type: "caas"
 owner: ""
-config: {}
+config:
+  uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
 environ-version: 0
 storage-pools:
   pools: []
@@ -201,8 +202,9 @@ secrets:
     - number: 1
       create-time: %[2]s
       update-time: %[2]s
-      content:
-        foo: bar2
+      value-ref:
+        backend-id: deadbeef-0bad-400d-8000-4b1d0d06f00d
+        revision-id: revision-id
     acl:
       model-deadbeef-0bad-400d-8000-4b1d0d06f00d:
         scope: model-deadbeef-0bad-400d-8000-4b1d0d06f00d
@@ -257,7 +259,8 @@ func (s *importSuite) TestImport(c *tc.C) {
 	dst, err := description.Deserialize([]byte(model))
 	c.Assert(err, tc.ErrorIsNil)
 
-	s.backendService.EXPECT().ListBackendIDs(gomock.Any()).Return([]string{"backend-id"}, nil)
+	s.backendService.EXPECT().GetBuiltInKubernetesBackendID(gomock.Any()).Return("caas-backend", nil).AnyTimes()
+	s.backendService.EXPECT().ListBackendIDs(gomock.Any()).Return([]string{"backend-id", "caas-backend"}, nil)
 	forImport := backendSecrets(uri, uri2, uri3, uri4, nextRotate, expire, timestamp)
 	s.service.EXPECT().ImportSecrets(gomock.Any(), &service.SecretImport{
 		Secrets:   forImport.Secrets,
@@ -288,7 +291,8 @@ func (s *importSuite) TestImportMissingBackend(c *tc.C) {
 	dst, err := description.Deserialize([]byte(model))
 	c.Assert(err, tc.ErrorIsNil)
 
-	s.backendService.EXPECT().ListBackendIDs(gomock.Any()).Return([]string{"backend-id2"}, nil)
+	s.backendService.EXPECT().GetBuiltInKubernetesBackendID(gomock.Any()).Return("caas-backend", nil).AnyTimes()
+	s.backendService.EXPECT().ListBackendIDs(gomock.Any()).Return([]string{"backend-id2", "caas-backend"}, nil)
 
 	op := s.newImportOperation(c)
 	err = op.Execute(c.Context(), dst)

--- a/domain/secret/modelmigration/migrations_mock_test.go
+++ b/domain/secret/modelmigration/migrations_mock_test.go
@@ -161,6 +161,45 @@ func (m *MockSecretBackendService) EXPECT() *MockSecretBackendServiceMockRecorde
 	return m.recorder
 }
 
+// GetBuiltInKubernetesBackendID mocks base method.
+func (m *MockSecretBackendService) GetBuiltInKubernetesBackendID(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBuiltInKubernetesBackendID", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBuiltInKubernetesBackendID indicates an expected call of GetBuiltInKubernetesBackendID.
+func (mr *MockSecretBackendServiceMockRecorder) GetBuiltInKubernetesBackendID(arg0 any) *MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuiltInKubernetesBackendID", reflect.TypeOf((*MockSecretBackendService)(nil).GetBuiltInKubernetesBackendID), arg0)
+	return &MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall{Call: call}
+}
+
+// MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall wrap *gomock.Call
+type MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall) Return(arg0 string, arg1 error) *MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall) Do(f func(context.Context) (string, error)) *MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall) DoAndReturn(f func(context.Context) (string, error)) *MockSecretBackendServiceGetBuiltInKubernetesBackendIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListBackendIDs mocks base method.
 func (m *MockSecretBackendService) ListBackendIDs(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/domain/secret/modelmigration/package_test.go
+++ b/domain/secret/modelmigration/package_test.go
@@ -68,6 +68,10 @@ func backendSecrets(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, tim
 				Revision:   1,
 				CreateTime: timestamp,
 				UpdateTime: timestamp,
+				ValueRef: &secrets.ValueRef{
+					BackendID:  "caas-backend",
+					RevisionID: "revision-id",
+				},
 			}},
 			uri3.ID: {},
 		},
@@ -77,11 +81,7 @@ func backendSecrets(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, tim
 					"foo": "bar",
 				},
 			},
-			uri2.ID: {
-				1: map[string]string{
-					"foo": "bar2",
-				},
-			},
+			uri2.ID: {},
 			uri3.ID: {},
 		},
 		Consumers: map[string][]service.ConsumerInfo{

--- a/domain/secretbackend/service/service.go
+++ b/domain/secretbackend/service/service.go
@@ -417,6 +417,18 @@ func validateExternalBackendName(name string) error {
 	return nil
 }
 
+// GetBuiltInCaaSBackendID returns the ID of the built-in CaaS backend.
+func (s *Service) GetBuiltInKubernetesBackendID(ctx context.Context) (string, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	result, err := s.st.GetSecretBackend(ctx, secretbackend.BackendIdentifier{Name: kubernetes.BackendName})
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+	return result.ID, nil
+}
+
 // ListBackendIDs returns the IDs of all the secret backends.
 func (s *Service) ListBackendIDs(ctx context.Context) ([]string, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())


### PR DESCRIPTION
In a CaaS model from 3.6, secret which belongs to the built-in backend are not exported by value (as in IaaS model), but instead they use a reference to a backend with an ID equal to de modelUUID.

This patch take advantage of this situation to resolve the modelUUID for backendID into the builtIn kubernetes backend before importing. 

Since the builtin backend is the model namespace on the k8s cluster (which can hold secrets), this work without any extra work. This behavior mimics the import logiccode  from 3.6.

Fixes #21936

> [!NOTE]
> 
> Limits: It is unclear how this behaves on cross-cluster migration. This will work if the model namespace is migrated from cluster to cluster with all its resources through the provider substrate. The migration code in 3.6 suggests it is the case since no special work is done for those secrets.
> 
> If it is not the case, extra works will need to be done for the usecase of inter-cluster migration.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Get the script:
[setup_secrets_k8s.sh](https://github.com/user-attachments/files/26121407/setup_secrets_k8s.sh)

```sh
sudo make go-install && sudo make microk8s-operator-update 
juju bootstrap microk8s c4 && juju_36 bootstrap microk8s c3 && bash setup_secrets_k8s.sh
# notice the secret url for app and unit secrets
juju migrate c3:moveme c4
juju switch c4:moveme
```

Checks
```sh
juju secrets # secrets should be shown
```
```sh
juju secret-backends # should have a moveme-local backend
```
```sh
juju exec --unit qa/0 -- secret-get <unit secret url> # should works
```
```sh
juju exec --unit qa/0 -- secret-get <app secret url> # should works
```


## Links

**Issue:** Fixes #21936.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9293](https://warthogs.atlassian.net/browse/JUJU-9293)


[JUJU-9293]: https://warthogs.atlassian.net/browse/JUJU-9293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ