### PR TITLE
fix: k8s redeployment issue

### DIFF
--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -187,6 +187,9 @@ func (st *State) CreateCAASApplication(
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := st.deleteApplicationSequence(ctx, tx, name); err != nil {
+			return errors.Errorf("deleting CAAS application sequence: %w", err)
+		}
 		if err := st.insertApplication(ctx, tx, name, appUUIDStr, args.BaseAddApplicationArg); err != nil {
 			return errors.Errorf("inserting CAAS application %q: %w", name, err)
 		}
@@ -3944,4 +3947,41 @@ FROM   model m
 		return "", errors.Capture(err)
 	}
 	return m.Type, nil
+}
+
+// deleteApplicationSequence deletes the unit sequence counter for the application
+// with the given name.
+//
+// This allows unit numbering to restart from zero when a CAAS application with
+// the same name is redeployed after deletion. This is required to preserve Juju
+// 3.6 compatibility and keep Juju unit numbers aligned with Kubernetes
+// StatefulSet pod ordinals, which start from 0 for a newly created StatefulSet.
+//
+// This matters because CAAS unit registration is tied to the Kubernetes pod
+// identity. The provider ID contains the pod ordinal, and RegisterCAASUnit uses
+// that information when registering the corresponding Juju unit. If the Juju
+// unit sequence has advanced but the recreated StatefulSet starts again at
+// ordinal 0, Juju unit names and Kubernetes pod identities can diverge. This can
+// cause recreated pods such as ordinal 0 to be treated as not assigned.
+func (st *State) deleteApplicationSequence(ctx context.Context, tx *sqlair.TX, appName string) error {
+	type sequenceNamespace struct {
+		Namespace string `db:"namespace"`
+	}
+
+	deleteSequenceStmt, err := st.Prepare(`
+DELETE FROM sequence WHERE namespace = $sequenceNamespace.namespace
+`, sequenceNamespace{})
+	if err != nil {
+		return errors.Errorf("preparing sequence delete: %w", err)
+	}
+
+	ns := sequenceNamespace{
+		Namespace: domainsequence.MakePrefixNamespace(
+			application.ApplicationSequenceNamespace, appName,
+		).String(),
+	}
+	if err := tx.Query(ctx, deleteSequenceStmt, ns).Run(); err != nil {
+		return errors.Errorf("deleting sequence for application %q: %w", appName, err)
+	}
+	return nil
 }

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -4322,3 +4322,72 @@ func (s *applicationStateSuite) TestGetDefaultSpaceUUIDFromModelConfig(c *tc.C) 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.Equals, spaceUUID)
 }
+
+// TestCreateCAASApplicationResetsExistingSequence is a regression test for
+// the case where redeploying a CAAS application with the same name after
+// deletion would produce unit/1 instead of unit/0, causing RegisterCAASUnit
+// to fail because Kubernetes StatefulSet pod ordinals always start at 0.
+// CreateCAASApplication must reset the sequence counter so that unit
+// numbering restarts from zero on redeployment.
+func (s *applicationStateSuite) TestCreateCAASApplicationResetsExistingSequence(c *tc.C) {
+	// Simulates initial application deployment and deletion by inserting a sequence row for the application.
+	_, err := s.DB().Exec(
+		"INSERT INTO sequence (namespace, value) VALUES ('application_app-name', 1)",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	s.checkApplicationSequence(c, "app-name", 1)
+
+	// Create the CAAS application.
+	_, err = s.state.CreateCAASApplication(c.Context(), "app-name", application.AddCAASApplicationArg{
+		BaseAddApplicationArg: application.BaseAddApplicationArg{
+			Platform: deployment.Platform{
+				Channel:      "22.04",
+				OSType:       deployment.Ubuntu,
+				Architecture: architecture.AMD64,
+			},
+			Charm: charm.Charm{
+				Metadata:      s.minimalMetadata(c, "app-name"),
+				Manifest:      s.minimalManifest(c),
+				Source:        charm.CharmHubSource,
+				ReferenceName: "app-name",
+				Revision:      1,
+				Architecture:  architecture.AMD64,
+			},
+			CharmDownloadInfo: &charm.DownloadInfo{
+				Provenance:  charm.ProvenanceDownload,
+				DownloadURL: "http://example.com/charm",
+			},
+		},
+		Scale: 0,
+	}, nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Ensure that the application sequence has been reset and there is no existing sequence for the application.
+	s.checkNoApplicationSequence(c, "app-name")
+}
+
+func (s *applicationStateSuite) checkNoApplicationSequence(c *tc.C, appName string) {
+	c.Helper()
+
+	row := s.DB().QueryRow(
+		"SELECT EXISTS(SELECT 1 FROM sequence WHERE namespace = CONCAT('application_', ?))",
+		appName,
+	)
+	var exists bool
+	err := row.Scan(&exists)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.IsFalse)
+}
+
+func (s *applicationStateSuite) checkApplicationSequence(c *tc.C, appName string, value int) {
+	c.Helper()
+
+	row := s.DB().QueryRow(
+		"SELECT value FROM sequence WHERE namespace = CONCAT('application_', ?)",
+		appName,
+	)
+	var got int
+	err := row.Scan(&got)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.Equals, value)
+}


### PR DESCRIPTION
When a CAAS application is removed and redeployed with the same name, the StatefulSet remains stuck at replicas: 0 and units never start.

1. ensurScale miscomputes the scale direction. In ensureScale, unitScale is derived as max(unit_ordinal) + 1. Because the stale sequence causes the first unit to be postgresql-k8s/1, unitScale evaluates to 1 + 1 = 2. The scale-up condition [scaleTarget(1) >= unitScale(2)] is false, so ensureScaleWithFsAttachments is not called and StatefulSet stays at replicas: 0 with no pods created.

There are two ways that we could resolve this:
1. Use len(units instead of max(ordinal) + 1 for the scale direction check in ensureScale.
2. Remove record from sequence table when we delete application.

There is an issue with solution 1. It does not resolve the underlying ordinal mismatch. Kubernetes StatefulSets always start pods from ordinal 0, so pod postgresql-k8s-0 calls RegisterCAASUnit with orderId = 0 and expects unit postgresql-k8s/0 to exist. When the sequence is not reset, juju inserts postgresql-k8s/1 unit during deployment instead, and even though we scale up the statefulset to 1, the pods will be stuck in the “Init” status instead of “Running”. 

The final design solution mimics the way we did things in 3.6. Whenever we create an application, we would delete the corresponding row from the sequence table.

https://github.com/CodingCookieRookie/juju/blob/3.6/state/state.go#L1424
```
kubectl get sts -n alvintestmodeldebug3
NAME             READY   AGE
postgresql-k8s   0/1     60m


kubectl get pods -n alvintestmodeldebug3
NAME                            READY   STATUS     RESTARTS   AGE
modeloperator-c8d4f54dd-bvm6w   1/1     Running    0          66m
postgresql-k8s-0                0/2     Init:0/1   0          60m

kubectl logs -n test2 postgresql-k8s-0 -c charm-init --tail=20
starting containeragent init command
failed to introduce pod postgresql-k8s-0: not assigned...
failed to introduce pod postgresql-k8s-0: not assigned...
```

Solution 2 is chosen because it is both functionally correct and aligned with Kubernetes StatefulSet semantics.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. Bootstrap a k8s controller and add a model.
```sh
juju bootstrap minikube alvinminitest --debug && juju add-model alvinminitestmodel
```

2. Deploy postgresql-k8s
```sh
juju deploy --force --trust --channel 16/edge postgresql-k8s
```

3. Remove juju remove-application postgresql-k8s
```sh
juju remove-application postgresql-k8s
```

4. Deploy postgresql-k8s
```sh
juju deploy --force --trust --channel 16/edge postgresql-k8s
```

5. Wait for a while and check juju status
Before fix (juju status stuck like this):
```
test@alvinchee98-Adder-WS:~/Desktop/repos/juju$ juju status
Model            Controller  Cloud/Region  Version  Timestamp
alvintestmodel3  alvintest3  minikube      4.0.6    10:42:51+08:00

App             Version  Status   Scale  Charm           Channel  Rev  Address  Exposed  Message
postgresql-k8s           waiting    0/1  postgresql-k8s  16/edge  866           no       installing agent

Unit              Workload  Agent       Address  Ports  Message
postgresql-k8s/1  waiting   allocating                  installing agent
```

After fix:
```
Model               Controller     Cloud/Region  Version  Timestamp
alvinminitestmodel  alvinminitest  minikube      4.0.8    12:23:20+08:00

App             Version  Status  Scale  Charm           Channel  Rev  Address  Exposed  Message
postgresql-k8s  16.13    active      1  postgresql-k8s  16/edge  893           no       

Unit               Workload  Agent  Address      Ports          Message
postgresql-k8s/0*  active    idle   10.244.0.12  5432,8008/tcp  Primary
```

## Links
**Github issues:** https://github.com/juju/juju/issues/21503

**Jira**: https://warthogs.atlassian.net/browse/JUJU-8997
[JUJU-8997]: https://warthogs.atlassian.net/browse/JUJU-8997