### PR TITLE
fix(ssh): force PTY allocation for debug-hooks and debug-code

### DIFF
--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -262,6 +262,13 @@ func (c *debugHooksCommand) commonRun(
 	innercmd := fmt.Sprintf(`F=$(mktemp); echo %s | base64 -d > $F; chmod +x $F; exec $F`, b64Script)
 	args := []string{fmt.Sprintf(c.decideEntryPoint(ctx), innercmd)}
 	c.provider.setArgs(args)
+
+	// debug-hooks and debug-code always need a PTY because they launch a
+	// tmux session on the remote side. Force PTY allocation so that the
+	// enablePty heuristic (which disables PTY when args are present) does
+	// not prevent it.
+	_ = c.pty.Set("true")
+
 	return c.sshCommand.Run(ctx)
 }
 

--- a/cmd/juju/ssh/debughooks_test.go
+++ b/cmd/juju/ssh/debughooks_test.go
@@ -56,6 +56,7 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
+		enablePty:       true,
 		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
 	},
 }, {
@@ -65,12 +66,23 @@ var debugHooksTests = []struct {
 	expected: &argsSpec{
 		hostKeyChecking: "yes",
 		knownHosts:      "0",
+		enablePty:       true,
 		withProxy:       true,
 		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
 	},
 }, {
 	info:        "pty enabled",
 	args:        []string{"--pty=true", "mysql/0"},
+	hostChecker: validAddresses("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
+	expected: &argsSpec{
+		hostKeyChecking: "yes",
+		knownHosts:      "0",
+		enablePty:       true,
+		argsMatch:       `ubuntu@0\.(private|public|1\.2\.3) exec sudo .+`, // can be any of the 3
+	},
+}, {
+	info:        "pty=false overridden by debug-hooks",
+	args:        []string{"--pty=false", "mysql/0"},
 	hostChecker: validAddresses("0.private", "0.public", "0.1.2.3"), // set by setAddresses() and setLinkLayerDevicesAddresses()
 	expected: &argsSpec{
 		hostKeyChecking: "yes",


### PR DESCRIPTION
This is a cherry-pick of the 3.6 commit that fixes debug-hook. I'm not going
to merge the whole of 3.6 into 4.0, as that's ongoing work from @hpidcock.

For now, just cherry-pick the fix that will unblock the release.

-----------------------

The enablePty heuristic introduced in PR #21716 disables PTY when remote
args are present. Since debug-hooks and debug-code always set args (the                                                               tmux debug script), PTY was never allocated, causing tmux to fail with
"open terminal failed: not a terminal".

Force PTY via c.pty.Set("true") in commonRun before calling sshCommand.Run, ensuring tmux gets the terminal it requires.

Fixes #21984

## QA Steps

```sh
$ juju bootstrap lxd src
$ juju debug-hook -m controller controller/0
```

The command should connect to a tmux session.