### PR TITLE
chore: move model_migrating triggers to 4.0.7 patch

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -167,6 +167,10 @@ var modelPostPatchFilesByVersion = []struct {
 		"0054-application-k8s-resources.PATCH.sql",
 		"0055-constraint-view.PATCH.sql",
 		"0056-blockdevice-partial.PATCH.sql",
+	},
+}, {
+	version: semversion.MustParse("4.0.7"),
+	files: []string{
 		"0057-model-migrating-triggers.PATCH.sql",
 	},
 }}

--- a/domain/schema/model/4.0.6-model-release.ddl
+++ b/domain/schema/model/4.0.6-model-release.ddl
@@ -8484,28 +8484,3 @@ BEGIN
 END;
 
 -- noqa: enable=all
-
--- This PATCH adds change_log triggers for model_migrating.
--- The table itself was created in 0037-model-migrating.PATCH.sql;
--- adding triggers separately keeps the namespace registration and
--- trigger DDL in the same SQL-level mechanism as the rest of the
--- post-patch files.
-
--- insert namespace for ModelMigrating
-INSERT INTO change_log_namespace VALUES (10041, 'model_migrating', 'ModelMigrating changes based on model_uuid');
-
--- insert trigger for ModelMigrating
-CREATE TRIGGER trg_log_model_migrating_insert
-AFTER INSERT ON model_migrating FOR EACH ROW
-BEGIN
-INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
-VALUES (1, 10041, new.model_uuid, DATETIME('now', 'utc'));
-END;
-
--- delete trigger for ModelMigrating
-CREATE TRIGGER trg_log_model_migrating_delete
-AFTER DELETE ON model_migrating FOR EACH ROW
-BEGIN
-INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
-VALUES (4, 10041, old.model_uuid, DATETIME('now', 'utc'));
-END;


### PR DESCRIPTION
_tl;dr; 4.0.6 had landed just before I landed the changes including a patch which I forgot to move to 4.0.7._

Keep the 4.0.6 release schema unchanged and apply the model_migrating change log trigger setup as a 4.0.7 post-patch.


## QA steps
N/A

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9655](https://warthogs.atlassian.net/browse/JUJU-9655)


[JUJU-9655]: https://warthogs.atlassian.net/browse/JUJU-9655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ