### PR TITLE
fix(access): filter credential model access by owner only

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -790,7 +790,7 @@ func (api *OffersAPI) getModelsFromOffers(ctx context.Context, user names.UserTa
 
 		qualifier := constructModelQualifier(url.ModelQualifier, user)
 		url.ModelQualifier = qualifier.String()
-		modelPath := fmt.Sprintf("%s/%s", url.ModelQualifier, url.ModelName)
+		modelPath := qualifier.QualifyName(url.ModelName)
 		if foundModel, ok := modelsCache[modelPath]; ok {
 			return url, foundModel, nil
 		}

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -45,14 +45,13 @@ type CloudAccessService interface {
 	// ReadAllAccessForUserAndObjectType returns UserAccess for the given
 	// subject (user) for all clouds based on objectType.
 	ReadAllAccessForUserAndObjectType(ctx context.Context, subject user.Name, objectType corepermission.ObjectType) ([]corepermission.UserAccess, error)
-	// AllModelAccessForCloudCredential for a given (cloud) credential key, return all
-	// model name and model access levels.
-	AllModelAccessForCloudCredential(ctx context.Context, key credential.Key) ([]access.CredentialOwnerModelAccess, error)
+	// AllModelAccessForOwner returns the model access for all activated models
+	// across every cloud credential owned by owner, grouped by credential key.
+	AllModelAccessForOwner(ctx context.Context, owner user.Name) ([]access.OwnerModelAccessByCredential, error)
 }
 
 // CredentialService provides access to the credential domain service.
 type CredentialService interface {
-	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
 	AllCloudCredentialsForOwner(ctx context.Context, owner user.Name) (map[credential.Key]cloud.Credential, error)
 	CloudCredentialsForOwner(ctx context.Context, owner user.Name, cloudName string) (map[string]cloud.Credential, error)
 	UpdateCloudCredential(ctx context.Context, key credential.Key, cred cloud.Credential) error

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -823,7 +823,11 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 		}
 		info.Models = make([]params.ModelAccess, len(models))
 		for i, m := range models {
-			info.Models[i] = params.ModelAccess{Model: m.ModelName, Access: m.OwnerAccess.String()}
+			modelName := m.ModelName
+			if m.ModelQualifier != "" {
+				modelName = fmt.Sprintf("%s/%s", m.ModelQualifier, m.ModelName)
+			}
+			info.Models[i] = params.ModelAccess{Model: modelName, Access: m.OwnerAccess.String()}
 		}
 
 		return params.CredentialContentResult{Result: &info}

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/access"
-	accesserrors "github.com/juju/juju/domain/access/errors"
 	clouderrors "github.com/juju/juju/domain/cloud/errors"
 	credentialerrors "github.com/juju/juju/domain/credential/errors"
 	"github.com/juju/juju/domain/credential/service"
@@ -764,107 +763,130 @@ func (api *CloudAPI) CredentialContents(ctx context.Context, args params.CloudCr
 }
 
 func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params.CloudCredentialArgs, includeValidity bool) (params.CredentialContentResults, error) {
-	// Helper to look up and cache credential schemas for clouds.
+	owner := user.NameFromTag(api.apiUser)
+
+	// Pre-fetch all credentials and model accesses for this owner in two
+	// queries, avoiding any per-credential round-trips.
+	allAccess, err := api.cloudAccessService.AllModelAccessForOwner(ctx, owner)
+	if err != nil {
+		return params.CredentialContentResults{}, errors.Trace(err)
+	}
+	accessByKey := make(map[credential.Key][]access.OwnerModelAccess, len(allAccess))
+	for _, entry := range allAccess {
+		accessByKey[entry.CredentialKey] = entry.Models
+	}
+
+	allCreds, err := api.credentialService.AllCloudCredentialsForOwner(ctx, owner)
+	if err != nil {
+		return params.CredentialContentResults{}, errors.Trace(err)
+	}
+
+	// Render results. If the caller specified credentials, produce one result
+	// per requested entry (error on invalid key or unknown credential).
+	// Otherwise produce one result per credential owned by the user.
 	schemaCache := make(map[string]map[cloud.AuthType]cloud.CredentialSchema)
-	credentialSchemas := func(cloudName string) (map[cloud.AuthType]cloud.CredentialSchema, error) {
-		if s, ok := schemaCache[cloudName]; ok {
-			return s, nil
-		}
-		aCloud, err := api.cloudService.Cloud(ctx, cloudName)
-		if errors.Is(err, clouderrors.NotFound) {
-			return nil, errors.NotFoundf("cloud %q", cloudName)
-		} else if err != nil {
-			return nil, err
-		}
-		aProvider, err := environs.Provider(aCloud.Type)
-		if err != nil {
-			return nil, err
-		}
-		schema := aProvider.CredentialSchemas()
-		schemaCache[cloudName] = schema
-		return schema, nil
-	}
-
-	// Helper to parse cloud.CloudCredential into an expected result item.
-	toParam := func(key credential.Key, cred cloud.Credential, includeSecrets bool) params.CredentialContentResult {
-		schemas, err := credentialSchemas(key.Cloud)
-		if err != nil {
-			return params.CredentialContentResult{Error: apiservererrors.ServerError(err)}
-		}
-		attrs := map[string]string{}
-		// Filter out the secrets.
-		if s, ok := schemas[cred.AuthType()]; ok {
-			for _, attr := range s {
-				if value, exists := cred.Attributes()[attr.Name]; exists {
-					if attr.Hidden && !includeSecrets {
-						continue
-					}
-					attrs[attr.Name] = value
-				}
-			}
-		}
-		info := params.ControllerCredentialInfo{
-			Content: params.CredentialContent{
-				Name:       cred.Label,
-				AuthType:   string(cred.AuthType()),
-				Attributes: attrs,
-				Cloud:      key.Cloud,
-			},
-		}
-		if includeValidity {
-			valid := !cred.Invalid
-			info.Content.Valid = &valid
-		}
-
-		// get model access
-		models, err := api.cloudAccessService.AllModelAccessForCloudCredential(ctx, key)
-		if err != nil && !errors.Is(err, accesserrors.PermissionNotFound) {
-			return params.CredentialContentResult{Error: apiservererrors.ServerError(err)}
-		}
-		info.Models = make([]params.ModelAccess, len(models))
-		for i, m := range models {
-			info.Models[i] = params.ModelAccess{Model: m.ModelQualifier.QualifyName(m.ModelName), Access: m.OwnerAccess.String()}
-		}
-
-		return params.CredentialContentResult{Result: &info}
-	}
-
 	var result []params.CredentialContentResult
-	if len(args.Credentials) == 0 {
-		credentials, err := api.credentialService.AllCloudCredentialsForOwner(ctx, user.NameFromTag(api.apiUser))
-		if err != nil {
-			return params.CredentialContentResults{}, errors.Trace(err)
-		}
-		for key, cred := range credentials {
-			result = append(result, toParam(key, cred, args.IncludeSecrets))
+	if len(args.Credentials) > 0 {
+		result = make([]params.CredentialContentResult, 0, len(args.Credentials))
+		for _, given := range args.Credentials {
+			key := credential.Key{Cloud: given.CloudName, Owner: owner, Name: given.CredentialName}
+			if err := key.Validate(); err != nil {
+				result = append(result, params.CredentialContentResult{
+					Error: apiservererrors.ServerError(errors.NotValidf("cloud credential ID %q", key)),
+				})
+				continue
+			}
+			cred, ok := allCreds[key]
+			if !ok {
+				result = append(result, params.CredentialContentResult{
+					Error: apiservererrors.ServerError(errors.NotFoundf("cloud credential %q", key)),
+				})
+				continue
+			}
+			schemas, err := api.cachedCredentialSchemas(ctx, schemaCache, key.Cloud)
+			if err != nil {
+				result = append(result, params.CredentialContentResult{Error: apiservererrors.ServerError(err)})
+				continue
+			}
+			result = append(result, buildCredentialResult(key, cred, schemas, accessByKey[key], includeValidity, args.IncludeSecrets))
 		}
 	} else {
-		// Helper to construct credential ID from cloud and name.
-		credKey := func(cloudName, credentialName string) credential.Key {
-			return credential.Key{
-				Cloud: cloudName, Owner: user.NameFromTag(api.apiUser), Name: credentialName}
-		}
-
-		result = make([]params.CredentialContentResult, len(args.Credentials))
-		for i, given := range args.Credentials {
-			key := credKey(given.CloudName, given.CredentialName)
-			if err := key.Validate(); err != nil {
-				result[i] = params.CredentialContentResult{
-					Error: apiservererrors.ServerError(errors.NotValidf("cloud credential ID %q", key)),
-				}
-				continue
-			}
-			cred, err := api.credentialService.CloudCredential(ctx, key)
+		result = make([]params.CredentialContentResult, 0, len(allCreds))
+		for key, cred := range allCreds {
+			schemas, err := api.cachedCredentialSchemas(ctx, schemaCache, key.Cloud)
 			if err != nil {
-				result[i] = params.CredentialContentResult{
-					Error: apiservererrors.ServerError(err),
-				}
+				result = append(result, params.CredentialContentResult{Error: apiservererrors.ServerError(err)})
 				continue
 			}
-			result[i] = toParam(key, cred, args.IncludeSecrets)
+			result = append(result, buildCredentialResult(key, cred, schemas, accessByKey[key], includeValidity, args.IncludeSecrets))
 		}
 	}
 	return params.CredentialContentResults{Results: result}, nil
+}
+
+// cachedCredentialSchemas looks up the credential schema for cloudName,
+// caching results in schemaCache to avoid repeated cloud lookups across
+// multiple credentials that share the same cloud.
+func (api *CloudAPI) cachedCredentialSchemas(ctx context.Context, cache map[string]map[cloud.AuthType]cloud.CredentialSchema, cloudName string) (map[cloud.AuthType]cloud.CredentialSchema, error) {
+	if s, ok := cache[cloudName]; ok {
+		return s, nil
+	}
+	aCloud, err := api.cloudService.Cloud(ctx, cloudName)
+	if errors.Is(err, clouderrors.NotFound) {
+		return nil, errors.NotFoundf("cloud %q", cloudName)
+	} else if err != nil {
+		return nil, err
+	}
+	aProvider, err := environs.Provider(aCloud.Type)
+	if err != nil {
+		return nil, err
+	}
+	s := aProvider.CredentialSchemas()
+	cache[cloudName] = s
+	return s, nil
+}
+
+// buildCredentialResult converts a cloud credential and its associated model
+// accesses into the wire-format result used by the CredentialContents API.
+func buildCredentialResult(
+	key credential.Key,
+	cred cloud.Credential,
+	schemas map[cloud.AuthType]cloud.CredentialSchema,
+	models []access.OwnerModelAccess,
+	includeValidity bool,
+	includeSecrets bool,
+) params.CredentialContentResult {
+	attrs := map[string]string{}
+	if s, ok := schemas[cred.AuthType()]; ok {
+		for _, attr := range s {
+			if value, exists := cred.Attributes()[attr.Name]; exists {
+				if attr.Hidden && !includeSecrets {
+					continue
+				}
+				attrs[attr.Name] = value
+			}
+		}
+	}
+	info := params.ControllerCredentialInfo{
+		Content: params.CredentialContent{
+			Name:       cred.Label,
+			AuthType:   string(cred.AuthType()),
+			Attributes: attrs,
+			Cloud:      key.Cloud,
+		},
+	}
+	if includeValidity {
+		valid := !cred.Invalid
+		info.Content.Valid = &valid
+	}
+	info.Models = make([]params.ModelAccess, len(models))
+	for i, m := range models {
+		info.Models[i] = params.ModelAccess{
+			Model:  m.ModelQualifier.QualifyName(m.ModelName),
+			Access: m.OwnerAccess.String(),
+		}
+	}
+	return params.CredentialContentResult{Result: &info}
 }
 
 // ModifyCloudAccess changes the model access granted to users.

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -823,11 +823,7 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 		}
 		info.Models = make([]params.ModelAccess, len(models))
 		for i, m := range models {
-			modelName := m.ModelName
-			if m.ModelQualifier != "" {
-				modelName = fmt.Sprintf("%s/%s", m.ModelQualifier, m.ModelName)
-			}
-			info.Models[i] = params.ModelAccess{Model: modelName, Access: m.OwnerAccess.String()}
+			info.Models[i] = params.ModelAccess{Model: m.ModelQualifier.QualifyName(m.ModelName), Access: m.OwnerAccess.String()}
 		}
 
 		return params.CredentialContentResult{Result: &info}

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -1165,24 +1165,13 @@ func (s *cloudSuite) TestCredentialContentsAllNoSecrets(c *tc.C) {
 	bruceTag := names.NewUserTag("bruce")
 	defer s.setup(c, bruceTag).Finish()
 
-	credentialOne, tagOne := cloudCredentialTag(credParams{name: "one", owner: "bruce", cloudName: "meep", authType: jujucloud.EmptyAuthType,
+	credentialOne, _ := cloudCredentialTag(credParams{name: "one", owner: "bruce", cloudName: "meep", authType: jujucloud.EmptyAuthType,
 		attrs: map[string]string{}})
 
-	credentialTwo, tagTwo := cloudCredentialTag(credParams{name: "two", owner: "bruce", cloudName: "meep", authType: jujucloud.UserPassAuthType,
+	credentialTwo, _ := cloudCredentialTag(credParams{name: "two", owner: "bruce", cloudName: "meep", authType: jujucloud.UserPassAuthType,
 		attrs: map[string]string{
 			"username": "admin",
 		}})
-	keyOne := credential.Key{
-		Cloud: tagOne.Cloud().Id(),
-		Owner: user.NameFromTag(tagOne.Owner()),
-		Name:  tagOne.Name(),
-	}
-	keyTwo := credential.Key{
-		Cloud: tagTwo.Cloud().Id(),
-		Owner: user.NameFromTag(tagTwo.Owner()),
-		Name:  tagTwo.Name(),
-	}
-
 	credentialTwo.Invalid = true
 	creds := map[credential.Key]jujucloud.Credential{
 		{Cloud: "meep", Owner: usertesting.GenNewName(c, "bruce"), Name: "one"}: credentialOne,
@@ -1195,15 +1184,12 @@ func (s *cloudSuite) TestCredentialContentsAllNoSecrets(c *tc.C) {
 		Regions:   []jujucloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 	}
 
-	ctx := c.Context()
 	s.credService.EXPECT().AllCloudCredentialsForOwner(gomock.Any(), user.NameFromTag(bruceTag)).Return(creds, nil)
-
 	s.cloudService.EXPECT().Cloud(gomock.Any(), "meep").Return(&cloud, nil)
-	modelCredentialService := s.cloudAccessService.EXPECT()
-	modelCredentialService.AllModelAccessForCloudCredential(ctx, keyOne).Return([]access.CredentialOwnerModelAccess{}, nil)
-	modelCredentialService.AllModelAccessForCloudCredential(ctx, keyTwo).Return([]access.CredentialOwnerModelAccess{}, nil)
+	s.cloudAccessService.EXPECT().AllModelAccessForOwner(gomock.Any(), user.NameFromTag(bruceTag)).
+		Return([]access.OwnerModelAccessByCredential{}, nil)
 
-	results, err := s.api.CredentialContents(ctx, params.CloudCredentialArgs{})
+	results, err := s.api.CredentialContents(c.Context(), params.CloudCredentialArgs{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	_true := true
@@ -1245,12 +1231,54 @@ func (s *cloudSuite) TestCredentialContentsCloudNotFound(c *tc.C) {
 	}
 
 	s.credService.EXPECT().AllCloudCredentialsForOwner(gomock.Any(), user.NameFromTag(bruceTag)).Return(creds, nil)
+	s.cloudAccessService.EXPECT().AllModelAccessForOwner(gomock.Any(), user.NameFromTag(bruceTag)).
+		Return([]access.OwnerModelAccessByCredential{}, nil)
 	s.cloudService.EXPECT().Cloud(gomock.Any(), "meep").Return(&jujucloud.Cloud{}, fmt.Errorf("%w fake-cloud", clouderrors.NotFound))
 
 	results, err := s.api.CredentialContents(c.Context(), params.CloudCredentialArgs{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 1)
 	c.Check(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
+}
+
+func (s *cloudSuite) TestCredentialContentsFilteredByArgs(c *tc.C) {
+	bruceTag := names.NewUserTag("bruce")
+	defer s.setup(c, bruceTag).Finish()
+
+	owner := usertesting.GenNewName(c, "bruce")
+	credOne, _ := cloudCredentialTag(credParams{name: "one", owner: "bruce", cloudName: "meep",
+		authType: jujucloud.EmptyAuthType, attrs: map[string]string{}})
+	credTwo, _ := cloudCredentialTag(credParams{name: "two", owner: "bruce", cloudName: "meep",
+		authType: jujucloud.UserPassAuthType, attrs: map[string]string{"username": "admin"}})
+	creds := map[credential.Key]jujucloud.Credential{
+		{Cloud: "meep", Owner: owner, Name: "one"}: credOne,
+		{Cloud: "meep", Owner: owner, Name: "two"}: credTwo,
+	}
+	aCloud := jujucloud.Cloud{
+		Name:      "dummy",
+		Type:      "dummy",
+		AuthTypes: []jujucloud.AuthType{jujucloud.EmptyAuthType, jujucloud.UserPassAuthType},
+	}
+
+	s.credService.EXPECT().AllCloudCredentialsForOwner(gomock.Any(), user.NameFromTag(bruceTag)).Return(creds, nil)
+	s.cloudAccessService.EXPECT().AllModelAccessForOwner(gomock.Any(), user.NameFromTag(bruceTag)).
+		Return([]access.OwnerModelAccessByCredential{}, nil)
+	s.cloudService.EXPECT().Cloud(gomock.Any(), "meep").Return(&aCloud, nil)
+
+	// Request only "one"; "two" and a non-existent "three" are also tested.
+	results, err := s.api.CredentialContents(c.Context(), params.CloudCredentialArgs{
+		Credentials: []params.CloudCredentialArg{
+			{CloudName: "meep", CredentialName: "one"},
+			{CloudName: "meep", CredentialName: "three"},
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 2)
+	// First result: "one" found.
+	c.Assert(results.Results[0].Error, tc.IsNil)
+	c.Check(results.Results[0].Result.Content.Name, tc.Equals, "one")
+	// Second result: "three" not found.
+	c.Check(params.IsCodeNotFound(results.Results[1].Error), tc.IsTrue)
 }
 
 func cloudCredentialTag(params credParams) (jujucloud.Credential, names.CloudCredentialTag) {

--- a/apiserver/facades/client/cloud/mocks/cloud_mock.go
+++ b/apiserver/facades/client/cloud/mocks/cloud_mock.go
@@ -201,45 +201,6 @@ func (c *MockCredentialServiceCheckCredentialModelsCall) DoAndReturn(f func(cont
 	return c
 }
 
-// CloudCredential mocks base method.
-func (m *MockCredentialService) CloudCredential(arg0 context.Context, arg1 credential.Key) (cloud.Credential, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudCredential", arg0, arg1)
-	ret0, _ := ret[0].(cloud.Credential)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CloudCredential indicates an expected call of CloudCredential.
-func (mr *MockCredentialServiceMockRecorder) CloudCredential(arg0, arg1 any) *MockCredentialServiceCloudCredentialCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudCredential", reflect.TypeOf((*MockCredentialService)(nil).CloudCredential), arg0, arg1)
-	return &MockCredentialServiceCloudCredentialCall{Call: call}
-}
-
-// MockCredentialServiceCloudCredentialCall wrap *gomock.Call
-type MockCredentialServiceCloudCredentialCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockCredentialServiceCloudCredentialCall) Return(arg0 cloud.Credential, arg1 error) *MockCredentialServiceCloudCredentialCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockCredentialServiceCloudCredentialCall) Do(f func(context.Context, credential.Key) (cloud.Credential, error)) *MockCredentialServiceCloudCredentialCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCredentialServiceCloudCredentialCall) DoAndReturn(f func(context.Context, credential.Key) (cloud.Credential, error)) *MockCredentialServiceCloudCredentialCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // CloudCredentialsForOwner mocks base method.
 func (m *MockCredentialService) CloudCredentialsForOwner(arg0 context.Context, arg1 user.Name, arg2 string) (map[string]cloud.Credential, error) {
 	m.ctrl.T.Helper()
@@ -632,41 +593,41 @@ func (m *MockCloudAccessService) EXPECT() *MockCloudAccessServiceMockRecorder {
 	return m.recorder
 }
 
-// AllModelAccessForCloudCredential mocks base method.
-func (m *MockCloudAccessService) AllModelAccessForCloudCredential(arg0 context.Context, arg1 credential.Key) ([]access.CredentialOwnerModelAccess, error) {
+// AllModelAccessForOwner mocks base method.
+func (m *MockCloudAccessService) AllModelAccessForOwner(arg0 context.Context, arg1 user.Name) ([]access.OwnerModelAccessByCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllModelAccessForCloudCredential", arg0, arg1)
-	ret0, _ := ret[0].([]access.CredentialOwnerModelAccess)
+	ret := m.ctrl.Call(m, "AllModelAccessForOwner", arg0, arg1)
+	ret0, _ := ret[0].([]access.OwnerModelAccessByCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AllModelAccessForCloudCredential indicates an expected call of AllModelAccessForCloudCredential.
-func (mr *MockCloudAccessServiceMockRecorder) AllModelAccessForCloudCredential(arg0, arg1 any) *MockCloudAccessServiceAllModelAccessForCloudCredentialCall {
+// AllModelAccessForOwner indicates an expected call of AllModelAccessForOwner.
+func (mr *MockCloudAccessServiceMockRecorder) AllModelAccessForOwner(arg0, arg1 any) *MockCloudAccessServiceAllModelAccessForOwnerCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelAccessForCloudCredential", reflect.TypeOf((*MockCloudAccessService)(nil).AllModelAccessForCloudCredential), arg0, arg1)
-	return &MockCloudAccessServiceAllModelAccessForCloudCredentialCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelAccessForOwner", reflect.TypeOf((*MockCloudAccessService)(nil).AllModelAccessForOwner), arg0, arg1)
+	return &MockCloudAccessServiceAllModelAccessForOwnerCall{Call: call}
 }
 
-// MockCloudAccessServiceAllModelAccessForCloudCredentialCall wrap *gomock.Call
-type MockCloudAccessServiceAllModelAccessForCloudCredentialCall struct {
+// MockCloudAccessServiceAllModelAccessForOwnerCall wrap *gomock.Call
+type MockCloudAccessServiceAllModelAccessForOwnerCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockCloudAccessServiceAllModelAccessForCloudCredentialCall) Return(arg0 []access.CredentialOwnerModelAccess, arg1 error) *MockCloudAccessServiceAllModelAccessForCloudCredentialCall {
+func (c *MockCloudAccessServiceAllModelAccessForOwnerCall) Return(arg0 []access.OwnerModelAccessByCredential, arg1 error) *MockCloudAccessServiceAllModelAccessForOwnerCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCloudAccessServiceAllModelAccessForCloudCredentialCall) Do(f func(context.Context, credential.Key) ([]access.CredentialOwnerModelAccess, error)) *MockCloudAccessServiceAllModelAccessForCloudCredentialCall {
+func (c *MockCloudAccessServiceAllModelAccessForOwnerCall) Do(f func(context.Context, user.Name) ([]access.OwnerModelAccessByCredential, error)) *MockCloudAccessServiceAllModelAccessForOwnerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCloudAccessServiceAllModelAccessForCloudCredentialCall) DoAndReturn(f func(context.Context, credential.Key) ([]access.CredentialOwnerModelAccess, error)) *MockCloudAccessServiceAllModelAccessForCloudCredentialCall {
+func (c *MockCloudAccessServiceAllModelAccessForOwnerCall) DoAndReturn(f func(context.Context, user.Name) ([]access.OwnerModelAccessByCredential, error)) *MockCloudAccessServiceAllModelAccessForOwnerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -131,6 +131,12 @@ func (q Qualifier) String() string {
 	return string(q)
 }
 
+// QualifyName returns the fully qualified model name in the form
+// "qualifier/name".
+func (q Qualifier) QualifyName(name string) string {
+	return q.String() + "/" + name
+}
+
 // Validate returns an error if the model qualifier is not valid.
 // The qualifier is expected to be a valid user identifier
 // (e.g. "admin", "alice@external").

--- a/domain/access/service/permission.go
+++ b/domain/access/service/permission.go
@@ -6,7 +6,6 @@ package service
 import (
 	"context"
 
-	"github.com/juju/juju/core/credential"
 	coreerrors "github.com/juju/juju/core/errors"
 	corepermission "github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/trace"
@@ -190,11 +189,11 @@ func (s *PermissionService) UpdatePermission(ctx context.Context, args access.Up
 	return errors.Capture(s.st.UpdatePermission(ctx, args))
 }
 
-// AllModelAccessForCloudCredential for a given (cloud) credential key, return all
-// model name and model access level combinations.
-func (s *PermissionService) AllModelAccessForCloudCredential(ctx context.Context, key credential.Key) ([]access.CredentialOwnerModelAccess, error) {
+// AllModelAccessForOwner returns the model access for all activated models
+// across every cloud credential owned by owner, grouped by credential key.
+func (s *PermissionService) AllModelAccessForOwner(ctx context.Context, owner user.Name) ([]access.OwnerModelAccessByCredential, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
-	results, err := s.st.AllModelAccessForCloudCredential(ctx, key)
+	results, err := s.st.AllModelAccessForOwner(ctx, owner)
 	return results, errors.Capture(err)
 }

--- a/domain/access/service/permission_test.go
+++ b/domain/access/service/permission_test.go
@@ -263,14 +263,27 @@ func (s *serviceSuite) TestReadAllAccessForUserAndObjectTypeError(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, coreerrors.NotValid, tc.Commentf("%+v", err))
 }
 
-func (s *serviceSuite) TestAllModelAccessForCloudCredential(c *tc.C) {
+func (s *serviceSuite) TestAllModelAccessForOwner(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	s.state.EXPECT().AllModelAccessForCloudCredential(gomock.Any(), gomock.AssignableToTypeOf(credential.Key{})).Return(nil, nil)
 
-	_, err := NewService(s.state, clock.WallClock).AllModelAccessForCloudCredential(
-		c.Context(),
-		credential.Key{})
+	owner := usertesting.GenNewName(c, "alice")
+	keyA := credential.Key{Cloud: "cloud-a", Owner: owner, Name: "cred-a"}
+	keyB := credential.Key{Cloud: "cloud-b", Owner: owner, Name: "cred-b"}
+	expected := []access.OwnerModelAccessByCredential{
+		{
+			CredentialKey: keyA,
+			Models:        []access.OwnerModelAccess{{ModelName: "model-a", OwnerAccess: corepermission.AdminAccess}},
+		},
+		{
+			CredentialKey: keyB,
+			Models:        []access.OwnerModelAccess{{ModelName: "model-b", OwnerAccess: corepermission.ReadAccess}},
+		},
+	}
+	s.state.EXPECT().AllModelAccessForOwner(gomock.Any(), owner).Return(expected, nil)
+
+	result, err := NewService(s.state, clock.WallClock).AllModelAccessForOwner(c.Context(), owner)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, expected)
 }
 
 func (s *serviceSuite) TestImportOfferAccess(c *tc.C) {

--- a/domain/access/service/service.go
+++ b/domain/access/service/service.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/clock"
 
-	"github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -216,9 +215,9 @@ type PermissionState interface {
 	// E.G. All clouds the user has access to.
 	ReadAllAccessForUserAndObjectType(ctx context.Context, subject user.Name, objectType permission.ObjectType) ([]permission.UserAccess, error)
 
-	// AllModelAccessForCloudCredential for a given (cloud) credential key, return all
-	// model name and model access levels.
-	AllModelAccessForCloudCredential(ctx context.Context, key credential.Key) ([]access.CredentialOwnerModelAccess, error)
+	// AllModelAccessForOwner returns the model access for all activated models
+	// across every cloud credential owned by owner, grouped by credential key.
+	AllModelAccessForOwner(ctx context.Context, owner user.Name) ([]access.OwnerModelAccessByCredential, error)
 }
 
 // Service provides the API for working with users.

--- a/domain/access/service/state_mock_test.go
+++ b/domain/access/service/state_mock_test.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 	time "time"
 
-	credential "github.com/juju/juju/core/credential"
 	model "github.com/juju/juju/core/model"
 	permission "github.com/juju/juju/core/permission"
 	user "github.com/juju/juju/core/user"
@@ -199,41 +198,41 @@ func (c *MockStateAddUserWithPasswordHashCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
-// AllModelAccessForCloudCredential mocks base method.
-func (m *MockState) AllModelAccessForCloudCredential(arg0 context.Context, arg1 credential.Key) ([]access.CredentialOwnerModelAccess, error) {
+// AllModelAccessForOwner mocks base method.
+func (m *MockState) AllModelAccessForOwner(arg0 context.Context, arg1 user.Name) ([]access.OwnerModelAccessByCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllModelAccessForCloudCredential", arg0, arg1)
-	ret0, _ := ret[0].([]access.CredentialOwnerModelAccess)
+	ret := m.ctrl.Call(m, "AllModelAccessForOwner", arg0, arg1)
+	ret0, _ := ret[0].([]access.OwnerModelAccessByCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AllModelAccessForCloudCredential indicates an expected call of AllModelAccessForCloudCredential.
-func (mr *MockStateMockRecorder) AllModelAccessForCloudCredential(arg0, arg1 any) *MockStateAllModelAccessForCloudCredentialCall {
+// AllModelAccessForOwner indicates an expected call of AllModelAccessForOwner.
+func (mr *MockStateMockRecorder) AllModelAccessForOwner(arg0, arg1 any) *MockStateAllModelAccessForOwnerCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelAccessForCloudCredential", reflect.TypeOf((*MockState)(nil).AllModelAccessForCloudCredential), arg0, arg1)
-	return &MockStateAllModelAccessForCloudCredentialCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelAccessForOwner", reflect.TypeOf((*MockState)(nil).AllModelAccessForOwner), arg0, arg1)
+	return &MockStateAllModelAccessForOwnerCall{Call: call}
 }
 
-// MockStateAllModelAccessForCloudCredentialCall wrap *gomock.Call
-type MockStateAllModelAccessForCloudCredentialCall struct {
+// MockStateAllModelAccessForOwnerCall wrap *gomock.Call
+type MockStateAllModelAccessForOwnerCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateAllModelAccessForCloudCredentialCall) Return(arg0 []access.CredentialOwnerModelAccess, arg1 error) *MockStateAllModelAccessForCloudCredentialCall {
+func (c *MockStateAllModelAccessForOwnerCall) Return(arg0 []access.OwnerModelAccessByCredential, arg1 error) *MockStateAllModelAccessForOwnerCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAllModelAccessForCloudCredentialCall) Do(f func(context.Context, credential.Key) ([]access.CredentialOwnerModelAccess, error)) *MockStateAllModelAccessForCloudCredentialCall {
+func (c *MockStateAllModelAccessForOwnerCall) Do(f func(context.Context, user.Name) ([]access.OwnerModelAccessByCredential, error)) *MockStateAllModelAccessForOwnerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAllModelAccessForCloudCredentialCall) DoAndReturn(f func(context.Context, credential.Key) ([]access.CredentialOwnerModelAccess, error)) *MockStateAllModelAccessForCloudCredentialCall {
+func (c *MockStateAllModelAccessForOwnerCall) DoAndReturn(f func(context.Context, user.Name) ([]access.OwnerModelAccessByCredential, error)) *MockStateAllModelAccessForOwnerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -622,13 +622,17 @@ func (st *PermissionState) AllModelAccessForCloudCredential(ctx context.Context,
 	}
 
 	query := `
-SELECT m.name AS &CredentialOwnerModelAccess.model_name, 
-       p.access_type AS &CredentialOwnerModelAccess.access_type
-FROM   v_model m
-       JOIN v_permission AS p ON m.uuid = p.grant_on
-WHERE  m.cloud_credential_owner_name = $input.owner_name 
+SELECT DISTINCT m.name AS &CredentialOwnerModelAccess.model_name,
+       pat.type AS &CredentialOwnerModelAccess.access_type
+FROM   v_model AS m
+       JOIN permission AS p ON m.uuid = p.grant_on
+       JOIN permission_access_type AS pat ON p.access_type_id = pat.id
+       JOIN user AS u ON p.grant_to = u.uuid
+WHERE  m.cloud_credential_owner_name = $input.owner_name
 AND    m.cloud_credential_cloud_name = $input.cloud_name
 AND    m.cloud_credential_name = $input.cred_name
+AND    u.name = $input.owner_name
+AND    u.removed = FALSE
 `
 	readStmt, err := st.Prepare(query, input{}, access.CredentialOwnerModelAccess{})
 	if err != nil {

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -607,9 +607,12 @@ AND    u.removed = false
 	return userAccess, nil
 }
 
-// AllModelAccessForCloudCredential for a given (cloud) credential key, return all
-// model name and model access level combinations.
-func (st *PermissionState) AllModelAccessForCloudCredential(ctx context.Context, key credential.Key) ([]access.CredentialOwnerModelAccess, error) {
+// AllModelAccessForOwner returns the model access for all activated models
+// across every cloud credential owned by owner, grouped by credential key.
+//
+// An empty slice is not an error — it means the owner has no activated models
+// associated with their credentials.
+func (st *PermissionState) AllModelAccessForOwner(ctx context.Context, owner user.Name) ([]access.OwnerModelAccessByCredential, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -617,14 +620,14 @@ func (st *PermissionState) AllModelAccessForCloudCredential(ctx context.Context,
 
 	type input struct {
 		OwnerName string `db:"owner_name"`
-		CloudName string `db:"cloud_name"`
-		CredName  string `db:"cred_name"`
 	}
 
 	query := `
-SELECT DISTINCT m.name      AS &CredentialOwnerModelAccess.model_name,
-       m.qualifier           AS &CredentialOwnerModelAccess.model_qualifier,
-       pat.type              AS &CredentialOwnerModelAccess.access_type
+SELECT DISTINCT cc.name AS &ownerModelAccess.cred_name,
+       c.name           AS &ownerModelAccess.cloud_name,
+       m.name           AS &ownerModelAccess.model_name,
+       m.qualifier      AS &ownerModelAccess.model_qualifier,
+       pat.type         AS &ownerModelAccess.access_type
 FROM   model AS m
        JOIN cloud_credential AS cc  ON m.cloud_credential_uuid = cc.uuid
        JOIN cloud             AS c  ON cc.cloud_uuid = c.uuid
@@ -633,29 +636,24 @@ FROM   model AS m
        JOIN permission_access_type AS pat ON p.access_type_id = pat.id
        JOIN user              AS u  ON p.grant_to = u.uuid
 WHERE  co.name = $input.owner_name
-AND    c.name  = $input.cloud_name
-AND    cc.name = $input.cred_name
 AND    m.activated = TRUE
 AND    u.name    = $input.owner_name
 AND    u.removed = FALSE
 `
-	readStmt, err := st.Prepare(query, input{}, access.CredentialOwnerModelAccess{})
+	readStmt, err := st.Prepare(query, input{}, ownerModelAccess{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	in := input{
-		OwnerName: key.Owner.Name(),
-		CloudName: key.Cloud,
-		CredName:  key.Name,
-	}
-	var results []access.CredentialOwnerModelAccess
+	in := input{OwnerName: owner.Name()}
+	var rows []ownerModelAccess
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err = tx.Query(ctx, readStmt, in).GetAll(&results)
+		err = tx.Query(ctx, readStmt, in).GetAll(&rows)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("for %q on %q: %w", key.Owner, key.Cloud, accesserrors.PermissionNotFound)
-		} else if err != nil {
-			return errors.Errorf("getting permissions for %q on %q: %w", key.Owner, key.Cloud, err)
+			return nil
+		}
+		if err != nil {
+			return errors.Errorf("getting model access for owner %q: %w", owner, err)
 		}
 		return nil
 	})
@@ -663,10 +661,22 @@ AND    u.removed = FALSE
 		return nil, errors.Capture(err)
 	}
 
-	return results, nil
+	// Group rows by credential key, preserving insertion order.
+	indexByKey := make(map[credential.Key]int, len(rows))
+	var result []access.OwnerModelAccessByCredential
+	for _, row := range rows {
+		key := credential.Key{Cloud: row.CloudName, Name: row.CredName, Owner: owner}
+		idx, ok := indexByKey[key]
+		if !ok {
+			idx = len(result)
+			indexByKey[key] = idx
+			result = append(result, access.OwnerModelAccessByCredential{CredentialKey: key})
+		}
+		result[idx].Models = append(result[idx].Models, row.toOwnerModelAccess())
+	}
+	return result, nil
 }
 
-// ImportOfferAccess imports the user access for offers in the model.
 func (st *PermissionState) ImportOfferAccess(
 	ctx context.Context,
 	importAccess []access.OfferImportAccess,

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -622,16 +622,21 @@ func (st *PermissionState) AllModelAccessForCloudCredential(ctx context.Context,
 	}
 
 	query := `
-SELECT DISTINCT m.name AS &CredentialOwnerModelAccess.model_name,
-       pat.type AS &CredentialOwnerModelAccess.access_type
-FROM   v_model AS m
-       JOIN permission AS p ON m.uuid = p.grant_on
+SELECT DISTINCT m.name      AS &CredentialOwnerModelAccess.model_name,
+       m.qualifier           AS &CredentialOwnerModelAccess.model_qualifier,
+       pat.type              AS &CredentialOwnerModelAccess.access_type
+FROM   model AS m
+       JOIN cloud_credential AS cc  ON m.cloud_credential_uuid = cc.uuid
+       JOIN cloud             AS c  ON cc.cloud_uuid = c.uuid
+       JOIN user              AS co ON cc.owner_uuid = co.uuid
+       JOIN permission        AS p  ON m.uuid = p.grant_on
        JOIN permission_access_type AS pat ON p.access_type_id = pat.id
-       JOIN user AS u ON p.grant_to = u.uuid
-WHERE  m.cloud_credential_owner_name = $input.owner_name
-AND    m.cloud_credential_cloud_name = $input.cloud_name
-AND    m.cloud_credential_name = $input.cred_name
-AND    u.name = $input.owner_name
+       JOIN user              AS u  ON p.grant_to = u.uuid
+WHERE  co.name = $input.owner_name
+AND    c.name  = $input.cloud_name
+AND    cc.name = $input.cred_name
+AND    m.activated = TRUE
+AND    u.name    = $input.owner_name
 AND    u.removed = FALSE
 `
 	readStmt, err := st.Prepare(query, input{}, access.CredentialOwnerModelAccess{})

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -1227,18 +1227,56 @@ func (s *permissionStateSuite) TestModelAccessForCloudCredential(c *tc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 	ctx := c.Context()
 
-	modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "model-access")
+	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "model-access")
 	key := credential.Key{
 		Cloud: "model-access",
 		Owner: usertesting.GenNewName(c, "test-usermodel-access"),
 		Name:  "foobar",
 	}
 
+	// Add a second user (bob) with write access to the same model. The query
+	// must only return the credential owner's access, not bob's.
+	_, err := st.CreatePermission(ctx, uuid.MustNewUUID(), corepermission.UserAccessSpec{
+		User: usertesting.GenNewName(c, "bob"),
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        modelUUID.String(),
+				ObjectType: corepermission.Model,
+			},
+			Access: corepermission.WriteAccess,
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
 	obtained, err := st.AllModelAccessForCloudCredential(ctx, key)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(obtained, tc.HasLen, 1)
 	c.Check(obtained[0].ModelName, tc.DeepEquals, "model-access")
 	c.Check(obtained[0].OwnerAccess, tc.DeepEquals, corepermission.AdminAccess)
+}
+
+func (s *permissionStateSuite) TestModelAccessForCloudCredentialRemovedOwner(c *tc.C) {
+	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+	ctx := c.Context()
+
+	modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "model-access-removed")
+	key := credential.Key{
+		Cloud: "model-access-removed",
+		Owner: usertesting.GenNewName(c, "test-usermodel-access-removed"),
+		Name:  "foobar",
+	}
+
+	// Mark the credential owner as removed.
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE user SET removed = true WHERE name = ?
+		`, key.Owner.Name())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = st.AllModelAccessForCloudCredential(ctx, key)
+	c.Assert(err, tc.ErrorIs, accesserrors.PermissionNotFound)
 }
 
 func (s *permissionStateSuite) TestImportOfferAccess(c *tc.C) {

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -1279,6 +1279,69 @@ func (s *permissionStateSuite) TestModelAccessForCloudCredentialRemovedOwner(c *
 	c.Assert(err, tc.ErrorIs, accesserrors.PermissionNotFound)
 }
 
+func (s *permissionStateSuite) TestModelAccessForCloudCredentialDistinctByQualifier(c *tc.C) {
+	// This test verifies that AllModelAccessForCloudCredential returns one result
+	// per (name, qualifier) pair. Two models sharing the same name but with
+	// different qualifiers must both appear in the result set. Without DISTINCT
+	// covering qualifier, they would be collapsed into a single row.
+	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+	ctx := c.Context()
+
+	// Create the first model (the helper sets qualifier to "prod").
+	modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "model-dup-qual")
+	key := credential.Key{
+		Cloud: "model-dup-qual",
+		Owner: usertesting.GenNewName(c, "test-usermodel-dup-qual"),
+		Name:  "foobar",
+	}
+
+	// Insert a second model with the same name but qualifier "staging", reusing
+	// the same cloud credential. This creates the duplicate-name scenario that
+	// requires DISTINCT to span both name and qualifier.
+	secondModelUUID, err := coremodel.NewUUID()
+	c.Assert(err, tc.ErrorIsNil)
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		var cloudUUID, credUUID string
+		err := tx.QueryRowContext(ctx, `
+			SELECT c.uuid, cc.uuid
+			FROM cloud AS c
+			JOIN cloud_credential AS cc ON cc.cloud_uuid = c.uuid
+			WHERE c.name = ? AND cc.name = 'foobar'
+		`, key.Cloud).Scan(&cloudUUID, &credUUID)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO model
+			    (uuid, name, qualifier, cloud_uuid, cloud_credential_uuid,
+			     model_type_id, life_id, activated)
+			VALUES (?, 'model-dup-qual', 'staging', ?, ?, 0, 0, true)
+		`, secondModelUUID.String(), cloudUUID, credUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Grant the credential owner admin access to the second model as well.
+	_, err = st.CreatePermission(ctx, uuid.MustNewUUID(), corepermission.UserAccessSpec{
+		User: key.Owner,
+		AccessSpec: corepermission.AccessSpec{
+			Target: corepermission.ID{
+				Key:        secondModelUUID.String(),
+				ObjectType: corepermission.Model,
+			},
+			Access: corepermission.AdminAccess,
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Both models must be returned: one per (name, qualifier) pair.
+	obtained, err := st.AllModelAccessForCloudCredential(ctx, key)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained, tc.HasLen, 2,
+		tc.Commentf("expected two results for models with same name but different qualifiers"))
+}
+
 func (s *permissionStateSuite) TestImportOfferAccess(c *tc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -1223,108 +1223,72 @@ func (s *permissionStateSuite) TestUpdatePermissionRevokeLastAdmin(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *permissionStateSuite) TestModelAccessForCloudCredential(c *tc.C) {
+func (s *permissionStateSuite) TestAllModelAccessForOwner(c *tc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 	ctx := c.Context()
 
-	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "model-access")
-	key := credential.Key{
-		Cloud: "model-access",
-		Owner: usertesting.GenNewName(c, "test-usermodel-access"),
+	// Create first credential+model for the owner.
+	modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "owner-a-first")
+	ownerName := usertesting.GenNewName(c, "test-userowner-a-first")
+	keyFirst := credential.Key{
+		Cloud: "owner-a-first",
+		Owner: ownerName,
 		Name:  "foobar",
 	}
 
-	// Add a second user (bob) with write access to the same model. The query
-	// must only return the credential owner's access, not bob's.
-	_, err := st.CreatePermission(ctx, uuid.MustNewUUID(), corepermission.UserAccessSpec{
-		User: usertesting.GenNewName(c, "bob"),
-		AccessSpec: corepermission.AccessSpec{
-			Target: corepermission.ID{
-				Key:        modelUUID.String(),
-				ObjectType: corepermission.Model,
-			},
-			Access: corepermission.WriteAccess,
-		},
-	})
+	// Add a second cloud+credential+model for the same owner, referencing a
+	// different cloud.  This tests that AllModelAccessForOwner groups results
+	// by credential key correctly when an owner has more than one credential.
+	secondCloudUUID, err := uuid.NewUUID()
 	c.Assert(err, tc.ErrorIsNil)
-
-	obtained, err := st.AllModelAccessForCloudCredential(ctx, key)
+	secondCredUUID, err := credential.NewUUID()
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(obtained, tc.HasLen, 1)
-	c.Check(obtained[0].ModelName, tc.DeepEquals, "model-access")
-	c.Check(obtained[0].OwnerAccess, tc.DeepEquals, corepermission.AdminAccess)
-}
-
-func (s *permissionStateSuite) TestModelAccessForCloudCredentialRemovedOwner(c *tc.C) {
-	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-	ctx := c.Context()
-
-	modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "model-access-removed")
-	key := credential.Key{
-		Cloud: "model-access-removed",
-		Owner: usertesting.GenNewName(c, "test-usermodel-access-removed"),
-		Name:  "foobar",
-	}
-
-	// Mark the credential owner as removed.
-	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-			UPDATE user SET removed = true WHERE name = ?
-		`, key.Owner.Name())
-		return err
-	})
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, err = st.AllModelAccessForCloudCredential(ctx, key)
-	c.Assert(err, tc.ErrorIs, accesserrors.PermissionNotFound)
-}
-
-func (s *permissionStateSuite) TestModelAccessForCloudCredentialDistinctByQualifier(c *tc.C) {
-	// This test verifies that AllModelAccessForCloudCredential returns one result
-	// per (name, qualifier) pair. Two models sharing the same name but with
-	// different qualifiers must both appear in the result set. Without DISTINCT
-	// covering qualifier, they would be collapsed into a single row.
-	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-	ctx := c.Context()
-
-	// Create the first model (the helper sets qualifier to "prod").
-	modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "model-dup-qual")
-	key := credential.Key{
-		Cloud: "model-dup-qual",
-		Owner: usertesting.GenNewName(c, "test-usermodel-dup-qual"),
-		Name:  "foobar",
-	}
-
-	// Insert a second model with the same name but qualifier "staging", reusing
-	// the same cloud credential. This creates the duplicate-name scenario that
-	// requires DISTINCT to span both name and qualifier.
 	secondModelUUID, err := coremodel.NewUUID()
 	c.Assert(err, tc.ErrorIsNil)
+
+	keySecond := credential.Key{
+		Cloud: "owner-a-second",
+		Owner: ownerName,
+		Name:  "foobar",
+	}
+
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		var cloudUUID, credUUID string
-		err := tx.QueryRowContext(ctx, `
-			SELECT c.uuid, cc.uuid
-			FROM cloud AS c
-			JOIN cloud_credential AS cc ON cc.cloud_uuid = c.uuid
-			WHERE c.name = ? AND cc.name = 'foobar'
-		`, key.Cloud).Scan(&cloudUUID, &credUUID)
-		if err != nil {
+		var ownerUUID string
+		if err := tx.QueryRowContext(ctx, `SELECT uuid FROM user WHERE name = ?`,
+			ownerName.Name()).Scan(&ownerUUID); err != nil {
 			return err
 		}
 
-		_, err = tx.ExecContext(ctx, `
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO cloud (uuid, name, cloud_type_id, endpoint, skip_tls_verify)
+			VALUES (?, 'owner-a-second', -1, '', true)
+		`, secondCloudUUID.String()); err != nil {
+			return err
+		}
+
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO cloud_credential (uuid, cloud_uuid, auth_type_id, owner_uuid, name, revoked, invalid)
+			VALUES (?, ?, 0, ?, 'foobar', false, false)
+		`, secondCredUUID, secondCloudUUID.String(), ownerUUID); err != nil {
+			return err
+		}
+
+		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO model
 			    (uuid, name, qualifier, cloud_uuid, cloud_credential_uuid,
 			     model_type_id, life_id, activated)
-			VALUES (?, 'model-dup-qual', 'staging', ?, ?, 0, 0, true)
-		`, secondModelUUID.String(), cloudUUID, credUUID)
-		return err
+			VALUES (?, 'owner-a-second', 'prod', ?, ?, 0, 0, true)
+		`, secondModelUUID.String(), secondCloudUUID.String(), secondCredUUID); err != nil {
+			return err
+		}
+
+		return nil
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	// Grant the credential owner admin access to the second model as well.
+	// Grant the owner admin access to the second model.
 	_, err = st.CreatePermission(ctx, uuid.MustNewUUID(), corepermission.UserAccessSpec{
-		User: key.Owner,
+		User: ownerName,
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
 				Key:        secondModelUUID.String(),
@@ -1335,11 +1299,41 @@ func (s *permissionStateSuite) TestModelAccessForCloudCredentialDistinctByQualif
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	// Both models must be returned: one per (name, qualifier) pair.
-	obtained, err := st.AllModelAccessForCloudCredential(ctx, key)
+	// Create an unrelated owner + credential to verify isolation.
+	modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "owner-b-only")
+
+	// AllModelAccessForOwner must return both of the first owner's credentials
+	// and none of the unrelated owner's credentials.
+	result, err := st.AllModelAccessForOwner(ctx, ownerName)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(obtained, tc.HasLen, 2,
-		tc.Commentf("expected two results for models with same name but different qualifiers"))
+	c.Assert(result, tc.HasLen, 2,
+		tc.Commentf("expected two credential keys in result"))
+
+	// Build a lookup map to assert both keys are present regardless of order.
+	byKey := make(map[credential.Key][]access.OwnerModelAccess, len(result))
+	for _, entry := range result {
+		byKey[entry.CredentialKey] = entry.Models
+	}
+
+	firstModels, ok := byKey[keyFirst]
+	c.Assert(ok, tc.IsTrue, tc.Commentf("expected key %v in result", keyFirst))
+	c.Assert(firstModels, tc.HasLen, 1)
+	c.Check(firstModels[0].ModelName, tc.Equals, "owner-a-first")
+
+	secondModels, ok := byKey[keySecond]
+	c.Assert(ok, tc.IsTrue, tc.Commentf("expected key %v in result", keySecond))
+	c.Assert(secondModels, tc.HasLen, 1)
+	c.Check(secondModels[0].ModelName, tc.Equals, "owner-a-second")
+}
+
+func (s *permissionStateSuite) TestAllModelAccessForOwnerNoCredentials(c *tc.C) {
+	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	// An owner with no credentials returns an empty slice, not an error.
+	result, err := st.AllModelAccessForOwner(c.Context(),
+		usertesting.GenNewName(c, "ghost-user"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.HasLen, 0)
 }
 
 func (s *permissionStateSuite) TestImportOfferAccess(c *tc.C) {

--- a/domain/access/state/types.go
+++ b/domain/access/state/types.go
@@ -6,8 +6,10 @@ package state
 import (
 	"time"
 
+	coremodel "github.com/juju/juju/core/model"
 	corepermission "github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
+	"github.com/juju/juju/domain/access"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -217,6 +219,27 @@ type dbModelExists struct {
 
 // dbEveryoneExternal represents the permissions of the everyone@external user.
 type dbEveryoneExternal dbPermission
+
+// ownerModelAccess is a sqlair scan target for the AllModelAccessForOwner
+// query. Each row represents a single (credential, model) pair for the owner.
+type ownerModelAccess struct {
+	CredName       string                `db:"cred_name"`
+	CloudName      string                `db:"cloud_name"`
+	ModelName      string                `db:"model_name"`
+	ModelQualifier coremodel.Qualifier   `db:"model_qualifier"`
+	OwnerAccess    corepermission.Access `db:"access_type"`
+}
+
+// toOwnerModelAccess converts the DB scan row to the domain OwnerModelAccess
+// type, discarding the credential-identifying fields which are handled by the
+// caller.
+func (r ownerModelAccess) toOwnerModelAccess() access.OwnerModelAccess {
+	return access.OwnerModelAccess{
+		ModelName:      r.ModelName,
+		ModelQualifier: r.ModelQualifier,
+		OwnerAccess:    r.OwnerAccess,
+	}
+}
 
 // nameAndUUID is an agnostic container for a `name` and `uuid`
 // column combination.

--- a/domain/access/types.go
+++ b/domain/access/types.go
@@ -4,6 +4,7 @@
 package access
 
 import (
+	"github.com/juju/juju/core/credential"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
@@ -38,12 +39,27 @@ func (args UpdatePermissionArgs) Validate() error {
 	return nil
 }
 
-// CredentialOwnerModelAccess stores cloud credential model information for the credential owner
-// or an error retrieving it.
-type CredentialOwnerModelAccess struct {
-	ModelName      string            `db:"model_name"`
-	ModelQualifier model.Qualifier   `db:"model_qualifier"`
-	OwnerAccess    permission.Access `db:"access_type"`
+// OwnerModelAccess describes the owner's access level on a single model
+// associated with one of their cloud credentials.
+type OwnerModelAccess struct {
+	// ModelName is the name of the model.
+	ModelName string
+	// ModelQualifier disambiguates models that share the same name across
+	// different owners or namespaces.
+	ModelQualifier model.Qualifier
+	// OwnerAccess is the permission level the credential owner holds on
+	// this model.
+	OwnerAccess permission.Access
+}
+
+// OwnerModelAccessByCredential groups a credential key with all models the
+// credential owner can access through that credential.
+type OwnerModelAccessByCredential struct {
+	// CredentialKey identifies the cloud credential.
+	CredentialKey credential.Key
+	// Models is the list of models accessible to the owner via this
+	// credential, together with the owner's access level on each.
+	Models []OwnerModelAccess
 }
 
 // OfferImport contains details to import access to an offer.

--- a/domain/access/types.go
+++ b/domain/access/types.go
@@ -5,6 +5,7 @@ package access
 
 import (
 	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/internal/errors"
@@ -41,7 +42,7 @@ func (args UpdatePermissionArgs) Validate() error {
 // or an error retrieving it.
 type CredentialOwnerModelAccess struct {
 	ModelName      string            `db:"model_name"`
-	ModelQualifier string            `db:"model_qualifier"`
+	ModelQualifier model.Qualifier   `db:"model_qualifier"`
 	OwnerAccess    permission.Access `db:"access_type"`
 }
 

--- a/domain/access/types.go
+++ b/domain/access/types.go
@@ -40,8 +40,9 @@ func (args UpdatePermissionArgs) Validate() error {
 // CredentialOwnerModelAccess stores cloud credential model information for the credential owner
 // or an error retrieving it.
 type CredentialOwnerModelAccess struct {
-	ModelName   string            `db:"model_name"`
-	OwnerAccess permission.Access `db:"access_type"`
+	ModelName      string            `db:"model_name"`
+	ModelQualifier string            `db:"model_qualifier"`
+	OwnerAccess    permission.Access `db:"access_type"`
 }
 
 // OfferImport contains details to import access to an offer.


### PR DESCRIPTION
## Summary

`AllModelAccessForCloudCredential` in `domain/access/state/permission.go` joined `v_permission` on the model UUID but never filtered by subject. This caused it to return permissions for **all users** who have access to the model rather than the credential owner alone.

The practical impact is visible in `juju show-credential`: because the `models:` field is a YAML map keyed by model name, the duplicate rows silently replace the owner's correct access level with another user's access level (e.g. showing `write` instead of `admin`).

The fix  replaces the `v_permission` view join with direct table joins on
`permission`, `permission_access_type` and `user` to avoid unbounded view
growth, and adds `DISTINCT` to guard against duplicate rows.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~Integration tests~
- [ ] ~doc.go added or updated in changed packages~

## QA steps

Setup (run on each controller under test):

```sh
# Add a second user and grant them write access to a model that uses the credential
juju add-user bob
juju add-model qa-model
juju grant bob write qa-model
```

Trigger:

```sh
juju show-credential --format yaml
```

**Expected (fixed / 3.6):**
```yaml
models:
  qa-model: admin   # owner's access, shown once
```

**Buggy (unfixed 4.0):**
```yaml
models:
  qa-model: write   # bob's access leaks and replaces the owner's admin
```

QA was run on three live controllers and confirmed:
- `legacy` (3.6): ✅ PASS — `qa-model: admin`
- `before4` (4.0 unfixed): ❌ FAIL — `qa-model: write` (bob's access leaked)
- `fixed4` (4.0 fixed): ✅ PASS — `qa-model: admin`

## Documentation changes

No user-facing documentation changes. The output of `juju show-credential` is corrected to show the credential owner's model access level rather than any other user's.

## Links

**Issue:** Fixes #22064.

**Jira card:** [JUJU-9478](https://warthogs.atlassian.net/browse/JUJU-9478)


[JUJU-9478]: https://warthogs.atlassian.net/browse/JUJU-9478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ