### PR TITLE
Update 2.9 release notes support statement

### DIFF
--- a/docs/releasenotes/juju_2.9.x.md
+++ b/docs/releasenotes/juju_2.9.x.md
@@ -1,8 +1,6 @@
 (juju29x)=
 # Juju 2.9 (LTS)
-> Currently in Security Fix Only support
->
->  April 2035: expected end of security fix support
+> April 2035: expected end of security and critical bug fix support
 
 ```{note}
 Juju 2.9 series is LTS


### PR DESCRIPTION
### Changes
- Updated the support end date statement in juju_2.9.x.md to use the standardized format: "April 2035: expected end of security and critical bug fix support"
- Removed the multi-line format that separately listed "Security Fix Only support" and the end date

### Context
Standardizing support statements across all Juju version release notes to provide clear, consistent information about long-term support timelines.