### PR TITLE
fix: removal of units with storage

### DIFF
--- a/domain/removal/service/unit.go
+++ b/domain/removal/service/unit.go
@@ -334,8 +334,16 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 	if l == life.Dying && !job.Force {
 		// Can the unit be marked as dead? If the unit has any associated
 		// entities that are still alive, we cannot mark it as dead.
-		if err := s.modelState.MarkUnitAsDeadWithNoEntities(ctx, job.EntityUUID); err != nil {
-			return errors.Errorf("unit %q is not dead", job.EntityUUID).Add(removalerrors.EntityNotDead)
+		err := s.modelState.MarkUnitAsDeadWithNoEntities(ctx, job.EntityUUID)
+		if errors.Is(err, applicationerrors.UnitNotFound) {
+			// The unit has already been removed.
+			// Indicate success so that this job will be deleted.
+			return nil
+		} else if errors.Is(err, removalerrors.EntityStillAlive) {
+			return errors.Errorf("marking unit %q as dead: %v", job.EntityUUID, err).
+				Add(removalerrors.EntityNotDead)
+		} else if err != nil {
+			return errors.Capture(err)
 		}
 	}
 
@@ -344,7 +352,11 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 	// in relation scopes. If the unit is dead, it transitioned to that
 	// state itself without departing relations, and can not act in that
 	// capacity again, so we depart all remaining scopes here.
-	if err := s.leaveAllRelationScopes(ctx, unit.UUID(job.EntityUUID)); err != nil {
+	if err := s.leaveAllRelationScopes(ctx, unit.UUID(job.EntityUUID)); errors.Is(err, applicationerrors.UnitNotFound) {
+		// The unit has already been removed.
+		// Indicate success so that this job will be deleted.
+		return nil
+	} else if err != nil {
 		return errors.Capture(err)
 	}
 
@@ -353,13 +365,30 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 	// A case has been made for the unit to create and update its own
 	// secrets directly, but for deletion we could safely remove that
 	// functionality and rely only on this code path.
-	if err := s.deleteUnitOwnedSecrets(ctx, unit.UUID(job.EntityUUID)); err != nil {
-		return errors.Capture(err)
+	if err := s.deleteUnitOwnedSecrets(ctx, unit.UUID(job.EntityUUID)); errors.Is(err, applicationerrors.UnitNotFound) {
+		// The unit has already been removed.
+		// Indicate success so that this job will be deleted.
+		return nil
+	} else if err != nil {
+		return errors.Errorf("deleting unit owned secrets: %w", err)
 	}
 
 	charmUUID, err := s.modelState.GetCharmForUnit(ctx, job.EntityUUID)
-	if err != nil {
-		return errors.Errorf("getting charm for unit %q: %w", job.EntityUUID, err)
+	if errors.Is(err, applicationerrors.UnitNotFound) {
+		// The unit has already been removed.
+		// Indicate success so that this job will be deleted.
+		return nil
+	} else if err != nil {
+		return errors.Errorf("getting charm for unit: %w", err)
+	}
+
+	applicationName, unitName, err := s.modelState.GetApplicationNameAndUnitNameByUnitUUID(ctx, job.EntityUUID)
+	if errors.Is(err, applicationerrors.UnitNotFound) {
+		// The unit has already been removed.
+		// Indicate success so that this job will be deleted.
+		return nil
+	} else if err != nil {
+		return errors.Errorf("getting application name and unit name: %w", err)
 	}
 
 	if err := s.modelState.DeleteUnit(ctx, job.EntityUUID, job.Force); errors.Is(err, applicationerrors.UnitNotFound) {
@@ -381,11 +410,6 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 	// sooner that the expiry of its last lease.
 	// For all other scenarios preventing lease renewal, the lease will be
 	// relinquished naturally by expiry.
-	applicationName, unitName, err := s.modelState.GetApplicationNameAndUnitNameByUnitUUID(ctx, job.EntityUUID)
-	if err != nil {
-		return errors.Errorf("getting application name and unit name: %w", err)
-	}
-
 	if err := s.leadershipRevoker.RevokeLeadership(applicationName, unit.Name(unitName)); err != nil && !errors.Is(err, leadership.ErrClaimNotHeld) {
 		return errors.Errorf("revoking leadership: %w", err)
 	}

--- a/domain/removal/service/unit_test.go
+++ b/domain/removal/service/unit_test.go
@@ -509,6 +509,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnitError(c *tc.C) {
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteUnit(gomock.Any(), j.EntityUUID, false).Return(errors.Errorf("the front fell off"))
@@ -564,7 +565,7 @@ func (s *unitSuite) TestExecuteJobForUnitNotDeadError(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
-	exp.MarkUnitAsDeadWithNoEntities(gomock.Any(), j.EntityUUID).Return(errors.Errorf("not dead"))
+	exp.MarkUnitAsDeadWithNoEntities(gomock.Any(), j.EntityUUID).Return(removalerrors.EntityStillAlive)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIs, removalerrors.EntityNotDead)

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -256,7 +256,22 @@ func (s *baseSuite) setupRelationService(c *tc.C) *relationservice.Service {
 }
 
 func (s *baseSuite) createIAASApplication(c *tc.C, svc *applicationservice.ProviderService, name string, units ...applicationservice.AddIAASUnitArg) coreapplication.UUID {
-	ch := &stubCharm{name: "test-charm"}
+	return s.createIAASApplicationWithCharm(
+		c,
+		svc,
+		name,
+		&stubCharm{name: "test-charm"},
+		units...,
+	)
+}
+
+func (s *baseSuite) createIAASApplicationWithCharm(
+	c *tc.C,
+	svc *applicationservice.ProviderService,
+	name string,
+	ch internalcharm.Charm,
+	units ...applicationservice.AddIAASUnitArg,
+) coreapplication.UUID {
 	appID, err := svc.CreateIAASApplication(c.Context(), name, ch, corecharm.Origin{
 		Source: corecharm.CharmHub,
 		Platform: corecharm.Platform{
@@ -1247,6 +1262,7 @@ func (s *baseSuite) addModelProvisionedVolume(c *tc.C) string {
 type stubCharm struct {
 	name        string
 	subordinate bool
+	storage     map[string]internalcharm.Storage
 }
 
 func (s *stubCharm) Meta() *internalcharm.Meta {
@@ -1286,6 +1302,7 @@ func (s *stubCharm) Meta() *internalcharm.Meta {
 				Type: "nvidia.com/gpu",
 			},
 		},
+		Storage: s.storage,
 	}
 }
 

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -571,8 +571,8 @@ AND    life_id = 1`, unitUUID)
 
 	// The following statements check for associated entities that would
 	// prevent the unit from being marked as dead. As long as there are no
-	// relations, storage attachments, or storage directives associated
-	// with the unit, we can mark it as dead.
+	// relations or storage attachments associated with the unit, we can mark
+	// it as dead.
 
 	relationStmt, err := st.Prepare(`
 SELECT count(*) AS &entityAssociationCount.count
@@ -592,41 +592,26 @@ WHERE  unit_uuid = $entityAssociationCount.uuid
 		return errors.Capture(err)
 	}
 
-	storageDirectiveStmt, err := st.Prepare(`
-SELECT count(*) AS &entityAssociationCount.count
-FROM   unit_storage_directive
-WHERE  unit_uuid = $entityAssociationCount.uuid
-`, unitUUID)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if l, err := st.getUnitLife(ctx, tx, uUUID); err != nil {
 			return errors.Errorf("getting unit life: %w", err)
 		} else if l == life.Dead {
 			return nil
 		} else if l == life.Alive {
-			return removalerrors.EntityStillAlive
+			return errors.Errorf("unit still alive").Add(removalerrors.EntityStillAlive)
 		}
 
 		var counter entityAssociationCount
 		if err := tx.Query(ctx, relationStmt, unitUUID).Get(&counter); err != nil {
 			return errors.Errorf("getting relation unit count: %w", err)
 		} else if counter.Count > 0 {
-			return removalerrors.EntityStillAlive
+			return errors.Errorf("unit still has relations in scope").Add(removalerrors.EntityStillAlive)
 		}
 
 		if err := tx.Query(ctx, storageAttachmentStmt, unitUUID).Get(&counter); err != nil {
 			return errors.Errorf("getting storage attachment count: %w", err)
 		} else if counter.Count > 0 {
-			return removalerrors.EntityStillAlive
-		}
-
-		if err := tx.Query(ctx, storageDirectiveStmt, unitUUID).Get(&counter); err != nil {
-			return errors.Errorf("getting storage directive count: %w", err)
-		} else if counter.Count > 0 {
-			return removalerrors.EntityStillAlive
+			return errors.Errorf("unit still has storage attachments").Add(removalerrors.EntityStillAlive)
 		}
 
 		if err := tx.Query(ctx, updateStmt, unitUUID).Run(); err != nil {

--- a/domain/removal/state/model/unit_test.go
+++ b/domain/removal/state/model/unit_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	applicationservice "github.com/juju/juju/domain/application/service"
+	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/life"
 	domainrelation "github.com/juju/juju/domain/relation"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
+	domainstorage "github.com/juju/juju/domain/storage"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -83,35 +85,7 @@ func (s *unitSuite) TestEnsureUnitNotAliveCascadeStorageAttachmentsDying(c *tc.C
 	unitUUID := unitUUIDs[0]
 
 	ctx := c.Context()
-
-	// Create a storage pool and a storage instance attached to the app's unit.
-	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		if _, err := tx.ExecContext(
-			ctx, "INSERT INTO storage_pool (uuid, name, type) VALUES ('pool-uuid', 'pool', 'whatever')",
-		); err != nil {
-			return err
-		}
-
-		inst := `
-INSERT INTO storage_instance (
-    uuid, storage_id, storage_pool_uuid, storage_kind_id, requested_size_mib,
-    charm_name, storage_name, life_id
-)
-VALUES ('instance-uuid', 'does-not-matter', 'pool-uuid', 1, 100, 'charm-name', 'storage-name', 0)`
-		if _, err := tx.ExecContext(ctx, inst); err != nil {
-			return err
-		}
-
-		attach := `
-INSERT INTO storage_attachment (uuid, storage_instance_uuid, unit_uuid, life_id)
-VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`
-		if _, err := tx.ExecContext(ctx, attach, unitUUID); err != nil {
-			return err
-		}
-
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	_, storageAttachmentUUID := s.addUnitStorageAttachment(c, unitUUID, false)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -122,13 +96,9 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`
 	s.checkUnitLife(c, unitUUID.String(), life.Dying)
 
 	// Storage attachment should be "dying".
-	row := s.DB().QueryRow("SELECT life_id FROM storage_attachment WHERE uuid = 'storage-attachment-uuid'")
-	var lifeID int
-	err = row.Scan(&lifeID)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	s.checkStorageAttachmentLife(c, storageAttachmentUUID, life.Dying)
 
-	c.Check(cascade.StorageAttachmentUUIDs, tc.DeepEquals, []string{"storage-attachment-uuid"})
+	c.Check(cascade.StorageAttachmentUUIDs, tc.DeepEquals, []string{storageAttachmentUUID})
 }
 
 func (s *unitSuite) TestEnsureUnitNotAliveDestroyStorage(c *tc.C) {
@@ -140,39 +110,7 @@ func (s *unitSuite) TestEnsureUnitNotAliveDestroyStorage(c *tc.C) {
 	unitUUID := unitUUIDs[0]
 
 	ctx := c.Context()
-
-	// Create a storage pool and a storage instance attached to the app's unit.
-	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		if _, err := tx.ExecContext(
-			ctx, "INSERT INTO storage_pool (uuid, name, type) VALUES ('pool-uuid', 'pool', 'whatever')",
-		); err != nil {
-			return err
-		}
-
-		inst := `
-INSERT INTO storage_instance (
-	uuid, storage_id, storage_pool_uuid, requested_size_mib, charm_name, storage_name, life_id, storage_kind_id
-)
-VALUES ('instance-uuid', 'does-not-matter', 'pool-uuid', 100, 'charm-name', 'storage-name', 0, 0)`
-		if _, err := tx.ExecContext(ctx, inst); err != nil {
-			return err
-		}
-
-		attach := `
-INSERT INTO storage_attachment (uuid, storage_instance_uuid, unit_uuid, life_id)
-VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`
-		if _, err := tx.ExecContext(ctx, attach, unitUUID); err != nil {
-			return err
-		}
-
-		owned := "INSERT INTO storage_unit_owner (storage_instance_uuid, unit_uuid) VALUES ('instance-uuid', ?)"
-		if _, err := tx.ExecContext(ctx, owned, unitUUID); err != nil {
-			return err
-		}
-
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
+	storageInstanceUUID, storageAttachmentUUID := s.addUnitStorageAttachment(c, unitUUID, true)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -183,20 +121,13 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`
 	s.checkUnitLife(c, unitUUID.String(), life.Dying)
 
 	// Storage attachment should be "dying".
-	row := s.DB().QueryRow("SELECT life_id FROM storage_attachment WHERE uuid = 'storage-attachment-uuid'")
-	var lifeID int
-	err = row.Scan(&lifeID)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	s.checkStorageAttachmentLife(c, storageAttachmentUUID, life.Dying)
 
 	// Storage instance should be "dying".
-	row = s.DB().QueryRow("SELECT life_id FROM storage_instance WHERE uuid = 'instance-uuid'")
-	err = row.Scan(&lifeID)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	s.checkStorageInstanceLife(c, storageInstanceUUID, life.Dying)
 
-	c.Check(cascade.StorageAttachmentUUIDs, tc.DeepEquals, []string{"storage-attachment-uuid"})
-	c.Check(cascade.StorageInstanceUUIDs, tc.DeepEquals, []string{"instance-uuid"})
+	c.Check(cascade.StorageAttachmentUUIDs, tc.DeepEquals, []string{storageAttachmentUUID})
+	c.Check(cascade.StorageInstanceUUIDs, tc.DeepEquals, []string{storageInstanceUUID})
 }
 
 func (s *unitSuite) TestEnsureUnitNotAliveCascadeNormalSuccessLastUnitParentMachine(c *tc.C) {
@@ -663,17 +594,69 @@ func (s *unitSuite) TestMarkUnitAsDeadNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *unitSuite) TesMarkUnitAsDeadWithNoEntities(c *tc.C) {
+func (s *unitSuite) TestMarkUnitAsDeadWithNoEntities(c *tc.C) {
 	svc := s.setupApplicationService(c)
-	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(
+			ctx, "INSERT INTO storage_pool (uuid, name, type) VALUES (?, ?, ?)",
+			poolUUID.String(), "pool", "whatever",
+		); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(
+			ctx,
+			`INSERT INTO model_storage_pool (storage_kind_id, storage_pool_uuid)
+VALUES (?, ?)`,
+			int(domainstorage.StorageKindFilesystem), poolUUID.String(),
+		)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	appUUID := s.createIAASApplicationWithCharm(
+		c,
+		svc,
+		"some-app",
+		&stubCharm{
+			name: "test-charm",
+			storage: map[string]internalcharm.Storage{
+				"data": {
+					Name:        "data",
+					Type:        internalcharm.StorageFilesystem,
+					CountMin:    0,
+					CountMax:    -1,
+					MinimumSize: 1024,
+				},
+				"cache": {
+					Name:        "cache",
+					Type:        internalcharm.StorageFilesystem,
+					CountMin:    0,
+					CountMax:    -1,
+					MinimumSize: 2048,
+				},
+			},
+		},
+		applicationservice.AddIAASUnitArg{},
+	)
 
 	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
 	c.Assert(len(unitUUIDs), tc.Equals, 1)
 	unitUUID := unitUUIDs[0]
 
+	row := s.DB().QueryRowContext(
+		c.Context(),
+		"SELECT COUNT(*) FROM unit_storage_directive WHERE unit_uuid = ?",
+		unitUUID.String(),
+	)
+	var count int
+	err = row.Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 2)
+
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err := st.MarkUnitAsDeadWithNoEntities(c.Context(), unitUUID.String())
+	err = st.MarkUnitAsDeadWithNoEntities(c.Context(), unitUUID.String())
 	c.Assert(err, tc.ErrorIs, removalerrors.EntityStillAlive)
 
 	_, err = s.DB().Exec("UPDATE unit SET life_id = 1 WHERE uuid = ?", unitUUID.String())
@@ -735,7 +718,28 @@ func (s *unitSuite) TestMarkUnitAsDeadWithNoEntitiesWithRelations(c *tc.C) {
 	s.checkUnitLife(c, unitUUID.String(), life.Dead)
 }
 
-func (s *unitSuite) TesMarkUnitAsDeadWithNoEntitiesNotFound(c *tc.C) {
+func (s *unitSuite) TestMarkUnitAsDeadWithNoEntitiesWithStorageAttachment(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+
+	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
+	c.Assert(len(unitUUIDs), tc.Equals, 1)
+	unitUUID := unitUUIDs[0]
+
+	s.addUnitStorageAttachment(c, unitUUID, false)
+
+	s.advanceUnitLife(c, unitUUID, life.Dying)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.MarkUnitAsDeadWithNoEntities(c.Context(), unitUUID.String())
+	c.Assert(err, tc.ErrorIs, removalerrors.EntityStillAlive)
+
+	// The unit should still be dying, as it wasn't marked dead.
+	s.checkUnitLife(c, unitUUID.String(), life.Dying)
+}
+
+func (s *unitSuite) TestMarkUnitAsDeadWithNoEntitiesNotFound(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	err := st.MarkUnitAsDeadWithNoEntities(c.Context(), "abc")
@@ -1297,4 +1301,63 @@ func (s *unitSuite) getCharmUUIDForUnit(c *tc.C, unitUUID string) string {
 	err := row.Scan(&charmUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	return charmUUID
+}
+
+func (s *unitSuite) addUnitStorageAttachment(
+	c *tc.C, unitUUID unit.UUID, unitOwned bool,
+) (string, string) {
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID).String()
+	storageInstanceUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID).String()
+	storageAttachmentUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID).String()
+	poolName := fmt.Sprintf("pool-%s", poolUUID[:8])
+	storageID := fmt.Sprintf("storage-%s", storageInstanceUUID[:8])
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(
+			ctx, "INSERT INTO storage_pool (uuid, name, type) VALUES (?, ?, ?)",
+			poolUUID, poolName, "whatever",
+		); err != nil {
+			return err
+		}
+
+		inst := `
+INSERT INTO storage_instance (
+    uuid, storage_id, storage_pool_uuid, storage_kind_id, requested_size_mib,
+    charm_name, storage_name, life_id
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		if _, err := tx.ExecContext(
+			ctx, inst,
+			storageInstanceUUID, storageID, poolUUID, 1, 100,
+			"charm-name", "storage-name", 0,
+		); err != nil {
+			return err
+		}
+
+		attach := `
+INSERT INTO storage_attachment (uuid, storage_instance_uuid, unit_uuid, life_id)
+VALUES (?, ?, ?, ?)`
+		if _, err := tx.ExecContext(
+			ctx, attach,
+			storageAttachmentUUID, storageInstanceUUID, unitUUID.String(), 0,
+		); err != nil {
+			return err
+		}
+
+		if unitOwned {
+			owned := `
+INSERT INTO storage_unit_owner (storage_instance_uuid, unit_uuid)
+VALUES (?, ?)`
+			if _, err := tx.ExecContext(
+				ctx, owned, storageInstanceUUID, unitUUID.String(),
+			); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	return storageInstanceUUID, storageAttachmentUUID
 }


### PR DESCRIPTION
If a unit has a corresponding unit_storage_directive, markUnitAsDeadWithNoEntities fails. However, unit_storage_directive is only removed when a unit itself is removed.

The assumption was unit_storage_directive would be cleaned up by the storage domain, but the directive is created before the storage, so it is not.

Also, as a flyuby, fix a bug when removing leadership. Move calls to get the unit and application name to before the unit is removed, avoiding a UnitNotFound error

NOTE: the storage domain is still in flight. This will likely need additional action to ensure correctness in the storage domain itself

fixes: https://github.com/juju/juju/issues/22012

@hpidcock should review this

## QA steps

```
juju add-model
juju deploy ubuntu; juju remove-application ubuntu --no-prompt
```