### PR TITLE
fix: objectstore authorizer

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -949,11 +949,13 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		handler:         modelToolsDownloadHandler,
 		unauthenticated: true,
 	}, {
-		pattern: modelRoutePrefix + "/applications/:application/resources/:resource",
-		handler: resourcesHandler,
+		pattern:    modelRoutePrefix + "/applications/:application/resources/:resource",
+		handler:    resourcesHandler,
+		authorizer: httpcontext.TODOAuthorizer{},
 	}, {
-		pattern: modelRoutePrefix + "/units/:unit/resources/:resource",
-		handler: unitResourcesHandler,
+		pattern:    modelRoutePrefix + "/units/:unit/resources/:resource",
+		handler:    unitResourcesHandler,
+		authorizer: httpcontext.TODOAuthorizer{},
 	}, {
 		pattern:    "/migrate/charms/:object",
 		handler:    migrateObjectsCharmsHTTPHandler,
@@ -1013,24 +1015,27 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		// for discharge required errors to be handled correctly.
 		unauthenticated: true,
 	}, {
-		pattern: charmsObjectsRoutePrefix,
-		methods: []string{"GET"},
-		handler: modelObjectsCharmsHTTPHandler,
+		pattern:    charmsObjectsRoutePrefix,
+		methods:    []string{"GET"},
+		handler:    modelObjectsCharmsHTTPHandler,
+		authorizer: httpcontext.TODOAuthorizer{},
 	}, {
 		pattern:    charmsObjectsRoutePrefix,
 		methods:    []string{"PUT"},
 		handler:    modelObjectsCharmsHTTPHandler,
 		authorizer: charmsObjectsAuthorizer,
 	}, {
-		pattern: objectsRoutePrefix,
-		methods: []string{"GET"},
-		handler: modelObjectsHTTPHandler,
+		pattern:    objectsRoutePrefix,
+		methods:    []string{"GET"},
+		handler:    modelObjectsHTTPHandler,
+		authorizer: httpcontext.TODOAuthorizer{},
 	}}
 	if srv.registerIntrospectionHandlers != nil {
 		add := func(subpath string, h http.Handler) {
 			handlers = append(handlers, handler{
-				pattern: path.Join("/introspection/", subpath),
-				handler: srv.monitoredHandler(introspectionHandler{httpCtxt, h}, "introspection"),
+				pattern:    path.Join("/introspection/", subpath),
+				handler:    srv.monitoredHandler(introspectionHandler{httpCtxt, h}, "introspection"),
+				authorizer: httpcontext.TODOAuthorizer{},
 			})
 		}
 		srv.registerIntrospectionHandlers(add)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -714,6 +714,12 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		if handler.tracked {
 			h = srv.trackRequests(h)
 		}
+
+		// This should be refactored once we have all the authorizers in place.
+		// The lack of an authorizer should indicate that the handler is
+		// unauthenticated. This two field approach is error prone and should be
+		// replaced with a single field that indicates the authentication and
+		// authorization requirements of the handler.
 		if !handler.unauthenticated {
 			h = &httpcontext.AuthHandler{
 				NextHandler:   h,
@@ -951,11 +957,11 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	}, {
 		pattern:    modelRoutePrefix + "/applications/:application/resources/:resource",
 		handler:    resourcesHandler,
-		authorizer: httpcontext.TODOAuthorizer{},
+		authorizer: httpcontext.TODOAuthorizer,
 	}, {
 		pattern:    modelRoutePrefix + "/units/:unit/resources/:resource",
 		handler:    unitResourcesHandler,
-		authorizer: httpcontext.TODOAuthorizer{},
+		authorizer: httpcontext.TODOAuthorizer,
 	}, {
 		pattern:    "/migrate/charms/:object",
 		handler:    migrateObjectsCharmsHTTPHandler,
@@ -1018,7 +1024,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		pattern:    charmsObjectsRoutePrefix,
 		methods:    []string{"GET"},
 		handler:    modelObjectsCharmsHTTPHandler,
-		authorizer: httpcontext.TODOAuthorizer{},
+		authorizer: httpcontext.TODOAuthorizer,
 	}, {
 		pattern:    charmsObjectsRoutePrefix,
 		methods:    []string{"PUT"},
@@ -1028,14 +1034,14 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		pattern:    objectsRoutePrefix,
 		methods:    []string{"GET"},
 		handler:    modelObjectsHTTPHandler,
-		authorizer: httpcontext.TODOAuthorizer{},
+		authorizer: httpcontext.ControllerAuthorizer,
 	}}
 	if srv.registerIntrospectionHandlers != nil {
 		add := func(subpath string, h http.Handler) {
 			handlers = append(handlers, handler{
 				pattern:    path.Join("/introspection/", subpath),
 				handler:    srv.monitoredHandler(introspectionHandler{httpCtxt, h}, "introspection"),
-				authorizer: httpcontext.TODOAuthorizer{},
+				authorizer: httpcontext.TODOAuthorizer,
 			})
 		}
 		srv.registerIntrospectionHandlers(add)

--- a/apiserver/authentication/interfaces.go
+++ b/apiserver/authentication/interfaces.go
@@ -42,8 +42,9 @@ type AuthInfo struct {
 	Controller bool
 
 	// IsExternallyAuthenticated reports whether the entity was authenticated
-	// via an external mechanism (JWT or macaroon discharge for an external user).
-	// Set by the authenticator; used to drive external user creation at login.
+	// via an external mechanism (JWT or macaroon discharge for an external
+	// user). Set by the authenticator; used to drive external user creation at
+	// login.
 	IsExternallyAuthenticated bool
 }
 
@@ -65,10 +66,10 @@ type AuthParams struct {
 }
 
 // PermissionDelegator is an interface that represents a window back into the
-// original authentication method that generated an AuthInfo struct. Specifically
-// it allows users of AuthInfo to ask specific details about an entity's
-// permissions that needs response aligned with the way in which they were
-// authenticated.
+// original authentication method that generated an AuthInfo struct.
+// Specifically it allows users of AuthInfo to ask specific details about an
+// entity's permissions that needs response aligned with the way in which they
+// were authenticated.
 type PermissionDelegator interface {
 	// SubjectPermissions returns the permission the entity has for the
 	// specified subject.

--- a/apiserver/httpcontext/auth.go
+++ b/apiserver/httpcontext/auth.go
@@ -32,8 +32,7 @@ type AuthHandler struct {
 	// the HTTP requests handled by this handler.
 	Authenticator authentication.HTTPAuthenticator
 
-	// Authorizer, if non-nil, will be called with the auth info
-	// returned by the Authenticator, to validate it for the route.
+	// Authorizer is mandatory for authentication.
 	Authorizer authentication.Authorizer
 }
 
@@ -58,19 +57,16 @@ func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if h.Authorizer != nil {
-		if err := h.Authorizer.Authorize(req.Context(), authInfo); err != nil {
-			http.Error(w,
-				fmt.Sprintf("authorization failed: %s", err),
-				http.StatusForbidden,
-			)
-			return
-		}
+	if err := h.Authorizer.Authorize(req.Context(), authInfo); err != nil {
+		http.Error(w,
+			fmt.Sprintf("authorization failed: %s", err),
+			http.StatusForbidden,
+		)
+		return
 	}
 
 	ctx := context.WithValue(req.Context(), authInfoKey{}, authInfo)
-	req = req.WithContext(ctx)
-	h.NextHandler.ServeHTTP(w, req)
+	h.NextHandler.ServeHTTP(w, req.WithContext(ctx))
 }
 
 type authInfoKey struct{}
@@ -104,4 +100,14 @@ type AuthorizerFunc func(authentication.AuthInfo) error
 // Authorize is part of the Authorizer interface.
 func (f AuthorizerFunc) Authorize(info authentication.AuthInfo) error {
 	return f(info)
+}
+
+// TODOAuthorizer is a placeholder Authorizer that always returns success. It
+// should be replaced with a real implementation before being used in
+// production.
+type TODOAuthorizer struct{}
+
+// Authorize is part of the Authorizer interface.
+func (a TODOAuthorizer) Authorize(_ context.Context, _ authentication.AuthInfo) error {
+	return nil
 }

--- a/apiserver/httpcontext/auth.go
+++ b/apiserver/httpcontext/auth.go
@@ -95,19 +95,27 @@ func (c CompositeAuthorizer) Authorize(ctx context.Context, authInfo authenticat
 }
 
 // AuthorizerFunc is a function type implementing Authorizer.
-type AuthorizerFunc func(authentication.AuthInfo) error
+type AuthorizerFunc func(context.Context, authentication.AuthInfo) error
 
 // Authorize is part of the Authorizer interface.
-func (f AuthorizerFunc) Authorize(info authentication.AuthInfo) error {
-	return f(info)
+func (f AuthorizerFunc) Authorize(ctx context.Context, info authentication.AuthInfo) error {
+	return f(ctx, info)
 }
 
-// TODOAuthorizer is a placeholder Authorizer that always returns success. It
-// should be replaced with a real implementation before being used in
-// production.
-type TODOAuthorizer struct{}
+// ControllerAuthorizer is an Authorizer that authorizes any request with a
+// controller credential.
+var ControllerAuthorizer AuthorizerFunc = func(_ context.Context, info authentication.AuthInfo) error {
+	if info.Controller {
+		return nil
+	}
+	return apiservererrors.ErrPerm
+}
 
-// Authorize is part of the Authorizer interface.
-func (a TODOAuthorizer) Authorize(_ context.Context, _ authentication.AuthInfo) error {
+// TODOAuthorizer is a placeholder Authorizer that always returns success. This
+// should be used until an appropriate Authorizer is implemented.
+//
+// Deprecated: TODOAuthorizer should be replaced with an appropriate Authorizer
+// and removed.
+var TODOAuthorizer AuthorizerFunc = func(context.Context, authentication.AuthInfo) error {
 	return nil
 }

--- a/apiserver/httpcontext/auth_test.go
+++ b/apiserver/httpcontext/auth_test.go
@@ -190,3 +190,23 @@ func (s *ControllerAuthorizerSuite) TestAuthorizeNonController(c *tc.C) {
 	err := ControllerAuthorizer.Authorize(c.Context(), authInfo)
 	c.Assert(err, tc.ErrorMatches, "permission denied")
 }
+
+type TODOAuthorizerSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestTODOAuthorizerSuite(t *testing.T) {
+	tc.Run(t, &TODOAuthorizerSuite{})
+}
+
+func (s *TODOAuthorizerSuite) TestAuthorizeController(c *tc.C) {
+	authInfo := authentication.AuthInfo{Controller: true}
+	err := TODOAuthorizer.Authorize(c.Context(), authInfo)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *TODOAuthorizerSuite) TestAuthorizeNonController(c *tc.C) {
+	authInfo := authentication.AuthInfo{Controller: false}
+	err := TODOAuthorizer.Authorize(c.Context(), authInfo)
+	c.Assert(err, tc.ErrorIsNil)
+}

--- a/apiserver/httpcontext/auth_test.go
+++ b/apiserver/httpcontext/auth_test.go
@@ -170,3 +170,23 @@ func (s *CompositeAuthSuite) TestAuthorizeFail(c *tc.C) {
 	err := auth.Authorize(context.Background(), authInfo)
 	c.Assert(err, tc.ErrorMatches, "permission denied")
 }
+
+type ControllerAuthorizerSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestControllerAuthorizerSuite(t *testing.T) {
+	tc.Run(t, &ControllerAuthorizerSuite{})
+}
+
+func (s *ControllerAuthorizerSuite) TestAuthorizeController(c *tc.C) {
+	authInfo := authentication.AuthInfo{Controller: true}
+	err := ControllerAuthorizer.Authorize(c.Context(), authInfo)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *ControllerAuthorizerSuite) TestAuthorizeNonController(c *tc.C) {
+	authInfo := authentication.AuthInfo{Controller: false}
+	err := ControllerAuthorizer.Authorize(c.Context(), authInfo)
+	c.Assert(err, tc.ErrorMatches, "permission denied")
+}

--- a/apiserver/httpcontext/auth_test.go
+++ b/apiserver/httpcontext/auth_test.go
@@ -120,15 +120,6 @@ func (s *BasicAuthHandlerSuite) TestAuthorizationFailure(c *tc.C) {
 	s.stub.CheckCallNames(c, "Authenticate", "Authorize")
 }
 
-func (s *BasicAuthHandlerSuite) TestAuthorizationOptional(c *tc.C) {
-	s.handler.Authorizer = nil
-
-	resp, err := s.server.Client().Get(s.server.URL)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(resp.StatusCode, tc.Equals, http.StatusOK)
-	defer resp.Body.Close()
-}
-
 type CompositeAuthSuite struct {
 	testhelpers.IsolationSuite
 }


### PR DESCRIPTION
The object endpoint should have an authorizer that is only accessible between controllers. Part of the issue was that we'd ignore nil based authorizers which would make them optional by default. Instead, the PR inverts the setup and all authorizers are required, unless they explicitly mark the endpoint(s) as `unauthenticated`. Note: most aren't unauthenticated, they require macaroon authenticators. The registration of the handlers is overly generic, leading to many foot-guns.

There is now a TODOAuthorizer which should be removed once correct and proper implementations are defined.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-unit -m controller controller -n 2
```

Ensure that there are no errors in the logs.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
