### PR TITLE
docs(apiserver): add package-level documentation

### DIFF
--- a/apiserver/doc.go
+++ b/apiserver/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package apiserver provides the server-side API implementation for Juju controllers.
+//
+// The server-side API handles authenticated client requests (from CLI commands,
+// agents, external tools, etc.) by routing them to versioned RPC facades
+// (endpoints organized by client type providing domain-specific operations).
+// The Server type manages the API server and routes incoming requests to
+// registered facades based on version and client authentication. Facades are
+// organized into subpackages by client type (agent, client, controller) and
+// registered at specific versions to support API evolution.
+//
+// See github.com/juju/juju/apiserver/facade for facade registration and
+// versioning. See github.com/juju/juju/api for the client-side connection
+// primitives. See subpackages (facades/agent, facades/client,
+// facades/controller) for specific API implementations.
+package apiserver

--- a/apiserver/doc.go
+++ b/apiserver/doc.go
@@ -4,7 +4,7 @@
 // Package apiserver provides the server-side API implementation for Juju controllers.
 //
 // The server-side API handles authenticated client requests (from CLI commands,
-// agents, external tools, etc.) by routing them to versioned RPC facades
+// agents, external tools, etc.) by routing them to versioned facades
 // (endpoints organized by client type providing domain-specific operations).
 // The Server type manages the API server and routes incoming requests to
 // registered facades based on version and client authentication. Facades are


### PR DESCRIPTION
This PR adds a doc.go for the top-level apiserver package cf. the guidelines in our AGENTS.doc-dot-go-rules.md file. 

## Links

**Jira card:** [JUJU-9463](https://warthogs.atlassian.net/browse/JUJU-9463)

[JUJU-9463]: https://warthogs.atlassian.net/browse/JUJU-9463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ