### PR TITLE
test: install juju-qa-dummy-storage from charmhub

### DIFF
--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -101,7 +101,8 @@ run_charm_storage() {
 	wait_for "{}" ".applications"
 
 	# Assessing storage with a named storage pool
-	juju deploy -m "${model_name}" ./testcharms/charms/dummy-storage --storage single-fs=tempy,1,10M
+	juju deploy -m "${model_name}" juju-qa-dummy-storage dummy-storage \
+		--storage single-fs=tempy,1,10M
 	wait_for "dummy-storage" ".applications"
 
 	# Verify tmpfs storage details

--- a/tests/suites/storage/model_storage_block.sh
+++ b/tests/suites/storage/model_storage_block.sh
@@ -29,7 +29,8 @@ test_default_block_storage() {
 	juju model-config -m "${model_name}" storage-default-block-source="${storage_type}"
 
 	# Deploy application with block storage without specifying storage type.
-	juju deploy -m "${model_name}" ./testcharms/charms/dummy-storage --storage single-blk=100M
+	juju deploy -m "${model_name}" juju-qa-dummy-storage dummy-storage \
+		--storage single-blk=100M
 
 	# Wait for the application to be active.
 	wait_for "dummy-storage" "$(active_condition "dummy-storage" 0)"

--- a/tests/suites/storage/model_storage_filesystem.sh
+++ b/tests/suites/storage/model_storage_filesystem.sh
@@ -32,7 +32,8 @@ test_default_filesystem_storage() {
 	juju model-config -m "${model_name}" storage-default-filesystem-source=${test_fs}
 
 	# Deploy application with filesystem storage without specifying storage type.
-	juju deploy -m "${model_name}" ./testcharms/charms/dummy-storage --storage single-fs=100M
+	juju deploy -m "${model_name}" juju-qa-dummy-storage dummy-storage \
+		--storage single-fs=100M
 
 	# Wait for the application to be active.
 	wait_for "dummy-storage" "$(active_condition "dummy-storage" 0)"

--- a/tests/suites/storage/persistent_storage.sh
+++ b/tests/suites/storage/persistent_storage.sh
@@ -19,9 +19,8 @@ run_persistent_storage() {
 	# dummy-storage is going to be deployed with 1 ebs block storage unit
 	# and 1 rootfs filesystem storage unit.
 	echo "dummy-storage is going to be deployed with 1 ebs block storage unit and 1 rootfs filesystem storage unit"
-	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage) --storage single-blk=ebs \
-		--storage single-fs=rootfs
+	juju deploy -m "${model_name}" juju-qa-dummy-storage dummy-storage \
+		--storage single-blk=ebs --storage single-fs=rootfs
 	echo "Checking current status of app dummy-storage."
 	# wait for current application-status to be active
 	wait_for "dummy-storage" "$(active_condition "dummy-storage" 0)"
@@ -95,8 +94,8 @@ run_persistent_storage() {
 	echo "Check status of persistent storage single-blk/0 after remove-application: PASSED"
 
 	# Deploy charm with an existing detached storage
-	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage) --attach-storage single-blk/0
+	juju deploy -m "${model_name}" juju-qa-dummy-storage dummy-storage \
+		--attach-storage single-blk/0
 	echo "Checking current status of app dummy-storage."
 	# wait for current application-status to be active
 	wait_for "dummy-storage" "$(active_condition "dummy-storage" 0)"


### PR DESCRIPTION
Tests trying to deploy the `dummy-storage` charm from the local file-system are failing.

The test charm is now published, so this update pulls from the store rather than trying to deploy locally.

```
$ juju info juju-qa-dummy-storage
name: juju-qa-dummy-storage
publisher: Juju Release Engineering
summary: Dummy charm that utilises storage.
description: This dummy-storage charm is used for testing persistent storage.
store-url: https://charmhub.io/juju-qa-dummy-storage
charm-id: zsHQzaHwTBc8EehtHjtkPCo12nVFTShd
supports: ubuntu@24.04
subordinate: false
channels: |
  latest/stable:     1  2026-04-16  (1)  3kB  amd64  ubuntu@24.04
  latest/candidate:  ↑
  latest/beta:       ↑
  latest/edge:       ↑
```
