### PR TITLE
feat(application-not-found): add not-found code to application-not-found const err

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/domain/access"
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	domaincharm "github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/controller"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
@@ -179,6 +180,8 @@ func (api *OffersAPI) Offer(ctx context.Context, all params.AddApplicationOffers
 		// We don't support updating offers via this API, so return an
 		// appropriate error.
 		err = errors.Errorf("offer %q already exists, updating offers is not supported", applicationOfferArgs.OfferName).Add(coreerrors.BadRequest)
+	} else if errors.Is(err, applicationerrors.ApplicationNotFound) {
+		err = errors.Errorf("application %q not found in model %q", applicationOfferArgs.ApplicationName, offerModelUUID.String()).Add(coreerrors.NotFound)
 	}
 	return handleErr(err), nil
 }

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -25,6 +25,7 @@ import (
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/controller"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
@@ -253,6 +254,47 @@ func (s *offerSuite) TestOfferError(c *tc.C) {
 	c.Assert(results, tc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{
 		{Error: &params.Error{Message: "boom"}},
 	}})
+}
+
+// TestOfferApplicationNotFound tests that an ApplicationNotFound error from
+// CreateOffer is returned as a not-found error to the caller.
+func (s *offerSuite) TestOfferApplicationNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	userTag := names.NewUserTag("fred")
+	s.authorizer.EXPECT().GetAuthTag().Return(userTag)
+	offerAPI := s.offerAPI(c)
+	modelTag := names.NewModelTag(offerAPI.modelUUID.String())
+	s.setupCheckAPIUserAdmin(offerAPI.controllerUUID, modelTag)
+
+	applicationName := "test-application"
+	offerName := "test-offer"
+	createOfferArgs := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       user.NameFromTag(userTag),
+	}
+	s.crossModelRelationService.EXPECT().CreateOffer(gomock.Any(), createOfferArgs).Return(applicationerrors.ApplicationNotFound)
+
+	one := params.AddApplicationOffer{
+		ModelTag:        modelTag.String(),
+		OfferName:       offerName,
+		ApplicationName: applicationName,
+		Endpoints:       map[string]string{"db": "db"},
+	}
+	all := params.AddApplicationOffers{Offers: []params.AddApplicationOffer{one}}
+
+	// Act
+	results, err := offerAPI.Offer(c.Context(), all)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Check(results.Results[0].Error.Code, tc.Equals, params.CodeNotFound)
+	c.Check(results.Results[0].Error.Message, tc.Matches,
+		fmt.Sprintf(`application %q not found in model %q`, applicationName, offerAPI.modelUUID.String()))
 }
 
 // TestOfferOnlyOne tests that called Offer with more than one AddApplicationOffer


### PR DESCRIPTION
# Description

After I've found an issue where creating an offer, via JIMM, for a not-existing application didn't return a not-found error, I've added the not-found code in the facade layer.

https://github.com/SimoneDutto/jimm/blob/dbb8ce358c702f57367d920cd830fbdf6ed3b704/testing/applicationoffers_test.go#L55-L59



# QA
With this new mapping the test passes.