### PR TITLE
fix(bundle): treat compare integral float values as ints

### DIFF
--- a/core/bundle/changes/diff.go
+++ b/core/bundle/changes/diff.go
@@ -324,7 +324,7 @@ func (d *differ) diffOptions(bundle, model map[string]interface{}) map[string]Op
 	for _, name := range all.Values() {
 		bundleValue := bundle[name]
 		modelValue := model[name]
-		if !reflect.DeepEqual(bundleValue, modelValue) {
+		if !optionValuesEqual(bundleValue, modelValue) {
 			result[name] = OptionDiff{
 				Bundle: bundleValue,
 				Model:  modelValue,
@@ -335,6 +335,39 @@ func (d *differ) diffOptions(bundle, model map[string]interface{}) map[string]Op
 		return nil
 	}
 	return result
+}
+
+// maybeAsInt checks whether a value is semantically an integer and if so
+// return it as int with the second return value true.
+// Otherwise, the second return value will be false.
+func maybeAsInt(x any) (int, bool) {
+	if xi, ok := x.(int); ok {
+		return xi, true
+	}
+
+	if xf, ok := x.(float64); ok {
+		xi := int(xf)
+		if xf == float64(xi) {
+			return xi, true
+		}
+	}
+
+	return 0, false
+}
+
+// optionValuesEqual compares to value of two configOptions, treating
+// integer-like floats (e.g. 10.0) as integers.
+func optionValuesEqual(x, y any) bool {
+	if x == nil || y == nil {
+		return x == y
+	}
+	if i1, ok1 := maybeAsInt(x); ok1 {
+		if i2, ok2 := maybeAsInt(y); ok2 {
+			return i1 == i2
+		}
+	}
+
+	return reflect.DeepEqual(x, y)
 }
 
 func (d *differ) diffExposedEndpoints(bundle map[string]charm.ExposedEndpointSpec, model map[string]ExposedEndpoint) map[string]ExposedEndpointDiff {

--- a/core/bundle/changes/diff_test.go
+++ b/core/bundle/changes/diff_test.go
@@ -755,6 +755,63 @@ func (s *diffSuite) TestApplicationOptions(c *gc.C) {
 	s.checkDiff(c, bundleContent, model, expectedDiff)
 }
 
+func (s *diffSuite) TestApplicationNumericOptions(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: ch:prometheus
+                revision: 7
+                series: xenial
+                channel: stable
+                num_units: 1
+                options:
+                    travis: 5
+                    clint: 6
+                    ellen: 11.0
+                    jane: 2
+                    john: 13.37
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:     "prometheus",
+				Charm:    "ch:prometheus",
+				Base:     corebase.MakeDefaultBase("ubuntu", "16.04"),
+				Channel:  "stable",
+				Revision: 7,
+				Options: map[string]interface{}{
+					"justin": 9,
+					"clint":  6.1,
+					"ellen":  11.0,
+					"jane":   2.0,
+					"john":   13.37,
+				},
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Options: map[string]bundlechanges.OptionDiff{
+					"travis": {5, nil},
+					"justin": {nil, 9},
+					"clint":  {6, 6.1},
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
 func (s *diffSuite) TestApplicationAnnotations(c *gc.C) {
 	bundleContent := `
         applications:

--- a/tests/suites/cli/diff_bundle.sh
+++ b/tests/suites/cli/diff_bundle.sh
@@ -1,0 +1,34 @@
+run_diff_bundle_reflexive() {
+	echo
+
+	file="${TEST_DIR}/test-cli-diff-bundle-reflexive.log"
+
+	ensure "test-cli-diff-bundle-reflexive" "${file}"
+
+	# Check that numbers are considered equal, even if YAML and JSON choose to interpret them differently
+
+	# Apache has integer config options
+	juju deploy apache2
+	# PostgreSQL has float config options
+	# that default to integral values
+	juju deploy postgresql
+
+	juju diff-bundle <(juju export-bundle --include-charm-defaults --include-series) | check "{}"
+
+	destroy_model "test-cli-diff-bundle-reflexive"
+}
+
+test_diff_bundle() {
+	if [ "$(skip 'test_diff_bundle')" ]; then
+		echo "==> TEST SKIPPED: diff-bundle tests"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_diff_bundle_reflexive"
+	)
+}

--- a/tests/suites/cli/task.sh
+++ b/tests/suites/cli/task.sh
@@ -20,6 +20,7 @@ test_cli() {
 	test_model_constraints
 	test_unregister
 	test_block_commands
+	test_diff_bundle
 
 	destroy_controller "test-cli"
 }


### PR DESCRIPTION
This is another fix for the differing unmarshaling strategies of yaml and json. A config option that is a float can take integral values, and yaml will parse it as an int. This leads to a situation where a value is not equal to itself in diff-bundle since one side of the comparison is loaded from json and the other from yaml, i.e. we get `10.0!=10`.

This patch treats float option values that "look like integers" as integers for the purpose of comparing with bundle yaml.

This change is a fix for #22058.  In principle this is somewhat redundant with the fix #21557, but the two don't conflict and provide somewhat of a belt and suspenders solution.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This can be verified in a manner very similar to #21557.

```
juju add-model coerce-numeric-options
juju deploy apache2
juju deploy postgresql
juju export-bundle --include-charm-defaults --include-series > bundle.yaml
```

Then run
```
juju diff-bundle bundle.yaml
```
and ensure that the result is an empty map.

Change, some integer options in bundle.yaml to different values and ensure 
```
juju diff-bundle bundle.yaml
```
now reflects that.

Finally,
```
juju deploy ./bundle.yaml
````
and now
```
juju diff-bundle bundle.yaml
````
should again be an empty map.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->
**Related Issue:** #21532
**Related PR:** #21557

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22058.