### PR TITLE
fix: secret watcher initial empty event

### DIFF
--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -2626,17 +2626,9 @@ func (s *serviceSuite) TestWatchObsoleteUserSecretsToPrune(c *tc.C) {
 	// initial change.
 	wc.AssertOneChange()
 
-	select {
-	case ch1 <- struct{}{}:
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out waiting for sending the secret revision changes")
-	}
+	ch1 <- struct{}{}
 	wc.AssertOneChange()
-	select {
-	case ch2 <- struct{}{}:
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out waiting for sending the secret URI changes")
-	}
+	ch2 <- struct{}{}
 	wc.AssertOneChange()
 }
 
@@ -2730,13 +2722,11 @@ func (s *serviceSuite) TestWatchSecretsRotationChanges(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(w, tc.NotNil)
 	defer workertest.CleanKill(c, w)
-	wC := watchertest.NewSecretsTriggerWatcherC(c, w)
 
-	select {
-	case ch <- []string{uri1.ID, uri2.ID}:
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out waiting for the initial changes")
-	}
+	wC := watchertest.NewSecretsTriggerWatcherC(c, w)
+	wC.AssertChange()
+
+	ch <- []string{uri1.ID, uri2.ID}
 
 	wC.AssertChange(
 		watcher.SecretTriggerChange{
@@ -2816,13 +2806,11 @@ func (s *serviceSuite) TestWatchSecretRevisionsExpiryChanges(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(w, tc.NotNil)
 	defer workertest.CleanKill(c, w)
-	wC := watchertest.NewSecretsTriggerWatcherC(c, w)
 
-	select {
-	case ch <- []string{"revision-uuid-1", "revision-uuid-2"}:
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out waiting for the initial changes")
-	}
+	wC := watchertest.NewSecretsTriggerWatcherC(c, w)
+	wC.AssertChange()
+
+	ch <- []string{"revision-uuid-1", "revision-uuid-2"}
 
 	wC.AssertChange(
 		watcher.SecretTriggerChange{

--- a/domain/secret/watcher.go
+++ b/domain/secret/watcher.go
@@ -57,12 +57,21 @@ func (w *secretWatcher[T]) scopedContext() (context.Context, context.CancelFunc)
 func (w *secretWatcher[T]) loop() error {
 	defer close(w.out)
 
+	// Secret watchers must always emit an initial event before any deltas.
+	// Send that empty initial state deterministically before reading from the
+	// source watcher, otherwise a buffered source event can win the select and
+	// be emitted first.
+	select {
+	case <-w.catacomb.Dying():
+		return w.catacomb.ErrDying()
+	case w.out <- nil:
+	}
+
 	var (
 		historyIDs set.Strings
 		changes    []T
 	)
-	// To allow the initial event to be sent.
-	out := w.out
+	var out chan []T
 	addChanges := func(events set.Strings) error {
 		if len(events) == 0 {
 			return nil

--- a/domain/secret/watcher_dedup_test.go
+++ b/domain/secret/watcher_dedup_test.go
@@ -36,6 +36,7 @@ func (s *watcherDedupSuite) TestDedupEvents(c *tc.C) {
 
 	defer watchertest.CleanKill(c, sw)
 	w := watchertest.NewStringsWatcherC(c, sw)
+	w.AssertChange()
 
 	addValues := func(values ...string) {
 		inputChan <- values
@@ -71,9 +72,8 @@ func (s *watcherDedupSuite) TestInitialEventSentBeforeBufferedSourceChanges(c *t
 	c.Assert(err, tc.ErrorIsNil)
 
 	defer watchertest.CleanKill(c, sw)
-	w := watchertest.NewWatcherC(c, sw)
-
-	w.CheckInitial(watchertest.SliceAssert([]string(nil)))
-	w.Check(watchertest.StringSliceAssert("foo"))
+	w := watchertest.NewStringsWatcherC(c, sw)
+	w.AssertChange()
+	w.AssertChange("foo")
 	w.AssertNoChange()
 }

--- a/domain/secret/watcher_dedup_test.go
+++ b/domain/secret/watcher_dedup_test.go
@@ -54,3 +54,26 @@ func (s *watcherDedupSuite) TestDedupEvents(c *tc.C) {
 	w.AssertChange("foo", "baz") // We should get foo again.
 	w.AssertNoChange()
 }
+
+func (s *watcherDedupSuite) TestInitialEventSentBeforeBufferedSourceChanges(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+
+	inputChan := make(chan []string, 1)
+	inputChan <- []string{"foo"}
+
+	sw, err := secret.NewSecretStringWatcher(
+		watchertest.NewMockStringsWatcher(inputChan),
+		logger,
+		func(ctx context.Context, events ...string) ([]string, error) {
+			return events, nil
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	defer watchertest.CleanKill(c, sw)
+	w := watchertest.NewWatcherC(c, sw)
+
+	w.CheckInitial(watchertest.SliceAssert([]string(nil)))
+	w.Check(watchertest.StringSliceAssert("foo"))
+	w.AssertNoChange()
+}


### PR DESCRIPTION
This fixes an intermittent test failure.

The `secretWatcher` uses a source watcher that may have initial events buffered, which get emitted instead of the initial nil event.

This fixes such a race by ensuring the nil event is always sent before dequeueing the source watcher's channel.

## QA steps

- `go test ./domain/secret -run 'TestWatcherSuite/TestWatchSecretsRotationChanges' -count=10`
- `go test ./domain/secret -run 'TestWatcherDedupSuite/TestInitialEventSentBeforeBufferedSourceChanges' -count=1 -v`
- `go test ./domain/secret -run 'TestWatcherSuite/TestWatchSecretsRevisionExpiryChanges' -count=1`


