### PR TITLE
fix: add recent introduced azure fallback cloud regions

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -355,6 +355,22 @@ clouds:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://login.microsoftonline.com
+      austriaeast:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://login.microsoftonline.com
+      belgiumcentral:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://login.microsoftonline.com
+      brazilsoutheast:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://login.microsoftonline.com
+      denmarkeast:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://login.microsoftonline.com
   azure-china:
     type: azure
     description: Microsoft Azure China

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -362,6 +362,22 @@ clouds:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://login.microsoftonline.com
+      austriaeast:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://login.microsoftonline.com
+      belgiumcentral:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://login.microsoftonline.com
+      brazilsoutheast:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://login.microsoftonline.com
+      denmarkeast:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://login.microsoftonline.com
   azure-china:
     type: azure
     description: Microsoft Azure China


### PR DESCRIPTION
Updated azure fallback cloud regions.

Included (austriaeast and belgiumcentral) that were specified by user.
There are two others that were missed from the below azure regions reference list (brazilsoutheast and denmarkeast)

Reference list:
https://learn.microsoft.com/en-us/azure/reliability/regions-list?tabs=all

## Checklist
~~- [ ] Code style: imports ordered, good names, simple structure, etc~~
~~- [ ] Comments saying why design decisions were made~~
~~- [ ] Go unit tests, with comments saying what you're testing~~
~~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
~~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps to run bootstrap using fallback regions

1. Make sure JUJU_DATA is set to $HOME/.local/share/juju and make sure the folder exists, if not create it manually or run bootstrap once.

2. Remove public clouds yaml if it exists.
```sh
rm -rf ~/.local/share/juju/public-clouds.yaml
```

3. Run bootstrap with new region belgiumcentral using fallback.
```sh
juju bootstrap azure/belgiumcentral bel --debug
```

If region does not exist, it would have shown
```
ERROR region "belgiumcentral2" for cloud "azure" not valid
```

## Links
**Github bug:** https://github.com/juju/juju/issues/21711
**Jira card:** https://warthogs.atlassian.net/browse/JUJU-9138

