### PR TITLE
fix(add-cloud): add a check for empty auth types

### DIFF
--- a/domain/cloud/service/service.go
+++ b/domain/cloud/service/service.go
@@ -58,6 +58,10 @@ func (s *Service) CreateCloud(ctx context.Context, owner user.Name, cloud cloud.
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
+	if len(cloud.AuthTypes) == 0 {
+		return errors.Errorf("empty auth-types %w", coreerrors.NotValid)
+	}
+
 	if cloud.Name == "" {
 		return errors.Errorf("%w cloud name cannot be empty", coreerrors.NotValid)
 	}
@@ -66,6 +70,7 @@ func (s *Service) CreateCloud(ctx context.Context, owner user.Name, cloud cloud.
 	if err != nil {
 		return errors.Errorf("creating uuid for cloud %q: %w", cloud.Name, err)
 	}
+
 	err = s.st.CreateCloud(ctx, owner, credUUID.String(), cloud)
 	if err != nil {
 		return errors.Errorf("creating cloud %q: %w", cloud.Name, err)

--- a/domain/cloud/service/service_test.go
+++ b/domain/cloud/service/service_test.go
@@ -28,7 +28,8 @@ func (s *serviceSuite) TestCreateCloudSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	cloud := cloud.Cloud{
-		Name: "fluffy",
+		Name:      "fluffy",
+		AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType},
 	}
 	s.state.EXPECT().CreateCloud(gomock.Any(), usertesting.GenNewName(c, "owner-name"), gomock.Any(), cloud).Return(nil)
 
@@ -40,12 +41,25 @@ func (s *serviceSuite) TestCreateCloudFail(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	cloud := cloud.Cloud{
-		Name: "fluffy",
+		Name:      "fluffy",
+		AuthTypes: cloud.AuthTypes{cloud.UserPassAuthType},
 	}
 	s.state.EXPECT().CreateCloud(gomock.Any(), usertesting.GenNewName(c, "owner-name"), gomock.Any(), cloud).Return(errors.New("boom"))
 
 	err := NewWatchableService(s.state, s.watcherFactory).CreateCloud(c.Context(), usertesting.GenNewName(c, "owner-name"), cloud)
 	c.Assert(err, tc.ErrorMatches, `creating cloud "fluffy": boom`)
+}
+
+func (s *serviceSuite) TestCreateCloudEmptyAuthTypes(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cloud := cloud.Cloud{
+		Name: "fluffy",
+	}
+
+	err := NewWatchableService(s.state, s.watcherFactory).CreateCloud(c.Context(), usertesting.GenNewName(c, "owner-name"), cloud)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+	c.Assert(err, tc.ErrorMatches, `.*empty auth-types.*`)
 }
 
 func (s *serviceSuite) TestCreateCloudEmptyName(c *tc.C) {


### PR DESCRIPTION
# Description

In Juju 3 there is a validation against adding a cloud with empty auth type, with this pr we add the same validation in Juju 4.

It is a problem in the current implementation because if you add a cloud with an empty auth type then you can't retrieve it. I guess it's because the SELECT is joining on the auth_types table and since the auth_type is empty the cloud is not found.

This fixes this e2e test in JIMM:  https://github.com/SimoneDutto/jimm/blob/skip-cloud-tests/testing/cloud_test.go#L559-L576

# QA

This test now passes in JIMM e2e suite.