### PR TITLE
fix: infinite recursive loop in provisioner task

### DIFF
--- a/apiserver/common/common_test.go
+++ b/apiserver/common/common_test.go
@@ -135,8 +135,6 @@ func (s *commonSuite) TestAuthAnyWith3(c *tc.C) {
 	c.Check(auth(names.NewUserTag("quux")), tc.IsFalse)
 }
 
-func u(unit string) names.Tag { return names.NewUnitTag(unit) }
-
 func (s *commonSuite) TestAuthFuncForTagKind(c *tc.C) {
 	// TODO(dimitern): This list of all supported tags and kinds needs
 	// to live in juju/names.

--- a/apiserver/common/instanceidgetter_test.go
+++ b/apiserver/common/instanceidgetter_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/common/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/machine"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -31,6 +32,11 @@ func TestInstanceIdGetterSuite(t *testing.T) {
 func (s *instanceIdGetterSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.machineService = mocks.NewMockMachineService(ctrl)
+
+	c.Cleanup(func() {
+		s.machineService = nil
+	})
+
 	return ctrl
 }
 
@@ -38,22 +44,19 @@ func (s *instanceIdGetterSuite) TestInstanceId(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	getCanRead := func(ctx context.Context) (common.AuthFunc, error) {
-		x0 := u("x/0")
-		x2 := u("x/2")
-		x3 := u("x/3")
 		return func(tag names.Tag) bool {
-			return tag == x0 || tag == x2 || tag == x3
+			return tag.Id() == "0" || tag.Id() == "2" || tag.Id() == "3"
 		}, nil
 	}
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("x/0")).Return("uuid-0", nil)
+	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid-0", nil)
 	s.machineService.EXPECT().GetInstanceID(gomock.Any(), machine.UUID("uuid-0")).Return("foo", nil)
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("x/2")).Return("uuid-2", nil)
+	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("2")).Return("uuid-2", nil)
 	s.machineService.EXPECT().GetInstanceID(gomock.Any(), machine.UUID("uuid-2")).Return("", errors.New("x2 error"))
-	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("x/3")).Return("uuid-3", nil)
+	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("3")).Return("uuid-3", nil)
 	s.machineService.EXPECT().GetInstanceID(gomock.Any(), machine.UUID("uuid-3")).Return("", errors.New("x3 error"))
 	ig := common.NewInstanceIdGetter(s.machineService, getCanRead)
 	entities := params.Entities{Entities: []params.Entity{
-		{Tag: "unit-x-0"}, {Tag: "unit-x-1"}, {Tag: "unit-x-2"}, {Tag: "unit-x-3"}, {Tag: "unit-x-4"},
+		{Tag: "machine-0"}, {Tag: "machine-1"}, {Tag: "machine-2"}, {Tag: "machine-3"}, {Tag: "machine-4"},
 	}}
 	results, err := ig.InstanceId(c.Context(), entities)
 	c.Assert(err, tc.ErrorIsNil)
@@ -75,4 +78,43 @@ func (s *instanceIdGetterSuite) TestInstanceIdError(c *tc.C) {
 	ig := common.NewInstanceIdGetter(s.machineService, getCanRead)
 	_, err := ig.InstanceId(c.Context(), params.Entities{Entities: []params.Entity{{Tag: "unit-x-0"}}})
 	c.Assert(err, tc.ErrorMatches, "pow")
+}
+
+func (s *instanceIdGetterSuite) TestInstanceIdErrorNotProvisioned(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	getCanRead := func(ctx context.Context) (common.AuthFunc, error) {
+		return func(names.Tag) bool { return true }, nil
+	}
+
+	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid-0", nil)
+	s.machineService.EXPECT().GetInstanceID(gomock.Any(), machine.UUID("uuid-0")).Return("", machineerrors.NotProvisioned)
+
+	entities := params.Entities{Entities: []params.Entity{
+		{Tag: "machine-0"},
+	}}
+	ig := common.NewInstanceIdGetter(s.machineService, getCanRead)
+	results, err := ig.InstanceId(c.Context(), entities)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Assert(results.Results[0].Error, tc.Satisfies, params.IsCodeNotProvisioned)
+}
+
+func (s *instanceIdGetterSuite) TestInstanceIdErrorNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	getCanRead := func(ctx context.Context) (common.AuthFunc, error) {
+		return func(names.Tag) bool { return true }, nil
+	}
+
+	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("", machineerrors.MachineNotFound)
+
+	entities := params.Entities{Entities: []params.Entity{
+		{Tag: "machine-0"},
+	}}
+	ig := common.NewInstanceIdGetter(s.machineService, getCanRead)
+	results, err := ig.InstanceId(c.Context(), entities)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Assert(results.Results[0].Error, tc.Satisfies, params.IsCodeNotFound)
 }

--- a/internal/provisionertask/provisioner_task.go
+++ b/internal/provisionertask/provisioner_task.go
@@ -183,11 +183,12 @@ func NewProvisionerTask(cfg TaskConfig) (ProvisionerTask, error) {
 }
 
 // The list of events that are passed into the eventProcessed callback by the
-// main loop.
+// provisioner task.
 const (
 	eventTypeProcessedMachines         = "processed-machines"
 	eventTypeRetriedMachinesWithErrors = "retried-machines-with-errors"
 	eventTypeResizedWorkerPool         = "resized-worker-pool"
+	eventTypeQueuedStopInstances       = "queued-stop-instances"
 )
 
 type provisionerTask struct {
@@ -594,29 +595,32 @@ func (task *provisionerTask) queueRemovalOfDeadMachines(
 	// Collect the list of machines to stop.
 	dead = task.lockedCollectStopListAndMark(dead)
 	// Collect the instances for all provisioned machines that are dead.
-	stopping, orphaned, redefer := task.lockedInstancesForDeadMachines(ctx, dead)
-	task.lockedDeferAlreadyStopping(redefer)
+	instanceClassification := task.lockedInstancesForDeadMachines(ctx, dead)
+	task.lockedForgetMissingMachines(instanceClassification.missing)
+	task.lockedDeferAlreadyStopping(instanceClassification.redefer)
 	task.machinesMutex.Unlock()
 
 	// Don't remove machines that need deferring again.
-	redeferIDs := transform.Slice(redefer, apiprovisioner.MachineProvisioner.Id)
+	redeferIDs := transform.Slice(instanceClassification.redefer, apiprovisioner.MachineProvisioner.Id)
+	missingIDs := transform.Slice(instanceClassification.missing, apiprovisioner.MachineProvisioner.Id)
 	dead = slices.DeleteFunc(dead, func(m apiprovisioner.MachineProvisioner) bool {
-		return slices.Contains(redeferIDs, m.Id())
+		id := m.Id()
+		return slices.Contains(redeferIDs, id) || slices.Contains(missingIDs, id)
 	})
 
 	// We know that there are dead machines, but none of them have an
 	// assigned instance, so there is nothing to stop in terms of an
 	// instance, but we still need to mark the machines for removal.
-	for _, machine := range orphaned {
+	for _, machine := range instanceClassification.orphaned {
 		task.logger.Infof(ctx, "removing dead machine with no machine ID")
 		if err := machine.MarkForRemoval(ctx); err != nil {
 			task.logger.Errorf(ctx, "failed to remove dead machine %q: %v", machine.Id(), err)
 		}
 	}
 
-	if len(stopping) == 0 &&
+	if len(instanceClassification.instances) == 0 &&
 		len(dead) == 0 &&
-		len(redefer) == 0 {
+		len(instanceClassification.redefer) == 0 {
 		// Nothing to do.
 		return nil
 	}
@@ -624,15 +628,15 @@ func (task *provisionerTask) queueRemovalOfDeadMachines(
 	provTask := workerpool.Task{
 		Type: "stop-instances",
 		Process: func() error {
-			if len(stopping) > 0 {
-				task.logger.Infof(ctx, "stopping known instances %v", instanceIds(stopping))
+			if len(instanceClassification.instances) > 0 {
+				task.logger.Infof(ctx, "stopping known instances %v", instanceIds(instanceClassification.instances))
 			}
 
 			// It is important that we stop unknown instances before starting
 			// pending ones, because if we start an instance and then fail to
 			// set its InstanceId on the machine.
 			// We don't want to start a new instance for the same machine ID.
-			if err := task.doStopInstances(ctx, stopping); err != nil {
+			if err := task.doStopInstances(ctx, instanceClassification.instances); err != nil {
 				return errors.Trace(err)
 			}
 
@@ -654,13 +658,13 @@ func (task *provisionerTask) queueRemovalOfDeadMachines(
 			}
 			task.machinesMutex.Unlock()
 
-			if len(redefer) > 0 {
+			if len(instanceClassification.redefer) > 0 {
 				// Re-trigger machines that failed to prepare for removal.
 				task.logger.Debugf(
 					ctx, "triggering removal of deferred machines %v",
 					redeferIDs,
 				)
-				return task.queueRemovalOfDeadMachines(ctx, redefer)
+				return task.queueRemovalOfDeadMachines(ctx, instanceClassification.redefer)
 			}
 
 			return nil
@@ -670,6 +674,7 @@ func (task *provisionerTask) queueRemovalOfDeadMachines(
 	select {
 	case task.wp.Queue() <- provTask:
 		// successfully enqueued removal request
+		task.notifyEventProcessedCallback(eventTypeQueuedStopInstances)
 		return nil
 	case <-task.catacomb.Dying():
 		return task.catacomb.ErrDying()
@@ -711,6 +716,17 @@ func (task *provisionerTask) lockedCollectStopListAndMark(dead []apiprovisioner.
 	return deadMachines
 }
 
+func (task *provisionerTask) lockedForgetMissingMachines(missing []apiprovisioner.MachineProvisioner) {
+	for _, machine := range missing {
+		task.lockedRemoveMachineFromAZMap(machine)
+		machID := machine.Id()
+		delete(task.machines, machID)
+		delete(task.machinesStopping, machID)
+		delete(task.machinesStopped, machID)
+		delete(task.machinesStopDeferred, machID)
+	}
+}
+
 // lockedDeferAlreadyStopping puts a machine back into the deferred stop.
 func (task *provisionerTask) lockedDeferAlreadyStopping(
 	redefer []apiprovisioner.MachineProvisioner,
@@ -733,21 +749,37 @@ func (task *provisionerTask) lockedDeferStopForNotYetStartedMachines(dead []apip
 	}
 }
 
+type machineInstancesClassification struct {
+	// missing are machines that have been removed entirely from state.
+	missing []apiprovisioner.MachineProvisioner
+	// orphaned are machines that do not have an instance associated with them.
+	orphaned []apiprovisioner.MachineProvisioner
+	// redefer are machines that failed to be classified for some misc reason,
+	// so we will try again later.
+	redefer []apiprovisioner.MachineProvisioner
+	// instances are the instances for the input machines which can be stopped.
+	instances []instances.Instance
+}
+
 // instancesForDeadMachines returns a list of instances that correspond to
 // machines with a life of "dead" in state. Missing machines and machines that
 // have not finished starting are omitted from the list.
 func (task *provisionerTask) lockedInstancesForDeadMachines(
 	ctx context.Context, dead []apiprovisioner.MachineProvisioner,
-) ([]instances.Instance, []apiprovisioner.MachineProvisioner, []apiprovisioner.MachineProvisioner) {
-	var (
-		deadInstances []instances.Instance
-		orphaned      []apiprovisioner.MachineProvisioner
-		redefer       []apiprovisioner.MachineProvisioner
-	)
+) machineInstancesClassification {
+	var ret machineInstancesClassification
 	for _, machine := range dead {
-		instId, err := machine.InstanceId(ctx)
-		if params.IsCodeNotProvisioned(err) {
-			orphaned = append(orphaned, machine)
+		instID, err := machine.InstanceId(ctx)
+		if params.IsCodeNotFound(err) {
+			// A NotFound error indicates that the machine itself does not exist.
+			// This means there is nothing to remove, so we should ignore this
+			// machine.
+			// This can happen in circumstances such as when a machine is removed
+			// without ever having an instance provisioned.
+			ret.missing = append(ret.missing, machine)
+			continue
+		} else if params.IsCodeNotProvisioned(err) {
+			ret.orphaned = append(ret.orphaned, machine)
 			continue
 		} else if err == nil {
 			keep, err := machine.KeepInstance(ctx)
@@ -756,27 +788,27 @@ func (task *provisionerTask) lockedInstancesForDeadMachines(
 					ctx, "cannot fetch machine %s keep-instance status from controller: %v",
 					machine.Id(), err,
 				)
-				redefer = append(redefer, machine)
+				ret.redefer = append(ret.redefer, machine)
 				continue
 			}
 			if keep {
-				task.logger.Debugf(ctx, "machine %v is dead but keep-instance is true", instId)
+				task.logger.Debugf(ctx, "machine %v is dead but keep-instance is true", instID)
 				continue
 			}
 			// If the instance is not found we can't stop it.
-			if inst, found := task.instances[instId]; found {
-				deadInstances = append(deadInstances, inst)
+			if inst, found := task.instances[instID]; found {
+				ret.instances = append(ret.instances, inst)
 			}
 		} else if err != nil {
 			task.logger.Errorf(
 				ctx, "cannot fetch machine %s instance ID from controller: %v",
 				machine.Id(), err,
 			)
-			redefer = append(redefer, machine)
+			ret.redefer = append(ret.redefer, machine)
 			continue
 		}
 	}
-	return deadInstances, orphaned, redefer
+	return ret
 }
 
 func (task *provisionerTask) doStopInstances(ctx context.Context, instances []instances.Instance) error {

--- a/internal/provisionertask/provisioner_task_test.go
+++ b/internal/provisionertask/provisioner_task_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1472,6 +1473,56 @@ func (s *ProvisionerTaskSuite) TestMachineAndDeadNotProvisionedMachineAreRemoved
 	s.waitForRemovalMark(c, m1)
 }
 
+// TestDeadMachineWithNotFoundInstanceIDIsIgnored ensures that a dead machine
+// with an instance ID lookup that returns NotFound is ignored.
+func (s *ProvisionerTaskSuite) TestDeadMachineWithNotFoundInstanceIDIsIgnored(c *tc.C) {
+	ctrl := s.setUpMocks(c)
+	defer ctrl.Finish()
+
+	m0 := &testMachine{
+		c:    c,
+		id:   "0",
+		life: life.Dead,
+		instanceIdErr: &params.Error{
+			Code: params.CodeNotFound,
+		},
+	}
+
+	broker := environmocks.NewMockEnviron(ctrl)
+	exp := broker.EXPECT()
+	exp.AllRunningInstances(gomock.Any()).Return(nil, nil).MinTimes(1)
+
+	s.machinesAPI.EXPECT().Machines(
+		gomock.Any(),
+		names.NewMachineTag("0"),
+	).Return([]apiprovisioner.MachineResult{{
+		Machine: m0,
+	}}, nil).MinTimes(1)
+
+	var queuedStopInstances atomic.Int32
+	callbackCh := make(chan struct{})
+	task := s.newProvisionerTaskWithBrokerAndEventCb(c, broker, nil, numProvisionWorkersForTesting, func(evt string) {
+		switch evt {
+		case "processed-machines":
+			close(callbackCh)
+		case "queued-stop-instances":
+			queuedStopInstances.Add(1)
+		}
+	})
+	defer workertest.CleanKill(c, task)
+
+	s.sendModelMachinesChange(c, "0")
+
+	select {
+	case <-callbackCh:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for processed-machines event")
+	}
+
+	c.Check(queuedStopInstances.Load(), tc.Equals, int32(0))
+	c.Check(m0.GetMarkForRemoval(), tc.IsFalse)
+}
+
 // setUpZonedEnviron creates a mock broker with instances based on those set
 // on the test suite, and 3 availability zones.
 func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller, machines ...*testMachine) *providermocks.MockZonedEnviron {
@@ -1692,7 +1743,7 @@ type machineClassificationTest struct {
 	description    string
 	life           life.Value
 	status         status.Status
-	idErr          string
+	instanceIdErr  string
 	ensureDeadErr  string
 	expectErrCode  string
 	expectErrFmt   string
@@ -1725,7 +1776,7 @@ func (s *MachineClassifySuite) TestMachineClassification(c *tc.C) {
 			instStatus:    t.status,
 			machineStatus: t.status,
 			id:            id,
-			idErr:         s2e(t.idErr),
+			instanceIdErr: s2e(t.instanceIdErr),
 			ensureDeadErr: s2e(t.ensureDeadErr),
 			statusErr:     s2e(t.statusErr),
 		}
@@ -1803,7 +1854,7 @@ type testMachine struct {
 
 	containersCh chan []string
 
-	idErr         error
+	instanceIdErr error
 	ensureDeadErr error
 	statusErr     error
 
@@ -1841,6 +1892,9 @@ func (m *testMachine) WatchContainers(_ context.Context, cType instance.Containe
 func (m *testMachine) InstanceId(context.Context) (instance.Id, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.instanceIdErr != nil {
+		return "", m.instanceIdErr
+	}
 	if m.instance == nil {
 		return "", params.Error{Code: "not provisioned"}
 	}


### PR DESCRIPTION
I found that when a machine has been removed that never created an instance (perhaps the disk was full), once that machine had been removed the provisioner task finds itself stuck in an infinite recursive loop.

The problem was the provisioner was trying to remove an instance that never existed.

This meant that, once the machine was removed, when the provisioner loops up it's InstanceId it gets machine not found.

This case is not handled, so the removal is re-deferred, which just has the same result.

Resolve this by skipping machines that are not found. They have already been removed, the provisioner does not need to worry about it.

## QA steps

Install Juju onto a VPS with lxd and limited storage capacity.

Bootstrap
```
$ juju bootstrap lxd lxd
$ juju add-model m
```
Reserve a small amount of space. I did this by downloading a small charm
```
$ juju download juju-qa-test
```
Fill up the remaining storage with junk
```
$ cat /dev.random > random.bin
cat: write error: No space left on device
```
and free up what you reserved
```
$ rm ./juju-qa-test_r25.charm
```
The drive is now almost full
```
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        24G   24G  2.2M 100% /
...
```
Add a machine. This will fail
```
$ juju add-machine
$ juju status
Model  Controller  Cloud/Region         Version  Timestamp
m      lxd         localhost/localhost  4.0.4.1  13:47:24Z

Machine  State  Address  Inst id  Base          AZ  Message
0        down            pending  ubuntu@24.04      failed to start machine 0 (Failed creating instance from image: Unpack failed: Failed to run: unsquashfs -f -d /var/s...
```
Remove the machine
```
$ juju remove-machine 0
(wait)
$ juju status
Model  Controller  Cloud/Region         Version  Timestamp
m      lxd         localhost/localhost  4.0.4.1  13:48:41Z

Model "admin/m" is empty.
```
Check there are no errors in `juju debug-log`