### PR TITLE
feat: add cloudspec api to client controller facade

### DIFF
--- a/api/controller/controller/controller_test.go
+++ b/api/controller/controller/controller_test.go
@@ -254,6 +254,45 @@ func (s *Suite) TestHostedModelConfigs_FormatResults(c *tc.C) {
 	c.Assert(second.Error.Error(), tc.Equals, "validating CloudSpec: empty Type not valid")
 }
 
+func (s *Suite) TestCloudSpec(c *tc.C) {
+	modelTag := names.NewModelTag(randomUUID())
+	apiCaller := apitesting.BestVersionCaller{APICallerFunc: func(objType string, version int, id, request string, arg, result any) error {
+		c.Assert(objType, tc.Equals, "Controller")
+		c.Assert(version, tc.Equals, 14)
+		c.Assert(request, tc.Equals, "CloudSpec")
+		c.Assert(arg, tc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: modelTag.String()}},
+		})
+		out := result.(*params.CloudSpecResults)
+		*out = params.CloudSpecResults{
+			Results: []params.CloudSpecResult{{
+				Result: &params.CloudSpec{
+					Type: "aws",
+					Name: "cloud",
+				},
+			}},
+		}
+		return nil
+	}, BestVersion: 14}
+	client := controller.NewClient(apiCaller)
+
+	spec, err := client.CloudSpec(c.Context(), modelTag)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(spec, tc.DeepEquals, environscloudspec.CloudSpec{
+		Type: "aws",
+		Name: "cloud",
+	})
+}
+
+func (s *Suite) TestCloudSpec_CallError(c *tc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, any, any) error {
+		return errors.New("boom")
+	})
+	client := controller.NewClient(apiCaller)
+	_, err := client.CloudSpec(c.Context(), names.NewModelTag(randomUUID()))
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
 func makeInitiateMigrationClient(results params.InitiateMigrationResults) (
 	*controller.Client, *testhelpers.Stub,
 ) {

--- a/api/controller/controller/controller_test.go
+++ b/api/controller/controller/controller_test.go
@@ -257,10 +257,10 @@ func (s *Suite) TestHostedModelConfigs_FormatResults(c *tc.C) {
 func (s *Suite) TestCloudSpec(c *tc.C) {
 	modelTag := names.NewModelTag(randomUUID())
 	apiCaller := apitesting.BestVersionCaller{APICallerFunc: func(objType string, version int, id, request string, arg, result any) error {
-		c.Assert(objType, tc.Equals, "Controller")
-		c.Assert(version, tc.Equals, 14)
-		c.Assert(request, tc.Equals, "CloudSpec")
-		c.Assert(arg, tc.DeepEquals, params.Entities{
+		c.Check(objType, tc.Equals, "Controller")
+		c.Check(version, tc.Equals, 14)
+		c.Check(request, tc.Equals, "CloudSpec")
+		c.Check(arg, tc.DeepEquals, params.Entities{
 			Entities: []params.Entity{{Tag: modelTag.String()}},
 		})
 		out := result.(*params.CloudSpecResults)

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -45,7 +45,7 @@ var facadeVersions = facades.FacadeVersions{
 	"Charms":                       {7},
 	"Client":                       {8},
 	"Cloud":                        {7},
-	"Controller":                   {12, 13},
+	"Controller":                   {12, 13, 14},
 	"CredentialManager":            {1},
 	"CredentialValidator":          {2, 3},
 	"CrossController":              {1},

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -258,7 +258,7 @@ type Authorizer interface {
 	// AuthOwner returns true if tag == .GetAuthTag().
 	AuthOwner(tag names.Tag) bool
 
-	// AuthClient returns true if the entity is an external user.
+	// AuthClient returns true if the entity is a user.
 	AuthClient() bool
 
 	// HasPermission reports whether the given access is allowed for the given

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -45,6 +45,11 @@ import (
 
 // ControllerAPIV12 implements the controller APIV12.
 type ControllerAPIV12 struct {
+	*ControllerAPIV13
+}
+
+// ControllerAPIV13 implements the controller APIV13.
+type ControllerAPIV13 struct {
 	*ControllerAPI
 }
 
@@ -268,6 +273,76 @@ func (c *ControllerAPI) AllModels(ctx context.Context) (params.UserModelList, er
 	return result, nil
 }
 
+// CloudSpec is not implemented in version 13.
+func (c *ControllerAPIV13) CloudSpec(ctx context.Context, _, _ struct{}) {}
+
+// CloudSpec returns cloud specifications for the specified models.
+func (c *ControllerAPI) CloudSpec(ctx context.Context, args params.Entities) (params.CloudSpecResults, error) {
+	// We could just compare to the controller model UUID directly, but keeping
+	// this abstraction from 3.6 allows aligns with the fact that we accept
+	// multiple model tags as args to this method.
+	authFunc, err := common.AuthFuncForTag(names.NewModelTag(c.controllerModelUUID.String()))(ctx)
+	if err != nil {
+		return params.CloudSpecResults{}, errors.Trace(err)
+	}
+	// Connected clients which are the controller agent
+	// or model agent can fetch credentials with the cloud spec.
+	// Users must be superusers or model admins.
+	credAllowed := c.authorizer.AuthController() || c.authorizer.AuthModelAgent()
+	if !credAllowed && c.authorizer.AuthClient() {
+		var err error
+		err = c.authorizer.HasPermission(ctx, permission.SuperuserAccess, names.NewControllerTag(c.controllerUUID))
+		if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+			return params.CloudSpecResults{}, errors.Trace(err)
+		}
+		credAllowed = err == nil
+	}
+	results := params.CloudSpecResults{
+		Results: make([]params.CloudSpecResult, len(args.Entities)),
+	}
+	for i, arg := range args.Entities {
+		results.Results[i] = c.getOneCloudSpec(ctx, arg.Tag, credAllowed, authFunc)
+	}
+	return results, nil
+}
+
+func (c *ControllerAPI) getOneCloudSpec(ctx context.Context, tagStr string, credAllowed bool, authFunc common.AuthFunc) params.CloudSpecResult {
+	tag, err := names.ParseModelTag(tagStr)
+	if err != nil {
+		return params.CloudSpecResult{
+			Error: apiservererrors.ServerError(errors.Trace(err)),
+		}
+	}
+	if !authFunc(tag) {
+		return params.CloudSpecResult{
+			Error: apiservererrors.ServerError(apiservererrors.ErrPerm),
+		}
+	}
+	spec, err := c.getCloudSpec(ctx, coremodel.UUID(tag.Id()))
+	if err != nil {
+		return params.CloudSpecResult{
+			Error: apiservererrors.ServerError(errors.Trace(err)),
+		}
+	}
+	// If not already allowed, only model admins
+	// can see the credentials.
+	if !credAllowed && c.authorizer.AuthClient() {
+		err = c.authorizer.HasPermission(ctx, permission.AdminAccess, tag)
+		if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+			return params.CloudSpecResult{
+				Error: apiservererrors.ServerError(errors.Trace(err)),
+			}
+		}
+		credAllowed = err == nil
+	}
+	if !credAllowed {
+		spec.Credential = nil
+	}
+	return params.CloudSpecResult{
+		Result: spec,
+	}
+}
+
 // ListBlockedModels returns a list of all models on the controller
 // which have a block in place.  The resulting slice is sorted by model
 // name, then owner. Callers must be controller administrators to retrieve the
@@ -425,10 +500,10 @@ func (c *ControllerAPI) WatchAllModelSummaries(ctx context.Context) (params.Summ
 		return params.SummaryWatcherID{}, errors.Trace(err)
 	}
 	// TODO(dqlite) - implement me
-	//w := c.controller.WatchAllModels()
-	//return params.SummaryWatcherID{
+	// w := c.controller.WatchAllModels()
+	// return params.SummaryWatcherID{
 	//	WatcherID: c.resources.Register(w),
-	//}, nil
+	// }, nil
 	return params.SummaryWatcherID{}, errors.NotSupportedf("WatchAllModelSummaries")
 }
 
@@ -437,11 +512,11 @@ func (c *ControllerAPI) WatchAllModelSummaries(ctx context.Context) (params.Summ
 func (c *ControllerAPI) WatchModelSummaries(ctx context.Context) (params.SummaryWatcherID, error) {
 	// TODO(dqlite) - implement me
 	return params.SummaryWatcherID{}, errors.NotSupportedf("WatchModelSummaries")
-	//user := c.apiUser.Id()
-	//w := c.controller.WatchModelsAsUser(user)
-	//return params.SummaryWatcherID{
+	// user := c.apiUser.Id()
+	// w := c.controller.WatchModelsAsUser(user)
+	// return params.SummaryWatcherID{
 	//	WatcherID: c.resources.Register(w),
-	//}, nil
+	// }, nil
 }
 
 // GetControllerAccess returns the level of access the specified users

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/client/controller"
 	"github.com/juju/juju/apiserver/facades/client/controller/mocks"
@@ -108,12 +109,13 @@ func (s *controllerSuite) SetUpTest(c *tc.C) {
 	s.leadershipReader = noopLeadershipReader{}
 	s.context = facadetest.MultiModelContext{
 		ModelContext: facadetest.ModelContext{
-			Auth_:             s.authorizer,
-			DomainServices_:   s.ControllerDomainServices(c),
-			Logger_:           loggertesting.WrapCheckLog(c),
-			LeadershipReader_: s.leadershipReader,
-			ControllerUUID_:   tc.Must0(c, model.NewUUID).String(),
-			ModelUUID_:        tc.Must0(c, model.NewUUID),
+			Auth_:                s.authorizer,
+			DomainServices_:      s.ControllerDomainServices(c),
+			Logger_:              loggertesting.WrapCheckLog(c),
+			LeadershipReader_:    s.leadershipReader,
+			ControllerUUID_:      tc.Must0(c, model.NewUUID).String(),
+			ControllerModelUUID_: s.ControllerModelUUID,
+			ModelUUID_:           s.DefaultModelUUID,
 		},
 		DomainServicesForModelFunc_: func(modelUUID model.UUID) internalservices.DomainServices {
 			return s.ModelDomainServices(c, modelUUID)
@@ -248,7 +250,7 @@ func (s *controllerSuite) controllerAPI(c *tc.C) *controller.ControllerAPI {
 		removalServiceGetter,
 		domainServices.Proxy(),
 		ctx.ObjectStore(),
-		ctx.ControllerModelUUID(),
+		s.ControllerModelUUID,
 		ctx.ControllerUUID(),
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -305,6 +307,82 @@ func (s *controllerSuite) TestHostedModelConfigs_OnlyHostedModelsReturned(c *tc.
 	c.Assert(one.Qualifier, tc.Equals, "prod")
 	c.Assert(two.Name, tc.Equals, "second")
 	c.Assert(two.Qualifier, tc.Equals, "staging")
+}
+
+func (s *controllerSuite) TestCloudSpec(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelTag := names.NewModelTag(s.ControllerModelUUID.String())
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: modelTag.String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Assert(result.Results[0].Error, tc.IsNil)
+
+	modelProvider := s.ModelDomainServices(c, s.ControllerModelUUID).ModelProvider()
+	expected, err := modelProvider.GetCloudSpec(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results[0].Result, tc.DeepEquals, common.CloudSpecToParams(expected))
+}
+
+func (s *controllerSuite) TestCloudSpecInvalidTag(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: names.NewMachineTag("0").String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Result, tc.IsNil)
+	c.Check(result.Results[0].Error, tc.ErrorMatches, `"machine-0" is not a valid model tag`)
+}
+
+func (s *controllerSuite) TestCloudSpecUnauthorisedModel(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	otherModelTag := names.NewModelTag(tc.Must(c, model.NewUUID).String())
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: otherModelTag.String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Assert(result.Results[0].Error, tc.ErrorMatches, "permission denied")
+}
+
+func (s *controllerSuite) TestCloudSpecNoCredentialsAllowed(c *tc.C) {
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("read-" + names.NewModelTag(s.ControllerModelUUID.String()).String()),
+	}
+	s.context.Auth_ = s.authorizer
+	defer s.setupMocks(c).Finish()
+
+	modelTag := names.NewModelTag(s.ControllerModelUUID.String())
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: modelTag.String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Assert(result.Results[0].Error, tc.IsNil)
+
+	modelProvider := s.ModelDomainServices(c, s.ControllerModelUUID).ModelProvider()
+	expected, err := modelProvider.GetCloudSpec(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	expected.Credential = nil
+	c.Assert(result.Results[0].Result, tc.DeepEquals, common.CloudSpecToParams(expected))
+}
+
+func (s *controllerSuite) TestCloudSpecServiceError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unknownModelTag := names.NewModelTag(tc.Must(c, model.NewUUID).String())
+	result, err := s.controller.CloudSpec(c.Context(), params.Entities{
+		Entities: []params.Entity{{Tag: unknownModelTag.String()}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Result, tc.IsNil)
+	c.Check(result.Results[0].Error, tc.NotNil)
 }
 
 func (s *controllerSuite) TestListBlockedModels(c *tc.C) {
@@ -529,7 +607,16 @@ func (s *controllerSuite) TestGrantControllerInvalidUserTag(c *tc.C) {
 
 func (s *controllerSuite) TestModelStatus(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-	modelTag := names.NewModelTag(s.context.ControllerModelUUID().String()).String()
+
+	s.mockModelService.EXPECT().Model(gomock.Any(), s.ControllerModelUUID).Return(
+		model.Model{
+			UUID:      s.ControllerModelUUID,
+			Name:      "controller",
+			Qualifier: "prod",
+		}, nil,
+	).Times(3)
+
+	modelTag := names.NewModelTag(s.ControllerModelUUID.String()).String()
 	// Check that we don't err out immediately if a model errs.
 	results, err := s.controller.ModelStatus(c.Context(), params.Entities{Entities: []params.Entity{{
 		Tag: "bad-tag",
@@ -539,6 +626,8 @@ func (s *controllerSuite) TestModelStatus(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 2)
 	c.Assert(results.Results[0].Error, tc.ErrorMatches, `"bad-tag" is not a valid tag`)
+	c.Assert(results.Results[1].Error, tc.IsNil)
+	c.Assert(results.Results[1].ModelTag, tc.Equals, modelTag)
 
 	// Check that we don't err out if a model errs even if some firsts in collection pass.
 	results, err = s.controller.ModelStatus(c.Context(), params.Entities{Entities: []params.Entity{{
@@ -549,6 +638,8 @@ func (s *controllerSuite) TestModelStatus(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 2)
 	c.Assert(results.Results[1].Error, tc.ErrorMatches, `"bad-tag" is not a valid tag`)
+	c.Assert(results.Results[0].Error, tc.IsNil)
+	c.Assert(results.Results[0].ModelTag, tc.Equals, modelTag)
 
 	// Check that we return successfully if no errors.
 	results, err = s.controller.ModelStatus(c.Context(), params.Entities{Entities: []params.Entity{{
@@ -556,6 +647,8 @@ func (s *controllerSuite) TestModelStatus(c *tc.C) {
 	}}})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results.Results, tc.HasLen, 1)
+	c.Assert(results.Results[0].Error, tc.IsNil)
+	c.Assert(results.Results[0].ModelTag, tc.Equals, modelTag)
 }
 
 func (s *controllerSuite) TestConfigSet(c *tc.C) {

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -25,20 +25,37 @@ func Register(registry facade.FacadeRegistry) {
 	}, reflect.TypeFor[*ControllerAPIV12]())
 	// v13 handles requests with a model qualifier instead of a model owner.
 	registry.MustRegisterForMultiModel("Controller", 13, func(stdCtx context.Context, ctx facade.MultiModelContext) (facade.Facade, error) {
-		api, err := makeControllerAPI(stdCtx, ctx)
+		api, err := makeControllerAPIV13(stdCtx, ctx)
 		if err != nil {
 			return nil, fmt.Errorf("creating Controller facade v13: %w", err)
+		}
+		return api, nil
+	}, reflect.TypeFor[*ControllerAPIV13]())
+	registry.MustRegisterForMultiModel("Controller", 14, func(stdCtx context.Context, ctx facade.MultiModelContext) (facade.Facade, error) {
+		api, err := makeControllerAPI(stdCtx, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("creating Controller facade v14: %w", err)
 		}
 		return api, nil
 	}, reflect.TypeFor[*ControllerAPI]())
 }
 
 func makeControllerAPIV12(stdCtx context.Context, ctx facade.MultiModelContext) (*ControllerAPIV12, error) {
-	api, err := makeControllerAPI(stdCtx, ctx)
+	api, err := makeControllerAPIV13(stdCtx, ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &ControllerAPIV12{
+		ControllerAPIV13: api,
+	}, nil
+}
+
+func makeControllerAPIV13(stdCtx context.Context, ctx facade.MultiModelContext) (*ControllerAPIV13, error) {
+	api, err := makeControllerAPI(stdCtx, ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ControllerAPIV13{
 		ControllerAPI: api,
 	}, nil
 }

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -512,7 +512,7 @@ func (a ModelAuthorizer) CanWrite(ctx context.Context) error {
 	return a.checkAccess(ctx, permission.WriteAccess)
 }
 
-// AuthClient returns true if the entity is an external user.
+// AuthClient returns true if the entity is a user.
 func (a ModelAuthorizer) AuthClient() bool {
 	return a.Authorizer.AuthClient()
 }

--- a/apiserver/facades/client/machinemanager/services.go
+++ b/apiserver/facades/client/machinemanager/services.go
@@ -79,7 +79,7 @@ type Authorizer interface {
 	// write is not possible.
 	CanWrite(context.Context) error
 
-	// AuthClient returns true if the entity is an external user.
+	// AuthClient returns true if the entity is a user.
 	AuthClient() bool
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -7821,7 +7821,7 @@
     {
         "Name": "Controller",
         "Description": "",
-        "Version": 13,
+        "Version": 14,
         "Schema": {
             "type": "object",
             "properties": {
@@ -7830,6 +7830,17 @@
                     "properties": {
                         "Result": {
                             "$ref": "#/definitions/UserModelList"
+                        }
+                    }
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResults"
                         }
                     }
                 },
@@ -8074,6 +8085,30 @@
                         "type",
                         "name"
                     ]
+                },
+                "CloudSpecResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudSpec"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudSpecResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudSpecResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
                 },
                 "ControllerAPIInfoResult": {
                     "type": "object",


### PR DESCRIPTION
https://github.com/juju/juju/pull/19551 removed the CloudSpec api from the controller facade.

We did the work in this PR before in https://github.com/juju/juju/pull/22049 but it was thought to not be needed so was reverted. But it's needed by the destroy controller API.

This PR adds it back but also ensure that, as was done in 3.6 for a CVE fix, only admins can see the cloud credential. Non privileged users just get the cloud detail. The implementation was copied from 3.6 and adjusted to suit the domain services.

## QA steps

unit tests

## Links

**Issue:** Fixes #22018.

**Jira card:** [JUJU-9438](https://warthogs.atlassian.net/browse/JUJU-9438)

[JUJU-9438]: https://warthogs.atlassian.net/browse/JUJU-9438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ