### PR TITLE
chore: add required gci import ordering steps to coding guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,20 @@ robustness.
 - `go test -run 'TestName' ./path/to/package` — Run specific test.
 - `make pre-check` — Static analysis (golangci-lint). Run before submitting.
 
+## Code Formatting
+
+After editing any Go file, MUST run `gci` to fix import ordering before
+committing. The project uses three import stanzas: stdlib, external, then
+`github.com/juju/juju` — each separated by a blank line.
+
+```
+gci write --section standard --section default --section "Prefix(github.com/juju/juju)" <file>
+```
+
+Run on every `.go` file touched in the change, excluding generated files
+(mocks, `*_mock_test.go`, etc.). Failing to do so will cause the `gci`
+linter to fail in CI.
+
 ### Running `stress` Tests
 
 Compile the go package into a binary and run the test through stress.


### PR DESCRIPTION
## Summary

Add a **Code Formatting** section to `AGENTS.md` instructing agents to run `gci` on every non-generated Go file they touch before committing.

## Motivation

Missing `gci` formatting caused a CI failure in #22236 (`domain/access/state/types.go` had imports in the wrong order). This rule ensures agents won't repeat that mistake.

## Change

- Documents the three-section `gci` invocation matching the project's `.golangci.yml` config
- Explicitly excludes generated files (mocks, `*_mock_test.go`)