### PR TITLE
test: make k8s secrets shell tests more robust

### DIFF
--- a/internal/provider/kubernetes/klog.go
+++ b/internal/provider/kubernetes/klog.go
@@ -124,7 +124,7 @@ type klogSuppressMessagePrefixes []*klogSuppressMessagePrefix
 var (
 	klogSuppressedPrefixes = klogSuppressMessagePrefixes{
 		&klogSuppressMessagePrefix{
-			prefix: "Use tokens from the TokenRequest API or manually created secret-based tokens instead of auto-generated secret-based tokens",
+			prefix: "Warning: Use tokens from the TokenRequest API or manually created secret-based tokens instead of auto-generated secret-based tokens",
 			// We suppress the message at a rate of 1 per 5 minute, but we
 			// allow the first message to go through.
 			rate: &rate.Sometimes{

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -78,7 +78,10 @@ type appLoopState struct {
 	storageConstraintsChan <-chan time.Time
 }
 
-const tryAgain errors.ConstError = "try again"
+const (
+	tryAgain      errors.ConstError = "try again"
+	unitsChurning errors.ConstError = "units churning"
+)
 
 type NewAppWorkerFunc func(AppWorkerConfig) func() (worker.Worker, error)
 
@@ -251,7 +254,8 @@ func (a *appWorker) loop() error {
 		retryDelay = 3 * time.Second
 	)
 
-	refreshTimer := a.clock.NewTimer(10 * time.Second)
+	const refreshInterval = 10 * time.Second
+	refreshTimer := a.clock.NewTimer(refreshInterval)
 	defer refreshTimer.Stop()
 	for {
 		shouldRefresh := true
@@ -435,7 +439,10 @@ func (a *appWorker) loop() error {
 			return nil
 		}
 		if shouldRefresh {
-			if err = a.ops.RefreshApplicationStatus(a.name, state.app, appLife, a.facade, a.logger); err != nil {
+			err = a.ops.RefreshApplicationStatus(a.name, state.app, state.appLife, a.facade, a.logger)
+			if errors.Is(err, unitsChurning) {
+				refreshTimer.Reset(refreshInterval)
+			} else if err != nil {
 				return errors.Annotatef(err, "refreshing application status for %q", a.name)
 			}
 		}

--- a/internal/worker/caasapplicationprovisioner/application_test.go
+++ b/internal/worker/caasapplicationprovisioner/application_test.go
@@ -144,7 +144,7 @@ func (s *ApplicationWorkerSuite) TestUpgradePodSpec(c *gc.C) {
 	ops := mocks.NewMockApplicationOps(ctrl)
 	done := make(chan struct{})
 
-	clk := testclock.NewClock(time.Time{})
+	clk := testclock.NewDilatedWallClock(time.Millisecond)
 	gomock.InOrder(
 		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(brokerApp),
 		facade.EXPECT().Life("test").Return(life.Alive, nil),
@@ -499,6 +499,79 @@ func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *gc.C) {
 	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, true)
 	s.waitDone(c, done)
 	workertest.CheckKill(c, appWorker)
+}
+
+func (s *ApplicationWorkerSuite) TestWorkerRefreshTimerResetOnUnitsChurning(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	broker := mocks.NewMockCAASBroker(ctrl)
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	unitFacade := mocks.NewMockCAASUnitProvisionerFacade(ctrl)
+	ops := mocks.NewMockApplicationOps(ctrl)
+
+	clk := testclock.NewDilatedWallClock(time.Millisecond)
+
+	scaleChan := make(chan struct{}, 1)
+	trustChan := make(chan []string, 1)
+	provisioningInfoChan := make(chan struct{}, 1)
+	appUnitsChan := make(chan []string, 1)
+	appChan := make(chan struct{}, 1)
+	appReplicasChan := make(chan struct{}, 1)
+	storageConsChan := make(chan struct{}, 1)
+
+	firstRefresh := make(chan struct{}, 1)
+	done := make(chan struct{})
+
+	gomock.InOrder(
+		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
+		facade.EXPECT().Life("test").Return(life.Alive, nil),
+
+		unitFacade.EXPECT().WatchApplicationScale("test").Return(watchertest.NewMockNotifyWatcher(scaleChan), nil),
+		unitFacade.EXPECT().WatchApplicationTrustHash("test").Return(watchertest.NewMockStringsWatcher(trustChan), nil),
+		facade.EXPECT().WatchUnits("test").Return(watchertest.NewMockStringsWatcher(appUnitsChan), nil),
+		facade.EXPECT().WatchStorageConstraints("test").Return(watchertest.NewMockNotifyWatcher(storageConsChan), nil),
+
+		facade.EXPECT().Life("test").Return(life.Alive, nil),
+		facade.EXPECT().ProvisioningState("test").Return(nil, nil),
+		facade.EXPECT().WatchProvisioningInfo("test").Return(watchertest.NewMockNotifyWatcher(provisioningInfoChan), nil),
+		app.EXPECT().Watch().Return(watchertest.NewMockNotifyWatcher(appChan), nil),
+		app.EXPECT().WatchReplicas().Return(watchertest.NewMockNotifyWatcher(appReplicasChan), nil),
+
+		ops.EXPECT().RefreshApplicationStatus("test", app, life.Alive, facade, s.logger).DoAndReturn(func(_ string, _ caas.Application, _ life.Value, _ caasapplicationprovisioner.CAASProvisionerFacade, _ caasapplicationprovisioner.Logger) error {
+			select {
+			case firstRefresh <- struct{}{}:
+			default:
+			}
+			return errors.ConstError("units churning")
+		}),
+		ops.EXPECT().RefreshApplicationStatus("test", app, life.Alive, facade, s.logger).DoAndReturn(func(_ string, _ caas.Application, _ life.Value, _ caasapplicationprovisioner.CAASProvisionerFacade, _ caasapplicationprovisioner.Logger) error {
+			close(done)
+			return nil
+		}),
+	)
+
+	appWorker := s.startAppWorker(c, clk, facade, broker, unitFacade, ops, true)
+
+	clk.Advance(0)
+	select {
+	case <-firstRefresh:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for initial refresh")
+	}
+
+	clk.Advance(9 * time.Second)
+	select {
+	case <-done:
+		c.Fatalf("refresh fired before interval elapsed")
+	default:
+	}
+
+	clk.Advance(1 * time.Second)
+	s.waitDone(c, done)
+
+	workertest.CleanKill(c, appWorker)
 }
 
 func (s *ApplicationWorkerSuite) TestWorkerScaleNotReadyRetry(c *gc.C) {

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -624,7 +624,12 @@ func refreshApplicationStatus(appName string, app caas.Application, appLife life
 		// Only set status to waiting for scale up.
 		// When the application gets scaled down, the desired units will be kept running and
 		// the application should be active always.
-		return setApplicationStatus(appName, status.Waiting, "waiting for units to settle down", nil, facade, logger)
+		statusErr := setApplicationStatus(appName, status.Waiting, "waiting for units to settle down", nil, facade, logger)
+		if statusErr != nil {
+			return statusErr
+		}
+		// Signal to the caller that units have not yet settled down.
+		return unitsChurning
 	}
 	return setApplicationStatus(appName, status.Active, "", nil, facade, logger)
 }

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -336,7 +336,7 @@ func (s *OpsSuite) TestUpdateState(c *gc.C) {
 	})
 }
 
-func (s *OpsSuite) TestRefreshApplicationStatus(c *gc.C) {
+func (s *OpsSuite) TestRefreshApplicationStatusChurning(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -356,6 +356,32 @@ func (s *OpsSuite) TestRefreshApplicationStatus(c *gc.C) {
 		app.EXPECT().State().Return(appState, nil),
 		facade.EXPECT().Units("test").Return(units, nil),
 		facade.EXPECT().SetOperatorStatus("test", status.Waiting, "waiting for units to settle down", nil).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.RefreshApplicationStatus("test", app, appLife, facade, s.logger)
+	c.Assert(errors.Is(err, errors.ConstError("units churning")), jc.IsTrue)
+}
+
+func (s *OpsSuite) TestRefreshApplicationStatusSettled(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appLife := life.Alive
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+
+	appState := caas.ApplicationState{
+		DesiredReplicas: 2,
+	}
+	units := []params.CAASUnit{{
+		UnitStatus: &params.UnitStatus{AgentStatus: params.DetailedStatus{Status: "active"}},
+	}, {
+		UnitStatus: &params.UnitStatus{AgentStatus: params.DetailedStatus{Status: "active"}},
+	}}
+	gomock.InOrder(
+		app.EXPECT().State().Return(appState, nil),
+		facade.EXPECT().Units("test").Return(units, nil),
+		facade.EXPECT().SetOperatorStatus("test", status.Active, "", nil).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.RefreshApplicationStatus("test", app, appLife, facade, s.logger)

--- a/internal/worker/secretsrevoker/worker.go
+++ b/internal/worker/secretsrevoker/worker.go
@@ -122,6 +122,14 @@ func (w *revoker) loop() (err error) {
 		fire  <-chan time.Time
 	)
 	for {
+		scheduleTime := func(target time.Time) time.Time {
+			now := clk.Now()
+			if !target.After(now) {
+				return now
+			}
+			return quantiseTime(target)
+		}
+
 		select {
 		case <-w.catacomb.Dying():
 			if !next.IsZero() {
@@ -149,7 +157,7 @@ func (w *revoker) loop() (err error) {
 			if earliest.IsZero() {
 				continue
 			}
-			earliestQuantised := quantiseTime(earliest)
+			earliestQuantised := scheduleTime(earliest)
 			if !next.Equal(earliestQuantised) {
 				next = earliestQuantised
 				logger.Debugf("scheduling revoke at %v", next)
@@ -171,7 +179,7 @@ func (w *revoker) loop() (err error) {
 				next = time.Time{}
 				continue
 			}
-			next = quantiseTime(nextRevoke)
+			next = scheduleTime(nextRevoke)
 			logger.Debugf("scheduling revoke at %v", next)
 			alarm.Reset(next)
 		}

--- a/internal/worker/secretsrevoker/worker_test.go
+++ b/internal/worker/secretsrevoker/worker_test.go
@@ -176,28 +176,37 @@ func (s *workerSuite) TestWorkerQuantisedSchedule(c *gc.C) {
 
 	const iterations = 100
 	clk := testclock.NewDilatedWallClock(50 * time.Microsecond)
+	type scheduleStep struct {
+		next      time.Time
+		quantised time.Time
+	}
+	steps := make([]scheduleStep, 0, iterations)
 	now := clk.Now().UTC().Truncate(time.Second)
-	times := map[time.Time]time.Time{}
-	first := time.Time{}
-	for i := range iterations {
-		next := now.Add(time.Duration(rand.Intn(600)) * time.Second)
-		nextQ := secretsrevoker.DefaultQuantiseTime(next)
-		times[next] = nextQ
-		if i == 0 {
-			first = next
-		} else {
-			s.facade.EXPECT().RevokeIssuedTokens(times[now]).Return(next, nil)
-		}
+	for range iterations {
+		next := now.Add(time.Duration(rand.Intn(600)+1) * time.Second)
+		steps = append(steps, scheduleStep{
+			next:      next,
+			quantised: secretsrevoker.DefaultQuantiseTime(next),
+		})
 		now = next
 	}
+	first := steps[0].next
 
 	done := make(chan struct{})
-	s.facade.EXPECT().RevokeIssuedTokens(
-		times[now],
-	).DoAndReturn(func(_ time.Time) (time.Time, error) {
-		defer close(done)
-		return time.Time{}, nil
-	})
+	for i, step := range steps {
+		s.facade.EXPECT().RevokeIssuedTokens(gomock.Any()).DoAndReturn(func(until time.Time) (time.Time, error) {
+			if !until.Equal(step.quantised) {
+				// If the clock has already passed the target expiry, the worker
+				// intentionally schedules immediate revocation.
+				c.Assert(until, jc.Before, clk.Now().Add(2*time.Second))
+			}
+			if i+1 >= len(steps) {
+				close(done)
+				return time.Time{}, nil
+			}
+			return steps[i+1].next, nil
+		})
+	}
 
 	ch := make(chan []string, 1)
 	ch <- []string(nil)
@@ -205,26 +214,54 @@ func (s *workerSuite) TestWorkerQuantisedSchedule(c *gc.C) {
 	defer workertest.CheckKilled(c, expiryWatcher)
 	s.facade.EXPECT().WatchIssuedTokenExpiry().Return(expiryWatcher, nil)
 
-	quantiseTime := func(x time.Time) time.Time {
-		for k, v := range times {
-			if k.Equal(x) {
-				return v
-			}
-		}
-		c.Errorf("unexpected time %q", x)
-		return x
-	}
 	w, err := secretsrevoker.NewWorker(secretsrevoker.Config{
 		Facade:       s.facade,
 		Logger:       loggo.GetLogger("test"),
 		Clock:        clk,
-		QuantiseTime: quantiseTime,
+		QuantiseTime: secretsrevoker.DefaultQuantiseTime,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 	defer workertest.CleanKill(c, w)
 
 	ch <- []string{first.Format(time.RFC3339)}
+	<-done
+}
+
+func (s *workerSuite) TestWorkerSchedulesImmediateForPastDueExpiry(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	clk := testclock.NewDilatedWallClock(time.Millisecond)
+	now := clk.Now().UTC().Truncate(time.Second)
+	pastDue := now.Add(-10 * time.Second)
+
+	ch := make(chan []string, 1)
+	ch <- []string(nil)
+	expiryWatcher := watchertest.NewMockStringsWatcher(ch)
+	defer workertest.CheckKilled(c, expiryWatcher)
+	s.facade.EXPECT().WatchIssuedTokenExpiry().Return(expiryWatcher, nil)
+
+	done := make(chan struct{})
+	s.facade.EXPECT().RevokeIssuedTokens(gomock.Any()).DoAndReturn(func(until time.Time) (time.Time, error) {
+		defer close(done)
+		c.Assert(until, jc.Before, now.Add(5*time.Second))
+		return time.Time{}, nil
+	})
+
+	w, err := secretsrevoker.NewWorker(secretsrevoker.Config{
+		Facade: s.facade,
+		Logger: loggo.GetLogger("test"),
+		Clock:  clk,
+		QuantiseTime: func(t time.Time) time.Time {
+			// Use a large offset to make accidental quantisation obvious.
+			return t.Add(10 * time.Minute)
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.NotNil)
+	defer workertest.CleanKill(c, w)
+
+	ch <- []string{pastDue.Format(time.RFC3339)}
 	<-done
 }
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -91,6 +91,10 @@ bootstrap() {
 		;;
 	"k8s")
 		cloud="${BOOTSTRAP_CLOUD:-$(default_k8s)}"
+		if [[ -z ${cloud} ]]; then
+			echo "must specify k8s cloud to bootstrap"
+			exit 1
+		fi
 		;;
 	"manual")
 		manual_name=${1}

--- a/tests/includes/k8s.sh
+++ b/tests/includes/k8s.sh
@@ -1,9 +1,11 @@
 kubectl() {
 	local k8s="${BOOTSTRAP_CLOUD}"
 	case "${BOOTSTRAP_PROVIDER}" in
-	"k8s") ;;
+	"k8s")
+		k8s="${BOOTSTRAP_CLOUD:-$(default_k8s)}"
+		;;
 	*)
-		# Use a local k8s that is available for IAAS testing needs.
+		# Use a local k8s that is available for CAAS testing needs.
 		k8s="$(default_k8s)"
 		;;
 	esac
@@ -25,9 +27,9 @@ kubectl() {
 }
 
 default_k8s() {
-	if which "minikube" >/dev/null 2>&1; then
+	if command -v minikube && [[ "Started" == "$(minikube status -o json | yq .Host)" ]]; then
 		printf "minikube"
-	elif which "microk8s" >/dev/null 2>&1; then
+	elif command -v microk8s && [[ "True" == "$(microk8s status --format yaml | yq .microk8s.running)" ]]; then
 		printf "microk8s"
 	fi
 }

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -54,7 +54,7 @@ run_secrets() {
 	done
 
 	echo "remove the app and the app owned secret should be deleted too"
-	juju --show-log remove-application prometheus-k8s
+	juju --show-log remove-application prometheus-k8s --no-prompt
 	attempt=0
 	until [[ -z $(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")') ]]; do
 		if [[ ${attempt} -ge 30 ]]; then

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -7,26 +7,26 @@ run_secrets() {
 	# k8s secrets are stored in an external backend.
 	# These checks ensure the secrets are deleted when the units and app are deleted.
 	echo "deploy an app and create an app owned secret and a unit owned secret"
-	juju --show-log deploy alertmanager-k8s --trust
-	wait_for "alertmanager-k8s" "$(active_idle_condition "alertmanager-k8s" 0 0)"
-	wait_for "active" '.applications["alertmanager-k8s"] | ."application-status".current'
-	full_uri1=$(juju exec --unit alertmanager-k8s/0 -- secret-add foo=bar)
+	juju --show-log deploy prometheus-k8s --trust
+	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0 0)"
+	wait_for "prometheus-k8s" "$(idle_condition "prometheus-k8s")"
+	full_uri1=$(juju exec --unit prometheus-k8s/0 -- secret-add foo=bar)
 	short_uri1=${full_uri1##*/}
-	full_uri2=$(juju exec --unit alertmanager-k8s/0 -- secret-add --owner unit foo=bar2)
+	full_uri2=$(juju exec --unit prometheus-k8s/0 -- secret-add --owner unit foo=bar2)
 	short_uri2=${full_uri2##*/}
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")')" "${short_uri1}-1"
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri2}"'-1")')" "${short_uri2}-1"
 
 	echo "add another unit and create a unit owned secret"
-	juju --show-log scale-application alertmanager-k8s 2
-	wait_for "alertmanager-k8s" "$(active_idle_condition "alertmanager-k8s" 0 1)"
-	full_uri3=$(juju exec --unit alertmanager-k8s/1 -- secret-add --owner unit foo=bar3)
+	juju --show-log scale-application prometheus-k8s 2
+	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0 1)"
+	full_uri3=$(juju exec --unit prometheus-k8s/1 -- secret-add --owner unit foo=bar3)
 	short_uri3=${full_uri3##*/}
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri3}"'-1")')" "${short_uri3}-1"
 
 	echo "remove a unit and check only its secret is removed"
-	juju --show-log scale-application alertmanager-k8s 1
-	wait_for_unit_count "alertmanager-k8s" 1
+	juju --show-log scale-application prometheus-k8s 1
+	wait_for_unit_count "prometheus-k8s" 1
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")')" "${short_uri1}-1"
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri2}"'-1")')" "${short_uri2}-1"
 	attempt=0
@@ -40,8 +40,8 @@ run_secrets() {
 	done
 
 	echo "remove the last unit and check only the app owned secret remains"
-	juju --show-log scale-application alertmanager-k8s 0
-	wait_for_unit_count "alertmanager-k8s" 0
+	juju --show-log scale-application prometheus-k8s 0
+	wait_for_unit_count "prometheus-k8s" 0
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")')" "${short_uri1}-1"
 	attempt=0
 	until [[ -z $(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri2}"'-1")') ]]; do
@@ -54,7 +54,7 @@ run_secrets() {
 	done
 
 	echo "remove the app and the app owned secret should be deleted too"
-	juju --show-log remove-application alertmanager-k8s
+	juju --show-log remove-application prometheus-k8s
 	attempt=0
 	until [[ -z $(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")') ]]; do
 		if [[ ${attempt} -ge 30 ]]; then
@@ -65,19 +65,16 @@ run_secrets() {
 		attempt=$((attempt + 1))
 	done
 
-	juju --show-log deploy alertmanager-k8s hello --trust
-	juju --show-log deploy nginx-ingress-integrator nginx --trust --config service-hostname=hello.test
-	juju --show-log integrate nginx hello
+	juju --show-log deploy prometheus-k8s hello --trust
+	juju --show-log deploy prometheus-k8s world --trust
+	juju --show-log integrate world:metrics-endpoint hello:self-metrics-endpoint
 
 	# create user secrets.
 	juju --show-log add-secret mysecret owned-by="$model_name" --info "this is a user secret"
 
-	wait_for "active" '.applications["hello"] | ."application-status".current'
-	wait_for "hello" "$(idle_condition "hello" 0)"
-	wait_for "active" '.applications["nginx"] | ."application-status".current' 900
-	wait_for "nginx" "$(idle_condition "nginx" 1 0)"
-	wait_for "active" "$(workload_status "nginx" 0).current"
-	wait_for "hello" '.applications["nginx"] | .relations.ingress[0]'
+	wait_for "hello" "$(active_idle_condition "hello" 0 0)"
+	wait_for "world" "$(active_idle_condition "world" 1 0)"
+	wait_for "hello" '.applications["world"] | .relations.metrics-endpoint[0].related-application'
 
 	echo "Apps deployed, creating secrets"
 	unit_owned_full_uri=$(juju exec --unit hello/0 -- secret-add --owner unit owned-by=hello/0)
@@ -109,30 +106,30 @@ run_secrets() {
 	echo "Checking: secret-info-get by label - metadata"
 	check_contains "$(juju exec --unit hello/0 -- secret-info-get --label=hello_0 --format json | yq ".${unit_owned_short_uri}.label")" hello_0
 
-	relation_id=$(juju --show-log show-unit hello/0 --format json | yq '."hello/0"."relation-info"[0]."relation-id"')
+	relation_id=$(juju --show-log show-unit hello/0 --format json | yq '."hello/0"."relation-info"[1]."relation-id"')
 	juju exec --unit hello/0 -- secret-grant "$unit_owned_full_uri" -r "$relation_id"
 	juju exec --unit hello/0 -- secret-grant "$app_owned_full_uri" -r "$relation_id"
 
 	echo "Checking: secret-get by URI - consume content"
-	check_contains "$(juju exec --unit nginx/0 -- secret-get "$unit_owned_full_uri")" 'owned-by: hello/0'
-	check_contains "$(juju exec --unit nginx/0 -- secret-get "$app_owned_full_uri")" 'owned-by: hello-app'
+	check_contains "$(juju exec --unit world/0 -- secret-get "$unit_owned_full_uri")" 'owned-by: hello/0'
+	check_contains "$(juju exec --unit world/0 -- secret-get "$app_owned_full_uri")" 'owned-by: hello-app'
 
-	juju exec --unit nginx/0 -- secret-get "$unit_owned_full_uri" --label=consumer_label_secret_owned_by_hello_0
-	juju exec --unit nginx/0 -- secret-get "$app_owned_full_uri" --label=consumer_label_secret_owned_by_hello
+	juju exec --unit world/0 -- secret-get "$unit_owned_full_uri" --label=consumer_label_secret_owned_by_hello_0
+	juju exec --unit world/0 -- secret-get "$app_owned_full_uri" --label=consumer_label_secret_owned_by_hello
 
-	check_contains "$(juju exec --unit nginx/0 -- secret-get --label=consumer_label_secret_owned_by_hello_0)" 'owned-by: hello/0'
-	check_contains "$(juju exec --unit nginx/0 -- secret-get --label=consumer_label_secret_owned_by_hello)" 'owned-by: hello-app'
+	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello_0)" 'owned-by: hello/0'
+	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello)" 'owned-by: hello-app'
 
 	check_contains "$(kubectl -n "$model_name" get "secrets/${unit_owned_short_uri}-1" -o json | yq -r '.data["owned-by"]' | base64 -d)" "hello/0"
 	check_contains "$(kubectl -n "$model_name" get "secrets/${app_owned_short_uri}-1" -o json | yq -r '.data["owned-by"]' | base64 -d)" "hello-app"
 
 	echo "Checking: secret-revoke by relation ID"
 	juju exec --unit hello/0 -- secret-revoke "$app_owned_full_uri" --relation "$relation_id"
-	check_contains "$(juju exec --unit nginx/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit world/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'permission denied'
 
 	echo "Checking: secret-revoke by app name"
-	juju exec --unit hello/0 -- secret-revoke "$unit_owned_short_uri" --app nginx
-	check_contains "$(juju exec --unit nginx/0 -- secret-get "$unit_owned_short_uri" 2>&1)" 'permission denied'
+	juju exec --unit hello/0 -- secret-revoke "$unit_owned_short_uri" --app world
+	check_contains "$(juju exec --unit world/0 -- secret-get "$unit_owned_short_uri" 2>&1)" 'permission denied'
 
 	echo "Checking: secret-remove"
 	juju exec --unit hello/0 -- secret-remove "$unit_owned_short_uri"
@@ -141,9 +138,9 @@ run_secrets() {
 	check_contains "$(juju exec --unit hello/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'not found'
 
 	# TODO: no need to remove-relation before destroying model once we fixed(lp:1952221).
-	juju --show-log remove-relation nginx hello
+	juju --show-log remove-relation world hello
 	# wait for relation removed.
-	wait_for null '.applications["nginx"] | .relations.source[0]'
+	wait_for null '.applications["world"] | .relations.self-metrics-endpoint[0]'
 	destroy_model "$model_name"
 }
 


### PR DESCRIPTION
Some k8s secrets tests were using flakey charms - use prometheus-k8s instead.

And, we have an existing issue where the initial deployment on k8s doesn't record the app status properly. It remains as "waiting" because the pods don't go active within the initial 10s window and the worker doesn't refresh again. So we add a special error on the refresh method so signal that things are churning and we use that to reset the refresh timer to try again.

Also fix the k8s detection to allow for both minikube and microk8s to be installed - it picks whatever one is running. And fix the kubectl detection.

Drive by: adjust the k8s log message prefix to suppress the "Use tokens from the TokenRequest API..." messages.

## QA steps

```
main.sh -v \
  -s test_secret_drain,test_user_secrets,test_user_secret_drain,test_add_multiple_secrets_parallel,test_secrets_cmr \
  secrets_k8s
```