### PR TITLE
fix: correct operator status

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -3719,7 +3719,7 @@ func (a *Application) Status() (status.StatusInfo, error) {
 // OperatorStatus returns the status of the application's operator, which is
 // only used on CAAS models.
 func (a *Application) OperatorStatus() (status.StatusInfo, error) {
-	info, err := getStatus(a.st.db(), a.globalKey(), "operator")
+	info, err := getStatus(a.st.db(), applicationGlobalOperatorKey(a.Name()), "operator")
 	if err != nil {
 		return status.StatusInfo{}, errors.Trace(err)
 	}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -5788,8 +5788,17 @@ func (s *CAASApplicationSuite) setupApplicationWithAttachStorage(c *gc.C, unitNu
 }
 
 func (s *ApplicationSuite) TestSetOperatorStatusNonCAAS(c *gc.C) {
-	_, err := state.ApplicationOperatorStatus(s.State, s.mysql.Name())
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	now := coretesting.ZeroTime()
+	sInfo := status.StatusInfo{
+		Status:  status.Error,
+		Message: "broken",
+		Since:   &now,
+	}
+	err := s.mysql.SetOperatorStatus(sInfo)
+	c.Assert(err, jc.ErrorIs, errors.NotSupported)
+
+	_, err = s.mysql.OperatorStatus()
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func (s *ApplicationSuite) TestSetOperatorStatus(c *gc.C) {
@@ -5811,7 +5820,7 @@ func (s *ApplicationSuite) TestSetOperatorStatus(c *gc.C) {
 	err := app.SetOperatorStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	appStatus, err := state.ApplicationOperatorStatus(st, app.Name())
+	appStatus, err := app.OperatorStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(appStatus.Status, gc.DeepEquals, status.Error)
 	c.Assert(appStatus.Message, gc.DeepEquals, "broken")


### PR DESCRIPTION
Simple fix to correctly fetch the operator status. The broken implementation was fetching application status instead of the operator's. 

The fix now allows ApplicationDisplayStatus ([here](https://github.com/juju/juju/blob/78832a31ad6b1ec5b7d5a24c267ae094a07333af/apiserver/facades/client/client/status.go#L1472) and [here](https://github.com/juju/juju/blob/78832a31ad6b1ec5b7d5a24c267ae094a07333af/core/status/caas.go#L63)) to surface the operator status if it has higher severity than application status.

**No need to merge forward to 4.0**

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


Bootstrap and add model

```sh
juju bootstrap minikube juju-9511-testing-1 
juju add-model test
```

Deploy

```sh
juju deploy postgresql-k8s --channel 14/stable --trust
```

Set operator status to error

Inside mongo shell
```sh
db.statuses.updateOne(   { _id: { $regex: "postgresql-k8s#operator" } },   {     $set: {       status: "error",       statusinfo: "forced error for testing"     }   } )
```

Check status

```
juju status

Model  Controller           Cloud/Region  Version  SLA          Timestamp
test   juju-9511-testing-1  minikube      3.6.20   unsupported  10:21:33+07:00

App             Version  Status  Scale  Charm           Channel    Rev  Address         Exposed  Message
postgresql-k8s  14.20    error       1  postgresql-k8s  14/stable  774  10.104.245.201  no       forced error for testing

Unit               Workload  Agent  Address       Ports  Message
postgresql-k8s/0*  active    idle   10.244.1.106         Primary


```

## Documentation changes

N/A

## Links


**Issue:** Fixes [#22092](https://github.com/juju/juju/issues/22092).

**Jira card:** [JUJU-9511](https://warthogs.atlassian.net/browse/JUJU-9511)


[JUJU-9511]: https://warthogs.atlassian.net/browse/JUJU-9511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ