### PR TITLE
fix(docs): handle missing juju binary in autogenerate-docs script

### DIFF
--- a/.github/workflows/context-tests.yml
+++ b/.github/workflows/context-tests.yml
@@ -82,6 +82,7 @@ jobs:
               - '**.go'
               - 'go.mod'
               - '.github/workflows/docs.yml'
+              - 'docs/**'
             check-ddl:
               - 'go.mod'
               - 'domain/schema/**'

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/status.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/status.md
@@ -5,6 +5,9 @@
 ## Summary
 Report the status of the model, its machines, applications and units.
 
+## Usage
+```juju status [options] [<selector> [...]]```
+
 ### Options
 | Flag | Default | Usage |
 | --- | --- | --- |
@@ -23,6 +26,18 @@ Report the status of the model, its machines, applications and units.
 
 ## Examples
 
+Report the status of units hosted on machine `0`:
+
+    juju status 0
+
+Report the status of the `mysql` application:
+
+    juju status mysql
+
+Report the status of the `mysql/0` unit:
+
+    juju status mysql/0
+
 Include information about storage and relations in output:
 
     juju status --storage --relations
@@ -34,7 +49,13 @@ Provide output as valid `JSON`:
 
 ## Details
 
-Report the model's status including its machines, applications and units.
+Report the model's status, optionally filtered by exact machine,
+application, or unit names.
+
+    juju status [<selector> [...]]
+
+When selectors are present, filter the report to exclude entities that do not
+match.
 
 
 ### Altering the output format

--- a/docs/scripts/autogenerate-docs.py
+++ b/docs/scripts/autogenerate-docs.py
@@ -51,11 +51,30 @@ def get_tree_juju_version():
 
 
 def get_juju_version():
-    """Check to see what version of Juju we are running."""
+    """Check to see what version of Juju we are running.
+    
+    Returns None, None if juju is not installed or fails to execute.
+    
+    Note: This function intentionally treats all errors (binary not found,
+    execution failure, etc.) as "juju not present" to allow docs generation
+    in CI environments where juju is not installed. If juju is installed but
+    failing, the actual doc generation (via `go run scripts/docgen.go`) will
+    fail with a clearer error message.
+    """
     # There is probably more that could be done here about all the possible
     # version strings juju spits out, but this should cover stripping things
     # like 'genericlinux' and the architecture out.
-    result = subprocess.run(['juju', 'version'], capture_output=True, text=True)
+    try:
+        result = subprocess.run(['juju', 'version'], capture_output=True, text=True)
+    except FileNotFoundError:
+        # juju binary not found in PATH (expected in CI without juju installed)
+        return None, None
+    
+    if result.returncode != 0:
+        # juju exists but failed to run - treat as not present to allow CI to proceed.
+        # If there's a real problem, doc generation will fail later with clearer errors.
+        return None, None
+    
     version = result.stdout.rstrip()
     major_minor = _major_minor_from_version_string(version)
     if major_minor is None:
@@ -70,7 +89,11 @@ def generate_cli_docs():
 
     tree_major_minor, tree_version = get_tree_juju_version()
     juju_major_minor, juju_version = get_juju_version()
-    if tree_major_minor != juju_major_minor:
+    
+    # If juju is not installed, skip the version check and use tree version
+    if juju_major_minor is None:
+        print("juju binary not found in PATH, generating cli command docs using tree version {}".format(tree_version))
+    elif tree_major_minor != juju_major_minor:
         warning = ("refusing to rebuild docs with a mismatched minor juju version.\n" +
                 "Found juju {} in $PATH, but the tree reports version {}".format(juju_version, tree_version))
         print(warning)


### PR DESCRIPTION
## Summary

Fixes CI documentation check failures and prevents similar issues in the future.

## The Full Problem

**Background:** The starter pack 1.6 upgrade (#22300) added `autogenerate-docs` as a dependency to the `html` target in `docs/Makefile`. This script verifies version consistency by calling `juju version`, then regenerates CLI documentation.

**Why it broke:**
1. The docs check workflow is triggered by a paths-filter that only runs when `.go` files, `go.mod`, or `.github/workflows/docs.yml` change
2. The starter pack PRs only modified `docs/` files → docs check never triggered → merged without testing
3. Later PRs touching `.go` files triggered the docs check for the first time
4. The check crashed: `FileNotFoundError: [Errno 2] No such file or directory: 'juju'`
5. The juju binary build was removed from CI in May 2025 (commit 7b5fdc6d1e5)

**The cascade:** Our fix allows the check to run → it discovered `status.md` was out of sync → we regenerated and committed the updated docs.

## Solution (3 commits)

1. **Script fix**: Modified `get_juju_version()` to return `(None, None)` when juju is not in PATH. When unavailable, skips version check and generates docs using tree version. Added comprehensive documentation explaining this intentional design.

2. **CI fix**: Added `docs/**` to the `check-docs` paths-filter in `context-tests.yml` to ensure docs checks run when documentation files are modified. This prevents the original problem from recurring.

3. **Docs update**: Regenerated `status.md` with latest CLI changes (additional usage examples and selector filtering details).

## ReadTheDocs Not Affected

RTD builds succeeded throughout because it calls `sphinx-build` directly (never runs the Makefile) and builds from pre-committed docs.

## Testing

- ✅ Script succeeds when juju is not in PATH (CI scenario)
- ✅ Version check still works when juju is installed (developer scenario)
- ✅ Docs check now runs and catches out-of-sync documentation
