### PR TITLE
feat: allows show SAAS application if status is missing

### DIFF
--- a/domain/status/state/model/crossmodelrelation.go
+++ b/domain/status/state/model/crossmodelrelation.go
@@ -316,7 +316,7 @@ SELECT    aro.uuid AS &remoteApplicationUUID.uuid
 FROM      application AS a
 -- left join ensures we can distinguish between an application that doesn't
 -- exist and one that is not remote
-LEFT JOIN application_remote_offerer AS aro
+LEFT JOIN application_remote_offerer AS aro ON a.uuid = aro.application_uuid
 WHERE     a.name = $applicationName.name `,
 		remoteApplicationUUID{}, appIdent)
 	if err != nil {

--- a/domain/status/state/model/crossmodelrelation.go
+++ b/domain/status/state/model/crossmodelrelation.go
@@ -109,8 +109,11 @@ SELECT
   re.relation_uuid AS &fullRemoteApplicationStatus.relation_uuid
 FROM      application AS a
 JOIN      application_remote_offerer        AS aro  ON a.uuid = aro.application_uuid
-JOIN      application_remote_offerer_status AS aros ON aro.uuid = aros.application_remote_offerer_uuid
--- No need to left join, since a remote app needs at least one endpoint to make sense.
+-- We can't guarantee that there will be a status for a remote application,
+-- so we need a left join here.
+LEFT JOIN application_remote_offerer_status AS aros ON aro.uuid = aros.application_remote_offerer_uuid
+-- No need to left join, since a remote app needs at least one endpoint to
+-- make sense.
 JOIN      application_endpoint              AS ae   ON a.uuid = ae.application_uuid
 JOIN      charm_relation                    AS cr   ON ae.charm_relation_uuid = cr.uuid
 JOIN      charm_relation_role               AS crr  ON cr.role_id = crr.id

--- a/domain/status/state/model/crossmodelrelation_test.go
+++ b/domain/status/state/model/crossmodelrelation_test.go
@@ -76,6 +76,18 @@ func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererUUIDByNameNotRe
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.ApplicationNotRemote)
 }
 
+func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererUUIDByNameNotRemoteWithOtherRemoteApplication(c *tc.C) {
+	// Regression guard for the join constraint in lookupRemoteApplicationOfferer:
+	// when a non-remote application exists alongside another remote
+	// application, the non-remote one must not resolve to an unrelated remote
+	// uuid.
+	s.createIAASApplication(c, "foo", life.Alive, s.workloadStatus(time.Now()))
+	s.createIAASRemoteApplicationOfferer(c, "bar")
+
+	_, err := s.state.GetRemoteApplicationOffererUUIDByName(c.Context(), "foo")
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.ApplicationNotRemote)
+}
+
 func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererUUIDByNameNotFound(c *tc.C) {
 	_, err := s.state.GetRemoteApplicationOffererUUIDByName(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)

--- a/domain/status/state/model/crossmodelrelation_test.go
+++ b/domain/status/state/model/crossmodelrelation_test.go
@@ -244,6 +244,35 @@ func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererStatuses(c *tc.
 	})
 }
 
+func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererStatusesStatusOptional(c *tc.C) {
+	s.createIAASRemoteApplicationOfferer(c, "foo")
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `DELETE FROM application_remote_offerer_status`)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	statuses, err := s.state.GetRemoteApplicationOffererStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(statuses, tc.HasLen, 1)
+
+	foo, ok := statuses["foo"]
+	c.Assert(ok, tc.IsTrue)
+	c.Check(foo.Status.Status, tc.Equals, status.WorkloadStatusUnset)
+	c.Check(foo.Status.Message, tc.Equals, "")
+	c.Check(foo.Status.Data, tc.DeepEquals, []byte(nil))
+	c.Check(foo.Status.Since, tc.IsNil)
+	c.Check(foo.OfferURL, tc.Equals, "controller:qualifier/model.foo")
+	c.Check(foo.Life, tc.Equals, life.Alive)
+
+	endpointNames := make([]string, 0, len(foo.Endpoints))
+	for _, ep := range foo.Endpoints {
+		endpointNames = append(endpointNames, ep.Name)
+	}
+	c.Check(endpointNames, tc.SameContents, []string{"endpoint", "juju-info", "misc"})
+}
+
 func (s *crossModelRelationSuite) TestGetRemoteApplicationOffererStatusesWithRelations(c *tc.C) {
 	appUUID, _ := s.createIAASRemoteApplicationOfferer(c, "foo")
 	relationUUID1 := s.addRelationWithLifeAndID(c, corelife.Alive, 1)


### PR DESCRIPTION
After migrating a 3.6 model with CMRs to a 4.0 controller, and there are multiple application remote offerers we don't always get the SAAS applications. This was caused by two issues:

 1. SAAS applications might not always have a status
 2. Looking up a remote application offerer would sometimes returns the wrong application

Fixing requires application_remote_offerer to have optional status, and ensuring the looking up of remote application offerers has a JOIN constraint.

## QA steps

Ensure you have 3.6 installed via snap:

```sh
$ /snap/bin/juju bootstrap localhost src
```

Create the offer model:

```sh
$ /snap/bin/juju add-model offer
$ /snap/bin/juju deploy juju-qa-dummy-source src1
$ /snap/bin/juju deploy juju-qa-dummy-source src2
$ /snap/bin/juju offer src1:sink
$ /snap/bin/juju offer src2:sink
```

Create the consume model:

```sh
$ /snap/bin/juju add-model to
$ /snap/bin/juju deploy juju-qa-dummy-sink sink1
$ /snap/bin/juju deploy juju-qa-dummy-sink sink2
$ /snap/bin/juju relate sink1 admin/from.src1
$ /snap/bin/juju relate sink2 admin/from.src2
```

Create the destination controller:

```sh
$ juju bootstrap localhost dst
```

Migrate:

```sh
$ juju migrate offer:to dst
```

Make sure it comes up correct.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes [#21825](https://github.com/juju/juju/issues/21825).

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9248](https://warthogs.atlassian.net/browse/JUJU-9248)


[JUJU-9248]: https://warthogs.atlassian.net/browse/JUJU-9248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ