### PR TITLE
feat: add CloudSpec api to controller facade

### DIFF
--- a/api/controller/controller/controller_test.go
+++ b/api/controller/controller/controller_test.go
@@ -254,6 +254,45 @@ func (s *Suite) TestHostedModelConfigs_FormatResults(c *tc.C) {
 	c.Assert(second.Error.Error(), tc.Equals, "validating CloudSpec: empty Type not valid")
 }
 
+func (s *Suite) TestCloudSpec(c *tc.C) {
+	modelTag := names.NewModelTag(randomUUID())
+	apiCaller := apitesting.BestVersionCaller{APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, tc.Equals, "Controller")
+		c.Assert(version, tc.Equals, 14)
+		c.Assert(request, tc.Equals, "CloudSpec")
+		c.Assert(arg, tc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: modelTag.String()}},
+		})
+		out := result.(*params.CloudSpecResults)
+		*out = params.CloudSpecResults{
+			Results: []params.CloudSpecResult{{
+				Result: &params.CloudSpec{
+					Type: "aws",
+					Name: "cloud",
+				},
+			}},
+		}
+		return nil
+	}, BestVersion: 14}
+	client := controller.NewClient(apiCaller)
+
+	spec, err := client.CloudSpec(c.Context(), modelTag)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(spec, tc.DeepEquals, environscloudspec.CloudSpec{
+		Type: "aws",
+		Name: "cloud",
+	})
+}
+
+func (s *Suite) TestCloudSpec_CallError(c *tc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("boom")
+	})
+	client := controller.NewClient(apiCaller)
+	_, err := client.CloudSpec(c.Context(), names.NewModelTag(randomUUID()))
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
 func makeInitiateMigrationClient(results params.InitiateMigrationResults) (
 	*controller.Client, *testhelpers.Stub,
 ) {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -45,7 +45,7 @@ var facadeVersions = facades.FacadeVersions{
 	"Charms":                       {7},
 	"Client":                       {8},
 	"Cloud":                        {7},
-	"Controller":                   {12, 13},
+	"Controller":                   {12, 13, 14},
 	"CredentialManager":            {1},
 	"CredentialValidator":          {2, 3},
 	"CrossController":              {1},

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -45,6 +45,11 @@ import (
 
 // ControllerAPIV12 implements the controller APIV12.
 type ControllerAPIV12 struct {
+	*ControllerAPIV13
+}
+
+// ControllerAPIV13 implements the controller APIV13.
+type ControllerAPIV13 struct {
 	*ControllerAPI
 }
 
@@ -268,6 +273,33 @@ func (c *ControllerAPI) AllModels(ctx context.Context) (params.UserModelList, er
 	return result, nil
 }
 
+// CloudSpec is not implemented in version 13.
+func (c *ControllerAPIV13) CloudSpec(ctx context.Context, _, _ struct{}) {}
+
+// CloudSpec returns cloud specifications for the specified models.
+func (c *ControllerAPI) CloudSpec(ctx context.Context, req params.Entities) (params.CloudSpecResults, error) {
+	results := params.CloudSpecResults{
+		Results: make([]params.CloudSpecResult, len(req.Entities)),
+	}
+	for i, entity := range req.Entities {
+		modelTag, err := names.ParseModelTag(entity.Tag)
+		if err != nil {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		if err := c.authorizer.HasPermission(ctx, permission.ReadAccess, modelTag); err != nil {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		spec, err := c.getCloudSpec(ctx, coremodel.UUID(modelTag.Id()))
+		results.Results[i] = params.CloudSpecResult{
+			Result: spec,
+			Error:  apiservererrors.ServerError(err),
+		}
+	}
+	return results, nil
+}
+
 // ListBlockedModels returns a list of all models on the controller
 // which have a block in place.  The resulting slice is sorted by model
 // name, then owner. Callers must be controller administrators to retrieve the
@@ -425,10 +457,10 @@ func (c *ControllerAPI) WatchAllModelSummaries(ctx context.Context) (params.Summ
 		return params.SummaryWatcherID{}, errors.Trace(err)
 	}
 	// TODO(dqlite) - implement me
-	//w := c.controller.WatchAllModels()
-	//return params.SummaryWatcherID{
+	// w := c.controller.WatchAllModels()
+	// return params.SummaryWatcherID{
 	//	WatcherID: c.resources.Register(w),
-	//}, nil
+	// }, nil
 	return params.SummaryWatcherID{}, errors.NotSupportedf("WatchAllModelSummaries")
 }
 
@@ -437,11 +469,11 @@ func (c *ControllerAPI) WatchAllModelSummaries(ctx context.Context) (params.Summ
 func (c *ControllerAPI) WatchModelSummaries(ctx context.Context) (params.SummaryWatcherID, error) {
 	// TODO(dqlite) - implement me
 	return params.SummaryWatcherID{}, errors.NotSupportedf("WatchModelSummaries")
-	//user := c.apiUser.Id()
-	//w := c.controller.WatchModelsAsUser(user)
-	//return params.SummaryWatcherID{
+	// user := c.apiUser.Id()
+	// w := c.controller.WatchModelsAsUser(user)
+	// return params.SummaryWatcherID{
 	//	WatcherID: c.resources.Register(w),
-	//}, nil
+	// }, nil
 }
 
 // GetControllerAccess returns the level of access the specified users

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/client/controller"
 	"github.com/juju/juju/apiserver/facades/client/controller/mocks"
@@ -306,6 +307,65 @@ func (s *controllerSuite) TestHostedModelConfigs_OnlyHostedModelsReturned(c *tc.
 	c.Assert(one.Qualifier, tc.Equals, "prod")
 	c.Assert(two.Name, tc.Equals, "second")
 	c.Assert(two.Qualifier, tc.Equals, "staging")
+}
+
+func (s *controllerSuite) TestCloudSpec(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelTag := names.NewModelTag(s.DefaultModelUUID.String())
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: modelTag.String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Assert(result.Results[0].Error, tc.IsNil)
+
+	modelProvider := s.ModelDomainServices(c, s.DefaultModelUUID).ModelProvider()
+	expected, err := modelProvider.GetCloudSpec(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results[0].Result, tc.DeepEquals, common.CloudSpecToParams(expected))
+}
+
+func (s *controllerSuite) TestCloudSpecInvalidTag(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: names.NewMachineTag("0").String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Result, tc.IsNil)
+	c.Check(result.Results[0].Error, tc.ErrorMatches, `"machine-0" is not a valid model tag`)
+}
+
+func (s *controllerSuite) TestCloudSpecUnauthorized(c *tc.C) {
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("read-" + names.NewModelTag(s.DefaultModelUUID.String()).String()),
+	}
+	s.context.Auth_ = s.authorizer
+	defer s.setupMocks(c).Finish()
+
+	otherModelTag := names.NewModelTag(tc.Must(c, model.NewUUID).String())
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: otherModelTag.String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Result, tc.IsNil)
+	c.Check(result.Results[0].Error, tc.ErrorMatches, "permission denied")
+}
+
+func (s *controllerSuite) TestCloudSpecServiceError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unknownModelTag := names.NewModelTag(tc.Must(c, model.NewUUID).String())
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: unknownModelTag.String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Result, tc.IsNil)
+	c.Check(result.Results[0].Error, tc.NotNil)
 }
 
 func (s *controllerSuite) TestListBlockedModels(c *tc.C) {

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -25,20 +25,37 @@ func Register(registry facade.FacadeRegistry) {
 	}, reflect.TypeOf((*ControllerAPIV12)(nil)))
 	// v13 handles requests with a model qualifier instead of a model owner.
 	registry.MustRegisterForMultiModel("Controller", 13, func(stdCtx context.Context, ctx facade.MultiModelContext) (facade.Facade, error) {
-		api, err := makeControllerAPI(stdCtx, ctx)
+		api, err := makeControllerAPIV13(stdCtx, ctx)
 		if err != nil {
 			return nil, fmt.Errorf("creating Controller facade v13: %w", err)
+		}
+		return api, nil
+	}, reflect.TypeOf((*ControllerAPIV13)(nil)))
+	registry.MustRegisterForMultiModel("Controller", 14, func(stdCtx context.Context, ctx facade.MultiModelContext) (facade.Facade, error) {
+		api, err := makeControllerAPI(stdCtx, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("creating Controller facade v14: %w", err)
 		}
 		return api, nil
 	}, reflect.TypeOf((*ControllerAPI)(nil)))
 }
 
 func makeControllerAPIV12(stdCtx context.Context, ctx facade.MultiModelContext) (*ControllerAPIV12, error) {
-	api, err := makeControllerAPI(stdCtx, ctx)
+	api, err := makeControllerAPIV13(stdCtx, ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &ControllerAPIV12{
+		ControllerAPIV13: api,
+	}, nil
+}
+
+func makeControllerAPIV13(stdCtx context.Context, ctx facade.MultiModelContext) (*ControllerAPIV13, error) {
+	api, err := makeControllerAPI(stdCtx, ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ControllerAPIV13{
 		ControllerAPI: api,
 	}, nil
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -7821,7 +7821,7 @@
     {
         "Name": "Controller",
         "Description": "",
-        "Version": 13,
+        "Version": 14,
         "Schema": {
             "type": "object",
             "properties": {
@@ -7830,6 +7830,17 @@
                     "properties": {
                         "Result": {
                             "$ref": "#/definitions/UserModelList"
+                        }
+                    }
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResults"
                         }
                     }
                 },
@@ -8074,6 +8085,30 @@
                         "type",
                         "name"
                     ]
+                },
+                "CloudSpecResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudSpec"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudSpecResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudSpecResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
                 },
                 "ControllerAPIInfoResult": {
                     "type": "object",


### PR DESCRIPTION
https://github.com/juju/juju/pull/19551 removed the CloudSpec api from the controller facade.

This PR adds it back as it's used by JAAS. A new V14 Controller facade is used.

## QA steps

unit tests

## Links

**Issue:** Fixes #22018.

**Jira card:** [JUJU-9438](https://warthogs.atlassian.net/browse/JUJU-9438)


[JUJU-9438]: https://warthogs.atlassian.net/browse/JUJU-9438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ