### PR TITLE
fix(removal): use child machine life when cascading container machines

### DIFF
--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -93,7 +93,7 @@ AND    life_id = 0;`, machineUUID)
 	selectContainerMachines, err := st.Prepare(`
 SELECT    mp.machine_uuid AS &entityUUID.uuid
 FROM      machine_parent AS mp
-JOIN      machine AS m ON mp.parent_uuid = m.uuid
+JOIN      machine AS m ON mp.machine_uuid = m.uuid
 WHERE     mp.parent_uuid = $entityUUID.uuid
 AND       m.life_id < 2;`, machineUUID)
 	if err != nil {

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -1026,7 +1026,10 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithoutForceFailsForMachi
 	s.checkInstanceLife(c, containerUUID.String(), life.Alive)
 }
 
-func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithForceCascadesAliveContainerWhenParentAlreadyDying(c *tc.C) {
+// TestEnsureMachineNotAliveCascadeWithForceParentDead covers a retry window
+// where the parent machine is already Dead while an alive child container
+// still exists and must be cascaded.
+func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithForceParentDead(c *tc.C) {
 	svc := s.setupMachineService(c)
 	machineRes, err := svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
@@ -1054,10 +1057,10 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithForceCascadesAliveCon
 	containerUUID, err := svc.GetMachineUUID(c.Context(), *containerRes.ChildMachineName)
 	c.Assert(err, tc.ErrorIsNil)
 
-	// Simulate a retry where the parent is already Dying but the container
-	// machine is still Alive.
-	s.advanceMachineLife(c, machineUUID, life.Dying)
-	s.advanceInstanceLife(c, machineUUID, life.Dying)
+	// Simulate a retry window where the parent already reached Dead but the
+	// container machine is still Alive and not removed yet.
+	s.advanceMachineLife(c, machineUUID, life.Dead)
+	s.advanceInstanceLife(c, machineUUID, life.Dead)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -1066,11 +1069,63 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithForceCascadesAliveCon
 	c.Check(cascaded.UnitUUIDs, tc.HasLen, 0)
 	c.Check(cascaded.MachineUUIDs, tc.DeepEquals, []string{containerUUID.String()})
 
-	// Parent remains Dying and the alive child container is cascaded to Dying.
-	s.checkMachineLife(c, machineUUID.String(), life.Dying)
-	s.checkInstanceLife(c, machineUUID.String(), life.Dying)
+	// Parent remains Dead and the alive child container is cascaded to Dying.
+	s.checkMachineLife(c, machineUUID.String(), life.Dead)
+	s.checkInstanceLife(c, machineUUID.String(), life.Dead)
 	s.checkMachineLife(c, containerUUID.String(), life.Dying)
 	s.checkInstanceLife(c, containerUUID.String(), life.Dying)
+}
+
+// TestEnsureMachineNotAliveCascadeWithForceParentDyingSkipsDeadChild covers a
+// retry where the parent is still Dying but the child container already
+// reached Dead and must not be cascaded again.
+func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithForceParentDyingSkipsDeadChild(c *tc.C) {
+	svc := s.setupMachineService(c)
+	machineRes, err := svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "24.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	containerRes, err := svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "24.04",
+		},
+		Directive: deployment.Placement{
+			Type:      deployment.PlacementTypeContainer,
+			Container: deployment.ContainerTypeLXD,
+			Directive: machineRes.MachineName.String(),
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	machineUUID, err := svc.GetMachineUUID(c.Context(), machineRes.MachineName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(containerRes.ChildMachineName, tc.NotNil)
+	containerUUID, err := svc.GetMachineUUID(c.Context(), *containerRes.ChildMachineName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Simulate a retry where the parent is Dying and the child already reached
+	// Dead but has not been deleted yet.
+	s.advanceMachineLife(c, machineUUID, life.Dying)
+	s.advanceInstanceLife(c, machineUUID, life.Dying)
+	s.advanceMachineLife(c, containerUUID, life.Dead)
+	s.advanceInstanceLife(c, containerUUID, life.Dead)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	cascaded, err := st.EnsureMachineNotAliveCascade(c.Context(), machineUUID.String(), true)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cascaded.UnitUUIDs, tc.HasLen, 0)
+	c.Check(cascaded.MachineUUIDs, tc.HasLen, 0)
+
+	// Parent remains Dying and the already dead child remains unchanged.
+	s.checkMachineLife(c, machineUUID.String(), life.Dying)
+	s.checkInstanceLife(c, machineUUID.String(), life.Dying)
+	s.checkMachineLife(c, containerUUID.String(), life.Dead)
+	s.checkInstanceLife(c, containerUUID.String(), life.Dead)
 }
 
 func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithoutForceFailsForMachineHostingUnits(c *tc.C) {

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -1011,7 +1011,8 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithoutForceFailsForMachi
 
 	machineUUID, err := svc.GetMachineUUID(c.Context(), machineRes.MachineName)
 	c.Assert(err, tc.ErrorIsNil)
-	containerUUID, err := svc.GetMachineUUID(c.Context(), containerRes.MachineName)
+	c.Assert(containerRes.ChildMachineName, tc.NotNil)
+	containerUUID, err := svc.GetMachineUUID(c.Context(), *containerRes.ChildMachineName)
 	c.Assert(err, tc.ErrorIsNil)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
@@ -1023,6 +1024,53 @@ func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithoutForceFailsForMachi
 	s.checkInstanceLife(c, machineUUID.String(), life.Alive)
 	s.checkMachineLife(c, containerUUID.String(), life.Alive)
 	s.checkInstanceLife(c, containerUUID.String(), life.Alive)
+}
+
+func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithForceCascadesAliveContainerWhenParentAlreadyDying(c *tc.C) {
+	svc := s.setupMachineService(c)
+	machineRes, err := svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "24.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	containerRes, err := svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "24.04",
+		},
+		Directive: deployment.Placement{
+			Type:      deployment.PlacementTypeContainer,
+			Container: deployment.ContainerTypeLXD,
+			Directive: machineRes.MachineName.String(),
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	machineUUID, err := svc.GetMachineUUID(c.Context(), machineRes.MachineName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(containerRes.ChildMachineName, tc.NotNil)
+	containerUUID, err := svc.GetMachineUUID(c.Context(), *containerRes.ChildMachineName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Simulate a retry where the parent is already Dying but the container
+	// machine is still Alive.
+	s.advanceMachineLife(c, machineUUID, life.Dying)
+	s.advanceInstanceLife(c, machineUUID, life.Dying)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	cascaded, err := st.EnsureMachineNotAliveCascade(c.Context(), machineUUID.String(), true)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cascaded.UnitUUIDs, tc.HasLen, 0)
+	c.Check(cascaded.MachineUUIDs, tc.DeepEquals, []string{containerUUID.String()})
+
+	// Parent remains Dying and the alive child container is cascaded to Dying.
+	s.checkMachineLife(c, machineUUID.String(), life.Dying)
+	s.checkInstanceLife(c, machineUUID.String(), life.Dying)
+	s.checkMachineLife(c, containerUUID.String(), life.Dying)
+	s.checkInstanceLife(c, containerUUID.String(), life.Dying)
 }
 
 func (s *machineSuite) TestEnsureMachineNotAliveCascadeWithoutForceFailsForMachineHostingUnits(c *tc.C) {


### PR DESCRIPTION
 When force-removing a parent machine that hosts LXD containers, the SQL query responsible for discovering child container machines was filtering on the parent machine's life instead of    
  each child container's life.

This problem was found by chance when writing tests for the patch https://github.com/juju/juju/pull/22008.
                                                                                                                                                                                              
 #### The bug         

  In `EnsureMachineNotAliveCascade`, the query that selects container machines to cascade to Dying was:                                                                                         
  ```
  SELECT    mp.machine_uuid AS &entityUUID.uuid                                                                                                                                               
  FROM      machine_parent AS mp
  JOIN      machine AS m ON mp.parent_uuid = m.uuid   -- joins to PARENT                                                                                                                      
  WHERE     mp.parent_uuid = $entityUUID.uuid
  AND       m.life_id < 2;                                                                                                                                                                    
   ```               
  The machine_parent table has two columns:                                                                                                                                                   
  - machine_uuid — the child/container machine (e.g. 0/lxd/0)
  - parent_uuid — the parent machine (e.g. 0)                                                                                                                                                 
                                             
  The JOIN condition `mp.parent_uuid = m.uuid` joins to the parent machine row. Since the WHERE clause already filters `mp.parent_uuid = $entityUUID.uuid`, the m alias always resolves to the    
  same single row — the parent. This means m.life_id < 2 checks whether the parent is not dead, rather than whether each child container is not dead.                                         
  
This has two consequences:                                                                                                                                                                  
  - If the parent is already Dead (life_id = 2), no containers are returned — even containers that are still Alive or Dying are silently skipped and never cascaded.
  - If a child container is already Dead but the parent is still Dying, the dead container is incorrectly returned — leading to unnecessary duplicate removal jobs being scheduled for it. 

#### The fix                                                                                                                                                                                     
                  
  SELECT    mp.machine_uuid AS &entityUUID.uuid                                                                                                                                               
  FROM      machine_parent AS mp
  JOIN      machine AS m ON mp.machine_uuid = m.uuid   -- joins to CHILD                                                                                                                      
  WHERE     mp.parent_uuid = $entityUUID.uuid                                                                                                                                                 
  AND       m.life_id < 2;                                                                                                                                                                    
                                                                                                                                                                                              
  Changing the JOIN to mp.machine_uuid = m.uuid joins to each child container row, so m.life_id < 2 correctly filters by each container's own life. Dead containers are skipped; alive and    
  dying containers are properly included regardless of the parent's state.
                                                                                                                                                                                              

## QA steps

  In practice, this state is reached through a race between two asynchronous processes:                                                                                                       
  1. The container's machiner agent marking the container as Dead (after its units are cleaned up).
  2. The container's force removal job deleting it from the database (scheduled ~1 minute out by default).                                                                                    
                                                                                                          
  The window where the bug is flexed is the few seconds between these two events. Reproducing this from the CLI would require issuing juju remove-machine at exactly the right moment  during that window, making it impractical to QA manually.                                                                                                                                   
                                                                                                                                                                                              
  The unit test `TestEnsureMachineNotAliveCascadeWithForceCascadesAliveContainerWhenParentAlreadyDying` deterministically reproduces this by directly advancing the parent's life to Dying while
   keeping the container Alive, then calling `EnsureMachineNotAliveCascade` — bypassing the race entirely. This test fails with the old JOIN and passes with the fix.


## Links

**Jira card:** [JUJU-8783](https://warthogs.atlassian.net/browse/JUJU-8783)


[JUJU-8783]: https://warthogs.atlassian.net/browse/JUJU-8783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ