### PR TITLE
fix: correctly handle cloud not found domain error

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -184,10 +184,9 @@ func (api *CloudAPI) Cloud(ctx context.Context, args params.Entities) (params.Cl
 			}
 		}
 		aCloud, err := api.cloudService.Cloud(ctx, tag.Id())
-		if err != nil {
-			if errors.Is(err, clouderrors.NotFound) {
-				return nil, errors.NotFoundf("cloud %q", tag.Id())
-			}
+		if errors.Is(err, clouderrors.NotFound) {
+			return nil, errors.NotFoundf("cloud %q", tag.Id())
+		} else if err != nil {
 			return nil, err
 		}
 		paramsCloud := cloudToParams(*aCloud)
@@ -244,10 +243,9 @@ func (api *CloudAPI) getCloudInfo(ctx context.Context, tag names.CloudTag) (*par
 	}
 
 	aCloud, err := api.cloudService.Cloud(ctx, tag.Id())
-	if err != nil {
-		if errors.Is(err, clouderrors.NotFound) {
-			return nil, errors.NotFoundf("cloud %q", tag.Id())
-		}
+	if errors.Is(err, clouderrors.NotFound) {
+		return nil, errors.NotFoundf("cloud %q", tag.Id())
+	} else if err != nil {
 		return nil, errors.Trace(err)
 	}
 	info := params.CloudInfo{
@@ -600,11 +598,10 @@ func (api *CloudAPI) Credential(ctx context.Context, args params.Entities) (para
 				return s, nil
 			}
 			aCloud, err := api.cloudService.Cloud(ctx, cloudName)
-			if err != nil {
-				if errors.Is(err, clouderrors.NotFound) {
-					return nil, errors.NotFoundf("cloud %q", cloudName)
-				}
-				return nil, err
+			if errors.Is(err, clouderrors.NotFound) {
+				return nil, errors.NotFoundf("cloud %q", cloudName)
+			} else if err != nil {
+				return nil, errors.Trace(err)
 			}
 			aProvider, err := environs.Provider(aCloud.Type)
 			if err != nil {
@@ -662,10 +659,9 @@ func (api *CloudAPI) AddCloud(ctx context.Context, cloudArgs params.AddCloudArgs
 	if cloudArgs.Cloud.Type != cloud.CloudTypeKubernetes {
 		// All non-k8s cloud need to go through whitelist.
 		controllerCloud, err := api.cloudService.Cloud(ctx, api.controllerCloud)
-		if err != nil {
-			if errors.Is(err, clouderrors.NotFound) {
-				return errors.NotFoundf("cloud %q", api.controllerCloud)
-			}
+		if errors.Is(err, clouderrors.NotFound) {
+			return errors.NotFoundf("cloud %q", api.controllerCloud)
+		} else if err != nil {
 			return errors.Trace(err)
 		}
 		if err := cloud.CurrentWhiteList().Check(controllerCloud.Type, cloudArgs.Cloud.Type); err != nil {
@@ -766,10 +762,9 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 			return s, nil
 		}
 		aCloud, err := api.cloudService.Cloud(ctx, cloudName)
-		if err != nil {
-			if errors.Is(err, clouderrors.NotFound) {
-				return nil, errors.NotFoundf("cloud %q", cloudName)
-			}
+		if errors.Is(err, clouderrors.NotFound) {
+			return nil, errors.NotFoundf("cloud %q", cloudName)
+		} else if err != nil {
 			return nil, err
 		}
 		aProvider, err := environs.Provider(aCloud.Type)

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -117,8 +117,7 @@ func (s *cloudSuite) TestCloudNotFound(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 1)
-	c.Assert(results.Results[0].Error, tc.ErrorMatches, "cloud \"no-dice\" not found")
-	c.Assert(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
+	c.Check(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
 }
 
 func (s *cloudSuite) TestClouds(c *tc.C) {
@@ -272,7 +271,7 @@ func (s *cloudSuite) TestCloudInfoNotFound(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 1)
-	c.Assert(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
+	c.Check(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
 }
 
 func (s *cloudSuite) TestAddCloud(c *tc.C) {
@@ -568,8 +567,7 @@ func (s *cloudSuite) TestUpdateNonExistentCloud(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 1)
-	c.Assert(results.Results[0].Error, tc.ErrorMatches, fmt.Sprintf("cloud %q not found", updatedCloud.Name))
-	c.Assert(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
+	c.Check(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
 }
 
 func (s *cloudSuite) TestListCloudInfo(c *tc.C) {
@@ -1061,7 +1059,7 @@ func (s *cloudSuite) TestCredentialCloudNotFound(c *tc.C) {
 	}}})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 1)
-	c.Assert(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
+	c.Check(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
 }
 
 func (s *cloudSuite) TestModifyCloudAccess(c *tc.C) {
@@ -1204,7 +1202,7 @@ func (s *cloudSuite) TestCredentialContentsCloudNotFound(c *tc.C) {
 	results, err := s.api.CredentialContents(c.Context(), params.CloudCredentialArgs{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 1)
-	c.Assert(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
+	c.Check(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
 }
 
 func cloudCredentialTag(params credParams) (jujucloud.Credential, names.CloudCredentialTag) {


### PR DESCRIPTION
This change correctly interprets a small set of domain errors in the API layer that were not previously being mishandled.

Described more thoroughly in #22020, the domain layer is returning its own specific error rather than a const error from `juju/errors` which causes the `ServerError` function to fail its extraction of an appropriate error code. The unit tests all assumed an error from `juju/errors` would be returned rather than a domain specific error.

The fix adds some `if errors.Is(err, clouderrors.NotFound) {` checks where appropriate and updates the tests to use the domain error. Nothing is currently stopping the domain error from changing, causing the behaviour to silently break again. A follow-up that adds a way to integrate the api layer together with the domain layer without spinning up a real controller would be useful.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Links

**Issue:** Fixes https://github.com/juju/juju/issues/22020.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9440](https://warthogs.atlassian.net/browse/JUJU-9440)


[JUJU-9440]: https://warthogs.atlassian.net/browse/JUJU-9440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ