### PR TITLE
refactor: enable modernize waitgroup check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,6 @@ linters:
     modernize:
       disable:
         - any
-        - waitgroup
         - omitzero
   exclusions:
     generated: lax

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -86,8 +86,7 @@ func (w *commonWatcher) commonLoop() {
 	defer close(w.in)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		// When the watcher has been stopped, we send a Stop request
 		// to the server, which will remove the watcher and return a
 		// CodeStopped error to any currently outstanding call to
@@ -95,7 +94,6 @@ func (w *commonWatcher) commonLoop() {
 		// been stopped, we'll get a CodeNotFound error; Either way
 		// we'll return, wait for the stop request to complete, and
 		// the watcher will die with all resources cleaned up.
-		defer wg.Done()
 		<-w.tomb.Dying()
 
 		// Give a reasonable amount of time for the watcher to stop. If it
@@ -125,17 +123,15 @@ func (w *commonWatcher) commonLoop() {
 			logger.Errorf(context.TODO(), "error trying to stop watcher: %v", err)
 			return
 		}
-	}()
+	})
 
 	ctx, cancel := context.WithCancel(w.tomb.Context(context.Background()))
 	defer cancel()
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		// Because Next blocks until there are changes, we need to
 		// call it in a separate goroutine, so the watcher can be
 		// stopped normally.
-		defer wg.Done()
 		for {
 			result := w.newResult()
 			err := w.call(ctx, "Next", &result)
@@ -163,7 +159,7 @@ func (w *commonWatcher) commonLoop() {
 				// Report back the result we just got.
 			}
 		}
-	}()
+	})
 	wg.Wait()
 }
 

--- a/apiserver/apiserverhttp/mux_bench_test.go
+++ b/apiserver/apiserverhttp/mux_bench_test.go
@@ -31,13 +31,11 @@ func benchmarkMux(b *testing.B, mux http.Handler) {
 	b.ResetTimer()
 	var wg sync.WaitGroup
 	for range 100 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for n := 0; n < b.N; n++ {
 				mux.ServeHTTP(nil, req)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/apiserver/apiserverhttp/mux_test.go
+++ b/apiserver/apiserverhttp/mux_test.go
@@ -98,14 +98,12 @@ func (s *MuxSuite) TestConcurrentAddHandler(c *tc.C) {
 	// bN is the number of add and remove handlers to make.
 	const bN = 1000
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range bN {
 			s.mux.AddHandler("POST", "/", http.NotFoundHandler())
 			s.mux.RemoveHandler("POST", "/")
 		}
-	}()
+	})
 	defer wg.Wait()
 
 	for range bN {

--- a/cmd/juju/action/exec_test.go
+++ b/cmd/juju/action/exec_test.go
@@ -457,13 +457,11 @@ func (s *ExecSuite) TestTimeout(c *tc.C) {
 		ctx *cmd.Context
 		err error
 	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, err = cmdtesting.RunCommand(c, runCmd,
 			"--format=yaml", "--all", "hostname", "--wait", "2s",
 		)
-	}()
+	})
 
 	wg.Wait()
 	c.Check(err, tc.ErrorMatches, "timed out waiting for results from: machine 1, machine 2")

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -1112,11 +1112,9 @@ func (s *RunSuite) testRunHelper(c *tc.C, client *fakeAPIClient,
 		ctx *cmd.Context
 		err error
 	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, err = cmdtesting.RunCommand(c, runCmd, args...)
-	}()
+	})
 
 	wg.Wait()
 

--- a/cmd/juju/action/showoperation_test.go
+++ b/cmd/juju/action/showoperation_test.go
@@ -344,11 +344,9 @@ func (s *ShowOperationSuite) testRunHelper(c *tc.C, client *fakeAPIClient,
 		ctx *cmd.Context
 		err error
 	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, err = cmdtesting.RunCommand(c, runCmd, args...)
-	}()
+	})
 
 	wg.Wait()
 

--- a/cmd/juju/action/showtask_test.go
+++ b/cmd/juju/action/showtask_test.go
@@ -390,11 +390,9 @@ func (s *ShowTaskSuite) testRunHelper(c *tc.C, client *fakeAPIClient,
 		ctx *cmd.Context
 		err error
 	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, err = cmdtesting.RunCommand(c, runCmd, args...)
-	}()
+	})
 
 	wg.Wait()
 

--- a/internal/network/ssh/testing/sshserver.go
+++ b/internal/network/ssh/testing/sshserver.go
@@ -53,16 +53,12 @@ func CreateTCPServer(c *tc.C, callback func(net.Conn)) (string, chan struct{}) {
 
 	shutdown := make(chan struct{}, 0)
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-shutdown
 		listener.Close()
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			tcpConn, err := listener.Accept()
 			if err != nil {
@@ -73,7 +69,7 @@ func CreateTCPServer(c *tc.C, callback func(net.Conn)) (string, chan struct{}) {
 			c.Logf("accepted tcp connection on %s from %s", localAddress, remoteAddress)
 			callback(tcpConn)
 		}
-	}()
+	})
 
 	c.Cleanup(func() {
 		wg.Wait()

--- a/internal/resource/limiter_test.go
+++ b/internal/resource/limiter_test.go
@@ -49,15 +49,13 @@ func (s *LimiterSuite) TestNoLimits(c *tc.C) {
 	finished := sync.WaitGroup{}
 	for range totalToAcquire {
 		started.Add(1)
-		finished.Add(1)
-		go func() {
-			defer finished.Done()
+		finished.Go(func() {
 			started.Done()
 			limiter.Acquire(c.Context(), "app1")
 			atomic.AddInt32(&totalAcquiredCount, 1)
 			<-trigger
 			limiter.Release("app1")
-		}()
+		})
 	}
 	started.Wait()
 
@@ -108,15 +106,13 @@ func (s *LimiterSuite) TestGlobalLimit(c *tc.C) {
 	finished := sync.WaitGroup{}
 	for range totalToAcquire {
 		started.Add(1)
-		finished.Add(1)
-		go func() {
-			defer finished.Done()
+		finished.Go(func() {
 			started.Done()
 			limiter.Acquire(c.Context(), "app1")
 			atomic.AddInt32(&totalAcquiredCount, 1)
 			<-trigger
 			limiter.Release("app1")
-		}()
+		})
 	}
 	started.Wait()
 

--- a/internal/sshtunneler/tunneler_test.go
+++ b/internal/sshtunneler/tunneler_test.go
@@ -100,16 +100,14 @@ func (s *sshTunnelerSuite) TestTunneler(c *tc.C) {
 
 	wg := sync.WaitGroup{}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx := c.Context()
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
 		_, err := tunnelTracker.RequestTunnel(ctx, tunnelReqArgs)
 		c.Check(err, tc.ErrorIsNil)
-	}()
+	})
 
 	// wait for the tunnel request to be processed
 	select {
@@ -186,16 +184,14 @@ func (s *sshTunnelerSuite) TestTunnelIsClosedWhenDialFails(c *tc.C) {
 
 	wg := sync.WaitGroup{}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx := c.Context()
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
 		_, err := tunnelTracker.RequestTunnel(ctx, tunnelReqArgs)
 		c.Check(err, tc.ErrorMatches, `failed-to-connect`)
-	}()
+	})
 
 	// wait for the tunnel request to be processed
 	select {

--- a/internal/testhelpers/tcpproxy_test.go
+++ b/internal/testhelpers/tcpproxy_test.go
@@ -157,13 +157,11 @@ func tcpEcho(wg *sync.WaitGroup, listener net.Listener) {
 		if err != nil {
 			return
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer conn.Close()
 			// Echo anything that was written.
 			io.Copy(conn, conn)
-		}()
+		})
 	}
 }
 

--- a/internal/worker/lease/fixture_test.go
+++ b/internal/worker/lease/fixture_test.go
@@ -84,9 +84,7 @@ func (fix *Fixture) RunTest(c *tc.C, test func(*lease.Manager, *testclock.Clock)
 	var wg sync.WaitGroup
 	testDone := make(chan struct{})
 	storeDone := make(chan struct{})
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		// Dirty tests will probably have stopped the manager anyway, but no
 		// sense leaving them around if things aren't exactly as we expect.
 		timeout := time.After(coretesting.LongWait)
@@ -107,13 +105,11 @@ func (fix *Fixture) RunTest(c *tc.C, test func(*lease.Manager, *testclock.Clock)
 		if !fix.expectDirty {
 			c.Check(err, tc.ErrorIsNil)
 		}
-	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	})
+	wg.Go(func() {
 		store.Wait(c)
 		close(storeDone)
-	}()
+	})
 	waitAlarms(c, clock, 1)
 	test(manager, clock)
 	close(testDone)

--- a/internal/worker/lease/manager_claim_test.go
+++ b/internal/worker/lease/manager_claim_test.go
@@ -83,12 +83,10 @@ func (s *ClaimSuite) TestClaimLease_Success_SameHolder(c *tc.C) {
 		// refuses. After claiming, we wait 50ms to let the refresh happen, then
 		// we notice that we are the holder, so we Extend instead of Claim.
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 			c.Check(err, tc.ErrorIsNil)
-			wg.Done()
-		}()
+		})
 		c.Check(clock.WaitAdvance(50*time.Millisecond, testhelpers.LongWait, 2), tc.ErrorIsNil)
 		wg.Wait()
 	})
@@ -121,12 +119,10 @@ func (s *ClaimSuite) TestClaimLeaseFailureHeldByClaimer(c *tc.C) {
 		// does not have the most up-to-date information. We then wake up again
 		// and see that our leases have expired and thus let things go.
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 			c.Check(err, tc.Equals, corelease.ErrClaimDenied)
-			wg.Done()
-		}()
+		})
 		c.Check(clock.WaitAdvance(50*time.Millisecond, testhelpers.LongWait, 2), tc.ErrorIsNil)
 		wg.Wait()
 	})
@@ -243,12 +239,10 @@ func (s *ClaimSuite) TestExtendLease_Success_Expired(c *tc.C) {
 		// reloaded our Leases and see that *nobody* is the holder. So then we try
 		// again and successfully Claim the lease.
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 			c.Check(err, tc.ErrorIsNil)
-			wg.Done()
-		}()
+		})
 		c.Check(clock.WaitAdvance(50*time.Millisecond, testhelpers.LongWait, 2), tc.ErrorIsNil)
 		wg.Wait()
 	})
@@ -287,12 +281,10 @@ func (s *ClaimSuite) TestExtendLease_Failure_OtherHolder(c *tc.C) {
 		// does not have the most up-to-date information. We then wake up again
 		// and see that our leases have expired and thus let things go.
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 			c.Check(err, tc.Equals, corelease.ErrClaimDenied)
-			wg.Done()
-		}()
+		})
 		c.Check(clock.WaitAdvance(50*time.Millisecond, testhelpers.LongWait, 2), tc.ErrorIsNil)
 		wg.Wait()
 	})
@@ -331,12 +323,10 @@ func (s *ClaimSuite) TestExtendLease_Failure_Retryable(c *tc.C) {
 		// does not have the most up-to-date information. We then wake up again
 		// and see that our leases have expired and thus let things go.
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
 			c.Check(err, tc.Equals, corelease.ErrClaimDenied)
-			wg.Done()
-		}()
+		})
 		c.Check(clock.WaitAdvance(50*time.Millisecond, testhelpers.LongWait, 2), tc.ErrorIsNil)
 		wg.Wait()
 	})

--- a/internal/worker/uniter/runner/jujuc/server_test.go
+++ b/internal/worker/uniter/runner/jujuc/server_test.go
@@ -156,8 +156,7 @@ func (s *ServerSuite) TestLocks(c *tc.C) {
 	var wg sync.WaitGroup
 	t0 := time.Now()
 	for range 4 {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			dir := c.MkDir()
 			resp, err := s.Call(c, jujuc.Request{
 				ContextId:   "validCtx",
@@ -167,8 +166,7 @@ func (s *ServerSuite) TestLocks(c *tc.C) {
 			})
 			c.Assert(err, tc.ErrorIsNil)
 			c.Assert(resp.Code, tc.Equals, 0)
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 	t1 := time.Now()

--- a/internal/worker/watcherregistry/worker_test.go
+++ b/internal/worker/watcherregistry/worker_test.go
@@ -127,32 +127,25 @@ func (s *registrySuite) TestConcurrency(c *tc.C) {
 	defer workertest.CleanKill(c, regGetter)
 
 	var wg sync.WaitGroup
-	start := func(f func()) {
-		wg.Add(1)
-		go func() {
-			f()
-			wg.Done()
-		}()
-	}
 	_, err := reg.Register(c.Context(), workertest.NewErrorWorker(nil))
 	c.Assert(err, tc.ErrorIsNil)
 
-	start(func() {
+	wg.Go(func() {
 		_, _ = reg.Register(c.Context(), workertest.NewErrorWorker(nil))
 	})
-	start(func() {
+	wg.Go(func() {
 		_ = reg.RegisterNamed(c.Context(), "named", workertest.NewErrorWorker(nil))
 	})
-	start(func() {
+	wg.Go(func() {
 		_ = reg.Stop("1")
 	})
-	start(func() {
+	wg.Go(func() {
 		_ = reg.Count()
 	})
-	start(func() {
+	wg.Go(func() {
 		_, _ = reg.Get("2")
 	})
-	start(func() {
+	wg.Go(func() {
 		_, _ = reg.Get("named")
 	})
 	wg.Wait()


### PR DESCRIPTION
This check was disabled when modernize was introduced, in order the changes could be manually inspected with more rigour.

Enable this check now

## QA steps

unit tests pass