### PR TITLE
fix: openstack storage regression

### DIFF
--- a/internal/provider/openstack/cinder.go
+++ b/internal/provider/openstack/cinder.go
@@ -73,21 +73,21 @@ func newCinderConfig(attrs map[string]any) (*cinderConfig, error) {
 
 // RecommendedPoolForKind returns the recommended storage pool to use for
 // the given storage kind. If no pool can be recommended nil is returned. The
-// openstack provider recommends the "cinder" pool for block and filesystem
-// storage.
+// OpenStack provider recommends the "cinder" pool for block storage when
+// available, and falls back to common IAAS recommendations for filesystems.
 //
 // Implements [storage.ProviderRegistry] interface.
 func (e *Environ) RecommendedPoolForKind(
 	kind storage.StorageKind,
 ) *storage.Config {
 	// If the volume url is nil it means that cinder is not supported in this
-	// enviorn region.
+	// environ region.
 	if e.volumeURL == nil {
 		return common.GetCommonRecommendedIAASPoolForKind(kind)
 	}
 
 	switch kind {
-	case storage.StorageKindBlock, storage.StorageKindFilesystem:
+	case storage.StorageKindBlock:
 		defaultPool, _ := storage.NewConfig(
 			CinderProviderType.String(), CinderProviderType, storage.Attrs{},
 		)

--- a/internal/provider/openstack/storageregistry_test.go
+++ b/internal/provider/openstack/storageregistry_test.go
@@ -23,8 +23,8 @@ func TestStorageRegistrySuite(t *testing.T) {
 }
 
 // TestRecommendedPoolForKindWithCinder ensures that when cinder is available to
-// the environ that the cinder pool is the recommended storage for filesystem
-// and block storage.
+// the environ that cinder is recommended for block storage, and the common
+// IAAS filesystem recommendation is used for filesystem storage.
 func (s *storageRegistrySuite) TestRecommendedPoolForKindWithCinder(c *tc.C) {
 	volumeURL, err := url.Parse("https://cinder.example.com")
 	c.Assert(err, tc.IsNil)
@@ -36,9 +36,9 @@ func (s *storageRegistrySuite) TestRecommendedPoolForKindWithCinder(c *tc.C) {
 	c.Check(bPool.Name(), tc.Equals, "cinder")
 	c.Check(bPool.Provider().String(), tc.Equals, "cinder")
 
-	fPool := env.RecommendedPoolForKind(internalstorage.StorageKindBlock)
-	c.Check(fPool.Name(), tc.Equals, "cinder")
-	c.Check(fPool.Provider().String(), tc.Equals, "cinder")
+	fPool := env.RecommendedPoolForKind(internalstorage.StorageKindFilesystem)
+	c.Check(fPool.Name(), tc.Equals, "rootfs")
+	c.Check(fPool.Provider().String(), tc.Equals, "rootfs")
 }
 
 // TestRecommendedPoolForKindWithoutCinder ensures that if cinder is not
@@ -53,7 +53,7 @@ func (s *storageRegistrySuite) TestRecommendedPoolForKindWithoutCinder(c *tc.C) 
 		c.Check(bPool.Provider().String(), tc.Not(tc.Equals), "cinder")
 	}
 
-	fPool := env.RecommendedPoolForKind(internalstorage.StorageKindBlock)
+	fPool := env.RecommendedPoolForKind(internalstorage.StorageKindFilesystem)
 	if fPool != nil {
 		c.Check(fPool.Name(), tc.Not(tc.Equals), "cinder")
 		c.Check(fPool.Provider().String(), tc.Not(tc.Equals), "cinder")


### PR DESCRIPTION
In Juju 3.6, filesystems on OpenStack would default to the rootfs provider / pool. However, in 4.0, this was changed to cinder.

See:
https://github.com/juju/juju/blob/30c6b0b26967076a85f16a9cd5fdbba58fc024ff/state/storage.go#L1984-L2097

Revert this back to rootfs

I believe either @hpidcock or @tlm should review this before merge

Note: other providers have a similar pattern, which I find suspicious. e.g.
https://github.com/juju/juju/blob/d118d9169e67924df8a34c939da06e5877843dec/internal/provider/ec2/ebs.go#L170-L182

## QA steps

TBA. This is still in progress