### PR TITLE
fix: add robust not found error handling in firewallers

### DIFF
--- a/api/common/charms/common.go
+++ b/api/common/charms/common.go
@@ -31,7 +31,7 @@ func (c *CharmInfoClient) CharmInfo(charmURL string) (*CharmInfo, error) {
 	args := params.CharmURL{URL: charmURL}
 	var info params.Charm
 	if err := c.facade.FacadeCall("CharmInfo", args, &info); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(params.TranslateWellKnownError(err))
 	}
 	return convertCharm(&info)
 }
@@ -52,7 +52,7 @@ func (c *ApplicationCharmInfoClient) ApplicationCharmInfo(appName string) (*Char
 	args := params.Entity{Tag: names.NewApplicationTag(appName).String()}
 	var info params.Charm
 	if err := c.facade.FacadeCall("ApplicationCharmInfo", args, &info); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(params.TranslateWellKnownError(err))
 	}
 	return convertCharm(&info)
 }

--- a/api/common/charms/common_test.go
+++ b/api/common/charms/common_test.go
@@ -6,6 +6,8 @@ package charms_test
 import (
 	"github.com/juju/charm/v12"
 	"github.com/juju/charm/v12/resource"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -197,6 +199,41 @@ func (s *suite) TestApplicationCharmInfo(c *gc.C) {
 		},
 	}
 	c.Assert(got, gc.DeepEquals, want)
+}
+
+func (s *suite) TestCharmInfoTranslatesCodeNotFound(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+
+	url := "local:quantal/dummy-1"
+	args := params.CharmURL{URL: url}
+	info := new(params.Charm)
+
+	mockFacadeCaller.EXPECT().FacadeCall("CharmInfo", args, info).Return(
+		&params.Error{Code: params.CodeNotFound, Message: "missing charm"})
+
+	client := apicommoncharms.NewCharmInfoClient(mockFacadeCaller)
+	_, err := client.CharmInfo(url)
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
+}
+
+func (s *suite) TestApplicationCharmInfoTranslatesCodeNotFound(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+
+	args := params.Entity{Tag: "application-foobar"}
+	info := new(params.Charm)
+
+	mockFacadeCaller.EXPECT().FacadeCall("ApplicationCharmInfo", args, info).Return(
+		&params.Error{Code: params.CodeNotFound, Message: "missing app"})
+
+	client := apicommoncharms.NewApplicationCharmInfoClient(mockFacadeCaller)
+	_, err := client.ApplicationCharmInfo("foobar")
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func intPtr(i int) *int {

--- a/internal/worker/caasfirewaller/application_worker.go
+++ b/internal/worker/caasfirewaller/application_worker.go
@@ -74,7 +74,7 @@ func (w *applicationWorker) Wait() error {
 func (w *applicationWorker) loop() (err error) {
 	defer func() {
 		// If the application has been deleted, we can return nil.
-		if errors.IsNotFound(err) {
+		if isNotFound(err) {
 			w.logger.Debugf("caas firewaller application %v has been removed", w.application)
 			err = nil
 		}
@@ -98,7 +98,7 @@ func (w *applicationWorker) loop() (err error) {
 
 			// If charm is (now) a v2 charm, exit the worker.
 			format, err := w.charmFormat()
-			if errors.IsNotFound(err) {
+			if isNotFound(err) {
 				w.logger.Debugf("application %q no longer exists", w.application)
 				return nil
 			} else if err != nil {
@@ -131,7 +131,7 @@ func (w *applicationWorker) processApplicationChange() (err error) {
 	defer func() {
 		// Not found could be because the app got removed or there's
 		// no container service created yet as the app is still being set up.
-		if errors.IsNotFound(err) {
+		if isNotFound(err) {
 			// Perhaps the app got removed while we were processing.
 			if _, err2 := w.lifeGetter.Life(w.application); err2 != nil {
 				err = err2

--- a/internal/worker/caasfirewaller/worker.go
+++ b/internal/worker/caasfirewaller/worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/worker/v3/catacomb"
 
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/rpc/params"
 )
 
 // Logger is here to stop the desire of creating a package level Logger.
@@ -105,7 +106,7 @@ func (p *firewaller) loop() error {
 			for _, appName := range apps {
 				// If charm is (now) a v2 charm, skip processing.
 				format, err := p.charmFormat(appName)
-				if errors.IsNotFound(err) {
+				if isNotFound(err) {
 					p.config.Logger.Debugf("application %q no longer exists", appName)
 					continue
 				} else if err != nil {
@@ -117,7 +118,7 @@ func (p *firewaller) loop() error {
 				}
 
 				appLife, err := p.config.LifeGetter.Life(appName)
-				if errors.IsNotFound(err) || appLife == life.Dead {
+				if isNotFound(err) || appLife == life.Dead {
 					if appWorker, ok := appWorkers[appName]; ok {
 						if err := worker.Stop(appWorker); err != nil {
 							logger.Errorf("error stopping caas firewaller: %v", err)
@@ -151,6 +152,10 @@ func (p *firewaller) loop() error {
 			}
 		}
 	}
+}
+
+func isNotFound(err error) bool {
+	return errors.Is(err, errors.NotFound) || params.IsCodeNotFound(err)
 }
 
 func (p *firewaller) charmFormat(appName string) (charm.Format, error) {

--- a/internal/worker/caasfirewaller/worker_test.go
+++ b/internal/worker/caasfirewaller/worker_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/internal/worker/caasfirewaller"
+	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -227,11 +228,11 @@ func (s *WorkerSuite) TestWatchApplicationDead(c *gc.C) {
 	workertest.CleanKill(c, w)
 }
 
-func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplication(c *gc.C) {
+func (s *WorkerSuite) assertRemoveApplicationStopsWatchingApplication(c *gc.C, lifeErr error) {
 	// Set up the errors before triggering any events to avoid racing
 	// with the worker loop. First time around the loop the
 	// application's alive, then it's gone.
-	s.lifeGetter.SetErrors(nil, errors.NotFoundf("application"))
+	s.lifeGetter.SetErrors(nil, lifeErr)
 
 	w, err := caasfirewaller.NewWorker(s.config)
 	c.Assert(err, jc.ErrorIsNil)
@@ -242,6 +243,14 @@ func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplication(c *gc.C) {
 
 	err = workertest.CheckKilled(c, s.applicationGetter.appWatcher)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplicationErrorsNotFound(c *gc.C) {
+	s.assertRemoveApplicationStopsWatchingApplication(c, errors.NotFoundf("application"))
+}
+
+func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplicationCodeNotFound(c *gc.C) {
+	s.assertRemoveApplicationStopsWatchingApplication(c, &params.Error{Code: params.CodeNotFound, Message: "application gone"})
 }
 
 func (s *WorkerSuite) TestRemoveApplicationStopsWorker(c *gc.C) {

--- a/internal/worker/caasfirewallersidecar/applicationworker.go
+++ b/internal/worker/caasfirewallersidecar/applicationworker.go
@@ -110,7 +110,7 @@ func (w *applicationWorker) setUp() (err error) {
 func (w *applicationWorker) loop() (err error) {
 	defer func() {
 		// If the application has been deleted, we can return nil.
-		if errors.IsNotFound(err) {
+		if isNotFound(err) {
 			w.logger.Debugf("sidecar caas firewaller application %v has been removed", w.appName)
 			err = nil
 		}
@@ -180,7 +180,7 @@ func (w *applicationWorker) onPortChanged() error {
 	}
 
 	err = w.portMutator.UpdatePorts(toServicePorts(changedPortRanges), false)
-	if errors.Is(err, errors.NotFound) {
+	if isNotFound(err) {
 		return nil
 	}
 	if err != nil {
@@ -195,7 +195,7 @@ func (w *applicationWorker) onApplicationChanged() (err error) {
 	defer func() {
 		// Not found could be because the app got removed or there's
 		// no container service created yet as the app is still being set up.
-		if errors.IsNotFound(err) {
+		if isNotFound(err) {
 			// Perhaps the app got removed while we were processing.
 			if _, err2 := w.lifeGetter.Life(w.appName); err2 != nil {
 				err = err2

--- a/internal/worker/caasfirewallersidecar/applicationworker_test.go
+++ b/internal/worker/caasfirewallersidecar/applicationworker_test.go
@@ -6,6 +6,7 @@ package caasfirewallersidecar_test
 import (
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
@@ -20,6 +21,7 @@ import (
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/internal/worker/caasfirewallersidecar"
 	"github.com/juju/juju/internal/worker/caasfirewallersidecar/mocks"
+	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/testing"
 )
 
@@ -164,4 +166,54 @@ func (s *appWorkerSuite) TestWorker(c *gc.C) {
 		c.Errorf("timed out waiting for worker")
 	}
 	workertest.CleanKill(c, w)
+}
+
+func (s *appWorkerSuite) assertPortChangeHandling(c *gc.C, getOpenPortsErr error) {
+	ctrl := s.getController(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+
+	go func() {
+		s.portsChanges <- []string{"port changes"}
+	}()
+
+	gomock.InOrder(
+		s.firewallerAPI.EXPECT().WatchApplication(s.appName).Return(s.appsWatcher, nil),
+		s.firewallerAPI.EXPECT().WatchOpenedPorts().Return(s.portsWatcher, nil),
+		s.broker.EXPECT().Application(s.appName, caas.DeploymentStateful).Return(s.brokerApp),
+		s.firewallerAPI.EXPECT().GetOpenedPorts(s.appName).Return(network.GroupedPortRanges{}, nil),
+		s.firewallerAPI.EXPECT().GetOpenedPorts(s.appName).DoAndReturn(func(_ string) (network.GroupedPortRanges, error) {
+			close(done)
+			return nil, getOpenPortsErr
+		}),
+	)
+
+	w := s.getWorker(c)
+
+	select {
+	case <-done:
+	case <-time.After(testing.ShortWait):
+		c.Errorf("timed out waiting for worker")
+	}
+
+	if getOpenPortsErr != nil {
+		err := workertest.CheckKilled(c, w)
+		c.Assert(err, jc.ErrorIsNil)
+	} else {
+		workertest.CheckAlive(c, w)
+		workertest.CleanKill(c, w)
+	}
+}
+
+func (s *appWorkerSuite) TestPortChangeSuccess(c *gc.C) {
+	s.assertPortChangeHandling(c, nil)
+}
+
+func (s *appWorkerSuite) TestPortChangeCodeNotFoundStopsGracefully(c *gc.C) {
+	s.assertPortChangeHandling(c, &params.Error{Code: params.CodeNotFound, Message: "app gone"})
+}
+
+func (s *appWorkerSuite) TestPortChangeNotFoundErrorStopsGracefully(c *gc.C) {
+	s.assertPortChangeHandling(c, errors.NotFound)
 }

--- a/internal/worker/caasfirewallersidecar/worker.go
+++ b/internal/worker/caasfirewallersidecar/worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/worker/v3/catacomb"
 
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/rpc/params"
 )
 
 // Logger is here to stop the desire of creating a package level Logger.
@@ -121,7 +122,7 @@ func (p *firewaller) loop() error {
 			for _, appName := range apps {
 				// If charm is a v1 charm, skip processing.
 				format, err := p.charmFormat(appName)
-				if errors.IsNotFound(err) {
+				if isNotFound(err) {
 					p.config.Logger.Debugf("application %q no longer exists", appName)
 					continue
 				} else if err != nil {
@@ -133,7 +134,7 @@ func (p *firewaller) loop() error {
 				}
 
 				appLife, err := p.config.LifeGetter.Life(appName)
-				if errors.IsNotFound(err) || appLife == life.Dead {
+				if isNotFound(err) || appLife == life.Dead {
 					w, ok := p.appWorkers[appName]
 					if ok {
 						if err := worker.Stop(w); err != nil {
@@ -172,6 +173,10 @@ func (p *firewaller) loop() error {
 			}
 		}
 	}
+}
+
+func isNotFound(err error) bool {
+	return errors.Is(err, errors.NotFound) || params.IsCodeNotFound(err)
 }
 
 func (p *firewaller) charmFormat(appName string) (charm.Format, error) {

--- a/internal/worker/firewaller/firewaller.go
+++ b/internal/worker/firewaller/firewaller.go
@@ -287,7 +287,7 @@ func (fw *Firewaller) loop() error {
 			return fw.catacomb.ErrDying()
 		case <-ensureModelFirewalls:
 			err := fw.flushModel()
-			if errors.Is(err, errors.NotFound) {
+			if isNotFound(err) {
 				ensureModelFirewalls = fw.clk.After(time.Second)
 			} else if err != nil {
 				return err
@@ -1710,7 +1710,7 @@ func (rd *remoteRelationData) updateProviderModel(cidrs []string) error {
 		BakeryVersion:   bakery.LatestVersion,
 	}
 	err = remoteModelAPI.PublishIngressNetworkChange(event)
-	if errors.IsNotFound(err) {
+	if isNotFound(err) {
 		rd.fw.logger.Debugf("relation id not found publishing %+v", event)
 		return nil
 	}
@@ -1722,6 +1722,10 @@ func (rd *remoteRelationData) updateProviderModel(cidrs []string) error {
 		return rd.fw.firewallerApi.SetRelationStatus(rd.tag.Id(), relation.Error, err.Error())
 	}
 	return errors.Annotate(err, "cannot publish ingress network change")
+}
+
+func isNotFound(err error) bool {
+	return errors.Is(err, errors.NotFound) || params.IsCodeNotFound(err)
 }
 
 // updateIngressNetworks processes the changed ingress networks on the relation.

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -656,6 +656,69 @@ func (s *InstanceModeSuite) TestShouldFlushModelWhenFlushingMachine(c *gc.C) {
 	s.waitForModelFlush(c)
 }
 
+func (s *InstanceModeSuite) assertModelFlushRetriesOnParamsNotFound(c *gc.C, modelRulesErr error) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	s.modelIngressRules = firewall.IngressRules{
+		firewall.NewIngressRule(network.MustParsePortRange("22"), firewall.AllNetworksIPV4CIDR),
+	}
+	s.ensureMocksWithoutMachine(ctrl)
+
+	modelRulesCalls := make(chan struct{}, 4)
+	firstCall := true
+	s.firewaller.EXPECT().ModelFirewallRules().AnyTimes().DoAndReturn(func() (firewall.IngressRules, error) {
+		modelRulesCalls <- struct{}{}
+		if firstCall {
+			firstCall = false
+			return nil, modelRulesErr
+		}
+		return s.modelIngressRules, nil
+	})
+	s.envModelFirewaller.EXPECT().ModelIngressRules(gomock.Any()).AnyTimes().DoAndReturn(func(arg0 context.ProviderCallContext) (firewall.IngressRules, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.envModelPorts, nil
+	})
+	s.envModelFirewaller.EXPECT().OpenModelPorts(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(_ context.ProviderCallContext, rules firewall.IngressRules) error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		add, _ := s.envModelPorts.Diff(rules)
+		s.envModelPorts = append(s.envModelPorts, add...)
+		return nil
+	})
+
+	m, _ := s.addMachine(ctrl)
+	inst := s.startInstance(c, ctrl, m)
+	inst.EXPECT().IngressRules(gomock.Any(), m.Tag().Id()).Return(nil, nil).AnyTimes()
+
+	fw := s.newFirewaller(c)
+	defer workertest.CleanKill(c, fw)
+
+	s.machinesCh <- []string{m.Tag().Id()}
+	s.waitForMachine(c, m.Tag().Id())
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-modelRulesCalls:
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timed out waiting for model firewall rules call %d", i+1)
+		}
+	}
+
+	s.waitForModelFlush(c)
+	s.assertModelIngressRules(c, s.modelIngressRules)
+	workertest.CheckAlive(c, fw)
+}
+
+func (s *InstanceModeSuite) TestModelFlushRetriesOnParamsCodeNotFound(c *gc.C) {
+	s.assertModelFlushRetriesOnParamsNotFound(c, &params.Error{Code: params.CodeNotFound, Message: "model not found"})
+}
+
+func (s *InstanceModeSuite) TestModelFlushRetriesOnErrorsNotFound(c *gc.C) {
+	s.assertModelFlushRetriesOnParamsNotFound(c, errors.NotFoundf("model"))
+}
+
 func (s *InstanceModeSuite) TestNotExposedApplicationWithoutModelFirewaller(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/pki/pem_test.go
+++ b/pki/pem_test.go
@@ -158,7 +158,11 @@ func (p *PEMSuite) TestSignerFromPKCS1Pem(c *gc.C) {
 
 		signerPem, err := pki.UnmarshalSignerFromPemBlock(block)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(signerPem, jc.DeepEquals, signer)
+		mc := jc.NewMultiChecker()
+		// Ignore the computed speedups for RSA since comparing byte for byte
+		// of bignumbers may fail due to superfluous zeros (despite the numbers matching)
+		mc.AddExpr("_.Precomputed", jc.Ignore)
+		c.Assert(signerPem, mc, signer)
 	}
 }
 


### PR DESCRIPTION
In a few places, the client API can return a `NotFound` errors const or a `params.Error` struct with a "not found" code string. Any callers need to account for this, and in a few places, we were just checking for the errors const using `errors.IsNotFound()`. The API does need to be fixed, but that's a much bigger job. We already account for this situation in other places - this PR adds the same approach to a few more places.

Also, in a couple of api methods, we can add the error translation directly.

The fix is to use a `isNotFound()` helper to check for both error types.


## QA steps

The bug report was AI generated so the repro steps don't really work so well - I suspect it's a bit timing dependent and use of force may be needed. But the change is trivial and easy to reason about and follows existing patterns. A regression test with existing cmr shell tests will suffice.

## Links

**Issue:** Fixes #22258.

**Jira card:** [JUJU-9695](https://warthogs.atlassian.net/browse/JUJU-9695)


[JUJU-9695]: https://warthogs.atlassian.net/browse/JUJU-9695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ