### PR TITLE
fix(auth): prevents external authentication masquerading as local users

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -355,6 +355,9 @@ func (a *admin) authenticate(ctx context.Context, modelExists bool, req params.L
 		if !ok {
 			return nil, errors.Errorf("externally authenticated entity %q is not a user", authInfo.Tag)
 		}
+		if userTag.IsLocal() {
+			return nil, errors.Forbiddenf("external user masquerading as local user")
+		}
 		userName := coreuser.NameFromTag(userTag)
 		if err := a.root.domainServices.Access().EnsureExternalUser(ctx, userName); err != nil {
 			logger.Warningf(ctx, "ensuring external user %q in database: %v", userName, err)

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -340,6 +340,16 @@ func (a *admin) authenticate(ctx context.Context, modelExists bool, req params.L
 		// Hide the fact that the model does not exist.
 		return nil, errors.Unauthorizedf("invalid entity name or password")
 	}
+	// Ensure externally authenticate users are not able to masquerade as local users.
+	if authInfo.IsExternallyAuthenticated {
+		userTag, ok := authInfo.Tag.(names.UserTag)
+		if !ok {
+			return nil, errors.Errorf("externally authenticated entity %q is not a user", authInfo.Tag)
+		}
+		if userTag.IsLocal() {
+			return nil, errors.Unauthorizedf("external user masquerading as local user")
+		}
+	}
 	if result.userLogin {
 		var err error
 		result.userInfo, err = a.checkUserPermissions(ctx, authInfo, result.controllerOnlyLogin)

--- a/apiserver/admin_external_login_jwt_test.go
+++ b/apiserver/admin_external_login_jwt_test.go
@@ -162,3 +162,53 @@ func (s *externalUserJWTLoginSuite) TestExternalUserNotCreatedWhenJWTLoginUnauth
 	c.Assert(err, tc.ErrorIs, accesserrors.UserNotFound,
 		tc.Commentf("testuser@external should not be created when JWT login is unauthorised"))
 }
+
+func (s *externalUserJWTLoginSuite) TestLoginJWTCannotMasqueradeAsLocalUser(c *tc.C) {
+	accessService := s.ControllerDomainServices(c).Access()
+
+	// The everyone@external user must exist as a user record (it's created
+	// during bootstrap and serves as the creator of other external users),
+	// but for the JWT path we do NOT need to grant it any permissions.
+	// This verifies that JWT login works without everyone@external having
+	// controller access — unlike the macaroon path which gates on that.
+	err := accessService.AddExternalUser(c.Context(), permission.EveryoneUserName, "", s.AdminUserUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Confirm the admin user exists in Juju's database.
+	userName := tc.Must1(c, user.NewName, "admin")
+	_, err = accessService.GetUserByName(c.Context(), userName)
+	c.Assert(err, tc.ErrorIsNil, tc.Commentf("admin user should exist before login"))
+
+	// Build a JWT token for "user-testuser@external" with superuser access
+	// on the controller. The token is base64-encoded, matching the format
+	// JIMM sends to Juju controllers.
+	controllerTag := names.NewControllerTag(s.ControllerUUID)
+	token, err := apitesting.NewEncodedJWT(apitesting.JWTParams{
+		Controller: s.ControllerUUID,
+		User:       "user-admin",
+		Access: map[string]string{
+			controllerTag.String(): "superuser",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Open an API connection using the JWT login provider. This triggers:
+	//   1. Client sends LoginRequest with Token set (the JWT).
+	//   2. Macaroon authenticator returns NotSupported (no macaroons).
+	//   3. JWT authenticator parses the token, extracts user-testuser@external.
+	//   4. admin.authenticate() validates permissions from the JWT claims.
+	//   5. On success, admin.authenticate() calls EnsureExternalUser, inserting
+	//      testuser@external into Juju's user table.
+	info := s.ControllerModelApiInfo()
+	info.Tag = nil
+	info.Password = ""
+	info.Macaroons = nil
+	_, err = api.Open(c.Context(), info, api.DialOpts{
+		LoginProvider: &jwtLoginProvider{
+			tag:   names.NewUserTag("admin"),
+			token: token,
+		},
+	})
+	// We expect the login to fail because JWT login must not allow masquerading as a local user.
+	c.Assert(err, tc.ErrorMatches, `external user masquerading as local user \(forbidden\)`)
+}

--- a/apiserver/admin_external_login_jwt_test.go
+++ b/apiserver/admin_external_login_jwt_test.go
@@ -162,3 +162,53 @@ func (s *externalUserJWTLoginSuite) TestExternalUserNotCreatedWhenJWTLoginUnauth
 	c.Assert(err, tc.ErrorIs, accesserrors.UserNotFound,
 		tc.Commentf("testuser@external should not be created when JWT login is unauthorised"))
 }
+
+func (s *externalUserJWTLoginSuite) TestLoginJWTCannotMasqueradeAsLocalUser(c *tc.C) {
+	accessService := s.ControllerDomainServices(c).Access()
+
+	// The everyone@external user must exist as a user record (it's created
+	// during bootstrap and serves as the creator of other external users),
+	// but for the JWT path we do NOT need to grant it any permissions.
+	// This verifies that JWT login works without everyone@external having
+	// controller access — unlike the macaroon path which gates on that.
+	err := accessService.AddExternalUser(c.Context(), permission.EveryoneUserName, "", s.AdminUserUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Confirm the admin user exists in Juju's database.
+	userName := tc.Must1(c, user.NewName, "admin")
+	_, err = accessService.GetUserByName(c.Context(), userName)
+	c.Assert(err, tc.ErrorIsNil, tc.Commentf("admin user should exist before login"))
+
+	// Build a JWT token for "user-testuser@external" with superuser access
+	// on the controller. The token is base64-encoded, matching the format
+	// JIMM sends to Juju controllers.
+	controllerTag := names.NewControllerTag(s.ControllerUUID)
+	token, err := apitesting.NewEncodedJWT(apitesting.JWTParams{
+		Controller: s.ControllerUUID,
+		User:       "user-admin",
+		Access: map[string]string{
+			controllerTag.String(): "superuser",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Open an API connection using the JWT login provider. This triggers:
+	//   1. Client sends LoginRequest with Token set (the JWT).
+	//   2. Macaroon authenticator returns NotSupported (no macaroons).
+	//   3. JWT authenticator parses the token, extracts user-testuser@external.
+	//   4. admin.authenticate() validates permissions from the JWT claims.
+	//   5. On success, admin.authenticate() calls EnsureExternalUser, inserting
+	//      testuser@external into Juju's user table.
+	info := s.ControllerModelApiInfo()
+	info.Tag = nil
+	info.Password = ""
+	info.Macaroons = nil
+	_, err = api.Open(c.Context(), info, api.DialOpts{
+		LoginProvider: &jwtLoginProvider{
+			tag:   names.NewUserTag("admin"),
+			token: token,
+		},
+	})
+	// We expect the login to fail because JWT login must not allow masquerading as a local user.
+	c.Assert(err, tc.ErrorMatches, `.*external user masquerading as local user.*`)
+}

--- a/apiserver/authentication/jwt/jwt.go
+++ b/apiserver/authentication/jwt/jwt.go
@@ -95,6 +95,14 @@ func (j *JWTAuthenticator) Authenticate(req *http.Request) (authentication.AuthI
 		return authentication.AuthInfo{}, fmt.Errorf("parsing jwt: %w", err)
 	}
 
+	user, ok := userTag.(names.UserTag)
+	if !ok {
+		return authentication.AuthInfo{}, fmt.Errorf("invalid user tag %q in jwt token", userTag)
+	}
+	if user.IsLocal() {
+		return authentication.AuthInfo{}, errors.Unauthorizedf("external identity provider has provided JWT with a local user")
+	}
+
 	return authentication.AuthInfo{
 		Tag:                       userTag,
 		Delegator:                 &PermissionDelegator{Token: token},

--- a/apiserver/authentication/jwt/jwt_test.go
+++ b/apiserver/authentication/jwt/jwt_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/authentication/jwt"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/internal/testing"
@@ -27,6 +28,57 @@ func TestLoginTokenSuite(t *stdtesting.T) {
 }
 
 func (s *loginTokenSuite) TestAuthenticate(c *tc.C) {
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+	modelTag := names.NewModelTag(modelUUID.String())
+	applicationOfferTag := names.NewApplicationOfferTag("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	tok, err := EncodedJWT(JWTParams{
+		Controller: testing.ControllerTag.Id(),
+		User:       "user-fred@external",
+		Access: map[string]string{
+			testing.ControllerTag.String(): "login",
+			modelTag.String():              "write",
+			applicationOfferTag.String():   "consume",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	params := authentication.AuthParams{
+		Token: base64.StdEncoding.EncodeToString(tok),
+	}
+
+	authenticator := jwt.NewAuthenticator(&testJWTParser{})
+
+	req, err := http.NewRequest("", "", nil)
+	c.Assert(err, tc.ErrorIsNil)
+	req.Header.Add("Authorization", "Bearer "+params.Token)
+	authInfo, err := authenticator.Authenticate(req)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(authInfo.Tag.String(), tc.Equals, "user-fred@external")
+	c.Assert(authInfo.IsExternallyAuthenticated, tc.IsTrue)
+	perm, err := authInfo.SubjectPermissions(c.Context(), permission.ID{
+		ObjectType: permission.Model,
+		Key:        modelTag.Id(),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(perm, tc.Equals, permission.WriteAccess)
+
+	perm, err = authInfo.SubjectPermissions(c.Context(), permission.ID{
+		ObjectType: permission.Controller,
+		Key:        testing.ControllerTag.Id(),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(perm, tc.Equals, permission.LoginAccess)
+
+	perm, err = authInfo.SubjectPermissions(c.Context(), permission.ID{
+		ObjectType: permission.Offer,
+		Key:        applicationOfferTag.Id(),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(perm, tc.Equals, permission.ConsumeAccess)
+}
+
+func (s *loginTokenSuite) TestAuthenticateLocalUserDenied(c *tc.C) {
 	modelUUID := tc.Must0(c, coremodel.NewUUID)
 	modelTag := names.NewModelTag(modelUUID.String())
 	applicationOfferTag := names.NewApplicationOfferTag("f47ac10b-58cc-4372-a567-0e02b2c3d479")
@@ -50,31 +102,8 @@ func (s *loginTokenSuite) TestAuthenticate(c *tc.C) {
 	req, err := http.NewRequest("", "", nil)
 	c.Assert(err, tc.ErrorIsNil)
 	req.Header.Add("Authorization", "Bearer "+params.Token)
-	authInfo, err := authenticator.Authenticate(req)
-	c.Assert(err, tc.ErrorIsNil)
-
-	c.Assert(authInfo.Tag.String(), tc.Equals, "user-fred")
-	c.Assert(authInfo.IsExternallyAuthenticated, tc.IsTrue)
-	perm, err := authInfo.SubjectPermissions(c.Context(), permission.ID{
-		ObjectType: permission.Model,
-		Key:        modelTag.Id(),
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(perm, tc.Equals, permission.WriteAccess)
-
-	perm, err = authInfo.SubjectPermissions(c.Context(), permission.ID{
-		ObjectType: permission.Controller,
-		Key:        testing.ControllerTag.Id(),
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(perm, tc.Equals, permission.LoginAccess)
-
-	perm, err = authInfo.SubjectPermissions(c.Context(), permission.ID{
-		ObjectType: permission.Offer,
-		Key:        applicationOfferTag.Id(),
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(perm, tc.Equals, permission.ConsumeAccess)
+	_, err = authenticator.Authenticate(req)
+	c.Assert(err, tc.ErrorIs, coreerrors.Unauthorized)
 }
 
 func (s *loginTokenSuite) TestAuthenticateInvalidHeader(c *tc.C) {


### PR DESCRIPTION
Prevents users authenticated via external authentication methods masquerading as local users.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Follow steps in #21848

## Documentation changes

N/A

## Links

N/A