### PR TITLE
fix: removal of model with offer connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dqlite-deps.tar.bz2
 .sphinx
 .envrc
 .direnv/
+.codex

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -134,7 +134,7 @@ func (s *watcherSuite) TestWatchCharm(c *tc.C) {
 
 	removalSt := removalstatemodel.NewState(modelDB, loggertesting.WrapCheckLog(c))
 	harness.AddTest(c, func(c *tc.C) {
-		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false, false)
+		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)
 		err = removalSt.DeleteApplication(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)
@@ -1232,7 +1232,7 @@ WHERE uuid=?
 	})
 
 	harness.AddTest(c, func(c *tc.C) {
-		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false, false)
+		_, err := removalSt.EnsureApplicationNotAliveCascade(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)
 		err = removalSt.DeleteApplication(c.Context(), appID.String(), false)
 		c.Assert(err, tc.ErrorIsNil)

--- a/domain/removal/errors/errors.go
+++ b/domain/removal/errors/errors.go
@@ -60,10 +60,6 @@ const (
 	// still has relations
 	OfferHasRelations = errors.ConstError("offer has relations")
 
-	// ApplicationHasOfferConnections indicates that an application cannot be
-	// deleted because it still has offer connections
-	ApplicationHasOfferConnections = errors.ConstError("application has offer connections")
-
 	// ApplicationIsRemoteOfferer indicates that an application cannot be deleted
 	// because it is a remote application offerer
 	ApplicationIsRemoteOfferer = errors.ConstError("application is remote")

--- a/domain/removal/service/application.go
+++ b/domain/removal/service/application.go
@@ -35,7 +35,7 @@ type ApplicationState interface {
 	// the last ones on their machines, it will cascade and the machines are
 	// also set to dying. The affected machine UUIDs are returned.
 	EnsureApplicationNotAliveCascade(
-		ctx context.Context, appUUID string, destroyStorage, force bool,
+		ctx context.Context, appUUID string, destroyStorage bool,
 	) (internal.CascadedApplicationLives, error)
 
 	// ApplicationScheduleRemoval schedules a removal job for the application
@@ -92,7 +92,7 @@ func (s *Service) RemoveApplication(
 		return "", errors.Errorf("application %q does not exist", appUUID).Add(applicationerrors.ApplicationNotFound)
 	}
 
-	cascaded, err := s.modelState.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), destroyStorage, force)
+	cascaded, err := s.modelState.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), destroyStorage)
 	if err != nil {
 		return "", errors.Errorf("application %q: %w", appUUID, err)
 	}

--- a/domain/removal/service/application_test.go
+++ b/domain/removal/service/application_test.go
@@ -41,7 +41,7 @@ func (s *applicationSuite) TestRemoveApplicationDestroyStorageNoForceSuccess(c *
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), true, false).Return(internal.CascadedApplicationLives{}, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), true).Return(internal.CascadedApplicationLives{}, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveApplication(c.Context(), appUUID, true, false, 0)
@@ -59,7 +59,7 @@ func (s *applicationSuite) TestRemoveApplicationForceNoWaitSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, true).Return(internal.CascadedApplicationLives{}, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{}, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), true, when.UTC()).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveApplication(c.Context(), appUUID, false, true, 0)
@@ -77,7 +77,7 @@ func (s *applicationSuite) TestRemoveApplicationForceWaitSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, true).Return(internal.CascadedApplicationLives{}, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{}, nil)
 
 	// The first normal removal scheduled immediately.
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
@@ -118,7 +118,7 @@ func (s *applicationSuite) TestRemoveApplicationRetrySchedulesRemovalJobs(c *tc.
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil).Times(2)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(cascaded, nil).Times(2)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(cascaded, nil).Times(2)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil).Times(2)
 	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "relation-1", false, when.UTC()).Return(nil).Times(2)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "unit-1", false, when.UTC()).Return(nil).Times(2)
@@ -168,8 +168,8 @@ func (s *applicationSuite) TestRemoveApplicationRetryWithForceSchedulesRemovalJo
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil).Times(2)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(cascaded, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, true).Return(cascaded, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(cascaded, nil)
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(cascaded, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), true, when.UTC()).Return(nil)
 	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "relation-1", false, when.UTC()).Return(nil)
@@ -223,7 +223,7 @@ func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithUnitsAndStorag
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(internal.CascadedApplicationLives{
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{
 		UnitUUIDs: []string{"unit-1", "unit-2"},
 		CascadedStorageLives: internal.CascadedStorageLives{
 			CascadedStorageAttachmentLives: internal.CascadedStorageAttachmentLives{
@@ -253,7 +253,7 @@ func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithMachines(c *tc
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(internal.CascadedApplicationLives{
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{
 		MachineUUIDs: []string{"machine-1", "machine-2"},
 	}, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
@@ -276,7 +276,7 @@ func (s *applicationSuite) TestRemoveApplicationNoForceSuccessWithRelations(c *t
 
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
-	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false, false).Return(internal.CascadedApplicationLives{
+	exp.EnsureApplicationNotAliveCascade(gomock.Any(), appUUID.String(), false).Return(internal.CascadedApplicationLives{
 		RelationUUIDs: []string{"relation-1", "relation-2"},
 	}, nil)
 	exp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), appUUID.String(), false, when.UTC()).Return(nil)
@@ -323,7 +323,7 @@ func (s *applicationSuite) TestRemoveApplicationCascadeStorage(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.ApplicationExists(gomock.Any(), appUUID.String()).Return(true, nil)
 	exp.EnsureApplicationNotAliveCascade(
-		gomock.Any(), appUUID.String(), false, false,
+		gomock.Any(), appUUID.String(), false,
 	).Return(cascaded, nil)
 	exp.ApplicationScheduleRemoval(
 		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), appUUID.String(), false, when,

--- a/domain/removal/service/model.go
+++ b/domain/removal/service/model.go
@@ -496,6 +496,7 @@ func (s *Service) removeApplications(
 			// error. The applications are already transitioned to dying and
 			// there is no way to transition them back to alive.
 			s.logger.Errorf(ctx, "scheduling removal of application %q: %v", applicationUUID, err)
+			continue
 		} else if err == nil {
 			continue
 		}
@@ -513,11 +514,10 @@ func (s *Service) removeApplications(
 			// If the unit fails to be scheduled for removal, we log out the
 			// error. The applications are already transitioned to dying and
 			// there is no way to transition them back to alive.
-			s.logger.Errorf(ctx, "scheduling removal of application %q: %v", applicationUUID, err)
+			s.logger.Errorf(ctx, "scheduling removal of remote application offerer %q: %v", applicationUUID, err)
+			continue
 		} else if err == nil {
 			continue
 		}
-
-		// TODO: Handle remote application consumers
 	}
 }

--- a/domain/removal/service/model_test.go
+++ b/domain/removal/service/model_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	coremodel "github.com/juju/juju/core/model"
+	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
 	"github.com/juju/juju/domain/life"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/removal"
@@ -102,7 +103,7 @@ func (s *modelSuite) TestRemoveModelRetrySchedulesRemovalJobs(c *tc.C) {
 	mExp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "some-machine-id", false, when.UTC()).Return(nil).Times(2)
 
 	mExp.ApplicationExists(gomock.Any(), "some-application-id").Return(true, nil).Times(2)
-	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true, false).Return(removalinternal.CascadedApplicationLives{}, nil).Times(2)
+	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true).Return(removalinternal.CascadedApplicationLives{}, nil).Times(2)
 	mExp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), "some-application-id", false, when.UTC()).Return(nil).Times(2)
 
 	jobUUID1, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)
@@ -159,8 +160,8 @@ func (s *modelSuite) TestRemoveModelRetryWithForceSchedulesRemovalJobs(c *tc.C) 
 	mExp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "some-machine-id", true, when.UTC()).Return(nil)
 
 	mExp.ApplicationExists(gomock.Any(), "some-application-id").Return(true, nil).Times(2)
-	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true, false).Return(removalinternal.CascadedApplicationLives{}, nil)
-	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true, true).Return(removalinternal.CascadedApplicationLives{}, nil)
+	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true).Return(removalinternal.CascadedApplicationLives{}, nil)
+	mExp.EnsureApplicationNotAliveCascade(gomock.Any(), "some-application-id", true).Return(removalinternal.CascadedApplicationLives{}, nil)
 	mExp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), "some-application-id", false, when.UTC()).Return(nil)
 	mExp.ApplicationScheduleRemoval(gomock.Any(), gomock.Any(), "some-application-id", true, when.UTC()).Return(nil)
 
@@ -271,6 +272,82 @@ func (s *modelSuite) TestRemoveModelForceWaitSuccess(c *tc.C) {
 	mExp.ModelScheduleRemoval(gomock.Any(), gomock.Any(), mUUID.String(), true, when.UTC().Add(time.Minute)).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveModel(c.Context(), mUUID, true, time.Minute)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *modelSuite) TestRemoveModelNoForceSuccessWithRemoteApplicationOfferer(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	mUUID := tc.Must0(c, coremodel.NewUUID)
+	remoteAppUUID := tc.Must(c, coreremoteapplication.NewUUID)
+
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when).Times(2)
+
+	cExp := s.controllerState.EXPECT()
+	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
+	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+
+	mExp := s.modelState.EXPECT()
+	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
+	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(removal.ModelArtifacts{
+		ApplicationUUIDs: []string{"some-application-id"},
+	}, nil)
+	mExp.ModelScheduleRemoval(
+		gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC(),
+	).Return(nil)
+	mExp.ApplicationExists(gomock.Any(), "some-application-id").Return(
+		false,
+		errors.Errorf(
+			"application %q is a remote application", "some-application-id",
+		).Add(removalerrors.ApplicationIsRemoteOfferer),
+	)
+	mExp.GetRemoteApplicationOffererUUIDByApplicationUUID(
+		gomock.Any(), "some-application-id",
+	).Return(remoteAppUUID.String(), nil)
+	mExp.RemoteApplicationOffererExists(
+		gomock.Any(), remoteAppUUID.String(),
+	).Return(true, nil)
+	mExp.EnsureRemoteApplicationOffererNotAliveCascade(
+		gomock.Any(), remoteAppUUID.String(),
+	).Return(removalinternal.CascadedRemoteApplicationOffererLives{}, nil)
+	mExp.RemoteApplicationOffererScheduleRemoval(
+		gomock.Any(), gomock.Any(), remoteAppUUID.String(), false, when.UTC(),
+	).Return(nil)
+
+	jobUUID, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *modelSuite) TestRemoveModelIgnoresApplicationErrorWithoutRemoteOffererFallback(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	mUUID := tc.Must0(c, coremodel.NewUUID)
+
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when)
+
+	cExp := s.controllerState.EXPECT()
+	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
+	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+
+	mExp := s.modelState.EXPECT()
+	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
+	mExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
+	mExp.EnsureModelNotAliveCascade(gomock.Any(), mUUID.String()).Return(removal.ModelArtifacts{
+		ApplicationUUIDs: []string{"some-application-id"},
+	}, nil)
+	mExp.ModelScheduleRemoval(
+		gomock.Any(), gomock.Any(), mUUID.String(), false, when.UTC(),
+	).Return(nil)
+	mExp.ApplicationExists(gomock.Any(), "some-application-id").Return(
+		false, errors.Errorf("the front fell off"),
+	)
+
+	jobUUID, err := s.newService(c).RemoveModel(c.Context(), mUUID, false, 0)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
 }

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -1682,18 +1682,18 @@ func (c *MockModelDBStateDeleteVolumeAttachmentPlanCall) DoAndReturn(f func(cont
 }
 
 // EnsureApplicationNotAliveCascade mocks base method.
-func (m *MockModelDBState) EnsureApplicationNotAliveCascade(arg0 context.Context, arg1 string, arg2, arg3 bool) (internal.CascadedApplicationLives, error) {
+func (m *MockModelDBState) EnsureApplicationNotAliveCascade(arg0 context.Context, arg1 string, arg2 bool) (internal.CascadedApplicationLives, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureApplicationNotAliveCascade", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "EnsureApplicationNotAliveCascade", arg0, arg1, arg2)
 	ret0, _ := ret[0].(internal.CascadedApplicationLives)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureApplicationNotAliveCascade indicates an expected call of EnsureApplicationNotAliveCascade.
-func (mr *MockModelDBStateMockRecorder) EnsureApplicationNotAliveCascade(arg0, arg1, arg2, arg3 any) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
+func (mr *MockModelDBStateMockRecorder) EnsureApplicationNotAliveCascade(arg0, arg1, arg2 any) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureApplicationNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureApplicationNotAliveCascade), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureApplicationNotAliveCascade", reflect.TypeOf((*MockModelDBState)(nil).EnsureApplicationNotAliveCascade), arg0, arg1, arg2)
 	return &MockModelDBStateEnsureApplicationNotAliveCascadeCall{Call: call}
 }
 
@@ -1709,13 +1709,13 @@ func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) Return(arg0 inter
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) Do(f func(context.Context, string, bool, bool) (internal.CascadedApplicationLives, error)) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) Do(f func(context.Context, string, bool) (internal.CascadedApplicationLives, error)) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) DoAndReturn(f func(context.Context, string, bool, bool) (internal.CascadedApplicationLives, error)) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
+func (c *MockModelDBStateEnsureApplicationNotAliveCascadeCall) DoAndReturn(f func(context.Context, string, bool) (internal.CascadedApplicationLives, error)) *MockModelDBStateEnsureApplicationNotAliveCascadeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -85,7 +85,7 @@ WHERE  application_uuid = $entityUUID.uuid`, count{}, applicationUUID)
 // also set to dying. Non-dead cascaded entity UUIDs are returned so retries
 // can re-schedule child removals with updated intent.
 func (st *State) EnsureApplicationNotAliveCascade(
-	ctx context.Context, aUUID string, destroyStorage bool, force bool,
+	ctx context.Context, aUUID string, destroyStorage bool,
 ) (internal.CascadedApplicationLives, error) {
 	var res internal.CascadedApplicationLives
 
@@ -95,18 +95,6 @@ func (st *State) EnsureApplicationNotAliveCascade(
 	}
 
 	applicationUUID := entityUUID{UUID: aUUID}
-	checkOfferConnectionsStmt, err := st.Prepare(`
-SELECT COUNT(*) AS &count.count
-FROM   offer_connection AS oc
-JOIN   offer AS o ON oc.offer_uuid = o.uuid
-JOIN   offer_endpoint AS oe ON o.uuid = oe.offer_uuid
-JOIN   application_endpoint AS ae ON oe.endpoint_uuid = ae.uuid
-WHERE  ae.application_uuid = $entityUUID.uuid
-	`, count{}, applicationUUID)
-	if err != nil {
-		return res, errors.Errorf("preparing offer connections query: %w", err)
-	}
-
 	updateApplicationStmt, err := st.Prepare(`
 UPDATE application
 SET    life_id = 1
@@ -151,17 +139,6 @@ AND    life_id < 2`, applicationUUID)
 	}
 
 	if err := errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if !force {
-			var count count
-			if err := tx.Query(ctx, checkOfferConnectionsStmt, applicationUUID).Get(&count); err != nil {
-				return errors.Errorf("checking offer connections: %w", err)
-			} else if count.Count > 0 {
-				return errors.Errorf("cannot remove application %q, it has %d offer connection(s)", aUUID, count.Count).
-					Add(removalerrors.ApplicationHasOfferConnections).
-					Add(removalerrors.ForceRequired)
-			}
-		}
-
 		if err := tx.Query(ctx, updateApplicationStmt, applicationUUID).Run(); err != nil {
 			return errors.Errorf("advancing application life: %w", err)
 		}

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -74,7 +74,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccess(c *
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// We don't have any units, so we expect an empty slice for both unit and
@@ -129,7 +129,7 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	// Perform the ensure operation with destroyStorage.
-	artifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true, false)
+	artifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(artifacts.RelationUUIDs, tc.HasLen, 0)
@@ -177,7 +177,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(artifacts.RelationUUIDs, tc.HasLen, 0)
@@ -217,7 +217,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(artifacts.RelationUUIDs, tc.HasLen, 0)
@@ -254,7 +254,7 @@ func (s *applicationSuite) TestEnsureApplicationOnMultipleMachines(c *tc.C) {
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID1.String(), false, false)
+	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID1.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	app1UnitUUIDs := s.getAllUnitUUIDs(c, appUUID1)
@@ -310,7 +310,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWith
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(artifacts.RelationUUIDs, tc.HasLen, 1)
@@ -331,7 +331,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeDyingSuccess(c *t
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	artifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// We don't have any units, so we expect an empty slice for both unit and
@@ -352,13 +352,13 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeRetryReturnsDying
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(firstArtifacts.RelationUUIDs, tc.HasLen, 0)
 	c.Check(firstArtifacts.UnitUUIDs, tc.HasLen, 1)
 	c.Check(firstArtifacts.MachineUUIDs, tc.HasLen, 1)
 
-	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(secondArtifacts.RelationUUIDs, tc.DeepEquals, firstArtifacts.RelationUUIDs)
 	c.Check(secondArtifacts.UnitUUIDs, tc.DeepEquals, firstArtifacts.UnitUUIDs)
@@ -383,13 +383,13 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeRetryReturnsDying
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(firstArtifacts.RelationUUIDs, tc.HasLen, 1)
 	c.Check(firstArtifacts.UnitUUIDs, tc.HasLen, 0)
 	c.Check(firstArtifacts.MachineUUIDs, tc.HasLen, 0)
 
-	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
+	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(secondArtifacts, tc.DeepEquals, firstArtifacts)
 
@@ -435,12 +435,12 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`, allUnitUUIDs[0])
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true, false)
+	firstArtifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(firstArtifacts.StorageAttachmentUUIDs, tc.DeepEquals, []string{"storage-attachment-uuid"})
 	c.Check(firstArtifacts.StorageInstanceUUIDs, tc.DeepEquals, []string{"instance-uuid"})
 
-	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true, false)
+	secondArtifacts, err := st.EnsureApplicationNotAliveCascade(ctx, appUUID.String(), true)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(secondArtifacts.StorageAttachmentUUIDs, tc.DeepEquals, firstArtifacts.StorageAttachmentUUIDs)
 	c.Check(secondArtifacts.StorageInstanceUUIDs, tc.DeepEquals, firstArtifacts.StorageInstanceUUIDs)
@@ -458,28 +458,15 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeOfferConnections(
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	_, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, false)
-	c.Assert(err, tc.ErrorIs, removalerrors.ApplicationHasOfferConnections)
-	c.Assert(err, tc.ErrorIs, removalerrors.ForceRequired)
-}
-
-func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeOfferConnectionsWithForce(c *tc.C) {
-	svc := s.setupApplicationService(c)
-	appUUID := s.createIAASApplication(c, svc, "some-app")
-	offerUUID := s.createOfferForApplication(c, "some-app", "some-offer")
-	s.createRemoteApplicationConsumer(c, "some-remote-app", offerUUID)
-
-	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-
-	_, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false, true)
+	_, err := st.EnsureApplicationNotAliveCascade(c.Context(), appUUID.String(), false)
+	// Offer connections should NOT block application removal.
 	c.Assert(err, tc.ErrorIsNil)
-	s.checkApplicationDyingState(c, appUUID)
 }
 
-func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNotExistsSuccess(c *tc.C) {
+func (s *applicationSuite) TestEnsureApplicationNotAliveCaadeNotExistsSuccess(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	_, err := st.EnsureApplicationNotAliveCascade(c.Context(), "some-application-uuid", false, false)
+	_, err := st.EnsureApplicationNotAliveCascade(c.Context(), "some-application-uuid", false)
 	c.Assert(err, tc.ErrorIsNil)
 }
 


### PR DESCRIPTION
Previously we incorrectly blocked an application's removal (unless force was provided) if the application had offer connections.

This is wrong, offer connections essentially represent metadata. They are cleaned up when the CMR relation is removed.

This check resulted in a failure to schedule application removal jobs when a model was removed, since RemoveApplication now returns an unexpected error, meaning the model removal gets stuck

Drop this check

As a flyby, amend removeApplication in model removal to skip an application on unexpected error, rather than fall back to removing a remote application. We should only do this in the specific case of an ApplicationIsRemoteOfferer error

## Links:

Fixes: https://github.com/juju/juju/issues/21766
Jira: https://warthogs.atlassian.net/browse/JUJU-9191

## QA steps

### Model removal
```
for c in "cns" "src"; do juju bootstrap lxd $c; done
juju switch src; juju add-model work-src; juju deploy juju-qa-dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju add-model work-cns; juju consume src:admin/work-src.dummy-source; juju deploy juju-qa-dummy-sink; juju relate dummy-source dummy-sink
```
And when settled:
```
$ juju destroy-model work-src
WARNING This command will destroy the "work-src" model and affect the following resources. It cannot be stopped.

 - 1 machine will be destroyed
  - machine list: "0 (juju-543df6-0)"
 - 2 applications will be removed
  - application list: "remote-01ab1d6d05154d63831e970b6141dff1" "dummy-source"
 - 0 filesystem and 0 volume will be destroyed

To continue, enter the name of the model to be unregistered: work-src
Destroying model

Waiting for model to be removed, 2 application(s).............
Waiting for model to be removed, 1 application(s).......
Waiting for model to be removed..........
Model destroyed.
```

### Application removal

```
for c in "cns" "src"; do juju bootstrap lxd $c; done
juju switch src; juju add-model work-src; juju deploy juju-qa-dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju add-model work-cns; juju consume src:admin/work-src.dummy-source; juju deploy juju-qa-dummy-sink; juju relate dummy-source dummy-sink
```
And when settled:
```
$ juju remove-application dummy-source
$ juju status
Model     Controller  Cloud/Region   Version  Timestamp
work-src  src         lxd/localhost  4.0.6.1  11:40:15+01:00

Model "admin/work-src" is empty.
```