### PR TITLE
fix: make charmrunner HookLogger.Stop thread-safe and idempotent

### DIFF
--- a/internal/worker/common/charmrunner/logger.go
+++ b/internal/worker/common/charmrunner/logger.go
@@ -35,6 +35,7 @@ type HookLogger struct {
 	r         io.ReadCloser
 	done      chan struct{}
 	mu        sync.Mutex
+	stopOnce  sync.Once
 	stopped   bool
 	receivers []MessageReceiver
 }
@@ -78,22 +79,23 @@ type Stopper interface {
 
 // Stop stops the hook logger.
 func (l *HookLogger) Stop() {
-	// Ensure Stop() is idempotent.
-	if l == nil || l.stopped {
+	if l == nil {
 		return
 	}
-	// We can see the process exit before the logger has processed
-	// all its output, so allow a moment for the data buffered
-	// in the pipe to be processed. We don't wait indefinitely though,
-	// because the hook may have started a background process
-	// that keeps the pipe open.
-	select {
-	case <-l.done:
-	case <-time.After(100 * time.Millisecond):
-	}
-	// We can't close the pipe asynchronously, so just
-	// stifle output instead.
-	l.mu.Lock()
-	l.stopped = true
-	l.mu.Unlock()
+	l.stopOnce.Do(func() {
+		// We can see the process exit before the logger has processed
+		// all its output, so allow a moment for the data buffered
+		// in the pipe to be processed. We don't wait indefinitely though,
+		// because the hook may have started a background process
+		// that keeps the pipe open.
+		select {
+		case <-l.done:
+		case <-time.After(100 * time.Millisecond):
+		}
+		// We can't close the pipe asynchronously, so just
+		// stifle output instead.
+		l.mu.Lock()
+		l.stopped = true
+		l.mu.Unlock()
+	})
 }

--- a/internal/worker/common/charmrunner/logger_test.go
+++ b/internal/worker/common/charmrunner/logger_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmrunner
+
+import (
+	"io"
+	"sync"
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+)
+
+type hookLoggerSuite struct{}
+
+func TestHookLoggerSuite(t *stdtesting.T) {
+	tc.Run(t, &hookLoggerSuite{})
+}
+
+func (*hookLoggerSuite) TestStopIsIdempotent(c *tc.C) {
+	reader, writer := io.Pipe()
+	logger := NewHookLogger(reader)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		logger.Run()
+	}()
+
+	stopDone := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			logger.Stop()
+		}()
+	}
+	go func() {
+		defer close(stopDone)
+		wg.Wait()
+	}()
+
+	select {
+	case <-stopDone:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for Stop calls to finish")
+	}
+
+	c.Assert(writer.Close(), tc.ErrorIsNil)
+
+	select {
+	case <-runDone:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for logger to stop")
+	}
+}


### PR DESCRIPTION
There was a little concurrency whoopsie where the read of `l.stopped` was not lock-protected, and therefore potentially racy for concurrent `Stop` calls.

This ensures the stop logic is executed at most once, preventing the race.

The first test coverage of this code is added.