### PR TITLE
fix: fix changed PTY allocation behavior upon ssh X sudo -i

### DIFF
--- a/cmd/juju/ssh/pty_test.go
+++ b/cmd/juju/ssh/pty_test.go
@@ -3,6 +3,8 @@
 package ssh
 
 import (
+	"bytes"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/retry"
 	"github.com/juju/testing"
@@ -63,51 +65,99 @@ func (m *mockSSHProvider) setRetryStrategy(retry.CallArgs)          {}
 func (m *mockSSHProvider) setPublicKeyRetryStrategy(retry.CallArgs) {}
 
 func (s *PTYSuite) TestRunPTYLogic(c *gc.C) {
+	// We use distinct buffer pointers for stdin and stdout so that
+	// the mock isTerminal function can tell which one is being queried.
+	stdinBuf := &bytes.Buffer{}
+	stdoutBuf := &bytes.Buffer{}
+
 	tests := []struct {
-		about       string
-		args        []string // args passed to the command (target is args[0])
-		flags       []string // flags like --pty=true
-		isTerminal  bool
-		expectedPTY bool
+		about            string
+		args             []string // args passed to the command (target is args[0])
+		flags            []string // flags like --pty=true
+		stdinIsTerminal  bool
+		stdoutIsTerminal bool
+		expectedPTY      bool
 	}{
+		// ── No command (interactive session) ──────────────────────
 		{
-			about:       "no command, is terminal -> pty=true",
-			args:        []string{"0"},
-			isTerminal:  true,
-			expectedPTY: true,
+			about:            "no command, stdin=tty -> pty=true",
+			args:             []string{"0"},
+			stdinIsTerminal:  true,
+			stdoutIsTerminal: true,
+			expectedPTY:      true,
 		},
 		{
-			about:       "no command, not terminal -> pty=false",
-			args:        []string{"0"},
-			isTerminal:  false,
-			expectedPTY: false,
+			about:            "no command, stdin=not tty -> pty=false",
+			args:             []string{"0"},
+			stdinIsTerminal:  false,
+			stdoutIsTerminal: true,
+			expectedPTY:      false,
+		},
+		// ── Command provided, both stdin+stdout are terminals ─────
+		// This is the #22070 fix: interactive 'sudo -i' at a terminal.
+		{
+			about:            "command, stdin=tty, stdout=tty -> pty=true (#22070 fix)",
+			args:             []string{"0", "sudo", "-i"},
+			stdinIsTerminal:  true,
+			stdoutIsTerminal: true,
+			expectedPTY:      true,
+		},
+		// ── Command provided, stdout piped/captured ───────────────
+		// This is the #19576 fix: output captured by script.
+		{
+			about:            "command, stdin=tty, stdout=pipe -> pty=false (#19576 fix)",
+			args:             []string{"0", "echo", "hello"},
+			stdinIsTerminal:  true,
+			stdoutIsTerminal: false,
+			expectedPTY:      false,
+		},
+		// ── Command provided, stdin piped ─────────────────────────
+		{
+			about:            "command, stdin=pipe, stdout=tty -> pty=false",
+			args:             []string{"0", "cat"},
+			stdinIsTerminal:  false,
+			stdoutIsTerminal: true,
+			expectedPTY:      false,
 		},
 		{
-			about:       "command provided, is terminal -> pty=false",
-			args:        []string{"0", "ls"},
-			isTerminal:  true,
-			expectedPTY: false,
+			about:            "command, stdin=pipe, stdout=pipe -> pty=false",
+			args:             []string{"0", "ls"},
+			stdinIsTerminal:  false,
+			stdoutIsTerminal: false,
+			expectedPTY:      false,
+		},
+		// ── Explicit --pty flag overrides ─────────────────────────
+		{
+			about:            "command, --pty=true overrides -> pty=true",
+			args:             []string{"0", "ls"},
+			flags:            []string{"--pty=true"},
+			stdinIsTerminal:  false,
+			stdoutIsTerminal: false,
+			expectedPTY:      true,
 		},
 		{
-			about:       "command provided, --pty=true -> pty=true",
-			args:        []string{"0", "ls"},
-			flags:       []string{"--pty=true"},
-			isTerminal:  true,
-			expectedPTY: true,
+			about:            "command, --pty=false overrides -> pty=false",
+			args:             []string{"0", "sudo", "-i"},
+			flags:            []string{"--pty=false"},
+			stdinIsTerminal:  true,
+			stdoutIsTerminal: true,
+			expectedPTY:      false,
 		},
 		{
-			about:       "command provided, --pty=false -> pty=false",
-			args:        []string{"0", "ls"},
-			flags:       []string{"--pty=false"},
-			isTerminal:  true,
-			expectedPTY: false,
+			about:            "no command, --pty=true, not terminal -> pty=true (forced)",
+			args:             []string{"0"},
+			flags:            []string{"--pty=true"},
+			stdinIsTerminal:  false,
+			stdoutIsTerminal: false,
+			expectedPTY:      true,
 		},
 		{
-			about:       "no command, --pty=true -> pty=true",
-			args:        []string{"0"},
-			flags:       []string{"--pty=true"},
-			isTerminal:  false,
-			expectedPTY: true, // forced
+			about:            "no command, --pty=false, is terminal -> pty=false (forced)",
+			args:             []string{"0"},
+			flags:            []string{"--pty=false"},
+			stdinIsTerminal:  true,
+			stdoutIsTerminal: true,
+			expectedPTY:      false,
 		},
 	}
 
@@ -116,13 +166,20 @@ func (s *PTYSuite) TestRunPTYLogic(c *gc.C) {
 
 		mock := &mockSSHProvider{}
 		sshCmd := &sshCommand{
-			provider:   mock,
-			isTerminal: func(interface{}) bool { return t.isTerminal },
-			// sshMachine/sshContainer embedded fields are zero-valued
+			provider: mock,
+			isTerminal: func(f interface{}) bool {
+				if f == stdinBuf {
+					return t.stdinIsTerminal
+				}
+				if f == stdoutBuf {
+					return t.stdoutIsTerminal
+				}
+				return false
+			},
 		}
 
-		// 1. Simulate flag parsing
-		// Since pty is autoBoolValue, default is nil.
+		// Simulate flag parsing.
+		sshCmd.pty.b = nil
 		if len(t.flags) > 0 {
 			for _, f := range t.flags {
 				if f == "--pty=true" || f == "--pty" {
@@ -135,17 +192,23 @@ func (s *PTYSuite) TestRunPTYLogic(c *gc.C) {
 			}
 		}
 
-		// 2. Set Args
-		// args[0] is target. args[1:] are command args.
+		// Set command args (args[0] is target, args[1:] are command args).
 		if len(t.args) > 1 {
 			mock.args = t.args[1:]
+		} else {
+			mock.args = nil
 		}
 
-		// 3. Run
-		ctx := &cmd.Context{Stdin: nil, Stdout: nil, Stderr: nil}
+		// Use our identifiable buffers as stdin/stdout so the mock
+		// isTerminal function can distinguish between them.
+		ctx := &cmd.Context{
+			Stdin:  stdinBuf,
+			Stdout: stdoutBuf,
+			Stderr: &bytes.Buffer{},
+		}
+
 		err := sshCmd.Run(ctx)
 		c.Assert(err, jc.ErrorIsNil)
-
 		c.Assert(mock.ptyEnabled, gc.Equals, t.expectedPTY)
 	}
 }

--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -286,22 +286,36 @@ func (c *sshCommand) Run(ctx *cmd.Context) error {
 }
 
 // enablePty determines whether a pseudo-terminal should be allocated
-// for the SSH session, based on the --pty flag and terminal availability.
+// for the SSH session, based on the --pty flag, terminal availability,
+// and whether a command is provided.
 func (c *sshCommand) enablePty(ctx *cmd.Context) bool {
 	if c.pty.b != nil {
 		return *c.pty.b
 	}
-	// Flag was not specified.
-	// If a command is supplied, we shouldn't use a pty
-	// unless requested (which is handled above).
-	// If no command is supplied, we use a pty if we have a terminal.
-	if len(c.provider.getArgs()) > 0 {
+
+	stdinIsTTY := c.checkTerminal(ctx.Stdin)
+
+	// No command args: allocate PTY only if stdin is a terminal
+	// (standard interactive session behavior).
+	if len(c.provider.getArgs()) == 0 {
+		return stdinIsTTY
+	}
+
+	// Command args are present. To fix CRLF in captured output
+	// while preserving interactive commands like 'sudo -i',
+	// allocate PTY only when BOTH stdin and stdout are terminals
+	// (i.e., the user is at an interactive terminal, not capturing output).
+	if !stdinIsTTY {
 		return false
 	}
+	return c.checkTerminal(ctx.Stdout)
+}
+
+func (c *sshCommand) checkTerminal(f interface{}) bool {
 	if c.isTerminal != nil {
-		return c.isTerminal(ctx.Stdin)
+		return c.isTerminal(f)
 	}
-	return isTerminal(ctx.Stdin)
+	return isTerminal(f)
 }
 
 // autoBoolValue is like gnuflag.boolValue, but remembers


### PR DESCRIPTION
#22070 reports that `juju ssh X sudo -i` no longer drops into a proper interactive shell after [PR #21716](https://github.com/juju/juju/pull/21716) changed PTY allocation behavior.

The fix says:

- No command (e.g., `juju ssh X`): Same as before — give a PTY if stdin is a terminal
- Command present (e.g.,` juju ssh X sudo -i`): Give a PTY only if BOTH stdin AND stdout are real terminals

It works because

- `juju ssh X sudo -i` at a terminal → stdin=terminal, stdout=terminal → PTY ✓ (interactive works)
- `result=$(juju ssh X echo hello) `→ stdin=terminal, stdout=pipe (not terminal) → no PTY ✓ (clean output)
- Script running` juju ssh X cmd `→ stdin=pipe, stdout=pipe → no PTY ✓ (clean output)

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

unit tests added

## Documentation changes


## Links

**Issue:** Fixes #22070 .

**Jira card:** [JUJU-9486](https://warthogs.atlassian.net/browse/JUJU-9486)


[JUJU-9486]: https://warthogs.atlassian.net/browse/JUJU-9486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ