### PR TITLE
fix(authorization): fixes external user creation

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -347,6 +347,7 @@ func (a *admin) authenticate(ctx context.Context, modelExists bool, req params.L
 			return nil, errors.Trace(err)
 		}
 	}
+
 	// Ensure external users are persisted only after authorisation checks
 	// pass. At this point the user has been both authenticated and authorised
 	// (via checkUserPermissions above), so it is safe to create a DB record.
@@ -355,10 +356,12 @@ func (a *admin) authenticate(ctx context.Context, modelExists bool, req params.L
 		if !ok {
 			return nil, errors.Errorf("externally authenticated entity %q is not a user", authInfo.Tag)
 		}
-		userName := coreuser.NameFromTag(userTag)
-		if err := a.root.domainServices.Access().EnsureExternalUser(ctx, userName); err != nil {
-			logger.Warningf(ctx, "ensuring external user %q in database: %v", userName, err)
-			return nil, errors.Annotatef(err, "ensuring external user %q", userName)
+		if !userTag.IsLocal() {
+			userName := coreuser.NameFromTag(userTag)
+			if err := a.root.domainServices.Access().EnsureExternalUser(ctx, userName); err != nil {
+				logger.Warningf(ctx, "ensuring external user %q in database: %v", userName, err)
+				return nil, errors.Annotatef(err, "ensuring external user %q", userName)
+			}
 		}
 	}
 

--- a/apiserver/admin_external_login_jwt_test.go
+++ b/apiserver/admin_external_login_jwt_test.go
@@ -123,6 +123,60 @@ func (s *externalUserJWTLoginSuite) TestExternalUserCreatedOnJWTLogin(c *tc.C) {
 		tc.Commentf("testuser@external was not created in Juju's DB after JWT login"))
 }
 
+// TestExternalUserCreatedOnJWTLogin verifies that an external user is
+// inserted into Juju's database after successfully authenticating via the
+// JWT path (the modern JAAS/JIMM flow).
+func (s *externalUserJWTLoginSuite) TestLoginWithAdminUserJWT(c *tc.C) {
+	accessService := s.ControllerDomainServices(c).Access()
+
+	// The everyone@external user must exist as a user record (it's created
+	// during bootstrap and serves as the creator of other external users),
+	// but for the JWT path we do NOT need to grant it any permissions.
+	// This verifies that JWT login works without everyone@external having
+	// controller access — unlike the macaroon path which gates on that.
+	err := accessService.AddExternalUser(c.Context(), permission.EveryoneUserName, "", s.AdminUserUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Confirm the admin user exists in Juju's database.
+	userName := tc.Must1(c, user.NewName, "admin")
+	_, err = accessService.GetUserByName(c.Context(), userName)
+	c.Assert(err, tc.ErrorIsNil, tc.Commentf("admin user should exist before login"))
+
+	// Build a JWT token for "user-testuser@external" with superuser access
+	// on the controller. The token is base64-encoded, matching the format
+	// JIMM sends to Juju controllers.
+	controllerTag := names.NewControllerTag(s.ControllerUUID)
+	token, err := apitesting.NewEncodedJWT(apitesting.JWTParams{
+		Controller: s.ControllerUUID,
+		User:       "user-admin",
+		Access: map[string]string{
+			controllerTag.String(): "superuser",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Open an API connection using the JWT login provider. This triggers:
+	//   1. Client sends LoginRequest with Token set (the JWT).
+	//   2. Macaroon authenticator returns NotSupported (no macaroons).
+	//   3. JWT authenticator parses the token, extracts user-testuser@external.
+	//   4. admin.authenticate() validates permissions from the JWT claims.
+	//   5. On success, admin.authenticate() calls EnsureExternalUser, inserting
+	//      testuser@external into Juju's user table.
+	info := s.ControllerModelApiInfo()
+	info.Tag = nil
+	info.Password = ""
+	info.Macaroons = nil
+	apiState, err := api.Open(c.Context(), info, api.DialOpts{
+		LoginProvider: &jwtLoginProvider{
+			tag:   names.NewUserTag("admin"),
+			token: token,
+		},
+	})
+	// Login should succeed with the admin user.
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = apiState.Close() }()
+}
+
 // TestExternalUserNotCreatedWhenJWTLoginUnauthorized verifies that an external
 // user is NOT inserted into Juju's database when the JWT token carries no
 // access permissions. The login should fail and no user row should be created.


### PR DESCRIPTION
In #21848 @nvinuesa implemented creation of externally authenticated users. Juju currently supports two external sources of authentication: Candid and JIMM.

For a bit of history: The way Juju controllers have always been added to JIMM is by passing to it the information needed to connect to a Juju controller. This included addresses, CA cert, username and password. The latter two were usually for the "admin" user. So when JIMM connected to a controller it would always log in as the "admin" user (using the stored password) and perform operations on behalf of the user.

With the switch to OAuth2/OIDC in JIMM it no longer uses the username and password. Instead it presents a JWT (on login) in which it states the user and claims about user's permissions (by default we add controller and model permission claims). 

For many call we have already changed JIMM to send a JWT with the username of the user that logged into JIMM along with permission claims for that user. Some calls, we have still not refactored. But there remains a set of calls that JIMM does as part of "business as usual" - these calls are not performed on behalf of any user and in those cases the plan is to keep sending a JWT that logs us in as a controller superuser - if that user will be "admin" or not, remains to be decided.

This PR addresses the cases where JIMM sends a JWT logging it in as the "admin" superuser, which already exists in Juju's database (this is the user that is created on bootstrap).


## QA steps

Follow steps in https://github.com/juju/juju/pull/21848

## Documentation changes

N/A

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
