### PR TITLE
fix: race with volume attachment and plan removal marking volume dead

### DIFF
--- a/cmd/juju/common/format.go
+++ b/cmd/juju/common/format.go
@@ -89,7 +89,12 @@ func HumaniseInterval(interval time.Duration) string {
 // FormatTime returns a string with the local time formatted
 // in an arbitrary format used for status or and localized tz
 // or in UTC timezone and format RFC3339 if u is specified.
+//
+// If [t] is nil, the unix epoch is returned.
 func FormatTime(t *time.Time, formatISO bool) string {
+	if t == nil {
+		t = new(time.Unix(0, 0))
+	}
 	if formatISO {
 		// If requested, use ISO time format.
 		// The format we use is RFC3339 without the "T". From the spec:

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -87,7 +87,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccess(c *
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWithAliveUnitsCascadedStorage(c *tc.C) {
@@ -147,13 +147,13 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 
 	// Storage instance should be "dying".
 	row = db.QueryRowContext(ctx, "SELECT life_id FROM storage_instance WHERE uuid = 'instance-uuid'")
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeNormalSuccessWithAliveAndDyingUnits(c *tc.C) {
@@ -344,7 +344,7 @@ func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeDyingSuccess(c *t
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeRetryReturnsDyingArtifacts(c *tc.C) {
@@ -1281,7 +1281,7 @@ func (s *applicationSuite) checkApplicationDyingState(c *tc.C, appUUID coreappli
 	var lifeID int
 	err := row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *applicationSuite) checkNoApplicationSequence(c *tc.C, appName string) {

--- a/domain/removal/state/model/relation_test.go
+++ b/domain/removal/state/model/relation_test.go
@@ -74,7 +74,7 @@ func (s *relationSuite) TestEnsureRelationNotAliveNormalSuccess(c *tc.C) {
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *relationSuite) TestEnsureRelationNotAliveDyingSuccess(c *tc.C) {
@@ -90,7 +90,7 @@ func (s *relationSuite) TestEnsureRelationNotAliveDyingSuccess(c *tc.C) {
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *relationSuite) TestEnsureRelationNotAliveNotExistsSuccess(c *tc.C) {

--- a/domain/removal/state/model/relationwithremoteconsumer_test.go
+++ b/domain/removal/state/model/relationwithremoteconsumer_test.go
@@ -65,13 +65,13 @@ func (s *relationWithRemoteConsumer) TestEnsureRelationWithRemoteConsumerNotAliv
 	row := s.DB().QueryRowContext(c.Context(), "SELECT life_id FROM relation where uuid = ?", relUUID.String())
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 
 	// The synth app should still be alive
 	row = s.DB().QueryRowContext(c.Context(), "SELECT life_id FROM application where uuid = ?", synthAppUUID.String())
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 0)
+	c.Check(lifeID, tc.Equals, int(life.Alive))
 
 	// But the synth units should all be dead
 	rows, err := s.DB().QueryContext(c.Context(), "SELECT life_id FROM unit where application_uuid = ?", synthAppUUID.String())
@@ -81,7 +81,7 @@ func (s *relationWithRemoteConsumer) TestEnsureRelationWithRemoteConsumerNotAliv
 		var lifeID int
 		err := rows.Scan(&lifeID)
 		c.Assert(err, tc.ErrorIsNil)
-		c.Check(lifeID, tc.Equals, 2)
+		c.Check(lifeID, tc.Equals, int(life.Dead))
 	}
 
 	// Check the returned synth rel units

--- a/domain/removal/state/model/relationwithremoteofferer_test.go
+++ b/domain/removal/state/model/relationwithremoteofferer_test.go
@@ -66,13 +66,13 @@ func (s *relationWithRemoteOfferer) TestEnsureRelationWithRemoteOffererNotAliveC
 	row := s.DB().QueryRowContext(c.Context(), "SELECT life_id FROM relation where uuid = ?", relUUID.String())
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 
 	// The synth app should still be alive
 	row = s.DB().QueryRowContext(c.Context(), "SELECT life_id FROM application where uuid = ?", synthAppUUID.String())
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 0)
+	c.Check(lifeID, tc.Equals, int(life.Alive))
 
 	// But the synth units should all be dead
 	rows, err := s.DB().QueryContext(c.Context(), "SELECT life_id FROM unit where application_uuid = ?", synthAppUUID.String())
@@ -82,7 +82,7 @@ func (s *relationWithRemoteOfferer) TestEnsureRelationWithRemoteOffererNotAliveC
 		var lifeID int
 		err := rows.Scan(&lifeID)
 		c.Assert(err, tc.ErrorIsNil)
-		c.Check(lifeID, tc.Equals, 2)
+		c.Check(lifeID, tc.Equals, int(life.Dead))
 	}
 
 	// Check the returned synth rel units

--- a/domain/removal/state/model/storage.go
+++ b/domain/removal/state/model/storage.go
@@ -1410,7 +1410,8 @@ SELECT COUNT(sfaB.uuid) AS &count.count
 FROM   storage_filesystem_attachment sfaA
 JOIN   storage_filesystem_attachment sfaB ON sfaB.storage_filesystem_uuid = sfaA.storage_filesystem_uuid
 WHERE  sfaA.uuid = $entityUUID.uuid AND
-       sfaB.uuid != $entityUUID.uuid
+       sfaB.uuid != $entityUUID.uuid AND
+       sfaB.life_id != 2
 `, fsaUUID, count{})
 	if err != nil {
 		return errors.Errorf(

--- a/domain/removal/state/model/storage.go
+++ b/domain/removal/state/model/storage.go
@@ -1637,12 +1637,14 @@ SELECT SUM(count) AS &count.count FROM (
     FROM   storage_volume_attachment svaA
     JOIN   storage_volume_attachment svaB ON svaB.storage_volume_uuid = svaA.storage_volume_uuid
     WHERE  svaA.uuid = $entityUUID.uuid AND
-           svaB.uuid != $entityUUID.uuid
+           svaB.uuid != $entityUUID.uuid AND
+           svaB.life_id != 2
     UNION
     SELECT COUNT(svap.uuid) AS count
     FROM   storage_volume_attachment sva
     JOIN   storage_volume_attachment_plan svap ON sva.storage_volume_uuid = svap.storage_volume_uuid
-    WHERE  sva.uuid = $entityUUID.uuid
+    WHERE  sva.uuid = $entityUUID.uuid AND
+           svap.life_id != 2
 )
 `, vaUUID, count{})
 	if err != nil {
@@ -1867,12 +1869,14 @@ SELECT SUM(count) AS &count.count FROM (
     FROM   storage_volume_attachment_plan svapA
     JOIN   storage_volume_attachment_plan svapB ON svapB.storage_volume_uuid = svapA.storage_volume_uuid
     WHERE  svapA.uuid = $entityUUID.uuid AND
-           svapB.uuid != $entityUUID.uuid
+           svapB.uuid != $entityUUID.uuid AND
+           svapB.life_id != 2
     UNION
     SELECT COUNT(sva.uuid) AS count
     FROM   storage_volume_attachment_plan svap
     JOIN   storage_volume_attachment sva ON svap.storage_volume_uuid = sva.storage_volume_uuid
-    WHERE  svap.uuid = $entityUUID.uuid
+    WHERE  svap.uuid = $entityUUID.uuid AND
+           sva.life_id != 2
 )
 `, vapUUID, count{})
 	if err != nil {

--- a/domain/removal/state/model/storage_test.go
+++ b/domain/removal/state/model/storage_test.go
@@ -1198,6 +1198,35 @@ func (s *storageSuite) TestMarkVolumeAttachmentAsDeadWithDyingVolumeButPlanBlock
 	c.Check(lifeID, tc.Equals, 1)
 }
 
+func (s *storageSuite) TestMarkVolumeAttachmentAsDeadWithDyingVolumeDeadPlanNotBlocking(c *tc.C) {
+	ctx := c.Context()
+
+	volUUID, vaUUID, vapUUID := s.addAttachedVolumeWithPlan(c)
+	s.setVolumeLife(c, volUUID, 1)
+	s.setVolumeAttachmentPlanLife(c, vapUUID, 2)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err := st.MarkVolumeAttachmentAsDead(ctx, vaUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Volume Attachment should be Dead.
+	row := s.DB().QueryRowContext(ctx,
+		"SELECT life_id FROM storage_volume_attachment WHERE uuid = ?",
+		vaUUID,
+	)
+	var lifeID int
+	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 2)
+
+	// Volume should be Dead too; the plan is already dead and
+	// does not block advancement.
+	row = s.DB().QueryRowContext(ctx,
+		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
+	)
+	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 2)
+}
+
 func (s *storageSuite) TestDeleteVolumeAttachment(c *tc.C) {
 	ctx := c.Context()
 
@@ -1305,6 +1334,35 @@ func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDeadWithDyingVolumeButVolum
 	)
 	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
 	c.Check(lifeID, tc.Equals, 1)
+}
+
+func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDeadWithDyingVolumeDeadAttachmentNotBlocking(c *tc.C) {
+	ctx := c.Context()
+
+	volUUID, vaUUID, vapUUID := s.addAttachedVolumeWithPlan(c)
+	s.setVolumeLife(c, volUUID, 1)
+	s.setVolumeAttachmentLife(c, vaUUID, 2)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err := st.MarkVolumeAttachmentPlanAsDead(ctx, vapUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Volume Attachment plan should be Dead.
+	row := s.DB().QueryRowContext(ctx,
+		"SELECT life_id FROM storage_volume_attachment_plan WHERE uuid = ?",
+		vapUUID,
+	)
+	var lifeID int
+	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 2)
+
+	// Volume should be Dead too; the attachment is already dead and
+	// does not block advancement.
+	row = s.DB().QueryRowContext(ctx,
+		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
+	)
+	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 2)
 }
 
 func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDead(c *tc.C) {

--- a/domain/removal/state/model/storage_test.go
+++ b/domain/removal/state/model/storage_test.go
@@ -83,7 +83,7 @@ func (s *storageSuite) TestEnsureStorageAttachmentNotAliveSuccess(c *tc.C) {
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 
 	// Idempotent. A "dying" attachment is a no-op. Life is unchanged.
 	cascaded, err = st.EnsureStorageAttachmentNotAlive(ctx, saUUID)
@@ -97,7 +97,7 @@ func (s *storageSuite) TestEnsureStorageAttachmentNotAliveSuccess(c *tc.C) {
 	row = s.DB().QueryRow("SELECT life_id FROM storage_attachment WHERE uuid = ?", saUUID)
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *storageSuite) TestScheduleStorageAttachmentRemovalSuccess(c *tc.C) {
@@ -180,7 +180,7 @@ func (s *storageSuite) TestEnsureStorageAttachmentDeadCascade(c *tc.C) {
 		"SELECT life_id FROM storage_attachment WHERE uuid = ?", saUUID)
 	var lifeId int
 	c.Assert(res.Scan(&lifeId), tc.ErrorIsNil)
-	c.Check(lifeId, tc.Equals, 2)
+	c.Check(lifeId, tc.Equals, int(life.Dead))
 }
 
 func (s *storageSuite) TestDeleteStorageAttachmentSuccess(c *tc.C) {
@@ -1027,15 +1027,15 @@ func (s *storageSuite) TestMarkFilesystemAttachmentAsDead(c *tc.C) {
 		fsaUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Filesystem should still be Alive
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_filesystem WHERE uuid = ?", fsUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 0)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Alive))
 }
 
 func (s *storageSuite) TestMarkFilesystemAttachmentAsDeadWithDyingFilesystem(c *tc.C) {
@@ -1054,15 +1054,15 @@ func (s *storageSuite) TestMarkFilesystemAttachmentAsDeadWithDyingFilesystem(c *
 		fsaUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Filesystem should be Dead too
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_filesystem WHERE uuid = ?", fsUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 }
 
 func (s *storageSuite) TestDeleteFilesystemAttachment(c *tc.C) {
@@ -1135,15 +1135,15 @@ func (s *storageSuite) TestMarkVolumeAttachmentAsDead(c *tc.C) {
 		"SELECT life_id FROM storage_volume_attachment WHERE uuid = ?", vaUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Volume should be Alive still
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 0)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Alive))
 }
 
 func (s *storageSuite) TestMarkVolumeAttachmentAsDeadWithDyingVolume(c *tc.C) {
@@ -1161,15 +1161,15 @@ func (s *storageSuite) TestMarkVolumeAttachmentAsDeadWithDyingVolume(c *tc.C) {
 		"SELECT life_id FROM storage_volume_attachment WHERE uuid = ?", vaUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Volume should be Dead too
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 }
 
 func (s *storageSuite) TestMarkVolumeAttachmentAsDeadWithDyingVolumeButPlanBlocking(c *tc.C) {
@@ -1187,15 +1187,15 @@ func (s *storageSuite) TestMarkVolumeAttachmentAsDeadWithDyingVolumeButPlanBlock
 		"SELECT life_id FROM storage_volume_attachment WHERE uuid = ?", vaUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Volume should be Dying still
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *storageSuite) TestMarkVolumeAttachmentAsDeadWithDyingVolumeDeadPlanNotBlocking(c *tc.C) {
@@ -1215,16 +1215,16 @@ func (s *storageSuite) TestMarkVolumeAttachmentAsDeadWithDyingVolumeDeadPlanNotB
 		vaUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Volume should be Dead too; the plan is already dead and
 	// does not block advancement.
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 }
 
 func (s *storageSuite) TestDeleteVolumeAttachment(c *tc.C) {
@@ -1299,15 +1299,15 @@ func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDeadWithDyingVolume(c *tc.C
 		"SELECT life_id FROM storage_volume_attachment_plan WHERE uuid = ?", vapUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Volume should be Dead too
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 }
 
 func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDeadWithDyingVolumeButVolumeAttachmentBlocking(c *tc.C) {
@@ -1325,15 +1325,15 @@ func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDeadWithDyingVolumeButVolum
 		"SELECT life_id FROM storage_volume_attachment_plan WHERE uuid = ?", vapUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Volume should be Dying still
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDeadWithDyingVolumeDeadAttachmentNotBlocking(c *tc.C) {
@@ -1353,16 +1353,16 @@ func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDeadWithDyingVolumeDeadAtta
 		vapUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 
 	// Volume should be Dead too; the attachment is already dead and
 	// does not block advancement.
 	row = s.DB().QueryRowContext(ctx,
 		"SELECT life_id FROM storage_volume WHERE uuid = ?", volUUID,
 	)
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 }
 
 func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDead(c *tc.C) {
@@ -1380,8 +1380,8 @@ func (s *storageSuite) TestMarkVolumeAttachmentPlanAsDead(c *tc.C) {
 		vapUUID,
 	)
 	var lifeID int
-	c.Check(row.Scan(&lifeID), tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 2)
+	c.Assert(row.Scan(&lifeID), tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 }
 
 func (s *storageSuite) TestGetDetachInfoForStorageAttachmentNotFound(c *tc.C) {
@@ -1494,7 +1494,7 @@ func (s *storageSuite) TestEnsureStorageAttachmentNotAliveWithFulfilment(c *tc.C
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 // TestEnsureStorageAttachmentNotAliveWithFulfilmentNotMet tests the scenario
@@ -1522,7 +1522,7 @@ func (s *storageSuite) TestEnsureStorageAttachmentNotAliveWithFulfilmentNotMet(c
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 0)
+	c.Check(lifeID, tc.Equals, int(life.Alive))
 }
 
 // TestEnsureStorageAttachmentNotAliveWithFulfilmentOnlyAlive tests that when
@@ -1558,7 +1558,7 @@ func (s *storageSuite) TestEnsureStorageAttachmentNotAliveWithFulfilmentOnlyAliv
 	var lifeID int
 	err = row.Scan(&lifeID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(lifeID, tc.Equals, 1)
+	c.Check(lifeID, tc.Equals, int(life.Dying))
 }
 
 // TestEnsureStorageAttachmentNotAliveWithFulfilmentNotFound tests that when the


### PR DESCRIPTION
This change addresses a race condition in storage removal where the volume
attachment and volume attachment plan for the same volume go to dead at
around the same time, but the removal jobs have not yet run for the other.
This would result in the volume never reaching a life of Dead.

The same was fixed with filesystems marking as dead, but that is a non-supported
use case at this stage.

Drive-by to fix a client-side panic that has issues with partially deleted storage.

## QA steps

Using an IAAS model.
Using a storage provider that backs filesystems with volumes.
Deploy a simple (we need it to die quick) application with a large number of units (10+).
Wait for the storage and units to settle.
Remove the model or application.
Try this a few times. The volumes should go to dead, then tombstone status then removed.