### PR TITLE
docs(cli): remove mention of 'selectors' from the 'juju status' documentation

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -77,21 +77,7 @@ var usageSummary = `
 Report the status of the model, its machines, applications and units.`[1:]
 
 var usageDetails = `
-Report the model's status, optionally filtered by names of applications or
-units. When selectors are present, filter the report to exclude entities that
-do not match.
-
-    juju status [<selector> [...]]
-
-` + "`<selector>`" + ` selects machines, units or applications from the model to display.
-Wildcard characters (` + "`*`" + `) enable multiple entities to be matched at the same
-time.
-
-    (<machine>|<unit>|<application>)[*]
-
-When an entity that matches <selector> is integrated with other applications, the
-status of those applications will also be presented. By default (without a
-` + "`<selector>`" + `) the status of all applications and their units will be displayed.
+Report the model's status including its machines, applications and units.
 
 
 ### Altering the output format
@@ -113,18 +99,6 @@ Provides information in a ` + "`JSON`" + ` or ` + "`YAML`" + ` format for progra
 `
 
 const usageExamples = `
-Report the status of units hosted on machine ` + "`0`" + `:
-
-    juju status 0
-
-Report the status of the ` + "`mysql`" + ` application:
-
-    juju status mysql
-
-Report the status for applications that start with ` + "`nova-`" + `:
-
-    juju status nova-*
-
 Include information about storage and relations in output:
 
     juju status --storage --relations
@@ -132,20 +106,12 @@ Include information about storage and relations in output:
 Provide output as valid ` + "`JSON`" + `:
 
     juju status --format=json
-
-Show only applications/units in active status:
-
-    juju status active
-
-Show only applications/units in error status:
-
-    juju status error
 `
 
 func (c *statusCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "status",
-		Args:     "[<selector> [...]]",
+		Args:     "",
 		Purpose:  usageSummary,
 		Doc:      usageDetails,
 		Examples: usageExamples,

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/status.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/status.md
@@ -5,9 +5,6 @@
 ## Summary
 Report the status of the model, its machines, applications and units.
 
-## Usage
-```juju status [options] [<selector> [...]]```
-
 ### Options
 | Flag | Default | Usage |
 | --- | --- | --- |
@@ -26,18 +23,6 @@ Report the status of the model, its machines, applications and units.
 
 ## Examples
 
-Report the status of units hosted on machine `0`:
-
-    juju status 0
-
-Report the status of the `mysql` application:
-
-    juju status mysql
-
-Report the status for applications that start with `nova-`:
-
-    juju status nova-*
-
 Include information about storage and relations in output:
 
     juju status --storage --relations
@@ -46,32 +31,10 @@ Provide output as valid `JSON`:
 
     juju status --format=json
 
-Show only applications/units in active status:
-
-    juju status active
-
-Show only applications/units in error status:
-
-    juju status error
-
 
 ## Details
 
-Report the model's status, optionally filtered by names of applications or
-units. When selectors are present, filter the report to exclude entities that
-do not match.
-
-    juju status [<selector> [...]]
-
-`<selector>` selects machines, units or applications from the model to display.
-Wildcard characters (`*`) enable multiple entities to be matched at the same
-time.
-
-    (<machine>|<unit>|<application>)[*]
-
-When an entity that matches &lt;selector&gt; is integrated with other applications, the
-status of those applications will also be presented. By default (without a
-`<selector>`) the status of all applications and their units will be displayed.
+Report the model's status including its machines, applications and units.
 
 
 ### Altering the output format

--- a/docs/releasenotes/juju_4.0.x/juju_4.0.0.md
+++ b/docs/releasenotes/juju_4.0.x/juju_4.0.0.md
@@ -54,7 +54,7 @@ to build them, then juju deploy the built artifact.
   * `juju deploy --force` no longer allows deploying to a base not declared by the charm. 
   * `juju refresh --force-series` removed; use `--force-base`.
 * **Status API filtering**: Server-side `StatusArgs.Patterns[]` filtering is removed (migrate to client-side filtering 
-until a replacement arrives).
+until a replacement arrives). For Juju users, this means that `juju status` no longer accepts selectors.
 * **Offers update (`juju offer`)**: Updating an existing offer is removed; use create/remove flows.
 * **Provider type rename (`manual` → `unmanaged`)**: Update all relevant cloud commands, bootstrap scripts, CI, and docs.
 * **Wait-for**: `juju wait-for` (and subcommands `wait-for model|application|machine|unit`) — removed. In `3.6` this 


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

The ability to provide selectors (machine, app, unit, status) in `juju status` was removed in Juju 4.0, and may or may not return. This PR updates the documentation to reflect that (if it does return, the documentation should be updated again to include the new functionality).

I've also added a note to the backwards incompatibility section in the release notes that makes it clearer for a Juju user (rather than a Juju developer) what the change is.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Build the documentation and read the `juju status` page. It should no longer mention "selectors".

## Documentation changes

Covered above.

## Links

N/A