### PR TITLE
feat(bootstrap): install controller snap via cloud-init

### DIFF
--- a/domain/export/types/v4_0_4/model.go
+++ b/domain/export/types/v4_0_4/model.go
@@ -1044,9 +1044,9 @@ type Relation struct {
 }
 
 type RelationApplicationSetting struct {
-	RelationEndpointUUID string  `db:"relation_endpoint_uuid" json:"relation_endpoint_uuid" yaml:"relation_endpoint_uuid"`
-	Key                  string  `db:"key" json:"key" yaml:"key"`
-	Value                *string `db:"value" json:"value" yaml:"value"`
+	RelationEndpointUUID string `db:"relation_endpoint_uuid" json:"relation_endpoint_uuid" yaml:"relation_endpoint_uuid"`
+	Key                  string `db:"key" json:"key" yaml:"key"`
+	Value                string `db:"value" json:"value" yaml:"value"`
 }
 
 type RelationApplicationSettingsHash struct {
@@ -1089,9 +1089,9 @@ type RelationUnit struct {
 }
 
 type RelationUnitSetting struct {
-	RelationUnitUUID string  `db:"relation_unit_uuid" json:"relation_unit_uuid" yaml:"relation_unit_uuid"`
-	Key              string  `db:"key" json:"key" yaml:"key"`
-	Value            *string `db:"value" json:"value" yaml:"value"`
+	RelationUnitUUID string `db:"relation_unit_uuid" json:"relation_unit_uuid" yaml:"relation_unit_uuid"`
+	Key              string `db:"key" json:"key" yaml:"key"`
+	Value            string `db:"value" json:"value" yaml:"value"`
 }
 
 type RelationUnitSettingArchive struct {

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -394,6 +394,9 @@ func (w *userdataConfig) ConfigureJuju() error {
 			if err = w.addControllerSnapUpload(); err != nil {
 				return errors.Trace(err)
 			}
+			if err = w.addControllerSnapInstall(); err != nil {
+				return errors.Trace(err)
+			}
 		}
 		if err := w.configureBootstrap(); err != nil {
 			return errors.Trace(err)
@@ -569,6 +572,38 @@ func (w *userdataConfig) addControllerSnapUpload() error {
 	f = path.Join(w.icfg.SnapDir(), bootstrap.ControllerSnapAssertArchive)
 	w.conf.AddRunBinaryFile(f, assertData, 0644)
 	logger.Debugf(context.TODO(), "added controller snap assert to cloud-init with path %q", f)
+
+	return nil
+}
+
+// addControllerSnapInstall appends cloud-init run commands that install the
+// controller snap that was previously uploaded by addControllerSnapUpload.
+// When an assertion file is present the snap is acknowledged before
+// installation; otherwise --dangerous is used to allow sideloading from a
+// local path without an assertion.
+func (w *userdataConfig) addControllerSnapInstall() error {
+	if w.icfg.Bootstrap == nil {
+		return nil
+	}
+
+	snapPath := w.icfg.Bootstrap.ControllerSnapPath
+	if snapPath == "" {
+		return nil
+	}
+
+	snapFile := path.Join(w.icfg.SnapDir(), bootstrap.ControllerSnapArchive)
+	assertPath := w.icfg.Bootstrap.ControllerSnapAssertPath
+
+	w.conf.AddRunCmd(cloudinit.LogProgressCmd("Installing controller snap from local path %q", snapFile))
+	if assertPath != "" {
+		assertFile := path.Join(w.icfg.SnapDir(), bootstrap.ControllerSnapAssertArchive)
+		w.conf.AddRunCmd(fmt.Sprintf("snap ack %s", assertFile))
+		w.conf.AddRunCmd(fmt.Sprintf("snap install %s", snapFile))
+		logger.Debugf(context.TODO(), "added snap install commands (with assertion) for %q", snapFile)
+	} else {
+		w.conf.AddRunCmd(fmt.Sprintf("snap install --dangerous %s", snapFile))
+		logger.Debugf(context.TODO(), "added snap install --dangerous command for %q", snapFile)
+	}
 
 	return nil
 }

--- a/internal/cloudconfig/userdatacfg_test.go
+++ b/internal/cloudconfig/userdatacfg_test.go
@@ -698,9 +698,12 @@ func (s *cloudinitSuite) TestCloudInitWithLocalControllerSnapOnly(c *tc.C) {
 
 	cfg := makeBootstrapConfig(jammy, 0).setControllerSnap(snapPath, "")
 	base64Content := base64.StdEncoding.EncodeToString(snapContent)
-	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(
-		"install -D -m 644 /dev/null '/var/lib/juju/snap/%s'\necho -n %s | base64 -d > '/var/lib/juju/snap/%s'\n",
-		bootstrap.ControllerSnapArchive, base64Content, bootstrap.ControllerSnapArchive,
+	snapFile := fmt.Sprintf("/var/lib/juju/snap/%s", bootstrap.ControllerSnapArchive)
+	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`
+install -D -m 644 /dev/null '%s'
+echo -n %s | base64 -d > '%[1]s'
+snap install --dangerous %[1]s`,
+		snapFile, base64Content,
 	))
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
@@ -721,11 +724,16 @@ func (s *cloudinitSuite) TestCloudInitWithLocalControllerSnapAndAssert(c *tc.C) 
 	cfg := makeBootstrapConfig(jammy, 0).setControllerSnap(snapPath, assertPath)
 	base64Snap := base64.StdEncoding.EncodeToString(snapContent)
 	base64Assert := base64.StdEncoding.EncodeToString(assertContent)
-	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(
-		"install -D -m 644 /dev/null '/var/lib/juju/snap/%s'\necho -n %s | base64 -d > '/var/lib/juju/snap/%s'\n"+
-			"install -D -m 644 /dev/null '/var/lib/juju/snap/%s'\necho -n %s | base64 -d > '/var/lib/juju/snap/%s'\n",
-		bootstrap.ControllerSnapArchive, base64Snap, bootstrap.ControllerSnapArchive,
-		bootstrap.ControllerSnapAssertArchive, base64Assert, bootstrap.ControllerSnapAssertArchive,
+	snapFile := fmt.Sprintf("/var/lib/juju/snap/%s", bootstrap.ControllerSnapArchive)
+	assertFile := fmt.Sprintf("/var/lib/juju/snap/%s", bootstrap.ControllerSnapAssertArchive)
+	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`
+install -D -m 644 /dev/null '%s'
+echo -n %s | base64 -d > '%[1]s'
+install -D -m 644 /dev/null '%[3]s'
+echo -n %s | base64 -d > '%[3]s'
+snap ack %[3]s
+snap install %[1]s`,
+		snapFile, base64Snap, assertFile, base64Assert,
 	))
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }

--- a/tests/suites/bootstrap/snap.sh
+++ b/tests/suites/bootstrap/snap.sh
@@ -1,11 +1,11 @@
-# run_bootstrap_controller_snap_local verifies that the controller snap
-# transport path works end-to-end for the local-build case.
+# run_bootstrap_controller_snap_path verifies that the controller snap
+# transport and installation works end-to-end for the local-build case with
+# an assertion file.
 #
 # It downloads the `juju` snap from the snap store as a stand-in for the
-# not-yet-published `juju-controller` snap.  The test is purely about
-# transport: it checks that the snap and assert files are written to the
-# instance's snap directory (/var/lib/juju/snap/) during bootstrap, not that
-# the snap is installed or the controller starts from it.
+# not-yet-published `juju-controller` snap.  The test verifies that:
+#   1. The snap and assert files are written to /var/lib/juju/snap/.
+#   2. The snap is installed on the controller machine via cloud-init.
 run_bootstrap_controller_snap_path() {
   echo
 
@@ -16,8 +16,7 @@ run_bootstrap_controller_snap_path() {
   # Download a real signed snap + assert pair from the store so that the
   # embedded cloud-init payload contains a valid assertion file.  We use
   # the `juju` snap as a stand-in because `juju-controller`
-  # is not yet published in the snap store.  The content is irrelevant for
-  # this transport test.
+  # is not yet published in the snap store.
   echo "==> Downloading juju snap from store for transport test"
   (
     cd "${TEST_DIR}" || exit 1
@@ -51,17 +50,76 @@ run_bootstrap_controller_snap_path() {
   echo "${name}" >>"${TEST_DIR}/jujus"
 
   # Switch to the controller model so we can SSH to machine 0 (the
-  # bootstrap/controller machine) and verify that the transport wrote the
-  # snap files to the expected directory.
+  # bootstrap/controller machine) and verify the snap files and installation.
   juju switch "${name}:controller"
 
   echo "==> Verifying snap files were transported to the controller machine"
 
-  # Assert the snap file is present in the snap dir.
+  # Assert the snap and assert files are present in the snap dir.
   snap_check=$(juju exec -m controller --unit controller/0 -- ls -h /var/lib/juju/snap)
   echo "${snap_check}"
   check_contains "${snap_check}" "juju-controller.snap"
   check_contains "${snap_check}" "juju-controller.assert"
+
+  echo "==> Verifying snap was installed on the controller machine"
+
+  # Assert the snap was installed (snap list includes the snap name derived
+  # from the downloaded snap, which is "juju" in this stand-in test).
+  snap_list=$(juju exec -m controller --unit controller/0 -- snap list)
+  echo "${snap_list}"
+  check_contains "${snap_list}" "juju"
+
+  # Clean up
+  destroy_controller "${name}"
+  export JUJU_DEV_FEATURE_FLAGS=""
+}
+
+# run_bootstrap_controller_snap_path_without_assert verifies the dangerous
+# install path: when no assertion file is provided, cloud-init installs the
+# snap with --dangerous.
+run_bootstrap_controller_snap_path_without_assert() {
+  echo
+
+  local name snap_path
+
+  name="test-bootstrap-snap-no-assert"
+
+  # Download only the snap (no assert file) to exercise the --dangerous path.
+  echo "==> Downloading juju snap from store (snap only, no assert)"
+  (
+    cd "${TEST_DIR}" || exit 1
+    snap download juju --channel=4.0/stable --basename=juju-controller-noassert 2>&1
+  )
+
+  snap_path="${TEST_DIR}/juju-controller-noassert.snap"
+
+  if [ ! -f "${snap_path}" ]; then
+    echo "ERROR: snap file not found at ${snap_path}" >&2
+    exit 1
+  fi
+
+  echo "Flags before test start: ${JUJU_DEV_FEATURE_FLAGS:-}"
+
+  export JUJU_DEV_FEATURE_FLAGS="controller-snap"
+
+  echo "==> Bootstrapping with snap transport enabled, snap path only (no assert): ${name}"
+  juju bootstrap "${BOOTSTRAP_PROVIDER:-}" "${name}" \
+    --controller-snap-path="${snap_path}"
+  echo "${name}" >>"${TEST_DIR}/jujus"
+
+  juju switch "${name}:controller"
+
+  echo "==> Verifying snap file was transported to the controller machine"
+
+  snap_check=$(juju exec -m controller --unit controller/0 -- ls -h /var/lib/juju/snap)
+  echo "${snap_check}"
+  check_contains "${snap_check}" "juju-controller.snap"
+
+  echo "==> Verifying snap was installed via --dangerous on the controller machine"
+
+  snap_list=$(juju exec -m controller --unit controller/0 -- snap list)
+  echo "${snap_list}"
+  check_contains "${snap_list}" "juju"
 
   # Clean up
   destroy_controller "${name}"
@@ -109,5 +167,25 @@ test_bootstrap_controller_snap_path() {
 
     run "run_feature_flag_check"
     run "run_bootstrap_controller_snap_path"
+  )
+}
+
+test_bootstrap_controller_snap_path_without_assert() {
+  if [ -n "$(skip 'test_bootstrap_controller_snap_path_without_assert')" ]; then
+    echo "==> SKIP: asked to skip test_bootstrap_controller_snap_path_without_assert"
+    return
+  fi
+
+  if [[ ${BOOTSTRAP_PROVIDER:-} == "k8s" || ${BOOTSTRAP_PROVIDER:-} == "microk8s" ]]; then
+    echo "==> TEST SKIPPED: test_bootstrap_controller_snap_path_without_assert, not supported on k8s controller"
+    return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    run "run_bootstrap_controller_snap_path_without_assert"
   )
 }

--- a/tests/suites/bootstrap/task.sh
+++ b/tests/suites/bootstrap/task.sh
@@ -12,4 +12,5 @@ test_bootstrap() {
 
   test_bootstrap_simplestream
   test_bootstrap_controller_snap_path
+  test_bootstrap_controller_snap_path_without_assert
 }


### PR DESCRIPTION
Builds on the snap upload work: after the snap (and optional assertion file)
has been transported to the controller machine, cloud-init now installs it.

**With an assertion file** (normal install path):
```
snap ack /var/lib/juju/snap/juju-controller.assert
snap install /var/lib/juju/snap/juju-controller.snap
```

**Without an assertion file** (dangerous install path):
```
snap install --dangerous /var/lib/juju/snap/juju-controller.snap
```

Both paths are gated by the `controller-snap` feature flag consistent with the
upload step. 

Regenerated files to fix the pipeline (problematic file
`domain/export/types/v4_0_4/model.go` is not related to this PR).

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


Upload snap+assert:

```sh
❯ export JUJU_DEV_FEATURE_FLAGS=controller-snap

❯ snap download juju

❯ juju bootstrap lxd src1 \
  --controller-snap-path ./juju_34486.snap \
  --controller-snap-assert-path ./juju_34486.assert

❯ juju exec -m controller --unit controller/0 -- snap list
Name    Version   Rev    Tracking       Publisher    Notes
core24  20260317  1587   latest/stable  canonical**  base
juju    3.6.21    34486  -              canonical**  -
snapd   2.74.1    26382  latest/stable  canonical**  snapd
```

Without assert file:

```sh 
❯ juju bootstrap lxd src3  --controller-snap-path ./juju_4.1-beta1_amd64.snap

❯ juju exec -m controller --unit controller/0 -- ls -lh /var/lib/juju/snap
total 103M
-rw-r--r-- 1 root root 103M Apr  6 13:47 juju-controller.snap

```


## Documentation changes


## Links

**Jira card:** [JUJU-9529](https://warthogs.atlassian.net/browse/JUJU-9529)

Relates to #22183


[JUJU-9529]: https://warthogs.atlassian.net/browse/JUJU-9529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ