### PR TITLE
fix(bootstrap): add riscv64 support for K8s app constraints

### DIFF
--- a/internal/provider/kubernetes/application/constraints.go
+++ b/internal/provider/kubernetes/application/constraints.go
@@ -54,6 +54,8 @@ func ApplyWorkloadConstraints(pod *core.PodSpec, appName string, cons constraint
 			cpuArch = "ppc64le"
 		case arch.S390X:
 			cpuArch = "s390x"
+		case arch.RISCV64:
+			cpuArch = "riscv64"
 		default:
 			return errors.NotSupportedf("architecture %q", cpuArch)
 		}

--- a/internal/provider/kubernetes/application/constraints_test.go
+++ b/internal/provider/kubernetes/application/constraints_test.go
@@ -161,10 +161,49 @@ func (s *applyConstraintsSuite) TestArch(c *tc.C) {
 	configureConstraint := func(got *corev1.PodSpec, resourceName corev1.ResourceName, value string) (err error) {
 		return errors.New("unexpected")
 	}
-	pod := &corev1.PodSpec{}
-	err := application.ApplyWorkloadConstraints(pod, "foo", constraints.MustParse("arch=arm64"), configureConstraint)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(pod.NodeSelector, tc.DeepEquals, map[string]string{"kubernetes.io/arch": "arm64"})
+	testCases := []struct {
+		name     string
+		arch     string
+		expected map[string]string
+	}{
+		{
+			name:     "amd64",
+			arch:     "amd64",
+			expected: map[string]string{"kubernetes.io/arch": "amd64"},
+		},
+		{
+			name:     "arm64",
+			arch:     "arm64",
+			expected: map[string]string{"kubernetes.io/arch": "arm64"},
+		},
+		{
+			name:     "ppc64el",
+			arch:     "ppc64el",
+			expected: map[string]string{"kubernetes.io/arch": "ppc64le"},
+		},
+		{
+			name:     "riscv64",
+			arch:     "riscv64",
+			expected: map[string]string{"kubernetes.io/arch": "riscv64"},
+		},
+		{
+			name:     "s390x",
+			arch:     "s390x",
+			expected: map[string]string{"kubernetes.io/arch": "s390x"},
+		},
+	}
+
+	for _, test := range testCases {
+		c.Run(test.name, func(t *stdtesting.T) {
+			pod := &corev1.PodSpec{}
+			err := application.ApplyWorkloadConstraints(
+				pod, "foo", constraints.MustParse("arch="+test.arch),
+				configureConstraint,
+			)
+			c.Assert(err, tc.ErrorIsNil)
+			c.Check(pod.NodeSelector, tc.DeepEquals, test.expected)
+		})
+	}
 }
 
 func (s *applyConstraintsSuite) TestPodAffinityJustTopologyKey(c *tc.C) {


### PR DESCRIPTION
The RISC-V architecture support is available in most of places, but missing in K8s app constraints.
Without the fix, `juju deploy postgresql-test-app` stuck on RISC-V K8s throwing error in debug-log:

```
> controller-0: 16:54:04 INFO juju.services.status.status-history since:
2026-04-03T16:54:04Z,status:error,category:status-history,data:null,kind:application,logger-tags:status-history,message:
generating application podspec: processing workload container constraints: architecture "riscv64" not supported,
namespace_id:postgresql-test-app status-history
(status: "error", status-message: "generating application podspec: processing workload container constraints: architecture \"riscv64\" not supported")
```

Fixes: https://github.com/juju/juju/issues/22158

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Describe steps to verify that the change works:

https://discourse.charmhub.io/t/seamless-postgresql-deployment-on-risc-v-with-juju-and-ubuntu/20147

 1. Bootstrap a 4.0 controller and deploy a charm.

```sh
# juju CLI 4.0.4+ build from sources for K8s
juju bootstrap k8s # on riscv64
juju add-model welcome
juju set-model-constraints arch=riscv64
juju deploy ch:postgresql-test-app --channel latest/edge/riscv --base ubuntu@24.04
```

## Documentation changes

None, Juju has no official RISC-V support.