### PR TITLE
docs: add package-level documentation for generate package

### DIFF
--- a/generate/doc.go
+++ b/generate/doc.go
@@ -3,16 +3,18 @@
 
 // Package generate provides code generation tools for Juju.
 //
-// Code generators are Go programs that produce source files, schemas, and test
-// data from templates, database schemas, or API definitions. Generators are
-// invoked via go generate directives embedded in source files or via Make
-// targets -- filetoconst converts files to Go constants, schemagen produces
-// JSON schemas for API facades, ddlgen creates DDL snapshots for schema
-// verification, triggergen generates database change triggers, certgen creates
-// test certificates, cloudcred generates credential schemas from registered
-// providers, and export generates export-related code from database schemas.
+// These tools are build-time programs invoked via go generate directives or
+// Make targets that transform inputs into generated artifacts as below:
 //
-// See the subpackages below for individual generator documentation. See the
+//   - certgen transforms PKI profiles into test certificates
+//   - cloudcred transforms registered provider schemas into credential metadata
+//   - ddlgen transforms database schemas into DDL snapshots for verification
+//   - export transforms database schemas into export-related code
+//   - filetoconst transforms files into Go string constants
+//   - schemagen transforms API facade definitions into JSON schemas
+//   - triggergen transforms database table definitions into change triggers
+//
+// See the subpackages for individual generator documentation. See the
 // Makefile for build-time generation targets (schema-gen, trigger-gen, ddl-gen,
 // export-gen). See go generate directives in domain/schema/controller.go and
 // domain/schema/model.go for trigger generation patterns.

--- a/generate/doc.go
+++ b/generate/doc.go
@@ -1,6 +1,19 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// Package generate provides code generation tools for Juju.
+//
+// Code generators are Go programs that produce source files, schemas, and test
+// data from templates, database schemas, or API definitions. Generators are
+// invoked via go generate directives embedded in source files or via Make
+// targets -- filetoconst converts files to Go constants, schemagen produces
+// JSON schemas for API facades, ddlgen creates DDL snapshots for schema
+// verification, triggergen generates database change triggers, certgen creates
+// test certificates, cloudcred generates credential schemas from registered
+// providers, and export generates export-related code from database schemas.
+//
+// See the subpackages below for individual generator documentation. See the
+// Makefile for build-time generation targets (schema-gen, trigger-gen, ddl-gen,
+// export-gen). See go generate directives in domain/schema/controller.go and
+// domain/schema/model.go for trigger generation patterns.
 package generate
-
-// Package generate contains commands called by go generate.


### PR DESCRIPTION
This PR expands the doc.go for the generate package from a stub to something that complies with the guidelines in our AGENTS.doc-dot-go-rules.md file. 

## Links

**Jira card:** [JUJU-9468](https://warthogs.atlassian.net/browse/JUJU-9468)

[JUJU-9468]: https://warthogs.atlassian.net/browse/JUJU-9468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ