### PR TITLE
ci: require agents to read PR template before opening a PR

### DIFF
--- a/.github/instructions/agent-commit.instructions.md
+++ b/.github/instructions/agent-commit.instructions.md
@@ -86,6 +86,13 @@ docs: add CLA requirements to contributing guidelines
 - **PRs with non-compliant commits will be blocked** by commitlint in CI
 - Validation runs automatically via `.github/commitlint.config.mjs`
 
+## Pull Request Description
+
+When creating a pull request, you MUST read `PULL_REQUEST_TEMPLATE.md` at the
+repository root and use it as the structure for the PR description. Fill in
+each section according to the changes being made. Do not omit sections; use
+strikethrough (`~text~`) for items that are not applicable.
+
 ## References
 
 - [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)


### PR DESCRIPTION
Agents were not reading the PR template when opening pull requests, requiring manual reminders each time. This change adds an explicit instruction in the agent commit guidelines to read `PULL_REQUEST_TEMPLATE.md` and use it as the structure for PR descriptions.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] Integration tests, with comments saying what you're testing~
- ~[ ] doc.go added or updated in changed packages~

## QA steps

This PR is its own QA — the agent read the template and filled this description correctly without being prompted.

```
  ________
 /   PR   \
|  ______  |
| |TMPL  | |   ✓ read
| |......| |   ✓ filled
| |......| |   ✓ nailed it
|  ------  |
 \________/
     ||
   agent
```

## Documentation changes

~N/A~

## Links

~N/A~