### PR TITLE
test: context canceled during flush workers

### DIFF
--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -331,6 +331,11 @@ func (w *objectStoreWorker) GetObjectStore(ctx context.Context, namespace string
 // the runner. This is only called from the main loop goroutine, so no
 // concurrent worker additions can occur during iteration.
 func (w *objectStoreWorker) stopAndRemoveAllWorkers(ctx context.Context) error {
+	// If the context is already done, return early with the context error.
+	if err := ctx.Err(); err != nil {
+		return errors.Trace(err)
+	}
+
 	for _, namespace := range w.runner.WorkerNames() {
 		err := w.runner.StopAndRemoveWorker(namespace, ctx.Done())
 		if err != nil && !errors.Is(err, errors.NotFound) {

--- a/internal/worker/objectstore/worker_test.go
+++ b/internal/worker/objectstore/worker_test.go
@@ -227,7 +227,7 @@ func (s *workerSuite) TestFlushWorkersCancelledContext(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	w := s.newWorker(c)
-	defer workertest.CleanKill(c, w)
+	defer workertest.DirtyKill(c, w)
 
 	s.ensureStartup(c)
 
@@ -236,8 +236,6 @@ func (s *workerSuite) TestFlushWorkersCancelledContext(c *tc.C) {
 
 	err := w.FlushWorkers(ctx)
 	c.Assert(err, tc.ErrorIs, context.Canceled)
-
-	workertest.CleanKill(c, w)
 }
 
 func (s *workerSuite) newWorker(c *tc.C) *objectStoreWorker {


### PR DESCRIPTION
This was a test composition failure, whereby the test wanted to ensure that no other error could occur. This would fail randomly because depending of the randomness of the selects, it's possible to bypass the context Done() channel check completely and so would not stop. This doesn't matter in real world examples, as this would be caught by stopping the workers call. Instead, we just need to check that the context isn't in error state before stopping the workers. Although, this is a bit of a work around, it does ensure correctness for now.


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/22343.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9769](https://warthogs.atlassian.net/browse/JUJU-9769)


[JUJU-9769]: https://warthogs.atlassian.net/browse/JUJU-9769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ