### PR TITLE
feat: inject default image repo during build

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Update microk8s operator image
         if: matrix.cloud == 'microk8s'
         run: |
-          # TODO: use temporary Docker account (set OCI_REGISTRY_USERNAME env var)
+          # TODO: use temporary Docker account (set PUSH_OCI_REGISTRY env var)
           sg snap_microk8s 'make microk8s-operator-update'
 
       - name: Smoke test (LXD)

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -168,7 +168,7 @@ jobs:
           EOL
           podman build $BUILD_TEMP -t ${OCI_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}
           podman push -f v2s2 "${OCI_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}" "docker://${OCI_REGISTRY}/test-repo/jujud-operator:${SOURCE_JUJU_VERSION}"
-          OCI_REGISTRY_USERNAME=${OCI_REGISTRY}/test-repo make seed-repository
+          PUSH_OCI_REGISTRY=${OCI_REGISTRY}/test-repo make seed-repository
 
       - name: Bootstrap Juju - localhost
         if: matrix.cloud == 'localhost'

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,8 @@ define link_flags_version
 -X $(PROJECT)/core/version.build=$(JUJU_BUILD_NUMBER) \
 -X $(PROJECT)/core/version.Grade=$(JUJU_GRADE) \
 -X $(PROJECT)/core/version.GoBuildTags=$(FINAL_BUILD_TAGS) \
--X $(PROJECT)/internal/debug/coveruploader.putURL=$(COVERAGE_COLLECT_URL)
+-X $(PROJECT)/internal/debug/coveruploader.putURL=$(COVERAGE_COLLECT_URL) \
+-X $(PROJECT)/internal/cloudconfig/podcfg.JujudOCINamespace=$(PULL_OCI_REGISTRY)
 endef
 
 # Enable coverage collection.
@@ -657,7 +658,10 @@ check-deps:
 
 # CAAS related targets
 export OCI_BUILDER         ?= $(shell (which podman 2>&1 > /dev/null && echo podman) || echo docker )
-OCI_REGISTRY_USERNAME      ?= ghcr.io/juju
+
+# PULL_OCI_REGISTRY is the registry Juju will pull its operator OCI images
+# from by default.
+PULL_OCI_REGISTRY          ?= ghcr.io/juju
 DOCKER_BUILDX_CONTEXT      ?= juju-make
 DOCKER_STAGING_DIR         ?= ${BUILD_DIR}/docker-staging
 JUJUD_STAGING_DIR          ?= ${DOCKER_STAGING_DIR}/jujud-operator

--- a/internal/cloudconfig/podcfg/image.go
+++ b/internal/cloudconfig/podcfg/image.go
@@ -17,10 +17,16 @@ import (
 )
 
 const (
-	JujudOCINamespace = "ghcr.io/juju"
-	JujudOCIName      = "jujud-operator"
-	CharmBaseName     = "charm-base"
+	JujudOCIName  = "jujud-operator"
+	CharmBaseName = "charm-base"
 )
+
+// JujudOCINamespace is the default container registry namespace for the jujud
+// operator and charm base images.
+//
+// NOTE: This is injected by the build system. In Makefile, we override
+// this value with the value of the PULL_OCI_REGISTRY environment variable.
+var JujudOCINamespace = "ghcr.io/juju"
 
 // GetControllerImagePath returns oci image path of jujud for a controller.
 func (cfg *ControllerPodConfig) GetControllerImagePath() (string, error) {

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -12,7 +12,7 @@ JUJU_BUILD_NUMBER=${JUJU_BUILD_NUMBER:-}
 
 # OCI variables
 OCI_BUILDER=${OCI_BUILDER:-docker}
-OCI_REGISTRY_USERNAME=${OCI_REGISTRY_USERNAME:-ghcr.io/juju}
+PUSH_OCI_REGISTRY=${PUSH_OCI_REGISTRY:-ghcr.io/juju}
 
 # Docker variables
 DOCKER_BUILDX_CONTEXT=${DOCKER_BUILDX_CONTEXT:-juju-make}
@@ -63,7 +63,7 @@ juju_version() {
 
 operator_image_release_path() {
     juju_version=$(juju_version)
-    echo "${OCI_REGISTRY_USERNAME}/jujud-operator:$(_image_version $juju_version)"
+    echo "${PUSH_OCI_REGISTRY}/jujud-operator:$(_image_version $juju_version)"
 }
 
 operator_image_path() {
@@ -71,7 +71,7 @@ operator_image_path() {
     if [[ -z "${JUJU_BUILD_NUMBER}" ]] || [[ ${JUJU_BUILD_NUMBER} -eq 0 ]]; then
         operator_image_release_path
     else
-        echo "${OCI_REGISTRY_USERNAME}/jujud-operator:$(_image_version "$juju_version").${JUJU_BUILD_NUMBER}"
+        echo "${PUSH_OCI_REGISTRY}/jujud-operator:$(_image_version "$juju_version").${JUJU_BUILD_NUMBER}"
     fi
 }
 
@@ -158,8 +158,8 @@ seed_repository() {
   # Copy all the lts that are available
   for (( i = 18; ; i += 2 )); do
     if "$DOCKER_BIN" pull "ghcr.io/juju/charm-base:ubuntu-$i.04" ; then
-      "$DOCKER_BIN" tag "ghcr.io/juju/charm-base:ubuntu-$i.04" "${OCI_REGISTRY_USERNAME}/charm-base:ubuntu-$i.04"
-      "$DOCKER_BIN" push "${OCI_REGISTRY_USERNAME}/charm-base:ubuntu-$i.04"
+      "$DOCKER_BIN" tag "ghcr.io/juju/charm-base:ubuntu-$i.04" "${PUSH_OCI_REGISTRY}/charm-base:ubuntu-$i.04"
+      "$DOCKER_BIN" push "${PUSH_OCI_REGISTRY}/charm-base:ubuntu-$i.04"
     else
       break
     fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -274,7 +274,7 @@ parts:
       export CGO_CFLAGS="$(pkg-config --cflags ${PACKAGES})"
       export CGO_LDFLAGS="$(pkg-config --libs ${PACKAGES}) -Wl,-z,stack-size=1048576"
       export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
-      export GO_LDFLAGS='-s -w -extldflags "-static" -linkmode "external" -X github.com/juju/juju/version.GitCommit= -X github.com/juju/juju/version.GitTreeState= -X github.com/juju/juju/version.Grade= -X github.com/juju/juju/version.build='
+      export GO_LDFLAGS='-s -w -extldflags "-static" -linkmode "external" -X github.com/juju/juju/core/version.GitCommit= -X github.com/juju/juju/core/version.GitTreeState= -X github.com/juju/juju/core/version.Grade= -X github.com/juju/juju/core/version.build= -X github.com/juju/juju/internal/cloudconfig/podcfg.JujudOCINamespace='
       go mod download
       go install -tags libsqlite3,dqlite -ldflags "${GO_LDFLAGS}" github.com/juju/juju/cmd/jujud-controller
       mv ${SNAPCRAFT_PART_INSTALL}/bin/jujud-controller ${SNAPCRAFT_PART_INSTALL}/bin/jujud
@@ -293,7 +293,7 @@ parts:
       export GOTOOLCHAIN=go1.26.0+auto
       export GOBIN="${CRAFT_PART_INSTALL}/bin"
       export CGO_ENABLED=0
-      export GO_LDFLAGS='-s -w -extldflags "-static" -X github.com/juju/juju/version.GitCommit= -X github.com/juju/juju/version.GitTreeState= -X github.com/juju/juju/version.Grade= -X github.com/juju/juju/version.build='
+      export GO_LDFLAGS='-s -w -extldflags "-static" -X github.com/juju/juju/core/version.GitCommit= -X github.com/juju/juju/core/version.GitTreeState= -X github.com/juju/juju/core/version.Grade= -X github.com/juju/juju/core/version.build= -X github.com/juju/juju/internal/cloudconfig/podcfg.JujudOCINamespace='
       go mod download
       go install -ldflags "${GO_LDFLAGS}" github.com/juju/juju/cmd/juju github.com/juju/juju/cmd/jujuc github.com/juju/juju/cmd/plugins/juju-metadata
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/juju/juju/pull/22255

We would like to enable user to bootstrap k8s controllers on edge channels. That means building and uploading jujud operator images somewhere accessible.

(We already do this, but upload to testing infra)

We should be able to do this without requiring caas-image-repo config item is set. However, we do not want to upload these edge images to our production registry. It is messy and risky.

This means, during the build we need to be able to inject a default registry to use. Do this via the linker

## QA steps

Create a public oci image repo. I have use gcp. I created a registry with path `europe-west2-docker.pkg.dev/the-name-329514/juju-edge`

I also ran: 
```
gcloud artifacts repositories add-iam-policy-binding juju-edge --location=europe-west2 --project the-name-329514 --member=allUsers --role=roles/artifactregistry.reader
```
to make the registry public

Then:
```
PUSH_OCI_REGISTRY="europe-west2-docker.pkg.dev/the-name-329514/juju-edge" \
  PULL_OCI_REGISTRY="europe-west2-docker.pkg.dev/the-name-329514/juju-edge" \
  make seed-repository install push-release-operator-image

$ juju bootstrap microk8s mk8s-40
Creating Juju controller "mk8s-40" on microk8s/localhost
Bootstrap to Kubernetes cluster identified as microk8s/localhost
Fetching Juju Dashboard 0.8.1
Creating k8s resources for controller "controller-mk8s-40"

Downloading images
Starting controller pod
Bootstrap agent now started
Contacting Juju controller at 10.152.183.135 to verify accessibility...

Bootstrap complete, controller "mk8s-40" is now available in namespace "controller-mk8s-40"

Now you can run
	juju add-model <model-name>
to create a new model to deploy k8s workloads.

$ microk8s.kubectl -n controller-mk8s-40 describe po controller-0
...
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  8s    default-scheduler  Successfully assigned controller-mk8s-40/controller-0 to jack
  Normal  Pulling    7s    kubelet            spec.containers{mongodb}: Pulling image "europe-west2-docker.pkg.dev/the-name-329514/juju-edge/juju-db:4.4.30"
  Normal  Pulled     7s    kubelet            spec.containers{mongodb}: Successfully pulled image "europe-west2-docker.pkg.dev/the-name-329514/juju-edge/juju-db:4.4.30" in 180ms (180ms including waiting). Image size: 177817841 bytes.
  Normal  Created    7s    kubelet            spec.containers{mongodb}: Container created
  Normal  Started    7s    kubelet            spec.containers{mongodb}: Container started
  Normal  Pulling    7s    kubelet            spec.containers{api-server}: Pulling image "europe-west2-docker.pkg.dev/the-name-329514/juju-edge/jujud-operator:2.9.58"
  Normal  Pulled     1s    kubelet            spec.containers{api-server}: Successfully pulled image "europe-west2-docker.pkg.dev/the-name-329514/juju-edge/jujud-operator:2.9.58" in 6.568s (6.568s including waiting). Image size: 154483188 bytes.
  Normal  Created    1s    kubelet            spec.containers{api-server}: Container created
  Normal  Started    1s    kubelet            spec.containers{api-server}: Container started
```