### PR TITLE
test: run destroy correctly

### DIFF
--- a/.github/workflows/postgresql-k8s.yml
+++ b/.github/workflows/postgresql-k8s.yml
@@ -65,7 +65,4 @@ jobs:
           cd tests
           export MODEL_ARCH=$(go env GOARCH)
 
-          # Skip destroy to keep the environment up.
-          export SKIP_DESTROY=true
-
           sg snap_microk8s './main.sh -c microk8s -v smoke_k8s_psql'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -73,9 +73,6 @@ jobs:
           export MODEL_ARCH=$(go env GOARCH)
           export BOOTSTRAP_ADDITIONAL_ARGS="--model-default enable-os-upgrade=false"
 
-          # Skip destroy to keep the environment up.
-          export SKIP_DESTROY=true
-
           ./main.sh -v -s 'test_build' smoke
 
       - name: Smoke test (MicroK8s)
@@ -84,9 +81,6 @@ jobs:
         run: |
           cd tests
           export MODEL_ARCH=$(go env GOARCH)
-
-          # Skip destroy to keep the environment up.
-          export SKIP_DESTROY=true
 
           sg snap_microk8s './main.sh -c microk8s -v smoke_k8s'
 
@@ -129,9 +123,6 @@ jobs:
           cd tests
           export MODEL_ARCH=$(go env GOARCH)
           export BOOTSTRAP_ADDITIONAL_ARGS="--model-default enable-os-upgrade=false --model-default logging-config='<root>=INFO;juju.worker.asynccharmdownloader=TRACE'"
-
-          # Skip destroy to keep the environment up.
-          export SKIP_DESTROY=true
 
           # Skip these tests for now, as they rely on cmrs
           ./main.sh -v -s 'test_cmr_bundles_export_overlay' deploy

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -89,8 +89,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, aws, quad-xlarge]
     timeout-minutes: 60
     if: github.event.pull_request.draft == false
-    strategy:
-      fail-fast: false
     steps:
 
       - name: Checkout


### PR DESCRIPTION
This is a partial revert of https://github.com/juju/juju/pull/18159/changes/79728535f271ff6aca6b7b866d3f076bf820e471#diff-3e3a544a7087b3bc7dc0bc79025624035297abd1dc4a6619e7d89ee4e9ca21a7

Destroying of models was skipped whilst we implemented the removal domain. This is now done, so these tests should pass accordingly.

## QA steps

The tests should start to pass.