### PR TITLE
feat: write storage adds in hook commit

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -187,7 +187,7 @@ type ApplicationService interface {
 		storageName corestorage.Name,
 		unitUUID coreunit.UUID,
 		count uint32,
-	) (domainstorage.UnitAddStorageArg, error)
+	) (domainstorage.IAASUnitAddStorageArg, error)
 
 	// SetUnitWorkloadVersion sets the workload version for the given unit.
 	SetUnitWorkloadVersion(ctx context.Context, unitName coreunit.Name, version string) error

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -810,10 +810,10 @@ func (c *MockApplicationServiceGetUnitWorkloadVersionCall) DoAndReturn(f func(co
 }
 
 // PrepareUnitAddStorage mocks base method.
-func (m *MockApplicationService) PrepareUnitAddStorage(arg0 context.Context, arg1 storage.Name, arg2 unit.UUID, arg3 uint32) (storage0.UnitAddStorageArg, error) {
+func (m *MockApplicationService) PrepareUnitAddStorage(arg0 context.Context, arg1 storage.Name, arg2 unit.UUID, arg3 uint32) (storage0.IAASUnitAddStorageArg, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareUnitAddStorage", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(storage0.UnitAddStorageArg)
+	ret0, _ := ret[0].(storage0.IAASUnitAddStorageArg)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -831,19 +831,19 @@ type MockApplicationServicePrepareUnitAddStorageCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServicePrepareUnitAddStorageCall) Return(arg0 storage0.UnitAddStorageArg, arg1 error) *MockApplicationServicePrepareUnitAddStorageCall {
+func (c *MockApplicationServicePrepareUnitAddStorageCall) Return(arg0 storage0.IAASUnitAddStorageArg, arg1 error) *MockApplicationServicePrepareUnitAddStorageCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServicePrepareUnitAddStorageCall) Do(f func(context.Context, storage.Name, unit.UUID, uint32) (storage0.UnitAddStorageArg, error)) *MockApplicationServicePrepareUnitAddStorageCall {
+func (c *MockApplicationServicePrepareUnitAddStorageCall) Do(f func(context.Context, storage.Name, unit.UUID, uint32) (storage0.IAASUnitAddStorageArg, error)) *MockApplicationServicePrepareUnitAddStorageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServicePrepareUnitAddStorageCall) DoAndReturn(f func(context.Context, storage.Name, unit.UUID, uint32) (storage0.UnitAddStorageArg, error)) *MockApplicationServicePrepareUnitAddStorageCall {
+func (c *MockApplicationServicePrepareUnitAddStorageCall) DoAndReturn(f func(context.Context, storage.Name, unit.UUID, uint32) (storage0.IAASUnitAddStorageArg, error)) *MockApplicationServicePrepareUnitAddStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3417,8 +3417,10 @@ func (s *commitHookChangesSuite) TestCommitHookChangesAddsPreparedStorage(c *tc.
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 
 	count := uint64(2)
-	prepared := domainstorage.UnitAddStorageArg{
-		CountLessThanEqual: 3,
+	prepared := domainstorage.IAASUnitAddStorageArg{
+		UnitAddStorageArg: domainstorage.UnitAddStorageArg{
+			CountLessThanEqual: 3,
+		},
 	}
 
 	s.expectGetUnitUUID(unitName, unitUUID, nil)

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -611,12 +611,28 @@ func (s *ProviderService) ResolveApplicationConstraints(
 
 // PrepareUnitAddStorage validates and prepares the storage add arguments for a
 // unit without performing any writes.
+//
+// The following errors can be expected:
+// - [coreerrors.NotSupported] with k8s models.
 func (s *ProviderService) PrepareUnitAddStorage(
 	ctx context.Context,
 	storageName corestorage.Name,
 	unitUUID coreunit.UUID,
 	addCount uint32,
 ) (domainstorage.IAASUnitAddStorageArg, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	modelType, err := s.st.GetModelType(ctx)
+	if err != nil {
+		return domainstorage.IAASUnitAddStorageArg{}, errors.Capture(err)
+	}
+	if modelType == model.CAAS {
+		return domainstorage.IAASUnitAddStorageArg{}, errors.New(
+			"adding storage to a unit is not supported on k8s",
+		).Add(coreerrors.NotSupported)
+	}
+
 	unitStorageArgs, err := s.populateAddStorageArgs(
 		ctx,
 		storageName,

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -616,14 +616,29 @@ func (s *ProviderService) PrepareUnitAddStorage(
 	storageName corestorage.Name,
 	unitUUID coreunit.UUID,
 	addCount uint32,
-) (domainstorage.UnitAddStorageArg, error) {
-	return s.populateAddStorageArgs(
+) (domainstorage.IAASUnitAddStorageArg, error) {
+	unitStorageArgs, err := s.populateAddStorageArgs(
 		ctx,
 		storageName,
 		unitUUID,
 		addCount,
 		application.AddUnitStorageOverride{},
 	)
+	if err != nil {
+		return domainstorage.IAASUnitAddStorageArg{}, errors.Capture(err)
+	}
+
+	iassUnitStorageArgs, err := s.storageService.MakeIAASUnitStorageArgs(
+		ctx, unitStorageArgs.StorageInstances)
+	if err != nil {
+		return domainstorage.IAASUnitAddStorageArg{}, errors.Capture(err)
+	}
+
+	return domainstorage.IAASUnitAddStorageArg{
+		UnitAddStorageArg: unitStorageArgs,
+		FilesystemsToOwn:  iassUnitStorageArgs.FilesystemsToOwn,
+		VolumesToOwn:      iassUnitStorageArgs.VolumesToOwn,
+	}, nil
 }
 
 func (s *ProviderService) makeIAASApplicationArg(ctx context.Context,

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3431,6 +3431,7 @@ func (s *providerServiceSuite) TestPrepareUnitAddStorage(c *tc.C) {
 		Size:             1024,
 	}
 
+	s.state.EXPECT().GetModelType(gomock.Any()).Return(model.IAAS, nil)
 	s.storageService.EXPECT().GetUnitStorageDirectiveByName(
 		gomock.Any(), unitUUID, corestorage.Name("pgdata"),
 	).Return(directive, nil)
@@ -3492,4 +3493,18 @@ func (s *providerServiceSuite) TestPrepareUnitAddStorage(c *tc.C) {
 		FilesystemsToOwn:  fsToOwn,
 		VolumesToOwn:      volToOwn,
 	})
+}
+
+func (s *providerServiceSuite) TestPrepareUnitAddStorageCAASNotSupported(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+
+	s.state.EXPECT().GetModelType(gomock.Any()).Return(model.CAAS, nil)
+
+	_, err := s.service.PrepareUnitAddStorage(
+		c.Context(), "pgdata", unitUUID, 3,
+	)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
 }

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3415,3 +3415,81 @@ func (s *providerServiceSuite) TestAddStorageForCAASUnit(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIs, nil)
 }
+
+func (s *providerServiceSuite) TestPrepareUnitAddStorage(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	directive := internal.StorageDirective{
+		Name:             "pgdata",
+		CharmStorageType: applicationcharm.StorageFilesystem,
+		Count:            1,
+		MaxCount:         10,
+		PoolUUID:         poolUUID,
+		Size:             1024,
+	}
+
+	s.storageService.EXPECT().GetUnitStorageDirectiveByName(
+		gomock.Any(), unitUUID, corestorage.Name("pgdata"),
+	).Return(directive, nil)
+	s.state.EXPECT().GetCharmStorageAndInstanceCountByUnitUUID(
+		gomock.Any(), unitUUID, corestorage.Name("pgdata"),
+	).Return(internalcharm.Storage{
+		Name:        "pgdata",
+		Type:        internalcharm.StorageFilesystem,
+		MinimumSize: 512,
+		CountMin:    1,
+		CountMax:    10,
+	}, 2, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(
+		gomock.Any(),
+		map[string]internalcharm.Storage{
+			"pgdata": {
+				Name:        "pgdata",
+				Type:        internalcharm.StorageFilesystem,
+				CountMin:    1,
+				CountMax:    10,
+				MinimumSize: 512,
+			},
+		},
+		map[string]storageservice.StorageDirectiveOverride{
+			"pgdata": {
+				Count:    new(uint32(5)),
+				PoolUUID: new(poolUUID),
+				Size:     new(uint64(1024)),
+			},
+		},
+	).Return(nil)
+
+	unitStorageArgs := domainstorage.UnitAddStorageArg{
+		StorageInstances: []domainstorage.CreateUnitStorageInstanceArg{{
+			Name: "pgdata",
+		}},
+		// CountLessThanEqual is set to CountMax-addCount.
+		CountLessThanEqual: 7,
+	}
+	fsToOwn := []domainstorage.FilesystemUUID{tc.Must(c, domainstorage.NewFilesystemUUID)}
+	volToOwn := []domainstorage.VolumeUUID{tc.Must(c, domainstorage.NewVolumeUUID)}
+
+	s.storageService.EXPECT().MakeUnitAddStorageArgs(
+		gomock.Any(), unitUUID, uint32(3), directive,
+	).Return(unitStorageArgs, nil)
+	s.storageService.EXPECT().MakeIAASUnitStorageArgs(
+		gomock.Any(), unitStorageArgs.StorageInstances,
+	).Return(domainstorage.CreateIAASUnitStorageArg{
+		FilesystemsToOwn: fsToOwn,
+		VolumesToOwn:     volToOwn,
+	}, nil)
+
+	got, err := s.service.PrepareUnitAddStorage(
+		c.Context(), "pgdata", unitUUID, 3,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, domainstorage.IAASUnitAddStorageArg{
+		UnitAddStorageArg: unitStorageArgs,
+		FilesystemsToOwn:  fsToOwn,
+		VolumesToOwn:      volToOwn,
+	})
+}

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -519,6 +519,12 @@ func (s *ProviderService) UpdateUnitCharm(ctx context.Context, unitName coreunit
 		).Add(err)
 	}
 
+	if args.CurrentCharmUUID == args.RefreshCharmUUID {
+		// The charm is already at the correct version. This happens when the
+		// uniter starts.
+		return nil
+	}
+
 	sic, sac, err := s.st.GetUnitOwnedStorageInstances(ctx, unitUUID)
 	if err != nil {
 		return errors.Errorf(

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -13,7 +13,6 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	corecharm "github.com/juju/juju/core/charm"
-	charmtesting "github.com/juju/juju/core/charm/testing"
 	coreerrors "github.com/juju/juju/core/errors"
 	corelife "github.com/juju/juju/core/life"
 	coremachine "github.com/juju/juju/core/machine"
@@ -82,7 +81,8 @@ func (s *unitServiceSuite) TestUpdateUnitCharmCharmNotFound(c *tc.C) {
 func (s *unitServiceSuite) TestUpdateUnitCharmUnitNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := charmtesting.GenCharmID(c)
+	currentID := tc.Must(c, corecharm.NewID)
+	targetID := tc.Must(c, corecharm.NewID)
 	unitName := coreunit.Name("bar/0")
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 
@@ -94,11 +94,13 @@ func (s *unitServiceSuite) TestUpdateUnitCharmUnitNotFound(c *tc.C) {
 		Source:   charm.CharmHubSource,
 	}
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.state.EXPECT().GetCharmID(gomock.Any(), locator.Name, locator.Revision, locator.Source).Return(id, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), locator.Name, locator.Revision, locator.Source).Return(targetID, nil)
 	storageRefreshArgs := applicationinternal.UnitStorageRefreshArgs{
-		NetNodeUUID: "net-node-uuid",
+		NetNodeUUID:      "net-node-uuid",
+		CurrentCharmUUID: currentID,
+		RefreshCharmUUID: targetID,
 	}
-	s.state.EXPECT().GetUnitStorageRefreshArgs(gomock.Any(), unitUUID, id).Return(storageRefreshArgs, nil)
+	s.state.EXPECT().GetUnitStorageRefreshArgs(gomock.Any(), unitUUID, targetID).Return(storageRefreshArgs, nil)
 	s.state.EXPECT().GetUnitOwnedStorageInstances(gomock.Any(), unitUUID).Return(
 		[]applicationinternal.StorageInstanceComposition{},
 		[]applicationinternal.StorageAttachmentComposition{},
@@ -111,7 +113,7 @@ func (s *unitServiceSuite) TestUpdateUnitCharmUnitNotFound(c *tc.C) {
 	).Return(storageArgs, nil)
 	s.state.EXPECT().UpdateUnitCharm(gomock.Any(), applicationinternal.UpdateUnitCharmArg{
 		UUID:        unitUUID,
-		CharmUUID:   id,
+		CharmUUID:   targetID,
 		UnitStorage: storageArgs,
 	}).Return(applicationerrors.UnitNotFound)
 
@@ -122,7 +124,8 @@ func (s *unitServiceSuite) TestUpdateUnitCharmUnitNotFound(c *tc.C) {
 func (s *unitServiceSuite) TestUpdateUnitCharm(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := charmtesting.GenCharmID(c)
+	currentID := tc.Must(c, corecharm.NewID)
+	targetID := tc.Must(c, corecharm.NewID)
 	unitName := coreunit.Name("bar/0")
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 
@@ -134,8 +137,8 @@ func (s *unitServiceSuite) TestUpdateUnitCharm(c *tc.C) {
 	}
 	storageRefreshArgs := applicationinternal.UnitStorageRefreshArgs{
 		NetNodeUUID:              "net-node-uuid",
-		CurrentCharmUUID:         tc.Must(c, corecharm.NewID),
-		RefreshCharmUUID:         tc.Must(c, corecharm.NewID),
+		CurrentCharmUUID:         currentID,
+		RefreshCharmUUID:         targetID,
 		RefreshStorageDirectives: []applicationinternal.StorageDirective{sd},
 	}
 	storageArgs := storage.CreateUnitStorageArg{
@@ -165,8 +168,8 @@ func (s *unitServiceSuite) TestUpdateUnitCharm(c *tc.C) {
 		Source:   charm.CharmHubSource,
 	}
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.state.EXPECT().GetCharmID(gomock.Any(), locator.Name, locator.Revision, locator.Source).Return(id, nil)
-	s.state.EXPECT().GetUnitStorageRefreshArgs(gomock.Any(), unitUUID, id).Return(storageRefreshArgs, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), locator.Name, locator.Revision, locator.Source).Return(targetID, nil)
+	s.state.EXPECT().GetUnitStorageRefreshArgs(gomock.Any(), unitUUID, targetID).Return(storageRefreshArgs, nil)
 	s.state.EXPECT().GetUnitOwnedStorageInstances(gomock.Any(), unitUUID).Return(
 		[]applicationinternal.StorageInstanceComposition{},
 		[]applicationinternal.StorageAttachmentComposition{},
@@ -179,7 +182,7 @@ func (s *unitServiceSuite) TestUpdateUnitCharm(c *tc.C) {
 	).Return(storageArgs, nil)
 	s.state.EXPECT().UpdateUnitCharm(gomock.Any(), applicationinternal.UpdateUnitCharmArg{
 		UUID:        unitUUID,
-		CharmUUID:   id,
+		CharmUUID:   targetID,
 		UnitStorage: storageArgs,
 	}).Return(nil)
 
@@ -187,10 +190,10 @@ func (s *unitServiceSuite) TestUpdateUnitCharm(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *unitServiceSuite) TestUpdateUnitCharmMachine(c *tc.C) {
+func (s *unitServiceSuite) TestUpdateUnitCharmSameCharm(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := charmtesting.GenCharmID(c)
+	currentID := tc.Must(c, corecharm.NewID)
 	unitName := coreunit.Name("bar/0")
 	unitUUID := tc.Must(c, coreunit.NewUUID)
 
@@ -202,8 +205,42 @@ func (s *unitServiceSuite) TestUpdateUnitCharmMachine(c *tc.C) {
 	}
 	storageRefreshArgs := applicationinternal.UnitStorageRefreshArgs{
 		NetNodeUUID:              "net-node-uuid",
-		CurrentCharmUUID:         tc.Must(c, corecharm.NewID),
-		RefreshCharmUUID:         tc.Must(c, corecharm.NewID),
+		CurrentCharmUUID:         currentID,
+		RefreshCharmUUID:         currentID,
+		RefreshStorageDirectives: []applicationinternal.StorageDirective{sd},
+	}
+
+	locator := charm.CharmLocator{
+		Name:     "foo",
+		Revision: 42,
+		Source:   charm.CharmHubSource,
+	}
+	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), locator.Name, locator.Revision, locator.Source).Return(currentID, nil)
+	s.state.EXPECT().GetUnitStorageRefreshArgs(gomock.Any(), unitUUID, currentID).Return(storageRefreshArgs, nil)
+
+	err := s.service.UpdateUnitCharm(c.Context(), unitName, locator)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *unitServiceSuite) TestUpdateUnitCharmMachine(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	currentID := tc.Must(c, corecharm.NewID)
+	targetID := tc.Must(c, corecharm.NewID)
+	unitName := coreunit.Name("bar/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+
+	sd := applicationinternal.StorageDirective{
+		Count:    1,
+		Name:     "foo",
+		PoolUUID: tc.Must(c, storage.NewStoragePoolUUID),
+		Size:     1024,
+	}
+	storageRefreshArgs := applicationinternal.UnitStorageRefreshArgs{
+		NetNodeUUID:              "net-node-uuid",
+		CurrentCharmUUID:         currentID,
+		RefreshCharmUUID:         targetID,
 		RefreshStorageDirectives: []applicationinternal.StorageDirective{sd},
 		MachineUUID:              new(tc.Must(c, coremachine.NewUUID)),
 	}
@@ -240,8 +277,8 @@ func (s *unitServiceSuite) TestUpdateUnitCharmMachine(c *tc.C) {
 		Source:   charm.CharmHubSource,
 	}
 	s.state.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
-	s.state.EXPECT().GetCharmID(gomock.Any(), locator.Name, locator.Revision, locator.Source).Return(id, nil)
-	s.state.EXPECT().GetUnitStorageRefreshArgs(gomock.Any(), unitUUID, id).Return(storageRefreshArgs, nil)
+	s.state.EXPECT().GetCharmID(gomock.Any(), locator.Name, locator.Revision, locator.Source).Return(targetID, nil)
+	s.state.EXPECT().GetUnitStorageRefreshArgs(gomock.Any(), unitUUID, targetID).Return(storageRefreshArgs, nil)
 	s.state.EXPECT().GetUnitOwnedStorageInstances(gomock.Any(), unitUUID).Return(
 		[]applicationinternal.StorageInstanceComposition{},
 		[]applicationinternal.StorageAttachmentComposition{},
@@ -260,7 +297,7 @@ func (s *unitServiceSuite) TestUpdateUnitCharmMachine(c *tc.C) {
 	}, nil)
 	s.state.EXPECT().UpdateUnitCharm(gomock.Any(), applicationinternal.UpdateUnitCharmArg{
 		UUID:        unitUUID,
-		CharmUUID:   id,
+		CharmUUID:   targetID,
 		UnitStorage: storageArgs,
 		MachineUUID: storageRefreshArgs.MachineUUID,
 		IAASUnitStorage: &storage.CreateIAASUnitStorageArg{

--- a/domain/unitstate/errors/errors.go
+++ b/domain/unitstate/errors/errors.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	// UnitLifePredicateFailed indicates that a comparison of unit life did not
-	// match the expected life.
-	UnitLifePredicateFailed = errors.ConstError("unit life predicate failed")
+	// UnitLifePreconditionFailed indicates that a comparison of unit life did
+	// not match the expected life.
+	UnitLifePreconditionFailed = errors.ConstError("unit life predicate failed")
 )

--- a/domain/unitstate/errors/errors.go
+++ b/domain/unitstate/errors/errors.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import (
+	"github.com/juju/juju/internal/errors"
+)
+
+const (
+	// UnitLifePredicateFailed indicates that a comparison of unit life did not
+	// match the expected life.
+	UnitLifePredicateFailed = errors.ConstError("unit life predicate failed")
+)

--- a/domain/unitstate/internal/types.go
+++ b/domain/unitstate/internal/types.go
@@ -6,7 +6,7 @@ package internal
 import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
-	"github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/unitstate"
 )
 
@@ -30,11 +30,31 @@ type RelationSettings struct {
 	ApplicationUnset []string
 }
 
+// CommitHookUnitInfo contains the unit data loaded before commit-hook writes.
+type CommitHookUnitInfo struct {
+	// UnitUUID is the UUID of the unit these changes pertain to.
+	UnitUUID string
+
+	// UnitLife is the life of the unit.
+	UnitLife life.Life
+
+	// MachineUUID is the UUID of the unit's machine, if the unit is
+	// machine-backed.
+	MachineUUID *string
+}
+
 // CommitHookChangesArg contains data needed to commit a hook change
 // represented by scalar types.
 type CommitHookChangesArg struct {
 	// UnitUUID is the uuid of the unit these changes pertain to.
-	UnitUUID unit.UUID
+	UnitUUID string
+
+	// UnitLife is the expected life of the unit.
+	UnitLife life.Life
+
+	// MachineUUID is the UUID of the unit's machine, if the unit is
+	// machine-backed.
+	MachineUUID *string
 
 	// UpdateNetworkInfo indicates that the relation network settings
 	// should be updated for this unit.
@@ -55,6 +75,10 @@ type CommitHookChangesArg struct {
 	// CharmState is key/value pairs for charm attributes.
 	CharmState *map[string]string
 
+	// AddStorage contains prepared unit storage adds to apply in the commit
+	// hook transaction.
+	AddStorage []unitstate.PreparedStorageAdd
+
 	// SecretCreates contains charm secrets to create.
 	SecretCreates []unitstate.CreateSecretArg
 
@@ -73,18 +97,18 @@ type CommitHookChangesArg struct {
 
 	// SecretDeletes contains charm secrets to delete.
 	SecretDeletes []unitstate.DeleteSecretArg
-
-	// AddStorage contains prepared unit storage adds to apply in the commit
-	// hook transaction.
-	AddStorage []unitstate.PreparedStorageAdd
 }
 
 // TransformCommitHookChangesArg takes a domain package CommitHookChangesArg
 // struct and return an internal package CommitHookChangesArg struct. Does not
 // include RelationSettings
-func TransformCommitHookChangesArg(in unitstate.CommitHookChangesArg, unitUUID unit.UUID) CommitHookChangesArg {
+func TransformCommitHookChangesArg(
+	in unitstate.CommitHookChangesArg, unitInfo CommitHookUnitInfo,
+) CommitHookChangesArg {
 	return CommitHookChangesArg{
-		UnitUUID:           unitUUID,
+		UnitUUID:           unitInfo.UnitUUID,
+		UnitLife:           unitInfo.UnitLife,
+		MachineUUID:        unitInfo.MachineUUID,
 		UpdateNetworkInfo:  in.UpdateNetworkInfo,
 		OpenPorts:          in.OpenPorts,
 		ClosePorts:         in.ClosePorts,

--- a/domain/unitstate/service/commithook.go
+++ b/domain/unitstate/service/commithook.go
@@ -11,6 +11,8 @@ import (
 
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/trace"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/domain/unitstate/internal"
 	"github.com/juju/juju/internal/errors"
@@ -30,9 +32,18 @@ func (s *LeadershipService) CommitHookChanges(ctx context.Context, arg unitstate
 		return nil
 	}
 
-	unitUUID, err := s.st.GetUnitUUIDByName(ctx, arg.UnitName)
+	unitInfo, err := s.st.GetCommitHookUnitInfo(ctx, arg.UnitName.String())
 	if err != nil {
 		return errors.Capture(err)
+	} else if unitInfo.UnitLife == life.Dead {
+		return errors.Errorf(
+			"unit %q is dead", arg.UnitName.String(),
+		).Add(applicationerrors.UnitIsDead)
+	}
+
+	if unitInfo.UnitLife == life.Dying {
+		// A dying unit cannot use new storage, so ignore storage add args.
+		arg.AddStorage = nil
 	}
 
 	relationSettings, err := s.transformRelationSettings(ctx, arg.RelationSettings)
@@ -40,7 +51,7 @@ func (s *LeadershipService) CommitHookChanges(ctx context.Context, arg unitstate
 		return errors.Capture(err)
 	}
 
-	newArgs := internal.TransformCommitHookChangesArg(arg, unitUUID)
+	newArgs := internal.TransformCommitHookChangesArg(arg, unitInfo)
 	newArgs.RelationSettings = relationSettings
 
 	withCaveat, err := s.getManagementCaveat(arg)

--- a/domain/unitstate/service/commithook_test.go
+++ b/domain/unitstate/service/commithook_test.go
@@ -61,10 +61,13 @@ func (s *commitHookSuite) TestCommitHookChangesNoLeadership(c *tc.C) {
 		}},
 	}
 	unitUUID := tc.Must(c, coreunit.NewUUID)
-	s.st.EXPECT().GetUnitUUIDByName(c.Context(), arg.UnitName).Return(unitUUID, nil)
+	unitInfo := internal.CommitHookUnitInfo{
+		UnitUUID: unitUUID.String(),
+	}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), arg.UnitName.String()).Return(unitInfo, nil)
 
 	expected := internal.CommitHookChangesArg{
-		UnitUUID: unitUUID,
+		UnitUUID: unitUUID.String(),
 		RelationSettings: []internal.RelationSettings{{
 			RelationUUID: expectedRelationUUID,
 			UnitSet:      map[string]string{"key": "value"},
@@ -100,8 +103,11 @@ func (s *commitHookSuite) TestCommitHookChangesLeadership(c *tc.C) {
 	}
 
 	unitUUID := tc.Must(c, coreunit.NewUUID)
-	s.st.EXPECT().GetUnitUUIDByName(c.Context(), arg.UnitName).Return(unitUUID, nil)
-	s.leadershipEnsurer.EXPECT().WithLeader(c.Context(), "test", "test/0", gomock.Any()).Return(nil)
+	unitInfo := internal.CommitHookUnitInfo{
+		UnitUUID: unitUUID.String(),
+	}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), arg.UnitName.String()).Return(unitInfo, nil)
+	s.leadershipEnsurer.EXPECT().WithLeader(gomock.Any(), "test", "test/0", gomock.Any()).Return(nil)
 
 	// Act
 	svc := NewLeadershipService(s.st, s.leadershipEnsurer, loggertesting.WrapCheckLog(c))

--- a/domain/unitstate/service/interface.go
+++ b/domain/unitstate/service/interface.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	corerelation "github.com/juju/juju/core/relation"
-	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/domain/unitstate/internal"
 )
@@ -46,10 +45,10 @@ type CommitHookState interface {
 		endpoint1, endpoint2 corerelation.EndpointIdentifier,
 	) (corerelation.UUID, error)
 
-	// GetUnitUUIDByName returns the UUID for the named unit, returning an
-	// error satisfying [applicationerrors.UnitNotFound] if the unit doesn't
-	// exist.
-	GetUnitUUIDByName(ctx context.Context, name coreunit.Name) (coreunit.UUID, error)
+	// GetCommitHookUnitInfo returns the unit UUID and machine UUID if assigned,
+	// returning an error satisfying
+	// [applicationerrors.UnitNotFound] if the unit doesn't exist.
+	GetCommitHookUnitInfo(ctx context.Context, unitName string) (internal.CommitHookUnitInfo, error)
 }
 
 // UnitStateState defines a persistence layer interface for retrieving

--- a/domain/unitstate/service/state_mock_test.go
+++ b/domain/unitstate/service/state_mock_test.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	relation "github.com/juju/juju/core/relation"
-	unit "github.com/juju/juju/core/unit"
 	unitstate "github.com/juju/juju/domain/unitstate"
 	internal "github.com/juju/juju/domain/unitstate/internal"
 	gomock "go.uber.org/mock/gomock"
@@ -77,6 +76,45 @@ func (c *MockStateCommitHookChangesCall) Do(f func(context.Context, internal.Com
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateCommitHookChangesCall) DoAndReturn(f func(context.Context, internal.CommitHookChangesArg) error) *MockStateCommitHookChangesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetCommitHookUnitInfo mocks base method.
+func (m *MockState) GetCommitHookUnitInfo(arg0 context.Context, arg1 string) (internal.CommitHookUnitInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCommitHookUnitInfo", arg0, arg1)
+	ret0, _ := ret[0].(internal.CommitHookUnitInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCommitHookUnitInfo indicates an expected call of GetCommitHookUnitInfo.
+func (mr *MockStateMockRecorder) GetCommitHookUnitInfo(arg0, arg1 any) *MockStateGetCommitHookUnitInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommitHookUnitInfo", reflect.TypeOf((*MockState)(nil).GetCommitHookUnitInfo), arg0, arg1)
+	return &MockStateGetCommitHookUnitInfoCall{Call: call}
+}
+
+// MockStateGetCommitHookUnitInfoCall wrap *gomock.Call
+type MockStateGetCommitHookUnitInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetCommitHookUnitInfoCall) Return(arg0 internal.CommitHookUnitInfo, arg1 error) *MockStateGetCommitHookUnitInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetCommitHookUnitInfoCall) Do(f func(context.Context, string) (internal.CommitHookUnitInfo, error)) *MockStateGetCommitHookUnitInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetCommitHookUnitInfoCall) DoAndReturn(f func(context.Context, string) (internal.CommitHookUnitInfo, error)) *MockStateGetCommitHookUnitInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -194,45 +232,6 @@ func (c *MockStateGetUnitStateCall) Do(f func(context.Context, string) (unitstat
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetUnitStateCall) DoAndReturn(f func(context.Context, string) (unitstate.RetrievedUnitState, error)) *MockStateGetUnitStateCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetUnitUUIDByName mocks base method.
-func (m *MockState) GetUnitUUIDByName(arg0 context.Context, arg1 unit.Name) (unit.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitUUIDByName", arg0, arg1)
-	ret0, _ := ret[0].(unit.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUnitUUIDByName indicates an expected call of GetUnitUUIDByName.
-func (mr *MockStateMockRecorder) GetUnitUUIDByName(arg0, arg1 any) *MockStateGetUnitUUIDByNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitUUIDByName", reflect.TypeOf((*MockState)(nil).GetUnitUUIDByName), arg0, arg1)
-	return &MockStateGetUnitUUIDByNameCall{Call: call}
-}
-
-// MockStateGetUnitUUIDByNameCall wrap *gomock.Call
-type MockStateGetUnitUUIDByNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitUUIDByNameCall) Return(arg0 unit.UUID, arg1 error) *MockStateGetUnitUUIDByNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitUUIDByNameCall) Do(f func(context.Context, unit.Name) (unit.UUID, error)) *MockStateGetUnitUUIDByNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitUUIDByNameCall) DoAndReturn(f func(context.Context, unit.Name) (unit.UUID, error)) *MockStateGetUnitUUIDByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/unitstate/state/addstorage.go
+++ b/domain/unitstate/state/addstorage.go
@@ -1,0 +1,709 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/collections/transform"
+
+	corestorage "github.com/juju/juju/core/storage"
+	sequencestate "github.com/juju/juju/domain/sequence/state"
+	"github.com/juju/juju/domain/status"
+	domainstorage "github.com/juju/juju/domain/storage"
+	storageerrors "github.com/juju/juju/domain/storage/errors"
+	domainstorageprovisioning "github.com/juju/juju/domain/storageprovisioning"
+	"github.com/juju/juju/domain/unitstate/internal"
+	"github.com/juju/juju/internal/errors"
+)
+
+type storageCount struct {
+	StorageName string `db:"storage_name"`
+	UnitUUID    string `db:"unit_uuid"`
+	Count       uint32 `db:"count"`
+}
+
+type insertStorageFilesystem struct {
+	FilesystemID     string `db:"filesystem_id"`
+	LifeID           int    `db:"life_id"`
+	ProvisionScopeID int    `db:"provision_scope_id"`
+	UUID             string `db:"uuid"`
+}
+
+type insertStorageFilesystemAttachment struct {
+	LifeID                int    `db:"life_id"`
+	NetNodeUUID           string `db:"net_node_uuid"`
+	ProvisionScopeID      int    `db:"provision_scope_id"`
+	StorageFilesystemUUID string `db:"storage_filesystem_uuid"`
+	UUID                  string `db:"uuid"`
+}
+
+type insertStorageFilesystemInstance struct {
+	StorageFilesystemUUID string `db:"storage_filesystem_uuid"`
+	StorageInstanceUUID   string `db:"storage_instance_uuid"`
+}
+
+type insertStorageFilesystemStatus struct {
+	FilesystemUUID string    `db:"filesystem_uuid"`
+	StatusID       int       `db:"status_id"`
+	UpdateAt       time.Time `db:"updated_at"`
+}
+
+type insertStorageInstance struct {
+	CharmName       string `db:"charm_name"`
+	LifeID          int    `db:"life_id"`
+	RequestSizeMiB  uint64 `db:"requested_size_mib"`
+	StorageID       string `db:"storage_id"`
+	StorageKindID   int    `db:"storage_kind_id"`
+	StorageName     string `db:"storage_name"`
+	StoragePoolUUID string `db:"storage_pool_uuid"`
+	UUID            string `db:"uuid"`
+}
+
+type insertStorageInstanceAttachment struct {
+	LifeID              int    `db:"life_id"`
+	StorageInstanceUUID string `db:"storage_instance_uuid"`
+	UnitUUID            string `db:"unit_uuid"`
+	UUID                string `db:"uuid"`
+}
+
+type insertStorageUnitOwner struct {
+	StorageInstanceUUID string `db:"storage_instance_uuid"`
+	UnitUUID            string `db:"unit_uuid"`
+}
+
+type insertStorageVolume struct {
+	LifeID           int    `db:"life_id"`
+	UUID             string `db:"uuid"`
+	VolumeID         string `db:"volume_id"`
+	ProvisionScopeID int    `db:"provision_scope_id"`
+}
+
+type insertStorageVolumeAttachment struct {
+	LifeID            int    `db:"life_id"`
+	NetNodeUUID       string `db:"net_node_uuid"`
+	ProvisionScopeID  int    `db:"provision_scope_id"`
+	StorageVolumeUUID string `db:"storage_volume_uuid"`
+	UUID              string `db:"uuid"`
+}
+
+type insertStorageVolumeInstance struct {
+	StorageInstanceUUID string `db:"storage_instance_uuid"`
+	StorageVolumeUUID   string `db:"storage_volume_uuid"`
+}
+
+type insertStorageVolumeStatus struct {
+	VolumeUUID string    `db:"volume_uuid"`
+	StatusID   int       `db:"status_id"`
+	UpdateAt   time.Time `db:"updated_at"`
+}
+
+type insertVolumeMachineOwner struct {
+	MachineUUID string `db:"machine_uuid"`
+	VolumeUUID  string `db:"volume_uuid"`
+}
+
+type insertFilesystemMachineOwner struct {
+	MachineUUID    string `db:"machine_uuid"`
+	FilesystemUUID string `db:"filesystem_uuid"`
+}
+
+func (st *State) addStorage(ctx context.Context, tx *sqlair.TX, arg internal.CommitHookChangesArg) error {
+	for _, add := range arg.AddStorage {
+		err := st.addStorageForUnit(ctx, tx, arg, add.StorageName.String(), add.Storage)
+		if err != nil {
+			return errors.Errorf("storage %q: %w", add.StorageName, err)
+		}
+	}
+	return nil
+}
+
+func (st *State) addStorageForUnit(
+	ctx context.Context,
+	tx *sqlair.TX,
+	arg internal.CommitHookChangesArg,
+	storageName string,
+	storageArg domainstorage.IAASUnitAddStorageArg,
+) error {
+	unitUUID := arg.UnitUUID
+
+	currentCount, err := st.getUnitStorageCount(ctx, tx, unitUUID, storageName)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if currentCount > storageArg.CountLessThanEqual {
+		return storageerrors.MaxStorageCountPreconditionFailed
+	}
+
+	_, err = st.insertUnitStorageInstances(ctx, tx, storageArg.StorageInstances)
+	if err != nil {
+		return errors.Errorf("inserting storage instances: %w", err)
+	}
+
+	err = st.insertUnitStorageAttachments(ctx, tx, unitUUID, storageArg.StorageToAttach)
+	if err != nil {
+		return errors.Errorf("creating storage attachments: %w", err)
+	}
+
+	err = st.insertUnitStorageOwnership(ctx, tx, unitUUID, storageArg.StorageToOwn)
+	if err != nil {
+		return errors.Errorf("inserting storage ownership: %w", err)
+	}
+
+	if arg.MachineUUID != nil {
+		err = st.insertMachineVolumeOwnership(ctx, tx, *arg.MachineUUID, storageArg.VolumesToOwn)
+		if err != nil {
+			return errors.Errorf("inserting volume ownership: %w", err)
+		}
+
+		err = st.insertMachineFilesystemOwnership(ctx, tx, *arg.MachineUUID, storageArg.FilesystemsToOwn)
+		if err != nil {
+			return errors.Errorf("inserting filesystem ownership: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (st *State) getUnitStorageCount(
+	ctx context.Context, tx *sqlair.TX, unitUUID string, storageName string,
+) (uint32, error) {
+	stmt, err := st.Prepare(`
+SELECT count(*) AS &storageCount.count
+FROM   storage_instance si
+JOIN   storage_unit_owner suo ON si.uuid = suo.storage_instance_uuid
+WHERE  suo.unit_uuid = $storageCount.unit_uuid
+AND    si.storage_name = $storageCount.storage_name
+`, storageCount{})
+	if err != nil {
+		return 0, errors.Capture(err)
+	}
+
+	result := storageCount{
+		StorageName: storageName,
+		UnitUUID:    unitUUID,
+	}
+	err = tx.Query(ctx, stmt, result).Get(&result)
+	if err != nil {
+		return 0, errors.Capture(err)
+	}
+	return result.Count, nil
+}
+
+func machineStorageOwnership(
+	storageInst []domainstorage.CreateUnitStorageInstanceArg,
+) ([]domainstorage.FilesystemUUID, []domainstorage.VolumeUUID, error) {
+	var filesystemsToOwn []domainstorage.FilesystemUUID
+	var volumesToOwn []domainstorage.VolumeUUID
+
+	for _, inst := range storageInst {
+		var comp domainstorageprovisioning.StorageInstanceComposition
+		if inst.Filesystem != nil {
+			comp.FilesystemRequired = true
+			comp.FilesystemProvisionScope = inst.Filesystem.ProvisionScope
+		}
+		if inst.Volume != nil {
+			comp.VolumeRequired = true
+			comp.VolumeProvisionScope = inst.Volume.ProvisionScope
+		}
+
+		scope, err := domainstorageprovisioning.CalculateStorageInstanceOwnershipScope(comp)
+		if err != nil {
+			return nil, nil, errors.Capture(err)
+		}
+		if scope != domainstorageprovisioning.OwnershipScopeMachine {
+			continue
+		}
+
+		if inst.Filesystem != nil {
+			filesystemsToOwn = append(filesystemsToOwn, inst.Filesystem.UUID)
+		}
+		if inst.Volume != nil {
+			volumesToOwn = append(volumesToOwn, inst.Volume.UUID)
+		}
+	}
+
+	return filesystemsToOwn, volumesToOwn, nil
+}
+
+func (st *State) insertUnitStorageAttachments(
+	ctx context.Context,
+	tx *sqlair.TX,
+	unitUUID string,
+	storageToAttach []domainstorage.CreateUnitStorageAttachmentArg,
+) error {
+	storageAttachmentArgs := makeInsertUnitStorageAttachmentArgs(unitUUID, storageToAttach)
+	fsAttachmentArgs := st.makeInsertUnitFilesystemAttachmentArgs(storageToAttach)
+	volAttachmentArgs := st.makeInsertUnitVolumeAttachmentArgs(storageToAttach)
+
+	insertStorageAttachmentStmt, err := st.Prepare(`
+INSERT INTO storage_attachment (*) VALUES ($insertStorageInstanceAttachment.*)
+`, insertStorageInstanceAttachment{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	insertFSAttachmentStmt, err := st.Prepare(`
+INSERT INTO storage_filesystem_attachment (*) VALUES ($insertStorageFilesystemAttachment.*)
+`, insertStorageFilesystemAttachment{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	insertVolAttachmentStmt, err := st.Prepare(`
+INSERT INTO storage_volume_attachment (*) VALUES ($insertStorageVolumeAttachment.*)
+`, insertStorageVolumeAttachment{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	if len(storageAttachmentArgs) != 0 {
+		err = tx.Query(ctx, insertStorageAttachmentStmt, storageAttachmentArgs).Run()
+		if err != nil {
+			return errors.Capture(err)
+		}
+	}
+
+	if len(fsAttachmentArgs) != 0 {
+		err = tx.Query(ctx, insertFSAttachmentStmt, fsAttachmentArgs).Run()
+		if err != nil {
+			return errors.Capture(err)
+		}
+	}
+
+	if len(volAttachmentArgs) != 0 {
+		err = tx.Query(ctx, insertVolAttachmentStmt, volAttachmentArgs).Run()
+		if err != nil {
+			return errors.Capture(err)
+		}
+	}
+
+	return nil
+}
+
+func (st *State) insertUnitStorageInstances(
+	ctx context.Context, tx *sqlair.TX, storageArgs []domainstorage.CreateUnitStorageInstanceArg,
+) ([]string, error) {
+	storageInstArgs, err := st.makeInsertUnitStorageInstanceArgs(ctx, tx, storageArgs)
+	if err != nil {
+		return nil, errors.Errorf("creating storage instance insert args: %w", err)
+	}
+
+	fsArgs, fsInstanceArgs, fsStatusArgs, err := st.makeInsertUnitFilesystemArgs(ctx, tx, storageArgs)
+	if err != nil {
+		return nil, errors.Errorf("creating filesystem insert args: %w", err)
+	}
+
+	vArgs, vInstanceArgs, vStatusArgs, err := st.makeInsertUnitVolumeArgs(ctx, tx, storageArgs)
+	if err != nil {
+		return nil, errors.Errorf("creating volume insert args: %w", err)
+	}
+
+	insertStorageInstStmt, err := st.Prepare(`
+INSERT INTO storage_instance (*) VALUES ($insertStorageInstance.*)
+`, insertStorageInstance{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	insertStorageFilesystemStmt, err := st.Prepare(`
+INSERT INTO storage_filesystem (*) VALUES ($insertStorageFilesystem.*)
+`, insertStorageFilesystem{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	insertStorageFilesystemInstStmt, err := st.Prepare(`
+INSERT INTO storage_instance_filesystem (*) VALUES ($insertStorageFilesystemInstance.*)
+`, insertStorageFilesystemInstance{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	insertStorageFilesystemStatusStmt, err := st.Prepare(`
+INSERT INTO storage_filesystem_status (*) VALUES ($insertStorageFilesystemStatus.*)
+`, insertStorageFilesystemStatus{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	insertStorageVolumeStmt, err := st.Prepare(`
+INSERT INTO storage_volume (*) VALUES ($insertStorageVolume.*)
+`, insertStorageVolume{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	insertStorageVolumeInstStmt, err := st.Prepare(`
+INSERT INTO storage_instance_volume (*) VALUES ($insertStorageVolumeInstance.*)
+`, insertStorageVolumeInstance{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	insertStorageVolumeStatusStmt, err := st.Prepare(`
+INSERT INTO storage_volume_status (*) VALUES ($insertStorageVolumeStatus.*)
+`, insertStorageVolumeStatus{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	if len(storageInstArgs) != 0 {
+		err = tx.Query(ctx, insertStorageInstStmt, storageInstArgs).Run()
+		if err != nil {
+			return nil, errors.Errorf("creating %d storage instance(s): %w", len(storageInstArgs), err)
+		}
+	}
+
+	if len(fsArgs) != 0 {
+		err = tx.Query(ctx, insertStorageFilesystemStmt, fsArgs).Run()
+		if err != nil {
+			return nil, errors.Errorf("creating %d storage filesystems: %w", len(fsArgs), err)
+		}
+	}
+
+	if len(fsInstanceArgs) != 0 {
+		err = tx.Query(ctx, insertStorageFilesystemInstStmt, fsInstanceArgs).Run()
+		if err != nil {
+			return nil, errors.Errorf("setting storage filesystem instance relationships: %w", err)
+		}
+	}
+
+	if len(fsStatusArgs) != 0 {
+		err = tx.Query(ctx, insertStorageFilesystemStatusStmt, fsStatusArgs).Run()
+		if err != nil {
+			return nil, errors.Errorf("setting storage filesystem status: %w", err)
+		}
+	}
+
+	if len(vArgs) != 0 {
+		err = tx.Query(ctx, insertStorageVolumeStmt, vArgs).Run()
+		if err != nil {
+			return nil, errors.Errorf("creating %d storage volumes: %w", len(vArgs), err)
+		}
+	}
+
+	if len(vInstanceArgs) != 0 {
+		err = tx.Query(ctx, insertStorageVolumeInstStmt, vInstanceArgs).Run()
+		if err != nil {
+			return nil, errors.Errorf("setting storage volume instance relationships: %w", err)
+		}
+	}
+
+	if len(vStatusArgs) != 0 {
+		err = tx.Query(ctx, insertStorageVolumeStatusStmt, vStatusArgs).Run()
+		if err != nil {
+			return nil, errors.Errorf("setting storage volume status: %w", err)
+		}
+	}
+
+	result := make([]string, 0, len(storageInstArgs))
+	for _, inst := range storageInstArgs {
+		result = append(result, inst.StorageID)
+	}
+	return result, nil
+}
+
+func (st *State) insertUnitStorageOwnership(
+	ctx context.Context, tx *sqlair.TX, unitUUID string, storageToOwn []domainstorage.StorageInstanceUUID,
+) error {
+	args := makeInsertUnitStorageOwnerArgs(ctx, unitUUID, storageToOwn)
+	if len(args) == 0 {
+		return nil
+	}
+
+	stmt, err := st.Prepare(`
+INSERT INTO storage_unit_owner (*) VALUES ($insertStorageUnitOwner.*)
+`, insertStorageUnitOwner{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, stmt, args).Run()
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return nil
+}
+
+func (st *State) insertMachineVolumeOwnership(
+	ctx context.Context, tx *sqlair.TX, machineUUID string, volumesToOwn []domainstorage.VolumeUUID,
+) error {
+	args := makeInsertMachineVolumeOwnerArgs(machineUUID, volumesToOwn)
+	if len(args) == 0 {
+		return nil
+	}
+
+	stmt, err := st.Prepare(`
+INSERT INTO machine_volume (*) VALUES ($insertVolumeMachineOwner.*)
+`, insertVolumeMachineOwner{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, stmt, args).Run()
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return nil
+}
+
+func (st *State) insertMachineFilesystemOwnership(
+	ctx context.Context, tx *sqlair.TX, machineUUID string, filesystemsToOwn []domainstorage.FilesystemUUID,
+) error {
+	args := makeInsertMachineFilesystemOwnerArgs(machineUUID, filesystemsToOwn)
+	if len(args) == 0 {
+		return nil
+	}
+
+	stmt, err := st.Prepare(`
+INSERT INTO machine_filesystem (*) VALUES ($insertFilesystemMachineOwner.*)
+`, insertFilesystemMachineOwner{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, stmt, args).Run()
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return nil
+}
+
+func (st *State) makeInsertUnitFilesystemArgs(
+	ctx context.Context, tx *sqlair.TX, args []domainstorage.CreateUnitStorageInstanceArg,
+) (
+	[]insertStorageFilesystem,
+	[]insertStorageFilesystemInstance,
+	[]insertStorageFilesystemStatus,
+	error,
+) {
+	argIndexes := make([]int, 0, len(args))
+	for i, arg := range args {
+		if arg.Filesystem == nil {
+			continue
+		}
+		argIndexes = append(argIndexes, i)
+	}
+	if len(argIndexes) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	fsIDs, err := sequencestate.NextNValues(
+		ctx, st, tx, uint64(len(argIndexes)),
+		domainstorage.FilesystemSequenceNamespace,
+	)
+	if err != nil {
+		return nil, nil, nil, errors.Errorf(
+			"generating %d new filesystem ids: %w", len(argIndexes), err,
+		)
+	}
+
+	fsStatus, err := status.EncodeStorageFilesystemStatus(status.StorageFilesystemStatusTypePending)
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("encoding filesystem status pending: %w", err)
+	}
+
+	fsRows := make([]insertStorageFilesystem, 0, len(argIndexes))
+	fsInstanceRows := make([]insertStorageFilesystemInstance, 0, len(argIndexes))
+	fsStatusRows := make([]insertStorageFilesystemStatus, 0, len(argIndexes))
+	statusTime := time.Now().UTC()
+	for i, argIndex := range argIndexes {
+		instArg := args[argIndex]
+		fsRows = append(fsRows, insertStorageFilesystem{
+			FilesystemID:     fmt.Sprintf("%d", fsIDs[i]),
+			LifeID:           0, // Alive.
+			UUID:             instArg.Filesystem.UUID.String(),
+			ProvisionScopeID: int(instArg.Filesystem.ProvisionScope),
+		})
+		fsInstanceRows = append(fsInstanceRows, insertStorageFilesystemInstance{
+			StorageInstanceUUID:   instArg.UUID.String(),
+			StorageFilesystemUUID: instArg.Filesystem.UUID.String(),
+		})
+		fsStatusRows = append(fsStatusRows, insertStorageFilesystemStatus{
+			FilesystemUUID: instArg.Filesystem.UUID.String(),
+			StatusID:       fsStatus,
+			UpdateAt:       statusTime,
+		})
+	}
+
+	return fsRows, fsInstanceRows, fsStatusRows, nil
+}
+
+func (st *State) makeInsertUnitFilesystemAttachmentArgs(
+	args []domainstorage.CreateUnitStorageAttachmentArg,
+) []insertStorageFilesystemAttachment {
+	var result []insertStorageFilesystemAttachment
+	for _, arg := range args {
+		if arg.FilesystemAttachment == nil {
+			continue
+		}
+
+		result = append(result, insertStorageFilesystemAttachment{
+			LifeID:                0, // Alive.
+			NetNodeUUID:           arg.FilesystemAttachment.NetNodeUUID.String(),
+			ProvisionScopeID:      int(arg.FilesystemAttachment.ProvisionScope),
+			StorageFilesystemUUID: arg.FilesystemAttachment.FilesystemUUID.String(),
+			UUID:                  arg.FilesystemAttachment.UUID.String(),
+		})
+	}
+
+	return result
+}
+
+func (st *State) makeInsertUnitStorageInstanceArgs(
+	ctx context.Context, tx *sqlair.TX, args []domainstorage.CreateUnitStorageInstanceArg,
+) ([]insertStorageInstance, error) {
+	result := make([]insertStorageInstance, 0, len(args))
+
+	for _, arg := range args {
+		id, err := sequencestate.NextValue(ctx, st, tx, domainstorage.StorageInstanceSequenceNamespace)
+		if err != nil {
+			return nil, errors.Errorf("creating unique storage instance id: %w", err)
+		}
+		storageID := corestorage.MakeID(corestorage.Name(arg.Name), id).String()
+
+		result = append(result, insertStorageInstance{
+			CharmName:       arg.CharmName,
+			LifeID:          0, // Alive.
+			RequestSizeMiB:  arg.RequestSizeMiB,
+			StorageID:       storageID,
+			StorageKindID:   int(arg.Kind),
+			StorageName:     arg.Name.String(),
+			StoragePoolUUID: arg.StoragePoolUUID.String(),
+			UUID:            arg.UUID.String(),
+		})
+	}
+
+	return result, nil
+}
+
+func (st *State) makeInsertUnitVolumeArgs(
+	ctx context.Context, tx *sqlair.TX, args []domainstorage.CreateUnitStorageInstanceArg,
+) (
+	[]insertStorageVolume,
+	[]insertStorageVolumeInstance,
+	[]insertStorageVolumeStatus,
+	error,
+) {
+	argIndexes := make([]int, 0, len(args))
+	for i, arg := range args {
+		if arg.Volume == nil {
+			continue
+		}
+		argIndexes = append(argIndexes, i)
+	}
+	if len(argIndexes) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	volumeIDs, err := sequencestate.NextNValues(
+		ctx, st, tx, uint64(len(argIndexes)),
+		domainstorage.VolumeSequenceNamespace,
+	)
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("generating %d new volume ids: %w", len(argIndexes), err)
+	}
+
+	volumeStatus, err := status.EncodeStorageVolumeStatus(status.StorageVolumeStatusTypePending)
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("encoding volume status pending: %w", err)
+	}
+
+	volumeRows := make([]insertStorageVolume, 0, len(argIndexes))
+	volumeInstanceRows := make([]insertStorageVolumeInstance, 0, len(argIndexes))
+	volumeStatusRows := make([]insertStorageVolumeStatus, 0, len(argIndexes))
+	statusTime := time.Now().UTC()
+	for i, argIndex := range argIndexes {
+		instArg := args[argIndex]
+		volumeRows = append(volumeRows, insertStorageVolume{
+			VolumeID:         fmt.Sprintf("%d", volumeIDs[i]),
+			LifeID:           0, // Alive.
+			UUID:             instArg.Volume.UUID.String(),
+			ProvisionScopeID: int(instArg.Volume.ProvisionScope),
+		})
+		volumeInstanceRows = append(volumeInstanceRows, insertStorageVolumeInstance{
+			StorageInstanceUUID: instArg.UUID.String(),
+			StorageVolumeUUID:   instArg.Volume.UUID.String(),
+		})
+		volumeStatusRows = append(volumeStatusRows, insertStorageVolumeStatus{
+			VolumeUUID: instArg.Volume.UUID.String(),
+			StatusID:   volumeStatus,
+			UpdateAt:   statusTime,
+		})
+	}
+
+	return volumeRows, volumeInstanceRows, volumeStatusRows, nil
+}
+
+func (st *State) makeInsertUnitVolumeAttachmentArgs(
+	args []domainstorage.CreateUnitStorageAttachmentArg,
+) []insertStorageVolumeAttachment {
+	var result []insertStorageVolumeAttachment
+	for _, arg := range args {
+		if arg.VolumeAttachment == nil {
+			continue
+		}
+
+		result = append(result, insertStorageVolumeAttachment{
+			LifeID:            0, // Alive.
+			NetNodeUUID:       arg.VolumeAttachment.NetNodeUUID.String(),
+			ProvisionScopeID:  int(arg.VolumeAttachment.ProvisionScope),
+			StorageVolumeUUID: arg.VolumeAttachment.VolumeUUID.String(),
+			UUID:              arg.VolumeAttachment.UUID.String(),
+		})
+	}
+
+	return result
+}
+
+func makeInsertUnitStorageAttachmentArgs(
+	unitUUID string, storageToAttach []domainstorage.CreateUnitStorageAttachmentArg,
+) []insertStorageInstanceAttachment {
+	return transform.Slice(storageToAttach,
+		func(sa domainstorage.CreateUnitStorageAttachmentArg) insertStorageInstanceAttachment {
+			return insertStorageInstanceAttachment{
+				LifeID:              0, // Alive.
+				StorageInstanceUUID: sa.StorageInstanceUUID.String(),
+				UnitUUID:            unitUUID,
+				UUID:                sa.UUID.String(),
+			}
+		})
+}
+
+func makeInsertUnitStorageOwnerArgs(
+	_ context.Context, unitUUID string, storageToOwn []domainstorage.StorageInstanceUUID,
+) []insertStorageUnitOwner {
+	return transform.Slice(storageToOwn, func(instUUID domainstorage.StorageInstanceUUID) insertStorageUnitOwner {
+		return insertStorageUnitOwner{
+			StorageInstanceUUID: instUUID.String(),
+			UnitUUID:            unitUUID,
+		}
+	})
+}
+
+func makeInsertMachineVolumeOwnerArgs(
+	machineUUID string, volumesToOwn []domainstorage.VolumeUUID,
+) []insertVolumeMachineOwner {
+	return transform.Slice(volumesToOwn, func(uuid domainstorage.VolumeUUID) insertVolumeMachineOwner {
+		return insertVolumeMachineOwner{
+			MachineUUID: machineUUID,
+			VolumeUUID:  uuid.String(),
+		}
+	})
+}
+
+func makeInsertMachineFilesystemOwnerArgs(
+	machineUUID string, filesystemsToOwn []domainstorage.FilesystemUUID,
+) []insertFilesystemMachineOwner {
+	return transform.Slice(filesystemsToOwn, func(uuid domainstorage.FilesystemUUID) insertFilesystemMachineOwner {
+		return insertFilesystemMachineOwner{
+			MachineUUID:    machineUUID,
+			FilesystemUUID: uuid.String(),
+		}
+	})
+}

--- a/domain/unitstate/state/addstorage.go
+++ b/domain/unitstate/state/addstorage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/domain/status"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
-	domainstorageprovisioning "github.com/juju/juju/domain/storageprovisioning"
 	"github.com/juju/juju/domain/unitstate/internal"
 	"github.com/juju/juju/internal/errors"
 )
@@ -192,42 +191,6 @@ AND    si.storage_name = $storageCount.storage_name
 		return 0, errors.Capture(err)
 	}
 	return result.Count, nil
-}
-
-func machineStorageOwnership(
-	storageInst []domainstorage.CreateUnitStorageInstanceArg,
-) ([]domainstorage.FilesystemUUID, []domainstorage.VolumeUUID, error) {
-	var filesystemsToOwn []domainstorage.FilesystemUUID
-	var volumesToOwn []domainstorage.VolumeUUID
-
-	for _, inst := range storageInst {
-		var comp domainstorageprovisioning.StorageInstanceComposition
-		if inst.Filesystem != nil {
-			comp.FilesystemRequired = true
-			comp.FilesystemProvisionScope = inst.Filesystem.ProvisionScope
-		}
-		if inst.Volume != nil {
-			comp.VolumeRequired = true
-			comp.VolumeProvisionScope = inst.Volume.ProvisionScope
-		}
-
-		scope, err := domainstorageprovisioning.CalculateStorageInstanceOwnershipScope(comp)
-		if err != nil {
-			return nil, nil, errors.Capture(err)
-		}
-		if scope != domainstorageprovisioning.OwnershipScopeMachine {
-			continue
-		}
-
-		if inst.Filesystem != nil {
-			filesystemsToOwn = append(filesystemsToOwn, inst.Filesystem.UUID)
-		}
-		if inst.Volume != nil {
-			volumesToOwn = append(volumesToOwn, inst.Volume.UUID)
-		}
-	}
-
-	return filesystemsToOwn, volumesToOwn, nil
 }
 
 func (st *State) insertUnitStorageAttachments(

--- a/domain/unitstate/state/commithook.go
+++ b/domain/unitstate/state/commithook.go
@@ -33,7 +33,7 @@ func (st *State) CommitHookChanges(ctx context.Context, arg internal.CommitHookC
 			return errors.Errorf("checking unit alive: %w", err)
 		}
 		if unitLife != int(arg.UnitLife) {
-			return unitstateerrors.UnitLifePredicateFailed
+			return unitstateerrors.UnitLifePreconditionFailed
 		}
 
 		if err := st.checkRelationsExist(ctx, tx, arg.RelationSettings); err != nil {

--- a/domain/unitstate/state/commithook.go
+++ b/domain/unitstate/state/commithook.go
@@ -9,10 +9,11 @@ import (
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
 
-	coreunit "github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/life"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
 	"github.com/juju/juju/domain/unitstate"
+	unitstateerrors "github.com/juju/juju/domain/unitstate/errors"
 	"github.com/juju/juju/domain/unitstate/internal"
 	"github.com/juju/juju/internal/errors"
 )
@@ -24,14 +25,19 @@ func (st *State) CommitHookChanges(ctx context.Context, arg internal.CommitHookC
 	if err != nil {
 		return errors.Capture(err)
 	}
-	unitUUID := arg.UnitUUID.String()
+	unitUUID := arg.UnitUUID
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		// TODO (hml) 2-Apr-2026
-		// For every UUID added to arg, add check that it exists in the model.
-		// Remove todo when this method is complete.
-		if err := st.ensureCommitHookChangesUUIDs(ctx, tx, arg); err != nil {
-			return errors.Errorf("unit data has changed since beginning:%w", err)
+		unitLife, err := st.getUnitLife(ctx, tx, arg.UnitUUID)
+		if err != nil {
+			return errors.Errorf("checking unit alive: %w", err)
+		}
+		if unitLife != int(arg.UnitLife) {
+			return unitstateerrors.UnitLifePredicateFailed
+		}
+
+		if err := st.checkRelationsExist(ctx, tx, arg.RelationSettings); err != nil {
+			return errors.Errorf("relations: %w", err)
 		}
 
 		if err := st.updateNetworkInfo(ctx, tx, arg.UpdateNetworkInfo); err != nil {
@@ -74,8 +80,10 @@ func (st *State) CommitHookChanges(ctx context.Context, arg internal.CommitHookC
 			return errors.Errorf("track latest secrets:%w", err)
 		}
 
-		// TODO: (hml) 10-Dec-2025
-		// Implement storage
+		if err := st.addStorage(ctx, tx, arg); err != nil {
+			return errors.Errorf("add storage:%w", err)
+		}
+
 		return nil
 	})
 }
@@ -129,64 +137,79 @@ func (st *State) trackSecrets(ctx context.Context, tx *sqlair.TX, secrets []stri
 	return nil
 }
 
-// GetUnitUUIDByName returns the UUID for the named unit, returning an
-// error satisfying [applicationerrors.UnitNotFound] if the unit doesn't
-// exist.
-func (st *State) GetUnitUUIDByName(ctx context.Context, name coreunit.Name) (coreunit.UUID, error) {
+// GetCommitHookUnitInfo returns the unit UUID and machine UUID if assigned,
+// returning an error satisfying
+//
+// The following errors can be expected:
+// - [applicationerrors.UnitNotFound] if the unit doesn't exist.
+func (st *State) GetCommitHookUnitInfo(ctx context.Context, name string) (internal.CommitHookUnitInfo, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return "", errors.Capture(err)
+		return internal.CommitHookUnitInfo{}, errors.Capture(err)
 	}
 
-	var result entityUUID
+	unitNameArg := unitName{Name: name}
+
+	stmt, err := st.Prepare(`
+SELECT u.uuid AS &commitHookUnitInfo.unit_uuid,
+       u.life_id AS &commitHookUnitInfo.unit_life_id,
+       m.uuid AS &commitHookUnitInfo.machine_uuid
+FROM   unit u
+LEFT JOIN machine m ON m.net_node_uuid = u.net_node_uuid
+WHERE  u.name = $unitName.name
+`, unitNameArg, commitHookUnitInfo{})
+	if err != nil {
+		return internal.CommitHookUnitInfo{}, errors.Capture(err)
+	}
+
+	var result commitHookUnitInfo
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		result, err = st.getUnitUUIDForName(ctx, tx, string(name))
-		return err
+		err := tx.Query(ctx, stmt, unitNameArg).Get(&result)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return applicationerrors.UnitNotFound
+		}
+		return errors.Capture(err)
 	})
-
 	if err != nil {
-		return "", errors.Capture(err)
+		return internal.CommitHookUnitInfo{}, errors.Capture(err)
 	}
 
-	return coreunit.UUID(result.UUID), nil
+	retVal := internal.CommitHookUnitInfo{
+		UnitUUID: result.UnitUUID,
+		UnitLife: life.Life(result.UnitLife),
+	}
+	if result.MachineUUID.Valid {
+		retVal.MachineUUID = &result.MachineUUID.String
+	}
+
+	return retVal, nil
 }
 
-// ensureCommitHookChangesUUIDs verifies that all UUIDs in arg still exist.
-// Do not check life, as hooks still run when various entities are dying,
-// e.g. relations.
-func (st *State) ensureCommitHookChangesUUIDs(ctx context.Context, tx *sqlair.TX, arg internal.CommitHookChangesArg) error {
-	if err := st.checkUnitExists(ctx, tx, arg.UnitUUID.String()); err != nil {
-		return err
-	}
+func (st *State) getUnitLife(
+	ctx context.Context,
+	tx *sqlair.TX,
+	unitUUID string,
+) (int, error) {
+	arg := entityUUID{UUID: unitUUID}
 
-	if err := st.checkRelationsExist(ctx, tx, arg.RelationSettings); err != nil {
-		return errors.Errorf("relations: %w", err)
-	}
-	return nil
-}
-
-// checkUnitExists checks if a unit with the given UUID exists in the model.
-func (st *State) checkUnitExists(
-	ctx context.Context, tx *sqlair.TX, uuid string,
-) error {
-
-	entityUUIDInput := entityUUID{UUID: uuid}
-	stmt, err := st.Prepare(
-		"SELECT &entityUUID.* FROM unit WHERE  uuid = $entityUUID.uuid",
-		entityUUIDInput,
-	)
+	stmt, err := st.Prepare(`
+SELECT &entityLife.*
+FROM   unit
+WHERE  uuid = $entityUUID.uuid
+`, arg, entityLife{})
 	if err != nil {
-		return errors.Capture(err)
+		return 0, errors.Capture(err)
 	}
 
-	err = tx.Query(ctx, stmt, entityUUIDInput).Get(&entityUUIDInput)
+	var result entityLife
+	err = tx.Query(ctx, stmt, arg).Get(&result)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return applicationerrors.UnitNotFound
+		return 0, applicationerrors.UnitNotFound
 	} else if err != nil {
-		return errors.Capture(err)
+		return 0, errors.Capture(err)
 	}
 
-	return nil
+	return result.Life, nil
 }
 
 // checkRelationsExist checks if all relations in settings exist in the model.
@@ -200,7 +223,7 @@ func (st *State) checkRelationsExist(ctx context.Context, tx *sqlair.TX, setting
 
 	stmt, err := st.Prepare(`
 SELECT COUNT(*) AS &countResult.count
-FROM   relation 
+FROM   relation
 WHERE  uuid IN ($uuids[:])
 `, countResult{}, uuids{})
 	if err != nil {
@@ -213,8 +236,10 @@ WHERE  uuid IN ($uuids[:])
 		return errors.Capture(err)
 	}
 	if result.Count != len(relationUUIDs) {
-		return errors.Errorf("expected %d, found %d", len(relationUUIDs),
-			result.Count).Add(relationerrors.RelationNotFound)
+		return errors.Errorf(
+			"expected %d relations but found %d",
+			len(relationUUIDs), result.Count,
+		).Add(relationerrors.RelationNotFound)
 	}
 	return nil
 }

--- a/domain/unitstate/state/commithook_test.go
+++ b/domain/unitstate/state/commithook_test.go
@@ -17,10 +17,13 @@ import (
 	coreunittesting "github.com/juju/juju/core/unit/testing"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/deployment/charm"
+	domainnetwork "github.com/juju/juju/domain/network"
 	domainrelation "github.com/juju/juju/domain/relation"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
+	domainstorage "github.com/juju/juju/domain/storage"
+	storageerrors "github.com/juju/juju/domain/storage/errors"
+	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/domain/unitstate/internal"
-	"github.com/juju/juju/internal/uuid"
 )
 
 type commitHookSuite struct {
@@ -34,7 +37,7 @@ func TestCommitHookSuite(t *testing.T) {
 func (s *commitHookSuite) TestCommitHookChanges(c *tc.C) {
 	// Arrange
 	arg := internal.CommitHookChangesArg{
-		UnitUUID:           coreunit.UUID(s.unitUUID),
+		UnitUUID:           s.unitUUID,
 		UpdateNetworkInfo:  true,
 		RelationSettings:   nil,
 		OpenPorts:          nil,
@@ -143,7 +146,7 @@ func (s *commitHookSuite) TestCommitHookRelationSettings(c *tc.C) {
 		"key3": "value3",
 	}
 	arg := internal.CommitHookChangesArg{
-		UnitUUID: unitUUID,
+		UnitUUID: unitUUID.String(),
 		RelationSettings: []internal.RelationSettings{{
 			RelationUUID:   relationUUID,
 			ApplicationSet: appSettings,
@@ -163,42 +166,399 @@ func (s *commitHookSuite) TestCommitHookRelationSettings(c *tc.C) {
 	c.Check(foundUnitSettings, tc.DeepEquals, unitSettings)
 }
 
-func (s *commitHookSuite) TestGetUnitUUIDByName(c *tc.C) {
-	// Arrange
-	spaceUUID := s.addSpace(c)
+func (s *commitHookSuite) TestCommitHookAddStorage(c *tc.C) {
+	poolUUID := s.addStoragePool(c, "test-pool", "lxd")
+	unitUUID := s.unitUUID
+	netNodeUUID := s.getUnitNetNodeUUID(c, s.unitUUID)
+	machineUUID := s.getUnitMachineUUID(c, s.unitUUID)
 
-	charmUUID := s.addCharm(c)
-	appUUID := s.addApplication(c, charmUUID, "testname", spaceUUID)
-	unitName := coreunit.Name("testname/0")
-	expectedUUID := s.addUnit(c, unitName, appUUID, charmUUID)
+	storageInstanceUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	volumeUUID := tc.Must(c, domainstorage.NewVolumeUUID)
+	storageAttachmentUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
+	volumeAttachmentUUID := tc.Must(c, domainstorage.NewVolumeAttachmentUUID)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID:    unitUUID,
+		MachineUUID: &machineUUID,
+		AddStorage: []unitstate.PreparedStorageAdd{{
+			StorageName: "data",
+			Storage: domainstorage.IAASUnitAddStorageArg{
+				UnitAddStorageArg: domainstorage.UnitAddStorageArg{
+					StorageInstances: []domainstorage.CreateUnitStorageInstanceArg{{
+						UUID:            storageInstanceUUID,
+						CharmName:       "app",
+						Kind:            domainstorage.StorageKindBlock,
+						Name:            "data",
+						RequestSizeMiB:  1024,
+						StoragePoolUUID: poolUUID,
+						Volume: &domainstorage.CreateUnitStorageVolumeArg{
+							UUID:           volumeUUID,
+							ProvisionScope: domainstorage.ProvisionScopeMachine,
+						},
+					}},
+					StorageToAttach: []domainstorage.CreateUnitStorageAttachmentArg{{
+						UUID:                storageAttachmentUUID,
+						StorageInstanceUUID: storageInstanceUUID,
+						VolumeAttachment: &domainstorage.CreateUnitStorageVolumeAttachmentArg{
+							UUID:           volumeAttachmentUUID,
+							NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
+							ProvisionScope: domainstorage.ProvisionScopeMachine,
+							VolumeUUID:     volumeUUID,
+						},
+					}},
+					StorageToOwn:       []domainstorage.StorageInstanceUUID{storageInstanceUUID},
+					CountLessThanEqual: 0,
+				},
+				VolumesToOwn: []domainstorage.VolumeUUID{
+					volumeUUID,
+				},
+			},
+		}},
+	}
+
+	err := s.state.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM storage_instance WHERE uuid = ?", storageInstanceUUID.String()),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c, "SELECT count(*) FROM storage_attachment WHERE storage_instance_uuid = ? AND unit_uuid = ?",
+			storageInstanceUUID.String(),
+			s.unitUUID,
+		),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c, "SELECT count(*) FROM storage_unit_owner WHERE storage_instance_uuid = ? AND unit_uuid = ?",
+			storageInstanceUUID.String(),
+			s.unitUUID,
+		),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM storage_volume WHERE uuid = ?", volumeUUID.String()),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c, "SELECT count(*) FROM machine_volume WHERE machine_uuid = ? AND volume_uuid = ?",
+			machineUUID,
+			volumeUUID.String(),
+		),
+		tc.Equals,
+		1,
+	)
+}
+
+func (s *commitHookSuite) TestCommitHookAddStorageVolumeBackedFilesystem(c *tc.C) {
+	poolUUID := s.addStoragePool(c, "test-pool", "lxd")
+	unitUUID := s.unitUUID
+	netNodeUUID := s.getUnitNetNodeUUID(c, s.unitUUID)
+	machineUUID := s.getUnitMachineUUID(c, s.unitUUID)
+
+	storageInstanceUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	volumeUUID := tc.Must(c, domainstorage.NewVolumeUUID)
+	filesystemUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
+	storageAttachmentUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
+	volumeAttachmentUUID := tc.Must(c, domainstorage.NewVolumeAttachmentUUID)
+	fsAttachmentUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID:    unitUUID,
+		MachineUUID: &machineUUID,
+		AddStorage: []unitstate.PreparedStorageAdd{{
+			StorageName: "data",
+			Storage: domainstorage.IAASUnitAddStorageArg{
+				UnitAddStorageArg: domainstorage.UnitAddStorageArg{
+					StorageInstances: []domainstorage.CreateUnitStorageInstanceArg{{
+						UUID:            storageInstanceUUID,
+						CharmName:       "app",
+						Kind:            domainstorage.StorageKindFilesystem,
+						Name:            "data",
+						RequestSizeMiB:  1024,
+						StoragePoolUUID: poolUUID,
+						Volume: &domainstorage.CreateUnitStorageVolumeArg{
+							UUID:           volumeUUID,
+							ProvisionScope: domainstorage.ProvisionScopeMachine,
+						},
+						Filesystem: &domainstorage.CreateUnitStorageFilesystemArg{
+							UUID:           filesystemUUID,
+							ProvisionScope: domainstorage.ProvisionScopeMachine,
+						},
+					}},
+					StorageToAttach: []domainstorage.CreateUnitStorageAttachmentArg{{
+						UUID:                storageAttachmentUUID,
+						StorageInstanceUUID: storageInstanceUUID,
+						VolumeAttachment: &domainstorage.CreateUnitStorageVolumeAttachmentArg{
+							UUID:           volumeAttachmentUUID,
+							NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
+							ProvisionScope: domainstorage.ProvisionScopeMachine,
+							VolumeUUID:     volumeUUID,
+						},
+						FilesystemAttachment: &domainstorage.CreateUnitStorageFilesystemAttachmentArg{
+							UUID:           fsAttachmentUUID,
+							NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
+							ProvisionScope: domainstorage.ProvisionScopeMachine,
+							FilesystemUUID: filesystemUUID,
+						},
+					}},
+					StorageToOwn:       []domainstorage.StorageInstanceUUID{storageInstanceUUID},
+					CountLessThanEqual: 0,
+				},
+				VolumesToOwn: []domainstorage.VolumeUUID{
+					volumeUUID,
+				},
+				FilesystemsToOwn: []domainstorage.FilesystemUUID{
+					filesystemUUID,
+				},
+			},
+		}},
+	}
+
+	err := s.state.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM storage_instance WHERE uuid = ?", storageInstanceUUID.String()),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c, "SELECT count(*) FROM storage_attachment WHERE storage_instance_uuid = ? AND unit_uuid = ?",
+			storageInstanceUUID.String(),
+			s.unitUUID,
+		),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c, "SELECT count(*) FROM storage_unit_owner WHERE storage_instance_uuid = ? AND unit_uuid = ?",
+			storageInstanceUUID.String(),
+			s.unitUUID,
+		),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM storage_volume WHERE uuid = ?", volumeUUID.String()),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c, "SELECT count(*) FROM machine_volume WHERE machine_uuid = ? AND volume_uuid = ?",
+			machineUUID,
+			volumeUUID.String(),
+		),
+		tc.Equals,
+		1,
+	)
+}
+
+func (s *commitHookSuite) TestCommitHookAddStorageWithoutMachineOwnership(c *tc.C) {
+	poolUUID := s.addStoragePool(c, "test-pool", "lxd")
+	unitName := coreunittesting.GenNewName(c, "app/8")
+	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	netNodeUUID := s.getUnitNetNodeUUID(c, unitUUID.String())
+
+	storageInstanceUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	filesystemUUID := tc.Must(c, domainstorage.NewFilesystemUUID)
+	storageAttachmentUUID := tc.Must(c, domainstorage.NewStorageAttachmentUUID)
+	filesystemAttachmentUUID := tc.Must(c, domainstorage.NewFilesystemAttachmentUUID)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: unitUUID.String(),
+		AddStorage: []unitstate.PreparedStorageAdd{{
+			StorageName: "data",
+			Storage: domainstorage.IAASUnitAddStorageArg{
+				UnitAddStorageArg: domainstorage.UnitAddStorageArg{
+					StorageInstances: []domainstorage.CreateUnitStorageInstanceArg{{
+						UUID:            storageInstanceUUID,
+						CharmName:       "app",
+						Kind:            domainstorage.StorageKindFilesystem,
+						Name:            "data",
+						RequestSizeMiB:  1024,
+						StoragePoolUUID: poolUUID,
+						Filesystem: &domainstorage.CreateUnitStorageFilesystemArg{
+							UUID:           filesystemUUID,
+							ProvisionScope: domainstorage.ProvisionScopeModel,
+						},
+					}},
+					StorageToAttach: []domainstorage.CreateUnitStorageAttachmentArg{{
+						UUID:                storageAttachmentUUID,
+						StorageInstanceUUID: storageInstanceUUID,
+						FilesystemAttachment: &domainstorage.CreateUnitStorageFilesystemAttachmentArg{
+							UUID:           filesystemAttachmentUUID,
+							NetNodeUUID:    domainnetwork.NetNodeUUID(netNodeUUID),
+							ProvisionScope: domainstorage.ProvisionScopeModel,
+							FilesystemUUID: filesystemUUID,
+						},
+					}},
+					StorageToOwn:       []domainstorage.StorageInstanceUUID{storageInstanceUUID},
+					CountLessThanEqual: 0,
+				},
+			},
+		}},
+	}
+
+	err := s.state.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM storage_instance WHERE uuid = ?", storageInstanceUUID.String()),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM storage_filesystem WHERE uuid = ?", filesystemUUID.String()),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c, "SELECT count(*) FROM storage_attachment WHERE storage_instance_uuid = ? AND unit_uuid = ?",
+			storageInstanceUUID.String(),
+			unitUUID.String(),
+		),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c,
+			"SELECT count(*) FROM storage_filesystem_attachment WHERE storage_filesystem_uuid = ? AND net_node_uuid = ?",
+			filesystemUUID.String(),
+			netNodeUUID,
+		),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(
+			c, "SELECT count(*) FROM storage_unit_owner WHERE storage_instance_uuid = ? AND unit_uuid = ?",
+			storageInstanceUUID.String(),
+			unitUUID.String(),
+		),
+		tc.Equals,
+		1,
+	)
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM machine_filesystem WHERE filesystem_uuid = ?", filesystemUUID.String()),
+		tc.Equals,
+		0,
+	)
+}
+
+func (s *commitHookSuite) TestCommitHookAddStorageCountPreconditionFailed(c *tc.C) {
+	poolUUID := s.addStoragePool(c, "test-pool", "lxd")
+	existingStorageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	s.query(c, `
+INSERT INTO storage_instance
+    (uuid, charm_name, storage_name, storage_kind_id, storage_id, life_id,
+     storage_pool_uuid, requested_size_mib)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`, existingStorageUUID.String(), "app", "data",
+		int(domainstorage.StorageKindBlock), "data/0", 0,
+		poolUUID.String(), 1024)
+	s.query(c, `
+INSERT INTO storage_unit_owner (storage_instance_uuid, unit_uuid)
+VALUES (?, ?)
+`, existingStorageUUID.String(), s.unitUUID)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		AddStorage: []unitstate.PreparedStorageAdd{{
+			StorageName: "data",
+			Storage: domainstorage.IAASUnitAddStorageArg{
+				UnitAddStorageArg: domainstorage.UnitAddStorageArg{
+					CountLessThanEqual: 0,
+				},
+			},
+		}},
+	}
+
+	err := s.state.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIs, storageerrors.MaxStorageCountPreconditionFailed)
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM storage_instance WHERE storage_name = ?", "data"), tc.Equals, 1)
+}
+
+func (s *commitHookSuite) TestCommitHookAddStorageRollsBackEarlierChanges(c *tc.C) {
+	poolUUID := s.addStoragePool(c, "test-pool", "lxd")
+	existingStorageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+
+	s.query(c, `
+INSERT INTO storage_instance
+    (uuid, charm_name, storage_name, storage_kind_id, storage_id, life_id,
+     storage_pool_uuid, requested_size_mib)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`, existingStorageUUID.String(), "app", "data",
+		int(domainstorage.StorageKindBlock), "data/0", 0,
+		poolUUID.String(), 1024)
+	s.query(c, `
+INSERT INTO storage_unit_owner (storage_instance_uuid, unit_uuid)
+VALUES (?, ?)
+`, existingStorageUUID.String(), s.unitUUID)
+
+	charmState := map[string]string{"foo": "bar"}
+	arg := internal.CommitHookChangesArg{
+		UnitUUID:   s.unitUUID,
+		CharmState: &charmState,
+		AddStorage: []unitstate.PreparedStorageAdd{{
+			StorageName: "data",
+			Storage: domainstorage.IAASUnitAddStorageArg{
+				UnitAddStorageArg: domainstorage.UnitAddStorageArg{
+					CountLessThanEqual: 0,
+				},
+			},
+		}},
+	}
+
+	err := s.state.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIs, storageerrors.MaxStorageCountPreconditionFailed)
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM unit_state_charm WHERE unit_uuid = ? AND key = ?", s.unitUUID, "foo"),
+		tc.Equals,
+		0,
+	)
+	c.Check(
+		s.countRows(c, "SELECT count(*) FROM storage_instance WHERE storage_name = ?", "data"),
+		tc.Equals,
+		1,
+	)
+}
+
+func (s *commitHookSuite) TestGetCommitHookUnitInfo(c *tc.C) {
+	unitName := s.unitName
+	expectedUUID := s.unitUUID
+	expectedMachineUUID := s.getUnitMachineUUID(c, s.unitUUID)
 
 	// Act
-	unitUUID, err := s.state.GetUnitUUIDByName(c.Context(), unitName)
+	unitInfo, err := s.state.GetCommitHookUnitInfo(c.Context(), unitName)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(unitUUID, tc.Equals, expectedUUID)
+	c.Check(unitInfo.UnitUUID, tc.Equals, expectedUUID)
+	c.Check(unitInfo.MachineUUID, tc.Deref(tc.Equals), expectedMachineUUID)
 }
 
-func (s *commitHookSuite) TestGetUnitUUIDByNameNotFound(c *tc.C) {
-	_, err := s.state.GetUnitUUIDByName(c.Context(), "foo")
+func (s *commitHookSuite) TestGetCommitHookUnitInfoNotFound(c *tc.C) {
+	_, err := s.state.GetCommitHookUnitInfo(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *commitHookSuite) TestEnsureCommitHookChangesUUIDsUnitNotFound(c *tc.C) {
-	// Arrange
-	arg := internal.CommitHookChangesArg{}
-
-	// Act
-	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return s.state.ensureCommitHookChangesUUIDs(ctx, tx, arg)
-	})
-
-	// Assert
-	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
-}
-
-func (s *commitHookSuite) TestEnsureCommitHookChangesRelationsNotFound(c *tc.C) {
+func (s *commitHookSuite) TestEnsureCheckRelationExistsNotFound(c *tc.C) {
 	// Arrange: add a unit
 	charmUUID := s.addCharm(c)
 	appUUID := s.addApplication(c, charmUUID, "testname", network.AlphaSpaceId.String())
@@ -207,7 +567,7 @@ func (s *commitHookSuite) TestEnsureCommitHookChangesRelationsNotFound(c *tc.C) 
 
 	// Arrange: setup the method input with a non-existent relation uuid
 	arg := internal.CommitHookChangesArg{
-		UnitUUID: unitUUID,
+		UnitUUID: unitUUID.String(),
 		RelationSettings: []internal.RelationSettings{{
 			RelationUUID: tc.Must(c, corerelation.NewUUID),
 		}},
@@ -215,16 +575,55 @@ func (s *commitHookSuite) TestEnsureCommitHookChangesRelationsNotFound(c *tc.C) 
 
 	// Act
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return s.state.ensureCommitHookChangesUUIDs(ctx, tx, arg)
+		return s.state.checkRelationsExist(ctx, tx, arg.RelationSettings)
 	})
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
-func (s *commitHookSuite) addSpace(c *tc.C) string {
-	spaceUUID := uuid.MustNewUUID().String()
-	s.query(c, `INSERT INTO space (uuid, name) VALUES (?, ?)`,
-		spaceUUID, spaceUUID)
-	return spaceUUID
+func (s *commitHookSuite) addStoragePool(
+	c *tc.C,
+	name, providerType string,
+) domainstorage.StoragePoolUUID {
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	s.query(c, `INSERT INTO storage_pool (uuid, name, type) VALUES (?, ?, ?)`,
+		poolUUID.String(), name, providerType)
+	return poolUUID
+}
+
+func (s *commitHookSuite) getUnitNetNodeUUID(c *tc.C, unitUUID string) string {
+	var netNodeUUID string
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(
+			ctx,
+			"SELECT net_node_uuid FROM unit WHERE uuid = ?",
+			unitUUID,
+		).Scan(&netNodeUUID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return netNodeUUID
+}
+
+func (s *commitHookSuite) getUnitMachineUUID(c *tc.C, unitUUID string) string {
+	var machineUUID string
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+SELECT m.uuid
+FROM unit u
+JOIN machine m ON m.net_node_uuid = u.net_node_uuid
+WHERE u.uuid = ?
+`, unitUUID).Scan(&machineUUID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return machineUUID
+}
+
+func (s *commitHookSuite) countRows(c *tc.C, query string, args ...any) int {
+	var count int
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, query, args...).Scan(&count)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return count
 }

--- a/domain/unitstate/state/types.go
+++ b/domain/unitstate/state/types.go
@@ -4,13 +4,21 @@
 package state
 
 import (
+	"database/sql"
+
 	"github.com/juju/juju/core/network"
 )
 
-// entityUUID identifies a unit.
+// entityUUID identifies an entity.
 type entityUUID struct {
-	// UUID is the universally unique identifier for a unit.
+	// UUID is the universally unique identifier for an entity.
 	UUID string `db:"uuid"`
+}
+
+// entityLife identifies a unit.
+type entityLife struct {
+	// Life is the life of an entity.
+	Life int `db:"life_id"`
 }
 
 type uuids []string
@@ -163,6 +171,17 @@ type unitState struct {
 	StorageState string `db:"storage_state"`
 	// SecretState is the units secret state YAML string.
 	SecretState string `db:"secret_state"`
+}
+
+// commitHookUnitInfo is data needed for a unit that does not change,
+// allowing us to fetch it up front, outside the write transaction.
+type commitHookUnitInfo struct {
+	// UnitUUID identifies a unit
+	UnitUUID string `db:"unit_uuid"`
+	// UnitLife is the life of a unit.
+	UnitLife int `db:"unit_life_id"`
+	// MachineUUID identifies the unit's machine if it is assigned to one.
+	MachineUUID sql.NullString `db:"machine_uuid"`
 }
 
 // unitStateVal is a type for holding a key/value pair that is

--- a/domain/unitstate/types.go
+++ b/domain/unitstate/types.go
@@ -123,7 +123,7 @@ type PreparedStorageAdd struct {
 	StorageName corestorage.Name
 
 	// Storage contains the prepared storage add writes.
-	Storage domainstorage.UnitAddStorageArg
+	Storage domainstorage.IAASUnitAddStorageArg
 }
 
 // CommitHookChangesArg contains data needed to commit a hook change.

--- a/domain/unitstate/types_test.go
+++ b/domain/unitstate/types_test.go
@@ -45,8 +45,10 @@ func (s *commitHookChangesArgSuite) TestValidateAndHasChangesAddStorage(c *tc.C)
 		UnitName: unittesting.GenNewName(c, "testing/0"),
 		AddStorage: []PreparedStorageAdd{{
 			StorageName: corestorage.Name("data"),
-			Storage: domainstorage.UnitAddStorageArg{
-				CountLessThanEqual: 1,
+			Storage: domainstorage.IAASUnitAddStorageArg{
+				UnitAddStorageArg: domainstorage.UnitAddStorageArg{
+					CountLessThanEqual: 1,
+				},
 			},
 		}},
 	}.ValidateAndHasChanges()

--- a/domain/unitstate/types_test.go
+++ b/domain/unitstate/types_test.go
@@ -26,7 +26,7 @@ func (s *commitHookChangesArgSuite) TestValidateAndHasChangesNoChanges(c *tc.C) 
 		UnitName: unittesting.GenNewName(c, "testing/0"),
 	}.ValidateAndHasChanges()
 
-	c.Check(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Check(hasChanges, tc.Equals, false)
 }
 
@@ -36,7 +36,7 @@ func (s *commitHookChangesArgSuite) TestValidateAndHasChangesCreateSecret(c *tc.
 		SecretCreates: []CreateSecretArg{{CreateCharmSecretParams: secret.CreateCharmSecretParams{}}},
 	}.ValidateAndHasChanges()
 
-	c.Check(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Check(hasChanges, tc.Equals, true)
 }
 
@@ -51,7 +51,7 @@ func (s *commitHookChangesArgSuite) TestValidateAndHasChangesAddStorage(c *tc.C)
 		}},
 	}.ValidateAndHasChanges()
 
-	c.Check(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Check(hasChanges, tc.Equals, true)
 }
 

--- a/tests/suites/hooktools/storage_tools.sh
+++ b/tests/suites/hooktools/storage_tools.sh
@@ -1,0 +1,93 @@
+run_storage_list() {
+	echo
+
+	model_name="test-storage-list"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy juju-qa-dummy-storage x --storage single-fs=1 \
+		--storage multi-fs=2
+	wait_for "x" "$(idle_condition "x")"
+
+	storage=$(juju exec --unit x/0 'storage-list')
+	echo "$storage" | awk -F'/' '/^multi-fs/{count++} END{print count+0}' | check '2'
+	echo "$storage" | awk -F'/' '/^single-fs/{count++} END{print count+0}' | check '1'
+
+	destroy_model "${model_name}"
+}
+
+run_storage_get() {
+	echo
+
+	model_name="test-storage-get"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy juju-qa-dummy-storage x --storage single-fs=1
+	wait_for "x" "$(idle_condition "x")"
+
+	kind=$(juju exec --unit x/0 'storage-get -s single-fs/0 kind')
+	echo $kind | check 'filesystem'
+	
+	location=$(juju exec --unit x/0 'storage-get -s single-fs/0 location')
+	check_contains "$location" '/srv/single-fs'
+
+	yaml=$(juju exec --unit x/0 'storage-get -s single-fs/0 --format=yaml')
+	echo "$yaml" | yq -r '.kind' | check "$kind"
+	echo "$yaml" | yq -r '.location' | check "$location"
+
+	destroy_model "${model_name}"
+}
+
+run_storage_add() {
+	echo
+
+	model_name="test-storage-add"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy juju-qa-dummy-storage x
+	wait_for "x" "$(idle_condition "x")"
+
+	storage=$(juju exec --unit x/0 'storage-list')
+	echo "$storage" | awk -F'/' '/^single-fs/{count++} END{print count+0}' | check '0'
+	echo "$storage" | awk -F'/' '/^multi-fs/{count++} END{print count+0}' | check '0'
+	
+	juju exec --unit x/0 'storage-add single-fs'
+	storage=$(juju exec --unit x/0 'storage-list')
+	echo "$storage" | awk -F'/' '/^single-fs/{count++} END{print count+0}' | check '1'
+	
+	juju exec --unit x/0 'storage-add multi-fs=2'
+	storage=$(juju exec --unit x/0 'storage-list')
+	echo "$storage" | awk -F'/' '/^multi-fs/{count++} END{print count+0}' | check '2'
+
+	destroy_model "${model_name}"
+}
+
+test_storage_hook_tools() {
+	if [ "$(skip 'test_storage_hook_tools')" ]; then
+		echo "==> TEST SKIPPED: storage hook tools"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_storage_get"
+		run "run_storage_list"
+		
+		case "${BOOTSTRAP_PROVIDER:-}" in
+		"k8s")
+			echo "==> TEST SKIPPED: storage_add"
+			;;
+		*)
+			run "run_storage_add"
+			;;
+		esac
+	)
+}

--- a/tests/suites/hooktools/task.sh
+++ b/tests/suites/hooktools/task.sh
@@ -14,6 +14,7 @@ test_hooktools() {
 	bootstrap "test-hooktools" "${file}"
 
 	test_state_hook_tools
+	test_storage_hook_tools
 
 	destroy_controller "test-hooktools"
 }


### PR DESCRIPTION
This is the final piece to implement storage additions during hook state commits.

Prior patches relocated storage types for common access, and added preparation via the application service in the uniter API.

Here we add the storage writes to the hook commit transaction.

A new file was added, _domain/unitstate/state/addstorage.go_ to contain logic that was largely duplicated from the application domain. This currently includes the types, which may yet be relocated to the _types.go_ file as further work in this domain continues.

The duplication was a deliberate choice taking into account:
- There are relatively few and simple SQL statements.
- The types and argument construction constitute a good deal of the copying.
- Some deviation from the original has already been instituted.
 
This adds _missing_ functionality to hook commits, and so is a priority for functional Juju. Further work will focus on bringing other aspects like secrets into the single transaction, and on tightening for duplication and all reads before any writes.

Integration tests are added to prove this change works, in addition to testing the other
storage hook commands.

Additionally, this change fixes a mistake where unit storage directives are lost after the uniter
has started.

## QA steps

`./main.sh -v hooktools test_storage_hook_tools`

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9032](https://warthogs.atlassian.net/browse/JUJU-9032)


[JUJU-9032]: https://warthogs.atlassian.net/browse/JUJU-9032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ