### PR TITLE
feat: add step to transition guide for storage pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ tests/tmp.*
 *.log
 dqlite-deps.tar.bz2
 .envrc
+.codex

--- a/docs/howto/upgrade-your-juju-deployment-from-36-to-40.md
+++ b/docs/howto/upgrade-your-juju-deployment-from-36-to-40.md
@@ -363,3 +363,21 @@ watch --color -n 1 juju status --color
 viddy juju status
 ```
 
+### 14. Volume-backed storage pools are preferred by default
+
+Where possible, Juju defaults to use volume-backed storage pools to create filesystems.
+
+**Juju 3.6**
+```bash
+juju deploy postgresql --storage pgdata=10G
+# This will result in a `rootfs` filesystem
+```
+
+**Juju 4.0**
+```bash
+juju deploy postgresql --storage pgdata=10G
+# This will result in `ebs`, `azure`, `gce`, `cinder`, etc. volume-backed filesystems for the providers `aws`, `azure`, `gce`, `openstack`, etc. respectively
+
+# To replicate the 3.6 behaviour, set the storage pool to `rootfs` in the storage directive
+juju deploy postgresql --storage pgdata=rootfs,10G
+```


### PR DESCRIPTION
In 3.6 there was a bug that meant juju would always default to the rootfs storage pool for filesystems. In 4.0 this behaviour was not carried across, thus fixed.

But since this is a change in behaviour, we need to include it in our upgrade from 3.6 to 4.0 guide