### PR TITLE
fix(cmr): populate offer connection details in list-offers API response

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -346,12 +346,7 @@ func (api *OffersAPI) applicationOffersFromModel(
 	requiredAccess permission.Access,
 	filters []crossmodelrelationservice.OfferFilter,
 ) ([]params.ApplicationOfferAdminDetailsV5, error) {
-	// If the user is a controller superuser or model admin, they are
-	// considered admin and can see all offers and their connections.
-	isAdmin := api.checkAPIUserAdmin(ctx, model.UUID(modelUUID)) == nil
-
-	// If admin access is required and the user is not an admin, reject.
-	if requiredAccess == permission.AdminAccess && !isAdmin {
+	if err := api.checkModelPermission(ctx, apiUser, model.UUID(modelUUID), requiredAccess); err != nil {
 		return nil, apiservererrors.ErrPerm
 	}
 
@@ -366,32 +361,16 @@ func (api *OffersAPI) applicationOffersFromModel(
 		return nil, errors.Capture(err)
 	}
 
-	modelTag := names.NewModelTag(modelUUID)
-	controllerTag := names.NewControllerTag(api.controllerUUID)
-
-	// Process data. For non-admin users, check per-offer access and skip
-	// offers the user has no access to.
+	// Process data.
 	var results []params.ApplicationOfferAdminDetailsV5
-	var adminOfferUUIDs []string
 	for _, appOffer := range offers {
-		isOfferAdmin := isAdmin
-		if !isAdmin {
-			userAccess, err := api.checkOfferAccess(ctx, apiUser, controllerTag, modelTag, appOffer.OfferUUID)
-			if err != nil {
-				return nil, errors.Capture(err)
-			}
-			if userAccess == permission.NoAccess {
-				continue
-			}
-			isOfferAdmin = userAccess == permission.AdminAccess
-		}
-
+		isAdminUser := api.authorizer.HasPermission(ctx, permission.AdminAccess, names.NewModelTag(modelUUID)) == nil
 		offerParams := api.makeOfferParams(
 			model.UUID(modelUUID),
 			appOffer,
 			apiUser,
 			apiUserDisplayName,
-			isOfferAdmin,
+			isAdminUser,
 		)
 
 		charmURL, err := charms.CharmURLFromLocator(appOffer.CharmLocator.Name, appOffer.CharmLocator)
@@ -403,18 +382,19 @@ func (api *OffersAPI) applicationOffersFromModel(
 			ApplicationName:           appOffer.ApplicationName,
 			CharmURL:                  charmURL,
 		})
-		if isOfferAdmin {
-			adminOfferUUIDs = append(adminOfferUUIDs, appOffer.OfferUUID)
-		}
 	}
 
-	// Populate offer connections for offers where the user has admin access.
-	if len(adminOfferUUIDs) > 0 {
+	// Populate offer connections when the caller requires admin access.
+	// At this point the user has been verified as superuser or model admin
+	// by checkModelPermission above.
+	if requiredAccess == permission.AdminAccess && len(results) > 0 {
+		offerUUIDs := make([]string, len(results))
 		offerIndexByUUID := make(map[string]int, len(results))
 		for i, r := range results {
+			offerUUIDs[i] = r.OfferUUID
 			offerIndexByUUID[r.OfferUUID] = i
 		}
-		connections, err := crossModelRelationService.GetOfferConnections(ctx, adminOfferUUIDs)
+		connections, err := crossModelRelationService.GetOfferConnections(ctx, offerUUIDs)
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
@@ -428,46 +408,6 @@ func (api *OffersAPI) applicationOffersFromModel(
 	}
 
 	return results, nil
-}
-
-// checkOfferAccess returns the level of access the authenticated user has to the offer,
-// checking in decreasing order: controller superuser, model admin, then
-// offer-level permissions (admin, consume, read).
-func (api *OffersAPI) checkOfferAccess(
-	ctx context.Context,
-	user names.UserTag,
-	controllerTag names.ControllerTag,
-	modelTag names.ModelTag,
-	offerUUID string,
-) (permission.Access, error) {
-	// If the authenticated user is controller superuser we return admin.
-	err := api.authorizer.EntityHasPermission(ctx, user, permission.SuperuserAccess, controllerTag)
-	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
-		return permission.NoAccess, errors.Capture(err)
-	} else if err == nil {
-		return permission.AdminAccess, nil
-	}
-
-	// If the authenticated user is model admin we return admin.
-	err = api.authorizer.EntityHasPermission(ctx, user, permission.AdminAccess, modelTag)
-	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
-		return permission.NoAccess, errors.Capture(err)
-	} else if err == nil {
-		return permission.AdminAccess, nil
-	}
-
-	// Check offer-level permissions in decreasing order.
-	offerTag := names.NewApplicationOfferTag(offerUUID)
-	for _, access := range []permission.Access{permission.AdminAccess, permission.ConsumeAccess, permission.ReadAccess} {
-		err := api.authorizer.EntityHasPermission(ctx, user, access, offerTag)
-		if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
-			return permission.NoAccess, errors.Capture(err)
-		} else if err == nil {
-			return access, nil
-		}
-	}
-
-	return permission.NoAccess, nil
 }
 
 func (api *OffersAPI) makeOfferParams(

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -25,6 +25,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/status"
 	coreuser "github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/access"
 	accesserrors "github.com/juju/juju/domain/access/errors"
@@ -276,9 +277,6 @@ func (api *OffersAPI) getApplicationOffersDetails(
 			offerDetails.OfferURL = corecrossmodel.MakeURL(m.Qualifier.String(), m.Name, offerDetails.OfferName, "")
 			result = append(result, offerDetails)
 		}
-
-		// TODO (cmr)
-		// Add offer connections if apiUser is superuser, model or offer admin
 	}
 	return result, nil
 }
@@ -348,7 +346,12 @@ func (api *OffersAPI) applicationOffersFromModel(
 	requiredAccess permission.Access,
 	filters []crossmodelrelationservice.OfferFilter,
 ) ([]params.ApplicationOfferAdminDetailsV5, error) {
-	if err := api.checkModelPermission(ctx, apiUser, model.UUID(modelUUID), requiredAccess); err != nil {
+	// If the user is a controller superuser or model admin, they are
+	// considered admin and can see all offers and their connections.
+	isAdmin := api.checkAPIUserAdmin(ctx, model.UUID(modelUUID)) == nil
+
+	// If admin access is required and the user is not an admin, reject.
+	if requiredAccess == permission.AdminAccess && !isAdmin {
 		return nil, apiservererrors.ErrPerm
 	}
 
@@ -363,16 +366,32 @@ func (api *OffersAPI) applicationOffersFromModel(
 		return nil, errors.Capture(err)
 	}
 
-	// Process data.
+	modelTag := names.NewModelTag(modelUUID)
+	controllerTag := names.NewControllerTag(api.controllerUUID)
+
+	// Process data. For non-admin users, check per-offer access and skip
+	// offers the user has no access to.
 	var results []params.ApplicationOfferAdminDetailsV5
+	var adminOfferUUIDs []string
 	for _, appOffer := range offers {
-		isAdminUser := api.authorizer.HasPermission(ctx, permission.AdminAccess, names.NewModelTag(modelUUID)) == nil
+		isOfferAdmin := isAdmin
+		if !isAdmin {
+			userAccess, err := api.checkOfferAccess(ctx, apiUser, controllerTag, modelTag, appOffer.OfferUUID)
+			if err != nil {
+				return nil, errors.Capture(err)
+			}
+			if userAccess == permission.NoAccess {
+				continue
+			}
+			isOfferAdmin = userAccess == permission.AdminAccess
+		}
+
 		offerParams := api.makeOfferParams(
 			model.UUID(modelUUID),
 			appOffer,
 			apiUser,
 			apiUserDisplayName,
-			isAdminUser,
+			isOfferAdmin,
 		)
 
 		charmURL, err := charms.CharmURLFromLocator(appOffer.CharmLocator.Name, appOffer.CharmLocator)
@@ -384,8 +403,71 @@ func (api *OffersAPI) applicationOffersFromModel(
 			ApplicationName:           appOffer.ApplicationName,
 			CharmURL:                  charmURL,
 		})
+		if isOfferAdmin {
+			adminOfferUUIDs = append(adminOfferUUIDs, appOffer.OfferUUID)
+		}
 	}
+
+	// Populate offer connections for offers where the user has admin access.
+	if len(adminOfferUUIDs) > 0 {
+		offerIndexByUUID := make(map[string]int, len(results))
+		for i, r := range results {
+			offerIndexByUUID[r.OfferUUID] = i
+		}
+		connections, err := crossModelRelationService.GetOfferConnections(ctx, adminOfferUUIDs)
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		for _, conn := range connections {
+			idx, ok := offerIndexByUUID[conn.OfferUUID]
+			if !ok {
+				continue
+			}
+			results[idx].Connections = append(results[idx].Connections, makeOfferConnection(conn))
+		}
+	}
+
 	return results, nil
+}
+
+// checkOfferAccess returns the level of access the authenticated user has to the offer,
+// checking in decreasing order: controller superuser, model admin, then
+// offer-level permissions (admin, consume, read).
+func (api *OffersAPI) checkOfferAccess(
+	ctx context.Context,
+	user names.UserTag,
+	controllerTag names.ControllerTag,
+	modelTag names.ModelTag,
+	offerUUID string,
+) (permission.Access, error) {
+	// If the authenticated user is controller superuser we return admin.
+	err := api.authorizer.EntityHasPermission(ctx, user, permission.SuperuserAccess, controllerTag)
+	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+		return permission.NoAccess, errors.Capture(err)
+	} else if err == nil {
+		return permission.AdminAccess, nil
+	}
+
+	// If the authenticated user is model admin we return admin.
+	err = api.authorizer.EntityHasPermission(ctx, user, permission.AdminAccess, modelTag)
+	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+		return permission.NoAccess, errors.Capture(err)
+	} else if err == nil {
+		return permission.AdminAccess, nil
+	}
+
+	// Check offer-level permissions in decreasing order.
+	offerTag := names.NewApplicationOfferTag(offerUUID)
+	for _, access := range []permission.Access{permission.AdminAccess, permission.ConsumeAccess, permission.ReadAccess} {
+		err := api.authorizer.EntityHasPermission(ctx, user, access, offerTag)
+		if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+			return permission.NoAccess, errors.Capture(err)
+		} else if err == nil {
+			return access, nil
+		}
+	}
+
+	return permission.NoAccess, nil
 }
 
 func (api *OffersAPI) makeOfferParams(
@@ -456,6 +538,21 @@ func findOfferUserAccess(userName string, in []crossmodelrelation.OfferUser) per
 		}
 	}
 	return permission.NoAccess
+}
+
+func makeOfferConnection(conn crossmodelrelation.OfferConnectionDetail) params.OfferConnection {
+	return params.OfferConnection{
+		SourceModelTag: names.NewModelTag(conn.SourceModelUUID).String(),
+		RelationId:     conn.RelationID,
+		Username:       conn.Username,
+		Endpoint:       conn.Endpoint,
+		Status: params.EntityStatus{
+			Status: status.Status(conn.Status),
+			Info:   conn.Message,
+			Since:  conn.StatusSince,
+		},
+		IngressSubnets: conn.IngressSubnets,
+	}
 }
 
 func makeOfferFilterFromParams(filter params.OfferFilter) (crossmodelrelationservice.OfferFilter, error) {

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -705,7 +705,7 @@ func (s *offerSuite) TestListApplicationOffers(c *tc.C) {
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectHasPermissionSuperuser()
+	s.expectEntityHasPermission(adminTag, permission.SuperuserAccess)
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -718,6 +718,10 @@ func (s *offerSuite) TestListApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+	s.authorizer.EXPECT().
+		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
+		Return(nil).
+		Times(2)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -814,7 +818,7 @@ func (s *offerSuite) TestListApplicationOffersError(c *tc.C) {
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectHasPermissionSuperuser()
+	s.expectEntityHasPermission(adminTag, permission.SuperuserAccess)
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -873,8 +877,8 @@ func (s *offerSuite) TestListApplicationOffersPermission(c *tc.C) {
 		UUID: tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(adminTag.Id())).Return(foundModel, nil)
-	s.expectHasPermissionNotSuperuser()
-	s.expectHasPermissionNoModelAdminAccessPermissions(foundModel.UUID.String())
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.AdminAccess)
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -905,7 +909,8 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectHasPermissionNotSuperuser()
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
 
 	modelName := "prod"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -916,7 +921,10 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
+	s.authorizer.EXPECT().
+		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
+		Return(nil).
+		Times(2)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -959,7 +967,6 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
-	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -1019,7 +1026,8 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectHasPermissionNotSuperuser()
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
 
 	modelName := "prod"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1031,7 +1039,10 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	}
 	s.modelService.EXPECT().GetAllModels(gomock.Any()).Return([]model.Model{foundModel}, nil)
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
+	s.authorizer.EXPECT().
+		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
+		Return(nil).
+		Times(2)
 
 	charmLocator := charm.CharmLocator{
 		Name:         "app",
@@ -1067,7 +1078,6 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), []crossmodelrelationservice.OfferFilter{{}}).Return(offerDetails, nil)
-	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	filters := params.OfferFilters{Filters: []params.OfferFilter{{}}}
 
@@ -1107,15 +1117,13 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	})
 }
 
-// TestFindApplicationOffersPermission tests that a non-admin user who has no
-// offer-level access sees no results (offers are filtered out by per-offer
-// access checks) rather than getting an error.
 func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -1125,41 +1133,7 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 		UUID: tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(adminTag.Id())).Return(foundModel, nil)
-	// User is not a superuser or model admin.
-	s.expectHasPermissionNotSuperuser()
-	s.expectHasPermissionNoModelAdminAccessPermissions(foundModel.UUID.String())
-
-	offerUUID := uuid.MustNewUUID().String()
-	charmLocator := charm.CharmLocator{
-		Name:         "app",
-		Revision:     42,
-		Source:       charm.CharmHubSource,
-		Architecture: architecture.AMD64,
-	}
-	offerDetails := []*crossmodelrelation.OfferDetail{
-		{
-			OfferUUID:              offerUUID,
-			OfferName:              "hosted-db2",
-			ApplicationName:        "test-app",
-			ApplicationDescription: "testing application",
-			CharmLocator:           charmLocator,
-			Endpoints: []crossmodelrelation.OfferEndpoint{
-				{Name: "db"},
-			},
-		},
-	}
-	domainFilters := []crossmodelrelationservice.OfferFilter{
-		{OfferName: "hosted-db2"},
-		{OfferName: "testing"},
-	}
-	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
-
-	// Per-offer access check: user has no access.
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ModelTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ConsumeAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ReadAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.ReadAccess)
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -1174,11 +1148,12 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 	}
 
 	// Act
-	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+	_, err := offerAPI.FindApplicationOffers(c.Context(), filters)
 
-	// Assert — non-admin user with no offer access sees no results.
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(obtained.Results, tc.HasLen, 0)
+	// Assert
+	c.Assert(err, tc.DeepEquals, &params.Error{
+		Message: "permission denied", Code: "unauthorized access"},
+	)
 }
 
 func (s *offerSuite) TestFindApplicationOffersError(c *tc.C) {
@@ -1187,7 +1162,7 @@ func (s *offerSuite) TestFindApplicationOffersError(c *tc.C) {
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectHasPermissionSuperuser()
+	s.expectEntityHasPermission(adminTag, permission.SuperuserAccess)
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -1304,7 +1279,8 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectHasPermissionNotSuperuser()
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1315,7 +1291,10 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
+	s.authorizer.EXPECT().
+		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
+		Return(nil).
+		Times(2)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1358,7 +1337,6 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
-	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.hosted-db2", "fred@external/test-model.testing"},
 	}
@@ -1410,7 +1388,8 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectHasPermissionNotSuperuser()
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1421,7 +1400,9 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
+	s.authorizer.EXPECT().
+		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
+		Return(nil)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1452,7 +1433,6 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
-	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.hosted-db2:endpoint", "fred@external/test-model.testing"},
 	}
@@ -1489,7 +1469,8 @@ func (s *offerSuite) TestApplicationOffersNotFound(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectHasPermissionNotSuperuser()
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1500,7 +1481,6 @@ func (s *offerSuite) TestApplicationOffersNotFound(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1533,7 +1513,7 @@ func (s *offerSuite) TestListApplicationOffersWithConnections(c *tc.C) {
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectHasPermissionSuperuser()
+	s.expectEntityHasPermission(adminTag, permission.SuperuserAccess)
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -1546,6 +1526,9 @@ func (s *offerSuite) TestListApplicationOffersWithConnections(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+	s.authorizer.EXPECT().
+		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
+		Return(nil)
 
 	offerUUID := uuid.MustNewUUID().String()
 	consumerModelUUID := uuid.MustNewUUID().String()
@@ -1617,86 +1600,7 @@ func (s *offerSuite) TestListApplicationOffersWithConnections(c *tc.C) {
 	})
 }
 
-// TestFindApplicationOffersNoConnectionsForNonAdmin tests that connections are
-// not populated for non-admin users who have offer-level consume access.
-func (s *offerSuite) TestFindApplicationOffersNoConnectionsForNonAdmin(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	// Arrange
-	offerAPI := s.offerAPI(c)
-	adminTag := s.setupAuthUser("admin")
-	adminUser := user.User{DisplayName: "fred smith"}
-	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-
-	modelName := "prod"
-	modelOwnerTag := names.NewUserTag("fred@external")
-
-	foundModel := model.Model{
-		Name:      modelName,
-		Qualifier: model.Qualifier(modelOwnerTag.Id()),
-		UUID:      tc.Must0(c, model.NewUUID),
-	}
-	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-
-	// User is not a superuser or model admin.
-	s.expectHasPermissionNotSuperuser()
-	s.expectHasPermissionNoModelAdminAccessPermissions(foundModel.UUID.String())
-
-	offerUUID := uuid.MustNewUUID().String()
-	charmLocator := charm.CharmLocator{
-		Name:         "app",
-		Revision:     42,
-		Source:       charm.CharmHubSource,
-		Architecture: architecture.AMD64,
-	}
-	offerDetails := []*crossmodelrelation.OfferDetail{
-		{
-			OfferUUID:              offerUUID,
-			OfferName:              "hosted-db2",
-			ApplicationName:        "test-app",
-			ApplicationDescription: "testing application",
-			CharmLocator:           charmLocator,
-			Endpoints: []crossmodelrelation.OfferEndpoint{
-				{Name: "db"},
-			},
-			OfferUsers: []crossmodelrelation.OfferUser{{Name: "admin", Access: permission.ConsumeAccess}},
-		},
-	}
-	domainFilters := []crossmodelrelationservice.OfferFilter{
-		{OfferName: "hosted-db2"},
-	}
-	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
-
-	// Per-offer access check: not superuser, not model admin, but has
-	// consume access on the offer.
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ModelTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ConsumeAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(nil)
-	// GetOfferConnections should NOT be called for non-admin users.
-
-	filters := params.OfferFilters{
-		Filters: []params.OfferFilter{
-			{
-				ModelQualifier: modelOwnerTag.Id(),
-				ModelName:      modelName,
-				OfferName:      "hosted-db2",
-			},
-		},
-	}
-
-	// Act
-	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
-
-	// Assert
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(obtained.Results, tc.HasLen, 1)
-	c.Assert(obtained.Results[0].Connections, tc.IsNil)
-}
-
-// TestApplicationOffersNoAccess tests that a non-admin user with no offer-level
-// access gets a NotFound result for the requested offer URL.
-func (s *offerSuite) TestApplicationOffersNoAccess(c *tc.C) {
+func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
@@ -1704,6 +1608,8 @@ func (s *offerSuite) TestApplicationOffersNoAccess(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.ReadAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1714,49 +1620,18 @@ func (s *offerSuite) TestApplicationOffersNoAccess(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	// User is not a superuser or model admin.
-	s.expectHasPermissionNotSuperuser()
-	s.expectHasPermissionNoModelAdminAccessPermissions(foundModel.UUID.String())
-
-	offerUUID := uuid.MustNewUUID().String()
-	charmLocator := charm.CharmLocator{
-		Name:         "app",
-		Revision:     42,
-		Source:       charm.CharmHubSource,
-		Architecture: architecture.AMD64,
-	}
-	offerDetails := []*crossmodelrelation.OfferDetail{
-		{
-			OfferUUID:       offerUUID,
-			OfferName:       "testing",
-			ApplicationName: "test-app",
-			CharmLocator:    charmLocator,
-		},
-	}
-	domainFilters := []crossmodelrelationservice.OfferFilter{
-		{OfferName: "testing"},
-	}
-	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
-
-	// Per-offer access check: user has no access at any level.
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ModelTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ConsumeAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ReadAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
-
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.testing"},
 	}
 
 	// Act
-	obtained, err := offerAPI.ApplicationOffers(c.Context(), args)
+	_, err := offerAPI.ApplicationOffers(c.Context(), args)
 
-	// Assert — offer filtered out by per-offer access → shows as NotFound.
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(obtained.Results, tc.HasLen, 1)
-	c.Assert(obtained.Results[0].Error, tc.Not(tc.IsNil))
-	c.Assert(obtained.Results[0].Error.Code, tc.Equals, params.CodeNotFound)
+	// Assert
+	c.Assert(err, tc.DeepEquals, &params.Error{
+		Message: "permission denied",
+		Code:    "unauthorized access",
+	})
 }
 
 // TestApplicationOfferURLAndFilterAPIUser tests a correct offer url text
@@ -2148,12 +2023,20 @@ func (s *offerSuite) expectHasPermissionNotSuperuser() {
 	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(authentication.ErrorEntityMissingPermission)
 }
 
-func (s *offerSuite) expectHasPermissionSuperuser() {
-	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(nil)
+func (s *offerSuite) expectEntityHasPermission(userTag names.UserTag, access permission.Access) {
+	matcher := gomock.AssignableToTypeOf(names.ModelTag{})
+	if access == permission.SuperuserAccess {
+		matcher = gomock.AssignableToTypeOf(names.ControllerTag{})
+	}
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), userTag, access, matcher).Return(nil)
 }
 
-func (s *offerSuite) expectHasPermissionModelAdmin(modelUUID string) {
-	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(modelUUID)).Return(nil)
+func (s *offerSuite) expectEntityHasPermissionMissingPermission(userTag names.UserTag, access permission.Access) {
+	matcher := gomock.AssignableToTypeOf(names.ModelTag{})
+	if access == permission.SuperuserAccess {
+		matcher = gomock.AssignableToTypeOf(names.ControllerTag{})
+	}
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), userTag, access, matcher).Return(authentication.ErrorEntityMissingPermission)
 }
 
 func (s *offerSuite) offerAPI(_ *tc.C) *OffersAPI {

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/offer"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/access"
 	accesserrors "github.com/juju/juju/domain/access/errors"
@@ -319,7 +320,7 @@ func (s *offerSuite) TestModifyOfferAccess(c *tc.C) {
 	results, err := s.offerAPI(c).ModifyOfferAccess(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}})
 }
 
@@ -380,7 +381,7 @@ func (s *offerSuite) TestModifyOfferAccessOfferOwner(c *tc.C) {
 	results, err := s.offerAPI(c).ModifyOfferAccess(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}})
 }
 
@@ -433,7 +434,7 @@ func (s *offerSuite) TestModifyOfferAccessModelAdmin(c *tc.C) {
 	results, err := s.offerAPI(c).ModifyOfferAccess(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}})
 }
 
@@ -493,7 +494,7 @@ func (s *offerSuite) TestModifyOfferAccessPermissionDenied(c *tc.C) {
 	results, err := s.offerAPI(c).ModifyOfferAccess(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{
 		Error: &params.Error{
 			Message: "permission denied", Code: "unauthorized access"},
@@ -704,7 +705,7 @@ func (s *offerSuite) TestListApplicationOffers(c *tc.C) {
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.SuperuserAccess, names.NewControllerTag(offerAPI.controllerUUID)).Return(nil)
+	s.expectHasPermissionSuperuser()
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -717,10 +718,6 @@ func (s *offerSuite) TestListApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil).
-		Times(2)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -759,6 +756,7 @@ func (s *offerSuite) TestListApplicationOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -778,7 +776,7 @@ func (s *offerSuite) TestListApplicationOffers(c *tc.C) {
 	obtained, err := offerAPI.ListApplicationOffers(c.Context(), filters)
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(obtained.Results, tc.HasLen, 2)
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_.ApplicationOfferDetailsV5.SourceModelTag", tc.Ignore)
@@ -816,7 +814,7 @@ func (s *offerSuite) TestListApplicationOffersError(c *tc.C) {
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectEntityHasPermission(adminTag, permission.SuperuserAccess)
+	s.expectHasPermissionSuperuser()
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -866,7 +864,6 @@ func (s *offerSuite) TestListApplicationOffersPermission(c *tc.C) {
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -876,7 +873,8 @@ func (s *offerSuite) TestListApplicationOffersPermission(c *tc.C) {
 		UUID: tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(adminTag.Id())).Return(foundModel, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.AdminAccess)
+	s.expectHasPermissionNotSuperuser()
+	s.expectHasPermissionNoModelAdminAccessPermissions(foundModel.UUID.String())
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -907,9 +905,7 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectHasPermissionNotSuperuser()
 
 	modelName := "prod"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -920,10 +916,7 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil).
-		Times(2)
+	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -966,6 +959,7 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -985,7 +979,7 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(obtained.Results, tc.HasLen, 2)
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_.ApplicationOfferDetailsV5.SourceModelTag", tc.Ignore)
@@ -1025,9 +1019,7 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectHasPermissionNotSuperuser()
 
 	modelName := "prod"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1039,10 +1031,7 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	}
 	s.modelService.EXPECT().GetAllModels(gomock.Any()).Return([]model.Model{foundModel}, nil)
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil).
-		Times(2)
+	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
 
 	charmLocator := charm.CharmLocator{
 		Name:         "app",
@@ -1078,6 +1067,7 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), []crossmodelrelationservice.OfferFilter{{}}).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	filters := params.OfferFilters{Filters: []params.OfferFilter{{}}}
 
@@ -1085,7 +1075,7 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(obtained.Results, tc.HasLen, 2)
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_.ApplicationOfferDetailsV5.SourceModelTag", tc.Ignore)
@@ -1117,13 +1107,15 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	})
 }
 
+// TestFindApplicationOffersPermission tests that a non-admin user who has no
+// offer-level access sees no results (offers are filtered out by per-offer
+// access checks) rather than getting an error.
 func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -1133,7 +1125,41 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 		UUID: tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(adminTag.Id())).Return(foundModel, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.ReadAccess)
+	// User is not a superuser or model admin.
+	s.expectHasPermissionNotSuperuser()
+	s.expectHasPermissionNoModelAdminAccessPermissions(foundModel.UUID.String())
+
+	offerUUID := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+		{OfferName: "testing"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// Per-offer access check: user has no access.
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ModelTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ConsumeAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ReadAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -1148,12 +1174,11 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 	}
 
 	// Act
-	_, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
 
-	// Assert
-	c.Assert(err, tc.DeepEquals, &params.Error{
-		Message: "permission denied", Code: "unauthorized access"},
-	)
+	// Assert — non-admin user with no offer access sees no results.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 0)
 }
 
 func (s *offerSuite) TestFindApplicationOffersError(c *tc.C) {
@@ -1162,7 +1187,7 @@ func (s *offerSuite) TestFindApplicationOffersError(c *tc.C) {
 	// Arrange
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectEntityHasPermission(adminTag, permission.SuperuserAccess)
+	s.expectHasPermissionSuperuser()
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -1257,7 +1282,7 @@ func (s *offerSuite) TestResolveOfferName(c *tc.C) {
 		output, err := resolveOfferName(in)
 
 		// Assert
-		c.Assert(err, tc.IsNil)
+		c.Assert(err, tc.ErrorIsNil)
 		c.Assert(output, tc.Equals, offerName)
 	}
 }
@@ -1267,7 +1292,7 @@ func (s *offerSuite) TestResolveOfferNameEmptyString(c *tc.C) {
 	output, err := resolveOfferName("")
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(output, tc.Equals, "")
 }
 
@@ -1279,9 +1304,7 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectHasPermissionNotSuperuser()
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1292,10 +1315,7 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil).
-		Times(2)
+	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1338,6 +1358,7 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.hosted-db2", "fred@external/test-model.testing"},
 	}
@@ -1389,9 +1410,7 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectHasPermissionNotSuperuser()
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1402,9 +1421,7 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil)
+	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1435,6 +1452,7 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.hosted-db2:endpoint", "fred@external/test-model.testing"},
 	}
@@ -1471,9 +1489,7 @@ func (s *offerSuite) TestApplicationOffersNotFound(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectHasPermissionNotSuperuser()
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1484,6 +1500,7 @@ func (s *offerSuite) TestApplicationOffersNotFound(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+	s.expectHasPermissionModelAdmin(foundModel.UUID.String())
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1508,7 +1525,178 @@ func (s *offerSuite) TestApplicationOffersNotFound(c *tc.C) {
 	})
 }
 
-func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
+// TestListApplicationOffersWithConnections tests that connections are populated
+// for admin users when listing offers.
+func (s *offerSuite) TestListApplicationOffersWithConnections(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	offerAPI := s.offerAPI(c)
+	adminTag := s.setupAuthUser("admin")
+	s.expectHasPermissionSuperuser()
+	adminUser := user.User{DisplayName: "fred smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
+
+	modelName := "prod"
+	modelOwnerTag := names.NewUserTag("fred@external")
+
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(modelOwnerTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+
+	offerUUID := uuid.MustNewUUID().String()
+	consumerModelUUID := uuid.MustNewUUID().String()
+
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{{Name: "admin", Access: permission.AdminAccess}},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	connections := []crossmodelrelation.OfferConnectionDetail{
+		{
+			OfferUUID:       offerUUID,
+			SourceModelUUID: consumerModelUUID,
+			RelationID:      42,
+			Username:        "consumer-user",
+			Endpoint:        "db",
+			Status:          "joined",
+			Message:         "",
+			IngressSubnets:  []string{"10.0.0.0/24"},
+		},
+	}
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), []string{offerUUID}).Return(connections, nil)
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelQualifier: modelOwnerTag.Id(),
+				ModelName:      modelName,
+				OfferName:      "hosted-db2",
+			},
+		},
+	}
+
+	// Act
+	obtained, err := offerAPI.ListApplicationOffers(c.Context(), filters)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 1)
+	c.Assert(obtained.Results[0].Connections, tc.HasLen, 1)
+	c.Check(obtained.Results[0].Connections[0], tc.DeepEquals, params.OfferConnection{
+		SourceModelTag: names.NewModelTag(consumerModelUUID).String(),
+		RelationId:     42,
+		Username:       "consumer-user",
+		Endpoint:       "db",
+		Status: params.EntityStatus{
+			Status: status.Status("joined"),
+		},
+		IngressSubnets: []string{"10.0.0.0/24"},
+	})
+}
+
+// TestFindApplicationOffersNoConnectionsForNonAdmin tests that connections are
+// not populated for non-admin users who have offer-level consume access.
+func (s *offerSuite) TestFindApplicationOffersNoConnectionsForNonAdmin(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	offerAPI := s.offerAPI(c)
+	adminTag := s.setupAuthUser("admin")
+	adminUser := user.User{DisplayName: "fred smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
+
+	modelName := "prod"
+	modelOwnerTag := names.NewUserTag("fred@external")
+
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(modelOwnerTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+
+	// User is not a superuser or model admin.
+	s.expectHasPermissionNotSuperuser()
+	s.expectHasPermissionNoModelAdminAccessPermissions(foundModel.UUID.String())
+
+	offerUUID := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{{Name: "admin", Access: permission.ConsumeAccess}},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// Per-offer access check: not superuser, not model admin, but has
+	// consume access on the offer.
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ModelTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ConsumeAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(nil)
+	// GetOfferConnections should NOT be called for non-admin users.
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelQualifier: modelOwnerTag.Id(),
+				ModelName:      modelName,
+				OfferName:      "hosted-db2",
+			},
+		},
+	}
+
+	// Act
+	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 1)
+	c.Assert(obtained.Results[0].Connections, tc.IsNil)
+}
+
+// TestApplicationOffersNoAccess tests that a non-admin user with no offer-level
+// access gets a NotFound result for the requested offer URL.
+func (s *offerSuite) TestApplicationOffersNoAccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
@@ -1516,9 +1704,6 @@ func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.ReadAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1529,18 +1714,49 @@ func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+	// User is not a superuser or model admin.
+	s.expectHasPermissionNotSuperuser()
+	s.expectHasPermissionNoModelAdminAccessPermissions(foundModel.UUID.String())
+
+	offerUUID := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:       offerUUID,
+			OfferName:       "testing",
+			ApplicationName: "test-app",
+			CharmLocator:    charmLocator,
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "testing"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// Per-offer access check: user has no access at any level.
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ModelTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ConsumeAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), adminTag, permission.ReadAccess, gomock.AssignableToTypeOf(names.ApplicationOfferTag{})).Return(authentication.ErrorEntityMissingPermission)
+
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.testing"},
 	}
 
 	// Act
-	_, err := offerAPI.ApplicationOffers(c.Context(), args)
+	obtained, err := offerAPI.ApplicationOffers(c.Context(), args)
 
-	// Arrange
-	c.Assert(err, tc.DeepEquals, &params.Error{
-		Message: "permission denied",
-		Code:    "unauthorized access",
-	})
+	// Assert — offer filtered out by per-offer access → shows as NotFound.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 1)
+	c.Assert(obtained.Results[0].Error, tc.Not(tc.IsNil))
+	c.Assert(obtained.Results[0].Error.Code, tc.Equals, params.CodeNotFound)
 }
 
 // TestApplicationOfferURLAndFilterAPIUser tests a correct offer url text
@@ -1548,10 +1764,10 @@ func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
 // replaced.
 func (s *offerSuite) TestApplicationOfferURLAndFilter(c *tc.C) {
 	// Act
-	offerURL, offerFilter, err := applicationOfferURLAndFilter("testuser/model.offer", names.NewUserTag("admin"))
+	offerURL, offerFilter, rpcParamsError := applicationOfferURLAndFilter("testuser/model.offer", names.NewUserTag("admin"))
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(rpcParamsError, tc.IsNil)
 	c.Check(offerURL, tc.Equals, "testuser/model.offer")
 	c.Check(offerFilter, tc.DeepEquals, params.OfferFilter{
 		ModelQualifier: "testuser",
@@ -1564,10 +1780,10 @@ func (s *offerSuite) TestApplicationOfferURLAndFilter(c *tc.C) {
 // added to the offer if a model qualifier is not included.
 func (s *offerSuite) TestApplicationOfferURLAndFilterAPIUser(c *tc.C) {
 	// Act
-	offerURL, offerFilter, err := applicationOfferURLAndFilter("model.offer", names.NewUserTag("admin"))
+	offerURL, offerFilter, rpcParamsError := applicationOfferURLAndFilter("model.offer", names.NewUserTag("admin"))
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(rpcParamsError, tc.IsNil)
 	c.Check(offerURL, tc.Equals, "admin/model.offer")
 	c.Check(offerFilter, tc.DeepEquals, params.OfferFilter{
 		ModelQualifier: "admin",
@@ -1932,20 +2148,12 @@ func (s *offerSuite) expectHasPermissionNotSuperuser() {
 	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(authentication.ErrorEntityMissingPermission)
 }
 
-func (s *offerSuite) expectEntityHasPermission(userTag names.UserTag, access permission.Access) {
-	matcher := gomock.AssignableToTypeOf(names.ModelTag{})
-	if access == permission.SuperuserAccess {
-		matcher = gomock.AssignableToTypeOf(names.ControllerTag{})
-	}
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), userTag, access, matcher).Return(nil)
+func (s *offerSuite) expectHasPermissionSuperuser() {
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, gomock.AssignableToTypeOf(names.ControllerTag{})).Return(nil)
 }
 
-func (s *offerSuite) expectEntityHasPermissionMissingPermission(userTag names.UserTag, access permission.Access) {
-	matcher := gomock.AssignableToTypeOf(names.ModelTag{})
-	if access == permission.SuperuserAccess {
-		matcher = gomock.AssignableToTypeOf(names.ControllerTag{})
-	}
-	s.authorizer.EXPECT().EntityHasPermission(gomock.Any(), userTag, access, matcher).Return(authentication.ErrorEntityMissingPermission)
+func (s *offerSuite) expectHasPermissionModelAdmin(modelUUID string) {
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(modelUUID)).Return(nil)
 }
 
 func (s *offerSuite) offerAPI(_ *tc.C) *OffersAPI {

--- a/apiserver/facades/client/applicationoffers/package_mock_test.go
+++ b/apiserver/facades/client/applicationoffers/package_mock_test.go
@@ -366,6 +366,45 @@ func (c *MockCrossModelRelationServiceGetConsumeDetailsCall) DoAndReturn(f func(
 	return c
 }
 
+// GetOfferConnections mocks base method.
+func (m *MockCrossModelRelationService) GetOfferConnections(arg0 context.Context, arg1 []string) ([]crossmodelrelation.OfferConnectionDetail, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOfferConnections", arg0, arg1)
+	ret0, _ := ret[0].([]crossmodelrelation.OfferConnectionDetail)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOfferConnections indicates an expected call of GetOfferConnections.
+func (mr *MockCrossModelRelationServiceMockRecorder) GetOfferConnections(arg0, arg1 any) *MockCrossModelRelationServiceGetOfferConnectionsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOfferConnections", reflect.TypeOf((*MockCrossModelRelationService)(nil).GetOfferConnections), arg0, arg1)
+	return &MockCrossModelRelationServiceGetOfferConnectionsCall{Call: call}
+}
+
+// MockCrossModelRelationServiceGetOfferConnectionsCall wrap *gomock.Call
+type MockCrossModelRelationServiceGetOfferConnectionsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCrossModelRelationServiceGetOfferConnectionsCall) Return(arg0 []crossmodelrelation.OfferConnectionDetail, arg1 error) *MockCrossModelRelationServiceGetOfferConnectionsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCrossModelRelationServiceGetOfferConnectionsCall) Do(f func(context.Context, []string) ([]crossmodelrelation.OfferConnectionDetail, error)) *MockCrossModelRelationServiceGetOfferConnectionsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCrossModelRelationServiceGetOfferConnectionsCall) DoAndReturn(f func(context.Context, []string) ([]crossmodelrelation.OfferConnectionDetail, error)) *MockCrossModelRelationServiceGetOfferConnectionsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetOfferUUID mocks base method.
 func (m *MockCrossModelRelationService) GetOfferUUID(arg0 context.Context, arg1 crossmodel.OfferURL) (offer.UUID, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/applicationoffers/service.go
+++ b/apiserver/facades/client/applicationoffers/service.go
@@ -76,6 +76,13 @@ type CrossModelRelationService interface {
 		ctx context.Context,
 		args crossmodelrelation.ApplicationOfferArgs,
 	) error
+
+	// GetOfferConnections returns the connection details for all offers with
+	// the given UUIDs. An empty result is returned if no connections are found.
+	GetOfferConnections(
+		ctx context.Context,
+		offerUUIDs []string,
+	) ([]crossmodelrelation.OfferConnectionDetail, error)
 }
 
 // RemovalService defines operations for removing juju entities,

--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -54,6 +54,11 @@ type ModelOfferState interface {
 	// the cross model relation UUID, returning an error satisfying
 	// [crossmodelrelationerrors.OfferNotFound] if the relation is not found.
 	GetOfferUUIDByRelationUUID(ctx context.Context, relationUUID string) (string, error)
+
+	// GetOfferConnections returns the connection details for all offers
+	// with the given UUIDs. An empty result is returned if no connections
+	// are found.
+	GetOfferConnections(ctx context.Context, offerUUIDs []string) ([]crossmodelrelation.OfferConnectionDetail, error)
 }
 
 // GetOfferUUID returns the uuid for the provided offer URL.
@@ -267,6 +272,19 @@ func (s *Service) addOfferUsers(
 	}
 
 	return output, nil
+}
+
+// GetOfferConnections returns the connection details for all offers with the
+// given UUIDs. An empty result is returned if no connections are found.
+func (s *Service) GetOfferConnections(
+	ctx context.Context,
+	offerUUIDs []string,
+) ([]crossmodelrelation.OfferConnectionDetail, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	offerConnections, err := s.modelState.GetOfferConnections(ctx, offerUUIDs)
+	return offerConnections, errors.Capture(err)
 }
 
 func encodeInternalOfferFilter(

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -670,6 +670,48 @@ func (m createOfferArgsMatcher) String() string {
 	return "match CreateOfferArgs"
 }
 
+func (s *offerServiceSuite) TestGetOfferConnections(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	offerUUIDs := []string{uuid.MustNewUUID().String()}
+	expected := []crossmodelrelation.OfferConnectionDetail{
+		{
+			OfferUUID:       offerUUIDs[0],
+			SourceModelUUID: uuid.MustNewUUID().String(),
+			RelationID:      42,
+			Username:        "consumer-user",
+			Endpoint:        "db",
+			Status:          "joined",
+			Message:         "",
+			IngressSubnets:  []string{"10.0.0.0/24"},
+		},
+	}
+	s.modelState.EXPECT().GetOfferConnections(gomock.Any(), offerUUIDs).Return(expected, nil)
+
+	// Act
+	result, err := s.service(c).GetOfferConnections(c.Context(), offerUUIDs)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, expected)
+}
+
+func (s *offerServiceSuite) TestGetOfferConnectionsError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	offerUUIDs := []string{uuid.MustNewUUID().String()}
+	s.modelState.EXPECT().GetOfferConnections(gomock.Any(), offerUUIDs).
+		Return(nil, errors.New("boom"))
+
+	// Act
+	_, err := s.service(c).GetOfferConnections(c.Context(), offerUUIDs)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
 func (s *offerServiceSuite) TestGetOfferUUIDByRelationUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -697,6 +697,45 @@ func (c *MockModelStateGetModelEgressSubnetsCall) DoAndReturn(f func(context.Con
 	return c
 }
 
+// GetOfferConnections mocks base method.
+func (m *MockModelState) GetOfferConnections(arg0 context.Context, arg1 []string) ([]crossmodelrelation.OfferConnectionDetail, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOfferConnections", arg0, arg1)
+	ret0, _ := ret[0].([]crossmodelrelation.OfferConnectionDetail)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOfferConnections indicates an expected call of GetOfferConnections.
+func (mr *MockModelStateMockRecorder) GetOfferConnections(arg0, arg1 any) *MockModelStateGetOfferConnectionsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOfferConnections", reflect.TypeOf((*MockModelState)(nil).GetOfferConnections), arg0, arg1)
+	return &MockModelStateGetOfferConnectionsCall{Call: call}
+}
+
+// MockModelStateGetOfferConnectionsCall wrap *gomock.Call
+type MockModelStateGetOfferConnectionsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateGetOfferConnectionsCall) Return(arg0 []crossmodelrelation.OfferConnectionDetail, arg1 error) *MockModelStateGetOfferConnectionsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateGetOfferConnectionsCall) Do(f func(context.Context, []string) ([]crossmodelrelation.OfferConnectionDetail, error)) *MockModelStateGetOfferConnectionsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateGetOfferConnectionsCall) DoAndReturn(f func(context.Context, []string) ([]crossmodelrelation.OfferConnectionDetail, error)) *MockModelStateGetOfferConnectionsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetOfferDetails mocks base method.
 func (m *MockModelState) GetOfferDetails(arg0 context.Context, arg1 crossmodelrelation.OfferFilter) ([]*crossmodelrelation.OfferDetail, error) {
 	m.ctrl.T.Helper()

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -486,6 +486,121 @@ WHERE  offer_uuid = $uuid.uuid`, uuid{})
 	return nil
 }
 
+// GetOfferConnections returns the connection details for all offers with the
+// given UUIDs. An empty result is returned if no connections are found.
+func (st *State) GetOfferConnections(
+	ctx context.Context,
+	offerUUIDs []string,
+) ([]crossmodelrelation.OfferConnectionDetail, error) {
+	if len(offerUUIDs) == 0 {
+		return nil, nil
+	}
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	type uuids []string
+
+	// Query connection details: relation id, username, consumer model UUID,
+	// endpoint name, and relation status.
+	connStmt, err := st.Prepare(`
+SELECT oc.offer_uuid            AS &offerConnectionDetail.offer_uuid,
+       r.relation_id            AS &offerConnectionDetail.relation_id,
+       oc.username              AS &offerConnectionDetail.username,
+       arc.consumer_model_uuid  AS &offerConnectionDetail.consumer_model_uuid,
+       cr.name                  AS &offerConnectionDetail.endpoint_name,
+       rst.name                 AS &offerConnectionDetail.status,
+       rs.message               AS &offerConnectionDetail.message,
+       rs.updated_at            AS &offerConnectionDetail.updated_at
+FROM   offer_connection AS oc
+JOIN   relation AS r ON oc.remote_relation_uuid = r.uuid
+JOIN   application_remote_consumer AS arc ON oc.uuid = arc.offer_connection_uuid
+JOIN   relation_endpoint AS re ON r.uuid = re.relation_uuid
+JOIN   application_endpoint AS ae
+       ON re.endpoint_uuid = ae.uuid
+       AND ae.application_uuid = arc.offerer_application_uuid
+JOIN   charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
+JOIN   relation_status AS rs ON r.uuid = rs.relation_uuid
+JOIN   relation_status_type AS rst ON rs.relation_status_type_id = rst.id
+WHERE  oc.offer_uuid IN ($uuids[:])
+`, offerConnectionDetail{}, uuids{})
+	if err != nil {
+		return nil, errors.Errorf("preparing offer connection detail query: %w", err)
+	}
+
+	// Query ingress subnets separately to avoid row multiplication.
+	ingressStmt, err := st.Prepare(`
+SELECT oc.offer_uuid   AS &offerConnectionIngress.offer_uuid,
+       r.relation_id   AS &offerConnectionIngress.relation_id,
+       rni.cidr         AS &offerConnectionIngress.cidr
+FROM   offer_connection AS oc
+JOIN   relation AS r ON oc.remote_relation_uuid = r.uuid
+JOIN   relation_network_ingress AS rni ON oc.remote_relation_uuid = rni.relation_uuid
+WHERE  oc.offer_uuid IN ($uuids[:])
+`, offerConnectionIngress{}, uuids{})
+	if err != nil {
+		return nil, errors.Errorf("preparing offer connection ingress query: %w", err)
+	}
+
+	var connDetails []offerConnectionDetail
+	var ingressRows []offerConnectionIngress
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// Fetch connection details.
+		err = tx.Query(ctx, connStmt, uuids(offerUUIDs)).GetAll(&connDetails)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return errors.Errorf("fetching offer connection details: %w", err)
+		}
+
+		// Fetch ingress subnets.
+		err = tx.Query(ctx, ingressStmt, uuids(offerUUIDs)).GetAll(&ingressRows)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return errors.Errorf("fetching offer connection ingress: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	// Build a map of (offerUUID, relationID) → ingress CIDRs.
+	type connKey struct {
+		OfferUUID  string
+		RelationID int
+	}
+	ingressMap := make(map[connKey][]string)
+	for _, row := range ingressRows {
+		key := connKey{OfferUUID: row.OfferUUID, RelationID: row.RelationID}
+		ingressMap[key] = append(ingressMap[key], row.CIDR)
+	}
+
+	// Convert to domain types.
+	return transform.Slice(connDetails, func(detail offerConnectionDetail) crossmodelrelation.OfferConnectionDetail {
+		key := connKey{OfferUUID: detail.OfferUUID, RelationID: detail.RelationID}
+		res := crossmodelrelation.OfferConnectionDetail{
+			OfferUUID:       detail.OfferUUID,
+			SourceModelUUID: detail.ConsumerModelUUID,
+			RelationID:      detail.RelationID,
+			Username:        detail.Username,
+			Endpoint:        detail.EndpointName,
+			Status:          detail.Status,
+			StatusSince:     detail.StatusSince,
+			IngressSubnets:  ingressMap[key],
+		}
+		if detail.Message.Valid {
+			res.Message = detail.Message.String
+		}
+		return res
+	}), nil
+}
+
 func (st *State) createOfferEndpoints(ctx context.Context, tx *sqlair.TX, offerUUID, applicationUUID string, endpoints []string) error {
 	endpointUUIDs, err := st.getEndpointUUIDs(ctx, tx, applicationUUID, endpoints)
 	if err != nil {

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/offer"
 	relationtesting "github.com/juju/juju/core/relation/testing"
 	"github.com/juju/juju/domain/application/architecture"
@@ -19,6 +20,7 @@ import (
 	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
 	"github.com/juju/juju/domain/deployment/charm"
 	domainstatus "github.com/juju/juju/domain/status"
+	internaluuid "github.com/juju/juju/internal/uuid"
 )
 
 type modelOfferSuite struct {
@@ -660,6 +662,116 @@ func (s *modelOfferSuite) setupOfferConnection(c *tc.C) (string, string) {
 	s.addOfferConnection(c, offerUUID, domainstatus.RelationStatusTypeJoining)
 
 	return crossModelRelUUID, offerUUID.String()
+}
+
+// addOfferConnectionWithConsumer sets up a complete offer connection scenario
+// including the synthetic remote consumer application. It returns the offer
+// UUID, consumer model UUID, and relation UUID.
+func (s *modelOfferSuite) addOfferConnectionWithConsumer(c *tc.C) (string, string, string) {
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	charmRelationUUID := s.addCharmRelation(c, charmUUID, relation)
+	appName := "test-app"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	appEndpointUUID := s.addApplicationEndpoint(c, appUUID, charmRelationUUID)
+
+	offerUUID := s.addOffer(c, "test-offer", []string{appEndpointUUID})
+
+	relUUID := s.addRelation(c)
+	s.addRelationEndpoint(c, relUUID.String(), appEndpointUUID)
+
+	connUUID := internaluuid.MustNewUUID().String()
+	s.query(c, `
+INSERT INTO offer_connection (uuid, offer_uuid, remote_relation_uuid, username)
+VALUES (?, ?, ?, 'consumer-user')`, connUUID, offerUUID, relUUID)
+
+	synthCharmUUID := s.addCMRCharm(c)
+	s.addCharmMetadata(c, synthCharmUUID, false)
+	s.query(c, `
+INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid)
+VALUES (?, 'remote-consumer', 0, ?, ?)`, connUUID, synthCharmUUID, network.AlphaSpaceId)
+
+	consumerModelUUID := internaluuid.MustNewUUID().String()
+	s.query(c, `
+INSERT INTO application_remote_consumer
+(offer_connection_uuid, offerer_application_uuid, consumer_application_uuid, consumer_model_uuid, life_id)
+VALUES (?, ?, ?, ?, 0)`, connUUID, appUUID, internaluuid.MustNewUUID().String(), consumerModelUUID)
+
+	return offerUUID.String(), consumerModelUUID, relUUID.String()
+}
+
+func (s *modelOfferSuite) TestGetOfferConnections(c *tc.C) {
+	offerUUID, consumerModelUUID, relUUID := s.addOfferConnectionWithConsumer(c)
+
+	// Set relation status with message and timestamp.
+	s.query(c, `
+INSERT INTO relation_status (relation_uuid, relation_status_type_id, message, updated_at)
+VALUES (?, '1', 'test message', '2025-06-15T10:30:00Z')`, relUUID)
+
+	// Add ingress subnets.
+	s.query(c, `
+INSERT INTO relation_network_ingress (relation_uuid, cidr) VALUES (?, '10.0.0.0/24')`, relUUID)
+	s.query(c, `
+INSERT INTO relation_network_ingress (relation_uuid, cidr) VALUES (?, '192.168.1.0/24')`, relUUID)
+
+	// Act
+	connections, err := s.state.GetOfferConnections(c.Context(), []string{offerUUID})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(connections, tc.HasLen, 1)
+	c.Check(connections[0].OfferUUID, tc.Equals, offerUUID)
+	c.Check(connections[0].SourceModelUUID, tc.Equals, consumerModelUUID)
+	c.Check(connections[0].RelationID, tc.Equals, 0)
+	c.Check(connections[0].Username, tc.Equals, "consumer-user")
+	c.Check(connections[0].Endpoint, tc.Equals, "db")
+	c.Check(connections[0].Status, tc.Equals, "joined")
+	c.Check(connections[0].Message, tc.Equals, "test message")
+	c.Assert(connections[0].StatusSince, tc.Not(tc.IsNil))
+	c.Check(connections[0].StatusSince.UTC().Format("2006-01-02T15:04:05Z"), tc.Equals, "2025-06-15T10:30:00Z")
+	c.Check(connections[0].IngressSubnets, tc.SameContents, []string{"10.0.0.0/24", "192.168.1.0/24"})
+}
+
+func (s *modelOfferSuite) TestGetOfferConnectionsNullMessageAndTimestamp(c *tc.C) {
+	offerUUID, consumerModelUUID, relUUID := s.addOfferConnectionWithConsumer(c)
+
+	// Set relation status with NULL message and NULL updated_at.
+	s.query(c, `
+INSERT INTO relation_status (relation_uuid, relation_status_type_id)
+VALUES (?, '0')`, relUUID)
+
+	// Act
+	connections, err := s.state.GetOfferConnections(c.Context(), []string{offerUUID})
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+	c.Assert(connections, tc.HasLen, 1)
+	c.Check(connections[0].OfferUUID, tc.Equals, offerUUID)
+	c.Check(connections[0].SourceModelUUID, tc.Equals, consumerModelUUID)
+	c.Check(connections[0].Username, tc.Equals, "consumer-user")
+	c.Check(connections[0].Endpoint, tc.Equals, "db")
+	c.Check(connections[0].Status, tc.Equals, "joining")
+	c.Check(connections[0].Message, tc.Equals, "")
+	c.Check(connections[0].StatusSince, tc.IsNil)
+	c.Check(connections[0].IngressSubnets, tc.IsNil)
+}
+
+func (s *modelOfferSuite) TestGetOfferConnectionsNoConnections(c *tc.C) {
+	connections, err := s.state.GetOfferConnections(c.Context(), []string{internaluuid.MustNewUUID().String()})
+	c.Assert(err, tc.IsNil)
+	c.Assert(connections, tc.HasLen, 0)
+}
+
+func (s *modelOfferSuite) TestGetOfferConnectionsEmptyUUIDs(c *tc.C) {
+	connections, err := s.state.GetOfferConnections(c.Context(), nil)
+	c.Assert(err, tc.IsNil)
+	c.Assert(connections, tc.IsNil)
 }
 
 func (s *modelOfferSuite) TestGetOfferUUIDByRelationUUID(c *tc.C) {

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -258,6 +258,18 @@ type offerConnectionQuery struct {
 	OfferUUID string `db:"offer_uuid"`
 }
 
+// offerConnectionDetail maps the result of the offer connection details query.
+type offerConnectionDetail struct {
+	OfferUUID         string         `db:"offer_uuid"`
+	RelationID        int            `db:"relation_id"`
+	Username          string         `db:"username"`
+	ConsumerModelUUID string         `db:"consumer_model_uuid"`
+	EndpointName      string         `db:"endpoint_name"`
+	Status            string         `db:"status"`
+	Message           sql.NullString `db:"message"`
+	StatusSince       *time.Time     `db:"updated_at"`
+}
+
 type relation struct {
 	UUID       string `db:"uuid"`
 	LifeID     int    `db:"life_id"`
@@ -432,6 +444,14 @@ type relationNetworkIngress struct {
 
 type cidr struct {
 	CIDR string `db:"cidr"`
+}
+
+// offerConnectionIngress is used to fetch ingress CIDRs keyed by
+// offer UUID and relation ID, so they can be matched to connection details.
+type offerConnectionIngress struct {
+	OfferUUID  string `db:"offer_uuid"`
+	RelationID int    `db:"relation_id"`
+	CIDR       string `db:"cidr"`
 }
 
 type lifeID struct {

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -6,6 +6,7 @@ package crossmodelrelation
 import (
 	"maps"
 	"slices"
+	"time"
 
 	"gopkg.in/macaroon.v2"
 
@@ -116,6 +117,36 @@ type OfferUser struct {
 	Name        string
 	DisplayName string
 	Access      permission.Access
+}
+
+// OfferConnectionDetail contains details about a connection to an offer.
+type OfferConnectionDetail struct {
+	// OfferUUID is the UUID of the offer this connection belongs to.
+	OfferUUID string
+
+	// SourceModelUUID is the UUID of the consuming model.
+	SourceModelUUID string
+
+	// RelationID is the integer id of the relation for this connection.
+	RelationID int
+
+	// Username is the name of the user who created the offer connection.
+	Username string
+
+	// Endpoint is the name of the endpoint on the offering side.
+	Endpoint string
+
+	// Status is the status of the relation (e.g. "joining", "joined").
+	Status string
+
+	// Message is the status message.
+	Message string
+
+	// StatusSince is the time the status was last updated.
+	StatusSince *time.Time
+
+	// IngressSubnets is the list of subnets from which traffic will originate.
+	IngressSubnets []string
 }
 
 // OfferImport contains details to import an offer during migration.


### PR DESCRIPTION
In Juju 3.6, running `juju list-offers --format yaml` would show a `connections` section with details about each consuming model—relation ID, status, ingress subnets, and username. After the 4.0 migration to DQlite, this data was never wired up: a TODO placeholder sat where the connection-fetching logic should have been, so the API always returned empty connection lists.

This patch adds that behaviour: a new `GetOfferConnections` state query joins the offer_connection, relation, relation_status, and relation_network_ingress tables to fetch every active connection for a batch of offer UUIDs, a thin service method exposes it, and the facade fills in `params.OfferConnection` entries for admin users.

The admin check semantics from 3.6 are kept:
A soft gate, adding per-offer access checks that walk the permission hierarchy
(superuser, model admin, then offer-level admin/consume/read), and tracking admin status per-offer so that connection details are populated for any offer the caller has admin access to.

## QA steps

The original QA steps from the issue should now work fine:
```
juju bootstrap c
juju add-model offering
juju add-model consuming
juju switch offering
juju deploy juju-qa-dummy-source --config token=abc
juju offer dummy-source:sink
juju switch consuming
juju deploy juju-qa-dummy-sink
juju relate dummy-sink admin/offering.dummy-source
juju switch offering
```
Then:
```
$ juju list-offers --format yaml
dummy-source:
  application: dummy-source
  store: c
  charm: ch:amd64/juju-qa-dummy-source-6
  offer-url: admin/offering.dummy-source
  endpoints:
    sink:
      interface: dummy-token
      role: requirer
  connections:
  - source-model-uuid: 36881c65-c08e-4c4c-8907-c7dc12fdcc9e
    username: admin
    relation-id: 0
    endpoint: sink
    status:
      current: joined
      since: 2 hours ago
  users:
    admin:
      display-name: admin
      access: admin
```
Which now includes the `connections` section.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21964.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9304](https://warthogs.atlassian.net/browse/JUJU-9304)


[JUJU-9304]: https://warthogs.atlassian.net/browse/JUJU-9304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ