### PR TITLE
fix: missing not-found code in RevokeCredential

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -5,6 +5,7 @@ package cloud
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -563,6 +565,11 @@ func (api *CloudAPI) RevokeCredentialsCheckModels(ctx context.Context, args para
 		}
 
 		if err = api.credentialService.CheckAndRevokeCredential(ctx, credential.KeyFromTag(tag), arg.Force); err != nil {
+			if errors.Is(err, credentialerrors.NotFound) {
+				err = internalerrors.New(
+					fmt.Sprintf("credential %s not found", tag.String()),
+				).Add(coreerrors.NotFound)
+			}
 			results.Results[i].Error = apiservererrors.ServerError(err)
 		}
 	}

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -935,6 +935,27 @@ func (s *cloudSuite) TestRevokeCredentials(c *tc.C) {
 	c.Assert(results.Results[2].Error, tc.IsNil)
 }
 
+func (s *cloudSuite) TestRevokeCredentialsNotFound(c *tc.C) {
+	bruceTag := names.NewUserTag("bruce")
+	defer s.setup(c, bruceTag).Finish()
+
+	_, tag := cloudCredentialTag(credParams{name: "three", owner: "bruce", cloudName: "meep", authType: jujucloud.EmptyAuthType,
+		attrs: map[string]string{}})
+
+	s.credService.EXPECT().CheckAndRevokeCredential(gomock.Any(), credential.KeyFromTag(tag), false).Return(credentialerrors.NotFound)
+
+	results, err := s.api.RevokeCredentialsCheckModels(c.Context(), params.RevokeCredentialArgs{
+		Credentials: []params.RevokeCredentialArg{
+			{Tag: "cloudcred-meep_bruce_three"},
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Check(params.IsCodeNotFound(results.Results[0].Error), tc.IsTrue)
+	c.Check(results.Results[0].Error.Message, tc.Equals, fmt.Sprintf("credential %s not found", tag.String()))
+	c.Check(results.Results[0].Error.Code, tc.Equals, params.CodeNotFound)
+}
+
 func (s *cloudSuite) TestRevokeCredentialsAdminAccess(c *tc.C) {
 	adminTag := names.NewUserTag("admin")
 	defer s.setup(c, adminTag).Finish()


### PR DESCRIPTION
# Description

When RevokeCredential is called on a not-existing cloud credentials it should return a not-found code to keep compatibility with 3.6

# QA

Run TestRevokeCredential e2e test in JIMM.
