### PR TITLE
fix: application offers

### DIFF
--- a/apiserver/common/permissions.go
+++ b/apiserver/common/permissions.go
@@ -6,12 +6,12 @@ package common
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
 	accesserrors "github.com/juju/juju/domain/access/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // UserAccessFunc represents a func that can answer the question about what
@@ -59,8 +59,12 @@ func HasPermission(
 		ObjectType: objectType,
 		Key:        target.Id(),
 	})
-	if err != nil && !(errors.Is(err, accesserrors.AccessNotFound) || errors.Is(err, accesserrors.UserNotFound)) {
-		return false, errors.Annotatef(err, "while obtaining %s user", target.Kind())
+	if err != nil && !errors.IsOneOf(err,
+		accesserrors.AccessNotFound,
+		accesserrors.UserNotFound,
+		accesserrors.PermissionNotFound,
+	) {
+		return false, errors.Errorf("while obtaining %s user: %w", target.Kind(), err)
 	}
 	if userAccess == permission.NoAccess {
 		return false, nil

--- a/apiserver/common/permissions_test.go
+++ b/apiserver/common/permissions_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	accesserrors "github.com/juju/juju/domain/access/errors"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -178,4 +179,48 @@ func (r *PermissionSuite) TestUserGetterErrorReturns(c *tc.C) {
 	c.Assert(userGetter.userNames[0], tc.DeepEquals, user.NameFromTag(userTag))
 	c.Assert(userGetter.targets, tc.HasLen, 1)
 	c.Assert(userGetter.targets[0], tc.DeepEquals, permission.ID{ObjectType: permission.Model, Key: target.Id()})
+}
+
+func (r *PermissionSuite) TestUserNotFoundReturnsNoPermission(c *tc.C) {
+	userTag := names.NewUserTag("validuser")
+	target := names.NewModelTag("beef1beef2-0000-0000-000011112222")
+	userGetter := &fakeUserAccess{
+		access: permission.NoAccess,
+		err:    accesserrors.UserNotFound,
+	}
+	hasPermission, err := common.HasPermission(c.Context(), userGetter.call, userTag, permission.ReadAccess, target)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(hasPermission, tc.IsFalse)
+}
+
+func (r *PermissionSuite) TestPermissionNotFoundReturnsNoPermission(c *tc.C) {
+	userTag := names.NewUserTag("validuser")
+	target := names.NewModelTag("beef1beef2-0000-0000-000011112222")
+	userGetter := &fakeUserAccess{
+		access: permission.NoAccess,
+		err:    accesserrors.PermissionNotFound,
+	}
+	hasPermission, err := common.HasPermission(c.Context(), userGetter.call, userTag, permission.ReadAccess, target)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(hasPermission, tc.IsFalse)
+}
+
+func (r *PermissionSuite) TestUnexpectedErrorPropagated(c *tc.C) {
+	userTag := names.NewUserTag("validuser")
+	target := names.NewModelTag("beef1beef2-0000-0000-000011112222")
+	userGetter := &fakeUserAccess{
+		access: permission.NoAccess,
+		err:    errors.New("database connection failed"),
+	}
+	hasPermission, err := common.HasPermission(c.Context(), userGetter.call, userTag, permission.ReadAccess, target)
+	c.Assert(err, tc.ErrorMatches, ".*database connection failed.*")
+	c.Assert(hasPermission, tc.IsFalse)
+}
+
+func (r *PermissionSuite) TestUnknownTargetKindReturnsNoPermission(c *tc.C) {
+	userTag := names.NewUserTag("validuser")
+	target := names.NewMachineTag("0")
+	hasPermission, err := common.HasPermission(c.Context(), (&fakeUserAccess{}).call, userTag, permission.ReadAccess, target)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(hasPermission, tc.IsFalse)
 }

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -349,7 +349,15 @@ func (api *OffersAPI) applicationOffersFromModel(
 	requiredAccess permission.Access,
 	filters []crossmodelrelationservice.OfferFilter,
 ) ([]params.ApplicationOfferAdminDetailsV5, error) {
-	if err := api.checkModelPermission(ctx, apiUser, model.UUID(modelUUID), requiredAccess); err != nil {
+	// Determine if the user is a controller superuser or model admin.
+	// This check is performed once outside the offer loop.
+	isModelAdmin := api.checkModelPermission(ctx, apiUser, model.UUID(modelUUID), permission.AdminAccess) == nil
+
+	requiresAdminAccess := requiredAccess == permission.AdminAccess
+
+	// If admin access is required (e.g. ListApplicationOffers), the user
+	// must be a controller superuser or model admin.
+	if requiresAdminAccess && !isModelAdmin {
 		return nil, apiservererrors.ErrPerm
 	}
 
@@ -367,13 +375,24 @@ func (api *OffersAPI) applicationOffersFromModel(
 	// Process data.
 	var results []params.ApplicationOfferAdminDetailsV5
 	for _, appOffer := range offers {
-		isAdminUser := api.authorizer.HasPermission(ctx, permission.AdminAccess, names.NewModelTag(modelUUID)) == nil
+		// If the user is not a model admin, check whether they have
+		// access to this specific offer. Users with offer-level access
+		// can see offers even without model-level access.
+		isAdmin := isModelAdmin
+		if !isModelAdmin {
+			offerAccess := api.userOfferAccess(ctx, apiUser, appOffer.OfferUUID)
+			if offerAccess == permission.NoAccess {
+				continue
+			}
+			isAdmin = offerAccess == permission.AdminAccess
+		}
+
 		offerParams := api.makeOfferParams(
 			model.UUID(modelUUID),
 			appOffer,
 			apiUser,
 			apiUserDisplayName,
-			isAdminUser,
+			isAdmin,
 		)
 
 		charmURL, err := charms.CharmURLFromLocator(appOffer.CharmLocator.Name, appOffer.CharmLocator)
@@ -387,10 +406,9 @@ func (api *OffersAPI) applicationOffersFromModel(
 		})
 	}
 
-	// Populate offer connections when the caller requires admin access.
-	// At this point the user has been verified as superuser or model admin
-	// by checkModelPermission above.
-	if requiredAccess == permission.AdminAccess && len(results) > 0 {
+	// Populate offer connections only when the caller requires admin access
+	// (i.e. ListApplicationOffers) and the user is verified as model admin.
+	if requiresAdminAccess && isModelAdmin && len(results) > 0 {
 		offerUUIDs := make([]string, len(results))
 		offerIndexByUUID := make(map[string]int, len(results))
 		for i, r := range results {
@@ -411,6 +429,31 @@ func (api *OffersAPI) applicationOffersFromModel(
 	}
 
 	return results, nil
+}
+
+// userOfferAccess returns the highest level of access the user has to the
+// specified offer. It checks access levels from highest to lowest and returns
+// the first match, or NoAccess if the user has no permissions on the offer.
+func (api *OffersAPI) userOfferAccess(
+	ctx context.Context,
+	user names.UserTag,
+	offerUUID string,
+) permission.Access {
+	offerTag := names.NewApplicationOfferTag(offerUUID)
+	for _, access := range []permission.Access{
+		permission.AdminAccess,
+		permission.ConsumeAccess,
+		permission.ReadAccess,
+	} {
+		err := api.authorizer.EntityHasPermission(ctx, user, access, offerTag)
+		if err == nil {
+			return access
+		}
+		if !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+			return permission.NoAccess
+		}
+	}
+	return permission.NoAccess
 }
 
 func (api *OffersAPI) makeOfferParams(
@@ -855,6 +898,11 @@ func filterFromURL(url corecrossmodel.OfferURL) params.OfferFilter {
 
 // FindApplicationOffers gets details about remote applications that match given filter.
 func (api *OffersAPI) FindApplicationOffers(ctx context.Context, filters params.OfferFilters) (params.QueryApplicationOffersResultsV5, error) {
+	apiUser, ok := api.authorizer.GetAuthTag().(names.UserTag)
+	if !ok {
+		return params.QueryApplicationOffersResultsV5{}, apiservererrors.ErrPerm
+	}
+
 	var (
 		result       params.QueryApplicationOffersResultsV5
 		filtersToUse params.OfferFilters
@@ -876,10 +924,6 @@ func (api *OffersAPI) FindApplicationOffers(ctx context.Context, filters params.
 		}
 	} else {
 		filtersToUse = filters
-	}
-	apiUser, ok := api.authorizer.GetAuthTag().(names.UserTag)
-	if !ok {
-		return params.QueryApplicationOffersResultsV5{}, apiservererrors.ErrPerm
 	}
 
 	offers, err := api.getApplicationOffersDetails(ctx, apiUser, permission.ReadAccess, filtersToUse)

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -352,18 +352,40 @@ func (api *OffersAPI) applicationOffersFromModel(
 	// Determine if the user is a controller superuser or model admin.
 	// This check is performed once outside the offer loop.
 	err := api.checkModelPermission(ctx, apiUser, model.UUID(modelUUID), permission.AdminAccess)
+	if errors.Is(err, authentication.ErrorEntityMissingPermission) && requiredAccess == permission.AdminAccess {
+		// The user is not a model admin, and admin access is required.
+		// Return permission error before doing any further processing.
+		return nil, apiservererrors.ErrPerm
+	}
+	// If the error is something other than missing permission, return it.
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return nil, errors.Capture(err)
 	}
+
 	isModelAdmin := err == nil
+	isModelReader := false
 
-	requiresAdminAccess := requiredAccess == permission.AdminAccess
-
-	// If admin access is required (e.g. ListApplicationOffers), the user
-	// must be a controller superuser or model admin.
-	if requiresAdminAccess && !isModelAdmin {
-		return nil, apiservererrors.ErrPerm
+	if requiredAccess == permission.ReadAccess && !isModelAdmin {
+		err := api.checkModelPermission(ctx, apiUser, model.UUID(modelUUID), permission.ReadAccess)
+		if err == nil {
+			isModelReader = true
+		} else if !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+			return nil, errors.Capture(err)
+		}
+		// At this point the user doesn't have model access, but they may have
+		// offer-level access to some offers within the model.
 	}
+
+	// One of the following should be true:
+	//
+	//  - The user has admin access to the model (superuser or model admin)
+	//  - The user has read access to the model but is not an admin
+	//  - The user has no access to the model, but may have offer-level access
+	//    to some offers within the model.
+	//
+	// We must verify that each offer returned is filtered according to the
+	// required access level, and that offer-level access is taken into account
+	// for users without model-level access.
 
 	// Get the relevant service for the specified model.
 	crossModelRelationService, err := api.crossModelRelationServiceGetter(ctx, model.UUID(modelUUID))
@@ -376,19 +398,24 @@ func (api *OffersAPI) applicationOffersFromModel(
 		return nil, errors.Capture(err)
 	}
 
-	// Process data.
+	// CanReadAllOffers is true if the user has sufficient access to read all
+	// offers in the model without needing to check offer-level access. This is
+	// true for model admins, but not for users with only read access, as there
+	// may be some offers they don't have access to.
+	canReadAllOffers := isModelAdmin || isModelReader
+
 	var results []params.ApplicationOfferAdminDetailsV5
 	for _, appOffer := range offers {
 		// If the user is not a model admin, check whether they have
 		// access to this specific offer. Users with offer-level access
 		// can see offers even without model-level access.
-		isAdmin := isModelAdmin
-		if !isModelAdmin {
-			offerAccess := api.userOfferAccess(ctx, apiUser, appOffer.OfferUUID)
-			if offerAccess == permission.NoAccess {
+		if !canReadAllOffers {
+			offerAccess, err := api.hasUserAccessToOffer(ctx, apiUser, appOffer.OfferUUID)
+			if err != nil {
+				return nil, errors.Capture(err)
+			} else if offerAccess == permission.NoAccess {
 				continue
 			}
-			isAdmin = offerAccess == permission.AdminAccess
 		}
 
 		offerParams := api.makeOfferParams(
@@ -396,7 +423,7 @@ func (api *OffersAPI) applicationOffersFromModel(
 			appOffer,
 			apiUser,
 			apiUserDisplayName,
-			isAdmin,
+			isModelAdmin,
 		)
 
 		charmURL, err := charms.CharmURLFromLocator(appOffer.CharmLocator.Name, appOffer.CharmLocator)
@@ -410,54 +437,62 @@ func (api *OffersAPI) applicationOffersFromModel(
 		})
 	}
 
+	// If the required access level is *only* read, then return the results at
+	// this point without populating the offer connections. Offer connections
+	// are only relevant to users with admin access.
+	if requiredAccess == permission.ReadAccess {
+		return results, nil
+	}
+
+	// If the user is not a model admin or there are no results,
+	// return the results without populating the offer connections.
+	if !isModelAdmin || len(results) == 0 {
+		return results, nil
+	}
+
 	// Populate offer connections only when the caller requires admin access
 	// (i.e. ListApplicationOffers) and the user is verified as model admin.
-	if requiresAdminAccess && isModelAdmin && len(results) > 0 {
-		offerUUIDs := make([]string, len(results))
-		offerIndexByUUID := make(map[string]int, len(results))
-		for i, r := range results {
-			offerUUIDs[i] = r.OfferUUID
-			offerIndexByUUID[r.OfferUUID] = i
+	offerUUIDs := make([]string, len(results))
+	offerIndexByUUID := make(map[string]int, len(results))
+	for i, r := range results {
+		offerUUIDs[i] = r.OfferUUID
+		offerIndexByUUID[r.OfferUUID] = i
+	}
+
+	connections, err := crossModelRelationService.GetOfferConnections(ctx, offerUUIDs)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	for _, conn := range connections {
+		idx, ok := offerIndexByUUID[conn.OfferUUID]
+		if !ok {
+			continue
 		}
-		connections, err := crossModelRelationService.GetOfferConnections(ctx, offerUUIDs)
-		if err != nil {
-			return nil, errors.Capture(err)
-		}
-		for _, conn := range connections {
-			idx, ok := offerIndexByUUID[conn.OfferUUID]
-			if !ok {
-				continue
-			}
-			results[idx].Connections = append(results[idx].Connections, makeOfferConnection(conn))
-		}
+		results[idx].Connections = append(results[idx].Connections, makeOfferConnection(conn))
 	}
 
 	return results, nil
 }
 
-// userOfferAccess returns the highest level of access the user has to the
-// specified offer. It checks access levels from highest to lowest and returns
-// the first match, or NoAccess if the user has no permissions on the offer.
-func (api *OffersAPI) userOfferAccess(
+// hasUserAccessToOffer returns the access level the user has to the offer,
+// which may be elevated above their model-level access. If the user has no
+// access to the offer, this will return permission.NoAccess and no error. An
+// error is only returned if there was a problem checking the user's access to
+// the offer.
+func (api *OffersAPI) hasUserAccessToOffer(
 	ctx context.Context,
 	user names.UserTag,
 	offerUUID string,
-) permission.Access {
+) (permission.Access, error) {
 	offerTag := names.NewApplicationOfferTag(offerUUID)
-	for _, access := range []permission.Access{
-		permission.AdminAccess,
-		permission.ConsumeAccess,
-		permission.ReadAccess,
-	} {
-		err := api.authorizer.EntityHasPermission(ctx, user, access, offerTag)
-		if err == nil {
-			return access
-		}
-		if !errors.Is(err, authentication.ErrorEntityMissingPermission) {
-			return permission.NoAccess
-		}
+
+	err := api.authorizer.EntityHasPermission(ctx, user, permission.ReadAccess, offerTag)
+	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+		return permission.NoAccess, errors.Capture(err)
+	} else if err != nil && errors.Is(err, authentication.ErrorEntityMissingPermission) {
+		return permission.NoAccess, nil
 	}
-	return permission.NoAccess
+	return permission.ReadAccess, nil
 }
 
 func (api *OffersAPI) makeOfferParams(
@@ -465,7 +500,7 @@ func (api *OffersAPI) makeOfferParams(
 	offer *crossmodelrelation.OfferDetail,
 	apiUser names.UserTag,
 	apiUserDisplayName string,
-	isAdminUser bool,
+	listAllUsers bool,
 ) *params.ApplicationOfferDetailsV5 {
 	if offer == nil {
 		return nil
@@ -486,8 +521,9 @@ func (api *OffersAPI) makeOfferParams(
 		})
 	}
 
-	// All OfferUsers only provided if apiUserAccess if Admin.
-	if !isAdminUser {
+	// If the user is not a allowed to see all users, only populate the access
+	// for the api user.
+	if !listAllUsers {
 		result.Users = append(result.Users, params.OfferUserDetails{
 			UserName:    apiUser.Id(),
 			DisplayName: apiUserDisplayName,

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -351,7 +351,11 @@ func (api *OffersAPI) applicationOffersFromModel(
 ) ([]params.ApplicationOfferAdminDetailsV5, error) {
 	// Determine if the user is a controller superuser or model admin.
 	// This check is performed once outside the offer loop.
-	isModelAdmin := api.checkModelPermission(ctx, apiUser, model.UUID(modelUUID), permission.AdminAccess) == nil
+	err := api.checkModelPermission(ctx, apiUser, model.UUID(modelUUID), permission.AdminAccess)
+	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+		return nil, errors.Capture(err)
+	}
+	isModelAdmin := err == nil
 
 	requiresAdminAccess := requiredAccess == permission.AdminAccess
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -1150,12 +1150,11 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange: a user with no model admin access and no offer-level
-	// access should get an empty result (not a permission error), because
-	// permission filtering happens per-offer.
+	// Arrange: a user with no model admin access, no model read access,
+	// and no offer-level access should get an empty result (not a
+	// permission error), because permission filtering happens per-offer.
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 
@@ -1165,8 +1164,14 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 		UUID: tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(adminTag.Id())).Return(foundModel, nil)
+
+	// User is not superuser (checked twice: once for admin, once for read).
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
 	// User is not model admin.
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.AdminAccess)
+	// User is not model reader.
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.ReadAccess)
 
 	offerUUID1 := uuid.MustNewUUID().String()
 	offerUUID2 := uuid.MustNewUUID().String()
@@ -1195,26 +1200,10 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
 
-	// User has no access to either offer.
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), adminTag, permission.AdminAccess,
-		names.NewApplicationOfferTag(offerUUID1),
-	).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), adminTag, permission.ConsumeAccess,
-		names.NewApplicationOfferTag(offerUUID1),
-	).Return(authentication.ErrorEntityMissingPermission)
+	// User has no access to either offer (only ReadAccess is checked).
 	s.authorizer.EXPECT().EntityHasPermission(
 		gomock.Any(), adminTag, permission.ReadAccess,
 		names.NewApplicationOfferTag(offerUUID1),
-	).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), adminTag, permission.AdminAccess,
-		names.NewApplicationOfferTag(offerUUID2),
-	).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), adminTag, permission.ConsumeAccess,
-		names.NewApplicationOfferTag(offerUUID2),
 	).Return(authentication.ErrorEntityMissingPermission)
 	s.authorizer.EXPECT().EntityHasPermission(
 		gomock.Any(), adminTag, permission.ReadAccess,
@@ -1244,13 +1233,16 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 func (s *offerSuite) TestFindApplicationOffersOfferLevelAccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange: user has no model admin access, but has read access to one
-	// offer. They should see only that offer.
+	// Arrange: user has no model admin or read access, but has read access
+	// to one offer. They should see only that offer.
 	offerAPI := s.offerAPI(c)
 	userTag := s.setupAuthUser("bob")
-	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
 	bobUser := user.User{DisplayName: "bob smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+
+	// User is not superuser (checked twice: admin check + read check).
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
 
 	modelName := "prod"
 	foundModel := model.Model{
@@ -1261,6 +1253,8 @@ func (s *offerSuite) TestFindApplicationOffersOfferLevelAccess(c *tc.C) {
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
 	// User is not model admin.
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+	// User is not model reader.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.ReadAccess)
 
 	offerUUID1 := uuid.MustNewUUID().String()
 	offerUUID2 := uuid.MustNewUUID().String()
@@ -1303,26 +1297,14 @@ func (s *offerSuite) TestFindApplicationOffersOfferLevelAccess(c *tc.C) {
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
 
-	// User has read access to offer 1.
+	// User has read access to offer 1 (only ReadAccess is checked).
 	offerTag1 := names.NewApplicationOfferTag(offerUUID1)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.AdminAccess, offerTag1,
-	).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.ConsumeAccess, offerTag1,
-	).Return(authentication.ErrorEntityMissingPermission)
 	s.authorizer.EXPECT().EntityHasPermission(
 		gomock.Any(), userTag, permission.ReadAccess, offerTag1,
 	).Return(nil)
 
 	// User has no access to offer 2.
 	offerTag2 := names.NewApplicationOfferTag(offerUUID2)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.AdminAccess, offerTag2,
-	).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.ConsumeAccess, offerTag2,
-	).Return(authentication.ErrorEntityMissingPermission)
 	s.authorizer.EXPECT().EntityHasPermission(
 		gomock.Any(), userTag, permission.ReadAccess, offerTag2,
 	).Return(authentication.ErrorEntityMissingPermission)
@@ -1799,15 +1781,21 @@ func (s *offerSuite) TestListApplicationOffersWithConnections(c *tc.C) {
 func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange: user has no model admin access and no offer-level access.
-	// The result should be per-offer NotFound errors (not a blanket
-	// permission error) since per-offer filtering is applied.
+	// Arrange: user has no model admin access, no model read access,
+	// and no offer-level access. The result should be per-offer NotFound
+	// errors (not a blanket permission error) since per-offer filtering
+	// is applied.
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
+	// User is not superuser (checked twice: admin check + read check).
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+	// User is not model admin.
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.AdminAccess)
+	// User is not model reader.
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.ReadAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1839,14 +1827,8 @@ func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
 
-	// User has no access to the offer.
+	// User has no access to the offer (only ReadAccess is checked).
 	offerTag := names.NewApplicationOfferTag(offerUUID)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), adminTag, permission.AdminAccess, offerTag,
-	).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), adminTag, permission.ConsumeAccess, offerTag,
-	).Return(authentication.ErrorEntityMissingPermission)
 	s.authorizer.EXPECT().EntityHasPermission(
 		gomock.Any(), adminTag, permission.ReadAccess, offerTag,
 	).Return(authentication.ErrorEntityMissingPermission)
@@ -2312,14 +2294,19 @@ func (s *offerSuite) TestListApplicationOffersModelAdmin(c *tc.C) {
 func (s *offerSuite) TestApplicationOffersOfferLevelAccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange: user is not model admin, but has consume access on the offer.
+	// Arrange: user is not model admin, not model reader, but has consume
+	// access on the offer. Since consume >= read, the offer is visible.
 	offerAPI := s.offerAPI(c)
 	userTag := s.setupAuthUser("bob")
 	bobUser := user.User{DisplayName: "bob smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
-	// Not superuser, not model admin.
+	// Not superuser (checked twice: admin check + read check).
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+	// Not model admin.
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+	// Not model reader.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.ReadAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -2358,13 +2345,11 @@ func (s *offerSuite) TestApplicationOffersOfferLevelAccess(c *tc.C) {
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
 
-	// User has consume access on the offer (not admin).
+	// User has read access on the offer (consume >= read in the hierarchy,
+	// so EntityHasPermission with ReadAccess returns nil).
 	offerTag := names.NewApplicationOfferTag(offerUUID)
 	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.AdminAccess, offerTag,
-	).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.ConsumeAccess, offerTag,
+		gomock.Any(), userTag, permission.ReadAccess, offerTag,
 	).Return(nil)
 
 	args := params.OfferURLs{
@@ -2397,16 +2382,19 @@ func (s *offerSuite) TestApplicationOffersOfferLevelAccess(c *tc.C) {
 }
 
 // TestFindApplicationOffersOfferLevelAdminAccess tests that a user with
-// admin access on an offer (but not model admin) sees the full user list
-// for that offer.
+// admin access on an offer (but not model admin) sees the offer but with
+// a limited user list (only their own access), since full user visibility
+// requires model admin.
 func (s *offerSuite) TestFindApplicationOffersOfferLevelAdminAccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange: user has offer admin but is not model admin.
+	// Arrange: user has offer admin but is not model admin or reader.
 	offerAPI := s.offerAPI(c)
 	userTag := s.setupAuthUser("bob")
 	bobUser := user.User{DisplayName: "bob smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	// Not superuser (checked twice: admin check + read check).
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
 
 	modelName := "prod"
@@ -2418,6 +2406,8 @@ func (s *offerSuite) TestFindApplicationOffersOfferLevelAdminAccess(c *tc.C) {
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
 	// User is not model admin.
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+	// User is not model reader.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.ReadAccess)
 
 	offerUUID := uuid.MustNewUUID().String()
 	charmLocator := charm.CharmLocator{
@@ -2447,10 +2437,10 @@ func (s *offerSuite) TestFindApplicationOffersOfferLevelAdminAccess(c *tc.C) {
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
 
-	// User has admin access on the offer.
+	// User has read access on the offer (admin >= read in the hierarchy).
 	offerTag := names.NewApplicationOfferTag(offerUUID)
 	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.AdminAccess, offerTag,
+		gomock.Any(), userTag, permission.ReadAccess, offerTag,
 	).Return(nil)
 
 	filters := params.OfferFilters{
@@ -2465,7 +2455,9 @@ func (s *offerSuite) TestFindApplicationOffersOfferLevelAdminAccess(c *tc.C) {
 	// Act
 	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
 
-	// Assert: user sees full user list because they have offer admin.
+	// Assert: user sees the offer but with limited user list (only their own
+	// access) because full user visibility requires model admin, not just
+	// offer admin.
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(obtained.Results, tc.HasLen, 1)
 	mc := tc.NewMultiChecker()
@@ -2478,8 +2470,7 @@ func (s *offerSuite) TestFindApplicationOffersOfferLevelAdminAccess(c *tc.C) {
 			ApplicationDescription: "testing application",
 			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 			Users: []params.OfferUserDetails{
-				{UserName: "bob", Access: "admin"},
-				{UserName: "george", Access: "consume"},
+				{UserName: "bob", DisplayName: "bob smith", Access: "admin"},
 			},
 		},
 		ApplicationName: "test-app",
@@ -2492,11 +2483,13 @@ func (s *offerSuite) TestFindApplicationOffersOfferLevelAdminAccess(c *tc.C) {
 func (s *offerSuite) TestFindApplicationOffersOfferConsumeAccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange: user has consume access on the offer, not admin.
+	// Arrange: user has consume access on the offer, not model admin.
 	offerAPI := s.offerAPI(c)
 	userTag := s.setupAuthUser("bob")
 	bobUser := user.User{DisplayName: "bob smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	// Not superuser (checked twice: admin check + read check).
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
 
 	modelName := "prod"
@@ -2508,6 +2501,8 @@ func (s *offerSuite) TestFindApplicationOffersOfferConsumeAccess(c *tc.C) {
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
 	// User is not model admin.
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+	// User is not model reader.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.ReadAccess)
 
 	offerUUID := uuid.MustNewUUID().String()
 	charmLocator := charm.CharmLocator{
@@ -2537,13 +2532,10 @@ func (s *offerSuite) TestFindApplicationOffersOfferConsumeAccess(c *tc.C) {
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
 
-	// User has consume access on the offer (not admin).
+	// User has read access on the offer (consume >= read in the hierarchy).
 	offerTag := names.NewApplicationOfferTag(offerUUID)
 	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.AdminAccess, offerTag,
-	).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.ConsumeAccess, offerTag,
+		gomock.Any(), userTag, permission.ReadAccess, offerTag,
 	).Return(nil)
 
 	filters := params.OfferFilters{
@@ -2581,16 +2573,18 @@ func (s *offerSuite) TestFindApplicationOffersOfferConsumeAccess(c *tc.C) {
 
 // TestFindApplicationOffersPermissionCheckError tests that when the
 // permission check on an offer returns an unexpected error (not
-// ErrorEntityMissingPermission), the offer is filtered out.
+// ErrorEntityMissingPermission), the error is propagated to the caller.
 func (s *offerSuite) TestFindApplicationOffersPermissionCheckError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange: user is not model admin, and permission check returns
-	// an unexpected error.
+	// Arrange: user is not model admin or reader, and the offer permission
+	// check returns an unexpected error.
 	offerAPI := s.offerAPI(c)
 	userTag := s.setupAuthUser("bob")
 	bobUser := user.User{DisplayName: "bob smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	// Not superuser (checked twice: admin check + read check).
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
 
 	modelName := "prod"
@@ -2602,6 +2596,8 @@ func (s *offerSuite) TestFindApplicationOffersPermissionCheckError(c *tc.C) {
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
 	// User is not model admin.
 	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+	// User is not model reader.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.ReadAccess)
 
 	offerUUID := uuid.MustNewUUID().String()
 	charmLocator := charm.CharmLocator{
@@ -2627,10 +2623,10 @@ func (s *offerSuite) TestFindApplicationOffersPermissionCheckError(c *tc.C) {
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
 
-	// Permission check returns an unexpected error on admin access check.
+	// Permission check returns an unexpected error on the offer read check.
 	offerTag := names.NewApplicationOfferTag(offerUUID)
 	s.authorizer.EXPECT().EntityHasPermission(
-		gomock.Any(), userTag, permission.AdminAccess, offerTag,
+		gomock.Any(), userTag, permission.ReadAccess, offerTag,
 	).Return(errors.New("unexpected database error"))
 
 	filters := params.OfferFilters{
@@ -2643,11 +2639,96 @@ func (s *offerSuite) TestFindApplicationOffersPermissionCheckError(c *tc.C) {
 	}
 
 	// Act
-	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+	_, err := offerAPI.FindApplicationOffers(c.Context(), filters)
 
-	// Assert: no outer error, but offer is filtered out due to the error.
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(obtained.Results, tc.HasLen, 0)
+	// Assert: the unexpected error is propagated to the caller.
+	c.Assert(err, tc.ErrorMatches, ".*unexpected database error.*")
+}
+
+// TestFindApplicationOffersModelAdminCheckError tests that when the model
+// admin permission check returns an unexpected error (not
+// ErrorEntityMissingPermission), the error is propagated to the caller.
+func (s *offerSuite) TestFindApplicationOffersModelAdminCheckError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: superuser check returns missing permission, then model admin
+	// check returns an unexpected error.
+	offerAPI := s.offerAPI(c)
+	userTag := s.setupAuthUser("bob")
+	bobUser := user.User{DisplayName: "bob smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+
+	modelName := "prod"
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(userTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
+
+	// Model admin check returns an unexpected error (e.g., database failure).
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ModelTag{}),
+	).Return(errors.New("unexpected database error"))
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelName: modelName,
+				OfferName: "hosted-db2",
+			},
+		},
+	}
+
+	// Act
+	_, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+
+	// Assert: the unexpected error is propagated.
+	c.Assert(err, tc.ErrorMatches, ".*unexpected database error.*")
+}
+
+// TestListApplicationOffersModelAdminCheckError tests that when the model
+// admin permission check returns an unexpected error (not
+// ErrorEntityMissingPermission), the error is propagated for list operations.
+func (s *offerSuite) TestListApplicationOffersModelAdminCheckError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: superuser check returns missing permission, then model admin
+	// check returns an unexpected error.
+	offerAPI := s.offerAPI(c)
+	adminTag := s.setupAuthUser("admin")
+	adminUser := user.User{DisplayName: "admin smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
+
+	modelName := "prod"
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(adminTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(adminTag.Id())).Return(foundModel, nil)
+
+	// Model admin check returns an unexpected error (e.g., database failure).
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.AdminAccess, gomock.AssignableToTypeOf(names.ModelTag{}),
+	).Return(errors.New("unexpected database error"))
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelName: modelName,
+				OfferName: "hosted-db2",
+			},
+		},
+	}
+
+	// Act
+	_, err := offerAPI.ListApplicationOffers(c.Context(), filters)
+
+	// Assert: the unexpected error is propagated.
+	c.Assert(err, tc.ErrorMatches, ".*unexpected database error.*")
 }
 
 // TestDestroyOffersSuperuser tests that a controller superuser can

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -760,10 +760,6 @@ func (s *offerSuite) TestListApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil).
-		Times(2)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -952,7 +948,7 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectEntityHasPermission(adminTag, permission.AdminAccess)
 
 	modelName := "prod"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -963,10 +959,6 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil).
-		Times(2)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1069,7 +1061,7 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectEntityHasPermission(adminTag, permission.AdminAccess)
 
 	modelName := "prod"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1081,10 +1073,6 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 	}
 	s.modelService.EXPECT().GetAllModels(gomock.Any()).Return([]model.Model{foundModel}, nil)
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil).
-		Times(2)
 
 	charmLocator := charm.CharmLocator{
 		Name:         "app",
@@ -1162,7 +1150,9 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange
+	// Arrange: a user with no model admin access and no offer-level
+	// access should get an empty result (not a permission error), because
+	// permission filtering happens per-offer.
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser("admin")
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
@@ -1175,7 +1165,61 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 		UUID: tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(adminTag.Id())).Return(foundModel, nil)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.ReadAccess)
+	// User is not model admin.
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.AdminAccess)
+
+	offerUUID1 := uuid.MustNewUUID().String()
+	offerUUID2 := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:       offerUUID1,
+			OfferName:       "hosted-db2",
+			ApplicationName: "test-app",
+			CharmLocator:    charmLocator,
+		}, {
+			OfferUUID:       offerUUID2,
+			OfferName:       "testing",
+			ApplicationName: "test-app",
+			CharmLocator:    charmLocator,
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+		{OfferName: "testing"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// User has no access to either offer.
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.AdminAccess,
+		names.NewApplicationOfferTag(offerUUID1),
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.ConsumeAccess,
+		names.NewApplicationOfferTag(offerUUID1),
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.ReadAccess,
+		names.NewApplicationOfferTag(offerUUID1),
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.AdminAccess,
+		names.NewApplicationOfferTag(offerUUID2),
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.ConsumeAccess,
+		names.NewApplicationOfferTag(offerUUID2),
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.ReadAccess,
+		names.NewApplicationOfferTag(offerUUID2),
+	).Return(authentication.ErrorEntityMissingPermission)
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -1190,12 +1234,132 @@ func (s *offerSuite) TestFindApplicationOffersPermission(c *tc.C) {
 	}
 
 	// Act
-	_, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+	result, err := offerAPI.FindApplicationOffers(c.Context(), filters)
 
-	// Assert
-	c.Assert(err, tc.DeepEquals, &params.Error{
-		Message: "permission denied", Code: "unauthorized access"},
-	)
+	// Assert: no error, but empty results since user has no offer access.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 0)
+}
+
+func (s *offerSuite) TestFindApplicationOffersOfferLevelAccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: user has no model admin access, but has read access to one
+	// offer. They should see only that offer.
+	offerAPI := s.offerAPI(c)
+	userTag := s.setupAuthUser("bob")
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+	bobUser := user.User{DisplayName: "bob smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+
+	modelName := "prod"
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(userTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
+	// User is not model admin.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+
+	offerUUID1 := uuid.MustNewUUID().String()
+	offerUUID2 := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID1,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{
+				{Name: "bob", Access: permission.ReadAccess},
+			},
+		}, {
+			OfferUUID:              offerUUID2,
+			OfferName:              "testing",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "endpoint"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{
+				{Name: "george", Access: permission.ConsumeAccess},
+			},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+		{OfferName: "testing"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// User has read access to offer 1.
+	offerTag1 := names.NewApplicationOfferTag(offerUUID1)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.AdminAccess, offerTag1,
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.ConsumeAccess, offerTag1,
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.ReadAccess, offerTag1,
+	).Return(nil)
+
+	// User has no access to offer 2.
+	offerTag2 := names.NewApplicationOfferTag(offerUUID2)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.AdminAccess, offerTag2,
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.ConsumeAccess, offerTag2,
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.ReadAccess, offerTag2,
+	).Return(authentication.ErrorEntityMissingPermission)
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelName: modelName,
+				OfferName: "hosted-db2",
+			}, {
+				ModelName: modelName,
+				OfferName: "testing",
+			},
+		},
+	}
+
+	// Act
+	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+
+	// Assert: only the offer the user has access to is returned.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 1)
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_.ApplicationOfferDetailsV5.SourceModelTag", tc.Ignore)
+	c.Check(obtained.Results[0], mc, params.ApplicationOfferAdminDetailsV5{
+		ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
+			OfferURL:               "bob/prod.hosted-db2",
+			OfferName:              "hosted-db2",
+			OfferUUID:              offerUUID1,
+			ApplicationDescription: "testing application",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
+			Users: []params.OfferUserDetails{
+				{UserName: "bob", DisplayName: "bob smith", Access: "read"},
+			}},
+		ApplicationName: "test-app",
+		CharmURL:        "ch:amd64/app-42",
+	})
 }
 
 func (s *offerSuite) TestFindApplicationOffersError(c *tc.C) {
@@ -1322,7 +1486,7 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectEntityHasPermission(adminTag, permission.AdminAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1333,10 +1497,6 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil).
-		Times(2)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1431,7 +1591,7 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectEntityHasPermission(adminTag, permission.AdminAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1442,9 +1602,6 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil)
 
 	domainFilters := []crossmodelrelationservice.OfferFilter{
 		{
@@ -1512,7 +1669,7 @@ func (s *offerSuite) TestApplicationOffersNotFound(c *tc.C) {
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-	s.expectEntityHasPermission(adminTag, permission.ReadAccess)
+	s.expectEntityHasPermission(adminTag, permission.AdminAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1568,9 +1725,6 @@ func (s *offerSuite) TestListApplicationOffersWithConnections(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
-	s.authorizer.EXPECT().
-		HasPermission(gomock.Any(), permission.AdminAccess, names.NewModelTag(foundModel.UUID.String())).
-		Return(nil)
 
 	offerUUID := uuid.MustNewUUID().String()
 	consumerModelUUID := uuid.MustNewUUID().String()
@@ -1645,13 +1799,15 @@ func (s *offerSuite) TestListApplicationOffersWithConnections(c *tc.C) {
 func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// Arrange
+	// Arrange: user has no model admin access and no offer-level access.
+	// The result should be per-offer NotFound errors (not a blanket
+	// permission error) since per-offer filtering is applied.
 	offerAPI := s.offerAPI(c)
 	adminTag := s.setupAuthUser(user.AdminUserName.Name())
 	adminUser := user.User{DisplayName: "fred smith"}
 	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
 	s.expectEntityHasPermissionMissingPermission(adminTag, permission.SuperuserAccess)
-	s.expectEntityHasPermissionMissingPermission(adminTag, permission.ReadAccess)
+	s.expectEntityHasPermissionMissingPermission(adminTag, permission.AdminAccess)
 
 	modelName := "test-model"
 	modelOwnerTag := names.NewUserTag("fred@external")
@@ -1662,17 +1818,52 @@ func (s *offerSuite) TestApplicationOffersNoRead(c *tc.C) {
 		UUID:      tc.Must0(c, model.NewUUID),
 	}
 	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+
+	offerUUID := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:       offerUUID,
+			OfferName:       "testing",
+			ApplicationName: "test-app",
+			CharmLocator:    charmLocator,
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "testing"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// User has no access to the offer.
+	offerTag := names.NewApplicationOfferTag(offerUUID)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.AdminAccess, offerTag,
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.ConsumeAccess, offerTag,
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), adminTag, permission.ReadAccess, offerTag,
+	).Return(authentication.ErrorEntityMissingPermission)
+
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.testing"},
 	}
 
 	// Act
-	_, err := offerAPI.ApplicationOffers(c.Context(), args)
+	obtainedOffers, err := offerAPI.ApplicationOffers(c.Context(), args)
 
-	// Assert
-	c.Assert(err, tc.DeepEquals, &params.Error{
-		Message: "permission denied",
-		Code:    "unauthorized access",
+	// Assert: no outer error, but offer is not visible to user.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtainedOffers.Results, tc.HasLen, 1)
+	c.Check(obtainedOffers.Results[0].Error, tc.DeepEquals, &params.Error{
+		Message: `application offer "fred@external/test-model.testing"`,
+		Code:    params.CodeNotFound,
 	})
 }
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -2207,6 +2207,481 @@ func (s *offerSuite) TestGetConsumeDetailsInvalidOfferURLSource(c *tc.C) {
 	})
 }
 
+// TestRemoteApplicationInfo tests that RemoteApplicationInfo returns empty
+// results (the method is a stub for the Dashboard).
+func (s *offerSuite) TestRemoteApplicationInfo(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	offerAPI := s.offerAPI(c)
+	results, err := offerAPI.RemoteApplicationInfo(c.Context(), params.OfferURLs{
+		OfferURLs: []string{"fred@external/test-model.hosted-mysql"},
+	})
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(results, tc.DeepEquals, params.RemoteApplicationInfoResults{})
+}
+
+// TestListApplicationOffersModelAdmin tests that a model admin who is not a
+// controller superuser can list application offers.
+func (s *offerSuite) TestListApplicationOffersModelAdmin(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: user is model admin but not superuser.
+	offerAPI := s.offerAPI(c)
+	userTag := s.setupAuthUser("bob")
+	bobUser := user.User{DisplayName: "bob smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	// Not superuser, but is model admin.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+
+	modelName := "prod"
+	modelOwnerTag := names.NewUserTag("fred@external")
+
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(modelOwnerTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+	// Model admin check passes.
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.AdminAccess, names.NewModelTag(foundModel.UUID.String()),
+	).Return(nil)
+
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              uuid.MustNewUUID().String(),
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{{Name: "bob", Access: permission.AdminAccess}},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelQualifier: modelOwnerTag.Id(),
+				ModelName:      modelName,
+				OfferName:      "hosted-db2",
+			},
+		},
+	}
+
+	// Act
+	obtained, err := offerAPI.ListApplicationOffers(c.Context(), filters)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 1)
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_.ApplicationOfferDetailsV5.SourceModelTag", tc.Ignore)
+	mc.AddExpr("_.ApplicationOfferDetailsV5.OfferUUID", tc.IsUUID)
+	c.Check(obtained.Results[0], mc, params.ApplicationOfferAdminDetailsV5{
+		ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
+			OfferURL:               "fred@external/prod.hosted-db2",
+			OfferName:              "hosted-db2",
+			ApplicationDescription: "testing application",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
+			Users: []params.OfferUserDetails{
+				{UserName: "bob", Access: "admin"},
+			}},
+		ApplicationName: "test-app",
+		CharmURL:        "ch:amd64/app-42",
+	})
+}
+
+// TestApplicationOffersOfferLevelAccess tests that a user with offer-level
+// consume access (but not model admin) can get application offers via
+// ApplicationOffers.
+func (s *offerSuite) TestApplicationOffersOfferLevelAccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: user is not model admin, but has consume access on the offer.
+	offerAPI := s.offerAPI(c)
+	userTag := s.setupAuthUser("bob")
+	bobUser := user.User{DisplayName: "bob smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	// Not superuser, not model admin.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+
+	modelName := "test-model"
+	modelOwnerTag := names.NewUserTag("fred@external")
+
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(modelOwnerTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+
+	offerUUID := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{
+				{Name: "bob", Access: permission.ConsumeAccess},
+			},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// User has consume access on the offer (not admin).
+	offerTag := names.NewApplicationOfferTag(offerUUID)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.AdminAccess, offerTag,
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.ConsumeAccess, offerTag,
+	).Return(nil)
+
+	args := params.OfferURLs{
+		OfferURLs: []string{"fred@external/test-model.hosted-db2"},
+	}
+
+	// Act
+	obtainedOffers, err := offerAPI.ApplicationOffers(c.Context(), args)
+
+	// Assert: user sees the offer with limited view (only their own access).
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtainedOffers.Results, tc.HasLen, 1)
+	c.Assert(obtainedOffers.Results[0].Error, tc.IsNil)
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_.ApplicationOfferDetailsV5.SourceModelTag", tc.Ignore)
+	c.Check(obtainedOffers.Results[0].Result, mc, &params.ApplicationOfferAdminDetailsV5{
+		ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
+			OfferURL:               "fred@external/test-model.hosted-db2",
+			OfferName:              "hosted-db2",
+			OfferUUID:              offerUUID,
+			ApplicationDescription: "testing application",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
+			Users: []params.OfferUserDetails{
+				{UserName: "bob", DisplayName: "bob smith", Access: "consume"},
+			},
+		},
+		ApplicationName: "test-app",
+		CharmURL:        "ch:amd64/app-42",
+	})
+}
+
+// TestFindApplicationOffersOfferLevelAdminAccess tests that a user with
+// admin access on an offer (but not model admin) sees the full user list
+// for that offer.
+func (s *offerSuite) TestFindApplicationOffersOfferLevelAdminAccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: user has offer admin but is not model admin.
+	offerAPI := s.offerAPI(c)
+	userTag := s.setupAuthUser("bob")
+	bobUser := user.User{DisplayName: "bob smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+
+	modelName := "prod"
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(userTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
+	// User is not model admin.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+
+	offerUUID := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{
+				{Name: "bob", Access: permission.AdminAccess},
+				{Name: "george", Access: permission.ConsumeAccess},
+			},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// User has admin access on the offer.
+	offerTag := names.NewApplicationOfferTag(offerUUID)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.AdminAccess, offerTag,
+	).Return(nil)
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelName: modelName,
+				OfferName: "hosted-db2",
+			},
+		},
+	}
+
+	// Act
+	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+
+	// Assert: user sees full user list because they have offer admin.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 1)
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_.ApplicationOfferDetailsV5.SourceModelTag", tc.Ignore)
+	c.Check(obtained.Results[0], mc, params.ApplicationOfferAdminDetailsV5{
+		ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
+			OfferURL:               "bob/prod.hosted-db2",
+			OfferName:              "hosted-db2",
+			OfferUUID:              offerUUID,
+			ApplicationDescription: "testing application",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
+			Users: []params.OfferUserDetails{
+				{UserName: "bob", Access: "admin"},
+				{UserName: "george", Access: "consume"},
+			},
+		},
+		ApplicationName: "test-app",
+		CharmURL:        "ch:amd64/app-42",
+	})
+}
+
+// TestFindApplicationOffersOfferConsumeAccess tests that a user with
+// consume-level access on an offer sees the offer with limited view.
+func (s *offerSuite) TestFindApplicationOffersOfferConsumeAccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: user has consume access on the offer, not admin.
+	offerAPI := s.offerAPI(c)
+	userTag := s.setupAuthUser("bob")
+	bobUser := user.User{DisplayName: "bob smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+
+	modelName := "prod"
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(userTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
+	// User is not model admin.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+
+	offerUUID := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{
+				{Name: "bob", Access: permission.ConsumeAccess},
+				{Name: "george", Access: permission.AdminAccess},
+			},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// User has consume access on the offer (not admin).
+	offerTag := names.NewApplicationOfferTag(offerUUID)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.AdminAccess, offerTag,
+	).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.ConsumeAccess, offerTag,
+	).Return(nil)
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelName: modelName,
+				OfferName: "hosted-db2",
+			},
+		},
+	}
+
+	// Act
+	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+
+	// Assert: user sees the offer but with limited view (only own access).
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 1)
+	mc := tc.NewMultiChecker()
+	mc.AddExpr("_.ApplicationOfferDetailsV5.SourceModelTag", tc.Ignore)
+	c.Check(obtained.Results[0], mc, params.ApplicationOfferAdminDetailsV5{
+		ApplicationOfferDetailsV5: params.ApplicationOfferDetailsV5{
+			OfferURL:               "bob/prod.hosted-db2",
+			OfferName:              "hosted-db2",
+			OfferUUID:              offerUUID,
+			ApplicationDescription: "testing application",
+			Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
+			Users: []params.OfferUserDetails{
+				{UserName: "bob", DisplayName: "bob smith", Access: "consume"},
+			},
+		},
+		ApplicationName: "test-app",
+		CharmURL:        "ch:amd64/app-42",
+	})
+}
+
+// TestFindApplicationOffersPermissionCheckError tests that when the
+// permission check on an offer returns an unexpected error (not
+// ErrorEntityMissingPermission), the offer is filtered out.
+func (s *offerSuite) TestFindApplicationOffersPermissionCheckError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: user is not model admin, and permission check returns
+	// an unexpected error.
+	offerAPI := s.offerAPI(c)
+	userTag := s.setupAuthUser("bob")
+	bobUser := user.User{DisplayName: "bob smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(userTag)).Return(bobUser, nil)
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.SuperuserAccess)
+
+	modelName := "prod"
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(userTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, model.Qualifier(userTag.Id())).Return(foundModel, nil)
+	// User is not model admin.
+	s.expectEntityHasPermissionMissingPermission(userTag, permission.AdminAccess)
+
+	offerUUID := uuid.MustNewUUID().String()
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{
+		{OfferName: "hosted-db2"},
+	}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	// Permission check returns an unexpected error on admin access check.
+	offerTag := names.NewApplicationOfferTag(offerUUID)
+	s.authorizer.EXPECT().EntityHasPermission(
+		gomock.Any(), userTag, permission.AdminAccess, offerTag,
+	).Return(errors.New("unexpected database error"))
+
+	filters := params.OfferFilters{
+		Filters: []params.OfferFilter{
+			{
+				ModelName: modelName,
+				OfferName: "hosted-db2",
+			},
+		},
+	}
+
+	// Act
+	obtained, err := offerAPI.FindApplicationOffers(c.Context(), filters)
+
+	// Assert: no outer error, but offer is filtered out due to the error.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtained.Results, tc.HasLen, 0)
+}
+
+// TestDestroyOffersSuperuser tests that a controller superuser can
+// destroy offers.
+func (s *offerSuite) TestDestroyOffersSuperuser(c *tc.C) {
+	s.setupMocks(c).Finish()
+
+	// Arrange
+	offerAPI := s.offerAPI(c)
+	offerURL, _ := corecrossmodel.ParseOfferURL("fred@external/prod.hosted-mysql")
+	modelUUID := s.expectGetModelByNameAndQualifier(c, names.NewUserTag("fred@external"), offerURL.ModelName)
+	s.setupAuthUser("simon")
+	// Superuser check passes.
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, names.NewControllerTag(offerAPI.controllerUUID)).Return(nil)
+	// ModelAdmin check is not needed (superuser short-circuits).
+	_ = modelUUID
+
+	offerUUID := tc.Must(c, offer.NewUUID)
+	s.crossModelRelationService.EXPECT().GetOfferUUID(gomock.Any(), offerURL).Return(offerUUID, nil)
+	s.removalService.EXPECT().RemoveOffer(gomock.Any(), offerUUID, false).Return(nil)
+
+	args := params.DestroyApplicationOffers{
+		OfferURLs: []string{offerURL.String()},
+	}
+
+	// Act
+	results, err := offerAPI.DestroyOffers(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Assert(results.Results[0].Error, tc.IsNil)
+}
+
 func (s *offerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.accessService = NewMockAccessService(ctrl)


### PR DESCRIPTION
The `FindApplicationOffers` in tandem to other callers of `getApplicationOffersDetails` were considerably broken.

 1. Redundant check in loop - isModelAdmin was re-evaluated on every iteration of the offers loop, making repeated expensive permission calls for no reason.
 2. Blocked offer-level access - The model permission check acted as a gate, rejecting users who had valid offer-level permissions (read/consume/admin) but no direct model access. A user granted access to a specific offer could never discover it through FindApplicationOffers.
 3. isAdmin mutation bug - The admin flag was mutated across loop iterations, meaning if a user had admin on one offer, subsequent offers would skip access checks entirely.

The solution was to check the user access permission correctly against an offer.

## QA steps

The following tests should pass:

```sh
cd tests && ./main.sh cmr
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/22334

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9766](https://warthogs.atlassian.net/browse/JUJU-9766)


[JUJU-9766]: https://warthogs.atlassian.net/browse/JUJU-9766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ