### PR TITLE
feat: persist platform when specified in the base

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -715,6 +715,7 @@ func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetChar
 	err = api.applicationService.SetApplicationCharm(ctx, args.ApplicationName, newCharmLocator, application.SetCharmParams{
 		CharmOrigin:               charmOrigin,
 		CharmUpgradeOnError:       args.Force,
+		ForceBase:                 args.ForceBase,
 		EndpointBindings:          transform.Map(args.EndpointBindings, func(k, v string) (string, network.SpaceName) { return k, network.SpaceName(v) }),
 		StorageDirectiveOverrides: storageDirectiveOverrides,
 	})
@@ -774,6 +775,11 @@ func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetChar
 		return apiservererrors.ParamsErrorf(
 			params.CodeNotSupported,
 			"cannot set charm %q because %s", args.CharmURL, locationErr.Error(),
+		)
+	case errors.Is(err, applicationerrors.IncompatibleBase):
+		return apiservererrors.ParamsErrorf(
+			params.CodeIncompatibleBase,
+			"cannot set charm %q because %s", args.CharmURL, err.Error(),
 		)
 	case errors.HasType[applicationerrors.CharmStorageTypeChanged](err):
 		typeErr, _ := errors.AsType[applicationerrors.CharmStorageTypeChanged](err)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -767,7 +767,7 @@ func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetChar
 	case errors.Is(err, applicationerrors.IncompatibleBase):
 		return apiservererrors.ParamsErrorf(
 			params.CodeIncompatibleBase,
-			"cannot set charm %q because %s", args.CharmURL, err.Error(),
+			"cannot set charm %q: %s", args.CharmURL, err.Error(),
 		)
 	case errors.HasType[applicationerrors.CharmStorageTypeChanged](err):
 		typeErr, _ := errors.AsType[applicationerrors.CharmStorageTypeChanged](err)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -703,6 +703,7 @@ func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetChar
 	err = api.applicationService.SetApplicationCharm(ctx, args.ApplicationName, newCharmLocator, application.SetCharmParams{
 		CharmOrigin:               charmOrigin,
 		CharmUpgradeOnError:       args.Force,
+		ForceBase:                 args.ForceBase,
 		EndpointBindings:          transform.Map(args.EndpointBindings, func(k, v string) (string, network.SpaceName) { return k, network.SpaceName(v) }),
 		StorageDirectiveOverrides: storageDirectiveOverrides,
 	})
@@ -762,6 +763,11 @@ func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetChar
 		return apiservererrors.ParamsErrorf(
 			params.CodeNotSupported,
 			"cannot set charm %q because %s", args.CharmURL, locationErr.Error(),
+		)
+	case errors.Is(err, applicationerrors.IncompatibleBase):
+		return apiservererrors.ParamsErrorf(
+			params.CodeIncompatibleBase,
+			"cannot set charm %q because %s", args.CharmURL, err.Error(),
 		)
 	case errors.HasType[applicationerrors.CharmStorageTypeChanged](err):
 		typeErr, _ := errors.AsType[applicationerrors.CharmStorageTypeChanged](err)

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -977,6 +977,7 @@ func (s *applicationSuite) TestSetCharm(c *tc.C) {
 			},
 		},
 		CharmUpgradeOnError: true,
+		ForceBase:           true,
 		EndpointBindings: map[string]network.SpaceName{
 			"binding-1": "endpoint-1",
 			"binding-2": "endpoint-2",
@@ -998,7 +999,8 @@ func (s *applicationSuite) TestSetCharm(c *tc.C) {
 			Track:        new("1.0"),
 			Risk:         "stable",
 		},
-		Force: true,
+		Force:     true,
+		ForceBase: true,
 		EndpointBindings: map[string]string{
 			"binding-1": "endpoint-1",
 			"binding-2": "endpoint-2",

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -79,6 +79,10 @@ const (
 	// application scale value.
 	ScaleChangeInvalid = errors.ConstError("scale change invalid")
 
+	// IncompatibleBase is returned when a charm refresh attempts to change the
+	// deployed application base incompatibly without explicit override.
+	IncompatibleBase = errors.ConstError("incompatible base for charm")
+
 	// MissingStorageDirective describes an error that occurs when expected
 	// storage directives are missing.
 	MissingStorageDirective = errors.ConstError("no storage directive specified")

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -1983,8 +1983,18 @@ func makeSetCharmStateArg(setCharmParams application.SetCharmParams,
 		return application.SetCharmStateParams{}, errors.Errorf("encoding charm channel: %w", err)
 	}
 
+	var platform *deployment.Platform
+	if setCharmParams.CharmOrigin.Platform != (corecharm.Platform{}) {
+		encodedPlatform, err := encodePlatform(setCharmParams.CharmOrigin.Platform)
+		if err != nil {
+			return application.SetCharmStateParams{}, errors.Errorf("encoding charm platform: %w", err)
+		}
+		platform = &encodedPlatform
+	}
+
 	return application.SetCharmStateParams{
 		Channel:                   channel,
+		Platform:                  platform,
 		EndpointBindings:          setCharmParams.EndpointBindings,
 		StorageDirectivesToCreate: toCreate,
 		StorageDirectivesToUpdate: toUpdate,

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -13,6 +13,7 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
+	corebase "github.com/juju/juju/core/base"
 	corecharm "github.com/juju/juju/core/charm"
 	coreconstraints "github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
@@ -1666,6 +1667,10 @@ func (s *ProviderService) SetApplicationCharm(ctx context.Context, appName strin
 		return errors.Errorf("getting charm ID: %w", err)
 	}
 
+	if err := s.validateCharmBaseCompatibility(ctx, appUUID, params); err != nil {
+		return errors.Capture(err)
+	}
+
 	// 1. Validate storage requirements between the existing and new charm.
 	// Prevent refresh if the new charm’s storage configuration is incompatible.
 	// For example, removing previously defined storage names is disallowed,
@@ -1760,6 +1765,50 @@ func (s *ProviderService) SetApplicationCharm(ctx context.Context, appName strin
 		return errors.Errorf("setting application %q charm: %w", appName, err)
 	}
 	return nil
+}
+
+func (s *ProviderService) validateCharmBaseCompatibility(
+	ctx context.Context,
+	appUUID coreapplication.UUID,
+	params application.SetCharmParams,
+) error {
+	if params.ForceBase {
+		return nil
+	}
+
+	requestedPlatform := params.CharmOrigin.Platform
+	if requestedPlatform.OS == "" || requestedPlatform.Channel == "" {
+		return nil
+	}
+
+	currentOrigin, err := s.st.GetApplicationCharmOrigin(ctx, appUUID)
+	if err != nil {
+		return errors.Errorf("getting application charm origin: %w", err)
+	}
+
+	currentPlatform := currentOrigin.Platform
+	if currentPlatform.OSType == deployment.Unknown || currentPlatform.Channel == "" {
+		return nil
+	}
+
+	currentBase, err := corebase.ParseBase(currentPlatform.OSType.String(), currentPlatform.Channel)
+	if err != nil {
+		return errors.Errorf("parsing current application base: %w", err)
+	}
+	requestedBase, err := corebase.ParseBase(requestedPlatform.OS, requestedPlatform.Channel)
+	if err != nil {
+		return errors.Errorf("parsing requested charm base: %w", err)
+	}
+
+	if currentBase.Empty() || requestedBase.Empty() || currentBase.IsCompatible(requestedBase) {
+		return nil
+	}
+
+	return errors.Errorf(
+		"cannot refresh application from base %q to %q without --force-base",
+		currentBase.DisplayString(),
+		requestedBase.DisplayString(),
+	).Add(applicationerrors.IncompatibleBase)
 }
 
 func getTrustSettingFromConfig(cfg map[string]string) (*bool, error) {

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -13,6 +13,7 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
+	corebase "github.com/juju/juju/core/base"
 	corecharm "github.com/juju/juju/core/charm"
 	coreconstraints "github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
@@ -1667,6 +1668,10 @@ func (s *ProviderService) SetApplicationCharm(ctx context.Context, appName strin
 		return errors.Errorf("getting charm ID: %w", err)
 	}
 
+	if err := s.validateCharmBaseCompatibility(ctx, appUUID, params); err != nil {
+		return errors.Capture(err)
+	}
+
 	// 1. Validate storage requirements between the existing and new charm.
 	// Prevent refresh if the new charm’s storage configuration is incompatible.
 	// For example, removing previously defined storage names is disallowed,
@@ -1764,6 +1769,50 @@ func (s *ProviderService) SetApplicationCharm(ctx context.Context, appName strin
 		return errors.Errorf("setting application %q charm: %w", appName, err)
 	}
 	return nil
+}
+
+func (s *ProviderService) validateCharmBaseCompatibility(
+	ctx context.Context,
+	appUUID coreapplication.UUID,
+	params application.SetCharmParams,
+) error {
+	if params.ForceBase {
+		return nil
+	}
+
+	requestedPlatform := params.CharmOrigin.Platform
+	if requestedPlatform.OS == "" || requestedPlatform.Channel == "" {
+		return nil
+	}
+
+	currentOrigin, err := s.st.GetApplicationCharmOrigin(ctx, appUUID)
+	if err != nil {
+		return errors.Errorf("getting application charm origin: %w", err)
+	}
+
+	currentPlatform := currentOrigin.Platform
+	if currentPlatform.OSType == deployment.Unknown || currentPlatform.Channel == "" {
+		return nil
+	}
+
+	currentBase, err := corebase.ParseBase(currentPlatform.OSType.String(), currentPlatform.Channel)
+	if err != nil {
+		return errors.Errorf("parsing current application base: %w", err)
+	}
+	requestedBase, err := corebase.ParseBase(requestedPlatform.OS, requestedPlatform.Channel)
+	if err != nil {
+		return errors.Errorf("parsing requested charm base: %w", err)
+	}
+
+	if currentBase.Empty() || requestedBase.Empty() || currentBase.IsCompatible(requestedBase) {
+		return nil
+	}
+
+	return errors.Errorf(
+		"cannot refresh application from base %q to %q without --force-base",
+		currentBase.DisplayString(),
+		requestedBase.DisplayString(),
+	).Add(applicationerrors.IncompatibleBase)
 }
 
 func getTrustSettingFromConfig(cfg map[string]string) (*bool, error) {

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -1987,8 +1987,18 @@ func makeSetCharmStateArg(setCharmParams application.SetCharmParams,
 		return application.SetCharmStateParams{}, errors.Errorf("encoding charm channel: %w", err)
 	}
 
+	var platform *deployment.Platform
+	if setCharmParams.CharmOrigin.Platform != (corecharm.Platform{}) {
+		encodedPlatform, err := encodePlatform(setCharmParams.CharmOrigin.Platform)
+		if err != nil {
+			return application.SetCharmStateParams{}, errors.Errorf("encoding charm platform: %w", err)
+		}
+		platform = &encodedPlatform
+	}
+
 	return application.SetCharmStateParams{
 		Channel:                   channel,
+		Platform:                  platform,
 		EndpointBindings:          setCharmParams.EndpointBindings,
 		StorageDirectivesToCreate: toCreate,
 		StorageDirectivesToUpdate: toUpdate,

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -1809,7 +1809,7 @@ func (s *ProviderService) validateCharmBaseCompatibility(
 	}
 
 	return errors.Errorf(
-		"cannot refresh application from base %q to %q without --force-base",
+		"refreshing application from base %q to %q",
 		currentBase.DisplayString(),
 		requestedBase.DisplayString(),
 	).Add(applicationerrors.IncompatibleBase)

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -1633,9 +1633,10 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithPlatformChange(c *t
 	}
 	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
 	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
-	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]application.StorageDirective{}, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]internal.StorageDirective{}, nil)
 	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(map[string]applicationcharm.Storage{}, nil)
 	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(nil), nil)
+	s.state.EXPECT().GetModelType(gomock.Any()).Return(model.IAAS, nil)
 	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -1613,6 +1613,45 @@ func (s *applicationServiceSuite) TestSetApplicationCharmEmptyChannel(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *applicationServiceSuite) TestSetApplicationCharmWithPlatformChange(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	origin := corecharm.Origin{
+		Source: corecharm.CharmHub,
+		ID:     "charm-id",
+		Platform: corecharm.Platform{
+			OS:           "ubuntu",
+			Architecture: arch.AMD64,
+			Channel:      "22.04",
+		},
+	}
+	params := application.SetCharmParams{
+		CharmOrigin: origin,
+	}
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]application.StorageDirective{}, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(map[string]applicationcharm.Storage{}, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(nil), nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).
+		Do(func(_ context.Context, _ coreapplication.UUID, _ corecharm.ID, params application.SetCharmStateParams) error {
+			// Verify that platform was correctly encoded and passed through.
+			c.Assert(params.Platform, tc.NotNil)
+			c.Assert(params.Platform.OSType, tc.Equals, deployment.Ubuntu)
+			c.Assert(params.Platform.Architecture, tc.Equals, architecture.AMD64)
+			c.Assert(params.Platform.Channel, tc.Equals, "22.04")
+			return nil
+		})
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 // TestSetApplicationCharmWithStorageNameAdded tests that adding a new
 // storage name in the new charm is allowed.
 func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageNameAdded(c *tc.C) {

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -1636,6 +1636,13 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithPlatformChange(c *t
 	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]internal.StorageDirective{}, nil)
 	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(map[string]applicationcharm.Storage{}, nil)
 	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(nil), nil)
+	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), appUUID).Return(application.CharmOrigin{
+		Platform: deployment.Platform{
+			OSType:       deployment.Ubuntu,
+			Architecture: architecture.AMD64,
+			Channel:      "22.04",
+		},
+	}, nil)
 	s.state.EXPECT().GetModelType(gomock.Any()).Return(model.IAAS, nil)
 	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
 	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -1653,8 +1660,75 @@ func (s *applicationServiceSuite) TestSetApplicationCharmWithPlatformChange(c *t
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-// TestSetApplicationCharmWithStorageNameAdded tests that adding a new
-// storage name in the new charm is allowed.
+// TestSetApplicationCharmRejectsIncompatibleBaseWithoutForceBase tests that
+// an incompatible base change is rejected unless force-base is set.
+func (s *applicationServiceSuite) TestSetApplicationCharmRejectsIncompatibleBaseWithoutForceBase(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	params := application.SetCharmParams{
+		CharmOrigin: corecharm.Origin{
+			Source: corecharm.CharmHub,
+			ID:     "charm-id",
+			Platform: corecharm.Platform{
+				OS:           "ubuntu",
+				Architecture: arch.AMD64,
+				Channel:      "24.04",
+			},
+		},
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.state.EXPECT().GetApplicationCharmOrigin(gomock.Any(), appUUID).Return(application.CharmOrigin{
+		Platform: deployment.Platform{
+			OSType:       deployment.Ubuntu,
+			Architecture: architecture.AMD64,
+			Channel:      "22.04",
+		},
+	}, nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorIs, applicationerrors.IncompatibleBase)
+}
+
+// TestSetApplicationCharmAllowsIncompatibleBaseWithForceBase tests that an
+// incompatible base change is allowed when force-base is set.
+func (s *applicationServiceSuite) TestSetApplicationCharmAllowsIncompatibleBaseWithForceBase(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appName := "foo"
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	charmID := charmtesting.GenCharmID(c)
+	params := application.SetCharmParams{
+		CharmOrigin: corecharm.Origin{
+			Source: corecharm.CharmHub,
+			ID:     "charm-id",
+			Platform: corecharm.Platform{
+				OS:           "ubuntu",
+				Architecture: arch.AMD64,
+				Channel:      "24.04",
+			},
+		},
+		ForceBase: true,
+	}
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), appName).Return(appUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(charmID, nil)
+	s.storageService.EXPECT().GetApplicationStorageDirectives(gomock.Any(), appUUID).Return([]internal.StorageDirective{}, nil)
+	s.state.EXPECT().GetCharmMetadataStorage(gomock.Any(), charmID).Return(map[string]applicationcharm.Storage{}, nil)
+	s.state.EXPECT().GetCharmByApplicationUUID(gomock.Any(), appUUID).Return(makeCharmWithStorage(nil), nil)
+	s.state.EXPECT().GetModelType(gomock.Any()).Return(model.IAAS, nil)
+	s.storageService.EXPECT().ReconcileStorageDirectivesAgainstCharmStorage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().SetApplicationCharm(gomock.Any(), appUUID, charmID, gomock.Any()).Return(nil)
+
+	err := s.service.SetApplicationCharm(c.Context(), appName, applicationcharm.CharmLocator{}, params)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *applicationServiceSuite) TestSetApplicationCharmWithStorageNameAdded(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1869,29 +1869,45 @@ ON CONFLICT(application_uuid) DO UPDATE SET
 	return nil
 }
 
-func (st *State) upsertApplicationPlatform(ctx context.Context, tx *sqlair.TX, platform deployment.Platform, appID string) error {
-	if platform.Architecture == architecture.Unknown {
-		return errors.Errorf("cannot upsert application platform with an empty architecture")
-	}
-
-	archID, err := encodeArchitecture(platform.Architecture)
-	if err != nil {
-		return errors.Errorf("encoding architecture: %w", err)
+func (st *State) getApplicationPlatformArchitectureID(ctx context.Context, tx *sqlair.TX, appID string) (int, error) {
+	type platformArchitecture struct {
+		ArchitectureID int `db:"architecture_id"`
 	}
 
 	appIDInput := entityUUID{UUID: appID}
-
-	// Need to delete manually as application_uuid doesn't have UNIQUE constraint here.
-	deleteStmt, err := st.Prepare(`
-DELETE FROM application_platform
+	stmt, err := st.Prepare(`
+SELECT architecture_id AS &platformArchitecture.architecture_id
+FROM   application_platform
 WHERE  application_uuid = $entityUUID.uuid
-`, appIDInput)
+LIMIT 1
+`, platformArchitecture{}, appIDInput)
 	if err != nil {
-		return errors.Capture(err)
+		return 0, errors.Capture(err)
 	}
 
-	if err := tx.Query(ctx, deleteStmt, appIDInput).Run(); err != nil {
-		return errors.Errorf("deleting old application platform: %w", err)
+	var result platformArchitecture
+	if err := tx.Query(ctx, stmt, appIDInput).Get(&result); err != nil {
+		return 0, err
+	}
+	return result.ArchitectureID, nil
+}
+
+func (st *State) upsertApplicationPlatform(ctx context.Context, tx *sqlair.TX, platform deployment.Platform, appID string) error {
+	var (
+		archID int
+		err    error
+	)
+
+	if platform.Architecture == architecture.Unknown {
+		archID, err = st.getApplicationPlatformArchitectureID(ctx, tx, appID)
+		if err != nil {
+			return errors.Errorf("getting existing application platform architecture: %w", err)
+		}
+	} else {
+		archID, err = encodeArchitecture(platform.Architecture)
+		if err != nil {
+			return errors.Errorf("encoding architecture: %w", err)
+		}
 	}
 
 	appPlatform := applicationPlatform{
@@ -1901,15 +1917,19 @@ WHERE  application_uuid = $entityUUID.uuid
 		ArchitectureID: archID,
 	}
 
-	insertStmt, err := st.Prepare(`
-INSERT INTO application_platform (*) VALUES ($applicationPlatform.*)
+	updateStmt, err := st.Prepare(`
+UPDATE application_platform
+SET    os_id = $applicationPlatform.os_id,
+       channel = $applicationPlatform.channel,
+       architecture_id = $applicationPlatform.architecture_id
+WHERE  application_uuid = $applicationPlatform.application_uuid
 `, applicationPlatform{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	if err := tx.Query(ctx, insertStmt, appPlatform).Run(); err != nil {
-		return errors.Errorf("inserting new application platform: %w", err)
+	if err := tx.Query(ctx, updateStmt, appPlatform).Run(); err != nil {
+		return errors.Errorf("updating application platform: %w", err)
 	}
 
 	return nil

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1816,6 +1816,12 @@ WHERE  uuid = $entityUUID.uuid
 			}
 		}
 
+		if params.Platform != nil {
+			if err := st.upsertApplicationPlatform(ctx, tx, *params.Platform, appID.String()); err != nil {
+				return errors.Errorf("updating application platform: %w", err)
+			}
+		}
+
 		charmModifiedVersionNamespace := domainsequence.MakePrefixNamespace(
 			application.ApplicationCharmSequenceNamespace, appID.String(),
 		)
@@ -1860,6 +1866,52 @@ ON CONFLICT(application_uuid) DO UPDATE SET
 	if err := tx.Query(ctx, upsertAppChannelStmt, appChannel).Run(); err != nil {
 		return errors.Errorf("upserting application channel: %w", err)
 	}
+	return nil
+}
+
+func (st *State) upsertApplicationPlatform(ctx context.Context, tx *sqlair.TX, platform deployment.Platform, appID string) error {
+	if platform.Architecture == architecture.Unknown {
+		return errors.Errorf("cannot upsert application platform with an empty architecture")
+	}
+
+	archID, err := encodeArchitecture(platform.Architecture)
+	if err != nil {
+		return errors.Errorf("encoding architecture: %w", err)
+	}
+
+	appIDInput := entityUUID{UUID: appID}
+
+	// Need to delete manually as application_uuid doesn't have UNIQUE constraint here.
+	deleteStmt, err := st.Prepare(`
+DELETE FROM application_platform
+WHERE  application_uuid = $entityUUID.uuid
+`, appIDInput)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if err := tx.Query(ctx, deleteStmt, appIDInput).Run(); err != nil {
+		return errors.Errorf("deleting old application platform: %w", err)
+	}
+
+	appPlatform := applicationPlatform{
+		ApplicationID:  appID,
+		OSTypeID:       int(platform.OSType),
+		Channel:        platform.Channel,
+		ArchitectureID: archID,
+	}
+
+	insertStmt, err := st.Prepare(`
+INSERT INTO application_platform (*) VALUES ($applicationPlatform.*)
+`, applicationPlatform{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if err := tx.Query(ctx, insertStmt, appPlatform).Run(); err != nil {
+		return errors.Errorf("inserting new application platform: %w", err)
+	}
+
 	return nil
 }
 

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1893,29 +1893,45 @@ ON CONFLICT(application_uuid) DO UPDATE SET
 	return nil
 }
 
-func (st *State) upsertApplicationPlatform(ctx context.Context, tx *sqlair.TX, platform deployment.Platform, appID string) error {
-	if platform.Architecture == architecture.Unknown {
-		return errors.Errorf("cannot upsert application platform with an empty architecture")
-	}
-
-	archID, err := encodeArchitecture(platform.Architecture)
-	if err != nil {
-		return errors.Errorf("encoding architecture: %w", err)
+func (st *State) getApplicationPlatformArchitectureID(ctx context.Context, tx *sqlair.TX, appID string) (int, error) {
+	type platformArchitecture struct {
+		ArchitectureID int `db:"architecture_id"`
 	}
 
 	appIDInput := entityUUID{UUID: appID}
-
-	// Need to delete manually as application_uuid doesn't have UNIQUE constraint here.
-	deleteStmt, err := st.Prepare(`
-DELETE FROM application_platform
+	stmt, err := st.Prepare(`
+SELECT architecture_id AS &platformArchitecture.architecture_id
+FROM   application_platform
 WHERE  application_uuid = $entityUUID.uuid
-`, appIDInput)
+LIMIT 1
+`, platformArchitecture{}, appIDInput)
 	if err != nil {
-		return errors.Capture(err)
+		return 0, errors.Capture(err)
 	}
 
-	if err := tx.Query(ctx, deleteStmt, appIDInput).Run(); err != nil {
-		return errors.Errorf("deleting old application platform: %w", err)
+	var result platformArchitecture
+	if err := tx.Query(ctx, stmt, appIDInput).Get(&result); err != nil {
+		return 0, err
+	}
+	return result.ArchitectureID, nil
+}
+
+func (st *State) upsertApplicationPlatform(ctx context.Context, tx *sqlair.TX, platform deployment.Platform, appID string) error {
+	var (
+		archID int
+		err    error
+	)
+
+	if platform.Architecture == architecture.Unknown {
+		archID, err = st.getApplicationPlatformArchitectureID(ctx, tx, appID)
+		if err != nil {
+			return errors.Errorf("getting existing application platform architecture: %w", err)
+		}
+	} else {
+		archID, err = encodeArchitecture(platform.Architecture)
+		if err != nil {
+			return errors.Errorf("encoding architecture: %w", err)
+		}
 	}
 
 	appPlatform := applicationPlatform{
@@ -1925,15 +1941,19 @@ WHERE  application_uuid = $entityUUID.uuid
 		ArchitectureID: archID,
 	}
 
-	insertStmt, err := st.Prepare(`
-INSERT INTO application_platform (*) VALUES ($applicationPlatform.*)
+	updateStmt, err := st.Prepare(`
+UPDATE application_platform
+SET    os_id = $applicationPlatform.os_id,
+       channel = $applicationPlatform.channel,
+       architecture_id = $applicationPlatform.architecture_id
+WHERE  application_uuid = $applicationPlatform.application_uuid
 `, applicationPlatform{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	if err := tx.Query(ctx, insertStmt, appPlatform).Run(); err != nil {
-		return errors.Errorf("inserting new application platform: %w", err)
+	if err := tx.Query(ctx, updateStmt, appPlatform).Run(); err != nil {
+		return errors.Errorf("updating application platform: %w", err)
 	}
 
 	return nil

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1840,6 +1840,12 @@ WHERE  uuid = $entityUUID.uuid
 			}
 		}
 
+		if params.Platform != nil {
+			if err := st.upsertApplicationPlatform(ctx, tx, *params.Platform, appID.String()); err != nil {
+				return errors.Errorf("updating application platform: %w", err)
+			}
+		}
+
 		charmModifiedVersionNamespace := domainsequence.MakePrefixNamespace(
 			application.ApplicationCharmSequenceNamespace, appID.String(),
 		)
@@ -1884,6 +1890,52 @@ ON CONFLICT(application_uuid) DO UPDATE SET
 	if err := tx.Query(ctx, upsertAppChannelStmt, appChannel).Run(); err != nil {
 		return errors.Errorf("upserting application channel: %w", err)
 	}
+	return nil
+}
+
+func (st *State) upsertApplicationPlatform(ctx context.Context, tx *sqlair.TX, platform deployment.Platform, appID string) error {
+	if platform.Architecture == architecture.Unknown {
+		return errors.Errorf("cannot upsert application platform with an empty architecture")
+	}
+
+	archID, err := encodeArchitecture(platform.Architecture)
+	if err != nil {
+		return errors.Errorf("encoding architecture: %w", err)
+	}
+
+	appIDInput := entityUUID{UUID: appID}
+
+	// Need to delete manually as application_uuid doesn't have UNIQUE constraint here.
+	deleteStmt, err := st.Prepare(`
+DELETE FROM application_platform
+WHERE  application_uuid = $entityUUID.uuid
+`, appIDInput)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if err := tx.Query(ctx, deleteStmt, appIDInput).Run(); err != nil {
+		return errors.Errorf("deleting old application platform: %w", err)
+	}
+
+	appPlatform := applicationPlatform{
+		ApplicationID:  appID,
+		OSTypeID:       int(platform.OSType),
+		Channel:        platform.Channel,
+		ArchitectureID: archID,
+	}
+
+	insertStmt, err := st.Prepare(`
+INSERT INTO application_platform (*) VALUES ($applicationPlatform.*)
+`, applicationPlatform{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if err := tx.Query(ctx, insertStmt, appPlatform).Run(); err != nil {
+		return errors.Errorf("inserting new application platform: %w", err)
+	}
+
 	return nil
 }
 

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -578,7 +578,7 @@ func (st *State) GetApplicationLife(ctx context.Context, appUUID coreapplication
 
 	ident := entityUUID{UUID: appUUID.String()}
 	stmt, err := st.Prepare(`
-SELECT a.life_id AS &lifeID.life_id 
+SELECT a.life_id AS &lifeID.life_id
 FROM   application AS a
 JOIN   charm AS c ON c.uuid = a.charm_uuid
 WHERE  a.uuid = $entityUUID.uuid;
@@ -885,7 +885,7 @@ func (st *State) SetDesiredApplicationScale(ctx context.Context, appUUID coreapp
 		Scale:         scale,
 	}
 	upsertApplicationScale := `
-UPDATE application_scale 
+UPDATE application_scale
 SET    scale = $applicationScale.scale
 WHERE  application_uuid = $applicationScale.application_uuid
 `
@@ -911,7 +911,7 @@ func (st *State) UpdateApplicationScale(ctx context.Context, appUUID coreapplica
 	}
 
 	upsertApplicationScale := `
-UPDATE application_scale 
+UPDATE application_scale
 SET    scale = $applicationScale.scale
 WHERE  application_uuid = $applicationScale.application_uuid
 `
@@ -1841,7 +1841,7 @@ WHERE  uuid = $entityUUID.uuid
 		}
 
 		if params.Platform != nil {
-			if err := st.upsertApplicationPlatform(ctx, tx, *params.Platform, appID.String()); err != nil {
+			if err := st.updateApplicationPlatform(ctx, tx, *params.Platform, appID.String()); err != nil {
 				return errors.Errorf("updating application platform: %w", err)
 			}
 		}
@@ -1903,7 +1903,6 @@ func (st *State) getApplicationPlatformArchitectureID(ctx context.Context, tx *s
 SELECT architecture_id AS &platformArchitecture.architecture_id
 FROM   application_platform
 WHERE  application_uuid = $entityUUID.uuid
-LIMIT 1
 `, platformArchitecture{}, appIDInput)
 	if err != nil {
 		return 0, errors.Capture(err)
@@ -1916,7 +1915,7 @@ LIMIT 1
 	return result.ArchitectureID, nil
 }
 
-func (st *State) upsertApplicationPlatform(ctx context.Context, tx *sqlair.TX, platform deployment.Platform, appID string) error {
+func (st *State) updateApplicationPlatform(ctx context.Context, tx *sqlair.TX, platform deployment.Platform, appID string) error {
 	var (
 		archID int
 		err    error
@@ -3506,10 +3505,10 @@ SELECT
 FROM application AS a
 JOIN charm_config AS cc ON a.charm_uuid = cc.charm_uuid
 JOIN charm_config_type AS cct ON cc.type_id = cct.id
-LEFT JOIN application_config AS ac 
+LEFT JOIN application_config AS ac
 	ON  ac.application_uuid = a.uuid
-	AND ac.type_id  = cc.type_id 
-	AND ac.key = cc.key 
+	AND ac.type_id  = cc.type_id
+	AND ac.key = cc.key
 WHERE a.uuid = $entityUUID.uuid;
 `, applicationConfig{}, appID)
 	if err != nil {

--- a/domain/application/state/application_refresh_test.go
+++ b/domain/application/state/application_refresh_test.go
@@ -242,6 +242,51 @@ SELECT track, risk, branch FROM application_channel WHERE application_uuid = ?`
 	})
 }
 
+func (s *applicationRefreshSuite) TestSetApplicationCharmChangePlatform(c *tc.C) {
+	// Arrange
+	appID := s.createApplication(c, createApplicationArgs{})
+	charmUUID := s.createCharm(c, createCharmArgs{
+		name: "foo",
+	})
+
+	var initialArchID int
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT architecture_id FROM application_platform WHERE application_uuid = ?", appID).Scan(&initialArchID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act
+	err = s.state.SetApplicationCharm(c.Context(), appID, charmUUID, application.SetCharmStateParams{
+		Platform: &deployment.Platform{
+			Channel:      "20.04",
+			OSType:       deployment.Ubuntu,
+			Architecture: architecture.Unknown,
+		},
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+
+	var count int
+	var platform applicationPlatform
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM application_platform WHERE application_uuid = ?", appID).Scan(&count); err != nil {
+			return err
+		}
+		return tx.QueryRowContext(ctx, `
+SELECT application_uuid, os_id, channel, architecture_id
+FROM   application_platform
+WHERE  application_uuid = ?
+`, appID).Scan(&platform.ApplicationID, &platform.OSTypeID, &platform.Channel, &platform.ArchitectureID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+	c.Check(platform.ApplicationID, tc.Equals, appID.String())
+	c.Check(platform.OSTypeID, tc.Equals, int(deployment.Ubuntu))
+	c.Check(platform.Channel, tc.Equals, "20.04")
+	c.Check(platform.ArchitectureID, tc.Equals, initialArchID)
+}
+
 func (s *applicationRefreshSuite) TestSetApplicationCharmFromEmptyChannel(c *tc.C) {
 	// Arrange
 	appName := "my-app"

--- a/domain/application/state/application_refresh_test.go
+++ b/domain/application/state/application_refresh_test.go
@@ -241,6 +241,51 @@ SELECT track, risk, branch FROM application_channel WHERE application_uuid = ?`
 	})
 }
 
+func (s *applicationRefreshSuite) TestSetApplicationCharmChangePlatform(c *tc.C) {
+	// Arrange
+	appID := s.createApplication(c, createApplicationArgs{})
+	charmUUID := s.createCharm(c, createCharmArgs{
+		name: "foo",
+	})
+
+	var initialArchID int
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT architecture_id FROM application_platform WHERE application_uuid = ?", appID).Scan(&initialArchID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act
+	err = s.state.SetApplicationCharm(c.Context(), appID, charmUUID, application.SetCharmStateParams{
+		Platform: &deployment.Platform{
+			Channel:      "20.04",
+			OSType:       deployment.Ubuntu,
+			Architecture: architecture.Unknown,
+		},
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+
+	var count int
+	var platform applicationPlatform
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM application_platform WHERE application_uuid = ?", appID).Scan(&count); err != nil {
+			return err
+		}
+		return tx.QueryRowContext(ctx, `
+SELECT application_uuid, os_id, channel, architecture_id
+FROM   application_platform
+WHERE  application_uuid = ?
+`, appID).Scan(&platform.ApplicationID, &platform.OSTypeID, &platform.Channel, &platform.ArchitectureID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+	c.Check(platform.ApplicationID, tc.Equals, appID.String())
+	c.Check(platform.OSTypeID, tc.Equals, int(deployment.Ubuntu))
+	c.Check(platform.Channel, tc.Equals, "20.04")
+	c.Check(platform.ArchitectureID, tc.Equals, initialArchID)
+}
+
 func (s *applicationRefreshSuite) TestSetApplicationCharmFromEmptyChannel(c *tc.C) {
 	// Arrange
 	appName := "my-app"

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -489,6 +489,10 @@ type SetCharmStateParams struct {
 	// risk and branch of the charm when it was downloaded from the charm store.
 	Channel *deployment.Channel
 
+	// Platform contains the platform information for the application. The
+	// operating system and architecture.
+	Platform *deployment.Platform
+
 	// EndpointBindings is an operator-defined map of endpoint names to
 	// space names that should be merged with any existing bindings.
 	EndpointBindings map[string]network.SpaceName

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -473,6 +473,10 @@ type SetCharmParams struct {
 	// even when on error.
 	CharmUpgradeOnError bool
 
+	// ForceBase allows a refresh to continue even if the requested base is
+	// incompatible with the currently deployed application base.
+	ForceBase bool
+
 	// EndpointBindings is an operator-defined map of endpoint names to
 	// space names that should be merged with any existing bindings.
 	EndpointBindings map[string]network.SpaceName

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -491,6 +491,10 @@ type SetCharmStateParams struct {
 	// risk and branch of the charm when it was downloaded from the charm store.
 	Channel *deployment.Channel
 
+	// Platform contains the platform information for the application. The
+	// operating system and architecture.
+	Platform *deployment.Platform
+
 	// EndpointBindings is an operator-defined map of endpoint names to
 	// space names that should be merged with any existing bindings.
 	EndpointBindings map[string]network.SpaceName

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -475,6 +475,10 @@ type SetCharmParams struct {
 	// even when on error.
 	CharmUpgradeOnError bool
 
+	// ForceBase allows a refresh to continue even if the requested base is
+	// incompatible with the currently deployed application base.
+	ForceBase bool
+
 	// EndpointBindings is an operator-defined map of endpoint names to
 	// space names that should be merged with any existing bindings.
 	EndpointBindings map[string]network.SpaceName


### PR DESCRIPTION
### The change
This PR fixes a Juju 4 regression (at least it seems so?) where base/platform changes sent during SetCharm refresh were accepted by the API but not persisted for the application. This was discovered because a test was failing in our Terraform Provider 4.0 branch, where it tested deploying an application with base 22.04, switching the base to 20.04, and then back to 22.04. We perform a replace for LXD, but in the case of K8S we use an update-in-place as Juju cycles the pods when the base is changed (at least in 3.6, and now in 4.0 after this change).

After a little bit of scouring, I realised, during the SetCharm(...) flow:

1. The API receives charm origin including platform/base.
2. The service converts SetCharm params into state params.
3. State updates charm UUID/channel.
4. The platform/base value was dropped between service and state, so application platform state was never updated. 

In 3.6, we simply written the encoded platofrm if it existed - I've repeated the same pattern here.

1. Added optional platform to set-charm state params.
2. Propagated platform from charm origin into state params in service.
3. Updated SetApplicationCharm state path to persist platform changes.
4. For persistence, ttransactional delete+insert for application_platform instead of ON CONFLICT(application_uuid), because that conflict target is not backed by a matching unique/primary constraint in current schema. Perhaps we should put a unique index on the application uuid, but I thought this is least touch "get it working".

I've verified this change does indeed fix our test in TF which behaves a little differently to the CLI. We allow refreshes for all scenarios, in the CLI it is only when the channel changes or we --switch/--path. To reproduce this in Juju, I've added a little revision switch, but to the same effect we can see the base changing (see QA steps).

### Additional scope
This PR also addresses https://github.com/juju/juju/issues/22248#issuecomment-4253259741 after discussion with @SimonRichardson. Plumbing the force-base flag in and rejecting incompatible bases. 

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
```bash
# Build and bootstrap a microk8s controller
# Add a model
jj add-model test-platforms
# Deploy cordons with 22.04
jj deploy coredns --channel=1.25/stable --base=ubuntu@22.04
# Wait for it to enter idle agent state
jjs
# Verify it is running 22.04
microk8s.kubectl exec -it coredns-0 -n test-platforms --  cat /etc/os-release | grep 'PRETTY_NAME' 
# Refresh it to a previous revision, with a new base
jj refresh coredns --channel=1.25/stable --base=ubuntu@20.04 --revision 32
```

You should see that the original base wasn't 20.04, and as such an incompatible base error rises. The charm does indeed support 20.04, but it must be forced.
```bash
Added charm-hub charm "coredns", revision 32 in channel 1.25/stable, to the model
ERROR cannot set charm "ch:amd64/coredns-32" because cannot refresh application from base "ubuntu@22.04" to "ubuntu@20.04" without --force-base (incompatible base)
```

Now, force it into 20.04 and verify
```bash
jj refresh coredns --channel=1.25/stable --base=ubuntu@20.04 --revision 32 --force-base
# Agent will get lost for a little while, just wait.
microk8s.kubectl exec -it coredns-0 -n test-platforms --  cat /etc/os-release | grep 'PRETTY_NAME' 
```



