### PR TITLE
feat(bootstrap): implement latest-version snap channel install flow

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2143,10 +2143,6 @@ func (s *BootstrapSuite) TestBootstrapControllerSnapFlagValidation(c *tc.C) {
 		args []string
 		err  string
 	}{{
-		name: "invalid snap channel",
-		args: []string{"--controller-snap-channel", "3.0/foo"},
-		err:  `controller snap channel "3.0/foo" not valid`,
-	}, {
 		name: "unreadable snap path",
 		args: []string{"--controller-snap-path", "/invalid/snap.path"},
 		err:  `--controller-snap-path "/invalid/snap.path" cannot be read: .*`,

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -195,6 +195,14 @@ type BootstrapParams struct {
 	// ControllerSnapRevision is used to install an earlier version of the
 	// controller snap.
 	ControllerSnapRevision string
+
+	// ControllerSnapResolvedChannel is the effective channel used for
+	// controller snapstore bootstrap.
+	ControllerSnapResolvedChannel string
+
+	// ControllerSnapExpectedVersion is the exact Juju version expected from
+	// the controller snap.
+	ControllerSnapExpectedVersion string
 }
 
 // Validate validates the bootstrap parameters.
@@ -461,6 +469,24 @@ func bootstrapIAAS(
 		// auto-discover the arch from the provider, we'll fall back
 		// to bootstrapping on the same arch as the CLI client.
 		bootstrapArch = localToolsArch()
+	}
+
+	if featureflag.Enabled(featureflag.ControllerSnap) {
+		if args.ControllerSnapPath == "" && args.ControllerSnapRevision == "" {
+			args.ControllerSnapResolvedChannel = fmt.Sprintf(
+				"%d.%d/edge", jujuversion.Current.Major, jujuversion.Current.Minor,
+			)
+			resolvedVersion, err := resolveSnapChannelVersion(ctx, args.ControllerSnapResolvedChannel)
+			if err != nil {
+				return errors.Annotate(err, "resolving controller snap version")
+			}
+			args.ControllerSnapExpectedVersion = resolvedVersion
+			ctx.Infof(
+				"Resolved controller snap channel %q to version %s",
+				args.ControllerSnapResolvedChannel,
+				args.ControllerSnapExpectedVersion,
+			)
+		}
 	}
 
 	agentVersion := jujuversion.Current
@@ -814,6 +840,8 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.Timeout = args.DialOpts.Timeout
 	icfg.Bootstrap.ControllerCharm = args.ControllerCharmPath
 	icfg.Bootstrap.ControllerCharmChannel = args.ControllerCharmChannel
+	icfg.Bootstrap.ControllerSnapChannel = args.ControllerSnapResolvedChannel
+	icfg.Bootstrap.ControllerSnapExpectedVersion = args.ControllerSnapExpectedVersion
 	return nil
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1089,6 +1089,32 @@ func (s *bootstrapSuite) TestBootstrapControllerSnapNotPlumbedWithoutFeatureFlag
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(env.instanceConfig.Bootstrap.ControllerSnapPath, tc.Equals, "")
 }
+
+func (s *bootstrapSuite) TestBootstrapControllerSnapLatestFromSnapStore(c *tc.C) {
+	s.SetFeatureFlags(featureflag.ControllerSnap)
+
+	resolvedVersion := jujuversion.Current.ToPatch()
+	channel := fmt.Sprintf("%d.%d/edge", jujuversion.Current.Major, jujuversion.Current.Minor)
+	s.PatchValue(bootstrap.RunSnapInfoCommand, func(_ context.Context, _ string) (string, error) {
+		return fmt.Sprintf("%s: %s\n", channel, resolvedVersion.String()), nil
+	})
+
+	env := newEnviron("foo", useDefaultKeys, nil)
+	ctx := cmdtesting.Context(c)
+	err := bootstrap.Bootstrap(environscmd.BootstrapContext(c.Context(), ctx), env,
+		bootstrap.BootstrapParams{
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             "admin-secret",
+			CAPrivateKey:            coretesting.CAKey,
+			SSHServerHostKey:        coretesting.SSHServerHostKey,
+			SupportedBootstrapBases: supportedJujuBases,
+		})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(env.instanceConfig.Bootstrap.ControllerSnapChannel, tc.Equals, channel)
+	c.Assert(env.instanceConfig.Bootstrap.ControllerSnapExpectedVersion, tc.Equals, resolvedVersion.String())
+}
+
 func createImageMetadata(c *tc.C) (dir string, _ []*imagemetadata.ImageMetadata) {
 	return createImageMetadataForArch(c, "amd64")
 }

--- a/environs/bootstrap/export_test.go
+++ b/environs/bootstrap/export_test.go
@@ -10,4 +10,5 @@ var (
 	FindTools                  = &findTools
 	FindBootstrapTools         = findBootstrapTools
 	FindPackagedTools          = findPackagedTools
+	RunSnapInfoCommand         = &runSnapInfoCommand
 )

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -38,6 +38,11 @@ const (
 	// ControllerSnapAssertArchive is the filename used when embedding the
 	// controller snap assertion in cloud-init for local-build bootstrap.
 	ControllerSnapAssertArchive = "juju-controller.assert"
+
+	// ControllerSnapPackageName is the snap package currently used for
+	// controller bootstrap wiring.
+	// TODO(ice): switch to the dedicated controller snap name.
+	ControllerSnapPackageName = "juju"
 )
 
 // PrepareParams contains the parameters for preparing a controller Environ

--- a/environs/bootstrap/snap.go
+++ b/environs/bootstrap/snap.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+var runSnapInfoCommand = func(ctx context.Context, packageName string) (string, error) {
+	cmd := exec.CommandContext(ctx, "snap", "info", packageName)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.Annotatef(err, "snap info failed: %s", strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func resolveSnapChannelVersion(ctx context.Context, channel string) (string, error) {
+	out, err := runSnapInfoCommand(ctx, ControllerSnapPackageName)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	pattern := fmt.Sprintf(`(?m)^\s*%s:\s*([^\s]+)`, regexp.QuoteMeta(channel))
+	matches := regexp.MustCompile(pattern).FindStringSubmatch(out)
+	if len(matches) < 2 {
+		return "", errors.Errorf("unable to resolve controller snap version in channel %q", channel)
+	}
+
+	return matches[1], nil
+}

--- a/internal/cloudconfig/instancecfg/instancecfg.go
+++ b/internal/cloudconfig/instancecfg/instancecfg.go
@@ -217,6 +217,14 @@ type BootstrapConfig struct {
 	// dangerous mode.
 	ControllerSnapAssertPath string
 
+	// ControllerSnapChannel is the snapstore channel used to resolve and
+	// install the controller snap.
+	ControllerSnapChannel string
+
+	// ControllerSnapExpectedVersion is the exact Juju version expected to be
+	// provided by the installed controller snap.
+	ControllerSnapExpectedVersion string
+
 	// Timeout is the amount of time to wait for bootstrap to complete.
 	Timeout time.Duration
 
@@ -379,6 +387,8 @@ type stateInitializationParamsInternal struct {
 	ControllerCloudCredential               *cloud.Credential                 `yaml:"controller-cloud-credential,omitempty"`
 	ControllerCharmPath                     string                            `yaml:"controller-charm-path,omitempty"`
 	ControllerCharmChannel                  charm.Channel                     `yaml:"controller-charm-channel,omitempty"`
+	ControllerSnapChannel                   string                            `yaml:"controller-snap-channel,omitempty"`
+	ControllerSnapExpectedVersion           string                            `yaml:"controller-snap-expected-version,omitempty"`
 	SSHServerHostKey                        string                            `yaml:"ssh-server-host-key,omitempty"`
 }
 

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -586,6 +586,10 @@ func (w *userdataConfig) addControllerSnapInstall() error {
 		return nil
 	}
 
+	if w.icfg.Bootstrap.ControllerSnapPath == "" {
+		return w.addControllerSnapStoreInstall()
+	}
+
 	snapPath := w.icfg.Bootstrap.ControllerSnapPath
 	if snapPath == "" {
 		return nil
@@ -603,6 +607,42 @@ func (w *userdataConfig) addControllerSnapInstall() error {
 	} else {
 		w.conf.AddRunCmd(fmt.Sprintf("snap install --dangerous %s", snapFile))
 		logger.Debugf(context.TODO(), "added snap install --dangerous command for %q", snapFile)
+	}
+
+	return nil
+}
+
+func (w *userdataConfig) addControllerSnapStoreInstall() error {
+	packageName := bootstrap.ControllerSnapPackageName
+	channel := w.icfg.Bootstrap.ControllerSnapChannel
+	if channel == "" {
+		agentVersion := w.icfg.AgentVersion().Number
+		channel = fmt.Sprintf("%d.%d/edge", agentVersion.Major, agentVersion.Minor)
+	}
+
+	snapDir := w.icfg.SnapDir()
+	snapFile := path.Join(snapDir, packageName+".snap")
+	assertFile := path.Join(snapDir, packageName+".assert")
+
+	w.conf.AddRunCmd(fmt.Sprintf("mkdir -p %s", shquote(snapDir)))
+	w.conf.AddRunCmd(cloudinit.LogProgressCmd(
+		"Downloading controller snap %q from channel %q", packageName, channel,
+	))
+	w.conf.AddRunCmd(fmt.Sprintf(
+		"(cd %s && snap download %s --channel=%s --basename=%s)",
+		shquote(snapDir), shquote(packageName), shquote(channel), shquote(packageName),
+	))
+	w.conf.AddRunCmd(fmt.Sprintf("snap ack %s", shquote(assertFile)))
+	w.conf.AddRunCmd(fmt.Sprintf("snap install %s", shquote(snapFile)))
+
+	if expected := w.icfg.Bootstrap.ControllerSnapExpectedVersion; expected != "" {
+		w.conf.AddRunCmd(cloudinit.LogProgressCmd(
+			"Validating installed controller snap version matches %q", expected,
+		))
+		w.conf.AddRunCmd(fmt.Sprintf(
+			`installed_version=$(snap list %s | awk 'NR>1 {print $2; exit}'); test "$installed_version" = %s || (echo "controller snap version mismatch: expected %s, got $installed_version"; exit 1)`,
+			shquote(packageName), shquote(expected), expected,
+		))
 	}
 
 	return nil
@@ -659,7 +699,7 @@ func (w *userdataConfig) addDownloadToolsCmds() error {
 		fmt.Sprintf("sha256sum $bin/tools.tar.gz > $bin/juju%s.sha256", tools.Version),
 		fmt.Sprintf(`grep '%s' $bin/juju%s.sha256 || (echo "Tools checksum mismatch"; exit 1)`,
 			tools.SHA256, tools.Version),
-		"tar zxf $bin/tools.tar.gz -C $bin",
+		"tar zxf $bin/tools.tar.gz -C $bin --no-same-owner",
 	)
 
 	toolsJson, err := json.Marshal(tools)

--- a/internal/cloudconfig/userdatacfg_test.go
+++ b/internal/cloudconfig/userdatacfg_test.go
@@ -346,7 +346,7 @@ echo 'Fetching Juju agent version.*
 .* curl .* --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz'.*
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
-tar zxf \$bin/tools.tar.gz -C \$bin
+tar zxf \$bin/tools.tar.gz -C \$bin --no-same-owner
 echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
@@ -381,7 +381,7 @@ echo 'Fetching Juju agent version.*
 curl .* --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3\.123-ubuntu-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3\.123-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3\.123-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
-tar zxf \$bin/tools.tar.gz -C \$bin
+tar zxf \$bin/tools.tar.gz -C \$bin --no-same-owner
 echo -n '{"version":"1\.2\.3\.123-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3\.123-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
@@ -414,7 +414,7 @@ echo 'Fetching Juju agent version.*
 .* curl -sSf --connect-timeout 20 --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-ubuntu-amd64'.*
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
-tar zxf \$bin/tools.tar.gz -C \$bin
+tar zxf \$bin/tools.tar.gz -C \$bin --no-same-owner
 echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-ubuntu-amd64","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-99'
 cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
@@ -735,6 +735,23 @@ snap ack %[3]s
 snap install %[1]s`,
 		snapFile, base64Snap, assertFile, base64Assert,
 	))
+	checkCloudInitWithContent(c, cfg, expectedScripts, "")
+}
+
+func (s *cloudinitSuite) TestCloudInitWithSnapStoreControllerSnap(c *tc.C) {
+	s.SetFeatureFlags(featureflag.ControllerSnap)
+
+	cfg := makeBootstrapConfig(jammy, 0).mutate(func(cfg *testInstanceConfig) {
+		cfg.Bootstrap.ControllerSnapChannel = "4.0/stable"
+		cfg.Bootstrap.ControllerSnapExpectedVersion = "4.0.1"
+	})
+
+	expectedScripts := regexp.QuoteMeta(`
+mkdir -p '/var/lib/juju/snap'
+(cd '/var/lib/juju/snap' && snap download 'juju' --channel='4.0/stable' --basename='juju')
+snap ack '/var/lib/juju/snap/juju.assert'
+snap install '/var/lib/juju/snap/juju.snap'
+installed_version=$(snap list 'juju' | awk 'NR>1 {print $2; exit}'); test "$installed_version" = '4.0.1' || (echo "controller snap version mismatch: expected 4.0.1, got $installed_version"; exit 1)`)
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
 


### PR DESCRIPTION
- Adds channel-based snap store bootstrap: when the controller-snap feature flag is enabled and no local snap path/revision is given, Juju resolves the MAJOR.MINOR/edge channel version via snap info and generates cloud-init commands to snap download + ack + install the snap.
- Fixes a bootstrap failure caused by tar trying to restore non-existent UIDs/GIDs from agent tarballs by adding --no-same-owner.
- Uses the juju snap as a temporary stand-in until the dedicated juju-controller snap is published.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
make simplestreams
JUJU_SIMPLESTREAMS_SOURCE=$PWD/_build/simplestreams/tools make serve-simplestreams

export JUJU_DEV_FEATURE_FLAGS="controller-snap"
juju bootstrap --config agent-metadata-url="http://192.168.1.28:8666/" lxd test
```

```sh
❯ juju ssh -m controller 0 -- snap list

Name    Version            Rev    Tracking       Publisher    Notes
core24  20260317           1587   latest/stable  canonical**  base
juju    4.1-beta1-d3c5307  34697  -              canonical**  -
snapd   2.74.1             26382  latest/stable  canonical**  snapd

❯ juju status -m controller
Model       Controller  Cloud/Region  Version    Timestamp
controller  test        lxd/default   4.1-beta1  19:21:07+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.29   17022,17070/tcp

Machine  State    Address        Inst id        Base          AZ      Message
0        started  10.159.202.29  juju-6bd0cc-0  ubuntu@24.04  tuxedo  Running

❯ juju ssh -m controller 0 -- cat /var/log/cloud-init-output.log | grep snap
  python3.12 python3.12-minimal rsyslog snapd systemd systemd-dev
Get:57 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 snapd amd64 2.74.1+ubuntu24.04.4 [35.2 MB]
Preparing to unpack .../37-snapd_2.74.1+ubuntu24.04.4_amd64.deb ...
Unpacking snapd (2.74.1+ubuntu24.04.4) over (2.73+ubuntu24.04.2) ...
Setting up snapd (2.74.1+ubuntu24.04.4) ...
snapd.failure.service is a disabled or a static unit not running, not starting it.
snapd.gpio-chardev-setup.target is a disabled or a static unit not running, not starting it.
snapd.snap-repair.service is a disabled or a static unit not running, not starting it.
Downloading controller snap "juju" from channel "4.1/edge"
Fetching snap "juju"
Install the snap with:
   snap ack juju.assert
   snap install juju.snap
2026-04-23T08:53:37Z INFO Waiting for automatic snapd restart...
Validating installed controller snap version matches "4.1-beta1-d3c5307"
```

## Documentation changes


## Links


**Jira card:** [JUJU-9643](https://warthogs.atlassian.net/browse/JUJU-9643)


[JUJU-9643]: https://warthogs.atlassian.net/browse/JUJU-9643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ