### PR TITLE
fix: ensure controller app is exposed on upgrade

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -322,6 +322,40 @@ nextUnit:
 	return nil
 }
 
+// ExposeControllerApplication runs an upgrade to expose the
+// controller application.
+func ExposeControllerApplication(pool *StatePool) error {
+	st, err := pool.SystemState()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	appsColl, closer := st.db().GetCollection(applicationsC)
+	defer closer()
+	var appData bson.M
+	err = appsColl.Find(bson.M{"_id": controllerAppName}).Select(bson.M{"exposed": 1}).One(&appData)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	exposed, _ := appData["exposed"].(bool)
+	if exposed {
+		return nil
+	}
+
+	ops := []txn.Op{{
+		C:      applicationsC,
+		Id:     st.docID(controllerAppName),
+		Assert: txn.DocExists,
+		Update: bson.D{{"$set", bson.D{
+			{"exposed", true},
+		}}},
+	}}
+	if err = st.runRawTransaction(ops); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 // PopulateApplicationStorageUniqueID has the responsibility of populating the
 // `storage-unique-id` field in the application document.
 func PopulateApplicationStorageUniqueID(

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -285,6 +285,27 @@ func (s *upgradesSuite) TestOpenControllerAPIPort(c *gc.C) {
 	)
 
 }
+
+func (s *upgradesSuite) TestExposeControllerApplication(c *gc.C) {
+	AddTestingApplication(c, s.state, "controller", AddTestingCharm(c, s.state, "wordpress"))
+
+	appsColl, closer := s.state.db().GetRawCollection(applicationsC)
+	defer closer()
+
+	var appData bson.M
+	err := appsColl.Find(bson.M{"_id": s.state.docID(controllerAppName)}).One(&appData)
+	c.Assert(err, jc.ErrorIsNil)
+	exposed, ok := appData["exposed"].(bool)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(exposed, jc.IsFalse)
+
+	appData["exposed"] = true
+	delete(appData, "txn-revno")
+	s.assertUpgradedData(c, ExposeControllerApplication, nil,
+		upgradedData(appsColl, []bson.M{appData}),
+	)
+}
+
 func (s *upgradesSuite) TestPopulateApplicationStorageUniqueID(c *gc.C) {
 	state1 := s.makeModel(c, "m1", coretesting.Attrs{}, ModelArgs{Type: ModelTypeCAAS})
 	state2 := s.makeModel(c, "m2", coretesting.Attrs{}, ModelArgs{Type: ModelTypeCAAS})

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -25,6 +25,7 @@ type StateBackend interface {
 	PopulateApplicationStorageUniqueID() error
 	OpenControllerAPIPort() error
 	ConvertScalingToCurrentOperationEnumField() error
+	ExposeControllerApplication() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -76,6 +77,12 @@ func (s stateBackend) PopulateApplicationStorageUniqueID() error {
 // scaling field to an enum field.
 func (s stateBackend) ConvertScalingToCurrentOperationEnumField() error {
 	return state.ConvertScalingToCurrentOperationEnumField(s.pool)
+}
+
+// ExposeControllerApplication runs an upgrade to expose
+// the controller application.
+func (s stateBackend) ExposeControllerApplication() error {
+	return state.ExposeControllerApplication(s.pool)
 }
 
 // newK8sClient initializes a new k8s client for a given model.

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -24,6 +24,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("3.6.13"), stateStepsFor3613()},
 		upgradeToVersion{version.MustParse("3.6.15"), stateStepsFor3615()},
 		upgradeToVersion{version.MustParse("3.6.21"), stateStepsFor3621()},
+		upgradeToVersion{version.MustParse("3.6.22"), stateStepsFor3622()},
 	}
 	return steps
 }

--- a/upgrades/steps_3622.go
+++ b/upgrades/steps_3622.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor3622 returns upgrade steps for Juju 3.6.22 that manipulate state directly.
+func stateStepsFor3622() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "expose controller application",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().ExposeControllerApplication()
+			},
+		},
+	}
+}

--- a/upgrades/steps_3622_test.go
+++ b/upgrades/steps_3622_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v3622 = version.MustParse("3.6.22")
+
+type steps3622Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps3622Suite{})
+
+func (s *steps3622Suite) TestExposeControllerApplication(c *gc.C) {
+	step := findStateStep(c, v3622, "expose controller application")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -596,7 +596,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"3.6.4", "3.6.5", "3.6.13", "3.6.15", "3.6.21"})
+	c.Assert(versions, gc.DeepEquals, []string{"3.6.4", "3.6.5", "3.6.13", "3.6.15", "3.6.21", "3.6.22"})
 }
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {


### PR DESCRIPTION
Depending on the version of 3.6, bootstrapping doesn't always result in the (built in) controller app being exposed.
eg bootstrapping 3.6.4 it wasn't exposed, 3.6.14 it was.

Starting in 3.6.19, the firewaller is used to manage the api port, so the controller app must be exposed.
This PR adds an upgrade step to ensure old versions are updated to have the controller app exposed.

## QA steps

Use a 3.6.4 client to bootstrap
juju status shows controller app not exposed

Upgrade controller
juju status shows controller app exposed

## Links

**Issue:** Fixes #22293.

**Jira card:** [JUJU-9737](https://warthogs.atlassian.net/browse/JUJU-9737)


[JUJU-9737]: https://warthogs.atlassian.net/browse/JUJU-9737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ