### PR TITLE
chore: reduce roundtrips for ProvisioningInfo call

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -630,7 +630,7 @@ func (api *ProvisionerAPI) DistributionGroup(ctx context.Context, args params.En
 // commonServiceInstances returns instances with
 // services in common with the specified machine.
 func (api *ProvisionerAPI) commonServiceInstances(ctx context.Context, machineName coremachine.Name) ([]instance.Id, error) {
-	unitNames, err := api.applicationService.GetUnitNamesOnMachine(ctx, machineName)
+	unitNames, err := api.applicationService.GetUnitNamesWithPrincipalOnMachine(ctx, machineName)
 	if errors.Is(err, applicationerrors.MachineNotFound) {
 		return nil, errors.Errorf(
 			"machine %q not found", machineName,
@@ -639,14 +639,12 @@ func (api *ProvisionerAPI) commonServiceInstances(ctx context.Context, machineNa
 		return nil, errors.Capture(err)
 	}
 	instanceIdSet := make(set.Strings)
-	for _, unitName := range unitNames {
-		if _, isPrincipal, err := api.applicationService.GetUnitPrincipal(ctx, unitName); err != nil {
-			return nil, errors.Capture(err)
-		} else if !isPrincipal {
+	for _, u := range unitNames {
+		if u.IsSubordinate() {
 			continue
 		}
 
-		appName := unitName.Application()
+		appName := u.Name.Application()
 		machineNames, err := api.applicationService.GetMachinesForApplication(ctx, appName)
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
 			return nil, errors.Errorf(
@@ -746,12 +744,12 @@ func (api *ProvisionerAPI) Constraints(ctx context.Context, args params.Entities
 			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
-		cons, err := api.machineService.GetMachineConstraints(ctx, coremachine.Name(tag.Id()))
+		pInfo, err := api.machineService.GetMachineProvisioningInfo(ctx, coremachine.Name(tag.Id()))
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		result.Results[i].Constraints = cons
+		result.Results[i].Constraints = pInfo.Constraints
 	}
 	return result, nil
 }

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/cloudimagemetadata"
+	"github.com/juju/juju/domain/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/domain/network/errors"
@@ -861,10 +862,10 @@ func (s *provisionerMockSuite) setupProvisioningInfoPrereqsWithSpaces(c *tc.C, s
 // getProvisioningInfo successfully with minimal result.
 func (s *provisionerMockSuite) setupMachineForProvisioning(machineName coremachine.Name, machineUUID coremachine.UUID) {
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(constraints.Value{}, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).Return(nil, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base: corebase.MakeDefaultBase("ubuntu", "22.04"),
+	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
 	s.cloudImageMetadataService.EXPECT().FindMetadata(gomock.Any(), gomock.Any()).
@@ -908,10 +909,10 @@ func (s *provisionerMockSuite) TestProvisioningInfoWithStorage(c *tc.C) {
 	machineName := coremachine.Name("0")
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(constraints.Value{}, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).Return(nil, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base: corebase.MakeDefaultBase("ubuntu", "22.04"),
+	}, nil)
 
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(
@@ -963,14 +964,11 @@ func (s *provisionerMockSuite) TestProvisioningInfoWithRootDisk(c *tc.C) {
 
 	machineUUID := machinetesting.GenUUID(c)
 	machineName := coremachine.Name("0")
-	rootDiskSource := "my-pool"
-
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(constraints.Value{
-		RootDiskSource: &rootDiskSource,
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).Return(nil, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base:        corebase.MakeDefaultBase("ubuntu", "22.04"),
+		Constraints: constraints.Value{RootDiskSource: new("my-pool")},
 	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
@@ -1021,10 +1019,10 @@ func (s *provisionerMockSuite) TestProvisioningInfoCloudInitUserData(c *tc.C) {
 	machineUUID := machinetesting.GenUUID(c)
 	machineName := coremachine.Name("0")
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(constraints.Value{}, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).Return(nil, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base: corebase.MakeDefaultBase("ubuntu", "22.04"),
+	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
 	s.cloudImageMetadataService.EXPECT().FindMetadata(gomock.Any(), gomock.Any()).
@@ -1061,29 +1059,23 @@ func (s *provisionerMockSuite) TestProvisioningInfoWithEndpointBindings(c *tc.C)
 	unitName := coreunit.Name("myapp/0")
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).
-		Return([]coreunit.Name{unitName}, nil)
-	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).
-		Return(coreunit.Name(""), true, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).
+		Return([]coreunit.NameWithPrincipal{{Name: unitName}}, nil)
 	s.applicationService.EXPECT().GetApplicationEndpointBindings(gomock.Any(), "myapp").
 		Return(map[string]network.SpaceUUID{
 			"":    spaceUUID,
 			"web": spaceUUID,
 		}, nil)
 
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(constraints.Value{}, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base: corebase.MakeDefaultBase("ubuntu", "22.04"),
+	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
 	s.cloudImageMetadataService.EXPECT().FindMetadata(gomock.Any(), gomock.Any()).
 		Return(map[string][]cloudimagemetadata.Metadata{
 			"default": {{ImageID: "img-1"}},
 		}, nil)
-
-	// For machineTags — GetUnitPrincipal is called again.
-	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).
-		Return(coreunit.Name(""), true, nil)
 
 	// machineSpaceTopology calls SpaceByName for bound spaces.
 	s.networkService.EXPECT().SpaceByName(gomock.Any(), network.SpaceName("myspace")).Return(&network.SpaceInfo{
@@ -1132,10 +1124,11 @@ func (s *provisionerMockSuite) TestProvisioningInfoWithMultiplePositiveSpaceCons
 	cons := constraints.MustParse("spaces=" + spaceConstraints)
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(cons, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).Return(nil, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base:        corebase.MakeDefaultBase("ubuntu", "22.04"),
+		Constraints: cons,
+	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
 	s.cloudImageMetadataService.EXPECT().FindMetadata(gomock.Any(), gomock.Any()).
@@ -1195,10 +1188,11 @@ func (s *provisionerMockSuite) TestProvisioningInfoWithUnsuitableSpacesConstrain
 	cons := constraints.MustParse("spaces=empty")
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(cons, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).Return(nil, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base:        corebase.MakeDefaultBase("ubuntu", "22.04"),
+		Constraints: cons,
+	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
 	s.cloudImageMetadataService.EXPECT().FindMetadata(gomock.Any(), gomock.Any()).
@@ -1245,28 +1239,23 @@ func (s *provisionerMockSuite) TestProvisioningInfoConflictingNegativeConstraint
 	cons := constraints.MustParse("spaces=^myspace")
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).
-		Return([]coreunit.Name{unitName}, nil)
-	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).
-		Return(coreunit.Name(""), true, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).
+		Return([]coreunit.NameWithPrincipal{{Name: unitName}}, nil)
 	s.applicationService.EXPECT().GetApplicationEndpointBindings(gomock.Any(), "myapp").
 		Return(map[string]network.SpaceUUID{
 			"web": spaceUUID,
 		}, nil)
 
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(cons, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base:        corebase.MakeDefaultBase("ubuntu", "22.04"),
+		Constraints: cons,
+	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
 	s.cloudImageMetadataService.EXPECT().FindMetadata(gomock.Any(), gomock.Any()).
 		Return(map[string][]cloudimagemetadata.Metadata{
 			"default": {{ImageID: "img-1"}},
 		}, nil)
-
-	// For machineTags.
-	s.applicationService.EXPECT().GetUnitPrincipal(gomock.Any(), unitName).
-		Return(coreunit.Name(""), true, nil)
 
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "machine-0"},
@@ -1289,10 +1278,11 @@ func (s *provisionerMockSuite) TestProvisioningInfoWithPlacement(c *tc.C) {
 	placement := "zone=us-east-1a"
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(&placement, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(constraints.Value{}, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).Return(nil, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base:               corebase.MakeDefaultBase("ubuntu", "22.04"),
+		PlacementDirective: &placement,
+	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
 	s.cloudImageMetadataService.EXPECT().FindMetadata(gomock.Any(), gomock.Any()).
@@ -1321,10 +1311,11 @@ func (s *provisionerMockSuite) TestProvisioningInfoWithConstraints(c *tc.C) {
 	cons := constraints.MustParse("cores=4 mem=8G")
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machineName).Return(machineUUID, nil)
-	s.applicationService.EXPECT().GetUnitNamesOnMachine(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineBase(gomock.Any(), machineName).Return(corebase.MakeDefaultBase("ubuntu", "22.04"), nil)
-	s.machineService.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName).Return(nil, nil)
-	s.machineService.EXPECT().GetMachineConstraints(gomock.Any(), machineName).Return(cons, nil)
+	s.applicationService.EXPECT().GetUnitNamesWithPrincipalOnMachine(gomock.Any(), machineName).Return(nil, nil)
+	s.machineService.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName).Return(machine.ProvisioningInfo{
+		Base:        corebase.MakeDefaultBase("ubuntu", "22.04"),
+		Constraints: cons,
+	}, nil)
 	s.storageProvisioningService.EXPECT().GetMachineProvisioningVolumeParams(gomock.Any(), machineUUID).
 		Return(nil, nil, nil)
 	s.cloudImageMetadataService.EXPECT().FindMetadata(gomock.Any(), gomock.Any()).

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -123,14 +123,12 @@ func (api *ProvisionerAPI) getProvisioningInfo(
 	machineUUID, err := api.machineService.GetMachineUUID(ctx, machineName)
 	switch {
 	case errors.Is(err, machineerrors.MachineNotFound):
-		return nil, errors.Errorf(
-			"machine %q does not exist", machineName,
-		).Add(coreerrors.NotFound)
+		return nil, errors.Errorf("machine %q does not exist", machineName).Add(coreerrors.NotFound)
 	case err != nil:
 		return nil, errors.Errorf("getting machine %q uuid: %w", machineName, err)
 	}
 
-	unitNames, err := api.applicationService.GetUnitNamesOnMachine(ctx, machineName)
+	unitNames, err := api.applicationService.GetUnitNamesWithPrincipalOnMachine(ctx, machineName)
 	if err != nil {
 		return nil, errors.Errorf("getting unit names on machine %q: %w", machineName, err)
 	}
@@ -177,60 +175,45 @@ func (api *ProvisionerAPI) getProvisioningInfoBase(
 	ctx context.Context,
 	machineName coremachine.Name,
 	machineUUID coremachine.UUID,
-	unitNames []coreunit.Name,
+	unitNames []coreunit.NameWithPrincipal,
 	endpointBindings map[string]string,
 	cloudInitUserData map[string]any,
 	imageStream string,
 	resourceTags tags.ResourceTagger,
 	cloudRegionSpec simplestreams.CloudSpec,
 ) (params.ProvisioningInfo, error) {
-	// TODO (stickupkid): Refactor these, so that we can just do this in
-	// one call (probably called GetProvisioningInfo) to the machine service.
-	machineBase, err := api.machineService.GetMachineBase(ctx, machineName)
+	pInfo, err := api.machineService.GetMachineProvisioningInfo(ctx, machineName)
 	if errors.Is(err, machineerrors.MachineNotFound) {
 		return params.ProvisioningInfo{}, apiservererrors.ServerError(jujuerrors.NotFoundf("machine %q", machineName))
 	} else if err != nil {
-		return params.ProvisioningInfo{}, errors.Errorf("getting machine base: %w", err)
+		return params.ProvisioningInfo{}, errors.Errorf("getting machine provisioning info: %w", err)
 	}
-	machinePlacement, err := api.machineService.GetMachinePlacementDirective(ctx, machineName)
-	if err != nil {
-		return params.ProvisioningInfo{}, errors.Errorf("getting machine placement directive: %w", err)
-	}
-	machineConstraints, err := api.machineService.GetMachineConstraints(ctx, machineName)
+	volumes, volumeAttachments, err := api.machineVolumeParams(ctx, machineName, machineUUID)
 	if err != nil {
 		return params.ProvisioningInfo{}, errors.Capture(err)
 	}
 
-	volumes, volumeAttachments, err := api.machineVolumeParams(
-		ctx, machineName, machineUUID,
-	)
+	rootDisk, err := api.machineRootDiskParams(ctx, pInfo.Constraints)
 	if err != nil {
 		return params.ProvisioningInfo{}, errors.Capture(err)
 	}
 
-	rootDisk, err := api.machineRootDiskParams(
-		ctx, machineConstraints,
-	)
-	if err != nil {
-		return params.ProvisioningInfo{}, errors.Capture(err)
-	}
-
-	imageMetadata, err := api.availableImageMetadata(ctx, machineName, machineBase, machineConstraints, imageStream, cloudRegionSpec)
+	imageMetadata, err := api.availableImageMetadata(ctx, pInfo.Base, pInfo.Constraints, imageStream, cloudRegionSpec)
 	if err != nil {
 		return params.ProvisioningInfo{}, errors.Errorf("cannot get available image metadata: %w", err)
 	}
 
 	result := params.ProvisioningInfo{
 		Base: params.Base{
-			Name:    machineBase.OS,
-			Channel: machineBase.Channel.String(),
+			Name:    pInfo.Base.OS,
+			Channel: pInfo.Base.Channel.String(),
 		},
 		CloudInitUserData: cloudInitUserData,
 		// EndpointBindings are used by MAAS by the provider. Operator defined
 		// space bindings are reflected in ProvisioningNetworkTopology.
 		EndpointBindings:  endpointBindings,
-		Constraints:       machineConstraints,
-		Placement:         unptr(machinePlacement),
+		Constraints:       pInfo.Constraints,
+		Placement:         unptr(pInfo.PlacementDirective),
 		Volumes:           volumes,
 		VolumeAttachments: volumeAttachments,
 		RootDisk:          rootDisk,
@@ -241,7 +224,7 @@ func (api *ProvisionerAPI) getProvisioningInfoBase(
 	// the processing as no controller-specific jobs or tags are required.
 	if !api.isControllerModel {
 		result.Jobs = []model.MachineJob{model.JobHostUnits}
-		result.Tags, err = api.machineTags(ctx, unitNames, machineName, false, resourceTags)
+		result.Tags, err = api.machineTags(unitNames, machineName, false, resourceTags)
 		if err != nil {
 			return result, errors.Capture(err)
 		}
@@ -268,7 +251,7 @@ func (api *ProvisionerAPI) getProvisioningInfoBase(
 	}
 	result.Jobs = jobs
 
-	result.Tags, err = api.machineTags(ctx, unitNames, machineName, isController, resourceTags)
+	result.Tags, err = api.machineTags(unitNames, machineName, isController, resourceTags)
 	if err != nil {
 		return result, errors.Capture(err)
 	}
@@ -386,26 +369,19 @@ func (api *ProvisionerAPI) machineRootDiskParams(
 
 // machineTags returns machine-specific tags to set on the instance.
 func (api *ProvisionerAPI) machineTags(
-	ctx context.Context,
-	unitNames []coreunit.Name,
+	unitNames []coreunit.NameWithPrincipal,
 	machineName coremachine.Name,
 	isController bool,
 	resourceTags tags.ResourceTagger,
 ) (map[string]string, error) {
 	// Names of all units deployed to the machine.
-	//
-	// TODO(axw) 2015-06-02 #1461358
-	// We need a worker that periodically updates
-	// instance tags with current deployment info.
 	principalUnitNames := make([]string, 0, len(unitNames))
 	for _, unitName := range unitNames {
-		_, isPrincipal, err := api.applicationService.GetUnitPrincipal(ctx, unitName)
-		if err != nil {
-			return nil, errors.Errorf("getting unit principal for unit %q: %w", unitName, err)
+		principleUnit := unitName.Name
+		if unitName.IsSubordinate() {
+			principleUnit = *unitName.Principal
 		}
-		if isPrincipal {
-			principalUnitNames = append(principalUnitNames, unitName.String())
-		}
+		principalUnitNames = append(principalUnitNames, principleUnit.String())
 	}
 	sort.Strings(principalUnitNames)
 
@@ -552,18 +528,17 @@ func (api *ProvisionerAPI) subnetsAndZonesForSpace(
 	return subnetsToZones, nil
 }
 
-func (api *ProvisionerAPI) machineEndpointBindings(ctx context.Context, unitNames []coreunit.Name) (map[string]map[string]network.SpaceUUID, error) {
+func (api *ProvisionerAPI) machineEndpointBindings(
+	ctx context.Context,
+	unitNames []coreunit.NameWithPrincipal,
+) (map[string]map[string]network.SpaceUUID, error) {
 	endpointBindings := make(map[string]map[string]network.SpaceUUID)
 	for _, unitName := range unitNames {
-		_, isPrincipal, err := api.applicationService.GetUnitPrincipal(ctx, unitName)
-		if err != nil {
-			return nil, errors.Errorf("checking principal for unit %q: %w", unitName, err)
-		}
-		if !isPrincipal {
+		if unitName.IsSubordinate() {
 			continue
 		}
 
-		appName := unitName.Application()
+		appName := unitName.Name.Application()
 		if _, ok := endpointBindings[appName]; ok {
 			// Already processed, skip it.
 			continue
@@ -587,8 +562,8 @@ func (api *ProvisionerAPI) translateEndpointBindingsToSpaces(spaceInfos network.
 
 		for endpoint, spaceID := range bindings {
 			space := spaceInfos.GetByID(spaceID)
-			boundSpaceNames = append(boundSpaceNames, space.Name)
 			if space != nil {
+				boundSpaceNames = append(boundSpaceNames, space.Name)
 				bound := string(space.ProviderId)
 				if bound == "" {
 					bound = space.Name.String()
@@ -608,13 +583,12 @@ func (api *ProvisionerAPI) translateEndpointBindingsToSpaces(spaceInfos network.
 // or an error fetching them.
 func (api *ProvisionerAPI) availableImageMetadata(
 	ctx context.Context,
-	machineName coremachine.Name,
 	machineBase corebase.Base,
 	machineConstraints constraints.Value,
 	imageStream string,
 	cloudRegionSpec simplestreams.CloudSpec,
 ) ([]params.CloudImageMetadata, error) {
-	imageConstraint, err := api.constructImageConstraint(ctx, machineName, machineBase, machineConstraints, imageStream, cloudRegionSpec)
+	imageConstraint, err := constructImageConstraint(machineBase, machineConstraints, imageStream, cloudRegionSpec)
 	if err != nil {
 		return nil, errors.Errorf("could not construct image constraint: %w", err)
 	}
@@ -632,9 +606,7 @@ func (api *ProvisionerAPI) availableImageMetadata(
 
 // constructImageConstraint returns model-specific criteria used to look for
 // image metadata.
-func (api *ProvisionerAPI) constructImageConstraint(
-	ctx context.Context,
-	machineName coremachine.Name,
+func constructImageConstraint(
 	machineBase corebase.Base,
 	machineConstraints constraints.Value,
 	imageStream string,

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -383,7 +383,8 @@ func (api *ProvisionerAPI) machineTags(
 		}
 		principalUnitNames = append(principalUnitNames, principalUnit.String())
 	}
-	sort.Strings(principalUnitNames)
+	slices.Sort(principalUnitNames)
+	principalUnitNames = slices.Compact(principalUnitNames)
 
 	machineTags := instancecfg.InstanceTags(api.modelUUID.String(), api.controllerUUID, resourceTags, isController)
 	if len(unitNames) > 0 {

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -377,11 +377,11 @@ func (api *ProvisionerAPI) machineTags(
 	// Names of all units deployed to the machine.
 	principalUnitNames := make([]string, 0, len(unitNames))
 	for _, unitName := range unitNames {
-		principleUnit := unitName.Name
+		principalUnit := unitName.Name
 		if unitName.IsSubordinate() {
-			principleUnit = *unitName.Principal
+			principalUnit = *unitName.Principal
 		}
-		principalUnitNames = append(principalUnitNames, principleUnit.String())
+		principalUnitNames = append(principalUnitNames, principalUnit.String())
 	}
 	sort.Strings(principalUnitNames)
 

--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -224,13 +224,8 @@ type KeyUpdaterService interface {
 
 // ApplicationService instances implement an application service.
 type ApplicationService interface {
-	// GetUnitNamesWithPrincipalOnMachine returns a slice of the unit names and their principles on the given machine.
+	// GetUnitNamesWithPrincipalOnMachine returns a slice of the unit names and their principals on the given machine.
 	GetUnitNamesWithPrincipalOnMachine(ctx context.Context, name coremachine.Name) ([]unit.NameWithPrincipal, error)
-
-	// GetUnitPrincipal gets the subordinates principal unit. If no principal unit
-	// is found, for example, when the unit is not a subordinate, then false is
-	// returned.
-	GetUnitPrincipal(context.Context, unit.Name) (unit.Name, bool, error)
 
 	// GetApplicationEndpointBindings returns the mapping for each endpoint name and
 	// the space ID it is bound to (or empty if unspecified). When no bindings are

--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -7,8 +7,6 @@ import (
 	"context"
 
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/base"
-	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/containermanager"
 	"github.com/juju/juju/core/instance"
@@ -20,6 +18,7 @@ import (
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/cloudimagemetadata"
+	domainmachine "github.com/juju/juju/domain/machine"
 	domainnetwork "github.com/juju/juju/domain/network"
 	domainstorage "github.com/juju/juju/domain/storage"
 	domainstorageprovisioning "github.com/juju/juju/domain/storageprovisioning"
@@ -127,17 +126,9 @@ type MachineService interface {
 	// life changes.
 	WatchMachineContainerLife(ctx context.Context, parentMachineName coremachine.Name) (watcher.StringsWatcher, error)
 
-	// GetMachinePlacementDirective returns the placement structure as it was
-	// recorded for the given machine.
-	GetMachinePlacementDirective(ctx context.Context, mName coremachine.Name) (*string, error)
-
-	// GetMachineConstraints returns the constraints for the given machine.
-	// Empty constraints are returned if no constraints exist for the given
-	// machine.
-	GetMachineConstraints(ctx context.Context, mName coremachine.Name) (constraints.Value, error)
-
-	// GetMachineBase returns the base for the given machine.
-	GetMachineBase(ctx context.Context, mName coremachine.Name) (base.Base, error)
+	// GetMachineProvisioningInfo returns the base, placement directive and
+	// constraints for the given machine.
+	GetMachineProvisioningInfo(ctx context.Context, mName coremachine.Name) (domainmachine.ProvisioningInfo, error)
 
 	// GetBootstrapEnviron returns the bootstrap environ.
 	GetBootstrapEnviron(ctx context.Context) (environs.BootstrapEnviron, error)
@@ -233,8 +224,8 @@ type KeyUpdaterService interface {
 
 // ApplicationService instances implement an application service.
 type ApplicationService interface {
-	// GetUnitNamesOnMachine returns a slice of the unit names on the given machine.
-	GetUnitNamesOnMachine(context.Context, coremachine.Name) ([]unit.Name, error)
+	// GetUnitNamesWithPrincipalOnMachine returns a slice of the unit names and their principles on the given machine.
+	GetUnitNamesWithPrincipalOnMachine(ctx context.Context, name coremachine.Name) ([]unit.NameWithPrincipal, error)
 
 	// GetUnitPrincipal gets the subordinates principal unit. If no principal unit
 	// is found, for example, when the unit is not a subordinate, then false is
@@ -254,7 +245,7 @@ type ApplicationService interface {
 // RemovalService provides access to the removal service.
 type RemovalService interface {
 	// MarkMachineAsDead marks the machine as dead. It will not remove the machine as
-	// that is a separate operation. This will advance the machines's life to dead
+	// that is a separate operation. This will advance the machine's life to dead
 	// and will not allow it to be transitioned back to alive.
 	// Returns an error if the machine does not exist.
 	MarkMachineAsDead(context.Context, coremachine.UUID) error

--- a/apiserver/facades/agent/provisioner/service_mock_test.go
+++ b/apiserver/facades/agent/provisioner/service_mock_test.go
@@ -14,8 +14,6 @@ import (
 	reflect "reflect"
 
 	controller "github.com/juju/juju/controller"
-	base "github.com/juju/juju/core/base"
-	constraints "github.com/juju/juju/core/constraints"
 	container "github.com/juju/juju/core/container"
 	containermanager "github.com/juju/juju/core/containermanager"
 	instance "github.com/juju/juju/core/instance"
@@ -27,6 +25,7 @@ import (
 	unit "github.com/juju/juju/core/unit"
 	watcher "github.com/juju/juju/core/watcher"
 	cloudimagemetadata "github.com/juju/juju/domain/cloudimagemetadata"
+	machine0 "github.com/juju/juju/domain/machine"
 	network0 "github.com/juju/juju/domain/network"
 	storage "github.com/juju/juju/domain/storage"
 	storageprovisioning "github.com/juju/juju/domain/storageprovisioning"
@@ -339,41 +338,41 @@ func (c *MockApplicationServiceGetMachinesForApplicationCall) DoAndReturn(f func
 	return c
 }
 
-// GetUnitNamesOnMachine mocks base method.
-func (m *MockApplicationService) GetUnitNamesOnMachine(arg0 context.Context, arg1 machine.Name) ([]unit.Name, error) {
+// GetUnitNamesWithPrincipalOnMachine mocks base method.
+func (m *MockApplicationService) GetUnitNamesWithPrincipalOnMachine(arg0 context.Context, arg1 machine.Name) ([]unit.NameWithPrincipal, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitNamesOnMachine", arg0, arg1)
-	ret0, _ := ret[0].([]unit.Name)
+	ret := m.ctrl.Call(m, "GetUnitNamesWithPrincipalOnMachine", arg0, arg1)
+	ret0, _ := ret[0].([]unit.NameWithPrincipal)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetUnitNamesOnMachine indicates an expected call of GetUnitNamesOnMachine.
-func (mr *MockApplicationServiceMockRecorder) GetUnitNamesOnMachine(arg0, arg1 any) *MockApplicationServiceGetUnitNamesOnMachineCall {
+// GetUnitNamesWithPrincipalOnMachine indicates an expected call of GetUnitNamesWithPrincipalOnMachine.
+func (mr *MockApplicationServiceMockRecorder) GetUnitNamesWithPrincipalOnMachine(arg0, arg1 any) *MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNamesOnMachine", reflect.TypeOf((*MockApplicationService)(nil).GetUnitNamesOnMachine), arg0, arg1)
-	return &MockApplicationServiceGetUnitNamesOnMachineCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNamesWithPrincipalOnMachine", reflect.TypeOf((*MockApplicationService)(nil).GetUnitNamesWithPrincipalOnMachine), arg0, arg1)
+	return &MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall{Call: call}
 }
 
-// MockApplicationServiceGetUnitNamesOnMachineCall wrap *gomock.Call
-type MockApplicationServiceGetUnitNamesOnMachineCall struct {
+// MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall wrap *gomock.Call
+type MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetUnitNamesOnMachineCall) Return(arg0 []unit.Name, arg1 error) *MockApplicationServiceGetUnitNamesOnMachineCall {
+func (c *MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall) Return(arg0 []unit.NameWithPrincipal, arg1 error) *MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetUnitNamesOnMachineCall) Do(f func(context.Context, machine.Name) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesOnMachineCall {
+func (c *MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall) Do(f func(context.Context, machine.Name) ([]unit.NameWithPrincipal, error)) *MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetUnitNamesOnMachineCall) DoAndReturn(f func(context.Context, machine.Name) ([]unit.Name, error)) *MockApplicationServiceGetUnitNamesOnMachineCall {
+func (c *MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall) DoAndReturn(f func(context.Context, machine.Name) ([]unit.NameWithPrincipal, error)) *MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -659,84 +658,6 @@ func (c *MockMachineServiceGetInstanceIDCall) DoAndReturn(f func(context.Context
 	return c
 }
 
-// GetMachineBase mocks base method.
-func (m *MockMachineService) GetMachineBase(arg0 context.Context, arg1 machine.Name) (base.Base, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachineBase", arg0, arg1)
-	ret0, _ := ret[0].(base.Base)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMachineBase indicates an expected call of GetMachineBase.
-func (mr *MockMachineServiceMockRecorder) GetMachineBase(arg0, arg1 any) *MockMachineServiceGetMachineBaseCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineBase", reflect.TypeOf((*MockMachineService)(nil).GetMachineBase), arg0, arg1)
-	return &MockMachineServiceGetMachineBaseCall{Call: call}
-}
-
-// MockMachineServiceGetMachineBaseCall wrap *gomock.Call
-type MockMachineServiceGetMachineBaseCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineBaseCall) Return(arg0 base.Base, arg1 error) *MockMachineServiceGetMachineBaseCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineBaseCall) Do(f func(context.Context, machine.Name) (base.Base, error)) *MockMachineServiceGetMachineBaseCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineBaseCall) DoAndReturn(f func(context.Context, machine.Name) (base.Base, error)) *MockMachineServiceGetMachineBaseCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetMachineConstraints mocks base method.
-func (m *MockMachineService) GetMachineConstraints(arg0 context.Context, arg1 machine.Name) (constraints.Value, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachineConstraints", arg0, arg1)
-	ret0, _ := ret[0].(constraints.Value)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMachineConstraints indicates an expected call of GetMachineConstraints.
-func (mr *MockMachineServiceMockRecorder) GetMachineConstraints(arg0, arg1 any) *MockMachineServiceGetMachineConstraintsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineConstraints", reflect.TypeOf((*MockMachineService)(nil).GetMachineConstraints), arg0, arg1)
-	return &MockMachineServiceGetMachineConstraintsCall{Call: call}
-}
-
-// MockMachineServiceGetMachineConstraintsCall wrap *gomock.Call
-type MockMachineServiceGetMachineConstraintsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachineConstraintsCall) Return(arg0 constraints.Value, arg1 error) *MockMachineServiceGetMachineConstraintsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachineConstraintsCall) Do(f func(context.Context, machine.Name) (constraints.Value, error)) *MockMachineServiceGetMachineConstraintsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachineConstraintsCall) DoAndReturn(f func(context.Context, machine.Name) (constraints.Value, error)) *MockMachineServiceGetMachineConstraintsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetMachineLife mocks base method.
 func (m *MockMachineService) GetMachineLife(arg0 context.Context, arg1 machine.Name) (life.Value, error) {
 	m.ctrl.T.Helper()
@@ -776,45 +697,6 @@ func (c *MockMachineServiceGetMachineLifeCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
-// GetMachinePlacementDirective mocks base method.
-func (m *MockMachineService) GetMachinePlacementDirective(arg0 context.Context, arg1 machine.Name) (*string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachinePlacementDirective", arg0, arg1)
-	ret0, _ := ret[0].(*string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMachinePlacementDirective indicates an expected call of GetMachinePlacementDirective.
-func (mr *MockMachineServiceMockRecorder) GetMachinePlacementDirective(arg0, arg1 any) *MockMachineServiceGetMachinePlacementDirectiveCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachinePlacementDirective", reflect.TypeOf((*MockMachineService)(nil).GetMachinePlacementDirective), arg0, arg1)
-	return &MockMachineServiceGetMachinePlacementDirectiveCall{Call: call}
-}
-
-// MockMachineServiceGetMachinePlacementDirectiveCall wrap *gomock.Call
-type MockMachineServiceGetMachinePlacementDirectiveCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceGetMachinePlacementDirectiveCall) Return(arg0 *string, arg1 error) *MockMachineServiceGetMachinePlacementDirectiveCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceGetMachinePlacementDirectiveCall) Do(f func(context.Context, machine.Name) (*string, error)) *MockMachineServiceGetMachinePlacementDirectiveCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceGetMachinePlacementDirectiveCall) DoAndReturn(f func(context.Context, machine.Name) (*string, error)) *MockMachineServiceGetMachinePlacementDirectiveCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetMachinePrincipalApplications mocks base method.
 func (m *MockMachineService) GetMachinePrincipalApplications(arg0 context.Context, arg1 machine.Name) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -850,6 +732,45 @@ func (c *MockMachineServiceGetMachinePrincipalApplicationsCall) Do(f func(contex
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceGetMachinePrincipalApplicationsCall) DoAndReturn(f func(context.Context, machine.Name) ([]string, error)) *MockMachineServiceGetMachinePrincipalApplicationsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetMachineProvisioningInfo mocks base method.
+func (m *MockMachineService) GetMachineProvisioningInfo(arg0 context.Context, arg1 machine.Name) (machine0.ProvisioningInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineProvisioningInfo", arg0, arg1)
+	ret0, _ := ret[0].(machine0.ProvisioningInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineProvisioningInfo indicates an expected call of GetMachineProvisioningInfo.
+func (mr *MockMachineServiceMockRecorder) GetMachineProvisioningInfo(arg0, arg1 any) *MockMachineServiceGetMachineProvisioningInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineProvisioningInfo", reflect.TypeOf((*MockMachineService)(nil).GetMachineProvisioningInfo), arg0, arg1)
+	return &MockMachineServiceGetMachineProvisioningInfoCall{Call: call}
+}
+
+// MockMachineServiceGetMachineProvisioningInfoCall wrap *gomock.Call
+type MockMachineServiceGetMachineProvisioningInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceGetMachineProvisioningInfoCall) Return(arg0 machine0.ProvisioningInfo, arg1 error) *MockMachineServiceGetMachineProvisioningInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceGetMachineProvisioningInfoCall) Do(f func(context.Context, machine.Name) (machine0.ProvisioningInfo, error)) *MockMachineServiceGetMachineProvisioningInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceGetMachineProvisioningInfoCall) DoAndReturn(f func(context.Context, machine.Name) (machine0.ProvisioningInfo, error)) *MockMachineServiceGetMachineProvisioningInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/provisioner/service_mock_test.go
+++ b/apiserver/facades/agent/provisioner/service_mock_test.go
@@ -377,46 +377,6 @@ func (c *MockApplicationServiceGetUnitNamesWithPrincipalOnMachineCall) DoAndRetu
 	return c
 }
 
-// GetUnitPrincipal mocks base method.
-func (m *MockApplicationService) GetUnitPrincipal(arg0 context.Context, arg1 unit.Name) (unit.Name, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitPrincipal", arg0, arg1)
-	ret0, _ := ret[0].(unit.Name)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetUnitPrincipal indicates an expected call of GetUnitPrincipal.
-func (mr *MockApplicationServiceMockRecorder) GetUnitPrincipal(arg0, arg1 any) *MockApplicationServiceGetUnitPrincipalCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitPrincipal", reflect.TypeOf((*MockApplicationService)(nil).GetUnitPrincipal), arg0, arg1)
-	return &MockApplicationServiceGetUnitPrincipalCall{Call: call}
-}
-
-// MockApplicationServiceGetUnitPrincipalCall wrap *gomock.Call
-type MockApplicationServiceGetUnitPrincipalCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceGetUnitPrincipalCall) Return(arg0 unit.Name, arg1 bool, arg2 error) *MockApplicationServiceGetUnitPrincipalCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceGetUnitPrincipalCall) Do(f func(context.Context, unit.Name) (unit.Name, bool, error)) *MockApplicationServiceGetUnitPrincipalCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceGetUnitPrincipalCall) DoAndReturn(f func(context.Context, unit.Name) (unit.Name, bool, error)) *MockApplicationServiceGetUnitPrincipalCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // MockControllerConfigService is a mock of ControllerConfigService interface.
 type MockControllerConfigService struct {
 	ctrl     *gomock.Controller

--- a/core/unit/principal.go
+++ b/core/unit/principal.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unit
+
+// NameWithPrincipal pairs a unit name with its optional principal unit name.
+// When Principal is nil the unit is a principal unit itself; when Principal is
+// non-nil the unit is a subordinate and Principal holds the name of the
+// principal unit it is deployed alongside.
+type NameWithPrincipal struct {
+	// Name is the name of the unit.
+	Name Name
+
+	// Principal is the name of the principal unit this unit is subordinate to.
+	// It is nil when the unit is not a subordinate.
+	Principal *Name
+}
+
+// IsSubordinate reports whether the unit is a subordinate (i.e. it has a
+// principal unit).
+func (u NameWithPrincipal) IsSubordinate() bool {
+	return u.Principal != nil
+}

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -3756,6 +3756,45 @@ func (c *MockStateGetUnitNamesForNetNodeCall) DoAndReturn(f func(context.Context
 	return c
 }
 
+// GetUnitNamesWithPrincipalForMachine mocks base method.
+func (m *MockState) GetUnitNamesWithPrincipalForMachine(arg0 context.Context, arg1 string) ([]unit.NameWithPrincipal, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitNamesWithPrincipalForMachine", arg0, arg1)
+	ret0, _ := ret[0].([]unit.NameWithPrincipal)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitNamesWithPrincipalForMachine indicates an expected call of GetUnitNamesWithPrincipalForMachine.
+func (mr *MockStateMockRecorder) GetUnitNamesWithPrincipalForMachine(arg0, arg1 any) *MockStateGetUnitNamesWithPrincipalForMachineCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitNamesWithPrincipalForMachine", reflect.TypeOf((*MockState)(nil).GetUnitNamesWithPrincipalForMachine), arg0, arg1)
+	return &MockStateGetUnitNamesWithPrincipalForMachineCall{Call: call}
+}
+
+// MockStateGetUnitNamesWithPrincipalForMachineCall wrap *gomock.Call
+type MockStateGetUnitNamesWithPrincipalForMachineCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitNamesWithPrincipalForMachineCall) Return(arg0 []unit.NameWithPrincipal, arg1 error) *MockStateGetUnitNamesWithPrincipalForMachineCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitNamesWithPrincipalForMachineCall) Do(f func(context.Context, string) ([]unit.NameWithPrincipal, error)) *MockStateGetUnitNamesWithPrincipalForMachineCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitNamesWithPrincipalForMachineCall) DoAndReturn(f func(context.Context, string) ([]unit.NameWithPrincipal, error)) *MockStateGetUnitNamesWithPrincipalForMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetUnitNetNodeUUID mocks base method.
 func (m *MockState) GetUnitNetNodeUUID(arg0 context.Context, arg1 unit.UUID) (string, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -197,6 +197,10 @@ type UnitState interface {
 	// GetUnitNamesForNetNode returns a slice of the unit names for the given net node
 	GetUnitNamesForNetNode(context.Context, string) ([]coreunit.Name, error)
 
+	// GetUnitNamesWithPrincipalForMachine returns the name of every unit on the
+	// given machine together with its optional principal unit name.
+	GetUnitNamesWithPrincipalForMachine(context.Context, string) ([]coreunit.NameWithPrincipal, error)
+
 	// GetMachineNetNodeUUIDFromName returns the net node UUID for the named
 	// machine. The following errors may be returned: -
 	// [applicationerrors.MachineNotFound] if the machine does not exist
@@ -1329,6 +1333,26 @@ func (s *Service) GetUnitNamesOnMachine(ctx context.Context, machineName coremac
 		return nil, errors.Capture(err)
 	}
 	return names, nil
+}
+
+// GetUnitNamesWithPrincipalOnMachine returns a slice of the unit names and
+// their principal unit names on the given machine.
+func (s *Service) GetUnitNamesWithPrincipalOnMachine(
+	ctx context.Context,
+	name coremachine.Name,
+) ([]coreunit.NameWithPrincipal, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := name.Validate(); err != nil {
+		return nil, errors.Capture(err)
+	}
+	netNodeUUID, err := s.st.GetMachineNetNodeUUIDFromName(ctx, name)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return s.st.GetUnitNamesWithPrincipalForMachine(ctx, netNodeUUID)
 }
 
 // SetUnitWorkloadVersion sets the workload version for the given unit.

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1285,6 +1285,14 @@ type principal struct {
 	SubordinateUnitName coreunit.Name `db:"subordinate_unit_name"`
 }
 
+// unitWithPrincipal is a scan target for a unit row joined with the optional
+// unit_principal row. PrincipalUnitName is NULL when the unit is not a
+// subordinate.
+type unitWithPrincipal struct {
+	Name              coreunit.Name  `db:"name"`
+	PrincipalUnitName sql.NullString `db:"principal_unit_name"`
+}
+
 type unitMachineName struct {
 	UnitUUID    string `db:"unit_uuid"`
 	MachineName string `db:"name"`

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1758,6 +1758,59 @@ func (st *State) getUnitNamesForNetNode(ctx context.Context, tx *sqlair.TX, uuid
 	}), nil
 }
 
+// GetUnitNamesWithPrincipalForMachine returns the name of every unit on the
+// given machine together with its principal unit name.
+func (st *State) GetUnitNamesWithPrincipalForMachine(
+	ctx context.Context,
+	uuid string,
+) ([]coreunit.NameWithPrincipal, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	netNodeUUID := netNodeUUID{NetNodeUUID: uuid}
+	stmt, err := st.Prepare(`
+SELECT u.name AS &unitWithPrincipal.name,
+       p.name AS &unitWithPrincipal.principal_unit_name
+FROM   machine AS m
+INNER JOIN unit AS u ON u.net_node_uuid = m.net_node_uuid
+LEFT JOIN unit_principal AS up ON u.uuid = up.unit_uuid
+LEFT JOIN unit AS p ON up.principal_uuid = p.uuid
+WHERE  m.net_node_uuid = $netNodeUUID.uuid
+`, unitWithPrincipal{}, netNodeUUID)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var rows []unitWithPrincipal
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, netNodeUUID).GetAll(&rows)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
+		return errors.Capture(err)
+	})
+	if err != nil {
+		return nil, errors.Errorf(
+			"querying unit names with principals for machine %q: %w", uuid, err,
+		)
+	}
+
+	result := make([]coreunit.NameWithPrincipal, len(rows))
+	for i, row := range rows {
+		nwp := coreunit.NameWithPrincipal{
+			Name: row.Name,
+		}
+		if row.PrincipalUnitName.Valid {
+			nwp.Principal = new(coreunit.Name(row.PrincipalUnitName.String))
+		}
+		result[i] = nwp
+		st.logger.Debugf(ctx, "found unit %q with principle: %q", row.Name.String(), row.PrincipalUnitName.String)
+	}
+	return result, nil
+}
+
 // SetUnitWorkloadVersion sets the workload version for the given unit.
 func (st *State) SetUnitWorkloadVersion(ctx context.Context, unitName coreunit.Name, version string) error {
 	db, err := st.DB(ctx)

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1762,22 +1762,21 @@ func (st *State) getUnitNamesForNetNode(ctx context.Context, tx *sqlair.TX, uuid
 // given machine together with its principal unit name.
 func (st *State) GetUnitNamesWithPrincipalForMachine(
 	ctx context.Context,
-	uuid string,
+	nodeUUID string,
 ) ([]coreunit.NameWithPrincipal, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	netNodeUUID := netNodeUUID{NetNodeUUID: uuid}
+	netNodeUUID := netNodeUUID{NetNodeUUID: nodeUUID}
 	stmt, err := st.Prepare(`
 SELECT u.name AS &unitWithPrincipal.name,
        p.name AS &unitWithPrincipal.principal_unit_name
-FROM   machine AS m
-INNER JOIN unit AS u ON u.net_node_uuid = m.net_node_uuid
+FROM      unit           AS u
 LEFT JOIN unit_principal AS up ON u.uuid = up.unit_uuid
-LEFT JOIN unit AS p ON up.principal_uuid = p.uuid
-WHERE  m.net_node_uuid = $netNodeUUID.uuid
+LEFT JOIN unit           AS p ON up.principal_uuid = p.uuid
+WHERE u.net_node_uuid = $netNodeUUID.uuid
 `, unitWithPrincipal{}, netNodeUUID)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -1793,7 +1792,7 @@ WHERE  m.net_node_uuid = $netNodeUUID.uuid
 	})
 	if err != nil {
 		return nil, errors.Errorf(
-			"querying unit names with principals for machine %q: %w", uuid, err,
+			"querying unit names with principals for machine %q: %w", nodeUUID, err,
 		)
 	}
 
@@ -1806,7 +1805,6 @@ WHERE  m.net_node_uuid = $netNodeUUID.uuid
 			nwp.Principal = new(coreunit.Name(row.PrincipalUnitName.String))
 		}
 		result[i] = nwp
-		st.logger.Debugf(ctx, "found unit %q with principle: %q", row.Name.String(), row.PrincipalUnitName.String)
 	}
 	return result, nil
 }

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -2090,6 +2090,123 @@ func (s *unitStateSubordinateSuite) createSubordinateApplication(c *tc.C, name s
 	return appID
 }
 
+// addUnitOnNetNode inserts a unit that shares an existing net node, placing
+// it on the same machine as any other unit that uses that net node.
+func (s *unitStateSubordinateSuite) addUnitOnNetNode(
+	c *tc.C,
+	unitName coreunit.Name,
+	appUUID coreapplication.UUID,
+	netNode domainnetwork.NetNodeUUID,
+) coreunit.UUID {
+	unitUUID := coreunittesting.GenUnitUUID(c)
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO unit (uuid, name, life_id, net_node_uuid, application_uuid, charm_uuid)
+SELECT ?, ?, 0, ?, uuid, charm_uuid
+FROM application WHERE uuid = ?
+`, unitUUID, unitName, netNode.String(), appUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return unitUUID
+}
+
+func (s *unitStateSubordinateSuite) TestGetUnitNamesWithPrincipalForMachineNoUnits(c *tc.C) {
+	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
+	var machineName coremachine.Name
+	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		names, err := machinestate.PlaceMachine(ctx, tx, s.state, clock.WallClock,
+			domainmachine.PlaceMachineArgs{
+				Directive:   deployment.Placement{Type: deployment.PlacementTypeUnset},
+				MachineUUID: machinetesting.GenUUID(c),
+				NetNodeUUID: netNodeUUID,
+			})
+		if err != nil {
+			return err
+		}
+		machineName = names[0]
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, err := s.state.GetUnitNamesWithPrincipalForMachine(c.Context(), machineName.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.HasLen, 0)
+}
+
+func (s *unitStateSubordinateSuite) TestGetUnitNamesWithPrincipalForMachine(c *tc.C) {
+	// Given: machine "0" has foo/0 (principal), foo/1 (principal) and
+	// sub/0 (a subordinate of foo/0). Machine "1" has foo/2, which must
+	// be absent from the result to confirm machine-level filtering.
+	machineUUID := machinetesting.GenUUID(c)
+	netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
+	altNetNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
+
+	s.createIAASApplication(c, "foo", life.Alive,
+		application.AddIAASUnitArg{
+			MachineUUID:        machineUUID,
+			MachineNetNodeUUID: netNodeUUID,
+			AddUnitArg: application.AddUnitArg{
+				UnitUUID:    tc.Must(c, coreunit.NewUUID),
+				NetNodeUUID: netNodeUUID,
+				Placement:   deployment.Placement{Directive: "0"},
+			},
+		},
+		application.AddIAASUnitArg{
+			MachineUUID:        machineUUID,
+			MachineNetNodeUUID: netNodeUUID,
+			AddUnitArg: application.AddUnitArg{
+				UnitUUID:    tc.Must(c, coreunit.NewUUID),
+				NetNodeUUID: netNodeUUID,
+				Placement:   deployment.Placement{Type: deployment.PlacementTypeMachine, Directive: "0"},
+			},
+		},
+		application.AddIAASUnitArg{
+			MachineUUID:        machinetesting.GenUUID(c),
+			MachineNetNodeUUID: altNetNodeUUID,
+			AddUnitArg: application.AddUnitArg{
+				UnitUUID:    tc.Must(c, coreunit.NewUUID),
+				NetNodeUUID: altNetNodeUUID,
+				Placement:   deployment.Placement{Directive: "1"},
+			},
+		},
+	)
+
+	// Get the UUID of foo/0 to establish the principal relationship.
+	principalUUID, err := s.state.GetUnitUUIDByName(c.Context(), "foo/0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Add a subordinate application and a unit on the same net node as M0.
+	subAppID := s.createSubordinateApplication(c, "sub", life.Alive)
+	subUUID := s.addUnitOnNetNode(c, coreunit.Name("sub/0"), subAppID, netNodeUUID)
+
+	// Wire sub/0 as a subordinate of foo/0.
+	s.addUnitPrincipal(c, principalUUID, subUUID)
+
+	// When: query by the net node UUID that identifies machine "0".
+	got, err := s.state.GetUnitNamesWithPrincipalForMachine(c.Context(), netNodeUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(got, tc.HasLen, 3)
+
+	// Build a lookup map for readable assertions.
+	byName := make(map[coreunit.Name]coreunit.NameWithPrincipal, len(got))
+	for _, nwp := range got {
+		byName[nwp.Name] = nwp
+	}
+
+	// foo/0 and foo/1 are principal units — they must have no principal.
+	c.Check(byName[coreunit.Name("foo/0")].Principal, tc.IsNil)
+	c.Check(byName[coreunit.Name("foo/1")].Principal, tc.IsNil)
+
+	// sub/0 is a subordinate of foo/0.
+	c.Assert(byName[coreunit.Name("sub/0")].Principal, tc.NotNil)
+	c.Check(*byName[coreunit.Name("sub/0")].Principal, tc.Equals, coreunit.Name("foo/0"))
+
+	// foo/2 lives on machine "1" and must not appear in the result.
+	_, found := byName[coreunit.Name("foo/2")]
+	c.Check(found, tc.IsFalse)
+}
+
 func (s *unitStateSuite) TestGetIAASUnitContext(c *tc.C) {
 	// Arrange: Create an IAAS unit with a machine
 	_, unitUUIDs := s.createIAASApplicationWithNUnits(c, "foo", life.Alive, 1)

--- a/domain/machine/import_integration_test.go
+++ b/domain/machine/import_integration_test.go
@@ -132,18 +132,16 @@ func (s *importSuite) TestImportMachine(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(base, tc.Equals, corebase.MustParseBaseFromString("ubuntu@24.04"))
 
-	cons, err := svc.GetMachineConstraints(c.Context(), machineName)
+	pInfo, err := svc.GetMachineProvisioningInfo(c.Context(), machineName)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(cons, tc.DeepEquals, constraints.Value{
+	c.Check(pInfo.Constraints, tc.DeepEquals, constraints.Value{
 		CpuCores: new(uint64(4)),
 		Mem:      new(uint64(8192)),
 		RootDisk: new(uint64(1024)),
 		Tags:     &[]string{"tag1", "tag2"},
 	})
-
-	placement, err := svc.GetMachinePlacementDirective(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(placement, tc.IsNil)
+	c.Check(pInfo.PlacementDirective, tc.IsNil)
+	c.Check(pInfo.Base, tc.Equals, corebase.MustParseBaseFromString("ubuntu@24.04"))
 
 	containerTypes, err := svc.GetSupportedContainersTypes(c.Context(), machineUUID)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -11,7 +11,6 @@ import (
 
 	coreagentbinary "github.com/juju/juju/core/agentbinary"
 	"github.com/juju/juju/core/base"
-	coreconstraints "github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	corelife "github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
@@ -171,19 +170,14 @@ type State interface {
 	// (non-subordinate) applications for the specified machine.
 	GetMachinePrincipalApplications(ctx context.Context, mName machine.Name) ([]string, error)
 
-	// GetMachinePlacementDirective returns the placement structure as it was
-	// recorded for the given machine.
-	GetMachinePlacementDirective(ctx context.Context, mName string) (*string, error)
-
-	// GetMachineConstraints returns the constraints for the given machine.
-	// Empty constraints are returned if no constraints exist for the given
-	// machine.
-	GetMachineConstraints(ctx context.Context, mName string) (constraints.Constraints, error)
-
 	// GetMachineBase returns the base for the given machine. Since the
 	// machine_platform table is populated when creating a machine, there should
 	// always be a base for a machine.
 	GetMachineBase(ctx context.Context, mName string) (base.Base, error)
+
+	// GetMachineProvisioningInfo returns the base, placement directive and
+	// constraints for the given machine.
+	GetMachineProvisioningInfo(ctx context.Context, mName string) (base.Base, *string, constraints.Constraints, error)
 
 	// GetModelConstraints returns the currently set constraints for the model.
 	// Note: This method should mirror the model domain method of the same name.
@@ -498,38 +492,31 @@ func (s *Service) GetMachinePrincipalApplications(ctx context.Context, mName mac
 	return s.st.GetMachinePrincipalApplications(ctx, mName)
 }
 
-// GetMachinePlacementDirective returns the placement structure as it was
-// recorded for the given machine.
+// GetMachineProvisioningInfo returns the base, placement directive and
+// constraints for the given machine.
 //
 // The following errors may be returned:
 // - [machineerrors.MachineNotFound] if the machine does not exist.
-func (s *Service) GetMachinePlacementDirective(ctx context.Context, mName machine.Name) (*string, error) {
+func (s *Service) GetMachineProvisioningInfo(ctx context.Context, mName machine.Name) (domainmachine.ProvisioningInfo, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	if err := mName.Validate(); err != nil {
-		return nil, errors.Errorf("validating machine name %q: %w", mName, err)
+		return domainmachine.ProvisioningInfo{}, errors.Errorf(
+			"validating machine name %q: %w", mName, err,
+		)
 	}
 
-	return s.st.GetMachinePlacementDirective(ctx, mName.String())
-}
-
-// GetMachineConstraints returns the constraints for the given machine.
-// Empty constraints are returned if no constraints exist for the given
-// machine.
-//
-// The following errors may be returned:
-// - [machineerrors.MachineNotFound] if the machine does not exist.
-func (s *Service) GetMachineConstraints(ctx context.Context, mName machine.Name) (coreconstraints.Value, error) {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	if err := mName.Validate(); err != nil {
-		return coreconstraints.Value{}, errors.Errorf("validating machine name %q: %w", mName, err)
+	b, placement, cons, err := s.st.GetMachineProvisioningInfo(ctx, mName.String())
+	if err != nil {
+		return domainmachine.ProvisioningInfo{}, errors.Capture(err)
 	}
 
-	cons, err := s.st.GetMachineConstraints(ctx, mName.String())
-	return constraints.EncodeConstraints(cons), errors.Capture(err)
+	return domainmachine.ProvisioningInfo{
+		Base:               b,
+		PlacementDirective: placement,
+		Constraints:        constraints.EncodeConstraints(cons),
+	}, nil
 }
 
 // GetMachineBase returns the base for the given machine.

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -20,6 +20,7 @@ import (
 	networktesting "github.com/juju/juju/core/network/testing"
 	"github.com/juju/juju/domain/constraints"
 	"github.com/juju/juju/domain/life"
+	domainmachine "github.com/juju/juju/domain/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -637,46 +638,17 @@ func (s *serviceSuite) TestGetMachinePrincipalUnitsError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `.*boom.*`)
 }
 
-func (s *serviceSuite) TestGetMachinePlacement(c *tc.C) {
+func (s *serviceSuite) TestGetMachineProvisioningInfo(c *tc.C) {
 	s.setupMocks(c)
 
 	machineName := machine.Name("0")
-
-	s.state.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName.String()).Return(new("0/lxd/42"), nil)
-
-	placement, err := NewService(s.state, s.statusHistory, clock.WallClock, loggertesting.WrapCheckLog(c)).
-		GetMachinePlacementDirective(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(*placement, tc.Equals, "0/lxd/42")
-}
-
-func (s *serviceSuite) TestGetMachinePlacementInvalidMachineName(c *tc.C) {
-	s.setupMocks(c)
-
-	machineName := machine.Name("invalid")
-
-	_, err := NewService(s.state, s.statusHistory, clock.WallClock, loggertesting.WrapCheckLog(c)).
-		GetMachinePlacementDirective(c.Context(), machineName)
-	c.Assert(err, tc.ErrorMatches, `.*validating machine name "invalid".*`)
-}
-
-func (s *serviceSuite) TestGetMachinePlacementNotFound(c *tc.C) {
-	s.setupMocks(c)
-
-	machineName := machine.Name("0")
-
-	s.state.EXPECT().GetMachinePlacementDirective(gomock.Any(), machineName.String()).Return(nil, machineerrors.MachineNotFound)
-
-	_, err := NewService(s.state, s.statusHistory, clock.WallClock, loggertesting.WrapCheckLog(c)).
-		GetMachinePlacementDirective(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
-}
-
-func (s *serviceSuite) TestGetMachineConstraintsFull(c *tc.C) {
-	s.setupMocks(c)
-
-	machineName := machine.Name("0")
-
+	b := base.Base{
+		OS: "ubuntu",
+		Channel: base.Channel{
+			Track: "26.04",
+			Risk:  "stable",
+		},
+	}
 	machineConstraints := constraints.Constraints{
 		Arch:           new("amd64"),
 		Container:      new(instance.LXD),
@@ -694,46 +666,46 @@ func (s *serviceSuite) TestGetMachineConstraintsFull(c *tc.C) {
 		Zones:            new([]string{"zone1", "zone2"}),
 		AllocatePublicIP: new(true),
 	}
-	s.state.EXPECT().GetMachineConstraints(gomock.Any(), machineName.String()).Return(machineConstraints, nil)
+
+	s.state.EXPECT().GetMachineProvisioningInfo(gomock.Any(), machineName.String()).
+		Return(b, new("0/lxd/42"), machineConstraints, nil)
 
 	obtained, err := NewService(s.state, s.statusHistory, clock.WallClock, loggertesting.WrapCheckLog(c)).
-		GetMachineConstraints(c.Context(), machineName)
+		GetMachineProvisioningInfo(c.Context(), machineName)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(obtained, tc.DeepEquals, coreconstraints.Value{
-		Arch:             new("amd64"),
-		Container:        new(instance.LXD),
-		CpuCores:         new(uint64(4)),
-		Mem:              new(uint64(1024)),
-		RootDisk:         new(uint64(1024)),
-		RootDiskSource:   new("root-disk-source"),
-		Tags:             new([]string{"tag1", "tag2"}),
-		InstanceRole:     new("instance-role"),
-		InstanceType:     new("instance-type"),
-		Spaces:           new([]string{"space1"}),
-		VirtType:         new("virt-type"),
-		Zones:            new([]string{"zone1", "zone2"}),
-		AllocatePublicIP: new(true),
+	c.Check(obtained, tc.DeepEquals, domainmachine.ProvisioningInfo{
+		Base: base.Base{
+			OS: "ubuntu",
+			Channel: base.Channel{
+				Track: "26.04",
+				Risk:  "stable",
+			},
+		},
+		Constraints: coreconstraints.Value{
+			Arch:             new("amd64"),
+			Container:        new(instance.LXD),
+			CpuCores:         new(uint64(4)),
+			Mem:              new(uint64(1024)),
+			RootDisk:         new(uint64(1024)),
+			RootDiskSource:   new("root-disk-source"),
+			Tags:             new([]string{"tag1", "tag2"}),
+			InstanceRole:     new("instance-role"),
+			InstanceType:     new("instance-type"),
+			Spaces:           new([]string{"space1"}),
+			VirtType:         new("virt-type"),
+			Zones:            new([]string{"zone1", "zone2"}),
+			AllocatePublicIP: new(true),
+		},
+		PlacementDirective: new("0/lxd/42"),
 	})
 }
 
-func (s *serviceSuite) TestGetMachineConstraintsInvalidMachineName(c *tc.C) {
+func (s *serviceSuite) TestGetMachineProvisioningInfoInvalidMachineName(c *tc.C) {
 	s.setupMocks(c)
 
 	_, err := NewService(s.state, s.statusHistory, clock.WallClock, loggertesting.WrapCheckLog(c)).
-		GetMachineConstraints(c.Context(), machine.Name("invalid"))
+		GetMachineProvisioningInfo(c.Context(), machine.Name("invalid"))
 	c.Assert(err, tc.ErrorMatches, `.*validating machine name "invalid".*`)
-}
-
-func (s *serviceSuite) TestGetMachineConstraintsMachineNotFound(c *tc.C) {
-	s.setupMocks(c)
-
-	machineName := machine.Name("0")
-
-	s.state.EXPECT().GetMachineConstraints(gomock.Any(), machineName.String()).Return(constraints.Constraints{}, machineerrors.MachineNotFound)
-
-	_, err := NewService(s.state, s.statusHistory, clock.WallClock, loggertesting.WrapCheckLog(c)).
-		GetMachineConstraints(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 func (s *serviceSuite) TestGetMachineBase(c *tc.C) {

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -518,45 +518,6 @@ func (c *MockStateGetMachineBaseCall) DoAndReturn(f func(context.Context, string
 	return c
 }
 
-// GetMachineConstraints mocks base method.
-func (m *MockState) GetMachineConstraints(ctx context.Context, mName string) (constraints.Constraints, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachineConstraints", ctx, mName)
-	ret0, _ := ret[0].(constraints.Constraints)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMachineConstraints indicates an expected call of GetMachineConstraints.
-func (mr *MockStateMockRecorder) GetMachineConstraints(ctx, mName any) *MockStateGetMachineConstraintsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineConstraints", reflect.TypeOf((*MockState)(nil).GetMachineConstraints), ctx, mName)
-	return &MockStateGetMachineConstraintsCall{Call: call}
-}
-
-// MockStateGetMachineConstraintsCall wrap *gomock.Call
-type MockStateGetMachineConstraintsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetMachineConstraintsCall) Return(arg0 constraints.Constraints, arg1 error) *MockStateGetMachineConstraintsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachineConstraintsCall) Do(f func(context.Context, string) (constraints.Constraints, error)) *MockStateGetMachineConstraintsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachineConstraintsCall) DoAndReturn(f func(context.Context, string) (constraints.Constraints, error)) *MockStateGetMachineConstraintsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetMachineContainers mocks base method.
 func (m *MockState) GetMachineContainers(ctx context.Context, mUUID string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -674,45 +635,6 @@ func (c *MockStateGetMachineParentUUIDCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
-// GetMachinePlacementDirective mocks base method.
-func (m *MockState) GetMachinePlacementDirective(ctx context.Context, mName string) (*string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachinePlacementDirective", ctx, mName)
-	ret0, _ := ret[0].(*string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMachinePlacementDirective indicates an expected call of GetMachinePlacementDirective.
-func (mr *MockStateMockRecorder) GetMachinePlacementDirective(ctx, mName any) *MockStateGetMachinePlacementDirectiveCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachinePlacementDirective", reflect.TypeOf((*MockState)(nil).GetMachinePlacementDirective), ctx, mName)
-	return &MockStateGetMachinePlacementDirectiveCall{Call: call}
-}
-
-// MockStateGetMachinePlacementDirectiveCall wrap *gomock.Call
-type MockStateGetMachinePlacementDirectiveCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetMachinePlacementDirectiveCall) Return(arg0 *string, arg1 error) *MockStateGetMachinePlacementDirectiveCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachinePlacementDirectiveCall) Do(f func(context.Context, string) (*string, error)) *MockStateGetMachinePlacementDirectiveCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachinePlacementDirectiveCall) DoAndReturn(f func(context.Context, string) (*string, error)) *MockStateGetMachinePlacementDirectiveCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetMachinePrincipalApplications mocks base method.
 func (m *MockState) GetMachinePrincipalApplications(ctx context.Context, mName machine.Name) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -748,6 +670,47 @@ func (c *MockStateGetMachinePrincipalApplicationsCall) Do(f func(context.Context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetMachinePrincipalApplicationsCall) DoAndReturn(f func(context.Context, machine.Name) ([]string, error)) *MockStateGetMachinePrincipalApplicationsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetMachineProvisioningInfo mocks base method.
+func (m *MockState) GetMachineProvisioningInfo(ctx context.Context, mName string) (base.Base, *string, constraints.Constraints, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineProvisioningInfo", ctx, mName)
+	ret0, _ := ret[0].(base.Base)
+	ret1, _ := ret[1].(*string)
+	ret2, _ := ret[2].(constraints.Constraints)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// GetMachineProvisioningInfo indicates an expected call of GetMachineProvisioningInfo.
+func (mr *MockStateMockRecorder) GetMachineProvisioningInfo(ctx, mName any) *MockStateGetMachineProvisioningInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineProvisioningInfo", reflect.TypeOf((*MockState)(nil).GetMachineProvisioningInfo), ctx, mName)
+	return &MockStateGetMachineProvisioningInfoCall{Call: call}
+}
+
+// MockStateGetMachineProvisioningInfoCall wrap *gomock.Call
+type MockStateGetMachineProvisioningInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetMachineProvisioningInfoCall) Return(arg0 base.Base, arg1 *string, arg2 constraints.Constraints, arg3 error) *MockStateGetMachineProvisioningInfoCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2, arg3)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetMachineProvisioningInfoCall) Do(f func(context.Context, string) (base.Base, *string, constraints.Constraints, error)) *MockStateGetMachineProvisioningInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetMachineProvisioningInfoCall) DoAndReturn(f func(context.Context, string) (base.Base, *string, constraints.Constraints, error)) *MockStateGetMachineProvisioningInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -928,87 +928,6 @@ ORDER BY a.name ASC
 	return result, nil
 }
 
-// GetMachinePlacement returns the placement structure as it was recorded for
-// the given machine.
-//
-// The following errors may be returned:
-// - [machineerrors.MachineNotFound] if the machine does not exist.
-func (st *State) GetMachinePlacementDirective(ctx context.Context, mName string) (*string, error) {
-	db, err := st.DB(ctx)
-	if err != nil {
-		return nil, errors.Capture(err)
-	}
-
-	stmt, err := st.Prepare(`
-SELECT &placementDirective.*
-FROM machine_placement
-WHERE machine_uuid = $entityUUID.uuid
-`, placementDirective{}, entityUUID{})
-	if err != nil {
-		return nil, errors.Capture(err)
-	}
-
-	var placementDirective placementDirective
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		machineUUID, err := st.getMachineUUIDFromName(ctx, tx, machine.Name(mName))
-		if err != nil {
-			return err
-		}
-		err = tx.Query(ctx, stmt, machineUUID).Get(&placementDirective)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return errors.Errorf("querying placement for machine %q: %w", mName, err)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, errors.Capture(err)
-	}
-
-	if placementDirective.Directive.Valid {
-		return &placementDirective.Directive.V, nil
-	}
-	return nil, nil
-}
-
-// GetMachineConstraints returns the constraints for the given machine.
-// Empty constraints are returned if no constraints exist for the given
-// machine.
-//
-// The following errors may be returned:
-// - [machineerrors.MachineNotFound] if the machine does not exist.
-func (st *State) GetMachineConstraints(ctx context.Context, mName string) (constraints.Constraints, error) {
-	db, err := st.DB(ctx)
-	if err != nil {
-		return constraints.Constraints{}, errors.Capture(err)
-	}
-
-	stmt, err := st.Prepare(`
-SELECT &machineConstraint.*
-FROM v_machine_constraint
-WHERE machine_uuid = $entityUUID.uuid;
-`, machineConstraint{}, entityUUID{})
-	if err != nil {
-		return constraints.Constraints{}, errors.Capture(err)
-	}
-	var result machineConstraints
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		machineUUID, err := st.getMachineUUIDFromName(ctx, tx, machine.Name(mName))
-		if err != nil {
-			return err
-		}
-		err = tx.Query(ctx, stmt, machineUUID).GetAll(&result)
-		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Capture(err)
-		}
-		return nil
-	})
-	if err != nil {
-		return constraints.Constraints{}, errors.Errorf("getting constraints for machine %q: %w", mName, err)
-	}
-
-	return decodeConstraints(result), nil
-}
-
 // GetModelConstraints returns the currently set constraints for the model.
 // The following error types can be expected:
 // - [modelerrors.NotFound]: when no model exists to set constraints for.
@@ -1158,6 +1077,84 @@ WHERE machine_uuid = $entityUUID.uuid
 	}
 
 	return base.ParseBase(result.OSName, result.Channel)
+}
+
+// GetMachineProvisioningInfo returns the base, placement directive and
+// constraints for the given machine using a single SELECT query with JOINs,
+// resolving the machine UUID only once.
+//
+// The following errors may be returned:
+// - [machineerrors.MachineNotFound] if the machine does not exist.
+func (st *State) GetMachineProvisioningInfo(ctx context.Context, mName string) (base.Base, *string, constraints.Constraints, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return base.Base{}, nil, constraints.Constraints{}, errors.Capture(err)
+	}
+
+	stmt, err := st.Prepare(`
+SELECT &machineProvisioningRow.*
+FROM machine AS m
+LEFT JOIN v_machine_platform AS vp ON vp.machine_uuid = m.uuid
+LEFT JOIN machine_placement AS mp ON mp.machine_uuid = m.uuid
+LEFT JOIN v_machine_constraint AS vc ON vc.machine_uuid = m.uuid
+WHERE m.name = $machineName.name
+`, machineProvisioningRow{}, machineName{})
+	if err != nil {
+		return base.Base{}, nil, constraints.Constraints{}, errors.Capture(err)
+	}
+
+	nameParam := machineName{Name: mName}
+	var rows machineProvisioningRows
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, nameParam).GetAll(&rows)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("machine %q: %w", mName, machineerrors.MachineNotFound)
+		}
+		return errors.Capture(err)
+	})
+	if err != nil {
+		return base.Base{}, nil, constraints.Constraints{},
+			errors.Errorf("getting provisioning info for machine %q: %w", mName, err)
+	}
+
+	firstRow := rows[0]
+	machineBase, err := base.ParseBase(firstRow.OSName, firstRow.Channel)
+	if err != nil {
+		return base.Base{}, nil, constraints.Constraints{},
+			errors.Errorf("parsing base for machine %q from OS %q and channel %q: %w",
+				mName, firstRow.OSName, firstRow.Channel, err)
+	}
+
+	var placement *string
+	if firstRow.Directive.Valid {
+		placement = &firstRow.Directive.V
+	}
+
+	// Convert provisioning rows to constraint rows for decoding via the
+	// existing decodeConstraints helper.
+	constraintRows := make(machineConstraints, len(rows))
+	for i, row := range rows {
+		constraintRows[i] = machineConstraint{
+			Arch:             row.Arch,
+			CPUCores:         row.CPUCores,
+			CPUPower:         row.CPUPower,
+			Mem:              row.Mem,
+			RootDisk:         row.RootDisk,
+			RootDiskSource:   row.RootDiskSource,
+			InstanceRole:     row.InstanceRole,
+			InstanceType:     row.InstanceType,
+			ContainerType:    row.ContainerType,
+			VirtType:         row.VirtType,
+			AllocatePublicIP: row.AllocatePublicIP,
+			ImageID:          row.ImageID,
+			SpaceName:        row.SpaceName,
+			SpaceExclude:     row.SpaceExclude,
+			Tag:              row.Tag,
+			Zone:             row.Zone,
+		}
+	}
+
+	return machineBase, placement, decodeConstraints(constraintRows), nil
 }
 
 // CountMachinesInSpace counts the number of machines with address in a given

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	stdtesting "testing"
 
-	"github.com/canonical/sqlair"
 	"github.com/juju/tc"
 
 	corebase "github.com/juju/juju/core/base"
@@ -616,28 +615,11 @@ WHERE uuid = ?
 	return machineName
 }
 
-func (s *stateSuite) TestGetMachinePlacementDirective(c *tc.C) {
-	machineUUID, machineName := s.addMachine(c)
-
-	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		return insertMachineProviderPlacement(c.Context(), tx, s.state, machineUUID.String(), "0/lxd/42")
-	})
-	c.Assert(err, tc.ErrorIsNil)
-
-	placement, err := s.state.GetMachinePlacementDirective(c.Context(), machineName.String())
-	c.Assert(err, tc.ErrorIsNil)
-
-	c.Assert(*placement, tc.Equals, "0/lxd/42")
-}
-
-func (s *stateSuite) TestGetMachinePlacementDirectiveNotFound(c *tc.C) {
-	_, err := s.state.GetMachinePlacementDirective(c.Context(), "1")
-	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
-}
-
-func (s *stateSuite) TestConstraintFull(c *tc.C) {
-	networkstate.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c)).AddSpace(c.Context(), "space-uuid-0", "space0", "", []string{})
-	networkstate.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c)).AddSpace(c.Context(), "space-uuid-1", "space1", "", []string{})
+func (s *stateSuite) TestGetProvisioningInfoFull(c *tc.C) {
+	_ = networkstate.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c)).
+		AddSpace(c.Context(), "space-uuid-0", "space0", "", []string{})
+	_ = networkstate.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c)).
+		AddSpace(c.Context(), "space-uuid-1", "space1", "", []string{})
 
 	_, machineNames, err := s.state.AddMachine(c.Context(), domainmachine.AddMachineArgs{
 		Platform: deployment.Platform{
@@ -669,7 +651,7 @@ func (s *stateSuite) TestConstraintFull(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	machineName := machineNames[0]
 
-	cons, err := s.state.GetMachineConstraints(c.Context(), machineName.String())
+	b, _, cons, err := s.state.GetMachineProvisioningInfo(c.Context(), machineName.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(*cons.Tags, tc.SameContents, []string{"tag0", "tag1"})
 	c.Check(*cons.Spaces, tc.SameContents, []constraints.SpaceConstraint{
@@ -689,6 +671,13 @@ func (s *stateSuite) TestConstraintFull(c *tc.C) {
 	c.Check(cons.VirtType, tc.DeepEquals, new("virt-type"))
 	c.Check(cons.AllocatePublicIP, tc.DeepEquals, new(true))
 	c.Check(cons.ImageID, tc.DeepEquals, new("image-id"))
+	c.Assert(b, tc.DeepEquals, corebase.Base{
+		OS: "ubuntu",
+		Channel: corebase.Channel{
+			Track: "22.04",
+			Risk:  "stable",
+		},
+	})
 }
 
 func (s *stateSuite) TestConstraintPartial(c *tc.C) {
@@ -708,7 +697,7 @@ func (s *stateSuite) TestConstraintPartial(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	machineName := machineNames[0]
 
-	cons, err := s.state.GetMachineConstraints(c.Context(), machineName.String())
+	_, _, cons, err := s.state.GetMachineProvisioningInfo(c.Context(), machineName.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(cons, tc.DeepEquals, constraints.Constraints{
 		Arch:             new("amd64"),
@@ -732,7 +721,7 @@ func (s *stateSuite) TestConstraintSingleValue(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	machineName := machineNames[0]
 
-	cons, err := s.state.GetMachineConstraints(c.Context(), machineName.String())
+	_, _, cons, err := s.state.GetMachineProvisioningInfo(c.Context(), machineName.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(cons, tc.DeepEquals, constraints.Constraints{
 		CpuCores: new(uint64(2)),
@@ -742,14 +731,9 @@ func (s *stateSuite) TestConstraintSingleValue(c *tc.C) {
 func (s *stateSuite) TestConstraintEmpty(c *tc.C) {
 	_, machineName := s.addMachine(c)
 
-	cons, err := s.state.GetMachineConstraints(c.Context(), machineName.String())
+	_, _, cons, err := s.state.GetMachineProvisioningInfo(c.Context(), machineName.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(cons, tc.DeepEquals, constraints.Constraints{})
-}
-
-func (s *stateSuite) TestConstraintsApplicationNotFound(c *tc.C) {
-	_, err := s.state.GetMachineConstraints(c.Context(), "foo")
-	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 func (s *stateSuite) TestGetMachineBase(c *tc.C) {

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -266,10 +266,6 @@ type acquireParentMachineForContainerArgs struct {
 	constraints constraints.Constraints
 }
 
-type placementDirective struct {
-	Directive sql.Null[string] `db:"directive"`
-}
-
 // machineConstraint represents a single returned row when joining the
 // constraint table with the constraint_space, constraint_tag and
 // constraint_zone.
@@ -294,6 +290,39 @@ type machineConstraint struct {
 }
 
 type machineConstraints []machineConstraint
+
+// machineProvisioningRow represents a single row returned by the combined
+// provisioning info query that joins v_machine_platform, machine_placement
+// and v_machine_constraint via the machine table.
+type machineProvisioningRow struct {
+	// From v_machine_platform:
+	OSName  string `db:"os_name"`
+	Channel string `db:"channel"`
+
+	// From machine_placement:
+	Directive sql.Null[string] `db:"directive"`
+
+	// From v_machine_constraint (one row per space/tag/zone combination;
+	// scalar fields are repeated across rows):
+	Arch             sql.NullString  `db:"arch"`
+	CPUCores         sql.Null[int64] `db:"cpu_cores"`
+	CPUPower         sql.Null[int64] `db:"cpu_power"`
+	Mem              sql.Null[int64] `db:"mem"`
+	RootDisk         sql.Null[int64] `db:"root_disk"`
+	RootDiskSource   sql.NullString  `db:"root_disk_source"`
+	InstanceRole     sql.NullString  `db:"instance_role"`
+	InstanceType     sql.NullString  `db:"instance_type"`
+	ContainerType    sql.NullString  `db:"container_type"`
+	VirtType         sql.NullString  `db:"virt_type"`
+	AllocatePublicIP sql.NullBool    `db:"allocate_public_ip"`
+	ImageID          sql.NullString  `db:"image_id"`
+	SpaceName        sql.NullString  `db:"space_name"`
+	SpaceExclude     sql.NullBool    `db:"space_exclude"`
+	Tag              sql.NullString  `db:"tag"`
+	Zone             sql.NullString  `db:"zone"`
+}
+
+type machineProvisioningRows []machineProvisioningRow
 
 type machinePlatform struct {
 	OSName       string `db:"os_name"`

--- a/domain/machine/types.go
+++ b/domain/machine/types.go
@@ -4,6 +4,8 @@
 package machine
 
 import (
+	"github.com/juju/juju/core/base"
+	coreconstraints "github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain/constraints"
@@ -124,3 +126,17 @@ type PollingInfo struct {
 
 // PollingInfos is a slice of PollingInfo.
 type PollingInfos []PollingInfo
+
+// ProvisioningInfo holds the base, placement directive and constraints
+// for a machine, combined for efficient provisioning info retrieval.
+type ProvisioningInfo struct {
+	// Base is the base OS for the machine.
+	Base base.Base
+
+	// PlacementDirective is the placement directive for the machine, or nil
+	// if no placement was specified.
+	PlacementDirective *string
+
+	// Constraints are the constraints for the machine.
+	Constraints coreconstraints.Value
+}


### PR DESCRIPTION
Combines following calls into a single call per machine:

- `machineService.GetMachineBase(ctx, machineName)` once
- `machineService.GetMachinePlacementDirective(ctx, machineName)` once
- `machineService.GetMachineConstraints(ctx, machineName)` once
  

Combines following calls into a single call per machine:

- `applicationService.GetUnitNamesOnMachine(ctx, machineName)` once
- `applicationService.GetUnitPrincipal(ctx, unitName)` is called twice per unit

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

No functional changes introduced. Following tests the provisioning flow:

```sh
juju bootstrap lxd c1
juju add-model m1
juju deploy ubuntu u1
juju add-machine -n 1

❯ juju status
Model  Controller  Cloud/Region  Version  Timestamp
m1     c1          lxd/default   4.0.8.1  12:44:33+02:00

App  Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
u1   24.04    active      1  ubuntu  latest/stable   26  no

Unit   Workload  Agent  Machine  Public address  Ports  Message
u1/0*  active    idle   0        10.159.202.19

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.19   juju-630b25-0  ubuntu@24.04  tuxedo  Running
1        started  10.159.202.159  juju-630b25-1  ubuntu@24.04  tuxedo  Running

```

## Documentation changes


## Links

**Issue:** #22170

**Jira card:** [JUJU-9586](https://warthogs.atlassian.net/browse/JUJU-9586)


[JUJU-9586]: https://warthogs.atlassian.net/browse/JUJU-9586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ