### PR TITLE
docs: fix typo in 2.9 release notes

### DIFF
--- a/docs/releasenotes/juju_2.9.x.md
+++ b/docs/releasenotes/juju_2.9.x.md
@@ -8,10 +8,12 @@
 Juju 2.9 series is LTS
 ```
 ### 🔸 **Juju 2.9.57**
-🗓️ 09 Apr 2025
+🗓️ 09 Apr 2026
 
 This is a security release for Juju 2.9, which includes fixes for a critical CVE
 which allows the cloud credential for the controller model to be leaked.
+We recommend that all users running Juju 2.9 upgrade to this release as soon
+as possible given the critical nature of the fixes included.
 
 🛠️ Fixes:
 


### PR DESCRIPTION
Trivial update to 2.9 release notes to fix a typo and add a missing line of text.