### PR TITLE
fix(relation): include in-scope units without settings in relation unit changes

### DIFF
--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -1326,9 +1326,6 @@ func (st *State) GetFullRelationUnitsChange(
 		}
 
 		inScopeUnits = append(inScopeUnits, id)
-		if len(data.UnitData) == 0 {
-			continue
-		}
 		unitSettings = append(unitSettings, domainrelation.UnitSettings{
 			UnitID:   id,
 			Settings: data.UnitData,
@@ -1405,9 +1402,6 @@ func (st *State) GetRelationUnitsChanges(
 			continue
 		}
 		inScopeUnits = append(inScopeUnits, id)
-		if len(data.UnitData) == 0 {
-			continue
-		}
 		unitSettings = append(unitSettings, domainrelation.UnitSettings{
 			UnitID:   id,
 			Settings: data.UnitData,

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -2766,6 +2766,10 @@ func (s *relationSuite) TestGetRelationUnitsChanges(c *tc.C) {
 		Life:         corelife.Alive,
 		UnitsSettings: []domainrelation.UnitSettings{
 			{
+				UnitID:   0,
+				Settings: map[string]string{},
+			},
+			{
 				UnitID:   3,
 				Settings: map[string]string{"foo": "bar"},
 			},
@@ -2782,6 +2786,7 @@ func (s *relationSuite) TestGetRelationUnitsChanges(c *tc.C) {
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_.AllUnits", tc.SameContents, []int{1, 0, 3})
 	mc.AddExpr("_.InScopeUnits", tc.SameContents, []int{0, 3})
+	mc.AddExpr("_.UnitsSettings", tc.SameContents, expected.UnitsSettings)
 	c.Assert(obtained, mc, expected)
 }
 
@@ -2792,6 +2797,35 @@ func (s *relationSuite) TestGetRelationUnitsChangesRelationNotFound(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
+}
+
+func (s *relationSuite) TestGetRelationUnitsChangesInScopeWithoutSettings(c *tc.C) {
+	// When a unit enters scope but has no relation unit settings
+	// rows (e.g. network addresses not yet available), it must still be
+	// returned in UnitsSettings with an empty settings map. This ensures
+	// consumers of the change always see in-scope units regardless of
+	// whether settings have been written.
+	charmUUID := s.addCharm(c)
+	charmRelationUUID := s.addCharmRelationWithDefaults(c, charmUUID)
+	appUUID := s.addApplication(c, charmUUID, "myapp")
+	appEndpointUUID := s.addApplicationEndpoint(c, appUUID, charmRelationUUID)
+	relationUUID := s.addRelation(c)
+	unitUUID := s.addUnit(c, "myapp/0", appUUID, charmUUID)
+	relationEndpointUUID := s.addRelationEndpoint(c, relationUUID, appEndpointUUID)
+	// Enter scope but do NOT add any relation_unit_setting rows.
+	s.addRelationUnit(c, unitUUID, relationEndpointUUID)
+
+	// Act
+	obtained, err := s.state.GetRelationUnitsChanges(c.Context(),
+		relationUUID, appUUID)
+
+	// Assert: the unit must still be present in UnitsSettings with empty
+	// settings.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtained.InScopeUnits, tc.SameContents, []int{0})
+	c.Assert(obtained.UnitsSettings, tc.HasLen, 1)
+	c.Check(obtained.UnitsSettings[0].UnitID, tc.Equals, 0)
+	c.Check(obtained.UnitsSettings[0].Settings, tc.HasLen, 0)
 }
 
 func (s *relationSuite) TestGetFullRelationUnitsChange(c *tc.C) {
@@ -2820,6 +2854,10 @@ func (s *relationSuite) TestGetFullRelationUnitsChange(c *tc.C) {
 			Life:         corelife.Alive,
 			UnitsSettings: []domainrelation.UnitSettings{
 				{
+					UnitID:   0,
+					Settings: map[string]string{},
+				},
+				{
 					UnitID:   3,
 					Settings: map[string]string{"foo": "bar"},
 				},
@@ -2839,6 +2877,7 @@ func (s *relationSuite) TestGetFullRelationUnitsChange(c *tc.C) {
 	mc := tc.NewMultiChecker()
 	mc.AddExpr("_.RelationUnitChange.AllUnits", tc.SameContents, []int{1, 0, 3})
 	mc.AddExpr("_.RelationUnitChange.InScopeUnits", tc.SameContents, []int{0, 3})
+	mc.AddExpr("_.RelationUnitChange.UnitsSettings", tc.SameContents, expected.RelationUnitChange.UnitsSettings)
 	mc.AddExpr("_.Macaroons", tc.Ignore)
 	c.Check(obtained, mc, expected)
 }


### PR DESCRIPTION
When a unit enters scope before its network addresses are available (e.g. during cross-model relation setup), it has no relation unit settings rows in the database. 
`GetRelationUnitsChanges` and `GetFullRelationUnitsChange` were filtering these units out of `UnitsSettings`, which meant the CMR consumer worker published empty `ChangedUnits` to the offering model. 

As a result, the remote unit never entered scope on the offerer and relation hooks like relation-joined never fired.

The fix is to always return unit changes by removing the check from the relation domain in state layer.



## QA steps

This fix originally targetted 3.6->4.0 CMRs, but it's currently broken and blocked by https://github.com/juju/juju/pull/22199.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22081.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9496](https://warthogs.atlassian.net/browse/JUJU-9496)


[JUJU-9496]: https://warthogs.atlassian.net/browse/JUJU-9496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ