### PR TITLE
fix: list-offers by matching juju 3 behavior

### DIFF
--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -288,12 +288,12 @@ func (st *State) getFilteredOfferDetails(ctx context.Context, tx *sqlair.TX, inp
 	stmt, err := st.Prepare(`
 SELECT &offerDetail.*
 FROM   v_offer_detail
-WHERE  offer_name = $offerFilter.offer_name
-OR     application_name LIKE $offerFilter.application_name
-OR     application_description LIKE $offerFilter.application_description
-OR     endpoint_name = $offerFilter.endpoint_name
-OR     endpoint_role = $offerFilter.endpoint_role
-OR     endpoint_interface = $offerFilter.endpoint_interface
+WHERE  (offer_name LIKE $offerFilter.offer_name OR $offerFilter.offer_name = '')
+AND    (application_name = $offerFilter.application_name OR $offerFilter.application_name = '')
+AND    (application_description LIKE $offerFilter.application_description OR $offerFilter.application_description = '')
+AND    (endpoint_name = $offerFilter.endpoint_name OR $offerFilter.endpoint_name = '')
+AND    (endpoint_role = $offerFilter.endpoint_role OR $offerFilter.endpoint_role = '')
+AND    (endpoint_interface = $offerFilter.endpoint_interface OR $offerFilter.endpoint_interface = '')
 `, offerDetail{}, offerFilter{})
 	if err != nil {
 		return nil, errors.Errorf("preparing filtered offer detail query: %w", err)
@@ -325,24 +325,23 @@ OR     endpoint_interface = $offerFilter.endpoint_interface
 // together to find offers. Thus, the input can be split into multiple
 // output.
 //
-// Application name and description filter values should be contained with
-// the actual result. Setup their values to use the LIKE operator by adding
-// an `%` before and after the word if provided.
+// ApplicatioName is matched exactly, while ApplicationDescription
+// and OfferName are matched with a "contains" match.
 func encodeOfferFilter(in crossmodelrelation.OfferFilter) ([]offerFilter, error) {
 	result := make([]offerFilter, 0)
 	if !in.EmptyModuloEndpoints() {
 		var (
-			applicationName, applicationDescription string
+			offerName, applicationDescription string
 		)
-		if in.ApplicationName != "" {
-			applicationName = fmt.Sprintf("%%%s%%", in.ApplicationName)
-		}
 		if in.ApplicationDescription != "" {
 			applicationDescription = fmt.Sprintf("%%%s%%", in.ApplicationDescription)
 		}
+		if in.OfferName != "" {
+			offerName = fmt.Sprintf("%%%s%%", in.OfferName)
+		}
 		result = append(result, offerFilter{
-			OfferName:              in.OfferName,
-			ApplicationName:        applicationName,
+			OfferName:              offerName,
+			ApplicationName:        in.ApplicationName,
 			ApplicationDescription: applicationDescription,
 		})
 	}

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -235,16 +235,95 @@ func (s *modelOfferSuite) TestDeleteFailedOffer(c *tc.C) {
 	c.Check(s.readOfferEndpoints(c), tc.HasLen, 0)
 }
 
+// TestGetOfferDetailsFilterTwoOffersSameApplication creates two offers for the
+// same application and verifies that filtering by offer name and application
+// name returns only the targeted offer.
+func (s *modelOfferSuite) TestGetOfferDetailsFilterTwoOffersSameApplication(c *tc.C) {
+	// Arrange - create one application with two offers, each exposing a
+	// different endpoint.
+	charmReferenceName := "test-charm"
+	charmUUID := s.addCharmWithReferenceName(c, charmReferenceName)
+	description := "testing application"
+	s.addCharmMetadataWithDescription(c, charmUUID, description)
+
+	relation1 := charm.Relation{
+		Name:      "db-admin",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+		Limit:     4,
+	}
+	relationUUID1 := s.addCharmRelation(c, charmUUID, relation1)
+
+	relation2 := charm.Relation{
+		Name:      "log",
+		Role:      charm.RoleRequirer,
+		Interface: "log",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID2 := s.addCharmRelation(c, charmUUID, relation2)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	endpointUUID1 := s.addApplicationEndpoint(c, appUUID, relationUUID1)
+	endpointUUID2 := s.addApplicationEndpoint(c, appUUID, relationUUID2)
+
+	offer1UUID := s.addOffer(c, "test-offer1", []string{endpointUUID1})
+	s.addOffer(c, "test-offer2", []string{endpointUUID2})
+
+	// Act - filter by both offer name and application name; the filter
+	// fields are ANDed so only test-offer1 should be returned.
+	results, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{
+		OfferName:       "test-offer1",
+		ApplicationName: appName,
+	})
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+	c.Assert(results, tc.HasLen, 1)
+	c.Check(results[0].OfferUUID, tc.Equals, offer1UUID.String())
+	c.Check(results[0].OfferName, tc.Equals, "test-offer1")
+	c.Check(results[0].ApplicationName, tc.Equals, appName)
+	c.Check(results[0].ApplicationDescription, tc.Equals, description)
+	c.Check(results[0].CharmLocator, tc.DeepEquals, domaincharm.CharmLocator{
+		Name:         charmReferenceName,
+		Revision:     42,
+		Source:       domaincharm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	})
+	c.Check(results[0].Endpoints, tc.DeepEquals, []crossmodelrelation.OfferEndpoint{{
+		Name:      relation1.Name,
+		Role:      domaincharm.RoleProvider,
+		Interface: relation1.Interface,
+		Limit:     relation1.Limit,
+	}})
+}
+
+func (s *modelOfferSuite) TestGetOfferDetailsFilterMultipleNoResult(c *tc.C) {
+	// Arrange
+	s.setupForGetOfferDetails(c)
+
+	// Act - filters are ANDed, so a valid offer name combined with
+	// a non-matching description should return no results.
+	results, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{
+		OfferName:              "test-offer",
+		ApplicationDescription: "failme",
+	})
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+	c.Assert(results, tc.HasLen, 0)
+}
+
 func (s *modelOfferSuite) TestGetOfferDetailsFilterMultiplePartialResult(c *tc.C) {
 	// Arrange
 	expected := s.setupForGetOfferDetails(c)
 
-	// Act
+	// Act - filters are ANDed; both offer name and description substring
+	// match the same offer so it is returned.
 	results, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{
-		OfferName: expected[0].OfferName,
-		// A charm with this metadata description does not exist,
-		// expect only 1 result.
-		ApplicationDescription: "failme",
+		OfferName:              expected[0].OfferName,
+		ApplicationDescription: "app",
 	})
 
 	// Assert
@@ -316,6 +395,20 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterOfferName(c *tc.C) {
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
+func (s *modelOfferSuite) TestGetOfferDetailsFilterPartialOfferName(c *tc.C) {
+	// Arrange
+	expected := s.setupForGetOfferDetails(c)
+
+	// Act - partial offer name should match with contains matching.
+	results, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{
+		OfferName: "test",
+	})
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+	c.Assert(results, tc.DeepEquals, expected)
+}
+
 func (s *modelOfferSuite) TestGetOfferDetailsFilterOfferUUID(c *tc.C) {
 	// Arrange
 	expected := s.setupForGetOfferDetails(c)
@@ -330,18 +423,32 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterOfferUUID(c *tc.C) {
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
-func (s *modelOfferSuite) TestGetOfferDetailsFilterPartialApplicationName(c *tc.C) {
+func (s *modelOfferSuite) TestGetOfferDetailsFilterExactApplicationName(c *tc.C) {
 	// Arrange
 	expected := s.setupForGetOfferDetails(c)
 
 	// Act
+	results, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{
+		ApplicationName: "test-application",
+	})
+
+	// Assert
+	c.Assert(err, tc.IsNil)
+	c.Assert(results, tc.DeepEquals, expected)
+}
+
+func (s *modelOfferSuite) TestGetOfferDetailsFilterPartialApplicationNameNoResult(c *tc.C) {
+	// Arrange
+	s.setupForGetOfferDetails(c)
+
+	// Act - partial application name should not match with exact matching.
 	results, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{
 		ApplicationName: "test",
 	})
 
 	// Assert
 	c.Assert(err, tc.IsNil)
-	c.Assert(results, tc.DeepEquals, expected)
+	c.Assert(results, tc.HasLen, 0)
 }
 
 func (s *modelOfferSuite) TestGetOfferDetailsFilterPartialApplicationDescription(c *tc.C) {


### PR DESCRIPTION
# Description

list-offers in juju 3 was based upon exact match on application name, "contains" match on the offer-name, filters ignore if empty string and in AND rather than OR conditions. This pr just re-implements these in Juju 4

juju 3.6 reference: https://github.com/juju/juju/blob/3.6/state/applicationoffers.go#L759
MongoDB reference talking about the implicit AND of multiple filters: https://github.com/juju/juju/blob/3.6/state/applicationoffers.go#L759


# QA
```
#!/bin/bash
set -eux

MODEL="offer-filter-test"

cleanup() {
    juju destroy-model "${MODEL}" --no-prompt --force --destroy-storage 2>/dev/null || true
}
trap cleanup EXIT

juju add-model "${MODEL}"
juju deploy juju-qa-test test-app

juju offer test-app:info test-offer1
juju offer test-app:info test-offer2

juju offers test-offer1 --application test-app --format yaml
```

Before the patch juju offers would return test-offer1 and test-offer2

Now it correctly returns test-offer1