### PR TITLE
docs(caas): add package-level documentation

### DIFF
--- a/caas/doc.go
+++ b/caas/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package caas provides abstractions for container orchestration platforms.
+//
+// These abstractions enable Juju to deploy and manage applications on
+// Kubernetes and other container platforms via the Broker interface (providing
+// application lifecycle operations, storage management, networking
+// configuration, model operator deployment, etc.). Applications are deployed
+// with configurable deployment types (stateless, stateful, daemon) and service
+// types (cluster, load balancer, external, etc.). The ContainerEnvironProvider
+// interface extends the standard environ provider to support container-specific
+// operations.
+//
+// See github.com/juju/juju/environs for the base environment provider
+// interface. See github.com/juju/juju/internal/provider/kubernetes for the
+// Kubernetes implementation. See github.com/juju/juju/internal/worker/caasapplicationprovisioner
+// for application provisioning using brokers.
+package caas

--- a/caas/doc.go
+++ b/caas/doc.go
@@ -4,13 +4,11 @@
 // Package caas provides abstractions for container orchestration platforms.
 //
 // These abstractions enable Juju to deploy and manage applications on
-// Kubernetes and other container platforms via the Broker interface (providing
+// Kubernetes and other container platforms (providing
 // application lifecycle operations, storage management, networking
 // configuration, model operator deployment, etc.). Applications are deployed
 // with configurable deployment types (stateless, stateful, daemon) and service
-// types (cluster, load balancer, external, etc.). The ContainerEnvironProvider
-// interface extends the standard environ provider to support container-specific
-// operations.
+// types (cluster, load balancer, external, etc.).
 //
 // See github.com/juju/juju/environs for the base environment provider
 // interface. See github.com/juju/juju/internal/provider/kubernetes for the


### PR DESCRIPTION
This PR adds a doc.go for the top-level caas package cf. the guidelines in our AGENTS.doc-dot-go-rules.md file. 

## Links

**Jira card:** [JUJU-9464](https://warthogs.atlassian.net/browse/JUJU-9464)

[JUJU-9464]: https://warthogs.atlassian.net/browse/JUJU-9464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ