### PR TITLE
feat: loki client library

### DIFF
--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -49,7 +49,8 @@ type Config struct {
 	FlushInterval time.Duration
 
 	// MaxRetries is the maximum number of retry attempts
-	// for a failed push request. Default: 3.
+	// after the initial push request. Set to 0 to disable
+	// retries. Default: 3.
 	MaxRetries int
 
 	// InitialBackoff is the delay before the first retry.
@@ -78,8 +79,8 @@ type Config struct {
 	// other error reporting mechanism.
 	OnError func(error)
 
-	// Clock is passed to the retry logic for testing. If nil, the wall clock is
-	// used.
+	// Clock is passed to the retry logic for testing.
+	// If nil, the wall clock is used.
 	Clock clock.Clock
 }
 
@@ -113,7 +114,8 @@ type Client struct {
 // NewClient creates and starts a new Loki push client worker.
 // The endpoint should be the full URL to the Loki push API
 // (e.g. http://loki:3100/loki/api/v1/push).
-// Zero-value fields in cfg are replaced with defaults.
+// Invalid and unset fields in cfg are replaced with defaults.
+// MaxRetries follows retry-count semantics: 0 disables retries.
 func NewClient(endpoint string, cfg Config) (*Client, error) {
 	if endpoint == "" {
 		return nil, internalerrors.Errorf("endpoint must not be empty")
@@ -132,6 +134,9 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 	}
 	if cfg.MaxBackoff <= 0 {
 		cfg.MaxBackoff = 30 * time.Second
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = clock.WallClock
 	}
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
@@ -159,7 +164,9 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 // size is reached or the flush interval elapses. Push blocks
 // if the internal channel is full, providing backpressure to
 // the caller. Returns tomb.ErrDying if the client is shutting
-// down.
+// down. Push does not deep-copy records, so callers should not
+// mutate record contents (especially Labels maps) after calling
+// this method.
 func (c *Client) Push(records ...Record) error {
 	for _, r := range records {
 		select {
@@ -173,6 +180,7 @@ func (c *Client) Push(records ...Record) error {
 
 // Kill requests the client to stop. Any buffered records are
 // flushed on a best-effort basis before the client exits.
+// Records in-flight during shutdown may be dropped.
 func (c *Client) Kill(reason error) {
 	c.tomb.Kill(reason)
 }
@@ -253,6 +261,9 @@ func (c *Client) flush(ctx context.Context, batch []Record) {
 // cancelled before the goroutine starts, the push is
 // abandoned.
 func (c *Client) flushAsync(ctx context.Context, batch []Record) {
+	batchCopy := make([]Record, len(batch))
+	copy(batchCopy, batch)
+
 	go func() {
 		select {
 		case <-c.tomb.Dying():
@@ -261,7 +272,7 @@ func (c *Client) flushAsync(ctx context.Context, batch []Record) {
 			return
 		default:
 		}
-		c.pushAll(ctx, batch)
+		c.pushAll(ctx, batchCopy)
 	}()
 }
 
@@ -303,8 +314,9 @@ func (c *Client) pushBatch(
 		return internalerrors.Errorf("marshaling payload: %w", err)
 	}
 
+	attempts := c.cfg.MaxRetries + 1
 	err = retry.Call(retry.CallArgs{
-		Attempts: c.cfg.MaxRetries,
+		Attempts: attempts,
 		Delay:    c.cfg.InitialBackoff,
 		MaxDelay: c.cfg.MaxBackoff,
 		Func: func() error {
@@ -364,13 +376,16 @@ func (c *Client) doRequest(
 			msg: fmt.Sprintf("sending request: %s", err),
 		}
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
 	// Read and discard the body to enable connection reuse.
 	if _, err = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024)); err != nil {
 		return &retryableError{
 			msg: fmt.Sprintf("reading response: %s", err),
 		}
 	}
-	_ = resp.Body.Close()
 
 	switch {
 	case resp.StatusCode == http.StatusNoContent ||

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -1,0 +1,453 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package loki
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/retry"
+	"gopkg.in/tomb.v2"
+
+	internalerrors "github.com/juju/juju/internal/errors"
+)
+
+// Record represents a single log entry to push to Loki.
+type Record struct {
+	// Timestamp is when the log entry was produced.
+	Timestamp time.Time
+
+	// Line is the log message text.
+	Line string
+
+	// Labels are the Loki stream labels for this entry.
+	// Records with identical label sets are grouped into
+	// the same stream.
+	Labels map[string]string
+}
+
+// Config holds configuration for the Loki push client.
+type Config struct {
+	// BatchSize is the maximum number of records to
+	// accumulate before flushing to Loki. Default: 100.
+	BatchSize int
+
+	// FlushInterval is how long to wait before flushing
+	// buffered records even if BatchSize hasn't been
+	// reached. Default: 10s.
+	FlushInterval time.Duration
+
+	// MaxRetries is the maximum number of retry attempts
+	// for a failed push request. Default: 3.
+	MaxRetries int
+
+	// InitialBackoff is the delay before the first retry.
+	// Subsequent retries double this value up to MaxBackoff.
+	// Default: 500ms.
+	InitialBackoff time.Duration
+
+	// MaxBackoff is the maximum delay between retries.
+	// Default: 30s.
+	MaxBackoff time.Duration
+
+	// HTTPClient is an optional HTTP client. If nil, a
+	// default client with a 10s timeout is used.
+	HTTPClient *http.Client
+
+	// AsyncFlush controls whether batches are pushed in a
+	// background goroutine. When true (the default), the
+	// loop continues consuming records while HTTP I/O
+	// happens concurrently. When false, each flush blocks
+	// the loop until the push completes.
+	AsyncFlush *bool
+
+	// OnError is called when a push fails after all retry
+	// attempts are exhausted. If nil, errors are silently
+	// dropped. This can be used to write to stderr or any
+	// other error reporting mechanism.
+	OnError func(error)
+
+	// Clock is passed to the retry logic for testing. If nil, the wall clock is
+	// used.
+	Clock clock.Clock
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		BatchSize:      100,
+		FlushInterval:  10 * time.Second,
+		MaxRetries:     3,
+		InitialBackoff: 500 * time.Millisecond,
+		MaxBackoff:     30 * time.Second,
+		Clock:          clock.WallClock,
+	}
+}
+
+// Client is a worker that buffers log records and pushes them
+// to a Loki endpoint. It flushes when the buffer reaches
+// BatchSize or when FlushInterval elapses, whichever comes
+// first. Flushes are asynchronous by default but can be made
+// synchronous via the AsyncFlush configuration option.
+type Client struct {
+	endpoint   string
+	cfg        Config
+	http       *http.Client
+	asyncFlush bool
+	onError    func(error)
+	records    chan Record
+	tomb       tomb.Tomb
+}
+
+// NewClient creates and starts a new Loki push client worker.
+// The endpoint should be the full URL to the Loki push API
+// (e.g. http://loki:3100/loki/api/v1/push).
+// Zero-value fields in cfg are replaced with defaults.
+func NewClient(endpoint string, cfg Config) (*Client, error) {
+	if endpoint == "" {
+		return nil, internalerrors.Errorf("endpoint must not be empty")
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 100
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = 10 * time.Second
+	}
+	if cfg.MaxRetries < 0 {
+		cfg.MaxRetries = 3
+	}
+	if cfg.InitialBackoff <= 0 {
+		cfg.InitialBackoff = 500 * time.Millisecond
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 30 * time.Second
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	onError := cfg.OnError
+	if onError == nil {
+		onError = func(error) {}
+	}
+	asyncFlush := cfg.AsyncFlush == nil || *cfg.AsyncFlush
+	c := &Client{
+		endpoint:   endpoint,
+		cfg:        cfg,
+		http:       httpClient,
+		asyncFlush: asyncFlush,
+		onError:    onError,
+		records:    make(chan Record, cfg.BatchSize),
+	}
+	c.tomb.Go(c.loop)
+	return c, nil
+}
+
+// Push sends records to the client for delivery to Loki.
+// Records are buffered internally and flushed when the batch
+// size is reached or the flush interval elapses. Push blocks
+// if the internal channel is full, providing backpressure to
+// the caller. Returns tomb.ErrDying if the client is shutting
+// down.
+func (c *Client) Push(records ...Record) error {
+	for _, r := range records {
+		select {
+		case c.records <- r:
+		case <-c.tomb.Dying():
+			return tomb.ErrDying
+		}
+	}
+	return nil
+}
+
+// Kill requests the client to stop. Any buffered records are
+// flushed on a best-effort basis before the client exits.
+func (c *Client) Kill(reason error) {
+	c.tomb.Kill(reason)
+}
+
+// Wait blocks until the client has stopped.
+func (c *Client) Wait() error {
+	return c.tomb.Wait()
+}
+
+// loop is the main worker loop. It accumulates records from
+// the channel into a buffer, flushing when the batch size is
+// reached or the flush interval timer fires. On shutdown, it
+// drains any remaining records from the channel and performs
+// a best-effort flush with a timeout.
+func (c *Client) loop() error {
+	buffer := make([]Record, 0, c.cfg.BatchSize)
+	timer := time.NewTimer(c.cfg.FlushInterval)
+	defer timer.Stop()
+
+	ctx := c.tomb.Context(context.Background())
+
+	for {
+		select {
+		case <-c.tomb.Dying():
+			c.drainChannel(&buffer)
+			if len(buffer) > 0 {
+				ctx, cancel := context.WithTimeout(
+					context.Background(), 5*time.Second,
+				)
+				defer cancel()
+				c.pushAll(ctx, buffer)
+			}
+			return tomb.ErrDying
+
+		case r := <-c.records:
+			buffer = append(buffer, r)
+			if len(buffer) >= c.cfg.BatchSize {
+				c.flush(ctx, buffer)
+				buffer = make([]Record, 0, c.cfg.BatchSize)
+				resetTimer(timer, c.cfg.FlushInterval)
+			}
+
+		case <-timer.C:
+			if len(buffer) > 0 {
+				c.flush(ctx, buffer)
+				buffer = make([]Record, 0, c.cfg.BatchSize)
+			}
+			timer.Reset(c.cfg.FlushInterval)
+		}
+	}
+}
+
+// drainChannel reads remaining records from the channel into
+// the buffer.
+func (c *Client) drainChannel(buffer *[]Record) {
+	for {
+		select {
+		case r := <-c.records:
+			*buffer = append(*buffer, r)
+		default:
+			return
+		}
+	}
+}
+
+// flush dispatches the batch either synchronously or
+// asynchronously based on the AsyncFlush configuration.
+func (c *Client) flush(ctx context.Context, batch []Record) {
+	if c.asyncFlush {
+		c.flushAsync(ctx, batch)
+		return
+	}
+	c.pushAll(ctx, batch)
+}
+
+// flushAsync sends the batch to Loki in a background
+// goroutine. If the tomb is dying or the context is
+// cancelled before the goroutine starts, the push is
+// abandoned.
+func (c *Client) flushAsync(ctx context.Context, batch []Record) {
+	go func() {
+		select {
+		case <-c.tomb.Dying():
+			return
+		case <-ctx.Done():
+			return
+		default:
+		}
+		c.pushAll(ctx, batch)
+	}()
+}
+
+// pushAll pushes all records to Loki, splitting into
+// BatchSize chunks. Push errors are reported via the
+// OnError callback.
+func (c *Client) pushAll(
+	ctx context.Context, records []Record,
+) {
+	for i := 0; i < len(records); i += c.cfg.BatchSize {
+		end := min(i+c.cfg.BatchSize, len(records))
+		if err := c.pushBatch(ctx, records[i:end]); err != nil {
+			c.onError(err)
+		}
+	}
+}
+
+// resetTimer safely resets a timer, draining the channel
+// if the timer has already fired.
+func resetTimer(t *time.Timer, d time.Duration) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	t.Reset(d)
+}
+
+// pushBatch marshals records into a Loki push payload and
+// sends it to the endpoint. Failed requests are retried
+// with exponential backoff.
+func (c *Client) pushBatch(
+	ctx context.Context, records []Record,
+) error {
+	payload := buildPayload(records)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return internalerrors.Errorf("marshaling payload: %w", err)
+	}
+
+	err = retry.Call(retry.CallArgs{
+		Attempts: c.cfg.MaxRetries,
+		Delay:    c.cfg.InitialBackoff,
+		MaxDelay: c.cfg.MaxBackoff,
+		Func: func() error {
+			return c.doRequest(ctx, data)
+		},
+		IsFatalError: func(err error) bool {
+			return !isRetryable(err)
+		},
+		BackoffFunc: retry.ExpBackoff(c.cfg.InitialBackoff, c.cfg.MaxBackoff, 2.0, true),
+		Clock:       c.cfg.Clock,
+		Stop:        ctx.Done(),
+	})
+	if retry.IsAttemptsExceeded(err) {
+		return retry.LastError(err)
+	}
+	if retry.IsRetryStopped(err) {
+		return ctx.Err()
+	}
+	return err
+}
+
+// retryableError indicates a push request failure that can
+// be retried.
+type retryableError struct {
+	msg string
+}
+
+func (e *retryableError) Error() string {
+	return e.msg
+}
+
+// isRetryable reports whether err is a retryableError.
+func isRetryable(err error) bool {
+	_, ok := err.(*retryableError)
+	return ok
+}
+
+// doRequest sends a single HTTP POST to the Loki push
+// endpoint. Returns a retryableError for transient failures
+// (network errors, 429, 5xx) or a plain error for
+// non-retryable status codes.
+func (c *Client) doRequest(
+	ctx context.Context, data []byte,
+) error {
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		c.endpoint, bytes.NewReader(data),
+	)
+	if err != nil {
+		return internalerrors.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return &retryableError{
+			msg: fmt.Sprintf("sending request: %s", err),
+		}
+	}
+	// Read and discard the body to enable connection reuse.
+	if _, err = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024)); err != nil {
+		return &retryableError{
+			msg: fmt.Sprintf("reading response: %s", err),
+		}
+	}
+	_ = resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusNoContent ||
+		resp.StatusCode == http.StatusOK:
+		return nil
+
+	case resp.StatusCode == http.StatusTooManyRequests ||
+		resp.StatusCode >= http.StatusInternalServerError:
+		return &retryableError{
+			msg: fmt.Sprintf(
+				"loki returned status %d", resp.StatusCode,
+			),
+		}
+
+	default:
+		return internalerrors.Errorf(
+			"loki returned status %d", resp.StatusCode,
+		)
+	}
+}
+
+// pushPayload is the JSON structure for the Loki push API.
+type pushPayload struct {
+	Streams []pushStream `json:"streams"`
+}
+
+// pushStream is a single stream within a push payload.
+type pushStream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]string        `json:"values"`
+}
+
+// buildPayload groups records by label set into streams.
+func buildPayload(records []Record) pushPayload {
+	groups := make(map[string]*pushStream)
+	order := make([]string, 0)
+
+	for _, r := range records {
+		key := labelKey(r.Labels)
+		s, ok := groups[key]
+		if !ok {
+			labels := make(map[string]string, len(r.Labels))
+			maps.Copy(labels, r.Labels)
+
+			s = &pushStream{Stream: labels}
+			groups[key] = s
+			order = append(order, key)
+		}
+		ts := strconv.FormatInt(
+			r.Timestamp.UnixNano(), 10,
+		)
+		s.Values = append(s.Values, []string{ts, r.Line})
+	}
+
+	streams := make([]pushStream, 0, len(order))
+	for _, key := range order {
+		streams = append(streams, *groups[key])
+	}
+	return pushPayload{Streams: streams}
+}
+
+// labelKey produces a deterministic string key from a label
+// map for grouping records into streams.
+func labelKey(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(labels[k])
+	}
+	return b.String()
+}

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -57,6 +57,65 @@ func (s *clientSuite) TestNewClientZeroRetriesIsValid(c *tc.C) {
 	c.Check(client.cfg.MaxRetries, tc.Equals, 0)
 }
 
+func (s *clientSuite) TestPushNoRetriesWhenMaxRetriesZero(c *tc.C) {
+	var attempts atomic.Int32
+	errCh := make(chan error, 1)
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+	)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	cfg.MaxRetries = 0
+	cfg.OnError = func(err error) {
+		errCh <- err
+	}
+
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	err = client.Push(Record{
+		Timestamp: time.Now(),
+		Line:      "no retries",
+		Labels:    map[string]string{"job": "test"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	pushErr := waitError(c, errCh)
+	c.Check(pushErr, tc.ErrorMatches, ".*loki returned status 500")
+	c.Check(attempts.Load(), tc.Equals, int32(1))
+}
+
+func (s *clientSuite) TestPushUsesWallClockWhenUnset(c *tc.C) {
+	srv, payloads := newTestServer(c)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	cfg.Clock = nil
+
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	err = client.Push(Record{
+		Timestamp: time.Now(),
+		Line:      "clock default",
+		Labels:    map[string]string{"job": "test"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	p := waitPayload(c, payloads)
+	c.Assert(p.Streams, tc.HasLen, 1)
+	c.Check(p.Streams[0].Values[0][1], tc.Equals, "clock default")
+}
+
 func (s *clientSuite) TestPushFlushOnBatchSize(c *tc.C) {
 	srv, payloads := newTestServer(c)
 	defer srv.Close()
@@ -474,6 +533,16 @@ func waitPayload(
 	case <-time.After(5 * time.Second):
 		c.Fatal("timed out waiting for payload")
 		return pushPayload{}
+	}
+}
+
+func waitError(c *tc.C, ch <-chan error) error {
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for error callback")
+		return nil
 	}
 }
 

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -1,0 +1,484 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package loki
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/tc"
+)
+
+type clientSuite struct{}
+
+func TestClientSuite(t *testing.T) {
+	tc.Run(t, &clientSuite{})
+}
+
+func (s *clientSuite) TestNewClientEmptyEndpoint(c *tc.C) {
+	_, err := NewClient("", DefaultConfig())
+	c.Assert(err, tc.ErrorMatches, "endpoint must not be empty")
+}
+
+func (s *clientSuite) TestNewClientDefaults(c *tc.C) {
+	cfg := DefaultConfig()
+	client, err := NewClient("http://loki:3100", cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+	c.Check(client.cfg.BatchSize, tc.Equals, 100)
+	c.Check(
+		client.cfg.FlushInterval,
+		tc.Equals,
+		10*time.Second,
+	)
+	c.Check(client.cfg.MaxRetries, tc.Equals, 3)
+	c.Check(
+		client.cfg.InitialBackoff,
+		tc.Equals,
+		500*time.Millisecond,
+	)
+	c.Check(
+		client.cfg.MaxBackoff,
+		tc.Equals,
+		30*time.Second,
+	)
+}
+
+func (s *clientSuite) TestNewClientZeroRetriesIsValid(c *tc.C) {
+	client, err := NewClient("http://loki:3100", Config{})
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+	c.Check(client.cfg.MaxRetries, tc.Equals, 0)
+}
+
+func (s *clientSuite) TestPushFlushOnBatchSize(c *tc.C) {
+	srv, payloads := newTestServer(c)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 3
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	ts := time.Now()
+	for range 3 {
+		err := client.Push(Record{
+			Timestamp: ts,
+			Line:      "line",
+			Labels:    map[string]string{"job": "test"},
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	p := waitPayload(c, payloads)
+	c.Assert(p.Streams, tc.HasLen, 1)
+	c.Check(p.Streams[0].Values, tc.HasLen, 3)
+}
+
+func (s *clientSuite) TestPushSyncFlush(c *tc.C) {
+	srv, payloads := newTestServer(c)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 2
+	asyncFlush := false
+	cfg.AsyncFlush = &asyncFlush
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	ts := time.Now()
+	err = client.Push(
+		Record{Timestamp: ts, Line: "s1",
+			Labels: map[string]string{"job": "test"}},
+		Record{Timestamp: ts, Line: "s2",
+			Labels: map[string]string{"job": "test"}},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	p := waitPayload(c, payloads)
+	c.Assert(p.Streams, tc.HasLen, 1)
+	c.Check(p.Streams[0].Values, tc.HasLen, 2)
+}
+
+func (s *clientSuite) TestPushFlushOnInterval(c *tc.C) {
+	srv, payloads := newTestServer(c)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.FlushInterval = 50 * time.Millisecond
+	cfg.BatchSize = 1000
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	err = client.Push(Record{
+		Timestamp: time.Now(),
+		Line:      "timer flush",
+		Labels:    map[string]string{"job": "test"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	p := waitPayload(c, payloads)
+	c.Assert(p.Streams, tc.HasLen, 1)
+	c.Check(p.Streams[0].Values[0][1], tc.Equals, "timer flush")
+}
+
+func (s *clientSuite) TestPushGroupsByLabels(c *tc.C) {
+	srv, payloads := newTestServer(c)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 3
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	ts := time.Now()
+	err = client.Push(
+		Record{
+			Timestamp: ts,
+			Line:      "a1",
+			Labels:    map[string]string{"job": "a"},
+		},
+		Record{
+			Timestamp: ts,
+			Line:      "b1",
+			Labels:    map[string]string{"job": "b"},
+		},
+		Record{
+			Timestamp: ts,
+			Line:      "a2",
+			Labels:    map[string]string{"job": "a"},
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	p := waitPayload(c, payloads)
+	c.Assert(p.Streams, tc.HasLen, 2)
+	c.Check(p.Streams[0].Stream["job"], tc.Equals, "a")
+	c.Check(p.Streams[0].Values, tc.HasLen, 2)
+	c.Check(p.Streams[1].Stream["job"], tc.Equals, "b")
+	c.Check(p.Streams[1].Values, tc.HasLen, 1)
+}
+
+func (s *clientSuite) TestPushBatching(c *tc.C) {
+	var requestCount atomic.Int32
+	done := make(chan struct{}, 10)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+			done <- struct{}{}
+		}),
+	)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 3
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	ts := time.Now()
+	// Send 6 records: triggers 2 flushes of 3.
+	for range 6 {
+		err := client.Push(Record{
+			Timestamp: ts,
+			Line:      "line",
+			Labels:    map[string]string{"job": "test"},
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	// Wait for both HTTP requests to arrive.
+	for range 2 {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			c.Fatal("timed out waiting for request")
+		}
+	}
+	c.Check(requestCount.Load(), tc.Equals, int32(2))
+}
+
+func (s *clientSuite) TestPushRetryOnServerError(c *tc.C) {
+	var attempts atomic.Int32
+	done := make(chan struct{}, 1)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := attempts.Add(1)
+			if n == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			done <- struct{}{}
+		}),
+	)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	err = client.Push(Record{
+		Timestamp: time.Now(),
+		Line:      "retry me",
+		Labels:    map[string]string{"job": "test"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for successful push")
+	}
+	c.Check(attempts.Load(), tc.Equals, int32(2))
+}
+
+func (s *clientSuite) TestPushRetryOnTooManyRequests(c *tc.C) {
+	var attempts atomic.Int32
+	done := make(chan struct{}, 1)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := attempts.Add(1)
+			if n <= 2 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			done <- struct{}{}
+		}),
+	)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	err = client.Push(Record{
+		Timestamp: time.Now(),
+		Line:      "throttled",
+		Labels:    map[string]string{"job": "test"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for successful push")
+	}
+	c.Check(attempts.Load(), tc.Equals, int32(3))
+}
+
+func (s *clientSuite) TestOnErrorCalledOnPushFailure(c *tc.C) {
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+	)
+	defer srv.Close()
+
+	errCh := make(chan error, 1)
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	cfg.MaxRetries = 1
+	cfg.OnError = func(err error) {
+		errCh <- err
+	}
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	err = client.Push(Record{
+		Timestamp: time.Now(),
+		Line:      "will fail",
+		Labels:    map[string]string{"job": "test"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case pushErr := <-errCh:
+		c.Check(
+			pushErr, tc.ErrorMatches,
+			".*loki returned status 500",
+		)
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for OnError callback")
+	}
+}
+
+func (s *clientSuite) TestKillDrainsBufferedRecords(c *tc.C) {
+	srv, payloads := newTestServer(c)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 1000
+	// Long interval so only kill-drain triggers flush.
+	cfg.FlushInterval = time.Minute
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	ts := time.Now()
+	err = client.Push(
+		Record{
+			Timestamp: ts,
+			Line:      "drain me",
+			Labels:    map[string]string{"job": "test"},
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	killAndWait(c, client)
+
+	p := waitPayload(c, payloads)
+	c.Assert(p.Streams, tc.HasLen, 1)
+	c.Check(
+		p.Streams[0].Values[0][1],
+		tc.Equals,
+		"drain me",
+	)
+}
+
+func (s *clientSuite) TestPushNilLabels(c *tc.C) {
+	srv, payloads := newTestServer(c)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	err = client.Push(Record{
+		Timestamp: time.Now(),
+		Line:      "no labels",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	p := waitPayload(c, payloads)
+	c.Assert(p.Streams, tc.HasLen, 1)
+	c.Check(p.Streams[0].Values, tc.HasLen, 1)
+}
+
+func (s *clientSuite) TestBuildPayload(c *tc.C) {
+	ts := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{
+			Timestamp: ts,
+			Line:      "a1",
+			Labels: map[string]string{
+				"job": "x", "env": "prod",
+			},
+		},
+		{
+			Timestamp: ts.Add(time.Second),
+			Line:      "b1",
+			Labels:    map[string]string{"job": "y"},
+		},
+		{
+			Timestamp: ts.Add(2 * time.Second),
+			Line:      "a2",
+			Labels: map[string]string{
+				"env": "prod", "job": "x",
+			},
+		},
+	}
+
+	payload := buildPayload(records)
+	c.Assert(payload.Streams, tc.HasLen, 2)
+
+	c.Check(
+		payload.Streams[0].Stream,
+		tc.DeepEquals,
+		map[string]string{"job": "x", "env": "prod"},
+	)
+	c.Check(payload.Streams[0].Values, tc.HasLen, 2)
+	c.Check(payload.Streams[0].Values[0][1], tc.Equals, "a1")
+	c.Check(payload.Streams[0].Values[1][1], tc.Equals, "a2")
+
+	c.Check(
+		payload.Streams[1].Stream,
+		tc.DeepEquals,
+		map[string]string{"job": "y"},
+	)
+	c.Check(payload.Streams[1].Values, tc.HasLen, 1)
+}
+
+func (s *clientSuite) TestLabelKey(c *tc.C) {
+	labels := map[string]string{
+		"z": "3", "a": "1", "m": "2",
+	}
+	key := labelKey(labels)
+	c.Check(key, tc.Equals, "a=1,m=2,z=3")
+}
+
+func (s *clientSuite) TestLabelKeyEmpty(c *tc.C) {
+	c.Check(labelKey(nil), tc.Equals, "")
+	c.Check(labelKey(map[string]string{}), tc.Equals, "")
+}
+
+// testConfig returns a Config suitable for tests with fast
+// flushing and minimal retry delays.
+func testConfig() Config {
+	return Config{
+		BatchSize:      100,
+		FlushInterval:  50 * time.Millisecond,
+		MaxRetries:     3,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		Clock:          clock.WallClock,
+	}
+}
+
+// newTestServer creates an httptest server that records push
+// payloads on a buffered channel.
+func newTestServer(
+	c *tc.C,
+) (*httptest.Server, <-chan pushPayload) {
+	payloads := make(chan pushPayload, 100)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(
+			w http.ResponseWriter, r *http.Request,
+		) {
+			var p pushPayload
+			err := json.NewDecoder(r.Body).Decode(&p)
+			c.Assert(err, tc.ErrorIsNil)
+			payloads <- p
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	return srv, payloads
+}
+
+// waitPayload waits for a payload on the channel, failing the
+// test if none arrives within 5 seconds.
+func waitPayload(
+	c *tc.C, ch <-chan pushPayload,
+) pushPayload {
+	select {
+	case p := <-ch:
+		return p
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for payload")
+		return pushPayload{}
+	}
+}
+
+func killAndWait(c *tc.C, client *Client) {
+	client.Kill(nil)
+	err := client.Wait()
+	c.Assert(err, tc.ErrorIsNil)
+}

--- a/internal/loki/doc.go
+++ b/internal/loki/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package loki provides a worker for pushing log records to a
+// Loki instance using the HTTP push API. The worker buffers
+// records and flushes them based on batch size or a time
+// interval, with retries and exponential backoff. Records are
+// grouped by label set into Loki streams.
+package loki


### PR DESCRIPTION
~~Requires https://github.com/juju/juju/pull/22414 to land first.~~


-----


Unfortunately we can't use the loki-client-go[1] as it mentions:

 > Loki Go client (Experimental. DO NOT USE IT)

I think that's cause for concern. We could use Alloy, but then we'd
need to have some sort of additional requirements on the machine or
host. Instead, we can just send the data directly to the POST endpoint
for loki[2].

The solution is quite simple, and mirrors some of the existing work for
the logsender worker. Except in this instance we've abstracted it
directly to a library in the internal package. If the loki client
becomes stable, we can always switch to that version.

 1. https://github.com/grafana/loki-client-go
 2. https://grafana.com/docs/loki/latest/reference/loki-http-api/#ingest-logs

## QA steps

Nothing is wired up yet.

## Links


**Jira card:** [JUJU-9764](https://warthogs.atlassian.net/browse/JUJU-9764)


[JUJU-9764]: https://warthogs.atlassian.net/browse/JUJU-9764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ