### PR TITLE
docs: add LLM guard-rails to doc.go rules

### DIFF
--- a/AGENTS.doc-dot-go-rules.md
+++ b/AGENTS.doc-dot-go-rules.md
@@ -148,6 +148,144 @@ when it is package-wide behavior (for example Juju creating a VCN in OCI).
    //	+-----------------+       |                 |       +-----------------+
    ```
 
+## Guard-Rails for LLM Consumption
+
+Beyond describing what a package does, doc.go should explicitly state behavioral boundaries that prevent misuse. These guard-rails help LLMs (and developers) make safe decisions when using or modifying the package.
+
+**The insight**: Implicit constraints are invisible to LLMs. Humans might learn through experience or tribal knowledge that "you always check grants before accessing secrets" or "domain packages never import from apiserver," but an LLM has no such experience. Making these explicit transforms doc.go from a map (here's what exists) into a rulebook (here's how to use this safely).
+
+### When to Add Guard-Rails
+
+Add guard-rail sections when the package has:
+- Transaction or concurrency requirements
+- Security-sensitive operations with specific handling rules
+- Immutability constraints on types
+- Required validation steps before operations
+- Layer boundary restrictions (what can/cannot be imported)
+- Initialization or cleanup requirements
+- Error handling patterns that must be followed
+- Performance-critical patterns that must be maintained
+
+### Guard-Rail Section Format
+
+Use section headers like:
+- `# Constraints` - for immutability and structural invariants
+- `# Transaction Requirements` - for database transaction boundaries
+- `# Security Invariants` - for security-sensitive handling rules
+- `# Concurrency` - for thread-safety guarantees (only what's explicitly guaranteed)
+- `# Lifecycle` - for initialization and cleanup requirements
+- `# Architecture Constraints` - for layer boundaries and import restrictions
+- `# Error Handling` - for required error handling patterns
+- `# Required Validations` - for mandatory validation steps
+
+Write guard-rails using RFC 2119 keywords:
+- **MUST** statements for mandatory requirements
+- **MUST NOT** statements for forbidden actions
+- **MAY** statements for optional behaviors
+- **SHOULD** statements for recommended but not mandatory practices
+
+Focus on **interface contracts**, not implementation details. State what callers must respect, not how the package implements protection internally.
+
+### Examples by Category
+
+**Transaction boundaries** (critical for domain packages):
+```go
+// # Transaction Requirements
+//
+// All write operations MUST occur within a transaction provided by the caller.
+// The state layer does not manage transaction lifecycle. Callers MUST NOT hold
+// transactions across multiple service calls to avoid deadlocks.
+```
+
+**Security constraints**:
+```go
+// # Security Invariants
+//
+// Secret values MUST NOT be logged or included in error messages. Callers MUST
+// validate grants before accessing secret content using CheckGrant(). The
+// service layer does not enforce grant checks automatically -- this is the
+// caller's responsibility.
+```
+
+**Layer boundaries** (preventing architectural erosion):
+```go
+// # Architecture Constraints
+//
+// This package MUST NOT import from apiserver or internal/worker packages.
+// Domain logic must remain transport-agnostic and independent of deployment
+// concerns. Only core/* and domain/* packages may be imported for type
+// definitions.
+```
+
+**Immutability constraints**:
+```go
+// # Constraints
+//
+// Secret URIs are immutable once created. Secret revisions are append-only --
+// existing revisions cannot be modified or deleted, only obsoleted through
+// expiry. Grant modifications must be performed atomically within a single
+// transaction to prevent partial access states.
+```
+
+**Validation requirements**:
+```go
+// # Required Validations
+//
+// Secret URIs MUST be validated using secret.ParseURI() before storage.
+// Rotation policies MUST be one of the enumerated constants (HourlyRotation,
+// DailyRotation, etc.) -- arbitrary durations are not supported. Grant scopes
+// MUST match the secret's ownership scope (model secrets cannot grant
+// unit-level access).
+```
+
+**Initialization and lifecycle**:
+```go
+// # Lifecycle
+//
+// Services MUST be initialized with a valid backend provider before use.
+// Secret watches MUST be closed explicitly to prevent goroutine leaks. Rotation
+// workers rely on monotonic clock progression -- callers MUST NOT manipulate
+// system time during testing without using the injected clock.
+```
+
+**Error handling patterns**:
+```go
+// # Error Handling
+//
+// All errors from the state layer MUST be wrapped with context using
+// errors.Annotatef() before returning to callers. NotFound errors MUST use
+// errors.NotFoundf() for consistent handling. Security-sensitive errors (grant
+// violations) MUST NOT expose the secret URI in the error message.
+```
+
+**Concurrency safety** (only what's explicitly guaranteed):
+```go
+// # Concurrency
+//
+// The service layer is concurrency-safe for reads. Write operations acquire
+// exclusive locks on the affected entities. Callers MAY call read methods
+// concurrently but MUST serialize write operations to the same entity.
+```
+
+### Balancing Comprehensiveness with Maintainability
+
+To avoid doc.go bloat:
+- Focus on **package-wide constraints** that affect multiple functions
+- Skip constraints that are **enforced by type systems** (e.g., if a function signature requires `*sql.Tx`, the transaction requirement is obvious from the types)
+- Document only what you can **verify in code** (stick to the "Facts vs Interpretation" principle)
+- Prioritize **security and correctness** constraints over performance or style preferences
+- Omit constraints that are **obvious from function names** (e.g., ValidateURI clearly validates)
+
+### Verification for Guard-Rails
+
+Verify each guard-rail statement by:
+1. **Searching for validation code** that enforces the constraint
+2. **Finding code comments** that explicitly state the requirement
+3. **Locating tests** that verify the boundary condition
+4. **Checking error messages** that indicate violation of the constraint
+
+If a constraint cannot be verified through code inspection, grep searches, or explicit comments, do not document it. Unverifiable guard-rails are interpretations, not facts.
+
 ## Verification Process
 
 Before finalizing a doc.go file:

--- a/AGENTS.doc-dot-go-rules.md
+++ b/AGENTS.doc-dot-go-rules.md
@@ -168,15 +168,7 @@ Add guard-rail sections when the package has:
 
 ### Guard-Rail Section Format
 
-Use section headers like:
-- `# Constraints` - for immutability and structural invariants
-- `# Transaction Requirements` - for database transaction boundaries
-- `# Security Invariants` - for security-sensitive handling rules
-- `# Concurrency` - for thread-safety guarantees (only what's explicitly guaranteed)
-- `# Lifecycle` - for initialization and cleanup requirements
-- `# Architecture Constraints` - for layer boundaries and import restrictions
-- `# Error Handling` - for required error handling patterns
-- `# Required Validations` - for mandatory validation steps
+In actual doc.go files, group all guard-rails under a single h1 section (typically `# Constraints` or `# Guard-Rails`). This distinguishes prescriptive constraints from descriptive pattern explanations. Within that section, organize by category using bold labels or paragraphs:
 
 Write guard-rails using RFC 2119 keywords:
 - **MUST** statements for mandatory requirements
@@ -186,86 +178,67 @@ Write guard-rails using RFC 2119 keywords:
 
 Focus on **interface contracts**, not implementation details. State what callers must respect, not how the package implements protection internally.
 
-### Examples by Category
+### Example Structure
 
-**Transaction boundaries** (critical for domain packages):
 ```go
-// # Transaction Requirements
+// # Secret Access and Grants
 //
-// All write operations MUST occur within a transaction provided by the caller.
-// The state layer does not manage transaction lifecycle. Callers MUST NOT hold
-// transactions across multiple service calls to avoid deadlocks.
-```
+// [Descriptive content explaining the pattern...]
 
-**Security constraints**:
-```go
-// # Security Invariants
+// # Rotation and Expiry
 //
-// Secret values MUST NOT be logged or included in error messages. Callers MUST
-// validate grants before accessing secret content using CheckGrant(). The
-// service layer does not enforce grant checks automatically -- this is the
-// caller's responsibility.
-```
+// [Descriptive content explaining the pattern...]
 
-**Layer boundaries** (preventing architectural erosion):
-```go
-// # Architecture Constraints
-//
-// This package MUST NOT import from apiserver or internal/worker packages.
-// Domain logic must remain transport-agnostic and independent of deployment
-// concerns. Only core/* and domain/* packages may be imported for type
-// definitions.
-```
-
-**Immutability constraints**:
-```go
 // # Constraints
 //
-// Secret URIs are immutable once created. Secret revisions are append-only --
-// existing revisions cannot be modified or deleted, only obsoleted through
-// expiry. Grant modifications must be performed atomically within a single
-// transaction to prevent partial access states.
+// **Immutability**: Secret URIs are immutable once created. Secret revisions
+// are append-only -- existing revisions cannot be modified or deleted, only
+// obsoleted through expiry.
+//
+// **Transactions**: All write operations MUST occur within a transaction
+// provided by the caller. The state layer does not manage transaction
+// lifecycle. Callers MUST NOT hold transactions across multiple service calls
+// to avoid deadlocks.
+//
+// **Security**: Secret values MUST NOT be logged or included in error messages.
+// Callers MUST validate grants before accessing secret content using
+// CheckGrant(). The service layer does not enforce grant checks automatically.
+//
+// **Architecture**: This package MUST NOT import from apiserver or
+// internal/worker packages. Domain logic must remain transport-agnostic. Only
+// core/* and domain/* packages may be imported for type definitions.
+//
+// **Validation**: Secret URIs MUST be validated using secret.ParseURI() before
+// storage. Rotation policies MUST be one of the enumerated constants
+// (HourlyRotation, DailyRotation, etc.). Grant scopes MUST match the secret's
+// ownership scope.
+//
+// **Lifecycle**: Services MUST be initialized with a valid backend provider
+// before use. Secret watches MUST be closed explicitly to prevent goroutine
+// leaks.
+//
+// **Error Handling**: All errors from the state layer MUST be wrapped with
+// context using errors.Annotatef(). NotFound errors MUST use errors.NotFoundf()
+// for consistent handling. Security-sensitive errors MUST NOT expose the secret
+// URI in the error message.
+//
+// **Concurrency**: The service layer is concurrency-safe for reads. Write
+// operations acquire exclusive locks on the affected entities. Callers MAY call
+// read methods concurrently but MUST serialize write operations to the same
+// entity.
 ```
 
-**Validation requirements**:
-```go
-// # Required Validations
-//
-// Secret URIs MUST be validated using secret.ParseURI() before storage.
-// Rotation policies MUST be one of the enumerated constants (HourlyRotation,
-// DailyRotation, etc.) -- arbitrary durations are not supported. Grant scopes
-// MUST match the secret's ownership scope (model secrets cannot grant
-// unit-level access).
-```
+### Categories to Consider
 
-**Initialization and lifecycle**:
-```go
-// # Lifecycle
-//
-// Services MUST be initialized with a valid backend provider before use.
-// Secret watches MUST be closed explicitly to prevent goroutine leaks. Rotation
-// workers rely on monotonic clock progression -- callers MUST NOT manipulate
-// system time during testing without using the injected clock.
-```
-
-**Error handling patterns**:
-```go
-// # Error Handling
-//
-// All errors from the state layer MUST be wrapped with context using
-// errors.Annotatef() before returning to callers. NotFound errors MUST use
-// errors.NotFoundf() for consistent handling. Security-sensitive errors (grant
-// violations) MUST NOT expose the secret URI in the error message.
-```
-
-**Concurrency safety** (only what's explicitly guaranteed):
-```go
-// # Concurrency
-//
-// The service layer is concurrency-safe for reads. Write operations acquire
-// exclusive locks on the affected entities. Callers MAY call read methods
-// concurrently but MUST serialize write operations to the same entity.
-```
+When documenting constraints, consider including (where applicable):
+- **Immutability** - structural invariants and append-only constraints
+- **Transactions** - database transaction boundaries (critical for domain packages)
+- **Security** - handling of sensitive data, access control requirements
+- **Architecture** - layer boundaries and import restrictions
+- **Validation** - mandatory validation steps before operations
+- **Lifecycle** - initialization and cleanup requirements
+- **Error Handling** - required error handling patterns
+- **Concurrency** - thread-safety guarantees (only what's explicitly guaranteed)
 
 ### Balancing Comprehensiveness with Maintainability
 

--- a/AGENTS.doc-dot-go-rules.md
+++ b/AGENTS.doc-dot-go-rules.md
@@ -129,15 +129,17 @@ when it is package-wide behavior (for example Juju creating a VCN in OCI).
 
 ## Writing Guidelines
 
-1. **Maintain the red thread**: Explicitly repeat the main topic (e.g., "agent configuration") rather than using pronouns like "it" or "this".
+1. **Maintain the red thread**: Explicitly repeat the main topic (e.g., "agent configuration") rather than using pronouns like "it" or "this". This applies to prose and to section/subsection labels (e.g., "**Secret access and grants**" instead of "**Access and grants**").
 
-2. **Document contracts, not implementation**: State what callers can rely on and what constraints they must respect. Never describe internal mechanisms (locks, goroutines, data structures).
+2. **Use sentence case for section labels**: Bold subsection labels within `# Package patterns` and `# Package constraints` should use sentence case, not title case.
 
-3. **Use " -- " for em dashes**: Not "-" or "—", but " -- " with spaces.
+3. **Document contracts, not implementation**: State what callers can rely on and what constraints they must respect. Never describe internal mechanisms (locks, goroutines, data structures).
 
-4. **Use " -> " for right arrows**: Not "→" or "⮕" or "➡" or "⇨" or "🡒" or "⟶", but " -> " with spaces.
+4. **Use " -- " for em dashes**: Not "-" or "—", but " -- " with spaces.
 
-5. **Use ASCII diagrams for workflows**: In doc.go files, when documenting state transitions, sequences, or data flow, add ASCII diagrams.
+5. **Use " -> " for right arrows**: Not "→" or "⮕" or "➡" or "⇨" or "🡒" or "⟶", but " -> " with spaces.
+
+6. **Use ASCII diagrams for workflows**: In doc.go files, when documenting state transitions, sequences, or data flow, add ASCII diagrams.
 
    Example:
    ```
@@ -168,45 +170,50 @@ Add guard-rail sections when the package has:
 
 ### Guard-Rail Section Format
 
-In actual doc.go files, group all guard-rails under a single h1 section (typically `# Constraints` or `# Guard-Rails`). This distinguishes prescriptive constraints from descriptive pattern explanations. Within that section, organize by category using bold labels or paragraphs:
+**Both sections document contract-level information** from the caller's perspective:
 
-Write guard-rails using RFC 2119 keywords:
+- `# How this package works` - Descriptive contract information (realis mood): what concepts exist, how they relate, what flows are available. This explains what the package **is**.
+- `# How to use this package correctly` - Prescriptive contract information (irrealis mood): constraints callers must respect. This states what callers **must do**.
+
+Neither section documents implementation details. Both focus on the interface contract.
+
+In the prescriptive section (`# How to use this package correctly`), organize by category using bold labels with sentence case. Write guard-rails using RFC 2119 keywords:
 - **MUST** statements for mandatory requirements
 - **MUST NOT** statements for forbidden actions
 - **MAY** statements for optional behaviors
 - **SHOULD** statements for recommended but not mandatory practices
 
-Focus on **interface contracts**, not implementation details. State what callers must respect, not how the package implements protection internally.
+The RFC 2119 keywords signal the prescriptive nature of this section.
 
 ### Example Structure
 
 ```go
-// # Secret Access and Grants
+// # How this package works
 //
-// [Descriptive content explaining the pattern...]
+// **Secret access and grants**: Access to a secret is managed through grants,
+// which define the role (view or manage) and the scope (unit, application,
+// model, or relation) of the permissions. [Continue with descriptive content...]
+//
+// **Secret rotation and expiry**: Secrets can be configured with rotation
+// policies (hourly, daily, weekly, etc.) that determine when a secret should be
+// updated. [Continue with descriptive content...]
 
-// # Rotation and Expiry
-//
-// [Descriptive content explaining the pattern...]
-
-// # Constraints
-//
-// **Immutability**: Secret URIs are immutable once created. Secret revisions
-// are append-only -- existing revisions cannot be modified or deleted, only
-// obsoleted through expiry.
-//
-// **Transactions**: All write operations MUST occur within a transaction
-// provided by the caller. The state layer does not manage transaction
-// lifecycle. Callers MUST NOT hold transactions across multiple service calls
-// to avoid deadlocks.
-//
-// **Security**: Secret values MUST NOT be logged or included in error messages.
-// Callers MUST validate grants before accessing secret content using
-// CheckGrant(). The service layer does not enforce grant checks automatically.
+// # How to use this package correctly
 //
 // **Architecture**: This package MUST NOT import from apiserver or
 // internal/worker packages. Domain logic must remain transport-agnostic. Only
 // core/* and domain/* packages may be imported for type definitions.
+//
+// **Immutability**: Secret URIs MUST NOT be modified after creation. Secret
+// revisions are append-only -- existing revisions cannot be modified or deleted,
+// only obsoleted through expiry.
+//
+// **Security**: Secret values MUST NOT be logged or included in error messages.
+// Secret values MUST NOT be accessed without verifying read permissions.
+//
+// **Transactions**: Callers MUST NOT hold transactions across multiple service
+// calls to avoid deadlocks. Write operations MUST occur within database
+// transactions.
 //
 // **Validation**: Secret URIs MUST be validated using secret.ParseURI() before
 // storage. Rotation policies MUST be one of the enumerated constants
@@ -228,17 +235,32 @@ Focus on **interface contracts**, not implementation details. State what callers
 // entity.
 ```
 
+### Section Naming Conventions
+
+**Top-level sections**: Use action-oriented headings that distinguish descriptive (realis) from prescriptive (irrealis) content:
+
+- `# How this package works` - Descriptive contract information: concepts, relationships, flows
+- `# How to use this package correctly` - Prescriptive contract information: constraints, requirements, boundaries
+
+The linguistic mood distinction (realis vs. irrealis) is inherent in the verb forms. The RFC 2119 keywords (MUST, MUST NOT, MAY, SHOULD) in the second section reinforce the prescriptive nature.
+
+**Subsection labels**: Use bold labels with sentence case (not title case).
+Apply the red thread pattern by repeating the main package topic:
+- Good: `**Secret access and grants**`, `**Secret rotation and expiry**`
+- Avoid: `**Access and grants**`, `**Rotation and expiry**` (loses context)
+
 ### Categories to Consider
 
-When documenting constraints, consider including (where applicable):
-- **Immutability** - structural invariants and append-only constraints
-- **Transactions** - database transaction boundaries (critical for domain packages)
-- **Security** - handling of sensitive data, access control requirements
+When documenting constraints, consider including (where applicable). Categories
+MUST be ordered alphabetically in doc.go files:
 - **Architecture** - layer boundaries and import restrictions
-- **Validation** - mandatory validation steps before operations
-- **Lifecycle** - initialization and cleanup requirements
-- **Error Handling** - required error handling patterns
 - **Concurrency** - thread-safety guarantees (only what's explicitly guaranteed)
+- **Error handling** - required error handling patterns
+- **Immutability** - structural invariants and append-only constraints
+- **Lifecycle** - initialization and cleanup requirements
+- **Security** - handling of sensitive data, access control requirements
+- **Transactions** - database transaction boundaries (critical for domain packages)
+- **Validation** - mandatory validation steps before operations
 
 ### Balancing Comprehensiveness with Maintainability
 
@@ -299,7 +321,7 @@ The first states what callers must do; the second reveals internal database stru
 
 1. **LLM analyzes code** and proposes constraint statements based on patterns
 2. **Human reviews proposals** to identify which are real contracts vs. current implementation
-3. **LLM drafts `# Constraints` section** with validated constraints in RFC 2119 language
+3. **LLM drafts `# How to use this package correctly` section** with validated constraints in RFC 2119 language
 4. **Human verifies** each constraint is observable in code (per "Verification for Guard-Rails")
 5. **Iterate** until all statements are contract-level and verifiable
 

--- a/AGENTS.doc-dot-go-rules.md
+++ b/AGENTS.doc-dot-go-rules.md
@@ -259,6 +259,52 @@ Verify each guard-rail statement by:
 
 If a constraint cannot be verified through code inspection, grep searches, or explicit comments, do not document it. Unverifiable guard-rails are interpretations, not facts.
 
+### AI-Assisted Guard-Rail Development
+
+LLMs can accelerate guard-rail documentation, but human oversight is critical to distinguish **interface contracts** from **implementation details**.
+
+**What LLMs can reasonably infer:**
+- Import patterns and architecture boundaries (what packages are imported/forbidden)
+- Function signatures and type relationships (what goes in and out)
+- Explicit error types and validation patterns visible in code
+- Structural patterns (e.g., State/Service layer separation)
+
+**What LLMs struggle to infer:**
+- Implicit behavioral rules ("always check grants before accessing secret values")
+- Required operation ordering ("must validate before persisting")
+- Transaction boundaries in domain packages (service calls `RunAtomic`, but state methods don't show `*sql.Tx` parameters)
+- Immutability constraints (types may be mutable in Go but conceptually immutable)
+- Security requirements that span multiple functions
+- Concurrency safety guarantees not enforced by type system
+
+**Critical distinction: Contract vs. Implementation**
+
+Guard-rails document **interface contracts** (what callers must respect), not **implementation details** (how the package enforces those contracts internally).
+
+Good guard-rail (contract):
+```
+**Security**: Secret values MUST NOT be accessed without verifying
+grants through GetSecretAccess.
+```
+
+Bad guard-rail (implementation detail):
+```
+**Security**: GetSecretAccess queries the secret_permission table
+with a JOIN on secret_metadata...
+```
+
+The first states what callers must do; the second reveals internal database structure.
+
+**Recommended workflow for AI-assisted guard-rails:**
+
+1. **LLM analyzes code** and proposes constraint statements based on patterns
+2. **Human reviews proposals** to identify which are real contracts vs. current implementation
+3. **LLM drafts `# Constraints` section** with validated constraints in RFC 2119 language
+4. **Human verifies** each constraint is observable in code (per "Verification for Guard-Rails")
+5. **Iterate** until all statements are contract-level and verifiable
+
+This workflow leverages LLM pattern recognition while maintaining human architectural authority on what constitutes a package contract.
+
 ## Verification Process
 
 Before finalizing a doc.go file:

--- a/agent/doc.go
+++ b/agent/doc.go
@@ -2,32 +2,28 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // Package agent manages agent configuration for Juju agents.
+// See the sections below for details about this package.
 //
-// Agents are Juju processes that run on behalf of specific entities (machines,
-// units, models, or controllers). Agent configuration provides
+// See github.com/juju/juju/api for establishing API connections using agent configuration.
+// See github.com/juju/juju/controller for controller-specific settings that agents should handle.
+//
+// # How this package works
+//
+// **Agents**: Agents are Juju processes that run on behalf of specific entities
+// (machines, units, models, or controllers). Agent configuration provides
 // persistent identity, credentials, and connection details -- API credentials,
 // controller addresses, CA certificates, directory paths, and operational
 // settings like logging configuration -- that allow them to authenticate to the
 // controller and perform their work.
 //
-// See github.com/juju/juju/api for establishing API connections using agent
-// configuration. See github.com/juju/juju/controller for controller-specific
-// settings that agents should handle. See the sections below for package-level
-// concerns that span multiple interfaces.
+// **Agent configuration persistence**: Configuration files use a versioned format.
+// Juju supports reading the current format and the format from the previous
+// stable release.
 //
-// # Configuration persistence
-//
-// Configuration files use a versioned format. Juju supports reading the current
-// format and the format from the previous stable release. Callers must not
-// parse configuration files directly. Use ReadConfig instead.
-//
-// # Password bootstrapping
-//
-// New agents are created with an old password but no current password. When an
-// agent first connects to the API server using the old password, it generates a
-// new secure password and saves it via SetPassword. The old password then
-// serves as a fallback. Callers must not assume both passwords are populated on
-// a newly created configuration.
+// **Agent password bootstrapping**: New agents are created with an old password
+// but no current password. When an agent first connects to the API server using
+// the old password, it generates a new secure password and saves it via
+// SetPassword. The old password then serves as a fallback.
 //
 //	New Agent                 First Connect              After Connect
 //	+-----------------+       +-----------------+       +-----------------+
@@ -39,4 +35,10 @@
 //	                          | Generate new    |
 //	                          | SetPassword()   |
 //	                          +-----------------+
+//
+// # How to use this package correctly
+//
+// **Validation**: Callers MUST NOT parse configuration files directly. Use
+// ReadConfig instead to ensure version compatibility. Callers MUST NOT assume
+// both passwords are populated on a newly created configuration.
 package agent

--- a/api/doc.go
+++ b/api/doc.go
@@ -2,18 +2,20 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // Package api provides client-side API connections to Juju controllers.
+// See the sections below for details about this package.
 //
-// API connections enable clients (CLI commands, agents, external tools, etc.)
-// to make authenticated calls to Juju controllers and models. The Open
-// function establishes connections using configuration from Info (controller
-// addresses, certificates, authentication credentials, etc.) and DialOpts
-// (timeouts, retry delays, etc.), returning a Connection interface that
-// provides facilities, authentication state, and server metadata.
+// See github.com/juju/juju/api/connector for higher-level connection abstractions.
+// See github.com/juju/juju/api/base for the APICaller interface used by facade clients.
+// See subpackages (agent, client, controller, etc.) for facade-specific API clients.
+//
+// # How this package works
+//
+// **API connections**: API connections enable clients (CLI commands, agents,
+// external tools, etc.) to make authenticated calls to Juju controllers and
+// models. The Open function establishes connections using configuration from
+// Info (controller addresses, certificates, authentication credentials, etc.)
+// and DialOpts (timeouts, retry delays, etc.), returning a Connection interface
+// that provides facilities, authentication state, and server metadata.
 // Authentication is performed by LoginProvider implementations supporting
 // various methods (password, macaroon, session token, etc.).
-//
-// See github.com/juju/juju/api/connector for higher-level connection
-// abstractions. See github.com/juju/juju/api/base for the APICaller interface
-// used by facade clients. See subpackages (agent, client, controller, etc.) for
-// facade-specific API clients.
 package api

--- a/core/life/doc.go
+++ b/core/life/doc.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package life defines lifecycle state values for Juju entities.
+// See the sections below for details about this package.
+//
+// # How this package works
+//
+// **Lifecycle states**: Juju entities (machines, units, applications, models)
+// follow a lifecycle from Alive to Dying to Dead. Alive means the entity should
+// exist and operate normally. Dying means the entity is scheduled for removal
+// but may have cleanup dependencies. Dead means cleanup is complete and the
+// entity can be removed from the database.
+//
+// **State transitions**: Valid transitions are Alive → Dying → Dead. Entities
+// cannot transition backward (e.g., from Dead to Alive). The transition from
+// Alive to Dying typically occurs when a user requests removal. The transition
+// from Dying to Dead occurs when all cleanup tasks (removing relations,
+// releasing resources, stopping units) are complete.
+//
+// **Predicates**: The package provides type-safe predicates (IsDead, IsAlive,
+// IsNotAlive, IsNotDead) for checking lifecycle state. These predicates enable
+// consistent state checks across the codebase.
+//
+// # How to use this package correctly
+//
+// **Validation**: Lifecycle values MUST be validated using Value.Validate()
+// before persistence. Only the three defined constants (Alive, Dying, Dead) are
+// valid.
+package life

--- a/core/model/doc.go
+++ b/core/model/doc.go
@@ -1,15 +1,33 @@
 // Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// Package model defines core model types and identifiers.
+// See the sections below for details about this package.
+//
+// See github.com/juju/juju/core/life for model lifecycle states.
+// See github.com/juju/juju/core/credential for model credential management.
+//
+// # How this package works
+//
+// **Models**: Models are isolated environments for deploying and managing
+// applications. Each model has a unique UUID, a qualified name (name + owner
+// qualifier), and a type (IAAS for infrastructure-as-a-service or CAAS for
+// container-as-a-service). Models track their target agent version, cloud
+// configuration (cloud name, type, region), and lifecycle state (alive, dying,
+// dead).
+//
+// **Model types**: IAAS models deploy applications to machines managed by Juju.
+// CAAS models deploy applications to Kubernetes clusters. The model type
+// determines the provider implementation and the available operations.
+//
+// **Model identification**: Models can be addressed by UUID (universal across
+// controllers) or by qualified name (owner/name within a controller). The
+// qualifier is typically the owner's username. Short UUIDs (first 6 characters)
+// are used in CLI output for brevity.
+//
+// # How to use this package correctly
+//
+// **Validation**: Model UUIDs MUST be validated using UUID.Validate() before
+// persistence. Model qualifiers MUST be valid user identifiers as defined by
+// names.IsValidUser(). ModelType values MUST be either IAAS or CAAS.
 package model
-
-// ## Block Type
-//
-// Model level Blocks are used to prevent accidental damage to Juju deployments.
-// Blocks can be switched on/off to prevent running some operations.
-//
-//  1. DestroyBlock type identifies block that prevents model destruction.
-//  2. RemoveBlock type identifies block that prevents removal of machines,
-//     applications, units or relations.
-//  3. ChangeBlock type identifies block that prevents model changes such as
-//     additions, modifications, removals of model entities.

--- a/domain/secret/doc.go
+++ b/domain/secret/doc.go
@@ -3,24 +3,23 @@
 
 // Package secret manages the lifecycle and access control of secrets.
 //
-// Secrets are sensitive data (like passwords, tokens, or certificates) that are
-// stored in versioned revisions and managed through backends -- such as Vault,
-// Kubernetes, or the built-in controller backend -- to ensure security and
-// persistence. Each secret is addressed by a unique URI and can be owned by a
-// model (user secrets), an application, or a unit (charm secrets).
+// See the sections below for details about this package.
+// See github.com/juju/juju/domain/secretbackend for backend configuration.
+// See github.com/juju/juju/core/secrets for core secret types.
 //
-// See github.com/juju/juju/domain/secretbackend for details on how different
-// backend providers are configured and selected. See
-// github.com/juju/juju/core/secrets for the core types used to represent secret
-// URIs, metadata, and values across the codebase. See the sections below for
-// package-level concerns that span multiple interfaces.
+// # How this package works
 //
-// # Secret Access and Grants
+// **Secrets**: Secrets are sensitive data (like passwords, tokens, or
+// certificates) that are stored in versioned revisions and managed through
+// backends -- such as Vault, Kubernetes, or the built-in controller backend --
+// to ensure security and persistence. Each secret is addressed by a unique URI
+// and can be owned by a model (user secrets), an application, or a unit (charm
+// secrets).
 //
-// Access to a secret is managed through grants, which define the role (view or
-// manage) and the scope (unit, application, model, or relation) of the
-// permissions. This allows for fine-grained control over which entities can
-// read or update a secret's revisions.
+// **Secret access and grants**: Access to a secret is managed through grants,
+// which define the role (view or manage) and the scope (unit, application,
+// model, or relation) of the permissions. This allows for fine-grained control
+// over which entities can read or update a secret's revisions.
 //
 //	Grant Request           Validation              Stored Grant
 //	+---------------+       +---------------+       +---------------+
@@ -29,13 +28,12 @@
 //	| Scope: rel    |       |               |       | Role/Scope    |
 //	+---------------+       +---------------+       +---------------+
 //
-// # Rotation and Expiry
-//
-// Secrets can be configured with rotation policies (hourly, daily, weekly,
-// etc.) that determine when a secret should be updated. The service tracks
-// rotation metadata, including the next rotation time, and notifies watchers
-// when a rotation event is required. Similarly, secret revisions can have an
-// expiry time, after which they are considered obsolete and may be pruned.
+// **Secret rotation and expiry**: Secrets can be configured with rotation policies
+// (hourly, daily, weekly, etc.) that determine when a secret should be updated.
+// The service tracks rotation metadata, including the next rotation time, and
+// notifies watchers when a rotation event is required. Similarly, secret
+// revisions can have an expiry time, after which they are considered obsolete
+// and may be pruned.
 //
 //	Policy Set              Monitoring              Rotation Event
 //	+---------------+       +---------------+       +---------------+
@@ -43,4 +41,60 @@
 //	| daily         | ----> | rotate time   | ----> | rotation      |
 //	|               |       |               |       | worker        |
 //	+---------------+       +---------------+       +---------------+
+//
+// # How to use this package correctly
+//
+// **Architecture**: This package MUST NOT import from apiserver or
+// internal/worker packages. Domain logic must remain transport-agnostic. Only
+// core/* and domain/* packages may be imported for type definitions.
+//
+// >> Is this layer boundary enforcement a formal contract for all domain
+// >> packages?
+//
+// >> **Concurrency**: Are there any concurrency guarantees this package
+// >> provides? Thread-safety for reads? Required serialization for writes?
+// >> If not verifiable, this category will be omitted.
+//
+// **Error handling**: NotFound errors MUST use secreterrors.SecretNotFound or
+// secreterrors.SecretRevisionNotFound. Permission errors MUST use
+// secreterrors.PermissionDenied. Security-sensitive errors MUST NOT expose
+// secret content in messages.
+//
+// >> Are these error type requirements part of the package contract, or
+// >> implementation choices?
+//
+// **Immutability**: Secret URIs MUST NOT be modified after creation. Secret
+// revisions MUST NOT be modified or deleted after creation -- they MAY only be
+// marked as obsolete through expiry.
+//
+// >> Is this append-only behavior a guaranteed contract, or just current
+// >> implementation?
+//
+// **Lifecycle**: SecretService MUST be initialized with valid State and
+// SecretBackendState implementations before use. Backend providers MUST be
+// initialized before content operations.
+//
+// >> Is initialization order a documented requirement or enforced by
+// >> panic/error?
+//
+// **Security**: Secret values MUST NOT be accessed without verifying read
+// permissions. Secret values MUST NOT be logged or included in error messages.
+//
+// >> Should this be stated as "service layer enforces grant checks" (current
+// >> implementation) or as caller obligation? Is the logging prohibition a
+// >> contract or best practice?
+//
+// **Transactions**: Callers MUST NOT hold transactions across multiple service
+// calls to avoid deadlocks. Write operations MUST occur within database
+// transactions.
+//
+// >> Is the transaction boundary guidance (no holding across calls) a
+// >> documented contract or tribal knowledge?
+//
+// **Validation**: Secret URIs MUST be validated before storage operations.
+// Rotation policies MUST use enumerated constants from secrets.RotatePolicy.
+// Grant scopes MUST match the secret's ownership scope.
+//
+// >> Are these validation requirements enforced by the package, or must callers
+// >> ensure validity?
 package secret

--- a/domain/secretbackend/doc.go
+++ b/domain/secretbackend/doc.go
@@ -1,58 +1,63 @@
+package main
 // Copyright 2025 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package secretbackend defines the secret backend domain.
+// Package secretbackend manages secret backend registration and selection.
+// See the sections below for details about this package.
 //
-// # What does this domain do?
+// See github.com/juju/juju/domain/secret for secret operations.
+// See github.com/juju/juju/internal/secrets/provider for backend provider implementations.
 //
-// The secret backend domain:
-//   - defines and validates secret backend records (identity, type, config).
-//   - creates, updates, lists, and deletes backends, with safeguards for
-//     immutability and in-use protection in the state layer.
-//   - tracks rotation metadata (token rotate interval and next rotation time)
-//     and emitting changes consumable by watchers used by rotation workers.
-//   - manages per-model backend selection. The default model backend is
-//     automatically resolved to the most appropriate built-in backend based on
-//     model type (IAAS or CAAS).
-//   - restores the default backend selection when a user-defined backend is
-//     destroyed, respecting the model type.
+// # How this package works
 //
-// # How does this domain work?
+// **Secret backends**: Secret backends store sensitive data for secrets. Backend
+// types include controller (built-in Juju backend), kubernetes (Kubernetes
+// provider), and vault (Vault provider). Backends can be addressed by UUID or
+// human-readable name.
 //
-//   - Backend identity: A backend can be addressed by UUID or by human-readable
-//     name. Only one is required for lookups/updates.
-//   - Backend type: Backend types are either `controller` for the built-in backend
-//     into Juju controller, `kubernetes` for the Kubernetes provider, or `vault` for
-//     the Vault provider. Types are represented by string constants.
-//   - Backend origin: Backends created at bootstrap time are marked as origin
-//     'built-in'. All other backends are marked as origin 'user'. 'built-in'
-//     backends are immutable and cannot be deleted.
-//   - Backend configuration: Each backend carries a Config `map[string]any`.
-//     Keys must be non-empty. Values must be non-nil and, when strings,
-//     non-empty. Values are stored as JSON.
-//   - Backend auth token rotation: Service interface allows specifying a rotation interval for
-//     backends. When set, the next rotation time is computed, then recorded and
-//     updated upon rotation events. Rotation events are emitted by
-//     the state layer through a watcher.
-//   - Default backend selection: For a given model, the effective backend name
-//     can be retrieved and set through the service layer. The special provider
-//     value “auto” resolves to the built-in `controller` backend for IAAS
-//     models and to the built-in `kubernetes` backend for CAAS models.
+// **Secret backend capabilities**: The secret backend domain defines and validates
+// secret backend records (identity, type, config), creates, updates, lists, and
+// deletes backends, tracks rotation metadata (token rotate interval and next
+// rotation time) and emits changes consumable by watchers used by rotation
+// workers, manages per-model backend selection (default model backend is
+// automatically resolved to the most appropriate built-in backend based on model
+// type - IAAS or CAAS), and restores the default backend selection when a
+// user-defined backend is destroyed.
 //
-// # Built-in Kubernetes Secret Backend
+// **Secret backend identity**: A backend can be addressed by UUID or by
+// human-readable name. Only one is required for lookups/updates.
 //
-// For models deployed on Kubernetes (CAAS), a built-in secret backend is
-// available. This backend is represented by a single entry in the
-// `secret_backend` table named 'kubernetes'.
+// **Secret backend origin**: Backends created at bootstrap time are marked as
+// origin 'built-in'. All other backends are marked as origin 'user'.
 //
-// Although multiple CAAS models might use this "built-in" backend, there is
-// only one entry for it in the database. When retrieving the backend
-// configuration for a specific CAAS model, Juju dynamically constructs the
-// configuration using the model's cloud and credential specifications (for
-// endpoint information) and the model's name (which maps to the Kubernetes
-// namespace).
+// **Secret backend configuration**: Each backend carries a Config map[string]any.
+// Values are stored as JSON.
 //
-// This means that from an architectural perspective, all CAAS models share the
-// same backend type and database record, but their effective run-time
+// **Secret backend rotation**: Service interface allows specifying a rotation
+// interval for backends. When set, the next rotation time is computed, then
+// recorded and updated upon rotation events. Rotation events are emitted by the
+// state layer through a watcher.
+//
+// **Secret backend selection**: For a given model, the effective backend name can
+// be retrieved and set through the service layer. The special provider value
+// "auto" resolves to the built-in controller backend for IAAS models and to the
+// built-in kubernetes backend for CAAS models.
+//
+// **Built-in Kubernetes secret backend**: For CAAS models, a built-in secret
+// backend is available, represented by a single entry in the secret_backend table
+// named 'kubernetes'. Although multiple CAAS models might use this backend, there
+// is only one database entry. When retrieving the backend configuration for a
+// specific CAAS model, Juju dynamically constructs the configuration using the
+// model's cloud and credential specifications (for endpoint information) and the
+// model's name (which maps to the Kubernetes namespace). All CAAS models share
+// the same backend type and database record, but their effective run-time
 // configuration is model-specific.
+//
+// # How to use this package correctly
+//
+// **Immutability**: Built-in backends MUST NOT be modified or deleted. Backend
+// types MUST NOT change after creation.
+//
+// **Validation**: Backend configuration keys MUST be non-empty strings. Values
+// MUST be non-nil. String values MUST be non-empty.
 package secretbackend

--- a/internal/worker/lease/doc.go
+++ b/internal/worker/lease/doc.go
@@ -1,19 +1,37 @@
 // Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package lease, also known as the manager, manages the leases used by
-// individual Juju workers.
+// Package lease manages lease allocation and lifecycle for Juju workers.
+// See the sections below for details about this package.
 //
-// Workers will claim a lease, and they are either attributed (i.e., the workers
-// gets the lease ) or blocked (i.e., the worker is waiting for a lease to
-// become available).
-// In the latter case, the manager will keep track of all the blocked claims.
-// When a worker's lease expires or gets revoked, then the manager will
-// re-attribute it to one of other workers, thus unblocking them and satisfying
-// their claim.
-// In the special case where a worker is upgrading an application, it will ask
-// the manager to "pin" the lease. This means that the lease will not expire or
-// be revoked during the upgrade, and the validity of the lease will get
-// refreshed once the upgrade has completed. The overall effect is that the
-// application unit does not lose leadership during an upgrade.
+// See github.com/juju/juju/core/lease for lease types and store interface.
+//
+// # How this package works
+//
+// **Leases**: Leases provide distributed locking for Juju workers that need
+// exclusive access to resources. Common uses include leadership election for
+// application units and singular worker coordination across controllers.
+//
+// **Lease claiming and attribution**: Workers claim leases through the manager.
+// Claims are either attributed (the worker receives the lease immediately) or
+// blocked (the worker waits for the lease to become available). The manager
+// tracks blocked claims and automatically attributes leases to waiting workers
+// when current leases expire or are revoked.
+//
+// **Lease expiry and reattribution**: When a lease expires or is explicitly
+// revoked, the manager selects one of the blocked workers and attributes the
+// lease to them. This ensures fair distribution and prevents lease starvation.
+//
+// **Lease pinning during upgrades**: During application upgrades, workers can
+// request that their lease be pinned. Pinned leases do not expire or get revoked
+// during the upgrade, and their validity is refreshed when the upgrade completes.
+// This prevents application units from losing leadership mid-upgrade, which could
+// cause upgrade failures or inconsistent state.
+//
+// # How to use this package correctly
+//
+// **Lifecycle**: The Manager implements worker.Worker and uses tomb for lifecycle
+// management. Callers MUST call Kill() to initiate shutdown and Wait() to block
+// until shutdown completes. The manager waits up to 55 seconds for in-flight
+// operations to complete before forcing shutdown.
 package lease


### PR DESCRIPTION
Our JIRA epic https://warthogs.atlassian.net/browse/JUJU-8927 aims to improve contributor documentation for Juju 4+. A big part of this is defining (and rolling out) a standard for `doc.go` files. In a past PR we've added an agents file that encodes this standard. The goal then was to produce `doc.go` files that would serve humans. However, chats with @SimonRichardson  suggest it would be good if these files could serve LLMs too. This PR revises our agents standard for `doc.go` files to include a "Guard-Rails for LLM Consumption" section with explicit behavioral boundaries—transaction requirements, security constraints, layer boundaries, validation rules, etc.