### PR TITLE
test: backport test fixes for model metrics shell tests

### DIFF
--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -8,18 +8,19 @@ run_model_metrics() {
 	file="${TEST_DIR}/test-${testname}.log"
 	ensure "${testname}" "${file}"
 
-	# deploy ubuntu with a different name, check that the metric send the charm name, not the application name.
+	# Deploy ubuntu with a different name, check that the metric send the charm name, not the application name.
 	juju deploy ubuntu app-one --series focal
-	juju deploy juju-qa-test
-	juju deploy ntp
-	juju relate ntp app-one
+	juju deploy juju-qa-test --series focal
+	juju deploy juju-qa-dummy-subordinate --series focal
+	juju config dummy-subordinate token=becomegreen
+	juju relate dummy-subordinate app-one
 
-	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 1)"
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 2)"
 	wait_for "app-one" "$(idle_condition "app-one" 0)"
-	wait_for "ntp" "$(idle_subordinate_condition "ntp" "app-one" 0)"
+	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "app-one" 0)"
 
-	juju relate ntp:juju-info juju-qa-test:juju-info
-	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test" 1)"
+	juju relate dummy-subordinate:juju-info juju-qa-test:juju-info
+	wait_for "dummy-subordinate" "$(idle_subordinate_condition "dummy-subordinate" "juju-qa-test" 1)"
 
 	juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE"
 
@@ -32,7 +33,7 @@ run_model_metrics() {
 	attempt=0
 	while true; do
 		OUT=$(juju debug-log -m controller --include-module juju.apiserver.charmrevisionupdater.client | grep metrics || true)
-		if echo "${OUT}" | grep -e '"metrics":{"relations":"juju-qa-test,ubuntu","units":"2"}' -e '"metrics":{"relations":"ntp","units":"1"}' -e '"model":{"applications":"3",' -e '"machines":"2",'; then
+		if echo "${OUT}" | grep -e '"metrics":{"relations":"juju-qa-test,ubuntu","units":"2"}' -e '"metrics":{"relations":"dummy-subordinate","units":"1"}' -e '"model":{"applications":"3",' -e '"machines":"2",'; then
 			break
 		fi
 		echo "${OUT}"


### PR DESCRIPTION
The 2.9 model metrics shell tests failed because the ntp charm is broken.
Backport the fixed from 3.6.

## QA steps

`./main.sh -v model`