### PR TITLE
refactor: controlsocket

### DIFF
--- a/internal/worker/controlsocket/middleware.go
+++ b/internal/worker/controlsocket/middleware.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build linux
+
+package controlsocket
+
+import (
+	"context"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/juju/juju/internal/errors"
+)
+
+// MiddlewareErrorWriter is an interface that defines a method for writing error
+// responses in middleware.
+type MiddlewareErrorWriter interface {
+	// WriteErrorResponse writes an error response to the given
+	// http.ResponseWriter, using the provided status code and error message.
+	WriteErrorResponse(ctx context.Context, w http.ResponseWriter, status int, err error)
+}
+
+type errorResponseWriter func(ctx context.Context, w http.ResponseWriter, status int, err error)
+
+func (f errorResponseWriter) WriteErrorResponse(ctx context.Context, w http.ResponseWriter, status int, err error) {
+	f(ctx, w, status, err)
+}
+
+// closeRequestBodyMiddleware is a middleware that ensures the request body is
+// closed after the request is processed.
+func closeRequestBodyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		next.ServeHTTP(resp, r)
+	})
+}
+
+// contentTypeMiddleware is a middleware that checks if the request has the
+// expected Content-Type header and returns an error response if it does not.
+func contentTypeMiddleware(next http.Handler, errorWriter MiddlewareErrorWriter) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, r *http.Request) {
+		if !hasContentType(r, "application/json") {
+			errorWriter.WriteErrorResponse(r.Context(), resp, http.StatusUnsupportedMediaType,
+				errors.New("request Content-Type must be application/json"))
+			return
+		}
+		next.ServeHTTP(resp, r)
+	})
+}
+
+// contentLengthMiddleware is a middleware that checks if the request body
+// exceeds a specified maximum length and returns an error response if it does.
+func contentLengthMiddleware(next http.Handler, errorWriter MiddlewareErrorWriter) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, r *http.Request) {
+		if r.ContentLength > maxPayloadBytes {
+			errorWriter.WriteErrorResponse(r.Context(), resp, http.StatusRequestEntityTooLarge,
+				errors.Errorf("request body must not exceed %d bytes", maxPayloadBytes))
+			return
+		}
+
+		r.Body = http.MaxBytesReader(resp, r.Body, maxPayloadBytes)
+
+		next.ServeHTTP(resp, r)
+	})
+}
+
+func hasContentType(r *http.Request, mimeType string) bool {
+	contentType := r.Header.Get("Content-type")
+	if contentType == "" {
+		return false
+	}
+
+	for v := range strings.SplitSeq(contentType, ",") {
+		t, _, err := mime.ParseMediaType(v)
+		if err != nil {
+			break
+		}
+		if t == mimeType {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worker/controlsocket/middleware_test.go
+++ b/internal/worker/controlsocket/middleware_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build linux
+
+package controlsocket
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+)
+
+func TestMiddlewareSuite(t *stdtesting.T) {
+	tc.Run(t, &middlewareSuite{})
+}
+
+type middlewareSuite struct{}
+
+func (*middlewareSuite) TestCloseRequestBodyMiddlewareClosesBody(c *tc.C) {
+	body := &closeTrackingBody{Reader: bytes.NewReader([]byte("payload"))}
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	resp := httptest.NewRecorder()
+
+	nextCalled := false
+	h := closeRequestBodyMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	h.ServeHTTP(resp, req)
+
+	c.Assert(nextCalled, tc.IsTrue)
+	c.Assert(body.closed, tc.IsTrue)
+}
+
+func (*middlewareSuite) TestContentTypeMiddlewareRejectsNonJSON(c *tc.C) {
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte("{}")))
+	resp := httptest.NewRecorder()
+
+	nextCalled := false
+	called := false
+	var gotStatus int
+	var gotErr error
+
+	h := contentTypeMiddleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+		}),
+		errorResponseWriter(func(_ context.Context, _ http.ResponseWriter, status int, err error) {
+			called = true
+			gotStatus = status
+			gotErr = err
+		}),
+	)
+
+	h.ServeHTTP(resp, req)
+
+	c.Assert(nextCalled, tc.IsFalse)
+	c.Assert(called, tc.IsTrue)
+	c.Assert(gotStatus, tc.Equals, http.StatusUnsupportedMediaType)
+	c.Assert(gotErr, tc.ErrorMatches, "request Content-Type must be application/json")
+}
+
+func (*middlewareSuite) TestContentTypeMiddlewareAcceptsJSON(c *tc.C) {
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	resp := httptest.NewRecorder()
+
+	nextCalled := false
+	writerCalled := false
+
+	h := contentTypeMiddleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		errorResponseWriter(func(_ context.Context, _ http.ResponseWriter, _ int, _ error) {
+			writerCalled = true
+		}),
+	)
+
+	h.ServeHTTP(resp, req)
+
+	c.Assert(nextCalled, tc.IsTrue)
+	c.Assert(writerCalled, tc.IsFalse)
+	c.Assert(resp.Code, tc.Equals, http.StatusNoContent)
+}
+
+func (*middlewareSuite) TestContentLengthMiddlewareRejectsOversizedContentLength(c *tc.C) {
+	body := bytes.Repeat([]byte("x"), maxPayloadBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+
+	nextCalled := false
+	called := false
+	var gotStatus int
+	var gotErr error
+
+	h := contentLengthMiddleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+		}),
+		errorResponseWriter(func(_ context.Context, _ http.ResponseWriter, status int, err error) {
+			called = true
+			gotStatus = status
+			gotErr = err
+		}),
+	)
+
+	h.ServeHTTP(resp, req)
+
+	c.Assert(nextCalled, tc.IsFalse)
+	c.Assert(called, tc.IsTrue)
+	c.Assert(gotStatus, tc.Equals, http.StatusRequestEntityTooLarge)
+	c.Assert(gotErr, tc.ErrorMatches, "request body must not exceed .* bytes")
+}
+
+func (*middlewareSuite) TestContentLengthMiddlewareMaxBytesReaderEnforced(c *tc.C) {
+	body := bytes.Repeat([]byte("x"), maxPayloadBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	// Unknown length bypasses the early ContentLength check.
+	req.ContentLength = -1
+	resp := httptest.NewRecorder()
+
+	nextCalled := false
+	writerCalled := false
+
+	h := contentLengthMiddleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+			_, err := io.ReadAll(r.Body)
+			c.Assert(err, tc.ErrorMatches, "http: request body too large")
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		errorResponseWriter(func(_ context.Context, _ http.ResponseWriter, _ int, _ error) {
+			writerCalled = true
+		}),
+	)
+
+	h.ServeHTTP(resp, req)
+
+	c.Assert(nextCalled, tc.IsTrue)
+	c.Assert(writerCalled, tc.IsFalse)
+	c.Assert(resp.Code, tc.Equals, http.StatusNoContent)
+}
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}

--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/catacomb"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
@@ -26,6 +27,7 @@ import (
 	usererrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/access/service"
 	"github.com/juju/juju/internal/auth"
+	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/socketlistener"
 )
 
@@ -38,6 +40,9 @@ const (
 	// This user CANNOT be a local user (it must have a domain), otherwise the
 	// model addUser code will complain about the user not existing.
 	userCreator = "juju-metrics"
+
+	// maxPayloadBytes is the maximum size of any payload.
+	maxPayloadBytes = 1 << 20 // 1MiB
 )
 
 // AccessService is the interface for the access service.
@@ -109,19 +114,19 @@ type Config struct {
 // Validate returns an error if config cannot drive the Worker.
 func (config Config) Validate() error {
 	if config.AccessService == nil {
-		return errors.NotValidf("nil AccessService")
+		return internalerrors.New("nil AccessService").Add(coreerrors.NotValid)
 	}
 	if config.ControllerModelUUID == "" {
-		return errors.NotValidf("empty ControllerModelUUID")
+		return internalerrors.New("empty ControllerModelUUID").Add(coreerrors.NotValid)
 	}
 	if config.SocketName == "" {
-		return errors.NotValidf("empty SocketName")
+		return internalerrors.New("empty SocketName").Add(coreerrors.NotValid)
 	}
 	if config.NewSocketListener == nil {
-		return errors.NotValidf("nil NewSocketListener func")
+		return internalerrors.New("nil NewSocketListener func").Add(coreerrors.NotValid)
 	}
 	if config.Logger == nil {
-		return errors.NotValidf("nil Logger")
+		return internalerrors.New("nil Logger").Add(coreerrors.NotValid)
 	}
 	return nil
 }
@@ -140,12 +145,12 @@ type Worker struct {
 // NewWorker returns a controlsocket worker with the given config.
 func NewWorker(config Config) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 
 	userCreatorName, err := user.NewName(userCreator)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 
 	w := &Worker{
@@ -161,7 +166,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		ShutdownTimeout:  500 * time.Millisecond,
 	})
 	if err != nil {
-		return nil, errors.Annotate(err, "control socket listener:")
+		return nil, internalerrors.Errorf("control socket listener: %w", err)
 	}
 
 	err = catacomb.Invoke(catacomb.Plan{
@@ -171,7 +176,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		Init: []worker.Worker{sl},
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 	return w, nil
 }
@@ -185,14 +190,12 @@ func (w *Worker) Wait() error {
 }
 
 func (w *Worker) loop() error {
-	select {
-	case <-w.catacomb.Dying():
-		return w.catacomb.ErrDying()
-	}
+	<-w.catacomb.Dying()
+	return w.catacomb.ErrDying()
 }
 
 func (w *Worker) registerHandlers(r *mux.Router) {
-	r.HandleFunc("/metrics-users", w.handleAddMetricsUser).
+	r.Handle("/metrics-users", w.handleJSONPost(w.handleAddMetricsUser)).
 		Methods(http.MethodPost)
 	r.HandleFunc("/metrics-users/{username}", w.handleRemoveMetricsUser).
 		Methods(http.MethodDelete)
@@ -204,24 +207,29 @@ type addMetricsUserBody struct {
 }
 
 func (w *Worker) handleAddMetricsUser(resp http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
 	var parsedBody addMetricsUserBody
-	defer req.Body.Close()
-	err := json.NewDecoder(req.Body).Decode(&parsedBody)
-	if errors.Is(err, io.EOF) {
-		w.writeResponse(req.Context(), resp, http.StatusBadRequest, errorf("missing request body"))
-		return
-	} else if err != nil {
-		w.writeResponse(req.Context(), resp, http.StatusBadRequest, errorf("request body is not valid JSON: %v", err))
+	if err := json.NewDecoder(req.Body).Decode(&parsedBody); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		switch {
+		case internalerrors.Is(err, io.EOF):
+			w.writeErrorResponse(ctx, resp, http.StatusBadRequest, internalerrors.New("missing request body"))
+		case internalerrors.As(err, &maxBytesErr):
+			w.writeErrorResponse(ctx, resp, http.StatusRequestEntityTooLarge, internalerrors.Errorf("request body must not exceed %d bytes", maxPayloadBytes))
+		default:
+			w.writeErrorResponse(ctx, resp, http.StatusBadRequest, internalerrors.Errorf("request body is not valid JSON: %v", err))
+		}
 		return
 	}
 
-	code, err := w.addMetricsUser(req.Context(), parsedBody.Username, auth.NewPassword(parsedBody.Password))
+	code, err := w.addMetricsUser(ctx, parsedBody.Username, auth.NewPassword(parsedBody.Password))
 	if err != nil {
-		w.writeResponse(req.Context(), resp, code, errorf("%v", err))
+		w.writeErrorResponse(ctx, resp, code, err)
 		return
 	}
 
-	w.writeResponse(req.Context(), resp, code, infof("created user %q", parsedBody.Username))
+	w.writeResponse(ctx, resp, code, infof("created user %q", parsedBody.Username))
 }
 
 func (w *Worker) addMetricsUser(ctx context.Context, username string, password auth.Password) (int, error) {
@@ -232,7 +240,7 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 
 	creatorUser, err := w.accessService.GetUserByName(ctx, w.userCreatorName)
 	if err != nil {
-		return http.StatusInternalServerError, errors.Annotatef(err, "retrieving creator user %q: %v", userCreator, err)
+		return http.StatusInternalServerError, internalerrors.Errorf("retrieving creator user %q: %w", userCreator, err)
 	}
 
 	controllerModelID := permission.ID{
@@ -250,7 +258,7 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 			Access: permission.ReadAccess,
 		},
 	})
-	if errors.Is(err, usererrors.UserAlreadyExists) {
+	if internalerrors.Is(err, usererrors.UserAlreadyExists) {
 		// Retrieve existing user
 		user, err := w.accessService.GetUserByAuth(ctx, validatedName, password)
 		if err != nil {
@@ -263,10 +271,10 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 		// So ensure the user is identical to what we would have created, and
 		// otherwise error.
 		if user.Disabled {
-			return http.StatusForbidden, errors.Forbiddenf("user %q is disabled", user.Name)
+			return http.StatusForbidden, internalerrors.Errorf("user %q is disabled", user.Name).Add(coreerrors.Forbidden)
 		}
 		if user.CreatorName != w.userCreatorName {
-			return http.StatusConflict, errors.AlreadyExistsf("user %q (created by %q)", user.Name, user.CreatorName)
+			return http.StatusConflict, internalerrors.Errorf("user %q (created by %q)", user.Name, user.CreatorName).Add(coreerrors.AlreadyExists)
 		}
 
 		accessLevel, err := w.accessService.ReadUserAccessLevelForTarget(ctx, validatedName, controllerModelID)
@@ -280,7 +288,7 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 			)
 		}
 	} else if err != nil {
-		return http.StatusInternalServerError, errors.Annotatef(err, "creating user %q: %v", username, err)
+		return http.StatusInternalServerError, internalerrors.Errorf("creating user %q: %w", username, err)
 	}
 	return http.StatusOK, nil
 }
@@ -304,14 +312,14 @@ func (w *Worker) removeMetricsUser(ctx context.Context, username string) (int, e
 
 	// We shouldn't mess with users that weren't created by us.
 	user, err := w.accessService.GetUserByName(ctx, validatedName)
-	if errors.Is(err, usererrors.UserNotFound) {
+	if internalerrors.Is(err, usererrors.UserNotFound) {
 		// succeed as no-op
 		return http.StatusOK, nil
 	} else if err != nil {
 		return http.StatusInternalServerError, err
 	}
 	if user.CreatorName != w.userCreatorName {
-		return http.StatusForbidden, errors.Forbiddenf("cannot remove user %q created by %q", user.Name, user.CreatorName)
+		return http.StatusForbidden, internalerrors.Errorf("cannot remove user %q created by %q", user.Name, user.CreatorName).Add(coreerrors.Forbidden)
 	}
 
 	err = w.accessService.RemoveUser(ctx, validatedName)
@@ -325,11 +333,11 @@ func (w *Worker) removeMetricsUser(ctx context.Context, username string) (int, e
 
 func validateMetricsUsername(username string) (user.Name, error) {
 	if username == "" {
-		return user.Name{}, errors.BadRequestf("missing username")
+		return user.Name{}, internalerrors.Errorf("missing username").Add(coreerrors.BadRequest)
 	}
 
 	if !strings.HasPrefix(username, jujuMetricsUserPrefix) {
-		return user.Name{}, errors.BadRequestf("metrics username %q should have prefix %q", username, jujuMetricsUserPrefix)
+		return user.Name{}, internalerrors.Errorf("metrics username %q should have prefix %q", username, jujuMetricsUserPrefix).Add(coreerrors.BadRequest)
 	}
 
 	name, err := user.NewName(username)
@@ -340,8 +348,27 @@ func validateMetricsUsername(username string) (user.Name, error) {
 	return name, nil
 }
 
+func (w *Worker) handleJSONPost(fn func(http.ResponseWriter, *http.Request)) http.Handler {
+	errorWriter := errorResponseWriter(w.writeErrorResponse)
+
+	return closeRequestBodyMiddleware(
+		contentTypeMiddleware(
+			contentLengthMiddleware(
+				http.HandlerFunc(fn),
+				errorWriter,
+			),
+			errorWriter,
+		),
+	)
+}
+
+func (w *Worker) writeErrorResponse(ctx context.Context, resp http.ResponseWriter, statusCode int, err error) {
+	w.logger.Errorf(ctx, "failed to handle request: %v", err)
+
+	w.writeResponse(ctx, resp, statusCode, errorf("%s", err.Error()))
+}
+
 func (w *Worker) writeResponse(ctx context.Context, resp http.ResponseWriter, statusCode int, body any) {
-	w.logger.Debugf(ctx, "operation finished with HTTP status %v", statusCode)
 	resp.Header().Set("Content-Type", "application/json")
 
 	message, err := json.Marshal(body)

--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -214,11 +214,14 @@ func (w *Worker) handleAddMetricsUser(resp http.ResponseWriter, req *http.Reques
 		var maxBytesErr *http.MaxBytesError
 		switch {
 		case internalerrors.Is(err, io.EOF):
-			w.writeErrorResponse(ctx, resp, http.StatusBadRequest, internalerrors.New("missing request body"))
+			w.writeErrorResponse(ctx, resp, http.StatusBadRequest,
+				internalerrors.New("missing request body"))
 		case internalerrors.As(err, &maxBytesErr):
-			w.writeErrorResponse(ctx, resp, http.StatusRequestEntityTooLarge, internalerrors.Errorf("request body must not exceed %d bytes", maxPayloadBytes))
+			w.writeErrorResponse(ctx, resp, http.StatusRequestEntityTooLarge,
+				internalerrors.Errorf("request body must not exceed %d bytes", maxPayloadBytes))
 		default:
-			w.writeErrorResponse(ctx, resp, http.StatusBadRequest, internalerrors.Errorf("request body is not valid JSON: %v", err))
+			w.writeErrorResponse(ctx, resp, http.StatusBadRequest,
+				internalerrors.Errorf("request body is not valid JSON: %v", err))
 		}
 		return
 	}
@@ -240,7 +243,8 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 
 	creatorUser, err := w.accessService.GetUserByName(ctx, w.userCreatorName)
 	if err != nil {
-		return http.StatusInternalServerError, internalerrors.Errorf("retrieving creator user %q: %w", userCreator, err)
+		return http.StatusInternalServerError,
+			internalerrors.Errorf("retrieving creator user %q: %w", userCreator, err)
 	}
 
 	controllerModelID := permission.ID{
@@ -271,10 +275,12 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 		// So ensure the user is identical to what we would have created, and
 		// otherwise error.
 		if user.Disabled {
-			return http.StatusForbidden, internalerrors.Errorf("user %q is disabled", user.Name).Add(coreerrors.Forbidden)
+			return http.StatusForbidden, internalerrors.Errorf("user %q is disabled", user.Name).
+				Add(coreerrors.Forbidden)
 		}
 		if user.CreatorName != w.userCreatorName {
-			return http.StatusConflict, internalerrors.Errorf("user %q (created by %q)", user.Name, user.CreatorName).Add(coreerrors.AlreadyExists)
+			return http.StatusConflict, internalerrors.Errorf("user %q (created by %q)", user.Name, user.CreatorName).
+				Add(coreerrors.AlreadyExists)
 		}
 
 		accessLevel, err := w.accessService.ReadUserAccessLevelForTarget(ctx, validatedName, controllerModelID)
@@ -319,7 +325,8 @@ func (w *Worker) removeMetricsUser(ctx context.Context, username string) (int, e
 		return http.StatusInternalServerError, err
 	}
 	if user.CreatorName != w.userCreatorName {
-		return http.StatusForbidden, internalerrors.Errorf("cannot remove user %q created by %q", user.Name, user.CreatorName).Add(coreerrors.Forbidden)
+		return http.StatusForbidden, internalerrors.Errorf("cannot remove user %q created by %q", user.Name, user.CreatorName).
+			Add(coreerrors.Forbidden)
 	}
 
 	err = w.accessService.RemoveUser(ctx, validatedName)
@@ -337,7 +344,8 @@ func validateMetricsUsername(username string) (user.Name, error) {
 	}
 
 	if !strings.HasPrefix(username, jujuMetricsUserPrefix) {
-		return user.Name{}, internalerrors.Errorf("metrics username %q should have prefix %q", username, jujuMetricsUserPrefix).Add(coreerrors.BadRequest)
+		return user.Name{}, internalerrors.Errorf("metrics username %q should have prefix %q", username, jujuMetricsUserPrefix).
+			Add(coreerrors.BadRequest)
 	}
 
 	name, err := user.NewName(username)

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -84,6 +84,7 @@ func (s *workerSuite) runHandlerTest(c *tc.C, test handlerTest) {
 		strings.NewReader(test.body),
 	)
 	c.Assert(err, tc.ErrorIsNil)
+	req.Header.Set("Content-Type", "application/json")
 
 	// Check server is up
 	resp, err := client(socket).Do(req)
@@ -217,7 +218,7 @@ func (s *workerSuite) TestMetricsUsersAddAlreadyExists(c *tc.C) {
 		endpoint:   "/metrics-users",
 		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
 		statusCode: http.StatusConflict,
-		response:   ".*user .* already exists.*",
+		response:   `.*user .*\(created by \\\"not-you\\\"\).*`,
 	})
 }
 


### PR DESCRIPTION
Refactors the controlsocket to handle the addition of more endpoints
in the future. There should be no functional changes to the API.

There is a common pattern for implementing middleware for http endpoints,
that should be widely used in the codebase. For now we can create them
here and move them to a better location in the future. They're generic
enough for most use cases.

Additionally, updated the error types to use the internal package.

## QA steps

```
$ juju bootstrap microk8s test-control-socket
$ juju add-model prom
$ juju deploy prometheus-k8s --trust
$ juju switch controller
$ juju offer controller:metrics-endpoint
$ juju switch prom
$ juju consume controller.controller
$ juju integrate promethus-k8s controller
$ juju users 
Controller: test-control-socket9

Name             Display name     Access     Date created    Last connection
admin*           admin            superuser  7 minutes ago   just now
juju-metrics     Juju Metrics     login      7 minutes ago   never connected
juju-metrics-r1  juju-metrics-r1             16 seconds ago  never connected

$ juju debug-log --replay # check for errors
$ juju remove-application prometheus-k8s
$ juju users
Controller: test-control-socket9

Name          Display name  Access     Date created    Last connection
admin*        admin         superuser  11 minutes ago  just now
juju-metrics  Juju Metrics  login      11 minutes ago  never connected
```


## Links

**Jira card:** [JUJU-9452](https://warthogs.atlassian.net/browse/JUJU-9452)


[JUJU-9452]: https://warthogs.atlassian.net/browse/JUJU-9452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ