### PR TITLE
refactor: rename the storage update apis to be compatible with 4.0

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -1275,7 +1275,7 @@ type ApplicationStorageUpdate struct {
 	// StorageConstraints is a map of storage names to storage constraints to
 	// update during the upgrade. This field is only understood by Application
 	// facade version 2 and greater.
-	StorageConstraints map[string]storage.Constraints `json:"storage-constraints,omitempty"`
+	StorageConstraints map[string]storage.Directives `json:"storage-constraints,omitempty"`
 }
 
 // UpdateApplicationStorage updates the storage constraints for multiple existing applications in bulk.
@@ -1284,8 +1284,8 @@ func (c *Client) UpdateApplicationStorage(applicationStorageUpdate ApplicationSt
 	for k, v := range applicationStorageUpdate.StorageConstraints {
 		sc[k] = params.StorageConstraints{
 			Pool:  v.Pool,
-			Size:  &v.Size,
-			Count: &v.Count,
+			Size:  v.Size,
+			Count: v.Count,
 		}
 	}
 	in := params.ApplicationStorageUpdateRequest{

--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -1221,34 +1221,35 @@ func paramsFromDeployFromRepositoryArg(arg DeployFromRepositoryArg) params.Deplo
 	}
 }
 
-// ApplicationStorageDirectives contains the storage directives for an application.
-type ApplicationStorageDirectives struct {
-	// StorageDirectives is a map of storage names to storage directives to
-	// update. This field is only understood by Application facade version 22 and greater.
-	StorageDirectives map[string]storage.Constraints
+// ApplicationStorageInfo contains the storage information for an application.
+type ApplicationStorageInfo struct {
+	// StorageConstraints is a map of storage names to storage constraints to
+	// update during the upgrade. This field is only understood by Application
+	// facade version 22 and greater.
+	StorageConstraints map[string]storage.Constraints `json:"storage-constraints,omitempty"`
 }
 
-// GetApplicationStorageDirectives retrieves storage information for the specified applications.
-func (c *Client) GetApplicationStorageDirectives(applicationName string) (ApplicationStorageDirectives, error) {
+// GetApplicationStorage retrieves storage information for the specified applications.
+func (c *Client) GetApplicationStorage(applicationName string) (ApplicationStorageInfo, error) {
 	application := names.NewApplicationTag(applicationName)
 	in := params.Entities{Entities: []params.Entity{{Tag: application.String()}}}
 	var out params.ApplicationStorageGetResults
-	err := c.facade.FacadeCall("GetApplicationStorageDirectives", in, &out)
+	err := c.facade.FacadeCall("GetApplicationStorage", in, &out)
 	if err != nil {
-		return ApplicationStorageDirectives{}, errors.Trace(err)
+		return ApplicationStorageInfo{}, errors.Trace(err)
 	}
 	if resultsLen := len(out.Results); resultsLen != 1 {
-		return ApplicationStorageDirectives{}, errors.Errorf("expected 1 result, got %d", resultsLen)
+		return ApplicationStorageInfo{}, errors.Errorf("expected 1 result, got %d", resultsLen)
 	}
 	res := out.Results[0]
 	if res.Error != nil {
-		return ApplicationStorageDirectives{}, apiservererrors.RestoreError(res.Error)
+		return ApplicationStorageInfo{}, apiservererrors.RestoreError(res.Error)
 	}
-	return makeApplicationStorageDirectiveInfo(res), nil
+	return makeApplicationStorageInfo(res), nil
 }
 
-func makeApplicationStorageDirectiveInfo(param params.ApplicationStorageGetResult) ApplicationStorageDirectives {
-	sd := make(map[string]storage.Constraints, len(param.StorageConstraints))
+func makeApplicationStorageInfo(param params.ApplicationStorageGetResult) ApplicationStorageInfo {
+	sc := make(map[string]storage.Constraints, len(param.StorageConstraints))
 	for k, v := range param.StorageConstraints {
 		con := storage.Constraints{
 			Pool: v.Pool,
@@ -1259,11 +1260,11 @@ func makeApplicationStorageDirectiveInfo(param params.ApplicationStorageGetResul
 		if v.Count != nil {
 			con.Count = *v.Count
 		}
-		sd[k] = con
+		sc[k] = con
 	}
 
-	return ApplicationStorageDirectives{
-		StorageDirectives: sd,
+	return ApplicationStorageInfo{
+		StorageConstraints: sc,
 	}
 }
 
@@ -1271,32 +1272,33 @@ func makeApplicationStorageDirectiveInfo(param params.ApplicationStorageGetResul
 type ApplicationStorageUpdate struct {
 	ApplicationTag names.ApplicationTag
 
-	// StorageDirectives is a map of storage names to storage directives to
-	// update. This field is only understood by Application facade version 22 and greater.
-	StorageDirectives map[string]storage.Directives
+	// StorageConstraints is a map of storage names to storage constraints to
+	// update during the upgrade. This field is only understood by Application
+	// facade version 2 and greater.
+	StorageConstraints map[string]storage.Constraints `json:"storage-constraints,omitempty"`
 }
 
-// UpdateApplicationStorageDirectives updates the storage directives for multiple existing applications in bulk.
-func (c *Client) UpdateApplicationStorageDirectives(applicationStorageUpdate ApplicationStorageUpdate) error {
-	sd := make(map[string]params.StorageConstraints)
-	for k, v := range applicationStorageUpdate.StorageDirectives {
-		sd[k] = params.StorageConstraints{
+// UpdateApplicationStorage updates the storage constraints for multiple existing applications in bulk.
+func (c *Client) UpdateApplicationStorage(applicationStorageUpdate ApplicationStorageUpdate) error {
+	sc := make(map[string]params.StorageConstraints)
+	for k, v := range applicationStorageUpdate.StorageConstraints {
+		sc[k] = params.StorageConstraints{
 			Pool:  v.Pool,
-			Size:  v.Size,
-			Count: v.Count,
+			Size:  &v.Size,
+			Count: &v.Count,
 		}
 	}
 	in := params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
 			{
-				ApplicationTag:    applicationStorageUpdate.ApplicationTag.String(),
-				StorageDirectives: sd,
+				ApplicationTag:     applicationStorageUpdate.ApplicationTag.String(),
+				StorageConstraints: sc,
 			},
 		},
 	}
 
 	var out params.ErrorResults
-	err := c.facade.FacadeCall("UpdateApplicationStorageDirectives", in, &out)
+	err := c.facade.FacadeCall("UpdateApplicationStorage", in, &out)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -1551,13 +1551,13 @@ func (s *applicationSuite) TestGetApplicationStorageSuccessful(c *gc.C) {
 		},
 	}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("GetApplicationStorageDirectives", args, result).SetArg(2, results).Return(nil)
+	mockFacadeCaller.EXPECT().FacadeCall("GetApplicationStorage", args, result).SetArg(2, results).Return(nil)
 
 	client := application.NewClientFromCaller(mockFacadeCaller)
-	info, err := client.GetApplicationStorageDirectives("storage-block")
+	info, err := client.GetApplicationStorage("storage-block")
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.StorageDirectives, gc.DeepEquals, map[string]storage.Constraints{
+	c.Assert(info.StorageConstraints, gc.DeepEquals, map[string]storage.Constraints{
 		"storage-block": {
 			Pool:  "loop",
 			Size:  uint64(5),
@@ -1587,10 +1587,10 @@ func (s *applicationSuite) TestGetApplicationStorageServerError(c *gc.C) {
 		},
 	}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("GetApplicationStorageDirectives", args, result).SetArg(2, results).Return(nil)
+	mockFacadeCaller.EXPECT().FacadeCall("GetApplicationStorage", args, result).SetArg(2, results).Return(nil)
 
 	client := application.NewClientFromCaller(mockFacadeCaller)
-	_, err := client.GetApplicationStorageDirectives("storage-block")
+	_, err := client.GetApplicationStorage("storage-block")
 
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
@@ -1604,7 +1604,7 @@ func (s *applicationSuite) TestUpdateApplicationStorageSuccessful(c *gc.C) {
 
 	args := params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
-			{ApplicationTag: "application-storage-block", StorageDirectives: map[string]params.StorageConstraints{
+			{ApplicationTag: "application-storage-block", StorageConstraints: map[string]params.StorageConstraints{
 				"storage-block": {
 					Pool:  "loop",
 					Size:  &sbSize,
@@ -1622,19 +1622,19 @@ func (s *applicationSuite) TestUpdateApplicationStorageSuccessful(c *gc.C) {
 		},
 	}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorageDirectives", args, result).SetArg(2, results).Return(nil)
+	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorage", args, result).SetArg(2, results).Return(nil)
 
 	applicationStorageUpdate := application.ApplicationStorageUpdate{
-		ApplicationTag: names.NewApplicationTag("storage-block"), StorageDirectives: map[string]storage.Directives{
+		ApplicationTag: names.NewApplicationTag("storage-block"), StorageConstraints: map[string]storage.Constraints{
 			"storage-block": {
 				Pool:  "loop",
-				Size:  toUint64Ptr(5),
-				Count: toUint64Ptr(1),
+				Size:  uint64(5),
+				Count: uint64(1),
 			},
 		},
 	}
 	client := application.NewClientFromCaller(mockFacadeCaller)
-	err := client.UpdateApplicationStorageDirectives(applicationStorageUpdate)
+	err := client.UpdateApplicationStorage(applicationStorageUpdate)
 
 	c.Assert(err, gc.IsNil)
 }
@@ -1648,7 +1648,7 @@ func (s *applicationSuite) TestUpdateApplicationStorageServerError(c *gc.C) {
 
 	args := params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
-			{ApplicationTag: "application-storage-block", StorageDirectives: map[string]params.StorageConstraints{
+			{ApplicationTag: "application-storage-block", StorageConstraints: map[string]params.StorageConstraints{
 				"storage-block": {
 					Pool:  "loop",
 					Size:  &sbSize,
@@ -1666,25 +1666,21 @@ func (s *applicationSuite) TestUpdateApplicationStorageServerError(c *gc.C) {
 		},
 	}
 	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorageDirectives", args, result).SetArg(2, results).Return(nil)
+	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorage", args, result).SetArg(2, results).Return(nil)
 
 	applicationStorageUpdate := application.ApplicationStorageUpdate{
-		ApplicationTag: names.NewApplicationTag("storage-block"), StorageDirectives: map[string]storage.Directives{
+		ApplicationTag: names.NewApplicationTag("storage-block"), StorageConstraints: map[string]storage.Constraints{
 			"storage-block": {
 				Pool:  "loop",
-				Size:  toUint64Ptr(5),
-				Count: toUint64Ptr(1),
+				Size:  uint64(5),
+				Count: uint64(1),
 			},
 		},
 	}
 
 	client := application.NewClientFromCaller(mockFacadeCaller)
-	err := client.UpdateApplicationStorageDirectives(applicationStorageUpdate)
+	err := client.UpdateApplicationStorage(applicationStorageUpdate)
 
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.DeepEquals, "test error1")
-}
-
-func toUint64Ptr(i uint64) *uint64 {
-	return &i
 }

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -1625,11 +1625,11 @@ func (s *applicationSuite) TestUpdateApplicationStorageSuccessful(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorage", args, result).SetArg(2, results).Return(nil)
 
 	applicationStorageUpdate := application.ApplicationStorageUpdate{
-		ApplicationTag: names.NewApplicationTag("storage-block"), StorageConstraints: map[string]storage.Constraints{
+		ApplicationTag: names.NewApplicationTag("storage-block"), StorageConstraints: map[string]storage.Directives{
 			"storage-block": {
 				Pool:  "loop",
-				Size:  uint64(5),
-				Count: uint64(1),
+				Size:  toUint64Ptr(5),
+				Count: toUint64Ptr(1),
 			},
 		},
 	}
@@ -1669,11 +1669,11 @@ func (s *applicationSuite) TestUpdateApplicationStorageServerError(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall("UpdateApplicationStorage", args, result).SetArg(2, results).Return(nil)
 
 	applicationStorageUpdate := application.ApplicationStorageUpdate{
-		ApplicationTag: names.NewApplicationTag("storage-block"), StorageConstraints: map[string]storage.Constraints{
+		ApplicationTag: names.NewApplicationTag("storage-block"), StorageConstraints: map[string]storage.Directives{
 			"storage-block": {
 				Pool:  "loop",
-				Size:  uint64(5),
-				Count: uint64(1),
+				Size:  toUint64Ptr(5),
+				Count: toUint64Ptr(1),
 			},
 		},
 	}
@@ -1683,4 +1683,8 @@ func (s *applicationSuite) TestUpdateApplicationStorageServerError(c *gc.C) {
 
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.DeepEquals, "test error1")
+}
+
+func toUint64Ptr(i uint64) *uint64 {
+	return &i
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -3131,7 +3131,7 @@ func (api *APIBase) DeployFromRepository(args params.DeployFromRepositoryArgs) (
 	}, nil
 }
 
-func (api *APIBase) getOneApplicationStorageDirective(entity params.Entity) (map[string]params.StorageConstraints, error) {
+func (api *APIBase) getOneApplicationStorage(entity params.Entity) (map[string]params.StorageConstraints, error) {
 	appTag, err := names.ParseTag(entity.Tag)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -3140,24 +3140,24 @@ func (api *APIBase) getOneApplicationStorageDirective(entity params.Entity) (map
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	storageDirectives, err := app.StorageConstraints()
+	storageConstraints, err := app.StorageConstraints()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	sd := make(map[string]params.StorageConstraints)
-	for key, cons := range storageDirectives {
-		sd[key] = params.StorageConstraints{
+	sc := make(map[string]params.StorageConstraints)
+	for key, cons := range storageConstraints {
+		sc[key] = params.StorageConstraints{
 			Pool:  cons.Pool,
 			Size:  &cons.Size,
 			Count: &cons.Count,
 		}
 	}
-	return sd, nil
+	return sc, nil
 }
 
-// GetApplicationStorageDirectives returns the current storage constraints for the specified applications in bulk.
-func (api *APIBase) GetApplicationStorageDirectives(args params.Entities) (params.ApplicationStorageGetResults, error) {
+// GetApplicationStorage returns the current storage constraints for the specified applications in bulk.
+func (api *APIBase) GetApplicationStorage(args params.Entities) (params.ApplicationStorageGetResults, error) {
 	resp := params.ApplicationStorageGetResults{
 		Results: make([]params.ApplicationStorageGetResult, len(args.Entities)),
 	}
@@ -3165,20 +3165,20 @@ func (api *APIBase) GetApplicationStorageDirectives(args params.Entities) (param
 		return resp, errors.Trace(err)
 	}
 	for i, entity := range args.Entities {
-		sd, err := api.getOneApplicationStorageDirective(entity)
+		sc, err := api.getOneApplicationStorage(entity)
 		if err != nil {
 			resp.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		resp.Results[i].StorageConstraints = sd
+		resp.Results[i].StorageConstraints = sc
 	}
 	return resp, nil
 }
 
-// GetApplicationStorageDirectives isn't on the v21 API.
-func (api *APIv21) GetApplicationStorageDirectives(_ struct{}) {}
+// GetApplicationStorage isn't on the v21 API.
+func (api *APIv21) GetApplicationStorage(_ struct{}) {}
 
-func (api *APIBase) updateOneApplicationStorageDirective(storageUpdate params.ApplicationStorageUpdate) error {
+func (api *APIBase) updateOneApplicationStorage(storageUpdate params.ApplicationStorageUpdate) error {
 	appTag, err := names.ParseTag(storageUpdate.ApplicationTag)
 	if err != nil {
 		return errors.Trace(err)
@@ -3189,15 +3189,15 @@ func (api *APIBase) updateOneApplicationStorageDirective(storageUpdate params.Ap
 	}
 
 	storageDirectivesUpdate := make(map[string]state.StorageDirectivesUpdate)
-	for storageName, directive := range storageUpdate.StorageDirectives {
+	for storageName, con := range storageUpdate.StorageConstraints {
 		sd := state.StorageDirectivesUpdate{
-			Pool: directive.Pool,
+			Pool: con.Pool,
 		}
-		if directive.Size != nil {
-			sd.Size = directive.Size
+		if con.Size != nil {
+			sd.Size = con.Size
 		}
-		if directive.Count != nil {
-			sd.Count = directive.Count
+		if con.Count != nil {
+			sd.Count = con.Count
 		}
 		storageDirectivesUpdate[storageName] = sd
 	}
@@ -3205,12 +3205,12 @@ func (api *APIBase) updateOneApplicationStorageDirective(storageUpdate params.Ap
 	return app.UpdateStorageConstraints(storageDirectivesUpdate)
 }
 
-// UpdateApplicationStorageDirectives updates the storage directives for multiple existing applications in bulk.
+// UpdateApplicationStorage updates the storage constraints for multiple existing applications in bulk.
 // We do not create new storage constraints since it is handled by addDefaultStorageConstraints during
 // application deployment. The storage constraints passed are validated against the charm's declared storage meta.
 // The following apiserver codes can be returned in each ErrorResult:
 //   - [params.CodeNotSupported]: If the update request includes a storage name not supported by the charm.
-func (api *APIBase) UpdateApplicationStorageDirectives(args params.ApplicationStorageUpdateRequest) (params.ErrorResults, error) {
+func (api *APIBase) UpdateApplicationStorage(args params.ApplicationStorageUpdateRequest) (params.ErrorResults, error) {
 	resp := params.ErrorResults{}
 	if err := api.checkCanWrite(); err != nil {
 		return resp, errors.Trace(err)
@@ -3220,12 +3220,12 @@ func (api *APIBase) UpdateApplicationStorageDirectives(args params.ApplicationSt
 	resp.Results = res
 
 	for i, storageUpdate := range args.ApplicationStorageUpdates {
-		err := api.updateOneApplicationStorageDirective(storageUpdate)
+		err := api.updateOneApplicationStorage(storageUpdate)
 		res[i].Error = apiservererrors.ServerError(err)
 	}
 
 	return resp, nil
 }
 
-// UpdateApplicationStorageDirectives isn't on the v21 API.
-func (api *APIv21) UpdateApplicationStorageDirectives(_ struct{}) {}
+// UpdateApplicationStorage isn't on the v21 API.
+func (api *APIv21) UpdateApplicationStorage(_ struct{}) {}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1700,7 +1700,7 @@ func (s *applicationSuite) TestGetOneApplicationStorageSuccess(c *gc.C) {
 	c.Assert(application.Name(), gc.Equals, "storage-block")
 
 	// Asserts that the application has defined the given directives.
-	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1736,7 +1736,7 @@ func (s *applicationSuite) TestGetMultipleApplicationStorageSuccess(c *gc.C) {
 	c.Assert(application2.Name(), gc.Equals, "cockroachdb")
 
 	// Retrieves info for both applications
-	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application1.Tag().String(),
 		},
@@ -1771,7 +1771,7 @@ func (s *applicationSuite) TestGetApplicationStorageDefaultExists(c *gc.C) {
 	c.Assert(application.Name(), gc.Equals, "storage-block")
 
 	// Asserts that the application has default storage constraints.
-	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1793,7 +1793,7 @@ func (s *applicationSuite) TestUpdateOneApplicationStorageSuccess(c *gc.C) {
 	c.Assert(application.Name(), gc.Equals, "storage-block")
 
 	// Asserts that the application has defined the given directives.
-	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1816,18 +1816,18 @@ func (s *applicationSuite) TestUpdateOneApplicationStorageSuccess(c *gc.C) {
 			Count: &count,
 		},
 	}
-	_, err = s.applicationAPI.UpdateApplicationStorageDirectives(params.ApplicationStorageUpdateRequest{
+	_, err = s.applicationAPI.UpdateApplicationStorage(params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
 			{
-				ApplicationTag:    application.Tag().String(),
-				StorageDirectives: newSC,
+				ApplicationTag:     application.Tag().String(),
+				StorageConstraints: newSC,
 			},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Asserts that the application has newly defined storage constraints.
-	resp, err = s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
+	resp, err = s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1863,7 +1863,7 @@ func (s *applicationSuite) TestUpdateMultipleApplicationStorageSuccess(c *gc.C) 
 	c.Assert(application2.Name(), gc.Equals, "cockroachdb")
 
 	// Asserts that both the applications have defined resp constraints.
-	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application1.Tag().String(),
 		},
@@ -1908,22 +1908,22 @@ func (s *applicationSuite) TestUpdateMultipleApplicationStorageSuccess(c *gc.C) 
 			Count: &count,
 		},
 	}
-	_, err = s.applicationAPI.UpdateApplicationStorageDirectives(params.ApplicationStorageUpdateRequest{
+	_, err = s.applicationAPI.UpdateApplicationStorage(params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
 			{
-				ApplicationTag:    application1.Tag().String(),
-				StorageDirectives: newSC1,
+				ApplicationTag:     application1.Tag().String(),
+				StorageConstraints: newSC1,
 			},
 			{
-				ApplicationTag:    application2.Tag().String(),
-				StorageDirectives: newSC2,
+				ApplicationTag:     application2.Tag().String(),
+				StorageConstraints: newSC2,
 			},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Asserts that the applications have newly defined storage constraints.
-	resp, err = s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
+	resp, err = s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application1.Tag().String(),
 		},
@@ -1963,7 +1963,7 @@ func (s *applicationSuite) TestUpdateApplicationStorageNameServerError(c *gc.C) 
 	c.Assert(application.Name(), gc.Equals, "storage-block")
 
 	// Asserts that the application has defined the given directives.
-	resp, err := s.applicationAPI.GetApplicationStorageDirectives(params.Entities{Entities: []params.Entity{
+	resp, err := s.applicationAPI.GetApplicationStorage(params.Entities{Entities: []params.Entity{
 		{
 			Tag: application.Tag().String(),
 		},
@@ -1979,11 +1979,11 @@ func (s *applicationSuite) TestUpdateApplicationStorageNameServerError(c *gc.C) 
 	// Updates the application with newly defined storage constraints that contains 2 unsupported storage names.
 	size := uint64(4096)
 	count := uint64(2)
-	res, err := s.applicationAPI.UpdateApplicationStorageDirectives(params.ApplicationStorageUpdateRequest{
+	res, err := s.applicationAPI.UpdateApplicationStorage(params.ApplicationStorageUpdateRequest{
 		ApplicationStorageUpdates: []params.ApplicationStorageUpdate{
 			{
 				ApplicationTag: application.Tag().String(),
-				StorageDirectives: map[string]params.StorageConstraints{
+				StorageConstraints: map[string]params.StorageConstraints{
 					charmStore: {
 						Pool:  "loop",
 						Size:  &size,

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -35,7 +35,7 @@ func Register(registry facade.FacadeRegistry) {
 		return newFacadeV21(ctx) // Added ScaleApplication attach storage support
 	}, reflect.TypeOf((*APIv21)(nil)))
 	registry.MustRegister("Application", 22, func(ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV22(ctx) // Added GetApplicationStorageDirectives and UpdateApplicationStorageDirectives storage constraints support
+		return newFacadeV22(ctx) // Added GetApplicationStorage and UpdateApplicationStorage storage constraints support
 	}, reflect.TypeOf((*APIv22)(nil)))
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1285,7 +1285,7 @@
                         }
                     }
                 },
-                "GetApplicationStorageDirectives": {
+                "GetApplicationStorage": {
                     "type": "object",
                     "properties": {
                         "Params": {
@@ -1463,7 +1463,7 @@
                         }
                     }
                 },
-                "UpdateApplicationStorageDirectives": {
+                "UpdateApplicationStorage": {
                     "type": "object",
                     "properties": {
                         "Params": {
@@ -2161,7 +2161,7 @@
                         "application-tag": {
                             "type": "string"
                         },
-                        "storage-directives": {
+                        "storage-constraints": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -2173,7 +2173,7 @@
                     "additionalProperties": false,
                     "required": [
                         "application-tag",
-                        "storage-directives"
+                        "storage-constraints"
                     ]
                 },
                 "ApplicationStorageUpdateRequest": {

--- a/cmd/juju/application/storage.go
+++ b/cmd/juju/application/storage.go
@@ -175,34 +175,34 @@ func (c *applicationStorageCommand) Run(ctx *cmd.Context) error {
 // StorageDirectivesAPI defines the API methods that the application storage command uses.
 type StorageDirectivesAPI interface {
 	Close() error
-	GetApplicationStorageDirectives(applicationName string) (application.ApplicationStorageDirectives, error)
-	UpdateApplicationStorageDirectives(applicationStorageUpdateParams application.ApplicationStorageUpdate) error
+	GetApplicationStorage(applicationName string) (application.ApplicationStorageInfo, error)
+	UpdateApplicationStorage(applicationStorageUpdateParams application.ApplicationStorageUpdate) error
 }
 
 // setConfig sets the provided key/value pairs on the application.
 func (c *applicationStorageCommand) setConfig(client StorageDirectivesAPI, attrs config.Attrs) error {
-	sd := make(map[string]storage.Directives, len(attrs))
+	sc := make(map[string]storage.Constraints, len(attrs))
 	for k, v := range attrs {
 		// This should give us a string of the form "10G,rootfs,1".
 		constraintsStr := fmt.Sprint(v)
-		parsedCons, err := storage.ParseDirectives(constraintsStr)
+		parsedCons, err := storage.ParseConstraints(constraintsStr)
 		if err != nil {
 			return errors.Annotatef(err, "parsing storage constraints for %q", k)
 		}
-		sd[k] = parsedCons
+		sc[k] = parsedCons
 	}
 
 	updateParams := application.ApplicationStorageUpdate{
-		ApplicationTag:    names.NewApplicationTag(c.applicationName),
-		StorageDirectives: sd,
+		ApplicationTag:     names.NewApplicationTag(c.applicationName),
+		StorageConstraints: sc,
 	}
 
-	return client.UpdateApplicationStorageDirectives(updateParams)
+	return client.UpdateApplicationStorage(updateParams)
 }
 
 // getConfig writes the value of a single application config key to the cmd.Context.
 func (c *applicationStorageCommand) getConfig(ctx *cmd.Context, client StorageDirectivesAPI) error {
-	applicationStorageInfo, err := client.GetApplicationStorageDirectives(c.applicationName)
+	applicationStorageInfo, err := client.GetApplicationStorage(c.applicationName)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (c *applicationStorageCommand) getConfig(ctx *cmd.Context, client StorageDi
 	}
 
 	storeKey := c.configBase.KeysToGet[0]
-	storageConsForKey, ok := applicationStorageInfo.StorageDirectives[storeKey]
+	storageConsForKey, ok := applicationStorageInfo.StorageConstraints[storeKey]
 	if !ok {
 		return errors.NotFoundf("storage %q", storeKey)
 	}
@@ -227,12 +227,12 @@ func (c *applicationStorageCommand) getConfig(ctx *cmd.Context, client StorageDi
 
 // getAllConfig returns the entire configuration for the selected application.
 func (c *applicationStorageCommand) getAllConfig(ctx *cmd.Context, client StorageDirectivesAPI) error {
-	applicationStorageInfo, err := client.GetApplicationStorageDirectives(c.applicationName)
+	applicationStorageInfo, err := client.GetApplicationStorage(c.applicationName)
 	if err != nil {
 		return err
 	}
 
-	return c.out.Write(ctx, applicationStorageInfo.StorageDirectives)
+	return c.out.Write(ctx, applicationStorageInfo.StorageConstraints)
 }
 
 // formatConfigTabular writes a tabular summary of config information.

--- a/cmd/juju/application/storage.go
+++ b/cmd/juju/application/storage.go
@@ -181,11 +181,11 @@ type StorageDirectivesAPI interface {
 
 // setConfig sets the provided key/value pairs on the application.
 func (c *applicationStorageCommand) setConfig(client StorageDirectivesAPI, attrs config.Attrs) error {
-	sc := make(map[string]storage.Constraints, len(attrs))
+	sc := make(map[string]storage.Directives, len(attrs))
 	for k, v := range attrs {
 		// This should give us a string of the form "10G,rootfs,1".
 		constraintsStr := fmt.Sprint(v)
-		parsedCons, err := storage.ParseConstraints(constraintsStr)
+		parsedCons, err := storage.ParseDirectives(constraintsStr)
 		if err != nil {
 			return errors.Annotatef(err, "parsing storage constraints for %q", k)
 		}

--- a/cmd/juju/application/storage_test.go
+++ b/cmd/juju/application/storage_test.go
@@ -185,8 +185,10 @@ func (s *ApplicationStorageSuite) TestSetDirectivesAllFields(c *gc.C) {
 
 	data := got.StorageConstraints["data"]
 	c.Assert(data.Pool, gc.Equals, "rootfs")
-	c.Assert(data.Count, gc.Equals, uint64(1))
-	c.Assert(data.Size, gc.Equals, uint64(102400))
+	c.Assert(data.Count, gc.NotNil)
+	c.Assert(data.Size, gc.NotNil)
+	c.Assert(*data.Count, gc.Equals, uint64(1))
+	c.Assert(*data.Size, gc.Equals, uint64(102400))
 }
 
 func (s *ApplicationStorageSuite) TestSetDirectivesAllFieldsShuffledOrder(c *gc.C) {
@@ -205,8 +207,10 @@ func (s *ApplicationStorageSuite) TestSetDirectivesAllFieldsShuffledOrder(c *gc.
 
 	data := got.StorageConstraints["data"]
 	c.Assert(data.Pool, gc.Equals, "rootfs")
-	c.Assert(data.Count, gc.Equals, uint64(1))
-	c.Assert(data.Size, gc.Equals, uint64(102400))
+	c.Assert(data.Count, gc.NotNil)
+	c.Assert(data.Size, gc.NotNil)
+	c.Assert(*data.Count, gc.Equals, uint64(1))
+	c.Assert(*data.Size, gc.Equals, uint64(102400))
 }
 
 func (s *ApplicationStorageSuite) TestSetDirectivesOneField(c *gc.C) {
@@ -225,8 +229,8 @@ func (s *ApplicationStorageSuite) TestSetDirectivesOneField(c *gc.C) {
 
 	data := got.StorageConstraints["data"]
 	c.Assert(data.Pool, gc.Equals, "rootfs")
-	c.Assert(data.Count, gc.Equals, uint64(1))
-	c.Assert(data.Size, gc.Equals, uint64(0))
+	c.Assert(data.Count, gc.IsNil)
+	c.Assert(data.Size, gc.IsNil)
 }
 
 func (s *ApplicationStorageSuite) TestSetDirectivesMultipleStorageKeys(c *gc.C) {
@@ -244,13 +248,16 @@ func (s *ApplicationStorageSuite) TestSetDirectivesMultipleStorageKeys(c *gc.C) 
 
 	data := got.StorageConstraints["data"]
 	c.Assert(data.Pool, gc.Equals, "rootfs")
-	c.Assert(data.Count, gc.Equals, uint64(1))
-	c.Assert(data.Size, gc.Equals, uint64(102400))
+	c.Assert(data.Count, gc.NotNil)
+	c.Assert(*data.Count, gc.Equals, uint64(1))
+	c.Assert(data.Size, gc.NotNil)
+	c.Assert(*data.Size, gc.Equals, uint64(102400))
 
 	allecto := got.StorageConstraints["allecto"]
 	c.Assert(allecto.Pool, gc.Equals, "loop")
-	c.Assert(allecto.Count, gc.Equals, uint64(2))
-	c.Assert(allecto.Size, gc.Equals, uint64(0))
+	c.Assert(allecto.Count, gc.NotNil)
+	c.Assert(*allecto.Count, gc.Equals, uint64(2))
+	c.Assert(allecto.Size, gc.IsNil)
 }
 
 func (s *ApplicationStorageSuite) TestSetDirectivesAPIError(c *gc.C) {

--- a/cmd/juju/application/storage_test.go
+++ b/cmd/juju/application/storage_test.go
@@ -46,9 +46,9 @@ func (s *ApplicationStorageSuite) SetUpTest(c *gc.C) {
 
 	// Default mock returns one application with two storage keys.
 	s.mockAPI = &mockStorageDirectivesAPI{
-		getFunc: func(app string) (apiapplication.ApplicationStorageDirectives, error) {
-			return apiapplication.ApplicationStorageDirectives{
-				StorageDirectives: map[string]storage.Constraints{
+		getFunc: func(app string) (apiapplication.ApplicationStorageInfo, error) {
+			return apiapplication.ApplicationStorageInfo{
+				StorageConstraints: map[string]storage.Constraints{
 					"data":    {Pool: "rootfs", Size: 10240, Count: 1}, // 10 GiB (MiB units)
 					"allecto": {Pool: "loop", Size: 20480, Count: 2},   // 20 GiB
 				},
@@ -162,8 +162,8 @@ func (s *ApplicationStorageSuite) TestGetDirectivesKeyNotFound(c *gc.C) {
 }
 
 func (s *ApplicationStorageSuite) TestGetDirectivesAPIError(c *gc.C) {
-	s.mockAPI.getFunc = func(app string) (apiapplication.ApplicationStorageDirectives, error) {
-		return apiapplication.ApplicationStorageDirectives{}, fmt.Errorf("api error")
+	s.mockAPI.getFunc = func(app string) (apiapplication.ApplicationStorageInfo, error) {
+		return apiapplication.ApplicationStorageInfo{}, fmt.Errorf("api error")
 	}
 	_, err := s.run(c, "storage-block")
 	c.Assert(err, gc.ErrorMatches, "api error")
@@ -183,12 +183,10 @@ func (s *ApplicationStorageSuite) TestSetDirectivesAllFields(c *gc.C) {
 	// Assert application tag.
 	c.Assert(got.ApplicationTag, gc.Equals, names.NewApplicationTag("storage-block"))
 
-	data := got.StorageDirectives["data"]
+	data := got.StorageConstraints["data"]
 	c.Assert(data.Pool, gc.Equals, "rootfs")
-	c.Assert(data.Count, gc.NotNil)
-	c.Assert(data.Size, gc.NotNil)
-	c.Assert(*data.Count, gc.Equals, uint64(1))
-	c.Assert(*data.Size, gc.Equals, uint64(102400))
+	c.Assert(data.Count, gc.Equals, uint64(1))
+	c.Assert(data.Size, gc.Equals, uint64(102400))
 }
 
 func (s *ApplicationStorageSuite) TestSetDirectivesAllFieldsShuffledOrder(c *gc.C) {
@@ -205,12 +203,10 @@ func (s *ApplicationStorageSuite) TestSetDirectivesAllFieldsShuffledOrder(c *gc.
 	// Assert application tag.
 	c.Assert(got.ApplicationTag, gc.Equals, names.NewApplicationTag("storage-block"))
 
-	data := got.StorageDirectives["data"]
+	data := got.StorageConstraints["data"]
 	c.Assert(data.Pool, gc.Equals, "rootfs")
-	c.Assert(data.Count, gc.NotNil)
-	c.Assert(data.Size, gc.NotNil)
-	c.Assert(*data.Count, gc.Equals, uint64(1))
-	c.Assert(*data.Size, gc.Equals, uint64(102400))
+	c.Assert(data.Count, gc.Equals, uint64(1))
+	c.Assert(data.Size, gc.Equals, uint64(102400))
 }
 
 func (s *ApplicationStorageSuite) TestSetDirectivesOneField(c *gc.C) {
@@ -227,10 +223,10 @@ func (s *ApplicationStorageSuite) TestSetDirectivesOneField(c *gc.C) {
 
 	c.Assert(got.ApplicationTag, gc.Equals, names.NewApplicationTag("storage-block"))
 
-	data := got.StorageDirectives["data"]
+	data := got.StorageConstraints["data"]
 	c.Assert(data.Pool, gc.Equals, "rootfs")
-	c.Assert(data.Count, gc.IsNil)
-	c.Assert(data.Size, gc.IsNil)
+	c.Assert(data.Count, gc.Equals, uint64(1))
+	c.Assert(data.Size, gc.Equals, uint64(0))
 }
 
 func (s *ApplicationStorageSuite) TestSetDirectivesMultipleStorageKeys(c *gc.C) {
@@ -246,18 +242,15 @@ func (s *ApplicationStorageSuite) TestSetDirectivesMultipleStorageKeys(c *gc.C) 
 
 	c.Assert(got.ApplicationTag, gc.Equals, names.NewApplicationTag("storage-block"))
 
-	data := got.StorageDirectives["data"]
+	data := got.StorageConstraints["data"]
 	c.Assert(data.Pool, gc.Equals, "rootfs")
-	c.Assert(data.Count, gc.NotNil)
-	c.Assert(*data.Count, gc.Equals, uint64(1))
-	c.Assert(data.Size, gc.NotNil)
-	c.Assert(*data.Size, gc.Equals, uint64(102400))
+	c.Assert(data.Count, gc.Equals, uint64(1))
+	c.Assert(data.Size, gc.Equals, uint64(102400))
 
-	allecto := got.StorageDirectives["allecto"]
+	allecto := got.StorageConstraints["allecto"]
 	c.Assert(allecto.Pool, gc.Equals, "loop")
-	c.Assert(allecto.Count, gc.NotNil)
-	c.Assert(*allecto.Count, gc.Equals, uint64(2))
-	c.Assert(allecto.Size, gc.IsNil)
+	c.Assert(allecto.Count, gc.Equals, uint64(2))
+	c.Assert(allecto.Size, gc.Equals, uint64(0))
 }
 
 func (s *ApplicationStorageSuite) TestSetDirectivesAPIError(c *gc.C) {
@@ -280,16 +273,16 @@ func assertTabLine(c *gc.C, line string, fields ...string) {
 
 // Mocks
 type mockStorageDirectivesAPI struct {
-	getFunc    func(app string) (apiapplication.ApplicationStorageDirectives, error)
+	getFunc    func(app string) (apiapplication.ApplicationStorageInfo, error)
 	updateFunc func(apiapplication.ApplicationStorageUpdate) error
 }
 
 func (m *mockStorageDirectivesAPI) Close() error { return nil }
 
-func (m *mockStorageDirectivesAPI) GetApplicationStorageDirectives(applicationName string) (apiapplication.ApplicationStorageDirectives, error) {
+func (m *mockStorageDirectivesAPI) GetApplicationStorage(applicationName string) (apiapplication.ApplicationStorageInfo, error) {
 	return m.getFunc(applicationName)
 }
 
-func (m *mockStorageDirectivesAPI) UpdateApplicationStorageDirectives(up apiapplication.ApplicationStorageUpdate) error {
+func (m *mockStorageDirectivesAPI) UpdateApplicationStorage(up apiapplication.ApplicationStorageUpdate) error {
 	return m.updateFunc(up)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.25.9
+go 1.25.10
 
 require (
 	cloud.google.com/go/compute v1.44.0

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -735,5 +735,5 @@ type ApplicationStorageUpdate struct {
 	ApplicationTag string `json:"application-tag"`
 
 	// Holds the application storage constraints where the key is the storage name.
-	StorageDirectives map[string]StorageConstraints `json:"storage-directives"`
+	StorageConstraints map[string]StorageConstraints `json:"storage-constraints"`
 }

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -27,6 +27,20 @@ type Constraints struct {
 	Count uint64
 }
 
+// Directives describes a set of storage directives.
+type Directives struct {
+	// Pool is the name of the storage pool (ebs, ceph, custompool, ...)
+	// that must provide the storage, or "" if the default pool should be
+	// used.
+	Pool string
+
+	// Size is the minimum size of the storage in MiB.
+	Size *uint64
+
+	// Count is the number of instances of the storage to create.
+	Count *uint64
+}
+
 var (
 	poolRE  = regexp.MustCompile("^[a-zA-Z]+[-?a-zA-Z0-9]*$")
 	countRE = regexp.MustCompile("^-?[0-9]+$")
@@ -92,6 +106,66 @@ func ParseConstraints(s string) (Constraints, error) {
 	}
 	if cons.Count == 0 {
 		cons.Count = 1
+	}
+	return cons, nil
+}
+
+// ParseDirectives parses the specified string and creates a
+// storage directives structure.
+//
+// The acceptable format for storage directives is a comma separated
+// sequence of: POOL, COUNT, and SIZE, where
+//
+//	POOL identifies the storage pool. POOL can be a string
+//	starting with a letter, followed by zero or more digits
+//	or letters optionally separated by hyphens.
+//
+//	COUNT is a positive integer indicating how many instances
+//	of the storage to create. If unspecified, and SIZE is
+//	specified, COUNT defaults to 1.
+//
+//	SIZE describes the minimum size of the storage instances to
+//	create. SIZE is a floating point number and multiplier from
+//	the set (M, G, T, P, E, Z, Y), which are all treated as
+//	powers of 1024.
+func ParseDirectives(s string) (Directives, error) {
+	var cons Directives
+	fields := strings.Split(s, ",")
+	for _, field := range fields {
+		if field == "" {
+			continue
+		}
+		if IsValidPoolName(field) {
+			if cons.Pool != "" {
+				return cons, errors.NotValidf("pool name is already set to %q, new value %q", cons.Pool, field)
+			}
+			cons.Pool = field
+			continue
+		}
+		if count, ok, err := parseCount(field); ok {
+			if err != nil {
+				return cons, errors.Annotate(err, "parsing storage count")
+			}
+			if cons.Count != nil {
+				return cons, errors.NotValidf("storage instance count is already set to %d, new value %d", cons.Count, count)
+			}
+			cons.Count = &count
+			continue
+		}
+		if size, ok, err := parseSize(field); ok {
+			if err != nil {
+				return cons, errors.Annotate(err, "cannot parse size")
+			}
+			if cons.Size != nil {
+				return cons, errors.NotValidf("storage size is already set to %d, new value %d", cons.Size, size)
+			}
+			cons.Size = &size
+			continue
+		}
+		return cons, errors.NotValidf("unrecognized storage constraint %q", field)
+	}
+	if cons.Count == nil && cons.Size == nil && cons.Pool == "" {
+		return Directives{}, errors.New("storage directives require at least one field to be specified")
 	}
 	return cons, nil
 }

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -27,20 +27,6 @@ type Constraints struct {
 	Count uint64
 }
 
-// Directives describes a set of storage directives.
-type Directives struct {
-	// Pool is the name of the storage pool (ebs, ceph, custompool, ...)
-	// that must provide the storage, or "" if the default pool should be
-	// used.
-	Pool string
-
-	// Size is the minimum size of the storage in MiB.
-	Size *uint64
-
-	// Count is the number of instances of the storage to create.
-	Count *uint64
-}
-
 var (
 	poolRE  = regexp.MustCompile("^[a-zA-Z]+[-?a-zA-Z0-9]*$")
 	countRE = regexp.MustCompile("^-?[0-9]+$")
@@ -106,66 +92,6 @@ func ParseConstraints(s string) (Constraints, error) {
 	}
 	if cons.Count == 0 {
 		cons.Count = 1
-	}
-	return cons, nil
-}
-
-// ParseDirectives parses the specified string and creates a
-// storage directives structure.
-//
-// The acceptable format for storage directives is a comma separated
-// sequence of: POOL, COUNT, and SIZE, where
-//
-//	POOL identifies the storage pool. POOL can be a string
-//	starting with a letter, followed by zero or more digits
-//	or letters optionally separated by hyphens.
-//
-//	COUNT is a positive integer indicating how many instances
-//	of the storage to create. If unspecified, and SIZE is
-//	specified, COUNT defaults to 1.
-//
-//	SIZE describes the minimum size of the storage instances to
-//	create. SIZE is a floating point number and multiplier from
-//	the set (M, G, T, P, E, Z, Y), which are all treated as
-//	powers of 1024.
-func ParseDirectives(s string) (Directives, error) {
-	var cons Directives
-	fields := strings.Split(s, ",")
-	for _, field := range fields {
-		if field == "" {
-			continue
-		}
-		if IsValidPoolName(field) {
-			if cons.Pool != "" {
-				return cons, errors.NotValidf("pool name is already set to %q, new value %q", cons.Pool, field)
-			}
-			cons.Pool = field
-			continue
-		}
-		if count, ok, err := parseCount(field); ok {
-			if err != nil {
-				return cons, errors.Annotate(err, "parsing storage count")
-			}
-			if cons.Count != nil {
-				return cons, errors.NotValidf("storage instance count is already set to %d, new value %d", cons.Count, count)
-			}
-			cons.Count = &count
-			continue
-		}
-		if size, ok, err := parseSize(field); ok {
-			if err != nil {
-				return cons, errors.Annotate(err, "cannot parse size")
-			}
-			if cons.Size != nil {
-				return cons, errors.NotValidf("storage size is already set to %d, new value %d", cons.Size, size)
-			}
-			cons.Size = &size
-			continue
-		}
-		return cons, errors.NotValidf("unrecognized storage constraint %q", field)
-	}
-	if cons.Count == nil && cons.Size == nil && cons.Pool == "" {
-		return Directives{}, errors.New("storage directives require at least one field to be specified")
 	}
 	return cons, nil
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -23,7 +23,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("3.6.5"), stateStepsFor365()},
 		upgradeToVersion{version.MustParse("3.6.13"), stateStepsFor3613()},
 		upgradeToVersion{version.MustParse("3.6.15"), stateStepsFor3615()},
-		upgradeToVersion{version.MustParse("3.6.22"), stateStepsFor3622()},
+		upgradeToVersion{version.MustParse("3.6.23"), stateStepsFor3623()},
 	}
 	return steps
 }

--- a/upgrades/steps_3623.go
+++ b/upgrades/steps_3623.go
@@ -3,8 +3,8 @@
 
 package upgrades
 
-// stateStepsFor3622 returns upgrade steps for Juju 3.6.22 that manipulate state directly.
-func stateStepsFor3622() []Step {
+// stateStepsFor3623 returns upgrade steps for Juju 3.6.23 that manipulate state directly.
+func stateStepsFor3623() []Step {
 	return []Step{
 		&upgradeStep{
 			description: "expose controller application",

--- a/upgrades/steps_3623_test.go
+++ b/upgrades/steps_3623_test.go
@@ -12,20 +12,20 @@ import (
 	"github.com/juju/juju/upgrades"
 )
 
-var v3622 = version.MustParse("3.6.22")
+var v3623 = version.MustParse("3.6.23")
 
-type steps3622Suite struct {
+type steps3623Suite struct {
 	testing.BaseSuite
 }
 
-var _ = gc.Suite(&steps3622Suite{})
+var _ = gc.Suite(&steps3623Suite{})
 
-func (s *steps3622Suite) TestExposeControllerApplication(c *gc.C) {
-	step := findStateStep(c, v3622, "expose controller application")
+func (s *steps3623Suite) TestExposeControllerApplication(c *gc.C) {
+	step := findStateStep(c, v3623, "expose controller application")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
-func (s *steps3622Suite) TestConvertScalingToCurrentOperationEnumField(c *gc.C) {
-	step := findStateStep(c, v3622, "convert scaling field to enum")
+func (s *steps3623Suite) TestConvertScalingToCurrentOperationEnumField(c *gc.C) {
+	step := findStateStep(c, v3623, "convert scaling field to enum")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -596,7 +596,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
-	c.Assert(versions, gc.DeepEquals, []string{"3.6.4", "3.6.5", "3.6.13", "3.6.15", "3.6.22"})
+	c.Assert(versions, gc.DeepEquals, []string{"3.6.4", "3.6.5", "3.6.13", "3.6.15", "3.6.23"})
 }
 
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {


### PR DESCRIPTION
When the api for getting and updating application storage landed, a rename to the api methods was done:
GetApplicationStorage -> GetApplicationStorageDirectives
UpdateApplicationStorage -> UpdateApplicationStorageDirectives

This change is incompatible with what was merged forward to 4.0.
So this PR reverts that change and now 3.6 and 4.0 are compatible.

The 3.6 with this change is only in candidate so we can do a new release.

Drive by: rename the 3.6.22 upgrade step to 3.6.23

## QA steps

bootstrap
```
cd testcharms/charms/dummy-storage
juju deploy . --storage single-fs=ebs,10M --storage multi-fs=rootfs,10M

juju application-storage dummy-storage

Storage     Pool    Size    Count
multi-blk   loop    10 MiB  0
multi-fs    rootfs  10 MiB  1
single-blk  loop    10 MiB  0
single-fs   ebs     10 MiB  1

juju application-storage dummy-storage multi-blk=20M,2

juju application-storage dummy-storage                

Storage     Pool    Size    Count
multi-blk   loop    20 MiB  2
multi-fs    rootfs  10 MiB  1
single-blk  loop    10 MiB  0
single-fs   ebs     10 MiB  1
```