### PR TITLE
fix: add a short model id to error messages

### DIFF
--- a/internal/worker/caasmodeloperator/manifold.go
+++ b/internal/worker/caasmodeloperator/manifold.go
@@ -30,7 +30,6 @@ type ManifoldConfig struct {
 	// Logger to use in this worker
 	Logger Logger
 	// ModelUUID is the id of the model this worker is operating on
-
 	ModelUUID string
 }
 

--- a/internal/worker/caasmodeloperator/modeloperator.go
+++ b/internal/worker/caasmodeloperator/modeloperator.go
@@ -35,12 +35,13 @@ type ModelOperatorBroker interface {
 // ModelOperatorManager defines the worker used for managing model operators in
 // caas
 type ModelOperatorManager struct {
-	agentConfig agent.Config
-	api         ModelOperatorAPI
-	broker      ModelOperatorBroker
-	catacomb    catacomb.Catacomb
-	logger      Logger
-	modelUUID   string
+	agentConfig  agent.Config
+	api          ModelOperatorAPI
+	broker       ModelOperatorBroker
+	catacomb     catacomb.Catacomb
+	logger       Logger
+	modelUUID    string
+	shortModelId string
 }
 
 const (
@@ -62,7 +63,7 @@ func (m *ModelOperatorManager) Wait() error {
 func (m *ModelOperatorManager) loop() error {
 	watcher, err := m.api.WatchModelOperatorProvisioningInfo()
 	if err != nil {
-		return errors.Annotate(err, "cannot watch model operator provisioning info")
+		return errors.Annotatef(err, "cannot watch model operator [%s] provisioning info", m.shortModelId)
 	}
 	err = m.catacomb.Add(watcher)
 	if err != nil {
@@ -76,7 +77,7 @@ func (m *ModelOperatorManager) loop() error {
 		case <-watcher.Changes():
 			err := m.update()
 			if err != nil {
-				return errors.Annotate(err, "failed to update model operator")
+				return errors.Annotatef(err, "failed to update model operator [%s]", m.shortModelId)
 			}
 		}
 	}
@@ -177,12 +178,17 @@ func NewModelOperatorManager(
 	modelUUID string,
 	agentConfig agent.Config,
 ) (*ModelOperatorManager, error) {
+	shortModelId := modelUUID
+	if names.IsValidModel(modelUUID) {
+		shortModelId = names.NewModelTag(modelUUID).ShortId()
+	}
 	m := &ModelOperatorManager{
-		agentConfig: agentConfig,
-		api:         api,
-		broker:      broker,
-		logger:      logger,
-		modelUUID:   modelUUID,
+		agentConfig:  agentConfig,
+		api:          api,
+		broker:       broker,
+		logger:       logger,
+		modelUUID:    modelUUID,
+		shortModelId: shortModelId,
 	}
 
 	if err := catacomb.Invoke(catacomb.Plan{
@@ -220,7 +226,7 @@ func (m *ModelOperatorManager) updateAgentConf(
 		},
 	)
 	if err != nil {
-		return nil, errors.Annotatef(err, "creating new agent config")
+		return nil, errors.Annotatef(err, "creating new agent config for model [%s]", m.shortModelId)
 	}
 
 	return conf, nil

--- a/internal/worker/caasmodeloperator/modeloperator.go
+++ b/internal/worker/caasmodeloperator/modeloperator.go
@@ -60,9 +60,13 @@ func (m *ModelOperatorManager) Wait() error {
 }
 
 func (m *ModelOperatorManager) loop() error {
+	shortModelID := m.modelUUID
+	if names.IsValidModel(m.modelUUID) {
+		shortModelID = names.NewModelTag(m.modelUUID).ShortId()
+	}
 	watcher, err := m.api.WatchModelOperatorProvisioningInfo()
 	if err != nil {
-		return errors.Annotate(err, "cannot watch model operator provisioning info")
+		return errors.Annotatef(err, "cannot watch model operator [%s] provisioning info", shortModelID)
 	}
 	err = m.catacomb.Add(watcher)
 	if err != nil {
@@ -76,7 +80,7 @@ func (m *ModelOperatorManager) loop() error {
 		case <-watcher.Changes():
 			err := m.update()
 			if err != nil {
-				return errors.Annotate(err, "failed to update model operator")
+				return errors.Annotatef(err, "failed to update model operator [%s]", shortModelID)
 			}
 		}
 	}
@@ -220,7 +224,7 @@ func (m *ModelOperatorManager) updateAgentConf(
 		},
 	)
 	if err != nil {
-		return nil, errors.Annotatef(err, "creating new agent config")
+		return nil, errors.Annotatef(err, "creating new agent config for model")
 	}
 
 	return conf, nil

--- a/internal/worker/caasmodeloperator/modeloperator_test.go
+++ b/internal/worker/caasmodeloperator/modeloperator_test.go
@@ -167,3 +167,44 @@ func (m *ModelOperatorManagerSuite) TestModelOperatorManagerApplying(c *gc.C) {
 
 	c.Assert(iteration, gc.Equals, n)
 }
+
+func (m *ModelOperatorManagerSuite) TestModelOperatorManagerWatchErrorContainsShortModelUUID(c *gc.C) {
+	modelUUID := "deadbeef-0bad-400d-8000-4b1d0d06f00d"
+
+	api := &dummyAPI{
+		watchProvInfo: func() (watcher.NotifyWatcher, error) {
+			return nil, errors.New("watch failed")
+		},
+	}
+
+	worker, err := caasmodeloperator.NewModelOperatorManager(loggo.Logger{},
+		api, &dummyBroker{}, modelUUID, &mockAgentConfig{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = worker.Wait()
+	c.Assert(err, gc.ErrorMatches, `cannot watch model operator \[deadbe\] provisioning info: watch failed`)
+}
+
+func (m *ModelOperatorManagerSuite) TestModelOperatorManagerUpdateErrorContainsShortModelUUID(c *gc.C) {
+	modelUUID := "deadbee0-0bad-400d-8000-4b1d0d06f00d"
+
+	changed := make(chan struct{}, 1)
+	api := &dummyAPI{
+		provInfo: func() (modeloperatorapi.ModelOperatorProvisioningInfo, error) {
+			return modeloperatorapi.ModelOperatorProvisioningInfo{}, errors.New("provisioning info failed")
+		},
+		watchProvInfo: func() (watcher.NotifyWatcher, error) {
+			return watchertest.NewMockNotifyWatcher(changed), nil
+		},
+	}
+
+	worker, err := caasmodeloperator.NewModelOperatorManager(loggo.Logger{},
+		api, &dummyBroker{}, modelUUID, &mockAgentConfig{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Trigger one update cycle which will return an error.
+	changed <- struct{}{}
+
+	err = worker.Wait()
+	c.Assert(err, gc.ErrorMatches, `failed to update model operator \[deadbe\]: provisioning info failed`)
+}


### PR DESCRIPTION
When producing an error trying to start up the CAASModelOperator, it was failing with a simple message about what failed, but without any context for you to fix the model that was failing.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

I'm not sure how to do a live QA test of a CAAS operator that is failing to provision. In this case, it was happening because the code was checking the tags on the existing objects, and would fail in a loop with:
```
juju.worker.dependency engine.go:695 "caas-model-operator" manifold worker returned unexpected error: failed to update model operator: deploying model operator: ensuring service account: ensuring ServiceAccount "modeloperator" with labels map[juju-modeloperator:modeloperator] : unexpected operator labels
```
However, on Prodstack, that could be 100s of possible models.

If we prefer, we could use the long model-uuid, but often we preferred the short one.

## Documentation changes

None

## Links

None