### PR TITLE
fix(relation): restore stable relation-info order

### DIFF
--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -3839,8 +3839,10 @@ SELECT r.uuid AS &relationIDUUIDAppName.uuid,
 FROM   relation AS r
 JOIN   relation_endpoint AS re ON r.uuid = re.relation_uuid
 JOIN   application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
+JOIN   charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
 JOIN   application AS a ON ae.application_uuid = a.uuid
 WHERE  a.uuid = $entityUUID.uuid
+ORDER BY cr.role_id, r.relation_id
 `, relationIDUUIDAppName{}, entityUUID{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -3817,7 +3817,7 @@ func (s *relationSuite) TestApplicationRelationsInfo(c *tc.C) {
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(results, tc.HasLen, 2)
-	c.Assert(results, tc.SameContents, expectedData)
+	c.Assert(results, tc.DeepEquals, expectedData)
 }
 
 // TestApplicationRelationsInfo tests getting ApplicationRelationsInfo for
@@ -3869,7 +3869,95 @@ func (s *relationSuite) TestApplicationRelationsInfoPeerRelation(c *tc.C) {
 
 	// Assert:
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(results, tc.SameContents, expectedData)
+	c.Assert(results, tc.DeepEquals, expectedData)
+}
+
+// TestApplicationRelationsInfoPeerRelationLast verifies that a peer relation
+// is ordered after a regular relation for the same application.
+func (s *relationSuite) TestApplicationRelationsInfoPeerRelationLast(c *tc.C) {
+	// Arrange: add application endpoints for the 2 default applications.
+	appEndpoint1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, s.fakeCharmRelationProvidesUUID)
+
+	// Add a third application with 2 units, this is the one tested.
+	charm3 := s.addCharm(c)
+	app3 := s.addApplication(c, charm3, "three")
+	charm3RegularUUID := s.addCharmRelation(c, charm3, charm.Relation{
+		Name:      "relation",
+		Role:      charm.RoleRequirer,
+		Interface: "fake-provides",
+		Scope:     charm.ScopeGlobal,
+	})
+	appEndpoint3 := s.addApplicationEndpoint(c, app3, charm3RegularUUID)
+	charm3PeerUUID := s.addCharmRelation(c, charm3, charm.Relation{
+		Name:  "peer-relation",
+		Role:  charm.RolePeer,
+		Scope: charm.ScopeGlobal,
+	})
+	appEndpointPeer := s.addApplicationEndpoint(c, app3, charm3PeerUUID)
+	unit1 := s.addUnit(c, "three/0", app3, charm3)
+	unit2 := s.addUnit(c, "three/1", app3, charm3)
+
+	// Add a peer relation first, then a regular relation. The result should
+	// still be ordered with the regular relation first and the peer last.
+	relIDPeer := 3
+	relUUIDPeer := s.addRelationWithID(c, relIDPeer)
+	relEndpointPeer := s.addRelationEndpoint(c, relUUIDPeer, appEndpointPeer)
+	_ = s.addRelationUnit(c, unit1, relEndpointPeer)
+	relPeerUnit2 := s.addRelationUnit(c, unit2, relEndpointPeer)
+	s.addRelationUnitSetting(c, relPeerUnit2, "foo", "baz")
+	relPeerData := domainrelation.EndpointRelationData{
+		RelationID:      3,
+		Endpoint:        "peer-relation",
+		RelatedEndpoint: "peer-relation",
+		ApplicationData: map[string]string{},
+		UnitRelationData: map[string]domainrelation.RelationData{
+			"three/0": {
+				InScope:  true,
+				UnitData: map[string]string{},
+			},
+			"three/1": {
+				InScope:  true,
+				UnitData: map[string]string{"foo": "baz"},
+			},
+		},
+	}
+
+	relIDRegular := 4
+	relUUIDRegular := s.addRelationWithID(c, relIDRegular)
+	_ = s.addRelationEndpoint(c, relUUIDRegular, appEndpoint1)
+	relEndpointRegular := s.addRelationEndpoint(c, relUUIDRegular, appEndpoint3)
+	relRegularUnit1 := s.addRelationUnit(c, unit1, relEndpointRegular)
+	relRegularUnit2 := s.addRelationUnit(c, unit2, relEndpointRegular)
+	s.addRelationUnitSetting(c, relRegularUnit1, "foo", "bar")
+	s.addRelationUnitSetting(c, relRegularUnit2, "foo", "baz")
+	relRegularData := domainrelation.EndpointRelationData{
+		RelationID:      4,
+		Endpoint:        "relation",
+		RelatedEndpoint: "fake-provides",
+		ApplicationData: map[string]string{},
+		UnitRelationData: map[string]domainrelation.RelationData{
+			"three/0": {
+				InScope:  true,
+				UnitData: map[string]string{"foo": "bar"},
+			},
+			"three/1": {
+				InScope:  true,
+				UnitData: map[string]string{"foo": "baz"},
+			},
+		},
+	}
+
+	expectedData := []domainrelation.EndpointRelationData{
+		relRegularData,
+		relPeerData,
+	}
+
+	// Act:
+	results, err := s.state.ApplicationRelationsInfo(c.Context(), app3)
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.DeepEquals, expectedData)
 }
 
 func (s *relationSuite) TestApplicationRelationsInfoNoApp(c *tc.C) {


### PR DESCRIPTION
## Why this change is needed

`show-unit` / `relation-info` relation ordering was non-deterministic in 4.0 (backed by dqlite) while 3.6 (backed by PostgreSQL) returned relations in a stable, consistent order — requires relations first, peers last.

The root cause was a missing `ORDER BY` clause in the `getEveryRelationForApplicationID` query in the relation state layer. Without it, the database could return rows in any order, producing unstable output across calls.

## What it does

Adds an explicit `ORDER BY cr.role_id, r.relation_id` to the relation lookup query, which ensures:
- Non-peer (requirer/provider) relations appear before peer relations (matching 3.6 behaviour).
- Stable, deterministic ordering when multiple relations of the same role exist.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap a microk8s controller with the patched binary, deploy the following scenario, and run the CI suite multiple times:

```sh
sudo make go-install && sudo make operator-update

juju bootstrap microk8s qa-mk8s
juju deploy alertmanager-k8s hello --trust
juju deploy nginx-ingress-integrator nginx --trust --config service-hostname=hello.test
juju integrate nginx hello

# Verify stable ordering: ingress before peer relation
juju show-unit hello/0
```

Run the secrets_k8s CI suite (covers `show-unit` relation-id usage):

```sh
cd tests && ./main.sh -l qa-mk8s secrets_k8s run_secrets
```

Repeat the suite run a few times to confirm ordering is stable across calls.

## Documentation changes

No user-visible workflow change — this restores the stable ordering that existed in 3.6.

## Links

**Jira card:** [JUJU-9813](https://warthogs.atlassian.net/browse/JUJU-9813)

[JUJU-9813]: https://warthogs.atlassian.net/browse/JUJU-9813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ