### PR TITLE
provisioner: stop after error to avoid nil info dereference

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -98,6 +98,7 @@ func (api *ProvisionerAPI) ProvisioningInfo(ctx context.Context, args params.Ent
 		)
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
 		}
 
 		// Attach the required controller config to the provisioning info,


### PR DESCRIPTION
Closes #22351. `ProvisioningInfo` set the per-result error from `getProvisioningInfo` but fell through to `info.ControllerConfig = controllerConfig` on the next line, panicking when `info` is nil.