### PR TITLE
fix: set hostname in machine import

### DIFF
--- a/domain/machine/import_integration_test.go
+++ b/domain/machine/import_integration_test.go
@@ -65,6 +65,7 @@ func (s *importSuite) TestImportMachine(c *tc.C) {
 		Base:                "ubuntu@24.04",
 		ContainerType:       "lxd",
 		SupportedContainers: &[]string{"lxd"},
+		Hostname:            "host-name-123",
 	})
 	m0.SetAddresses([]description.AddressArgs{{
 		Value:   "192.168.0.1",

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -53,8 +53,8 @@ type ImportService interface {
 	// CreateMachine creates the specified machine.
 	CreateMachine(
 		ctx context.Context,
-		hostname string,
 		machineName machine.Name,
+		hostname string,
 		nonce *string,
 		platform deployment.Platform,
 		placement deployment.Placement,
@@ -64,9 +64,9 @@ type ImportService interface {
 	// CreateSubordinateMachine creates the specified subordinate machine.
 	CreateSubordinateMachine(
 		ctx context.Context,
-		hostname string,
 		machineName machine.Name,
 		parentUUID machine.UUID,
+		hostname string,
 		nonce *string,
 		platform deployment.Platform,
 		placement deployment.Placement,
@@ -131,8 +131,8 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		// We need skeleton machines in dqlite.
 		machineUUID, err := i.service.CreateMachine(
 			ctx,
-			m.Hostname(),
 			machine.Name(m.Id()),
+			m.Hostname(),
 			new(m.Nonce()),
 			machinePlatform,
 			domainPlacement,
@@ -160,9 +160,9 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 			containerUUID, err := i.service.CreateSubordinateMachine(
 				ctx,
-				c.Hostname(),
 				machine.Name(c.Id()),
 				machineUUID,
+				c.Hostname(),
 				new(c.Nonce()),
 				machinePlatform,
 				domainPlacement,

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -53,6 +53,7 @@ type ImportService interface {
 	// CreateMachine creates the specified machine.
 	CreateMachine(
 		ctx context.Context,
+		hostname string,
 		machineName machine.Name,
 		nonce *string,
 		platform deployment.Platform,
@@ -63,6 +64,7 @@ type ImportService interface {
 	// CreateSubordinateMachine creates the specified subordinate machine.
 	CreateSubordinateMachine(
 		ctx context.Context,
+		hostname string,
 		machineName machine.Name,
 		parentUUID machine.UUID,
 		nonce *string,
@@ -129,6 +131,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		// We need skeleton machines in dqlite.
 		machineUUID, err := i.service.CreateMachine(
 			ctx,
+			m.Hostname(),
 			machine.Name(m.Id()),
 			new(m.Nonce()),
 			machinePlatform,
@@ -157,6 +160,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 			containerUUID, err := i.service.CreateSubordinateMachine(
 				ctx,
+				c.Hostname(),
 				machine.Name(c.Id()),
 				machineUUID,
 				new(c.Nonce()),

--- a/domain/machine/modelmigration/import_test.go
+++ b/domain/machine/modelmigration/import_test.go
@@ -75,6 +75,7 @@ func (s *importSuite) TestImport(c *tc.C) {
 		Nonce:     "nonce",
 		Base:      base.MakeDefaultBase("ubuntu", "24.04").String(),
 		Placement: "0",
+		Hostname:  "host-name-123",
 	})
 	m0.SetConstraints(description.ConstraintsArgs{
 		CpuCores: 8,
@@ -83,6 +84,7 @@ func (s *importSuite) TestImport(c *tc.C) {
 
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
+		"host-name-123",
 		machine.Name("666"),
 		new("nonce"),
 		deployment.Platform{
@@ -110,13 +112,15 @@ func (s *importSuite) TestFailImportMachineWithoutCloudInstance(c *tc.C) {
 
 	model := description.NewModel(description.ModelArgs{})
 	model.AddMachine(description.MachineArgs{
-		Id:    "0",
-		Nonce: "nonce",
-		Base:  base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Id:       "0",
+		Nonce:    "nonce",
+		Base:     base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Hostname: "host-name-123",
 	})
 
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
+		"host-name-123",
 		machine.Name("0"),
 		new("nonce"),
 		deployment.Platform{
@@ -138,9 +142,10 @@ func (s *importSuite) TestFailImportMachineWithCloudInstance(c *tc.C) {
 
 	model := description.NewModel(description.ModelArgs{})
 	machine0 := model.AddMachine(description.MachineArgs{
-		Id:    "0",
-		Nonce: "nonce",
-		Base:  base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Id:       "0",
+		Nonce:    "nonce",
+		Base:     base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Hostname: "host-name-123",
 	})
 	cloudInstanceArgs := description.CloudInstanceArgs{
 		InstanceId:       "inst-0",
@@ -160,6 +165,7 @@ func (s *importSuite) TestFailImportMachineWithCloudInstance(c *tc.C) {
 	expectedMachineUUID := tc.Must(c, machine.NewUUID)
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
+		"host-name-123",
 		machine.Name("0"),
 		new("nonce"),
 		deployment.Platform{
@@ -200,9 +206,10 @@ func (s *importSuite) TestImportMachineWithCloudInstance(c *tc.C) {
 
 	model := description.NewModel(description.ModelArgs{})
 	machine0 := model.AddMachine(description.MachineArgs{
-		Id:    "0",
-		Nonce: "nonce",
-		Base:  base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Id:       "0",
+		Nonce:    "nonce",
+		Base:     base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Hostname: "host-name-123",
 	})
 	cloudInstanceArgs := description.CloudInstanceArgs{
 		InstanceId:       "inst-0",
@@ -222,6 +229,7 @@ func (s *importSuite) TestImportMachineWithCloudInstance(c *tc.C) {
 	expectedMachineUUID := tc.Must(c, machine.NewUUID)
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
+		"host-name-123",
 		machine.Name("0"),
 		new("nonce"),
 		deployment.Platform{
@@ -262,27 +270,31 @@ func (s *importSuite) TestImportMachineWithContainers(c *tc.C) {
 
 	model := description.NewModel(description.ModelArgs{})
 	machine0 := model.AddMachine(description.MachineArgs{
-		Id:    "666",
-		Nonce: "nonce",
-		Base:  base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Id:       "666",
+		Nonce:    "nonce",
+		Base:     base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Hostname: "host-name-123",
 	})
 	machine0.AddContainer(description.MachineArgs{
 		Id:        "666/lxd/0",
 		Nonce:     "nonce",
 		Placement: "lxd:666",
 		Base:      base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Hostname:  "host-name-container-456",
 	})
 	machine0.AddContainer(description.MachineArgs{
 		Id:        "666/lxd/1",
 		Nonce:     "nonce",
 		Placement: "lxd:666",
 		Base:      base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Hostname:  "host-name-container-789",
 	})
 
 	expectedMachineUUID := tc.Must(c, machine.NewUUID)
 
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
+		"host-name-123",
 		machine.Name("666"),
 		new("nonce"),
 		deployment.Platform{
@@ -296,6 +308,7 @@ func (s *importSuite) TestImportMachineWithContainers(c *tc.C) {
 
 	s.service.EXPECT().CreateSubordinateMachine(
 		gomock.Any(),
+		"host-name-container-456",
 		machine.Name("666/lxd/0"),
 		expectedMachineUUID,
 		new("nonce"),
@@ -314,6 +327,7 @@ func (s *importSuite) TestImportMachineWithContainers(c *tc.C) {
 
 	s.service.EXPECT().CreateSubordinateMachine(
 		gomock.Any(),
+		"host-name-container-789",
 		machine.Name("666/lxd/1"),
 		expectedMachineUUID,
 		new("nonce"),
@@ -340,15 +354,17 @@ func (s *importSuite) TestImportMachineWithContainerWithCloudInstances(c *tc.C) 
 
 	model := description.NewModel(description.ModelArgs{})
 	machine0 := model.AddMachine(description.MachineArgs{
-		Id:    "0",
-		Nonce: "nonce",
-		Base:  base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Id:       "0",
+		Nonce:    "nonce",
+		Base:     base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Hostname: "host-name-123",
 	})
 	container0 := machine0.AddContainer(description.MachineArgs{
 		Id:        "0/lxd/0",
 		Nonce:     "nonce",
 		Placement: "lxd:0",
 		Base:      base.MakeDefaultBase("ubuntu", "24.04").String(),
+		Hostname:  "host-name-container-456",
 	})
 
 	cloudInstanceArgs := description.CloudInstanceArgs{
@@ -372,6 +388,7 @@ func (s *importSuite) TestImportMachineWithContainerWithCloudInstances(c *tc.C) 
 
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
+		"host-name-123",
 		machine.Name("0"),
 		new("nonce"),
 		deployment.Platform{
@@ -404,6 +421,7 @@ func (s *importSuite) TestImportMachineWithContainerWithCloudInstances(c *tc.C) 
 
 	s.service.EXPECT().CreateSubordinateMachine(
 		gomock.Any(),
+		"host-name-container-456",
 		machine.Name("0/lxd/0"),
 		expectedMachineUUID,
 		new("nonce"),

--- a/domain/machine/modelmigration/import_test.go
+++ b/domain/machine/modelmigration/import_test.go
@@ -84,8 +84,8 @@ func (s *importSuite) TestImport(c *tc.C) {
 
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
-		"host-name-123",
 		machine.Name("666"),
+		"host-name-123",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,
@@ -120,8 +120,8 @@ func (s *importSuite) TestFailImportMachineWithoutCloudInstance(c *tc.C) {
 
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
-		"host-name-123",
 		machine.Name("0"),
+		"host-name-123",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,
@@ -165,8 +165,8 @@ func (s *importSuite) TestFailImportMachineWithCloudInstance(c *tc.C) {
 	expectedMachineUUID := tc.Must(c, machine.NewUUID)
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
-		"host-name-123",
 		machine.Name("0"),
+		"host-name-123",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,
@@ -229,8 +229,8 @@ func (s *importSuite) TestImportMachineWithCloudInstance(c *tc.C) {
 	expectedMachineUUID := tc.Must(c, machine.NewUUID)
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
-		"host-name-123",
 		machine.Name("0"),
+		"host-name-123",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,
@@ -294,8 +294,8 @@ func (s *importSuite) TestImportMachineWithContainers(c *tc.C) {
 
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
-		"host-name-123",
 		machine.Name("666"),
+		"host-name-123",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,
@@ -308,9 +308,9 @@ func (s *importSuite) TestImportMachineWithContainers(c *tc.C) {
 
 	s.service.EXPECT().CreateSubordinateMachine(
 		gomock.Any(),
-		"host-name-container-456",
 		machine.Name("666/lxd/0"),
 		expectedMachineUUID,
+		"host-name-container-456",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,
@@ -327,9 +327,9 @@ func (s *importSuite) TestImportMachineWithContainers(c *tc.C) {
 
 	s.service.EXPECT().CreateSubordinateMachine(
 		gomock.Any(),
-		"host-name-container-789",
 		machine.Name("666/lxd/1"),
 		expectedMachineUUID,
+		"host-name-container-789",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,
@@ -388,8 +388,8 @@ func (s *importSuite) TestImportMachineWithContainerWithCloudInstances(c *tc.C) 
 
 	s.service.EXPECT().CreateMachine(
 		gomock.Any(),
-		"host-name-123",
 		machine.Name("0"),
+		"host-name-123",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,
@@ -421,9 +421,9 @@ func (s *importSuite) TestImportMachineWithContainerWithCloudInstances(c *tc.C) 
 
 	s.service.EXPECT().CreateSubordinateMachine(
 		gomock.Any(),
-		"host-name-container-456",
 		machine.Name("0/lxd/0"),
 		expectedMachineUUID,
+		"host-name-container-456",
 		new("nonce"),
 		deployment.Platform{
 			OSType:       deployment.Ubuntu,

--- a/domain/machine/modelmigration/migrations_mock_test.go
+++ b/domain/machine/modelmigration/migrations_mock_test.go
@@ -104,18 +104,18 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2 *string, arg3 deployment.Platform, arg4 deployment.Placement, arg5 constraints.Constraints) (machine.UUID, error) {
+func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 string, arg2 machine.Name, arg3 *string, arg4 deployment.Platform, arg5 deployment.Placement, arg6 constraints.Constraints) (machine.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateMachine indicates an expected call of CreateMachine.
-func (mr *MockImportServiceMockRecorder) CreateMachine(arg0, arg1, arg2, arg3, arg4, arg5 any) *MockImportServiceCreateMachineCall {
+func (mr *MockImportServiceMockRecorder) CreateMachine(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *MockImportServiceCreateMachineCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockImportService)(nil).CreateMachine), arg0, arg1, arg2, arg3, arg4, arg5)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockImportService)(nil).CreateMachine), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	return &MockImportServiceCreateMachineCall{Call: call}
 }
 
@@ -131,30 +131,30 @@ func (c *MockImportServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, machine.Name, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, string, machine.Name, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, string, machine.Name, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateSubordinateMachine mocks base method.
-func (m *MockImportService) CreateSubordinateMachine(arg0 context.Context, arg1 machine.Name, arg2 machine.UUID, arg3 *string, arg4 deployment.Platform, arg5 deployment.Placement, arg6 constraints.Constraints) (machine.UUID, error) {
+func (m *MockImportService) CreateSubordinateMachine(arg0 context.Context, arg1 string, arg2 machine.Name, arg3 machine.UUID, arg4 *string, arg5 deployment.Platform, arg6 deployment.Placement, arg7 constraints.Constraints) (machine.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSubordinateMachine", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "CreateSubordinateMachine", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(machine.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSubordinateMachine indicates an expected call of CreateSubordinateMachine.
-func (mr *MockImportServiceMockRecorder) CreateSubordinateMachine(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *MockImportServiceCreateSubordinateMachineCall {
+func (mr *MockImportServiceMockRecorder) CreateSubordinateMachine(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *MockImportServiceCreateSubordinateMachineCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubordinateMachine", reflect.TypeOf((*MockImportService)(nil).CreateSubordinateMachine), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubordinateMachine", reflect.TypeOf((*MockImportService)(nil).CreateSubordinateMachine), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	return &MockImportServiceCreateSubordinateMachineCall{Call: call}
 }
 
@@ -170,13 +170,13 @@ func (c *MockImportServiceCreateSubordinateMachineCall) Return(arg0 machine.UUID
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateSubordinateMachineCall) Do(f func(context.Context, machine.Name, machine.UUID, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
+func (c *MockImportServiceCreateSubordinateMachineCall) Do(f func(context.Context, string, machine.Name, machine.UUID, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateSubordinateMachineCall) DoAndReturn(f func(context.Context, machine.Name, machine.UUID, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
+func (c *MockImportServiceCreateSubordinateMachineCall) DoAndReturn(f func(context.Context, string, machine.Name, machine.UUID, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/modelmigration/migrations_mock_test.go
+++ b/domain/machine/modelmigration/migrations_mock_test.go
@@ -104,7 +104,7 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 string, arg2 machine.Name, arg3 *string, arg4 deployment.Platform, arg5 deployment.Placement, arg6 constraints.Constraints) (machine.UUID, error) {
+func (m *MockImportService) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2 string, arg3 *string, arg4 deployment.Platform, arg5 deployment.Placement, arg6 constraints.Constraints) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(machine.UUID)
@@ -131,19 +131,19 @@ func (c *MockImportServiceCreateMachineCall) Return(arg0 machine.UUID, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, string, machine.Name, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) Do(f func(context.Context, machine.Name, string, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, string, machine.Name, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
+func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, string, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateSubordinateMachine mocks base method.
-func (m *MockImportService) CreateSubordinateMachine(arg0 context.Context, arg1 string, arg2 machine.Name, arg3 machine.UUID, arg4 *string, arg5 deployment.Platform, arg6 deployment.Placement, arg7 constraints.Constraints) (machine.UUID, error) {
+func (m *MockImportService) CreateSubordinateMachine(arg0 context.Context, arg1 machine.Name, arg2 machine.UUID, arg3 string, arg4 *string, arg5 deployment.Platform, arg6 deployment.Placement, arg7 constraints.Constraints) (machine.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSubordinateMachine", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(machine.UUID)
@@ -170,13 +170,13 @@ func (c *MockImportServiceCreateSubordinateMachineCall) Return(arg0 machine.UUID
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateSubordinateMachineCall) Do(f func(context.Context, string, machine.Name, machine.UUID, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
+func (c *MockImportServiceCreateSubordinateMachineCall) Do(f func(context.Context, machine.Name, machine.UUID, string, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateSubordinateMachineCall) DoAndReturn(f func(context.Context, string, machine.Name, machine.UUID, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
+func (c *MockImportServiceCreateSubordinateMachineCall) DoAndReturn(f func(context.Context, machine.Name, machine.UUID, string, *string, deployment.Platform, deployment.Placement, constraints.Constraints) (machine.UUID, error)) *MockImportServiceCreateSubordinateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/migration.go
+++ b/domain/machine/service/migration.go
@@ -72,8 +72,8 @@ func NewMigrationService(
 // already exists.
 func (s *MigrationService) CreateMachine(
 	ctx context.Context,
-	hostname string,
 	machineName coremachine.Name,
+	hostname string,
 	nonce *string,
 	platform deployment.Platform,
 	placement deployment.Placement,
@@ -118,9 +118,9 @@ func (s *MigrationService) CreateMachine(
 // already exists.
 func (s *MigrationService) CreateSubordinateMachine(
 	ctx context.Context,
-	hostname string,
 	machineName coremachine.Name,
 	parentUUID coremachine.UUID,
+	hostname string,
 	nonce *string,
 	platform deployment.Platform,
 	placement deployment.Placement,

--- a/domain/machine/service/migration.go
+++ b/domain/machine/service/migration.go
@@ -72,6 +72,7 @@ func NewMigrationService(
 // already exists.
 func (s *MigrationService) CreateMachine(
 	ctx context.Context,
+	hostname string,
 	machineName coremachine.Name,
 	nonce *string,
 	platform deployment.Platform,
@@ -93,6 +94,7 @@ func (s *MigrationService) CreateMachine(
 		return "", errors.Errorf("creating net node UUID for machine %q: %w", machineName, err)
 	}
 	err = s.st.InsertMigratingMachine(ctx, machineName.String(), machine.CreateMachineArgs{
+		Hostname:    hostname,
 		MachineUUID: machineUUID,
 		NetNodeUUID: netNodeUUID,
 		Nonce:       nonce,
@@ -116,6 +118,7 @@ func (s *MigrationService) CreateMachine(
 // already exists.
 func (s *MigrationService) CreateSubordinateMachine(
 	ctx context.Context,
+	hostname string,
 	machineName coremachine.Name,
 	parentUUID coremachine.UUID,
 	nonce *string,
@@ -138,6 +141,7 @@ func (s *MigrationService) CreateSubordinateMachine(
 		return "", errors.Errorf("creating net node UUID for machine %q: %w", machineName, err)
 	}
 	err = s.st.InsertMigratingSubordinateMachine(ctx, machineName.String(), parentUUID.String(), machine.CreateMachineArgs{
+		Hostname:    hostname,
 		MachineUUID: machineUUID,
 		NetNodeUUID: netNodeUUID,
 		Nonce:       nonce,

--- a/domain/machine/service/migration_test.go
+++ b/domain/machine/service/migration_test.go
@@ -117,6 +117,7 @@ func (s *migrationServiceSuite) TestCreateMachine(c *tc.C) {
 
 	obtainedUUID, err := s.service.CreateMachine(
 		c.Context(),
+		"host-name-123",
 		"666",
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
@@ -143,6 +144,7 @@ func (s *migrationServiceSuite) TestCreateMachineSuccessNonce(c *tc.C) {
 
 	obtainedUUID, err := s.service.CreateMachine(
 		c.Context(),
+		"host-name-123",
 		"666",
 		new("foo"),
 		deployment.Platform{Architecture: architecture.AMD64},
@@ -163,6 +165,7 @@ func (s *migrationServiceSuite) TestCreateMachineError(c *tc.C) {
 
 	_, err := s.service.CreateMachine(
 		c.Context(),
+		"host-name-123",
 		"666",
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
@@ -184,6 +187,7 @@ func (s *migrationServiceSuite) TestCreateMachineAlreadyExists(c *tc.C) {
 
 	_, err := s.service.CreateMachine(
 		c.Context(),
+		"host-name-123",
 		coremachine.Name("666"),
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
@@ -208,6 +212,7 @@ func (s *migrationServiceSuite) TestCreateSubordinateMachine(c *tc.C) {
 
 	obtainedUUID, err := s.service.CreateSubordinateMachine(
 		c.Context(),
+		"host-name-123",
 		coremachine.Name("666"),
 		coremachine.UUID("parent-uuid"),
 		nil,
@@ -235,6 +240,7 @@ func (s *migrationServiceSuite) TestCreateSubordinateMachineNonce(c *tc.C) {
 
 	obtainedUUID, err := s.service.CreateSubordinateMachine(
 		c.Context(),
+		"host-name-123",
 		coremachine.Name("666"),
 		coremachine.UUID("parent-uuid"),
 		new("foo"),
@@ -256,6 +262,7 @@ func (s *migrationServiceSuite) TestCreateSubordinateMachineError(c *tc.C) {
 
 	_, err := s.service.CreateSubordinateMachine(
 		c.Context(),
+		"host-name-123",
 		coremachine.Name("666"),
 		coremachine.UUID("parent-uuid"),
 		nil,
@@ -278,6 +285,7 @@ func (s *migrationServiceSuite) TestCreateSubordinateMachineAlreadyExists(c *tc.
 
 	_, err := s.service.CreateSubordinateMachine(
 		c.Context(),
+		"host-name-123",
 		coremachine.Name("666"),
 		coremachine.UUID("parent-uuid"),
 		nil,

--- a/domain/machine/service/migration_test.go
+++ b/domain/machine/service/migration_test.go
@@ -117,8 +117,8 @@ func (s *migrationServiceSuite) TestCreateMachine(c *tc.C) {
 
 	obtainedUUID, err := s.service.CreateMachine(
 		c.Context(),
-		"host-name-123",
 		"666",
+		"host-name-123",
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
 		deployment.Placement{},
@@ -144,8 +144,8 @@ func (s *migrationServiceSuite) TestCreateMachineSuccessNonce(c *tc.C) {
 
 	obtainedUUID, err := s.service.CreateMachine(
 		c.Context(),
-		"host-name-123",
 		"666",
+		"host-name-123",
 		new("foo"),
 		deployment.Platform{Architecture: architecture.AMD64},
 		deployment.Placement{},
@@ -165,8 +165,8 @@ func (s *migrationServiceSuite) TestCreateMachineError(c *tc.C) {
 
 	_, err := s.service.CreateMachine(
 		c.Context(),
-		"host-name-123",
 		"666",
+		"host-name-123",
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
 		deployment.Placement{},
@@ -187,8 +187,8 @@ func (s *migrationServiceSuite) TestCreateMachineAlreadyExists(c *tc.C) {
 
 	_, err := s.service.CreateMachine(
 		c.Context(),
-		"host-name-123",
 		coremachine.Name("666"),
+		"host-name-123",
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
 		deployment.Placement{},
@@ -212,9 +212,9 @@ func (s *migrationServiceSuite) TestCreateSubordinateMachine(c *tc.C) {
 
 	obtainedUUID, err := s.service.CreateSubordinateMachine(
 		c.Context(),
-		"host-name-123",
 		coremachine.Name("666"),
 		coremachine.UUID("parent-uuid"),
+		"host-name-123",
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
 		deployment.Placement{},
@@ -240,9 +240,9 @@ func (s *migrationServiceSuite) TestCreateSubordinateMachineNonce(c *tc.C) {
 
 	obtainedUUID, err := s.service.CreateSubordinateMachine(
 		c.Context(),
-		"host-name-123",
 		coremachine.Name("666"),
 		coremachine.UUID("parent-uuid"),
+		"host-name-123",
 		new("foo"),
 		deployment.Platform{Architecture: architecture.AMD64},
 		deployment.Placement{},
@@ -262,9 +262,9 @@ func (s *migrationServiceSuite) TestCreateSubordinateMachineError(c *tc.C) {
 
 	_, err := s.service.CreateSubordinateMachine(
 		c.Context(),
-		"host-name-123",
 		coremachine.Name("666"),
 		coremachine.UUID("parent-uuid"),
+		"host-name-123",
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
 		deployment.Placement{},
@@ -285,9 +285,9 @@ func (s *migrationServiceSuite) TestCreateSubordinateMachineAlreadyExists(c *tc.
 
 	_, err := s.service.CreateSubordinateMachine(
 		c.Context(),
-		"host-name-123",
 		coremachine.Name("666"),
 		coremachine.UUID("parent-uuid"),
+		"host-name-123",
 		nil,
 		deployment.Platform{Architecture: architecture.AMD64},
 		deployment.Placement{},

--- a/domain/machine/state/migration.go
+++ b/domain/machine/state/migration.go
@@ -118,6 +118,7 @@ func (st *State) InsertMigratingMachine(ctx context.Context, machineName string,
 			).Add(machineerrors.MachineAlreadyExists)
 		}
 		return CreateMachineWithName(ctx, tx, st, st.clock, machineName, CreateMachineArgs{
+			Hostname:    args.Hostname,
 			MachineUUID: args.MachineUUID.String(),
 			NetNodeUUID: args.NetNodeUUID.String(),
 			Platform:    args.Platform,
@@ -173,6 +174,7 @@ VALUES ($machineParent.*);
 		}
 
 		err = CreateMachineWithName(ctx, tx, st, st.clock, machineName, CreateMachineArgs{
+			Hostname:    args.Hostname,
 			MachineUUID: args.MachineUUID.String(),
 			NetNodeUUID: args.NetNodeUUID.String(),
 			Platform:    args.Platform,

--- a/domain/machine/state/migration.go
+++ b/domain/machine/state/migration.go
@@ -118,11 +118,11 @@ func (st *State) InsertMigratingMachine(ctx context.Context, machineName string,
 			).Add(machineerrors.MachineAlreadyExists)
 		}
 		return CreateMachineWithName(ctx, tx, st, st.clock, machineName, CreateMachineArgs{
-			Hostname:    args.Hostname,
 			MachineUUID: args.MachineUUID.String(),
 			NetNodeUUID: args.NetNodeUUID.String(),
 			Platform:    args.Platform,
 			Constraints: args.Constraints,
+			Hostname:    args.Hostname,
 			Nonce:       args.Nonce,
 		})
 	})
@@ -174,11 +174,11 @@ VALUES ($machineParent.*);
 		}
 
 		err = CreateMachineWithName(ctx, tx, st, st.clock, machineName, CreateMachineArgs{
-			Hostname:    args.Hostname,
 			MachineUUID: args.MachineUUID.String(),
 			NetNodeUUID: args.NetNodeUUID.String(),
 			Platform:    args.Platform,
 			Constraints: args.Constraints,
+			Hostname:    args.Hostname,
 			Nonce:       args.Nonce,
 		})
 		if err != nil {

--- a/domain/machine/state/migration_test.go
+++ b/domain/machine/state/migration_test.go
@@ -17,6 +17,7 @@ import (
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/domain/network"
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -110,6 +111,7 @@ func (s *migrationStateSuite) TestInsertMigratingMachine(c *tc.C) {
 	err := s.state.InsertMigratingMachine(c.Context(), "777", machine.CreateMachineArgs{
 		MachineUUID: machineUUID,
 		NetNodeUUID: netNodeUUID,
+		Hostname:    "host-name-123",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -121,6 +123,7 @@ func (s *migrationStateSuite) TestInsertMigratingMachine(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(retrievedNetNodeUUID, tc.Equals, netNodeUUID.String())
+	s.checkHostnameForMachine(c, "777", "host-name-123")
 }
 
 func (s *migrationStateSuite) TestInsertMigratingSubordinateMachineAlreadyExists(c *tc.C) {
@@ -143,6 +146,7 @@ func (s *migrationStateSuite) TestInsertMigratingSubordinateMachine(c *tc.C) {
 	err := s.state.InsertMigratingSubordinateMachine(c.Context(), "0/lxd/888", parentUUID.String(), machine.CreateMachineArgs{
 		MachineUUID: containerUUID,
 		NetNodeUUID: netNodeUUID,
+		Hostname:    "host-name-123",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -158,6 +162,7 @@ func (s *migrationStateSuite) TestInsertMigratingSubordinateMachine(c *tc.C) {
 	retrievedParentUUID, err := s.state.GetMachineParentUUID(c.Context(), containerUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(retrievedParentUUID, tc.Equals, parentUUID)
+	s.checkHostnameForMachine(c, "0/lxd/888", "host-name-123")
 }
 
 func (s *migrationStateSuite) addMachine(c *tc.C) (coremachine.UUID, coremachine.Name) {
@@ -193,4 +198,21 @@ func (s *migrationStateSuite) addSubordinateMachine(c *tc.C, parentName coremach
 	machineUUID, err := s.state.GetMachineUUID(c.Context(), mNames[0])
 	c.Assert(err, tc.ErrorIsNil)
 	return machineUUID, mNames[0]
+}
+
+func (s *migrationStateSuite) checkHostnameForMachine(c *tc.C, name string, expected string) {
+	var hostname string
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRow(`
+SELECT hostname
+FROM machine
+WHERE name = ?
+`, name).Scan(&hostname)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return errors.Capture(err)
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(hostname, tc.Equals, expected)
 }

--- a/domain/machine/state/placement.go
+++ b/domain/machine/state/placement.go
@@ -166,6 +166,7 @@ func CreateMachineWithName(
 		UUID:        args.MachineUUID,
 		NetNodeUUID: args.NetNodeUUID,
 		Name:        machineName,
+		Hostname:    args.Hostname,
 		LifeID:      lifeID,
 	}
 	if args.Nonce != nil && *args.Nonce != "" {
@@ -173,7 +174,7 @@ func CreateMachineWithName(
 	}
 
 	insertMachineQuery := `
-INSERT INTO machine (uuid, net_node_uuid, name, life_id, nonce)
+INSERT INTO machine (uuid, net_node_uuid, name, hostname, life_id, nonce)
 VALUES ($insertMachine.*);
 `
 	insertMachineStmt, err := preparer.Prepare(insertMachineQuery, m)

--- a/domain/machine/state/placement_test.go
+++ b/domain/machine/state/placement_test.go
@@ -767,7 +767,6 @@ func (s *placementSuite) TestCreateMachineWithName_PopulatesHardwareCharacterist
 					Architecture: architecture.ARM64,
 				},
 				HardwareCharacteristics: characteristics,
-				Hostname:                "host-name-123",
 			},
 		)
 
@@ -791,8 +790,6 @@ WHERE m.machine_uuid = ?
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(azUuid, tc.Equals, expectedAzUUID.String())
-
-	s.checkHostnameForMachine(c, "0", "host-name-123")
 }
 
 func (s *placementSuite) TestCreateMachineWithNameIndicatesUnmanagedMachine(c *tc.C) {
@@ -811,7 +808,6 @@ func (s *placementSuite) TestCreateMachineWithNameIndicatesUnmanagedMachine(c *t
 				MachineUUID: machineUUID.String(),
 				NetNodeUUID: netNodeUUID.String(),
 				InstanceID:  &instanceID,
-				Hostname:    "host-name-123",
 			},
 		)
 	})
@@ -826,8 +822,6 @@ func (s *placementSuite) TestCreateMachineWithNameIndicatesUnmanagedMachine(c *t
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 1)
-
-	s.checkHostnameForMachine(c, "0", "host-name-123")
 }
 
 func (s *placementSuite) checkSequenceForMachineNamespace(c *tc.C, expected int) {
@@ -960,21 +954,4 @@ WHERE name = ?
 	} else {
 		c.Check(nonce.V, tc.Equals, *expected)
 	}
-}
-
-func (s *placementSuite) checkHostnameForMachine(c *tc.C, name machine.Name, expected string) {
-	var nonce sql.Null[string]
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRow(`
-SELECT hostname
-FROM machine
-WHERE name = ?
-`, name).Scan(&nonce)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return errors.Capture(err)
-		}
-		return nil
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(nonce.V, tc.Equals, expected)
 }

--- a/domain/machine/state/placement_test.go
+++ b/domain/machine/state/placement_test.go
@@ -767,6 +767,7 @@ func (s *placementSuite) TestCreateMachineWithName_PopulatesHardwareCharacterist
 					Architecture: architecture.ARM64,
 				},
 				HardwareCharacteristics: characteristics,
+				Hostname:                "host-name-123",
 			},
 		)
 
@@ -790,6 +791,8 @@ WHERE m.machine_uuid = ?
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(azUuid, tc.Equals, expectedAzUUID.String())
+
+	s.checkHostnameForMachine(c, "0", "host-name-123")
 }
 
 func (s *placementSuite) TestCreateMachineWithNameIndicatesUnmanagedMachine(c *tc.C) {
@@ -808,6 +811,7 @@ func (s *placementSuite) TestCreateMachineWithNameIndicatesUnmanagedMachine(c *t
 				MachineUUID: machineUUID.String(),
 				NetNodeUUID: netNodeUUID.String(),
 				InstanceID:  &instanceID,
+				Hostname:    "host-name-123",
 			},
 		)
 	})
@@ -822,6 +826,8 @@ func (s *placementSuite) TestCreateMachineWithNameIndicatesUnmanagedMachine(c *t
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 1)
+
+	s.checkHostnameForMachine(c, "0", "host-name-123")
 }
 
 func (s *placementSuite) checkSequenceForMachineNamespace(c *tc.C, expected int) {
@@ -954,4 +960,21 @@ WHERE name = ?
 	} else {
 		c.Check(nonce.V, tc.Equals, *expected)
 	}
+}
+
+func (s *placementSuite) checkHostnameForMachine(c *tc.C, name machine.Name, expected string) {
+	var nonce sql.Null[string]
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRow(`
+SELECT hostname
+FROM machine
+WHERE name = ?
+`, name).Scan(&nonce)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return errors.Capture(err)
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(nonce.V, tc.Equals, expected)
 }

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -24,6 +24,7 @@ type CreateMachineArgs struct {
 	MachineUUID string
 	NetNodeUUID string
 	Platform    deployment.Platform
+	Hostname    string
 	Nonce       *string
 
 	// InstanceID is the provider instance ID for the machine being created.
@@ -32,9 +33,6 @@ type CreateMachineArgs struct {
 	// HardwareCharacteristics contains the hardware characteristics for a
 	// manually provisioned machine.
 	HardwareCharacteristics instance.HardwareCharacteristics
-
-	// Hostname is the hostname of the machine.
-	Hostname string
 }
 
 // instanceData represents the struct to be inserted into the instance_data

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -32,6 +32,9 @@ type CreateMachineArgs struct {
 	// HardwareCharacteristics contains the hardware characteristics for a
 	// manually provisioned machine.
 	HardwareCharacteristics instance.HardwareCharacteristics
+
+	// Hostname is the hostname of the machine.
+	Hostname string
 }
 
 // instanceData represents the struct to be inserted into the instance_data
@@ -202,6 +205,7 @@ type insertMachine struct {
 	UUID        string           `db:"uuid"`
 	Nonce       sql.Null[string] `db:"nonce"`
 	LifeID      int64            `db:"life_id"`
+	Hostname    string           `db:"hostname"`
 }
 
 type machinePlatformUUID struct {

--- a/domain/machine/types.go
+++ b/domain/machine/types.go
@@ -27,6 +27,9 @@ type ExportMachine struct {
 
 // CreateMachineArgs contains arguments for creating a machine.
 type CreateMachineArgs struct {
+	// Hostname is the hostname of the machine.
+	Hostname string
+
 	// MachineUUID represents the uuid to use for the new machine being created.
 	MachineUUID machine.UUID
 

--- a/domain/machine/types.go
+++ b/domain/machine/types.go
@@ -27,9 +27,6 @@ type ExportMachine struct {
 
 // CreateMachineArgs contains arguments for creating a machine.
 type CreateMachineArgs struct {
-	// Hostname is the hostname of the machine.
-	Hostname string
-
 	// MachineUUID represents the uuid to use for the new machine being created.
 	MachineUUID machine.UUID
 
@@ -46,6 +43,9 @@ type CreateMachineArgs struct {
 	// NetNodeUUID represents the uuid of the new machines net node that is
 	// created.
 	NetNodeUUID network.NetNodeUUID
+
+	// Hostname is the hostname of the machine.
+	Hostname string
 
 	// Nonce is an optional nonce to associate with the machine being created.
 	Nonce *string


### PR DESCRIPTION
This PR persists the machine hostname when we import a 3.6 model. 

Requires #22207 to test as it contains setting the hostname in the description machine struct.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


#### Test Case 1 - Migrate machine

Outcome: migrate from 3.6 to 4.0.6 works. 4.0.6 sets the machine hostname.

Checkout this branch. Bootstrap 4.0 controller.

```
juju bootstrap localhost 406-dst --build-agent
```

Checkout #22207. Bootstrap source controller. Add model, deploy charm, add machine.

```
juju bootstrap localhost 3622-src --build-agent
juju add-model moveme
juju deploy ubuntu u1
juju add-machine
```

Wait to stabilize. 

```
# take note of the machine hostname
juju status --format json | jq '.machines | .[] | .hostname'

"juju-6fe27a-0"
"juju-6fe27a-0"

```

Migrate to destination

```
juju migrate moveme 406-dst
juju switch 406-dst:admin/moveme
```

```
Check hostname are carried over

juju status --format json | jq '.machines | .[] | .hostname'

"juju-6fe27a-0"
"juju-6fe27a-0"

```

#### Test Case 2 - Migrate machine hosting a container

Outcome: hostnames of host machine and its container are migrated. Unfortunately, an existing bug fails to import the layer link device #22224.

Apply this patch as a workaround to verify hostnames are set. It gives us enough time to query the records in DB.

```
diff --git a/domain/network/modelmigration/import_linklayerdevices.go b/domain/network/modelmigration/import_linklayerdevices.go
index 01330b6ddb..c789eb04c9 100644
--- a/domain/network/modelmigration/import_linklayerdevices.go
+++ b/domain/network/modelmigration/import_linklayerdevices.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/juju/description/v12"
 
@@ -65,6 +66,10 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 
 // Execute the import of the link layer devices contained in the model.
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
+	i.logger.Infof(ctx, "[linklayerimport] sleeping for 3 mins...")
+	<-time.After(3 * time.Minute)
+	i.logger.Infof(ctx, "[linklayerimport] woke up from sleep...")
+
 	if err := i.importLinkLayerDevices(ctx, model.LinkLayerDevices(), model.IPAddresses()); err != nil {
 		return errors.Capture(err)
 	}
```



Checkout this branch. Bootstrap 4.0 destination controller

```
juju bootstrap localhost 40-dst-new --build-agent
```

Checkout #22207. Bootstrap source controller. Add model and machines.

```
juju bootstrap localhost 36-src-new --debug
juju add-model moveme
juju add-machine
# create container on machine 0
juju add-machine lxd:0
```

Wait until machines are started... Check machine and container hostname. Note them down

```
juju status --format json \
| jq '.machines[]
      | (.hostname,
         .containers[]?.hostname)'

"juju-6fe27a-0"
"juju-6fe27a-0-lxd-0"
```

Then migrate

```
juju migrate moveme 40-dst-new
```

We have 3 minutes to check the records in DB before the next import operation is run. 

```
juju switch 40-dst-new
juju ssh -m controller controller/0

repl (controller)> .switch model-move

repl (model-move)> select name, hostname from machine
name	hostname		
0	juju-6fe27a-0		
0/lxd/0	juju-6fe27a-0-lxd-0	
```

Eventually migration fails with 

```
 migration model data transfer failed, failed to import model into target controller: execute operation import link layer devices: importing link layer devices: converting device "lxdbr0" on machine "0": converting address "10.136.55.1/24": no subnet found, nor created
```

However, this occurs in link layer devices import ([ref](https://github.com/juju/juju/blob/f3d234040cc8ad825373628d03e0b6d875a8bb28/domain/modelmigration/import.go#L83)) which is executed after machines import. So we know that the machine import was successful. 


Ideally, if the link layer device import succeeded, you should be able to juju status to see the hostnames set.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

**Issue:** Fixes #18641.

**Jira card:** [JUJU-7682](https://warthogs.atlassian.net/browse/JUJU-7682)


[JUJU-7682]: https://warthogs.atlassian.net/browse/JUJU-7682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ