### PR TITLE
refactor(cloudcred): removes the juju version from the generated file

### DIFF
--- a/api/common/cloudcred/attr.go
+++ b/api/common/cloudcred/attr.go
@@ -2,9 +2,6 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 //
 // GENERATED FILE - DO NOT EDIT
-//
-// Generated from:
-//   Juju Version:   3.6.20
 
 package cloudcred
 

--- a/generate/cloudcred/main.go
+++ b/generate/cloudcred/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/environs"
 	_ "github.com/juju/juju/internal/provider/all"
 	_ "github.com/juju/juju/internal/provider/dummy"
-	"github.com/juju/juju/version"
 )
 
 var file = flag.String("o", "", "`file` to write.")
@@ -38,7 +37,6 @@ func main() {
 	}
 
 	p := params{
-		JujuVersion: version.Current.String(),
 		PackageName: *packageName,
 		Attributes:  visibleAttributes,
 	}
@@ -76,7 +74,6 @@ func main() {
 }
 
 type params struct {
-	JujuVersion string
 	PackageName string
 	Attributes  map[string]bool
 }
@@ -86,9 +83,6 @@ var tmpl = template.Must(template.New("").Parse(`
 // Licensed under the AGPLv3, see LICENCE file for details.
 //
 // GENERATED FILE - DO NOT EDIT
-// 
-// Generated from:
-//   Juju Version:   {{.JujuVersion}}
 
 package {{.PackageName}}
 


### PR DESCRIPTION
Removes the Juju version from the generated file in api/common/cloudcred.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. `cd api/common/cloudcred`
2. `go generate ./...`
3. verify the generated `attr.go` file does not contain a juju version

## Documentation changes

N/A

## Links

N/A