### PR TITLE
fix: exclude empty checksum from backup metadata json

### DIFF
--- a/state/backups/archive_data_test.go
+++ b/state/backups/archive_data_test.go
@@ -172,6 +172,23 @@ const (
 		`"ControllerMachineID":"10",` +
 		`"ControllerMachineInstanceID":"inst-10101010"` +
 		`}` + "\n"
+
+	testMetadataV2 = `{` +
+		`"ID":"20140909-115934.asdf-zxcv-qwe",` +
+		`"FormatVersion":2,` +
+		`"Stored":"0001-01-01T00:00:00Z",` +
+		`"Started":"2014-09-09T11:59:34Z",` +
+		`"Finished":"2014-09-09T12:00:34Z",` +
+		`"Notes":"",` +
+		`"ModelUUID":"asdf-zxcv-qwe",` +
+		`"Machine":"0",` +
+		`"Hostname":"myhost",` +
+		`"Version":"1.21-alpha3",` +
+		`"ControllerUUID":"controller-uuid",` +
+		`"HANodes":3,` +
+		`"ControllerMachineID":"10",` +
+		`"ControllerMachineInstanceID":"inst-10101010"` +
+		`}` + "\n"
 )
 
 func (s *baseArchiveDataSuite) setupMetadata(c *gc.C, metadata string) {
@@ -197,5 +214,5 @@ type archiveDataSuite struct {
 
 func (s *archiveDataSuite) SetUpTest(c *gc.C) {
 	s.archiveDataSuiteV0.SetUpTest(c)
-	s.setupMetadata(c, testMetadataV1)
+	s.setupMetadata(c, testMetadataV2)
 }

--- a/state/backups/archive_workspace_test.go
+++ b/state/backups/archive_workspace_test.go
@@ -21,6 +21,7 @@ type workspaceSuiteV0 struct {
 
 var _ = gc.Suite(&workspaceSuiteV0{})
 var _ = gc.Suite(&workspaceSuiteV1{})
+var _ = gc.Suite(&workspaceSuiteV2{})
 
 func (s *workspaceSuiteV0) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
@@ -93,4 +94,14 @@ type workspaceSuiteV1 struct {
 func (s *workspaceSuiteV1) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.baseArchiveDataSuite.setupMetadata(c, testMetadataV1)
+}
+
+type workspaceSuiteV2 struct {
+	testing.IsolationSuite
+	baseArchiveDataSuite
+}
+
+func (s *workspaceSuiteV2) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.baseArchiveDataSuite.setupMetadata(c, testMetadataV2)
 }

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -106,9 +106,8 @@ type ControllerMetadata struct {
 	HANodes int64
 }
 
-// All un-versioned metadata is considered to be version 0,
-// so the versions start with 1.
-const currentFormatVersion = 1
+// currentFormatVersion is the most recent metadata version.
+const currentFormatVersion = 2
 
 // NewMetadata returns a new Metadata for a state backup archive,
 // in the most current format.
@@ -228,11 +227,8 @@ func (flat *flatMetadataV0) inflate() (*Metadata, error) {
 	return meta, nil
 }
 
-// flatMetadata contains the latest format of the backup.
-// NOTE If any changes need to be made here, rename this struct to
-// reflect version 1, for example flatMetadataV1 and construct
-// new flatMetadata with desired modifications.
-type flatMetadata struct {
+// flatMetadataV1 contains format version 1 of backup metadata.
+type flatMetadataV1 struct {
 	ID            string
 	FormatVersion int64
 
@@ -259,12 +255,73 @@ type flatMetadata struct {
 	ControllerMachineInstanceID string
 }
 
+func (flat *flatMetadataV1) inflate() (*Metadata, error) {
+	meta := NewMetadata()
+	meta.SetID(flat.ID)
+	meta.FormatVersion = flat.FormatVersion
+
+	if flat.Size != 0 || flat.Checksum != "" || flat.ChecksumFormat != "" {
+		err := meta.SetFileInfo(flat.Size, flat.Checksum, flat.ChecksumFormat)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	if !flat.Stored.IsZero() {
+		meta.SetStored(&flat.Stored)
+	}
+
+	meta.Started = flat.Started
+	if !flat.Finished.IsZero() {
+		meta.Finished = &flat.Finished
+	}
+	meta.Notes = flat.Notes
+	meta.Origin = Origin{
+		Model:    flat.ModelUUID,
+		Machine:  flat.Machine,
+		Hostname: flat.Hostname,
+		Version:  flat.Version,
+		Base:     flat.Base,
+	}
+
+	meta.Controller = ControllerMetadata{
+		UUID:              flat.ControllerUUID,
+		MachineID:         flat.ControllerMachineID,
+		MachineInstanceID: flat.ControllerMachineInstanceID,
+		HANodes:           flat.HANodes,
+	}
+	return meta, nil
+}
+
+// flatMetadata contains the latest format of backup metadata.
+// File-level details are intentionally omitted from metadata.json.
+type flatMetadata struct {
+	ID            string
+	FormatVersion int64
+
+	// file storage
+
+	Stored time.Time
+
+	// backup
+
+	Started                     time.Time
+	Finished                    time.Time
+	Notes                       string
+	ModelUUID                   string
+	Machine                     string
+	Hostname                    string
+	Version                     version.Number
+	Base                        string
+	ControllerUUID              string
+	HANodes                     int64
+	ControllerMachineID         string
+	ControllerMachineInstanceID string
+}
+
 func (m *Metadata) flat() flatMetadata {
 	flat := flatMetadata{
 		ID:                          m.ID(),
-		Checksum:                    m.Checksum(),
-		ChecksumFormat:              m.ChecksumFormat(),
-		Size:                        m.Size(),
 		Started:                     m.Started,
 		Notes:                       m.Notes,
 		ModelUUID:                   m.Origin.Model,
@@ -293,11 +350,6 @@ func (flat *flatMetadata) inflate() (*Metadata, error) {
 	meta := NewMetadata()
 	meta.SetID(flat.ID)
 	meta.FormatVersion = flat.FormatVersion
-
-	err := meta.SetFileInfo(flat.Size, flat.Checksum, flat.ChecksumFormat)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 
 	if !flat.Stored.IsZero() {
 		meta.SetStored(&flat.Stored)
@@ -341,14 +393,15 @@ func NewMetadataJSONReader(in io.Reader) (*Metadata, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// We always want to decode into the most recent format version.
-	var flat flatMetadata
-	if err := json.Unmarshal(data, &flat); err != nil {
+	var versioned struct {
+		FormatVersion int64
+	}
+	if err := json.Unmarshal(data, &versioned); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// Cater for old backup files, taken as version 0 or with no version.
-	switch flat.FormatVersion {
+	switch versioned.FormatVersion {
 	case 0:
 		{
 			var v0 flatMetadataV0
@@ -358,9 +411,19 @@ func NewMetadataJSONReader(in io.Reader) (*Metadata, error) {
 			return v0.inflate()
 		}
 	case 1:
+		var v1 flatMetadataV1
+		if err := json.Unmarshal(data, &v1); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return v1.inflate()
+	case 2:
+		var flat flatMetadata
+		if err := json.Unmarshal(data, &flat); err != nil {
+			return nil, errors.Trace(err)
+		}
 		return flat.inflate()
 	default:
-		return nil, errors.NotSupportedf("backup format %d", flat.FormatVersion)
+		return nil, errors.NotSupportedf("backup format %d", versioned.FormatVersion)
 	}
 }
 

--- a/state/backups/metadata_test.go
+++ b/state/backups/metadata_test.go
@@ -30,9 +30,6 @@ func (s *metadataSuite) TestAsJSONBuffer(c *gc.C) {
 	s.assertMetadata(c, meta, `{`+
 		`"ID":"20140909-115934.asdf-zxcv-qwe",`+
 		`"FormatVersion":0,`+
-		`"Checksum":"123af2cef",`+
-		`"ChecksumFormat":"SHA-1, base64 encoded",`+
-		`"Size":10,`+
 		`"Stored":"0001-01-01T00:00:00Z",`+
 		`"Started":"2014-09-09T11:59:34Z",`+
 		`"Finished":"2014-09-09T12:00:34Z",`+
@@ -77,9 +74,9 @@ func (s *metadataSuite) assertMetadata(c *gc.C, meta *backups.Metadata, expected
 	c.Check(buf.(*bytes.Buffer).String(), jc.DeepEquals, expected)
 }
 
-func (s *metadataSuite) TestAsJSONBufferV1NonHA(c *gc.C) {
+func (s *metadataSuite) TestAsJSONBufferV2NonHA(c *gc.C) {
 	meta := s.createTestMetadata(c)
-	meta.FormatVersion = 1
+	meta.FormatVersion = 2
 	meta.Controller = backups.ControllerMetadata{
 		UUID:              "controller-uuid",
 		MachineInstanceID: "inst-10101010",
@@ -87,10 +84,7 @@ func (s *metadataSuite) TestAsJSONBufferV1NonHA(c *gc.C) {
 	}
 	s.assertMetadata(c, meta, `{`+
 		`"ID":"20140909-115934.asdf-zxcv-qwe",`+
-		`"FormatVersion":1,`+
-		`"Checksum":"123af2cef",`+
-		`"ChecksumFormat":"SHA-1, base64 encoded",`+
-		`"Size":10,`+
+		`"FormatVersion":2,`+
 		`"Stored":"0001-01-01T00:00:00Z",`+
 		`"Started":"2014-09-09T11:59:34Z",`+
 		`"Finished":"2014-09-09T12:00:34Z",`+
@@ -107,9 +101,9 @@ func (s *metadataSuite) TestAsJSONBufferV1NonHA(c *gc.C) {
 		`}`+"\n")
 }
 
-func (s *metadataSuite) TestAsJSONBufferV1HA(c *gc.C) {
+func (s *metadataSuite) TestAsJSONBufferV2HA(c *gc.C) {
 	meta := s.createTestMetadata(c)
-	meta.FormatVersion = 1
+	meta.FormatVersion = 2
 	meta.Controller = backups.ControllerMetadata{
 		UUID:              "controller-uuid",
 		MachineInstanceID: "inst-10101010",
@@ -119,10 +113,7 @@ func (s *metadataSuite) TestAsJSONBufferV1HA(c *gc.C) {
 
 	s.assertMetadata(c, meta, `{`+
 		`"ID":"20140909-115934.asdf-zxcv-qwe",`+
-		`"FormatVersion":1,`+
-		`"Checksum":"123af2cef",`+
-		`"ChecksumFormat":"SHA-1, base64 encoded",`+
-		`"Size":10,`+
+		`"FormatVersion":2,`+
 		`"Stored":"0001-01-01T00:00:00Z",`+
 		`"Started":"2014-09-09T11:59:34Z",`+
 		`"Finished":"2014-09-09T12:00:34Z",`+
@@ -218,10 +209,49 @@ func (s *metadataSuite) TestNewMetadataJSONReaderV1(c *gc.C) {
 	c.Check(meta.Controller.MachineID, gc.Equals, "10")
 }
 
-func (s *metadataSuite) TestNewMetadataJSONReaderUnsupported(c *gc.C) {
+func (s *metadataSuite) TestNewMetadataJSONReaderV2(c *gc.C) {
 	file := bytes.NewBufferString(`{` +
 		`"ID":"20140909-115934.asdf-zxcv-qwe",` +
 		`"FormatVersion":2,` +
+		`"Stored":"0001-01-01T00:00:00Z",` +
+		`"Started":"2014-09-09T11:59:34Z",` +
+		`"Finished":"2014-09-09T12:00:34Z",` +
+		`"Notes":"",` +
+		`"ModelUUID":"asdf-zxcv-qwe",` +
+		`"Machine":"0",` +
+		`"Hostname":"myhost",` +
+		`"Version":"1.21-alpha3",` +
+		`"ControllerUUID":"controller-uuid",` +
+		`"HANodes":3,` +
+		`"ControllerMachineID":"10",` +
+		`"ControllerMachineInstanceID":"inst-10101010"` +
+		`}` + "\n")
+	meta, err := backups.NewMetadataJSONReader(file)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(meta.ID(), gc.Equals, "20140909-115934.asdf-zxcv-qwe")
+	c.Check(meta.Checksum(), gc.Equals, "")
+	c.Check(meta.ChecksumFormat(), gc.Equals, "")
+	c.Check(meta.Size(), gc.Equals, int64(0))
+	c.Check(meta.Stored(), gc.IsNil)
+	c.Check(meta.Started.Unix(), gc.Equals, int64(1410263974))
+	c.Check(meta.Finished.Unix(), gc.Equals, int64(1410264034))
+	c.Check(meta.Notes, gc.Equals, "")
+	c.Check(meta.Origin.Model, gc.Equals, "asdf-zxcv-qwe")
+	c.Check(meta.Origin.Machine, gc.Equals, "0")
+	c.Check(meta.Origin.Hostname, gc.Equals, "myhost")
+	c.Check(meta.Origin.Version.String(), gc.Equals, "1.21-alpha3")
+	c.Check(meta.FormatVersion, gc.Equals, int64(2))
+	c.Check(meta.Controller.UUID, gc.Equals, "controller-uuid")
+	c.Check(meta.Controller.HANodes, gc.Equals, int64(3))
+	c.Check(meta.Controller.MachineInstanceID, gc.Equals, "inst-10101010")
+	c.Check(meta.Controller.MachineID, gc.Equals, "10")
+}
+
+func (s *metadataSuite) TestNewMetadataJSONReaderUnsupported(c *gc.C) {
+	file := bytes.NewBufferString(`{` +
+		`"ID":"20140909-115934.asdf-zxcv-qwe",` +
+		`"FormatVersion":3,` +
 		`"Checksum":"123af2cef",` +
 		`"ChecksumFormat":"SHA-1, base64 encoded",` +
 		`"Size":10,` +

--- a/tests/suites/backup/backup.sh
+++ b/tests/suites/backup/backup.sh
@@ -6,7 +6,7 @@ run_basic_backup_create() {
 	ensure "test-basic-backup-create" "${file}"
 
 	juju switch controller
-	juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz"
+	checksum=$(juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz" | tee /dev/tty | awk '/^checksum:/ {print $2}' | base64 -d | xxd -p)
 
 	# Do some basic sanity checks on what's inside the backup
 	tar xf "${TEST_DIR}/basic_backup.tar.gz" -C "${TEST_DIR}"
@@ -16,6 +16,8 @@ run_basic_backup_create() {
 	test -s "${TEST_DIR}/juju-backup/root.tar"
 	echo "checking oplog.bson is present"
 	test -s "${TEST_DIR}/juju-backup/dump/oplog.bson"
+	echo "validating checksum"
+	sha1sum "${TEST_DIR}/basic_backup.tar.gz" | cut -f1 -d' ' | check "${checksum}"
 
 	destroy_model "test-basic-backup-create"
 }


### PR DESCRIPTION
The backup metadata.json embedded in the archive tarball previously included Checksum, ChecksumFormat, and Size fields. These fields could never be correct because metadata.json is serialized and injected into the archive before the archive itself is built and checksummed - making those fields always empty strings in practice.

Introduce metadata format version 2 which intentionally omits those fields.
The checksum and size are still available to the create-backup command and printed to stdout etc.

## QA steps

```
$ juju create-backup    

backup format version: 2 
juju version:          3.6.22.1 
base:                  ubuntu@24.04 

controller UUID:       2f76b0ce-fe24-493d-80bf-99c780b75b4d
model UUID:            4c3ceb23-c764-4bed-8a1c-fcbd9368e0bb 
machine ID:            0 
created on host:       ip-172-31-13-17 

checksum:              7uLUojbHvHxAtHMi5I6+68KyfKI= 
checksum format:       SHA-1, base64 encoded 
size (B):              128677432 
stored:                0001-01-01 00:00:00 +0000 UTC 
started:               2026-04-16 05:48:44.081668069 +0000 UTC 
finished:              2026-04-16 05:48:51.005676976 +0000 UTC 

notes:                  

Downloaded to juju-backup-20260416-054844.tar.gz
```
The metadata.json file from the backup:
```
{"ID":"","FormatVersion":2,"Stored":"0001-01-01T00:00:00Z","Started":"2026-04-17T02:09:37.207644023Z","Finished":"0001-01-01T00:00:00Z","Notes":"","ModelUUID":"7f8b672a-2994-4c87-85f8-d06571bba1bd","Machine":"0","Hostname":"ip-172-31-7-89","Version":"3.6.22.1","Base":"ubuntu@24.04","ControllerUUID":"c3d2dc23-240d-41fe-8943-f40a4f070a0e","HANodes":1,"ControllerMachineID":"0","ControllerMachineInstanceID":"i-07c91fb773da3866d"}
```


## Links

**Issue:** Fixes #22250.

**Jira card:** [JUJU-9676](https://warthogs.atlassian.net/browse/JUJU-9676)


[JUJU-9676]: https://warthogs.atlassian.net/browse/JUJU-9676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ