### PR TITLE
docs: add package-level documentation for juju package

### DIFF
--- a/juju/doc.go
+++ b/juju/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package juju provides client-side utilities for connecting to Juju.
+//
+// These utilities establish authenticated API connections to Juju controllers
+// (enabling CLI commands and other clients to interact with controllers and
+// controllers and models) and initialize the Juju client environment
+// (preparing the Juju data directory and SSH configuration before CLI
+// commands run).
+//
+// See github.com/juju/juju/api for the underlying connection primitives.
+// See github.com/juju/juju/api/jujuclient for controller store management.
+// See github.com/juju/juju/cmd/juju/commands for CLI initialization patterns.
+package juju

--- a/juju/doc.go
+++ b/juju/doc.go
@@ -5,11 +5,13 @@
 //
 // These utilities establish authenticated API connections to Juju controllers
 // (enabling CLI commands and other clients to interact with controllers and
-// controllers and models) and initialize the Juju client environment
-// (preparing the Juju data directory and SSH configuration before CLI
-// commands run).
+// models) and initialize the Juju client environment (preparing the Juju data
+// directory and SSH configuration before CLI commands run).
 //
-// See github.com/juju/juju/api for the underlying connection primitives.
-// See github.com/juju/juju/api/jujuclient for controller store management.
-// See github.com/juju/juju/cmd/juju/commands for CLI initialization patterns.
+// Note: This package is deprecated and its contents should be distributed in
+// better places. Nothing new should be added here.
+//
+// See github.com/juju/juju/api for the underlying connection primitives. See
+// github.com/juju/juju/api/jujuclient for controller store management. See
+// github.com/juju/juju/cmd/juju/commands for CLI initialization patterns.
 package juju


### PR DESCRIPTION
This PR adds a doc.go for the top-level juju package cf. the guidelines in our AGENTS.doc-dot-go-rules.md file. 

## Links

**Jira card:** [JUJU-9467](https://warthogs.atlassian.net/browse/JUJU-9467)


[JUJU-9467]: https://warthogs.atlassian.net/browse/JUJU-9467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ