### PR TITLE
fix: network-get for mismatched endpoint and relation

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"maps"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -198,15 +199,16 @@ func (u *UniterAPI) OpenedMachinePortRangesByEndpoint(ctx context.Context, args 
 			}
 
 			// Ensure results are sorted by endpoint name to be consistent.
-			sort.Slice(result.Results[i].UnitPortRanges[unitTag], func(a, b int) bool {
-				return result.Results[i].UnitPortRanges[unitTag][a].Endpoint < result.Results[i].UnitPortRanges[unitTag][b].Endpoint
-			})
+			r := result.Results[i].UnitPortRanges[unitTag]
+			sort.Slice(r, func(a, b int) bool { return r[a].Endpoint < r[b].Endpoint })
 		}
 	}
 	return result, nil
 }
 
-func (u *UniterAPI) getOneMachineOpenedPortRanges(ctx context.Context, canAccess common.AuthFunc, machineTag string) (map[coreunit.Name]network.GroupedPortRanges, error) {
+func (u *UniterAPI) getOneMachineOpenedPortRanges(
+	ctx context.Context, canAccess common.AuthFunc, machineTag string,
+) (map[coreunit.Name]network.GroupedPortRanges, error) {
 	tag, err := names.ParseMachineTag(machineTag)
 	if err != nil {
 		return nil, apiservererrors.ErrPerm
@@ -2340,6 +2342,19 @@ func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoPara
 		Results: make(map[string]params.NetworkInfoResult),
 	}
 
+	if len(args.Endpoints) > 0 {
+		infos, err := u.networkService.GetUnitEndpointNetworks(ctx, unitName, args.Endpoints)
+		if errors.Is(err, applicationerrors.UnitNotFound) {
+			return params.NetworkInfoResults{}, errors.NotFoundf("unit %q", unitTag.Id())
+		} else if err != nil {
+			return params.NetworkInfoResults{}, internalerrors.Capture(err)
+		}
+
+		for _, info := range infos {
+			results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
+		}
+	}
+
 	if args.RelationId != nil {
 		relationUUID, err := u.relationService.GetRelationUUIDByID(
 			ctx, *args.RelationId,
@@ -2359,26 +2374,19 @@ func (u *UniterAPI) NetworkInfo(ctx context.Context, args params.NetworkInfoPara
 		} else if err != nil {
 			return params.NetworkInfoResults{}, internalerrors.Capture(err)
 		}
-		results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
-		return results, nil
-	}
 
-	infos, err := u.networkService.GetUnitEndpointNetworks(ctx, unitName, args.Endpoints)
-	if errors.Is(err, applicationerrors.UnitNotFound) {
-		return params.NetworkInfoResults{}, errors.NotFoundf("unit %q", unitTag.Id())
-	} else if err != nil {
-		return params.NetworkInfoResults{}, internalerrors.Capture(err)
-	}
-
-	for _, info := range infos {
-		results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
+		overrideRelationEndpoint := len(args.Endpoints) == 0 ||
+			slices.Contains(args.Endpoints, info.EndpointName)
+		if overrideRelationEndpoint {
+			results.Results[info.EndpointName] = unitNetworkToNetworkInfoResult(info)
+		}
 	}
 	return results, nil
 }
 
 // WatchUnitRelations returns a StringsWatcher, for each given
 // unit, that notifies of changes to the lifecycles of relations
-// relevant to that unit. For principal units, this will be all of the
+// relevant to that unit. For principal units, this will be all the
 // relations for the application. For subordinate units, only
 // relations with the principal unit's application will be monitored.
 func (u *UniterAPI) WatchUnitRelations(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
@@ -3210,14 +3218,14 @@ func (u *UniterAPI) watchUnit(ctx context.Context, tag names.UnitTag) (watcher.N
 
 // Merge merges in the provided leadership settings. Only leaders for
 // the given service may perform this operation.
-func (u *UniterAPIv20) Merge(ctx context.Context, bulkArgs params.MergeLeadershipSettingsBulkParams) (params.ErrorResults, error) {
+func (u *UniterAPIv20) Merge(_ context.Context, bulkArgs params.MergeLeadershipSettingsBulkParams) (params.ErrorResults, error) {
 	results := make([]params.ErrorResult, len(bulkArgs.Params))
 	return params.ErrorResults{Results: results}, nil
 }
 
 // Read reads leadership settings for the provided service ID. Any
 // unit of the service may perform this operation.
-func (u *UniterAPIv20) Read(ctx context.Context, bulkArgs params.Entities) (params.GetLeadershipSettingsBulkResults, error) {
+func (u *UniterAPIv20) Read(_ context.Context, bulkArgs params.Entities) (params.GetLeadershipSettingsBulkResults, error) {
 	results := make([]params.GetLeadershipSettingsResult, len(bulkArgs.Entities))
 	return params.GetLeadershipSettingsBulkResults{Results: results}, nil
 }
@@ -3252,9 +3260,9 @@ func (u *UniterAPI) Merge(ctx context.Context, _, _ struct{}) {}
 func (u *UniterAPI) Read(ctx context.Context, _, _ struct{}) {}
 
 // WatchLeadershipSettings is not implemented in version 21 of the uniter.
-func (u *UniterAPI) WatchLeadershipSettings(ctx context.Context, _, _ struct{}) {}
+func (u *UniterAPI) WatchLeadershipSettings(_ context.Context, _, _ struct{}) {}
 
-// GetUnitContexts returns the contexts of the units specified in the request.
+// GetUnitContext returns the contexts of the units specified in the request.
 func (u *UniterAPI) GetUnitContext(ctx context.Context, args params.Entity) (params.UnitContext, error) {
 	canAccess, err := u.accessUnit(ctx)
 	if err != nil {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2359,10 +2359,13 @@ func (s *uniterRelationSuite) TestNetworkInfoWithRelationUsesRelationNetwork(c *
 		RelationId: &relID,
 	}
 
-	s.expectGetRelationUUIDByID(relID, relUUID, nil)
 	s.networkService.EXPECT().GetUnitEndpointNetworks(
 		gomock.Any(), unitName, args.Endpoints,
-	).Times(0)
+	).Return([]domainnetwork.UnitNetwork{{
+		EndpointName:     "database",
+		IngressAddresses: []string{"192.0.2.10"},
+	}}, nil)
+	s.expectGetRelationUUIDByID(relID, relUUID, nil)
 	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relUUID).Return(domainnetwork.UnitNetwork{
 		EndpointName:     "database",
 		IngressAddresses: []string{"198.51.100.10"},
@@ -2394,6 +2397,42 @@ func (s *uniterRelationSuite) TestNetworkInfoWithRelationUsesRelationNetwork(c *
 				}},
 				IngressAddresses: []string{"198.51.100.10"},
 				EgressSubnets:    []string{"203.0.113.0/24"},
+			},
+		},
+	})
+}
+
+func (s *uniterRelationSuite) TestNetworkInfoWithRelationPreservesRequestedEndpointNetworks(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	relID := 42
+	relUUID := tc.Must(c, corerelation.NewUUID)
+	unitName := coreunit.Name(s.wordpressUnitTag.Id())
+	args := params.NetworkInfoParams{
+		Unit:       s.wordpressUnitTag.String(),
+		Endpoints:  []string{"database"},
+		RelationId: &relID,
+	}
+
+	s.networkService.EXPECT().GetUnitEndpointNetworks(
+		gomock.Any(), unitName, args.Endpoints,
+	).Return([]domainnetwork.UnitNetwork{{
+		EndpointName:     "database",
+		IngressAddresses: []string{"192.0.2.10"},
+	}}, nil)
+	s.expectGetRelationUUIDByID(relID, relUUID, nil)
+	s.networkService.EXPECT().GetUnitRelationNetwork(gomock.Any(), unitName, relUUID).Return(domainnetwork.UnitNetwork{
+		EndpointName:     "database-peers",
+		IngressAddresses: []string{"198.51.100.10"},
+		EgressSubnets:    []string{"203.0.113.0/24"},
+	}, nil)
+
+	result, err := s.uniter.NetworkInfo(c.Context(), args)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.NetworkInfoResults{
+		Results: map[string]params.NetworkInfoResult{
+			"database": {
+				IngressAddresses: []string{"192.0.2.10"},
 			},
 		},
 	})


### PR DESCRIPTION
The `network-get` hook tool can be called from within a relation hook context for an endpoint not in that relation. 

The logic in the `uniter` API was to always resolve the networks for a relation when it was supplied, and fall back to passed endpoints otherwise. For the case above, this sends the charm into an error state, because no info can be located for the endpoint. 

This change restores the behaviour from 3.6 where the endpoint is always resolved, _then overridden with the relation network data if that endpoint is in the relation_.

There is some redundant processing associated with handling in this fashion. Aggressive optimisation will follow in subsequent patches.

## QA steps

On LXD using a profile with two devices on different bridges:
- `juju add-model work`.
- `juju spaces` shows topology:
```
Name   Space ID                              Subnets
alpha  656b4a82-e28c-53d6-a014-f0dd53417eb6  10.155.5.0/24
                                             10.155.6.0/24
                                             172.17.0.0/16
```
- `juju add-space beta 10.155.6.0/24`.
- `juju deploy postgresql --channel 16/edge --force -n 3 --bind beta`
- The deployment will quiesce without errors:
```
Model  Controller  Cloud/Region  Version  Timestamp
work   lxd         lxd/default   4.0.7.1  12:22:46+02:00

App         Version  Status  Scale  Charm       Channel   Rev  Exposed  Message
postgresql  16.13    active      3  postgresql  16/edge  1101  no

Unit           Workload  Agent  Machine  Public address  Ports     Message
postgresql/0   active    idle   0        10.155.5.164    5432/tcp
postgresql/1   active    idle   1        10.155.5.95     5432/tcp
postgresql/2*  active    idle   2        10.155.5.103    5432/tcp  Primary

Machine  State    Address       Inst id        Base          AZ      Message
0        started  10.155.5.164  juju-2c01b8-0  ubuntu@24.04  rashan  Running
1        started  10.155.5.95   juju-2c01b8-1  ubuntu@24.04  rashan  Running
2        started  10.155.5.103  juju-2c01b8-2  ubuntu@24.04  rashan  Running
```   

## Links

**Issue:** Fixes https://github.com/juju/juju/issues/22294.
