### PR TITLE
test: update juju-qa-test to include a float option

### DIFF
--- a/testcharms/charm-hub/charms/juju-qa-test/config.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/config.yaml
@@ -16,9 +16,11 @@ options:
     default: 0
     description: Skill level.
     type: int
+  floatiness:
+    default: 0
+    description: Degree of floatiness
+    type: float
   foo-file:
     default: False
     description: Get resource and set log contents of foo-file as Info.
     type: boolean
-
-

--- a/tests/suites/cli/bundles/juju-qa-test_full-options_bundle.yaml
+++ b/tests/suites/cli/bundles/juju-qa-test_full-options_bundle.yaml
@@ -1,0 +1,22 @@
+default-base: ubuntu@20.04/stable
+series: focal
+applications:
+  juju-qa-test:
+    charm: juju-qa-test
+    channel: latest/stable
+    revision: 25
+    resources:
+      foo-file: 2
+    num_units: 1
+    to:
+      - "0"
+    options:
+      foo-file: false
+      skill: 0
+      status: hello
+      thing: "\U0001F381"
+      floatiness: 0
+    constraints: arch=amd64
+machines:
+  "0":
+    constraints: arch=amd64

--- a/tests/suites/cli/diff_bundle.sh
+++ b/tests/suites/cli/diff_bundle.sh
@@ -6,14 +6,13 @@ run_diff_bundle_reflexive() {
 	ensure "test-cli-diff-bundle-reflexive" "${file}"
 
 	# Check that numbers are considered equal, even if YAML and JSON choose to interpret them differently
+	# The juju-qa-test charm includes both int and float options
+	# so we install it from a bundle and then compare the model to the bundle
 
-	# Apache has integer config options
-	juju deploy apache2
-	# PostgreSQL has float config options
-	# that default to integral values
-	juju deploy postgresql
+	bundle="./test/suites/cli/bundles/juju-qa-test_full-options_bundle.yaml"
 
-	juju diff-bundle <(juju export-bundle --include-charm-defaults --include-series) | check "{}"
+	juju deploy bundle
+	juju diff-bundle "${bundle}" | check "{}"
 
 	destroy_model "test-cli-diff-bundle-reflexive"
 }


### PR DESCRIPTION
This is mostly a follow up to #22061 which currently relies on `export-bundle` for testing, so that it is easier to merge up to 4.0.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x ] Code style: imports ordered, good names, simple structure, etc
- [x ] Comments saying why design decisions were made
~- [ ] Go unit tests, with comments saying what you're testing~
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This is a test only change, so the QA is running the test suite. At the moment there's a slight chicken and egg problem, where the tests will not pass until juju-qa-test is updated, but this PR should be reviewed before making any changes to juju-qa-test.

