### PR TITLE
fix(logsink,logsender): send proper WebSocket close codes and treat them as io.EOF

### DIFF
--- a/api/logsender/logsender.go
+++ b/api/logsender/logsender.go
@@ -102,6 +102,7 @@ func (w *writer) WriteLog(m *params.LogRecord) error {
 			gorillaws.CloseNormalClosure,
 			gorillaws.CloseGoingAway,
 			gorillaws.CloseNoStatusReceived,
+			gorillaws.CloseAbnormalClosure,
 		) {
 			joinedErr = stderrors.Join(joinedErr, io.EOF)
 		}

--- a/api/logsender/logsender.go
+++ b/api/logsender/logsender.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 
+	gorillaws "github.com/gorilla/websocket"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/base"
@@ -64,10 +65,19 @@ func newWriter(conn base.Stream) *writer {
 // readLoop is necessary for the client to process websocket control messages.
 // If we get an error, enqueue it so that if a subsequent call to WriteLog
 // fails do to our closure of the socket, we can enhance the resulting error.
+// Clean close codes are normalised to io.EOF so callers can distinguish an
+// expected server-side close from a real network error.
 // Close() is safe to call concurrently.
 func (w *writer) readLoop() {
 	for {
 		if _, _, err := w.conn.NextReader(); err != nil {
+			if gorillaws.IsCloseError(err,
+				gorillaws.CloseNormalClosure,
+				gorillaws.CloseGoingAway,
+				gorillaws.CloseNoStatusReceived,
+			) {
+				err = io.EOF
+			}
 			select {
 			case w.readErrs <- err:
 			default:
@@ -89,10 +99,13 @@ func (w *writer) WriteLog(m *params.LogRecord) error {
 	if err := w.conn.WriteJSON(m); err != nil {
 		var readErr error
 		select {
-		case readErr, _ = <-w.readErrs:
+		case readErr = <-w.readErrs:
 		default:
 		}
 
+		if errors.Is(readErr, io.EOF) {
+			return io.EOF
+		}
 		if readErr != nil {
 			err = errors.Annotate(err, readErr.Error())
 		}

--- a/api/logsender/logsender.go
+++ b/api/logsender/logsender.go
@@ -4,6 +4,7 @@
 package logsender
 
 import (
+	stderrors "errors"
 	"io"
 	"net/url"
 
@@ -64,20 +65,11 @@ func newWriter(conn base.Stream) *writer {
 
 // readLoop is necessary for the client to process websocket control messages.
 // If we get an error, enqueue it so that if a subsequent call to WriteLog
-// fails do to our closure of the socket, we can enhance the resulting error.
-// Clean close codes are normalised to io.EOF so callers can distinguish an
-// expected server-side close from a real network error.
+// fails due to our closure of the socket, we can enhance the resulting error.
 // Close() is safe to call concurrently.
 func (w *writer) readLoop() {
 	for {
 		if _, _, err := w.conn.NextReader(); err != nil {
-			if gorillaws.IsCloseError(err,
-				gorillaws.CloseNormalClosure,
-				gorillaws.CloseGoingAway,
-				gorillaws.CloseNoStatusReceived,
-			) {
-				err = io.EOF
-			}
 			select {
 			case w.readErrs <- err:
 			default:
@@ -99,17 +91,21 @@ func (w *writer) WriteLog(m *params.LogRecord) error {
 	if err := w.conn.WriteJSON(m); err != nil {
 		var readErr error
 		select {
-		case readErr = <-w.readErrs:
+		case readErr, _ = <-w.readErrs:
 		default:
 		}
 
-		if errors.Is(readErr, io.EOF) {
-			return io.EOF
+		// Join all errors so callers can check with errors.Is
+		// without losing context.
+		joinedErr := stderrors.Join(err, readErr)
+		if gorillaws.IsCloseError(readErr,
+			gorillaws.CloseNormalClosure,
+			gorillaws.CloseGoingAway,
+			gorillaws.CloseNoStatusReceived,
+		) {
+			joinedErr = stderrors.Join(joinedErr, io.EOF)
 		}
-		if readErr != nil {
-			err = errors.Annotate(err, readErr.Error())
-		}
-		return errors.Annotate(err, "sending log message")
+		return errors.Annotate(joinedErr, "sending log message")
 	}
 	return nil
 }

--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -105,6 +105,10 @@ func (s *LogSenderSuite) TestWriteLogReturnsEOFOnGoingAway(c *gc.C) {
 	s.testCleanCloseReturnsEOF(c, gorillaws.CloseGoingAway)
 }
 
+func (s *LogSenderSuite) TestWriteLogReturnsEOFOnAbnormalClosure(c *gc.C) {
+	s.testCleanCloseReturnsEOF(c, gorillaws.CloseAbnormalClosure)
+}
+
 func (s *LogSenderSuite) TestNewAPIReadError(c *gc.C) {
 	conn := &mockConnector{
 		c:          c,

--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -89,7 +89,7 @@ func (s *LogSenderSuite) testCleanCloseReturnsEOF(c *gc.C, code int) {
 	}
 
 	err = w.WriteLog(new(params.LogRecord))
-	c.Assert(err, gc.Equals, io.EOF)
+	c.Assert(err, jc.ErrorIs, io.EOF)
 	c.Assert(conn.written, gc.HasLen, 0)
 }
 
@@ -122,7 +122,7 @@ func (s *LogSenderSuite) TestNewAPIReadError(c *gc.C) {
 	}
 
 	err = w.WriteLog(new(params.LogRecord))
-	c.Assert(err, gc.ErrorMatches, "sending log message: read foo: closed yo")
+	c.Assert(err, gc.ErrorMatches, `sending log message: closed yo\nread foo`)
 	c.Assert(conn.written, gc.HasLen, 0)
 }
 

--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	gorillaws "github.com/gorilla/websocket"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -68,6 +69,40 @@ func (s *LogSenderSuite) TestNewAPIWriteError(c *gc.C) {
 	err = w.WriteLog(new(params.LogRecord))
 	c.Assert(err, gc.ErrorMatches, "sending log message: foo")
 	c.Assert(conn.written, gc.HasLen, 0)
+}
+
+func (s *LogSenderSuite) testCleanCloseReturnsEOF(c *gc.C, code int) {
+	conn := &mockConnector{
+		c:          c,
+		closed:     make(chan bool),
+		readError:  &gorillaws.CloseError{Code: code},
+		writeError: errors.New("use of closed network connection"),
+	}
+	a := logsender.NewAPI(conn)
+	w, err := a.LogWriter()
+	c.Assert(err, gc.IsNil)
+
+	select {
+	case <-conn.closed:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timeout waiting for connection to close")
+	}
+
+	err = w.WriteLog(new(params.LogRecord))
+	c.Assert(err, gc.Equals, io.EOF)
+	c.Assert(conn.written, gc.HasLen, 0)
+}
+
+func (s *LogSenderSuite) TestWriteLogReturnsEOFOnCloseNoStatusReceived(c *gc.C) {
+	s.testCleanCloseReturnsEOF(c, gorillaws.CloseNoStatusReceived)
+}
+
+func (s *LogSenderSuite) TestWriteLogReturnsEOFOnNormalClose(c *gc.C) {
+	s.testCleanCloseReturnsEOF(c, gorillaws.CloseNormalClosure)
+}
+
+func (s *LogSenderSuite) TestWriteLogReturnsEOFOnGoingAway(c *gc.C) {
+	s.testCleanCloseReturnsEOF(c, gorillaws.CloseGoingAway)
 }
 
 func (s *LogSenderSuite) TestNewAPIReadError(c *gc.C) {

--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -331,7 +331,7 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn,
 				// care that much.
 				h.mu.Lock()
 				defer h.mu.Unlock()
-				_ = socket.WriteMessage(gorillaws.CloseMessage, []byte{})
+				_ = socket.WriteMessage(gorillaws.CloseMessage, gorillaws.FormatCloseMessage(gorillaws.CloseGoingAway, ""))
 				return
 			}
 			h.metrics.LogReadCount(resolvedModelUUID, metricLogReadLabelSuccess).Inc()

--- a/apiserver/websocket/websocket.go
+++ b/apiserver/websocket/websocket.go
@@ -82,7 +82,7 @@ func (conn *Conn) SendInitialErrorV0(err error) error {
 
 	if wrapped.Error != nil {
 		// Tell the other end we are closing.
-		_ = conn.WriteMessage(websocket.CloseMessage, []byte{})
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseGoingAway, ""))
 	}
 
 	return errors.Trace(err)

--- a/internal/worker/logsender/worker.go
+++ b/internal/worker/logsender/worker.go
@@ -5,10 +5,12 @@ package logsender
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
 
 	"github.com/juju/juju/api/logsender"
 	jworker "github.com/juju/juju/internal/worker"
@@ -70,6 +72,9 @@ func New(logs LogRecordCh, logSenderAPI *logsender.API) worker.Worker {
 					Labels:   rec.Labels,
 				})
 				if err != nil {
+					if errors.Is(err, io.EOF) {
+						return dependency.ErrBounce
+					}
 					return errors.Trace(err)
 				}
 				if rec.DroppedAfter > 0 {
@@ -95,6 +100,9 @@ func New(logs LogRecordCh, logSenderAPI *logsender.API) worker.Worker {
 						Message: fmt.Sprintf("%d log messages dropped due to lack of API connectivity", rec.DroppedAfter),
 					})
 					if err != nil {
+						if errors.Is(err, io.EOF) {
+							return dependency.ErrBounce
+						}
 						return errors.Trace(err)
 					}
 				}

--- a/internal/worker/logsender/worker_test.go
+++ b/internal/worker/logsender/worker_test.go
@@ -220,7 +220,11 @@ type mockStream struct {
 
 func (s *mockStream) NextReader() (int, io.Reader, error) {
 	if s.writesReady != nil {
-		<-s.writesReady
+		select {
+		case <-s.writesReady:
+		case <-time.After(testing.LongWait):
+			s.c.Fatalf("expected number of writes not received")
+		}
 	}
 	return 0, nil, &gorillaws.CloseError{Code: gorillaws.CloseNormalClosure}
 }

--- a/internal/worker/logsender/worker_test.go
+++ b/internal/worker/logsender/worker_test.go
@@ -5,16 +5,23 @@ package logsender_test
 
 import (
 	"fmt"
+	"io"
+	"net/url"
+	"sync"
+	"sync/atomic"
 	"time"
 
+	gorillaws "github.com/gorilla/websocket"
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3/dependency"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	apilogsender "github.com/juju/juju/api/logsender"
 	"github.com/juju/juju/internal/worker/logsender"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -186,4 +193,107 @@ func (s *workerSuite) TestDroppedLogs(c *gc.C) {
 		"x": "42 log messages dropped due to lack of API connectivity",
 	})
 	c.Assert(docs[2]["x"], gc.Equals, "message1")
+}
+
+type workerBounceSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&workerBounceSuite{})
+
+type mockConnector struct {
+	stream base.Stream
+}
+
+func (c *mockConnector) ConnectStream(_ string, _ url.Values) (base.Stream, error) {
+	return c.stream, nil
+}
+
+type mockStream struct {
+	c              *gc.C
+	succeedNWrites int
+	writeCount     int32
+	writesReady    chan struct{}
+	closed         chan struct{}
+	closeOnce      sync.Once
+}
+
+func (s *mockStream) NextReader() (int, io.Reader, error) {
+	if s.writesReady != nil {
+		<-s.writesReady
+	}
+	return 0, nil, &gorillaws.CloseError{Code: gorillaws.CloseNormalClosure}
+}
+
+func (s *mockStream) WriteJSON(v interface{}) error {
+	count := atomic.AddInt32(&s.writeCount, 1)
+	if int(count) <= s.succeedNWrites {
+		if int(count) == s.succeedNWrites {
+			close(s.writesReady)
+		}
+		return nil
+	}
+	// Ensure readLoop has processed the close error before we return.
+	select {
+	case <-s.closed:
+	case <-time.After(testing.LongWait):
+		s.c.Fatal("timed out waiting for mock stream close")
+	}
+	return fmt.Errorf("use of closed network connection")
+}
+
+func (s *mockStream) ReadJSON(v interface{}) error {
+	s.c.Fatal("ReadJSON called unexpectedly")
+	return nil
+}
+
+func (s *mockStream) Close() error {
+	s.closeOnce.Do(func() { close(s.closed) })
+	return nil
+}
+
+func (s *workerBounceSuite) TestWriteLogEOFReturnsBounce(c *gc.C) {
+	stream := &mockStream{
+		c:              c,
+		succeedNWrites: 0,
+		closed:         make(chan struct{}),
+	}
+	logSenderAPI := apilogsender.NewAPI(&mockConnector{stream: stream})
+
+	logsCh := make(logsender.LogRecordCh, 1)
+	logsCh <- &logsender.LogRecord{
+		Time:     time.Now(),
+		Module:   "test",
+		Location: "test:1",
+		Level:    loggo.INFO,
+		Message:  "hello",
+	}
+
+	w := logsender.New(logsCh, logSenderAPI)
+	err := w.Wait()
+	c.Assert(err, gc.Equals, dependency.ErrBounce)
+}
+
+func (s *workerBounceSuite) TestDroppedLogWriteEOFReturnsBounce(c *gc.C) {
+	stream := &mockStream{
+		c:              c,
+		succeedNWrites: 1,
+		writesReady:    make(chan struct{}),
+		closed:         make(chan struct{}),
+	}
+	logSenderAPI := apilogsender.NewAPI(&mockConnector{stream: stream})
+
+	logsCh := make(logsender.LogRecordCh, 1)
+	logsCh <- &logsender.LogRecord{
+		Time:         time.Now(),
+		Module:       "test",
+		Location:     "test:1",
+		Level:        loggo.INFO,
+		Message:      "hello",
+		DroppedAfter: 5,
+	}
+
+	w := logsender.New(logsCh, logSenderAPI)
+	err := w.Wait()
+	c.Assert(err, gc.Equals, dependency.ErrBounce)
 }


### PR DESCRIPTION
The logsink server sent close frames with an empty payload ([]byte{}) when receiveLogs hit an error (e.g. read-deadline timeout after a missed pong). An empty close frame carries no status code, so gorilla/websocket reports it as CloseNoStatusReceived (1005).

On the client side, readLoop passed the raw *CloseError to readErrs. WriteLog then annotated it as "sending log message: close 1005: ...", which the worker treated as an unexpected error. This caused the dependency engine to log an ERROR on every reconnect cycle.

server side

replace the empty payload with FormatCloseMessage using CloseGoingAway (1001) so clients receive a proper close code. The same fix is applied to websocket.SendInitialErrorV0.

client side

normalise close codes 1000, 1001, and 1005 to io.EOF in readLoop, consistent with rpc/jsoncodec/conn.go. WriteLog returns unwrapped io.EOF, and the worker converts it to dependency.ErrBounce for a silent reconnect. This keeps backwards compatibility with older controllers that still send empty close frames.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

### QA steps

Verified on a MAAS-provisioned machine running nested LXD controllers with shortened ping/pong timeouts (PingPeriod=5s, PongDelay=10s).

#### test 1 — both sides patched

1. Bootstrap a controller from the patched source with `--build-agent`.
2. Deploy the `ubuntu` charm and set `logging-config="<root>=DEBUG"`.
3. Block the agent's outbound traffic only to simulate pong loss:

```sh
lxc exec <unit-container> -- iptables -A OUTPUT -p tcp --dport 17070 -j DROP
sleep 90
lxc exec <unit-container> -- iptables -D OUTPUT -p tcp --dport 17070 -j DROP
```

The 90-second wait covers PongDelay (10s) + WriteWait (10s) + TCP retransmission margin.

The server's pong timeout fires and it attempts to send `CloseGoingAway` (1001), but since the agent cannot ACK, gorilla may generate `CloseAbnormalClosure` (1006) on the client side instead.

4. After unblocking, trigger a config change to force the idle agent to call `WriteLog` on the dead logsink connection:

```sh
juju config ubuntu hostname=test123
```

5. Verify the client logs show `log-sender` bouncing before `api-caller` dies — proving it detected the close frame independently, not as a dependency cascade:

```
"log-sender" manifold worker stopped: restart immediately
"log-sender" manifold worker started at ...
  ... (seconds later) ...
"api-caller" manifold worker stopped: api connection broken unexpectedly
```

`"restart immediately"` confirms `dependency.ErrBounce` was returned.

6. Verify no ERROR-level log mentions `log-sender`:

```sh
grep ERROR <unit-log> | grep log-sender   # should be empty
```

`log-sender` returned `ErrBounce` 10–21 seconds before `api-caller` detected the broken connection.
No ERROR logs for `log-sender`. Tested on both IPv4 and IPv6 connections.


#### test 2 — old server + new client (backwards compatibility)

1. Bootstrap a controller from unpatched 3.6 source (still sends `[]byte{}` → 1005).
2. Deploy the `ubuntu` charm and replace the agent's `jujud` binary with the patched build. Restart the agent.
3. Repeat the iptables test above.

`log-sender` returned `ErrBounce` 10 seconds before `api-caller` detected the broken connection.
No ERROR logs for `log-sender`.
Although the unpatched server intends to send `CloseNoStatusReceived` (1005), the degraded TCP state (agent cannot ACK) may cause gorilla to generate `CloseAbnormalClosure` (1006) on the client side instead.
Both codes are handled by the same `IsCloseError` check.

## Documentation changes
N/A

## Links
N/A