### PR TITLE
feat: reimplement migration dry run

### DIFF
--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -563,8 +563,7 @@ func (c *ControllerAPI) initiateOneMigration(ctx context.Context, spec params.Mi
 		return "", errors.Trace(err)
 	}
 
-	// TODO - wire up the dryRun parameter
-	migrationID, err := modelMigrationService.InitiateMigration(ctx, targetInfo, c.apiUser.Id())
+	migrationID, err := modelMigrationService.InitiateMigration(ctx, targetInfo, c.apiUser.Id(), dryRun)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -22,10 +22,12 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/controller/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	usertesting "github.com/juju/juju/core/user/testing"
+	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/domain/access"
 	"github.com/juju/juju/domain/blockcommand"
 	servicefactorytesting "github.com/juju/juju/domain/services/testing"
@@ -65,7 +67,6 @@ func (s *controllerSuite) TestStub(c *tc.C) {
 - Watch model summaries by non admin.
 - Watch all model summaries by admin.
 - Identity provider with and without URL in config.
-- Test InitiateMigration with dry run.
 `)
 }
 
@@ -425,6 +426,52 @@ func (s *controllerSuite) TestRemoveBlocksNotAll(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "not supported")
 }
 
+func (s *controllerSuite) TestInitiateMigrationDryRun(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	targetServer := apiservertesting.NewAPIServer(func(string) (any, error) {
+		return &fakeMigrationTargetRoot{}, nil
+	})
+	defer targetServer.Close()
+
+	modelUUID := s.DefaultModelUUID
+	args := params.InitiateMigrationArgs{
+		DryRun: true,
+		Specs: []params.MigrationSpec{
+			{
+				ModelTag: names.NewModelTag(modelUUID.String()).String(),
+				TargetInfo: params.MigrationTargetInfo{
+					ControllerTag:  randomControllerTag(),
+					Addrs:          targetServer.Addrs,
+					CACert:         testing.CACert,
+					AuthTag:        names.NewUserTag("admin").String(),
+					Password:       "secret",
+					SkipUserChecks: true,
+				},
+			},
+		},
+	}
+	s.mockModelService.EXPECT().Model(gomock.Any(), modelUUID).Return(
+		model.Model{
+			UUID:      modelUUID,
+			Name:      "test",
+			Qualifier: "prod",
+			Life:      life.Alive,
+			ModelType: model.IAAS,
+		}, nil,
+	).AnyTimes()
+	s.mockModelService.EXPECT().GetModelUsers(gomock.Any(), modelUUID).Return(nil, nil)
+	s.mockModelService.EXPECT().ControllerModel(gomock.Any()).Return(model.Model{}, nil)
+
+	out, err := s.controller.InitiateMigration(c.Context(), args)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(out.Results, tc.HasLen, 1)
+	result := out.Results[0]
+	c.Check(result.ModelTag, tc.Equals, args.Specs[0].ModelTag)
+	c.Check(result.Error, tc.IsNil)
+	c.Check(result.MigrationId, tc.Equals, "")
+}
+
 func (s *controllerSuite) TestInitiateMigrationInvalidMacaroons(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -461,6 +508,37 @@ func (s *controllerSuite) TestInitiateMigrationInvalidMacaroons(c *tc.C) {
 func randomControllerTag() string {
 	uuid := uuid.MustNewUUID().String()
 	return names.NewControllerTag(uuid).String()
+}
+
+const fakeMigrationTargetUUID = "f47ac10b-58cc-dead-beef-0e02b2c3d479"
+
+type fakeMigrationTargetRoot struct{}
+
+type fakeMigrationAdminFacade struct{}
+
+type fakeMigrationTargetFacade struct{}
+
+func (*fakeMigrationTargetRoot) Admin(string) (fakeMigrationAdminFacade, error) {
+	return fakeMigrationAdminFacade{}, nil
+}
+
+func (*fakeMigrationTargetRoot) MigrationTarget(string) (fakeMigrationTargetFacade, error) {
+	return fakeMigrationTargetFacade{}, nil
+}
+
+func (fakeMigrationAdminFacade) Login(params.LoginRequest) (params.LoginResult, error) {
+	return params.LoginResult{
+		ControllerTag: names.NewControllerTag(fakeMigrationTargetUUID).String(),
+		UserInfo: &params.AuthUserInfo{
+			DisplayName: "admin",
+			Identity:    "user-admin",
+		},
+		ServerVersion: jujuversion.Current.String(),
+	}, nil
+}
+
+func (fakeMigrationTargetFacade) Prechecks(params.MigrationModelInfoLegacy) error {
+	return nil
 }
 
 func (s *controllerSuite) TestGrantControllerInvalidUserTag(c *tc.C) {

--- a/apiserver/facades/client/controller/service.go
+++ b/apiserver/facades/client/controller/service.go
@@ -224,7 +224,7 @@ type ModelMigrationService interface {
 	// ModelMigrationMode returns the current migration mode for the model.
 	ModelMigrationMode(ctx context.Context) (modelmigration.MigrationMode, error)
 	// InitiateMigration kicks off migrating this model to the target controller.
-	InitiateMigration(ctx context.Context, targetInfo migration.TargetInfo, userName string) (string, error)
+	InitiateMigration(ctx context.Context, targetInfo migration.TargetInfo, userName string, dryRun bool) (string, error)
 }
 
 // ModelConfigService is an interface that provides access to the

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -234,9 +234,14 @@ func (s *Service) Migration(ctx context.Context) (modelmigration.Migration, erro
 }
 
 // InitiateMigration kicks off migrating this model to the target controller.
-func (s *Service) InitiateMigration(ctx context.Context, targetInfo migration.TargetInfo, userName string) (string, error) {
+func (s *Service) InitiateMigration(ctx context.Context, targetInfo migration.TargetInfo, userName string, dryRun bool) (string, error) {
 	_, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
+
+	if dryRun {
+		return "", nil
+	}
+
 	// TODO(modelmigration): implement migration info reporting.
 	return "", errors.ConstError("migration is not implemented")
 }

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -13,6 +13,7 @@ import (
 
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/core/semversion"
@@ -30,6 +31,20 @@ type serviceSuite struct {
 
 func TestServiceSuite(t *testing.T) {
 	tc.Run(t, &serviceSuite{})
+}
+
+func (s *serviceSuite) TestInitiateMigrationDryRun(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	migrationID, err := NewService(
+		s.controllerState,
+		s.modelState,
+		"test-model-uuid",
+		s.instanceProviderGetter(c),
+		s.resourceProviderGetter(c),
+	).InitiateMigration(c.Context(), migration.TargetInfo{}, "admin", true)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(migrationID, tc.Equals, "")
 }
 
 // TestAdoptResources is testing the happy path of adopting a models cloud


### PR DESCRIPTION
Reimplements the dry run flag for model migration see done in [this pr](https://github.com/juju/juju/pull/21552) from 3.6.

It cannot be QA'd as the source pre-checks will not pass as there's nothing to deserialise right now.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

