### PR TITLE
feat: add support of '--file' for update-cloud

### DIFF
--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -126,6 +126,7 @@ func (c *updateCloudCommand) Info() *cmd.Info {
 func (c *updateCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.OptionalControllerCommand.SetFlags(f)
 	f.StringVar(&c.CloudFile, "f", "", "The path to a cloud definition file")
+	f.StringVar(&c.CloudFile, "file", "", "The path to a cloud definition file")
 }
 
 func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -80,11 +80,20 @@ func (s *updateCloudSuite) createLocalCacheFile(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *updateCloudSuite) TestUpdateLocalCacheFromFile(c *tc.C) {
+func (s *updateCloudSuite) TestUpdateLocalCacheFromFileShortOption(c *tc.C) {
 	command, fileName := s.setupCloudFileScenario(c, garageMaasYamlFile, func(ctx context.Context) (cloud.UpdateCloudAPI, error) {
 		return nil, errors.New("")
 	})
 	_, err := cmdtesting.RunCommand(c, command, "garage-maas", "-f", fileName, "--client")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(s.api.Calls(), tc.HasLen, 0)
+}
+
+func (s *updateCloudSuite) TestUpdateLocalCacheFromFileLongOption(c *tc.C) {
+	command, fileName := s.setupCloudFileScenario(c, garageMaasYamlFile, func(ctx context.Context) (cloud.UpdateCloudAPI, error) {
+		return nil, errors.New("")
+	})
+	_, err := cmdtesting.RunCommand(c, command, "garage-maas", "--file", fileName, "--client")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(s.api.Calls(), tc.HasLen, 0)
 }


### PR DESCRIPTION
This pull request adds support for the long option (`--file`) to specify the cloud definition file in the `update-cloud` command. It also updates and adds tests to ensure both options work correctly.

**Command-line interface improvements:**

* Added support for the `--file` long option (in addition to the existing `-f` short option) for specifying the cloud definition file in the `update-cloud` command (`updatecloud.go`).

**Testing updates:**

* Renamed the test to `TestUpdateLocalCacheFromFileShortOption` to clarify it tests the short option (`-f`).
* Added a new test, `TestUpdateLocalCacheFromFileLongOption`, to verify the new `--file` long option works as expected.