### PR TITLE
fix: jaas-bakery missing cleanDischargeURL and key

### DIFF
--- a/apiserver/internal/crossmodel/bakery/jaas.go
+++ b/apiserver/internal/crossmodel/bakery/jaas.go
@@ -6,12 +6,15 @@ package bakery
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"path"
 	"strings"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/juju/clock"
+	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"gopkg.in/macaroon.v2"
 
@@ -47,11 +50,15 @@ func NewJAASOfferBakery(
 	logger logger.Logger,
 ) (*JAASOfferBakery, error) {
 	store := apimacaroon.NewRootKeyStore(backingStore, apimacaroon.DefaultPolicy, clock)
-
-	externalKeyLocator := newExternalPublicKeyLocator(endpoint, httpClient, logger)
+	cleanedEndpoint, err := cleanDischargeURL(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	externalKeyLocator := newExternalPublicKeyLocator(cleanedEndpoint, httpClient, logger)
 	bakery := &bakeryutil.StorageBakery{
 		Bakery: bakery.New(bakery.BakeryParams{
 			Location:      location,
+			Key:           keyPair,
 			Locator:       externalKeyLocator,
 			RootKeyStore:  store,
 			Checker:       checker,
@@ -62,10 +69,31 @@ func NewJAASOfferBakery(
 	return &JAASOfferBakery{
 		baseBakery: baseBakery{checker: bakery.Checker},
 		oven:       bakery,
-		endpoint:   endpoint,
+		endpoint:   cleanedEndpoint,
 		clock:      clock,
 		logger:     logger,
 	}, nil
+}
+
+// cleanDischargeURL expects an address to JIMM's login-token-refresh-url,
+// and attempts to remove the .well-known/jwks.json path segments,
+// whilst preserving any pre-existing prefixes.
+//
+// For example:
+//   - jimm.com/.well-known/jwks.json -> jimm.com/macaroons
+//   - jimm.com/myprefix/.well-known/jwks.json -> jimm.com/myprefix/macaroons
+func cleanDischargeURL(addr string) (string, error) {
+	refreshURL, err := url.Parse(addr)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	cleanedPath, ok := strings.CutSuffix(refreshURL.Path, "/.well-known/jwks.json")
+	if !ok {
+		return "", errors.Trace(errors.New("failed to cut .well-known"))
+	}
+	refreshURL.Path = path.Join(cleanedPath, "macaroons")
+
+	return refreshURL.String(), nil
 }
 
 // GetConsumeOfferCaveats returns the caveats for consuming an offer.

--- a/apiserver/internal/crossmodel/bakery/jaas_test.go
+++ b/apiserver/internal/crossmodel/bakery/jaas_test.go
@@ -30,7 +30,6 @@ type jaasBakerySuite struct {
 func TestJAASBakerySuite(t *testing.T) {
 	tc.Run(t, &jaasBakerySuite{})
 }
-
 func (s *jaasBakerySuite) TestNewJAASOfferBakery(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -49,6 +48,25 @@ func (s *jaasBakerySuite) TestNewJAASOfferBakery(c *tc.C) {
 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(bakery, tc.Not(tc.IsNil))
+}
+
+func (s *jaasBakerySuite) TestNewJAASOfferBakeryError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	checker := checkers.New(apimacaroon.MacaroonNamespace)
+	_, err := NewJAASOfferBakery(
+		s.keyPair,
+		"juju model",
+		"http://offer-access/public-key",
+		s.store,
+		checker,
+		s.authorizer,
+		s.httpClient,
+		s.clock,
+		loggertesting.WrapCheckLog(c),
+	)
+
+	c.Assert(err, tc.ErrorMatches, "failed to cut .well-known.*")
 }
 
 func (s *jaasBakerySuite) TestParseCaveatNoOfferPermission(c *tc.C) {

--- a/apiserver/internal/crossmodel/bakery/jaas_test.go
+++ b/apiserver/internal/crossmodel/bakery/jaas_test.go
@@ -38,7 +38,7 @@ func (s *jaasBakerySuite) TestNewJAASOfferBakery(c *tc.C) {
 	bakery, err := NewJAASOfferBakery(
 		s.keyPair,
 		"juju model",
-		"http://offer-access",
+		"http://offer-access/.well-known/jwks.json",
 		s.store,
 		checker,
 		s.authorizer,


### PR DESCRIPTION
# Description

While trying to run an integration test in JAAS I've noticed two errors: 
1. complaining about the wrong location for the JWKS endpoint, and I see we were missing the clean func from juju 3.6. See https://github.com/juju/juju/blob/3.6/apiserver/common/crossmodel/bakery.go#L136
2. complaining about not having the private key, which was indeed missing.

# QA

https://github.com/SimoneDutto/jimm/blob/reenable-integration-tests/tests/modelmigration/migrate-providing-model.sh#L155

This test with this other pr https://github.com/canonical/jimm/pull/1970, works.
