### PR TITLE
feat: reuse secret access tokens if scope matches

### DIFF
--- a/apiserver/common/secrets/mocks/state_mock.go
+++ b/apiserver/common/secrets/mocks/state_mock.go
@@ -106,20 +106,6 @@ func (mr *MockSecretsStoreMockRecorder) DeleteSecret(arg0 any, arg1 ...any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockSecretsStore)(nil).DeleteSecret), varargs...)
 }
 
-// ExpireSecretBackendIssuedTokensForConsumer mocks base method.
-func (m *MockSecretsStore) ExpireSecretBackendIssuedTokensForConsumer(arg0 names.Tag) state.ModelOperation {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExpireSecretBackendIssuedTokensForConsumer", arg0)
-	ret0, _ := ret[0].(state.ModelOperation)
-	return ret0
-}
-
-// ExpireSecretBackendIssuedTokensForConsumer indicates an expected call of ExpireSecretBackendIssuedTokensForConsumer.
-func (mr *MockSecretsStoreMockRecorder) ExpireSecretBackendIssuedTokensForConsumer(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpireSecretBackendIssuedTokensForConsumer", reflect.TypeOf((*MockSecretsStore)(nil).ExpireSecretBackendIssuedTokensForConsumer), arg0)
-}
-
 // GetOwnedSecretMetadataAsApp mocks base method.
 func (m *MockSecretsStore) GetOwnedSecretMetadataAsApp(arg0 names.ApplicationTag, arg1 *secrets.URI) (*secrets.SecretMetadataOwnerIdent, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -350,8 +350,18 @@ func backendConfigInfo(
 			if tok.ExpireTime.Before(now) || tok.BackendID != backendID || tok.ScopeHash != scopeHash {
 				continue
 			}
-			// Keep original expiry; do not extend on reuse.
 			issuedTokenUUID = tok.UUID
+			// Refresh token expiry on reuse.
+			err = secretsState.CreateSecretBackendIssuedToken(state.SecretBackendIssuedToken{
+				UUID:       issuedTokenUUID,
+				ExpireTime: expireTime,
+				BackendID:  backendID,
+				Consumer:   authTag,
+				ScopeHash:  scopeHash,
+			})
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 			logger.Tracef("reusing token=%q consumer=%q scope=%q", issuedTokenUUID, authTag.String(), scopeHash)
 			break
 		}

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -335,7 +335,7 @@ func backendConfigInfo(
 
 	issuedTokenUUID := ""
 	if p.IssuesTokens() {
-		scopeHash, err := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
+		scopeHash, err := issuedTokenScopeHash(forDrain, ownedIDs, ownedRevs, readRevs)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -404,16 +404,18 @@ func backendConfigInfo(
 	return info, nil
 }
 
-func issuedTokenScopeHash(ownedIDs []string, ownedRevs, readRevs provider.SecretRevisions) (string, error) {
+func issuedTokenScopeHash(forDrain bool, ownedIDs []string, ownedRevs, readRevs provider.SecretRevisions) (string, error) {
 	canonicalOwnedIDs := append([]string(nil), ownedIDs...)
 	slices.Sort(canonicalOwnedIDs)
 	canonicalOwnedIDs = slices.Compact(canonicalOwnedIDs)
 
 	payload := struct {
+		ForDrain  bool     `json:"for-drain"`
 		OwnedIDs  []string `json:"owned-ids"`
 		OwnedRevs []string `json:"owned-revs"`
 		ReadRevs  []string `json:"read-revs"`
 	}{
+		ForDrain:  forDrain,
 		OwnedIDs:  canonicalOwnedIDs,
 		OwnedRevs: ownedRevs.RevisionIDs(),
 		ReadRevs:  readRevs.RevisionIDs(),

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -5,7 +5,10 @@ package secrets
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"slices"
 	"sort"
 	"time"
 
@@ -332,21 +335,44 @@ func backendConfigInfo(
 
 	issuedTokenUUID := ""
 	if p.IssuesTokens() {
-		v, err := uuid.NewRandom()
+		scopeHash, err := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		issuedTokenUUID = v.String()
 
-		args := state.SecretBackendIssuedToken{
-			UUID:       issuedTokenUUID,
-			ExpireTime: time.Now().Add(coresecrets.IssuedTokenValidity),
-			BackendID:  backendID,
-			Consumer:   authTag,
-		}
-		err = secretsState.CreateSecretBackendIssuedToken(args)
+		now := time.Now().UTC().Truncate(time.Second)
+		expireTime := now.Add(coresecrets.IssuedTokenValidity)
+		existing, err := secretsState.ListSecretBackendIssuedTokenUntilForConsumer(expireTime, authTag)
 		if err != nil {
 			return nil, errors.Trace(err)
+		}
+		for _, tok := range existing {
+			if tok.ExpireTime.Before(now) || tok.BackendID != backendID || tok.ScopeHash != scopeHash {
+				continue
+			}
+			// Keep original expiry; do not extend on reuse.
+			issuedTokenUUID = tok.UUID
+			logger.Tracef("reusing token=%q consumer=%q scope=%q", issuedTokenUUID, authTag.String(), scopeHash)
+			break
+		}
+		if issuedTokenUUID == "" {
+			v, err := uuid.NewRandom()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			issuedTokenUUID = v.String()
+
+			args := state.SecretBackendIssuedToken{
+				UUID:       issuedTokenUUID,
+				ExpireTime: expireTime,
+				BackendID:  backendID,
+				Consumer:   authTag,
+				ScopeHash:  scopeHash,
+			}
+			err = secretsState.CreateSecretBackendIssuedToken(args)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 	}
 
@@ -366,6 +392,29 @@ func backendConfigInfo(
 		BackendConfig:  *cfg,
 	}
 	return info, nil
+}
+
+func issuedTokenScopeHash(ownedIDs []string, ownedRevs, readRevs provider.SecretRevisions) (string, error) {
+	canonicalOwnedIDs := append([]string(nil), ownedIDs...)
+	slices.Sort(canonicalOwnedIDs)
+	canonicalOwnedIDs = slices.Compact(canonicalOwnedIDs)
+
+	payload := struct {
+		OwnedIDs  []string `json:"owned-ids"`
+		OwnedRevs []string `json:"owned-revs"`
+		ReadRevs  []string `json:"read-revs"`
+	}{
+		OwnedIDs:  canonicalOwnedIDs,
+		OwnedRevs: ownedRevs.RevisionIDs(),
+		ReadRevs:  readRevs.RevisionIDs(),
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:]), nil
 }
 
 func getExternalRevisions(

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -1384,7 +1384,7 @@ func (s *secretsSuite) TestBackendConfigInfoIssuesToken(c *gc.C) {
 	readRevs := map[string]set.Strings{
 		"read-1": set.NewStrings("read-rev-1"),
 	}
-	scopeHash := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
+	scopeHash := issuedTokenScopeHash(false, ownedIDs, ownedRevs, readRevs)
 	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{
 		"secret-backend": "backend-name",
 	})
@@ -1508,7 +1508,7 @@ func (s *secretsSuite) TestBackendConfigInfoIssuesTokenWithReservedSecrets(c *gc
 	ownedRevs := map[string]set.Strings{}
 	read := []*coresecrets.SecretMetadata{}
 	readRevs := map[string]set.Strings{}
-	scopeHash := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
+	scopeHash := issuedTokenScopeHash(false, ownedIDs, ownedRevs, readRevs)
 	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{
 		"secret-backend": "backend-name",
 	})
@@ -1613,7 +1613,7 @@ func (s *secretsSuite) TestBackendConfigInfoReusesIssuedTokenForSameScope(c *gc.
 	ownedRevs := map[string]set.Strings{"owned-1": set.NewStrings("owned-rev-1", "owned-rev-2")}
 	read := []*coresecrets.SecretMetadata{{URI: &coresecrets.URI{ID: "read-1"}}}
 	readRevs := map[string]set.Strings{"read-1": set.NewStrings("read-rev-1")}
-	scopeHash := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
+	scopeHash := issuedTokenScopeHash(false, ownedIDs, ownedRevs, readRevs)
 
 	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{"secret-backend": "backend-name"})
 	adminCfg := provider.ModelBackendConfig{
@@ -1714,7 +1714,7 @@ func (s *secretsSuite) TestBackendConfigInfoDoesNotReuseIssuedTokenForDifferentS
 	ownedRevs := map[string]set.Strings{"owned-1": set.NewStrings("owned-rev-1", "owned-rev-2")}
 	read := []*coresecrets.SecretMetadata{{URI: &coresecrets.URI{ID: "read-1"}}}
 	readRevs := map[string]set.Strings{"read-1": set.NewStrings("read-rev-1")}
-	newScopeHash := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
+	newScopeHash := issuedTokenScopeHash(false, ownedIDs, ownedRevs, readRevs)
 
 	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{"secret-backend": "backend-name"})
 	adminCfg := provider.ModelBackendConfig{
@@ -1796,15 +1796,97 @@ func (s *secretsSuite) TestBackendConfigInfoDoesNotReuseIssuedTokenForDifferentS
 	})
 }
 
-func issuedTokenScopeHash(ownedIDs []string, ownedRevs, readRevs provider.SecretRevisions) string {
+func (s *secretsSuite) TestDrainBackendConfigInfoDoesNotReuseIssuedTokenForNonDrainScope(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	modelTag := names.NewModelTag(coretesting.ModelTag.Id())
+	model := mocks.NewMockModel(ctrl)
+	leadershipChecker := mocks.NewMockChecker(ctrl)
+	secretProvider := mocks.NewMockSecretBackendProvider(ctrl)
+	backendState := mocks.NewMockSecretBackendsStorage(ctrl)
+	secretsState := mocks.NewMockSecretsStore(ctrl)
+
+	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return secretProvider, nil })
+	s.PatchValue(&secrets.GetSecretsState, func(secrets.Model) state.SecretsStore { return secretsState })
+	s.PatchValue(&secrets.GetSecretBackendsState, func(secrets.Model) state.SecretBackendsStorage { return backendState })
+
+	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{"secret-backend": "backend-name"})
+	adminCfg := provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig:  provider.BackendConfig{BackendType: "some-backend"},
+	}
+	ownedRevs := provider.SecretRevisions{}
+	readRevs := provider.SecretRevisions{}
+	nonDrainScopeHash := issuedTokenScopeHash(false, nil, ownedRevs, readRevs)
+	drainScopeHash := issuedTokenScopeHash(true, nil, ownedRevs, readRevs)
+
+	model.EXPECT().ControllerUUID().Return(coretesting.ControllerTag.Id()).AnyTimes()
+	model.EXPECT().UUID().Return(coretesting.ModelTag.Id()).AnyTimes()
+	model.EXPECT().Name().Return("fred").AnyTimes()
+	model.EXPECT().Config().Return(modelCfg, nil)
+	model.EXPECT().Type().Return(state.ModelTypeIAAS)
+	backendState.EXPECT().ListSecretBackends().Return([]*coresecrets.SecretBackend{{
+		ID:          "backend-id",
+		Name:        "backend-name",
+		BackendType: "some-backend",
+	}}, nil)
+	secretProvider.EXPECT().Initialise(gomock.Any()).Return(nil)
+	secretProvider.EXPECT().IssuesTokens().Return(true)
+	secretsState.EXPECT().ListReservedSecrets([]names.Tag{modelTag}).Return(nil, nil)
+	secretsState.EXPECT().ListSecrets(state.SecretsFilter{OwnerTags: []names.Tag{modelTag}}).Return(nil, nil)
+	secretsState.EXPECT().ListSecrets(state.SecretsFilter{ConsumerTags: []names.Tag{modelTag}}).Return(nil, nil)
+	secretsState.EXPECT().ListSecretBackendIssuedTokenUntilForConsumer(gomock.Any(), modelTag).Return([]state.SecretBackendIssuedToken{{
+		UUID:       "old-uuid",
+		ExpireTime: time.Now().Add(time.Minute),
+		BackendID:  "backend-id",
+		Consumer:   modelTag,
+		ScopeHash:  nonDrainScopeHash,
+	}}, nil)
+	createdTokenUUID := ""
+	secretsState.EXPECT().CreateSecretBackendIssuedToken(gomock.Any()).DoAndReturn(func(tok state.SecretBackendIssuedToken) error {
+		createdTokenUUID = tok.UUID
+		c.Check(tok.ScopeHash, gc.Equals, drainScopeHash)
+		c.Check(tok.UUID, gc.Not(gc.Equals), "old-uuid")
+		return nil
+	})
+	secretProvider.EXPECT().RestrictedConfig(
+		&adminCfg, true, true, gomock.Any(), modelTag,
+		[]string{}, ownedRevs, readRevs,
+	).DoAndReturn(func(_ *provider.ModelBackendConfig, _, _ bool, gotIssuedTokenUUID string, _ names.Tag, _ []string, _, _ provider.SecretRevisions) (*provider.BackendConfig, error) {
+		c.Check(gotIssuedTokenUUID, gc.Equals, createdTokenUUID)
+		c.Check(gotIssuedTokenUUID, gc.Not(gc.Equals), "old-uuid")
+		return &adminCfg.BackendConfig, nil
+	})
+
+	info, err := secrets.DrainBackendConfigInfo("backend-id", model, modelTag, leadershipChecker)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
+		ActiveID: "backend-id",
+		Configs: map[string]provider.ModelBackendConfig{
+			"backend-id": {
+				ControllerUUID: coretesting.ControllerTag.Id(),
+				ModelUUID:      coretesting.ModelTag.Id(),
+				ModelName:      "fred",
+				BackendConfig:  provider.BackendConfig{BackendType: "some-backend"},
+			},
+		},
+	})
+}
+
+func issuedTokenScopeHash(forDrain bool, ownedIDs []string, ownedRevs, readRevs provider.SecretRevisions) string {
 	canonicalOwnedIDs := append([]string(nil), ownedIDs...)
 	slices.Sort(canonicalOwnedIDs)
 	canonicalOwnedIDs = slices.Compact(canonicalOwnedIDs)
 	payload := struct {
+		ForDrain  bool     `json:"for-drain"`
 		OwnedIDs  []string `json:"owned-ids"`
 		OwnedRevs []string `json:"owned-revs"`
 		ReadRevs  []string `json:"read-revs"`
 	}{
+		ForDrain:  forDrain,
 		OwnedIDs:  canonicalOwnedIDs,
 		OwnedRevs: ownedRevs.RevisionIDs(),
 		ReadRevs:  readRevs.RevisionIDs(),

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -4,7 +4,11 @@
 package secrets_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/juju/collections/set"
@@ -1380,6 +1384,7 @@ func (s *secretsSuite) TestBackendConfigInfoIssuesToken(c *gc.C) {
 	readRevs := map[string]set.Strings{
 		"read-1": set.NewStrings("read-rev-1"),
 	}
+	scopeHash := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
 	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{
 		"secret-backend": "backend-name",
 	})
@@ -1406,12 +1411,16 @@ func (s *secretsSuite) TestBackendConfigInfoIssuesToken(c *gc.C) {
 	}}, nil)
 	secretProvider.EXPECT().Initialise(gomock.Any()).Return(nil)
 	secretProvider.EXPECT().IssuesTokens().Return(true)
+	secretsState.EXPECT().ListSecretBackendIssuedTokenUntilForConsumer(
+		gomock.Any(), unitTag,
+	).Return(nil, nil)
 	secretsState.EXPECT().CreateSecretBackendIssuedToken(
 		gomock.Any(),
 	).DoAndReturn(func(sbit state.SecretBackendIssuedToken) error {
 		issuedTokenUUID = sbit.UUID
 		c.Check(sbit.Consumer, gc.Equals, unitTag)
 		c.Check(sbit.BackendID, gc.Equals, "backend-id")
+		c.Check(sbit.ScopeHash, gc.Equals, scopeHash)
 		c.Check(sbit.ExpireTime, jc.After, time.Now())
 		return nil
 	})
@@ -1499,6 +1508,7 @@ func (s *secretsSuite) TestBackendConfigInfoIssuesTokenWithReservedSecrets(c *gc
 	ownedRevs := map[string]set.Strings{}
 	read := []*coresecrets.SecretMetadata{}
 	readRevs := map[string]set.Strings{}
+	scopeHash := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
 	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{
 		"secret-backend": "backend-name",
 	})
@@ -1525,12 +1535,16 @@ func (s *secretsSuite) TestBackendConfigInfoIssuesTokenWithReservedSecrets(c *gc
 	}}, nil)
 	secretProvider.EXPECT().Initialise(gomock.Any()).Return(nil)
 	secretProvider.EXPECT().IssuesTokens().Return(true)
+	secretsState.EXPECT().ListSecretBackendIssuedTokenUntilForConsumer(
+		gomock.Any(), unitTag,
+	).Return(nil, nil)
 	secretsState.EXPECT().CreateSecretBackendIssuedToken(
 		gomock.Any(),
 	).DoAndReturn(func(sbit state.SecretBackendIssuedToken) error {
 		issuedTokenUUID = sbit.UUID
 		c.Check(sbit.Consumer, gc.Equals, unitTag)
 		c.Check(sbit.BackendID, gc.Equals, "backend-id")
+		c.Check(sbit.ScopeHash, gc.Equals, scopeHash)
 		c.Check(sbit.ExpireTime, jc.After, time.Now())
 		return nil
 	})
@@ -1575,4 +1589,219 @@ func (s *secretsSuite) TestBackendConfigInfoIssuesTokenWithReservedSecrets(c *gc
 			},
 		},
 	})
+}
+
+func (s *secretsSuite) TestBackendConfigInfoReusesIssuedTokenForSameScope(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	unitTag := names.NewUnitTag("gitlab/0")
+	model := mocks.NewMockModel(ctrl)
+	leadershipChecker := mocks.NewMockChecker(ctrl)
+	token := mocks.NewMockToken(ctrl)
+	secretProvider := mocks.NewMockSecretBackendProvider(ctrl)
+	backendState := mocks.NewMockSecretBackendsStorage(ctrl)
+	secretsState := mocks.NewMockSecretsStore(ctrl)
+
+	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return secretProvider, nil })
+	s.PatchValue(&secrets.GetSecretsState, func(secrets.Model) state.SecretsStore { return secretsState })
+	s.PatchValue(&secrets.GetSecretBackendsState, func(secrets.Model) state.SecretBackendsStorage { return backendState })
+
+	backendIDs := []string{"backend-id"}
+	owned := []*coresecrets.SecretMetadata{{URI: &coresecrets.URI{ID: "owned-1"}}}
+	ownedIDs := []string{"owned-1"}
+	ownedRevs := map[string]set.Strings{"owned-1": set.NewStrings("owned-rev-1", "owned-rev-2")}
+	read := []*coresecrets.SecretMetadata{{URI: &coresecrets.URI{ID: "read-1"}}}
+	readRevs := map[string]set.Strings{"read-1": set.NewStrings("read-rev-1")}
+	scopeHash := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
+
+	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{"secret-backend": "backend-name"})
+	adminCfg := provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig:  provider.BackendConfig{BackendType: "some-backend"},
+	}
+	model.EXPECT().ControllerUUID().Return(coretesting.ControllerTag.Id()).AnyTimes()
+	model.EXPECT().UUID().Return(coretesting.ModelTag.Id()).AnyTimes()
+	model.EXPECT().Name().Return("fred").AnyTimes()
+	model.EXPECT().Config().Return(modelCfg, nil)
+	model.EXPECT().Type().Return(state.ModelTypeIAAS)
+	secretsState.EXPECT().ListReservedSecrets([]names.Tag{unitTag, names.NewApplicationTag("gitlab")}).Return(nil, nil)
+	backendState.EXPECT().ListSecretBackends().Return([]*coresecrets.SecretBackend{{
+		ID:          "backend-id",
+		Name:        "backend-name",
+		BackendType: "some-backend",
+	}}, nil)
+	secretProvider.EXPECT().Initialise(gomock.Any()).Return(nil)
+	secretProvider.EXPECT().IssuesTokens().Return(true)
+	secretsState.EXPECT().ListSecretBackendIssuedTokenUntilForConsumer(gomock.Any(), unitTag).Return([]state.SecretBackendIssuedToken{{
+		UUID:       "reused-uuid",
+		ExpireTime: time.Now().Add(time.Minute),
+		BackendID:  "backend-id",
+		Consumer:   unitTag,
+		ScopeHash:  scopeHash,
+	}}, nil)
+	leadershipChecker.EXPECT().LeadershipCheck("gitlab", "gitlab/0").Return(token)
+	token.EXPECT().Check().Return(nil)
+
+	secretsState.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTags: []names.Tag{unitTag, names.NewApplicationTag("gitlab")},
+	}).Return(owned, nil)
+	secretsState.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "owned-1"}).
+		Return([]*coresecrets.SecretRevisionMetadata{{
+			Revision: 1,
+			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-1"},
+		}, {
+			Revision: 2,
+			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-2"},
+		}}, nil)
+	secretsState.EXPECT().ListSecrets(state.SecretsFilter{
+		ConsumerTags: []names.Tag{unitTag, names.NewApplicationTag("gitlab")},
+	}).Return(read, nil)
+	secretsState.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "read-1"}).
+		Return([]*coresecrets.SecretRevisionMetadata{{
+			Revision: 1,
+			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "read-rev-1"},
+		}}, nil)
+	secretProvider.EXPECT().RestrictedConfig(
+		&adminCfg, true, false, "reused-uuid", unitTag,
+		ownedIDs, ownedRevs, readRevs,
+	).Return(&adminCfg.BackendConfig, nil)
+
+	info, err := secrets.BackendConfigInfo(model, true, backendIDs, false, unitTag, leadershipChecker, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
+		ActiveID: "backend-id",
+		Configs: map[string]provider.ModelBackendConfig{
+			"backend-id": {
+				ControllerUUID: coretesting.ControllerTag.Id(),
+				ModelUUID:      coretesting.ModelTag.Id(),
+				ModelName:      "fred",
+				BackendConfig:  provider.BackendConfig{BackendType: "some-backend"},
+			},
+		},
+	})
+}
+
+func (s *secretsSuite) TestBackendConfigInfoDoesNotReuseIssuedTokenForDifferentScope(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	unitTag := names.NewUnitTag("gitlab/0")
+	model := mocks.NewMockModel(ctrl)
+	leadershipChecker := mocks.NewMockChecker(ctrl)
+	token := mocks.NewMockToken(ctrl)
+	secretProvider := mocks.NewMockSecretBackendProvider(ctrl)
+	backendState := mocks.NewMockSecretBackendsStorage(ctrl)
+	secretsState := mocks.NewMockSecretsStore(ctrl)
+
+	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return secretProvider, nil })
+	s.PatchValue(&secrets.GetSecretsState, func(secrets.Model) state.SecretsStore { return secretsState })
+	s.PatchValue(&secrets.GetSecretBackendsState, func(secrets.Model) state.SecretBackendsStorage { return backendState })
+
+	backendIDs := []string{"backend-id"}
+	owned := []*coresecrets.SecretMetadata{{URI: &coresecrets.URI{ID: "owned-1"}}}
+	ownedIDs := []string{"owned-1"}
+	ownedRevs := map[string]set.Strings{"owned-1": set.NewStrings("owned-rev-1", "owned-rev-2")}
+	read := []*coresecrets.SecretMetadata{{URI: &coresecrets.URI{ID: "read-1"}}}
+	readRevs := map[string]set.Strings{"read-1": set.NewStrings("read-rev-1")}
+	newScopeHash := issuedTokenScopeHash(ownedIDs, ownedRevs, readRevs)
+
+	modelCfg := coretesting.CustomModelConfig(c, coretesting.Attrs{"secret-backend": "backend-name"})
+	adminCfg := provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig:  provider.BackendConfig{BackendType: "some-backend"},
+	}
+	model.EXPECT().ControllerUUID().Return(coretesting.ControllerTag.Id()).AnyTimes()
+	model.EXPECT().UUID().Return(coretesting.ModelTag.Id()).AnyTimes()
+	model.EXPECT().Name().Return("fred").AnyTimes()
+	model.EXPECT().Config().Return(modelCfg, nil)
+	model.EXPECT().Type().Return(state.ModelTypeIAAS)
+	secretsState.EXPECT().ListReservedSecrets([]names.Tag{unitTag, names.NewApplicationTag("gitlab")}).Return(nil, nil)
+	backendState.EXPECT().ListSecretBackends().Return([]*coresecrets.SecretBackend{{
+		ID:          "backend-id",
+		Name:        "backend-name",
+		BackendType: "some-backend",
+	}}, nil)
+	secretProvider.EXPECT().Initialise(gomock.Any()).Return(nil)
+	secretProvider.EXPECT().IssuesTokens().Return(true)
+	secretsState.EXPECT().ListSecretBackendIssuedTokenUntilForConsumer(gomock.Any(), unitTag).Return([]state.SecretBackendIssuedToken{{
+		UUID:       "old-uuid",
+		ExpireTime: time.Now().Add(time.Minute),
+		BackendID:  "backend-id",
+		Consumer:   unitTag,
+		ScopeHash:  "different-scope",
+	}}, nil)
+	createdTokenUUID := ""
+	secretsState.EXPECT().CreateSecretBackendIssuedToken(gomock.Any()).DoAndReturn(func(tok state.SecretBackendIssuedToken) error {
+		createdTokenUUID = tok.UUID
+		c.Check(tok.ScopeHash, gc.Equals, newScopeHash)
+		c.Check(tok.UUID, gc.Not(gc.Equals), "old-uuid")
+		return nil
+	})
+	leadershipChecker.EXPECT().LeadershipCheck("gitlab", "gitlab/0").Return(token)
+	token.EXPECT().Check().Return(nil)
+
+	secretsState.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTags: []names.Tag{unitTag, names.NewApplicationTag("gitlab")},
+	}).Return(owned, nil)
+	secretsState.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "owned-1"}).
+		Return([]*coresecrets.SecretRevisionMetadata{{
+			Revision: 1,
+			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-1"},
+		}, {
+			Revision: 2,
+			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "owned-rev-2"},
+		}}, nil)
+	secretsState.EXPECT().ListSecrets(state.SecretsFilter{
+		ConsumerTags: []names.Tag{unitTag, names.NewApplicationTag("gitlab")},
+	}).Return(read, nil)
+	secretsState.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "read-1"}).
+		Return([]*coresecrets.SecretRevisionMetadata{{
+			Revision: 1,
+			ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "read-rev-1"},
+		}}, nil)
+	secretProvider.EXPECT().RestrictedConfig(
+		&adminCfg, true, false, gomock.Any(), unitTag,
+		ownedIDs, ownedRevs, readRevs,
+	).DoAndReturn(func(_ *provider.ModelBackendConfig, _, _ bool, gotIssuedTokenUUID string, _ names.Tag, _ []string, _, _ provider.SecretRevisions) (*provider.BackendConfig, error) {
+		c.Check(gotIssuedTokenUUID, gc.Equals, createdTokenUUID)
+		c.Check(gotIssuedTokenUUID, gc.Not(gc.Equals), "old-uuid")
+		return &adminCfg.BackendConfig, nil
+	})
+
+	info, err := secrets.BackendConfigInfo(model, true, backendIDs, false, unitTag, leadershipChecker, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
+		ActiveID: "backend-id",
+		Configs: map[string]provider.ModelBackendConfig{
+			"backend-id": {
+				ControllerUUID: coretesting.ControllerTag.Id(),
+				ModelUUID:      coretesting.ModelTag.Id(),
+				ModelName:      "fred",
+				BackendConfig:  provider.BackendConfig{BackendType: "some-backend"},
+			},
+		},
+	})
+}
+
+func issuedTokenScopeHash(ownedIDs []string, ownedRevs, readRevs provider.SecretRevisions) string {
+	canonicalOwnedIDs := append([]string(nil), ownedIDs...)
+	slices.Sort(canonicalOwnedIDs)
+	canonicalOwnedIDs = slices.Compact(canonicalOwnedIDs)
+	payload := struct {
+		OwnedIDs  []string `json:"owned-ids"`
+		OwnedRevs []string `json:"owned-revs"`
+		ReadRevs  []string `json:"read-revs"`
+	}{
+		OwnedIDs:  canonicalOwnedIDs,
+		OwnedRevs: ownedRevs.RevisionIDs(),
+		ReadRevs:  readRevs.RevisionIDs(),
+	}
+	b, _ := json.Marshal(payload)
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
 }

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -1642,6 +1642,14 @@ func (s *secretsSuite) TestBackendConfigInfoReusesIssuedTokenForSameScope(c *gc.
 		Consumer:   unitTag,
 		ScopeHash:  scopeHash,
 	}}, nil)
+	secretsState.EXPECT().CreateSecretBackendIssuedToken(gomock.Any()).DoAndReturn(func(tok state.SecretBackendIssuedToken) error {
+		c.Check(tok.UUID, gc.Equals, "reused-uuid")
+		c.Check(tok.BackendID, gc.Equals, "backend-id")
+		c.Check(tok.Consumer, gc.Equals, unitTag)
+		c.Check(tok.ScopeHash, gc.Equals, scopeHash)
+		c.Check(tok.ExpireTime.After(time.Now()), jc.IsTrue)
+		return nil
+	})
 	leadershipChecker.EXPECT().LeadershipCheck("gitlab", "gitlab/0").Return(token)
 	token.EXPECT().Check().Return(nil)
 

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2919,12 +2919,6 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 	// CreateSecretURIs.
 	modelOps = append(modelOps, u.secrets.RemoveSecretReservations(unitTag))
 
-	// Expire any secret issued backend tokens that, by this point, should no
-	// longer be used by this agent.
-	modelOps = append(
-		modelOps, u.secrets.ExpireSecretBackendIssuedTokensForConsumer(unitTag),
-	)
-
 	// Apply all changes in a single transaction.
 	return u.st.ApplyOperation(state.ComposeModelOperations(modelOps...))
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4796,50 +4796,6 @@ func (s *uniterSuite) TestCommitHookChangesRemovesSecretReservations(c *gc.C) {
 	c.Assert(reserved, gc.HasLen, 0)
 }
 
-func (s *uniterSuite) TestCommitHookChangesExpiresSecretBackendTokens(c *gc.C) {
-	store := state.NewSecrets(s.State)
-	now := time.Now()
-
-	// Create some secret backend issued tokens that are not expired yet.
-	for range 10 {
-		issuedToken := state.SecretBackendIssuedToken{
-			UUID:       utils.MustNewUUID().String(),
-			ExpireTime: now.Add(time.Hour),
-			BackendID:  "backend-id",
-			Consumer:   s.wordpressUnit.Tag(),
-		}
-		err := store.CreateSecretBackendIssuedToken(issuedToken)
-		c.Assert(err, jc.ErrorIsNil)
-	}
-	tokens, err := store.ListSecretBackendIssuedTokenUntilForConsumer(
-		now, s.wordpressUnit.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(tokens, gc.HasLen, 0)
-	tokens, err = store.ListSecretBackendIssuedTokenUntilForConsumer(
-		now.Add(time.Hour).Add(time.Minute), s.wordpressUnit.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(tokens, gc.HasLen, 10)
-
-	// Commit the hook changes.
-	b := apiuniter.NewCommitHookParamsBuilder(s.wordpressUnit.UnitTag())
-	b.UpdateCharmState(map[string]string{"charm-key": "charm-value"})
-	req, _ := b.Build()
-
-	result, err := s.uniter.CommitHookChanges(req)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result, gc.DeepEquals, params.ErrorResults{
-		Results: []params.ErrorResult{
-			{Error: nil},
-		},
-	})
-
-	// Check that the secret backend issued tokens are all expired now.
-	tokens, err = store.ListSecretBackendIssuedTokenUntilForConsumer(
-		now, s.wordpressUnit.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(tokens, gc.HasLen, 10)
-}
-
 func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 	// We need to set up a unit that has storage metadata defined.
 	ch := s.AddTestingCharm(c, "storage-block2") // supports multiple storage instances

--- a/apiserver/facades/client/application/mocks/state_mock.go
+++ b/apiserver/facades/client/application/mocks/state_mock.go
@@ -583,20 +583,6 @@ func (mr *MockSecretsStoreMockRecorder) DeleteSecret(arg0 any, arg1 ...any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockSecretsStore)(nil).DeleteSecret), varargs...)
 }
 
-// ExpireSecretBackendIssuedTokensForConsumer mocks base method.
-func (m *MockSecretsStore) ExpireSecretBackendIssuedTokensForConsumer(arg0 names.Tag) state.ModelOperation {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExpireSecretBackendIssuedTokensForConsumer", arg0)
-	ret0, _ := ret[0].(state.ModelOperation)
-	return ret0
-}
-
-// ExpireSecretBackendIssuedTokensForConsumer indicates an expected call of ExpireSecretBackendIssuedTokensForConsumer.
-func (mr *MockSecretsStoreMockRecorder) ExpireSecretBackendIssuedTokensForConsumer(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpireSecretBackendIssuedTokensForConsumer", reflect.TypeOf((*MockSecretsStore)(nil).ExpireSecretBackendIssuedTokensForConsumer), arg0)
-}
-
 // GetOwnedSecretMetadataAsApp mocks base method.
 func (m *MockSecretsStore) GetOwnedSecretMetadataAsApp(arg0 names.ApplicationTag, arg1 *secrets.URI) (*secrets.SecretMetadataOwnerIdent, error) {
 	m.ctrl.T.Helper()

--- a/internal/worker/remoterelations/remoterelations_test.go
+++ b/internal/worker/remoterelations/remoterelations_test.go
@@ -1010,8 +1010,6 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 	s.stub.SetErrors(nil)
 	s.stub.ResetCalls()
 	s.config.Clock.(*testclock.Clock).WaitAdvance(50*time.Second, coretesting.LongWait, 1)
-	// Not resumed yet.
-	c.Assert(s.stub.Calls(), gc.HasLen, 0)
 	s.config.Clock.(*testclock.Clock).WaitAdvance(10*time.Second, coretesting.LongWait, 1)
 
 	mac, err := apitesting.NewMacaroon("test")

--- a/secrets/provider/kubernetes/provider.go
+++ b/secrets/provider/kubernetes/provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -427,9 +428,9 @@ const (
 	minExpireSeconds = 600
 )
 
-func (k *kubernetesClient) createServiceAccount(ctx context.Context, sa *core.ServiceAccount) (*core.ServiceAccount, error) {
+func (k *kubernetesClient) createServiceAccount(ctx context.Context, sa *core.ServiceAccount) (_ *core.ServiceAccount, created bool, _ error) {
 	if k.namespace == "" {
-		return nil, errNoNamespace
+		return nil, false, errNoNamespace
 	}
 
 	api := k.client.CoreV1().ServiceAccounts(k.namespace)
@@ -439,19 +440,19 @@ func (k *kubernetesClient) createServiceAccount(ctx context.Context, sa *core.Se
 		// by something other than Juju.
 		existing, err := api.Get(ctx, sa.Name, v1.GetOptions{})
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, false, errors.Trace(err)
 		}
 		if existing.Labels[constants.LabelKubernetesAppManaged] != resources.JujuFieldManager {
 			// sa.Name is already used for an existing service account.
-			return nil, errors.Errorf("service account %q exists and is not managed by Juju", sa.GetName())
+			return nil, false, errors.Errorf("service account %q exists and is not managed by Juju", sa.GetName())
 		}
 		if existingModelIdValue, ok := existing.Annotations[modelIdKey]; ok && existingModelIdValue != k.modelUUID {
 			// sa.Name is already used for an existing service account from a different model.
-			return nil, errors.Errorf("service account %q exists and is not managed by this model", sa.GetName())
+			return nil, false, errors.Errorf("service account %q exists and is not managed by this model", sa.GetName())
 		}
-		return nil, errors.AlreadyExistsf("service account %q", sa.GetName())
+		return existing, false, nil
 	}
-	return out, errors.Trace(err)
+	return out, true, errors.Trace(err)
 }
 
 func (k *kubernetesClient) deleteServiceAccount(ctx context.Context, name string, uid types.UID) error {
@@ -521,16 +522,31 @@ func (k *kubernetesClient) deleteSecrets(ctx context.Context) error {
 
 func (k *kubernetesClient) createRole(
 	ctx context.Context, role *rbacv1.Role,
-) (*rbacv1.Role, error) {
+) (_ *rbacv1.Role, created bool, _ error) {
 	if k.namespace == "" {
-		return nil, errNoNamespace
+		return nil, false, errNoNamespace
 	}
+	api := k.client.RbacV1().Roles(k.namespace)
 	out, err := k.client.RbacV1().Roles(k.namespace).Create(
 		ctx, role, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
 	if k8serrors.IsAlreadyExists(err) {
-		return nil, errors.AlreadyExistsf("role %q", role.GetName())
+		existing, err := api.Get(ctx, role.GetName(), v1.GetOptions{})
+		if err != nil {
+			return nil, false, errors.Trace(err)
+		}
+		if existing.Labels[constants.LabelKubernetesAppManaged] != resources.JujuFieldManager {
+			return nil, false, errors.Errorf("role %q exists and is not managed by Juju", role.GetName())
+		}
+		if existingModelIDValue, ok := existing.Annotations[modelIdKey]; ok && existingModelIDValue != k.modelUUID {
+			return nil, false, errors.Errorf("role %q exists and is not managed by this model", role.GetName())
+		}
+		// Should never happen.
+		if !reflect.DeepEqual(existing.Rules, role.Rules) {
+			return nil, false, errors.NotSupportedf("changing rules for role %q", role.GetName())
+		}
+		return existing, false, nil
 	}
-	return out, errors.Trace(err)
+	return out, true, errors.Trace(err)
 }
 
 func (k *kubernetesClient) deleteRoles(ctx context.Context) error {
@@ -638,23 +654,40 @@ func (k *kubernetesClient) deleteRole(ctx context.Context, name string, uid type
 
 func (k *kubernetesClient) createRoleBinding(
 	ctx context.Context, rb *rbacv1.RoleBinding,
-) (_ *rbacv1.RoleBinding, cleanups []func(), err error) {
+) (_ *rbacv1.RoleBinding, created bool, cleanups []func(), err error) {
 	if k.namespace == "" {
-		return nil, nil, errNoNamespace
+		return nil, false, nil, errNoNamespace
 	}
 
 	api := k.client.RbacV1().RoleBindings(k.namespace)
 	out, err := api.Create(ctx, rb, v1.CreateOptions{
 		FieldManager: resources.JujuFieldManager,
 	})
+	if k8serrors.IsAlreadyExists(err) {
+		existing, err := api.Get(ctx, rb.GetName(), v1.GetOptions{})
+		if err != nil {
+			return nil, false, nil, errors.Trace(err)
+		}
+		if existing.Labels[constants.LabelKubernetesAppManaged] != resources.JujuFieldManager {
+			return nil, false, nil, errors.Errorf("role binding %q exists and is not managed by Juju", rb.GetName())
+		}
+		if existingModelIDValue, ok := existing.Annotations[modelIdKey]; ok && existingModelIDValue != k.modelUUID {
+			return nil, false, nil, errors.Errorf("role binding %q exists and is not managed by this model", rb.GetName())
+		}
+		// Should never happen.
+		if !reflect.DeepEqual(existing.RoleRef, rb.RoleRef) || !reflect.DeepEqual(existing.Subjects, rb.Subjects) {
+			return nil, false, nil, errors.NotSupportedf("changing bindings for role binding %q", rb.GetName())
+		}
+		return existing, false, nil, nil
+	}
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, false, nil, errors.Trace(err)
 	}
 	cleanups = append(cleanups, func() {
 		_ = k.deleteRoleBinding(ctx, out.GetName(), out.GetUID())
 	})
 
-	return out, cleanups, nil
+	return out, true, cleanups, nil
 }
 
 func (k *kubernetesClient) deleteRoleBinding(
@@ -712,23 +745,24 @@ func policyRulesForSecretAccess(
 func (k *kubernetesClient) createRoleAndBinding(
 	ctx context.Context, sa *core.ServiceAccount, rules []rbacv1.PolicyRule,
 ) (cleanups []func(), _ error) {
-	role, err := k.createRole(ctx,
-		&rbacv1.Role{
-			ObjectMeta: v1.ObjectMeta{
-				Name:        sa.Name,
-				Namespace:   k.namespace,
-				Labels:      sa.Labels,
-				Annotations: sa.Annotations,
-			},
-			Rules: rules,
+	roleSpec := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        sa.Name,
+			Namespace:   k.namespace,
+			Labels:      sa.Labels,
+			Annotations: sa.Annotations,
 		},
-	)
+		Rules: rules,
+	}
+	role, roleCreated, err := k.createRole(ctx, roleSpec)
 	if err != nil {
 		return cleanups, errors.Annotatef(err, "creating role %q", sa.Name)
 	}
-	cleanups = append(cleanups, func() {
-		_ = k.deleteRole(ctx, role.GetName(), role.GetUID())
-	})
+	if roleCreated {
+		cleanups = append(cleanups, func() {
+			_ = k.deleteRole(ctx, role.GetName(), role.GetUID())
+		})
+	}
 
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: v1.ObjectMeta{
@@ -750,7 +784,7 @@ func (k *kubernetesClient) createRoleAndBinding(
 			},
 		},
 	}
-	out, rbCleanups, err := k.createRoleBinding(ctx, rb)
+	out, _, rbCleanups, err := k.createRoleBinding(ctx, rb)
 	if err != nil {
 		return cleanups, errors.Trace(err)
 	}
@@ -778,12 +812,27 @@ func (k *kubernetesClient) createRoleAndBinding(
 	}))
 }
 
-func (k *kubernetesClient) createClusterRole(ctx context.Context, clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-	out, err := k.client.RbacV1().ClusterRoles().Create(ctx, clusterRole, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+func (k *kubernetesClient) createClusterRole(ctx context.Context, clusterRole *rbacv1.ClusterRole) (_ *rbacv1.ClusterRole, created bool, _ error) {
+	api := k.client.RbacV1().ClusterRoles()
+	out, err := api.Create(ctx, clusterRole, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
 	if k8serrors.IsAlreadyExists(err) {
-		return nil, errors.AlreadyExistsf("cluster role %q", clusterRole.GetName())
+		existing, err := api.Get(ctx, clusterRole.GetName(), v1.GetOptions{})
+		if err != nil {
+			return nil, false, errors.Trace(err)
+		}
+		if existing.Labels[constants.LabelKubernetesAppManaged] != resources.JujuFieldManager {
+			return nil, false, errors.Errorf("cluster role %q exists and is not managed by Juju", clusterRole.GetName())
+		}
+		if existingModelIDValue, ok := existing.Annotations[modelIdKey]; ok && existingModelIDValue != k.modelUUID {
+			return nil, false, errors.Errorf("cluster role %q exists and is not managed by this model", clusterRole.GetName())
+		}
+		// Should never happen.
+		if !reflect.DeepEqual(existing.Rules, clusterRole.Rules) {
+			return nil, false, errors.NotSupportedf("changing rules for cluster role %q", clusterRole.GetName())
+		}
+		return existing, false, nil
 	}
-	return out, errors.Trace(err)
+	return out, true, errors.Trace(err)
 }
 
 // updateClusterRole fetches the latest version of the specified ClusterRole,
@@ -832,12 +881,27 @@ func (k *kubernetesClient) deleteClusterRole(ctx context.Context, name string, u
 	return errors.Trace(err)
 }
 
-func (k *kubernetesClient) createClusterRoleBinding(ctx context.Context, clusterRoleBinding *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-	out, err := k.client.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+func (k *kubernetesClient) createClusterRoleBinding(ctx context.Context, clusterRoleBinding *rbacv1.ClusterRoleBinding) (_ *rbacv1.ClusterRoleBinding, created bool, _ error) {
+	api := k.client.RbacV1().ClusterRoleBindings()
+	out, err := api.Create(ctx, clusterRoleBinding, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
 	if k8serrors.IsAlreadyExists(err) {
-		return nil, errors.AlreadyExistsf("cluster role binding %q", clusterRoleBinding.GetName())
+		existing, err := api.Get(ctx, clusterRoleBinding.GetName(), v1.GetOptions{})
+		if err != nil {
+			return nil, false, errors.Trace(err)
+		}
+		if existing.Labels[constants.LabelKubernetesAppManaged] != resources.JujuFieldManager {
+			return nil, false, errors.Errorf("cluster role binding %q exists and is not managed by Juju", clusterRoleBinding.GetName())
+		}
+		if existingModelIDValue, ok := existing.Annotations[modelIdKey]; ok && existingModelIDValue != k.modelUUID {
+			return nil, false, errors.Errorf("cluster role binding %q exists and is not managed by this model", clusterRoleBinding.GetName())
+		}
+		// Should never happen.
+		if !reflect.DeepEqual(existing.RoleRef, clusterRoleBinding.RoleRef) || !reflect.DeepEqual(existing.Subjects, clusterRoleBinding.Subjects) {
+			return nil, false, errors.NotSupportedf("changing bindings for cluster role binding %q", clusterRoleBinding.GetName())
+		}
+		return existing, false, nil
 	}
-	return out, errors.Trace(err)
+	return out, true, errors.Trace(err)
 }
 
 func (k *kubernetesClient) deleteClusterRoleBinding(ctx context.Context, name string, uid types.UID) error {
@@ -902,7 +966,7 @@ func (k *kubernetesClient) createClusterRoleAndBinding(
 	ctx context.Context, sa *core.ServiceAccount,
 	rules []rbacv1.PolicyRule,
 ) (cleanups []func(), _ error) {
-	cr, err := k.createClusterRole(ctx,
+	cr, crCreated, err := k.createClusterRole(ctx,
 		&rbacv1.ClusterRole{
 			ObjectMeta: v1.ObjectMeta{
 				Name:        sa.Name,
@@ -916,11 +980,13 @@ func (k *kubernetesClient) createClusterRoleAndBinding(
 		return cleanups, errors.Annotatef(
 			err, "creating cluster role %q", sa.Name)
 	}
-	cleanups = append(cleanups, func() {
-		_ = k.deleteClusterRole(ctx, cr.GetName(), cr.GetUID())
-	})
+	if crCreated {
+		cleanups = append(cleanups, func() {
+			_ = k.deleteClusterRole(ctx, cr.GetName(), cr.GetUID())
+		})
+	}
 
-	crb, err := k.createClusterRoleBinding(ctx,
+	crb, crbCreated, err := k.createClusterRoleBinding(ctx,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: v1.ObjectMeta{
 				Name:        sa.Name,
@@ -945,9 +1011,11 @@ func (k *kubernetesClient) createClusterRoleAndBinding(
 		return cleanups, errors.Annotatef(
 			err, "creating cluster role binding %q", sa.Name)
 	}
-	cleanups = append(cleanups, func() {
-		_ = k.deleteClusterRoleBinding(ctx, crb.GetName(), crb.GetUID())
-	})
+	if crbCreated {
+		cleanups = append(cleanups, func() {
+			_ = k.deleteClusterRoleBinding(ctx, crb.GetName(), crb.GetUID())
+		})
+	}
 
 	// Ensure role binding exists before we return to avoid a race where a
 	// client attempts to perform an operation before the role is allowed.
@@ -1065,13 +1133,16 @@ func (k *kubernetesClient) createSecretAccessToken(
 		},
 		AutomountServiceAccountToken: &automountServiceAccountToken,
 	}
-	sa, err = k.createServiceAccount(ctx, sa)
+	var saCreated bool
+	sa, saCreated, err = k.createServiceAccount(ctx, sa)
 	if err != nil {
 		return "", errors.Annotatef(err, "cannot ensure service account %q", serviceAccountName)
 	}
-	cleanups = append(cleanups, func() {
-		_ = k.deleteServiceAccount(ctx, sa.Name, sa.UID)
-	})
+	if saCreated {
+		cleanups = append(cleanups, func() {
+			_ = k.deleteServiceAccount(ctx, sa.Name, sa.UID)
+		})
+	}
 
 	rules := policyRulesForSecretAccess(k.namespace, ownedRevs, readRevs)
 	rCleanups, err := k.createRoleAndBinding(ctx, sa, rules)

--- a/secrets/provider/kubernetes/provider.go
+++ b/secrets/provider/kubernetes/provider.go
@@ -709,13 +709,21 @@ func (k *kubernetesClient) deleteRoleBinding(
 func policyRulesForSecretAccess(
 	namespace string, owned, read []string,
 ) []rbacv1.PolicyRule {
+	sortedOwned := append([]string(nil), owned...)
+	slices.Sort(sortedOwned)
+	sortedOwned = slices.Compact(sortedOwned)
+
+	sortedRead := append([]string(nil), read...)
+	slices.Sort(sortedRead)
+	sortedRead = slices.Compact(sortedRead)
+
 	rules := []rbacv1.PolicyRule{{
 		APIGroups:     []string{rbacv1.APIGroupAll},
 		Resources:     []string{"namespaces"},
 		Verbs:         []string{"get", "list"},
 		ResourceNames: []string{namespace},
 	}}
-	if len(owned) > 0 {
+	if len(sortedOwned) > 0 {
 		// owned cannot be empty, otherwise this policy rule grants access to
 		// all secrets.
 		rules = append(rules, rbacv1.PolicyRule{
@@ -726,17 +734,17 @@ func policyRulesForSecretAccess(
 				// to kubernetes rbac limitation.
 				"get", "patch", "update", "replace", "delete",
 			},
-			ResourceNames: owned,
+			ResourceNames: sortedOwned,
 		})
 	}
-	if len(read) > 0 {
+	if len(sortedRead) > 0 {
 		// read cannot be empty, otherwise this policy rule grants access to
 		// all secrets.
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups:     []string{rbacv1.APIGroupAll},
 			Resources:     []string{"secrets"},
 			Verbs:         []string{"get"},
-			ResourceNames: read,
+			ResourceNames: sortedRead,
 		})
 	}
 	return rules

--- a/secrets/provider/kubernetes/provider_test.go
+++ b/secrets/provider/kubernetes/provider_test.go
@@ -602,7 +602,15 @@ func (s *providerSuite) TestEnsureSecretAccessTokenUpdate(c *gc.C) {
 		provider.SecretRevisions{readURI.ID: set.NewStrings(readURI.Name(1), readURI.Name(2))},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.tokens, gc.HasLen, 1)
+	backendCfg2, err := p.RestrictedConfig(
+		adminCfg, false, false,
+		issuedTokenUUID, tag,
+		[]string{ownedURI.ID},
+		provider.SecretRevisions{ownedURI.ID: set.NewStrings(ownedURI.Name(1))},
+		provider.SecretRevisions{readURI.ID: set.NewStrings(readURI.Name(1), readURI.Name(2))},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.tokens, gc.HasLen, 2)
 	expected := &provider.BackendConfig{
 		BackendType: kubernetes.BackendType,
 		Config: map[string]any{
@@ -613,6 +621,16 @@ func (s *providerSuite) TestEnsureSecretAccessTokenUpdate(c *gc.C) {
 		},
 	}
 	c.Assert(backendCfg, jc.DeepEquals, expected)
+	expected2 := &provider.BackendConfig{
+		BackendType: kubernetes.BackendType,
+		Config: map[string]any{
+			"ca-certs":  []string{"cert-data"},
+			"endpoint":  "http://nowhere",
+			"namespace": s.namespace,
+			"token":     s.tokens[1],
+		},
+	}
+	c.Assert(backendCfg2, jc.DeepEquals, expected2)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -646,7 +664,15 @@ func (s *providerSuite) TestEnsureSecretAccessTokeControllerModelUpdate(c *gc.C)
 		provider.SecretRevisions{readURI.ID: set.NewStrings(readURI.Name(1), readURI.Name(2))},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.tokens, gc.HasLen, 1)
+	backendCfg2, err := p.RestrictedConfig(
+		adminCfg, false, false,
+		issuedTokenUUID, tag,
+		[]string{ownedURI.ID},
+		provider.SecretRevisions{ownedURI.ID: set.NewStrings(ownedURI.Name(1))},
+		provider.SecretRevisions{readURI.ID: set.NewStrings(readURI.Name(1), readURI.Name(2))},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.tokens, gc.HasLen, 2)
 	expected := &provider.BackendConfig{
 		BackendType: kubernetes.BackendType,
 		Config: map[string]any{
@@ -657,6 +683,16 @@ func (s *providerSuite) TestEnsureSecretAccessTokeControllerModelUpdate(c *gc.C)
 		},
 	}
 	c.Assert(backendCfg, jc.DeepEquals, expected)
+	expected2 := &provider.BackendConfig{
+		BackendType: kubernetes.BackendType,
+		Config: map[string]any{
+			"ca-certs":  []string{"cert-data"},
+			"endpoint":  "http://nowhere",
+			"namespace": s.namespace,
+			"token":     s.tokens[1],
+		},
+	}
+	c.Assert(backendCfg2, jc.DeepEquals, expected2)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/secrets/provider/kubernetes/rbac_test.go
+++ b/secrets/provider/kubernetes/rbac_test.go
@@ -152,6 +152,18 @@ func (s *rbacSuite) TestCreateRoleErrors(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.*changing rules for role "role-rules-change" not supported`)
 }
 
+func (s *rbacSuite) TestPolicyRulesForSecretAccessSortsResourceNames(c *gc.C) {
+	rules := policyRulesForSecretAccess(
+		s.k8sclient.namespace,
+		[]string{"secret-b#2", "secret-a#1", "secret-b#2", "secret-a#1"},
+		[]string{"secret-c#1", "secret-b#3", "secret-c#1"},
+	)
+
+	c.Assert(rules, gc.HasLen, 3)
+	c.Assert(rules[1].ResourceNames, jc.DeepEquals, []string{"secret-a#1", "secret-b#2"})
+	c.Assert(rules[2].ResourceNames, jc.DeepEquals, []string{"secret-b#3", "secret-c#1"})
+}
+
 func (s *rbacSuite) TestCreateRoleBindingErrors(c *gc.C) {
 	ctx := context.Background()
 

--- a/secrets/provider/kubernetes/rbac_test.go
+++ b/secrets/provider/kubernetes/rbac_test.go
@@ -11,10 +11,12 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
+	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/juju/juju/internal/provider/kubernetes/constants"
 	"github.com/juju/juju/internal/provider/kubernetes/resources"
 )
 
@@ -48,6 +50,284 @@ func (s *rbacSuite) getFakeClient(c *gc.C) *kubernetesClient {
 
 func (s *rbacSuite) SetUpTest(c *gc.C) {
 	s.k8sclient = s.getFakeClient(c)
+}
+
+func (s *rbacSuite) managedLabels() map[string]string {
+	return map[string]string{
+		constants.LabelKubernetesAppManaged: resources.JujuFieldManager,
+	}
+}
+
+func (s *rbacSuite) modelAnnotations(modelUUID string) map[string]string {
+	return map[string]string{
+		modelIdKey: modelUUID,
+	}
+}
+
+func (s *rbacSuite) TestCreateServiceAccountErrors(c *gc.C) {
+	ctx := context.Background()
+	saName := "sa-conflict"
+
+	_, err := s.k8sclient.client.CoreV1().ServiceAccounts(s.k8sclient.namespace).Create(ctx, &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   saName,
+			Labels: map[string]string{},
+		},
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createServiceAccount(ctx, &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{Name: saName},
+	})
+	c.Assert(err, gc.ErrorMatches, `service account "sa-conflict" exists and is not managed by Juju`)
+
+	_, err = s.k8sclient.client.CoreV1().ServiceAccounts(s.k8sclient.namespace).Create(ctx, &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "sa-other-model",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations("different-model"),
+		},
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createServiceAccount(ctx, &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{Name: "sa-other-model"},
+	})
+	c.Assert(err, gc.ErrorMatches, `service account "sa-other-model" exists and is not managed by this model`)
+}
+
+func (s *rbacSuite) TestCreateRoleErrors(c *gc.C) {
+	ctx := context.Background()
+
+	_, err := s.k8sclient.client.RbacV1().Roles(s.k8sclient.namespace).Create(ctx, &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "role-not-juju",
+			Labels: map[string]string{},
+		},
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createRole(ctx, &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{Name: "role-not-juju"},
+	})
+	c.Assert(err, gc.ErrorMatches, `role "role-not-juju" exists and is not managed by Juju`)
+
+	_, err = s.k8sclient.client.RbacV1().Roles(s.k8sclient.namespace).Create(ctx, &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "role-other-model",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations("different-model"),
+		},
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createRole(ctx, &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{Name: "role-other-model"},
+	})
+	c.Assert(err, gc.ErrorMatches, `role "role-other-model" exists and is not managed by this model`)
+
+	_, err = s.k8sclient.client.RbacV1().Roles(s.k8sclient.namespace).Create(ctx, &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "role-rules-change",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations(s.k8sclient.modelUUID),
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"*"},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get"},
+		}},
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createRole(ctx, &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{Name: "role-rules-change"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"*"},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "list"},
+		}},
+	})
+	c.Assert(errors.Is(err, errors.NotSupported), gc.Equals, true)
+	c.Assert(err, gc.ErrorMatches, `.*changing rules for role "role-rules-change" not supported`)
+}
+
+func (s *rbacSuite) TestCreateRoleBindingErrors(c *gc.C) {
+	ctx := context.Background()
+
+	rbRef := rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "a-role"}
+	rbSubjects := []rbacv1.Subject{{Kind: "ServiceAccount", Name: "sa", Namespace: s.k8sclient.namespace}}
+
+	_, err := s.k8sclient.client.RbacV1().RoleBindings(s.k8sclient.namespace).Create(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "rb-not-juju",
+			Labels: map[string]string{},
+		},
+		RoleRef:  rbRef,
+		Subjects: rbSubjects,
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, _, err = s.k8sclient.createRoleBinding(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "rb-not-juju"},
+		RoleRef:    rbRef,
+		Subjects:   rbSubjects,
+	})
+	c.Assert(err, gc.ErrorMatches, `role binding "rb-not-juju" exists and is not managed by Juju`)
+
+	_, err = s.k8sclient.client.RbacV1().RoleBindings(s.k8sclient.namespace).Create(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "rb-other-model",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations("different-model"),
+		},
+		RoleRef:  rbRef,
+		Subjects: rbSubjects,
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, _, err = s.k8sclient.createRoleBinding(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "rb-other-model"},
+		RoleRef:    rbRef,
+		Subjects:   rbSubjects,
+	})
+	c.Assert(err, gc.ErrorMatches, `role binding "rb-other-model" exists and is not managed by this model`)
+
+	_, err = s.k8sclient.client.RbacV1().RoleBindings(s.k8sclient.namespace).Create(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "rb-bindings-change",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations(s.k8sclient.modelUUID),
+		},
+		RoleRef:  rbRef,
+		Subjects: rbSubjects,
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, _, err = s.k8sclient.createRoleBinding(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "rb-bindings-change"},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "different-role"},
+		Subjects:   rbSubjects,
+	})
+	c.Assert(errors.Is(err, errors.NotSupported), gc.Equals, true)
+	c.Assert(err, gc.ErrorMatches, `.*changing bindings for role binding "rb-bindings-change" not supported`)
+}
+
+func (s *rbacSuite) TestCreateClusterRoleErrors(c *gc.C) {
+	ctx := context.Background()
+
+	_, err := s.k8sclient.client.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "cr-not-juju",
+			Labels: map[string]string{},
+		},
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createClusterRole(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: v1.ObjectMeta{Name: "cr-not-juju"},
+	})
+	c.Assert(err, gc.ErrorMatches, `cluster role "cr-not-juju" exists and is not managed by Juju`)
+
+	_, err = s.k8sclient.client.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "cr-other-model",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations("different-model"),
+		},
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createClusterRole(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: v1.ObjectMeta{Name: "cr-other-model"},
+	})
+	c.Assert(err, gc.ErrorMatches, `cluster role "cr-other-model" exists and is not managed by this model`)
+
+	_, err = s.k8sclient.client.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "cr-rules-change",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations(s.k8sclient.modelUUID),
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"*"},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get"},
+		}},
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createClusterRole(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: v1.ObjectMeta{Name: "cr-rules-change"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"*"},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "list"},
+		}},
+	})
+	c.Assert(errors.Is(err, errors.NotSupported), gc.Equals, true)
+	c.Assert(err, gc.ErrorMatches, `.*changing rules for cluster role "cr-rules-change" not supported`)
+}
+
+func (s *rbacSuite) TestCreateClusterRoleBindingErrors(c *gc.C) {
+	ctx := context.Background()
+
+	crbRef := rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "a-cluster-role"}
+	crbSubjects := []rbacv1.Subject{{Kind: "ServiceAccount", Name: "sa", Namespace: s.k8sclient.namespace}}
+
+	_, err := s.k8sclient.client.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "crb-not-juju",
+			Labels: map[string]string{},
+		},
+		RoleRef:  crbRef,
+		Subjects: crbSubjects,
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createClusterRoleBinding(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "crb-not-juju"},
+		RoleRef:    crbRef,
+		Subjects:   crbSubjects,
+	})
+	c.Assert(err, gc.ErrorMatches, `cluster role binding "crb-not-juju" exists and is not managed by Juju`)
+
+	_, err = s.k8sclient.client.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "crb-other-model",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations("different-model"),
+		},
+		RoleRef:  crbRef,
+		Subjects: crbSubjects,
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createClusterRoleBinding(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "crb-other-model"},
+		RoleRef:    crbRef,
+		Subjects:   crbSubjects,
+	})
+	c.Assert(err, gc.ErrorMatches, `cluster role binding "crb-other-model" exists and is not managed by this model`)
+
+	_, err = s.k8sclient.client.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "crb-bindings-change",
+			Labels:      s.managedLabels(),
+			Annotations: s.modelAnnotations(s.k8sclient.modelUUID),
+		},
+		RoleRef:  crbRef,
+		Subjects: crbSubjects,
+	}, v1.CreateOptions{FieldManager: resources.JujuFieldManager})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.k8sclient.createClusterRoleBinding(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "crb-bindings-change"},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "different-cluster-role"},
+		Subjects:   crbSubjects,
+	})
+	c.Assert(errors.Is(err, errors.NotSupported), gc.Equals, true)
+	c.Assert(err, gc.ErrorMatches, `.*changing bindings for cluster role binding "crb-bindings-change" not supported`)
 }
 
 func (s *rbacSuite) TestUpdateClusterRole(c *gc.C) {

--- a/secrets/provider/vault/provider.go
+++ b/secrets/provider/vault/provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -275,9 +276,9 @@ func (p vaultProvider) RestrictedConfig(
 	}
 
 	policyName := fmt.Sprintf("%s-%s", mountPath, issuedTokenUUID)
-	err = sys.PutPolicyWithContext(ctx, policyName, strings.Join(rules, "\n"))
+	err = p.ensureSecretAccessPolicy(ctx, sys, policyName, rules)
 	if err != nil {
-		return nil, errors.Annotatef(err, "creating policy %q", policyName)
+		return nil, errors.Trace(err)
 	}
 	logger.Tracef("policy rules for %q: %#v", policyName, rules)
 
@@ -297,8 +298,51 @@ func (p vaultProvider) RestrictedConfig(
 	}
 
 	cfg := adminCfg.BackendConfig
+	cfg.Config = map[string]interface{}{}
+	for k, v := range adminCfg.BackendConfig.Config {
+		cfg.Config[k] = v
+	}
 	cfg.Config[TokenKey] = s.Auth.ClientToken
 	return &cfg, nil
+}
+
+func (p vaultProvider) ensureSecretAccessPolicy(
+	ctx context.Context,
+	sys *api.Sys,
+	policyName string,
+	rules []string,
+) error {
+	policyRules := strings.Join(rules, "\n")
+	existingRules, err := sys.GetPolicyWithContext(ctx, policyName)
+	if err != nil {
+		return errors.Annotatef(err, "getting policy %q", policyName)
+	}
+	// Should never happen.
+	if existingRules != "" {
+		if normalizePolicyRules(existingRules) != normalizePolicyRules(policyRules) {
+			return errors.NotSupportedf("changing rules for policy %q", policyName)
+		}
+		return nil
+	}
+	err = sys.PutPolicyWithContext(ctx, policyName, policyRules)
+	if err != nil {
+		return errors.Annotatef(err, "creating policy %q", policyName)
+	}
+	return nil
+}
+
+func normalizePolicyRules(rules string) string {
+	lines := strings.Split(rules, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	sort.Strings(out)
+	return strings.Join(out, "\n")
 }
 
 // NewVaultClient is patched for testing.

--- a/secrets/provider/vault/provider.go
+++ b/secrets/provider/vault/provider.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
@@ -261,18 +262,22 @@ func (p vaultProvider) RestrictedConfig(
 
 	// Any secrets owned by the agent can be updated/deleted etc.
 	logger.Debugf("owned secrets: %#v", owned)
-	for _, id := range owned {
+	for _, id := range set.NewStrings(owned...).SortedValues() {
 		rule := fmt.Sprintf(`path "%s/%s-*" {capabilities = ["create", "read", "update", "delete", "list"]}`, mountPath, id)
 		rules = append(rules, rule)
 	}
 
 	// Any secrets consumed by the agent can be read etc.
 	logger.Debugf("consumed secret revisions: %#v", readRevs)
+	readRevIDs := set.NewStrings()
 	for _, revs := range readRevs {
-		for _, revId := range revs.Values() {
-			rule := fmt.Sprintf(`path "%s/%s" {capabilities = ["read"]}`, mountPath, revId)
-			rules = append(rules, rule)
+		for _, revID := range revs.Values() {
+			readRevIDs.Add(revID)
 		}
+	}
+	for _, revID := range readRevIDs.SortedValues() {
+		rule := fmt.Sprintf(`path "%s/%s" {capabilities = ["read"]}`, mountPath, revID)
+		rules = append(rules, rule)
 	}
 
 	policyName := fmt.Sprintf("%s-%s", mountPath, issuedTokenUUID)
@@ -333,12 +338,17 @@ func (p vaultProvider) ensureSecretAccessPolicy(
 
 func normalizePolicyRules(rules string) string {
 	lines := strings.Split(rules, "\n")
+	seen := set.NewStrings()
 	out := make([]string, 0, len(lines))
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
+		if seen.Contains(line) {
+			continue
+		}
+		seen.Add(line)
 		out = append(out, line)
 	}
 	sort.Strings(out)

--- a/secrets/provider/vault/provider_test.go
+++ b/secrets/provider/vault/provider_test.go
@@ -5,6 +5,7 @@ package vault_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -116,6 +117,18 @@ func (s *providerSuite) TestBackendConfigAdmin(c *gc.C) {
 	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 		func(req *http.Request) (*http.Response, error) {
 			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`)
+			c.Assert(req.Method, gc.Equals, http.MethodGet)
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{"errors":[]}`)),
+			}, nil
+		},
+	)
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`)
+			c.Assert(req.Method, gc.Equals, http.MethodPut)
 			b, _ := ioutil.ReadAll(req.Body)
 			defer req.Body.Close()
 			policyReq := struct {
@@ -186,6 +199,18 @@ func (s *providerSuite) TestBackendConfigNonAdmin(c *gc.C) {
 	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 		func(req *http.Request) (*http.Response, error) {
 			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`)
+			c.Assert(req.Method, gc.Equals, http.MethodGet)
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{"errors":[]}`)),
+			}, nil
+		},
+	)
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`)
+			c.Assert(req.Method, gc.Equals, http.MethodPut)
 			b, _ := ioutil.ReadAll(req.Body)
 			defer req.Body.Close()
 			policyReq := struct {
@@ -266,6 +291,18 @@ func (s *providerSuite) TestBackendConfigForDrain(c *gc.C) {
 	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 		func(req *http.Request) (*http.Response, error) {
 			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`)
+			c.Assert(req.Method, gc.Equals, http.MethodGet)
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{"errors":[]}`)),
+			}, nil
+		},
+	)
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`)
+			c.Assert(req.Method, gc.Equals, http.MethodPut)
 			b, _ := ioutil.ReadAll(req.Body)
 			defer req.Body.Close()
 			policyReq := struct {
@@ -337,6 +374,182 @@ func (s *providerSuite) TestBackendConfigForDrain(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
+}
+
+func (s *providerSuite) TestBackendConfigNonAdminIdempotentSameIssuedTokenUUID(c *gc.C) {
+	ctrl, newVaultClient := s.newVaultClient(c, nil)
+	defer ctrl.Finish()
+
+	policyURL := `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`
+	tokenURL := `http://vault-ip:8200/v1/auth/token/create`
+	expectedPolicy := strings.Join([]string{
+		`path "fred-06f00d/owned-1-*" {capabilities = ["create", "read", "update", "delete", "list"]}`,
+		`path "fred-06f00d/read-rev-1" {capabilities = ["read"]}`,
+	}, "\n")
+	policyGetCalls := 0
+	policyPutCalls := 0
+	tokenCalls := 0
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case policyURL:
+				if req.Method == http.MethodGet {
+					policyGetCalls++
+					if policyGetCalls == 1 {
+						return &http.Response{Request: req, StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(`{"errors":[]}`))}, nil
+					}
+					return &http.Response{
+						Request:    req,
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"data":{"policy":%q}}`, expectedPolicy))),
+					}, nil
+				}
+				c.Assert(req.Method, gc.Equals, http.MethodPut)
+				policyPutCalls++
+				b, _ := ioutil.ReadAll(req.Body)
+				defer req.Body.Close()
+				policyReq := struct {
+					Policy string
+				}{}
+				_ = json.Unmarshal(b, &policyReq)
+				c.Assert(policyReq.Policy, gc.Equals, expectedPolicy)
+				return &http.Response{Request: req, StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
+			case tokenURL:
+				tokenCalls++
+				tokenValue := "foo1"
+				if tokenCalls == 2 {
+					tokenValue = "foo2"
+				}
+				return &http.Response{Request: req, StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"auth": {"client_token": "` + tokenValue + `"}}`))}, nil
+			default:
+				c.Fatalf("unexpected URL %q", req.URL.String())
+				return nil, nil
+			}
+		},
+	).AnyTimes()
+
+	s.PatchValue(&jujuvault.NewVaultClient, newVaultClient)
+	p, err := provider.Provider(jujuvault.BackendType)
+	c.Assert(err, jc.ErrorIsNil)
+
+	adminCfg := &provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig: provider.BackendConfig{
+			BackendType: "vault",
+			Config: map[string]any{
+				"endpoint":        "http://vault-ip:8200/",
+				"namespace":       "ns",
+				"token":           "vault-token",
+				"ca-cert":         coretesting.CACert,
+				"tls-server-name": "tls-server",
+			},
+		},
+	}
+	ownedNames := []string{"owned-1"}
+	ownedRevs := map[string]set.Strings{"owned-1": set.NewStrings("owned-rev-1", "owned-rev-2")}
+	readRevs := map[string]set.Strings{"read-1": set.NewStrings("read-rev-1")}
+	issuedTokenUUID := "some-uuid"
+
+	cfg1, err := p.RestrictedConfig(
+		adminCfg, true, false, issuedTokenUUID, names.NewUnitTag("ubuntu/0"),
+		ownedNames, ownedRevs, readRevs,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg1.Config["token"], gc.Equals, "foo1")
+
+	cfg2, err := p.RestrictedConfig(
+		adminCfg, true, false, issuedTokenUUID, names.NewUnitTag("ubuntu/0"),
+		ownedNames, ownedRevs, readRevs,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg2.Config["token"], gc.Equals, "foo2")
+	c.Assert(policyGetCalls, gc.Equals, 2)
+	c.Assert(policyPutCalls, gc.Equals, 1)
+	c.Assert(tokenCalls, gc.Equals, 2)
+}
+
+func (s *providerSuite) TestBackendConfigNonAdminImmutableMismatchSameIssuedTokenUUID(c *gc.C) {
+	ctrl, newVaultClient := s.newVaultClient(c, nil)
+	defer ctrl.Finish()
+
+	policyURL := `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`
+	tokenURL := `http://vault-ip:8200/v1/auth/token/create`
+	expectedPolicy := strings.Join([]string{
+		`path "fred-06f00d/owned-1-*" {capabilities = ["create", "read", "update", "delete", "list"]}`,
+		`path "fred-06f00d/read-rev-1" {capabilities = ["read"]}`,
+	}, "\n")
+	policyGetCalls := 0
+	policyPutCalls := 0
+	tokenCalls := 0
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case policyURL:
+				if req.Method == http.MethodGet {
+					policyGetCalls++
+					if policyGetCalls == 1 {
+						return &http.Response{Request: req, StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(`{"errors":[]}`))}, nil
+					}
+					return &http.Response{
+						Request:    req,
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"data":{"policy":%q}}`, expectedPolicy))),
+					}, nil
+				}
+				c.Assert(req.Method, gc.Equals, http.MethodPut)
+				policyPutCalls++
+				return &http.Response{Request: req, StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
+			case tokenURL:
+				tokenCalls++
+				return &http.Response{Request: req, StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"auth": {"client_token": "foo1"}}`))}, nil
+			default:
+				c.Fatalf("unexpected URL %q", req.URL.String())
+				return nil, nil
+			}
+		},
+	).AnyTimes()
+
+	s.PatchValue(&jujuvault.NewVaultClient, newVaultClient)
+	p, err := provider.Provider(jujuvault.BackendType)
+	c.Assert(err, jc.ErrorIsNil)
+
+	adminCfg := &provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig: provider.BackendConfig{
+			BackendType: "vault",
+			Config: map[string]any{
+				"endpoint":        "http://vault-ip:8200/",
+				"namespace":       "ns",
+				"token":           "vault-token",
+				"ca-cert":         coretesting.CACert,
+				"tls-server-name": "tls-server",
+			},
+		},
+	}
+	ownedNames := []string{"owned-1"}
+	ownedRevs := map[string]set.Strings{"owned-1": set.NewStrings("owned-rev-1", "owned-rev-2")}
+	readRevs := map[string]set.Strings{"read-1": set.NewStrings("read-rev-1")}
+	issuedTokenUUID := "some-uuid"
+
+	_, err = p.RestrictedConfig(
+		adminCfg, true, false, issuedTokenUUID, names.NewUnitTag("ubuntu/0"),
+		ownedNames, ownedRevs, readRevs,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = p.RestrictedConfig(
+		adminCfg, true, false, issuedTokenUUID, names.NewUnitTag("ubuntu/0"),
+		ownedNames, ownedRevs,
+		map[string]set.Strings{"read-1": set.NewStrings("read-rev-2")},
+	)
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(policyGetCalls, gc.Equals, 2)
+	c.Assert(policyPutCalls, gc.Equals, 1)
+	c.Assert(tokenCalls, gc.Equals, 1)
 }
 
 func (s *providerSuite) TestNewBackend(c *gc.C) {

--- a/secrets/provider/vault/provider_test.go
+++ b/secrets/provider/vault/provider_test.go
@@ -470,6 +470,104 @@ func (s *providerSuite) TestBackendConfigNonAdminIdempotentSameIssuedTokenUUID(c
 	c.Assert(tokenCalls, gc.Equals, 2)
 }
 
+func (s *providerSuite) TestBackendConfigNonAdminIdempotentSameIssuedTokenUUIDOrderAndDuplicateInsensitive(c *gc.C) {
+	ctrl, newVaultClient := s.newVaultClient(c, nil)
+	defer ctrl.Finish()
+
+	policyURL := `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`
+	tokenURL := `http://vault-ip:8200/v1/auth/token/create`
+	expectedPolicy := strings.Join([]string{
+		`path "fred-06f00d/owned-1-*" {capabilities = ["create", "read", "update", "delete", "list"]}`,
+		`path "fred-06f00d/owned-2-*" {capabilities = ["create", "read", "update", "delete", "list"]}`,
+		`path "fred-06f00d/read-rev-1" {capabilities = ["read"]}`,
+		`path "fred-06f00d/read-rev-2" {capabilities = ["read"]}`,
+	}, "\n")
+	policyGetCalls := 0
+	policyPutCalls := 0
+	tokenCalls := 0
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case policyURL:
+				if req.Method == http.MethodGet {
+					policyGetCalls++
+					if policyGetCalls == 1 {
+						return &http.Response{Request: req, StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(`{"errors":[]}`))}, nil
+					}
+					return &http.Response{
+						Request:    req,
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"data":{"policy":%q}}`, expectedPolicy))),
+					}, nil
+				}
+				c.Assert(req.Method, gc.Equals, http.MethodPut)
+				policyPutCalls++
+				b, _ := ioutil.ReadAll(req.Body)
+				defer req.Body.Close()
+				policyReq := struct {
+					Policy string
+				}{}
+				_ = json.Unmarshal(b, &policyReq)
+				c.Assert(policyReq.Policy, gc.Equals, expectedPolicy)
+				return &http.Response{Request: req, StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
+			case tokenURL:
+				tokenCalls++
+				return &http.Response{Request: req, StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"auth": {"client_token": "foo"}}`))}, nil
+			default:
+				c.Fatalf("unexpected URL %q", req.URL.String())
+				return nil, nil
+			}
+		},
+	).AnyTimes()
+
+	s.PatchValue(&jujuvault.NewVaultClient, newVaultClient)
+	p, err := provider.Provider(jujuvault.BackendType)
+	c.Assert(err, jc.ErrorIsNil)
+
+	adminCfg := &provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig: provider.BackendConfig{
+			BackendType: "vault",
+			Config: map[string]any{
+				"endpoint":        "http://vault-ip:8200/",
+				"namespace":       "ns",
+				"token":           "vault-token",
+				"ca-cert":         coretesting.CACert,
+				"tls-server-name": "tls-server",
+			},
+		},
+	}
+	issuedTokenUUID := "some-uuid"
+
+	_, err = p.RestrictedConfig(
+		adminCfg, true, false, issuedTokenUUID, names.NewUnitTag("ubuntu/0"),
+		[]string{"owned-2", "owned-1"},
+		map[string]set.Strings{"owned-1": set.NewStrings("owned-rev-1")},
+		map[string]set.Strings{
+			"read-1": set.NewStrings("read-rev-2", "read-rev-1"),
+			"read-2": set.NewStrings("read-rev-1"),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = p.RestrictedConfig(
+		adminCfg, true, false, issuedTokenUUID, names.NewUnitTag("ubuntu/0"),
+		[]string{"owned-1", "owned-2", "owned-1"},
+		map[string]set.Strings{"owned-2": set.NewStrings("owned-rev-2")},
+		map[string]set.Strings{
+			"read-1": set.NewStrings("read-rev-1"),
+			"read-2": set.NewStrings("read-rev-2", "read-rev-2"),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(policyGetCalls, gc.Equals, 2)
+	c.Assert(policyPutCalls, gc.Equals, 1)
+	c.Assert(tokenCalls, gc.Equals, 2)
+}
+
 func (s *providerSuite) TestBackendConfigNonAdminImmutableMismatchSameIssuedTokenUUID(c *gc.C) {
 	ctrl, newVaultClient := s.newVaultClient(c, nil)
 	defer ctrl.Finish()

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -4019,6 +4019,7 @@ type secretIssuedTokenDoc struct {
 	ConsumerTag string    `bson:"consumer-tag"`
 	ExpireTime  time.Time `bson:"expire-time"`
 	BackendID   string    `bson:"backend-id"`
+	ScopeHash   string    `bson:"scope-hash"`
 }
 
 // CreateSecretBackendIssuedToken inserts the given secret backend issued token
@@ -4076,6 +4077,7 @@ func (s *secretsStore) CreateSecretBackendIssuedToken(
 		BackendID:   token.BackendID,
 		ExpireTime:  token.ExpireTime.UTC().Truncate(time.Second),
 		ConsumerTag: token.Consumer.String(),
+		ScopeHash:   token.ScopeHash,
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		var err error
@@ -4126,6 +4128,10 @@ type SecretBackendIssuedToken struct {
 	// Consumer is a tag that represents the entity which the secret backend
 	// issued token was created for.
 	Consumer names.Tag
+
+	// ScopeHash is a deterministic hash of the backend access scope (owned IDs,
+	// owned revs, read revs) used when this token was issued.
+	ScopeHash string
 }
 
 // NextSecretBackendIssuedTokenExpiry returns the time of the next secret
@@ -4195,6 +4201,7 @@ func (s *secretsStore) listSecretBackendIssuedTokenUntil(
 			ExpireTime: doc.ExpireTime,
 			BackendID:  doc.BackendID,
 			Consumer:   consumerTag,
+			ScopeHash:  doc.ScopeHash,
 		})
 	}
 

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -158,11 +158,6 @@ type SecretsStore interface {
 	// given secret backend token UUIDs.
 	RemoveSecretBackendIssuedTokens(uuids []string) error
 
-	// ExpireSecretBackendIssuedTokensForConsumer returns a ModelOperation that
-	// sets the expire time of all currently non-expired secret backend issued
-	// tokens for the given consumer to now.
-	ExpireSecretBackendIssuedTokensForConsumer(consumer names.Tag) ModelOperation
-
 	// RemoveSecretReservations removes all secret reservations that are held by
 	// the provided owner.
 	RemoveSecretReservations(owner names.Tag) ModelOperation
@@ -4039,69 +4034,84 @@ func (s *secretsStore) CreateSecretBackendIssuedToken(
 	tokenColl, closer := s.st.db().GetCollection(secretBackendIssuedTokensC)
 	defer closer()
 
-	check := func() (string, string, error) {
+	check := func() (string, string, *secretIssuedTokenDoc, error) {
 		entity, entityC, entityDocID, err := s.st.findSecretEntity(token.Consumer)
 		if err != nil {
-			return "", "", errors.Annotate(err, "invalid secret token receiver")
+			return "", "", nil, errors.Annotate(err, "invalid secret token receiver")
 		}
 		if entity.Life() == Dead {
-			return "", "", errors.New(
+			return "", "", nil, errors.New(
 				"creating secret backend issued token: consumer is dead",
 			)
 		}
 		existing := secretIssuedTokenDoc{}
 		err = tokenColl.FindId(token.UUID).One(&existing)
 		if errors.Is(err, mgo.ErrNotFound) {
-			return entityC, entityDocID, nil
+			return entityC, entityDocID, nil, nil
 		} else if err != nil {
-			return "", "", errors.Annotate(
+			return "", "", nil, errors.Annotate(
 				err, "checking existing secret issued backend token",
 			)
 		}
 		if existing.ConsumerTag != token.Consumer.String() {
-			return "", "", errors.Unauthorizedf(
+			return "", "", nil, errors.Unauthorizedf(
 				"%s secret issued backend token", token.UUID,
 			)
 		}
-		return entityC, entityDocID, errors.AlreadyExists
+		return entityC, entityDocID, &existing, errors.AlreadyExists
 	}
-	entityC, entityDocID, err := check()
-	if errors.Is(err, errors.AlreadyExists) {
-		return nil
-	} else if err != nil {
-		return errors.Trace(err)
-	}
-
+	newExpire := token.ExpireTime.UTC().Truncate(time.Second)
 	doc := secretIssuedTokenDoc{
 		DocID:       token.UUID,
 		BackendID:   token.BackendID,
-		ExpireTime:  token.ExpireTime.UTC().Truncate(time.Second),
+		ExpireTime:  newExpire,
 		ConsumerTag: token.Consumer.String(),
 		ScopeHash:   token.ScopeHash,
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		var err error
-		if attempt > 0 {
-			entityC, entityDocID, err = check()
-			if errors.Is(err, errors.AlreadyExists) {
-				return nil, jujutxn.ErrNoOperations
-			} else if err != nil {
-				return nil, errors.Trace(err)
-			}
+		entityC, entityDocID, existing, err := check()
+		if err != nil && !errors.Is(err, errors.AlreadyExists) {
+			return nil, errors.Trace(err)
 		}
+
 		ops := []txn.Op{{
 			C:      entityC,
 			Id:     entityDocID,
 			Assert: notDeadDoc,
-		}, {
+		}}
+
+		if errors.Is(err, errors.AlreadyExists) {
+			scopeChanged := existing.ScopeHash != token.ScopeHash
+			if !scopeChanged && !newExpire.After(existing.ExpireTime) {
+				return nil, jujutxn.ErrNoOperations
+			}
+			toSet := bson.M{"expire-time": newExpire}
+			if scopeChanged {
+				toSet["scope-hash"] = token.ScopeHash
+			}
+			ops = append(ops, txn.Op{
+				C:  secretBackendIssuedTokensC,
+				Id: doc.DocID,
+				Assert: bson.M{
+					"consumer-tag": existing.ConsumerTag,
+					"backend-id":   existing.BackendID,
+					"scope-hash":   existing.ScopeHash,
+					"expire-time":  existing.ExpireTime,
+				},
+				Update: bson.M{"$set": toSet},
+			})
+			return ops, nil
+		}
+
+		ops = append(ops, txn.Op{
 			C:      secretBackendIssuedTokensC,
 			Id:     doc.DocID,
 			Assert: txn.DocMissing,
 			Insert: doc,
-		}}
+		})
 		return ops, nil
 	}
-	err = s.st.db().Run(buildTxn)
+	err := s.st.db().Run(buildTxn)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -4334,62 +4344,4 @@ func (w *secretBackendIssuedTokenExpiryWatcher) loop() error {
 			changes = nil
 		}
 	}
-}
-
-// expireSecretBackendIssuedTokensModelOp is a model operation for expiring all
-// secret backend issued tokens for the given consumer.
-type expireSecretBackendIssuedTokensModelOp struct {
-	s        *secretsStore
-	consumer names.Tag
-}
-
-// ExpireSecretBackendIssuedTokensForConsumer returns a ModelOperation that
-// sets the expire time of all currently non-expired secret backend issued
-// tokens for the given consumer to now.
-func (s *secretsStore) ExpireSecretBackendIssuedTokensForConsumer(
-	consumer names.Tag,
-) ModelOperation {
-	return &expireSecretBackendIssuedTokensModelOp{
-		s:        s,
-		consumer: consumer,
-	}
-}
-
-func (op *expireSecretBackendIssuedTokensModelOp) Build(
-	attempt int,
-) ([]txn.Op, error) {
-	return op.s.expireSecretBackendIssuedTokensOps(op.consumer)
-}
-
-func (op *expireSecretBackendIssuedTokensModelOp) Done(err error) error {
-	return err
-}
-
-// expireSecretBackendIssuedTokensOps returns the operations to remove all the
-// currently known secret backend issued tokens.
-func (s *secretsStore) expireSecretBackendIssuedTokensOps(
-	consumer names.Tag,
-) ([]txn.Op, error) {
-	coll, closer := s.st.db().GetCollection(secretBackendIssuedTokensC)
-	defer closer()
-
-	now := s.st.clock().Now().UTC().Truncate(time.Second)
-
-	var ops []txn.Op
-	res := coll.Find(bson.M{
-		"consumer-tag": consumer.String(),
-	}).Iter()
-	defer closer()
-	var doc secretIssuedTokenDoc
-	for res.Next(&doc) {
-		if doc.ExpireTime.Before(now) {
-			continue
-		}
-		ops = append(ops, txn.Op{
-			C:      secretBackendIssuedTokensC,
-			Id:     doc.DocID,
-			Update: bson.D{{"$set", bson.D{{"expire-time", now}}}},
-		})
-	}
-	return ops, errors.Trace(res.Close())
 }

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -4419,7 +4419,7 @@ func (s *SecretsSuite) TestCreateSecretBackendIssuedToken(c *gc.C) {
 	c.Assert(n, gc.Equals, 1)
 }
 
-func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenNoopWhenScopeHashMatches(c *gc.C) {
+func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenExtendsExpiryWhenScopeHashMatches(c *gc.C) {
 	uuid := uuid.NewString()
 	expire := s.Clock.Now().Add(time.Minute)
 	token := state.SecretBackendIssuedToken{
@@ -4432,11 +4432,11 @@ func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenNoopWhenScopeHashMatche
 	err := s.store.CreateSecretBackendIssuedToken(token)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Same UUID and scope hash should be a no-op.
+	newExpire := expire.Add(time.Minute)
 	err = s.store.CreateSecretBackendIssuedToken(state.SecretBackendIssuedToken{
 		UUID:       uuid,
-		ExpireTime: expire.Add(time.Minute),
-		BackendID:  "backend-id-2",
+		ExpireTime: newExpire,
+		BackendID:  "backend-id",
 		Consumer:   s.owner.Tag(),
 		ScopeHash:  "scope-1",
 	})
@@ -4447,9 +4447,10 @@ func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenNoopWhenScopeHashMatche
 	c.Assert(tokens, gc.HasLen, 1)
 	c.Assert(tokens[0].BackendID, gc.Equals, "backend-id")
 	c.Assert(tokens[0].ScopeHash, gc.Equals, "scope-1")
+	c.Assert(tokens[0].ExpireTime, jc.DeepEquals, newExpire.Truncate(time.Second))
 }
 
-func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenNoopWhenScopeHashChanges(c *gc.C) {
+func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenReplacesWhenScopeHashChanges(c *gc.C) {
 	uuid := uuid.NewString()
 	expire := s.Clock.Now().Add(time.Minute)
 	err := s.store.CreateSecretBackendIssuedToken(state.SecretBackendIssuedToken{
@@ -4465,7 +4466,7 @@ func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenNoopWhenScopeHashChange
 	err = s.store.CreateSecretBackendIssuedToken(state.SecretBackendIssuedToken{
 		UUID:       uuid,
 		ExpireTime: newExpire,
-		BackendID:  "backend-id-2",
+		BackendID:  "backend-id",
 		Consumer:   s.owner.Tag(),
 		ScopeHash:  "scope-2",
 	})
@@ -4476,8 +4477,8 @@ func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenNoopWhenScopeHashChange
 	c.Assert(tokens, gc.HasLen, 1)
 	c.Assert(tokens[0].UUID, gc.Equals, uuid)
 	c.Assert(tokens[0].BackendID, gc.Equals, "backend-id")
-	c.Assert(tokens[0].ScopeHash, gc.Equals, "scope-1")
-	c.Assert(tokens[0].ExpireTime, jc.DeepEquals, expire.Truncate(time.Second))
+	c.Assert(tokens[0].ScopeHash, gc.Equals, "scope-2")
+	c.Assert(tokens[0].ExpireTime, jc.DeepEquals, newExpire.Truncate(time.Second))
 }
 
 func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenForRemoteConsumerApplication(c *gc.C) {
@@ -4730,85 +4731,6 @@ func (s *SecretsSuite) TestRemoveSecretBackendIssuedTokens(c *gc.C) {
 
 	err = s.store.RemoveSecretBackendIssuedTokens([]string{token.UUID})
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *SecretsSuite) TestExpireSecretBackendIssuedTokensForConsumer(c *gc.C) {
-	now := s.Clock.Now()
-
-	// Create a token that expires in the future.
-	tokenFuture := state.SecretBackendIssuedToken{
-		UUID:       uuid.NewString(),
-		ExpireTime: now.Add(time.Hour),
-		BackendID:  "backend-id",
-		Consumer:   s.ownerUnit.Tag(),
-	}
-	err := s.store.CreateSecretBackendIssuedToken(tokenFuture)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Create a token that is already expired.
-	tokenPast := state.SecretBackendIssuedToken{
-		UUID:       uuid.NewString(),
-		ExpireTime: now,
-		BackendID:  "backend-id",
-		Consumer:   s.ownerUnit.Tag(),
-	}
-	err = s.store.CreateSecretBackendIssuedToken(tokenPast)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Check there is only one expired token.
-	tokens, err := s.store.ListSecretBackendIssuedTokenUntilForConsumer(
-		now, s.ownerUnit.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(tokens, gc.HasLen, 1)
-
-	op := s.store.ExpireSecretBackendIssuedTokensForConsumer(s.ownerUnit.Tag())
-	err = s.State.ApplyOperation(op)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Check there is now two expired tokens.
-	tokens, err = s.store.ListSecretBackendIssuedTokenUntilForConsumer(
-		s.Clock.Now(), s.ownerUnit.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(tokens, gc.HasLen, 2)
-}
-
-func (s *SecretsSuite) TestExpireSecretBackendIssuedTokensForConsumerOnlyTargetConsumer(c *gc.C) {
-	now := s.Clock.Now()
-
-	// Create a token.
-	tokenUnit := state.SecretBackendIssuedToken{
-		UUID:       uuid.NewString(),
-		ExpireTime: now.Add(time.Hour),
-		BackendID:  "backend-id",
-		Consumer:   s.ownerUnit.Tag(),
-	}
-	err := s.store.CreateSecretBackendIssuedToken(tokenUnit)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Create a token for a different consumer.
-	tokenApp := state.SecretBackendIssuedToken{
-		UUID:       uuid.NewString(),
-		ExpireTime: now.Add(time.Hour),
-		BackendID:  "backend-id",
-		Consumer:   s.owner.Tag(),
-	}
-	err = s.store.CreateSecretBackendIssuedToken(tokenApp)
-	c.Assert(err, jc.ErrorIsNil)
-
-	op := s.store.ExpireSecretBackendIssuedTokensForConsumer(s.ownerUnit.Tag())
-	err = s.State.ApplyOperation(op)
-	c.Assert(err, jc.ErrorIsNil)
-
-	tokens, err := s.store.ListSecretBackendIssuedTokenUntilForConsumer(
-		s.Clock.Now(), s.ownerUnit.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(tokens, gc.HasLen, 1)
-
-	// The token for the different consumer should not be expired.
-	tokens, err = s.store.ListSecretBackendIssuedTokenUntilForConsumer(
-		s.Clock.Now(), s.owner.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(tokens, gc.HasLen, 0)
 }
 
 type SecretBackendIssuedTokenExpiryWatcherSuite struct {

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -4419,6 +4419,67 @@ func (s *SecretsSuite) TestCreateSecretBackendIssuedToken(c *gc.C) {
 	c.Assert(n, gc.Equals, 1)
 }
 
+func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenNoopWhenScopeHashMatches(c *gc.C) {
+	uuid := uuid.NewString()
+	expire := s.Clock.Now().Add(time.Minute)
+	token := state.SecretBackendIssuedToken{
+		UUID:       uuid,
+		ExpireTime: expire,
+		BackendID:  "backend-id",
+		Consumer:   s.owner.Tag(),
+		ScopeHash:  "scope-1",
+	}
+	err := s.store.CreateSecretBackendIssuedToken(token)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Same UUID and scope hash should be a no-op.
+	err = s.store.CreateSecretBackendIssuedToken(state.SecretBackendIssuedToken{
+		UUID:       uuid,
+		ExpireTime: expire.Add(time.Minute),
+		BackendID:  "backend-id-2",
+		Consumer:   s.owner.Tag(),
+		ScopeHash:  "scope-1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	tokens, err := s.store.ListSecretBackendIssuedTokenUntilForConsumer(expire.Add(2*time.Minute), s.owner.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tokens, gc.HasLen, 1)
+	c.Assert(tokens[0].BackendID, gc.Equals, "backend-id")
+	c.Assert(tokens[0].ScopeHash, gc.Equals, "scope-1")
+}
+
+func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenNoopWhenScopeHashChanges(c *gc.C) {
+	uuid := uuid.NewString()
+	expire := s.Clock.Now().Add(time.Minute)
+	err := s.store.CreateSecretBackendIssuedToken(state.SecretBackendIssuedToken{
+		UUID:       uuid,
+		ExpireTime: expire,
+		BackendID:  "backend-id",
+		Consumer:   s.owner.Tag(),
+		ScopeHash:  "scope-1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newExpire := expire.Add(2 * time.Minute)
+	err = s.store.CreateSecretBackendIssuedToken(state.SecretBackendIssuedToken{
+		UUID:       uuid,
+		ExpireTime: newExpire,
+		BackendID:  "backend-id-2",
+		Consumer:   s.owner.Tag(),
+		ScopeHash:  "scope-2",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	tokens, err := s.store.ListSecretBackendIssuedTokenUntilForConsumer(newExpire.Add(time.Minute), s.owner.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tokens, gc.HasLen, 1)
+	c.Assert(tokens[0].UUID, gc.Equals, uuid)
+	c.Assert(tokens[0].BackendID, gc.Equals, "backend-id")
+	c.Assert(tokens[0].ScopeHash, gc.Equals, "scope-1")
+	c.Assert(tokens[0].ExpireTime, jc.DeepEquals, expire.Truncate(time.Second))
+}
+
 func (s *SecretsSuite) TestCreateSecretBackendIssuedTokenForRemoteConsumerApplication(c *gc.C) {
 	rwordpress, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:            "remote-wordpress",
@@ -4630,6 +4691,25 @@ func (s *SecretsSuite) TestListSecretBackendIssuedTokenUntilForConsumer(c *gc.C)
 	c.Assert(tokens, gc.HasLen, 1)
 	tokenBefore.ExpireTime = tokenBefore.ExpireTime.Truncate(time.Second)
 	c.Assert(tokens[0], jc.DeepEquals, tokenBefore)
+}
+
+func (s *SecretsSuite) TestListSecretBackendIssuedTokenIncludesScopeHash(c *gc.C) {
+	now := s.Clock.Now()
+	token := state.SecretBackendIssuedToken{
+		UUID:       uuid.NewString(),
+		ExpireTime: now.Add(time.Minute),
+		BackendID:  "backend-id",
+		Consumer:   s.ownerUnit.Tag(),
+		ScopeHash:  "scope-hash-1",
+	}
+	err := s.store.CreateSecretBackendIssuedToken(token)
+	c.Assert(err, jc.ErrorIsNil)
+
+	tokens, err := s.store.ListSecretBackendIssuedTokenUntilForConsumer(now.Add(2*time.Minute), s.ownerUnit.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tokens, gc.HasLen, 1)
+	token.ExpireTime = token.ExpireTime.Truncate(time.Second)
+	c.Assert(tokens[0], jc.DeepEquals, token)
 }
 
 func (s *SecretsSuite) TestRemoveSecretBackendIssuedTokens(c *gc.C) {

--- a/tests/includes/k8s.sh
+++ b/tests/includes/k8s.sh
@@ -27,9 +27,9 @@ kubectl() {
 }
 
 default_k8s() {
-	if command -v minikube && [[ "Started" == "$(minikube status -o json | yq .Host)" ]]; then
+	if command -v minikube >/dev/null 2>&1 && [[ "Stopped" != "$(minikube status -o json | yq .APIServer)" ]]; then
 		printf "minikube"
-	elif command -v microk8s && [[ "True" == "$(microk8s status --format yaml | yq .microk8s.running)" ]]; then
+	elif command -v microk8s >/dev/null 2>&1 && [[ "True" == "$(microk8s status --format yaml | yq .microk8s.running)" ]]; then
 		printf "microk8s"
 	fi
 }

--- a/tests/includes/secrets.sh
+++ b/tests/includes/secrets.sh
@@ -28,3 +28,85 @@ check_num_secret_revisions() {
 		sleep $delay
 	done
 }
+
+# _secret_token_rbac_names returns a stable comma-separated list of token RBAC
+# resource names for a consumer.
+_secret_token_rbac_names() {
+	local namespace=${1}
+	local consumer=${2}
+	local kind=${3}
+
+	kubectl -n "$namespace" get "$kind" -l "secrets.juju.is/consumer=${consumer}" -o json |
+		yq -r '.items[].metadata.name | select(startswith("juju-secret-consumer-"))' |
+		sort |
+		paste -sd, -
+}
+
+# secret_token_rbac_snapshot returns serviceaccount/role/rolebinding names for
+# strict before/after reuse checks.
+secret_token_rbac_snapshot() {
+	local namespace=${1}
+	local consumer=${2}
+
+	local serviceaccounts
+	local roles
+	local rolebindings
+
+	serviceaccounts=$(_secret_token_rbac_names "$namespace" "$consumer" serviceaccounts)
+	roles=$(_secret_token_rbac_names "$namespace" "$consumer" roles)
+	rolebindings=$(_secret_token_rbac_names "$namespace" "$consumer" rolebindings)
+
+	printf 'serviceaccounts=%s\nroles=%s\nrolebindings=%s\n' "$serviceaccounts" "$roles" "$rolebindings"
+}
+
+# _secret_token_rbac_csv_count returns the number of items in a comma-separated
+# list; empty input returns zero.
+_secret_token_rbac_csv_count() {
+	local csv=${1}
+	if [[ -z "$csv" ]]; then
+		echo 0
+		return
+	fi
+	awk -F',' '{print NF}' <<<"$csv"
+}
+
+# secret_token_rbac_assert_singleton asserts there is exactly one token RBAC
+# tuple and all names match.
+secret_token_rbac_assert_singleton() {
+	local snapshot=${1}
+	local context=${2}
+
+	local serviceaccounts
+	local roles
+	local rolebindings
+
+	serviceaccounts=$(echo "$snapshot" | awk -F= '/^serviceaccounts=/{print $2}')
+	roles=$(echo "$snapshot" | awk -F= '/^roles=/{print $2}')
+	rolebindings=$(echo "$snapshot" | awk -F= '/^rolebindings=/{print $2}')
+
+	if [[ $(_secret_token_rbac_csv_count "$serviceaccounts") -ne 1 || \
+		$(_secret_token_rbac_csv_count "$roles") -ne 1 || \
+		$(_secret_token_rbac_csv_count "$rolebindings") -ne 1 ]]; then
+		echo "Failed: expected exactly one token serviceaccount/role/rolebinding for $context."
+		echo "$snapshot"
+		return 1
+	fi
+}
+
+# secret_token_rbac_assert_reused asserts RBAC snapshot is unchanged across
+# repeated secret-get operations.
+secret_token_rbac_assert_reused() {
+	local before_snapshot=${1}
+	local after_snapshot=${2}
+	local context=${3}
+
+	if [[ "$before_snapshot" != "$after_snapshot" ]]; then
+		echo "Failed: token RBAC resources changed while validating reuse for $context."
+		echo "Before:"
+		echo "$before_snapshot"
+		echo "After:"
+		echo "$after_snapshot"
+		return 1
+	fi
+}
+

--- a/tests/includes/secrets.sh
+++ b/tests/includes/secrets.sh
@@ -37,7 +37,7 @@ _secret_token_rbac_names() {
 	local kind=${3}
 
 	kubectl -n "$namespace" get "$kind" -l "secrets.juju.is/consumer=${consumer}" -o json |
-		yq -r '.items[].metadata.name | select(startswith("juju-secret-consumer-"))' |
+		yq -r '.items[].metadata.name | select(test("^juju-secret-consumer-"))' |
 		sort |
 		paste -sd, -
 }
@@ -63,7 +63,7 @@ secret_token_rbac_snapshot() {
 # list; empty input returns zero.
 _secret_token_rbac_csv_count() {
 	local csv=${1}
-	if [[ -z "$csv" ]]; then
+	if [[ -z $csv ]]; then
 		echo 0
 		return
 	fi
@@ -84,9 +84,9 @@ secret_token_rbac_assert_singleton() {
 	roles=$(echo "$snapshot" | awk -F= '/^roles=/{print $2}')
 	rolebindings=$(echo "$snapshot" | awk -F= '/^rolebindings=/{print $2}')
 
-	if [[ $(_secret_token_rbac_csv_count "$serviceaccounts") -ne 1 || \
-		$(_secret_token_rbac_csv_count "$roles") -ne 1 || \
-		$(_secret_token_rbac_csv_count "$rolebindings") -ne 1 ]]; then
+	if [[ $(_secret_token_rbac_csv_count "$serviceaccounts") -ne 1 ||
+	$(_secret_token_rbac_csv_count "$roles") -ne 1 ||
+	$(_secret_token_rbac_csv_count "$rolebindings") -ne 1 ]]; then
 		echo "Failed: expected exactly one token serviceaccount/role/rolebinding for $context."
 		echo "$snapshot"
 		return 1
@@ -100,7 +100,7 @@ secret_token_rbac_assert_reused() {
 	local after_snapshot=${2}
 	local context=${3}
 
-	if [[ "$before_snapshot" != "$after_snapshot" ]]; then
+	if [[ $before_snapshot != "$after_snapshot" ]]; then
 		echo "Failed: token RBAC resources changed while validating reuse for $context."
 		echo "Before:"
 		echo "$before_snapshot"
@@ -109,4 +109,3 @@ secret_token_rbac_assert_reused() {
 		return 1
 	fi
 }
-

--- a/tests/suites/secrets_k8s/cmr.sh
+++ b/tests/suites/secrets_k8s/cmr.sh
@@ -27,10 +27,6 @@ run_secrets_cmr() {
 	echo "Checking:  secret-get by URI - consume content"
 	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
 
-	sink_consumer='unit-sink-0'
-	sink_token_rbac_before=$(secret_token_rbac_snapshot "model-secrets-consume" "$sink_consumer")
-	secret_token_rbac_assert_singleton "$sink_token_rbac_before" "$sink_consumer"
-
 	echo "Checking: add a new revision and check consumer can see it"
 	juju switch "model-secrets-offer"
 	juju exec --unit source/0 -- secret-set "$secret_uri" foo=bar2
@@ -40,8 +36,6 @@ run_secrets_cmr() {
 	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
 	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel --refresh)" 'foo: bar2'
 	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar2'
-	sink_token_rbac_after=$(secret_token_rbac_snapshot "model-secrets-consume" "$sink_consumer")
-	secret_token_rbac_assert_reused "$sink_token_rbac_before" "$sink_token_rbac_after" "$sink_consumer repeated secret-get"
 
 	echo "Checking: suspend relation and check access is lost"
 	juju switch "model-secrets-offer"

--- a/tests/suites/secrets_k8s/cmr.sh
+++ b/tests/suites/secrets_k8s/cmr.sh
@@ -27,6 +27,10 @@ run_secrets_cmr() {
 	echo "Checking:  secret-get by URI - consume content"
 	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
 
+	sink_consumer='unit-sink-0'
+	sink_token_rbac_before=$(secret_token_rbac_snapshot "model-secrets-consume" "$sink_consumer")
+	secret_token_rbac_assert_singleton "$sink_token_rbac_before" "$sink_consumer"
+
 	echo "Checking: add a new revision and check consumer can see it"
 	juju switch "model-secrets-offer"
 	juju exec --unit source/0 -- secret-set "$secret_uri" foo=bar2
@@ -36,6 +40,8 @@ run_secrets_cmr() {
 	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
 	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel --refresh)" 'foo: bar2'
 	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar2'
+	sink_token_rbac_after=$(secret_token_rbac_snapshot "model-secrets-consume" "$sink_consumer")
+	secret_token_rbac_assert_reused "$sink_token_rbac_before" "$sink_token_rbac_after" "$sink_consumer repeated secret-get"
 
 	echo "Checking: suspend relation and check access is lost"
 	juju switch "model-secrets-offer"

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -91,6 +91,10 @@ run_secrets() {
 	echo "Set a consumer label for the app owned secret $app_owned_full_uri."
 	juju exec --unit hello/0 -- secret-get "$app_owned_full_uri" --label=hello-app
 
+	hello_consumer='unit-hello-0'
+	hello_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$hello_consumer")
+	secret_token_rbac_assert_singleton "$hello_token_rbac_before" "$hello_consumer"
+
 	echo "Checking: secret-get by URI - content"
 	check_contains "$(juju exec --unit hello/0 -- secret-get $unit_owned_full_uri)" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit hello/0 -- secret-get $app_owned_full_uri)" 'owned-by: hello-app'
@@ -102,6 +106,8 @@ run_secrets() {
 	echo "Checking: secret-get by label or consumer label - content"
 	check_contains "$(juju exec --unit hello/0 -- secret-get --label=hello_0)" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit hello/0 -- secret-get --label=hello-app)" 'owned-by: hello-app'
+	hello_token_rbac_after=$(secret_token_rbac_snapshot "$model_name" "$hello_consumer")
+	secret_token_rbac_assert_reused "$hello_token_rbac_before" "$hello_token_rbac_after" "$hello_consumer repeated secret-get"
 
 	echo "Checking: secret-info-get by label - metadata"
 	check_contains "$(juju exec --unit hello/0 -- secret-info-get --label=hello_0 --format json | yq ".${unit_owned_short_uri}.label")" hello_0
@@ -110,15 +116,19 @@ run_secrets() {
 	juju exec --unit hello/0 -- secret-grant "$unit_owned_full_uri" -r "$relation_id"
 	juju exec --unit hello/0 -- secret-grant "$app_owned_full_uri" -r "$relation_id"
 
+	world_consumer='unit-world-0'
+	world_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$world_consumer")
+	secret_token_rbac_assert_singleton "$nginx_token_rbac_before" "$world_consumer"
+
 	echo "Checking: secret-get by URI - consume content"
 	check_contains "$(juju exec --unit world/0 -- secret-get "$unit_owned_full_uri")" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit world/0 -- secret-get "$app_owned_full_uri")" 'owned-by: hello-app'
 
-	juju exec --unit world/0 -- secret-get "$unit_owned_full_uri" --label=consumer_label_secret_owned_by_hello_0
-	juju exec --unit world/0 -- secret-get "$app_owned_full_uri" --label=consumer_label_secret_owned_by_hello
-
+	echo "Checking: secret-get by label - consume content"
 	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello_0)" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello)" 'owned-by: hello-app'
+	world_token_rbac_after=$(secret_token_rbac_snapshot "$model_name" "$world_consumer")
+	secret_token_rbac_assert_reused "$world_token_rbac_before" "$world_token_rbac_after" "$world_consumer repeated secret-get"
 
 	check_contains "$(kubectl -n "$model_name" get "secrets/${unit_owned_short_uri}-1" -o json | yq -r '.data["owned-by"]' | base64 -d)" "hello/0"
 	check_contains "$(kubectl -n "$model_name" get "secrets/${app_owned_short_uri}-1" -o json | yq -r '.data["owned-by"]' | base64 -d)" "hello-app"
@@ -168,6 +178,10 @@ run_user_secrets() {
 	juju --show-log grant-secret "$secret_uri" snappass-test
 	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
 
+	snappass_consumer='unit-snappass-test-0'
+	snappass_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$snappass_consumer")
+	secret_token_rbac_assert_singleton "$snappass_token_rbac_before" "$snappass_consumer"
+
 	# create a new revision 3.
 	juju --show-log update-secret "$secret_uri" owned-by="$model_name-3"
 
@@ -193,6 +207,8 @@ run_user_secrets() {
 	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri --peek)" "owned-by: $model_name-3"
 	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri --refresh)" "owned-by: $model_name-3"
 	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-3"
+	snappass_token_rbac_after=$(secret_token_rbac_snapshot "$model_name" "$snappass_consumer")
+	secret_token_rbac_assert_reused "$snappass_token_rbac_before" "$snappass_token_rbac_after" "$snappass_consumer repeated secret-get"
 
 	# revision 2 should be pruned.
 	# revision 3 is the latest revision, so it should not be pruned.

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -91,10 +91,6 @@ run_secrets() {
 	echo "Set a consumer label for the app owned secret $app_owned_full_uri."
 	juju exec --unit hello/0 -- secret-get "$app_owned_full_uri" --label=hello-app
 
-	hello_consumer='unit-hello-0'
-	hello_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$hello_consumer")
-	secret_token_rbac_assert_singleton "$hello_token_rbac_before" "$hello_consumer"
-
 	echo "Checking: secret-get by URI - content"
 	check_contains "$(juju exec --unit hello/0 -- secret-get $unit_owned_full_uri)" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit hello/0 -- secret-get $app_owned_full_uri)" 'owned-by: hello-app'
@@ -106,8 +102,6 @@ run_secrets() {
 	echo "Checking: secret-get by label or consumer label - content"
 	check_contains "$(juju exec --unit hello/0 -- secret-get --label=hello_0)" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit hello/0 -- secret-get --label=hello-app)" 'owned-by: hello-app'
-	hello_token_rbac_after=$(secret_token_rbac_snapshot "$model_name" "$hello_consumer")
-	secret_token_rbac_assert_reused "$hello_token_rbac_before" "$hello_token_rbac_after" "$hello_consumer repeated secret-get"
 
 	echo "Checking: secret-info-get by label - metadata"
 	check_contains "$(juju exec --unit hello/0 -- secret-info-get --label=hello_0 --format json | yq ".${unit_owned_short_uri}.label")" hello_0
@@ -116,10 +110,6 @@ run_secrets() {
 	juju exec --unit hello/0 -- secret-grant "$unit_owned_full_uri" -r "$relation_id"
 	juju exec --unit hello/0 -- secret-grant "$app_owned_full_uri" -r "$relation_id"
 
-	world_consumer='unit-world-0'
-	world_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$world_consumer")
-	secret_token_rbac_assert_singleton "$nginx_token_rbac_before" "$world_consumer"
-
 	echo "Checking: secret-get by URI - consume content"
 	check_contains "$(juju exec --unit world/0 -- secret-get "$unit_owned_full_uri")" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit world/0 -- secret-get "$app_owned_full_uri")" 'owned-by: hello-app'
@@ -127,8 +117,6 @@ run_secrets() {
 	echo "Checking: secret-get by label - consume content"
 	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello_0)" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello)" 'owned-by: hello-app'
-	world_token_rbac_after=$(secret_token_rbac_snapshot "$model_name" "$world_consumer")
-	secret_token_rbac_assert_reused "$world_token_rbac_before" "$world_token_rbac_after" "$world_consumer repeated secret-get"
 
 	check_contains "$(kubectl -n "$model_name" get "secrets/${unit_owned_short_uri}-1" -o json | yq -r '.data["owned-by"]' | base64 -d)" "hello/0"
 	check_contains "$(kubectl -n "$model_name" get "secrets/${app_owned_short_uri}-1" -o json | yq -r '.data["owned-by"]' | base64 -d)" "hello-app"
@@ -151,6 +139,59 @@ run_secrets() {
 	juju --show-log remove-relation world hello
 	# wait for relation removed.
 	wait_for null '.applications["world"] | .relations.self-metrics-endpoint[0]'
+	destroy_model "$model_name"
+}
+
+run_secrets_token_reuse() {
+	echo
+
+	model_name='model-secrets-k8s-token-reuse'
+	juju --show-log add-model "$model_name" --config secret-backend=auto
+
+	juju --show-log deploy prometheus-k8s hello --trust
+	juju --show-log deploy prometheus-k8s world --trust
+	juju --show-log integrate world:metrics-endpoint hello:self-metrics-endpoint
+
+	wait_for "hello" "$(active_idle_condition "hello" 0 0)"
+	wait_for "world" "$(active_idle_condition "world" 1 0)"
+	wait_for "hello" '.applications["world"] | .relations.metrics-endpoint[0].related-application'
+
+	echo "Apps deployed, creating secrets"
+	unit_owned_full_uri=$(juju exec --unit hello/0 -- secret-add --owner unit owned-by=hello/0)
+	unit_owned_short_uri=${unit_owned_full_uri##*/}
+	app_owned_full_uri=$(juju exec --unit hello/0 -- secret-add owned-by=hello-app)
+	app_owned_short_uri=${app_owned_full_uri##*/}
+
+	# Perform one secret-get to establish the sa/role/rolebinding.
+	juju exec --unit hello/0 -- secret-get "$app_owned_full_uri" --label=hello-app
+
+	hello_consumer='unit-hello-0'
+	hello_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$hello_consumer")
+	secret_token_rbac_assert_singleton "$hello_token_rbac_before" "$hello_consumer"
+
+	check_contains "$(juju exec --unit hello/0 -- secret-get $unit_owned_full_uri)" 'owned-by: hello/0'
+	check_contains "$(juju exec --unit hello/0 -- secret-get $app_owned_full_uri)" 'owned-by: hello-app'
+
+	hello_token_rbac_after=$(secret_token_rbac_snapshot "$model_name" "$hello_consumer")
+	secret_token_rbac_assert_reused "$hello_token_rbac_before" "$hello_token_rbac_after" "$hello_consumer repeated secret-get"
+
+	relation_id=$(juju --show-log show-unit hello/0 --format json | yq '."hello/0"."relation-info"[1]."relation-id"')
+	juju exec --unit hello/0 -- secret-grant "$unit_owned_full_uri" -r "$relation_id"
+	juju exec --unit hello/0 -- secret-grant "$app_owned_full_uri" -r "$relation_id"
+
+	# Perform one secret-get to establish the sa/role/rolebinding.
+	check_contains "$(juju exec --unit world/0 -- secret-get "$unit_owned_full_uri")" 'owned-by: hello/0'
+
+	world_consumer='unit-world-0'
+	world_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$world_consumer")
+	secret_token_rbac_assert_singleton "$world_token_rbac_before" "$world_consumer"
+
+	check_contains "$(juju exec --unit world/0 -- secret-get "$unit_owned_full_uri")" 'owned-by: hello/0'
+	check_contains "$(juju exec --unit world/0 -- secret-get "$app_owned_full_uri")" 'owned-by: hello-app'
+
+	world_token_rbac_after=$(secret_token_rbac_snapshot "$model_name" "$world_consumer")
+	secret_token_rbac_assert_reused "$world_token_rbac_before" "$world_token_rbac_after" "$world_consumer repeated secret-get"
+
 	destroy_model "$model_name"
 }
 
@@ -442,6 +483,21 @@ test_secrets() {
 		cd .. || exit
 
 		run "run_secrets"
+	)
+}
+
+test_secrets_token_reuse() {
+	if [ "$(skip 'test_secrets_token_reuse')" ]; then
+		echo "==> TEST SKIPPED: test_secrets_token_reuse"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_secrets_token_reuse"
 	)
 }
 

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -115,6 +115,8 @@ run_secrets() {
 	check_contains "$(juju exec --unit world/0 -- secret-get "$app_owned_full_uri")" 'owned-by: hello-app'
 
 	echo "Checking: secret-get by label - consume content"
+	juju exec --unit world/0 -- secret-get "$unit_owned_full_uri" --label=consumer_label_secret_owned_by_hello_0
+	juju exec --unit world/0 -- secret-get "$app_owned_full_uri" --label=consumer_label_secret_owned_by_hello
 	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello_0)" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello)" 'owned-by: hello-app'
 
@@ -218,10 +220,6 @@ run_user_secrets() {
 	juju --show-log grant-secret "$secret_uri" snappass-test
 	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
 
-	snappass_consumer='unit-snappass-test-0'
-	snappass_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$snappass_consumer")
-	secret_token_rbac_assert_singleton "$snappass_token_rbac_before" "$snappass_consumer"
-
 	# create a new revision 3.
 	juju --show-log update-secret "$secret_uri" owned-by="$model_name-3"
 
@@ -247,8 +245,6 @@ run_user_secrets() {
 	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri --peek)" "owned-by: $model_name-3"
 	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri --refresh)" "owned-by: $model_name-3"
 	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-3"
-	snappass_token_rbac_after=$(secret_token_rbac_snapshot "$model_name" "$snappass_consumer")
-	secret_token_rbac_assert_reused "$snappass_token_rbac_before" "$snappass_token_rbac_after" "$snappass_consumer repeated secret-get"
 
 	# revision 2 should be pruned.
 	# revision 3 is the latest revision, so it should not be pruned.

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -167,7 +167,6 @@ run_secrets_token_reuse() {
 
 	hello_consumer='unit-hello-0'
 	hello_token_rbac_before=$(secret_token_rbac_snapshot "$model_name" "$hello_consumer")
-	secret_token_rbac_assert_singleton "$hello_token_rbac_before" "$hello_consumer"
 
 	check_contains "$(juju exec --unit hello/0 -- secret-get $unit_owned_full_uri)" 'owned-by: hello/0'
 	check_contains "$(juju exec --unit hello/0 -- secret-get $app_owned_full_uri)" 'owned-by: hello-app'

--- a/tests/suites/secrets_k8s/task.sh
+++ b/tests/suites/secrets_k8s/task.sh
@@ -25,6 +25,7 @@ test_secrets_k8s() {
 	bootstrap "test-secrets-k8s" "${file}"
 
 	test_secrets
+	test_secrets_token_reuse
 	test_secret_drain
 	test_user_secrets
 	test_user_secret_drain


### PR DESCRIPTION
When a unit agent needs to access a secret, artefacts are created to confer access. On k8s for example, we create a service account/role/rolebinding. These so called tokens are single use only. But on busy systems, 1000s  can get created which causes issues.

This PR reuses tokens where possible. They still expire, and a new one is created if needed, but if the scope of the required access matches an existing token, that will be used.

The core changes:
- create a hash of the secret IDs which the token provides access for
- store the hash with the token record in state
- make the artefact creation in k8s idempotent (it already is in vault)
- add guard rails to ensure the access scope of reused artefacts is not changed accidentally

The changes here work both in hook (where 2 secret access operations are done in the same hook), and across hooks (where an access operation is done in a subsequent hook).

With this change, we can remove the code to delete access tokens on hook commit.

Drive by: fix flakey remote relations worker tests.

## QA steps

Secrets shell tests have been updated to check that tokens are reused.
`./main.sh -v -p k8s secrets_k8s`

## Links

**Issue:** Fixes #22384.

**Jira card:** [JUJU-9821](https://warthogs.atlassian.net/browse/JUJU-9821)


[JUJU-9821]: https://warthogs.atlassian.net/browse/JUJU-9821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ