### PR TITLE
refactor: prevent api remote caller blocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,22 @@ If guidance conflicts, architectural rules take precedence.
 
 ## Running Tests
 
+Tests must be run with the `-race` flag for code with mutexes or goroutines.
+For code with goroutines, tombs or catacombs, stress must be used to ensure
+robustness.
+
 - `go test ./path/to/package` — Run package tests.
 - `go test -run 'TestName' ./path/to/package` — Run specific test.
 - `make pre-check` — Static analysis (golangci-lint). Run before submitting.
+
+### Running `stress` Tests
+
+Compile the go package into a binary and run the test through stress.
+A timeout must wrap the `stress` command to ensure that stress halts in a good
+timeframe.
+
+ - `go test ./path/to/package -c -race`
+ - `timeout 31 stress -timeout 30s ./package.test`
 
 ## Integration Tests (bash-based)
 

--- a/internal/worker/apiremotecaller/package_mocks_test.go
+++ b/internal/worker/apiremotecaller/package_mocks_test.go
@@ -153,6 +153,44 @@ func (c *MockRemoteServerKillCall) DoAndReturn(f func()) *MockRemoteServerKillCa
 	return c
 }
 
+// Report mocks base method.
+func (m *MockRemoteServer) Report(arg0 context.Context) map[string]any {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Report", arg0)
+	ret0, _ := ret[0].(map[string]any)
+	return ret0
+}
+
+// Report indicates an expected call of Report.
+func (mr *MockRemoteServerMockRecorder) Report(arg0 any) *MockRemoteServerReportCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockRemoteServer)(nil).Report), arg0)
+	return &MockRemoteServerReportCall{Call: call}
+}
+
+// MockRemoteServerReportCall wrap *gomock.Call
+type MockRemoteServerReportCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRemoteServerReportCall) Return(arg0 map[string]any) *MockRemoteServerReportCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRemoteServerReportCall) Do(f func(context.Context) map[string]any) *MockRemoteServerReportCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRemoteServerReportCall) DoAndReturn(f func(context.Context) map[string]any) *MockRemoteServerReportCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpdateAddresses mocks base method.
 func (m *MockRemoteServer) UpdateAddresses(arg0 []string) {
 	m.ctrl.T.Helper()

--- a/internal/worker/apiremotecaller/remote.go
+++ b/internal/worker/apiremotecaller/remote.go
@@ -36,6 +36,7 @@ type RemoteConnection interface {
 // responsible modeling the remote API server.
 type RemoteServer interface {
 	worker.Worker
+	worker.Reporter
 	RemoteConnection
 	UpdateAddresses(addresses []string)
 }
@@ -241,14 +242,14 @@ func (w *remoteServer) loop() error {
 
 				// Keep request handoff to the main loop non-blocking and
 				// latest-wins. If the queue is full, replace the stale request.
-			ENQUEUE:
+			enqueue:
 				for {
 					select {
 					case <-w.tomb.Dying():
 						requestCancel(context.Canceled)
 						return tomb.ErrDying
 					case requests <- req:
-						break ENQUEUE
+						break enqueue
 					case stale := <-requests:
 						stale.cancel(newChangeRequestError)
 					}

--- a/internal/worker/apiremotecaller/remote.go
+++ b/internal/worker/apiremotecaller/remote.go
@@ -177,6 +177,7 @@ func (w *remoteServer) Report(ctx context.Context) map[string]any {
 
 type request struct {
 	ctx       context.Context
+	cancel    context.CancelCauseFunc
 	addresses []string
 }
 
@@ -194,7 +195,7 @@ func (w *remoteServer) loop() error {
 
 	w.logger.Tracef(ctx, "starting remote API caller for controller %q", w.controllerID)
 
-	requests := make(chan request)
+	requests := make(chan request, 1)
 	w.tomb.Go(func() error {
 		// When we receive a new change, we want to be able to cancel the current
 		// connection attempt. The current setup is that it will dial indefinitely
@@ -230,21 +231,27 @@ func (w *remoteServer) loop() error {
 				}
 
 				// Create a new context for the next connection attempt.
-				var requestCtx context.Context
-				requestCtx, canceler = context.WithCancelCause(ctx)
-
-				// We might want to consider only sending a change after a
-				// period of time, to avoid sending too many changes at once.
-				select {
-				case <-w.tomb.Dying():
-					// We'll always have a canceler if we're dying, so we can
-					// safely call it here.
-					canceler(context.Canceled)
-					return tomb.ErrDying
-				case requests <- request{
+				requestCtx, requestCancel := context.WithCancelCause(ctx)
+				canceler = requestCancel
+				req := request{
 					ctx:       requestCtx,
+					cancel:    requestCancel,
 					addresses: addresses,
-				}:
+				}
+
+				// Keep request handoff to the main loop non-blocking and
+				// latest-wins. If the queue is full, replace the stale request.
+			ENQUEUE:
+				for {
+					select {
+					case <-w.tomb.Dying():
+						requestCancel(context.Canceled)
+						return tomb.ErrDying
+					case requests <- req:
+						break ENQUEUE
+					case stale := <-requests:
+						stale.cancel(newChangeRequestError)
+					}
 				}
 			}
 		}

--- a/internal/worker/apiremotecaller/remote_test.go
+++ b/internal/worker/apiremotecaller/remote_test.go
@@ -468,6 +468,105 @@ func (s *RemoteSuite) TestConnectWithBrokenConnection(c *tc.C) {
 	workertest.CleanKill(c, w)
 }
 
+func (s *RemoteSuite) TestReconnectWithBrokenConnectionMultipleUpdatesKeepProgress(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	reconnectStarted := make(chan struct{})
+	releaseReconnect := make(chan struct{})
+
+	var attempts atomic.Int64
+	s.apiConnectHandler = func(ctx context.Context) error {
+		switch attempts.Add(1) {
+		case 1, 3:
+			select {
+			case s.apiConnect <- struct{}{}:
+			case <-c.Context().Done():
+				c.Fatalf("waiting for API connect: %v", c.Context().Err())
+			}
+			return nil
+		case 2:
+			close(reconnectStarted)
+			select {
+			case <-releaseReconnect:
+			case <-c.Context().Done():
+				c.Fatalf("waiting for reconnect release: %v", c.Context().Err())
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+
+	s.expectClock()
+	s.expectClockAfter(make(<-chan time.Time))
+
+	addr0 := &url.URL{Scheme: "wss", Host: "10.0.0.1"}
+	addr1 := &url.URL{Scheme: "wss", Host: "10.0.0.2"}
+	addr2 := &url.URL{Scheme: "wss", Host: "10.0.0.3"}
+
+	broken := make(chan struct{})
+
+	gomock.InOrder(
+		s.apiConnection.EXPECT().Broken().Return(broken),
+		s.apiConnection.EXPECT().Close().Return(nil),
+		s.apiConnection.EXPECT().Broken().Return(make(<-chan struct{})),
+		s.apiConnection.EXPECT().Close().Return(nil),
+	)
+
+	w := s.newRemoteServer(c)
+	defer workertest.DirtyKill(c, w)
+	reporter := w.(interface{ Report() map[string]any })
+
+	s.ensureStartup(c)
+
+	w.UpdateAddresses([]string{addr0.String()})
+	select {
+	case <-s.apiConnect:
+	case <-c.Context().Done():
+		c.Fatalf("waiting for initial API connect: %v", c.Context().Err())
+	}
+	s.ensureChanged(c)
+
+	close(broken)
+	select {
+	case <-reconnectStarted:
+	case <-c.Context().Done():
+		c.Fatalf("waiting for reconnect attempt: %v", c.Context().Err())
+	}
+
+	w.UpdateAddresses([]string{addr1.String()})
+
+	secondUpdateDone := make(chan struct{})
+	go func() {
+		w.UpdateAddresses([]string{addr2.String()})
+		close(secondUpdateDone)
+	}()
+
+	select {
+	case <-secondUpdateDone:
+	case <-c.Context().Done():
+		c.Fatalf("waiting for second address update: %v", c.Context().Err())
+	}
+
+	close(releaseReconnect)
+
+	select {
+	case <-s.apiConnect:
+	case <-c.Context().Done():
+		c.Fatalf("waiting for reconnect API connect: %v", c.Context().Err())
+	}
+	s.ensureChanged(c)
+
+	report := reporter.Report()
+	addresses, ok := report["addresses"].([]string)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(addresses, tc.DeepEquals, []string{addr2.String()})
+	c.Assert(attempts.Load(), tc.GreaterThan, int64(2))
+
+	workertest.CleanKill(c, w)
+}
+
 func (s *RemoteSuite) TestReportReturnsAddressSnapshot(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/internal/worker/apiremotecaller/remote_test.go
+++ b/internal/worker/apiremotecaller/remote_test.go
@@ -563,6 +563,7 @@ func (s *RemoteSuite) TestReconnectWithBrokenConnectionMultipleUpdatesKeepProgre
 	c.Assert(ok, tc.IsTrue)
 	c.Assert(addresses, tc.DeepEquals, []string{addr2.String()})
 	c.Assert(attempts.Load(), tc.GreaterThan, int64(2))
+	c.Assert(attempts.Load(), tc.LessThan, int64(5))
 
 	workertest.CleanKill(c, w)
 }

--- a/internal/worker/apiremotecaller/remote_test.go
+++ b/internal/worker/apiremotecaller/remote_test.go
@@ -492,7 +492,7 @@ func (s *RemoteSuite) TestReconnectWithBrokenConnectionMultipleUpdatesKeepProgre
 				c.Fatalf("waiting for reconnect release: %v", c.Context().Err())
 			}
 			<-ctx.Done()
-			return ctx.Err()
+			return context.Cause(ctx)
 		default:
 			return nil
 		}
@@ -516,7 +516,6 @@ func (s *RemoteSuite) TestReconnectWithBrokenConnectionMultipleUpdatesKeepProgre
 
 	w := s.newRemoteServer(c)
 	defer workertest.DirtyKill(c, w)
-	reporter := w.(interface{ Report() map[string]any })
 
 	s.ensureStartup(c)
 
@@ -558,7 +557,7 @@ func (s *RemoteSuite) TestReconnectWithBrokenConnectionMultipleUpdatesKeepProgre
 	}
 	s.ensureChanged(c)
 
-	report := reporter.Report()
+	report := w.Report(c.Context())
 	addresses, ok := report["addresses"].([]string)
 	c.Assert(ok, tc.IsTrue)
 	c.Assert(addresses, tc.DeepEquals, []string{addr2.String()})
@@ -581,9 +580,6 @@ func (s *RemoteSuite) TestReportReturnsAddressSnapshot(c *tc.C) {
 
 	w := s.newRemoteServer(c)
 	defer workertest.DirtyKill(c, w)
-	reporter := w.(interface {
-		Report(ctx context.Context) map[string]any
-	})
 
 	s.ensureStartup(c)
 
@@ -597,14 +593,14 @@ func (s *RemoteSuite) TestReportReturnsAddressSnapshot(c *tc.C) {
 
 	s.ensureChanged(c)
 
-	report := reporter.Report(c.Context())
+	report := w.Report(c.Context())
 	addresses, ok := report["addresses"].([]string)
 	c.Assert(ok, tc.IsTrue)
 	c.Assert(addresses, tc.DeepEquals, []string{addr.String()})
 
 	addresses[0] = "wss://10.0.0.99"
 
-	report = reporter.Report(c.Context())
+	report = w.Report(c.Context())
 	addresses, ok = report["addresses"].([]string)
 	c.Assert(ok, tc.IsTrue)
 	c.Assert(addresses, tc.DeepEquals, []string{addr.String()})


### PR DESCRIPTION
The api remote caller might block when multiple requests to the api
addresses happen. This is not ideal, instead, when we see multiple
addresses at once, we should drop the stale ones and just connect with
the fresh ones.

The coordination in here is quite hairy, and I'm not a fan of label
usage, but it does seem legitimate.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-unit -m controller controller -n 2
$ juju remove-unit -m controller controller 2
$ juju add-unit -m controller controller/1
```

Ensure the tests pass correctly and that there are no unwanted logs.