### PR TITLE
feat: simple status patterns

### DIFF
--- a/apiserver/facades/client/client/fullstatus_test.go
+++ b/apiserver/facades/client/client/fullstatus_test.go
@@ -408,7 +408,7 @@ func (s *fullStatusSuite) TestFullStatusExposedEndpointsFetchedInBulk(c *tc.C) {
 			CharmLocator: charm.CharmLocator{
 				Name:         "mysql",
 				Revision:     1,
-				Source:       charm.CharmHubSource,
+				Source:       charm.LocalSource,
 				Architecture: architecture.AMD64,
 			},
 			Platform: deployment.Platform{
@@ -444,6 +444,122 @@ func (s *fullStatusSuite) TestFullStatusExposedEndpointsFetchedInBulk(c *tc.C) {
 	})
 }
 
+func (s *fullStatusSuite) TestFullStatusFilteredByApplicationName(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	client := s.client(false)
+	s.expectCheckCanRead(client, true)
+	s.expectCheckIsAdmin(client, false)
+
+	s.modelInfoService.EXPECT().GetModelInfo(c.Context()).Return(model.ModelInfo{
+		Name:      "controller",
+		Cloud:     "dummy",
+		CloudType: "dummy",
+		Type:      model.IAAS,
+	}, nil)
+	s.statusService.EXPECT().GetModelStatus(gomock.Any()).Return(status.StatusInfo{
+		Status: status.Available,
+	}, nil)
+	s.applicationService.EXPECT().GetAllEndpointBindings(gomock.Any()).Return(nil, nil)
+	s.statusService.EXPECT().GetApplicationAndUnitStatuses(gomock.Any()).Return(map[string]service.Application{
+		"mysql": {
+			CharmLocator: charm.CharmLocator{
+				Name:         "mysql",
+				Revision:     1,
+				Source:       charm.LocalSource,
+				Architecture: architecture.AMD64,
+			},
+			Platform: deployment.Platform{
+				OSType:  deployment.Ubuntu,
+				Channel: "22.04/stable",
+			},
+			Status: status.StatusInfo{
+				Status: status.Active,
+			},
+			Units: map[coreunit.Name]service.Unit{
+				"mysql/0": {
+					ApplicationName: "mysql",
+					MachineName:     ptrMachineName("1"),
+					AgentStatus: status.StatusInfo{
+						Status: status.Idle,
+					},
+					WorkloadStatus: status.StatusInfo{
+						Status: status.Active,
+					},
+				},
+			},
+		},
+		"wordpress": {
+			CharmLocator: charm.CharmLocator{
+				Name:         "wordpress",
+				Revision:     1,
+				Source:       charm.LocalSource,
+				Architecture: architecture.AMD64,
+			},
+			Platform: deployment.Platform{
+				OSType:  deployment.Ubuntu,
+				Channel: "22.04/stable",
+			},
+			Status: status.StatusInfo{
+				Status: status.Active,
+			},
+			Units: map[coreunit.Name]service.Unit{
+				"wordpress/0": {
+					ApplicationName: "wordpress",
+					MachineName:     ptrMachineName("2"),
+					AgentStatus: status.StatusInfo{
+						Status: status.Idle,
+					},
+					WorkloadStatus: status.StatusInfo{
+						Status: status.Active,
+					},
+				},
+			},
+		},
+	}, nil)
+	s.statusService.EXPECT().GetRemoteApplicationOffererStatuses(gomock.Any()).Return(nil, nil)
+	s.statusService.EXPECT().GetMachineFullStatuses(gomock.Any()).Return(map[machine.Name]service.Machine{
+		"1": {
+			Name:        "1",
+			IPAddresses: []string{"10.0.0.1"},
+			Platform: deployment.Platform{
+				OSType:  deployment.Ubuntu,
+				Channel: "22.04/stable",
+			},
+		},
+		"2": {
+			Name:        "2",
+			IPAddresses: []string{"10.0.0.2"},
+			Platform: deployment.Platform{
+				OSType:  deployment.Ubuntu,
+				Channel: "22.04/stable",
+			},
+		},
+	}, nil)
+	s.portService.EXPECT().GetAllOpenedPorts(gomock.Any()).Return(nil, nil)
+	s.networkService.EXPECT().GetAllSpaces(gomock.Any()).Return(nil, nil)
+	s.networkService.EXPECT().GetAllDevicesByMachineNames(gomock.Any()).Return(nil, nil)
+	s.relationService.EXPECT().GetAllRelationDetails(gomock.Any()).Return(nil, nil)
+
+	output, err := client.FullStatus(c.Context(), params.StatusParams{
+		Patterns: []string{"mysql"},
+	})
+	c.Assert(err, tc.IsNil)
+
+	c.Check(output.IsEmpty(), tc.IsFalse)
+	c.Check(output.Applications, tc.HasLen, 1)
+	c.Check(output.Machines, tc.HasLen, 1)
+	_, ok := output.Applications["mysql"]
+	c.Check(ok, tc.IsTrue)
+	_, ok = output.Applications["wordpress"]
+	c.Check(ok, tc.IsFalse)
+	_, ok = output.Machines["1"]
+	c.Check(ok, tc.IsTrue)
+	_, ok = output.Machines["2"]
+	c.Check(ok, tc.IsFalse)
+	c.Check(output.Applications["mysql"].Units, tc.HasLen, 1)
+}
+
 func (s *fullStatusSuite) client(isControllerModel bool) *Client {
 	return &Client{
 		controllerTag:     names.NewControllerTag(internaluuid.MustNewUUID().String()),
@@ -464,6 +580,10 @@ func (s *fullStatusSuite) client(isControllerModel bool) *Client {
 		statusService:             s.statusService,
 		controllerConfigService:   s.controllerConfigService,
 	}
+}
+
+func ptrMachineName(name machine.Name) *machine.Name {
+	return &name
 }
 
 func (s *fullStatusSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/apiserver/facades/client/client/fullstatus_test.go
+++ b/apiserver/facades/client/client/fullstatus_test.go
@@ -479,7 +479,7 @@ func (s *fullStatusSuite) TestFullStatusFilteredByApplicationName(c *tc.C) {
 			Units: map[coreunit.Name]service.Unit{
 				"mysql/0": {
 					ApplicationName: "mysql",
-					MachineName:     ptrMachineName("1"),
+					MachineName:     new(machine.Name("1")),
 					AgentStatus: status.StatusInfo{
 						Status: status.Idle,
 					},
@@ -506,7 +506,7 @@ func (s *fullStatusSuite) TestFullStatusFilteredByApplicationName(c *tc.C) {
 			Units: map[coreunit.Name]service.Unit{
 				"wordpress/0": {
 					ApplicationName: "wordpress",
-					MachineName:     ptrMachineName("2"),
+					MachineName:     new(machine.Name("2")),
 					AgentStatus: status.StatusInfo{
 						Status: status.Idle,
 					},
@@ -580,10 +580,6 @@ func (s *fullStatusSuite) client(isControllerModel bool) *Client {
 		statusService:             s.statusService,
 		controllerConfigService:   s.controllerConfigService,
 	}
-}
-
-func ptrMachineName(name machine.Name) *machine.Name {
-	return &name
 }
 
 func (s *fullStatusSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -130,15 +130,6 @@ func (c *Client) FullStatus(ctx context.Context, args params.StatusParams) (para
 		return params.FullStatus{}, err
 	}
 
-	if len(args.Patterns) > 0 {
-		// Patterns have been disabled until we tackle the status epic. This
-		// will require pushing the patterns down through the status service.
-		// For now, just black hole the request.
-		return params.FullStatus{}, internalerrors.Errorf("patterns are not implemented").Add(
-			errors.NotImplemented,
-		)
-	}
-
 	machineJobFetcher := func(_ context.Context, _ statusservice.Machine) []model.MachineJob {
 		return []model.MachineJob{model.JobHostUnits}
 	}
@@ -232,6 +223,18 @@ func (c *Client) FullStatus(ctx context.Context, args params.StatusParams) (para
 		logger.Tracef(ctx, "Relations: %v", context.relations)
 	}
 
+	var matchedUnits map[coreunit.Name]struct{}
+	if len(args.Patterns) > 0 {
+		matches := statusservice.MatchStatusNames(
+			args.Patterns,
+			context.allAppsUnitsCharmBindings.applications,
+			context.units,
+			context.allMachines,
+		)
+		context.applyNameMatches(matches)
+		matchedUnits = matches.Units
+	}
+
 	modelStatus, err := context.processModel(ctx)
 	if err != nil {
 		return noStatus, internalerrors.Errorf("cannot determine model status: %w", err)
@@ -244,7 +247,7 @@ func (c *Client) FullStatus(ctx context.Context, args params.StatusParams) (para
 	)
 	if args.IncludeStorage {
 		allStorage, filesystems, volumes, err = processStorage(ctx,
-			c.statusService)
+			c.statusService, matchedUnits)
 		if err != nil {
 			return noStatus, internalerrors.Errorf("fetching storage: %w", err)
 		}
@@ -517,6 +520,111 @@ func fetchNetworkInterfaces(
 	})
 
 	return ipAddresses, devices, nil
+}
+
+func (c *statusContext) applyNameMatches(matches statusservice.NameMatchResult) {
+	keptApplications := make(map[string]statusservice.Application, len(matches.Applications))
+	keptCharmURLs := make(map[string]string, len(matches.Applications))
+	keptBindings := make(map[string]map[string]network.SpaceName, len(matches.Applications))
+	keptExposedEndpoints := make(map[string]map[string]application.ExposedEndpoint, len(matches.Applications))
+	keptLeaders := make(map[string]string, len(matches.Applications))
+	for appName, app := range c.allAppsUnitsCharmBindings.applications {
+		if _, ok := matches.Applications[appName]; !ok {
+			continue
+		}
+		filteredUnits := make(map[coreunit.Name]statusservice.Unit)
+		for unitName, unit := range app.Units {
+			if _, ok := matches.Units[unitName]; ok {
+				filteredUnits[unitName] = unit
+			}
+		}
+		app.Units = filteredUnits
+		keptApplications[appName] = app
+		if charmURL, ok := c.allAppsUnitsCharmBindings.applicationCharmURL[appName]; ok {
+			keptCharmURLs[appName] = charmURL
+		}
+		if bindings, ok := c.allAppsUnitsCharmBindings.endpointBindings[appName]; ok {
+			keptBindings[appName] = bindings
+		}
+		if endpoints, ok := c.exposedEndpoints[appName]; ok {
+			keptExposedEndpoints[appName] = endpoints
+		}
+		if leader, ok := c.leaders[appName]; ok {
+			keptLeaders[appName] = leader
+		}
+	}
+	c.allAppsUnitsCharmBindings.applications = keptApplications
+	c.allAppsUnitsCharmBindings.applicationCharmURL = keptCharmURLs
+	c.allAppsUnitsCharmBindings.endpointBindings = keptBindings
+	c.exposedEndpoints = keptExposedEndpoints
+	c.leaders = keptLeaders
+
+	keptUnits := make(map[coreunit.Name]statusservice.Unit, len(matches.Units))
+	keptPodsInfo := make(map[coreunit.Name]application.K8sPodInfo, len(matches.Units))
+	for unitName, unit := range c.units {
+		if _, ok := matches.Units[unitName]; !ok {
+			continue
+		}
+		keptUnits[unitName] = unit
+		if podInfo, ok := c.podsInfo[unitName]; ok {
+			keptPodsInfo[unitName] = podInfo
+		}
+	}
+	c.units = keptUnits
+	c.podsInfo = keptPodsInfo
+
+	keptMachines := make(map[coremachine.Name][]statusservice.Machine)
+	for hostMachineName, machines := range c.machines {
+		filtered := make([]statusservice.Machine, 0, len(machines))
+		for _, machine := range machines {
+			if _, ok := matches.Machines[machine.Name]; ok {
+				filtered = append(filtered, machine)
+			}
+		}
+		if len(filtered) > 0 {
+			keptMachines[hostMachineName] = filtered
+		}
+	}
+	c.machines = keptMachines
+
+	keptAllMachines := make(map[coremachine.Name]statusservice.Machine, len(matches.Machines))
+	for machineName, machine := range c.allMachines {
+		if _, ok := matches.Machines[machineName]; ok {
+			keptAllMachines[machineName] = machine
+		}
+	}
+	c.allMachines = keptAllMachines
+
+	keptRelationsByID := make(map[int]relationStatus)
+	keptRelations := make(map[string][]relationStatus)
+	for id, rel := range c.relationsByID {
+		keep := true
+		for _, endpoint := range rel.Endpoints {
+			if _, ok := matches.Applications[endpoint.ApplicationName]; !ok {
+				keep = false
+				break
+			}
+		}
+		if !keep {
+			continue
+		}
+		keptRelationsByID[id] = rel
+		for _, endpoint := range rel.Endpoints {
+			keptRelations[endpoint.ApplicationName] = append(keptRelations[endpoint.ApplicationName], rel)
+		}
+	}
+	c.relationsByID = keptRelationsByID
+	c.relations = keptRelations
+
+	keptOffers := make(map[string]offerStatus)
+	for offerName, offer := range c.offers {
+		if _, ok := matches.Applications[offer.ApplicationName]; ok {
+			keptOffers[offerName] = offer
+		}
+	}
+	c.offers = keptOffers
+
+	c.remoteAppOfferers = map[string]statusservice.RemoteApplicationOfferer{}
 }
 
 // fetchAllApplicationsAndUnits returns a map from application name to application,
@@ -1340,11 +1448,16 @@ func encodeOSType(ostype deployment.OSType) (string, error) {
 
 // processStorage produces status for all storage in the model.
 func processStorage(
-	ctx context.Context, statusService StatusService,
+	ctx context.Context,
+	statusService StatusService,
+	matchedUnits map[coreunit.Name]struct{},
 ) ([]params.StorageDetails, []params.FilesystemDetails, []params.VolumeDetails, error) {
 	storageInstances, err := statusService.GetAllStorageInstanceStatuses(ctx)
 	if err != nil {
 		return nil, nil, nil, internalerrors.Capture(err)
+	}
+	if matchedUnits != nil {
+		storageInstances = filterStorageInstances(storageInstances, matchedUnits)
 	}
 
 	// zeroTime is used to set the status time no status time is available.
@@ -1402,6 +1515,9 @@ func processStorage(
 	if err != nil {
 		return nil, nil, nil, internalerrors.Capture(err)
 	}
+	if matchedUnits != nil {
+		filesystems = filterFilesystems(filesystems, storageInstances)
+	}
 	filesystemResult := make([]params.FilesystemDetails, 0, len(filesystems))
 	for _, v := range filesystems {
 		details := params.FilesystemDetails{
@@ -1457,6 +1573,9 @@ func processStorage(
 	volumes, err := statusService.GetAllVolumeStatuses(ctx)
 	if err != nil {
 		return nil, nil, nil, internalerrors.Capture(err)
+	}
+	if matchedUnits != nil {
+		volumes = filterVolumes(volumes, storageInstances)
 	}
 	volumeResult := make([]params.VolumeDetails, 0, len(volumes))
 	for _, v := range volumes {
@@ -1545,6 +1664,62 @@ func processStorage(
 	}
 
 	return storageResult, filesystemResult, volumeResult, nil
+}
+
+func filterStorageInstances(
+	storageInstances []statusservice.StorageInstance,
+	matchedUnits map[coreunit.Name]struct{},
+) []statusservice.StorageInstance {
+	filtered := make([]statusservice.StorageInstance, 0, len(storageInstances))
+	for _, storageInstance := range storageInstances {
+		if storageInstance.Owner == nil {
+			continue
+		}
+		if _, ok := matchedUnits[*storageInstance.Owner]; ok {
+			filtered = append(filtered, storageInstance)
+		}
+	}
+	return filtered
+}
+
+func filterFilesystems(
+	filesystems []statusservice.Filesystem,
+	storageInstances []statusservice.StorageInstance,
+) []statusservice.Filesystem {
+	matchedStorageUUIDs := make(map[string]struct{}, len(storageInstances))
+	for _, storageInstance := range storageInstances {
+		matchedStorageUUIDs[storageInstance.UUID.String()] = struct{}{}
+	}
+	filtered := make([]statusservice.Filesystem, 0, len(filesystems))
+	for _, filesystem := range filesystems {
+		if filesystem.StorageUUID == nil {
+			continue
+		}
+		if _, ok := matchedStorageUUIDs[filesystem.StorageUUID.String()]; ok {
+			filtered = append(filtered, filesystem)
+		}
+	}
+	return filtered
+}
+
+func filterVolumes(
+	volumes []statusservice.Volume,
+	storageInstances []statusservice.StorageInstance,
+) []statusservice.Volume {
+	matchedStorageUUIDs := make(map[string]struct{}, len(storageInstances))
+	for _, storageInstance := range storageInstances {
+		matchedStorageUUIDs[storageInstance.UUID.String()] = struct{}{}
+	}
+	filtered := make([]statusservice.Volume, 0, len(volumes))
+	for _, volume := range volumes {
+		if volume.StorageUUID == nil {
+			continue
+		}
+		if _, ok := matchedStorageUUIDs[volume.StorageUUID.String()]; ok {
+			filtered = append(filtered, volume)
+		}
+	}
+	return filtered
 }
 
 func hasExposedApplications(applications map[string]statusservice.Application) bool {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -77,7 +77,13 @@ var usageSummary = `
 Report the status of the model, its machines, applications and units.`[1:]
 
 var usageDetails = `
-Report the model's status including its machines, applications and units.
+Report the model's status, optionally filtered by exact machine,
+application, or unit names.
+
+    juju status [<selector> [...]]
+
+When selectors are present, filter the report to exclude entities that do not
+match.
 
 
 ### Altering the output format
@@ -99,6 +105,18 @@ Provides information in a ` + "`JSON`" + ` or ` + "`YAML`" + ` format for progra
 `
 
 const usageExamples = `
+Report the status of units hosted on machine ` + "`0`" + `:
+
+    juju status 0
+
+Report the status of the ` + "`mysql`" + ` application:
+
+    juju status mysql
+
+Report the status of the ` + "`mysql/0`" + ` unit:
+
+    juju status mysql/0
+
 Include information about storage and relations in output:
 
     juju status --storage --relations
@@ -111,7 +129,7 @@ Provide output as valid ` + "`JSON`" + `:
 func (c *statusCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "status",
-		Args:     "",
+		Args:     "[<selector> [...]]",
 		Purpose:  usageSummary,
 		Doc:      usageDetails,
 		Examples: usageExamples,

--- a/docs/howto/manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40.md
+++ b/docs/howto/manage-your-juju-deployment/upgrade-your-juju-deployment-from-36-to-40.md
@@ -207,10 +207,14 @@ juju add-model mymodel
 juju add-ssh-key "ssh-ed25519 AAAA... yourkeycomment"
 ```
 
-### 4. Status API filtering removed (`StatusArgs.Patterns[]`)
+### 4. Status API filtering is simplified (`StatusArgs.Patterns[]`)
 
-Server-side status filtering via `StatusArgs.Patterns[]` is removed.
-API clients must fetch full status and filter client-side.
+Server-side status filtering via `StatusArgs.Patterns[]` works as follows:
+- Matching occurs only on applications, units and machines.
+- Filtering is based on complete matches - no wildcards or globbing. Examples:
+  - `postgresql` (application)
+  - `postgresql/2` (unit)
+  - `0/lxd/1` (machine)
 
 **Juju 3.6 (API consumer idea)**
 ```go

--- a/domain/status/service/filter_names.go
+++ b/domain/status/service/filter_names.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	coremachine "github.com/juju/juju/core/machine"
+	coreunit "github.com/juju/juju/core/unit"
+)
+
+// NameMatchResult records the entities that should be retained after applying
+// name-based status selectors.
+type NameMatchResult struct {
+	Applications map[string]struct{}
+	Units        map[coreunit.Name]struct{}
+	Machines     map[coremachine.Name]struct{}
+}
+
+// MatchStatusNames matches exact machine, application, and unit names from the
+// supplied status snapshot and expands the result enough to keep status output
+// coherent.
+func MatchStatusNames(
+	patterns []string,
+	applications map[string]Application,
+	units map[coreunit.Name]Unit,
+	machines map[coremachine.Name]Machine,
+) NameMatchResult {
+	result := newNameMatchResult()
+	if len(patterns) == 0 {
+		for appName := range applications {
+			result.addApplication(appName)
+		}
+		for unitName := range units {
+			result.addUnit(unitName)
+		}
+		for machineName := range machines {
+			result.addMachine(machineName)
+		}
+		return result
+	}
+
+	patternSet := make(map[string]struct{}, len(patterns))
+	for _, pattern := range patterns {
+		patternSet[pattern] = struct{}{}
+	}
+
+	directMachines := make(map[coremachine.Name]struct{})
+	for appName, app := range applications {
+		if _, ok := patternSet[appName]; !ok {
+			continue
+		}
+		result.addApplication(appName)
+		for unitName := range app.Units {
+			result.addUnit(unitName)
+		}
+	}
+	for unitName := range units {
+		if _, ok := patternSet[unitName.String()]; ok {
+			result.addUnit(unitName)
+		}
+	}
+	for machineName := range machines {
+		if _, ok := patternSet[machineName.String()]; ok {
+			directMachines[machineName] = struct{}{}
+		}
+	}
+
+	for machineName := range directMachines {
+		result.addMachine(machineName)
+		if machineName.IsContainer() {
+			result.addMachine(machineName.Parent())
+			continue
+		}
+		for candidate := range machines {
+			if candidate == machineName || candidate.Parent() == machineName {
+				result.addMachine(candidate)
+			}
+		}
+	}
+
+	for unitName := range units {
+		machineName, ok := machineNameForUnit(unitName, units)
+		if ok && result.hasMachine(machineName) {
+			result.addUnit(unitName)
+		}
+	}
+
+	result.expandUnitClosure(units)
+	for unitName := range result.Units {
+		machineName, ok := machineNameForUnit(unitName, units)
+		if !ok {
+			continue
+		}
+		result.addMachine(machineName)
+		if machineName.IsContainer() {
+			result.addMachine(machineName.Parent())
+		}
+	}
+
+	return result
+}
+
+func newNameMatchResult() NameMatchResult {
+	return NameMatchResult{
+		Applications: make(map[string]struct{}),
+		Units:        make(map[coreunit.Name]struct{}),
+		Machines:     make(map[coremachine.Name]struct{}),
+	}
+}
+
+func (r NameMatchResult) addApplication(name string) bool {
+	if _, ok := r.Applications[name]; ok {
+		return false
+	}
+	r.Applications[name] = struct{}{}
+	return true
+}
+
+func (r NameMatchResult) addUnit(name coreunit.Name) bool {
+	if _, ok := r.Units[name]; ok {
+		return false
+	}
+	r.Units[name] = struct{}{}
+	return true
+}
+
+func (r NameMatchResult) addMachine(name coremachine.Name) bool {
+	if _, ok := r.Machines[name]; ok {
+		return false
+	}
+	r.Machines[name] = struct{}{}
+	return true
+}
+
+func (r NameMatchResult) hasMachine(name coremachine.Name) bool {
+	_, ok := r.Machines[name]
+	return ok
+}
+
+func (r NameMatchResult) expandUnitClosure(units map[coreunit.Name]Unit) {
+	changed := true
+	for changed {
+		changed = false
+		for unitName := range r.Units {
+			unit, ok := units[unitName]
+			if !ok {
+				continue
+			}
+			if r.addApplication(unit.ApplicationName) {
+				changed = true
+			}
+			if unit.Subordinate {
+				if unit.PrincipalName != nil && r.addUnit(*unit.PrincipalName) {
+					changed = true
+				}
+				continue
+			}
+			for _, subordinateName := range unit.SubordinateNames {
+				if _, ok := units[subordinateName]; !ok {
+					continue
+				}
+				if r.addUnit(subordinateName) {
+					changed = true
+				}
+			}
+		}
+	}
+}
+
+func machineNameForUnit(unitName coreunit.Name, units map[coreunit.Name]Unit) (coremachine.Name, bool) {
+	return machineNameForUnitWithVisited(unitName, units, make(map[coreunit.Name]struct{}))
+}
+
+func machineNameForUnitWithVisited(
+	unitName coreunit.Name,
+	units map[coreunit.Name]Unit,
+	visited map[coreunit.Name]struct{},
+) (coremachine.Name, bool) {
+	if _, ok := visited[unitName]; ok {
+		return "", false
+	}
+	visited[unitName] = struct{}{}
+
+	unit, ok := units[unitName]
+	if !ok {
+		return "", false
+	}
+	if unit.MachineName != nil {
+		return *unit.MachineName, true
+	}
+	if unit.PrincipalName == nil {
+		return "", false
+	}
+	return machineNameForUnitWithVisited(*unit.PrincipalName, units, visited)
+}

--- a/domain/status/service/filter_names_test.go
+++ b/domain/status/service/filter_names_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/juju/tc"
+
+	coremachine "github.com/juju/juju/core/machine"
+	coreunit "github.com/juju/juju/core/unit"
+)
+
+type filterNamesSuite struct{}
+
+func TestFilterNamesSuite(t *testing.T) {
+	tc.Run(t, &filterNamesSuite{})
+}
+
+func (s *filterNamesSuite) TestMatchStatusNamesApplicationIncludesUnitsAndMachines(c *tc.C) {
+	units := map[coreunit.Name]Unit{
+		"mysql/0": {
+			ApplicationName: "mysql",
+			MachineName:     ptrMachineName("1"),
+		},
+		"wordpress/0": {
+			ApplicationName: "wordpress",
+			MachineName:     ptrMachineName("2"),
+		},
+	}
+	applications := map[string]Application{
+		"mysql": {
+			Units: map[coreunit.Name]Unit{
+				"mysql/0": units["mysql/0"],
+			},
+		},
+		"wordpress": {
+			Units: map[coreunit.Name]Unit{
+				"wordpress/0": units["wordpress/0"],
+			},
+		},
+	}
+	machines := map[coremachine.Name]Machine{
+		"1": {Name: "1"},
+		"2": {Name: "2"},
+	}
+
+	result := MatchStatusNames([]string{"mysql"}, applications, units, machines)
+
+	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"mysql"})
+	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"mysql/0"})
+	c.Check(sortedMachineNames(result), tc.DeepEquals, []string{"1"})
+}
+
+func (s *filterNamesSuite) TestMatchStatusNamesPrincipalUnitIncludesSubordinate(c *tc.C) {
+	units := map[coreunit.Name]Unit{
+		"mysql/0": {
+			ApplicationName:  "mysql",
+			MachineName:      ptrMachineName("1"),
+			SubordinateNames: []coreunit.Name{"logging/0"},
+		},
+		"logging/0": {
+			ApplicationName: "logging",
+			Subordinate:     true,
+			PrincipalName:   ptrUnitName("mysql/0"),
+		},
+	}
+	applications := map[string]Application{
+		"mysql": {
+			Units: map[coreunit.Name]Unit{
+				"mysql/0": units["mysql/0"],
+			},
+		},
+		"logging": {
+			Units: map[coreunit.Name]Unit{
+				"logging/0": units["logging/0"],
+			},
+		},
+	}
+	machines := map[coremachine.Name]Machine{
+		"1": {Name: "1"},
+	}
+
+	result := MatchStatusNames([]string{"mysql/0"}, applications, units, machines)
+
+	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"logging", "mysql"})
+	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"logging/0", "mysql/0"})
+	c.Check(sortedMachineNames(result), tc.DeepEquals, []string{"1"})
+}
+
+func (s *filterNamesSuite) TestMatchStatusNamesSubordinateIncludesPrincipal(c *tc.C) {
+	units := map[coreunit.Name]Unit{
+		"mysql/0": {
+			ApplicationName:  "mysql",
+			MachineName:      ptrMachineName("1"),
+			SubordinateNames: []coreunit.Name{"logging/0"},
+		},
+		"logging/0": {
+			ApplicationName: "logging",
+			Subordinate:     true,
+			PrincipalName:   ptrUnitName("mysql/0"),
+		},
+	}
+	applications := map[string]Application{
+		"mysql": {
+			Units: map[coreunit.Name]Unit{
+				"mysql/0": units["mysql/0"],
+			},
+		},
+		"logging": {
+			Units: map[coreunit.Name]Unit{
+				"logging/0": units["logging/0"],
+			},
+		},
+	}
+	machines := map[coremachine.Name]Machine{
+		"1": {Name: "1"},
+	}
+
+	result := MatchStatusNames([]string{"logging/0"}, applications, units, machines)
+
+	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"logging", "mysql"})
+	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"logging/0", "mysql/0"})
+	c.Check(sortedMachineNames(result), tc.DeepEquals, []string{"1"})
+}
+
+func (s *filterNamesSuite) TestMatchStatusNamesMachineIncludesHostedUnitsAndContainers(c *tc.C) {
+	units := map[coreunit.Name]Unit{
+		"mysql/0": {
+			ApplicationName: "mysql",
+			MachineName:     ptrMachineName("0"),
+		},
+		"wordpress/0": {
+			ApplicationName: "wordpress",
+			MachineName:     ptrMachineName("0/lxd/0"),
+		},
+	}
+	applications := map[string]Application{
+		"mysql": {
+			Units: map[coreunit.Name]Unit{
+				"mysql/0": units["mysql/0"],
+			},
+		},
+		"wordpress": {
+			Units: map[coreunit.Name]Unit{
+				"wordpress/0": units["wordpress/0"],
+			},
+		},
+	}
+	machines := map[coremachine.Name]Machine{
+		"0":       {Name: "0"},
+		"0/lxd/0": {Name: "0/lxd/0"},
+		"1":       {Name: "1"},
+	}
+
+	result := MatchStatusNames([]string{"0"}, applications, units, machines)
+
+	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"mysql", "wordpress"})
+	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"mysql/0", "wordpress/0"})
+	c.Check(sortedMachineNames(result), tc.DeepEquals, []string{"0", "0/lxd/0"})
+}
+
+func ptrMachineName(name coremachine.Name) *coremachine.Name {
+	return &name
+}
+
+func ptrUnitName(name coreunit.Name) *coreunit.Name {
+	return &name
+}
+
+func sortedAppNames(result NameMatchResult) []string {
+	out := make([]string, 0, len(result.Applications))
+	for name := range result.Applications {
+		out = append(out, name)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func sortedUnitNames(result NameMatchResult) []string {
+	out := make([]string, 0, len(result.Units))
+	for name := range result.Units {
+		out = append(out, name.String())
+	}
+	slices.Sort(out)
+	return out
+}
+
+func sortedMachineNames(result NameMatchResult) []string {
+	out := make([]string, 0, len(result.Machines))
+	for name := range result.Machines {
+		out = append(out, name.String())
+	}
+	slices.Sort(out)
+	return out
+}

--- a/domain/status/service/filter_names_test.go
+++ b/domain/status/service/filter_names_test.go
@@ -23,11 +23,11 @@ func (s *filterNamesSuite) TestMatchStatusNamesApplicationIncludesUnitsAndMachin
 	units := map[coreunit.Name]Unit{
 		"mysql/0": {
 			ApplicationName: "mysql",
-			MachineName:     ptrMachineName("1"),
+			MachineName:     new(coremachine.Name("1")),
 		},
 		"wordpress/0": {
 			ApplicationName: "wordpress",
-			MachineName:     ptrMachineName("2"),
+			MachineName:     new(coremachine.Name("2")),
 		},
 	}
 	applications := map[string]Application{
@@ -58,13 +58,13 @@ func (s *filterNamesSuite) TestMatchStatusNamesPrincipalUnitIncludesSubordinate(
 	units := map[coreunit.Name]Unit{
 		"mysql/0": {
 			ApplicationName:  "mysql",
-			MachineName:      ptrMachineName("1"),
+			MachineName:      new(coremachine.Name("1")),
 			SubordinateNames: []coreunit.Name{"logging/0"},
 		},
 		"logging/0": {
 			ApplicationName: "logging",
 			Subordinate:     true,
-			PrincipalName:   ptrUnitName("mysql/0"),
+			PrincipalName:   new(coreunit.Name("mysql/0")),
 		},
 	}
 	applications := map[string]Application{
@@ -94,13 +94,13 @@ func (s *filterNamesSuite) TestMatchStatusNamesSubordinateIncludesPrincipal(c *t
 	units := map[coreunit.Name]Unit{
 		"mysql/0": {
 			ApplicationName:  "mysql",
-			MachineName:      ptrMachineName("1"),
+			MachineName:      new(coremachine.Name("1")),
 			SubordinateNames: []coreunit.Name{"logging/0"},
 		},
 		"logging/0": {
 			ApplicationName: "logging",
 			Subordinate:     true,
-			PrincipalName:   ptrUnitName("mysql/0"),
+			PrincipalName:   new(coreunit.Name("mysql/0")),
 		},
 	}
 	applications := map[string]Application{
@@ -130,11 +130,11 @@ func (s *filterNamesSuite) TestMatchStatusNamesMachineIncludesHostedUnitsAndCont
 	units := map[coreunit.Name]Unit{
 		"mysql/0": {
 			ApplicationName: "mysql",
-			MachineName:     ptrMachineName("0"),
+			MachineName:     new(coremachine.Name("0")),
 		},
 		"wordpress/0": {
 			ApplicationName: "wordpress",
-			MachineName:     ptrMachineName("0/lxd/0"),
+			MachineName:     new(coremachine.Name("0/lxd/0")),
 		},
 	}
 	applications := map[string]Application{
@@ -160,14 +160,6 @@ func (s *filterNamesSuite) TestMatchStatusNamesMachineIncludesHostedUnitsAndCont
 	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"mysql", "wordpress"})
 	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"mysql/0", "wordpress/0"})
 	c.Check(sortedMachineNames(result), tc.DeepEquals, []string{"0", "0/lxd/0"})
-}
-
-func ptrMachineName(name coremachine.Name) *coremachine.Name {
-	return &name
-}
-
-func ptrUnitName(name coreunit.Name) *coreunit.Name {
-	return &name
 }
 
 func sortedAppNames(result NameMatchResult) []string {


### PR DESCRIPTION
This is a minimal reinstatement of `patterns` for Juju status, which were dropped in the transition to 4.0.

The matches are direct only (no wild-carding), and apply to application, unit and machine names.

This is largely an experiment to test the appetite for reintroduction. Therefore, the following considerations were applied:
- As stated, filtering applies to a smaller set of entities than the original, but these should provide the most value.
- The original logic in the status domain is not modified - we don't thread pattens in to the prior calls, and filtering is not applied directly to queries.
- There is a second step in the API layer to apply the domain service filtering logic to whole status output.

This doesn't buy anything in terms of performance. Much like 3.6 it is applied to content already retrieved from the database, and so is a convenience mechanism. 

## QA steps

- Bootstrap and add a model.
- `juju deploy ubuntu`.
- `juju deploy juju-qa-dummy-source`.
- Baseline `juju status`:
```
Model  Controller  Cloud/Region  Version  Timestamp
work   lxd         lxd/default   4.0.6.1  12:10:44+02:00

App           Version  Status       Scale  Charm                 Channel        Rev  Exposed  Message
dummy-source           maintenance      1  juju-qa-dummy-source  latest/stable    6  no       Started
ubuntu        24.04    active           1  ubuntu                latest/stable   26  no

Unit             Workload     Agent  Machine  Public address  Ports  Message
dummy-source/0*  maintenance  idle   1        10.155.5.165           Started
ubuntu/0*        active       idle   0        10.155.5.214

Machine  State    Address       Inst id        Base          AZ      Message
0        started  10.155.5.214  juju-473d67-0  ubuntu@24.04  rashan  Running
1        started  10.155.5.165  juju-473d67-1  ubuntu@20.04  rashan  Running
```
- `juju status 0`.
```
Model  Controller  Cloud/Region  Version  Timestamp
work   lxd         lxd/default   4.0.6.1  12:12:02+02:00

App     Version  Status   Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           waiting      1  ubuntu  latest/stable   26  no       waiting for machine

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.155.5.214

Machine  State    Address       Inst id        Base          AZ      Message
0        started  10.155.5.214  juju-473d67-0  ubuntu@24.04  rashan  Running
```
- `juju status dummy-source`:
```
Model  Controller  Cloud/Region  Version  Timestamp
work   lxd         lxd/default   4.0.6.1  12:12:49+02:00

App           Version  Status       Scale  Charm                 Channel        Rev  Exposed  Message
dummy-source           maintenance      1  juju-qa-dummy-source  latest/stable    6  no       Started

Unit             Workload     Agent  Machine  Public address  Ports  Message
dummy-source/0*  maintenance  idle   1        10.155.5.165           Started

Machine  State    Address       Inst id        Base          AZ      Message
1        started  10.155.5.165  juju-473d67-1  ubuntu@20.04  rashan  Running
```
- `juju status ubuntu`:
```
Model  Controller  Cloud/Region  Version  Timestamp
work   lxd         lxd/default   4.0.6.1  12:14:11+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           active      2  ubuntu  latest/stable   26  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.155.5.214
ubuntu/1   active    idle   2        10.155.5.205

Machine  State    Address       Inst id        Base          AZ      Message
0        started  10.155.5.214  juju-473d67-0  ubuntu@24.04  rashan  Running
2        started  10.155.5.205  juju-473d67-2  ubuntu@24.04  rashan  Running
```
- `juju status ubuntu/1`:
```
Model  Controller  Cloud/Region  Version  Timestamp
work   lxd         lxd/default   4.0.6.1  12:14:41+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           active      1  ubuntu  latest/stable   26  no

Unit      Workload  Agent  Machine  Public address  Ports  Message
ubuntu/1  active    idle   2        10.155.5.205

Machine  State    Address       Inst id        Base          AZ      Message
2        started  10.155.5.205  juju-473d67-2  ubuntu@24.04  rashan  Running
```   

## Documentation changes

The transition guide is updated regarding this change, instead of copy for complete omission of the feature.

## Links

**Issue:** Fixes https://github.com/juju/juju/issues/22161.
