### PR TITLE
fix: snap linker for JujudOCINamespace

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -98,6 +98,7 @@ parts:
       github.com/juju/juju/version.GitCommit: ""
       github.com/juju/juju/version.GitTreeState: ""
       github.com/juju/juju/version.build: ""
+      github.com/juju/juju/cloudconfig/podcfg.JujudOCINamespace: ""
     # go-static is not supported by the standard go plugin.
     go-static: true
     # go-strip is not supported by the standard go plugin.


### PR DESCRIPTION
Follow up for https://github.com/juju/juju/pull/22255

We recently starting linking the JujudOCINamespace var when building Juju. However, a chaneg to snapcraft.yaml is required to build the snaps.

Fix this

## QA steps

Apply the following diff
```diff
diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
index 97596163fc..39b97cd520 100644
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -98,7 +98,7 @@ parts:
       github.com/juju/juju/version.GitCommit: ""
       github.com/juju/juju/version.GitTreeState: ""
       github.com/juju/juju/version.build: ""
-      github.com/juju/juju/cloudconfig/podcfg.JujuOCINamespace: ""
+      github.com/juju/juju/cloudconfig/podcfg.JujuOCINamespace: "us-central1-docker.pkg.dev/gothic-list-89514/juju-testing/juju"
     # go-static is not supported by the standard go plugin.
     go-static: true
     # go-strip is not supported by the standard go plugin.
```
And run `snapcraft build`.

Observe in output:
```
+ go install -p 2 -ldflags '-s -w -extldflags -static -X github.com/juju/juju/version.GitCommit= -X github.com/juju/juju/version.GitTreeState= -X github.com/juju/juju/version.build= -X github.com/juju/juju/cloudconfig/podcfg.JujuOCINamespace=us-central1-docker.pkg.dev/gothic-list-89514/juju-testing/juju' github.com/juju/juju/cmd/juju github.com/juju/juju/cmd/jujuc github.com/juju/juju/cmd/jujud github.com/juju/juju/cmd/plugins/juju-metadata github.com/juju/juju/cmd/plugins/juju-wait-for
```