### PR TITLE
fix: change stream flaky tests

### DIFF
--- a/internal/changestream/stream/package_test.go
+++ b/internal/changestream/stream/package_test.go
@@ -45,6 +45,13 @@ func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.metrics = NewMockMetricsCollector(ctrl)
 	s.FileNotifier = NewMockFileNotifier(ctrl)
 
+	c.Cleanup(func() {
+		s.clock = nil
+		s.timer = nil
+		s.metrics = nil
+		s.FileNotifier = nil
+	})
+
 	return ctrl
 }
 

--- a/internal/changestream/stream/stream.go
+++ b/internal/changestream/stream/stream.go
@@ -241,6 +241,7 @@ func (s *Stream) loop() error {
 	s.reportState(stateBegin)
 
 	var attempt int
+OUTER:
 	for {
 		select {
 		case <-s.tomb.Dying():
@@ -312,7 +313,7 @@ func (s *Stream) loop() error {
 				// the db was slow. In any case, continue and let the worker
 				// die if it's dying.
 				if errors.Is(errors.Cause(err), context.Canceled) {
-					continue
+					continue OUTER
 				}
 				// If we get an error attempting to read the changes, the Txn
 				// will have retried multiple times. There just isn't anything
@@ -338,7 +339,7 @@ func (s *Stream) loop() error {
 				attempt++
 
 				if traceEnabled {
-					s.logger.Tracef(ctx, "no changes, with attempt %d", attempt)
+					s.logger.Tracef(ctx, "no changes with attempt %d", attempt)
 				}
 
 				select {
@@ -348,7 +349,7 @@ func (s *Stream) loop() error {
 					if err := s.reportIdleState(ctx, attempt); err != nil {
 						return errors.Trace(err)
 					}
-					continue
+					continue OUTER
 				}
 			}
 
@@ -418,7 +419,7 @@ func (s *Stream) loop() error {
 					// when the worker is dying. We don't want to block the
 					// change stream, so we just continue.
 					s.logger.Infof(ctx, "term has been aborted")
-					continue
+					continue OUTER
 				}
 
 				// Only when the term is completed, do we update the lower
@@ -447,7 +448,7 @@ func (s *Stream) loop() error {
 					case <-s.tomb.Dying():
 						return tomb.ErrDying
 					case <-s.clock.After(backOffStrategy(0, attempt)):
-						continue
+						continue OUTER
 					}
 				}
 

--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -57,7 +57,7 @@ func (s *streamSuite) TestWithNoNamespace(c *tc.C) {
 	select {
 	case <-stream.Terms():
 		c.Fatal("timed out waiting for term")
-	case <-c.Context().Done():
+	case <-time.After(witnessChangeLongDuration):
 	}
 
 	workertest.CleanKill(c, stream)
@@ -80,7 +80,7 @@ func (s *streamSuite) TestNoData(c *tc.C) {
 	select {
 	case <-stream.Terms():
 		c.Fatal("timed out waiting for term")
-	case <-c.Context().Done():
+	case <-time.After(witnessChangeLongDuration):
 	}
 
 	workertest.CleanKill(c, stream)
@@ -831,7 +831,7 @@ func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *tc.C) 
 func (s *streamSuite) TestOneChangeIsBlockedByFile(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectTermAfterAnyTimes()
+	s.expectAfterWithoutTermTimeout()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -956,12 +956,18 @@ func (s *streamSuite) TestReport(c *tc.C) {
 	// the change. This is because we wait until after the done channel is
 	// closed before we update the watermark.
 	syncPoint := func(c *tc.C) map[string]any {
-		for range 3 {
+		for i := range 25 {
 			data := stream.Report(c.Context())
 			if strings.Contains(data["watermarks"].(string), strconv.Itoa(changestream.DefaultNumTermWatermarks)) {
 				return data
 			}
-			<-c.Context().Done()
+
+			// Exponential backoff with a maximum of 10 seconds, we don't want
+			// to wait too long, but we also want to ensure that we give the
+			// worker enough time to process the change and update the
+			// watermark.
+			backoff := time.Duration(1<<i) * time.Millisecond
+			<-time.After(min(backoff, time.Second*10))
 		}
 		c.Fatalf("timed out waiting for sync point")
 		return nil
@@ -1195,7 +1201,9 @@ func (s *streamSuite) TestWatermarkWriteUpdatesToTheLaterOne(c *tc.C) {
 }
 
 func (s *streamSuite) TestReadChangesWithNoChanges(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	stream := s.newNonRunningStream()
 
 	s.insertNamespace(c, 1000, "foo")
 
@@ -1206,7 +1214,9 @@ func (s *streamSuite) TestReadChangesWithNoChanges(c *tc.C) {
 }
 
 func (s *streamSuite) TestReadChangesWithOneChange(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	stream := s.newNonRunningStream()
 
 	s.insertNamespace(c, 1000, "foo")
 
@@ -1225,7 +1235,9 @@ func (s *streamSuite) TestReadChangesWithOneChange(c *tc.C) {
 }
 
 func (s *streamSuite) TestReadChangesWithMultipleSameChange(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	stream := s.newNonRunningStream()
 
 	s.insertNamespace(c, 1000, "foo")
 
@@ -1247,7 +1259,9 @@ func (s *streamSuite) TestReadChangesWithMultipleSameChange(c *tc.C) {
 }
 
 func (s *streamSuite) TestReadChangesWithMultipleChanges(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	stream := s.newNonRunningStream()
 
 	s.insertNamespace(c, 1000, "foo")
 
@@ -1272,7 +1286,9 @@ func (s *streamSuite) TestReadChangesWithMultipleChanges(c *tc.C) {
 }
 
 func (s *streamSuite) TestReadChangesWithMultipleChangesGroupsCorrectly(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	stream := s.newNonRunningStream()
 
 	s.insertNamespace(c, 1000, "foo")
 
@@ -1305,7 +1321,9 @@ func (s *streamSuite) TestReadChangesWithMultipleChangesGroupsCorrectly(c *tc.C)
 }
 
 func (s *streamSuite) TestReadChangesWithMultipleChangesInterweavedGroupsCorrectly(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	stream := s.newNonRunningStream()
 
 	s.insertNamespace(c, 1000, "foo")
 	s.insertNamespace(c, 2000, "bar")
@@ -1396,7 +1414,11 @@ func (s *streamSuite) TestReadChangesWithMultipleChangesInterweavedGroupsCorrect
 }
 
 func (s *streamSuite) TestProcessWatermark(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	s.expectMetrics()
+
+	stream := s.newNonRunningStream()
 
 	err := stream.processWatermark(func(tv *termView) error {
 		c.Fatalf("unexpected call to process watermark")
@@ -1452,7 +1474,11 @@ func (s *streamSuite) TestProcessWatermark(c *tc.C) {
 }
 
 func (s *streamSuite) TestProcessWatermarkBufferFull(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	s.expectMetrics()
+
+	stream := s.newNonRunningStream()
 
 	err := stream.processWatermark(func(tv *termView) error {
 		c.Fatalf("unexpected call to process watermark")
@@ -1492,7 +1518,11 @@ func (s *streamSuite) TestProcessWatermarkBufferFull(c *tc.C) {
 }
 
 func (s *streamSuite) TestUpperBound(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	s.expectMetrics()
+
+	stream := s.newNonRunningStream()
 
 	c.Check(stream.upperBound(), tc.Equals, int64(-1))
 
@@ -1520,7 +1550,9 @@ func (s *streamSuite) TestUpperBound(c *tc.C) {
 }
 
 func (s *streamSuite) TestCreateWatermarkTwice(c *tc.C) {
-	stream := s.newStream()
+	defer s.setupMocks(c).Finish()
+
+	stream := s.newNonRunningStream()
 	err := stream.createWatermark()
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -1528,12 +1560,13 @@ func (s *streamSuite) TestCreateWatermarkTwice(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *streamSuite) newStream() *Stream {
+func (s *streamSuite) newNonRunningStream() *Stream {
 	return &Stream{
-		db:         s.TxnRunner(),
-		id:         uuid.MustNewUUID().String(),
-		metrics:    s.metrics,
-		watermarks: make([]*termView, changestream.DefaultNumTermWatermarks),
+		db:             s.TxnRunner(),
+		id:             uuid.MustNewUUID().String(),
+		metrics:        s.metrics,
+		watermarks:     make([]*termView, changestream.DefaultNumTermWatermarks),
+		internalStates: nil,
 	}
 }
 

--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/core/changestream"
 	changestreamtesting "github.com/juju/juju/core/changestream/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
-	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -58,7 +57,7 @@ func (s *streamSuite) TestWithNoNamespace(c *tc.C) {
 	select {
 	case <-stream.Terms():
 		c.Fatal("timed out waiting for term")
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 	}
 
 	workertest.CleanKill(c, stream)
@@ -81,7 +80,7 @@ func (s *streamSuite) TestNoData(c *tc.C) {
 	select {
 	case <-stream.Terms():
 		c.Fatal("timed out waiting for term")
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 	}
 
 	workertest.CleanKill(c, stream)
@@ -113,7 +112,7 @@ func (s *streamSuite) TestOneChange(c *tc.C) {
 		results = term.Changes()
 		term.Done(false, make(chan struct{}))
 
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -152,7 +151,7 @@ func (s *streamSuite) TestOneChangeDoesNotRepeatSameChange(c *tc.C) {
 		results = term.Changes()
 		term.Done(false, make(chan struct{}))
 
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -169,7 +168,7 @@ func (s *streamSuite) TestOneChangeDoesNotRepeatSameChange(c *tc.C) {
 		results = term.Changes()
 		term.Done(false, make(chan struct{}))
 
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -208,7 +207,7 @@ func (s *streamSuite) TestOneChangeWithEmptyResults(c *tc.C) {
 		results = term.Changes()
 		term.Done(true, make(chan struct{}))
 
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -247,7 +246,7 @@ func (s *streamSuite) TestOneChangeWithClosedAbort(c *tc.C) {
 		close(ch)
 		term.Done(false, ch)
 
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -284,7 +283,7 @@ func (s *streamSuite) TestOneChangeWithDelayedTermDone(c *tc.C) {
 	case term = <-stream.Terms():
 		results = term.Changes()
 
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -323,7 +322,7 @@ func (s *streamSuite) TestOneChangeWithTermDoneAfterKill(c *tc.C) {
 	case term = <-stream.Terms():
 		results = term.Changes()
 
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -368,7 +367,7 @@ func (s *streamSuite) TestOneChangeWithTimeoutCausesWorkerToBounce(c *tc.C) {
 		// the worker is bounced, so we'll just let the term timeout.
 		<-time.After(witnessChangeShortDuration)
 
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -411,7 +410,7 @@ func (s *streamSuite) TestMultipleTerms(c *tc.C) {
 			results = term.Changes()
 			term.Done(false, make(chan struct{}))
 
-		case <-time.After(testing.LongWait):
+		case <-c.Context().Done():
 			c.Fatal("timed out waiting for change")
 		}
 
@@ -472,7 +471,7 @@ func (s *streamSuite) TestMultipleTermsAllEmpty(c *tc.C) {
 			results = term.Changes()
 			term.Done(true, make(chan struct{}))
 
-		case <-time.After(testing.LongWait):
+		case <-c.Context().Done():
 			c.Fatal("timed out waiting for change")
 		}
 
@@ -626,7 +625,7 @@ func (s *streamSuite) TestMultipleChangesWithSameUUIDCoalesce(c *tc.C) {
 	select {
 	case term := <-stream.Terms():
 		results = append(results, term.Changes()...)
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -672,7 +671,7 @@ func (s *streamSuite) TestMultipleChangesWithNamespaces(c *tc.C) {
 	select {
 	case term := <-stream.Terms():
 		results = append(results, term.Changes()...)
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -737,7 +736,7 @@ func (s *streamSuite) TestMultipleChangesWithNamespacesCoalesce(c *tc.C) {
 	select {
 	case term := <-stream.Terms():
 		results = append(results, term.Changes()...)
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -810,7 +809,7 @@ func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *tc.C) 
 	select {
 	case term := <-stream.Terms():
 		results = append(results, term.Changes()...)
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -852,7 +851,7 @@ func (s *streamSuite) TestOneChangeIsBlockedByFile(c *tc.C) {
 		}()
 		select {
 		case <-notified:
-		case <-time.After(testing.LongWait):
+		case <-c.Context().Done():
 			c.Fatal("timed out waiting for blocking change")
 		}
 	}
@@ -877,7 +876,7 @@ func (s *streamSuite) TestOneChangeIsBlockedByFile(c *tc.C) {
 	select {
 	case term := <-stream.Terms():
 		results = append(results, term.Changes()...)
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for change")
 	}
 
@@ -948,7 +947,7 @@ func (s *streamSuite) TestReport(c *tc.C) {
 			c.Check(data["last-recorded-watermark"], tc.Equals, "")
 
 			term.Done(false, make(chan struct{}))
-		case <-time.After(testing.LongWait):
+		case <-c.Context().Done():
 			c.Fatal("timed out waiting for change")
 		}
 	}
@@ -962,7 +961,7 @@ func (s *streamSuite) TestReport(c *tc.C) {
 			if strings.Contains(data["watermarks"].(string), strconv.Itoa(changestream.DefaultNumTermWatermarks)) {
 				return data
 			}
-			<-time.After(testing.LongWait)
+			<-c.Context().Done()
 		}
 		c.Fatalf("timed out waiting for sync point")
 		return nil
@@ -976,13 +975,13 @@ func (s *streamSuite) TestReport(c *tc.C) {
 
 	select {
 	case ch <- time.Now().UTC():
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for timer")
 	}
 
 	select {
 	case <-sync:
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for timer")
 	}
 
@@ -1040,20 +1039,20 @@ func (s *streamSuite) TestWatermarkWrite(c *tc.C) {
 		case term := <-stream.Terms():
 			c.Assert(term.Changes(), tc.HasLen, 1)
 			term.Done(false, make(chan struct{}))
-		case <-time.After(testing.LongWait):
+		case <-c.Context().Done():
 			c.Fatal("timed out waiting for change")
 		}
 	}
 
 	select {
 	case ch <- time.Now().UTC():
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for timer")
 	}
 
 	select {
 	case <-sync:
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for timer")
 	}
 
@@ -1104,20 +1103,20 @@ func (s *streamSuite) TestWatermarkWriteIsIgnored(c *tc.C) {
 		case term := <-stream.Terms():
 			c.Assert(term.Changes(), tc.HasLen, 1)
 			term.Done(false, make(chan struct{}))
-		case <-time.After(testing.LongWait):
+		case <-c.Context().Done():
 			c.Fatal("timed out waiting for change")
 		}
 	}
 
 	select {
 	case ch <- time.Now().UTC():
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for timer")
 	}
 
 	select {
 	case <-sync:
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for timer")
 	}
 
@@ -1169,7 +1168,7 @@ func (s *streamSuite) TestWatermarkWriteUpdatesToTheLaterOne(c *tc.C) {
 		case term := <-stream.Terms():
 			c.Assert(term.Changes(), tc.HasLen, 1)
 			term.Done(false, make(chan struct{}))
-		case <-time.After(testing.LongWait):
+		case <-c.Context().Done():
 			c.Fatal("timed out waiting for change")
 		}
 	}
@@ -1180,13 +1179,13 @@ func (s *streamSuite) TestWatermarkWriteUpdatesToTheLaterOne(c *tc.C) {
 
 	select {
 	case ch <- time.Now().UTC():
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for timer")
 	}
 
 	select {
 	case <-sync:
-	case <-time.After(testing.LongWait):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for timer")
 	}
 


### PR DESCRIPTION
Spotted in PR https://github.com/juju/juju/pull/22283

-----

There was two issues with the stream tests:

 1. The report test was taking to long for sync points. Instead we can
    use exponential backoff with an upper limit to keep retrying.
 2. Some tests didn't setup mocks, so when mocks where called it was
    ignored, which lead to undefined behaviour.

## QA steps

```
$ go test -v ./internal/changestream/stream
$ go test -v ./internal/changestream/stream -race
$ go test -v ./internal/changestream/stream -race -c
$ stress ./stream.test
stress ./stream.test
5s: 0 runs so far, 0 failures, 32 active
10s: 0 runs so far, 0 failures, 32 active
15s: 32 runs so far, 0 failures, 32 active
20s: 32 runs so far, 0 failures, 32 active
25s: 33 runs so far, 0 failures, 32 active
30s: 64 runs so far, 0 failures, 32 active
35s: 64 runs so far, 0 failures, 32 active
40s: 72 runs so far, 0 failures, 32 active
45s: 96 runs so far, 0 failures, 32 active
50s: 96 runs so far, 0 failures, 32 active
55s: 107 runs so far, 0 failures, 32 active
1m0s: 128 runs so far, 0 failures, 32 active
1m5s: 128 runs so far, 0 failures, 32 active
1m10s: 137 runs so far, 0 failures, 32 active
1m15s: 160 runs so far, 0 failures, 32 active
1m20s: 161 runs so far, 0 failures, 32 active
1m25s: 176 runs so far, 0 failures, 32 active
1m30s: 192 runs so far, 0 failures, 32 active
1m35s: 194 runs so far, 0 failures, 32 active
1m40s: 211 runs so far, 0 failures, 32 active
1m45s: 225 runs so far, 0 failures, 32 active
1m50s: 226 runs so far, 0 failures, 32 active
1m55s: 245 runs so far, 0 failures, 32 active
2m0s: 257 runs so far, 0 failures, 32 active
2m5s: 270 runs so far, 0 failures, 32 active
2m10s: 289 runs so far, 0 failures, 32 active
```
