### PR TITLE
docs: update sphinx-llm to v0.4.0 with absolute URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,10 +317,9 @@ llms_txt_description = (
     "and managing applications across Kubernetes, VMs, and bare metal using "
     "software operators called charms."
 )
-## Disable concatenated file generation (because file counterproductively large):
-llms_txt_full_build = False
 ## Get cleaner markdown URLs (e.g., `page.md` instead of `page/index.html.md`):
 llms_txt_suffix_mode = "url-suffix"
+markdown_http_base = "https://documentation.ubuntu.com/juju/3.6"
 
 
 # Excludes files or directories from processing

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ sphinxext-opengraph
 sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
-sphinx-llm @ git+https://github.com/NVIDIA/sphinx-llm
+sphinx-llm
 sphinx-related-links>=0.1.1
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2


### PR DESCRIPTION
We're trying to make our docs more AI friendly. To that end, a few weeks ago we added `sphinx-llm` etc. However, the extension had bugs, so we pinned to a specific version, and lacked some of the functionality it should have had; also, we mistakenly thought it was more advantageous to disable `llms-full.txt`, but it has since emerged the pros outweigh the cons. This PR fixes all of that.

<details>

- Switch from git version to `sphinx-llm` from PyPI (v0.4.0)
- Remove `llms_txt_full_build` = False option (publishing `llms-full.txt` is now desirable per upstream recommendation)
- Add `markdown_http_base = "https://documentation.ubuntu.com/juju/3.6"` to generate fully-qualified URLs. This improves AI agent discoverability by providing absolute HTTP(S) URLs in `llms.txt` instead of relative paths, which tools like Agent Score require to properly index documentation.

</details>

## QA steps

**tl;dr** Try https://canonical-ubuntu-documentation-library--22256.com.readthedocs.build/juju/22256/llms-full.txt 

**Otherwise:**

In `docs` run `make clean && make run`. Open the browser preview and append `llms.txt`, `llms-full.txt`, or click on some page and delete the trailing / and add `.md`.

http://127.0.0.1:8000/llms.txt
http://127.0.0.1:8000/llms-full.txt
http://127.0.0.1:8000/howto.md

## Note on forward merge

When merging to newer branches: In `conf.py` > `markdown_http_base`, update the version number to match the branch. E.g., `markdown_http_base = "https://documentation.ubuntu.com/juju/4.0"`. Then build the docs and check that in  `llms.txt` the URLs contain the correct version.
