### PR TITLE
fix: ensure create backup works after upgrade

### DIFF
--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -4,6 +4,8 @@
 package backups
 
 import (
+	"os"
+
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/replicaset/v2"
@@ -32,6 +34,8 @@ func (a *API) Create(args params.BackupsCreateArgs) (params.BackupsMetadataResul
 	return result, nil
 }
 
+const dataPathForJujuDbSnap = "/var/snap/juju-db/common"
+
 func (a *APIv2) Create(args params.BackupsCreateArgs) (params.BackupsMetadataResult, error) {
 	backupsMethods := newBackups(a.paths)
 
@@ -57,7 +61,12 @@ func (a *APIv2) Create(args params.BackupsCreateArgs) (params.BackupsMetadataRes
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	dbInfo, err := backups.NewDBInfo(mgoInfo, sessionShim{session}, mongoVersion)
+
+	dataDir := a.paths.DataDir
+	if _, err := os.Stat(dataPathForJujuDbSnap); err == nil {
+		dataDir = dataPathForJujuDbSnap
+	}
+	dbInfo, err := backups.NewDBInfo(mgoInfo, sessionShim{session}, mongoVersion, dataDir)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	stdcontext "context"
 	"encoding/json"
+	"encoding/pem"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -850,7 +851,7 @@ func (s *MachineSuite) TestJobManageModelRunsMinUnitsWorker(c *gc.C) {
 }
 
 func (s *MachineSuite) TestMachineAgentRunsAuthorisedKeysWorker(c *gc.C) {
-	//TODO(bogdanteleaga): Fix once we get authentication worker up on windows
+	// TODO(bogdanteleaga): Fix once we get authentication worker up on windows
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: authentication worker not yet implemented on windows")
 	}
@@ -1085,7 +1086,22 @@ func (s *MachineSuite) testCertificateDNSUpdated(c *gc.C, a *MachineAgent) {
 	// Check the mongo certificate file too.
 	pemContent, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "server.pem"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(string(pemContent), gc.Equals, stateInfo.Cert+"\n"+stateInfo.PrivateKey)
+	cert := leafCertificatePEM(stateInfo.Cert)
+	c.Check(string(pemContent), gc.Equals, cert+"\n"+stateInfo.PrivateKey)
+}
+
+func leafCertificatePEM(cert string) string {
+	rest := []byte(cert)
+	for {
+		block, remainder := pem.Decode(rest)
+		if block == nil {
+			return cert
+		}
+		rest = remainder
+		if block.Type == "CERTIFICATE" {
+			return string(pem.EncodeToMemory(block))
+		}
+	}
 }
 
 func (s *MachineSuite) setupIgnoreAddresses(c *gc.C, expectedIgnoreValue bool) chan bool {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -6,6 +6,7 @@ package mongo
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -664,12 +665,29 @@ func tweakSysctlForMongo(editables map[string]string) {
 
 // UpdateSSLKey writes a new SSL key used by mongo to validate connections from Juju controller(s)
 func UpdateSSLKey(dataDir, cert, privateKey, cacert string) error {
-	err := utils.AtomicWriteFile(sslKeyPath(dataDir), []byte(GenerateSSLKey(cert, privateKey)), 0600)
+	err := utils.AtomicWriteFile(sslKeyPath(dataDir), []byte(GenerateSSLKey(leafCertificatePEM(cert), privateKey)), 0600)
 	if err != nil {
 		return errors.Annotate(err, "cannot write SSL key")
 	}
 	err = utils.AtomicWriteFile(caCertKeyPath(dataDir), []byte(cacert), 0600)
 	return errors.Annotate(err, "cannot write CA Cert")
+}
+
+// leafCertificatePEM returns the first certificate block from a PEM bundle.
+// Mongo tooling (eg mongodump) expects server.pem to contain a single cert
+// paired with the private key. CA certificates are provided via ca.crt.
+func leafCertificatePEM(cert string) string {
+	rest := []byte(cert)
+	for {
+		block, remainder := pem.Decode(rest)
+		if block == nil {
+			return cert
+		}
+		rest = remainder
+		if block.Type == "CERTIFICATE" {
+			return string(pem.EncodeToMemory(block))
+		}
+	}
 }
 
 // GenerateSSLKey combines cert and private key to generate the ssl key - server.pem.

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -5,6 +5,7 @@ package mongo_test
 
 import (
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,6 +26,7 @@ import (
 	"github.com/juju/juju/service/common"
 	svctesting "github.com/juju/juju/service/common/testing"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type MongoSuite struct {
@@ -89,6 +91,8 @@ func (s *MongoSuite) makeConfigArgs(dataDir string) mongo.ConfigArgs {
 
 func (s *MongoSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+
+	s.PatchValue(&series.HostSeries, func() (string, error) { return version.DefaultSupportedLTS(), nil })
 
 	s.mongodVersion = mongo.Mongo24
 
@@ -509,6 +513,21 @@ func (s *MongoSuite) TestNoMongoDir(c *gc.C) {
 
 	_, err = os.Stat(filepath.Join(dataDir, "db"))
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MongoSuite) TestUpdateSSLKeyUsesLeafCertificateOnly(c *gc.C) {
+	dataDir := c.MkDir()
+
+	firstCert := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("first-cert")}))
+	secondCert := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("second-cert")}))
+	bundle := firstCert + secondCert
+
+	err := mongo.UpdateSSLKey(dataDir, bundle, testInfo.PrivateKey, "ignored-ca")
+	c.Assert(err, jc.ErrorIsNil)
+
+	contents, err := os.ReadFile(mongo.SSLKeyPath(dataDir))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(contents), gc.Equals, mongo.GenerateSSLKey(firstCert, testInfo.PrivateKey))
 }
 
 func (s *MongoSuite) TestSelectPeerAddress(c *gc.C) {

--- a/state/backups/archive_data_test.go
+++ b/state/backups/archive_data_test.go
@@ -173,6 +173,23 @@ const (
 		`"ControllerMachineID":"10",` +
 		`"ControllerMachineInstanceID":"inst-10101010"` +
 		`}` + "\n"
+
+	testMetadataV2 = `{` +
+		`"ID":"20140909-115934.asdf-zxcv-qwe",` +
+		`"FormatVersion":2,` +
+		`"Stored":"0001-01-01T00:00:00Z",` +
+		`"Started":"2014-09-09T11:59:34Z",` +
+		`"Finished":"2014-09-09T12:00:34Z",` +
+		`"Notes":"",` +
+		`"ModelUUID":"asdf-zxcv-qwe",` +
+		`"Machine":"0",` +
+		`"Hostname":"myhost",` +
+		`"Version":"1.21-alpha3",` +
+		`"ControllerUUID":"controller-uuid",` +
+		`"HANodes":3,` +
+		`"ControllerMachineID":"10",` +
+		`"ControllerMachineInstanceID":"inst-10101010"` +
+		`}` + "\n"
 )
 
 func (s *baseArchiveDataSuite) setupMetadata(c *gc.C, metadata string) {
@@ -198,5 +215,5 @@ type archiveDataSuite struct {
 
 func (s *archiveDataSuite) SetUpTest(c *gc.C) {
 	s.archiveDataSuiteV0.SetUpTest(c)
-	s.setupMetadata(c, testMetadataV1)
+	s.setupMetadata(c, testMetadataV2)
 }

--- a/state/backups/archive_workspace_test.go
+++ b/state/backups/archive_workspace_test.go
@@ -21,6 +21,7 @@ type workspaceSuiteV0 struct {
 
 var _ = gc.Suite(&workspaceSuiteV0{})
 var _ = gc.Suite(&workspaceSuiteV1{})
+var _ = gc.Suite(&workspaceSuiteV2{})
 
 func (s *workspaceSuiteV0) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
@@ -93,4 +94,14 @@ type workspaceSuiteV1 struct {
 func (s *workspaceSuiteV1) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.baseArchiveDataSuite.setupMetadata(c, testMetadataV1)
+}
+
+type workspaceSuiteV2 struct {
+	testing.IsolationSuite
+	baseArchiveDataSuite
+}
+
+func (s *workspaceSuiteV2) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.baseArchiveDataSuite.setupMetadata(c, testMetadataV2)
 }

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -36,6 +36,8 @@ var runCommandFn = runCommand
 // the database. This includes a simplification of the information in
 // authentication.MongoInfo.
 type DBInfo struct {
+	// DataDir is the location of the certificates.
+	DataDir string
 	// Address is the DB system's host address.
 	Address string
 	// Username is used when connecting to the DB system.
@@ -73,7 +75,7 @@ type Database interface {
 
 // NewDBInfo returns the information needed by backups to dump
 // the database.
-func NewDBInfo(mgoInfo *mongo.MongoInfo, session DBSession, version mongo.Version) (*DBInfo, error) {
+func NewDBInfo(mgoInfo *mongo.MongoInfo, session DBSession, version mongo.Version, dataDir string) (*DBInfo, error) {
 	targets, err := getBackupTargetDatabases(session)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -98,6 +100,7 @@ func NewDBInfo(mgoInfo *mongo.MongoInfo, session DBSession, version mongo.Versio
 	}
 
 	info := DBInfo{
+		DataDir:      dataDir,
 		Address:      mgoInfo.Addrs[0],
 		Password:     mgoInfo.Password,
 		Targets:      targets,
@@ -207,17 +210,9 @@ func (md *mongoDumper) options(dumpDir string) []string {
 		"--password", md.Password,
 		"--out", dumpDir,
 		"--oplog",
-	}
-	if md.MongoVersion.NewerThan(mongo.Version{
-		Major: 4,
-		Minor: 4,
-		Point: 30,
-	}) >= 0 {
-		options = append(options,
-			"--sslCAFile", "/var/snap/juju-db/common/ca.crt",
-			"--sslPEMKeyFile", "/var/snap/juju-db/common/server.pem",
-			"--sslPEMKeyPassword", "ignore",
-		)
+		"--sslCAFile", fmt.Sprintf("%s/ca.crt", md.DataDir),
+		"--sslPEMKeyFile", fmt.Sprintf("%s/server.pem", md.DataDir),
+		"--sslPEMKeyPassword", "ignore",
 	}
 	return options
 }

--- a/state/backups/db_info_test.go
+++ b/state/backups/db_info_test.go
@@ -70,9 +70,10 @@ func (s *dbInfoSuite) TestNewDBInfoOkay(c *gc.C) {
 		Tag:      tag,
 		Password: "eggs",
 	}
-	dbInfo, err := backups.NewDBInfo(mgoInfo, &session, mongo.Mongo32wt)
+	dbInfo, err := backups.NewDBInfo(mgoInfo, &session, mongo.Mongo32wt, "/path/to/data")
 	c.Assert(err, jc.ErrorIsNil)
 
+	c.Check(dbInfo.DataDir, gc.Equals, "/path/to/data")
 	c.Check(dbInfo.Address, gc.Equals, "localhost:8080")
 	c.Check(dbInfo.Username, gc.Equals, "machine-0")
 	c.Check(dbInfo.Password, gc.Equals, "eggs")
@@ -88,9 +89,10 @@ func (s *dbInfoSuite) TestNewDBInfoMissingTag(c *gc.C) {
 		},
 		Password: "eggs",
 	}
-	dbInfo, err := backups.NewDBInfo(mgoInfo, &session, mongo.Mongo32wt)
+	dbInfo, err := backups.NewDBInfo(mgoInfo, &session, mongo.Mongo32wt, "/path/to/data")
 	c.Assert(err, jc.ErrorIsNil)
 
+	c.Check(dbInfo.DataDir, gc.Equals, "/path/to/data")
 	c.Check(dbInfo.Username, gc.Equals, "")
 	c.Check(dbInfo.Address, gc.Equals, "localhost:8080")
 	c.Check(dbInfo.Password, gc.Equals, "eggs")

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -107,9 +107,8 @@ type ControllerMetadata struct {
 	HANodes int64
 }
 
-// All un-versioned metadata is considered to be version 0,
-// so the versions start with 1.
-const currentFormatVersion = 1
+// currentFormatVersion is the most recent metadata version.
+const currentFormatVersion = 2
 
 // NewMetadata returns a new Metadata for a state backup archive,
 // in the most current format.
@@ -229,11 +228,8 @@ func (flat *flatMetadataV0) inflate() (*Metadata, error) {
 	return meta, nil
 }
 
-// flatMetadata contains the latest format of the backup.
-// NOTE If any changes need to be made here, rename this struct to
-// reflect version 1, for example flatMetadataV1 and construct
-// new flatMetadata with desired modifications.
-type flatMetadata struct {
+// flatMetadataV1 contains format version 1 of backup metadata.
+type flatMetadataV1 struct {
 	ID            string
 	FormatVersion int64
 
@@ -260,12 +256,73 @@ type flatMetadata struct {
 	ControllerMachineInstanceID string
 }
 
+func (flat *flatMetadataV1) inflate() (*Metadata, error) {
+	meta := NewMetadata()
+	meta.SetID(flat.ID)
+	meta.FormatVersion = flat.FormatVersion
+
+	if flat.Size != 0 || flat.Checksum != "" || flat.ChecksumFormat != "" {
+		err := meta.SetFileInfo(flat.Size, flat.Checksum, flat.ChecksumFormat)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	if !flat.Stored.IsZero() {
+		meta.SetStored(&flat.Stored)
+	}
+
+	meta.Started = flat.Started
+	if !flat.Finished.IsZero() {
+		meta.Finished = &flat.Finished
+	}
+	meta.Notes = flat.Notes
+	meta.Origin = Origin{
+		Model:    flat.ModelUUID,
+		Machine:  flat.Machine,
+		Hostname: flat.Hostname,
+		Version:  flat.Version,
+		Series:   flat.Series,
+	}
+
+	meta.Controller = ControllerMetadata{
+		UUID:              flat.ControllerUUID,
+		MachineID:         flat.ControllerMachineID,
+		MachineInstanceID: flat.ControllerMachineInstanceID,
+		HANodes:           flat.HANodes,
+	}
+	return meta, nil
+}
+
+// flatMetadata contains the latest format of backup metadata.
+// File-level details are intentionally omitted from metadata.json.
+type flatMetadata struct {
+	ID            string
+	FormatVersion int64
+
+	// file storage
+
+	Stored time.Time
+
+	// backup
+
+	Started                     time.Time
+	Finished                    time.Time
+	Notes                       string
+	ModelUUID                   string
+	Machine                     string
+	Hostname                    string
+	Version                     version.Number
+	Series                      string
+	ControllerUUID              string
+	HANodes                     int64
+	ControllerMachineID         string
+	ControllerMachineInstanceID string
+}
+
 func (m *Metadata) flat() flatMetadata {
 	flat := flatMetadata{
 		ID:                          m.ID(),
-		Checksum:                    m.Checksum(),
-		ChecksumFormat:              m.ChecksumFormat(),
-		Size:                        m.Size(),
 		Started:                     m.Started,
 		Notes:                       m.Notes,
 		ModelUUID:                   m.Origin.Model,
@@ -294,11 +351,6 @@ func (flat *flatMetadata) inflate() (*Metadata, error) {
 	meta := NewMetadata()
 	meta.SetID(flat.ID)
 	meta.FormatVersion = flat.FormatVersion
-
-	err := meta.SetFileInfo(flat.Size, flat.Checksum, flat.ChecksumFormat)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 
 	if !flat.Stored.IsZero() {
 		meta.SetStored(&flat.Stored)
@@ -342,14 +394,15 @@ func NewMetadataJSONReader(in io.Reader) (*Metadata, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// We always want to decode into the most recent format version.
-	var flat flatMetadata
-	if err := json.Unmarshal(data, &flat); err != nil {
+	var versioned struct {
+		FormatVersion int64
+	}
+	if err := json.Unmarshal(data, &versioned); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// Cater for old backup files, taken as version 0 or with no version.
-	switch flat.FormatVersion {
+	switch versioned.FormatVersion {
 	case 0:
 		{
 			var v0 flatMetadataV0
@@ -359,9 +412,19 @@ func NewMetadataJSONReader(in io.Reader) (*Metadata, error) {
 			return v0.inflate()
 		}
 	case 1:
+		var v1 flatMetadataV1
+		if err := json.Unmarshal(data, &v1); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return v1.inflate()
+	case 2:
+		var flat flatMetadata
+		if err := json.Unmarshal(data, &flat); err != nil {
+			return nil, errors.Trace(err)
+		}
 		return flat.inflate()
 	default:
-		return nil, errors.NotSupportedf("backup format %d", flat.FormatVersion)
+		return nil, errors.NotSupportedf("backup format %d", versioned.FormatVersion)
 	}
 }
 

--- a/state/backups/metadata_test.go
+++ b/state/backups/metadata_test.go
@@ -30,9 +30,6 @@ func (s *metadataSuite) TestAsJSONBuffer(c *gc.C) {
 	s.assertMetadata(c, meta, `{`+
 		`"ID":"20140909-115934.asdf-zxcv-qwe",`+
 		`"FormatVersion":0,`+
-		`"Checksum":"123af2cef",`+
-		`"ChecksumFormat":"SHA-1, base64 encoded",`+
-		`"Size":10,`+
 		`"Stored":"0001-01-01T00:00:00Z",`+
 		`"Started":"2014-09-09T11:59:34Z",`+
 		`"Finished":"2014-09-09T12:00:34Z",`+
@@ -77,9 +74,9 @@ func (s *metadataSuite) assertMetadata(c *gc.C, meta *backups.Metadata, expected
 	c.Check(buf.(*bytes.Buffer).String(), jc.DeepEquals, expected)
 }
 
-func (s *metadataSuite) TestAsJSONBufferV1NonHA(c *gc.C) {
+func (s *metadataSuite) TestAsJSONBufferV2NonHA(c *gc.C) {
 	meta := s.createTestMetadata(c)
-	meta.FormatVersion = 1
+	meta.FormatVersion = 2
 	meta.Controller = backups.ControllerMetadata{
 		UUID:              "controller-uuid",
 		MachineInstanceID: "inst-10101010",
@@ -87,10 +84,7 @@ func (s *metadataSuite) TestAsJSONBufferV1NonHA(c *gc.C) {
 	}
 	s.assertMetadata(c, meta, `{`+
 		`"ID":"20140909-115934.asdf-zxcv-qwe",`+
-		`"FormatVersion":1,`+
-		`"Checksum":"123af2cef",`+
-		`"ChecksumFormat":"SHA-1, base64 encoded",`+
-		`"Size":10,`+
+		`"FormatVersion":2,`+
 		`"Stored":"0001-01-01T00:00:00Z",`+
 		`"Started":"2014-09-09T11:59:34Z",`+
 		`"Finished":"2014-09-09T12:00:34Z",`+
@@ -107,9 +101,9 @@ func (s *metadataSuite) TestAsJSONBufferV1NonHA(c *gc.C) {
 		`}`+"\n")
 }
 
-func (s *metadataSuite) TestAsJSONBufferV1HA(c *gc.C) {
+func (s *metadataSuite) TestAsJSONBufferV2HA(c *gc.C) {
 	meta := s.createTestMetadata(c)
-	meta.FormatVersion = 1
+	meta.FormatVersion = 2
 	meta.Controller = backups.ControllerMetadata{
 		UUID:              "controller-uuid",
 		MachineInstanceID: "inst-10101010",
@@ -119,10 +113,7 @@ func (s *metadataSuite) TestAsJSONBufferV1HA(c *gc.C) {
 
 	s.assertMetadata(c, meta, `{`+
 		`"ID":"20140909-115934.asdf-zxcv-qwe",`+
-		`"FormatVersion":1,`+
-		`"Checksum":"123af2cef",`+
-		`"ChecksumFormat":"SHA-1, base64 encoded",`+
-		`"Size":10,`+
+		`"FormatVersion":2,`+
 		`"Stored":"0001-01-01T00:00:00Z",`+
 		`"Started":"2014-09-09T11:59:34Z",`+
 		`"Finished":"2014-09-09T12:00:34Z",`+
@@ -218,10 +209,49 @@ func (s *metadataSuite) TestNewMetadataJSONReaderV1(c *gc.C) {
 	c.Check(meta.Controller.MachineID, gc.Equals, "10")
 }
 
-func (s *metadataSuite) TestNewMetadataJSONReaderUnsupported(c *gc.C) {
+func (s *metadataSuite) TestNewMetadataJSONReaderV2(c *gc.C) {
 	file := bytes.NewBufferString(`{` +
 		`"ID":"20140909-115934.asdf-zxcv-qwe",` +
 		`"FormatVersion":2,` +
+		`"Stored":"0001-01-01T00:00:00Z",` +
+		`"Started":"2014-09-09T11:59:34Z",` +
+		`"Finished":"2014-09-09T12:00:34Z",` +
+		`"Notes":"",` +
+		`"ModelUUID":"asdf-zxcv-qwe",` +
+		`"Machine":"0",` +
+		`"Hostname":"myhost",` +
+		`"Version":"1.21-alpha3",` +
+		`"ControllerUUID":"controller-uuid",` +
+		`"HANodes":3,` +
+		`"ControllerMachineID":"10",` +
+		`"ControllerMachineInstanceID":"inst-10101010"` +
+		`}` + "\n")
+	meta, err := backups.NewMetadataJSONReader(file)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(meta.ID(), gc.Equals, "20140909-115934.asdf-zxcv-qwe")
+	c.Check(meta.Checksum(), gc.Equals, "")
+	c.Check(meta.ChecksumFormat(), gc.Equals, "")
+	c.Check(meta.Size(), gc.Equals, int64(0))
+	c.Check(meta.Stored(), gc.IsNil)
+	c.Check(meta.Started.Unix(), gc.Equals, int64(1410263974))
+	c.Check(meta.Finished.Unix(), gc.Equals, int64(1410264034))
+	c.Check(meta.Notes, gc.Equals, "")
+	c.Check(meta.Origin.Model, gc.Equals, "asdf-zxcv-qwe")
+	c.Check(meta.Origin.Machine, gc.Equals, "0")
+	c.Check(meta.Origin.Hostname, gc.Equals, "myhost")
+	c.Check(meta.Origin.Version.String(), gc.Equals, "1.21-alpha3")
+	c.Check(meta.FormatVersion, gc.Equals, int64(2))
+	c.Check(meta.Controller.UUID, gc.Equals, "controller-uuid")
+	c.Check(meta.Controller.HANodes, gc.Equals, int64(3))
+	c.Check(meta.Controller.MachineInstanceID, gc.Equals, "inst-10101010")
+	c.Check(meta.Controller.MachineID, gc.Equals, "10")
+}
+
+func (s *metadataSuite) TestNewMetadataJSONReaderUnsupported(c *gc.C) {
+	file := bytes.NewBufferString(`{` +
+		`"ID":"20140909-115934.asdf-zxcv-qwe",` +
+		`"FormatVersion":3,` +
 		`"Checksum":"123af2cef",` +
 		`"ChecksumFormat":"SHA-1, base64 encoded",` +
 		`"Size":10,` +

--- a/tests/suites/backup/backup.sh
+++ b/tests/suites/backup/backup.sh
@@ -6,7 +6,7 @@ run_basic_backup_create() {
 	ensure "test-basic-backup-create" "${file}"
 
 	juju switch controller
-	juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz"
+	checksum=$(juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz" | tee /dev/tty | awk '/^checksum:/ {print $2}' | base64 -d | xxd -p)
 
 	# Do some basic sanity checks on what's inside the backup
 	tar xf "${TEST_DIR}/basic_backup.tar.gz" -C "${TEST_DIR}"
@@ -16,6 +16,8 @@ run_basic_backup_create() {
 	test -s "${TEST_DIR}/juju-backup/root.tar"
 	echo "checking oplog.bson is present"
 	test -s "${TEST_DIR}/juju-backup/dump/oplog.bson"
+	echo "validating checksum"
+	sha1sum "${TEST_DIR}/basic_backup.tar.gz" | cut -f1 -d' ' | check "${checksum}"
 
 	destroy_model "test-basic-backup-create"
 }


### PR DESCRIPTION
There are 2 fixes:

1. Fix create-backup on upgraded controllers
2. Backport fix from https://github.com/juju/juju/pull/22261 to omit empty checksum from backup metadata

`juju create-backup` was failing on upgraded controllers for 2 reasons. Firstly, we were only passing the SSL args if the mongo version was 4.4.30 but we need to always to it. Second, on startup of jujud, we are updating the DNS names of the cert used for mongod
https://github.com/juju/juju/blob/main/cmd/jujud/agent/machine.go#L383

Writing the `server.pem` file was including the TLS cert and also CA cert. We now separately pass the CA cert as an arg to the mongo binaries (mongod, mongodump) and mongodump complains if the `server.pem` file contains the CA cert. So we strip it out when writing the `server.pem` file.

We also need to account for upgrading from older 2.8 controllers where mongo was installed from deb - the dir used to write the certs is different to that when snap is used.

The second commit backports a fix proposed for 3.6. We were writing an empty checksum to the `metadata.json` file inside the backup archive.

## QA steps

1. Start with old 2.8 controller with uses mongo from deb
juju bootstrap with juju CLI 2.8.13
juju upgrade-controller --build-agent
juju create-backup

2. Start with older 2.9 controller
juju bootstrap --agent-version 2.9.51
juju upgrade-controller --build-agent
juju create-backup

3. Start with controller from this PR
juju bootstrap
juju create-backup

You can ssh to the controller and inspec the `server.pem` to see the CA cert is omitted.

## Links

**Issue:** Fixes #22249 .

**Jira card:** [JUJU-9675](https://warthogs.atlassian.net/browse/JUJU-9675)


[JUJU-9675]: https://warthogs.atlassian.net/browse/JUJU-9675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ