### PR TITLE
WIP ci: add required fields to test charm charmcraft.yaml files

### DIFF
--- a/testcharms/charms/departer/charmcraft.yaml
+++ b/testcharms/charms/departer/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: departer
+summary: "A test charm to verify that relation-departed hooks include departing unit"
+description: "This is a longer description."
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/departer/metadata.yaml
+++ b/testcharms/charms/departer/metadata.yaml
@@ -1,6 +1,3 @@
-name: departer
-summary: "A test charm to verify that relation-departed hooks include departing unit"
-description: "This is a longer description."
 peers:
   self:
     interface: dummy

--- a/testcharms/charms/dummy-sink/charmcraft.yaml
+++ b/testcharms/charms/dummy-sink/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: dummy-sink
+summary: Dummy charm that accepts data
+description: This dummy charm is used to verify that a relationship is created correctly
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/dummy-sink/metadata.yaml
+++ b/testcharms/charms/dummy-sink/metadata.yaml
@@ -1,8 +1,4 @@
-name: dummy-sink
 maintainer: Juju Crew <juju-crew@canonical.com>
-summary: Dummy charm that accepts data
-description: |
-  This dummy charm is used to verify that a relationship is created correctly
 provides:
   source:
     interface: dummy-token
@@ -13,4 +9,3 @@ series:
   - bionic
   - focal
   - jammy
-

--- a/testcharms/charms/dummy-source/charmcraft.yaml
+++ b/testcharms/charms/dummy-source/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: dummy-source
+summary: Dummy charm that provides data
+description: This dummy charm is used to verify that a relationship is created correctly
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/dummy-source/metadata.yaml
+++ b/testcharms/charms/dummy-source/metadata.yaml
@@ -1,8 +1,4 @@
-name: dummy-source
 maintainer: Juju Crew <juju-crew@canonical.com>
-summary: Dummy charm that provides data
-description: |
-  This dummy charm is used to verify that a relationship is created correctly
 requires:
   sink:
     interface: dummy-token
@@ -13,4 +9,3 @@ series:
   - bionic
   - focal
   - jammy
-

--- a/testcharms/charms/dummy-storage-fs/charmcraft.yaml
+++ b/testcharms/charms/dummy-storage-fs/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: dummy-storage-fs
+summary: Test charm for storage
+description: description
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/dummy-storage-fs/metadata.yaml
+++ b/testcharms/charms/dummy-storage-fs/metadata.yaml
@@ -1,6 +1,4 @@
-description: description
 maintainer: juju-qa@lists.canonical.com
-name: dummy-storage-fs
 series:
 - jammy
 - focal
@@ -9,4 +7,3 @@ storage:
   data:
     location: /srv/data
     type: filesystem
-summary: Test charm for storage

--- a/testcharms/charms/dummy-storage-lp/charmcraft.yaml
+++ b/testcharms/charms/dummy-storage-lp/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: dummy-storage-lp
+summary: Test charm for storage
+description: description
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/dummy-storage-lp/metadata.yaml
+++ b/testcharms/charms/dummy-storage-lp/metadata.yaml
@@ -1,6 +1,4 @@
-description: description
 maintainer: juju-qa@lists.canonical.com
-name: dummy-storage-lp
 series:
 - jammy
 - focal
@@ -10,4 +8,3 @@ storage:
     multiple:
       range: 0-10
     type: block
-summary: Test charm for storage

--- a/testcharms/charms/dummy-storage-mp/charmcraft.yaml
+++ b/testcharms/charms/dummy-storage-mp/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: dummy-storage-mp
+summary: Test charm for storage
+description: description
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/dummy-storage-mp/metadata.yaml
+++ b/testcharms/charms/dummy-storage-mp/metadata.yaml
@@ -1,6 +1,4 @@
-description: description
 maintainer: juju-qa@lists.canonical.com
-name: dummy-storage-mp
 series:
 - jammy
 - focal
@@ -13,4 +11,3 @@ storage:
     multiple:
       range: 0-10
     type: block
-summary: Test charm for storage

--- a/testcharms/charms/dummy-storage-np/charmcraft.yaml
+++ b/testcharms/charms/dummy-storage-np/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: dummy-storage-np
+summary: Test charm for storage
+description: description
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/dummy-storage-np/metadata.yaml
+++ b/testcharms/charms/dummy-storage-np/metadata.yaml
@@ -1,6 +1,4 @@
-description: description
 maintainer: juju-qa@lists.canonical.com
-name: dummy-storage-np
 series:
 - jammy
 - focal
@@ -9,4 +7,3 @@ storage:
   data:
     location: /srv/data
     type: filesystem
-summary: Test charm for storage

--- a/testcharms/charms/dummy-storage-tp/charmcraft.yaml
+++ b/testcharms/charms/dummy-storage-tp/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: dummy-storage-tp
+summary: Test charm for storage
+description: description
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/dummy-storage-tp/metadata.yaml
+++ b/testcharms/charms/dummy-storage-tp/metadata.yaml
@@ -1,6 +1,4 @@
-description: description
 maintainer: juju-qa@lists.canonical.com
-name: dummy-storage-tp
 series:
 - jammy
 - focal
@@ -9,4 +7,3 @@ storage:
   data:
     location: /srv/data
     type: filesystem
-summary: Test charm for storage

--- a/testcharms/charms/dummy-storage/charmcraft.yaml
+++ b/testcharms/charms/dummy-storage/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: dummy-storage
+summary: Dummy charm that utilises storage.
+description: This dummy-storage charm is used for testing persistent storage.
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/dummy-storage/metadata.yaml
+++ b/testcharms/charms/dummy-storage/metadata.yaml
@@ -1,9 +1,6 @@
-name: dummy-storage
 maintainer:
   - Christopher Lee <chris.lee@canonical.com>
   - Burton Swan <burton.swan@canonical.com>
-summary: Dummy charm that utilises storage.
-description: This dummy-storage charm is used for testing persistent storage.
 categories:
   - misc
 series:

--- a/testcharms/charms/lxd-profile-subordinate/charmcraft.yaml
+++ b/testcharms/charms/lxd-profile-subordinate/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: lxd-profile-subordinate
+summary: start a juju machine with a lxd profile subordinate
+description: Run an Ubuntu system, with the given subordinate lxd-profile
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/lxd-profile-subordinate/metadata.yaml
+++ b/testcharms/charms/lxd-profile-subordinate/metadata.yaml
@@ -1,8 +1,4 @@
-name: lxd-profile-subordinate
-summary: start a juju machine with a lxd profile subordinate
 maintainer: Juju QA
-description: |
-  Run an Ubuntu system, with the given subordinate lxd-profile
 tags:
   - misc
   - application_development

--- a/testcharms/charms/lxd-profile/charmcraft.yaml
+++ b/testcharms/charms/lxd-profile/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: lxd-profile
+summary: start a juju machine with a lxd profile
+description: Run an Ubuntu system, with the given lxd-profile
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/lxd-profile/metadata.yaml
+++ b/testcharms/charms/lxd-profile/metadata.yaml
@@ -1,8 +1,4 @@
-name: lxd-profile
-summary: start a juju machine with a lxd profile
 maintainer: Juju Crew <juju-crew@canonical.com>
-description: |
-  Run an Ubuntu system, with the given lxd-profile
 provides:
   ubuntu:
     interface: ubuntu
@@ -17,4 +13,3 @@ series:
   - focal
   - bionic
   - xenial
-

--- a/testcharms/charms/sidecar-non-root/charmcraft.yaml
+++ b/testcharms/charms/sidecar-non-root/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: sidecar-non-root
+summary: sidecar charm with rootless charm and workloads
+description: sidecar charm with rootless charm and workloads
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/sidecar-non-root/metadata.yaml
+++ b/testcharms/charms/sidecar-non-root/metadata.yaml
@@ -1,6 +1,3 @@
-name: sidecar-non-root
-summary: sidecar charm with rootless charm and workloads
-description: ""
 containers:
   rootful:
     resource: ubuntu

--- a/testcharms/charms/sidecar-sudoer/charmcraft.yaml
+++ b/testcharms/charms/sidecar-sudoer/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: sidecar-sudoer
+summary: sidecar charm with rootless charm and workloads
+description: sidecar charm with rootless charm and workloads
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/sidecar-sudoer/metadata.yaml
+++ b/testcharms/charms/sidecar-sudoer/metadata.yaml
@@ -1,6 +1,3 @@
-name: sidecar-sudoer
-summary: sidecar charm with rootless charm and workloads
-description: ""
 containers:
   rootful:
     resource: ubuntu

--- a/testcharms/charms/space-defender/charmcraft.yaml
+++ b/testcharms/charms/space-defender/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: space-defender
+summary: Defend your spaces against invaders
+description: Defend your spaces against invaders
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/testcharms/charms/space-defender/metadata.yaml
+++ b/testcharms/charms/space-defender/metadata.yaml
@@ -1,8 +1,4 @@
-name: space-defender
-summary: Defend your spaces against invaders
 maintainer: juju QA <juju-qa@canonical.com>
-description: |
-  Defend your spaces against invaders
 tags:
   - security
 series:

--- a/tests/suites/deploy/charms/lxd-profile-alt/charmcraft.yaml
+++ b/tests/suites/deploy/charms/lxd-profile-alt/charmcraft.yaml
@@ -1,3 +1,6 @@
+name: lxd-profile-alt
+summary: start a juju machine with a lxd profile
+description: Run an Ubuntu system, with the given lxd-profile
 type: "charm"
 base: ubuntu@24.04
 platforms:

--- a/tests/suites/deploy/charms/lxd-profile-alt/metadata.yaml
+++ b/tests/suites/deploy/charms/lxd-profile-alt/metadata.yaml
@@ -1,8 +1,4 @@
-name: lxd-profile-alt
-summary: start a juju machine with a lxd profile
 maintainer: Juju QA
-description: |
-  Run an Ubuntu system, with the given lxd-profile
 provides:
   ubuntu:
     interface: ubuntu


### PR DESCRIPTION
Charmcraft 4.x requires `name`, `summary`, and `description` to be present directly in `charmcraft.yaml` for new-style charms (using `base:` + `platforms:`). These fields are defined as required in the `CharmProject` pydantic model. Without them, charmcraft fails validation before building. Additionally, these fields must NOT appear in both files — remove them from `metadata.yaml` accordingly.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~Integration tests, with comments saying what you're testing~
- [ ] ~doc.go added or updated in changed packages~

## QA steps

Re-run the previously failing CI tests (from the `tests/` directory):

```sh
# Deploy suite
cd tests && ./main.sh deploy test_deploy_charms

# Relations suite
cd tests && ./main.sh relations test_relation_departing_unit

# Sidecar suite
cd tests && ./main.sh sidecar test_rootless

# Spaces suite
cd tests && ./main.sh spaces_ec2 test_juju_bind
cd tests && ./main.sh spaces_ec2 test_upgrade_charm_with_bind

# Storage suite
cd tests && ./main.sh storage test_charm_storage
```

All tests should successfully build the local charms (`lxd-profile-alt`, `departer`, `sidecar-non-root`, `space-defender`, `dummy-storage-fs`) and produce `.charm` artifacts.

## Documentation changes

None.

## Links

**Jira card:** [JUJU-9795](https://warthogs.atlassian.net/browse/JUJU-9795)

[JUJU-9795]: https://warthogs.atlassian.net/browse/JUJU-9795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ