### PR TITLE
fix: use stderr not tty in backup shell test

### DIFF
--- a/tests/suites/backup/backup.sh
+++ b/tests/suites/backup/backup.sh
@@ -6,7 +6,7 @@ run_basic_backup_create() {
 	ensure "test-basic-backup-create" "${file}"
 
 	juju switch controller
-	checksum=$(juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz" | tee /dev/tty | awk '/^checksum:/ {print $2}' | base64 -d | xxd -p)
+	checksum=$(juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz" | tee /dev/stderr | awk '/^checksum:/ {print $2}' | base64 -d | xxd -p)
 
 	# Do some basic sanity checks on what's inside the backup
 	tar xf "${TEST_DIR}/basic_backup.tar.gz" -C "${TEST_DIR}"


### PR DESCRIPTION
A previous fix had a typo - it used `/dev/tty` instead of `/dev/stderr` in the backup shell test. This broke on jenkins.

## QA steps

`./main.sh -v backup`