### PR TITLE
feat(dqlite): update dqlite 1.18.6

### DIFF
--- a/scripts/dqlite/scripts/dqlite/dqlite-install.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-install.sh
@@ -8,8 +8,8 @@ check_dependencies sha256sum
 
 sha() {
 	case ${BUILD_ARCH} in
-		amd64) echo "d9811654898507a661147ac0d26eb896b97177603335e04ef427a230db776c91" ;;
-		arm64) echo "2a04593d397451ab30c056e0d2ad828270ed54da7158477ee014bc449bbf3fe2" ;;
+		amd64) echo "45c9bbc1291e3ae3a1254e8098fda0e1a4d9b0a64178093e4e253e6ac75caa3b" ;;
+		arm64) echo "e4c1e2ca250a80bc389930495bafa78dd45bd411eaca05b79bf72839c6050904" ;;
 		*) { echo "Unsupported arch ${BUILD_ARCH}."; exit 1; } ;;
 	esac
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -227,7 +227,7 @@ parts:
       - libuv
       - libsqlite3
     source: https://github.com/canonical/dqlite.git
-    source-tag: v1.18.5
+    source-tag: v1.18.6
     source-type: git
     source-depth: 1
     plugin: nil


### PR DESCRIPTION
Follows on from https://github.com/juju/juju/pull/22289

----

Updates dqlite to 1.18.6 in both the snapcraft.yaml and the dev
dependencies.

Updates both amd64 and arm64:

 - amd64:
   - 45c9bbc1291e3ae3a1254e8098fda0e1a4d9b0a64178093e4e253e6ac75caa3b
   - https://jenkins.juju.canonical.com/job/build-dqlite-amd64/81/console
 - arm64:
   - e4c1e2ca250a80bc389930495bafa78dd45bd411eaca05b79bf72839c6050904
   - https://jenkins.juju.canonical.com/job/build-dqlite-arm64/53/console

It is required that the manual removal of the directory
_deps/dqlite-deps-{arch} is done, so it will be replace with the new
content.

## QA steps

```
$ rm -rf _deps/dqlite-deps-*
$ juju bootstrap lxd test
```

## Links

Issue: https://github.com/juju/juju/issues/22112

Jira: [JUJU-9732](https://warthogs.atlassian.net/browse/JUJU-9732)

[JUJU-9732]: https://warthogs.atlassian.net/browse/JUJU-9732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ