### PR TITLE
feat(dqlite): update dqlite 1.18.6

### DIFF
--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -65,7 +65,7 @@ TAG_LIBNSL=v2.0.1
 TAG_LIBUV=v1.51.0
 TAG_LIBLZ4=v1.9.4
 TAG_SQLITE=version-3.47.0
-TAG_DQLITE=v1.18.5
+TAG_DQLITE=v1.18.6
 
 S3_BUCKET=s3://dqlite-static-libs
 S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${BUILD_ARCH}.tar.bz2


### PR DESCRIPTION
This updates the 3.6 branch to the latest dqlite 1.18.6 branch. With this change[1], it should prevent the AppArmor issue with the latest kernel(s). This manifested with the inability to deploy to LXD correctly.

This change will just allow jenkins to see which version of dqlite it can build. Once that is done, another commit with the hashes will be stored and the snapcraft.yaml will be updated.

 1. https://github.com/canonical/dqlite/pull/878


## QA steps

Nothing, this will allow the follow job to be run https://jenkins.juju.canonical.com/job/build-dqlite/

## Links

Issue: https://github.com/juju/juju/issues/22112

Jira: [JUJU-9732](https://warthogs.atlassian.net/browse/JUJU-9732)

[JUJU-9732]: https://warthogs.atlassian.net/browse/JUJU-9732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ