### PR TITLE
feat: k8s storage size update

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -516,6 +516,8 @@ type mockStorage struct {
 	storageFilesystems map[names.StorageTag]names.FilesystemTag
 	storageVolumes     map[names.StorageTag]names.VolumeTag
 	storageAttachments map[names.UnitTag]names.StorageTag
+	filesystemInfos    map[names.FilesystemTag]state.FilesystemInfo
+	volumeInfos        map[names.VolumeTag]state.VolumeInfo
 	backingVolume      names.VolumeTag
 }
 
@@ -531,7 +533,7 @@ func (m *mockStorage) AllFilesystems() ([]state.Filesystem, error) {
 	m.MethodCall(m, "AllFilesystems")
 	var result []state.Filesystem
 	for _, fsTag := range m.storageFilesystems {
-		result = append(result, &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume})
+		result = append(result, &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume, info: m.filesystemInfos[fsTag]})
 	}
 	return result, nil
 }
@@ -553,11 +555,12 @@ func (m *mockStorage) DestroyVolume(tag names.VolumeTag) (err error) {
 
 func (m *mockStorage) Filesystem(fsTag names.FilesystemTag) (state.Filesystem, error) {
 	m.MethodCall(m, "Filesystem", fsTag)
-	return &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume}, nil
+	return &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume, info: m.filesystemInfos[fsTag]}, nil
 }
 
 func (m *mockStorage) StorageInstanceFilesystem(tag names.StorageTag) (state.Filesystem, error) {
-	return &mockFilesystem{Stub: &m.Stub, tag: m.storageFilesystems[tag], volTag: m.backingVolume}, nil
+	fsTag := m.storageFilesystems[tag]
+	return &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume, info: m.filesystemInfos[fsTag]}, nil
 }
 
 func (m *mockStorage) UnitStorageAttachments(unit names.UnitTag) ([]state.StorageAttachment, error) {
@@ -582,11 +585,12 @@ func (m *mockStorage) SetFilesystemAttachmentInfo(host names.Tag, fsTag names.Fi
 
 func (m *mockStorage) Volume(volTag names.VolumeTag) (state.Volume, error) {
 	m.MethodCall(m, "Volume", volTag)
-	return &mockVolume{Stub: &m.Stub, tag: volTag}, nil
+	return &mockVolume{Stub: &m.Stub, tag: volTag, info: m.volumeInfos[volTag]}, nil
 }
 
 func (m *mockStorage) StorageInstanceVolume(tag names.StorageTag) (state.Volume, error) {
-	return &mockVolume{Stub: &m.Stub, tag: m.storageVolumes[tag]}, nil
+	volTag := m.storageVolumes[tag]
+	return &mockVolume{Stub: &m.Stub, tag: volTag, info: m.volumeInfos[volTag]}, nil
 }
 
 func (m *mockStorage) SetVolumeInfo(volTag names.VolumeTag, volInfo state.VolumeInfo) error {
@@ -634,6 +638,7 @@ type mockFilesystem struct {
 	state.Filesystem
 	tag    names.FilesystemTag
 	volTag names.VolumeTag
+	info   state.FilesystemInfo
 }
 
 func (f *mockFilesystem) Tag() names.Tag {
@@ -657,13 +662,17 @@ func (f *mockFilesystem) SetStatus(statusInfo status.StatusInfo) error {
 }
 
 func (f *mockFilesystem) Info() (state.FilesystemInfo, error) {
+	if f.info != (state.FilesystemInfo{}) {
+		return f.info, nil
+	}
 	return state.FilesystemInfo{}, errors.NotProvisionedf("filesystem")
 }
 
 type mockVolume struct {
 	*testing.Stub
 	state.Volume
-	tag names.VolumeTag
+	tag  names.VolumeTag
+	info state.VolumeInfo
 }
 
 func (v *mockVolume) Tag() names.Tag {
@@ -680,6 +689,9 @@ func (v *mockVolume) SetStatus(statusInfo status.StatusInfo) error {
 }
 
 func (v *mockVolume) Info() (state.VolumeInfo, error) {
+	if v.info != (state.VolumeInfo{}) {
+		return v.info, nil
+	}
 	return state.VolumeInfo{}, errors.NotProvisionedf("volume")
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -1176,9 +1176,7 @@ func (a *API) updateVolumeInfo(volumeUpdates map[string]volumeInfo, volumeStatus
 		if err != nil {
 			return errors.Trace(err)
 		}
-		// If we have already recorded the provisioning info,
-		// it's an error to try and do it again.
-		_, err = vol.Info()
+		existingInfo, err := vol.Info()
 		if err != nil && !errors.IsNotProvisioned(err) {
 			return errors.Trace(err)
 		}
@@ -1191,6 +1189,19 @@ func (a *API) updateVolumeInfo(volumeUpdates map[string]volumeInfo, volumeStatus
 			})
 			if err != nil {
 				return errors.Trace(err)
+			}
+		} else {
+			updatedInfo := existingInfo
+			updatedInfo.Size = volData.size
+			updatedInfo.Persistent = volData.persistent
+			if volData.volumeId != "" {
+				updatedInfo.VolumeId = volData.volumeId
+			}
+			if updatedInfo != existingInfo {
+				err = a.storage.SetVolumeInfo(volTag, updatedInfo)
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 		}
 
@@ -1249,9 +1260,7 @@ func (a *API) updateFilesystemInfo(filesystemUpdates map[string]filesystemInfo, 
 		if err != nil {
 			return errors.Trace(err)
 		}
-		// If we have already recorded the provisioning info,
-		// it's an error to try and do it again.
-		_, err = fs.Info()
+		existingInfo, err := fs.Info()
 		if err != nil && !errors.IsNotProvisioned(err) {
 			return errors.Trace(err)
 		}
@@ -1263,6 +1272,18 @@ func (a *API) updateFilesystemInfo(filesystemUpdates map[string]filesystemInfo, 
 			})
 			if err != nil {
 				return errors.Trace(err)
+			}
+		} else {
+			updatedInfo := existingInfo
+			updatedInfo.Size = fsData.size
+			if fsData.filesystemId != "" {
+				updatedInfo.FilesystemId = fsData.filesystemId
+			}
+			if updatedInfo != existingInfo {
+				err = a.storage.SetFilesystemInfo(fsTag, updatedInfo)
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 		}
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -69,6 +69,8 @@ func (s *CAASApplicationProvisionerSuite) SetUpTest(c *gc.C) {
 		storageFilesystems: make(map[names.StorageTag]names.FilesystemTag),
 		storageVolumes:     make(map[names.StorageTag]names.VolumeTag),
 		storageAttachments: make(map[names.UnitTag]names.StorageTag),
+		filesystemInfos:    make(map[names.FilesystemTag]state.FilesystemInfo),
+		volumeInfos:        make(map[names.VolumeTag]state.VolumeInfo),
 		backingVolume:      names.NewVolumeTag("66"),
 	}
 	s.storagePoolManager = &mockStoragePoolManager{}
@@ -653,6 +655,123 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithoutStor
 	s.storage.CheckCallNames(c, "AllFilesystems")
 	s.st.model.CheckCallNames(c, "Containers")
 	s.st.model.CheckCall(c, 0, "Containers", []string{"gitlab-0", "gitlab-1"})
+}
+
+func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithProvisionedStorageInfo(c *gc.C) {
+	s.st.app = &mockApplication{
+		tag:  names.NewApplicationTag("gitlab"),
+		life: state.Alive,
+		charm: &mockCharm{
+			meta: &charm.Meta{
+				Deployment: &charm.Deployment{
+					DeploymentType: charm.DeploymentStateful,
+				},
+			},
+			manifest: &charm.Manifest{
+				Bases: []charm.Base{{
+					Name: "ubuntu",
+					Channel: charm.Channel{
+						Risk:  "stable",
+						Track: "20.04",
+					},
+				}},
+			},
+			url: "ch:gitlab",
+		},
+		units: []*mockUnit{{
+			tag: names.NewUnitTag("gitlab/0"),
+			containerInfo: &mockCloudContainer{
+				unit:       "gitlab/0",
+				providerId: "gitlab-0",
+			},
+		}},
+	}
+
+	storageTag := names.NewStorageTag("data/0")
+	fsTag := names.NewFilesystemTag("gitlab/0/0")
+	volTag := names.NewVolumeTag("0")
+
+	s.storage.storageFilesystems[storageTag] = fsTag
+	s.storage.storageVolumes[storageTag] = volTag
+	s.storage.storageAttachments[names.NewUnitTag("gitlab/0")] = storageTag
+	s.storage.filesystemInfos[fsTag] = state.FilesystemInfo{
+		Size:         10,
+		Pool:         "filesystem-pool",
+		FilesystemId: "old-fs-id",
+	}
+	s.storage.volumeInfos[volTag] = state.VolumeInfo{
+		Size:       10,
+		Pool:       "volume-pool",
+		VolumeId:   "old-vol-id",
+		Persistent: true,
+	}
+
+	args := params.UpdateApplicationUnitArgs{
+		Args: []params.UpdateApplicationUnits{{
+			ApplicationTag: "application-gitlab",
+			Units: []params.ApplicationUnitParams{{
+				ProviderId: "gitlab-0",
+				Address:    "address",
+				Ports:      []string{"port"},
+				Status:     "running",
+				Info:       "message",
+				Stateful:   true,
+				FilesystemInfo: []params.KubernetesFilesystemInfo{{
+					StorageName:  "data",
+					FilesystemId: "new-fs-id",
+					Size:         200,
+					MountPoint:   "/path/to/here",
+					ReadOnly:     true,
+					Status:       "attached",
+					Info:         "ready",
+					Volume: params.KubernetesVolumeInfo{
+						VolumeId:   "new-vol-id",
+						Size:       200,
+						Persistent: true,
+						Status:     "attached",
+						Info:       "vol ready",
+					},
+				}},
+			}},
+		}},
+	}
+
+	results, err := s.api.UpdateApplicationsUnits(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+
+	now := s.clock.Now()
+	s.storage.CheckCallNames(c,
+		"UnitStorageAttachments", "StorageInstance",
+		"AllFilesystems",
+		"Volume", "SetVolumeInfo", "SetVolumeAttachmentInfo", "Volume", "SetStatus",
+		"Filesystem", "SetFilesystemInfo", "SetFilesystemAttachmentInfo", "Filesystem", "SetStatus",
+	)
+	s.storage.CheckCall(c, 4, "SetVolumeInfo", volTag, state.VolumeInfo{
+		Size:       200,
+		Pool:       "volume-pool",
+		VolumeId:   "new-vol-id",
+		Persistent: true,
+	})
+	s.storage.CheckCall(c, 5, "SetVolumeAttachmentInfo",
+		names.NewUnitTag("gitlab/0"), volTag,
+		state.VolumeAttachmentInfo{ReadOnly: true},
+	)
+	s.storage.CheckCall(c, 7, "SetStatus", status.StatusInfo{
+		Status:  status.Attached,
+		Message: "vol ready",
+		Since:   &now,
+	})
+	s.storage.CheckCall(c, 9, "SetFilesystemInfo", fsTag, state.FilesystemInfo{
+		Size:         200,
+		Pool:         "filesystem-pool",
+		FilesystemId: "new-fs-id",
+	})
+	s.storage.CheckCall(c, 12, "SetStatus", status.StatusInfo{
+		Status:  status.Attached,
+		Message: "ready",
+		Since:   &now,
+	})
 }
 
 func strPtr(s string) *string {

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -361,6 +361,8 @@ type mockStorage struct {
 	storageVolumes     map[names.StorageTag]names.VolumeTag
 	storageAttachments map[names.UnitTag]names.StorageTag
 	backingVolume      names.VolumeTag
+	provisionedFsInfo  map[names.FilesystemTag]state.FilesystemInfo
+	provisionedVolInfo map[names.VolumeTag]state.VolumeInfo
 }
 
 func (m *mockStorage) StorageInstance(tag names.StorageTag) (state.StorageInstance, error) {
@@ -375,7 +377,14 @@ func (m *mockStorage) AllFilesystems() ([]state.Filesystem, error) {
 	m.MethodCall(m, "AllFilesystems")
 	var result []state.Filesystem
 	for _, fsTag := range m.storageFilesystems {
-		result = append(result, &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume})
+		var existingInfo *state.FilesystemInfo
+		if m.provisionedFsInfo != nil {
+			if info, ok := m.provisionedFsInfo[fsTag]; ok {
+				infoCopy := info
+				existingInfo = &infoCopy
+			}
+		}
+		result = append(result, &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume, existingInfo: existingInfo})
 	}
 	return result, nil
 }
@@ -397,7 +406,14 @@ func (m *mockStorage) DestroyVolume(tag names.VolumeTag) (err error) {
 
 func (m *mockStorage) Filesystem(fsTag names.FilesystemTag) (state.Filesystem, error) {
 	m.MethodCall(m, "Filesystem", fsTag)
-	return &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume}, nil
+	var existingInfo *state.FilesystemInfo
+	if m.provisionedFsInfo != nil {
+		if info, ok := m.provisionedFsInfo[fsTag]; ok {
+			infoCopy := info
+			existingInfo = &infoCopy
+		}
+	}
+	return &mockFilesystem{Stub: &m.Stub, tag: fsTag, volTag: m.backingVolume, existingInfo: existingInfo}, nil
 }
 
 func (m *mockStorage) StorageInstanceFilesystem(tag names.StorageTag) (state.Filesystem, error) {
@@ -426,11 +442,26 @@ func (m *mockStorage) SetFilesystemAttachmentInfo(host names.Tag, fsTag names.Fi
 
 func (m *mockStorage) Volume(volTag names.VolumeTag) (state.Volume, error) {
 	m.MethodCall(m, "Volume", volTag)
-	return &mockVolume{Stub: &m.Stub, tag: volTag}, nil
+	var existingInfo *state.VolumeInfo
+	if m.provisionedVolInfo != nil {
+		if info, ok := m.provisionedVolInfo[volTag]; ok {
+			infoCopy := info
+			existingInfo = &infoCopy
+		}
+	}
+	return &mockVolume{Stub: &m.Stub, tag: volTag, existingInfo: existingInfo}, nil
 }
 
 func (m *mockStorage) StorageInstanceVolume(tag names.StorageTag) (state.Volume, error) {
-	return &mockVolume{Stub: &m.Stub, tag: m.storageVolumes[tag]}, nil
+	volTag := m.storageVolumes[tag]
+	var existingInfo *state.VolumeInfo
+	if m.provisionedVolInfo != nil {
+		if info, ok := m.provisionedVolInfo[volTag]; ok {
+			infoCopy := info
+			existingInfo = &infoCopy
+		}
+	}
+	return &mockVolume{Stub: &m.Stub, tag: volTag, existingInfo: existingInfo}, nil
 }
 
 func (m *mockStorage) SetVolumeInfo(volTag names.VolumeTag, volInfo state.VolumeInfo) error {
@@ -489,8 +520,9 @@ func (a *mockStorageAttachment) StorageInstance() names.StorageTag {
 type mockFilesystem struct {
 	*testing.Stub
 	state.Filesystem
-	tag    names.FilesystemTag
-	volTag names.VolumeTag
+	tag          names.FilesystemTag
+	volTag       names.VolumeTag
+	existingInfo *state.FilesystemInfo
 }
 
 func (f *mockFilesystem) Tag() names.Tag {
@@ -513,14 +545,22 @@ func (f *mockFilesystem) SetStatus(statusInfo status.StatusInfo) error {
 	return nil
 }
 
+func (f *mockFilesystem) Storage() (names.StorageTag, error) {
+	return names.StorageTag{}, errors.NotFoundf("storage")
+}
+
 func (f *mockFilesystem) Info() (state.FilesystemInfo, error) {
+	if f.existingInfo != nil {
+		return *f.existingInfo, nil
+	}
 	return state.FilesystemInfo{}, errors.NotProvisionedf("filesystem")
 }
 
 type mockVolume struct {
 	*testing.Stub
 	state.Volume
-	tag names.VolumeTag
+	tag          names.VolumeTag
+	existingInfo *state.VolumeInfo
 }
 
 func (v *mockVolume) Tag() names.Tag {
@@ -537,6 +577,9 @@ func (v *mockVolume) SetStatus(statusInfo status.StatusInfo) error {
 }
 
 func (v *mockVolume) Info() (state.VolumeInfo, error) {
+	if v.existingInfo != nil {
+		return *v.existingInfo, nil
+	}
 	return state.VolumeInfo{}, errors.NotProvisionedf("volume")
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -1249,9 +1249,7 @@ func (f *Facade) updateVolumeInfo(volumeUpdates map[string]volumeInfo, volumeSta
 		if err != nil {
 			return errors.Trace(err)
 		}
-		// If we have already recorded the provisioning info,
-		// it's an error to try and do it again.
-		_, err = vol.Info()
+		existingInfo, err := vol.Info()
 		if err != nil && !errors.IsNotProvisioned(err) {
 			return errors.Trace(err)
 		}
@@ -1264,6 +1262,19 @@ func (f *Facade) updateVolumeInfo(volumeUpdates map[string]volumeInfo, volumeSta
 			})
 			if err != nil {
 				return errors.Trace(err)
+			}
+		} else {
+			updatedInfo := existingInfo
+			updatedInfo.Size = volData.size
+			updatedInfo.Persistent = volData.persistent
+			if volData.volumeId != "" {
+				updatedInfo.VolumeId = volData.volumeId
+			}
+			if updatedInfo != existingInfo {
+				err = f.storage.SetVolumeInfo(volTag, updatedInfo)
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 		}
 
@@ -1322,9 +1333,7 @@ func (f *Facade) updateFilesystemInfo(filesystemUpdates map[string]filesystemInf
 		if err != nil {
 			return errors.Trace(err)
 		}
-		// If we have already recorded the provisioning info,
-		// it's an error to try and do it again.
-		_, err = fs.Info()
+		existingInfo, err := fs.Info()
 		if err != nil && !errors.IsNotProvisioned(err) {
 			return errors.Trace(err)
 		}
@@ -1336,6 +1345,18 @@ func (f *Facade) updateFilesystemInfo(filesystemUpdates map[string]filesystemInf
 			})
 			if err != nil {
 				return errors.Trace(err)
+			}
+		} else {
+			updatedInfo := existingInfo
+			updatedInfo.Size = fsData.size
+			if fsData.filesystemId != "" {
+				updatedInfo.FilesystemId = fsData.filesystemId
+			}
+			if updatedInfo != existingInfo {
+				err = f.storage.SetFilesystemInfo(fsTag, updatedInfo)
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 		}
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -104,6 +104,7 @@ func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
 		storageVolumes:     make(map[names.StorageTag]names.VolumeTag),
 		storageAttachments: make(map[names.UnitTag]names.StorageTag),
 		backingVolume:      names.NewVolumeTag("66"),
+		provisionedVolInfo: make(map[names.VolumeTag]state.VolumeInfo),
 	}
 	s.storagePoolManager = &mockStoragePoolManager{}
 	s.devices = &mockDeviceBackend{}
@@ -1015,3 +1016,99 @@ func (s *CAASProvisionerSuite) TestSetOperatorStatus(c *gc.C) {
 		Since:   &now,
 	})
 }
+
+func (s *CAASProvisionerSuite) TestUpdateUnitsWithProvisionedStorageInfo(c *gc.C) {
+	ctrl := s.setupFacade(c)
+	defer ctrl.Finish()
+
+	s.st.application.units = []caasunitprovisioner.Unit{
+		&mockUnit{name: "gitlab/0", containerInfo: &mockContainerInfo{providerId: "uuid"}, life: state.Alive},
+	}
+	s.st.model.containers = []state.CloudContainer{
+		&mockContainerInfo{unitName: "gitlab/0", providerId: "uuid"},
+	}
+
+	storageTag := names.NewStorageTag("data/0")
+	fsTag := names.NewFilesystemTag("gitlab/0/0")
+	volTag := names.NewVolumeTag("0")
+
+	s.storage.storageFilesystems[storageTag] = fsTag
+	s.storage.storageVolumes[storageTag] = volTag
+	s.storage.storageAttachments[names.NewUnitTag("gitlab/0")] = storageTag
+
+	s.storage.provisionedFsInfo = map[names.FilesystemTag]state.FilesystemInfo{
+		fsTag: {
+			Size:         100,
+			FilesystemId: "old-fs-id",
+			Pool:         "filesystem-pool",
+		},
+	}
+	s.storage.provisionedVolInfo[volTag] = state.VolumeInfo{
+		Size:       100,
+		Pool:       "volume-pool",
+		VolumeId:   "old-vol-id",
+		Persistent: true,
+	}
+
+	units := []params.ApplicationUnitParams{
+		{ProviderId: "uuid", Address: "address", Ports: []string{"port"},
+			Status: "running", Info: "message", Stateful: true,
+			FilesystemInfo: []params.KubernetesFilesystemInfo{
+				{StorageName: "data", FilesystemId: "new-fs-id", Size: 200, MountPoint: "/path/to/here", ReadOnly: false,
+					Status: "attached", Info: "ready",
+					Volume: params.KubernetesVolumeInfo{
+						VolumeId:   "new-vol-id",
+						Size:       200,
+						Persistent: true,
+						Status:     "attached",
+						Info:       "vol ready",
+					},
+				},
+			},
+		},
+	}
+	s.st.application.scale = 1
+	args := params.UpdateApplicationUnitArgs{
+		Args: []params.UpdateApplicationUnits{
+			{ApplicationTag: "application-gitlab", Units: units, Scale: intPtr(1), Generation: int64Ptr(1)},
+		},
+	}
+	results, err := s.facade.UpdateApplicationsUnits(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+
+	now := s.clock.Now()
+	s.storage.CheckCallNames(c,
+		"UnitStorageAttachments", "StorageInstance",
+		"AllFilesystems",
+		"Volume", "SetVolumeInfo", "SetVolumeAttachmentInfo", "Volume", "SetStatus",
+		"Filesystem", "SetFilesystemInfo", "SetFilesystemAttachmentInfo", "Filesystem", "SetStatus",
+	)
+	s.storage.CheckCall(c, 4, "SetVolumeInfo", volTag, state.VolumeInfo{
+		Size:       200,
+		Pool:       "volume-pool",
+		VolumeId:   "new-vol-id",
+		Persistent: true,
+	})
+	s.storage.CheckCall(c, 5, "SetVolumeAttachmentInfo",
+		names.NewUnitTag("gitlab/0"), volTag,
+		state.VolumeAttachmentInfo{ReadOnly: false},
+	)
+	s.storage.CheckCall(c, 7, "SetStatus", status.StatusInfo{
+		Status:  status.Attached,
+		Message: "vol ready",
+		Since:   &now,
+	})
+	s.storage.CheckCall(c, 9, "SetFilesystemInfo", fsTag,
+		state.FilesystemInfo{
+			Size:         200,
+			Pool:         "filesystem-pool",
+			FilesystemId: "new-fs-id",
+		})
+	s.storage.CheckCall(c, 12, "SetStatus", status.StatusInfo{
+		Status:  status.Attached,
+		Message: "ready",
+		Since:   &now,
+	})
+}
+

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -1111,4 +1111,3 @@ func (s *CAASProvisionerSuite) TestUpdateUnitsWithProvisionedStorageInfo(c *gc.C
 		Since:   &now,
 	})
 }
-

--- a/internal/provider/kubernetes/application/application.go
+++ b/internal/provider/kubernetes/application/application.go
@@ -1407,6 +1407,12 @@ func (a *app) Watch() (watcher.NotifyWatcher, error) {
 			o.FieldSelector = a.fieldSelector()
 		}),
 	)
+	pvcFactory := informers.NewSharedInformerFactoryWithOptions(a.client, 0,
+		informers.WithNamespace(a.namespace),
+		informers.WithTweakListOptions(func(o *metav1.ListOptions) {
+			o.LabelSelector = a.labelSelector()
+		}),
+	)
 	var informer cache.SharedIndexInformer
 	switch a.deploymentType {
 	case caas.DeploymentStateful:
@@ -1426,7 +1432,11 @@ func (a *app) Watch() (watcher.NotifyWatcher, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return watcher.NewMultiNotifyWatcher(w1, w2), nil
+	w3, err := a.newWatcher(pvcFactory.Core().V1().PersistentVolumeClaims().Informer(), a.name, a.clock)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return watcher.NewMultiNotifyWatcher(w1, w2, w3), nil
 }
 
 func (a *app) WatchReplicas() (watcher.NotifyWatcher, error) {

--- a/internal/provider/kubernetes/watcher/k8swatcher.go
+++ b/internal/provider/kubernetes/watcher/k8swatcher.go
@@ -104,6 +104,12 @@ func (w *kubernetesNotifyWatcher) loop() error {
 	var delayCh <-chan time.Time
 
 	go w.informer.Run(w.catacomb.Dying())
+
+	// Wait for the informer cache to sync before processing events
+	if ok := cache.WaitForCacheSync(w.catacomb.Dying(), w.informer.HasSynced); !ok {
+		return errors.New("failed to wait for cache to sync")
+	}
+
 	for {
 		select {
 		case <-w.catacomb.Dying():
@@ -228,6 +234,12 @@ func (w *kubernetesStringsWatcher) loop() error {
 	var pendingEvents []string
 
 	go w.informer.Run(w.catacomb.Dying())
+
+	// Wait for the informer cache to sync before processing events
+	if ok := cache.WaitForCacheSync(w.catacomb.Dying(), w.informer.HasSynced); !ok {
+		return errors.New("failed to wait for cache to sync")
+	}
+
 	for {
 		select {
 		case <-w.catacomb.Dying():

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -1297,7 +1297,7 @@ func (sb *storageBackend) SetFilesystemInfo(tag names.FilesystemTag, info Filesy
 			if err != nil {
 				return nil, err
 			}
-			if err := validateFilesystemInfoChange(info, oldInfo); err != nil {
+			if err := validateFilesystemInfoChange(info, oldInfo, sb.modelType); err != nil {
 				return nil, err
 			}
 		}
@@ -1307,16 +1307,18 @@ func (sb *storageBackend) SetFilesystemInfo(tag names.FilesystemTag, info Filesy
 	return sb.mb.db().Run(buildTxn)
 }
 
-func validateFilesystemInfoChange(newInfo, oldInfo FilesystemInfo) error {
+func validateFilesystemInfoChange(newInfo, oldInfo FilesystemInfo, modelType ModelType) error {
 	if newInfo.Pool != oldInfo.Pool {
 		return errors.Errorf(
 			"cannot change pool from %q to %q",
 			oldInfo.Pool, newInfo.Pool,
 		)
 	}
-	if newInfo.FilesystemId != oldInfo.FilesystemId {
+	// FilesystemId is allowed to change only for CAAS models to support the case
+	// where a manual storage resize recreates the underlying PVC with a new ID.
+	if newInfo.FilesystemId != oldInfo.FilesystemId && modelType != ModelTypeCAAS {
 		return errors.Errorf(
-			"cannot change filesystem ID from %q to %q",
+			"cannot change filesystem ID from %q to %q for machine models",
 			oldInfo.FilesystemId, newInfo.FilesystemId,
 		)
 	}

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -185,6 +185,48 @@ func (s *FilesystemStateSuite) TestSetFilesystemInfoImmutable(c *gc.C) {
 	s.assertFilesystemInfo(c, filesystemTag, filesystemInfoSet)
 }
 
+func (s *FilesystemIAASModelSuite) TestSetFilesystemInfoRejectsFilesystemIdChange(c *gc.C) {
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "rootfs")
+	hostTag := s.maybeAssignUnit(c, u)
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
+	filesystemTag := filesystem.FilesystemTag()
+
+	if _, ok := hostTag.(names.MachineTag); ok {
+		machine := unitMachine(c, s.st, u)
+		err := machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	initial := state.FilesystemInfo{Size: 123, FilesystemId: "fs-old"}
+	err := s.storageBackend.SetFilesystemInfo(filesystemTag, initial)
+	c.Assert(err, jc.ErrorIsNil)
+	initial.Pool = "rootfs"
+	s.assertFilesystemInfo(c, filesystemTag, initial)
+
+	// For IAAS models, changing identifier should fail.
+	updated := state.FilesystemInfo{Size: 456, FilesystemId: "fs-new", Pool: "rootfs"}
+	err = s.storageBackend.SetFilesystemInfo(filesystemTag, updated)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for filesystem ".*0/0": cannot change filesystem ID from "fs-old" to "fs-new" for machine models`)
+}
+
+func (s *FilesystemCAASModelSuite) TestSetFilesystemInfoAllowsFilesystemIdAndSizeUpdate(c *gc.C) {
+	_, _, storageTag := s.setupSingleStorage(c, "filesystem", "kubernetes")
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
+	filesystemTag := filesystem.FilesystemTag()
+
+	initial := state.FilesystemInfo{Size: 123, FilesystemId: "fs-old", Pool: "kubernetes"}
+	err := s.storageBackend.SetFilesystemInfo(filesystemTag, initial)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertFilesystemInfo(c, filesystemTag, initial)
+
+	// For CAAS models, FilesystemId changes are allowed to support PVC resize
+	updated := state.FilesystemInfo{Size: 456, FilesystemId: "fs-new", Pool: "kubernetes"}
+	err = s.storageBackend.SetFilesystemInfo(filesystemTag, updated)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertFilesystemInfo(c, filesystemTag, updated)
+}
+
 func (s *FilesystemStateSuite) maybeAssignUnit(c *gc.C, u *state.Unit) names.Tag {
 	m, err := s.st.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -210,12 +210,23 @@ func (s *FilesystemIAASModelSuite) TestSetFilesystemInfoRejectsFilesystemIdChang
 }
 
 func (s *FilesystemCAASModelSuite) TestSetFilesystemInfoAllowsFilesystemIdAndSizeUpdate(c *gc.C) {
-	_, _, storageTag := s.setupSingleStorage(c, "filesystem", "kubernetes")
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "kubernetes")
+	hostTag := s.maybeAssignUnit(c, u)
 	filesystem := s.storageInstanceFilesystem(c, storageTag)
 	filesystemTag := filesystem.FilesystemTag()
+	volume := s.filesystemVolume(c, filesystemTag)
+
+	err := s.storageBackend.SetVolumeInfo(volume.VolumeTag(), state.VolumeInfo{VolumeId: "vol-123"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.storageBackend.SetVolumeAttachmentInfo(
+		hostTag,
+		volume.VolumeTag(),
+		state.VolumeAttachmentInfo{DeviceName: "sdc"},
+	)
+	c.Assert(err, jc.ErrorIsNil)
 
 	initial := state.FilesystemInfo{Size: 123, FilesystemId: "fs-old", Pool: "kubernetes"}
-	err := s.storageBackend.SetFilesystemInfo(filesystemTag, initial)
+	err = s.storageBackend.SetFilesystemInfo(filesystemTag, initial)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertFilesystemInfo(c, filesystemTag, initial)
 

--- a/state/volume.go
+++ b/state/volume.go
@@ -1476,7 +1476,7 @@ func (sb *storageBackend) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (e
 			if err != nil {
 				return nil, err
 			}
-			if err := validateVolumeInfoChange(info, oldInfo); err != nil {
+			if err := validateVolumeInfoChange(info, oldInfo, sb.modelType); err != nil {
 				return nil, err
 			}
 		}
@@ -1486,16 +1486,18 @@ func (sb *storageBackend) SetVolumeInfo(tag names.VolumeTag, info VolumeInfo) (e
 	return sb.mb.db().Run(buildTxn)
 }
 
-func validateVolumeInfoChange(newInfo, oldInfo VolumeInfo) error {
+func validateVolumeInfoChange(newInfo, oldInfo VolumeInfo, modelType ModelType) error {
 	if newInfo.Pool != oldInfo.Pool {
 		return errors.Errorf(
 			"cannot change pool from %q to %q",
 			oldInfo.Pool, newInfo.Pool,
 		)
 	}
-	if newInfo.VolumeId != oldInfo.VolumeId {
+	// VolumeId is allowed to change only for CAAS models to support the case
+	// where a manual storage resize recreates the underlying PVC with a new ID.
+	if newInfo.VolumeId != oldInfo.VolumeId && modelType != ModelTypeCAAS {
 		return errors.Errorf(
-			"cannot change volume ID from %q to %q",
+			"cannot change volume ID from %q to %q for machine models",
 			oldInfo.VolumeId, newInfo.VolumeId,
 		)
 	}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -10,8 +10,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	k8stesting "github.com/juju/juju/caas/kubernetes/testing"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	k8sprovider "github.com/juju/juju/internal/provider/kubernetes"
 	"github.com/juju/juju/state"
 	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/state/testing"
@@ -25,7 +27,22 @@ type VolumeStateSuite struct {
 	StorageStateSuiteBase
 }
 
-var _ = gc.Suite(&VolumeStateSuite{})
+type VolumeIAASModelSuite struct {
+	VolumeStateSuite
+}
+
+type VolumeCAASModelSuite struct {
+	VolumeStateSuite
+}
+
+var _ = gc.Suite(&VolumeIAASModelSuite{})
+var _ = gc.Suite(&VolumeCAASModelSuite{})
+
+func (s *VolumeCAASModelSuite) SetUpTest(c *gc.C) {
+	s.series = "kubernetes"
+	s.VolumeStateSuite.SetUpTest(c)
+	s.PatchValue(&k8sprovider.NewK8sClients, k8stesting.NoopFakeK8sClients)
+}
 
 func (s *VolumeStateSuite) TestAddMachine(c *gc.C) {
 	_, unit, _ := s.setupSingleStorage(c, "block", "loop-pool")
@@ -255,6 +272,40 @@ func (s *VolumeStateSuite) TestSetVolumeInfoImmutable(c *gc.C) {
 
 	volumeInfoSet.Pool = "loop-pool"
 	s.assertVolumeInfo(c, volumeTag, volumeInfoSet)
+}
+
+func (s *VolumeIAASModelSuite) TestSetVolumeInfoRejectsVolumeIdChange(c *gc.C) {
+	_, _, storageTag := s.setupSingleStorage(c, "volume", "rootfs")
+	volume := s.storageInstanceVolume(c, storageTag)
+	volumeTag := volume.VolumeTag()
+
+	initial := state.VolumeInfo{Size: 123, VolumeId: "vol-old", Pool: "rootfs"}
+	err := s.storageBackend.SetVolumeInfo(volumeTag, initial)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertVolumeInfo(c, volumeTag, initial)
+
+	// For IAAS models, changing identifier should fail.
+	updated := state.VolumeInfo{Size: 456, VolumeId: "vol-new", Pool: "rootfs"}
+	err = s.storageBackend.SetVolumeInfo(volumeTag, updated)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for volume ".*0/0": cannot change volume ID from "vol-old" to "vol-new" for machine models`)
+}
+
+func (s *VolumeCAASModelSuite) TestSetVolumeInfoAllowsVolumeIdAndSizeUpdate(c *gc.C) {
+	_, _, storageTag := s.setupSingleStorage(c, "volume", "kubernetes")
+	volume := s.storageInstanceVolume(c, storageTag)
+	volumeTag := volume.VolumeTag()
+
+	initial := state.VolumeInfo{Size: 123, VolumeId: "vol-old", Pool: "kubernetes"}
+	err := s.storageBackend.SetVolumeInfo(volumeTag, initial)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertVolumeInfo(c, volumeTag, initial)
+
+	// For CAAS models, VolumeId changes are allowed to support PVC resize
+	updated := state.VolumeInfo{Size: 456, VolumeId: "vol-new", Pool: "kubernetes"}
+	err = s.storageBackend.SetVolumeInfo(volumeTag, updated)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertVolumeInfo(c, volumeTag, updated)
 }
 
 func (s *VolumeStateSuite) TestWatchVolumeAttachment(c *gc.C) {

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -32,7 +32,7 @@ type VolumeIAASModelSuite struct {
 }
 
 type VolumeCAASModelSuite struct {
-	VolumeStateSuite
+	StorageStateSuiteBase
 }
 
 var _ = gc.Suite(&VolumeIAASModelSuite{})
@@ -40,7 +40,7 @@ var _ = gc.Suite(&VolumeCAASModelSuite{})
 
 func (s *VolumeCAASModelSuite) SetUpTest(c *gc.C) {
 	s.series = "kubernetes"
-	s.VolumeStateSuite.SetUpTest(c)
+	s.StorageStateSuiteBase.SetUpTest(c)
 	s.PatchValue(&k8sprovider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 }
 
@@ -275,24 +275,29 @@ func (s *VolumeStateSuite) TestSetVolumeInfoImmutable(c *gc.C) {
 }
 
 func (s *VolumeIAASModelSuite) TestSetVolumeInfoRejectsVolumeIdChange(c *gc.C) {
-	_, _, storageTag := s.setupSingleStorage(c, "volume", "rootfs")
-	volume := s.storageInstanceVolume(c, storageTag)
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "modelscoped-block")
+	err := s.State.AssignUnit(u, state.AssignCleanEmpty)
+	c.Assert(err, jc.ErrorIsNil)
+
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
+	volume := s.filesystemVolume(c, filesystem.FilesystemTag())
 	volumeTag := volume.VolumeTag()
 
-	initial := state.VolumeInfo{Size: 123, VolumeId: "vol-old", Pool: "rootfs"}
-	err := s.storageBackend.SetVolumeInfo(volumeTag, initial)
+	initial := state.VolumeInfo{Size: 123, VolumeId: "vol-old", Pool: "modelscoped-block"}
+	err = s.storageBackend.SetVolumeInfo(volumeTag, initial)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVolumeInfo(c, volumeTag, initial)
 
 	// For IAAS models, changing identifier should fail.
-	updated := state.VolumeInfo{Size: 456, VolumeId: "vol-new", Pool: "rootfs"}
+	updated := state.VolumeInfo{Size: 456, VolumeId: "vol-new", Pool: "modelscoped-block"}
 	err = s.storageBackend.SetVolumeInfo(volumeTag, updated)
-	c.Assert(err, gc.ErrorMatches, `cannot set info for volume ".*0/0": cannot change volume ID from "vol-old" to "vol-new" for machine models`)
+	c.Assert(err, gc.ErrorMatches, `cannot set info for volume ".*0(/0)?": cannot change volume ID from "vol-old" to "vol-new" for machine models`)
 }
 
 func (s *VolumeCAASModelSuite) TestSetVolumeInfoAllowsVolumeIdAndSizeUpdate(c *gc.C) {
-	_, _, storageTag := s.setupSingleStorage(c, "volume", "kubernetes")
-	volume := s.storageInstanceVolume(c, storageTag)
+	_, _, storageTag := s.setupSingleStorage(c, "filesystem", "kubernetes")
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
+	volume := s.filesystemVolume(c, filesystem.FilesystemTag())
 	volumeTag := volume.VolumeTag()
 
 	initial := state.VolumeInfo{Size: 123, VolumeId: "vol-old", Pool: "kubernetes"}

--- a/tests/includes/k8s.sh
+++ b/tests/includes/k8s.sh
@@ -27,9 +27,9 @@ kubectl() {
 }
 
 default_k8s() {
-	if command -v minikube && [[ "Started" == "$(minikube status -o json | yq .Host)" ]]; then
+	if command -v minikube >/dev/null 2>&1 && [[ "Stopped" != "$(minikube status -o json | yq .APIServer)" ]]; then
 		printf "minikube"
-	elif command -v microk8s && [[ "True" == "$(microk8s status --format yaml | yq .microk8s.running)" ]]; then
+	elif command -v microk8s >/dev/null 2>&1 && [[ "True" == "$(microk8s status --format yaml | yq .microk8s.running)" ]]; then
 		printf "microk8s"
 	fi
 }

--- a/tests/suites/storage_k8s/resize.sh
+++ b/tests/suites/storage_k8s/resize.sh
@@ -79,6 +79,34 @@ storage_id_for_pod() {
 	echo "${storage_id}"
 }
 
+pvc_name_for_storage() {
+	local model_name pod_name storage_name claim_name_prefix_regex
+	local pod_json pvc_name
+
+	model_name=${1}
+	pod_name=${2}
+	storage_name=${3}
+	claim_name_prefix_regex="$storage_name-.*-$pod_name$"
+
+	pod_json=$(kubectl get pod "${pod_name}" -n "${model_name}" -o json 2>/dev/null || true)
+	if [[ -z ${pod_json} ]]; then
+		return 1
+	fi
+
+	pvc_name=$(echo "${pod_json}" | CLAIM_NAME_PREFIX="$claim_name_prefix_regex" yq -o json -r '
+		[
+			.spec.volumes[]?
+			| select(.persistentVolumeClaim != null)
+			| .persistentVolumeClaim.claimName
+		] | map(select(test(strenv(CLAIM_NAME_PREFIX)))) | .[0] // ""
+	')
+
+	if [[ -z ${pvc_name} ]]; then
+		return 1
+	fi
+	echo "${pvc_name}"
+}
+
 wait_for_active_units() {
 	local app_name expected_count app_index
 
@@ -894,6 +922,51 @@ EOF
 	if [[ -n $current_storage_class ]]; then
 		kubectl annotate sc "$current_storage_class" storageclass.kubernetes.io/is-default-class="true"
 	fi
+
+	destroy_model "${model_name}"
+}
+
+# Scenario: delete the pvc for an existing unit after app storage
+# directives have been updated. The pvc gets the new size which
+# then should be reflected in the Juju model.
+test_deleted_pvc_recreated_with_new_storage() {
+	if [ "$(skip 'test_deleted_pvc_recreated_with_new_storage')" ]; then
+		echo "==> TEST SKIPPED: test_deleted_pvc_recreated_with_new_storage"
+		return
+	fi
+
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# Ensure a bootstrap Juju model exists.
+	model_name="update-pvc"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	juju deploy postgresql-k8s --channel 14/stable --trust --storage pgdata=100M
+
+	# Wait until the application is active.
+	wait_for_active_units "postgresql-k8s" 1
+	postgresql_k8s_0_storage_id=$(storage_id_for_pod "${model_name}" "postgresql-k8s-0" "pgdata")
+	echo "postgresql-k8s-0 storage ID: $postgresql_k8s_0_storage_id"
+	wait_for_storage "attached" ".storage[\"$postgresql_k8s_0_storage_id\"][\"status\"].current"
+
+	# Update the storage to 200M.
+	juju application-storage postgresql-k8s pgdata=200M
+
+	# Delete the PVC in Kubernetes.
+	pvc_name=$(pvc_name_for_storage "${model_name}" "postgresql-k8s-0" "pgdata")
+	kubectl delete pvc -n "${model_name}" "${pvc_name}" --wait=false
+	kubectl delete pod -n "${model_name}" "postgresql-k8s-0"
+
+	# The operator should recreate it with the new size.
+	wait_for_active_units "postgresql-k8s" 1
+	juju storage --format json |
+		yq -o json ".volumes | to_entries[] | select(.value.storage == \"$postgresql_k8s_0_storage_id\") | .value.size" |
+		check 200
+	juju storage --format json |
+		yq -o json ".filesystems | to_entries[] | select(.value.storage == \"$postgresql_k8s_0_storage_id\") | .value.size" |
+		check 200
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/storage_k8s/task.sh
+++ b/tests/suites/storage_k8s/task.sh
@@ -32,6 +32,7 @@ test_storage_k8s() {
 		test_remove_app_while_storage_update_stuck
 		test_update_storage_constraints_validation_error
 		test_update_pool_same_provider_different_storage_class
+		test_deleted_pvc_recreated_with_new_storage
 		;;
 	*)
 		echo "==> TEST SKIPPED: storage k8s tests, not a k8s provider"


### PR DESCRIPTION
When using the Juju storage resize feature, only new pods get the new storage size. Users want to manually delete the pvc for existing pods so those pods also get the resized pvc. This works, but the Juju model did not reflect the new PVC size. 

This PR adds a PVC watcher and plumbs through the size updates to the Juju model.

## QA steps

A new test cases is added to the storage_k8s tests.

`./main.sh -p k8s storage_k8s`

