### PR TITLE
docs: add package-level documentation for controller package

### DIFF
--- a/controller/doc.go
+++ b/controller/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package controller provides controller configuration for Juju.
+//
+// This configuration defines operational settings for a Juju controller (API
+// configuration, auditing, rate limiting, logging, etc.). Configuration is
+// stored as key-value pairs validated against a schema, with keys defined as
+// constants (APIPort, AuditingEnabled, AgentRateLimitMax, etc.) and values
+// coerced to appropriate types (integers, durations, strings, etc.). Controllers
+// use this configuration to control runtime behavior across all models they
+// manage.
+//
+// See github.com/juju/juju/apiserver for how controllers use this
+// configuration. See github.com/juju/juju/cmd/juju/controller for CLI commands
+// that manipulate controller configuration.
+package controller


### PR DESCRIPTION
This PR adds doc.go for the controller package, which previously had no  package-level documentation. The documentation complies with the guidelines  in AGENTS.doc-dot-go-rules.md.

## Links

**Jira card:** [JUJU-9465](https://warthogs.atlassian.net/browse/JUJU-9465)


[JUJU-9465]: https://warthogs.atlassian.net/browse/JUJU-9465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ