### PR TITLE
test: close the right conn

### DIFF
--- a/internal/testhelpers/tcpproxy_test.go
+++ b/internal/testhelpers/tcpproxy_test.go
@@ -87,8 +87,8 @@ func (*tcpProxySuite) TestCloseConns(c *tc.C) {
 
 	conn2, err := net.Dial("tcp", p.Addr())
 	c.Assert(err, tc.IsNil)
-	defer conn1.Close()
-	assertEcho(c, conn1)
+	defer conn2.Close()
+	assertEcho(c, conn2)
 
 	p.CloseConns()
 


### PR DESCRIPTION
Closing the wrong connection causes the test to fail.

This was spotted whilst looking at different jenkins failures.