### PR TITLE
fix: use relation id and not string

### DIFF
--- a/apiserver/internal/crossmodel/authcontext.go
+++ b/apiserver/internal/crossmodel/authcontext.go
@@ -171,7 +171,7 @@ func (a *AuthContext) CreateRemoteRelationMacaroon(
 	return a.bakery.NewMacaroon(
 		ctx, version,
 		a.bakery.GetRemoteRelationCaveats(offerUUID, modelUUID.String(), username, rel.Id()),
-		crossModelRelateOp(rel.String()),
+		crossModelRelateOp(rel.Id()),
 	)
 }
 

--- a/apiserver/internal/crossmodel/authcontext_test.go
+++ b/apiserver/internal/crossmodel/authcontext_test.go
@@ -311,7 +311,7 @@ func (s *authSuite) TestCreateRemoteRelationMacaroon(c *tc.C) {
 		gomock.Any(),
 		bakery.LatestVersion,
 		s.caveatWithRelation(now),
-		crossModelRelateOp(relationTag.String()),
+		crossModelRelateOp(relationTag.Id()),
 	).Return(expected, nil)
 
 	authContext := s.newAuthContext(c)


### PR DESCRIPTION
Fixed: CreateRemoteRelationMacaroon now uses rel.Id() (the relation key, e.g. "mediawiki:db mysql:server") instead of rel.String() (the full tag, e.g. "relation-mediawiki:db#mysql:server"), matching 3.6 behavior and the corresponding CheckRelationMacaroons which verifies with relationTag.Id()

## QA steps

 ### 4.0 to 4.0 cross-controller CMR

 ```sh
 # Build juju on this branch
 $ juju bootstrap lxd offering
 $ juju add-model m
 $ juju deploy juju-qa-dummy-source
 $ juju config dummy-source token=abc
 $ juju offer dummy-source:sink
```

```
 $ juju bootstrap lxd consuming
 $ juju add-model m
 $ juju consume offering:admin/m.dummy-source
 $ juju deploy juju-qa-dummy-sink
 $ juju relate dummy-sink dummy-source
 # Wait until relation joins
 $ juju status --relations
 $ juju exec --unit dummy-sink/0 -- cat /var/run/dummy-sink/token
 abc
```

Verify no macaroon errors in logs

```
 $ juju debug-log -m offering:m --include-labels cmr-auth 2>&1 | grep -i "error\|perm"
 $ juju debug-log -m consuming:m --include-labels cmr-auth 2>&1 | grep -i "error\|perm"
```

No permission or macaroon errors should appear. The relation should reach joined status and the token should propagate.

 ### 3.6 to 4.0 cross-controller CMR

```sh
 $ juju_36 bootstrap lxd c36
 $ juju_36 add-model m
 $ juju_36 deploy juju-qa-dummy-source
 $ juju_36 config dummy-source token=abc
 $ juju_36 offer dummy-source:sink
```

```
 # Build juju on this branch
 $ juju bootstrap lxd c40
 $ juju add-model m
 $ juju consume c36:admin/m.dummy-source
 $ juju deploy juju-qa-dummy-sink
 $ juju relate dummy-sink dummy-source
 # Wait until relation joins
 $ juju status --relations
 $ juju exec --unit dummy-sink/0 -- cat /var/run/dummy-sink/token
 abc
```