### PR TITLE
docs: add package-level documentation for environs package

### DIFF
--- a/environs/doc.go
+++ b/environs/doc.go
@@ -6,10 +6,8 @@
 // These abstractions enable Juju to manage infrastructure across different
 // clouds (AWS, Azure, OpenStack, LXD, etc.), with supporting functionality
 // for cloud image metadata and simplestreams discovery. Each cloud type has
-// a provider implementation that registers via RegisterProvider and implements
-// either EnvironProvider (for all providers) or CloudEnvironProvider (for
-// traditional clouds) to create Environ instances. A Juju environment on a
-// specific cloud instance is represented by an Environ, which provides
+// a provider implementation that creates Environ instances. A Juju environment
+// on a specific cloud instance is represented by an Environ, which provides
 // operations for instance lifecycle management, networking configuration,
 // storage provisioning, bootstrapping, etc.
 //

--- a/environs/doc.go
+++ b/environs/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package environs provides abstractions for cloud infrastructure providers.
+//
+// These abstractions enable Juju to manage infrastructure across different
+// clouds (AWS, Azure, OpenStack, LXD, etc.). Each cloud type has a provider
+// implementation that registers via RegisterProvider and implements either
+// EnvironProvider (for all providers) or CloudEnvironProvider (for traditional
+// clouds) to create Environ instances. A Juju environment on a specific cloud
+// instance is represented by an Environ, which provides operations for instance
+// lifecycle management, networking configuration, storage provisioning,
+// bootstrapping, etc.
+//
+// See github.com/juju/juju/environs/config for environment configuration. See
+// github.com/juju/juju/environs/bootstrap for controller bootstrapping. See
+// github.com/juju/juju/internal/provider for cloud provider implementations.
+package environs

--- a/environs/doc.go
+++ b/environs/doc.go
@@ -6,10 +6,10 @@
 // These abstractions enable Juju to manage infrastructure across different
 // clouds (AWS, Azure, OpenStack, LXD, etc.), with supporting functionality
 // for cloud image metadata and simplestreams discovery. Each cloud type has
-// a provider implementation that creates Environ instances. A Juju environment
-// on a specific cloud instance is represented by an Environ, which provides
-// operations for instance lifecycle management, networking configuration,
-// storage provisioning, bootstrapping, etc.
+// a provider implementation that creates Environ instances. Each Environ
+// instance represents a Juju environment on a specific cloud instance and
+// provides operations for instance lifecycle management, networking
+// configuration, storage provisioning, bootstrapping, etc.
 //
 // See github.com/juju/juju/environs/config for environment configuration. See
 // github.com/juju/juju/environs/bootstrap for controller bootstrapping. See

--- a/environs/doc.go
+++ b/environs/doc.go
@@ -1,16 +1,17 @@
 // Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package environs provides abstractions for cloud infrastructure providers.
+// Package environs provides abstractions for cloud infrastructure management.
 //
 // These abstractions enable Juju to manage infrastructure across different
-// clouds (AWS, Azure, OpenStack, LXD, etc.). Each cloud type has a provider
-// implementation that registers via RegisterProvider and implements either
-// EnvironProvider (for all providers) or CloudEnvironProvider (for traditional
-// clouds) to create Environ instances. A Juju environment on a specific cloud
-// instance is represented by an Environ, which provides operations for instance
-// lifecycle management, networking configuration, storage provisioning,
-// bootstrapping, etc.
+// clouds (AWS, Azure, OpenStack, LXD, etc.), with supporting functionality
+// for cloud image metadata and simplestreams discovery. Each cloud type has
+// a provider implementation that registers via RegisterProvider and implements
+// either EnvironProvider (for all providers) or CloudEnvironProvider (for
+// traditional clouds) to create Environ instances. A Juju environment on a
+// specific cloud instance is represented by an Environ, which provides
+// operations for instance lifecycle management, networking configuration,
+// storage provisioning, bootstrapping, etc.
 //
 // See github.com/juju/juju/environs/config for environment configuration. See
 // github.com/juju/juju/environs/bootstrap for controller bootstrapping. See


### PR DESCRIPTION
This PR adds a doc.go for the top-level environs package cf. the guidelines in our AGENTS.doc-dot-go-rules.md file. 

## Links

**Jira card:** [JUJU-9466](https://warthogs.atlassian.net/browse/JUJU-9466)

[JUJU-9466]: https://warthogs.atlassian.net/browse/JUJU-9466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ