### PR TITLE
fix: misc asynccharmdownloader issues

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -1105,10 +1105,9 @@ func (s *Service) ResolveCharmDownload(ctx context.Context, appUUID coreapplicat
 	// This has the added benefit of returning the charm hash, so that we can
 	// verify the charm download. We don't want it to be passed in the resolve
 	// charm download, in case the caller has the wrong hash.
-	info, err := s.GetAsyncCharmDownloadInfo(ctx, appUUID)
+	info, err := s.st.GetAsyncCharmDownloadInfo(ctx, appUUID)
 	// There is nothing to do if the charm is already downloaded or resolved.
-	if errors.Is(err, applicationerrors.CharmAlreadyAvailable) ||
-		errors.Is(err, applicationerrors.CharmAlreadyResolved) {
+	if errors.Is(err, applicationerrors.CharmAlreadyAvailable) {
 		return nil
 	} else if err != nil {
 		return errors.Capture(err)

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -330,34 +330,6 @@ func (s *applicationServiceSuite) TestResolveCharmDownloadAlreadyAvailable(c *tc
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *applicationServiceSuite) TestResolveCharmDownloadAlreadyResolved(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	appUUID := tc.Must(c, coreapplication.NewUUID)
-	charmUUID := charmtesting.GenCharmID(c)
-
-	info := application.CharmDownloadInfo{
-		CharmUUID: charmUUID,
-		Name:      "foo",
-		SHA256:    "hash",
-		DownloadInfo: applicationcharm.DownloadInfo{
-			Provenance:         applicationcharm.ProvenanceDownload,
-			CharmhubIdentifier: "foo",
-			DownloadURL:        "https://example.com/foo",
-			DownloadSize:       42,
-		},
-	}
-
-	s.state.EXPECT().GetAsyncCharmDownloadInfo(gomock.Any(), appUUID).Return(info, applicationerrors.CharmAlreadyResolved)
-
-	err := s.service.ResolveCharmDownload(c.Context(), appUUID, application.ResolveCharmDownload{
-		CharmUUID: charmUUID,
-		Path:      "foo",
-		Size:      42,
-	})
-	c.Assert(err, tc.ErrorIsNil)
-}
-
 func (s *applicationServiceSuite) TestResolveCharmDownloadCharmUUIDMismatch(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1557,7 +1557,9 @@ func (st *State) GetApplicationsWithPendingCharmsFromUUIDs(ctx context.Context, 
 SELECT a.uuid AS &entityUUID.uuid
 FROM   application AS a
 JOIN   charm AS c ON a.charm_uuid = c.uuid
-WHERE  a.uuid IN ($applicationIDs[:]) AND c.available = FALSE
+WHERE  a.uuid IN ($applicationIDs[:])
+AND c.available = FALSE
+AND c.source_id < 2
 `, entityUUID{}, applicationIDs{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -2031,7 +2033,7 @@ WHERE  uuid = $entityUUID.uuid;`
 
 		// Write the charm actions.yaml, this will actually disappear once the
 		// charmhub store provides this information.
-		if err = st.addCharmActions(ctx, tx, id, info.Actions); err != nil {
+		if err := st.addCharmActions(ctx, tx, id, info.Actions); err != nil {
 			return errors.Errorf("setting charm actions for %q: %w", id, err)
 		}
 

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -2032,6 +2032,25 @@ func (s *applicationStateSuite) TestGetApplicationsWithPendingCharmsFromUUIDsNot
 	c.Check(expected, tc.HasLen, 0)
 }
 
+func (s *applicationStateSuite) TestGetApplicationsWithPendingCharmsFromUUIDsSyntheticExcludedFromMixed(c *tc.C) {
+	synthAppUUID := s.createIAASApplication(c, "foo", life.Alive)
+	appUUID := s.createIAASApplication(c, "bar", life.Alive)
+
+	// Switch the source_id of a charm to a synthetic CMR charm.
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE charm SET source_id = 2, architecture_id = NULL WHERE uuid = (
+SELECT charm_uuid FROM application WHERE uuid = ?
+)`, synthAppUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	expected, err := s.state.GetApplicationsWithPendingCharmsFromUUIDs(c.Context(), []coreapplication.UUID{synthAppUUID, appUUID})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(expected, tc.DeepEquals, []coreapplication.UUID{appUUID})
+}
+
 func (s *applicationStateSuite) TestGetApplicationsWithPendingCharmsFromUUIDsForSameCharm(c *tc.C) {
 	// These use the same charm, so once you set one applications charm, you
 	// set both.

--- a/domain/deployment/charm/charmdownloader/downloader.go
+++ b/domain/deployment/charm/charmdownloader/downloader.go
@@ -107,7 +107,7 @@ func (d *CharmDownloader) Download(ctx context.Context, url *url.URL, hash strin
 		return nil, errors.Errorf("%w: %q, got %q", ErrInvalidDigestHash, hash, digest.SHA256)
 	}
 
-	d.logger.Debugf(ctx, "downloaded charm: %q", url)
+	d.logger.Infof(ctx, "downloaded charm: %q", url)
 
 	return &DownloadResult{
 		SHA256: digest.SHA256,

--- a/internal/worker/asynccharmdownloader/downloader.go
+++ b/internal/worker/asynccharmdownloader/downloader.go
@@ -83,6 +83,7 @@ func (w *asyncDownloadWorker) loop() error {
 	if errors.Is(err, applicationerrors.CharmAlreadyAvailable) {
 		// If the application is already downloading a charm, we can skip this
 		// application.
+		w.logger.Infof(ctx, "charm for application %q is already available", w.appID)
 		return nil
 	} else if err != nil {
 		return errors.Capture(err)
@@ -101,6 +102,7 @@ func (w *asyncDownloadWorker) loop() error {
 			ctx, cancel := context.WithTimeout(ctx, downloadTimeout)
 			defer cancel()
 
+			var err error
 			result, err = w.downloader.Download(ctx, url, info.SHA256)
 			if err != nil {
 				return errors.Capture(err)
@@ -126,6 +128,10 @@ func (w *asyncDownloadWorker) loop() error {
 	}()
 
 	// The charm has been downloaded, we can now resolve the download slot.
+	//
+	// TODO: If this fails (which it sometimes does), the result is that the
+	// charm is redownloaded on the next attempt. We should re-architecture
+	// these workers to avoid this unnecessary work
 	err = w.applicationService.ResolveCharmDownload(ctx, w.appID, domainapplication.ResolveCharmDownload{
 		SHA256:    result.SHA256,
 		SHA384:    result.SHA384,
@@ -134,10 +140,12 @@ func (w *asyncDownloadWorker) loop() error {
 		Size:      result.Size,
 	})
 	if err != nil && !errors.Is(err, applicationerrors.CharmAlreadyResolved) {
+		w.logger.Errorf(ctx, "failed to resolve charm download for application %q: %v", w.appID, err)
 		return errors.Capture(err)
 	}
 
 	// Exit cleanly, so the worker doesn't get restarted.
+	w.logger.Infof(ctx, "downloaded and resolved charm for application %q", w.appID)
 	return nil
 }
 

--- a/internal/worker/asynccharmdownloader/downloadworker.go
+++ b/internal/worker/asynccharmdownloader/downloadworker.go
@@ -6,6 +6,7 @@ package asynccharmdownloader
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/juju/clock"
 	jujuerrors "github.com/juju/errors"
@@ -24,6 +25,8 @@ import (
 const (
 	// States which report the state of the worker.
 	stateStarted = "started"
+
+	restartDelay = 20 * time.Second
 )
 
 // ApplicationService describes the API exposed by the charm downloader facade.
@@ -112,11 +115,14 @@ func newWorker(config Config, internalState chan string) (*Worker, error) {
 		IsFatal: func(err error) bool {
 			return false
 		},
+		// Allow restarts, since it is necessary that a charm is downloaded and
+		// resolved to allow the deploy process to continue. This is unbounded
 		ShouldRestart: func(err error) bool {
-			return false
+			return true
 		},
-		Clock:  config.Clock,
-		Logger: internalworker.WrapLogger(config.Logger),
+		RestartDelay: restartDelay,
+		Clock:        config.Clock,
+		Logger:       internalworker.WrapLogger(config.Logger),
 	})
 	if err != nil {
 		return nil, errors.Capture(err)


### PR DESCRIPTION
- GetApplicationsWithPendingCharmsFromUUIDs incorrectly emitted synthetic applications
- GetAsyncCharmDownloadInfo does not emit applicationerrors.CharmAlreadyResolved errors
- Increase logging for the asynccharmdownloader. Since we have both ShouldRestart and IsFatal set to constantly false, we do not log any errors to logs when the worker exits, even with an error. This means errors were missed. Increase the logging to avoid this

## QA steps

```
juju bootstrap lxd lxd
juju add-model m 
juju deploy juju-qa-test
```