### PR TITLE
feat: implement Migration mode

### DIFF
--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -118,6 +118,11 @@ type ModelState interface {
 	// changestream namespace. A change in this namespace indicates that this
 	// model has started or stopped undergoing a migration.
 	GetNamespaceModelMigrating() string
+
+	// IsModelMigrating returns true if the model has an entry in the
+	// model_migrating table, indicating that the model is currently being
+	// imported as part of a migration.
+	IsModelMigrating(ctx context.Context) (bool, error)
 }
 
 // NewService is responsible for constructing a new [Service] to handle model
@@ -241,9 +246,16 @@ func (s *Service) CheckMachines(
 
 // ModelMigrationMode returns the current migration mode for the model.
 func (s *Service) ModelMigrationMode(ctx context.Context) (modelmigration.MigrationMode, error) {
-	_, span := trace.Start(ctx, trace.NameFromFunc())
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
-	// TODO(modelmigration): implement migration mode reporting.
+
+	isMigrating, err := s.modelState.IsModelMigrating(ctx)
+	if err != nil {
+		return modelmigration.MigrationModeNone, errors.Errorf("checking if model is migrating: %w", err)
+	}
+	if isMigrating {
+		return modelmigration.MigrationModeImporting, nil
+	}
 	return modelmigration.MigrationModeNone, nil
 }
 

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -123,6 +123,11 @@ type ModelState interface {
 	// model_migrating table, indicating that the model is currently being
 	// imported as part of a migration.
 	IsModelMigrating(ctx context.Context) (bool, error)
+
+	// IsModelExporting returns true if the model has an entry in the
+	// model_exporting table, indicating that the model is currently being
+	// exported as part of a migration to another controller.
+	IsModelExporting(ctx context.Context) (bool, error)
 }
 
 // NewService is responsible for constructing a new [Service] to handle model
@@ -249,13 +254,22 @@ func (s *Service) ModelMigrationMode(ctx context.Context) (modelmigration.Migrat
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	isMigrating, err := s.modelState.IsModelMigrating(ctx)
+	isImporting, err := s.modelState.IsModelMigrating(ctx)
 	if err != nil {
-		return modelmigration.MigrationModeNone, errors.Errorf("checking if model is migrating: %w", err)
+		return modelmigration.MigrationModeNone, errors.Errorf("checking if model is importing: %w", err)
 	}
-	if isMigrating {
+	if isImporting {
 		return modelmigration.MigrationModeImporting, nil
 	}
+
+	isExporting, err := s.modelState.IsModelExporting(ctx)
+	if err != nil {
+		return modelmigration.MigrationModeNone, errors.Errorf("checking if model is exporting: %w", err)
+	}
+	if isExporting {
+		return modelmigration.MigrationModeExporting, nil
+	}
+
 	return modelmigration.MigrationModeNone, nil
 }
 

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -119,10 +119,10 @@ type ModelState interface {
 	// model has started or stopped undergoing a migration.
 	GetNamespaceModelMigrating() string
 
-	// IsModelMigrating returns true if the model has an entry in the
+	// IsModelImporting returns true if the model has an entry in the
 	// model_migrating table, indicating that the model is currently being
 	// imported as part of a migration.
-	IsModelMigrating(ctx context.Context) (bool, error)
+	IsModelImporting(ctx context.Context) (bool, error)
 
 	// IsModelExporting returns true if the model has an entry in the
 	// model_exporting table, indicating that the model is currently being
@@ -254,7 +254,7 @@ func (s *Service) ModelMigrationMode(ctx context.Context) (modelmigration.Migrat
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	isImporting, err := s.modelState.IsModelMigrating(ctx)
+	isImporting, err := s.modelState.IsModelImporting(ctx)
 	if err != nil {
 		return modelmigration.MigrationModeNone, errors.Errorf("checking if model is importing: %w", err)
 	}

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -460,6 +460,45 @@ func (c *MockModelStateGetNamespaceModelMigratingCall) DoAndReturn(f func() stri
 	return c
 }
 
+// IsModelExporting mocks base method.
+func (m *MockModelState) IsModelExporting(arg0 context.Context) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsModelExporting", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsModelExporting indicates an expected call of IsModelExporting.
+func (mr *MockModelStateMockRecorder) IsModelExporting(arg0 any) *MockModelStateIsModelExportingCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsModelExporting", reflect.TypeOf((*MockModelState)(nil).IsModelExporting), arg0)
+	return &MockModelStateIsModelExportingCall{Call: call}
+}
+
+// MockModelStateIsModelExportingCall wrap *gomock.Call
+type MockModelStateIsModelExportingCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateIsModelExportingCall) Return(arg0 bool, arg1 error) *MockModelStateIsModelExportingCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateIsModelExportingCall) Do(f func(context.Context) (bool, error)) *MockModelStateIsModelExportingCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateIsModelExportingCall) DoAndReturn(f func(context.Context) (bool, error)) *MockModelStateIsModelExportingCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // IsModelMigrating mocks base method.
 func (m *MockModelState) IsModelMigrating(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -499,41 +499,41 @@ func (c *MockModelStateIsModelExportingCall) DoAndReturn(f func(context.Context)
 	return c
 }
 
-// IsModelMigrating mocks base method.
-func (m *MockModelState) IsModelMigrating(arg0 context.Context) (bool, error) {
+// IsModelImporting mocks base method.
+func (m *MockModelState) IsModelImporting(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsModelMigrating", arg0)
+	ret := m.ctrl.Call(m, "IsModelImporting", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsModelMigrating indicates an expected call of IsModelMigrating.
-func (mr *MockModelStateMockRecorder) IsModelMigrating(arg0 any) *MockModelStateIsModelMigratingCall {
+// IsModelImporting indicates an expected call of IsModelImporting.
+func (mr *MockModelStateMockRecorder) IsModelImporting(arg0 any) *MockModelStateIsModelImportingCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsModelMigrating", reflect.TypeOf((*MockModelState)(nil).IsModelMigrating), arg0)
-	return &MockModelStateIsModelMigratingCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsModelImporting", reflect.TypeOf((*MockModelState)(nil).IsModelImporting), arg0)
+	return &MockModelStateIsModelImportingCall{Call: call}
 }
 
-// MockModelStateIsModelMigratingCall wrap *gomock.Call
-type MockModelStateIsModelMigratingCall struct {
+// MockModelStateIsModelImportingCall wrap *gomock.Call
+type MockModelStateIsModelImportingCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelStateIsModelMigratingCall) Return(arg0 bool, arg1 error) *MockModelStateIsModelMigratingCall {
+func (c *MockModelStateIsModelImportingCall) Return(arg0 bool, arg1 error) *MockModelStateIsModelImportingCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateIsModelMigratingCall) Do(f func(context.Context) (bool, error)) *MockModelStateIsModelMigratingCall {
+func (c *MockModelStateIsModelImportingCall) Do(f func(context.Context) (bool, error)) *MockModelStateIsModelImportingCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateIsModelMigratingCall) DoAndReturn(f func(context.Context) (bool, error)) *MockModelStateIsModelMigratingCall {
+func (c *MockModelStateIsModelImportingCall) DoAndReturn(f func(context.Context) (bool, error)) *MockModelStateIsModelImportingCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -460,6 +460,45 @@ func (c *MockModelStateGetNamespaceModelMigratingCall) DoAndReturn(f func() stri
 	return c
 }
 
+// IsModelMigrating mocks base method.
+func (m *MockModelState) IsModelMigrating(arg0 context.Context) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsModelMigrating", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsModelMigrating indicates an expected call of IsModelMigrating.
+func (mr *MockModelStateMockRecorder) IsModelMigrating(arg0 any) *MockModelStateIsModelMigratingCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsModelMigrating", reflect.TypeOf((*MockModelState)(nil).IsModelMigrating), arg0)
+	return &MockModelStateIsModelMigratingCall{Call: call}
+}
+
+// MockModelStateIsModelMigratingCall wrap *gomock.Call
+type MockModelStateIsModelMigratingCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelStateIsModelMigratingCall) Return(arg0 bool, arg1 error) *MockModelStateIsModelMigratingCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelStateIsModelMigratingCall) Do(f func(context.Context) (bool, error)) *MockModelStateIsModelMigratingCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelStateIsModelMigratingCall) DoAndReturn(f func(context.Context) (bool, error)) *MockModelStateIsModelMigratingCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetModelTargetAgentVersion mocks base method.
 func (m *MockModelState) SetModelTargetAgentVersion(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -362,7 +362,7 @@ func (s *serviceSuite) TestWatchForMigrationError(c *tc.C) {
 func (s *serviceSuite) TestModelMigrationModeImporting(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(true, nil)
+	s.modelState.EXPECT().IsModelImporting(gomock.Any()).Return(true, nil)
 
 	mode, err := NewService(
 		s.controllerState,
@@ -382,7 +382,7 @@ func (s *serviceSuite) TestModelMigrationModeImporting(c *tc.C) {
 func (s *serviceSuite) TestModelMigrationModeExporting(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, nil)
+	s.modelState.EXPECT().IsModelImporting(gomock.Any()).Return(false, nil)
 	s.modelState.EXPECT().IsModelExporting(gomock.Any()).Return(true, nil)
 
 	mode, err := NewService(
@@ -403,7 +403,7 @@ func (s *serviceSuite) TestModelMigrationModeExporting(c *tc.C) {
 func (s *serviceSuite) TestModelMigrationModeNone(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, nil)
+	s.modelState.EXPECT().IsModelImporting(gomock.Any()).Return(false, nil)
 	s.modelState.EXPECT().IsModelExporting(gomock.Any()).Return(false, nil)
 
 	mode, err := NewService(
@@ -423,7 +423,7 @@ func (s *serviceSuite) TestModelMigrationModeNone(c *tc.C) {
 func (s *serviceSuite) TestModelMigrationModeImportingError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, errors.Errorf("boom"))
+	s.modelState.EXPECT().IsModelImporting(gomock.Any()).Return(false, errors.Errorf("boom"))
 
 	_, err := NewService(
 		s.controllerState,
@@ -441,7 +441,7 @@ func (s *serviceSuite) TestModelMigrationModeImportingError(c *tc.C) {
 func (s *serviceSuite) TestModelMigrationModeExportingError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, nil)
+	s.modelState.EXPECT().IsModelImporting(gomock.Any()).Return(false, nil)
 	s.modelState.EXPECT().IsModelExporting(gomock.Any()).Return(false, errors.Errorf("boom"))
 
 	_, err := NewService(

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -376,13 +376,35 @@ func (s *serviceSuite) TestModelMigrationModeImporting(c *tc.C) {
 	c.Check(mode, tc.Equals, modelmigration.MigrationModeImporting)
 }
 
-// TestModelMigrationModeNone tests that ModelMigrationMode returns
-// MigrationModeNone when the model has no entry in the model_migrating
+// TestModelMigrationModeExporting tests that ModelMigrationMode returns
+// MigrationModeExporting when the model has an entry in the model_exporting
 // table.
+func (s *serviceSuite) TestModelMigrationModeExporting(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, nil)
+	s.modelState.EXPECT().IsModelExporting(gomock.Any()).Return(true, nil)
+
+	mode, err := NewService(
+		s.controllerState,
+		s.modelState,
+		"test-model-uuid",
+		s.watcherFactory,
+		s.instanceProviderGetter(c),
+		s.resourceProviderGetter(c),
+	).ModelMigrationMode(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(mode, tc.Equals, modelmigration.MigrationModeExporting)
+}
+
+// TestModelMigrationModeNone tests that ModelMigrationMode returns
+// MigrationModeNone when the model has no entry in the model_migrating or
+// model_exporting tables.
 func (s *serviceSuite) TestModelMigrationModeNone(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, nil)
+	s.modelState.EXPECT().IsModelExporting(gomock.Any()).Return(false, nil)
 
 	mode, err := NewService(
 		s.controllerState,
@@ -396,12 +418,31 @@ func (s *serviceSuite) TestModelMigrationModeNone(c *tc.C) {
 	c.Check(mode, tc.Equals, modelmigration.MigrationModeNone)
 }
 
-// TestModelMigrationModeError tests that ModelMigrationMode returns an error
-// when the state layer fails.
-func (s *serviceSuite) TestModelMigrationModeError(c *tc.C) {
+// TestModelMigrationModeImportingError tests that ModelMigrationMode returns an
+// error when the importing check fails.
+func (s *serviceSuite) TestModelMigrationModeImportingError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, errors.Errorf("boom"))
+
+	_, err := NewService(
+		s.controllerState,
+		s.modelState,
+		"test-model-uuid",
+		s.watcherFactory,
+		s.instanceProviderGetter(c),
+		s.resourceProviderGetter(c),
+	).ModelMigrationMode(c.Context())
+	c.Assert(err, tc.ErrorMatches, ".*boom")
+}
+
+// TestModelMigrationModeExportingError tests that ModelMigrationMode returns an
+// error when the exporting check fails.
+func (s *serviceSuite) TestModelMigrationModeExportingError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, nil)
+	s.modelState.EXPECT().IsModelExporting(gomock.Any()).Return(false, errors.Errorf("boom"))
 
 	_, err := NewService(
 		s.controllerState,

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/domain/modelmigration"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/internal/errors"
 )
@@ -352,6 +353,64 @@ func (s *serviceSuite) TestWatchForMigrationError(c *tc.C) {
 		s.resourceProviderGetter(c),
 	)
 	_, err := svc.WatchForMigration(c.Context())
+	c.Assert(err, tc.ErrorMatches, ".*boom")
+}
+
+// TestModelMigrationModeImporting tests that ModelMigrationMode returns
+// MigrationModeImporting when the model has an entry in the model_migrating
+// table.
+func (s *serviceSuite) TestModelMigrationModeImporting(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(true, nil)
+
+	mode, err := NewService(
+		s.controllerState,
+		s.modelState,
+		"test-model-uuid",
+		s.watcherFactory,
+		s.instanceProviderGetter(c),
+		s.resourceProviderGetter(c),
+	).ModelMigrationMode(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(mode, tc.Equals, modelmigration.MigrationModeImporting)
+}
+
+// TestModelMigrationModeNone tests that ModelMigrationMode returns
+// MigrationModeNone when the model has no entry in the model_migrating
+// table.
+func (s *serviceSuite) TestModelMigrationModeNone(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, nil)
+
+	mode, err := NewService(
+		s.controllerState,
+		s.modelState,
+		"test-model-uuid",
+		s.watcherFactory,
+		s.instanceProviderGetter(c),
+		s.resourceProviderGetter(c),
+	).ModelMigrationMode(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(mode, tc.Equals, modelmigration.MigrationModeNone)
+}
+
+// TestModelMigrationModeError tests that ModelMigrationMode returns an error
+// when the state layer fails.
+func (s *serviceSuite) TestModelMigrationModeError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelState.EXPECT().IsModelMigrating(gomock.Any()).Return(false, errors.Errorf("boom"))
+
+	_, err := NewService(
+		s.controllerState,
+		s.modelState,
+		"test-model-uuid",
+		s.watcherFactory,
+		s.instanceProviderGetter(c),
+		s.resourceProviderGetter(c),
+	).ModelMigrationMode(c.Context())
 	c.Assert(err, tc.ErrorMatches, ".*boom")
 }
 

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -177,6 +177,41 @@ WHERE model_uuid = $entityUUID.uuid`, count{}, entityUUID{})
 	return result.Count > 0, nil
 }
 
+// IsModelExporting returns true if the model has an entry in the
+// model_exporting table, indicating that the model is currently being
+// exported as part of a migration to another controller.
+func (s *State) IsModelExporting(ctx context.Context) (bool, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	var result count
+	stmt, err := s.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM model_exporting
+WHERE model_uuid = $entityUUID.uuid`, count{}, entityUUID{})
+	if err != nil {
+		return false, errors.Errorf("preparing is model exporting statement: %w", err)
+	}
+
+	modelUUIDArg := entityUUID{
+		UUID: s.modelUUID.String(),
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, stmt, modelUUIDArg).Get(&result); err != nil {
+			return errors.Errorf("checking if model is exporting: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return result.Count > 0, nil
+}
+
 // GetModelTargetAgentVersion returns the target agent version currently set for
 // the model. This func expects that the target agent version for the model has
 // already been set.

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -142,6 +142,41 @@ WHERE model_uuid = $entityUUID.uuid
 	})
 }
 
+// IsModelMigrating returns true if the model has an entry in the
+// model_migrating table, indicating that the model is currently being
+// imported as part of a migration.
+func (s *State) IsModelMigrating(ctx context.Context) (bool, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	var result count
+	stmt, err := s.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM model_migrating
+WHERE model_uuid = $entityUUID.uuid`, count{}, entityUUID{})
+	if err != nil {
+		return false, errors.Errorf("preparing is model migrating statement: %w", err)
+	}
+
+	modelUUIDArg := entityUUID{
+		UUID: s.modelUUID.String(),
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, stmt, modelUUIDArg).Get(&result); err != nil {
+			return errors.Errorf("checking if model is migrating: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return result.Count > 0, nil
+}
+
 // GetModelTargetAgentVersion returns the target agent version currently set for
 // the model. This func expects that the target agent version for the model has
 // already been set.

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -142,10 +142,10 @@ WHERE model_uuid = $entityUUID.uuid
 	})
 }
 
-// IsModelMigrating returns true if the model has an entry in the
+// IsModelImporting returns true if the model has an entry in the
 // model_migrating table, indicating that the model is currently being
 // imported as part of a migration.
-func (s *State) IsModelMigrating(ctx context.Context) (bool, error) {
+func (s *State) IsModelImporting(ctx context.Context) (bool, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
 		return false, errors.Capture(err)

--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -309,6 +309,31 @@ func (s *migrationSuite) TestIsModelMigratingFalse(c *tc.C) {
 	c.Check(isMigrating, tc.IsFalse)
 }
 
+// TestIsModelExportingTrue tests that IsModelExporting returns true
+// when the model has an entry in the model_exporting table.
+func (s *migrationSuite) TestIsModelExportingTrue(c *tc.C) {
+	db := s.DB()
+
+	// Insert a model_exporting entry.
+	exportingUUID := uuid.MustNewUUID().String()
+	_, err := db.ExecContext(c.Context(),
+		"INSERT INTO model_exporting (uuid, model_uuid) VALUES (?, ?)",
+		exportingUUID, s.modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	isExporting, err := New(s.TxnRunnerFactory(), s.modelUUID).IsModelExporting(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(isExporting, tc.IsTrue)
+}
+
+// TestIsModelExportingFalse tests that IsModelExporting returns false
+// when the model has no entry in the model_exporting table.
+func (s *migrationSuite) TestIsModelExportingFalse(c *tc.C) {
+	isExporting, err := New(s.TxnRunnerFactory(), s.modelUUID).IsModelExporting(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(isExporting, tc.IsFalse)
+}
+
 func (s *migrationSuite) TestSetModelTargetAgentVersionDifferentVersion(c *tc.C) {
 	toVersion := semversion.MustParse("5.2.0").String()
 

--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -284,6 +284,31 @@ func (s *migrationSuite) TestSetModelTargetAgentVersion(c *tc.C) {
 	c.Check(ver, tc.Equals, "5.2.0")
 }
 
+// TestIsModelMigratingTrue tests that IsModelMigrating returns true
+// when the model has an entry in the model_migrating table.
+func (s *migrationSuite) TestIsModelMigratingTrue(c *tc.C) {
+	db := s.DB()
+
+	// Insert a model_migrating entry.
+	migratingUUID := uuid.MustNewUUID().String()
+	_, err := db.ExecContext(c.Context(),
+		"INSERT INTO model_migrating (uuid, model_uuid) VALUES (?, ?)",
+		migratingUUID, s.modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	isMigrating, err := New(s.TxnRunnerFactory(), s.modelUUID).IsModelMigrating(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(isMigrating, tc.IsTrue)
+}
+
+// TestIsModelMigratingFalse tests that IsModelMigrating returns false
+// when the model has no entry in the model_migrating table.
+func (s *migrationSuite) TestIsModelMigratingFalse(c *tc.C) {
+	isMigrating, err := New(s.TxnRunnerFactory(), s.modelUUID).IsModelMigrating(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(isMigrating, tc.IsFalse)
+}
+
 func (s *migrationSuite) TestSetModelTargetAgentVersionDifferentVersion(c *tc.C) {
 	toVersion := semversion.MustParse("5.2.0").String()
 

--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -284,9 +284,9 @@ func (s *migrationSuite) TestSetModelTargetAgentVersion(c *tc.C) {
 	c.Check(ver, tc.Equals, "5.2.0")
 }
 
-// TestIsModelMigratingTrue tests that IsModelMigrating returns true
+// TestIsModelImportingTrue tests that IsModelImporting returns true
 // when the model has an entry in the model_migrating table.
-func (s *migrationSuite) TestIsModelMigratingTrue(c *tc.C) {
+func (s *migrationSuite) TestIsModelImportingTrue(c *tc.C) {
 	db := s.DB()
 
 	// Insert a model_migrating entry.
@@ -296,15 +296,15 @@ func (s *migrationSuite) TestIsModelMigratingTrue(c *tc.C) {
 		migratingUUID, s.modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
-	isMigrating, err := New(s.TxnRunnerFactory(), s.modelUUID).IsModelMigrating(c.Context())
+	isMigrating, err := New(s.TxnRunnerFactory(), s.modelUUID).IsModelImporting(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(isMigrating, tc.IsTrue)
 }
 
-// TestIsModelMigratingFalse tests that IsModelMigrating returns false
+// TestIsModelImportingFalse tests that IsModelImporting returns false
 // when the model has no entry in the model_migrating table.
-func (s *migrationSuite) TestIsModelMigratingFalse(c *tc.C) {
-	isMigrating, err := New(s.TxnRunnerFactory(), s.modelUUID).IsModelMigrating(c.Context())
+func (s *migrationSuite) TestIsModelImportingFalse(c *tc.C) {
+	isMigrating, err := New(s.TxnRunnerFactory(), s.modelUUID).IsModelImporting(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(isMigrating, tc.IsFalse)
 }

--- a/domain/modelmigration/state/model/types.go
+++ b/domain/modelmigration/state/model/types.go
@@ -20,6 +20,11 @@ type entityUUID struct {
 	UUID string `db:"uuid"`
 }
 
+// count is a helper type used with sqlair to read a COUNT(*) result.
+type count struct {
+	Count int `db:"count"`
+}
+
 // agentVersionTarget represents the target agent version column from the
 // agent_version table.
 type agentVersionTarget struct {

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -173,6 +173,11 @@ var modelPostPatchFilesByVersion = []struct {
 	files: []string{
 		"0057-model-migrating-triggers.PATCH.sql",
 	},
+}, {
+	version: semversion.MustParse("4.0.9"),
+	files: []string{
+		"0058-model-exporting.PATCH.sql",
+	},
 }}
 
 // ModelDDL is used to create model databases.

--- a/domain/schema/model/sql/0058-model-exporting.PATCH.sql
+++ b/domain/schema/model/sql/0058-model-exporting.PATCH.sql
@@ -1,0 +1,15 @@
+-- This PATCH adds the model_exporting table.
+-- An entry in this table indicates that the model is currently being
+-- exported as part of a migration to another controller. It is the
+-- counterpart to model_migrating, which tracks the importing side.
+
+CREATE TABLE model_exporting (
+    uuid TEXT NOT NULL PRIMARY KEY,
+    model_uuid TEXT NOT NULL,
+    CONSTRAINT fk_model_exporting_model
+    FOREIGN KEY (model_uuid)
+    REFERENCES model (uuid)
+);
+
+CREATE UNIQUE INDEX idx_model_exporting_model_uuid
+ON model_exporting (model_uuid);

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -140,6 +140,7 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		// Model config
 		"model_config",
 		"model_constraint",
+		"model_exporting",
 		"model_migrating",
 
 		// Object store metadata


### PR DESCRIPTION
__Note: this PR targets 4.0 (instead of main) because this work will be necessary for the model export when migrating from 4.0 to 4.1.__

Fills in the `ModelMigrationMode()` model migration domain method, which previously returned `MigrationModeNone` for every   
model. Callers such as the login flow, log transfer, and migration precheck now get an accurate answer  
for models that are mid-migration.
                                                       
##### Importing detection (commit 1)                                                                          
- Replaces the TODO stub in `domain/modelmigration/service` with a real implementation that queries the
model database via a new `IsModelMigrating` state method.                                                 
- When a row exists in the existing `model_migrating` table for the model, the service returns
`MigrationModeImporting` mode.                                                                                 
                                                                                                          
##### Exporting detection (commit 2)
- Adds a new `model_exporting` table to the model database, mirroring the shape of `model_migrating`. An    
entry indicates the model is currently being exported as part of a migration to another controller.     
- The table is introduced via 0058-model-exporting.PATCH.sql and registered under a new 4.0.9 entry in the patches list.                       
- Adds `IsModelExporting` to the state layer and extends `ModelMigrationMode()` to return            
`MigrationModeExporting` mode when the table has a row for the model.

_It is unfortunate that we named the table `model_migrating` instead of `model_importing`._                  
                                                                            
##### What is intentionally not in this PR
                                                                                                          
- The controller-side model_migration table is left untouched. It will be populated as part of the      
InitiateMigration implementation, which is also responsible for inserting into model_exporting on the
export side.                                                                                            

## QA steps

Nothing wired yet, the domain is currently being implemented.

## Links

**Jira card:** [JUJU-9750](https://warthogs.atlassian.net/browse/JUJU-9750)


[JUJU-9750]: https://warthogs.atlassian.net/browse/JUJU-9750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ