### PR TITLE
ci(upgrade): expose simplestreams through server instead of sync

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -185,16 +185,27 @@ jobs:
           juju set-model-constraints arch=$(go env GOARCH)
           juju status
 
+      - name: Publish binaries on simplestreams
+        if: matrix.cloud == 'microk8s'
+        run: |
+          set -euxo pipefail
+
+          make simplestreams
+
       - name: Bootstrap Juju - microk8s
         if: matrix.cloud == 'microk8s'
         run: |
           set -euxo pipefail
+          
+          JUJU_SIMPLESTREAMS_SOURCE=$PWD/_build/simplestreams/tools make serve-simplestreams &
+          LOCAL_HOST_IP=$(hostname -I | awk '{print $1}')
 
           juju version
           sg snap_microk8s <<EOF
             juju bootstrap microk8s c \
               --constraints "arch=$(go env GOARCH)" \
-              --config caas-image-repo="${OCI_REGISTRY}/test-repo"
+              --config caas-image-repo="${OCI_REGISTRY}/test-repo" \
+              --config agent-metadata-url="http://${LOCAL_HOST_IP}:8666"
           EOF
 
           juju add-model m
@@ -261,28 +272,6 @@ jobs:
           EOL
           podman build $BUILD_TEMP -t ${OCI_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}
           podman push -f v2s2 "${OCI_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}" "docker://${OCI_REGISTRY}/test-repo/jujud-operator:${TARGET_JUJU_VERSION}"
-
-      - name: Publish binaries on simplestreams
-        if: matrix.cloud == 'microk8s'
-        run: |
-          set -euxo pipefail
-
-          make simplestreams
-
-      - name: Sync local simplestreams to controller
-        if: matrix.cloud == 'microk8s'
-        env:
-          TARGET_JUJU_VERSION: ${{ needs.setup.outputs.version }}
-        run: |
-          set -euxo pipefail
-
-          # Sync the local simplestreams to the controller. It will make it aware of the new jujud-operator image,
-          # even if the binary itself will not be used as is. upgrade will simply fetch the new image from the registry.
-          # However, without this step, upgrade will fail as it will not be able to find the new jujud-operator image.
-          juju --debug sync-agent-binary -m controller \
-            --source="$PWD/_build/simplestreams" \
-            --stream=${JUJU_PUBLISH_STREAM} \
-            --agent-version ${TARGET_JUJU_VERSION}
 
       - name: Preflight
         shell: bash

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -35,6 +35,7 @@ func newSyncAgentBinaryCommand() cmd.Command {
 // a local directory to the controller.
 type syncAgentBinaryCommand struct {
 	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
 	versionStr    string
 	targetVersion semversion.Number
 	dryRun        bool


### PR DESCRIPTION
## Pull request overview

Alternative approach to #22093 for making the microk8s upgrade CI path work.

Instead of removing the IAAS-only restriction from `sync-agent-binary` and syncing binaries into the controller after bootstrap, this PR exposes the local simplestreams via an HTTP server **before** bootstrap and points the controller to it via `agent-metadata-url`. This avoids the need for `sync-agent-binary` to operate on CAAS models.

**Changes:**
- Start a local simplestreams HTTP server (`make serve-simplestreams`) before bootstrapping the microk8s controller.
- Pass `--config agent-metadata-url="http://<host-ip>:8666"` during bootstrap so the controller discovers agent binaries from the local server.
- Remove the post-bootstrap "Sync local simplestreams to controller" step (no longer needed).
- Re-add `IAASOnlyCommand` restriction to `sync-agent-binary`, reverting the CAAS allowance from #22093.

## QA steps

CI should pass including the optional step "upgrade from microk8s"

## Links

**Jira card:** [JUJU-9088](https://warthogs.atlassian.net/browse/JUJU-9088)


[JUJU-9088]: https://warthogs.atlassian.net/browse/JUJU-9088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ