### PR TITLE
fix: removal of ambigous singular relations

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1433,7 +1433,11 @@ func (api *APIBase) DestroyRelation(ctx context.Context, args params.DestroyRela
 		RelationID: args.RelationId,
 	}
 	relUUID, err := api.relationService.GetRelationUUIDForRemoval(ctx, getUUIDArgs)
-	if err != nil {
+	if errors.Is(err, relationerrors.RelationNotFound) {
+		return errors.NotFoundf("relation with endpoints %v or id %d", args.Endpoints, args.RelationId)
+	} else if errors.Is(err, relationerrors.AmbiguousRelation) {
+		return errors.BadRequestf("endpoints %q are ambiguous, specify relation endpoints or id", args.Endpoints)
+	} else if err != nil {
 		return internalerrors.Capture(err)
 	}
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1356,7 +1356,7 @@ func (s *applicationSuite) TestDestroyRelationRelationNotFound(c *tc.C) {
 	err := s.api.DestroyRelation(c.Context(), arg)
 
 	// Assert
-	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
+	c.Assert(err, tc.Satisfies, errors.IsNotFound)
 }
 
 func (s *applicationSuite) TestDestroyRelationByID(c *tc.C) {

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -976,6 +976,8 @@ func (s *Service) GetRelationUUIDByKey(ctx context.Context, relationKey corerela
 // The following error types can be expected to be returned:
 //   - [relationerrors.RelationNotFound] is returned if endpoints cannot be
 //     found.
+//   - [relationerrors.AmbiguousRelation] is returned if multiple existing
+//     relations are found between the two applications.
 func (s *Service) GetRelationUUIDForRemoval(
 	ctx context.Context,
 	args relation.GetRelationUUIDForRemovalArgs,
@@ -1015,6 +1017,8 @@ func (s *Service) GetRelationUUIDForRemoval(
 // The following error types can be expected to be returned:
 //   - [relationerrors.RelationNotFound] is returned if endpoints cannot be
 //     found.
+//   - [relationerrors.AmbiguousRelation] is returned if multiple existing
+//     relations are found between the two applications.
 func (s *Service) inferRelationUUIDByEndpoints(ctx context.Context, ep1, ep2 string) (corerelation.UUID, error) {
 	idep1, err := relation.NewCandidateEndpointIdentifier(ep1)
 	if err != nil {

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -157,9 +157,19 @@ func (st *State) AddRelation(
 
 // InferRelationUUIDByEndpoints infers the relation based on two endpoints.
 //
+// When the endpoint identifiers are not fully qualified (i.e., no endpoint
+// name is specified), this method first attempts to infer the relation from
+// charm metadata. If this results in ambiguity (multiple possible endpoint
+// pairs), it falls back to querying existing relations between the two
+// applications directly. This handles the common case where a user specifies
+// only application names for removal and there is a single existing relation
+// between them.
+//
 // The following error types can be expected to be returned:
 //   - [relationerrors.RelationNotFound] is returned if endpoints cannot be
 //     found.
+//   - [relationerrors.AmbiguousRelation] is returned if multiple existing
+//     relations are found between the two applications.
 func (st *State) InferRelationUUIDByEndpoints(
 	ctx context.Context,
 	epIdentifier1, epIdentifier2 domainrelation.CandidateEndpointIdentifier,
@@ -172,10 +182,21 @@ func (st *State) InferRelationUUIDByEndpoints(
 	var potentialUUIDs []relationUUID
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		ep1, ep2, err := st.inferEndpoints(ctx, tx, epIdentifier1, epIdentifier2)
-		if errors.Is(err, relationerrors.CompatibleEndpointsNotFound) ||
-			errors.Is(err, relationerrors.RelationEndpointNotFound) ||
-			errors.Is(err, relationerrors.AmbiguousRelation) {
+		if errors.IsOneOf(err,
+			relationerrors.CompatibleEndpointsNotFound,
+			relationerrors.RelationEndpointNotFound,
+		) {
 			return relationerrors.RelationNotFound
+		} else if errors.Is(err, relationerrors.AmbiguousRelation) {
+			// Charm metadata yields multiple compatible endpoint pairs.
+			// Fall back to checking which relations actually exist between
+			// the two applications.
+			potentialUUIDs, err = st.getExistingRegularRelationUUIDBetweenApplications(
+				ctx, tx,
+				epIdentifier1.ApplicationName,
+				epIdentifier2.ApplicationName,
+			)
+			return err
 		} else if err != nil {
 			return errors.Errorf("inferring endpoints: %w", err)
 		}
@@ -196,12 +217,19 @@ func (st *State) InferRelationUUIDByEndpoints(
 		return "", errors.Capture(err)
 	}
 
-	if len(potentialUUIDs) > 1 {
-		// This should never happen.
-		return "", errors.Errorf("found multiple relations for endpoint pair")
+	switch len(potentialUUIDs) {
+	case 0:
+		return "", relationerrors.RelationNotFound
+	case 1:
+		return corerelation.UUID(potentialUUIDs[0].UUID), nil
+	default:
+		return "", errors.Errorf(
+			"%w: multiple relations exist between %q and %q",
+			relationerrors.AmbiguousRelation,
+			epIdentifier1.ApplicationName,
+			epIdentifier2.ApplicationName,
+		)
 	}
-
-	return corerelation.UUID(potentialUUIDs[0].UUID), nil
 }
 
 func (st *State) addRelation(
@@ -1065,6 +1093,57 @@ AND    e2.endpoint_name    = $endpointIdentifier2.endpoint_name
 		return uuid, relationerrors.RelationNotFound
 	}
 	return uuid, errors.Capture(err)
+}
+
+// getExistingRegularRelationUUIDBetweenApplications queries for all existing
+// non-peer relations between two applications identified by name. A non-peer
+// relation is one that has endpoints from two distinct applications. This is
+// used as a fallback when endpoint inference from charm metadata is ambiguous
+// but the user has specified only application names for relation removal.
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.RelationNotFound] is returned if no existing relation
+//     is found between the two applications.
+func (st *State) getExistingRegularRelationUUIDBetweenApplications(
+	ctx context.Context,
+	tx *sqlair.TX,
+	appName1, appName2 string,
+) ([]relationUUID, error) {
+	type applicationName1 struct {
+		Name string `db:"application_name"`
+	}
+	type applicationName2 struct {
+		Name string `db:"application_name"`
+	}
+	a1 := applicationName1{Name: appName1}
+	a2 := applicationName2{Name: appName2}
+
+	// Find relations that have endpoints from both applications. The INNER
+	// JOIN on two distinct endpoints of the same relation guarantees we only
+	// return regular (non-peer) relations, since peer relations have a
+	// single endpoint.
+	stmt, err := st.Prepare(`
+SELECT DISTINCT r.uuid AS &relationUUID.uuid
+FROM   relation r
+JOIN   v_relation_endpoint_identifier e1 ON r.uuid = e1.relation_uuid
+JOIN   v_relation_endpoint_identifier e2 ON r.uuid = e2.relation_uuid
+WHERE  e1.application_name = $applicationName1.application_name
+AND    e2.application_name = $applicationName2.application_name
+AND    e1.application_name != e2.application_name
+`, relationUUID{}, a1, a2)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var uuids []relationUUID
+	err = tx.Query(ctx, stmt, a1, a2).GetAll(&uuids)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return nil, relationerrors.RelationNotFound
+	}
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return uuids, nil
 }
 
 // GetPeerRelationUUIDByEndpointIdentifiers gets the UUID of a peer

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -4171,6 +4171,134 @@ func (s *relationSuite) TestInferRelationUUIDByEndpointsFailGetUUID(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
+// TestInferRelationUUIDByEndpointsAmbiguousCharmSingleRelation tests that
+// when charm metadata has multiple compatible endpoint pairs (causing
+// ambiguity in inference), but only ONE relation actually exists between the
+// two applications, InferRelationUUIDByEndpoints successfully falls back to
+// finding the existing relation.
+func (s *relationSuite) TestInferRelationUUIDByEndpointsAmbiguousCharmSingleRelation(c *tc.C) {
+	// Arrange: Create two endpoints on app1 that can both relate to app2's
+	// endpoint (same interface, provider/requirer pair). This causes
+	// ambiguity during inference from charm metadata.
+	relation1a := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "postgresql_client",
+		Scope:     charm.ScopeGlobal,
+	}
+	relation1b := charm.Relation{
+		Name:      "db-admin",
+		Role:      charm.RoleProvider,
+		Interface: "postgresql_client",
+		Scope:     charm.ScopeGlobal,
+	}
+	relation2a := charm.Relation{
+		Name:      "database",
+		Role:      charm.RoleRequirer,
+		Interface: "postgresql_client",
+		Scope:     charm.ScopeGlobal,
+	}
+
+	charmRelUUID1a := s.addCharmRelation(c, s.fakeCharmUUID1, relation1a)
+	charmRelUUID1b := s.addCharmRelation(c, s.fakeCharmUUID1, relation1b)
+	_ = charmRelUUID1b // used only to create ambiguity in charm metadata
+	charmRelUUID2a := s.addCharmRelation(c, s.fakeCharmUUID2, relation2a)
+	s.addCharmMetadata(c, s.fakeCharmUUID1, false)
+	s.addCharmMetadata(c, s.fakeCharmUUID2, false)
+
+	// Create application endpoints and a single actual relation between
+	// app1:db and app2:database.
+	appEndpointUUID1a := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelUUID1a)
+	s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelUUID1b)
+	appEndpointUUID2a := s.addApplicationEndpoint(c, s.fakeApplicationUUID2, charmRelUUID2a)
+
+	relUUID := s.addRelation(c)
+	s.addRelationEndpoint(c, relUUID, appEndpointUUID1a)
+	s.addRelationEndpoint(c, relUUID, appEndpointUUID2a)
+
+	candidate1 := domainrelation.CandidateEndpointIdentifier{
+		ApplicationName: s.fakeApplicationName1,
+	}
+	candidate2 := domainrelation.CandidateEndpointIdentifier{
+		ApplicationName: s.fakeApplicationName2,
+	}
+
+	// Act
+	obtainedUUID, err := s.state.InferRelationUUIDByEndpoints(c.Context(), candidate1, candidate2)
+
+	// Assert: despite ambiguity in charm metadata, falls back to the single
+	// existing relation.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtainedUUID, tc.Equals, relUUID)
+}
+
+// TestInferRelationUUIDByEndpointsAmbiguousMultipleExisting tests that when
+// charm metadata is ambiguous AND multiple relations actually exist between
+// the two applications, AmbiguousRelation is returned.
+func (s *relationSuite) TestInferRelationUUIDByEndpointsAmbiguousMultipleExisting(c *tc.C) {
+	// Arrange: Create two endpoints on app1 that can relate to two
+	// endpoints on app2.
+	relation1a := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "postgresql_client",
+		Scope:     charm.ScopeGlobal,
+	}
+	relation1b := charm.Relation{
+		Name:      "db-admin",
+		Role:      charm.RoleProvider,
+		Interface: "postgresql_client",
+		Scope:     charm.ScopeGlobal,
+	}
+	relation2a := charm.Relation{
+		Name:      "database",
+		Role:      charm.RoleRequirer,
+		Interface: "postgresql_client",
+		Scope:     charm.ScopeGlobal,
+	}
+	relation2b := charm.Relation{
+		Name:      "first-database",
+		Role:      charm.RoleRequirer,
+		Interface: "postgresql_client",
+		Scope:     charm.ScopeGlobal,
+	}
+
+	charmRelUUID1a := s.addCharmRelation(c, s.fakeCharmUUID1, relation1a)
+	charmRelUUID1b := s.addCharmRelation(c, s.fakeCharmUUID1, relation1b)
+	charmRelUUID2a := s.addCharmRelation(c, s.fakeCharmUUID2, relation2a)
+	charmRelUUID2b := s.addCharmRelation(c, s.fakeCharmUUID2, relation2b)
+	s.addCharmMetadata(c, s.fakeCharmUUID1, false)
+	s.addCharmMetadata(c, s.fakeCharmUUID2, false)
+
+	// Create application endpoints for both pairs.
+	appEndpointUUID1a := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelUUID1a)
+	appEndpointUUID1b := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelUUID1b)
+	appEndpointUUID2a := s.addApplicationEndpoint(c, s.fakeApplicationUUID2, charmRelUUID2a)
+	appEndpointUUID2b := s.addApplicationEndpoint(c, s.fakeApplicationUUID2, charmRelUUID2b)
+
+	// Create TWO actual relations.
+	relUUID1 := s.addRelation(c)
+	s.addRelationEndpoint(c, relUUID1, appEndpointUUID1a)
+	s.addRelationEndpoint(c, relUUID1, appEndpointUUID2a)
+
+	relUUID2 := s.addRelation(c)
+	s.addRelationEndpoint(c, relUUID2, appEndpointUUID1b)
+	s.addRelationEndpoint(c, relUUID2, appEndpointUUID2b)
+
+	candidate1 := domainrelation.CandidateEndpointIdentifier{
+		ApplicationName: s.fakeApplicationName1,
+	}
+	candidate2 := domainrelation.CandidateEndpointIdentifier{
+		ApplicationName: s.fakeApplicationName2,
+	}
+
+	// Act
+	_, err := s.state.InferRelationUUIDByEndpoints(c.Context(), candidate1, candidate2)
+
+	// Assert: multiple existing relations → ambiguous.
+	c.Assert(err, tc.ErrorIs, relationerrors.AmbiguousRelation)
+}
+
 func (s *relationSuite) TestInsertRelationUnitHappyPath(c *tc.C) {
 	// Arrange: Add a relation with endpoints
 	relationUUID := s.addRelation(c)


### PR DESCRIPTION
If providing no endpoints for relation removal, and there is some potential ambiguity when removing it, we should check if there is a singular relation backing that ambiguity. If there is only one relation then that issue becomes a moot point and we know what the user meant.

This is how 3.6 was working (although the code was different), and we should remain compatible where possible.


## QA steps

```sh
$ juju bootstrap lxd src
$ juju deploy postgresql --channel 16/edge --force
$ juju deploy postgresql-test-app
$ juju relate postgresql postgresql-test-app:database
$ juju remove-relation postgresql postgresql-test-app
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/22386

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9823](https://warthogs.atlassian.net/browse/JUJU-9823)


[JUJU-9823]: https://warthogs.atlassian.net/browse/JUJU-9823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ