### PR TITLE
feat: add a timeout to downloads for asynccharmdownloader

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           cd tests
           export MODEL_ARCH=$(go env GOARCH)
-          export BOOTSTRAP_ADDITIONAL_ARGS="--model-default enable-os-upgrade=false"
+          export BOOTSTRAP_ADDITIONAL_ARGS="--model-default enable-os-upgrade=false --model-default logging-config='<root>=INFO;juju.worker.asynccharmdownloader=TRACE'"
 
           # Skip destroy to keep the environment up.
           export SKIP_DESTROY=true

--- a/domain/deployment/charm/charmdownloader/downloader.go
+++ b/domain/deployment/charm/charmdownloader/downloader.go
@@ -91,8 +91,13 @@ func (d *CharmDownloader) Download(ctx context.Context, url *url.URL, hash strin
 		}
 	}()
 
+	opts := make([]charmhub.DownloadOption, 0)
+	if d.logger.IsLevelEnabled(logger.TRACE) {
+		opts = append(opts, charmhub.WithProgressBar(charmhub.NewLoggingProgressBar(d.logger)))
+	}
+
 	// Force the sha256 digest to be calculated on download.
-	digest, err := d.client.Download(ctx, url, tmpFile.Name())
+	digest, err := d.client.Download(ctx, url, tmpFile.Name(), opts...)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/internal/charmhub/download.go
+++ b/internal/charmhub/download.go
@@ -91,17 +91,6 @@ const (
 	DownloadNameKey downloadKey = "download-name-key"
 )
 
-// ProgressBar defines a progress bar type for giving feedback to the user about
-// the state of the download.
-type ProgressBar interface {
-	io.Writer
-
-	// Start progress with max "total" steps.
-	Start(label string, total float64)
-	// Finished the progress display
-	Finished()
-}
-
 // Download returns the raw charm zip file, which is retrieved from the given
 // URL.
 // It is expected that the archive path doesn't already exist and if it does, it

--- a/internal/charmhub/progressbar.go
+++ b/internal/charmhub/progressbar.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	corelogger "github.com/juju/juju/core/logger"
+)
+
+// ProgressBar defines a progress bar type for giving feedback to the user about
+// the state of the download.
+type ProgressBar interface {
+	io.Writer
+
+	// Start progress with max "total" steps.
+	Start(label string, total float64)
+	// Finished the progress display
+	Finished()
+}
+
+type LoggingProgressBar struct {
+	logger  corelogger.Logger
+	label   string
+	total   float64
+	written float64
+}
+
+var _ ProgressBar = (*LoggingProgressBar)(nil)
+
+// NewLoggingProgressBar creates a progress bar that logs percentage updates.
+func NewLoggingProgressBar(logger corelogger.Logger) ProgressBar {
+	return &LoggingProgressBar{
+		logger: logger,
+	}
+}
+
+// Start progress with max "total" steps.
+func (p *LoggingProgressBar) Start(label string, total float64) {
+	p.label = label
+	p.total = total
+	p.written = 0
+}
+
+// Finished the progress display.
+func (*LoggingProgressBar) Finished() {}
+
+func (p *LoggingProgressBar) Write(bs []byte) (n int, err error) {
+	n = len(bs)
+	p.written += float64(n)
+
+	if p.logger == nil {
+		return n, nil
+	}
+
+	if p.label == "" {
+		p.logger.Tracef(context.TODO(), "download progress %s complete", p.percent())
+		return n, nil
+	}
+
+	p.logger.Tracef(context.TODO(), `download %q progress %s complete`, p.label, p.percent())
+	return n, nil
+}
+
+func (p *LoggingProgressBar) percent() string {
+	if p.total == 0 {
+		return "100%"
+	}
+	q := p.written * 100 / p.total
+	if q > 100 || q < 0 {
+		return "???%"
+	}
+	return fmt.Sprintf("%3.0f%%", q)
+}

--- a/internal/charmhub/progressbar_test.go
+++ b/internal/charmhub/progressbar_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/juju/tc"
+
+	corelogger "github.com/juju/juju/core/logger"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type progressBarSuite struct{}
+
+func TestProgressBarSuite(t *testing.T) {
+	tc.Run(t, &progressBarSuite{})
+}
+
+func (progressBarSuite) TestWriteLogsPercentage(c *tc.C) {
+	logs := captureLogs{c: c}
+	logger := loggertesting.WrapCheckLogWithLevel(&logs, corelogger.TRACE)
+
+	pb := NewLoggingProgressBar(logger)
+	pb.Start("dummy", 10)
+
+	n, err := pb.Write([]byte("abc"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(n, tc.Equals, 3)
+
+	n, err = pb.Write([]byte("1234567"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(n, tc.Equals, 7)
+
+	c.Check(logs.messages, tc.DeepEquals, []string{
+		`TRACE: download "dummy" progress  30% complete`,
+		`TRACE: download "dummy" progress 100% complete`,
+	})
+}
+
+func (progressBarSuite) TestWriteLogsUnknownPercentageForZeroTotal(c *tc.C) {
+	logs := captureLogs{c: c}
+	logger := loggertesting.WrapCheckLogWithLevel(&logs, corelogger.TRACE)
+
+	pb := NewLoggingProgressBar(logger)
+	pb.Start("dummy", 0)
+
+	_, err := pb.Write([]byte("abc"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(logs.messages, tc.DeepEquals, []string{
+		`TRACE: download "dummy" progress 100% complete`,
+	})
+}
+
+type captureLogs struct {
+	c        *tc.C
+	messages []string
+}
+
+func (l *captureLogs) Logf(msg string, args ...any) {
+	l.messages = append(l.messages, fmt.Sprintf(msg, args...))
+}
+
+func (l *captureLogs) Context() context.Context {
+	return l.c.Context()
+}
+
+func (*captureLogs) Helper() {}

--- a/internal/worker/asynccharmdownloader/downloader.go
+++ b/internal/worker/asynccharmdownloader/downloader.go
@@ -25,6 +25,11 @@ import (
 const (
 	retryAttempts = 3
 	retryDelay    = 20 * time.Second
+
+	// downloadTimeout is the maximum amount of time to allow for a charm
+	// download before timing out. We might want to make this configurable in
+	// the future
+	downloadTimeout = 5 * time.Minute
 )
 
 type asyncDownloadWorker struct {
@@ -93,6 +98,9 @@ func (w *asyncDownloadWorker) loop() error {
 	var result *charmdownloader.DownloadResult
 	if err := retry.Call(retry.CallArgs{
 		Func: func() error {
+			ctx, cancel := context.WithTimeout(ctx, downloadTimeout)
+			defer cancel()
+
 			result, err = w.downloader.Download(ctx, url, info.SHA256)
 			if err != nil {
 				return errors.Capture(err)


### PR DESCRIPTION
We have experienced rare errors where a uniter gets stuck bouncing after a charm deploy. We see repeated errors `blob data for "..." not found`

We don't know the root cause for this 100%, but I managed to replicate exactly the same scenario by breaking the downloader to hang forever when downloading. This is feasible if there are network/server problems.

Resolve this by adding a timeout to the context we pass in to the downloader, ensuring the download fails if it takes more than 5 minutes.

5 mins was picked somewhat arbitrarily, on the assumption that it is long enough to say for sure safely that something is wrong if the download takes longer than this. We may want to make this configurable in the future.

Also, to help verify this issue, add a trace log progress bar to the download options is TRACE is enabled. This logs to trace the percentage complete of a download every time the cache is flushed. Enable this in our CI tests, meaning next time we see this failure we can diagnose the issue for sure

Fixes: https://github.com/juju/juju/issues/21997

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju model-config logging-config="<root>=INFO;juju.worker.asynccharmdownloader=TRACE"
$ juju deploy juju-qa-test
```
And check the logs for:
```
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   0% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   1% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   1% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   2% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   3% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   4% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   4% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   5% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   6% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   7% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   7% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   8% complete
machine-0: 11:40:34 TRACE juju.worker.asynccharmdownloader download progress   9% complete
...
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress  94% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress  95% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress  95% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress  96% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress  97% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress  98% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress  98% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress  99% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress 100% complete
machine-0: 11:40:35 TRACE juju.worker.asynccharmdownloader download progress 100% complete
machine-0: 11:40:35 DEBUG juju.worker.asynccharmdownloader downloaded charm: "https://api.charmhub.io/api/v1/charms/download/Hw30RWzpUBnJLGtO71SX8VDWvd3WrjaJ_25.charm"
```