### PR TITLE
docs: add llms4

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,6 +295,7 @@ extensions = [
     "sphinx_config_options",
     "sphinx_contributor_listing",
     "sphinx_filtered_toctree",
+    "sphinx_llm.txt",
     "sphinx_related_links",
     "sphinx_roles",
     "sphinx_terminal",
@@ -309,6 +310,18 @@ extensions = [
     'sphinxcontrib.lightbox2',
     'ibnote',
 ]
+
+# Customize sphinx_llm.txt
+## Add project summary:
+llms_txt_description = (
+    "Juju is an open source orchestration engine for deploying, integrating, "
+    "and managing applications across Kubernetes, VMs, and bare metal using "
+    "software operators called charms."
+)
+## Get cleaner markdown URLs (e.g., `page.md` instead of `page/index.html.md`):
+llms_txt_suffix_mode = "url-suffix"
+markdown_http_base = "https://documentation.ubuntu.com/juju/4.0"
+
 
 # Excludes files or directories from processing
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,7 @@ sphinxext-opengraph
 sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
+sphinx-llm
 sphinx-related-links>=0.1.1
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2


### PR DESCRIPTION
## Descriptions

Cherry-picked llms.txt setup from 3.6 to 4.0.

## Changes

- Add sphinx-llm extension 
- Configure llms.txt generation with `markdown_http_base` set to `juju/4.0`

## Original commit

Cherry-picked from 5cc26e9e0b9eb6d26aa6a7a6a198cf5352608245

## QA steps

**tl;dr** Try https://canonical-ubuntu-documentation-library--22262.com.readthedocs.build/juju/22262/llms-full.txt

**Otherwise:**

In `docs` run `make clean && make run`. Open the browser preview and append `llms.txt`, `llms-full.txt`, or click on some page and delete the trailing / and add `.md`.

http://127.0.0.1:8000/llms.txt
http://127.0.0.1:8000/llms-full.txt
http://127.0.0.1:8000/howto.md