### PR TITLE
fix: application endpoint offer only global scopes

### DIFF
--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -5,6 +5,8 @@ package service
 
 import (
 	"context"
+	"maps"
+	"slices"
 
 	"github.com/juju/collections/transform"
 
@@ -59,6 +61,10 @@ type ModelOfferState interface {
 	// with the given UUIDs. An empty result is returned if no connections
 	// are found.
 	GetOfferConnections(ctx context.Context, offerUUIDs []string) ([]crossmodelrelation.OfferConnectionDetail, error)
+
+	// ValidateApplicationAndEndpointsForOffer checks that the application
+	// exists and is not dead, and that the endpoints are valid.
+	ValidateApplicationAndEndpointsForOffer(ctx context.Context, applicationName string, endpoints []string) (string, error)
 }
 
 // GetOfferUUID returns the uuid for the provided offer URL.
@@ -132,17 +138,26 @@ func (s *Service) CreateOffer(
 	if err != nil {
 		return errors.Capture(err)
 	}
-	createArgs := crossmodelrelation.MakeCreateOfferArgs(args, offerUUID)
 
 	// Check if the offer already exists.
 	existingOfferUUID, err := s.modelState.GetOfferUUID(ctx, args.OfferName)
 	if err != nil && !errors.Is(err, crossmodelrelationerrors.OfferNotFound) {
-		return errors.Errorf("create offer: %w", err)
+		return errors.Errorf("creating offer: %w", err)
 	} else if err == nil {
 		// The offer exists, this means that we have to return an error since we
 		// don't support updating offers.
-		return errors.Errorf("create offer: offer %q already exists with UUID %q",
+		return errors.Errorf("creating offer: offer %q already exists with UUID %q",
 			args.OfferName, existingOfferUUID).Add(crossmodelrelationerrors.OfferAlreadyExists)
+	}
+
+	endpoints := slices.Collect(maps.Keys(args.Endpoints))
+
+	// Verify the application exists and is not dead before creating the offer,
+	// and that the application endpoints are valid.
+	// Return a valid application UUID for offer creation.
+	applicationUUID, err := s.modelState.ValidateApplicationAndEndpointsForOffer(ctx, args.ApplicationName, endpoints)
+	if err != nil {
+		return errors.Errorf("creating offer %q: %w", args.OfferName, err)
 	}
 
 	// Verify the owner exists, has not been removed, and
@@ -150,13 +165,18 @@ func (s *Service) CreateOffer(
 	// update an offer, such an admin.
 	ownerUUID, err := s.controllerState.GetUserUUIDByName(ctx, args.OwnerName)
 	if err != nil {
-		return errors.Errorf("create offer: %w", err)
+		return errors.Errorf("creating offer: %w", err)
 	}
 
 	// The offer does not exist, create it.
-	err = s.modelState.CreateOffer(ctx, createArgs)
+	err = s.modelState.CreateOffer(ctx, crossmodelrelation.CreateOfferArgs{
+		UUID:            offerUUID,
+		ApplicationUUID: applicationUUID,
+		Endpoints:       endpoints,
+		OfferName:       args.OfferName,
+	})
 	if err != nil {
-		return errors.Errorf("create offer: %w", err)
+		return errors.Errorf("creating offer: %w", err)
 	}
 
 	err = s.controllerState.CreateOfferAccess(ctx, permissionUUID, offerUUID, ownerUUID)

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/juju/juju/core/crossmodel"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/offer"
 	"github.com/juju/juju/core/permission"
 	relationtesting "github.com/juju/juju/core/relation/testing"
@@ -35,22 +36,22 @@ func (s *offerServiceSuite) TestOfferCreate(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
-	// Expect to call CreateOffer by receiving OfferNotFound from GetOfferUUID.
 	applicationName := "test-application"
 	offerName := "test-offer"
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
-
+	applicationUUID := uuid.MustNewUUID().String()
 	ownerName := usertesting.GenNewName(c, "admin")
 	ownerUUID := uuid.MustNewUUID()
+
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
+		Return(applicationUUID, nil)
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
-	args := crossmodelrelation.ApplicationOfferArgs{
-		ApplicationName: applicationName,
+
+	m := createOfferArgsMatcher{c: c, expected: crossmodelrelation.CreateOfferArgs{
+		ApplicationUUID: applicationUUID,
 		OfferName:       offerName,
-		Endpoints:       map[string]string{"db": "db"},
-		OwnerName:       ownerName,
-	}
-	createOfferArgs := crossmodelrelation.MakeCreateOfferArgs(args, "")
-	m := createOfferArgsMatcher{c: c, expected: createOfferArgs}
+		Endpoints:       []string{"db"},
+	}}
 	s.modelState.EXPECT().CreateOffer(gomock.Any(), m).Return(nil)
 
 	s.controllerState.EXPECT().CreateOfferAccess(
@@ -59,6 +60,13 @@ func (s *offerServiceSuite) TestOfferCreate(c *tc.C) {
 		gomock.AssignableToTypeOf(offer.UUID("")),
 		ownerUUID,
 	).Return(nil)
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       ownerName,
+	}
 
 	// Act
 	err := s.service(c).CreateOffer(c.Context(), args)
@@ -73,22 +81,22 @@ func (s *offerServiceSuite) TestOfferCreateAccessErr(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
-	// Expect to call CreateOffer by receiving OfferNotFound from GetOfferUUID.
 	applicationName := "test-application"
 	offerName := "test-offer"
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
-
+	applicationUUID := uuid.MustNewUUID().String()
 	ownerName := usertesting.GenNewName(c, "admin")
 	ownerUUID := uuid.MustNewUUID()
+
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
+		Return(applicationUUID, nil)
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
-	args := crossmodelrelation.ApplicationOfferArgs{
-		ApplicationName: applicationName,
+
+	m := createOfferArgsMatcher{c: c, expected: crossmodelrelation.CreateOfferArgs{
+		ApplicationUUID: applicationUUID,
 		OfferName:       offerName,
-		Endpoints:       map[string]string{"db": "db"},
-		OwnerName:       ownerName,
-	}
-	createOfferArgs := crossmodelrelation.MakeCreateOfferArgs(args, "")
-	m := createOfferArgsMatcher{c: c, expected: createOfferArgs}
+		Endpoints:       []string{"db"},
+	}}
 	s.modelState.EXPECT().CreateOffer(gomock.Any(), m).Return(nil)
 
 	// Fail creating offer access and delete the newly created offer
@@ -99,6 +107,13 @@ func (s *offerServiceSuite) TestOfferCreateAccessErr(c *tc.C) {
 		ownerUUID,
 	).Return(errors.Errorf("boom"))
 	s.modelState.EXPECT().DeleteFailedOffer(gomock.Any(), gomock.AssignableToTypeOf(offer.UUID(""))).Return(nil)
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       ownerName,
+	}
 
 	// Act
 	err := s.service(c).CreateOffer(c.Context(), args)
@@ -113,29 +128,36 @@ func (s *offerServiceSuite) TestOfferCreateError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
-	// Expect to call CreateOffer by receiving OfferNotFound from GetOfferUUID.
 	applicationName := "test-application"
 	offerName := "test-offer"
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
-
+	applicationUUID := uuid.MustNewUUID().String()
 	ownerName := usertesting.GenNewName(c, "admin")
 	ownerUUID := uuid.MustNewUUID()
+
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
+		Return(applicationUUID, nil)
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
+
+	m := createOfferArgsMatcher{c: c, expected: crossmodelrelation.CreateOfferArgs{
+		ApplicationUUID: applicationUUID,
+		OfferName:       offerName,
+		Endpoints:       []string{"db"},
+	}}
+	s.modelState.EXPECT().CreateOffer(gomock.Any(), m).Return(errors.Errorf("boom"))
+
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: applicationName,
 		OfferName:       offerName,
 		Endpoints:       map[string]string{"db": "db"},
 		OwnerName:       ownerName,
 	}
-	createOfferArgs := crossmodelrelation.MakeCreateOfferArgs(args, "")
-	m := createOfferArgsMatcher{c: c, expected: createOfferArgs}
-	s.modelState.EXPECT().CreateOffer(gomock.Any(), m).Return(errors.Errorf("boom"))
 
 	// Act
 	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.ErrorMatches, "create offer: boom")
+	c.Assert(err, tc.ErrorMatches, "creating offer: boom")
 }
 
 // TestOfferAlreadyExists tests that Offer returns an error when an offer
@@ -148,6 +170,10 @@ func (s *offerServiceSuite) TestOfferAlreadyExists(c *tc.C) {
 	offerName := "test-offer"
 	ownerName := usertesting.GenNewName(c, "admin")
 	existingOfferUUID := uuid.MustNewUUID().String()
+
+	// Return an existing offer UUID to simulate the offer already exists
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return(existingOfferUUID, nil)
+
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: applicationName,
 		OfferName:       offerName,
@@ -155,14 +181,11 @@ func (s *offerServiceSuite) TestOfferAlreadyExists(c *tc.C) {
 		OwnerName:       ownerName,
 	}
 
-	// Return an existing offer UUID to simulate the offer already exists
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return(existingOfferUUID, nil)
-
 	// Act
 	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.ErrorMatches, `create offer: offer "test-offer" already exists with UUID ".*"`)
+	c.Assert(err, tc.ErrorMatches, `creating offer: offer "test-offer" already exists with UUID ".*"`)
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferAlreadyExists)
 }
 
@@ -175,6 +198,10 @@ func (s *offerServiceSuite) TestOfferGetOfferUUIDError(c *tc.C) {
 	applicationName := "test-application"
 	offerName := "test-offer"
 	ownerName := usertesting.GenNewName(c, "admin")
+
+	// Return a database error when checking if offer exists
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", errors.Errorf("database error"))
+
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: applicationName,
 		OfferName:       offerName,
@@ -182,14 +209,11 @@ func (s *offerServiceSuite) TestOfferGetOfferUUIDError(c *tc.C) {
 		OwnerName:       ownerName,
 	}
 
-	// Return a database error when checking if offer exists
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", errors.Errorf("database error"))
-
 	// Act
 	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.ErrorMatches, "create offer: database error")
+	c.Assert(err, tc.ErrorMatches, "creating offer: database error")
 }
 
 // TestOfferOwnerNotFound tests that Offer returns an error when
@@ -200,7 +224,15 @@ func (s *offerServiceSuite) TestOfferOwnerNotFound(c *tc.C) {
 	// Arrange
 	applicationName := "test-application"
 	offerName := "test-offer"
+	applicationUUID := uuid.MustNewUUID().String()
 	ownerName := usertesting.GenNewName(c, "nonexistent")
+
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
+		Return(applicationUUID, nil)
+	// Owner user doesn't exist
+	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(uuid.UUID{}, errors.Errorf("user not found"))
+
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: applicationName,
 		OfferName:       offerName,
@@ -208,16 +240,170 @@ func (s *offerServiceSuite) TestOfferOwnerNotFound(c *tc.C) {
 		OwnerName:       ownerName,
 	}
 
-	// Offer doesn't exist yet
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
-	// Owner user doesn't exist
-	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(uuid.UUID{}, errors.Errorf("user not found"))
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, "creating offer: user not found")
+}
+
+// TestCreateOfferValidateArgsEmptyAppName tests that CreateOffer returns
+// an error when the application name is empty.
+func (s *offerServiceSuite) TestCreateOfferValidateArgsEmptyAppName(c *tc.C) {
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), crossmodelrelation.ApplicationOfferArgs{
+		Endpoints: map[string]string{"db": "db"},
+		OwnerName: usertesting.GenNewName(c, "admin"),
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestCreateOfferValidateArgsEmptyOwnerName tests that CreateOffer returns
+// an error when the owner name is empty.
+func (s *offerServiceSuite) TestCreateOfferValidateArgsEmptyOwnerName(c *tc.C) {
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: "test-application",
+		Endpoints:       map[string]string{"db": "db"},
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestCreateOfferValidateArgsEmptyEndpoints tests that CreateOffer returns
+// an error when the endpoints are empty.
+func (s *offerServiceSuite) TestCreateOfferValidateArgsEmptyEndpoints(c *tc.C) {
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: "test-application",
+		OwnerName:       usertesting.GenNewName(c, "admin"),
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestCreateOfferDefaultOfferName tests that when no offer name is provided,
+// it defaults to the application name.
+func (s *offerServiceSuite) TestCreateOfferDefaultOfferName(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	applicationName := "test-application"
+	applicationUUID := uuid.MustNewUUID().String()
+	ownerName := usertesting.GenNewName(c, "admin")
+	ownerUUID := uuid.MustNewUUID()
+
+	// The offer name defaults to the application name.
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), applicationName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).Return(applicationUUID, nil)
+	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
+
+	m := createOfferArgsMatcher{c: c, expected: crossmodelrelation.CreateOfferArgs{
+		ApplicationUUID: applicationUUID,
+		OfferName:       applicationName,
+		Endpoints:       []string{"db"},
+	}}
+	s.modelState.EXPECT().CreateOffer(gomock.Any(), m).Return(nil)
+
+	s.controllerState.EXPECT().CreateOfferAccess(
+		gomock.Any(),
+		gomock.AssignableToTypeOf(uuid.UUID{}),
+		gomock.AssignableToTypeOf(offer.UUID("")),
+		ownerUUID,
+	).Return(nil)
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       ownerName,
+	}
 
 	// Act
 	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.ErrorMatches, "create offer: user not found")
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestCreateOfferValidateApplicationFails tests that CreateOffer returns an
+// error when the application validation fails.
+func (s *offerServiceSuite) TestCreateOfferValidateApplicationFails(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	applicationName := "test-application"
+	offerName := "test-offer"
+	ownerName := usertesting.GenNewName(c, "admin")
+
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(
+		gomock.Any(), applicationName, []string{"db"},
+	).Return("", errors.Errorf("application is dead"))
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       ownerName,
+	}
+
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, "creating offer: application is dead")
+}
+
+// TestCreateOfferAccessAndDeleteFail tests that when both CreateOfferAccess
+// and DeleteFailedOffer fail, the errors are joined.
+func (s *offerServiceSuite) TestCreateOfferAccessAndDeleteFail(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	applicationName := "test-application"
+	offerName := "test-offer"
+	applicationUUID := uuid.MustNewUUID().String()
+	ownerName := usertesting.GenNewName(c, "admin")
+	ownerUUID := uuid.MustNewUUID()
+
+	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
+		Return(applicationUUID, nil)
+	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
+
+	m := createOfferArgsMatcher{c: c, expected: crossmodelrelation.CreateOfferArgs{
+		ApplicationUUID: applicationUUID,
+		OfferName:       offerName,
+		Endpoints:       []string{"db"},
+	}}
+	s.modelState.EXPECT().CreateOffer(gomock.Any(), m).Return(nil)
+
+	s.controllerState.EXPECT().CreateOfferAccess(
+		gomock.Any(),
+		gomock.AssignableToTypeOf(uuid.UUID{}),
+		gomock.AssignableToTypeOf(offer.UUID("")),
+		ownerUUID,
+	).Return(errors.Errorf("access boom"))
+	s.modelState.EXPECT().DeleteFailedOffer(
+		gomock.Any(), gomock.AssignableToTypeOf(offer.UUID("")),
+	).Return(errors.Errorf("delete boom"))
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       ownerName,
+	}
+
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, `creating access for offer "test-offer": access boom\ndelete boom`)
 }
 
 func (s *offerServiceSuite) TestGetOffersEmptyFilters(c *tc.C) {
@@ -491,7 +677,8 @@ func (s *offerServiceSuite) TestGetOffersWithAllowedConsumersNotFoundMoreInFilte
 			},
 		},
 	}
-	s.modelState.EXPECT().GetOfferDetails(gomock.Any(), crossmodelrelation.OfferFilter{OfferName: "test-offer"}).Return(offerDetails, nil)
+	s.modelState.EXPECT().GetOfferDetails(gomock.Any(), crossmodelrelation.OfferFilter{OfferName: "test-offer"}).
+		Return(offerDetails, nil)
 
 	offerUsers := map[string][]crossmodelrelation.OfferUser{
 		offerUUIDs[0]: {
@@ -632,7 +819,8 @@ func (s *offerServiceSuite) TestGetConsumeDetailsError(c *tc.C) {
 	// Arrange
 	offerURL, err := crossmodel.ParseOfferURL("postgresql.db-admin")
 	c.Assert(err, tc.IsNil)
-	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerURL.Name).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerURL.Name).
+		Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
 
 	// Act
 	_, err = s.service(c).GetConsumeDetails(c.Context(), offerURL)

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -355,7 +355,7 @@ func (s *offerServiceSuite) TestCreateOfferValidateApplicationFails(c *tc.C) {
 	err := s.service(c).CreateOffer(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.ErrorMatches, "creating offer: application is dead")
+	c.Assert(err, tc.ErrorMatches, "creating offer .*: application is dead")
 }
 
 // TestCreateOfferAccessAndDeleteFail tests that when both CreateOfferAccess

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -2144,6 +2144,45 @@ func (c *MockModelStateUpdateRemoteSecretRevisionCall) DoAndReturn(f func(contex
 	return c
 }
 
+// ValidateApplicationAndEndpointsForOffer mocks base method.
+func (m *MockModelState) ValidateApplicationAndEndpointsForOffer(arg0 context.Context, arg1 string, arg2 []string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateApplicationAndEndpointsForOffer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateApplicationAndEndpointsForOffer indicates an expected call of ValidateApplicationAndEndpointsForOffer.
+func (mr *MockModelStateMockRecorder) ValidateApplicationAndEndpointsForOffer(arg0, arg1, arg2 any) *MockModelStateValidateApplicationAndEndpointsForOfferCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateApplicationAndEndpointsForOffer", reflect.TypeOf((*MockModelState)(nil).ValidateApplicationAndEndpointsForOffer), arg0, arg1, arg2)
+	return &MockModelStateValidateApplicationAndEndpointsForOfferCall{Call: call}
+}
+
+// MockModelStateValidateApplicationAndEndpointsForOfferCall wrap *gomock.Call
+type MockModelStateValidateApplicationAndEndpointsForOfferCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateValidateApplicationAndEndpointsForOfferCall) Return(arg0 string, arg1 error) *MockModelStateValidateApplicationAndEndpointsForOfferCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateValidateApplicationAndEndpointsForOfferCall) Do(f func(context.Context, string, []string) (string, error)) *MockModelStateValidateApplicationAndEndpointsForOfferCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateValidateApplicationAndEndpointsForOfferCall) DoAndReturn(f func(context.Context, string, []string) (string, error)) *MockModelStateValidateApplicationAndEndpointsForOfferCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockModelMigrationState is a mock of ModelMigrationState interface.
 type MockModelMigrationState struct {
 	ctrl     *gomock.Controller

--- a/domain/crossmodelrelation/state/model/import.go
+++ b/domain/crossmodelrelation/state/model/import.go
@@ -269,7 +269,7 @@ func (st *State) GetApplicationUUIDByName(ctx context.Context, name string) (str
 
 	var id string
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		id, err = st.getApplicationUUID(ctx, tx, name)
+		id, _, err = st.getApplicationUUIDAndLife(ctx, tx, name)
 		return err
 	}); err != nil {
 		return "", errors.Capture(err)

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -93,13 +93,11 @@ func (st *State) ValidateApplicationAndEndpointsForOffer(
 	// types. scope_id is container scope, which is not allowed to be offered.
 	stmt, err := st.Prepare(`
 SELECT COUNT(*) AS &countResult.count
-FROM   application AS a
-JOIN   application_endpoint AS ae ON a.uuid = ae.application_uuid
+FROM   application_endpoint AS ae
 JOIN   charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
-WHERE  a.uuid = $uuid.uuid
 AND    ae.uuid IN ($uuids[:])
 AND    cr.scope_id == 1
-`, uuids{}, uuid{}, countResult{})
+`, uuids{}, countResult{})
 	if err != nil {
 		return "", errors.Errorf("preparing application and endpoint validation query: %w", err)
 	}
@@ -123,7 +121,7 @@ AND    cr.scope_id == 1
 			return errors.Capture(err)
 		}
 
-		err = tx.Query(ctx, stmt, uuid{UUID: applicationUUID}, uuids(endpointUUIDs)).Get(&count)
+		err = tx.Query(ctx, stmt, uuids(endpointUUIDs)).Get(&count)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			// No endpoints with container types, validation successful.
 			return nil

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -15,10 +15,14 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
+	domainlife "github.com/juju/juju/domain/life"
 	"github.com/juju/juju/internal/errors"
 )
 
-// CreateOffer creates an offer and links the endpoints to it.
+// CreateOffer creates an offer and links the endpoints to it. Returns an error
+// if the offer already exists, if the application does not exist or is dead, if
+// any of the endpoints do not exist or are not valid for offering, or if there
+// was an error creating the offer.
 func (st *State) CreateOffer(
 	ctx context.Context,
 	args crossmodelrelation.CreateOfferArgs,
@@ -26,6 +30,15 @@ func (st *State) CreateOffer(
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
+	}
+
+	applicationLifeStmt, err := st.Prepare(`
+SELECT life_id AS &lifeID.life_id
+FROM   application
+WHERE  uuid = $uuid.uuid
+`, uuid{}, lifeID{})
+	if err != nil {
+		return errors.Errorf("preparing application life query: %w", err)
 	}
 
 	createOfferStmt, err := st.Prepare(`
@@ -36,20 +49,23 @@ INSERT INTO offer (*) VALUES ($nameAndUUID.*)`, nameAndUUID{})
 	offer := nameAndUUID{Name: args.OfferName, UUID: args.UUID.String()}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		applicationUUID, err := st.getApplicationUUID(ctx, tx, args.ApplicationName)
-		if err != nil {
+		var life lifeID
+		err := tx.Query(ctx, applicationLifeStmt, uuid{UUID: args.ApplicationUUID}).Get(&life)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return applicationerrors.ApplicationNotFound
+		} else if err != nil {
 			return errors.Capture(err)
 		}
 
-		if err := st.checkApplicationNotDead(ctx, tx, applicationUUID); err != nil {
-			return errors.Capture(err)
+		if life.Life == int(domainlife.Dead) {
+			return applicationerrors.ApplicationIsDead
 		}
 
 		if err := tx.Query(ctx, createOfferStmt, offer).Run(); err != nil {
 			return errors.Errorf("inserting offer row for %q: %w", args.OfferName, err)
 		}
 
-		if err := st.createOfferEndpoints(ctx, tx, args.UUID.String(), applicationUUID, args.Endpoints); err != nil {
+		if err := st.createOfferEndpoints(ctx, tx, args.UUID.String(), args.ApplicationUUID, args.Endpoints); err != nil {
 			return errors.Errorf("offer %q: %w", args.OfferName, err)
 		}
 
@@ -57,6 +73,73 @@ INSERT INTO offer (*) VALUES ($nameAndUUID.*)`, nameAndUUID{})
 	})
 
 	return errors.Capture(err)
+}
+
+// ValidateApplicationAndEndpointsForOffer checks that the application exists
+// and is not dead, and that the endpoints are valid.
+func (st *State) ValidateApplicationAndEndpointsForOffer(
+	ctx context.Context,
+	applicationName string,
+	endpoints []string,
+) (string, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	type uuids []string
+
+	// Check that there is a valid application with no endpoints with container
+	// types. scope_id is container scope, which is not allowed to be offered.
+	stmt, err := st.Prepare(`
+SELECT COUNT(*) AS &countResult.count
+FROM   application AS a
+JOIN   application_endpoint AS ae ON a.uuid = ae.application_uuid
+JOIN   charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
+WHERE  a.uuid = $uuid.uuid
+AND    ae.uuid IN ($uuids[:])
+AND    cr.scope_id == 1
+`, uuids{}, uuid{}, countResult{})
+	if err != nil {
+		return "", errors.Errorf("preparing application and endpoint validation query: %w", err)
+	}
+
+	var (
+		count           countResult
+		applicationUUID string
+	)
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var applicationLife int
+		var err error
+		applicationUUID, applicationLife, err = st.getApplicationUUIDAndLife(ctx, tx, applicationName)
+		if err != nil {
+			return errors.Capture(err)
+		} else if applicationLife == int(domainlife.Dead) {
+			return applicationerrors.ApplicationIsDead
+		}
+
+		endpointUUIDs, err := st.getEndpointUUIDs(ctx, tx, applicationUUID, endpoints)
+		if err != nil {
+			return errors.Capture(err)
+		}
+
+		err = tx.Query(ctx, stmt, uuid{UUID: applicationUUID}, uuids(endpointUUIDs)).Get(&count)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			// No endpoints with container types, validation successful.
+			return nil
+		} else if err != nil {
+			return errors.Errorf("validating application %q and endpoints: %w", applicationName, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if count.Count > 0 {
+		return "", errors.Errorf(`can only offer endpoints with global scope, provided scope "container"`)
+	}
+	return applicationUUID, nil
 }
 
 // DeleteFailedOffer deletes the provided offer, when adding permissions
@@ -355,23 +438,23 @@ func encodeOfferFilter(in crossmodelrelation.OfferFilter) ([]offerFilter, error)
 	return result, nil
 }
 
-func (st *State) getApplicationUUID(ctx context.Context, tx *sqlair.TX, appName string) (string, error) {
+func (st *State) getApplicationUUIDAndLife(ctx context.Context, tx *sqlair.TX, appName string) (string, int, error) {
 	stmt, err := st.Prepare(`
-SELECT uuid AS &uuid.uuid
+SELECT &uuidAndLife.*
 FROM   application
 WHERE  name = $name.name
-`, name{}, uuid{})
+`, name{}, uuidAndLife{})
 	if err != nil {
-		return "", errors.Errorf("preparing application uuid query: %w", err)
+		return "", -1, errors.Errorf("preparing application uuid and life query: %w", err)
 	}
 
-	var result uuid
+	var result uuidAndLife
 	if err := tx.Query(ctx, stmt, name{Name: appName}).Get(&result); errors.Is(err, sqlair.ErrNoRows) {
-		return "", applicationerrors.ApplicationNotFound
+		return "", -1, applicationerrors.ApplicationNotFound
 	} else if err != nil {
-		return "", errors.Capture(err)
+		return "", -1, errors.Capture(err)
 	}
-	return result.UUID, nil
+	return result.UUID, result.Life, nil
 }
 
 func (st *State) getApplicationUUIDs(ctx context.Context, tx *sqlair.TX, appNames []string) (map[string]string, error) {

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -57,7 +57,7 @@ func (s *modelOfferSuite) TestCreateOffer(c *tc.C) {
 
 	args := crossmodelrelation.CreateOfferArgs{
 		UUID:            tc.Must(c, offer.NewUUID),
-		ApplicationName: appName,
+		ApplicationUUID: appUUID.String(),
 		Endpoints:       []string{relation.Name, relation2.Name},
 		OfferName:       "test-offer",
 	}
@@ -66,7 +66,7 @@ func (s *modelOfferSuite) TestCreateOffer(c *tc.C) {
 	err := s.state.CreateOffer(c.Context(), args)
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	obtainedOffers := s.readOffers(c)
 	c.Check(obtainedOffers, tc.DeepEquals, []nameAndUUID{
 		{
@@ -118,7 +118,7 @@ func (s *modelOfferSuite) TestCreateOfferDyingAplication(c *tc.C) {
 
 	args := crossmodelrelation.CreateOfferArgs{
 		UUID:            tc.Must(c, offer.NewUUID),
-		ApplicationName: appName,
+		ApplicationUUID: appUUID.String(),
 		Endpoints:       []string{relation.Name, relation2.Name},
 		OfferName:       "test-offer",
 	}
@@ -162,7 +162,7 @@ func (s *modelOfferSuite) TestCreateOfferDeadAplication(c *tc.C) {
 
 	args := crossmodelrelation.CreateOfferArgs{
 		UUID:            tc.Must(c, offer.NewUUID),
-		ApplicationName: appName,
+		ApplicationUUID: appUUID.String(),
 		Endpoints:       []string{relation.Name, relation2.Name},
 		OfferName:       "test-offer",
 	}
@@ -193,7 +193,7 @@ func (s *modelOfferSuite) TestCreateOfferEndpointFail(c *tc.C) {
 
 	args := crossmodelrelation.CreateOfferArgs{
 		UUID:            tc.Must(c, offer.NewUUID),
-		ApplicationName: appName,
+		ApplicationUUID: appUUID.String(),
 		Endpoints:       []string{"fail-me"},
 		OfferName:       "test-offer",
 	}
@@ -279,7 +279,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterTwoOffersSameApplication(c *t
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.HasLen, 1)
 	c.Check(results[0].OfferUUID, tc.Equals, offer1UUID.String())
 	c.Check(results[0].OfferName, tc.Equals, "test-offer1")
@@ -311,7 +311,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterMultipleNoResult(c *tc.C) {
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.HasLen, 0)
 }
 
@@ -327,7 +327,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterMultiplePartialResult(c *tc.C
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -341,7 +341,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsNoFilter(c *tc.C) {
 	results, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -377,7 +377,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterNoResult(c *tc.C) {
 	results, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.HasLen, 0)
 }
 
@@ -391,7 +391,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterOfferName(c *tc.C) {
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -405,7 +405,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterPartialOfferName(c *tc.C) {
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -419,7 +419,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterOfferUUID(c *tc.C) {
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -433,7 +433,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterExactApplicationName(c *tc.C)
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -447,7 +447,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterPartialApplicationNameNoResul
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.HasLen, 0)
 }
 
@@ -461,7 +461,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterPartialApplicationDescription
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -477,7 +477,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterEndpointName(c *tc.C) {
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -493,7 +493,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterEndpointRole(c *tc.C) {
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
 
@@ -510,7 +510,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterEndpointInterface(c *tc.C) {
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Logf("%+v", results)
 	c.Assert(results, tc.DeepEquals, expected)
 }
@@ -529,7 +529,7 @@ func (s *modelOfferSuite) TestGetOfferDetailsFilterMultiEndpoint(c *tc.C) {
 	})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.SameContents, expected)
 }
 
@@ -857,7 +857,7 @@ VALUES (?, '0')`, relUUID)
 	connections, err := s.state.GetOfferConnections(c.Context(), []string{offerUUID})
 
 	// Assert
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(connections, tc.HasLen, 1)
 	c.Check(connections[0].OfferUUID, tc.Equals, offerUUID)
 	c.Check(connections[0].SourceModelUUID, tc.Equals, consumerModelUUID)
@@ -871,13 +871,13 @@ VALUES (?, '0')`, relUUID)
 
 func (s *modelOfferSuite) TestGetOfferConnectionsNoConnections(c *tc.C) {
 	connections, err := s.state.GetOfferConnections(c.Context(), []string{internaluuid.MustNewUUID().String()})
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(connections, tc.HasLen, 0)
 }
 
 func (s *modelOfferSuite) TestGetOfferConnectionsEmptyUUIDs(c *tc.C) {
 	connections, err := s.state.GetOfferConnections(c.Context(), nil)
-	c.Assert(err, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(connections, tc.IsNil)
 }
 
@@ -891,4 +891,246 @@ func (s *modelOfferSuite) TestGetOfferUUIDByRelationUUID(c *tc.C) {
 func (s *modelOfferSuite) TestGetOfferUUIDByRelationUUIDNotFound(c *tc.C) {
 	_, err := s.state.GetOfferUUIDByRelationUUID(c.Context(), relationtesting.GenRelationUUID(c).String())
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferNotFound)
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOffer(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+	relation2 := charm.Relation{
+		Name:      "log",
+		Role:      charm.RoleProvider,
+		Interface: "log",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID2 := s.addCharmRelation(c, charmUUID, relation2)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+	s.addApplicationEndpoint(c, appUUID, relationUUID2)
+
+	// Act
+	obtainedUUID, err := s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), appName, []string{relation.Name, relation2.Name},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtainedUUID, tc.Equals, string(appUUID))
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOfferSingleEndpoint(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	// Act
+	obtainedUUID, err := s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), appName, []string{relation.Name},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtainedUUID, tc.Equals, string(appUUID))
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOfferApplicationNotFound(c *tc.C) {
+	// Act
+	_, err := s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), "no-such-app", []string{"db"},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOfferDeadApplication(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "UPDATE application SET life_id = 2 WHERE uuid = ?", appUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act
+	_, err = s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), appName, []string{relation.Name},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationIsDead)
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOfferDyingApplication(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "UPDATE application SET life_id = 1 WHERE uuid = ?", appUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act — dying is not dead, should succeed.
+	obtainedUUID, err := s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), appName, []string{relation.Name},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtainedUUID, tc.Equals, string(appUUID))
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOfferEndpointNotFound(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	// Act
+	_, err := s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), appName, []string{"no-such-endpoint"},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, applicationerrors.EndpointNotFound)
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOfferMissingEndpoints(c *tc.C) {
+	// Arrange — request two endpoints but only one exists.
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	// Act
+	_, err := s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), appName, []string{relation.Name, "missing-one"},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.MissingEndpoints)
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOfferContainerScope(c *tc.C) {
+	// Arrange — endpoint with container scope should be rejected.
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "juju-info",
+		Role:      charm.RoleProvider,
+		Interface: "juju-info",
+		Scope:     charm.ScopeContainer,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	// Act
+	_, err := s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), appName, []string{relation.Name},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, `can only offer endpoints with global scope, provided scope "container"`)
+}
+
+func (s *modelOfferSuite) TestValidateApplicationAndEndpointsForOfferMixedScope(c *tc.C) {
+	// Arrange — one global endpoint and one container endpoint.
+	// The container endpoint should cause failure.
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	globalRelation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	globalRelUUID := s.addCharmRelation(c, charmUUID, globalRelation)
+	containerRelation := charm.Relation{
+		Name:      "juju-info",
+		Role:      charm.RoleProvider,
+		Interface: "juju-info",
+		Scope:     charm.ScopeContainer,
+	}
+	containerRelUUID := s.addCharmRelation(c, charmUUID, containerRelation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, globalRelUUID)
+	s.addApplicationEndpoint(c, appUUID, containerRelUUID)
+
+	// Act
+	_, err := s.state.ValidateApplicationAndEndpointsForOffer(
+		c.Context(), appName, []string{globalRelation.Name, containerRelation.Name},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, `can only offer endpoints with global scope, provided scope "container"`)
 }

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -37,6 +37,11 @@ type uuid struct {
 	UUID string `db:"uuid"`
 }
 
+type uuidAndLife struct {
+	UUID string `db:"uuid"`
+	Life int    `db:"life_id"`
+}
+
 type applicationUUIDAndCharmSource struct {
 	UUID        string            `db:"uuid"`
 	CharmSource charm.CharmSource `db:"name"`

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -4,8 +4,6 @@
 package crossmodelrelation
 
 import (
-	"maps"
-	"slices"
 	"time"
 
 	"gopkg.in/macaroon.v2"
@@ -376,28 +374,15 @@ type CreateOfferArgs struct {
 	// UUID is the unique identifier of the new offer.
 	UUID offer.UUID
 
-	// ApplicationName is the name of the application to which the offer pertains.
-	ApplicationName string
+	// ApplicationUUID is the UUID of the application to which the offer
+	// pertains.
+	ApplicationUUID string
 
 	// Endpoints is the collection of endpoint names offered.
 	Endpoints []string
 
 	// OfferName is the name of the offer.
 	OfferName string
-}
-
-// MakeCreateOfferArgs returns a CreateOfferArgs from the given
-// ApplicationOfferArgs and uuid.
-func MakeCreateOfferArgs(in ApplicationOfferArgs, offerUUID offer.UUID) CreateOfferArgs {
-	return CreateOfferArgs{
-		UUID:            offerUUID,
-		ApplicationName: in.ApplicationName,
-		// There was an original intention to allow for endpoint aliases,
-		// however it was never implemented. Just use the maps keys from
-		// here.
-		Endpoints: slices.Collect(maps.Keys(in.Endpoints)),
-		OfferName: in.OfferName,
-	}
 }
 
 // OfferFilter is used to query applications offered

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -454,7 +454,7 @@ VALUES ('storage-attachment-uuid', 'instance-uuid', ?, 0)`, allUnitUUIDs[0])
 func (s *applicationSuite) TestEnsureApplicationNotAliveCascadeOfferConnections(c *tc.C) {
 	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app")
-	offerUUID := s.createOfferForApplication(c, "some-app", "some-offer")
+	offerUUID := s.createOfferForApplication(c, appUUID, "some-offer")
 	s.createRemoteApplicationConsumer(c, "some-remote-app", offerUUID)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
@@ -1229,8 +1229,8 @@ func (s *applicationSuite) TestDeleteApplicationWithSharedObjectstoreResource(c 
 func (s *applicationSuite) TestDeleteApplicationWithOffers(c *tc.C) {
 	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app")
-	offerUUID1 := s.createOfferForApplication(c, "some-app", "some-offer")
-	offerUUID2 := s.createOfferForApplication(c, "some-app", "some-other-offer")
+	offerUUID1 := s.createOfferForApplication(c, appUUID, "some-offer")
+	offerUUID2 := s.createOfferForApplication(c, appUUID, "some-other-offer")
 
 	s.advanceApplicationLife(c, appUUID, life.Dead)
 

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -370,12 +370,12 @@ func (s *baseSuite) createOffer(c *tc.C, offerName string) offer.UUID {
 	cmrState := crossmodelrelationstate.NewState(
 		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
 	)
-	s.createIAASApplication(c, s.setupApplicationService(c), offerName)
+	applicationUUID := s.createIAASApplication(c, s.setupApplicationService(c), offerName)
 	offerUUID := tc.Must(c, offer.NewUUID)
 
 	err := cmrState.CreateOffer(c.Context(), crossmodelrelation.CreateOfferArgs{
 		UUID:            offerUUID,
-		ApplicationName: offerName,
+		ApplicationUUID: applicationUUID.String(),
 		Endpoints:       []string{"foo", "bar"},
 		OfferName:       offerName,
 	})
@@ -384,7 +384,7 @@ func (s *baseSuite) createOffer(c *tc.C, offerName string) offer.UUID {
 	return offerUUID
 }
 
-func (s *baseSuite) createOfferForApplication(c *tc.C, appName string, offerName string) offer.UUID {
+func (s *baseSuite) createOfferForApplication(c *tc.C, appUUID coreapplication.UUID, offerName string) offer.UUID {
 	cmrState := crossmodelrelationstate.NewState(
 		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()), testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
 	)
@@ -392,7 +392,7 @@ func (s *baseSuite) createOfferForApplication(c *tc.C, appName string, offerName
 
 	err := cmrState.CreateOffer(c.Context(), crossmodelrelation.CreateOfferArgs{
 		UUID:            offerUUID,
-		ApplicationName: appName,
+		ApplicationUUID: appUUID.String(),
 		Endpoints:       []string{"foo", "bar"},
 		OfferName:       offerName,
 	})
@@ -577,8 +577,8 @@ func (s *baseSuite) createRelationWithRemoteOfferer(c *tc.C) (relation.UUID, cor
 
 func (s *baseSuite) createRelationWithRemoteConsumer(c *tc.C) (relation.UUID, coreapplication.UUID, offer.UUID) {
 	svc := s.setupApplicationService(c)
-	s.createIAASApplication(c, svc, "bar")
-	offerUUID := s.createOfferForApplication(c, "bar", "some-offer")
+	appUUID := s.createIAASApplication(c, svc, "bar")
+	offerUUID := s.createOfferForApplication(c, appUUID, "some-offer")
 	synthAppUUID, _ := s.createRemoteApplicationConsumer(c, "foo", offerUUID)
 
 	relSvc := s.setupRelationService(c)


### PR DESCRIPTION
We should only offer application endpoints that have global scopes. The fix here is to validate the endpoints before we create the offer. It's not possible to update the offer like in 3.6, so there is no need to validate that workflow. The validation step is front loaded as there is a real possibility that the validation will catch a scope issue, so do the reads before any writes can occur.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model foo
$ juju deploy juju-qa-test
$ juju offer juju-qa-test:info
ERROR creating offer "juju-qa-test": can only offer endpoints with global scope, provided scope "container"
$ juju offer juju-qa-test:juju-info
Application "juju-qa-test" endpoints [juju-info] available at "admin/foo.juju-qa-test"
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/22279.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9731](https://warthogs.atlassian.net/browse/JUJU-9731)


[JUJU-9731]: https://warthogs.atlassian.net/browse/JUJU-9731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ