### PR TITLE
feat: always revoke any secret tokens, even in a readonly hook

### DIFF
--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -971,6 +971,12 @@ func (b *CommitHookParamsBuilder) AddTrackLatest(trackLatest []string) {
 	copy(b.arg.TrackLatest, trackLatest)
 }
 
+// SetExpireIssuedTokensOnly requests a minimal commit that only expires secret
+// backend issued tokens for the unit.
+func (b *CommitHookParamsBuilder) SetExpireIssuedTokensOnly() {
+	b.arg.ExpireIssuedTokensOnly = true
+}
+
 // SecretGrantRevokeArgs holds parameters for updating a secret's access.
 type SecretGrantRevokeArgs struct {
 	URI             *secrets.URI

--- a/apiserver/facades/agent-schema.json
+++ b/apiserver/facades/agent-schema.json
@@ -14038,6 +14038,9 @@
                                 "$ref": "#/definitions/EntityPortRange"
                             }
                         },
+                        "expire-issued-tokens-only": {
+                            "type": "boolean"
+                        },
                         "open-ports": {
                             "type": "array",
                             "items": {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2686,6 +2686,16 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 	}
 	appTag := names.NewApplicationTag(appName)
 
+	if changes.ExpireIssuedTokensOnly {
+		if hasOtherCommitHookChanges(changes) {
+			// Should never happen.
+			return errors.New("expire-issued-tokens-only cannot be combined with other commit hook changes")
+		}
+		return u.st.ApplyOperation(state.ComposeModelOperations(
+			u.secrets.ExpireSecretBackendIssuedTokensForConsumer(unitTag),
+		))
+	}
+
 	var modelOps []state.ModelOperation
 
 	if changes.UpdateNetworkInfo {
@@ -2927,6 +2937,19 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 
 	// Apply all changes in a single transaction.
 	return u.st.ApplyOperation(state.ComposeModelOperations(modelOps...))
+}
+
+func hasOtherCommitHookChanges(changes params.CommitHookChangesArg) bool {
+	if changes.UpdateNetworkInfo || changes.SetUnitState != nil ||
+		changes.SetPodSpec != nil || changes.SetRawK8sSpec != nil {
+		return true
+	}
+	return len(changes.RelationUnitSettings) > 0 ||
+		len(changes.OpenPorts) > 0 || len(changes.ClosePorts) > 0 ||
+		len(changes.AddStorage) > 0 || len(changes.SecretCreates) > 0 ||
+		len(changes.TrackLatest) > 0 || len(changes.SecretUpdates) > 0 ||
+		len(changes.SecretGrants) > 0 || len(changes.SecretRevokes) > 0 ||
+		len(changes.SecretDeletes) > 0
 }
 
 // WatchInstanceData is a shim to call the LXDProfileAPIv2 version of this method.

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4840,6 +4840,46 @@ func (s *uniterSuite) TestCommitHookChangesExpiresSecretBackendTokens(c *gc.C) {
 	c.Check(tokens, gc.HasLen, 10)
 }
 
+func (s *uniterSuite) TestCommitHookChangesExpireIssuedTokensOnly(c *gc.C) {
+	store := state.NewSecrets(s.State)
+	now := time.Now()
+
+	// Create 3 tokens to check expiry.
+	for range 3 {
+		issuedToken := state.SecretBackendIssuedToken{
+			UUID:       utils.MustNewUUID().String(),
+			ExpireTime: now.Add(time.Hour),
+			BackendID:  "backend-id",
+			Consumer:   s.wordpressUnit.Tag(),
+		}
+		err := store.CreateSecretBackendIssuedToken(issuedToken)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	reservedURI := secrets.NewURI()
+	err := store.ReserveSecret(reservedURI, s.wordpressUnit.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	b := apiuniter.NewCommitHookParamsBuilder(s.wordpressUnit.UnitTag())
+	b.SetExpireIssuedTokensOnly()
+	req, _ := b.Build()
+
+	result, err := s.uniter.CommitHookChanges(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+
+	// Tokens are expired by just setting the expire tokens bool.
+	tokens, err := store.ListSecretBackendIssuedTokenUntilForConsumer(now, s.wordpressUnit.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(tokens, gc.HasLen, 3)
+
+	// Read-only secret access commit must not remove secret reservations.
+	reserved, err := store.ListReservedSecrets([]names.Tag{s.wordpressUnit.Tag()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(reserved, gc.HasLen, 1)
+}
+
 func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 	// We need to set up a unit that has storage metadata defined.
 	ch := s.AddTestingCharm(c, "storage-block2") // supports multiple storage instances

--- a/internal/worker/secretsrevoker/worker.go
+++ b/internal/worker/secretsrevoker/worker.go
@@ -121,6 +121,15 @@ func (w *revoker) loop() (err error) {
 		next  time.Time
 		fire  <-chan time.Time
 	)
+	// Expiry times that are already due should be processed immediately,
+	// while future times are still bucketed for normal quantised scheduling.
+	scheduleTime := func(when time.Time) time.Time {
+		now := clk.Now()
+		if !when.After(now) {
+			return now
+		}
+		return quantiseTime(when)
+	}
 	for {
 		select {
 		case <-w.catacomb.Dying():
@@ -149,7 +158,7 @@ func (w *revoker) loop() (err error) {
 			if earliest.IsZero() {
 				continue
 			}
-			earliestQuantised := quantiseTime(earliest)
+			earliestQuantised := scheduleTime(earliest)
 			if !next.Equal(earliestQuantised) {
 				next = earliestQuantised
 				logger.Debugf("scheduling revoke at %v", next)
@@ -171,7 +180,7 @@ func (w *revoker) loop() (err error) {
 				next = time.Time{}
 				continue
 			}
-			next = quantiseTime(nextRevoke)
+			next = scheduleTime(nextRevoke)
 			logger.Debugf("scheduling revoke at %v", next)
 			alarm.Reset(next)
 		}

--- a/internal/worker/secretsrevoker/worker_test.go
+++ b/internal/worker/secretsrevoker/worker_test.go
@@ -176,28 +176,37 @@ func (s *workerSuite) TestWorkerQuantisedSchedule(c *gc.C) {
 
 	const iterations = 100
 	clk := testclock.NewDilatedWallClock(50 * time.Microsecond)
+	type scheduledExpiry struct {
+		when      time.Time
+		quantised time.Time
+	}
+	times := make([]scheduledExpiry, 0, iterations)
 	now := clk.Now().UTC().Truncate(time.Second)
-	times := map[time.Time]time.Time{}
-	first := time.Time{}
-	for i := range iterations {
-		next := now.Add(time.Duration(rand.Intn(600)) * time.Second)
-		nextQ := secretsrevoker.DefaultQuantiseTime(next)
-		times[next] = nextQ
-		if i == 0 {
-			first = next
-		} else {
-			s.facade.EXPECT().RevokeIssuedTokens(times[now]).Return(next, nil)
-		}
+	for range iterations {
+		next := now.Add(time.Duration(rand.Intn(600)+1) * time.Second)
+		times = append(times, scheduledExpiry{
+			when:      next,
+			quantised: secretsrevoker.DefaultQuantiseTime(next),
+		})
 		now = next
 	}
+	first := times[0].when
 
 	done := make(chan struct{})
-	s.facade.EXPECT().RevokeIssuedTokens(
-		times[now],
-	).DoAndReturn(func(_ time.Time) (time.Time, error) {
-		defer close(done)
-		return time.Time{}, nil
-	})
+	for i, nextExpiry := range times {
+		s.facade.EXPECT().RevokeIssuedTokens(gomock.Any()).DoAndReturn(func(until time.Time) (time.Time, error) {
+			if !until.Equal(nextExpiry.quantised) {
+				// If the clock has already passed the target expiry, the worker
+				// intentionally schedules immediate revocation.
+				c.Assert(until, jc.Before, clk.Now().Add(2*time.Second))
+			}
+			if i+1 >= len(times) {
+				close(done)
+				return time.Time{}, nil
+			}
+			return times[i+1].when, nil
+		})
+	}
 
 	ch := make(chan []string, 1)
 	ch <- []string(nil)
@@ -205,26 +214,54 @@ func (s *workerSuite) TestWorkerQuantisedSchedule(c *gc.C) {
 	defer workertest.CheckKilled(c, expiryWatcher)
 	s.facade.EXPECT().WatchIssuedTokenExpiry().Return(expiryWatcher, nil)
 
-	quantiseTime := func(x time.Time) time.Time {
-		for k, v := range times {
-			if k.Equal(x) {
-				return v
-			}
-		}
-		c.Errorf("unexpected time %q", x)
-		return x
-	}
 	w, err := secretsrevoker.NewWorker(secretsrevoker.Config{
 		Facade:       s.facade,
 		Logger:       loggo.GetLogger("test"),
 		Clock:        clk,
-		QuantiseTime: quantiseTime,
+		QuantiseTime: secretsrevoker.DefaultQuantiseTime,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 	defer workertest.CleanKill(c, w)
 
 	ch <- []string{first.Format(time.RFC3339)}
+	<-done
+}
+
+func (s *workerSuite) TestWorkerSchedulesImmediateForPastDueExpiry(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	clk := testclock.NewDilatedWallClock(time.Millisecond)
+	now := clk.Now().UTC().Truncate(time.Second)
+	pastDue := now.Add(-10 * time.Second)
+
+	ch := make(chan []string, 1)
+	ch <- []string(nil)
+	expiryWatcher := watchertest.NewMockStringsWatcher(ch)
+	defer workertest.CheckKilled(c, expiryWatcher)
+	s.facade.EXPECT().WatchIssuedTokenExpiry().Return(expiryWatcher, nil)
+
+	done := make(chan struct{})
+	s.facade.EXPECT().RevokeIssuedTokens(gomock.Any()).DoAndReturn(func(until time.Time) (time.Time, error) {
+		defer close(done)
+		c.Assert(until, jc.Before, now.Add(5*time.Second))
+		return time.Time{}, nil
+	})
+
+	w, err := secretsrevoker.NewWorker(secretsrevoker.Config{
+		Facade: s.facade,
+		Logger: loggo.GetLogger("test"),
+		Clock:  clk,
+		QuantiseTime: func(t time.Time) time.Time {
+			// Use a large offset to make accidental quantisation obvious.
+			return t.Add(10 * time.Minute)
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.NotNil)
+	defer workertest.CleanKill(c, w)
+
+	ch <- []string{pastDue.Format(time.RFC3339)}
 	<-done
 }
 

--- a/internal/worker/uniter/runner/context/context.go
+++ b/internal/worker/uniter/runner/context/context.go
@@ -363,6 +363,10 @@ type HookContext struct {
 	// secretChanges records changes to secrets during a hook execution.
 	secretChanges *secretsChangeRecorder
 
+	// secretAccessPerformed tracks whether a secret get was requested during
+	// this hook, so a "read-only" hook can still commit token-expiry cleanup.
+	secretAccessPerformed bool
+
 	mu sync.Mutex
 }
 
@@ -900,6 +904,7 @@ func (ctx *HookContext) GetSecret(uri *coresecrets.URI, label string, refresh, p
 			}
 		}
 	}
+	ctx.secretAccessPerformed = true
 	backend, err := ctx.getSecretsBackend()
 	if err != nil {
 		return nil, err
@@ -1833,9 +1838,16 @@ func (ctx *HookContext) doFlush(process string) error {
 		}
 	}
 
-	// Generate change request but skip its execution if no changes are pending.
+	// Generate change request but skip its execution if no changes are pending,
+	// unless we still need to expire issued tokens after secret access.
 	commitReq, numChanges := b.Build()
-	if numChanges > 0 {
+	shouldCommit := numChanges > 0
+	if !shouldCommit && ctx.secretAccessPerformed {
+		b.SetExpireIssuedTokensOnly()
+		commitReq, _ = b.Build()
+		shouldCommit = true
+	}
+	if shouldCommit {
 		if err := ctx.unit.CommitHookChanges(commitReq); err != nil {
 			ctx.logger.Errorf("cannot apply changes: %v", err)
 		cleanupDone:
@@ -1853,6 +1865,7 @@ func (ctx *HookContext) doFlush(process string) error {
 
 	// Call completed successfully; update local state
 	ctx.charmStateCacheDirty = false
+	ctx.secretAccessPerformed = false
 	return nil
 }
 

--- a/internal/worker/uniter/runner/context/export_test.go
+++ b/internal/worker/uniter/runner/context/export_test.go
@@ -137,7 +137,7 @@ func NewMockUnitHookContextWithState(mockUnit *mocks.MockHookUnit, state State) 
 func NewMockUnitHookContextWithStateAndModelType(mockUnit *mocks.MockHookUnit, state State, modelType model.ModelType) *HookContext {
 	logger := loggo.GetLogger("test")
 	return &HookContext{
-		unitName:               mockUnit.Tag().Id(), //unitName used by the action finaliser method.
+		unitName:               mockUnit.Tag().Id(), // unitName used by the action finaliser method.
 		unit:                   mockUnit,
 		state:                  state,
 		logger:                 logger,
@@ -151,7 +151,7 @@ func NewMockUnitHookContextWithStateAndModelType(mockUnit *mocks.MockHookUnit, s
 func NewMockUnitHookContextWithStateAndStorage(unitName string, unit HookUnit, state State, storageTag names.StorageTag) *HookContext {
 	logger := loggo.GetLogger("test")
 	return &HookContext{
-		unitName:               unit.Tag().Id(), //unitName used by the action finaliser method.
+		unitName:               unit.Tag().Id(), // unitName used by the action finaliser method.
 		unit:                   unit,
 		state:                  state,
 		logger:                 logger,
@@ -384,4 +384,8 @@ func (ctx *HookContext) PendingSecretTrackLatest() map[string]bool {
 
 func (ctx *HookContext) SetInClusterConfig(inClusterConfig func() (*rest.Config, error)) {
 	ctx.inClusterConfig = inClusterConfig
+}
+
+func (ctx *HookContext) SetSecretAccessPerformed(performed bool) {
+	ctx.secretAccessPerformed = performed
 }

--- a/internal/worker/uniter/runner/context/flush_test.go
+++ b/internal/worker/uniter/runner/context/flush_test.go
@@ -407,6 +407,29 @@ func (s *FlushContextSuite) TestRunHookUpdatesSecrets(c *gc.C) {
 	c.Assert(access, gc.Equals, secrets.RoleNone)
 }
 
+func (s *FlushContextSuite) TestFlushReadOnlySecretAccessExpiresIssuedTokens(c *gc.C) {
+	ctx := s.context(c)
+	ctx.SetSecretAccessPerformed(true)
+
+	store := state.NewSecrets(s.State)
+	now := time.Now()
+	token := state.SecretBackendIssuedToken{
+		UUID:       utils.MustNewUUID().String(),
+		ExpireTime: now.Add(time.Hour),
+		BackendID:  "backend-id",
+		Consumer:   s.unit.Tag(),
+	}
+	err := store.CreateSecretBackendIssuedToken(token)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = ctx.Flush("secret-get", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expired, err := store.ListSecretBackendIssuedTokenUntilForConsumer(now, s.unit.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(expired, gc.HasLen, 1)
+}
+
 func (s *HookContextSuite) context(c *gc.C) *context.HookContext {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -321,6 +321,10 @@ type CommitHookChangesArg struct {
 	SecretGrants         []GrantRevokeSecretArg `json:"secret-grants,omitempty"`
 	SecretRevokes        []GrantRevokeSecretArg `json:"secret-revokes,omitempty"`
 	SecretDeletes        []DeleteSecretArg      `json:"secret-deletes,omitempty"`
+	// ExpireIssuedTokensOnly requests a minimal commit operation that only
+	// expires secret backend issued tokens. It's used when there's no
+	// other changes but we still need to expire tokens.
+	ExpireIssuedTokensOnly bool `json:"expire-issued-tokens-only,omitempty"`
 }
 
 // ModelConfig holds a model configuration.


### PR DESCRIPTION
This PR optimises the cleanup of "tokens" used to confer secret access to a unit running a hook and calling "secret-get".

There's 2 fixes:
1. When just secret-get is called, and there's nothing to commit (eg relation data, new secrets etc), then no commit is done and the previously landed optimisation to make any token(s) for expiry "now" is not done;
2. The revoke worker gets a tweak so that any expiry times already due are processed immediately

## QA steps

Deploy a charm, eg snappass-test
Create a secret
`juju exec -u snappass-test/0 -- secret-add foo=bar`
Read the secret
`juju exec -u snappass-test/0 -- secret-get <uri>`
Check the sa, role, rolebinding is removed almost immediately.

## Links

**Issue:** Mitigates #22384.

**Jira card:** [JUJU-9821](https://warthogs.atlassian.net/browse/JUJU-9821)


[JUJU-9821]: https://warthogs.atlassian.net/browse/JUJU-9821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ