### PR TITLE
fix: cross-controller CMR between 3.6 and 4.0

### DIFF
--- a/internal/worker/remoterelationconsumer/consumerunitrelations/worker.go
+++ b/internal/worker/remoterelationconsumer/consumerunitrelations/worker.go
@@ -35,7 +35,11 @@ type Service interface {
 // required to authenticate with the remote model.
 type RelationUnitChange struct {
 	relation.RelationUnitChange
-	Macaroon *macaroon.Macaroon
+	// ConsumerApplicationUUID is the UUID of the consuming application
+	// in the local (consumer) model. This is used as the application
+	// token when publishing changes to the offering model.
+	ConsumerApplicationUUID coreapplication.UUID
+	Macaroon                *macaroon.Macaroon
 }
 
 // ReportableWorker is an interface that allows a worker to be reported
@@ -209,8 +213,9 @@ func (w *localWorker) loop() error {
 			case <-w.catacomb.Dying():
 				return w.catacomb.ErrDying()
 			case w.changes <- RelationUnitChange{
-				RelationUnitChange: event,
-				Macaroon:           w.macaroon,
+				RelationUnitChange:      event,
+				ConsumerApplicationUUID: w.consumerApplicationUUID,
+				Macaroon:                w.macaroon,
 			}:
 			}
 

--- a/internal/worker/remoterelationconsumer/consumerunitrelations/worker_test.go
+++ b/internal/worker/remoterelationconsumer/consumerunitrelations/worker_test.go
@@ -179,7 +179,8 @@ func (s *localUnitRelationsWorker) TestChangeEvent(c *tc.C) {
 				"foo": "bar",
 			},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 
 	workertest.CleanKill(c, w)

--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -271,6 +271,7 @@ func (w *localConsumerWorker) PublishModelDying(ctx context.Context) error {
 		type RelationMacaroonGetter interface {
 			RelationUUID() corerelation.UUID
 			Macaroon() *macaroon.Macaroon
+			ConsumerApplicationUUID() application.UUID
 		}
 
 		relationWorker, ok := rw.(RelationMacaroonGetter)
@@ -279,6 +280,7 @@ func (w *localConsumerWorker) PublishModelDying(ctx context.Context) error {
 		}
 
 		w.publishRelationDyingChange(
+			relationWorker.ConsumerApplicationUUID(),
 			relationWorker.RelationUUID(),
 			relationWorker.Macaroon(),
 			"model is dying",
@@ -562,6 +564,7 @@ func (w *localConsumerWorker) handleRelationRemoved(ctx context.Context, relatio
 // but not propagated. Uses a fresh context since the catacomb context may be
 // cancelled.
 func (w *localConsumerWorker) publishRelationDyingChange(
+	applicationUUID application.UUID,
 	relationUUID corerelation.UUID,
 	mac *macaroon.Macaroon,
 	debugMsg string,
@@ -579,7 +582,7 @@ func (w *localConsumerWorker) publishRelationDyingChange(
 	change := params.RemoteRelationChangeEvent{
 		RelationToken:           relationUUID.String(),
 		Life:                    life.Dying,
-		ApplicationOrOfferToken: w.offerUUID,
+		ApplicationOrOfferToken: applicationUUID.String(),
 		Macaroons:               macaroon.Slice{mac},
 		BakeryVersion:           defaultBakeryVersion,
 		ForceCleanup:            new(true),
@@ -592,7 +595,7 @@ func (w *localConsumerWorker) publishRelationDyingChange(
 }
 
 func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(ctx context.Context, relationUUID corerelation.UUID) error {
-	offererUnitRelationWorker, err := w.runner.Worker(offererUnitRelationWorkerName(relationUUID), ctx.Done())
+	offererUnitWorker, err := w.runner.Worker(offererUnitRelationWorkerName(relationUUID), ctx.Done())
 	if errors.Is(err, errors.NotFound) {
 		// If the worker doesn't exist, then it either hasn't been created yet,
 		// or has already been removed, in either case, we can skip sending the
@@ -602,15 +605,17 @@ func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(ctx context
 		return errors.Annotatef(err, "stopping offerer unit relation worker for %q", relationUUID)
 	}
 
-	type MacaroonGetter interface {
+	type offererWorkerDetails interface {
 		Macaroon() *macaroon.Macaroon
+		ConsumerApplicationUUID() application.UUID
 	}
 
-	mac := offererUnitRelationWorker.(MacaroonGetter).Macaroon()
+	rw := offererUnitWorker.(offererWorkerDetails)
 
 	w.publishRelationDyingChange(
+		rw.ConsumerApplicationUUID(),
 		relationUUID,
-		mac,
+		rw.Macaroon(),
 		"relation %q removed locally, notifying offering model",
 		"removal",
 	)
@@ -625,8 +630,13 @@ func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(ctx context
 // the removal worker. Uses a fresh context since the catacomb context may be
 // cancelled. This is a best-effort notification: errors are logged but not
 // propagated.
-func (w *localConsumerWorker) publishRelationDyingWithMacaroon(relationUUID corerelation.UUID, mac *macaroon.Macaroon) {
+func (w *localConsumerWorker) publishRelationDyingWithMacaroon(
+	consumerAppUUID application.UUID,
+	relationUUID corerelation.UUID,
+	mac *macaroon.Macaroon,
+) {
 	w.publishRelationDyingChange(
+		consumerAppUUID,
 		relationUUID,
 		mac,
 		"relation %q removed locally during registration, notifying offering model",
@@ -749,7 +759,7 @@ func (w *localConsumerWorker) handleRelationConsumption(
 	// Handle the case where the relation is dying, and ensure we have no
 	// workers still running for it.
 	if life.IsNotAlive(details.Life) {
-		if err := w.handleRelationDying(ctx, details.UUID, result.macaroon, !relationKnown); err != nil {
+		if err := w.handleRelationDying(ctx, details.UUID, result.macaroon, consumingApplicationUUID, !relationKnown); err != nil {
 			return err
 		}
 		return nil
@@ -790,6 +800,7 @@ func (w *localConsumerWorker) handleRelationDying(
 	ctx context.Context,
 	relationUUID corerelation.UUID,
 	mac *macaroon.Macaroon,
+	consumerAppUUID application.UUID,
 	forceCleanup bool,
 ) error {
 	w.logger.Debugf(ctx, "relation %q is dying", relationUUID)
@@ -797,7 +808,7 @@ func (w *localConsumerWorker) handleRelationDying(
 	change := params.RemoteRelationChangeEvent{
 		RelationToken:           relationUUID.String(),
 		Life:                    life.Dying,
-		ApplicationOrOfferToken: w.offerUUID,
+		ApplicationOrOfferToken: consumerAppUUID.String(),
 		Macaroons:               macaroon.Slice{mac},
 		BakeryVersion:           defaultBakeryVersion,
 	}
@@ -882,13 +893,14 @@ func (w *localConsumerWorker) ensureUnitRelationWorkers(
 
 	if err := w.runner.StartWorker(ctx, offererUnitRelationWorkerName(details.UUID), func(ctx context.Context) (worker.Worker, error) {
 		return w.newOffererUnitRelationsWorker(offererunitrelations.Config{
-			Client:                 w.remoteModelClient,
-			ConsumerRelationUUID:   details.UUID,
-			OffererApplicationUUID: offerApplicationUUID,
-			Macaroon:               mac,
-			Changes:                w.offererRelationUnitChanges,
-			Clock:                  w.clock,
-			Logger:                 w.logger.Child("offerer-unit"),
+			Client:                  w.remoteModelClient,
+			ConsumerRelationUUID:    details.UUID,
+			ConsumerApplicationUUID: consumingApplicationUUID,
+			OffererApplicationUUID:  offerApplicationUUID,
+			Macaroon:                mac,
+			Changes:                 w.offererRelationUnitChanges,
+			Clock:                   w.clock,
+			Logger:                  w.logger.Child("offerer-unit"),
 		})
 	}); err != nil && !errors.Is(err, errors.AlreadyExists) {
 		return errors.Annotatef(err, "starting offerer unit relation worker for %q", details.UUID)
@@ -964,7 +976,7 @@ func (w *localConsumerWorker) registerConsumerRelation(
 		// already created on the offering side by RegisterRemoteRelations
 		// above. Immediately notify the offering model to clean it up,
 		// using the macaroon we just received.
-		w.publishRelationDyingWithMacaroon(relationUUID, registerResult.Macaroon)
+		w.publishRelationDyingWithMacaroon(consumingApplicationUUID, relationUUID, registerResult.Macaroon)
 		return consumerRelationResult{}, errors.Annotatef(err, "saving macaroon for %q", relationUUID)
 	}
 
@@ -982,7 +994,7 @@ func (w *localConsumerWorker) handleConsumerUnitChange(ctx context.Context, chan
 	// Create the event to send to the offering model.
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           change.RelationUUID.String(),
-		ApplicationOrOfferToken: w.offerUUID,
+		ApplicationOrOfferToken: change.ConsumerApplicationUUID.String(),
 		ApplicationSettings:     convertSettingsMap(change.ApplicationSettings),
 
 		ChangedUnits: transform.Slice(change.UnitsSettings, func(v relation.UnitSettings) params.RemoteRelationUnitChange {

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -51,12 +51,13 @@ func TestLocalConsumerWorker(t *stdtesting.T) {
 type localConsumerWorkerSuite struct {
 	baseSuite
 
-	applicationName   string
-	applicationUUID   application.UUID
-	offererModelUUID  string
-	consumerModelUUID model.UUID
-	offerUUID         string
-	macaroon          *macaroon.Macaroon
+	applicationName         string
+	applicationUUID         application.UUID
+	consumerApplicationUUID application.UUID
+	offererModelUUID        string
+	consumerModelUUID       model.UUID
+	offerUUID               string
+	macaroon                *macaroon.Macaroon
 
 	relationLifeChanges          chan []string
 	secretRevisionChanges        chan []watcher.SecretRevisionChange
@@ -72,6 +73,7 @@ func (s *localConsumerWorkerSuite) SetUpTest(c *tc.C) {
 
 	s.applicationName = "foo"
 	s.applicationUUID = tc.Must(c, application.NewUUID)
+	s.consumerApplicationUUID = tc.Must(c, application.NewUUID)
 	s.offererModelUUID = tc.Must(c, model.NewUUID).String()
 	s.consumerModelUUID = tc.Must(c, model.NewUUID)
 	s.offerUUID = tc.Must(c, uuid.NewUUID).String()
@@ -406,7 +408,7 @@ func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChangedNotFound(c *
 		return newErrWorker(nil), nil
 	})
 	w.runner.StartWorker(c.Context(), offererUnitRelationWorkerName(relationUUID), func(ctx context.Context) (worker.Worker, error) {
-		return newMacaroonErrWorker(mac, relationUUID), nil
+		return newMacaroonErrWorker(mac, relationUUID, s.consumerApplicationUUID), nil
 	})
 
 	s.waitForWorkerStarted(c, w.runner,
@@ -505,11 +507,10 @@ func (s *localConsumerWorkerSuite) expectRegisterRemoteRelation(c *tc.C) relatio
 
 func (s *localConsumerWorkerSuite) expectRegisterRemoteRelationMultiple(c *tc.C, times int) relation.UUID {
 	consumingRelationUUID := tc.Must(c, relation.NewUUID)
-	consumingApplicationUUID := tc.Must(c, application.NewUUID)
 
 	mac := newMacaroon(c, "test")
 	arg := params.RegisterConsumingRelationArg{
-		ConsumerApplicationToken: consumingApplicationUUID.String(),
+		ConsumerApplicationToken: s.consumerApplicationUUID.String(),
 		SourceModelTag:           names.NewModelTag(s.consumerModelUUID.String()).String(),
 		RelationToken:            consumingRelationUUID.String(),
 		OfferUUID:                s.offerUUID,
@@ -526,7 +527,7 @@ func (s *localConsumerWorkerSuite) expectRegisterRemoteRelationMultiple(c *tc.C,
 
 	s.crossModelService.EXPECT().
 		GetApplicationUUIDByName(gomock.Any(), "bar").
-		Return(consumingApplicationUUID, nil).Times(times)
+		Return(s.consumerApplicationUUID, nil).Times(times)
 	offeredAppToken := tc.Must(c, uuid.NewUUID).String()
 	s.remoteModelRelationClient.EXPECT().
 		RegisterRemoteRelations(gomock.Any(), arg).
@@ -753,13 +754,12 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelation(c *tc.C) {
 
 	token := tc.Must(c, application.NewUUID)
 	consumingRelationUUID := tc.Must(c, relation.NewUUID)
-	consumingApplicationUUID := tc.Must(c, application.NewUUID)
 	mac := newMacaroon(c, "test")
 
 	done := s.expectWorkerStartup()
 
 	arg := params.RegisterConsumingRelationArg{
-		ConsumerApplicationToken: consumingApplicationUUID.String(),
+		ConsumerApplicationToken: s.consumerApplicationUUID.String(),
 		SourceModelTag:           names.NewModelTag(s.consumerModelUUID.String()).String(),
 		RelationToken:            consumingRelationUUID.String(),
 		OfferUUID:                s.offerUUID,
@@ -799,7 +799,7 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelation(c *tc.C) {
 	result, err := w.registerConsumerRelation(c.Context(),
 		consumingRelationUUID,
 		s.offerUUID,
-		consumingApplicationUUID,
+		s.consumerApplicationUUID,
 		domainrelation.Endpoint{
 			ApplicationName: "foo",
 			Relation: charm.Relation{
@@ -821,12 +821,11 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationFailedRequest(c *
 	defer s.setupMocks(c).Finish()
 
 	consumingRelationUUID := tc.Must(c, relation.NewUUID)
-	consumingApplicationUUID := tc.Must(c, application.NewUUID)
 
 	done := s.expectWorkerStartup()
 
 	arg := params.RegisterConsumingRelationArg{
-		ConsumerApplicationToken: consumingApplicationUUID.String(),
+		ConsumerApplicationToken: s.consumerApplicationUUID.String(),
 		SourceModelTag:           names.NewModelTag(s.consumerModelUUID.String()).String(),
 		RelationToken:            consumingRelationUUID.String(),
 		OfferUUID:                s.offerUUID,
@@ -857,7 +856,7 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationFailedRequest(c *
 	_, err := w.registerConsumerRelation(c.Context(),
 		consumingRelationUUID,
 		s.offerUUID,
-		consumingApplicationUUID,
+		s.consumerApplicationUUID,
 		domainrelation.Endpoint{
 			ApplicationName: "foo",
 			Relation: charm.Relation{
@@ -875,12 +874,11 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationInvalidResultLeng
 	defer s.setupMocks(c).Finish()
 
 	consumingRelationUUID := tc.Must(c, relation.NewUUID)
-	consumingApplicationUUID := tc.Must(c, application.NewUUID)
 
 	done := s.expectWorkerStartup()
 
 	arg := params.RegisterConsumingRelationArg{
-		ConsumerApplicationToken: consumingApplicationUUID.String(),
+		ConsumerApplicationToken: s.consumerApplicationUUID.String(),
 		SourceModelTag:           names.NewModelTag(s.consumerModelUUID.String()).String(),
 		RelationToken:            consumingRelationUUID.String(),
 		OfferUUID:                s.offerUUID,
@@ -911,7 +909,7 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationInvalidResultLeng
 	_, err := w.registerConsumerRelation(c.Context(),
 		consumingRelationUUID,
 		s.offerUUID,
-		consumingApplicationUUID,
+		s.consumerApplicationUUID,
 		domainrelation.Endpoint{
 			ApplicationName: "foo",
 			Relation: charm.Relation{
@@ -929,12 +927,11 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationFailedRequestErro
 	defer s.setupMocks(c).Finish()
 
 	consumingRelationUUID := tc.Must(c, relation.NewUUID)
-	consumingApplicationUUID := tc.Must(c, application.NewUUID)
 
 	done := s.expectWorkerStartup()
 
 	arg := params.RegisterConsumingRelationArg{
-		ConsumerApplicationToken: consumingApplicationUUID.String(),
+		ConsumerApplicationToken: s.consumerApplicationUUID.String(),
 		SourceModelTag:           names.NewModelTag(s.consumerModelUUID.String()).String(),
 		RelationToken:            consumingRelationUUID.String(),
 		OfferUUID:                s.offerUUID,
@@ -970,7 +967,7 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationFailedRequestErro
 	_, err := w.registerConsumerRelation(c.Context(),
 		consumingRelationUUID,
 		s.offerUUID,
-		consumingApplicationUUID,
+		s.consumerApplicationUUID,
 		domainrelation.Endpoint{
 			ApplicationName: "bar",
 			Relation: charm.Relation{
@@ -1030,7 +1027,7 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationFailedToSaveMacar
 		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
 			RelationToken:           consumingRelationUUID.String(),
 			Life:                    life.Dying,
-			ApplicationOrOfferToken: s.offerUUID,
+			ApplicationOrOfferToken: consumingApplicationUUID.String(),
 			Macaroons:               macaroon.Slice{mac},
 			BakeryVersion:           bakery.LatestVersion,
 			ForceCleanup:            new(true),
@@ -1075,17 +1072,16 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationSaveMacaroonFails
 	done := s.expectWorkerStartup()
 
 	consumingRelationUUID := tc.Must(c, relation.NewUUID)
-	consumingApplicationUUID := tc.Must(c, application.NewUUID)
 	offeredAppToken := tc.Must(c, uuid.NewUUID).String()
 	mac := newMacaroon(c, "test")
 
 	s.crossModelService.EXPECT().
 		GetApplicationUUIDByName(gomock.Any(), "bar").
-		Return(consumingApplicationUUID, nil)
+		Return(s.consumerApplicationUUID, nil)
 
 	s.remoteModelRelationClient.EXPECT().
 		RegisterRemoteRelations(gomock.Any(), params.RegisterConsumingRelationArg{
-			ConsumerApplicationToken: consumingApplicationUUID.String(),
+			ConsumerApplicationToken: s.consumerApplicationUUID.String(),
 			SourceModelTag:           names.NewModelTag(s.consumerModelUUID.String()).String(),
 			RelationToken:            consumingRelationUUID.String(),
 			OfferUUID:                s.offerUUID,
@@ -1120,7 +1116,7 @@ func (s *localConsumerWorkerSuite) TestRegisterConsumerRelationSaveMacaroonFails
 		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
 			RelationToken:           consumingRelationUUID.String(),
 			Life:                    life.Dying,
-			ApplicationOrOfferToken: s.offerUUID,
+			ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 			Macaroons:               macaroon.Slice{mac},
 			BakeryVersion:           bakery.LatestVersion,
 			ForceCleanup:            new(true),
@@ -1327,7 +1323,7 @@ func (s *localConsumerWorkerSuite) TestHandleRelationConsumptionRelationDying(c 
 		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
 			RelationToken:           consumingRelationUUID.String(),
 			Life:                    life.Dying,
-			ApplicationOrOfferToken: s.offerUUID,
+			ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 			Macaroons:               macaroon.Slice{s.macaroon},
 			BakeryVersion:           bakery.LatestVersion,
 			ForceCleanup:            new(true),
@@ -1404,7 +1400,7 @@ func (s *localConsumerWorkerSuite) TestHandleRelationConsumptionRelationDyingDis
 		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
 			RelationToken:           consumingRelationUUID.String(),
 			Life:                    life.Dying,
-			ApplicationOrOfferToken: s.offerUUID,
+			ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 			Macaroons:               macaroon.Slice{s.macaroon},
 			BakeryVersion:           bakery.LatestVersion,
 			ForceCleanup:            new(true),
@@ -1599,7 +1595,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChange(c *tc.C) {
 
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           consumingRelationUUID.String(),
-		ApplicationOrOfferToken: s.offerUUID,
+		ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId: 0,
 			Settings: map[string]any{
@@ -1651,7 +1647,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChange(c *tc.C) {
 			AllUnits:     []int{0, 1, 2, 3},
 			InScopeUnits: []int{0, 1, 2},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -1665,7 +1662,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeNonNilApplication
 
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           consumingRelationUUID.String(),
-		ApplicationOrOfferToken: s.offerUUID,
+		ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 		ApplicationSettings: map[string]any{
 			"foo": "bar",
 		},
@@ -1723,7 +1720,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeNonNilApplication
 			AllUnits:     []int{0, 1, 2, 3},
 			InScopeUnits: []int{0, 1, 2},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -1737,7 +1735,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeNilUnitSettings(c
 
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           consumingRelationUUID.String(),
-		ApplicationOrOfferToken: s.offerUUID,
+		ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId: 0,
 		}},
@@ -1783,7 +1781,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeNilUnitSettings(c
 			AllUnits:     []int{0, 1, 2, 3},
 			InScopeUnits: []int{0, 1, 2},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -1797,7 +1796,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeAlreadyDeadWithIn
 
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           consumingRelationUUID.String(),
-		ApplicationOrOfferToken: s.offerUUID,
+		ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId: 0,
 			Settings: map[string]any{
@@ -1840,7 +1839,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeAlreadyDeadWithIn
 			AllUnits:     []int{0, 1, 2, 3},
 			InScopeUnits: []int{0, 1, 2},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -1853,7 +1853,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeAlreadyDeadWithNo
 
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           consumingRelationUUID.String(),
-		ApplicationOrOfferToken: s.offerUUID,
+		ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId: 0,
 			Settings: map[string]any{
@@ -1939,7 +1939,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangeAlreadyDeadWithNo
 			}},
 			AllUnits: []int{3},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -1959,7 +1960,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangePublishRelationCh
 
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           relationUUID.String(),
-		ApplicationOrOfferToken: s.offerUUID,
+		ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId: 0,
 			Settings: map[string]any{
@@ -1999,7 +2000,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangePublishRelationCh
 			AllUnits:     []int{0, 1, 2, 3},
 			InScopeUnits: []int{0, 1, 2},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 	c.Assert(err, tc.ErrorMatches, `.*front fell off.*`)
 }
@@ -2013,7 +2015,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangePublishRelationCh
 
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           relationUUID.String(),
-		ApplicationOrOfferToken: s.offerUUID,
+		ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId: 0,
 			Settings: map[string]any{
@@ -2053,7 +2055,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangePublishRelationCh
 			AllUnits:     []int{0, 1, 2, 3},
 			InScopeUnits: []int{0, 1, 2},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -2067,7 +2070,7 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangePublishRelationCh
 
 	event := params.RemoteRelationChangeEvent{
 		RelationToken:           relationUUID.String(),
-		ApplicationOrOfferToken: s.offerUUID,
+		ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId: 0,
 			Settings: map[string]any{
@@ -2114,7 +2117,8 @@ func (s *localConsumerWorkerSuite) TestHandleConsumerUnitChangePublishRelationCh
 			AllUnits:     []int{0, 1, 2, 3},
 			InScopeUnits: []int{0, 1, 2},
 		},
-		Macaroon: s.macaroon,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		Macaroon:                s.macaroon,
 	})
 	c.Assert(params.ErrCode(err) == params.CodeDischargeRequired, tc.IsTrue)
 }
@@ -2860,7 +2864,7 @@ func (s *localConsumerWorkerSuite) newLocalConsumerWorkerConfig(c *tc.C) LocalCo
 					c.Fatalf("timed out trying to send on offererUnitRelationsWorkerStarted channel")
 				}
 			}()
-			return newMacaroonErrWorker(cfg.Macaroon, cfg.ConsumerRelationUUID), nil
+			return newMacaroonErrWorker(cfg.Macaroon, cfg.ConsumerRelationUUID, cfg.ConsumerApplicationUUID), nil
 		},
 		NewOffererRelationsWorker: func(offererrelations.Config) (offererrelations.ReportableWorker, error) {
 			defer func() {
@@ -3016,7 +3020,7 @@ func (s *localConsumerWorkerSuite) TestRelationRemovedNotifiesOfferingModel(c *t
 		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
 			RelationToken:           consumingRelationUUID.String(),
 			Life:                    life.Dying,
-			ApplicationOrOfferToken: s.offerUUID,
+			ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 			Macaroons:               macaroon.Slice{newMacaroon(c, "test")},
 			BakeryVersion:           bakery.LatestVersion,
 			ForceCleanup:            new(true),
@@ -3200,7 +3204,7 @@ func (s *localConsumerWorkerSuite) TestPublishModelDying(c *tc.C) {
 		PublishRelationChange(gomock.Any(), params.RemoteRelationChangeEvent{
 			RelationToken:           consumingRelationUUID.String(),
 			Life:                    life.Dying,
-			ApplicationOrOfferToken: s.offerUUID,
+			ApplicationOrOfferToken: s.consumerApplicationUUID.String(),
 			Macaroons:               macaroon.Slice{newMacaroon(c, "test")},
 			BakeryVersion:           bakery.LatestVersion,
 			ForceCleanup:            new(true),

--- a/internal/worker/remoterelationconsumer/offererunitrelations/worker.go
+++ b/internal/worker/remoterelationconsumer/offererunitrelations/worker.go
@@ -85,13 +85,14 @@ type ReportableWorker interface {
 // Config contains the configuration parameters for a remote relation units
 // worker.
 type Config struct {
-	Client                 RemoteModelRelationsClient
-	ConsumerRelationUUID   corerelation.UUID
-	OffererApplicationUUID coreapplication.UUID
-	Macaroon               *macaroon.Macaroon
-	Changes                chan<- RelationUnitChange
-	Clock                  clock.Clock
-	Logger                 logger.Logger
+	Client                  RemoteModelRelationsClient
+	ConsumerRelationUUID    corerelation.UUID
+	ConsumerApplicationUUID coreapplication.UUID
+	OffererApplicationUUID  coreapplication.UUID
+	Macaroon                *macaroon.Macaroon
+	Changes                 chan<- RelationUnitChange
+	Clock                   clock.Clock
+	Logger                  logger.Logger
 }
 
 // Validate ensures the configuration is valid.
@@ -101,6 +102,9 @@ func (c Config) Validate() error {
 	}
 	if c.ConsumerRelationUUID == "" {
 		return errors.NotValidf("consumer relation uuid cannot be empty")
+	}
+	if c.ConsumerApplicationUUID == "" {
+		return errors.NotValidf("consumer application uuid cannot be empty")
 	}
 	if c.OffererApplicationUUID == "" {
 		return errors.NotValidf("offerer application token cannot be empty")
@@ -130,8 +134,9 @@ type remoteWorker struct {
 	client   RemoteModelRelationsClient
 	macaroon *macaroon.Macaroon
 
-	consumerRelationUUID   corerelation.UUID
-	offererApplicationUUID coreapplication.UUID
+	consumerRelationUUID    corerelation.UUID
+	consumerApplicationUUID coreapplication.UUID
+	offererApplicationUUID  coreapplication.UUID
 
 	changes chan<- RelationUnitChange
 
@@ -154,9 +159,10 @@ func NewWorker(cfg Config) (ReportableWorker, error) {
 	w := &remoteWorker{
 		client: cfg.Client,
 
-		consumerRelationUUID:   cfg.ConsumerRelationUUID,
-		offererApplicationUUID: cfg.OffererApplicationUUID,
-		macaroon:               cfg.Macaroon,
+		consumerRelationUUID:    cfg.ConsumerRelationUUID,
+		consumerApplicationUUID: cfg.ConsumerApplicationUUID,
+		offererApplicationUUID:  cfg.OffererApplicationUUID,
+		macaroon:                cfg.Macaroon,
 
 		changes: cfg.Changes,
 		clock:   cfg.Clock,
@@ -194,6 +200,12 @@ func (w *remoteWorker) Macaroon() *macaroon.Macaroon {
 // RelationUUID returns the consumer relation UUID for this worker.
 func (w *remoteWorker) RelationUUID() corerelation.UUID {
 	return w.consumerRelationUUID
+}
+
+// ConsumerApplicationUUID returns the UUID of the consuming application in
+// the local (consumer) model for this relation.
+func (w *remoteWorker) ConsumerApplicationUUID() coreapplication.UUID {
+	return w.consumerApplicationUUID
 }
 
 func (w *remoteWorker) loop() error {

--- a/internal/worker/remoterelationconsumer/offererunitrelations/worker_test.go
+++ b/internal/worker/remoterelationconsumer/offererunitrelations/worker_test.go
@@ -28,8 +28,9 @@ import (
 type offererUnitRelationsWorker struct {
 	client *MockRemoteModelRelationsClient
 
-	consumerRelationUUID   corerelation.UUID
-	offererApplicationUUID coreapplication.UUID
+	consumerRelationUUID    corerelation.UUID
+	consumerApplicationUUID coreapplication.UUID
+	offererApplicationUUID  coreapplication.UUID
 
 	macaroon *macaroon.Macaroon
 
@@ -43,6 +44,7 @@ func TestOffererUnitRelationsWorker(t *testing.T) {
 
 func (s *offererUnitRelationsWorker) SetUpTest(c *tc.C) {
 	s.consumerRelationUUID = tc.Must(c, corerelation.NewUUID)
+	s.consumerApplicationUUID = tc.Must(c, coreapplication.NewUUID)
 	s.offererApplicationUUID = tc.Must(c, coreapplication.NewUUID)
 
 	s.macaroon = newMacaroon(c, "test")
@@ -59,6 +61,11 @@ func (s *offererUnitRelationsWorker) TestValidate(c *tc.C) {
 
 	cfg = s.newConfig(c)
 	cfg.Client = nil
+	err = cfg.Validate()
+	c.Check(err, tc.ErrorIs, errors.NotValid)
+
+	cfg = s.newConfig(c)
+	cfg.ConsumerApplicationUUID = ""
 	err = cfg.Validate()
 	c.Check(err, tc.ErrorIs, errors.NotValid)
 
@@ -306,13 +313,14 @@ func (s *offererUnitRelationsWorker) TestReport(c *tc.C) {
 
 func (s *offererUnitRelationsWorker) newConfig(c *tc.C) Config {
 	return Config{
-		Client:                 s.client,
-		OffererApplicationUUID: s.offererApplicationUUID,
-		ConsumerRelationUUID:   s.consumerRelationUUID,
-		Macaroon:               s.macaroon,
-		Changes:                s.changes,
-		Clock:                  clock.WallClock,
-		Logger:                 loggertesting.WrapCheckLog(c),
+		Client:                  s.client,
+		OffererApplicationUUID:  s.offererApplicationUUID,
+		ConsumerApplicationUUID: s.consumerApplicationUUID,
+		ConsumerRelationUUID:    s.consumerRelationUUID,
+		Macaroon:                s.macaroon,
+		Changes:                 s.changes,
+		Clock:                   clock.WallClock,
+		Logger:                  loggertesting.WrapCheckLog(c),
 	}
 }
 

--- a/internal/worker/remoterelationconsumer/package_test.go
+++ b/internal/worker/remoterelationconsumer/package_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/macaroon.v2"
 	"gopkg.in/tomb.v2"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	corerelation "github.com/juju/juju/core/relation"
@@ -74,18 +75,25 @@ func (w *errWorker) Wait() error {
 	return w.tomb.Wait()
 }
 
-// macaroonErrWorker extends errWorker with Macaroon() and RelationUUID()
-// methods, so it can be used as an offerer unit relation worker in tests.
+// macaroonErrWorker extends errWorker with Macaroon(), RelationUUID(), and
+// ConsumerApplicationUUID() methods, so it can be used as an offerer unit
+// relation worker in tests.
 type macaroonErrWorker struct {
 	errWorker
-	macaroon     *macaroon.Macaroon
-	relationUUID corerelation.UUID
+	macaroon                *macaroon.Macaroon
+	relationUUID            corerelation.UUID
+	consumerApplicationUUID coreapplication.UUID
 }
 
-func newMacaroonErrWorker(mac *macaroon.Macaroon, relationUUID corerelation.UUID) *macaroonErrWorker {
+func newMacaroonErrWorker(
+	mac *macaroon.Macaroon,
+	relationUUID corerelation.UUID,
+	consumerApplicationUUID coreapplication.UUID,
+) *macaroonErrWorker {
 	w := &macaroonErrWorker{
-		macaroon:     mac,
-		relationUUID: relationUUID,
+		macaroon:                mac,
+		relationUUID:            relationUUID,
+		consumerApplicationUUID: consumerApplicationUUID,
 	}
 	w.tomb.Go(func() error {
 		<-w.tomb.Dying()
@@ -100,6 +108,10 @@ func (w *macaroonErrWorker) Macaroon() *macaroon.Macaroon {
 
 func (w *macaroonErrWorker) RelationUUID() corerelation.UUID {
 	return w.relationUUID
+}
+
+func (w *macaroonErrWorker) ConsumerApplicationUUID() coreapplication.UUID {
+	return w.consumerApplicationUUID
 }
 
 type reportableWorker struct {


### PR DESCRIPTION
When a Juju 4.0 controller consumes an offer from a Juju 3.6 controller, the relation gets stuck at
"joining" status. The consuming unit's charm never receives the data it expects via relation-get,
because the offering unit's relation-joined hook never fires.

The issue is that when the 4.0 consumer published relation changes to the remote model, it sent the `offerUUID` as the 
`ApplicationOrOfferToken`. A 4.0 offerer handles this fine because its domain layer has fallback logic to resolve
offer UUIDs. But a 3.6 offerer calls `GetRemoteEntity(token)`, which only knows about the consuming application's
UUID — the token it imported during `registerRemoteRelation`. Since the `offerUUID` doesn't match any remote entity,
the lookup returns `NotFound`, `applicationTag` becomes nil, and `PublishRelationChange` silently returns without
calling `EnterScope` for any units. The offering unit never enters scope, so relation-joined never fires on the
offering charm.

The fix carries the consuming application UUID in the offerer unit relation worker alongside the macaroon and
relation UUID it already owns, and uses it as `ApplicationOrOfferToken` in every relation change event published to
the offering model. This also removes a previous map-based approach that had a data race between the worker loop
(writes) and PublishModelDying (reads).


## QA steps

Create a CMR between an offering 3.6 controller and a 4.0 consuming controller.
```
$ juju_36 bootstrap lxd c36
$ juju_36 add-model m
$ juju_36 deploy juju-qa-dummy-source
$ juju_36 config dummy-source token=abc
$ juju_36 offer dummy-source:sink
 
# build juju on this branch
$ juju bootstrap lxd c40
$ juju add-model consume-model
$ juju consume c36:admin/m.dummy-source
$ juju deploy juju-qa-dummy-sink
$ juju relate dummy-sink dummy-source
# wait until relation joins, then check the token from status and exec 
$ juju status --relations 
$ juju exec --unit dummy-sink/0 -- cat /var/run/dummy-sink/token
abc
```

Also check that 4.0->4.0 cross-controller CMRs still work:
```
# build juju on this branch

$ juju bootstrap lxd offering
$ juju add-model m
$ juju deploy juju-qa-dummy-source
$ juju config dummy-source token=abc
$ juju offer dummy-source:sink
 
$ juju bootstrap lxd consuming
$ juju add-model m
$ juju consume offering:admin/m.dummy-source
$ juju deploy juju-qa-dummy-sink
$ juju relate dummy-sink dummy-source
# wait until relation joins, then check the token from status and exec 
$ juju status --relations 
$ juju exec --unit dummy-sink/0 -- cat /var/run/dummy-sink/token
abc
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22081.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9496](https://warthogs.atlassian.net/browse/JUJU-9496)


[JUJU-9496]: https://warthogs.atlassian.net/browse/JUJU-9496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ