### PR TITLE
fix: grouping ports issue

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -354,7 +354,7 @@ type OutputWriter interface {
 
 func printPorts(w OutputWriter, ps []string) {
 	sorted := append([]string(nil), ps...)
-	sort.Strings(sorted)
+	sort.Sort(sortablePorts(sorted))
 
 	protocols := map[string]*protocol{}
 	proto := func(p string) *protocol {

--- a/cmd/juju/status/output_tabular_test.go
+++ b/cmd/juju/status/output_tabular_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package status
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujutesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&outputTabularSuite{})
+
+type outputTabularSuite struct {
+	jujutesting.BaseSuite
+}
+
+func (s *outputTabularSuite) TestFormatOnelinePortsGroupedNumerically(c *gc.C) {
+	fs := formattedStatus{
+		Applications: map[string]applicationStatus{
+			"app": {
+				Units: map[string]unitStatus{
+					"app/0": {
+						OpenedPorts: []string{
+							"9998/tcp",
+							"9999/tcp",
+							"10000/tcp",
+							"10002/tcp",
+							"10003/tcp",
+							"10004/tcp",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	buff := &bytes.Buffer{}
+	err := formatOneline(buff, false, fs, func(out io.Writer, format, uName string, u unitStatus, level int) {
+		fmt.Fprintf(out, format, uName, "running", level)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(buff.String(), jc.Contains, "9998-10000,10002-10004/tcp")
+}


### PR DESCRIPTION
Fix port grouping in `juju status`.

Open ports were being sorted as strings before grouping, which breaks ranges that cross a digit boundary, like `9999` → `10000`. This change sorts ports numerically first, so contiguous ports are grouped correctly in the output.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Go unit tests, with comments saying what you're testing
- [x] Integration tests, with comments saying what you're testing

## QA steps

1. Run the unit tests for the status package.
2. Check that `juju status` now groups ports like `9998-10001/tcp` instead of splitting them at `10000`.


## Links

**Issue:** Fixes #22076.