### PR TITLE
fix(removal): delete k8s_service after its dependent net node rows

### DIFF
--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -560,36 +560,27 @@ func (st *State) deleteSimpleApplicationReferences(ctx context.Context, tx *sqla
 func (st *State) deleteCloudServices(ctx context.Context, tx *sqlair.TX, aUUID string) error {
 	app := entityUUID{UUID: aUUID}
 
-	deleteFqdnAddressStmt, err := st.Prepare(`
-DELETE FROM net_node_fqdn_address WHERE net_node_uuid IN (
-    SELECT net_node_uuid
-    FROM k8s_service
-    WHERE application_uuid = $entityUUID.uuid
-)`, app)
+	// Capture the net node UUID before any deletions. We cannot subquery
+	// through k8s_service at delete time because k8s_service must itself be
+	// deleted before net_node (FK constraint), which would make the subquery
+	// return nothing.
+	selectNetNodeStmt, err := st.Prepare(`
+SELECT net_node_uuid AS &entityUUID.uuid
+FROM   k8s_service
+WHERE  application_uuid = $entityUUID.uuid`, app)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	deleteHostnameAddressStmt, err := st.Prepare(`
-DELETE FROM net_node_hostname_address WHERE net_node_uuid IN (
-    SELECT net_node_uuid
-    FROM k8s_service
-    WHERE application_uuid = $entityUUID.uuid
-)`, app)
-	if err != nil {
-		return errors.Capture(err)
+	var netNode entityUUID
+	if err := tx.Query(ctx, selectNetNodeStmt, app).Get(&netNode); errors.Is(err, sqlair.ErrNoRows) {
+		return nil
+	} else if err != nil {
+		return errors.Errorf("getting net node UUID for cloud service: %w", err)
 	}
 
-	deleteNodeStmt, err := st.Prepare(`
-DELETE FROM net_node WHERE uuid IN (
-    SELECT net_node_uuid
-    FROM k8s_service
-    WHERE application_uuid = $entityUUID.uuid
-)`, app)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
+	// k8s_service holds a FK to net_node, so delete it before tearing down
+	// the net node itself.
 	deleteCloudServiceStmt, err := st.Prepare(`
 DELETE FROM k8s_service
 WHERE application_uuid = $entityUUID.uuid
@@ -597,18 +588,15 @@ WHERE application_uuid = $entityUUID.uuid
 	if err != nil {
 		return errors.Capture(err)
 	}
-
 	if err := tx.Query(ctx, deleteCloudServiceStmt, app).Run(); err != nil {
 		return errors.Capture(err)
 	}
-	if err := tx.Query(ctx, deleteFqdnAddressStmt, app).Run(); err != nil {
-		return errors.Errorf("deleting net node fqdn address for cloud service: %w", err)
-	}
-	if err := tx.Query(ctx, deleteHostnameAddressStmt, app).Run(); err != nil {
-		return errors.Errorf("deleting net node hostname address for cloud service: %w", err)
-	}
-	if err := tx.Query(ctx, deleteNodeStmt, app).Run(); err != nil {
-		return errors.Errorf("deleting net node for cloud service: %w", err)
+
+	// The net node and all the network entities it owns (IP addresses,
+	// link-layer devices, address junctions) belong to the network domain.
+	// Use the shared helper to clean them up.
+	if err := st.removeNetNode(ctx, tx, netNode.UUID); err != nil {
+		return errors.Errorf("removing net node for cloud service: %w", err)
 	}
 	return nil
 }

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -876,12 +876,49 @@ func (s *applicationSuite) TestDeleteCAASApplicationWithCloudService(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
+	// Capture the net node UUID before deletion so we can verify it is removed.
+	var netNodeUUID string
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT net_node_uuid FROM k8s_service WHERE application_uuid = ?", appUUID.String(),
+	).Scan(&netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
 	s.advanceApplicationLife(c, appUUID, life.Dead)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	// DeleteApplication handles cloud service cleanup internally.
 	err = st.DeleteApplication(c.Context(), appUUID.String(), false)
+	c.Assert(err, tc.ErrorIsNil)
+
+	exists, err := st.ApplicationExists(c.Context(), appUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+
+	// Verify the net node and cloud service rows were cleaned up, not orphaned.
+	var count int
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM net_node WHERE uuid = ?", netNodeUUID,
+	).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0, tc.Commentf("net_node should be deleted"))
+
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM k8s_service WHERE application_uuid = ?", appUUID.String(),
+	).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0, tc.Commentf("k8s_service should be deleted"))
+}
+
+func (s *applicationSuite) TestDeleteCAASApplicationWithoutK8sService(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createCAASApplication(c, svc, "some-app")
+
+	s.advanceApplicationLife(c, appUUID, life.Dead)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.DeleteApplication(c.Context(), appUUID.String(), false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	exists, err := st.ApplicationExists(c.Context(), appUUID.String())


### PR DESCRIPTION
_This patch addresses https://github.com/juju/juju/pull/21905#discussion_r3046039922_

Removing a CAAS application's cloud service was leaving rows behind in
net_node and the tables it references (`ip_address`, `link_layer_device`).
The original cleanup only deleted `k8s_service`, `net_node`, and its
address junction rows — and did so in an order that made the
subqueries return no rows once k8s_service was gone, orphaning
everything.

This is fixed by capturing the `net_node_uuid` upfront, then delete the dependent tables
(`ip_address`, `link_layer_device`) before deleting `k8s_service`, and only
then delete net_node so no FK constraint is violated.


## QA steps
Bootstrap on microk8s and deploy `zinc-k8s`:
```
$ make go-install
$ make microks8-operator-update
$ juju bootstrap microk8s c
$ juju add-model m
$ juju deploy zinc-k8s
```
Once the app is active, capture the IDs before removal:
```
$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> .switch model-m
repl (model-m)> SELECT a.uuid, ks.net_node_uuid FROM application a JOIN k8s_service ks ON ks.application_uuid = a.uuid WHERE a.name = 'zinc-k8s';
uuid					net_node_uuid				
e676cf55-e7e3-4d21-8649-c3fb17c6daba	fc75f189-fb9f-4c4e-8cdb-6ae29af563cd	
```
Now remove the app:
```
$ juju remove-application zinc-k8s
```
Wait until it's gone and verify the cleanup back in the repl:
```
repl (model-mmmm)> SELECT * FROM k8s_service WHERE application_uuid = 'e676cf55-e7e3-4d21-8649-c3fb17c6daba';
uuid	application_uuid	net_node_uuid	provider_id	

repl (model-mmmm)> SELECT * FROM net_node WHERE uuid = 'fc75f189-fb9f-4c4e-8cdb-6ae29af563cd';
uuid	

repl (model-mmmm)> SELECT * FROM net_node_fqdn_address WHERE net_node_uuid = 'fc75f189-fb9f-4c4e-8cdb-6ae29af563cd';
net_node_uuid	address_uuid	

repl (model-mmmm)> SELECT * FROM net_node_hostname_address WHERE net_node_uuid = 'fc75f189-fb9f-4c4e-8cdb-6ae29af563cd';
net_node_uuid	address_uuid	

```

