### PR TITLE
fix: missing code already-exists in AddCloud

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -686,7 +686,9 @@ func (api *CloudAPI) AddCloud(ctx context.Context, cloudArgs params.AddCloudArgs
 	}
 
 	err = api.cloudService.CreateCloud(ctx, user.NameFromTag(api.apiUser), aCloud)
-	if err != nil {
+	if errors.Is(err, clouderrors.AlreadyExists) {
+		return internalerrors.New(fmt.Sprintf("cloud %q already exists", cloudArgs.Name)).Add(coreerrors.AlreadyExists)
+	} else if err != nil {
 		return errors.Annotatef(err, "creating cloud %q", cloudArgs.Name)
 	}
 	return nil

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/mock/gomock"
 
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facades/client/cloud"
 	"github.com/juju/juju/apiserver/facades/client/cloud/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	usertesting "github.com/juju/juju/core/user/testing"
@@ -485,6 +487,31 @@ func (s *cloudSuite) TestAddCloudNoAdminPerms(c *tc.C) {
 		}}
 	err := s.api.AddCloud(c.Context(), paramsCloud)
 	c.Assert(err, tc.ErrorMatches, "permission denied")
+}
+
+func (s *cloudSuite) TestAddCloudAlreadyExists(c *tc.C) {
+	adminTag := names.NewUserTag("admin")
+	defer s.setup(c, adminTag).Finish()
+
+	cloud := jujucloud.Cloud{
+		Name: "newcloudname",
+		Type: "maas",
+	}
+	s.cloudService.EXPECT().Cloud(gomock.Any(), "dummy").Return(&cloud, nil)
+	newCloud := jujucloud.Cloud{
+		Name:      "newcloudname",
+		Type:      "maas",
+		AuthTypes: []jujucloud.AuthType{jujucloud.EmptyAuthType, jujucloud.UserPassAuthType},
+		Endpoint:  "fake-endpoint",
+		Regions:   []jujucloud.Region{{Name: "nether", Endpoint: "nether-endpoint"}},
+	}
+	s.cloudService.EXPECT().CreateCloud(gomock.Any(), user.NameFromTag(adminTag), newCloud).
+		Return(clouderrors.AlreadyExists)
+
+	err := s.api.AddCloud(c.Context(), createAddCloudParam("maas"))
+	c.Assert(err, tc.ErrorIs, coreerrors.AlreadyExists)
+	serverErr := apiservererrors.ServerError(err)
+	c.Check(serverErr.Code, tc.Equals, params.CodeAlreadyExists)
 }
 
 func (s *cloudSuite) TestUpdateCloud(c *tc.C) {

--- a/domain/cloud/errors/errors.go
+++ b/domain/cloud/errors/errors.go
@@ -6,6 +6,10 @@ package errors
 import "github.com/juju/juju/internal/errors"
 
 const (
+	// AlreadyExists describes an error that occurs when a cloud with the same
+	// name already exists.
+	AlreadyExists = errors.ConstError("cloud already exists")
+
 	// NotFound describes an error that occurs when the cloud being operated on
 	// does not exist.
 	NotFound = errors.ConstError("cloud not found")

--- a/domain/cloud/service/service.go
+++ b/domain/cloud/service/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/juju/cloud"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
@@ -57,6 +58,10 @@ func (s *Service) CreateCloud(ctx context.Context, owner user.Name, cloud cloud.
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
+	if cloud.Name == "" {
+		return errors.Errorf("%w cloud name cannot be empty", coreerrors.NotValid)
+	}
+
 	credUUID, err := uuid.NewUUID()
 	if err != nil {
 		return errors.Errorf("creating uuid for cloud %q: %w", cloud.Name, err)
@@ -72,6 +77,10 @@ func (s *Service) CreateCloud(ctx context.Context, owner user.Name, cloud cloud.
 func (s *Service) UpdateCloud(ctx context.Context, cloud cloud.Cloud) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
+
+	if cloud.Name == "" {
+		return errors.Errorf("%w cloud name cannot be empty", coreerrors.NotValid)
+	}
 
 	if err := s.st.UpdateCloud(ctx, cloud); err != nil {
 		return errors.Errorf("updating cloud %q: %w", cloud.Name, err)

--- a/domain/cloud/service/service_test.go
+++ b/domain/cloud/service/service_test.go
@@ -48,6 +48,13 @@ func (s *serviceSuite) TestCreateCloudFail(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `creating cloud "fluffy": boom`)
 }
 
+func (s *serviceSuite) TestCreateCloudEmptyName(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := NewWatchableService(s.state, s.watcherFactory).CreateCloud(c.Context(), usertesting.GenNewName(c, "owner-name"), cloud.Cloud{})
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
 func (s *serviceSuite) TestUpdateCloudSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -70,6 +77,13 @@ func (s *serviceSuite) TestUpdateCloudError(c *tc.C) {
 
 	err := NewWatchableService(s.state, s.watcherFactory).UpdateCloud(c.Context(), cloud)
 	c.Assert(err, tc.ErrorMatches, `updating cloud "fluffy": boom`)
+}
+
+func (s *serviceSuite) TestUpdateCloudEmptyName(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := NewWatchableService(s.state, s.watcherFactory).UpdateCloud(c.Context(), cloud.Cloud{})
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestDeleteCloudSuccess(c *tc.C) {

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -391,10 +391,6 @@ func updateCloud(ctx context.Context, tx *sqlair.TX, cloudUUID string, cloud clo
 }
 
 func upsertCloud(ctx context.Context, tx *sqlair.TX, cloudUUID string, cloud cloud.Cloud) error {
-	if cloud.Name == "" {
-		return errors.Errorf("%w cloud name cannot be empty", coreerrors.NotValid)
-	}
-
 	cloudFromDB, err := dbCloudFromCloud(ctx, tx, cloudUUID, cloud)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -414,6 +414,8 @@ ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
 	err = tx.Query(ctx, insertCloudStmt, cloudFromDB).Run()
 	if database.IsErrConstraintCheck(err) {
 		return errors.Errorf("%w cloud name cannot be empty", coreerrors.NotValid).Add(err)
+	} else if database.IsErrConstraintUnique(err) {
+		return errors.Errorf("cloud %q %w", cloud.Name, clouderrors.AlreadyExists).Add(err)
 	} else if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -391,9 +391,30 @@ func updateCloud(ctx context.Context, tx *sqlair.TX, cloudUUID string, cloud clo
 }
 
 func upsertCloud(ctx context.Context, tx *sqlair.TX, cloudUUID string, cloud cloud.Cloud) error {
+	if cloud.Name == "" {
+		return errors.Errorf("%w cloud name cannot be empty", coreerrors.NotValid)
+	}
+
 	cloudFromDB, err := dbCloudFromCloud(ctx, tx, cloudUUID, cloud)
 	if err != nil {
 		return errors.Capture(err)
+	}
+
+	// Check for a name conflict before upserting.
+	selectByNameStmt, err := sqlair.Prepare(`
+SELECT &dbCloud.uuid
+FROM   cloud
+WHERE  name = $dbCloud.name`, dbCloud{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	var nameCheck dbCloud
+	err = tx.Query(ctx, selectByNameStmt, cloudFromDB).Get(&nameCheck)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Capture(err)
+	} else if err == nil && nameCheck.UUID != cloudUUID {
+		return errors.Errorf("cloud %q %w", cloud.Name, clouderrors.AlreadyExists)
 	}
 
 	insertCloudStmt, err := sqlair.Prepare(`
@@ -411,15 +432,7 @@ ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
 		return errors.Capture(err)
 	}
 
-	err = tx.Query(ctx, insertCloudStmt, cloudFromDB).Run()
-	if database.IsErrConstraintCheck(err) {
-		return errors.Errorf("%w cloud name cannot be empty", coreerrors.NotValid).Add(err)
-	} else if database.IsErrConstraintUnique(err) {
-		return errors.Errorf("cloud %q %w", cloud.Name, clouderrors.AlreadyExists).Add(err)
-	} else if err != nil {
-		return errors.Capture(err)
-	}
-	return nil
+	return errors.Capture(tx.Query(ctx, insertCloudStmt, cloudFromDB).Run())
 }
 
 // loadAuthTypes reads the cloud auth type values and ids

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -275,6 +275,14 @@ func (s *stateSuite) TestCreateCloudUpdateExisting(c *tc.C) {
 	c.Assert(originalUUID, tc.Equals, cloudUUID)
 }
 
+func (s *stateSuite) TestCreateCloudWithExistingNameNewUUID(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	s.assertInsertCloud(c, st, testCloud)
+
+	err := st.CreateCloud(c.Context(), usertesting.GenNewName(c, "admin"), uuid.MustNewUUID().String(), testCloud)
+	c.Assert(err, tc.ErrorIs, clouderrors.AlreadyExists)
+}
+
 func (s *stateSuite) TestCreateCloudInvalidType(c *tc.C) {
 	cld := testCloud
 	cld.Type = "mycloud"

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/cloud"
 	corecloud "github.com/juju/juju/core/cloud"
 	cloudtesting "github.com/juju/juju/core/cloud/testing"
-	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -290,15 +289,6 @@ func (s *stateSuite) TestCreateCloudInvalidType(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	err := st.CreateCloud(c.Context(), usertesting.GenNewName(c, "admin"), uuid.MustNewUUID().String(), cld)
 	c.Assert(err, tc.ErrorMatches, `.* cloud type "mycloud" not valid`)
-}
-
-func (s *stateSuite) TestCloudWithEmptyNameFails(c *tc.C) {
-	cld := testCloud
-	cld.Name = ""
-
-	st := NewState(s.TxnRunnerFactory())
-	err := st.CreateCloud(c.Context(), usertesting.GenNewName(c, "admin"), uuid.MustNewUUID().String(), cld)
-	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *stateSuite) TestCreateCloudInvalidAuthType(c *tc.C) {


### PR DESCRIPTION
# Description

AddCloud should return `CodeAlreadyExists` when we try to insert a cloud with an already exisiting name. This is correct, but it also needed to match Juju 3 behavior JAAS was relying on.

Before this patch adding a cloud with the same was returning:
`updating cloud 33589e48-2cba-4efd-8dd5-e8bb867b9e73: UNIQUE constraint failed: cloud.name`

Now it correctly returns the code in the error.

To accomplish this:
- check unique constraint error in state layer
- create a sentinel error in state layer
- traslate the error in the apiserver/client layer
- add some unit tests

# QA

This test https://github.com/SimoneDutto/jimm/blob/skip-cloud-tests/testing/jimm_test.go#L773 passes with this fix.