### PR TITLE
feat(maas): support explicit VM provisioning via virtual-machine virt-type

### DIFF
--- a/apiserver/common/storagecommon/blockdevices.go
+++ b/apiserver/common/storagecommon/blockdevices.go
@@ -4,6 +4,7 @@
 package storagecommon
 
 import (
+	"path"
 	"strings"
 
 	"github.com/juju/loggo"
@@ -112,6 +113,17 @@ func matchingBlockDevice(
 				logger.Tracef("hwid match on %v", volumeInfo.HardwareId)
 				return &dev, true
 			}
+			if serialMatchesHardwareID(volumeInfo.HardwareId, dev.SerialId) {
+				logger.Tracef("serial %q matched hardware id %q", dev.SerialId, volumeInfo.HardwareId)
+				return &dev, true
+			}
+			for _, link := range dev.DeviceLinks {
+				linkID := path.Base(link)
+				if volumeInfo.HardwareId == linkID || serialMatchesHardwareID(volumeInfo.HardwareId, linkID) {
+					logger.Tracef("device link %q matched hardware id %q", link, volumeInfo.HardwareId)
+					return &dev, true
+				}
+			}
 		}
 		logger.Tracef("no match for block device hardware id: %v", volumeInfo.HardwareId)
 	}
@@ -177,4 +189,17 @@ func matchingBlockDevice(
 		logger.Tracef("no match for block device name: %v", attachmentInfo.DeviceName)
 	}
 	return nil, false
+}
+
+func serialMatchesHardwareID(hardwareID, serial string) bool {
+	if hardwareID == "" || serial == "" {
+		return false
+	}
+	if hardwareID == serial {
+		return true
+	}
+	// MAAS/KVM often reports hardware IDs like
+	// "scsi-SQEMU_QEMU_HARDDISK_lxd_disk1" while discovered devices carry
+	// serial IDs like "lxd_disk1".
+	return strings.HasSuffix(hardwareID, "_"+serial) || strings.HasSuffix(hardwareID, "-"+serial)
 }

--- a/apiserver/common/storagecommon/blockdevices_test.go
+++ b/apiserver/common/storagecommon/blockdevices_test.go
@@ -63,6 +63,26 @@ func (s *BlockDeviceSuite) TestBlockDeviceMatchingHardwareID(c *gc.C) {
 	})
 }
 
+func (s *BlockDeviceSuite) TestBlockDeviceMatchingHardwareIDBySerialSuffix(c *gc.C) {
+	blockDevices := []state.BlockDeviceInfo{
+		{
+			DeviceName: "sdc",
+			SerialId:   "lxd_disk1",
+		},
+	}
+	volumeInfo := state.VolumeInfo{
+		HardwareId: "scsi-SQEMU_QEMU_HARDDISK_lxd_disk1",
+	}
+	attachmentInfo := state.VolumeAttachmentInfo{}
+	planBlockInfo := state.BlockDeviceInfo{}
+	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(blockDevices, volumeInfo, attachmentInfo, planBlockInfo)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
+		DeviceName: "sdc",
+		SerialId:   "lxd_disk1",
+	})
+}
+
 func (s *BlockDeviceSuite) TestBlockDevicesAWS(c *gc.C) {
 	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(awsTestBlockDevices, awsTestVolumeInfo, awsTestAttachmentInfo, awsTestPlanBlockInfo)
 	c.Assert(ok, jc.IsTrue)

--- a/core/instance/virttype.go
+++ b/core/instance/virttype.go
@@ -19,12 +19,19 @@ const (
 	DefaultInstanceType = api.InstanceTypeContainer
 )
 
+const (
+	// VirtTypeContainer represents a container instance type.
+	VirtTypeContainer = "container"
+	// VirtTypeMachine represents a VM instance type.
+	VirtTypeMachine = "virtual-machine"
+)
+
 // ParseVirtType parses a string into a VirtType.
 func ParseVirtType(s string) (VirtType, error) {
 	switch strings.ToLower(s) {
-	case "container":
+	case VirtTypeContainer:
 		return api.InstanceTypeContainer, nil
-	case "virtual-machine":
+	case VirtTypeMachine:
 		return api.InstanceTypeVM, nil
 	case "":
 		// Constraints are optional and the absence of a constraint will

--- a/docs/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju.md
@@ -46,25 +46,25 @@ Attributes:
 
 ## Supported constraints
 
-| {ref}`CONSTRAINT <constraint>`         |                                                                                                  |
-|----------------------------------------|--------------------------------------------------------------------------------------------------|
-| conflicting:                           |                                                                                                  |
-| supported?                             |                                                                                                  |
-| - {ref}`constraint-allocate-public-ip` | &#10005;                                                                                         |
-| - {ref}`constraint-arch`               | &#10003; <br> Valid values: See cloud provider.                                                  |
-| - {ref}`constraint-container`          | &#10003;                                                                                         |
-| - {ref}`constraint-cores`              | &#10003;                                                                                         |
-| - {ref}`constraint-cpu-power`          | &#10005;                                                                                         |
-| - {ref}`constraint-image-id`           | &#10003; (Starting with Juju 3.2) <br> Type: String. <br> Valid values: An image name from MAAS. |
-| - {ref}`constraint-instance-role`      | &#10005;                                                                                         |
-| - {ref}`constraint-instance-type`      | &#10005;                                                                                         |
-| - {ref}`constraint-mem`                | &#10003;                                                                                         |
-| - {ref}`constraint-root-disk`          | &#10003;                                                                                         |
-| - {ref}`constraint-root-disk-source`   | &#10005;                                                                                         |
-| - {ref}`constraint-spaces`             | &#10003;                                                                                         |
-| - {ref}`constraint-tags`               | &#10003;                                                                                         |
-| - {ref}`constraint-virt-type`          | &#10005;                                                                                         |
-| - {ref}`constraint-zones`              | &#10003;                                                                                         |
+| {ref}`CONSTRAINT <constraint>`         |                                                                                                                                                               |
+|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| conflicting:                           |                                                                                                                                                               |
+| supported?                             |                                                                                                                                                               |
+| - {ref}`constraint-allocate-public-ip` | &#10005;                                                                                                                                                      |
+| - {ref}`constraint-arch`               | &#10003; <br> Valid values: See cloud provider.                                                                                                               |
+| - {ref}`constraint-container`          | &#10003;                                                                                                                                                      |
+| - {ref}`constraint-cores`              | &#10003;                                                                                                                                                      |
+| - {ref}`constraint-cpu-power`          | &#10005;                                                                                                                                                      |
+| - {ref}`constraint-image-id`           | &#10003; (Starting with Juju 3.2) <br> Type: String. <br> Valid values: An image name from MAAS.                                                              |
+| - {ref}`constraint-instance-role`      | &#10005;                                                                                                                                                      |
+| - {ref}`constraint-instance-type`      | &#10005;                                                                                                                                                      |
+| - {ref}`constraint-mem`                | &#10003;                                                                                                                                                      |
+| - {ref}`constraint-root-disk`          | &#10003;                                                                                                                                                      |
+| - {ref}`constraint-root-disk-source`   | &#10005;                                                                                                                                                      |
+| - {ref}`constraint-spaces`             | &#10003;                                                                                                                                                      |
+| - {ref}`constraint-tags`               | &#10003;                                                                                                                                                      |
+| - {ref}`constraint-virt-type`          | &#10003; (Starting with Juju 3.6.22) <br> Valid values: `[virtual-machine]`. <br> Default value: "". <br> Use `virtual-machine` to provision a VM from a pod. |
+| - {ref}`constraint-zones`              | &#10003;                                                                                                                                                      |
 
 ## Supported placement directives
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -27,6 +27,7 @@ import (
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	corecontext "github.com/juju/juju/core/context"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
@@ -224,7 +225,7 @@ func withDefaultControllerConstraints(cons constraints.Value) constraints.Value 
 	// If we're bootstrapping a controller on a lxd virtual machine, we want to
 	// ensure that it has at least 2 cores. Less than 2 cores can cause the
 	// controller to become unresponsive when installing.
-	if !cons.HasCpuCores() && cons.HasVirtType() && *cons.VirtType == "virtual-machine" {
+	if !cons.HasCpuCores() && cons.HasVirtType() && *cons.VirtType == instance.VirtTypeMachine {
 		var cores = uint64(2)
 		cons.CpuCores = &cores
 	}

--- a/go.mod
+++ b/go.mod
@@ -328,4 +328,4 @@ replace go.uber.org/mock => go.uber.org/mock v0.4.0
 
 replace go.opencensus.io => github.com/census-instrumentation/opencensus-go v0.24.0
 
-replace github.com/juju/gomaasapi/v2 => github.com/wallyworld/gomaasapi/v2 v2.0.0-20260421043303-d216ef077b72
+replace github.com/juju/gomaasapi/v2 => github.com/wallyworld/gomaasapi/v2 v2.0.0-20260507000738-f2c8a7a825da

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0
 	github.com/juju/gojsonschema v1.0.0
-	github.com/juju/gomaasapi/v2 v2.3.0
+	github.com/juju/gomaasapi/v2 v2.4.0
 	github.com/juju/http/v2 v2.0.1
 	github.com/juju/idmclient/v2 v2.0.0
 	github.com/juju/jsonschema v1.0.0
@@ -327,5 +327,3 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
 replace go.uber.org/mock => go.uber.org/mock v0.4.0
 
 replace go.opencensus.io => github.com/census-instrumentation/opencensus-go v0.24.0
-
-replace github.com/juju/gomaasapi/v2 => github.com/wallyworld/gomaasapi/v2 v2.0.0-20260507000738-f2c8a7a825da

--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 // indirect
 	github.com/juju/loggo/v2 v2.2.0 // indirect
 	github.com/juju/lru v1.0.0 // indirect
-	github.com/juju/mgo/v2 v2.0.2 // indirect
+	github.com/juju/mgo/v2 v2.0.3 // indirect
 	github.com/juju/usso v1.0.1 // indirect
 	github.com/juju/version v0.0.0-20210303051006-2015802527a8 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
@@ -327,3 +327,5 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
 replace go.uber.org/mock => go.uber.org/mock v0.4.0
 
 replace go.opencensus.io => github.com/census-instrumentation/opencensus-go v0.24.0
+
+replace github.com/juju/gomaasapi/v2 => github.com/wallyworld/gomaasapi/v2 v2.0.0-20260421043303-d216ef077b72

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,6 @@ github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 h1:huRsqE0iXm
 github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33/go.mod h1:UxUZdlQkjnbl3YoCZT1y5uxmvG2KMwqgffBFccD7qHI=
 github.com/juju/gojsonschema v1.0.0 h1:v0hVxinRWko/SwRYCZ99fBH20Q1JtDqKtplcovXewt0=
 github.com/juju/gojsonschema v1.0.0/go.mod h1:w3BDUH3gGgrcrAyvEbBy3lNb1vmdqG31UMn3njL8oGc=
-github.com/juju/gomaasapi/v2 v2.3.0 h1:97yPBrp/U+JwX/UVrBpkWsZKVREmIlykl8n/a58PYlE=
-github.com/juju/gomaasapi/v2 v2.3.0/go.mod h1:ZsohFbU4xShV1aSQYQ21hR1lKj7naNGY0SPuyelcUmk=
 github.com/juju/http/v2 v2.0.1 h1:cTt8RHvdVv9uZFmAb/7zQrRitT1bgywEDOf8nLpYd8M=
 github.com/juju/http/v2 v2.0.1/go.mod h1:V9dcD7DkT4xkwWjXpFr1C0ZNq7gG+eN9f+Mi2c7GnCs=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
@@ -432,8 +430,8 @@ github.com/juju/lumberjack/v2 v2.0.2 h1:FlxrR62Vb7FfN7jwpSBqqereyq5bBQUF0LqOhZ2V
 github.com/juju/lumberjack/v2 v2.0.2/go.mod h1:BChCvBPxdUuWiy/d+Uw7tvbHjp1zXmoaz0atJ1RBYO0=
 github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208/go.mod h1:0OChplkvPTZ174D2FYZXg4IB9hbEwyHkD+zT+/eK+Fg=
 github.com/juju/mgo/v2 v2.0.0-20220111072304-f200228f1090/go.mod h1:N614SE0a4e+ih2rg96Vi2PeC3cTpUOWgCTv3Cgk974c=
-github.com/juju/mgo/v2 v2.0.2 h1:ufYtW2OFNjniTuxOngecP3Mk5sSclo8Zl1mnmyGWUWA=
-github.com/juju/mgo/v2 v2.0.2/go.mod h1:Z2QbXIrR9JuJcSyankQOw31tINNA5p3qevW73oDoHsM=
+github.com/juju/mgo/v2 v2.0.3 h1:srSbVKwJlH5/D1+VUvXKxKrWyamfFjO9/kkSWwnKb2g=
+github.com/juju/mgo/v2 v2.0.3/go.mod h1:Z2QbXIrR9JuJcSyankQOw31tINNA5p3qevW73oDoHsM=
 github.com/juju/mgo/v3 v3.0.9 h1:tqzxZpjpAuVOl7cNBHD/mywGL/a7UMkUVJ0AWU9Vz40=
 github.com/juju/mgo/v3 v3.0.9/go.mod h1:fAvhDCRbUlEbRIae6UQT8RvPUoLwKnJsBgO6OzHKNxw=
 github.com/juju/mgotest v1.0.1/go.mod h1:vTaDufYul+Ps8D7bgseHjq87X8eu0ivlKLp9mVc/Bfc=
@@ -777,6 +775,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmware/govmomi v0.34.1 h1:Hqu2Uke2itC+cNoIcFQBLEZvX9wBRTTOP04J7V1fqRw=
 github.com/vmware/govmomi v0.34.1/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
+github.com/wallyworld/gomaasapi/v2 v2.0.0-20260421043303-d216ef077b72 h1:4ASrUvpf4CDjA6QvYJcvYUZQcxITjiDxL6wdh/KW2qM=
+github.com/wallyworld/gomaasapi/v2 v2.0.0-20260421043303-d216ef077b72/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 h1:huRsqE0iXm
 github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33/go.mod h1:UxUZdlQkjnbl3YoCZT1y5uxmvG2KMwqgffBFccD7qHI=
 github.com/juju/gojsonschema v1.0.0 h1:v0hVxinRWko/SwRYCZ99fBH20Q1JtDqKtplcovXewt0=
 github.com/juju/gojsonschema v1.0.0/go.mod h1:w3BDUH3gGgrcrAyvEbBy3lNb1vmdqG31UMn3njL8oGc=
+github.com/juju/gomaasapi/v2 v2.4.0 h1:fKsAEakrE0csf/KgBLeqjUfoqqTXdKFINKR4ZhD+Kns=
+github.com/juju/gomaasapi/v2 v2.4.0/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
 github.com/juju/http/v2 v2.0.1 h1:cTt8RHvdVv9uZFmAb/7zQrRitT1bgywEDOf8nLpYd8M=
 github.com/juju/http/v2 v2.0.1/go.mod h1:V9dcD7DkT4xkwWjXpFr1C0ZNq7gG+eN9f+Mi2c7GnCs=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
@@ -775,8 +777,6 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmware/govmomi v0.34.1 h1:Hqu2Uke2itC+cNoIcFQBLEZvX9wBRTTOP04J7V1fqRw=
 github.com/vmware/govmomi v0.34.1/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
-github.com/wallyworld/gomaasapi/v2 v2.0.0-20260507000738-f2c8a7a825da h1:Rc1IcFjFgLRW6hV2OJ9wvaPuKDwoSUTzCWRJVJncObs=
-github.com/wallyworld/gomaasapi/v2 v2.0.0-20260507000738-f2c8a7a825da/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=

--- a/go.sum
+++ b/go.sum
@@ -775,8 +775,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmware/govmomi v0.34.1 h1:Hqu2Uke2itC+cNoIcFQBLEZvX9wBRTTOP04J7V1fqRw=
 github.com/vmware/govmomi v0.34.1/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
-github.com/wallyworld/gomaasapi/v2 v2.0.0-20260421043303-d216ef077b72 h1:4ASrUvpf4CDjA6QvYJcvYUZQcxITjiDxL6wdh/KW2qM=
-github.com/wallyworld/gomaasapi/v2 v2.0.0-20260421043303-d216ef077b72/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
+github.com/wallyworld/gomaasapi/v2 v2.0.0-20260507000738-f2c8a7a825da h1:Rc1IcFjFgLRW6hV2OJ9wvaPuKDwoSUTzCWRJVJncObs=
+github.com/wallyworld/gomaasapi/v2 v2.0.0-20260507000738-f2c8a7a825da/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=

--- a/internal/provider/lxd/environ_policy.go
+++ b/internal/provider/lxd/environ_policy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 )
@@ -38,7 +39,7 @@ func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (const
 	validator := constraints.NewValidator()
 
 	validator.RegisterUnsupported(unsupportedConstraints)
-	validator.RegisterVocabulary(constraints.VirtType, []string{"", "container", "virtual-machine"})
+	validator.RegisterVocabulary(constraints.VirtType, []string{"", instance.VirtTypeContainer, instance.VirtTypeMachine})
 
 	// Only consume supported juju architectures for this release. This will
 	// also remove any duplicate architectures.
@@ -53,7 +54,7 @@ func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (const
 // ShouldApplyControllerConstraints returns if bootstrapping logic should use
 // default constraints
 func (env *environ) ShouldApplyControllerConstraints(cons constraints.Value) bool {
-	if cons.HasVirtType() && *cons.VirtType == "virtual-machine" {
+	if cons.HasVirtType() && *cons.VirtType == instance.VirtTypeMachine {
 		return true
 	}
 	return false

--- a/internal/provider/maas/constraints.go
+++ b/internal/provider/maas/constraints.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs/context"
 )
 
 var unsupportedConstraints = []string{
 	constraints.CpuPower,
 	constraints.InstanceType,
-	constraints.VirtType,
 	constraints.AllocatePublicIP,
 }
 
@@ -37,6 +37,8 @@ func (env *maasEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (c
 	supported := set.NewStrings(arch.AllSupportedArches...).Intersection(maasArches)
 
 	validator.RegisterVocabulary(constraints.Arch, supported.SortedValues())
+	// "virtual-machine" causes machines to be composed from a pod (KVM/LXD host).
+	validator.RegisterVocabulary(constraints.VirtType, []string{"", instance.VirtTypeMachine})
 
 	return validator, nil
 }

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -639,7 +639,7 @@ func (env *maasEnviron) acquireNode(
 	positiveSpaceIDs set.Strings,
 	negativeSpaceIDs set.Strings,
 	volumes []volumeInfo,
-) (*maasInstance, error) {
+) (_ *maasInstance, acquireErr error) {
 	// When the caller explicitly requests a virtual machine, compose it from
 	// a pod rather than trying to acquire a pre-existing machine.
 	if cons.HasVirtType() && *cons.VirtType == instance.VirtTypeMachine {
@@ -653,6 +653,15 @@ func (env *maasEnviron) acquireNode(
 			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			return nil, errors.Annotate(err, "composing virtual machine")
 		}
+		defer func() {
+			if acquireErr == nil {
+				return
+			}
+			if err := env.maasController.DeleteMachine(systemId); err != nil {
+				logger.Errorf("cannot delete unused composed node %v: %v", systemId, err)
+				common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx)
+			}
+		}()
 	}
 
 	acquireParams := convertConstraints(cons)
@@ -729,6 +738,7 @@ func (env *maasEnviron) composeNode(
 	}
 
 	// Use the first pod that can commission the machine.
+	var lastComposeErr error
 	for _, pod := range pods {
 		// Filter by zone if specified.
 		if zoneName != "" && pod.Zone() != nil && pod.Zone().Name() != zoneName {
@@ -736,6 +746,11 @@ func (env *maasEnviron) composeNode(
 		}
 		machine, err := pod.ComposeMachine(composeArgs)
 		if err != nil {
+			if gomaasapi.IsNoMatchError(err) || gomaasapi.IsCannotCompleteError(err) {
+				lastComposeErr = err
+				logger.Debugf("pod %q could not compose machine, trying next pod: %v", pod.Name(), err)
+				continue
+			}
 			return "", errors.Annotate(err, "composing machine")
 		}
 		systemID := machine.SystemID()
@@ -753,6 +768,9 @@ func (env *maasEnviron) composeNode(
 			return "", errors.Annotate(err, "waiting for machine to be ready")
 		}
 		return systemID, nil
+	}
+	if lastComposeErr != nil {
+		return "", errors.Annotate(lastComposeErr, "composing machine")
 	}
 
 	return "", errors.New("no pods matched the zone requirement")
@@ -1146,7 +1164,7 @@ func (env *maasEnviron) releaseNodesIndividually(ctx context.ProviderCallContext
 		err := env.releaseNodes(ctx, []instance.Id{id}, false)
 		if err != nil {
 			lastErr = err
-			logger.Errorf("error while releasing node %v (%v)", id, err)
+			logger.Errorf("cannot release node %v: %v", id, err)
 			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 				break
 			}
@@ -1176,7 +1194,7 @@ func (env *maasEnviron) deleteAnyComposedNodes(ctx context.ProviderCallContext, 
 		err = env.maasController.DeleteMachine(m.SystemID())
 		if err != nil {
 			lastErr = err
-			logger.Errorf("error while deleting node %v (%v)", m.SystemID(), err)
+			logger.Errorf("cannot delete node %v: %v", m.SystemID(), err)
 			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 				break
 			}

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -429,12 +429,20 @@ func (env *maasEnviron) parsePlacement(ctx context.ProviderCallContext, placemen
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }
 
+const systemIdVMPlacementError = errors.ConstError("cannot specify system-id placement constraint when requesting a virtual machine")
+
 func (env *maasEnviron) PrecheckInstance(ctx context.ProviderCallContext, args environs.PrecheckInstanceParams) error {
 	if args.Placement == "" {
 		return nil
 	}
-	_, err := env.parsePlacement(ctx, args.Placement)
-	return err
+	p, err := env.parsePlacement(ctx, args.Placement)
+	if err != nil {
+		return err
+	}
+	if p.systemId != "" && args.Constraints.HasVirtType() {
+		return systemIdVMPlacementError
+	}
+	return nil
 }
 
 // getCapabilities asks the MAAS server for its capabilities, if
@@ -635,8 +643,12 @@ func (env *maasEnviron) acquireNode(
 	// When the caller explicitly requests a virtual machine, compose it from
 	// a pod rather than trying to acquire a pre-existing machine.
 	if cons.HasVirtType() && *cons.VirtType == instance.VirtTypeMachine {
-		logger.Criticalf("virt-type=virtual-machine: using pod compose workflow")
-		err := env.composeNode(ctx, nodeName, zoneName, cons, positiveSpaceIDs, volumes)
+		// Should never happen - checked in PrecheckInstance().
+		if systemId != "" {
+			return nil, systemIdVMPlacementError
+		}
+		var err error
+		systemId, err = env.composeNode(ctx, nodeName, zoneName, cons, positiveSpaceIDs, volumes)
 		if err != nil {
 			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 			return nil, errors.Annotate(err, "composing virtual machine")
@@ -675,13 +687,13 @@ func (env *maasEnviron) composeNode(
 	cons constraints.Value,
 	positiveSpaceIDs set.Strings,
 	volumes []volumeInfo,
-) error {
+) (string, error) {
 	pods, err := env.maasController.Pods()
 	if err != nil {
-		return errors.Annotate(err, "listing pods")
+		return "", errors.Annotate(err, "listing pods")
 	}
 	if len(pods) == 0 {
-		return errors.New("no pods available to compose machine")
+		return "", errors.New("no pods available to compose machine")
 	}
 
 	composeArgs := gomaasapi.ComposeMachineArgs{
@@ -724,26 +736,26 @@ func (env *maasEnviron) composeNode(
 		}
 		machine, err := pod.ComposeMachine(composeArgs)
 		if err != nil {
-			// If compose failed, try to clean up any machine that may have been
-			// partially created before the error occurred.
-			env.cleanupOrphanedComposedMachine(nodeName)
-			return errors.Annotate(err, "composing machine")
+			return "", errors.Annotate(err, "composing machine")
 		}
-		logger.Infof("composed machine %q in pod %q", machine.SystemID(), pod.Name())
+		systemID := machine.SystemID()
+		logger.Infof("composed machine %q in pod %q", systemID, pod.Name())
 
 		// The composed machine goes through MAAS commissioning before it
 		// reaches "Ready" state. AllocateMachine only works on Ready
 		// machines, so we must wait here.
-		if err := env.waitForComposedMachineReady(ctx, machine.SystemID()); err != nil {
+		if err := env.waitForComposedMachineReady(ctx, systemID); err != nil {
 			// If compose failed, try to clean up any machine that may have been
 			// partially created before the error occurred.
-			env.cleanupOrphanedComposedMachine(nodeName)
-			return errors.Annotate(err, "waiting for machine to be ready")
+			if deleteErr := env.maasController.DeleteMachine(systemID); deleteErr != nil {
+				logger.Warningf("failed to delete orphaned machine %q: %v", systemID, deleteErr)
+			}
+			return "", errors.Annotate(err, "waiting for machine to be ready")
 		}
-		return nil
+		return systemID, nil
 	}
 
-	return errors.New("no pods matched the zone requirement")
+	return "", errors.New("no pods matched the zone requirement")
 }
 
 // waitForComposedMachineReady polls MAAS until the machine with the given
@@ -790,29 +802,6 @@ func (env *maasEnviron) waitForComposedMachineReady(ctx context.ProviderCallCont
 		return errors.Errorf("timed out waiting for composed machine %q to become ready", systemID)
 	}
 	return errors.Trace(err)
-}
-
-// cleanupOrphanedComposedMachine attempts to find and release the machine
-// that may have been created by a failed ComposeMachine call.
-// This handles cases where the pod API created the machine but failed to return
-// successfully, leaving it orphaned in MAAS.
-func (env *maasEnviron) cleanupOrphanedComposedMachine(hostname string) {
-	machines, err := env.maasController.Machines(gomaasapi.MachinesArgs{
-		Hostnames: []string{hostname},
-	})
-	if err != nil {
-		logger.Warningf("could not get machine %q for orphan cleanup: %v", err, hostname)
-		return
-	}
-	if len(machines) == 0 {
-		return
-	}
-
-	systemID := machines[0].SystemID()
-	logger.Infof("cleaning up orphaned machine %q", systemID)
-	if err := env.maasController.DeleteMachine(systemID); err != nil {
-		logger.Warningf("failed to delete orphaned machine %q: %v", systemID, err)
-	}
 }
 
 // DistributeInstances implements the state.InstanceDistributor policy.

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -707,6 +707,7 @@ func (env *maasEnviron) composeNode(
 
 	composeArgs := gomaasapi.ComposeMachineArgs{
 		Hostname: nodeName,
+		Zone:     zoneName,
 	}
 	if cons.CpuCores != nil {
 		composeArgs.MinCPUCount = int(*cons.CpuCores)
@@ -740,10 +741,6 @@ func (env *maasEnviron) composeNode(
 	// Use the first pod that can commission the machine.
 	var lastComposeErr error
 	for _, pod := range pods {
-		// Filter by zone if specified.
-		if zoneName != "" && pod.Zone() != nil && pod.Zone().Name() != zoneName {
-			continue
-		}
 		machine, err := pod.ComposeMachine(composeArgs)
 		if err != nil {
 			if gomaasapi.IsNoMatchError(err) || gomaasapi.IsCannotCompleteError(err) {

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -621,6 +621,9 @@ func (env *maasEnviron) networkSpaceRequirements(ctx context.ProviderCallContext
 }
 
 // acquireNode allocates a machine from MAAS.
+// If cons.VirtType is set to "virtual-machine" the machine is always obtained
+// by composing a new VM in a pod (KVM/LXD host) and then allocating it.
+// For all other cases the standard AllocateMachine workflow is used.
 func (env *maasEnviron) acquireNode(
 	ctx context.ProviderCallContext,
 	nodeName, zoneName, systemId string,
@@ -629,6 +632,17 @@ func (env *maasEnviron) acquireNode(
 	negativeSpaceIDs set.Strings,
 	volumes []volumeInfo,
 ) (*maasInstance, error) {
+	// When the caller explicitly requests a virtual machine, compose it from
+	// a pod rather than trying to acquire a pre-existing machine.
+	if cons.HasVirtType() && *cons.VirtType == instance.VirtTypeMachine {
+		logger.Criticalf("virt-type=virtual-machine: using pod compose workflow")
+		err := env.composeNode(ctx, nodeName, zoneName, cons, positiveSpaceIDs, volumes)
+		if err != nil {
+			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			return nil, errors.Annotate(err, "composing virtual machine")
+		}
+	}
+
 	acquireParams := convertConstraints(cons)
 	addInterfaces(&acquireParams, positiveSpaceIDs, negativeSpaceIDs)
 	addStorage(&acquireParams, volumes)
@@ -652,6 +666,153 @@ func (env *maasEnviron) acquireNode(
 		constraintMatches: constraintMatches,
 		environ:           env,
 	}, nil
+}
+
+// composeNode finds a suitable pod, composes a VM with the required resources.
+func (env *maasEnviron) composeNode(
+	ctx context.ProviderCallContext,
+	nodeName, zoneName string,
+	cons constraints.Value,
+	positiveSpaceIDs set.Strings,
+	volumes []volumeInfo,
+) error {
+	pods, err := env.maasController.Pods()
+	if err != nil {
+		return errors.Annotate(err, "listing pods")
+	}
+	if len(pods) == 0 {
+		return errors.New("no pods available to compose machine")
+	}
+
+	composeArgs := gomaasapi.ComposeMachineArgs{
+		Hostname: nodeName,
+	}
+	if cons.CpuCores != nil {
+		composeArgs.MinCPUCount = int(*cons.CpuCores)
+	}
+	if cons.Mem != nil {
+		composeArgs.MinMemory = int(*cons.Mem)
+	}
+	// Convert volumes to storage specs for the compose call.
+	for _, v := range volumes {
+		sizeGB := v.sizeInGB
+		if v.name == rootDiskLabel && sizeGB == 0 {
+			// For compose, MAAS treats the first storage entry as the root disk.
+			// If Juju did not specify RootDisk, default to a practical root size
+			// so curtin can complete installation.
+			sizeGB = common.MinRootDiskSizeGiB(ostype.Ubuntu)
+		}
+		composeArgs.Storage = append(composeArgs.Storage, gomaasapi.StorageSpec{
+			Label: v.name,
+			Size:  int(sizeGB),
+			Tags:  v.tags,
+		})
+	}
+	// Convert space requirements to interface specs.
+	for _, spaceID := range positiveSpaceIDs.SortedValues() {
+		composeArgs.Interfaces = append(composeArgs.Interfaces, gomaasapi.InterfaceSpec{
+			Label: spaceID,
+			Space: spaceID,
+		})
+	}
+
+	// Use the first pod that can commission the machine.
+	for _, pod := range pods {
+		// Filter by zone if specified.
+		if zoneName != "" && pod.Zone() != nil && pod.Zone().Name() != zoneName {
+			continue
+		}
+		machine, err := pod.ComposeMachine(composeArgs)
+		if err != nil {
+			// If compose failed, try to clean up any machine that may have been
+			// partially created before the error occurred.
+			env.cleanupOrphanedComposedMachine(nodeName)
+			return errors.Annotate(err, "composing machine")
+		}
+		logger.Infof("composed machine %q in pod %q", machine.SystemID(), pod.Name())
+
+		// The composed machine goes through MAAS commissioning before it
+		// reaches "Ready" state. AllocateMachine only works on Ready
+		// machines, so we must wait here.
+		if err := env.waitForComposedMachineReady(ctx, machine.SystemID()); err != nil {
+			// If compose failed, try to clean up any machine that may have been
+			// partially created before the error occurred.
+			env.cleanupOrphanedComposedMachine(nodeName)
+			return errors.Annotate(err, "waiting for machine to be ready")
+		}
+		return nil
+	}
+
+	return errors.New("no pods matched the zone requirement")
+}
+
+// waitForComposedMachineReady polls MAAS until the machine with the given
+// system ID reaches "Ready" state (i.e. commissioning has completed).
+// It returns an error if the machine moves to a failed state or the
+// timeout is exceeded.
+func (env *maasEnviron) waitForComposedMachineReady(ctx context.ProviderCallContext, systemID string) error {
+	retryStrategy := env.longRetryStrategy
+	retryStrategy.IsFatalError = func(err error) bool {
+		if errors.Is(err, errors.NotProvisioned) {
+			return true
+		}
+		return common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx)
+	}
+	retryStrategy.NotifyFunc = func(lastErr error, attempts int) {
+		logger.Debugf("waiting for composed machine %q to become ready (attempt %d): %v", systemID, attempts, lastErr)
+	}
+	retryStrategy.Func = func() error {
+		machines, err := env.maasController.Machines(gomaasapi.MachinesArgs{
+			SystemIDs: []string{systemID},
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(machines) == 0 {
+			return errors.NotFoundf("composed machine %q", systemID)
+		}
+		machine := machines[0]
+		switch machine.StatusName() {
+		case "Ready":
+			return nil
+		case "Failed commissioning", "Failed testing", "Broken": // These strings are defined by MAAS.
+			// Fatal: commissioning failed, no point retrying.
+			return errors.NewNotProvisioned(nil,
+				fmt.Sprintf("composed machine %q entered failed state: %s (%s)",
+					systemID, machine.StatusName(), machine.StatusMessage()))
+		default:
+			return errors.NewNotYetAvailable(nil,
+				fmt.Sprintf("composed machine %q is %s, waiting for Ready", systemID, machine.StatusName()))
+		}
+	}
+	err := retry.Call(retryStrategy)
+	if retry.IsAttemptsExceeded(err) || retry.IsDurationExceeded(err) {
+		return errors.Errorf("timed out waiting for composed machine %q to become ready", systemID)
+	}
+	return errors.Trace(err)
+}
+
+// cleanupOrphanedComposedMachine attempts to find and release the machine
+// that may have been created by a failed ComposeMachine call.
+// This handles cases where the pod API created the machine but failed to return
+// successfully, leaving it orphaned in MAAS.
+func (env *maasEnviron) cleanupOrphanedComposedMachine(hostname string) {
+	machines, err := env.maasController.Machines(gomaasapi.MachinesArgs{
+		Hostnames: []string{hostname},
+	})
+	if err != nil {
+		logger.Warningf("could not get machine %q for orphan cleanup: %v", err, hostname)
+		return
+	}
+	if len(machines) == 0 {
+		return
+	}
+
+	systemID := machines[0].SystemID()
+	logger.Infof("cleaning up orphaned machine %q", systemID)
+	if err := env.maasController.DeleteMachine(systemID); err != nil {
+		logger.Warningf("failed to delete orphaned machine %q: %v", systemID, err)
+	}
 }
 
 // DistributeInstances implements the state.InstanceDistributor policy.
@@ -853,7 +1014,7 @@ func (env *maasEnviron) waitForNodeDeployment(ctx context.ProviderCallContext, i
 	retryStrategy := env.longRetryStrategy
 	retryStrategy.MaxDuration = timeout
 	retryStrategy.IsFatalError = func(err error) bool {
-		if errors.IsNotProvisioned(err) {
+		if errors.Is(err, errors.NotProvisioned) {
 			return true
 		}
 		if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
@@ -862,7 +1023,7 @@ func (env *maasEnviron) waitForNodeDeployment(ctx context.ProviderCallContext, i
 		return false
 	}
 	retryStrategy.NotifyFunc = func(lastErr error, attempts int) {
-		if errors.IsNotFound(lastErr) {
+		if errors.Is(lastErr, errors.NotFound) {
 			logger.Warningf("failed to get instance from provider attempt %d", attempts)
 		}
 	}
@@ -1005,6 +1166,39 @@ func (env *maasEnviron) releaseNodesIndividually(ctx context.ProviderCallContext
 	return errors.Trace(lastErr)
 }
 
+// deleteAnyComposedNodes determines which instance ids are for VMs provisioned
+// by a pod (rather than pre-existing machines) and deletes them.
+// This is necessary to clean up the composed machines after release,
+// as ReleaseMachine only releases the machine but does not delete it from MAAS,
+// and we don't need composed machines to be reused for future allocations.
+func (env *maasEnviron) deleteAnyComposedNodes(ctx context.ProviderCallContext, ids []instance.Id) error {
+	machines, err := env.maasController.Machines(gomaasapi.MachinesArgs{
+		SystemIDs: instanceIdsToSystemIDs(ids),
+	})
+	if err != nil {
+		common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return errors.Annotate(err, "getting machines for deletion")
+	}
+	var lastErr error
+	for _, m := range machines {
+		if m.Pod() == nil && m.PowerType() != "virsh" && m.PowerType() != "lxd" {
+			continue
+		}
+		err = env.maasController.DeleteMachine(m.SystemID())
+		if err != nil {
+			lastErr = err
+			logger.Errorf("error while deleting node %v (%v)", m.SystemID(), err)
+			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+				break
+			}
+		}
+	}
+	if lastErr != nil {
+		return errors.Annotate(lastErr, "deleting composed machines")
+	}
+	return nil
+}
+
 func instanceIdsToSystemIDs(ids []instance.Id) []string {
 	systemIDs := make([]string, len(ids))
 	for index, id := range ids {
@@ -1024,6 +1218,11 @@ func (env *maasEnviron) StopInstances(ctx context.ProviderCallContext, ids ...in
 	if err != nil {
 		return errors.Trace(err)
 	}
+	err = env.deleteAnyComposedNodes(ctx, ids)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	return common.RemoveStateInstances(env.Storage(), ids...)
 }
 

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -649,6 +649,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 		composeMachineArgsCheck: func(args gomaasapi.ComposeMachineArgs) {
 			c.Assert(args, jc.DeepEquals, gomaasapi.ComposeMachineArgs{
 				Hostname:    "vm-1",
+				Zone:        "mossack",
 				MinCPUCount: 2,
 				MinMemory:   4096,
 				Storage: []gomaasapi.StorageSpec{{
@@ -752,7 +753,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchAllPod
 	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
 }
 
-func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchNextPodSkipped(c *gc.C) {
+func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchPodsSkipped(c *gc.C) {
 	controller := &fakeController{
 		Stub: &testing.Stub{},
 		pods: []gomaasapi.Pod{
@@ -762,8 +763,9 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchNextPo
 				composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources"),
 			},
 			&fakePod{
-				name: "pod-b",
-				zone: &fakeZone{name: "fonseca"},
+				name:              "pod-b",
+				zone:              &fakeZone{name: "fonseca"},
+				composeMachineErr: gomaasapi.NewCannotCompleteError("no available machines"),
 			},
 		},
 	}
@@ -779,7 +781,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchNextPo
 		nil,
 		nil,
 	)
-	c.Assert(err, gc.ErrorMatches, "composing virtual machine: composing machine: insufficient resources")
+	c.Assert(err, gc.ErrorMatches, "composing virtual machine: composing machine: no available machines")
 }
 
 func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineAllocateFailureCleansUnusedComposedNode(c *gc.C) {

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -295,6 +295,16 @@ func collectReleaseArgs(controller *fakeController) []gomaasapi.ReleaseMachinesA
 	return args
 }
 
+func collectDeleteMachineArgs(controller *fakeController) []string {
+	args := []string{}
+	for _, call := range controller.Stub.Calls() {
+		if call.FuncName == "DeleteMachine" {
+			args = append(args, call.Args[0].(string))
+		}
+	}
+	return args
+}
+
 func (suite *maasEnvironSuite) TestStopInstancesReturnsIfParameterEmpty(c *gc.C) {
 	controller := newFakeController()
 	err := suite.makeEnviron(c, controller).StopInstances(suite.callCtx)
@@ -357,6 +367,45 @@ func (suite *maasEnvironSuite) TestStopInstancesReturnsUnexpectedMAASError(c *gc
 
 func (suite *maasEnvironSuite) TestStopInstancesReturnsUnexpectedError(c *gc.C) {
 	suite.checkStopInstancesFails(c, errors.New("Something completely unexpected!"))
+}
+
+func (suite *maasEnvironSuite) TestStopInstancesDeletesComposedNodes(c *gc.C) {
+	controller := newFakeControllerWithFiles(&fakeFile{name: coretesting.ModelTag.Id() + "-provider-state"})
+	controller.machines = []gomaasapi.Machine{
+		&fakeMachine{systemID: "test1", pod: &fakePod{}},
+		&fakeMachine{systemID: "test2", powerType: "virsh"},
+		&fakeMachine{systemID: "test3", powerType: "ipmi"},
+	}
+
+	err := suite.makeEnviron(c, controller).StopInstances(suite.callCtx, "test1", "test2", "test3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(collectDeleteMachineArgs(controller), jc.SameContents, []string{"test1", "test2"})
+}
+
+func (suite *maasEnvironSuite) TestStopInstancesDoesNotDeleteNonComposedNodes(c *gc.C) {
+	controller := newFakeControllerWithFiles(&fakeFile{name: coretesting.ModelTag.Id() + "-provider-state"})
+	controller.machines = []gomaasapi.Machine{
+		&fakeMachine{systemID: "test3", powerType: "ipmi"},
+	}
+
+	err := suite.makeEnviron(c, controller).StopInstances(suite.callCtx, "test3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
+	args := collectReleaseArgs(controller)
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0].SystemIDs, jc.SameContents, []string{"test3"})
+}
+
+func (suite *maasEnvironSuite) TestStopInstancesReturnsDeleteComposedNodesError(c *gc.C) {
+	controller := newFakeControllerWithFiles(&fakeFile{name: coretesting.ModelTag.Id() + "-provider-state"})
+	controller.machines = []gomaasapi.Machine{
+		&fakeMachine{systemID: "test1", powerType: "lxd"},
+	}
+	controller.deleteMachineError = errors.New("delete failed")
+
+	err := suite.makeEnviron(c, controller).StopInstances(suite.callCtx, "test1")
+	c.Assert(err, gc.ErrorMatches, "deleting composed machines: delete failed")
+	c.Assert(collectDeleteMachineArgs(controller), jc.SameContents, []string{"test1"})
 }
 
 func (suite *maasEnvironSuite) TestStartInstanceError(c *gc.C) {
@@ -589,6 +638,81 @@ func (suite *maasEnvironSuite) TestAcquireNodeStorage(c *gc.C) {
 		_, err := env.acquireNode(suite.callCtx, "", "", "", constraints.Value{}, nil, nil, test.volumes)
 		c.Check(err, jc.ErrorIsNil)
 	}
+}
+
+func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
+	composedMachine := &fakeMachine{systemID: "composed-1", hostname: "vm-1", statusName: "Ready"}
+	pod := &fakePod{
+		name: "pod-a",
+		zone: fakeZone{name: "mossack"},
+		composeMachineArgsCheck: func(args gomaasapi.ComposeMachineArgs) {
+			c.Assert(args, gc.DeepEquals, gomaasapi.ComposeMachineArgs{
+				Hostname:    "vm-1",
+				MinCPUCount: 2,
+				MinMemory:   4096,
+				Storage: []gomaasapi.StorageSpec{{
+					Label: "data",
+					Size:  20,
+					Tags:  []string{"fast"},
+				}},
+				Interfaces: []gomaasapi.InterfaceSpec{
+					{Label: "5", Space: "5"},
+					{Label: "7", Space: "7"},
+				},
+			})
+		},
+		composeMachine: composedMachine,
+	}
+	controller := &fakeController{
+		Stub: &testing.Stub{},
+		pods: []gomaasapi.Pod{pod},
+		allocateMachine: &fakeMachine{
+			systemID:     "allocated-1",
+			architecture: arch.HostArch(),
+		},
+		allocateMachineMatches: gomaasapi.ConstraintMatches{Storage: map[string][]gomaasapi.StorageDevice{}},
+		machines:               []gomaasapi.Machine{composedMachine},
+	}
+	env := suite.makeEnviron(c, controller)
+
+	cons := constraints.MustParse("virt-type=virtual-machine cpu-cores=2 mem=4G")
+	_, err := env.acquireNode(
+		suite.callCtx,
+		"vm-1",
+		"mossack",
+		"",
+		cons,
+		set.NewStrings("7", "5"),
+		nil,
+		[]volumeInfo{{name: "data", sizeInGB: 20, tags: []string{"fast"}}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
+}
+
+func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeFailureCleansOrphan(c *gc.C) {
+	orphan := &fakeMachine{systemID: "orphan-1", hostname: "vm-2"}
+	controller := &fakeController{
+		Stub:                   &testing.Stub{},
+		pods:                   []gomaasapi.Pod{&fakePod{composeMachineErr: errors.New("boom")}},
+		allocateMachine:        newFakeMachine("allocated-1", arch.HostArch(), ""),
+		allocateMachineMatches: gomaasapi.ConstraintMatches{Storage: map[string][]gomaasapi.StorageDevice{}},
+		machines:               []gomaasapi.Machine{orphan},
+	}
+	env := suite.makeEnviron(c, controller)
+
+	_, err := env.acquireNode(
+		suite.callCtx,
+		"vm-2",
+		"",
+		"",
+		constraints.MustParse("virt-type=virtual-machine"),
+		nil,
+		nil,
+		nil,
+	)
+	c.Assert(err, gc.ErrorMatches, `composing virtual machine: composing machine: boom`)
+	c.Assert(collectDeleteMachineArgs(controller), jc.SameContents, []string{"orphan-1"})
 }
 
 func (suite *maasEnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
@@ -2599,10 +2723,10 @@ func (suite *maasEnvironSuite) TestConstraintsValidator(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=virtual-machine")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type"})
 }
 
 func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *gc.C) {
@@ -2614,10 +2738,53 @@ func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *gc
 	env := suite.makeEnviron(c, controller)
 	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=virtual-machine")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type"})
+}
+
+func (suite *maasEnvironSuite) TestPrecheckInstanceRejectsUnknownPlacementDirective(c *gc.C) {
+	controller := newFakeController()
+	env := suite.makeEnviron(c, controller)
+	err := env.PrecheckInstance(suite.callCtx, environs.PrecheckInstanceParams{
+		Placement: "pod=pod-a",
+	})
+	c.Assert(err, gc.ErrorMatches, `unknown placement directive: pod=pod-a`)
+}
+
+func (suite *maasEnvironSuite) TestPrecheckInstanceAllowsZonePlacement(c *gc.C) {
+	controller := newFakeController()
+	env := suite.makeEnviron(c, controller)
+	err := env.PrecheckInstance(suite.callCtx, environs.PrecheckInstanceParams{
+		Placement: "zone=mossack",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (suite *maasEnvironSuite) TestPrecheckInstanceRejectsUnknownZonePlacement(c *gc.C) {
+	controller := newFakeController()
+	env := suite.makeEnviron(c, controller)
+	err := env.PrecheckInstance(suite.callCtx, environs.PrecheckInstanceParams{
+		Placement: "zone=not-a-zone",
+	})
+	c.Assert(err, gc.NotNil)
+}
+
+func (suite *maasEnvironSuite) TestPrecheckInstanceAllowsSystemIDPlacement(c *gc.C) {
+	controller := newFakeController()
+	env := suite.makeEnviron(c, controller)
+	err := env.PrecheckInstance(suite.callCtx, environs.PrecheckInstanceParams{
+		Placement: "system-id=abc123",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (suite *maasEnvironSuite) TestPrecheckInstanceNoPlacement(c *gc.C) {
+	controller := newFakeController()
+	env := suite.makeEnviron(c, controller)
+	err := env.PrecheckInstance(suite.callCtx, environs.PrecheckInstanceParams{})
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (suite *maasEnvironSuite) TestConstraintsValidatorInvalidCredential(c *gc.C) {

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -694,6 +694,118 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
 }
 
+func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchTriesNextPod(c *gc.C) {
+	composedMachine := &fakeMachine{systemID: "composed-2", hostname: "vm-2", statusName: "Ready"}
+	controller := &fakeController{
+		Stub: &testing.Stub{},
+		pods: []gomaasapi.Pod{
+			&fakePod{name: "pod-a", composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources")},
+			&fakePod{name: "pod-b", composeMachine: composedMachine},
+		},
+		allocateMachineArgsCheck: func(args gomaasapi.AllocateMachineArgs) {
+			c.Assert(args.SystemId, gc.Equals, "composed-2")
+		},
+		allocateMachine: &fakeMachine{
+			systemID:     "composed-2",
+			architecture: arch.HostArch(),
+		},
+		allocateMachineMatches: gomaasapi.ConstraintMatches{Storage: map[string][]gomaasapi.StorageDevice{}},
+		machines:               []gomaasapi.Machine{composedMachine},
+	}
+	env := suite.makeEnviron(c, controller)
+
+	_, err := env.acquireNode(
+		suite.callCtx,
+		"vm-2",
+		"",
+		"",
+		constraints.MustParse("virt-type=virtual-machine"),
+		nil,
+		nil,
+		nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
+}
+
+func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchAllPodsFail(c *gc.C) {
+	controller := &fakeController{
+		Stub: &testing.Stub{},
+		pods: []gomaasapi.Pod{
+			&fakePod{name: "pod-a", composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources")},
+			&fakePod{name: "pod-b", composeMachineErr: gomaasapi.NewCannotCompleteError("cannot compose right now")},
+		},
+	}
+	env := suite.makeEnviron(c, controller)
+
+	_, err := env.acquireNode(
+		suite.callCtx,
+		"vm-2",
+		"",
+		"",
+		constraints.MustParse("virt-type=virtual-machine"),
+		nil,
+		nil,
+		nil,
+	)
+	c.Assert(err, gc.ErrorMatches, "composing virtual machine: composing machine: cannot compose right now")
+	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
+}
+
+func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchNextPodSkipped(c *gc.C) {
+	controller := &fakeController{
+		Stub: &testing.Stub{},
+		pods: []gomaasapi.Pod{
+			&fakePod{
+				name:              "pod-a",
+				zone:              &fakeZone{name: "mossack"},
+				composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources"),
+			},
+			&fakePod{
+				name: "pod-b",
+				zone: &fakeZone{name: "fonseca"},
+			},
+		},
+	}
+	env := suite.makeEnviron(c, controller)
+
+	_, err := env.acquireNode(
+		suite.callCtx,
+		"vm-2",
+		"mossack",
+		"",
+		constraints.MustParse("virt-type=virtual-machine"),
+		nil,
+		nil,
+		nil,
+	)
+	c.Assert(err, gc.ErrorMatches, "composing virtual machine: composing machine: insufficient resources")
+}
+
+func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineAllocateFailureCleansUnusedComposedNode(c *gc.C) {
+	composedMachine := &fakeMachine{systemID: "composed-2", hostname: "vm-2", statusName: "Ready"}
+	controller := &fakeController{
+		Stub:                 &testing.Stub{},
+		pods:                 []gomaasapi.Pod{&fakePod{composeMachine: composedMachine}},
+		machines:             []gomaasapi.Machine{composedMachine},
+		allocateMachineError: errors.New("allocate failed"),
+	}
+	env := suite.makeEnviron(c, controller)
+
+	_, err := env.acquireNode(
+		suite.callCtx,
+		"vm-2",
+		"",
+		"",
+		constraints.MustParse("virt-type=virtual-machine"),
+		nil,
+		nil,
+		nil,
+	)
+	c.Assert(err, gc.ErrorMatches, "allocate failed")
+	c.Assert(collectDeleteMachineArgs(controller), jc.SameContents, []string{"composed-2"})
+}
+
 func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineWaitReadyFailureCleansOrphan(c *gc.C) {
 	orphan := &fakeMachine{
 		systemID:      "orphan-1",

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -2800,10 +2800,10 @@ func (suite *maasEnvironSuite) TestConstraintsValidator(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=virtual-machine")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type"})
 }
 
 func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *gc.C) {
@@ -2815,7 +2815,7 @@ func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *gc
 	env := suite.makeEnviron(c, controller)
 	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=virtual-machine")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type"})

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -646,7 +647,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 		name: "pod-a",
 		zone: fakeZone{name: "mossack"},
 		composeMachineArgsCheck: func(args gomaasapi.ComposeMachineArgs) {
-			c.Assert(args, gc.DeepEquals, gomaasapi.ComposeMachineArgs{
+			c.Assert(args, jc.DeepEquals, gomaasapi.ComposeMachineArgs{
 				Hostname:    "vm-1",
 				MinCPUCount: 2,
 				MinMemory:   4096,
@@ -666,8 +667,11 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 	controller := &fakeController{
 		Stub: &testing.Stub{},
 		pods: []gomaasapi.Pod{pod},
+		allocateMachineArgsCheck: func(args gomaasapi.AllocateMachineArgs) {
+			c.Assert(args.SystemId, gc.Equals, "composed-1")
+		},
 		allocateMachine: &fakeMachine{
-			systemID:     "allocated-1",
+			systemID:     "composed-1",
 			architecture: arch.HostArch(),
 		},
 		allocateMachineMatches: gomaasapi.ConstraintMatches{Storage: map[string][]gomaasapi.StorageDevice{}},
@@ -690,14 +694,17 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
 }
 
-func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeFailureCleansOrphan(c *gc.C) {
-	orphan := &fakeMachine{systemID: "orphan-1", hostname: "vm-2"}
+func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineWaitReadyFailureCleansOrphan(c *gc.C) {
+	orphan := &fakeMachine{
+		systemID:      "orphan-1",
+		hostname:      "vm-2",
+		statusName:    "Failed commissioning",
+		statusMessage: "commissioning scripts failed",
+	}
 	controller := &fakeController{
-		Stub:                   &testing.Stub{},
-		pods:                   []gomaasapi.Pod{&fakePod{composeMachineErr: errors.New("boom")}},
-		allocateMachine:        newFakeMachine("allocated-1", arch.HostArch(), ""),
-		allocateMachineMatches: gomaasapi.ConstraintMatches{Storage: map[string][]gomaasapi.StorageDevice{}},
-		machines:               []gomaasapi.Machine{orphan},
+		Stub:     &testing.Stub{},
+		pods:     []gomaasapi.Pod{&fakePod{composeMachine: orphan}},
+		machines: []gomaasapi.Machine{orphan},
 	}
 	env := suite.makeEnviron(c, controller)
 
@@ -711,8 +718,78 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeFailureCleans
 		nil,
 		nil,
 	)
-	c.Assert(err, gc.ErrorMatches, `composing virtual machine: composing machine: boom`)
+	c.Assert(err, gc.ErrorMatches, `composing virtual machine: waiting for machine to be ready: composed machine "orphan-1" entered failed state: Failed commissioning \(commissioning scripts failed\)`)
 	c.Assert(collectDeleteMachineArgs(controller), jc.SameContents, []string{"orphan-1"})
+}
+
+func (suite *maasEnvironSuite) TestWaitForComposedMachineReady(c *gc.C) {
+	composed := &fakeMachine{systemID: "composed-1", statusName: "Ready"}
+	controller := &fakeController{
+		machines: []gomaasapi.Machine{composed},
+		machinesArgsCheck: func(args gomaasapi.MachinesArgs) {
+			c.Assert(args.SystemIDs, jc.DeepEquals, []string{"composed-1"})
+		},
+	}
+	env := suite.makeEnviron(c, controller)
+
+	err := env.waitForComposedMachineReady(suite.callCtx, "composed-1")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (suite *maasEnvironSuite) TestWaitForComposedMachineReadyRetriesUntilReady(c *gc.C) {
+	composed := &fakeMachine{systemID: "composed-1", statusName: "Commissioning"}
+	polls := 0
+	controller := &fakeController{
+		machines: []gomaasapi.Machine{composed},
+		machinesArgsCheck: func(args gomaasapi.MachinesArgs) {
+			polls++
+			c.Assert(args.SystemIDs, jc.DeepEquals, []string{"composed-1"})
+			if polls == 2 {
+				composed.statusName = "Ready"
+			}
+		},
+	}
+	env := suite.makeEnviron(c, controller)
+	env.longRetryStrategy.Delay = time.Millisecond
+	env.longRetryStrategy.MaxDuration = 50 * time.Millisecond
+
+	err := env.waitForComposedMachineReady(suite.callCtx, "composed-1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(polls, gc.Equals, 2)
+}
+
+func (suite *maasEnvironSuite) TestWaitForComposedMachineReadyFailedStates(c *gc.C) {
+	for _, state := range []string{"Failed commissioning", "Failed testing", "Broken"} {
+		composed := &fakeMachine{
+			systemID:      "composed-1",
+			statusName:    state,
+			statusMessage: "failed state",
+		}
+		controller := &fakeController{machines: []gomaasapi.Machine{composed}}
+		env := suite.makeEnviron(c, controller)
+
+		err := env.waitForComposedMachineReady(suite.callCtx, "composed-1")
+		c.Assert(err, jc.ErrorIs, errors.NotProvisioned)
+	}
+}
+
+func (suite *maasEnvironSuite) TestWaitForComposedMachineReadyTimeout(c *gc.C) {
+	composed := &fakeMachine{systemID: "composed-1", statusName: "Commissioning"}
+	polls := 0
+	controller := &fakeController{
+		machines: []gomaasapi.Machine{composed},
+		machinesArgsCheck: func(args gomaasapi.MachinesArgs) {
+			polls++
+			c.Assert(args.SystemIDs, jc.DeepEquals, []string{"composed-1"})
+		},
+	}
+	env := suite.makeEnviron(c, controller)
+	env.longRetryStrategy.Delay = time.Millisecond
+	env.longRetryStrategy.MaxDuration = 20 * time.Millisecond
+
+	err := env.waitForComposedMachineReady(suite.callCtx, "composed-1")
+	c.Assert(err, gc.ErrorMatches, `timed out waiting for composed machine "composed-1" to become ready`)
+	c.Assert(polls, gc.Not(gc.Equals), 0)
 }
 
 func (suite *maasEnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
@@ -2723,10 +2800,10 @@ func (suite *maasEnvironSuite) TestConstraintsValidator(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=virtual-machine")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
 }
 
 func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *gc.C) {
@@ -2738,7 +2815,7 @@ func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *gc
 	env := suite.makeEnviron(c, controller)
 	validator, err := env.ConstraintsValidator(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=virtual-machine")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type"})
@@ -2778,6 +2855,16 @@ func (suite *maasEnvironSuite) TestPrecheckInstanceAllowsSystemIDPlacement(c *gc
 		Placement: "system-id=abc123",
 	})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (suite *maasEnvironSuite) TestPrecheckInstanceRejectsSystemIDPlacementForVirtualMachine(c *gc.C) {
+	controller := newFakeController()
+	env := suite.makeEnviron(c, controller)
+	err := env.PrecheckInstance(suite.callCtx, environs.PrecheckInstanceParams{
+		Placement:   "system-id=abc123",
+		Constraints: constraints.MustParse("virt-type=virtual-machine"),
+	})
+	c.Assert(errors.Cause(err), gc.Equals, systemIdVMPlacementError)
 }
 
 func (suite *maasEnvironSuite) TestPrecheckInstanceNoPlacement(c *gc.C) {

--- a/internal/provider/maas/maas_test.go
+++ b/internal/provider/maas/maas_test.go
@@ -83,6 +83,9 @@ type fakeController struct {
 	spacesError        error
 	staticRoutes       []gomaasapi.StaticRoute
 	staticRoutesError  error
+	pods               []gomaasapi.Pod
+	podsError          error
+	deleteMachineError error
 
 	allocateMachine          gomaasapi.Machine
 	allocateMachineMatches   gomaasapi.ConstraintMatches
@@ -132,17 +135,18 @@ func (c *fakeController) Machines(args gomaasapi.MachinesArgs) ([]gomaasapi.Mach
 	if c.machinesError != nil {
 		return nil, c.machinesError
 	}
-	if len(args.SystemIDs) > 0 {
-		result := []gomaasapi.Machine{}
-		systemIds := set.NewStrings(args.SystemIDs...)
-		for _, machine := range c.machines {
-			if systemIds.Contains(machine.SystemID()) {
-				result = append(result, machine)
-			}
-		}
-		return result, nil
+	if len(args.SystemIDs) == 0 && len(args.Hostnames) == 0 {
+		return c.machines, nil
 	}
-	return c.machines, nil
+	result := []gomaasapi.Machine{}
+	systemIDs := set.NewStrings(args.SystemIDs...)
+	hostnames := set.NewStrings(args.Hostnames...)
+	for _, machine := range c.machines {
+		if systemIDs.Contains(machine.SystemID()) || hostnames.Contains(machine.Hostname()) {
+			result = append(result, machine)
+		}
+	}
+	return result, nil
 }
 
 func (c *fakeController) Domains() ([]gomaasapi.Domain, error) {
@@ -218,6 +222,18 @@ func (c *fakeController) ReleaseMachines(args gomaasapi.ReleaseMachinesArgs) err
 	return c.NextErr()
 }
 
+func (c *fakeController) DeleteMachine(systemID string) error {
+	c.MethodCall(c, "DeleteMachine", systemID)
+	return c.deleteMachineError
+}
+
+func (c *fakeController) Pods() ([]gomaasapi.Pod, error) {
+	if c.podsError != nil {
+		return nil, c.podsError
+	}
+	return c.pods, nil
+}
+
 type fakeBootResource struct {
 	gomaasapi.BootResource
 	name         string
@@ -245,6 +261,8 @@ type fakeMachine struct {
 	cpuCount      int
 	memory        int
 	architecture  string
+	powerType     string
+	pod           gomaasapi.Pod
 	interfaceSet  []gomaasapi.Interface
 	tags          []string
 	createDevice  gomaasapi.Device
@@ -300,6 +318,14 @@ func (m *fakeMachine) FQDN() string {
 
 func (m *fakeMachine) IPAddresses() []string {
 	return m.ipAddresses
+}
+
+func (m *fakeMachine) PowerType() string {
+	return m.powerType
+}
+
+func (m *fakeMachine) Pod() gomaasapi.Pod {
+	return m.pod
 }
 
 func (m *fakeMachine) StatusName() string {
@@ -695,4 +721,48 @@ type fakeDomain struct{}
 
 func (*fakeDomain) Name() string {
 	return "maas"
+}
+
+type fakePod struct {
+	gomaasapi.Pod
+
+	id    int
+	name  string
+	type_ string
+	zone  gomaasapi.Zone
+	pool  gomaasapi.Pool
+
+	composeMachine          gomaasapi.Machine
+	composeMachineErr       error
+	composeMachineArgsCheck func(gomaasapi.ComposeMachineArgs)
+}
+
+func (p *fakePod) ID() int {
+	return p.id
+}
+
+func (p *fakePod) Name() string {
+	return p.name
+}
+
+func (p *fakePod) Type() string {
+	return p.type_
+}
+
+func (p *fakePod) Zone() gomaasapi.Zone {
+	return p.zone
+}
+
+func (p *fakePod) Pool() gomaasapi.Pool {
+	return p.pool
+}
+
+func (p *fakePod) ComposeMachine(args gomaasapi.ComposeMachineArgs) (gomaasapi.Machine, error) {
+	if p.composeMachineArgsCheck != nil {
+		p.composeMachineArgsCheck(args)
+	}
+	if p.composeMachineErr != nil {
+		return nil, p.composeMachineErr
+	}
+	return p.composeMachine, nil
 }


### PR DESCRIPTION
Allow MAAS instances to be explicitly provisioned as VMs when the constraints include `virt-type=virtual-machine`.
`virt-type` is an existing constraint used to distinguish between lxd and kvm for the lxd provider. This extends the same concept to maas.

When virt-type is omitted, maas acquires a node from its pool of machines as usual. With `virt-type=virtual-machine`, instead of relying only on the normal allocation path, Juju now:

1. composes a VM from a MAAS KVM pod
2. waits for commissioning to finish
3. allocates that machine to Juju using the existing code / workflow as for any other machine

The compose step is needed because that's the only way to configure the resulting vm to have any storage needed by Juju storage directives in addition to the root disk.

As with the lxd provider, using `virt-type` still results in Juju seeing a provisioned "machine" - the constraint just influences how that machine is created. When such a machine is deleted from the Juju model, it is not just released but also deleted from maas. This differs from maas bare metal nodes which are just released.

Part of the fix required an enhancement to the block device mapping function to account for how MAAS KVMs label block devices.

Includes drive by fix for flakey `TestCommitHookChangesExpiresSecretBackendTokens`
and also a drive by cli doc fix.

Uses https://github.com/juju/gomaasapi/pull/106.

## QA steps

You need a MAAS with a KVM pod configured.
eg
<img width="1226" height="361" alt="image" src="https://github.com/user-attachments/assets/3642f13e-e6aa-4652-970c-d00f6c094025" />

`juju bootstrap mymaas test`

will bootstrap on a machine without using the new provisioning workflow and which will draw from whatever pool of machines MAAS has available. 

Then we can deploy a test storage charm:
```
cd testcharms/charms/dummy-storage
juju deploy . --storage single-fs=maas,10M --storage multi-fs=maas,10M --constraints "virt-type=virtual-machine" --series noble --force
```

This will force MAAS to provision a "machine" as far as Juju is concerned but it will be a vm from the pod.

Use `juju status --storage` to see the storage is provisioned and attached.
You can ssh into the unit and also see the storage locations are mounted.

You can use `remove-application` and then check that the KVM vm is fully deleted from MAAS.

## Documentation changes

I updated the MAAS cloud doc.

## Links

**Jira card:** [JUJU-9698](https://warthogs.atlassian.net/browse/JUJU-9698)


[JUJU-9698]: https://warthogs.atlassian.net/browse/JUJU-9698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ