### PR TITLE
fix(db-not-found): add not-found code to db-not-found error

### DIFF
--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/errors"
 
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	corelogger "github.com/juju/juju/core/logger"
@@ -191,6 +192,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeSecretBackendNotFound
 	case errors.Is(err, modelerrors.NotFound):
 		code = params.CodeModelNotFound
+	case errors.Is(err, coredatabase.ErrDBNotFound):
+		code = params.CodeNotFound
 	case errors.Is(err, errors.AlreadyExists):
 		code = params.CodeAlreadyExists
 	case errors.Is(err, secretbackenderrors.AlreadyExists):

--- a/apiserver/errors/errors_test.go
+++ b/apiserver/errors/errors_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/macaroon.v2"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/network"
@@ -201,6 +202,14 @@ var errorTransformTests = []struct {
 	code:   "",
 	targetTester: func(e error) bool {
 		return e.Error() == "foo"
+	},
+}, {
+	err:        coredatabase.ErrDBNotFound,
+	code:       params.CodeNotFound,
+	status:     http.StatusNotFound,
+	helperFunc: params.IsCodeNotFound,
+	targetTester: func(e error) bool {
+		return errors.Is(e, errors.NotFound)
 	},
 }, {
 	err:        apiservererrors.UnknownModelError,

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -45,6 +45,7 @@ func (*importSuite) TestImports(c *tc.C) {
 		"core/charm/metrics",
 		"core/constraints",
 		"core/credential",
+		"core/database",
 		"core/devices",
 		"core/errors",
 		"core/facades",


### PR DESCRIPTION
# Description

During the qa of jaas with juju 4.0 some tests were failing because we were relying on ModelInfo to return a not-found code on models that have been destroyed. After digging into Juju code I've noticed we weren't converting db-not-found errors to not-found error code. I've added that and now my test in jaas is passing.

Juju 3 for `ModelInfo` returns a `NotFound` error when a model is not-found, so it should Juju 4. 


# QA
The output before was:
```
setup_jimm.go:386: 
        error:
          got non-nil error
        got:
          e"invoking getDB: database not found"
```
from https://github.com/canonical/jimm/actions/runs/23941447772/job/69828462553?pr=1937

Running some of these tests locally now pass with this patch.