### PR TITLE
fix: application-storage tabular output to use humanize size

### DIFF
--- a/cmd/juju/application/storage.go
+++ b/cmd/juju/application/storage.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sort"
 
+	"github.com/dustin/go-humanize"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -255,7 +256,7 @@ func formatConfigTabular(writer io.Writer, value interface{}) error {
 
 	for _, name := range valueNames {
 		info := configValues[name]
-		w.Println(name, info.Pool, info.Size, info.Count)
+		w.Println(name, info.Pool, humanize.IBytes(info.Size*humanize.MiByte), info.Count)
 	}
 
 	tw.Flush()

--- a/cmd/juju/application/storage_test.go
+++ b/cmd/juju/application/storage_test.go
@@ -117,8 +117,8 @@ func (s *ApplicationStorageSuite) TestGetDirectivesAllTabular(c *gc.C) {
 	c.Assert(len(lines), gc.Equals, 3)
 
 	assertTabLine(c, lines[0], "Storage", "Pool", "Size", "Count")
-	assertTabLine(c, lines[1], "allecto", "loop", "20480", "2")
-	assertTabLine(c, lines[2], "data", "rootfs", "10240", "1")
+	assertTabLine(c, lines[1], "allecto", "loop", "20", "GiB", "2")
+	assertTabLine(c, lines[2], "data", "rootfs", "10", "GiB", "1")
 
 	c.Assert(strings.TrimSpace(cmdtesting.Stderr(ctx)), gc.Equals, "")
 }
@@ -132,7 +132,7 @@ func (s *ApplicationStorageSuite) TestGetDirectivesSingleKeyTabular(c *gc.C) {
 	c.Assert(len(lines), gc.Equals, 2)
 
 	assertTabLine(c, lines[0], "Storage", "Pool", "Size", "Count")
-	assertTabLine(c, lines[1], "data", "rootfs", "10240", "1")
+	assertTabLine(c, lines[1], "data", "rootfs", "10", "GiB", "1")
 
 	c.Assert(strings.TrimSpace(cmdtesting.Stderr(ctx)), gc.Equals, "")
 }


### PR DESCRIPTION
Simple fix. The tabular output for application-storage formats the size to be human friendly.

YAML and JSON format still use raw values. This is what `juju storage --format {json,yaml}` does too.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
juju deploy postgresql-k8s --channel 14/stable --trust

```
juju application-storage postgresql-k8s                                  
Storage  Pool        Size     Count
pgdata   kubernetes  1.0 GiB  1
```

juju application-storage postgresql-k8s --format json | jq           

```json
{
  "pgdata": {
    "Pool": "kubernetes",
    "Size": 1024,
    "Count": 1
  }
}
```

juju application-storage postgresql-k8s --format yaml               

```yaml
pgdata:
  pool: kubernetes
  size: 1024
  count: 1
```

## Documentation changes

N/A

## Links

N/A