### PR TITLE
chore(bootstrap): install controller snap from specified channel

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -473,9 +473,7 @@ func bootstrapIAAS(
 
 	if featureflag.Enabled(featureflag.ControllerSnap) {
 		if args.ControllerSnapPath == "" && args.ControllerSnapRevision == "" {
-			args.ControllerSnapResolvedChannel = fmt.Sprintf(
-				"%d.%d/edge", jujuversion.Current.Major, jujuversion.Current.Minor,
-			)
+			args.ControllerSnapResolvedChannel = resolveSnapChannel(args.ControllerSnapChannel)
 			resolvedVersion, err := resolveSnapChannelVersion(ctx, args.ControllerSnapResolvedChannel)
 			if err != nil {
 				return errors.Annotate(err, "resolving controller snap version")
@@ -712,6 +710,16 @@ func bootstrapIAAS(
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func resolveSnapChannel(channel charm.Channel) string {
+	if !channel.Empty() {
+		return channel.String()
+	}
+
+	return fmt.Sprintf(
+		"%d.%d/edge", jujuversion.Current.Major, jujuversion.Current.Minor,
+	)
 }
 
 func finaliseInstanceRole(

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1115,6 +1115,36 @@ func (s *bootstrapSuite) TestBootstrapControllerSnapLatestFromSnapStore(c *tc.C)
 	c.Assert(env.instanceConfig.Bootstrap.ControllerSnapExpectedVersion, tc.Equals, resolvedVersion.String())
 }
 
+func (s *bootstrapSuite) TestBootstrapControllerSnapCandidateChannel(c *tc.C) {
+	s.SetFeatureFlags(featureflag.ControllerSnap)
+
+	resolvedVersion := jujuversion.Current.ToPatch()
+	s.PatchValue(bootstrap.RunSnapInfoCommand, func(_ context.Context, _ string) (string, error) {
+		return fmt.Sprintf(`
+  4.0/stable:    4.0.5             2026-03-26 (34378) 107MB -
+  4.0/candidate: %s                2026-04-28 (34852) 108MB -
+  4.0/beta:      ↑
+  4.0/edge:      4.0.10-e0c5d0b    2026-04-29 (34868) 108MB -
+`, resolvedVersion.String()), nil
+	})
+
+	env := newEnviron("foo", useDefaultKeys, nil)
+	ctx := cmdtesting.Context(c)
+	err := bootstrap.Bootstrap(environscmd.BootstrapContext(c.Context(), ctx), env,
+		bootstrap.BootstrapParams{
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             "admin-secret",
+			CAPrivateKey:            coretesting.CAKey,
+			SSHServerHostKey:        coretesting.SSHServerHostKey,
+			SupportedBootstrapBases: supportedJujuBases,
+			ControllerSnapChannel:   charm.Channel{Track: "4.0", Risk: charm.Candidate},
+		})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(env.instanceConfig.Bootstrap.ControllerSnapChannel, tc.Equals, "4.0/candidate")
+	c.Assert(env.instanceConfig.Bootstrap.ControllerSnapExpectedVersion, tc.Equals, resolvedVersion.String())
+}
+
 func createImageMetadata(c *tc.C) (dir string, _ []*imagemetadata.ImageMetadata) {
 	return createImageMetadataForArch(c, "amd64")
 }

--- a/environs/bootstrap/snap.go
+++ b/environs/bootstrap/snap.go
@@ -31,6 +31,20 @@ func resolveSnapChannelVersion(ctx context.Context, channel string) (string, err
 	pattern := fmt.Sprintf(`(?m)^\s*%s:\s*([^\s]+)`, regexp.QuoteMeta(channel))
 	matches := regexp.MustCompile(pattern).FindStringSubmatch(out)
 	if len(matches) < 2 {
+		return "", errors.Errorf("unable to find controller snap version in channel %q", channel)
+	}
+
+	// validate the version of the snap matches following structure:
+	//  4.1/edge:      4.1-beta2-cbd20b2
+	//  4.0/stable:    4.0.5
+	//  4.0/edge:      4.0.10-e0c5d0b
+	//  3.6/beta:      3.6-beta2
+	//
+	// But not any of:
+	//  4/beta:        ↑
+	//  4.1/beta:      –
+	v := strings.Split(matches[1], ".")
+	if len(v) < 2 {
 		return "", errors.Errorf("unable to resolve controller snap version in channel %q", channel)
 	}
 


### PR DESCRIPTION
This PR makes bootstrap honor the `--controller-snap-channel` argument when
resolving which controller snap to install, instead of always defaulting to the
current `<major>.<minor>/edge` channel when no snap path or revision is
provided.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```sh
export JUJU_DEV_FEATURE_FLAGS="controller-snap"

❯ juju bootstrap lxd c --controller-snap-channel 4/beta
Creating Juju controller "c" on lxd/default
ERROR failed to bootstrap model: resolving controller snap version: unable to resolve controller snap version in channel "4/beta"

❯ juju bootstrap lxd c --controller-snap-channel 4.5/beta
Creating Juju controller "c" on lxd/default
ERROR failed to bootstrap model: resolving controller snap version: unable to find controller snap version in channel "4.5/beta"
```

This is still bootstrapping the current version instead of the resolved version. Because if we implemented it now, it wouldn't be able to find any tools in simplestreams in 4.1. We'll leave the tools version to later when we have actual snaps.

```
❯ juju bootstrap lxd c --controller-snap-channel 4.0/candidate
Creating Juju controller "c" on lxd/default
Resolved controller snap channel "4.0/candidate" to version 4.0.9
Looking for packaged Juju agent version 4.1-beta2 for amd64  

❯ juju ssh -m controller 0 -- snap list
Name    Version   Rev    Tracking       Publisher    Notes
core24  20260317  1587   latest/stable  canonical**  base
juju    4.0.9     34852  -              canonical**  -
snapd   2.75.2    26865  latest/stable  canonical**  snapd
```

Snap from candidate channel was installed:
```sh
❯ snap info juju | grep 4.0/candidate
  4.0/candidate: 4.0.9             2026-04-28 (34852) 108MB -

❯ juju ssh -m controller 0 -- snap list
Name    Version   Rev    Tracking       Publisher    Notes
core24  20260317  1587   latest/stable  canonical**  base
juju    4.0.9     34852  -              canonical**  -
snapd   2.75.2    26865  latest/stable  canonical**  snapd
```

## Documentation changes

## Links

**Jira card:** [JUJU-9648](https://warthogs.atlassian.net/browse/JUJU-9648)


[JUJU-9648]: https://warthogs.atlassian.net/browse/JUJU-9648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ