### PR TITLE
docs: get llms txt to include full URLs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -89,14 +89,18 @@ run: install convert-excalidraw-to-svg
 	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) \
 	 --pre-build "bash scripts/convert-excalidraw-to-svg-recursively.sh" \
 	 --pre-build "python3 scripts/autogenerate-docs.py" \
-	 --post-build "sh -c 'test -f $(BUILDDIR)/llms.txt && python3 scripts/fix_llms_txt_urls.py $(BUILDDIR)/llms.txt || true'" \
+	 --post-build "sh -c 'if [ -f $(BUILDDIR)/llms.txt ]; then python3 scripts/fix_llms_txt_urls.py $(BUILDDIR)/llms.txt; else echo \"No llms.txt file found, skipping URL conversion\"; fi'" \
 	 "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Does not depend on $(BUILDDIR) to rebuild properly at every run.
 html: install convert-excalidraw-to-svg
 	. $(VENV); $(SPHINXBUILD) --keep-going -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)
 	@echo "Post-processing llms.txt to use absolute URLs..."
-	@test -f "$(BUILDDIR)/llms.txt" && python3 scripts/fix_llms_txt_urls.py "$(BUILDDIR)/llms.txt" || echo "No llms.txt file found, skipping URL conversion"
+	@if [ -f "$(BUILDDIR)/llms.txt" ]; then \
+		python3 scripts/fix_llms_txt_urls.py "$(BUILDDIR)/llms.txt"; \
+	else \
+		echo "No llms.txt file found, skipping URL conversion"; \
+	fi
 
 epub: install
 	. $(VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -89,11 +89,14 @@ run: install convert-excalidraw-to-svg
 	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) \
 	 --pre-build "bash scripts/convert-excalidraw-to-svg-recursively.sh" \
 	 --pre-build "python3 scripts/autogenerate-docs.py" \
+	 --post-build "sh -c 'test -f $(BUILDDIR)/llms.txt && python3 scripts/fix_llms_txt_urls.py $(BUILDDIR)/llms.txt || true'" \
 	 "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Does not depend on $(BUILDDIR) to rebuild properly at every run.
 html: install convert-excalidraw-to-svg
 	. $(VENV); $(SPHINXBUILD) --keep-going -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)
+	@echo "Post-processing llms.txt to use absolute URLs..."
+	@test -f "$(BUILDDIR)/llms.txt" && python3 scripts/fix_llms_txt_urls.py "$(BUILDDIR)/llms.txt" || echo "No llms.txt file found, skipping URL conversion"
 
 epub: install
 	. $(VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)

--- a/docs/scripts/fix_llms_txt_urls.py
+++ b/docs/scripts/fix_llms_txt_urls.py
@@ -55,7 +55,7 @@ def convert_llms_txt_to_absolute_urls(file_path, base_url):
         return False
 
     # Read the file
-    content = file_path.read_text()
+    content = file_path.read_text(encoding='utf-8')
 
     # Function to convert relative path to absolute URL
     def convert_path(match):
@@ -66,25 +66,32 @@ def convert_llms_txt_to_absolute_urls(file_path, base_url):
         if rel_path.startswith(('http://', 'https://', '/')):
             return match.group(0)  # Return unchanged
 
-        # Convert .md path to absolute URL
-        url_path = rel_path[:-3]  # Remove .md extension
-        if url_path == 'index':
-            absolute_url = base_url
-        else:
-            absolute_url = base_url + url_path + '/'
-        
-        return f'[{title}]({absolute_url})'
-    
-    # Replace all markdown links with relative paths
-    # Pattern matches: [Title](path.md) or [Title](path/to/file.md)
-    pattern = r'\[([^\]]+)\]\(([^)]+\.md)\)'
-    new_content = re.sub(pattern, convert_path, content)
+        # Build absolute URL by prepending base URL to relative path
+        # Keep .md extension and anchors intact for AI-friendliness
+        absolute_url = base_url + rel_path
 
-    # Count conversions
+        return f'[{title}]({absolute_url})'
+
+    # Replace all markdown links with relative paths
+    # Pattern matches: [Title](path.md) or [Title](path.md#anchor)
+    # Must contain .md to be processed
+    pattern = r'\[([^\]]+)\]\(([^)]*\.md[^)]*)\)'
+
+    # Count conversions to be made
     original_count = len(re.findall(pattern, content))
 
+    # Perform replacements
+    new_content = re.sub(pattern, convert_path, content)
+
+    # Verify conversions worked
+    absolute_url_pattern = r'\]\(https?://.*\.md'
+    converted_count = len(re.findall(absolute_url_pattern, new_content))
+
+    if converted_count < original_count:
+        print(f"Warning: Only {converted_count}/{original_count} conversions verified", file=sys.stderr)
+
     # Write back to file
-    file_path.write_text(new_content)
+    file_path.write_text(new_content, encoding='utf-8')
 
     print(f"Successfully converted {original_count} relative paths to absolute URLs in {file_path}")
     return True

--- a/docs/scripts/fix_llms_txt_urls.py
+++ b/docs/scripts/fix_llms_txt_urls.py
@@ -62,19 +62,19 @@ def convert_llms_txt_to_absolute_urls(file_path, base_url):
         title = match.group(1)
         rel_path = match.group(2)
 
+        # Skip if URL is already absolute
+        if rel_path.startswith(('http://', 'https://', '/')):
+            return match.group(0)  # Return unchanged
+
         # Convert .md path to absolute URL
-        if rel_path.endswith('.md'):
-            url_path = rel_path[:-3]  # Remove .md extension
-            if url_path == 'index':
-                absolute_url = base_url
-            else:
-                absolute_url = base_url + url_path + '/'
+        url_path = rel_path[:-3]  # Remove .md extension
+        if url_path == 'index':
+            absolute_url = base_url
         else:
-            # If no .md extension, keep as is
-            absolute_url = base_url + rel_path + '/'
-
+            absolute_url = base_url + url_path + '/'
+        
         return f'[{title}]({absolute_url})'
-
+    
     # Replace all markdown links with relative paths
     # Pattern matches: [Title](path.md) or [Title](path/to/file.md)
     pattern = r'\[([^\]]+)\]\(([^)]+\.md)\)'

--- a/docs/scripts/fix_llms_txt_urls.py
+++ b/docs/scripts/fix_llms_txt_urls.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Post-processing script to convert relative paths in llms.txt to absolute URLs.
+
+This script is run after the Sphinx build to ensure LLM consumers can fetch
+documentation pages without having to infer the base URL.
+
+Usage:
+    python3 scripts/fix_llms_txt_urls.py _build/llms.txt [base_url]
+
+The script determines the version in the following order:
+1. Explicit base_url argument (if provided)
+2. READTHEDOCS_VERSION environment variable (on ReadTheDocs)
+3. Auto-detected from ../version/version.go (for local builds)
+4. Falls back to 'latest' if version cannot be determined
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def get_juju_version():
+    """
+    Detect the Juju version from version/version.go.
+    Returns major.minor version (e.g., '3.6') or None if not found.
+    """
+    try:
+        # Look for version.go relative to the docs directory
+        version_file = Path(__file__).parent.parent.parent / 'version' / 'version.go'
+        if version_file.exists():
+            content = version_file.read_text()
+            # Look for: const version = "3.6.20"
+            match = re.search(r'const version = "(\d+\.\d+)\.\d+"', content)
+            if match:
+                return match.group(1)
+    except Exception:
+        pass
+    return None
+
+
+def convert_llms_txt_to_absolute_urls(file_path, base_url):
+    """
+    Convert all relative markdown links in llms.txt to absolute URLs.
+
+    Args:
+        file_path: Path to the llms.txt file
+        base_url: Base URL for the documentation (e.g., 'https://documentation.ubuntu.com/juju/latest/')
+    """
+    file_path = Path(file_path)
+
+    if not file_path.exists():
+        print(f"Error: File {file_path} does not exist", file=sys.stderr)
+        return False
+
+    # Read the file
+    content = file_path.read_text()
+
+    # Function to convert relative path to absolute URL
+    def convert_path(match):
+        title = match.group(1)
+        rel_path = match.group(2)
+
+        # Convert .md path to absolute URL
+        if rel_path.endswith('.md'):
+            url_path = rel_path[:-3]  # Remove .md extension
+            if url_path == 'index':
+                absolute_url = base_url
+            else:
+                absolute_url = base_url + url_path + '/'
+        else:
+            # If no .md extension, keep as is
+            absolute_url = base_url + rel_path + '/'
+
+        return f'[{title}]({absolute_url})'
+
+    # Replace all markdown links with relative paths
+    # Pattern matches: [Title](path.md) or [Title](path/to/file.md)
+    pattern = r'\[([^\]]+)\]\(([^)]+\.md)\)'
+    new_content = re.sub(pattern, convert_path, content)
+
+    # Count conversions
+    original_count = len(re.findall(pattern, content))
+
+    # Write back to file
+    file_path.write_text(new_content)
+
+    print(f"Successfully converted {original_count} relative paths to absolute URLs in {file_path}")
+    return True
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: python3 fix_llms_txt_urls.py <llms.txt_path> [base_url]", file=sys.stderr)
+        sys.exit(1)
+
+    llms_txt_path = sys.argv[1]
+
+    # Determine base URL
+    if len(sys.argv) >= 3:
+        # Use explicitly provided base URL
+        base_url = sys.argv[2]
+    elif 'READTHEDOCS_VERSION' in os.environ:
+        # Use ReadTheDocs version (e.g., '3.6', 'latest', etc.)
+        version = os.environ['READTHEDOCS_VERSION']
+        base_url = f'https://documentation.ubuntu.com/juju/{version}/'
+    else:
+        # Try to detect version from version.go
+        detected_version = get_juju_version()
+        if detected_version:
+            base_url = f'https://documentation.ubuntu.com/juju/{detected_version}/'
+        else:
+            # Fall back to 'latest' if version cannot be detected
+            base_url = 'https://documentation.ubuntu.com/juju/latest/'
+
+    # Ensure base URL ends with /
+    if not base_url.endswith('/'):
+        base_url += '/'
+
+    print(f"Converting relative paths to absolute URLs with base: {base_url}")
+    success = convert_llms_txt_to_absolute_urls(llms_txt_path, base_url)
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

The `llms.txt` spec says to include full URLs (https://llmstxt.org/) -- this helps LLMs retrieve pages directly instead of having to infer them and running into fetch issues because of that. However, our `llms.txt` setup only included relative paths (e.g., `reference/action.md`). This PR fixes that by automatically converting all relative paths to absolute URLs (e.g., `https://documentation.ubuntu.com/juju/3.6/reference/action/`) during the build process.

## Changes

- Added `docs/scripts/fix_llms_txt_urls.py` - post-processing script that converts relative paths to absolute URLs.
- Updated `docs/Makefile` - automatically runs the script after HTML build (`make html`) and during live preview (`make run`).
- Version-aware: detects version from `version/version.go` for local builds, or uses `READTHEDOCS_VERSION` env var when building on ReadTheDocs.

## Impact

All 393 links in llms.txt now use absolute URLs with the correct version path. AI assistants can now directly fetch Juju documentation pages without needing to guess the base URL.

## QA Steps

1. Build the docs: `cd docs && make html`
2. Verify the script runs: Check for "Converting relative paths to absolute URLs" in build output
3. Check generated file: `cat _build/llms.txt | head -20`
4. Confirm all links use absolute URLs with correct version and preserve .md extensions (e.g., https://documentation.ubuntu.com/juju/3.6/reference/action.md)
5. Test a few URLs with `.md` are accessible: 
```
curl -I https://documentation.ubuntu.com/juju/3.6/index.md
curl -I https://documentation.ubuntu.com/juju/3.6/reference/action.md
```

## Links

Jira card: [JUJU-9475](
https://warthogs.atlassian.net/browse/JUJU-9475)



[JUJU-9475]: https://warthogs.atlassian.net/browse/JUJU-9475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ