### PR TITLE
feat: atomic commit hook update network info

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -266,13 +266,15 @@ type NetworkService interface {
 	GetUnitPrivateAddress(ctx context.Context, unitName coreunit.Name) (network.SpaceAddress, error)
 
 	// GetUnitRelationNetwork retrieves network relation information for a given
-	// unit and relation UUID.
+	// unit and relation UUIDs.
 	//
 	// The following errors may be returned:
 	// - [applicationerrors.UnitNotFound] if the unit does not exist
 	// - [relationerrors.RelationNotFound] if the relation doesn't belong to the
 	//   unit.
-	GetUnitRelationNetwork(ctx context.Context, unitName coreunit.Name, relationUUID corerelation.UUID) (domainnetwork.UnitNetwork, error)
+	GetUnitRelationNetwork(
+		ctx context.Context, unitName coreunit.Name, relationUUID []corerelation.UUID,
+	) (map[corerelation.UUID]domainnetwork.UnitNetwork, error)
 
 	// GetUnitEndpointNetworks retrieves network relation information for a given unit and specified endpoints.
 	// It returns exactly one info for each endpoint names passed in argument,
@@ -281,7 +283,9 @@ type NetworkService interface {
 	//
 	// The following errors may be returned:
 	// - [applicationerrors.UnitNotFound] if the unit does not exist
-	GetUnitEndpointNetworks(ctx context.Context, unitName coreunit.Name, endpointNames []string) ([]domainnetwork.UnitNetwork, error)
+	GetUnitEndpointNetworks(
+		ctx context.Context, unitName coreunit.Name, endpointNames []string,
+	) ([]domainnetwork.UnitNetwork, error)
 }
 
 type ResolveService interface {
@@ -490,6 +494,10 @@ type RelationService interface {
 	// GetRelationDetails returns the relation details requested by the uniter
 	// for a relation.
 	GetRelationDetails(ctx context.Context, relationUUID corerelation.UUID) (relation.RelationDetails, error)
+
+	// GetRelationUUIDsByUnitName returns a slice of relation UUIDs for relations
+	// the given unit is part of and in scope.
+	GetRelationUUIDsByUnitName(ctx context.Context, unitName coreunit.Name) ([]corerelation.UUID, error)
 
 	// GetRelationUnitUUID returns the relation unit UUID for the given unit
 	// within the given relation.

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -265,15 +265,15 @@ type NetworkService interface {
 	// - [network.NoAddressError] if the unit has no private address associated
 	GetUnitPrivateAddress(ctx context.Context, unitName coreunit.Name) (network.SpaceAddress, error)
 
-	// GetUnitRelationNetwork retrieves network relation information for a given
+	// GetUnitRelationNetworks retrieves network relation information for a given
 	// unit and relation UUIDs.
 	//
 	// The following errors may be returned:
 	// - [applicationerrors.UnitNotFound] if the unit does not exist
 	// - [relationerrors.RelationNotFound] if the relation doesn't belong to the
 	//   unit.
-	GetUnitRelationNetwork(
-		ctx context.Context, unitName coreunit.Name, relationUUID []corerelation.UUID,
+	GetUnitRelationNetworks(
+		ctx context.Context, unitName coreunit.Name, relationUUIDs []corerelation.UUID,
 	) (map[corerelation.UUID]domainnetwork.UnitNetwork, error)
 
 	// GetUnitEndpointNetworks retrieves network relation information for a given unit and specified endpoints.

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -1846,6 +1846,45 @@ func (c *MockRelationServiceGetRelationUUIDByKeyCall) DoAndReturn(f func(context
 	return c
 }
 
+// GetRelationUUIDsByUnitName mocks base method.
+func (m *MockRelationService) GetRelationUUIDsByUnitName(arg0 context.Context, arg1 unit.Name) ([]relation.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRelationUUIDsByUnitName", arg0, arg1)
+	ret0, _ := ret[0].([]relation.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelationUUIDsByUnitName indicates an expected call of GetRelationUUIDsByUnitName.
+func (mr *MockRelationServiceMockRecorder) GetRelationUUIDsByUnitName(arg0, arg1 any) *MockRelationServiceGetRelationUUIDsByUnitNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUUIDsByUnitName", reflect.TypeOf((*MockRelationService)(nil).GetRelationUUIDsByUnitName), arg0, arg1)
+	return &MockRelationServiceGetRelationUUIDsByUnitNameCall{Call: call}
+}
+
+// MockRelationServiceGetRelationUUIDsByUnitNameCall wrap *gomock.Call
+type MockRelationServiceGetRelationUUIDsByUnitNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRelationServiceGetRelationUUIDsByUnitNameCall) Return(arg0 []relation.UUID, arg1 error) *MockRelationServiceGetRelationUUIDsByUnitNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRelationServiceGetRelationUUIDsByUnitNameCall) Do(f func(context.Context, unit.Name) ([]relation.UUID, error)) *MockRelationServiceGetRelationUUIDsByUnitNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRelationServiceGetRelationUUIDsByUnitNameCall) DoAndReturn(f func(context.Context, unit.Name) ([]relation.UUID, error)) *MockRelationServiceGetRelationUUIDsByUnitNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationUnitChanges mocks base method.
 func (m *MockRelationService) GetRelationUnitChanges(arg0 context.Context, arg1 relation.UUID, arg2 []unit.UUID, arg3 []application.UUID) (relation0.RelationUnitsChange, error) {
 	m.ctrl.T.Helper()
@@ -2732,10 +2771,10 @@ func (c *MockNetworkServiceGetUnitPublicAddressCall) DoAndReturn(f func(context.
 }
 
 // GetUnitRelationNetwork mocks base method.
-func (m *MockNetworkService) GetUnitRelationNetwork(arg0 context.Context, arg1 unit.Name, arg2 relation.UUID) (network0.UnitNetwork, error) {
+func (m *MockNetworkService) GetUnitRelationNetwork(arg0 context.Context, arg1 unit.Name, arg2 []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitRelationNetwork", arg0, arg1, arg2)
-	ret0, _ := ret[0].(network0.UnitNetwork)
+	ret0, _ := ret[0].(map[relation.UUID]network0.UnitNetwork)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2753,19 +2792,19 @@ type MockNetworkServiceGetUnitRelationNetworkCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockNetworkServiceGetUnitRelationNetworkCall) Return(arg0 network0.UnitNetwork, arg1 error) *MockNetworkServiceGetUnitRelationNetworkCall {
+func (c *MockNetworkServiceGetUnitRelationNetworkCall) Return(arg0 map[relation.UUID]network0.UnitNetwork, arg1 error) *MockNetworkServiceGetUnitRelationNetworkCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNetworkServiceGetUnitRelationNetworkCall) Do(f func(context.Context, unit.Name, relation.UUID) (network0.UnitNetwork, error)) *MockNetworkServiceGetUnitRelationNetworkCall {
+func (c *MockNetworkServiceGetUnitRelationNetworkCall) Do(f func(context.Context, unit.Name, []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error)) *MockNetworkServiceGetUnitRelationNetworkCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkServiceGetUnitRelationNetworkCall) DoAndReturn(f func(context.Context, unit.Name, relation.UUID) (network0.UnitNetwork, error)) *MockNetworkServiceGetUnitRelationNetworkCall {
+func (c *MockNetworkServiceGetUnitRelationNetworkCall) DoAndReturn(f func(context.Context, unit.Name, []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error)) *MockNetworkServiceGetUnitRelationNetworkCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -2770,41 +2770,41 @@ func (c *MockNetworkServiceGetUnitPublicAddressCall) DoAndReturn(f func(context.
 	return c
 }
 
-// GetUnitRelationNetwork mocks base method.
-func (m *MockNetworkService) GetUnitRelationNetwork(arg0 context.Context, arg1 unit.Name, arg2 []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error) {
+// GetUnitRelationNetworks mocks base method.
+func (m *MockNetworkService) GetUnitRelationNetworks(arg0 context.Context, arg1 unit.Name, arg2 []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitRelationNetwork", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetUnitRelationNetworks", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[relation.UUID]network0.UnitNetwork)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetUnitRelationNetwork indicates an expected call of GetUnitRelationNetwork.
-func (mr *MockNetworkServiceMockRecorder) GetUnitRelationNetwork(arg0, arg1, arg2 any) *MockNetworkServiceGetUnitRelationNetworkCall {
+// GetUnitRelationNetworks indicates an expected call of GetUnitRelationNetworks.
+func (mr *MockNetworkServiceMockRecorder) GetUnitRelationNetworks(arg0, arg1, arg2 any) *MockNetworkServiceGetUnitRelationNetworksCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitRelationNetwork", reflect.TypeOf((*MockNetworkService)(nil).GetUnitRelationNetwork), arg0, arg1, arg2)
-	return &MockNetworkServiceGetUnitRelationNetworkCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitRelationNetworks", reflect.TypeOf((*MockNetworkService)(nil).GetUnitRelationNetworks), arg0, arg1, arg2)
+	return &MockNetworkServiceGetUnitRelationNetworksCall{Call: call}
 }
 
-// MockNetworkServiceGetUnitRelationNetworkCall wrap *gomock.Call
-type MockNetworkServiceGetUnitRelationNetworkCall struct {
+// MockNetworkServiceGetUnitRelationNetworksCall wrap *gomock.Call
+type MockNetworkServiceGetUnitRelationNetworksCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockNetworkServiceGetUnitRelationNetworkCall) Return(arg0 map[relation.UUID]network0.UnitNetwork, arg1 error) *MockNetworkServiceGetUnitRelationNetworkCall {
+func (c *MockNetworkServiceGetUnitRelationNetworksCall) Return(arg0 map[relation.UUID]network0.UnitNetwork, arg1 error) *MockNetworkServiceGetUnitRelationNetworksCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNetworkServiceGetUnitRelationNetworkCall) Do(f func(context.Context, unit.Name, []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error)) *MockNetworkServiceGetUnitRelationNetworkCall {
+func (c *MockNetworkServiceGetUnitRelationNetworksCall) Do(f func(context.Context, unit.Name, []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error)) *MockNetworkServiceGetUnitRelationNetworksCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkServiceGetUnitRelationNetworkCall) DoAndReturn(f func(context.Context, unit.Name, []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error)) *MockNetworkServiceGetUnitRelationNetworkCall {
+func (c *MockNetworkServiceGetUnitRelationNetworksCall) DoAndReturn(f func(context.Context, unit.Name, []relation.UUID) (map[relation.UUID]network0.UnitNetwork, error)) *MockNetworkServiceGetUnitRelationNetworksCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"maps"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -2346,6 +2347,19 @@ func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoPara
 		Results: make(map[string]params.NetworkInfoResult),
 	}
 
+	if len(args.Endpoints) > 0 {
+		infos, err := u.networkService.GetUnitEndpointNetworks(ctx, unitName, args.Endpoints)
+		if errors.Is(err, applicationerrors.UnitNotFound) {
+			return params.NetworkInfoResults{}, errors.NotFoundf("unit %q", unitTag.Id())
+		} else if err != nil {
+			return params.NetworkInfoResults{}, internalerrors.Capture(err)
+		}
+
+		for _, info := range infos {
+			results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
+		}
+	}
+
 	if args.RelationId != nil {
 		relationUUID, err := u.relationService.GetRelationUUIDByID(
 			ctx, *args.RelationId,
@@ -2370,19 +2384,12 @@ func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoPara
 		if !ok {
 			return params.NetworkInfoResults{}, apiservererrors.ErrPerm
 		}
-		results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
-		return results, nil
-	}
 
-	infos, err := u.networkService.GetUnitEndpointNetworks(ctx, unitName, args.Endpoints)
-	if errors.Is(err, applicationerrors.UnitNotFound) {
-		return params.NetworkInfoResults{}, errors.NotFoundf("unit %q", unitTag.Id())
-	} else if err != nil {
-		return params.NetworkInfoResults{}, internalerrors.Capture(err)
-	}
-
-	for _, info := range infos {
-		results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
+		overrideRelationEndpoint := len(args.Endpoints) == 0 ||
+			slices.Contains(args.Endpoints, info.EndpointName)
+		if overrideRelationEndpoint {
+			results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
+		}
 	}
 	return results, nil
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2861,7 +2861,7 @@ func (u *UniterAPI) updatedNetworkInfo(
 	return transform.Map(relationNetworkInfos, func(relationUUID corerelation.UUID, relationNetworkInfo domainnetork.UnitNetwork) (corerelation.UUID, unitstate.Settings) {
 		var ingress, egress string
 		if len(relationNetworkInfo.EgressSubnets) > 0 {
-			egress = strings.Join(relationNetworkInfo.EgressSubnets, ", ")
+			egress = strings.Join(relationNetworkInfo.EgressSubnets, ",")
 		}
 		if len(relationNetworkInfo.IngressAddresses) > 0 {
 			ingress = relationNetworkInfo.IngressAddresses[0]

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"maps"
 	"math"
-	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -1671,7 +1670,7 @@ func (u *UniterAPI) oneEnterScope(ctx context.Context, canAccess common.AuthFunc
 		return internalerrors.Capture(err)
 	}
 
-	info, err := u.networkService.GetUnitRelationNetwork(ctx, unitName, relUUID)
+	infos, err := u.networkService.GetUnitRelationNetwork(ctx, unitName, []corerelation.UUID{relUUID})
 	switch {
 	case errors.Is(err, applicationerrors.UnitNotFound):
 		return errors.NotFoundf("unit %s", unitTag)
@@ -1679,6 +1678,11 @@ func (u *UniterAPI) oneEnterScope(ctx context.Context, canAccess common.AuthFunc
 		return errors.NotFoundf("relation %s", relTagStr)
 	case err != nil:
 		return internalerrors.Capture(err)
+	}
+
+	info, ok := infos[relUUID]
+	if !ok {
+		return errors.NotFoundf("relation %s", relTagStr)
 	}
 
 	err = u.relationService.EnterScope(
@@ -2342,19 +2346,6 @@ func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoPara
 		Results: make(map[string]params.NetworkInfoResult),
 	}
 
-	if len(args.Endpoints) > 0 {
-		infos, err := u.networkService.GetUnitEndpointNetworks(ctx, unitName, args.Endpoints)
-		if errors.Is(err, applicationerrors.UnitNotFound) {
-			return params.NetworkInfoResults{}, errors.NotFoundf("unit %q", unitTag.Id())
-		} else if err != nil {
-			return params.NetworkInfoResults{}, internalerrors.Capture(err)
-		}
-
-		for _, info := range infos {
-			results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
-		}
-	}
-
 	if args.RelationId != nil {
 		relationUUID, err := u.relationService.GetRelationUUIDByID(
 			ctx, *args.RelationId,
@@ -2364,8 +2355,8 @@ func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoPara
 		} else if err != nil {
 			return params.NetworkInfoResults{}, internalerrors.Capture(err)
 		}
-		info, err := u.networkService.GetUnitRelationNetwork(
-			ctx, unitName, relationUUID,
+		infos, err := u.networkService.GetUnitRelationNetwork(
+			ctx, unitName, []corerelation.UUID{relationUUID},
 		)
 		if errors.Is(err, applicationerrors.UnitNotFound) {
 			return params.NetworkInfoResults{}, errors.NotFoundf("unit %q", unitTag.Id())
@@ -2375,11 +2366,23 @@ func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoPara
 			return params.NetworkInfoResults{}, internalerrors.Capture(err)
 		}
 
-		overrideRelationEndpoint := len(args.Endpoints) == 0 ||
-			slices.Contains(args.Endpoints, info.EndpointName)
-		if overrideRelationEndpoint {
-			results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
+		info, ok := infos[relationUUID]
+		if !ok {
+			return params.NetworkInfoResults{}, apiservererrors.ErrPerm
 		}
+		results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
+		return results, nil
+	}
+
+	infos, err := u.networkService.GetUnitEndpointNetworks(ctx, unitName, args.Endpoints)
+	if errors.Is(err, applicationerrors.UnitNotFound) {
+		return params.NetworkInfoResults{}, errors.NotFoundf("unit %q", unitTag.Id())
+	} else if err != nil {
+		return params.NetworkInfoResults{}, internalerrors.Capture(err)
+	}
+
+	for _, info := range infos {
+		results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
 	}
 	return results, nil
 }
@@ -2839,6 +2842,38 @@ func (u *UniterAPI) CommitHookChanges(ctx context.Context, args params.CommitHoo
 	return params.ErrorResults{Results: res}, nil
 }
 
+func (u *UniterAPI) updatedNetworkInfo(
+	ctx context.Context, unitName coreunit.Name,
+) (map[corerelation.UUID]unitstate.Settings, error) {
+	relationUUIDs, err := u.relationService.GetRelationUUIDsByUnitName(ctx, unitName)
+	if err != nil {
+		return nil, internalerrors.Errorf("getting relation UUIDs of unit %q: %w", unitName, err)
+	}
+	if len(relationUUIDs) == 0 {
+		return nil, nil
+	}
+
+	relationNetworkInfos, err := u.networkService.GetUnitRelationNetwork(ctx, unitName, relationUUIDs)
+	if err != nil {
+		return nil, internalerrors.Errorf("getting updated relation network info for unit %q: %w", unitName, err)
+	}
+
+	return transform.Map(relationNetworkInfos, func(relationUUID corerelation.UUID, relationNetworkInfo domainnetork.UnitNetwork) (corerelation.UUID, unitstate.Settings) {
+		var ingress, egress string
+		if len(relationNetworkInfo.EgressSubnets) > 0 {
+			egress = strings.Join(relationNetworkInfo.EgressSubnets, ", ")
+		}
+		if len(relationNetworkInfo.IngressAddresses) > 0 {
+			ingress = relationNetworkInfo.IngressAddresses[0]
+		}
+		settings := unitstate.Settings{
+			unitstate.EgressSubnetsKey:  egress,
+			unitstate.IngressAddressKey: ingress,
+		}
+		return relationUUID, settings
+	}), nil
+}
+
 func (u *UniterAPI) commitHookChangesForOneUnit(
 	ctx context.Context,
 	unitTag names.UnitTag,
@@ -2853,9 +2888,12 @@ func (u *UniterAPI) commitHookChangesForOneUnit(
 	}
 
 	if changes.UpdateNetworkInfo {
-		err := u.setUnitRelationNetworks(ctx, unitName)
+		relationNetworkSettings, err := u.updatedNetworkInfo(ctx, unitName)
 		if err != nil {
-			return internalerrors.Errorf("updating network info: %w", err)
+			return internalerrors.Capture(err)
+		}
+		if len(relationNetworkSettings) != 0 {
+			arg.UpdatedRelationNetworkInfo = relationNetworkSettings
 		}
 	}
 
@@ -3046,11 +3084,15 @@ func (u *UniterAPI) setUnitRelationNetworks(ctx context.Context, name coreunit.N
 		if err != nil {
 			return internalerrors.Errorf("getting relation UUID: %w", err)
 		}
-		unitNetwork, err := u.networkService.GetUnitRelationNetwork(
-			ctx, name, relationUUID,
+		unitNetworks, err := u.networkService.GetUnitRelationNetwork(
+			ctx, name, []corerelation.UUID{relationUUID},
 		)
 		if err != nil {
 			return internalerrors.Errorf("getting relation network: %w", err)
+		}
+		unitNetwork, ok := unitNetworks[relationUUID]
+		if !ok {
+			return internalerrors.Errorf("relation network not found")
 		}
 
 		// Set relation settings.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1670,7 +1670,7 @@ func (u *UniterAPI) oneEnterScope(ctx context.Context, canAccess common.AuthFunc
 		return internalerrors.Capture(err)
 	}
 
-	infos, err := u.networkService.GetUnitRelationNetwork(ctx, unitName, []corerelation.UUID{relUUID})
+	infos, err := u.networkService.GetUnitRelationNetworks(ctx, unitName, []corerelation.UUID{relUUID})
 	switch {
 	case errors.Is(err, applicationerrors.UnitNotFound):
 		return errors.NotFoundf("unit %s", unitTag)
@@ -2355,7 +2355,7 @@ func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoPara
 		} else if err != nil {
 			return params.NetworkInfoResults{}, internalerrors.Capture(err)
 		}
-		infos, err := u.networkService.GetUnitRelationNetwork(
+		infos, err := u.networkService.GetUnitRelationNetworks(
 			ctx, unitName, []corerelation.UUID{relationUUID},
 		)
 		if errors.Is(err, applicationerrors.UnitNotFound) {
@@ -2853,7 +2853,7 @@ func (u *UniterAPI) updatedNetworkInfo(
 		return nil, nil
 	}
 
-	relationNetworkInfos, err := u.networkService.GetUnitRelationNetwork(ctx, unitName, relationUUIDs)
+	relationNetworkInfos, err := u.networkService.GetUnitRelationNetworks(ctx, unitName, relationUUIDs)
 	if err != nil {
 		return nil, internalerrors.Errorf("getting updated relation network info for unit %q: %w", unitName, err)
 	}
@@ -3084,7 +3084,7 @@ func (u *UniterAPI) setUnitRelationNetworks(ctx context.Context, name coreunit.N
 		if err != nil {
 			return internalerrors.Errorf("getting relation UUID: %w", err)
 		}
-		unitNetworks, err := u.networkService.GetUnitRelationNetwork(
+		unitNetworks, err := u.networkService.GetUnitRelationNetworks(
 			ctx, name, []corerelation.UUID{relationUUID},
 		)
 		if err != nil {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3415,10 +3415,10 @@ func (s *commitHookChangesSuite) TestCommitHookChangesOneTxn(c *tc.C) {
 		CharmState: arg.SetUnitState.CharmState,
 		UpdatedRelationNetworkInfo: map[corerelation.UUID]unitstate.Settings{
 			relationUUID: map[string]string{
-				unitstate.IngressAddressKey: "10.0.0.7",
-				unitstate.EgressSubnetsKey:  "10.0.0.0/24, 10.0.1.0/24",
+					unitstate.IngressAddressKey: "10.0.0.7",
+					unitstate.EgressSubnetsKey:  "10.0.0.0/24,10.0.1.0/24",
+				},
 			},
-		},
 		ClosePorts: network.GroupedPortRanges{
 			"ep0": []network.PortRange{{
 				Protocol: "icmp", FromPort: 22, ToPort: 22,

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2359,8 +2359,13 @@ func (s *uniterRelationSuite) TestNetworkInfoWithRelationUsesRelationNetwork(c *
 		RelationId: &relID,
 	}
 
+	s.networkService.EXPECT().GetUnitEndpointNetworks(
+		gomock.Any(), unitName, args.Endpoints,
+	).Return([]domainnetwork.UnitNetwork{{
+		EndpointName:     "database",
+		IngressAddresses: []string{"192.0.2.10"},
+	}}, nil)
 	s.expectGetRelationUUIDByID(relID, relUUID, nil)
-	s.networkService.EXPECT().GetUnitEndpointNetworks(gomock.Any(), unitName, args.Endpoints).Times(0)
 	s.networkService.EXPECT().GetUnitRelationNetworks(
 		gomock.Any(), unitName, []corerelation.UUID{relUUID},
 	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
@@ -2396,6 +2401,46 @@ func (s *uniterRelationSuite) TestNetworkInfoWithRelationUsesRelationNetwork(c *
 				}},
 				IngressAddresses: []string{"198.51.100.10"},
 				EgressSubnets:    []string{"203.0.113.0/24"},
+			},
+		},
+	})
+}
+
+func (s *uniterRelationSuite) TestNetworkInfoWithRelationPreservesRequestedEndpointNetworks(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relID := 42
+	relUUID := tc.Must(c, corerelation.NewUUID)
+	unitName := coreunit.Name(s.wordpressUnitTag.Id())
+	args := params.NetworkInfoParams{
+		Unit:       s.wordpressUnitTag.String(),
+		Endpoints:  []string{"database"},
+		RelationId: &relID,
+	}
+
+	s.networkService.EXPECT().GetUnitEndpointNetworks(
+		gomock.Any(), unitName, args.Endpoints,
+	).Return([]domainnetwork.UnitNetwork{{
+		EndpointName:     "database",
+		IngressAddresses: []string{"192.0.2.10"},
+	}}, nil)
+	s.expectGetRelationUUIDByID(relID, relUUID, nil)
+	s.networkService.EXPECT().GetUnitRelationNetworks(
+		gomock.Any(), unitName, []corerelation.UUID{relUUID},
+	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+		relUUID: {
+			EndpointName:     "database-peers",
+			IngressAddresses: []string{"198.51.100.10"},
+			EgressSubnets:    []string{"203.0.113.0/24"},
+		},
+	}, nil)
+
+	result, err := s.uniter.NetworkInfo(c.Context(), args)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.NetworkInfoResults{
+		Results: map[string]params.NetworkInfoResult{
+			"database": {
+				IngressAddresses: []string{"192.0.2.10"},
 			},
 		},
 	})
@@ -3415,10 +3460,10 @@ func (s *commitHookChangesSuite) TestCommitHookChangesOneTxn(c *tc.C) {
 		CharmState: arg.SetUnitState.CharmState,
 		UpdatedRelationNetworkInfo: map[corerelation.UUID]unitstate.Settings{
 			relationUUID: map[string]string{
-					unitstate.IngressAddressKey: "10.0.0.7",
-					unitstate.EgressSubnetsKey:  "10.0.0.0/24,10.0.1.0/24",
-				},
+				unitstate.IngressAddressKey: "10.0.0.7",
+				unitstate.EgressSubnetsKey:  "10.0.0.0/24,10.0.1.0/24",
 			},
+		},
 		ClosePorts: network.GroupedPortRanges{
 			"ep0": []network.PortRange{{
 				Protocol: "icmp", FromPort: 22, ToPort: 22,

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2359,26 +2359,25 @@ func (s *uniterRelationSuite) TestNetworkInfoWithRelationUsesRelationNetwork(c *
 		RelationId: &relID,
 	}
 
-	s.networkService.EXPECT().GetUnitEndpointNetworks(
-		gomock.Any(), unitName, args.Endpoints,
-	).Return([]domainnetwork.UnitNetwork{{
-		EndpointName:     "database",
-		IngressAddresses: []string{"192.0.2.10"},
-	}}, nil)
 	s.expectGetRelationUUIDByID(relID, relUUID, nil)
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relUUID).Return(domainnetwork.UnitNetwork{
-		EndpointName:     "database",
-		IngressAddresses: []string{"198.51.100.10"},
-		EgressSubnets:    []string{"203.0.113.0/24"},
-		DeviceInfos: []domainnetwork.DeviceInfo{{
-			Name:       "eth0",
-			MACAddress: "aa:bb:cc:dd:ee:ff",
-			Addresses: []domainnetwork.AddressInfo{{
-				Hostname: "db.internal",
-				Value:    "10.0.0.10",
-				CIDR:     "10.0.0.0/24",
+	s.networkService.EXPECT().GetUnitEndpointNetworks(gomock.Any(), unitName, args.Endpoints).Times(0)
+	s.networkService.EXPECT().GetUnitRelationNetwork(
+		gomock.Any(), unitName, []corerelation.UUID{relUUID},
+	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+		relUUID: {
+			EndpointName:     "database",
+			IngressAddresses: []string{"198.51.100.10"},
+			EgressSubnets:    []string{"203.0.113.0/24"},
+			DeviceInfos: []domainnetwork.DeviceInfo{{
+				Name:       "eth0",
+				MACAddress: "aa:bb:cc:dd:ee:ff",
+				Addresses: []domainnetwork.AddressInfo{{
+					Hostname: "db.internal",
+					Value:    "10.0.0.10",
+					CIDR:     "10.0.0.0/24",
+				}},
 			}},
-		}},
+		},
 	}, nil)
 
 	result, err := s.uniter.NetworkInfo(c.Context(), args)
@@ -2397,42 +2396,6 @@ func (s *uniterRelationSuite) TestNetworkInfoWithRelationUsesRelationNetwork(c *
 				}},
 				IngressAddresses: []string{"198.51.100.10"},
 				EgressSubnets:    []string{"203.0.113.0/24"},
-			},
-		},
-	})
-}
-
-func (s *uniterRelationSuite) TestNetworkInfoWithRelationPreservesRequestedEndpointNetworks(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	relID := 42
-	relUUID := tc.Must(c, corerelation.NewUUID)
-	unitName := coreunit.Name(s.wordpressUnitTag.Id())
-	args := params.NetworkInfoParams{
-		Unit:       s.wordpressUnitTag.String(),
-		Endpoints:  []string{"database"},
-		RelationId: &relID,
-	}
-
-	s.networkService.EXPECT().GetUnitEndpointNetworks(
-		gomock.Any(), unitName, args.Endpoints,
-	).Return([]domainnetwork.UnitNetwork{{
-		EndpointName:     "database",
-		IngressAddresses: []string{"192.0.2.10"},
-	}}, nil)
-	s.expectGetRelationUUIDByID(relID, relUUID, nil)
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relUUID).Return(domainnetwork.UnitNetwork{
-		EndpointName:     "database-peers",
-		IngressAddresses: []string{"198.51.100.10"},
-		EgressSubnets:    []string{"203.0.113.0/24"},
-	}, nil)
-
-	result, err := s.uniter.NetworkInfo(c.Context(), args)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result, tc.DeepEquals, params.NetworkInfoResults{
-		Results: map[string]params.NetworkInfoResult{
-			"database": {
-				IngressAddresses: []string{"192.0.2.10"},
 			},
 		},
 	})
@@ -2907,9 +2870,13 @@ func (s *uniterRelationSuite) TestEnterScope(c *tc.C) {
 	settings := map[string]string{"ingress-address": addr}
 	s.expectEnterScope(relUUID, unitName, settings, nil)
 
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relUUID).Return(domainnetwork.UnitNetwork{
-		EndpointName:     "mysql",
-		IngressAddresses: []string{addr},
+	s.networkService.EXPECT().GetUnitRelationNetwork(
+		gomock.Any(), unitName, []corerelation.UUID{relUUID},
+	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+		relUUID: {
+			EndpointName:     "mysql",
+			IngressAddresses: []string{addr},
+		},
 	}, nil)
 
 	// act
@@ -2938,10 +2905,14 @@ func (s *uniterRelationSuite) TestEnterScopeWithEgress(c *tc.C) {
 
 	s.expectGetRelationUUIDByKey(relKey, relUUID, nil)
 	s.expectEnterScope(relUUID, unitName, settings, nil)
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relUUID).Return(domainnetwork.UnitNetwork{
-		EndpointName:     "mysql",
-		IngressAddresses: []string{"x.x.x.x"},
-		EgressSubnets:    []string{"192.168.0.0/24", "10.0.0.0/8"},
+	s.networkService.EXPECT().GetUnitRelationNetwork(
+		gomock.Any(), unitName, []corerelation.UUID{relUUID},
+	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+		relUUID: {
+			EndpointName:     "mysql",
+			IngressAddresses: []string{"x.x.x.x"},
+			EgressSubnets:    []string{"192.168.0.0/24", "10.0.0.0/8"},
+		},
 	}, nil)
 
 	// act
@@ -2970,9 +2941,13 @@ func (s *uniterRelationSuite) TestEnterScopeReturnsPotentialRelationUnitNotValid
 	settings := map[string]string{"ingress-address": addr}
 	s.expectEnterScope(relUUID, unitName, settings,
 		relationerrors.PotentialRelationUnitNotValid)
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relUUID).Return(domainnetwork.UnitNetwork{
-		EndpointName:     "mysql",
-		IngressAddresses: []string{addr},
+	s.networkService.EXPECT().GetUnitRelationNetwork(
+		gomock.Any(), unitName, []corerelation.UUID{relUUID},
+	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+		relUUID: {
+			EndpointName:     "mysql",
+			IngressAddresses: []string{addr},
+		},
 	}, nil)
 
 	// act
@@ -3400,7 +3375,8 @@ func (s *commitHookChangesSuite) TestCommitHookChangesOneTxn(c *tc.C) {
 
 	// Arrange: SetUnitStateArg
 	arg := params.CommitHookChangesArg{
-		Tag: unitTag.String(),
+		Tag:               unitTag.String(),
+		UpdateNetworkInfo: true,
 		SetUnitState: &params.SetUnitStateArg{
 			Tag:        unitTag.String(),
 			CharmState: &map[string]string{"key": "value"},
@@ -3419,10 +3395,30 @@ func (s *commitHookChangesSuite) TestCommitHookChangesOneTxn(c *tc.C) {
 		}},
 	}
 
+	// Arrange: update network info
+	relationUUID := tc.Must(c, corerelation.NewUUID)
+	s.relationService.EXPECT().GetRelationUUIDsByUnitName(
+		gomock.Any(), unitName,
+	).Return([]corerelation.UUID{relationUUID}, nil)
+	s.networkService.EXPECT().GetUnitRelationNetwork(
+		gomock.Any(), unitName, []corerelation.UUID{relationUUID},
+	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+		relationUUID: {
+			IngressAddresses: []string{"10.0.0.7"},
+			EgressSubnets:    []string{"10.0.0.0/24", "10.0.1.0/24"},
+		},
+	}, nil)
+
 	// Arrange: CommitHookChanges service call
 	domainArg := unitstate.CommitHookChangesArg{
 		UnitName:   unitName,
 		CharmState: arg.SetUnitState.CharmState,
+		UpdatedRelationNetworkInfo: map[corerelation.UUID]unitstate.Settings{
+			relationUUID: map[string]string{
+				unitstate.IngressAddressKey: "10.0.0.7",
+				unitstate.EgressSubnetsKey:  "10.0.0.0/24, 10.0.1.0/24",
+			},
+		},
 		ClosePorts: network.GroupedPortRanges{
 			"ep0": []network.PortRange{{
 				Protocol: "icmp", FromPort: 22, ToPort: 22,
@@ -3798,21 +3794,23 @@ func (s *commitHookChangesSuite) expectedSetRelationUnitSettings(unitName coreun
 
 func (s *commitHookChangesSuite) expectGetUnitRelationNetwork(unitName coreunit.Name, relationUUID corerelation.UUID,
 	ingress string) {
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relationUUID).Return(domainnetwork.UnitNetwork{
-		IngressAddresses: []string{ingress},
+	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+		relationUUID: {IngressAddresses: []string{ingress}},
 	}, nil)
 }
 
 func (s *commitHookChangesSuite) expectGetUnitRelationNetworkWithEgress(unitName coreunit.Name, relationUUID corerelation.UUID,
 	ingress, egress string) {
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relationUUID).Return(domainnetwork.UnitNetwork{
-		IngressAddresses: []string{ingress},
-		EgressSubnets:    []string{egress},
+	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+		relationUUID: {
+			IngressAddresses: []string{ingress},
+			EgressSubnets:    []string{egress},
+		},
 	}, nil)
 }
 
 func (s *commitHookChangesSuite) expectGetUnitRelationNetworkError(unitName coreunit.Name, relationUUID corerelation.UUID, err error) {
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relationUUID).Return(domainnetwork.UnitNetwork{}, err)
+	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{}, err)
 }
 
 func (s *commitHookChangesSuite) expectGetUnitUUID(unitName coreunit.Name, unitUUID coreunit.UUID, err error) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2361,7 +2361,7 @@ func (s *uniterRelationSuite) TestNetworkInfoWithRelationUsesRelationNetwork(c *
 
 	s.expectGetRelationUUIDByID(relID, relUUID, nil)
 	s.networkService.EXPECT().GetUnitEndpointNetworks(gomock.Any(), unitName, args.Endpoints).Times(0)
-	s.networkService.EXPECT().GetUnitRelationNetwork(
+	s.networkService.EXPECT().GetUnitRelationNetworks(
 		gomock.Any(), unitName, []corerelation.UUID{relUUID},
 	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
 		relUUID: {
@@ -2870,7 +2870,7 @@ func (s *uniterRelationSuite) TestEnterScope(c *tc.C) {
 	settings := map[string]string{"ingress-address": addr}
 	s.expectEnterScope(relUUID, unitName, settings, nil)
 
-	s.networkService.EXPECT().GetUnitRelationNetwork(
+	s.networkService.EXPECT().GetUnitRelationNetworks(
 		gomock.Any(), unitName, []corerelation.UUID{relUUID},
 	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
 		relUUID: {
@@ -2905,7 +2905,7 @@ func (s *uniterRelationSuite) TestEnterScopeWithEgress(c *tc.C) {
 
 	s.expectGetRelationUUIDByKey(relKey, relUUID, nil)
 	s.expectEnterScope(relUUID, unitName, settings, nil)
-	s.networkService.EXPECT().GetUnitRelationNetwork(
+	s.networkService.EXPECT().GetUnitRelationNetworks(
 		gomock.Any(), unitName, []corerelation.UUID{relUUID},
 	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
 		relUUID: {
@@ -2941,7 +2941,7 @@ func (s *uniterRelationSuite) TestEnterScopeReturnsPotentialRelationUnitNotValid
 	settings := map[string]string{"ingress-address": addr}
 	s.expectEnterScope(relUUID, unitName, settings,
 		relationerrors.PotentialRelationUnitNotValid)
-	s.networkService.EXPECT().GetUnitRelationNetwork(
+	s.networkService.EXPECT().GetUnitRelationNetworks(
 		gomock.Any(), unitName, []corerelation.UUID{relUUID},
 	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
 		relUUID: {
@@ -3400,7 +3400,7 @@ func (s *commitHookChangesSuite) TestCommitHookChangesOneTxn(c *tc.C) {
 	s.relationService.EXPECT().GetRelationUUIDsByUnitName(
 		gomock.Any(), unitName,
 	).Return([]corerelation.UUID{relationUUID}, nil)
-	s.networkService.EXPECT().GetUnitRelationNetwork(
+	s.networkService.EXPECT().GetUnitRelationNetworks(
 		gomock.Any(), unitName, []corerelation.UUID{relationUUID},
 	).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
 		relationUUID: {
@@ -3591,7 +3591,7 @@ func (s *commitHookChangesSuite) TestSetUnitRelationNetworks(c *tc.C) {
 
 	// For relation 1
 	s.expectGetRelationUUIDByKey(relKey1, relUUID1)
-	s.expectGetUnitRelationNetworkWithEgress(unitName, relUUID1, "10.0.0.1", "192.168.0.0/24")
+	s.expectGetUnitRelationNetworksWithEgress(unitName, relUUID1, "10.0.0.1", "192.168.0.0/24")
 	s.expectedSetRelationUnitSettings(unitName, relUUID1, map[string]string{
 		"ingress-address": "10.0.0.1",
 		"egress-subnets":  "192.168.0.0/24",
@@ -3599,7 +3599,7 @@ func (s *commitHookChangesSuite) TestSetUnitRelationNetworks(c *tc.C) {
 
 	// For relation 2
 	s.expectGetRelationUUIDByKey(relKey2, relUUID2)
-	s.expectGetUnitRelationNetwork(unitName, relUUID2, "10.0.0.2")
+	s.expectGetUnitRelationNetworks(unitName, relUUID2, "10.0.0.2")
 	s.expectedSetRelationUnitSettings(unitName, relUUID2, map[string]string{
 		"ingress-address": "10.0.0.2",
 	})
@@ -3671,7 +3671,7 @@ func (s *commitHookChangesSuite) TestSetUnitRelationNetworksGetRelationUUIDError
 	c.Assert(err.Error(), tc.Matches, `getting relation UUID: relation not found`)
 }
 
-func (s *commitHookChangesSuite) TestSetUnitRelationNetworksGetUnitRelationNetworkError(c *tc.C) {
+func (s *commitHookChangesSuite) TestSetUnitRelationNetworksGetUnitRelationNetworksError(c *tc.C) {
 	// arrange
 	defer s.setupMocks(c).Finish()
 	unitName := coreunit.Name("wordpress/0")
@@ -3686,7 +3686,7 @@ func (s *commitHookChangesSuite) TestSetUnitRelationNetworksGetUnitRelationNetwo
 		{Key: relKey, InScope: true},
 	}, nil)
 	s.expectGetRelationUUIDByKey(relKey, relUUID)
-	s.expectGetUnitRelationNetworkError(unitName, relUUID, expectedErr)
+	s.expectGetUnitRelationNetworksError(unitName, relUUID, expectedErr)
 
 	// act
 	err := s.uniter.setUnitRelationNetworks(c.Context(), unitName)
@@ -3711,7 +3711,7 @@ func (s *commitHookChangesSuite) TestSetUnitRelationNetworksSetRelationSettingsE
 		{Key: relKey, InScope: true},
 	}, nil)
 	s.expectGetRelationUUIDByKey(relKey, relUUID)
-	s.expectGetUnitRelationNetwork(unitName, relUUID, "10.0.0.1")
+	s.expectGetUnitRelationNetworks(unitName, relUUID, "10.0.0.1")
 	s.relationService.EXPECT().SetRelationUnitSettings(
 		gomock.Any(),
 		unitName,
@@ -3744,7 +3744,7 @@ func (s *commitHookChangesSuite) TestSetUnitRelationNetworksSkipsRelationsNotInS
 	// Only relation 2 should be processed
 	relUUID2 := tc.Must(c, corerelation.NewUUID)
 	s.expectGetRelationUUIDByKey(relKey2, relUUID2)
-	s.expectGetUnitRelationNetwork(unitName, relUUID2, "10.0.0.2")
+	s.expectGetUnitRelationNetworks(unitName, relUUID2, "10.0.0.2")
 	s.expectedSetRelationUnitSettings(unitName, relUUID2, map[string]string{
 		"ingress-address": "10.0.0.2",
 	})
@@ -3792,16 +3792,16 @@ func (s *commitHookChangesSuite) expectedSetRelationUnitSettings(unitName coreun
 	s.relationService.EXPECT().SetRelationUnitSettings(gomock.Any(), unitName, uuid, unitSettings).Return(nil)
 }
 
-func (s *commitHookChangesSuite) expectGetUnitRelationNetwork(unitName coreunit.Name, relationUUID corerelation.UUID,
+func (s *commitHookChangesSuite) expectGetUnitRelationNetworks(unitName coreunit.Name, relationUUID corerelation.UUID,
 	ingress string) {
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+	s.networkService.EXPECT().GetUnitRelationNetworks(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
 		relationUUID: {IngressAddresses: []string{ingress}},
 	}, nil)
 }
 
-func (s *commitHookChangesSuite) expectGetUnitRelationNetworkWithEgress(unitName coreunit.Name, relationUUID corerelation.UUID,
+func (s *commitHookChangesSuite) expectGetUnitRelationNetworksWithEgress(unitName coreunit.Name, relationUUID corerelation.UUID,
 	ingress, egress string) {
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
+	s.networkService.EXPECT().GetUnitRelationNetworks(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{
 		relationUUID: {
 			IngressAddresses: []string{ingress},
 			EgressSubnets:    []string{egress},
@@ -3809,8 +3809,8 @@ func (s *commitHookChangesSuite) expectGetUnitRelationNetworkWithEgress(unitName
 	}, nil)
 }
 
-func (s *commitHookChangesSuite) expectGetUnitRelationNetworkError(unitName coreunit.Name, relationUUID corerelation.UUID, err error) {
-	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{}, err)
+func (s *commitHookChangesSuite) expectGetUnitRelationNetworksError(unitName coreunit.Name, relationUUID corerelation.UUID, err error) {
+	s.networkService.EXPECT().GetUnitRelationNetworks(gomock.Any(), unitName, []corerelation.UUID{relationUUID}).Return(map[corerelation.UUID]domainnetwork.UnitNetwork{}, err)
 }
 
 func (s *commitHookChangesSuite) expectGetUnitUUID(unitName coreunit.Name, unitUUID coreunit.UUID, err error) {

--- a/core/watcher/watchertest/harness.go
+++ b/core/watcher/watchertest/harness.go
@@ -112,15 +112,13 @@ func (h *Harness[T]) Run(c *tc.C, initial ...T) {
 		test.setup(c)
 		h.idler.AssertChangeStreamIdle(c)
 		test.assert(h.watcher)
+
+		// Ensure that the watcher doesn't emit any more changes.
+		h.watcher.AssertNoChange()
+		h.idler.AssertChangeStreamIdle(c)
 	}
 
-	// Ensure that the watcher doesn't emit any more changes.
-
-	h.watcher.AssertNoChange()
-	h.idler.AssertChangeStreamIdle(c)
-
-	// Now ensure that the watcher is also killed cleanly.
-
+	// Ensure that the watcher is killed cleanly.
 	h.watcher.AssertKilled()
 }
 

--- a/domain/network/service/unitinfo.go
+++ b/domain/network/service/unitinfo.go
@@ -22,55 +22,56 @@ import (
 )
 
 // GetUnitRelationNetwork retrieves network relation information for a given
-// unit and relation UUID.
+// unit and relation UUIDs.
 //
 // The following errors may be returned:
 //   - [applicationerrors.UnitNotFound] if the unit does not exist.
 //   - [relationerrors.RelationNotFound] if the relation doesn't belong to the
 //     unit.
-func (s *ProviderService) GetUnitRelationNetwork(ctx context.Context, unitName coreunit.Name,
-	relationUUID corerelation.UUID) (domainnetwork.UnitNetwork, error) {
+func (s *ProviderService) GetUnitRelationNetwork(
+	ctx context.Context, unitName coreunit.Name, relationUUIDs []corerelation.UUID,
+) (map[corerelation.UUID]domainnetwork.UnitNetwork, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	unitUUID, err := s.st.GetUnitUUIDByName(ctx, unitName)
 	if err != nil {
-		return domainnetwork.UnitNetwork{}, internalerrors.Capture(err)
+		return nil, internalerrors.Capture(err)
 	}
 
-	endpointName, err := s.st.GetUnitRelationEndpointName(
-		ctx, unitUUID.String(), relationUUID.String(),
-	)
-	if internalerrors.Is(err, relationerrors.RelationNotFound) {
-		return domainnetwork.UnitNetwork{}, relationerrors.RelationNotFound
-	} else if err != nil {
-		return domainnetwork.UnitNetwork{}, internalerrors.Errorf(
-			"getting endpoint name for relation %q: %w", relationUUID, err,
+	result := make(map[corerelation.UUID]domainnetwork.UnitNetwork, len(relationUUIDs))
+	for _, relationUUID := range relationUUIDs {
+		endpointName, err := s.st.GetUnitRelationEndpointName(
+			ctx, unitUUID.String(), relationUUID.String(),
 		)
-	}
+		if internalerrors.Is(err, relationerrors.RelationNotFound) {
+			return nil, relationerrors.RelationNotFound
+		} else if err != nil {
+			return nil, internalerrors.Errorf(
+				"getting endpoint name for relation %q: %w", relationUUID, err,
+			)
+		}
 
-	egressSubnets, err := s.getRelationEgressSubnets(ctx, relationUUID, unitUUID)
-	if err != nil {
-		return domainnetwork.UnitNetwork{}, internalerrors.Capture(err)
-	}
+		egressSubnets, err := s.getRelationEgressSubnets(ctx, relationUUID, unitUUID)
+		if err != nil {
+			return nil, internalerrors.Capture(err)
+		}
 
-	infos, err := s.getUnitEndpointNetworks(
-		ctx, unitUUID.String(), []string{endpointName}, egressSubnets,
-	)
-	if err != nil {
-		return domainnetwork.UnitNetwork{}, internalerrors.Errorf("getting unit endpoint networks: %w", err)
-	}
-	if len(infos) != 1 {
-		// Should not happen unless the interface contract for
-		// GetUnitEndpointNetworks is broken.
-		// If not broken, providing exactly one endpoint as a parameter for
-		// GetUnitEndpointNetworks should return exactly one info.
-		return domainnetwork.UnitNetwork{}, internalerrors.Errorf(
-			"expected 1 NetworkInfo for unit %q on endpoint %q, got %d",
-			unitName, endpointName, len(infos),
+		infos, err := s.getUnitEndpointNetworks(
+			ctx, unitUUID.String(), []string{endpointName}, egressSubnets,
 		)
+		if err != nil {
+			return nil, internalerrors.Errorf("getting unit endpoint networks: %w", err)
+		}
+		if len(infos) != 1 {
+			return nil, internalerrors.Errorf(
+				"expected 1 NetworkInfo for unit %q on endpoint %q, got %d",
+				unitName, endpointName, len(infos),
+			)
+		}
+		result[relationUUID] = infos[0]
 	}
-	return infos[0], nil
+	return result, nil
 }
 
 // GetUnitEndpointNetworks retrieves network relation information for a given

--- a/domain/network/service/unitinfo.go
+++ b/domain/network/service/unitinfo.go
@@ -95,21 +95,19 @@ func (s *ProviderService) GetUnitEndpointNetworks(
 		return nil, internalerrors.Capture(err)
 	}
 
-	egressSubnets, err := s.getUnitEgressSubnets(ctx, unitUUID)
+	defaultEgressSubnets, err := s.st.GetModelEgressSubnets(ctx)
 	if err != nil {
-		return nil, internalerrors.Capture(err)
+		return nil, internalerrors.Errorf("getting model egress subnets: %w", err)
 	}
 
-	return s.getUnitEndpointNetworks(
-		ctx, unitUUID.String(), endpointNames, egressSubnets,
-	)
+	return s.getUnitEndpointNetworks(ctx, unitUUID.String(), endpointNames, defaultEgressSubnets)
 }
 
 func (s *ProviderService) getUnitEndpointNetworks(
 	ctx context.Context,
 	unitUUID string,
 	endpointNames []string,
-	egressSubnets []string,
+	defaultEgressSubnets []string,
 ) ([]domainnetwork.UnitNetwork, error) {
 	supportsNetworking, err := s.supportsNetworking(ctx)
 	if err != nil {
@@ -122,13 +120,10 @@ func (s *ProviderService) getUnitEndpointNetworks(
 	}
 
 	if !supportsNetworking {
-		return s.getUnitEndpointNetworksWithoutProviderNetworking(
-			ctx, unitUUID, endpointNames, isCaas, egressSubnets)
+		return s.getUnitEndpointNetworksWithoutProviderNetworking(ctx, unitUUID, endpointNames, isCaas, defaultEgressSubnets)
 	}
 
-	endpointNetworks, err := s.st.GetUnitEndpointNetworkInfo(
-		ctx, unitUUID, endpointNames,
-	)
+	endpointNetworks, err := s.st.GetUnitEndpointNetworkInfo(ctx, unitUUID, endpointNames)
 	if err != nil {
 		return nil, internalerrors.Errorf("getting unit endpoint network info: %w", err)
 	}
@@ -141,7 +136,10 @@ func (s *ProviderService) getUnitEndpointNetworks(
 			isCaas,
 		)
 		info.EndpointName = endpointNetwork.EndpointName
-		info.EgressSubnets = egressSubnets
+		info.EgressSubnets = defaultEgressSubnets
+		if len(info.EgressSubnets) == 0 {
+			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
+		}
 		result[i] = info
 	}
 
@@ -178,29 +176,6 @@ func (s *ProviderService) getRelationEgressSubnets(
 		)
 	}
 	return publicEgressSubnets, nil
-}
-
-func (s *ProviderService) getUnitEgressSubnets(
-	ctx context.Context,
-	unitUUID coreunit.UUID,
-) ([]string, error) {
-	egressSubnets, err := s.st.GetUnitEgressSubnets(ctx, unitUUID.String())
-	if err != nil {
-		return nil, internalerrors.Errorf("getting unit egress subnets: %w", err)
-	}
-	if len(egressSubnets) > 0 {
-		return egressSubnets, nil
-	}
-
-	modelEgressSubnets, err := s.st.GetModelEgressSubnets(ctx)
-	if err != nil {
-		return nil, internalerrors.Errorf("getting model egress subnets: %w", err)
-	}
-	if len(modelEgressSubnets) > 0 {
-		return modelEgressSubnets, nil
-	}
-
-	return s.getUnitPublicEgressSubnets(ctx, unitUUID)
 }
 
 func (s *ProviderService) getUnitPublicEgressSubnets(
@@ -264,19 +239,25 @@ func normaliseAddress(address string) string {
 	return before
 }
 
+func subnetsForAddresses(addrs []string) []string {
+	if egress := corenetwork.SubnetsForAddresses(addrs); len(egress) > 0 {
+		return egress[:1]
+	}
+	return nil
+}
+
 func (s *ProviderService) getUnitEndpointNetworksWithoutProviderNetworking(
-	ctx context.Context, unitUUID string, endpointNames []string, isCaas bool, egressSubnets []string,
+	ctx context.Context, unitUUID string, endpointNames []string, isCaas bool, defaultEgressSubnets []string,
 ) ([]domainnetwork.UnitNetwork, error) {
 	unitNetwork, err := s.st.GetUnitNetworkInfo(ctx, unitUUID)
 	if err != nil {
-		return nil, internalerrors.Errorf(
-			"getting unit network info: %w", err,
-		)
+		return nil, internalerrors.Errorf("getting unit network info: %w", err)
 	}
-	info := buildUnitNetworkWithIngressAddresses(
-		unitNetwork.Addresses, unitNetwork.IngressAddresses, isCaas,
-	)
-	info.EgressSubnets = egressSubnets
+	info := buildUnitNetworkWithIngressAddresses(unitNetwork.Addresses, unitNetwork.IngressAddresses, isCaas)
+	info.EgressSubnets = defaultEgressSubnets
+	if len(info.EgressSubnets) == 0 {
+		info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
+	}
 
 	infos := make([]domainnetwork.UnitNetwork, len(endpointNames))
 	for i, endpointName := range endpointNames {

--- a/domain/network/service/unitinfo.go
+++ b/domain/network/service/unitinfo.go
@@ -21,14 +21,14 @@ import (
 	internalerrors "github.com/juju/juju/internal/errors"
 )
 
-// GetUnitRelationNetwork retrieves network relation information for a given
+// GetUnitRelationNetworks retrieves network relation information for a given
 // unit and relation UUIDs.
 //
 // The following errors may be returned:
 //   - [applicationerrors.UnitNotFound] if the unit does not exist.
 //   - [relationerrors.RelationNotFound] if the relation doesn't belong to the
 //     unit.
-func (s *ProviderService) GetUnitRelationNetwork(
+func (s *ProviderService) GetUnitRelationNetworks(
 	ctx context.Context, unitName coreunit.Name, relationUUIDs []corerelation.UUID,
 ) (map[corerelation.UUID]domainnetwork.UnitNetwork, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())

--- a/domain/network/service/unitinfo_test.go
+++ b/domain/network/service/unitinfo_test.go
@@ -258,10 +258,12 @@ func (s *infoSuite) TestGetUnitRelationNetwork(c *tc.C) {
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	info, err := service.GetUnitRelationNetwork(
-		c.Context(), unitName, relationUUID,
+	infoMap, err := service.GetUnitRelationNetwork(
+		c.Context(), unitName, []corerelation.UUID{relationUUID},
 	)
 	c.Assert(err, tc.ErrorIsNil)
+	info, ok := infoMap[relationUUID]
+	c.Assert(ok, tc.IsTrue)
 	c.Check(info.EndpointName, tc.Equals, endpointName)
 	c.Check(info.IngressAddresses, tc.DeepEquals, []string{"192.168.1.10"})
 	c.Check(info.EgressSubnets, tc.DeepEquals, []string{"192.168.1.0/24"})
@@ -298,10 +300,12 @@ func (s *infoSuite) TestGetUnitRelationNetworkFallsBackToModelEgressSubnets(c *t
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	info, err := service.GetUnitRelationNetwork(
-		c.Context(), unitName, relationUUID,
+	infoMap, err := service.GetUnitRelationNetwork(
+		c.Context(), unitName, []corerelation.UUID{relationUUID},
 	)
 	c.Assert(err, tc.ErrorIsNil)
+	info, ok := infoMap[relationUUID]
+	c.Assert(ok, tc.IsTrue)
 	c.Check(info.EgressSubnets, tc.DeepEquals, []string{"203.0.113.0/24"})
 }
 
@@ -339,10 +343,12 @@ func (s *infoSuite) TestGetUnitRelationNetworkFallsBackToPublicEgressSubnets(c *
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	info, err := service.GetUnitRelationNetwork(
-		c.Context(), unitName, relationUUID,
+	infoMap, err := service.GetUnitRelationNetwork(
+		c.Context(), unitName, []corerelation.UUID{relationUUID},
 	)
 	c.Assert(err, tc.ErrorIsNil)
+	info, ok := infoMap[relationUUID]
+	c.Assert(ok, tc.IsTrue)
 	c.Check(info.EgressSubnets, tc.DeepEquals, []string{"198.51.100.10/32"})
 }
 
@@ -361,7 +367,7 @@ func (s *infoSuite) TestGetUnitRelationNetworkRelationNotFound(c *tc.C) {
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	_, err := service.GetUnitRelationNetwork(c.Context(), unitName, relationUUID)
+	_, err := service.GetUnitRelationNetwork(c.Context(), unitName, []corerelation.UUID{relationUUID})
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
@@ -384,7 +390,7 @@ func (s *infoSuite) TestGetUnitRelationNetworkGetRelationEgressSubnetsError(c *t
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	_, err := service.GetUnitRelationNetwork(c.Context(), unitName, relationUUID)
+	_, err := service.GetUnitRelationNetwork(c.Context(), unitName, []corerelation.UUID{relationUUID})
 	c.Assert(
 		err,
 		tc.ErrorMatches,

--- a/domain/network/service/unitinfo_test.go
+++ b/domain/network/service/unitinfo_test.go
@@ -228,7 +228,7 @@ func (s *infoSuite) TestGetUnitEndpointNetworksFallsBackToPublicEgressSubnets(c 
 	c.Check(infos[0].EgressSubnets, tc.DeepEquals, []string{"198.51.100.10/32"})
 }
 
-func (s *infoSuite) TestGetUnitRelationNetwork(c *tc.C) {
+func (s *infoSuite) TestGetUnitRelationNetworks(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	unitName := coreunit.Name("mysql/0")
@@ -258,7 +258,7 @@ func (s *infoSuite) TestGetUnitRelationNetwork(c *tc.C) {
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	infoMap, err := service.GetUnitRelationNetwork(
+	infoMap, err := service.GetUnitRelationNetworks(
 		c.Context(), unitName, []corerelation.UUID{relationUUID},
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -269,7 +269,7 @@ func (s *infoSuite) TestGetUnitRelationNetwork(c *tc.C) {
 	c.Check(info.EgressSubnets, tc.DeepEquals, []string{"192.168.1.0/24"})
 }
 
-func (s *infoSuite) TestGetUnitRelationNetworkFallsBackToModelEgressSubnets(c *tc.C) {
+func (s *infoSuite) TestGetUnitRelationNetworksFallsBackToModelEgressSubnets(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	unitName := coreunit.Name("mysql/0")
@@ -300,7 +300,7 @@ func (s *infoSuite) TestGetUnitRelationNetworkFallsBackToModelEgressSubnets(c *t
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	infoMap, err := service.GetUnitRelationNetwork(
+	infoMap, err := service.GetUnitRelationNetworks(
 		c.Context(), unitName, []corerelation.UUID{relationUUID},
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -309,7 +309,7 @@ func (s *infoSuite) TestGetUnitRelationNetworkFallsBackToModelEgressSubnets(c *t
 	c.Check(info.EgressSubnets, tc.DeepEquals, []string{"203.0.113.0/24"})
 }
 
-func (s *infoSuite) TestGetUnitRelationNetworkFallsBackToPublicEgressSubnets(c *tc.C) {
+func (s *infoSuite) TestGetUnitRelationNetworksFallsBackToPublicEgressSubnets(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	unitName := coreunit.Name("mysql/0")
@@ -343,7 +343,7 @@ func (s *infoSuite) TestGetUnitRelationNetworkFallsBackToPublicEgressSubnets(c *
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	infoMap, err := service.GetUnitRelationNetwork(
+	infoMap, err := service.GetUnitRelationNetworks(
 		c.Context(), unitName, []corerelation.UUID{relationUUID},
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -352,7 +352,7 @@ func (s *infoSuite) TestGetUnitRelationNetworkFallsBackToPublicEgressSubnets(c *
 	c.Check(info.EgressSubnets, tc.DeepEquals, []string{"198.51.100.10/32"})
 }
 
-func (s *infoSuite) TestGetUnitRelationNetworkRelationNotFound(c *tc.C) {
+func (s *infoSuite) TestGetUnitRelationNetworksRelationNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	unitName := coreunit.Name("mysql/0")
@@ -367,11 +367,11 @@ func (s *infoSuite) TestGetUnitRelationNetworkRelationNotFound(c *tc.C) {
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	_, err := service.GetUnitRelationNetwork(c.Context(), unitName, []corerelation.UUID{relationUUID})
+	_, err := service.GetUnitRelationNetworks(c.Context(), unitName, []corerelation.UUID{relationUUID})
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
-func (s *infoSuite) TestGetUnitRelationNetworkGetRelationEgressSubnetsError(c *tc.C) {
+func (s *infoSuite) TestGetUnitRelationNetworksGetRelationEgressSubnetsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	unitName := coreunit.Name("mysql/0")
@@ -390,7 +390,7 @@ func (s *infoSuite) TestGetUnitRelationNetworkGetRelationEgressSubnetsError(c *t
 	service := NewProviderService(
 		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
 	)
-	_, err := service.GetUnitRelationNetwork(c.Context(), unitName, []corerelation.UUID{relationUUID})
+	_, err := service.GetUnitRelationNetworks(c.Context(), unitName, []corerelation.UUID{relationUUID})
 	c.Assert(
 		err,
 		tc.ErrorMatches,

--- a/domain/network/service/unitinfo_test.go
+++ b/domain/network/service/unitinfo_test.go
@@ -112,11 +112,9 @@ func (s *infoSuite) TestGetUnitEndpointNetworks(c *tc.C) {
 	}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"192.168.1.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return([]string{"192.168.1.0/24"}, nil)
-	s.st.EXPECT().GetUnitEndpointNetworkInfo(
-		gomock.Any(), unitUUID.String(), endpointNames,
-	).Return(stateNetworkInfo, nil)
+	s.st.EXPECT().GetUnitEndpointNetworkInfo(gomock.Any(), unitUUID.String(), endpointNames).Return(stateNetworkInfo, nil)
 
 	service := NewProviderService(s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c))
 	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
@@ -149,8 +147,8 @@ func (s *infoSuite) TestGetUnitEndpointNetworksSortsIngressAddresses(c *tc.C) {
 	}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().GetUnitEndpointNetworkInfo(
 		gomock.Any(), unitUUID.String(), endpointNames,
 	).Return(stateNetworkInfo, nil)
@@ -178,23 +176,20 @@ func (s *infoSuite) TestGetUnitEndpointNetworksFallsBackToModelEgressSubnets(c *
 	}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return(nil, nil)
 	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"203.0.113.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, nil)
 	s.st.EXPECT().GetUnitEndpointNetworkInfo(
 		gomock.Any(), unitUUID.String(), endpointNames,
 	).Return(stateNetworkInfo, nil)
 
-	service := NewProviderService(
-		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
-	)
+	service := NewProviderService(s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c))
 	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(infos, tc.HasLen, 1)
 	c.Check(infos[0].EgressSubnets, tc.DeepEquals, []string{"203.0.113.0/24"})
 }
 
-func (s *infoSuite) TestGetUnitEndpointNetworksFallsBackToPublicEgressSubnets(c *tc.C) {
+func (s *infoSuite) TestGetUnitEndpointNetworksFallsBackToIngressSubnets(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	unitName := coreunit.Name("mysql/0")
@@ -209,23 +204,15 @@ func (s *infoSuite) TestGetUnitEndpointNetworksFallsBackToPublicEgressSubnets(c 
 	}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return(nil, nil)
 	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{}, nil)
-	s.st.EXPECT().GetUnitPublicAddressForEgress(
-		gomock.Any(), unitUUID.String(),
-	).Return("198.51.100.10/24", nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, nil)
-	s.st.EXPECT().GetUnitEndpointNetworkInfo(
-		gomock.Any(), unitUUID.String(), endpointNames,
-	).Return(stateNetworkInfo, nil)
+	s.st.EXPECT().GetUnitEndpointNetworkInfo(gomock.Any(), unitUUID.String(), endpointNames).Return(stateNetworkInfo, nil)
 
-	service := NewProviderService(
-		s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c),
-	)
+	service := NewProviderService(s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c))
 	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(infos, tc.HasLen, 1)
-	c.Check(infos[0].EgressSubnets, tc.DeepEquals, []string{"198.51.100.10/32"})
+	c.Check(infos[0].EgressSubnets, tc.DeepEquals, []string{"192.168.1.10/32"})
 }
 
 func (s *infoSuite) TestGetUnitRelationNetworks(c *tc.C) {
@@ -418,8 +405,8 @@ func (s *infoSuite) TestGetUnitEndpointNetworksStateError(c *tc.C) {
 	endpointNames := []string{"db"}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().GetUnitEndpointNetworkInfo(
 		gomock.Any(), unitUUID.String(), endpointNames,
 	).Return(nil, errors.New("state error"))
@@ -436,9 +423,7 @@ func (s *infoSuite) TestGetUnitEndpointNetworksIsCaasUnitError(c *tc.C) {
 	unitUUID := coreunit.UUID("unit-uuid-123")
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(
-		gomock.Any(), unitUUID.String(),
-	).Return([]string{"10.0.0.0/24"}, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, errors.New("boom"))
 
 	service := NewProviderService(s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c))
@@ -446,7 +431,7 @@ func (s *infoSuite) TestGetUnitEndpointNetworksIsCaasUnitError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "checking if unit is caas: boom")
 }
 
-func (s *infoSuite) TestGetUnitEndpointNetworksGetUnitEgressSubnetsError(c *tc.C) {
+func (s *infoSuite) TestGetUnitEndpointNetworksGetModelEgressSubnetsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	unitName := coreunit.Name("mysql/0")
@@ -454,11 +439,11 @@ func (s *infoSuite) TestGetUnitEndpointNetworksGetUnitEgressSubnetsError(c *tc.C
 	endpointNames := []string{"db"}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return(nil, errors.New("boom"))
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return(nil, errors.New("boom"))
 
 	service := NewProviderService(s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c))
 	_, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
-	c.Assert(err, tc.ErrorMatches, "getting unit egress subnets: boom")
+	c.Assert(err, tc.ErrorMatches, "getting model egress subnets: boom")
 }
 
 func (s *infoSuite) TestGetUnitEndpointNetworksDeprioritisesVethIngress(c *tc.C) {
@@ -482,8 +467,8 @@ func (s *infoSuite) TestGetUnitEndpointNetworksDeprioritisesVethIngress(c *tc.C)
 	}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"192.168.1.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return([]string{"192.168.1.0/24"}, nil)
 	s.st.EXPECT().GetUnitEndpointNetworkInfo(
 		gomock.Any(), unitUUID.String(), endpointNames,
 	).Return(stateNetworkInfo, nil)
@@ -533,8 +518,8 @@ func (s *infoSuite) TestGetUnitEndpointNetworksCaasUsesServiceAddressForIngress(
 	}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().GetUnitEndpointNetworkInfo(
 		gomock.Any(), unitUUID.String(), endpointNames,
 	).Return(stateNetworkInfo, nil)
@@ -573,8 +558,8 @@ func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedUsesUnitAddresses(c *
 	}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"192.168.1.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return([]string{"192.168.1.0/24"}, nil)
 	s.st.EXPECT().GetUnitNetworkInfo(
 		gomock.Any(), unitUUID.String(),
 	).Return(unitNetworkInfo([]string{"192.168.1.10/24"}, addresses...), nil)
@@ -636,8 +621,8 @@ func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedSortsIngressAddresses
 	}
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(gomock.Any(), unitUUID.String()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().GetUnitNetworkInfo(
 		gomock.Any(), unitUUID.String(),
 	).Return(unitNetworkInfo([]string{"10.0.0.9", "10.0.1.9"}, unitAddresses...), nil)
@@ -657,9 +642,7 @@ func (s *infoSuite) TestGetUnitEndpointNetworksSupportsNetworkingError(c *tc.C) 
 	unitUUID := coreunit.UUID("unit-uuid-123")
 
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.st.EXPECT().GetUnitEgressSubnets(
-		gomock.Any(), unitUUID.String(),
-	).Return([]string{"10.0.0.0/24"}, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 
 	service := NewProviderService(s.st, s.genericErrorProviderGetter, nil, loggertesting.WrapCheckLog(c))
 	_, err := service.GetUnitEndpointNetworks(c.Context(), unitName, []string{"db"})

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -1166,6 +1166,45 @@ func (c *MockStateGetRelationUUIDByIDCall) DoAndReturn(f func(context.Context, i
 	return c
 }
 
+// GetRelationUUIDsByUnitName mocks base method.
+func (m *MockState) GetRelationUUIDsByUnitName(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRelationUUIDsByUnitName", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelationUUIDsByUnitName indicates an expected call of GetRelationUUIDsByUnitName.
+func (mr *MockStateMockRecorder) GetRelationUUIDsByUnitName(arg0, arg1 any) *MockStateGetRelationUUIDsByUnitNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUUIDsByUnitName", reflect.TypeOf((*MockState)(nil).GetRelationUUIDsByUnitName), arg0, arg1)
+	return &MockStateGetRelationUUIDsByUnitNameCall{Call: call}
+}
+
+// MockStateGetRelationUUIDsByUnitNameCall wrap *gomock.Call
+type MockStateGetRelationUUIDsByUnitNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetRelationUUIDsByUnitNameCall) Return(arg0 []string, arg1 error) *MockStateGetRelationUUIDsByUnitNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetRelationUUIDsByUnitNameCall) Do(f func(context.Context, string) ([]string, error)) *MockStateGetRelationUUIDsByUnitNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetRelationUUIDsByUnitNameCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockStateGetRelationUUIDsByUnitNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationUnitChanges mocks base method.
 func (m *MockState) GetRelationUnitChanges(arg0 context.Context, arg1 string, arg2 []unit.UUID, arg3 []application.UUID) (relation0.RelationUnitsChange, error) {
 	m.ctrl.T.Helper()

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -218,6 +218,10 @@ type State interface {
 	// provided relation endpoint uuid.
 	GetRelationUnitUUIDsByEndpointUUID(ctx context.Context, relationEndpointUUID string) ([]string, error)
 
+	// GetRelationUUIDsByUnitName retrieves the UUIDs of all in scope relations
+	// for the specified unit.
+	GetRelationUUIDsByUnitName(ctx context.Context, unitName string) ([]string, error)
+
 	// InferRelationUUIDByEndpoints infers the relation based on two endpoints.
 	InferRelationUUIDByEndpoints(
 		ctx context.Context,
@@ -1223,4 +1227,24 @@ func (s *Service) GetRelationKeyByUUID(ctx context.Context, relationUUID corerel
 	}
 
 	return key, nil
+}
+
+// GetRelationUUIDsByUnitName returns a slice of relation UUIDs for relations
+// the given unit is part of and in scope.
+func (s *Service) GetRelationUUIDsByUnitName(ctx context.Context, unitName unit.Name) ([]corerelation.UUID, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := unitName.Validate(); err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	results, err := s.st.GetRelationUUIDsByUnitName(ctx, unitName.String())
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return transform.Slice(results, func(in string) corerelation.UUID {
+		return corerelation.UUID(in)
+	}), nil
 }

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -1473,6 +1473,40 @@ func (s *relationServiceSuite) TestSetRelationErrorStatusStateError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
+func (s *relationServiceSuite) TestGetRelationUUIDsByUnitName_Success(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	ctx := c.Context()
+	unitName := coreunit.Name("foo/0")
+	fakeUUIDs := []string{"rel-uuid-1", "rel-uuid-2"}
+
+	s.state.EXPECT().GetRelationUUIDsByUnitName(ctx, unitName.String()).Return(fakeUUIDs, nil)
+
+	relUUIDs, err := s.service.GetRelationUUIDsByUnitName(ctx, unitName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(relUUIDs, tc.DeepEquals, []corerelation.UUID{"rel-uuid-1", "rel-uuid-2"})
+}
+
+func (s *relationServiceSuite) TestGetRelationUUIDsByUnitName_Error(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	ctx := c.Context()
+	unitName := coreunit.Name("foo/0")
+	s.state.EXPECT().GetRelationUUIDsByUnitName(ctx, unitName.String()).Return(nil, errors.New("fail"))
+
+	relUUIDs, err := s.service.GetRelationUUIDsByUnitName(ctx, unitName)
+	c.Assert(err, tc.ErrorMatches, "fail")
+	c.Check(relUUIDs, tc.IsNil)
+}
+
+func (s *relationServiceSuite) TestGetRelationUUIDsByUnitName_InvalidUnitName(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	ctx := c.Context()
+	invalidUnitName := coreunit.Name("")
+
+	relUUIDs, err := s.service.GetRelationUUIDsByUnitName(ctx, invalidUnitName)
+	c.Assert(err, tc.NotNil)
+	c.Check(relUUIDs, tc.IsNil)
+}
+
 type relationLeadershipServiceSuite struct {
 	baseServiceSuite
 

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -2573,6 +2573,54 @@ AND    re.relation_uuid = $relationAndApplicationUUID.relation_uuid
 	return endpointUUID.UUID, nil
 }
 
+// GetRelationUUIDsByUnitUUID retrieves the UUIDs of all in scope relations
+// for the specified unit.
+func (st *State) GetRelationUUIDsByUnitName(
+	ctx context.Context, unitName string,
+) ([]string, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	type relationUUIDRow struct {
+		RelationUUID string `db:"relation_uuid"`
+	}
+
+	ident := name{Name: unitName}
+	stmt, err := st.Prepare(`
+SELECT DISTINCT r.uuid AS &relationUUIDRow.relation_uuid
+FROM   relation AS r
+JOIN   relation_endpoint AS re ON r.uuid = re.relation_uuid
+JOIN   relation_unit AS ru ON re.uuid = ru.relation_endpoint_uuid
+JOIN   unit AS u ON ru.unit_uuid = u.uuid
+WHERE  u.name = $name.name
+`, relationUUIDRow{}, name{})
+	if err != nil {
+		return nil, errors.Errorf("preparing select unit relation uuids statement: %w", err)
+	}
+
+	var rows []relationUUIDRow
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, ident).GetAll(&rows)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("querying unit relation uuids: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	return transform.Slice(rows, func(row relationUUIDRow) string {
+		return row.RelationUUID
+	}), nil
+}
+
 // GetPrincipalSubordinateApplicationUUIDs returns the Principal and Subordinate
 // application UUIDs for the given unit. The principal will be the first UUID
 // returned and the subordinate will be the second. If the unit is not a

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -4215,6 +4215,67 @@ func (s *relationSuite) TestGetConsumerRelationUnitsChangeNoSettings(c *tc.C) {
 	c.Check(changes.DepartedUnits, tc.SameContents, []string{"noSetting/1"})
 }
 
+func (s *relationSuite) TestGetRelationUUIDsByUnitUUID(c *tc.C) {
+	// Arrange
+	endpoint1 := domainrelation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Optional:  true,
+			Limit:     20,
+			Scope:     charm.ScopeGlobal,
+		},
+	}
+
+	endpoint2 := domainrelation.Endpoint{
+		ApplicationName: s.fakeApplicationName2,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-2",
+			Role:      charm.RoleRequirer,
+			Interface: "database",
+			Optional:  false,
+			Limit:     10,
+			Scope:     charm.ScopeGlobal,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	charmRelationUUID2 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint2.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	applicationEndpointUUID2 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID2)
+
+	relationUUID := s.addRelation(c)
+	relationEndpointUUID1 := s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
+	relation2UUID := s.addRelation(c)
+	relationEndpointUUID2 := s.addRelationEndpoint(c, relation2UUID, applicationEndpointUUID2)
+
+	unitName := coreunit.Name("unit-name1")
+	unitUUID1 := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	s.addRelationUnit(c, unitUUID1, relationEndpointUUID1)
+	s.addRelationUnit(c, unitUUID1, relationEndpointUUID2)
+
+	// Act
+	obtained, err := s.state.GetRelationUUIDsByUnitName(c.Context(), unitName.String())
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtained, tc.SameContents, []string{relationUUID.String(), relation2UUID.String()})
+}
+
+func (s *relationSuite) TestGetRelationUUIDsByUnitUUIDEmpty(c *tc.C) {
+	// Arrange: unit
+	unitName := coreunittesting.GenNewName(c, "unit/3")
+	s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+
+	// Act
+	obtained, err := s.state.GetRelationUUIDsByUnitName(c.Context(), unitName.String())
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtained, tc.HasLen, 0)
+}
+
 // addRelationUnitSettingsHash inserts a relation unit settings hash into the
 // database using the provided relationUnitUUID.
 func (s *relationSuite) addRelationUnitSettingsHash(c *tc.C, relationUnitUUID corerelation.UnitUUID, hash string) {

--- a/domain/unitstate/internal/types.go
+++ b/domain/unitstate/internal/types.go
@@ -56,10 +56,6 @@ type CommitHookChangesArg struct {
 	// machine-backed.
 	MachineUUID *string
 
-	// UpdateNetworkInfo indicates that the relation network settings
-	// should be updated for this unit.
-	UpdateNetworkInfo bool
-
 	// RelationUnitSettings settings for the relation unit and application
 	// which need to be updated.
 	RelationSettings []RelationSettings
@@ -109,7 +105,6 @@ func TransformCommitHookChangesArg(
 		UnitUUID:           unitInfo.UnitUUID,
 		UnitLife:           unitInfo.UnitLife,
 		MachineUUID:        unitInfo.MachineUUID,
-		UpdateNetworkInfo:  in.UpdateNetworkInfo,
 		OpenPorts:          in.OpenPorts,
 		ClosePorts:         in.ClosePorts,
 		CharmState:         in.CharmState,

--- a/domain/unitstate/service/commithook.go
+++ b/domain/unitstate/service/commithook.go
@@ -6,10 +6,11 @@ package service
 import (
 	"context"
 	"maps"
+	"slices"
 
 	"github.com/juju/collections/transform"
 
-	corerelation "github.com/juju/juju/core/relation"
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/trace"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
@@ -46,7 +47,7 @@ func (s *LeadershipService) CommitHookChanges(ctx context.Context, arg unitstate
 		arg.AddStorage = nil
 	}
 
-	relationSettings, err := s.transformRelationSettings(ctx, arg.RelationSettings)
+	relationSettings, err := s.transformRelationSettings(ctx, arg.UpdatedRelationNetworkInfo, arg.RelationSettings)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -82,15 +83,21 @@ func (s *LeadershipService) getManagementCaveat(
 }
 
 func (s *Service) transformRelationSettings(
-	ctx context.Context, in []unitstate.RelationSettings,
+	ctx context.Context, networkUpdate map[relation.UUID]unitstate.Settings, in []unitstate.RelationSettings,
 ) ([]internal.RelationSettings, error) {
-	return transform.SliceOrErr(in, func(in unitstate.RelationSettings) (internal.RelationSettings, error) {
+	// If networkUpdates and relationSettings are empty, return early.
+	if len(networkUpdate) == 0 && len(in) == 0 {
+		return nil, nil
+	}
+
+	relationSettings, err := transform.SliceOrErr(in, func(in unitstate.RelationSettings) (internal.RelationSettings, error) {
 		relationUUID, err := s.getRelationUUIDByKey(ctx, in.RelationKey)
 		if err != nil {
 			return internal.RelationSettings{}, errors.Capture(err)
 		}
 		settings := make(map[string]string, len(in.Settings))
 		maps.Copy(settings, in.Settings)
+		// The ingress address and egress subnets should be written only by juju.
 		delete(settings, unitstate.IngressAddressKey)
 		delete(settings, unitstate.EgressSubnetsKey)
 		unitSet, unitUnset := parseForSetAndUnsetSettings(settings)
@@ -103,6 +110,62 @@ func (s *Service) transformRelationSettings(
 			ApplicationUnset: appUnset,
 		}, nil
 	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	if len(networkUpdate) == 0 {
+		return relationSettings, nil
+	}
+
+	// Build map for deduplication and merging.
+	merged := make(map[relation.UUID]internal.RelationSettings)
+	for _, rs := range relationSettings {
+		merged[rs.RelationUUID] = rs
+	}
+
+	networkSettings := transform.MapToSlice(networkUpdate, func(key relation.UUID, value unitstate.Settings) []internal.RelationSettings {
+		unitSet, unitUnset := parseForSetAndUnsetSettings(value)
+		return []internal.RelationSettings{{
+			RelationUUID: key,
+			UnitSet:      unitSet,
+			UnitUnset:    unitUnset,
+		}}
+	})
+	for _, ns := range networkSettings {
+		rs, exists := merged[ns.RelationUUID]
+		if exists {
+			// Merge UnitSet: networkSettings take precedence.
+			if rs.UnitSet == nil {
+				rs.UnitSet = make(unitstate.Settings)
+			}
+			maps.Copy(rs.UnitSet, ns.UnitSet)
+			// Merge UnitUnset: union of both.
+			unsetMap := make(map[string]struct{})
+			for _, u := range rs.UnitUnset {
+				unsetMap[u] = struct{}{}
+			}
+			for _, u := range ns.UnitUnset {
+				unsetMap[u] = struct{}{}
+			}
+			unitUnset := make([]string, 0, len(unsetMap))
+			for u := range unsetMap {
+				unitUnset = append(unitUnset, u)
+			}
+			if len(unitUnset) == 0 {
+				rs.UnitUnset = nil
+			} else {
+				rs.UnitUnset = unitUnset
+			}
+			merged[ns.RelationUUID] = rs
+		} else {
+			if len(ns.UnitUnset) == 0 {
+				ns.UnitUnset = nil
+			}
+			merged[ns.RelationUUID] = ns
+		}
+	}
+
+	return slices.Collect(maps.Values(merged)), nil
 }
 
 func parseForSetAndUnsetSettings(in unitstate.Settings) (unitstate.Settings, []string) {
@@ -125,12 +188,12 @@ func parseForSetAndUnsetSettings(in unitstate.Settings) (unitstate.Settings, []s
 }
 
 // getRelationUUIDByKey returns a relation UUID for the given Key.
-func (s *Service) getRelationUUIDByKey(ctx context.Context, relationKey corerelation.Key) (corerelation.UUID, error) {
+func (s *Service) getRelationUUIDByKey(ctx context.Context, relationKey relation.Key) (relation.UUID, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	eids := relationKey.EndpointIdentifiers()
-	var uuid corerelation.UUID
+	var uuid relation.UUID
 	var err error
 	switch len(eids) {
 	case 1:

--- a/domain/unitstate/service/commithook_test.go
+++ b/domain/unitstate/service/commithook_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
+	corerelation "github.com/juju/juju/core/relation"
 	corerelationtesting "github.com/juju/juju/core/relation/testing"
 	coreunit "github.com/juju/juju/core/unit"
 	unittesting "github.com/juju/juju/core/unit/testing"
@@ -19,6 +20,8 @@ import (
 )
 
 type commitHookSuite struct {
+	svc *LeadershipService
+
 	st                *MockState
 	leadershipEnsurer *MockEnsurer
 }
@@ -29,14 +32,14 @@ func TestCommitHookSuite(t *testing.T) {
 
 func (s *commitHookSuite) TestCommitHookChangesNoChanges(c *tc.C) {
 	defer s.setupMocks(c).Finish()
+
 	// Arrange: args which no changes are needed
 	arg := unitstate.CommitHookChangesArg{
 		UnitName: unittesting.GenNewName(c, "test/0"),
 	}
 
 	// Act
-	svc := NewLeadershipService(s.st, s.leadershipEnsurer, loggertesting.WrapCheckLog(c))
-	err := svc.CommitHookChanges(c.Context(), arg)
+	err := s.svc.CommitHookChanges(c.Context(), arg)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -48,13 +51,14 @@ func (s *commitHookSuite) TestCommitHookChangesNoLeadership(c *tc.C) {
 	// Arrange: args which indicate leadership is not required
 	key := corerelationtesting.GenNewKey(c, "app-1:fake-endpoint-name-1 app-2:fake-endpoint-name-2")
 	eids := key.EndpointIdentifiers()
-	expectedRelationUUID := corerelationtesting.GenRelationUUID(c)
+	expectedRelationUUID := tc.Must(c, corerelation.NewUUID)
 	s.st.EXPECT().GetRegularRelationUUIDByEndpointIdentifiers(
 		gomock.Any(), eids[0], eids[1],
 	).Return(expectedRelationUUID, nil)
 
+	unitName := unittesting.GenNewName(c, "test/0")
 	arg := unitstate.CommitHookChangesArg{
-		UnitName: unittesting.GenNewName(c, "test/0"),
+		UnitName: unitName,
 		RelationSettings: []unitstate.RelationSettings{{
 			RelationKey: key,
 			Settings:    map[string]string{"key": "value"},
@@ -64,7 +68,7 @@ func (s *commitHookSuite) TestCommitHookChangesNoLeadership(c *tc.C) {
 	unitInfo := internal.CommitHookUnitInfo{
 		UnitUUID: unitUUID.String(),
 	}
-	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), arg.UnitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
 
 	expected := internal.CommitHookChangesArg{
 		UnitUUID: unitUUID.String(),
@@ -77,8 +81,7 @@ func (s *commitHookSuite) TestCommitHookChangesNoLeadership(c *tc.C) {
 	s.st.EXPECT().CommitHookChanges(c.Context(), expected).Return(nil)
 
 	// Act
-	svc := NewLeadershipService(s.st, s.leadershipEnsurer, loggertesting.WrapCheckLog(c))
-	err := svc.CommitHookChanges(c.Context(), arg)
+	err := s.svc.CommitHookChanges(c.Context(), arg)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -89,7 +92,7 @@ func (s *commitHookSuite) TestCommitHookChangesLeadership(c *tc.C) {
 	// Arrange: args which indicate leadership is required
 	key := corerelationtesting.GenNewKey(c, "app-1:fake-endpoint-name-1 app-2:fake-endpoint-name-2")
 	eids := key.EndpointIdentifiers()
-	expectedRelationUUID := corerelationtesting.GenRelationUUID(c)
+	expectedRelationUUID := tc.Must(c, corerelation.NewUUID)
 	s.st.EXPECT().GetRegularRelationUUIDByEndpointIdentifiers(
 		gomock.Any(), eids[0], eids[1],
 	).Return(expectedRelationUUID, nil)
@@ -110,8 +113,77 @@ func (s *commitHookSuite) TestCommitHookChangesLeadership(c *tc.C) {
 	s.leadershipEnsurer.EXPECT().WithLeader(gomock.Any(), "test", "test/0", gomock.Any()).Return(nil)
 
 	// Act
-	svc := NewLeadershipService(s.st, s.leadershipEnsurer, loggertesting.WrapCheckLog(c))
-	err := svc.CommitHookChanges(c.Context(), arg)
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *commitHookSuite) TestCommitHookChangesUpdateNetworkInfo(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: Unit
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{
+		UnitUUID: unitUUID.String(),
+	}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+
+	// Arrange: relations
+	relation1UUID := tc.Must(c, corerelation.NewUUID)
+	relation2UUID := tc.Must(c, corerelation.NewUUID)
+	key := corerelationtesting.GenNewKey(c, "app-1:fake-endpoint-name-1 app-2:fake-endpoint-name-2")
+	eids := key.EndpointIdentifiers()
+	s.st.EXPECT().GetRegularRelationUUIDByEndpointIdentifiers(
+		gomock.Any(), eids[0], eids[1],
+	).Return(relation1UUID, nil)
+
+	// Arrange: CommitHookChanges state call
+	expected := internal.CommitHookChangesArg{
+		UnitUUID: unitUUID.String(),
+		RelationSettings: []internal.RelationSettings{
+			{
+				RelationUUID: relation1UUID,
+				UnitSet: map[string]string{
+					"key":                       "value",
+					unitstate.IngressAddressKey: "10.0.0.6",
+					unitstate.EgressSubnetsKey:  "192.0.2.0/24, 192.51.100.0/24",
+				},
+			}, {
+				RelationUUID: relation2UUID,
+				UnitSet: map[string]string{
+					unitstate.IngressAddressKey: "10.0.1.23",
+					unitstate.EgressSubnetsKey:  "203.0.113.0/24",
+				},
+			},
+		},
+	}
+	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_.RelationSettings`, tc.SameContents, expected.RelationSettings)
+	s.st.EXPECT().CommitHookChanges(c.Context(), tc.Bind(mc, expected)).Return(nil)
+
+	// Arrange args for call
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		RelationSettings: []unitstate.RelationSettings{{
+			RelationKey: key,
+			Settings:    map[string]string{"key": "value"},
+		}},
+		UpdatedRelationNetworkInfo: map[corerelation.UUID]unitstate.Settings{
+			relation1UUID: {
+				unitstate.IngressAddressKey: "10.0.0.6",
+				unitstate.EgressSubnetsKey:  "192.0.2.0/24, 192.51.100.0/24",
+			},
+			relation2UUID: {
+				unitstate.IngressAddressKey: "10.0.1.23",
+				unitstate.EgressSubnetsKey:  "203.0.113.0/24",
+			},
+		},
+	}
+
+	// Act
+	err := s.svc.CommitHookChanges(c.Context(), arg)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
@@ -130,8 +202,7 @@ func (s *commitHookSuite) TestGetRelationUUIDByKeyPeer(c *tc.C) {
 	).Return(expectedRelationUUID, nil)
 
 	// Act:
-	svc := NewLeadershipService(s.st, s.leadershipEnsurer, loggertesting.WrapCheckLog(c))
-	uuid, err := svc.getRelationUUIDByKey(c.Context(), key)
+	uuid, err := s.svc.getRelationUUIDByKey(c.Context(), key)
 
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
@@ -151,8 +222,7 @@ func (s *commitHookSuite) TestGetRelationUUIDByKeyRegular(c *tc.C) {
 	).Return(expectedRelationUUID, nil)
 
 	// Act:
-	svc := NewLeadershipService(s.st, s.leadershipEnsurer, loggertesting.WrapCheckLog(c))
-	uuid, err := svc.getRelationUUIDByKey(c.Context(), key)
+	uuid, err := s.svc.getRelationUUIDByKey(c.Context(), key)
 
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
@@ -168,8 +238,7 @@ func (s *commitHookSuite) TestGetRelationUUIDByKeyRelationNotFound(c *tc.C) {
 	).Return("", relationerrors.RelationNotFound)
 
 	// Act:
-	svc := NewLeadershipService(s.st, s.leadershipEnsurer, loggertesting.WrapCheckLog(c))
-	_, err := svc.getRelationUUIDByKey(
+	_, err := s.svc.getRelationUUIDByKey(
 		c.Context(),
 		corerelationtesting.GenNewKey(c, "app-1:fake-endpoint-name-1 app-2:fake-endpoint-name-2"),
 	)
@@ -228,7 +297,14 @@ func (s *commitHookSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.st = NewMockState(ctrl)
 	s.leadershipEnsurer = NewMockEnsurer(ctrl)
 
+	s.svc = NewLeadershipService(
+		s.st,
+		s.leadershipEnsurer,
+		loggertesting.WrapCheckLog(c),
+	)
+
 	c.Cleanup(func() {
+		s.svc = nil
 		s.st = nil
 		s.leadershipEnsurer = nil
 	})

--- a/domain/unitstate/service/interface.go
+++ b/domain/unitstate/service/interface.go
@@ -9,6 +9,7 @@ import (
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/domain/unitstate/internal"
+	"github.com/juju/juju/environs"
 )
 
 // State defines an interface for interacting with the underlying state.
@@ -64,4 +65,10 @@ type UnitStateState interface {
 	// SetUnitState persists the input unit state selectively,
 	// based on its populated values.
 	SetUnitState(context.Context, unitstate.UnitState) error
+}
+
+// ProviderWithNetworking describes the interface needed from providers that
+// support networking capabilities.
+type ProviderWithNetworking interface {
+	environs.Networking
 }

--- a/domain/unitstate/state/commithook.go
+++ b/domain/unitstate/state/commithook.go
@@ -40,10 +40,6 @@ func (st *State) CommitHookChanges(ctx context.Context, arg internal.CommitHookC
 			return errors.Errorf("relations: %w", err)
 		}
 
-		if err := st.updateNetworkInfo(ctx, tx, arg.UpdateNetworkInfo); err != nil {
-			return errors.Errorf("update network info: %w", err)
-		}
-
 		if err := st.updateRelationSettings(ctx, tx, unitUUID, arg.RelationSettings); err != nil {
 			return errors.Errorf("update relation settings:%w", err)
 		}
@@ -86,10 +82,6 @@ func (st *State) CommitHookChanges(ctx context.Context, arg internal.CommitHookC
 
 		return nil
 	})
-}
-
-func (st *State) updateNetworkInfo(ctx context.Context, tx *sqlair.TX, info bool) error {
-	return nil
 }
 
 func (st *State) updateRelationSettings(

--- a/domain/unitstate/state/commithook_test.go
+++ b/domain/unitstate/state/commithook_test.go
@@ -38,7 +38,6 @@ func (s *commitHookSuite) TestCommitHookChanges(c *tc.C) {
 	// Arrange
 	arg := internal.CommitHookChangesArg{
 		UnitUUID:           s.unitUUID,
-		UpdateNetworkInfo:  true,
 		RelationSettings:   nil,
 		OpenPorts:          nil,
 		ClosePorts:         nil,
@@ -133,7 +132,7 @@ func (s *commitHookSuite) TestCommitHookRelationSettings(c *tc.C) {
 
 	// Arrange: Add a unit to the relation.
 	unitName := coreunittesting.GenNewName(c, "app/7")
-	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	unitUUID := s.addUnitAndNetNode(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
 	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
 
 	// Arrange: setup the method input
@@ -368,7 +367,7 @@ func (s *commitHookSuite) TestCommitHookAddStorageVolumeBackedFilesystem(c *tc.C
 func (s *commitHookSuite) TestCommitHookAddStorageWithoutMachineOwnership(c *tc.C) {
 	poolUUID := s.addStoragePool(c, "test-pool", "lxd")
 	unitName := coreunittesting.GenNewName(c, "app/8")
-	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	unitUUID := s.addUnitAndNetNode(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
 	netNodeUUID := s.getUnitNetNodeUUID(c, unitUUID.String())
 
 	storageInstanceUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
@@ -561,9 +560,9 @@ func (s *commitHookSuite) TestGetCommitHookUnitInfoNotFound(c *tc.C) {
 func (s *commitHookSuite) TestEnsureCheckRelationExistsNotFound(c *tc.C) {
 	// Arrange: add a unit
 	charmUUID := s.addCharm(c)
-	appUUID := s.addApplication(c, charmUUID, "testname", network.AlphaSpaceId.String())
+	appUUID := s.addApplicationWithName(c, charmUUID, "testname", network.AlphaSpaceId.String())
 	unitName := coreunit.Name("testname/0")
-	unitUUID := s.addUnit(c, unitName, appUUID, charmUUID)
+	unitUUID := s.addUnitAndNetNode(c, unitName, appUUID, charmUUID)
 
 	// Arrange: setup the method input with a non-existent relation uuid
 	arg := internal.CommitHookChangesArg{

--- a/domain/unitstate/state/package_test.go
+++ b/domain/unitstate/state/package_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/tc"
 
 	coreapplication "github.com/juju/juju/core/application"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	corerelation "github.com/juju/juju/core/relation"
@@ -98,14 +97,7 @@ func (s *baseSuite) addUnitStateCharm(c *tc.C, key any, value string) {
 	s.query(c, q, s.unitUUID, key, value)
 }
 
-func (s *baseSuite) addCharm(c *tc.C) string {
-	charmUUID := tc.Must(c, corecharm.NewID).String()
-	s.query(c, `INSERT INTO charm (uuid, reference_name, create_time) VALUES (?, ?, ?)`,
-		charmUUID, charmUUID, time.Now())
-	return charmUUID
-}
-
-func (s *baseSuite) addApplication(c *tc.C, charmUUID, appName, spaceUUID string) string {
+func (s *baseSuite) addApplicationWithName(c *tc.C, charmUUID, appName, spaceUUID string) string {
 	appUUID := tc.Must(c, coreapplication.NewUUID).String()
 	s.query(c, `INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, ?, ?, ?, ?)`,
 		appUUID, appName, life.Alive, charmUUID, spaceUUID)
@@ -168,8 +160,8 @@ func (s *commitHookBaseSuite) SetUpTest(c *tc.C) {
 	s.fakeCharmUUID1 = s.addCharm(c)
 	s.fakeCharmUUID2 = s.addCharm(c)
 	s.fakeCharmRelationProvidesUUID = s.addCharmRelationWithDefaults(c, s.fakeCharmUUID1)
-	s.fakeApplicationUUID1 = s.addApplication(c, s.fakeCharmUUID1, s.fakeApplicationName1, network.AlphaSpaceId.String())
-	s.fakeApplicationUUID2 = s.addApplication(c, s.fakeCharmUUID2, s.fakeApplicationName2, network.AlphaSpaceId.String())
+	s.fakeApplicationUUID1 = s.addApplicationWithName(c, s.fakeCharmUUID1, s.fakeApplicationName1, network.AlphaSpaceId.String())
+	s.fakeApplicationUUID2 = s.addApplicationWithName(c, s.fakeCharmUUID2, s.fakeApplicationName2, network.AlphaSpaceId.String())
 
 	c.Cleanup(func() {
 		s.fakeCharmUUID1 = ""
@@ -183,45 +175,18 @@ func (s *commitHookBaseSuite) SetUpTest(c *tc.C) {
 	})
 }
 
-// addUnit adds a new unit to the specified application in the database with
-// the given UUID and name. Returns the unit uuid.
-func (s *commitHookBaseSuite) addUnit(c *tc.C, unitName coreunit.Name, appUUID, charmUUID string) coreunit.UUID {
-	unitUUID := tc.Must(c, coreunit.NewUUID)
-	netNodeUUID := tc.Must(c, uuid.NewUUID).String()
-	s.query(c, `
-INSERT INTO net_node (uuid)
-VALUES (?)
-ON CONFLICT DO NOTHING
-`, netNodeUUID)
-	s.query(c, `
-INSERT INTO unit (uuid, name, life_id, application_uuid, charm_uuid, net_node_uuid)
-VALUES (?, ?, ?, ?, ?, ?)
-`, unitUUID, unitName, 0 /* alive */, appUUID, charmUUID, netNodeUUID)
-	return unitUUID
-}
-
 // addCharmRelation inserts a new charm relation into the database with the
 // given UUID and attributes. Returns the relation UUID.
 func (s *commitHookBaseSuite) addCharmRelation(c *tc.C, charmUUID string, r deploymentcharm.Relation) string {
 	charmRelationUUID := tc.Must(c, uuid.NewUUID).String()
 	s.query(c, `
-INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, interface, optional, capacity, scope_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-`, charmRelationUUID, charmUUID, r.Name, s.encodeRoleID(r.Role), r.Interface, r.Optional, r.Limit, s.encodeScopeID(r.Scope))
+INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, interface, optional, capacity, scope_id) 
+VALUES (?, ?, ?,
+       (SELECT id FROM charm_relation_role WHERE name = ?),
+       ?, ?, ?,
+       (SELECT id FROM charm_relation_scope WHERE name = ?))
+`, charmRelationUUID, charmUUID, r.Name, r.Role, r.Interface, r.Optional, r.Limit, r.Scope)
 	return charmRelationUUID
-}
-
-// addApplicationEndpoint inserts a new application endpoint into the database
-// with the specified UUIDs. Returns the endpoint uuid.
-func (s *commitHookBaseSuite) addApplicationEndpoint(
-	c *tc.C, applicationUUID string, charmRelationUUID string,
-) string {
-	applicationEndpointUUID := uuid.MustNewUUID().String()
-	s.query(c, `
-INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid,space_uuid)
-VALUES (?, ?, ?, ?)
-`, applicationEndpointUUID, applicationUUID, charmRelationUUID, network.AlphaSpaceId)
-	return applicationEndpointUUID
 }
 
 // addRelation inserts a new relation into the database with default relation
@@ -258,6 +223,20 @@ INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid)
 VALUES (?,?,?)
 `, relationEndpointUUID, relationUUID, applicationEndpointUUID)
 	return relationEndpointUUID
+}
+
+// addApplicationEndpoint inserts a new application endpoint into the
+// database with the specified UUIDs. Returns the endpoint uuid.
+func (s *commitHookBaseSuite) addApplicationEndpoint(
+	c *tc.C, applicationUUID, charmRelationUUID string,
+) string {
+	applicationEndpointUUID := tc.Must(c, uuid.NewUUID).String()
+	var spacePtr *string
+	s.query(c, `
+INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid, space_uuid)
+VALUES (?, ?, ?, ?)
+`, applicationEndpointUUID, applicationUUID, charmRelationUUID, spacePtr)
+	return applicationEndpointUUID
 }
 
 // addCharmRelationWithDefaults inserts a new charm relation into the database
@@ -347,21 +326,27 @@ WHERE relation_endpoint_uuid = ?
 	return settings
 }
 
-// encodeRoleID returns the ID used in the database for the given charm role. This
-// reflects the contents of the charm_relation_role table.
-func (s *commitHookBaseSuite) encodeRoleID(role deploymentcharm.RelationRole) int {
-	return map[deploymentcharm.RelationRole]int{
-		deploymentcharm.RoleProvider: 0,
-		deploymentcharm.RoleRequirer: 1,
-		deploymentcharm.RolePeer:     2,
-	}[role]
+func (s *commitHookBaseSuite) addCharm(c *tc.C) string {
+	charmUUID := tc.Must(c, uuid.NewUUID).String()
+	s.query(c, `INSERT INTO charm (uuid, reference_name, create_time) VALUES (?, ?, ?)`,
+		charmUUID, charmUUID, time.Now())
+	return charmUUID
 }
 
-// encodeScopeID returns the ID used in the database for the given charm scope. This
-// reflects the contents of the charm_relation_scope table.
-func (s *commitHookBaseSuite) encodeScopeID(role deploymentcharm.RelationScope) int {
-	return map[deploymentcharm.RelationScope]int{
-		deploymentcharm.ScopeGlobal:    0,
-		deploymentcharm.ScopeContainer: 1,
-	}[role]
+// addUnitAndNetNode adds a new unit to the specified application in the
+// database with the given UUID and name. A netnode is created for the unit.
+// Returns the unit uuid.
+func (s *commitHookBaseSuite) addUnitAndNetNode(c *tc.C, unitName coreunit.Name, appUUID, charmUUID string) coreunit.UUID {
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	netNodeUUID := tc.Must(c, uuid.NewUUID).String()
+	s.query(c, `
+INSERT INTO net_node (uuid)
+VALUES (?)
+ON CONFLICT DO NOTHING
+`, netNodeUUID)
+	s.query(c, `
+INSERT INTO unit (uuid, name, life_id, application_uuid, charm_uuid, net_node_uuid)
+VALUES (?, ?, ?, ?, ?, ?)
+`, unitUUID, unitName, 0 /* alive */, appUUID, charmUUID, netNodeUUID)
+	return unitUUID
 }

--- a/domain/unitstate/state/unitrelations_test.go
+++ b/domain/unitstate/state/unitrelations_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/tc"
 
 	corerelation "github.com/juju/juju/core/relation"
-	coreunittesting "github.com/juju/juju/core/unit/testing"
 	"github.com/juju/juju/domain/deployment/charm"
 	domainrelation "github.com/juju/juju/domain/relation"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
@@ -264,8 +263,7 @@ func (s *unitRelationsSuite) TestSetRelationApplicationAndUnitSettings(c *tc.C) 
 	}
 
 	// Arrange: Add a unit to the relation.
-	unitName := coreunittesting.GenNewName(c, "app/7")
-	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	unitUUID := s.addUnitAndNetNode(c, "app/7", s.fakeApplicationUUID1, s.fakeCharmUUID1)
 	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
 
 	unitInitialSettings := map[string]string{
@@ -326,8 +324,7 @@ func (s *unitRelationsSuite) TestSetRelationApplicationAndUnitSettingsNilMap(c *
 	relationEndpointUUID1 := s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
 
 	// Arrange: Add a unit to the relation.
-	unitName := coreunittesting.GenNewName(c, "app/3")
-	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	unitUUID := s.addUnitAndNetNode(c, "app/3", s.fakeApplicationUUID1, s.fakeCharmUUID1)
 	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
 
 	// Act:

--- a/domain/unitstate/state/updateunitports_test.go
+++ b/domain/unitstate/state/updateunitports_test.go
@@ -15,7 +15,7 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/machine"
-	"github.com/juju/juju/core/model"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
 	coreunit "github.com/juju/juju/core/unit"
@@ -772,7 +772,7 @@ func (s *updateUnitPortsSuite) createApplicationWithRelations(c *tc.C, appName s
 		}
 	}
 
-	applicationSt := applicationstate.NewState(s.TxnRunnerFactory(), model.UUID(s.ModelUUID()), clock.WallClock, loggertesting.WrapCheckLog(c))
+	applicationSt := applicationstate.NewState(s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), clock.WallClock, loggertesting.WrapCheckLog(c))
 	appUUID, _, err := applicationSt.CreateIAASApplication(c.Context(), appName, application.AddIAASApplicationArg{
 		BaseAddApplicationArg: application.BaseAddApplicationArg{
 			Charm: charm.Charm{
@@ -804,7 +804,7 @@ func (s *updateUnitPortsSuite) createApplicationWithRelations(c *tc.C, appName s
 // createUnit creates a new unit in state and returns its UUID. The unit is assigned
 // to the net node with uuid `netNodeUUID` and application with name `appName`.
 func (s *updateUnitPortsSuite) createUnit(c *tc.C, netNodeUUID, appName string) (string, string) {
-	applicationSt := applicationstate.NewState(s.TxnRunnerFactory(), model.UUID(s.ModelUUID()), clock.WallClock, loggertesting.WrapCheckLog(c))
+	applicationSt := applicationstate.NewState(s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), clock.WallClock, loggertesting.WrapCheckLog(c))
 
 	appID, err := applicationSt.GetApplicationUUIDByName(c.Context(), appName)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/unitstate/types.go
+++ b/domain/unitstate/types.go
@@ -131,9 +131,9 @@ type CommitHookChangesArg struct {
 	// UnitName is the name of the unit these changes pertain to.
 	UnitName unit.Name
 
-	// UpdateNetworkInfo indicates that the relation network settings
-	// should be updated for this unit.
-	UpdateNetworkInfo bool
+	// UpdatedRelationNetworkInfo contain data to update relation network
+	// settings this unit.
+	UpdatedRelationNetworkInfo map[relation.UUID]Settings
 
 	// RelationUnitSettings settings for the relation unit and application
 	// which need to be updated.
@@ -185,8 +185,11 @@ func (c CommitHookChangesArg) ValidateAndHasChanges() (bool, error) {
 	if err := c.UnitName.Validate(); err != nil {
 		errs = append(errs, err)
 	}
-	hasChanges := c.UpdateNetworkInfo
+	var hasChanges bool
 	if c.CharmState != nil {
+		hasChanges = true
+	}
+	if len(c.UpdatedRelationNetworkInfo) > 0 {
 		hasChanges = true
 	}
 	for _, settings := range c.RelationSettings {


### PR DESCRIPTION
Move UpdateNetworkInfo functionality from the uniter facade into the unitstate domain, CommitHookChanges. When UpdateNetworkInfo is true, get the `ingress-address` and `egress-subnets` for each relation the unit is active in. Add those values to the RelationSettings as the same mechanism updates the data in the db.

Per @manadart, we're changing the approach for CommitHookChanges here. All reads are done at the facade level with new and updated methods. The data is sent into the unitstate domain for processing and persistence. This is a small compromise in that there is some service orchestration in the facade.

A new relation domain method of GetRelationUUIDsByUnitName was implemented to find all relations the unit is in-scope with. GetUnitRelationNetwork is updated to take a slice of relation UUIDs and renamed GetUnitRelationsNetwork. A naive approach was used to update GetUnitRelationsNetwork, the different relations are handled at the facade layer. The state methods can be updated later

As done in the uniter facade, `ingress-address` and `egress-subnet` keys are removed from the unit settings in RelationSettings. The values are supplied by juju, not a unit.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

With CMR:
```
$ juju add-model offer && juju deploy juju-qa-dummy-source source && juju offer source:sink

$ juju add-model consume && juju deploy juju-qa-dummy-sink sink && juju integrate admin/offer.source sink --via 10.21.51.0/24

# wait for the model to settle
$ juju config -m offer source token="goat"

# verify in juju status output
$ juju status
Model    Controller  Cloud/Region         Version  Timestamp
consume  thursday    localhost/localhost  4.0.4.1  19:43:25Z

SAAS    Status  Store     URL
source  active  thursday  admin/test.source

App   Version  Status  Scale  Charm               Channel        Rev  Exposed  Message
sink           active      1  juju-qa-dummy-sink  latest/stable    7  no       Token is goat

Unit     Workload  Agent  Machine  Public address  Ports  Message
sink/0*  active    idle   0        10.21.51.133           Token is goat

Machine  State    Address       Inst id        Base          AZ              Message
0        started  10.21.51.133  juju-2321e0-0  ubuntu@20.04  ubuntu-nuc-two  Running

$ juju ssh -m controller 0 sudo /var/lib/juju/tools/machine-0/jujud db-repl --machine-id 0
...
repl (model-test)> select * from relation_unit_setting
relation_unit_uuid			key		value
84dd7da0-3f48-4769-8d18-c135782634ee	ingress-address	10.21.51.43
30384910-889f-4ad5-8c14-f0dd69096c23	ingress-address	10.21.51.135
84dd7da0-3f48-4769-8d18-c135782634ee	token		goat

# to ensure network info is updated:
$ juju config sink token=heyya

repl (model-consume)> select * from relation_unit_setting
relation_unit_uuid			key		value
9fb61678-a786-4989-872b-5f5442cd1625	ingress-address	10.21.51.133
9e0dfbdd-3b42-43c7-891a-7c019787f550	ingress-address	10.21.51.52
9e0dfbdd-3b42-43c7-891a-7c019787f550	token		heyya
9fb61678-a786-4989-872b-5f5442cd1625	egress-subnets	10.42.42.0/24
```

Without CMR, get egress addresses from model config.
```
$ juju add-model test
$ juju deploy juju-qa-dummy-source source
$ juju deploy juju-qa-dummy-sink sink
$ juju integrate sink source

# to ensure network info is updated:
$ juju model-config egress-subnets=10.21.51.0/24
$ juju config sink token=heya

repl (model-test)> select * from relation_unit_setting
relation_unit_uuid			key		value
213aee33-ec6c-468f-86ad-166f4a4df0e4	ingress-address	10.21.51.57/24
213aee33-ec6c-468f-86ad-166f4a4df0e4	egress-subnets	10.21.51.0/24
d37e121f-b22a-4adc-8a5c-e75ec0d48cc0	ingress-address	10.21.51.10/24
d37e121f-b22a-4adc-8a5c-e75ec0d48cc0	egress-subnets	10.21.51.0/24
d37e121f-b22a-4adc-8a5c-e75ec0d48cc0	token		heyya
```

## Links

**Jira card:** [JUJU-9030](https://warthogs.atlassian.net/browse/JUJU-9030)


[JUJU-9030]: https://warthogs.atlassian.net/browse/JUJU-9030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ