### PR TITLE
fix: head of line blocking

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -81,9 +81,6 @@ func (e *RequestError) UnmarshalInfo(to any) error {
 }
 
 func (conn *Conn) send(call *Call) uint64 {
-	conn.sending.Lock()
-	defer conn.sending.Unlock()
-
 	// Register this call.
 	conn.mutex.Lock()
 	if conn.dead == nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -97,8 +97,7 @@ func (conn *Conn) send(call *Call) uint64 {
 		call.done(conn.context)
 		return 0
 	}
-	conn.reqId++
-	reqId := conn.reqId
+	reqId := conn.reqId.Add(1)
 	conn.clientPending[reqId] = call
 	conn.mutex.Unlock()
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -89,7 +89,7 @@ func (conn *Conn) send(call *Call) uint64 {
 		call.done(conn.context)
 		return 0
 	}
-	if conn.closing || conn.shutdown {
+	if conn.closing.Load() || conn.shutdown {
 		call.Error = errors.Errorf(
 			"connection is shutdown before send",
 		).Add(ErrShutdown)

--- a/rpc/export_test.go
+++ b/rpc/export_test.go
@@ -10,5 +10,5 @@ const CodeNotImplemented = codeNotImplemented
 // ClientRequestID exposes the client's request ID which is
 // incremented everytime a connection sends a request.
 func (c *Conn) ClientRequestID() uint64 {
-	return c.reqId
+	return c.reqId.Load()
 }

--- a/rpc/export_test.go
+++ b/rpc/export_test.go
@@ -3,6 +3,8 @@
 
 package rpc
 
+import "time"
+
 const CodeNotImplemented = codeNotImplemented
 
 // TODO(katco): Remove this as it is exposing internal state of Conn. Age old story: ran out of time to rewrite the tests to do this correctly.
@@ -11,4 +13,23 @@ const CodeNotImplemented = codeNotImplemented
 // incremented everytime a connection sends a request.
 func (c *Conn) ClientRequestID() uint64 {
 	return c.reqId.Load()
+}
+
+// SetCloseTimeout overrides the timeout Close waits for outstanding
+// server requests to complete. Intended for tests only.
+func (c *Conn) SetCloseTimeout(d time.Duration) {
+	c.closeTimeout = d
+}
+
+// SetWriteFlushTimeout overrides the timeout Close waits for queued
+// responses to be written. Intended for tests only.
+func (c *Conn) SetWriteFlushTimeout(d time.Duration) {
+	c.writeFlushTimeout = d
+}
+
+// SetResponseHook installs a channel that is signalled (non-blocking)
+// each time sendResponse completes (whether the response was queued or
+// dropped). It must be called before Start. Intended for tests only.
+func (c *Conn) SetResponseHook(ch chan struct{}) {
+	c.responseHook = ch
 }

--- a/rpc/export_test.go
+++ b/rpc/export_test.go
@@ -27,9 +27,14 @@ func (c *Conn) SetWriteFlushTimeout(d time.Duration) {
 	c.writeFlushTimeout = d
 }
 
-// SetResponseHook installs a channel that is signalled (non-blocking)
-// each time sendResponse completes (whether the response was queued or
-// dropped). It must be called before Start. Intended for tests only.
-func (c *Conn) SetResponseHook(ch chan struct{}) {
-	c.responseHook = ch
+// WaitForPendingServerRequests waits for all server request goroutines to
+// return. Intended for tests only.
+func (c *Conn) WaitForPendingServerRequests() {
+	c.srvPending.Wait()
+}
+
+// PendingResponseCount returns the number of responses being queued or
+// written. Intended for tests only.
+func (c *Conn) PendingResponseCount() int64 {
+	return c.pendingWrites.n.Load()
 }

--- a/rpc/jsoncodec/codec_test.go
+++ b/rpc/jsoncodec/codec_test.go
@@ -306,13 +306,10 @@ func (*suite) TestNetJSONConnConcurrentSend(c *tc.C) {
 	start := make(chan struct{})
 	errs := make(chan error, goroutines*sendsPerGoroutine)
 	var wg sync.WaitGroup
-	for i := 0; i < goroutines; i++ {
-		i := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for i := range goroutines {
+		wg.Go(func() {
 			<-start
-			for j := 0; j < sendsPerGoroutine; j++ {
+			for j := range sendsPerGoroutine {
 				errs <- conn.Send(struct {
 					G int `json:"g"`
 					S int `json:"s"`
@@ -321,7 +318,7 @@ func (*suite) TestNetJSONConnConcurrentSend(c *tc.C) {
 					S: j,
 				})
 			}
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/rpc/jsoncodec/codec_test.go
+++ b/rpc/jsoncodec/codec_test.go
@@ -4,10 +4,13 @@
 package jsoncodec_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/juju/tc"
@@ -290,6 +293,53 @@ func (*suite) TestWrite(c *tc.C) {
 	}
 }
 
+func (*suite) TestNetJSONConnConcurrentSend(c *tc.C) {
+	var out bytes.Buffer
+	conn := jsoncodec.NetJSONConn(&readerWriterCloser{
+		Reader: strings.NewReader(""),
+		Writer: &out,
+	})
+
+	const goroutines = 16
+	const sendsPerGoroutine = 32
+
+	start := make(chan struct{})
+	errs := make(chan error, goroutines*sendsPerGoroutine)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < sendsPerGoroutine; j++ {
+				errs <- conn.Send(struct {
+					G int `json:"g"`
+					S int `json:"s"`
+				}{
+					G: i,
+					S: j,
+				})
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	c.Assert(lines, tc.HasLen, goroutines*sendsPerGoroutine)
+	for _, line := range lines {
+		var msg map[string]int
+		err := json.Unmarshal([]byte(line), &msg)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+}
+
 func (*suite) TestDumpRequest(c *tc.C) {
 	for i, test := range []struct {
 		hdr    rpc.Header
@@ -447,5 +497,14 @@ func (c *testConn) Send(msg any) error {
 
 func (c *testConn) Close() error {
 	c.closed = true
+	return nil
+}
+
+type readerWriterCloser struct {
+	io.Reader
+	io.Writer
+}
+
+func (*readerWriterCloser) Close() error {
 	return nil
 }

--- a/rpc/jsoncodec/conn.go
+++ b/rpc/jsoncodec/conn.go
@@ -199,12 +199,15 @@ func NetJSONConn(conn io.ReadWriteCloser) JSONConn {
 }
 
 type netConn struct {
+	mu   sync.Mutex
 	enc  *json.Encoder
 	dec  *json.Decoder
 	conn io.ReadWriteCloser
 }
 
 func (conn *netConn) Send(msg any) error {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
 	return conn.enc.Encode(msg)
 }
 

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -846,10 +846,8 @@ func (*rpcSuite) TestClientRequestIDConcurrentRead(c *tc.C) {
 
 	const callCount = 64
 	var wg sync.WaitGroup
-	for i := 0; i < callCount; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range callCount {
+		wg.Go(func() {
 			var response stringVal
 			err := client.Call(c.Context(), rpc.Request{
 				Type:    "SimpleMethods",
@@ -859,7 +857,7 @@ func (*rpcSuite) TestClientRequestIDConcurrentRead(c *tc.C) {
 			}, nil, &response)
 			c.Check(err, tc.ErrorIsNil)
 			c.Check(response, tc.Equals, stringVal{Val: "Call0r1 ret"})
-		}()
+		})
 	}
 	wg.Wait()
 	close(stopReads)
@@ -1260,12 +1258,10 @@ func (*rpcSuite) TestClientCloseConcurrentIdempotent(c *tc.C) {
 	const closeCalls = 16
 	errs := make(chan error, closeCalls)
 	var wg sync.WaitGroup
-	for i := 0; i < closeCalls; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range closeCalls {
+		wg.Go(func() {
 			errs <- client.Close()
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"reflect"
 	"regexp"
@@ -781,6 +782,92 @@ func (*rpcSuite) TestConcurrentCalls(c *tc.C) {
 	chanRead(c, done2, "method 2 done")
 }
 
+func (*rpcSuite) TestErrorResponseWriteDoesNotBlockRequestHandling(c *tc.C) {
+	codec := newBlockingServerCodec(
+		rpc.Header{
+			RequestId: 1,
+			Request: rpc.Request{
+				Type:    "UnknownMethods",
+				Version: 0,
+				Id:      "",
+				Action:  "Nope",
+			},
+			Version: 1,
+		},
+		rpc.Header{
+			RequestId: 2,
+			Request: rpc.Request{
+				Type:    "BlockingWriteMethods",
+				Version: 0,
+				Id:      "",
+				Action:  "Ping",
+			},
+			Version: 1,
+		},
+	)
+	methods := &blockingWriteMethods{
+		called: make(chan struct{}),
+	}
+	root := &blockingWriteRoot{
+		methods: methods,
+	}
+
+	conn := rpc.NewConn(codec, nil)
+	conn.Serve(root, nil, nil)
+	conn.Start(c.Context())
+	defer func() {
+		codec.unblockFirstWrite()
+		err := conn.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	chanRead(c, codec.firstWriteStarted, "first response write started")
+	chanRead(c, methods.called, "second request handled")
+}
+
+func (*rpcSuite) TestClientRequestIDConcurrentRead(c *tc.C) {
+	root := SimpleRoot(c)
+	client, _, srvDone, _ := newRPCClientServer(c, root, nil, false)
+	defer closeClient(c, client, srvDone)
+
+	stopReads := make(chan struct{})
+	readsDone := make(chan struct{})
+	go func() {
+		defer close(readsDone)
+		for {
+			select {
+			case <-stopReads:
+				return
+			default:
+				_ = client.ClientRequestID()
+			}
+		}
+	}()
+
+	const callCount = 64
+	var wg sync.WaitGroup
+	for i := 0; i < callCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var response stringVal
+			err := client.Call(c.Context(), rpc.Request{
+				Type:    "SimpleMethods",
+				Version: 0,
+				Id:      "a99",
+				Action:  "Call0r1",
+			}, nil, &response)
+			c.Check(err, tc.ErrorIsNil)
+			c.Check(response, tc.Equals, stringVal{Val: "Call0r1 ret"})
+		}()
+	}
+	wg.Wait()
+	close(stopReads)
+	<-readsDone
+
+	c.Assert(client.ClientRequestID(), tc.Equals, uint64(callCount))
+}
+
 type codedError struct {
 	m    string
 	code string
@@ -1167,6 +1254,30 @@ func (*rpcSuite) TestClientCloseIdempotent(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (*rpcSuite) TestClientCloseConcurrentIdempotent(c *tc.C) {
+	client, _, srvDone, _ := newRPCClientServer(c, &Root{c: c}, nil, false)
+
+	const closeCalls = 16
+	errs := make(chan error, closeCalls)
+	var wg sync.WaitGroup
+	for i := 0; i < closeCalls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- client.Close()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	err := chanReadError(c, srvDone, "server done")
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (*rpcSuite) TestBidirectional(c *tc.C) {
 	srvRoot := &Root{c: c}
 	client, _, srvDone, _ := newRPCClientServer(c, srvRoot, nil, true)
@@ -1489,6 +1600,96 @@ func closeClient(c tc.LikeTB, client *rpc.Conn, srvDone <-chan error) {
 	tc.Assert(c, err, tc.ErrorIsNil)
 	err = chanReadError(c, srvDone, "server done")
 	tc.Assert(c, err, tc.ErrorIsNil)
+}
+
+type blockingWriteRoot struct {
+	methods *blockingWriteMethods
+}
+
+func (r *blockingWriteRoot) BlockingWriteMethods(string) (*blockingWriteMethods, error) {
+	return r.methods, nil
+}
+
+type blockingWriteMethods struct {
+	called chan struct{}
+	once   sync.Once
+}
+
+func (m *blockingWriteMethods) Ping() {
+	m.once.Do(func() {
+		close(m.called)
+	})
+}
+
+type blockingServerCodec struct {
+	mu                sync.Mutex
+	headers           []rpc.Header
+	readIndex         int
+	closeCh           chan struct{}
+	closeOnce         sync.Once
+	firstWriteStarted chan struct{}
+	firstWriteOnce    sync.Once
+	unblockWrite      chan struct{}
+	unblockWriteOnce  sync.Once
+	writeCount        int
+}
+
+func newBlockingServerCodec(headers ...rpc.Header) *blockingServerCodec {
+	copied := make([]rpc.Header, len(headers))
+	copy(copied, headers)
+	return &blockingServerCodec{
+		headers:           copied,
+		closeCh:           make(chan struct{}),
+		firstWriteStarted: make(chan struct{}),
+		unblockWrite:      make(chan struct{}),
+	}
+}
+
+func (c *blockingServerCodec) ReadHeader(hdr *rpc.Header) error {
+	c.mu.Lock()
+	if c.readIndex < len(c.headers) {
+		*hdr = c.headers[c.readIndex]
+		c.readIndex++
+		c.mu.Unlock()
+		return nil
+	}
+	closeCh := c.closeCh
+	c.mu.Unlock()
+
+	<-closeCh
+	return io.EOF
+}
+
+func (*blockingServerCodec) ReadBody(any, bool) error {
+	return nil
+}
+
+func (c *blockingServerCodec) WriteMessage(_ *rpc.Header, _ any) error {
+	c.mu.Lock()
+	c.writeCount++
+	writeCount := c.writeCount
+	c.mu.Unlock()
+
+	if writeCount == 1 {
+		c.firstWriteOnce.Do(func() {
+			close(c.firstWriteStarted)
+		})
+		<-c.unblockWrite
+	}
+	return nil
+}
+
+func (c *blockingServerCodec) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closeCh)
+	})
+	return nil
+}
+
+func (c *blockingServerCodec) unblockFirstWrite() {
+	c.unblockWriteOnce.Do(func() {
+		close(c.unblockWrite)
+	})
 }
 
 // testCodec wraps an rpc.Codec with extra error checking code.

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -866,6 +866,109 @@ func (*rpcSuite) TestClientRequestIDConcurrentRead(c *tc.C) {
 	c.Assert(client.ClientRequestID(), tc.Equals, uint64(callCount))
 }
 
+// TestCloseWithStuckWriteCompletes verifies that Close does not hang
+// forever when a server-side write is stalled (e.g. by TCP
+// backpressure). The write here blocks until the codec is closed; the
+// bounded writeFlushTimeout lets Close proceed to codec.Close, which
+// unblocks the stalled write. Previously the unbounded
+// pendingWrites.Wait gated codec.Close and deadlocked Close.
+func (*rpcSuite) TestCloseWithStuckWriteCompletes(c *tc.C) {
+	codec := newPauseableCodec(rpc.Header{
+		RequestId: 1,
+		Request: rpc.Request{
+			Type:    "BlockingWriteMethods",
+			Version: 0,
+			Id:      "",
+			Action:  "Ping",
+		},
+		Version: 1,
+	})
+	methods := &blockingWriteMethods{
+		called: make(chan struct{}),
+	}
+	root := &blockingWriteRoot{
+		methods: methods,
+	}
+
+	conn := rpc.NewConn(codec, nil)
+	conn.SetCloseTimeout(100 * time.Millisecond)
+	conn.SetWriteFlushTimeout(100 * time.Millisecond)
+	conn.Serve(root, nil, nil)
+	conn.Start(c.Context())
+
+	// The writer is now blocked inside WriteMessage for the Ping reply.
+	chanRead(c, codec.writeStarted, "writer started writing")
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- conn.Close() }()
+
+	select {
+	case err := <-closeDone:
+		c.Assert(err, tc.ErrorIsNil)
+	case <-time.After(5 * time.Second):
+		c.Fatalf("Close hung waiting for a stalled write to complete")
+	}
+}
+
+// TestCloseWithLateResponseDoesNotPanic verifies that a handler which
+// outlives the srvPending timeout and then calls sendResponse after the
+// writer has been torn down does not panic. Previously Close closed the
+// responses channel, so a late sendResponse could panic with
+// "send on closed channel"; responses is now never closed and the late
+// response is dropped via the <-dead path.
+func (*rpcSuite) TestCloseWithLateResponseDoesNotPanic(c *tc.C) {
+	codec := newPauseableCodec(rpc.Header{
+		RequestId: 1,
+		Request: rpc.Request{
+			Type:    "LateResponseMethods",
+			Version: 0,
+			Id:      "",
+			Action:  "Block",
+		},
+		Version: 1,
+	})
+	methods := &lateResponseMethods{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	root := &lateResponseRoot{methods: methods}
+
+	// The response hook fires when sendResponse completes (either branch).
+	// A panic in sendResponse would prevent it from firing, so receiving
+	// on the hook proves sendResponse returned without panicking.
+	responseHook := make(chan struct{}, 1)
+
+	conn := rpc.NewConn(codec, nil)
+	conn.SetCloseTimeout(100 * time.Millisecond)
+	conn.SetWriteFlushTimeout(100 * time.Millisecond)
+	conn.SetResponseHook(responseHook)
+	conn.Serve(root, nil, nil)
+	conn.Start(c.Context())
+
+	closeDone := make(chan error, 1)
+
+	// Wait for the handler to be spawned and start running before
+	// calling Close, so handleRequest's closing check doesn't short-
+	// circuit it into an error response.
+	chanRead(c, methods.started, "handler started")
+	go func() { closeDone <- conn.Close() }()
+
+	// Close's srvPending wait times out because the handler is blocked;
+	// it then tears the writer down. Assert Close completes promptly.
+	select {
+	case err := <-closeDone:
+		c.Assert(err, tc.ErrorIsNil)
+	case <-time.After(5 * time.Second):
+		c.Fatalf("Close did not complete with a late handler running")
+	}
+
+	// Release the handler. Its sendResponse now runs after the writer is
+	// gone and dead is closed. It must not panic (responses not closed)
+	// and must not block (dead is closed); the response is dropped.
+	close(methods.release)
+	chanRead(c, responseHook, "late sendResponse completed without panicking")
+}
+
 type codedError struct {
 	m    string
 	code string
@@ -1686,6 +1789,91 @@ func (c *blockingServerCodec) unblockFirstWrite() {
 	c.unblockWriteOnce.Do(func() {
 		close(c.unblockWrite)
 	})
+}
+
+// pauseableCodec is a server-side codec used to exercise the writer
+// shutdown paths. ReadHeader serves the configured headers and then
+// blocks until Close. WriteMessage signals writeStarted and then blocks
+// until either unblockWrite is closed or the codec is closed (emulating a
+// stalled write that is only unblocked by codec.Close, like the write
+// deadline set by wsJSONConn.Close).
+type pauseableCodec struct {
+	mu               sync.Mutex
+	headers          []rpc.Header
+	readIndex        int
+	closeCh          chan struct{}
+	closeOnce        sync.Once
+	writeStarted     chan struct{}
+	writeStartedOnce sync.Once
+}
+
+func newPauseableCodec(headers ...rpc.Header) *pauseableCodec {
+	copied := make([]rpc.Header, len(headers))
+	copy(copied, headers)
+	return &pauseableCodec{
+		headers:      copied,
+		closeCh:      make(chan struct{}),
+		writeStarted: make(chan struct{}),
+	}
+}
+
+func (c *pauseableCodec) ReadHeader(hdr *rpc.Header) error {
+	c.mu.Lock()
+	if c.readIndex < len(c.headers) {
+		*hdr = c.headers[c.readIndex]
+		c.readIndex++
+		c.mu.Unlock()
+		return nil
+	}
+	c.mu.Unlock()
+	<-c.closeCh
+	return io.EOF
+}
+
+func (*pauseableCodec) ReadBody(any, bool) error {
+	return nil
+}
+
+func (c *pauseableCodec) WriteMessage(_ *rpc.Header, _ any) error {
+	c.writeStartedOnce.Do(func() {
+		close(c.writeStarted)
+	})
+	select {
+	case <-c.closeCh:
+		// Codec closed while writing; emulate a peer-closed write error.
+		return io.ErrClosedPipe
+	}
+}
+
+func (c *pauseableCodec) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closeCh)
+	})
+	return nil
+}
+
+// lateResponseRoot serves lateResponseMethods.
+type lateResponseRoot struct {
+	methods *lateResponseMethods
+}
+
+func (r *lateResponseRoot) LateResponseMethods(string) (*lateResponseMethods, error) {
+	return r.methods, nil
+}
+
+// lateResponseMethods blocks in Block until released, simulating a
+// long-running handler that outlives Close's srvPending timeout.
+type lateResponseMethods struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (m *lateResponseMethods) Block() {
+	m.once.Do(func() {
+		close(m.started)
+	})
+	<-m.release
 }
 
 // testCodec wraps an rpc.Codec with extra error checking code.

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"reflect"
 	"regexp"
+	"runtime"
 	"sync"
 	stdtesting "testing"
 	"time"
@@ -825,6 +826,50 @@ func (*rpcSuite) TestErrorResponseWriteDoesNotBlockRequestHandling(c *tc.C) {
 	chanRead(c, methods.called, "second request handled")
 }
 
+func (*rpcSuite) TestResponseQueueBackpressureDoesNotLoseResponses(c *tc.C) {
+	const responseCount = 130
+	headers := make([]rpc.Header, responseCount)
+	for i := range headers {
+		headers[i] = rpc.Header{
+			RequestId: uint64(i + 1),
+			Request: rpc.Request{
+				Type: "BlockingWriteMethods", Action: "Ping",
+			},
+		}
+	}
+	codec := newBlockingServerCodec(headers...)
+	methods := &blockingWriteMethods{called: make(chan struct{})}
+	root := &blockingWriteRoot{methods: methods}
+
+	conn := rpc.NewConn(codec, nil)
+	conn.Serve(root, nil, nil)
+	conn.Start(c.Context())
+	defer func() {
+		err := conn.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	chanRead(c, codec.firstWriteStarted, "first response write started")
+	for conn.PendingResponseCount() != responseCount {
+		select {
+		case <-c.Context().Done():
+			c.Fatal("responses did not fill the queue")
+		default:
+			runtime.Gosched()
+		}
+	}
+	codec.unblockFirstWrite()
+	chanRead(c, codec.allWritesDone, "all queued responses written")
+	for conn.PendingResponseCount() != 0 {
+		select {
+		case <-c.Context().Done():
+			c.Fatal("pending response count did not return to zero")
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
 func (*rpcSuite) TestClientRequestIDConcurrentRead(c *tc.C) {
 	root := SimpleRoot(c)
 	client, _, srvDone, _ := newRPCClientServer(c, root, nil, false)
@@ -915,7 +960,7 @@ func (*rpcSuite) TestCloseWithStuckWriteCompletes(c *tc.C) {
 // writer has been torn down does not panic. Previously Close closed the
 // responses channel, so a late sendResponse could panic with
 // "send on closed channel"; responses is now never closed and the late
-// response is dropped via the <-dead path.
+// response is dropped after the writer is stopped.
 func (*rpcSuite) TestCloseWithLateResponseDoesNotPanic(c *tc.C) {
 	codec := newPauseableCodec(rpc.Header{
 		RequestId: 1,
@@ -933,15 +978,9 @@ func (*rpcSuite) TestCloseWithLateResponseDoesNotPanic(c *tc.C) {
 	}
 	root := &lateResponseRoot{methods: methods}
 
-	// The response hook fires when sendResponse completes (either branch).
-	// A panic in sendResponse would prevent it from firing, so receiving
-	// on the hook proves sendResponse returned without panicking.
-	responseHook := make(chan struct{}, 1)
-
 	conn := rpc.NewConn(codec, nil)
 	conn.SetCloseTimeout(100 * time.Millisecond)
 	conn.SetWriteFlushTimeout(100 * time.Millisecond)
-	conn.SetResponseHook(responseHook)
 	conn.Serve(root, nil, nil)
 	conn.Start(c.Context())
 
@@ -966,7 +1005,215 @@ func (*rpcSuite) TestCloseWithLateResponseDoesNotPanic(c *tc.C) {
 	// gone and dead is closed. It must not panic (responses not closed)
 	// and must not block (dead is closed); the response is dropped.
 	close(methods.release)
-	chanRead(c, responseHook, "late sendResponse completed without panicking")
+	conn.WaitForPendingServerRequests()
+	c.Check(conn.PendingResponseCount(), tc.Equals, int64(0))
+}
+
+// TestCloseWithWriteNotUnblockedByCodecClose verifies that Close remains
+// bounded even when a codec satisfies its read-unblocking contract but leaves
+// an in-progress WriteMessage blocked.
+func (*rpcSuite) TestCloseWithWriteNotUnblockedByCodecClose(c *tc.C) {
+	codec := newPauseableCodec(rpc.Header{
+		RequestId: 1,
+		Request: rpc.Request{
+			Type:    "BlockingWriteMethods",
+			Version: 0,
+			Id:      "",
+			Action:  "Ping",
+		},
+		Version: 1,
+	})
+	codec.closeUnblocksWrite = false
+	methods := &blockingWriteMethods{called: make(chan struct{})}
+	root := &blockingWriteRoot{methods: methods}
+
+	conn := rpc.NewConn(codec, nil)
+	conn.SetCloseTimeout(100 * time.Millisecond)
+	conn.SetWriteFlushTimeout(100 * time.Millisecond)
+	conn.Serve(root, nil, nil)
+	conn.Start(c.Context())
+
+	chanRead(c, codec.writeStarted, "writer started writing")
+	err := conn.Close()
+	c.Assert(err, tc.ErrorIsNil)
+	codec.unblock()
+}
+
+// TestResponseWritePanicDoesNotStopWriter verifies that a panic while a codec
+// marshals one response cannot crash the process or prevent later responses
+// from being written.
+func (*rpcSuite) TestResponseWritePanicDoesNotStopWriter(c *tc.C) {
+	panicStarted := make(chan struct{})
+	codec := newMarshalServerCodec(
+		rpc.Header{
+			RequestId: 1,
+			Request: rpc.Request{
+				Type: "MarshalMethods", Action: "Panic",
+			},
+		},
+		rpc.Header{
+			RequestId: 2,
+			Request: rpc.Request{
+				Type: "MarshalMethods", Action: "Good",
+			},
+		},
+	)
+	root := &marshalRoot{methods: &marshalMethods{panicStarted: panicStarted}}
+
+	conn := rpc.NewConn(codec, nil)
+	conn.Serve(root, nil, nil)
+	conn.Start(c.Context())
+	defer func() {
+		err := conn.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	hdr := <-codec.errorWritten
+	c.Check(hdr.RequestId, tc.Equals, uint64(1))
+	c.Check(hdr.Error, tc.Equals, "panic writing response: cannot marshal response")
+	chanRead(c, codec.goodWritten, "response after panicking response")
+}
+
+func (*rpcSuite) TestErrorResponseWritePanicDoesNotStopWriter(c *tc.C) {
+	panicStarted := make(chan struct{})
+	codec := newMarshalServerCodec(
+		rpc.Header{
+			RequestId: 1,
+			Request: rpc.Request{
+				Type: "MarshalMethods", Action: "Panic",
+			},
+		},
+		rpc.Header{
+			RequestId: 2,
+			Request: rpc.Request{
+				Type: "MarshalMethods", Action: "Good",
+			},
+		},
+	)
+	codec.panicErrorResponse = true
+	root := &marshalRoot{methods: &marshalMethods{panicStarted: panicStarted}}
+
+	conn := rpc.NewConn(codec, nil)
+	conn.Serve(root, nil, nil)
+	conn.Start(c.Context())
+	defer func() {
+		err := conn.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	chanRead(c, codec.goodWritten, "response after panicking error response")
+}
+
+func (*rpcSuite) TestResponseWritePanicRecordedOnRequestSpan(c *tc.C) {
+	panicStarted := make(chan struct{})
+	codec := newMarshalServerCodec(rpc.Header{
+		RequestId: 1,
+		Request: rpc.Request{
+			Type: "MarshalMethods", Action: "Panic",
+		},
+	})
+	methods := &marshalMethods{panicStarted: panicStarted}
+	span := newRecordingSpan()
+	root := newTracingRoot(&marshalRoot{methods: methods}, span)
+
+	conn := rpc.NewConn(codec, nil)
+	conn.ServeRoot(root, nil, nil)
+	conn.Start(c.Context())
+	defer func() {
+		err := conn.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	err := chanReadError(c, span.errors, "response write span error")
+	c.Check(err, tc.ErrorMatches, "panic writing response: cannot marshal response")
+	chanRead(c, span.ended, "request span ended after response write")
+}
+
+func (*rpcSuite) TestRequestSpanRemainsOpenUntilResponseWriteCompletes(c *tc.C) {
+	codec := newPauseableCodec(rpc.Header{
+		RequestId: 1,
+		Request: rpc.Request{
+			Type: "BlockingWriteMethods", Action: "Ping",
+		},
+	})
+	methods := &blockingWriteMethods{called: make(chan struct{})}
+	span := newRecordingSpan()
+	root := newTracingRoot(&blockingWriteRoot{methods: methods}, span)
+
+	conn := rpc.NewConn(codec, nil)
+	conn.ServeRoot(root, nil, nil)
+	conn.Start(c.Context())
+	defer func() {
+		err := conn.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	chanRead(c, codec.writeStarted, "response write started")
+	select {
+	case <-span.ended:
+		c.Fatal("request span ended before its response write completed")
+	default:
+	}
+	codec.unblock()
+	chanRead(c, span.ended, "request span ended after response write")
+}
+
+func (*rpcSuite) TestResponseWriteErrorRecordedBeforeRequestSpanEnds(c *tc.C) {
+	writeErr := errors.New("response write failed")
+	codec := newPauseableCodec(rpc.Header{
+		RequestId: 1,
+		Request: rpc.Request{
+			Type: "BlockingWriteMethods", Action: "Ping",
+		},
+	})
+	codec.writeErr = writeErr
+	methods := &blockingWriteMethods{called: make(chan struct{})}
+	span := newRecordingSpan()
+	root := newTracingRoot(&blockingWriteRoot{methods: methods}, span)
+
+	conn := rpc.NewConn(codec, nil)
+	conn.ServeRoot(root, nil, nil)
+	conn.Start(c.Context())
+	defer func() {
+		err := conn.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	chanRead(c, codec.writeStarted, "response write started")
+	codec.unblock()
+	err := <-span.errors
+	c.Check(err, tc.ErrorIs, writeErr)
+	chanRead(c, span.ended, "request span ended after recording write error")
+}
+
+func (*rpcSuite) TestRequestSpanPanicDoesNotStopResponseWriter(c *tc.C) {
+	span := newPanicEndSpan()
+	codec := newMarshalServerCodec(
+		rpc.Header{
+			RequestId: 1,
+			Request: rpc.Request{
+				Type: "SpanEndMethods", Action: "First",
+			},
+		},
+		rpc.Header{
+			RequestId: 2,
+			Request: rpc.Request{
+				Type: "SpanEndMethods", Action: "Good",
+			},
+		},
+	)
+	methods := &spanEndMethods{firstSpanEnded: span.panicked}
+	root := newTracingRoot(&spanEndRoot{methods: methods}, span)
+
+	conn := rpc.NewConn(codec, nil)
+	conn.ServeRoot(root, nil, nil)
+	conn.Start(c.Context())
+	defer func() {
+		err := conn.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	chanRead(c, codec.goodWritten, "response after request span panic")
 }
 
 type codedError struct {
@@ -1731,6 +1978,8 @@ type blockingServerCodec struct {
 	unblockWrite      chan struct{}
 	unblockWriteOnce  sync.Once
 	writeCount        int
+	allWritesDone     chan struct{}
+	allWritesOnce     sync.Once
 }
 
 func newBlockingServerCodec(headers ...rpc.Header) *blockingServerCodec {
@@ -1741,6 +1990,7 @@ func newBlockingServerCodec(headers ...rpc.Header) *blockingServerCodec {
 		closeCh:           make(chan struct{}),
 		firstWriteStarted: make(chan struct{}),
 		unblockWrite:      make(chan struct{}),
+		allWritesDone:     make(chan struct{}),
 	}
 }
 
@@ -1767,6 +2017,7 @@ func (c *blockingServerCodec) WriteMessage(_ *rpc.Header, _ any) error {
 	c.mu.Lock()
 	c.writeCount++
 	writeCount := c.writeCount
+	writeTotal := len(c.headers)
 	c.mu.Unlock()
 
 	if writeCount == 1 {
@@ -1774,6 +2025,11 @@ func (c *blockingServerCodec) WriteMessage(_ *rpc.Header, _ any) error {
 			close(c.firstWriteStarted)
 		})
 		<-c.unblockWrite
+	}
+	if writeCount == writeTotal {
+		c.allWritesOnce.Do(func() {
+			close(c.allWritesDone)
+		})
 	}
 	return nil
 }
@@ -1798,22 +2054,28 @@ func (c *blockingServerCodec) unblockFirstWrite() {
 // stalled write that is only unblocked by codec.Close, like the write
 // deadline set by wsJSONConn.Close).
 type pauseableCodec struct {
-	mu               sync.Mutex
-	headers          []rpc.Header
-	readIndex        int
-	closeCh          chan struct{}
-	closeOnce        sync.Once
-	writeStarted     chan struct{}
-	writeStartedOnce sync.Once
+	mu                 sync.Mutex
+	headers            []rpc.Header
+	readIndex          int
+	closeCh            chan struct{}
+	closeOnce          sync.Once
+	closeUnblocksWrite bool
+	unblockWrite       chan struct{}
+	unblockOnce        sync.Once
+	writeErr           error
+	writeStarted       chan struct{}
+	writeStartedOnce   sync.Once
 }
 
 func newPauseableCodec(headers ...rpc.Header) *pauseableCodec {
 	copied := make([]rpc.Header, len(headers))
 	copy(copied, headers)
 	return &pauseableCodec{
-		headers:      copied,
-		closeCh:      make(chan struct{}),
-		writeStarted: make(chan struct{}),
+		headers:            copied,
+		closeCh:            make(chan struct{}),
+		closeUnblocksWrite: true,
+		unblockWrite:       make(chan struct{}),
+		writeStarted:       make(chan struct{}),
 	}
 }
 
@@ -1838,10 +2100,16 @@ func (c *pauseableCodec) WriteMessage(_ *rpc.Header, _ any) error {
 	c.writeStartedOnce.Do(func() {
 		close(c.writeStarted)
 	})
+	closeCh := c.closeCh
+	if !c.closeUnblocksWrite {
+		closeCh = nil
+	}
 	select {
-	case <-c.closeCh:
+	case <-closeCh:
 		// Codec closed while writing; emulate a peer-closed write error.
 		return io.ErrClosedPipe
+	case <-c.unblockWrite:
+		return c.writeErr
 	}
 }
 
@@ -1850,6 +2118,200 @@ func (c *pauseableCodec) Close() error {
 		close(c.closeCh)
 	})
 	return nil
+}
+
+func (c *pauseableCodec) unblock() {
+	c.unblockOnce.Do(func() {
+		close(c.unblockWrite)
+	})
+}
+
+type marshalServerCodec struct {
+	mu                 sync.Mutex
+	headers            []rpc.Header
+	readIndex          int
+	closeCh            chan struct{}
+	closeOnce          sync.Once
+	goodWritten        chan struct{}
+	goodOnce           sync.Once
+	errorWritten       chan rpc.Header
+	panicErrorResponse bool
+}
+
+func newMarshalServerCodec(headers ...rpc.Header) *marshalServerCodec {
+	return &marshalServerCodec{
+		headers:      headers,
+		closeCh:      make(chan struct{}),
+		goodWritten:  make(chan struct{}),
+		errorWritten: make(chan rpc.Header, 1),
+	}
+}
+
+func (c *marshalServerCodec) ReadHeader(hdr *rpc.Header) error {
+	c.mu.Lock()
+	if c.readIndex < len(c.headers) {
+		*hdr = c.headers[c.readIndex]
+		c.readIndex++
+		c.mu.Unlock()
+		return nil
+	}
+	c.mu.Unlock()
+	<-c.closeCh
+	return io.EOF
+}
+
+func (*marshalServerCodec) ReadBody(any, bool) error {
+	return nil
+}
+
+func (c *marshalServerCodec) WriteMessage(hdr *rpc.Header, body any) error {
+	if _, err := json.Marshal(body); err != nil {
+		return err
+	}
+	if hdr.Error != "" {
+		if c.panicErrorResponse {
+			panic("cannot write error response")
+		}
+		c.errorWritten <- *hdr
+	}
+	if hdr.RequestId == 2 {
+		c.goodOnce.Do(func() {
+			close(c.goodWritten)
+		})
+	}
+	return nil
+}
+
+func (c *marshalServerCodec) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closeCh)
+	})
+	return nil
+}
+
+type marshalRoot struct {
+	methods *marshalMethods
+}
+
+func (r *marshalRoot) MarshalMethods(string) (*marshalMethods, error) {
+	return r.methods, nil
+}
+
+type marshalMethods struct {
+	panicStarted chan struct{}
+}
+
+func (m *marshalMethods) Panic() panicMarshalResult {
+	return panicMarshalResult{started: m.panicStarted}
+}
+
+func (m *marshalMethods) Good() stringVal {
+	<-m.panicStarted
+	return stringVal{Val: "good"}
+}
+
+type panicMarshalResult struct {
+	started chan struct{}
+}
+
+func (r panicMarshalResult) MarshalJSON() ([]byte, error) {
+	close(r.started)
+	panic("cannot marshal response")
+}
+
+type tracingRoot struct {
+	rpcreflect.Value
+	span trace.Span
+}
+
+func newTracingRoot(root any, span trace.Span) *tracingRoot {
+	return &tracingRoot{
+		Value: rpcreflect.ValueOf(reflect.ValueOf(root)),
+		span:  span,
+	}
+}
+
+func (*tracingRoot) Kill() {}
+
+func (r *tracingRoot) StartTrace(ctx context.Context) (context.Context, trace.Span) {
+	return trace.WithSpan(ctx, r.span), r.span
+}
+
+func (*tracingRoot) FlightRecorder() flightrecorder.FlightRecorder {
+	return flightrecorder.NoopRecorder{}
+}
+
+type recordingSpan struct {
+	errors chan error
+	ended  chan struct{}
+	once   sync.Once
+}
+
+func newRecordingSpan() *recordingSpan {
+	return &recordingSpan{
+		errors: make(chan error, 1),
+		ended:  make(chan struct{}),
+	}
+}
+
+func (*recordingSpan) Scope() trace.Scope {
+	return trace.NoopScope{}
+}
+
+func (*recordingSpan) AddEvent(string, ...trace.Attribute) {}
+
+func (s *recordingSpan) RecordError(err error, _ ...trace.Attribute) {
+	if err != nil {
+		s.errors <- err
+	}
+}
+
+func (s *recordingSpan) End(...trace.Attribute) {
+	s.once.Do(func() {
+		close(s.ended)
+	})
+}
+
+type panicEndSpan struct {
+	panicked chan struct{}
+	once     sync.Once
+}
+
+func newPanicEndSpan() *panicEndSpan {
+	return &panicEndSpan{panicked: make(chan struct{})}
+}
+
+func (*panicEndSpan) Scope() trace.Scope {
+	return trace.NoopScope{}
+}
+
+func (*panicEndSpan) AddEvent(string, ...trace.Attribute) {}
+
+func (*panicEndSpan) RecordError(error, ...trace.Attribute) {}
+
+func (s *panicEndSpan) End(...trace.Attribute) {
+	s.once.Do(func() {
+		close(s.panicked)
+	})
+	panic("cannot end request span")
+}
+
+type spanEndRoot struct {
+	methods *spanEndMethods
+}
+
+func (r *spanEndRoot) SpanEndMethods(string) (*spanEndMethods, error) {
+	return r.methods, nil
+}
+
+type spanEndMethods struct {
+	firstSpanEnded chan struct{}
+}
+
+func (*spanEndMethods) First() {}
+
+func (m *spanEndMethods) Good() {
+	<-m.firstSpanEnded
 }
 
 // lateResponseRoot serves lateResponseMethods.

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -976,12 +976,13 @@ func (*rpcSuite) TestCloseWithLateResponseDoesNotPanic(c *tc.C) {
 		started: make(chan struct{}),
 		release: make(chan struct{}),
 	}
-	root := &lateResponseRoot{methods: methods}
+	span := newRecordingSpan()
+	root := newTracingRoot(&lateResponseRoot{methods: methods}, span)
 
 	conn := rpc.NewConn(codec, nil)
 	conn.SetCloseTimeout(100 * time.Millisecond)
 	conn.SetWriteFlushTimeout(100 * time.Millisecond)
-	conn.Serve(root, nil, nil)
+	conn.ServeRoot(root, nil, nil)
 	conn.Start(c.Context())
 
 	closeDone := make(chan error, 1)
@@ -1007,6 +1008,13 @@ func (*rpcSuite) TestCloseWithLateResponseDoesNotPanic(c *tc.C) {
 	close(methods.release)
 	conn.WaitForPendingServerRequests()
 	c.Check(conn.PendingResponseCount(), tc.Equals, int64(0))
+	chanRead(c, span.ended, "late response span ended")
+	select {
+	case err := <-span.errors:
+		c.Check(err, tc.ErrorIs, rpc.ErrShutdown)
+	case <-c.Context().Done():
+		c.Fatal("late response span did not record shutdown")
+	}
 }
 
 // TestCloseWithWriteNotUnblockedByCodecClose verifies that Close remains

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -185,11 +185,14 @@ type Conn struct {
 	// the hot path.
 	config atomic.Pointer[serverConfig]
 
-	// mutex guards the following values.
-	mutex sync.Mutex
+	// reqId holds the latest client request id. It is accessed
+	// atomically and does not require the mutex for correctness.
+	reqId atomic.Uint64
 
-	// reqId holds the latest client request id.
-	reqId uint64
+	// mutex guards the client-side connection state: clientPending,
+	// tombstones, shutdown, and dead. It also serializes Start()
+	// initialization of context, dead, responses, and writerDone.
+	mutex sync.Mutex
 
 	// clientPending holds all pending client requests.
 	clientPending map[uint64]*Call
@@ -211,12 +214,13 @@ type Conn struct {
 	cancelContext context.CancelFunc
 
 	// inputLoopError holds the error that caused the input loop to
-	// terminate prematurely.  It is set before dead is closed.
+	// terminate prematurely. It is set before dead is closed, so
+	// readers after <-dead observe it without a lock.
 	inputLoopError error
 
 	// responses is a buffered channel used to queue server response
 	// messages for the writer goroutine. Handler goroutines push
-	// responses here instead of directly acquiring the sending mutex,
+	// responses here instead of writing directly to the codec,
 	// eliminating head-of-line blocking between concurrent handlers.
 	responses chan responseMsg
 
@@ -625,8 +629,9 @@ func (conn *Conn) sendResponse(hdr *Header, body any) {
 }
 
 // writer is the dedicated goroutine that drains the responses channel
-// and writes messages to the codec. It serializes all response writes,
-// eliminating mutex contention between handler goroutines.
+// and writes messages to the codec sequentially. This decouples handler
+// goroutines from write latency and provides natural backpressure via
+// the channel buffer.
 func (conn *Conn) writer() {
 	defer close(conn.writerDone)
 	for msg := range conn.responses {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -163,6 +163,68 @@ type serverConfig struct {
 	recorderFactory RecorderFactory
 }
 
+// writeCounter tracks the number of responses that have been queued by
+// handler goroutines but not yet written by the writer goroutine. Close
+// waits on it (with a timeout) to flush responses before closing the
+// codec.
+//
+// The count is an atomic, so the hot path (add on every response, done
+// after every write) is lock-free. Wakeup is push-based: the done() that
+// brings the count to zero does a non-blocking send on a buffered(1)
+// notify channel, which unblocks a waiting Close. The notification is a
+// "re-check" hint rather than a guarantee, so a stale or dropped send
+// can never cause a missed wakeup: wait() always re-verifies n==0 after
+// each wakeup, and it checks n==0 before blocking. The channel is never
+// closed, so there is no send-on-closed risk.
+//
+// Unlike sync.WaitGroup, a handler that outlives Close's srvPending
+// timeout may still call add/done after wait() has returned; that is
+// safe here because every transition is an atomic op with no
+// happens-before coupling to a prior Wait.
+type writeCounter struct {
+	n      atomic.Int64
+	notify chan struct{}
+}
+
+// newWriteCounter returns a writeCounter in the idle (zero) state.
+func newWriteCounter() *writeCounter {
+	return &writeCounter{notify: make(chan struct{}, 1)}
+}
+
+// add increments the pending count. It must be matched by a later done.
+func (w *writeCounter) add() { w.n.Add(1) }
+
+// done decrements the pending count and, when it reaches zero, pushes a
+// non-blocking wakeup to any waiting Close.
+func (w *writeCounter) done() {
+	if w.n.Add(-1) == 0 {
+		select {
+		case w.notify <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// wait blocks until the counter reaches zero or the timeout elapses. It
+// returns true if the counter reached zero.
+func (w *writeCounter) wait(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if w.n.Load() == 0 {
+			return true
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+		select {
+		case <-w.notify:
+		case <-time.After(remaining):
+			return false
+		}
+	}
+}
+
 // Conn represents an RPC endpoint.  It can both initiate and receive
 // RPC requests.  There may be multiple outstanding Calls associated
 // with a single Client, and a Client may be used by multiple goroutines
@@ -222,15 +284,40 @@ type Conn struct {
 	// messages for the writer goroutine. Handler goroutines push
 	// responses here instead of writing directly to the codec,
 	// eliminating head-of-line blocking between concurrent handlers.
+	//
+	// responses is never closed: handler goroutines may still be
+	// running (and therefore still sending) when Close tears the writer
+	// down, so closing it would risk a send-on-closed-channel panic.
+	// Instead the writer is signaled to stop via writerStop, and late
+	// senders drop their response via the <-dead path in sendResponse.
 	responses chan responseMsg
+
+	// writerStop is closed by Close to ask the writer goroutine to
+	// exit. The writer selects on it alongside responses, so it can
+	// finish draining any buffered messages before returning.
+	writerStop chan struct{}
 
 	// writerDone is closed when the writer goroutine exits.
 	writerDone chan struct{}
 
 	// pendingWrites tracks responses that have been queued but not yet
-	// written by the writer goroutine. Close() waits on this to ensure
-	// all responses are flushed before the codec is closed.
-	pendingWrites sync.WaitGroup
+	// written by the writer goroutine. Close() waits on it (with a
+	// timeout) to flush responses before closing the codec.
+	pendingWrites *writeCounter
+
+	// closeTimeout bounds the wait for outstanding server requests
+	// during Close. It is overridable for tests.
+	closeTimeout time.Duration
+
+	// writeFlushTimeout bounds the wait for queued responses to be
+	// written during Close. It is overridable for tests.
+	writeFlushTimeout time.Duration
+
+	// responseHook, when non-nil, is signalled (non-blocking) once a
+	// response has been queued or dropped in sendResponse. It is nil in
+	// production and used only by tests to observe sendResponse
+	// completion. It must be set before Start.
+	responseHook chan struct{}
 }
 
 // NewConn creates a new connection that uses the given codec for
@@ -239,9 +326,12 @@ type Conn struct {
 // non-nil, it will be called to get a new recorder for every request.
 func NewConn(codec Codec, factory RecorderFactory) *Conn {
 	conn := &Conn{
-		codec:         codec,
-		clientPending: make(map[uint64]*Call),
-		tombstones:    make(map[uint64]struct{}),
+		codec:             codec,
+		clientPending:     make(map[uint64]*Call),
+		tombstones:        make(map[uint64]struct{}),
+		closeTimeout:      time.Minute,
+		writeFlushTimeout: time.Minute,
+		pendingWrites:     newWriteCounter(),
 	}
 	conn.config.Store(&serverConfig{
 		recorderFactory: ensureFactory(factory),
@@ -264,6 +354,7 @@ func (conn *Conn) Start(ctx context.Context) {
 		conn.context, conn.cancelContext = context.WithCancel(ctx)
 		conn.dead = make(chan struct{})
 		conn.responses = make(chan responseMsg, 128)
+		conn.writerStop = make(chan struct{})
 		conn.writerDone = make(chan struct{})
 		go conn.writer()
 		go conn.input()
@@ -392,7 +483,7 @@ func (conn *Conn) Close() error {
 	}()
 	select {
 	case <-done:
-	case <-time.After(time.Minute):
+	case <-time.After(conn.closeTimeout):
 		// A request is refusing to close, so we're blocked. We can't wait
 		// indefinitely, and a minute is a lifetime for any request. Close it,
 		// but warn in the logs that the connection is refusing to go away.
@@ -407,9 +498,17 @@ func (conn *Conn) Close() error {
 	}
 
 	// Wait for any responses queued by handler goroutines to be written
-	// by the writer goroutine. This ensures all responses are flushed to
-	// the client before the codec is closed.
-	conn.pendingWrites.Wait()
+	// by the writer goroutine. This attempts to flush responses to the
+	// client before the codec is closed.
+	//
+	// The wait is bounded: if a write is stalled (e.g. by TCP
+	// backpressure or a slow client), the only thing that can unblock
+	// it is the write deadline set by codec.Close. Gating codec.Close
+	// behind an unbounded wait would therefore deadlock Close, so we
+	// time out and let codec.Close force the stalled write to return.
+	if !conn.pendingWrites.wait(conn.writeFlushTimeout) {
+		logger.Warningf(conn.context, "timed out waiting for outstanding writes, closing anyway")
+	}
 
 	// Closing the codec should cause the input loop to terminate.
 	if err := conn.codec.Close(); err != nil {
@@ -417,10 +516,13 @@ func (conn *Conn) Close() error {
 	}
 	<-conn.dead
 
-	// Now that the input loop has exited and all handler goroutines are
-	// done, close the responses channel to signal the writer to drain
-	// any remaining messages and exit.
-	close(conn.responses)
+	// The input loop has exited and dead is closed. Signal the writer
+	// to stop. responses is intentionally not closed: handler
+	// goroutines that survived the srvPending timeout may still call
+	// sendResponse, and closing responses would risk a
+	// send-on-closed-channel panic. Late senders drop their response
+	// via the <-dead path in sendResponse instead.
+	close(conn.writerStop)
 	<-conn.writerDone
 
 	return conn.inputLoopError
@@ -620,11 +722,17 @@ func (conn *Conn) sendErrorResponse(reqHdr *Header, err error, recorder Recorder
 // It blocks if the response buffer is full, providing natural backpressure.
 // If the connection is dead, the response is dropped.
 func (conn *Conn) sendResponse(hdr *Header, body any) {
-	conn.pendingWrites.Add(1)
+	conn.pendingWrites.add()
 	select {
 	case conn.responses <- responseMsg{hdr: hdr, body: body}:
 	case <-conn.dead:
-		conn.pendingWrites.Done()
+		conn.pendingWrites.done()
+	}
+	if h := conn.responseHook; h != nil {
+		select {
+		case h <- struct{}{}:
+		default:
+		}
 	}
 }
 
@@ -632,17 +740,45 @@ func (conn *Conn) sendResponse(hdr *Header, body any) {
 // and writes messages to the codec sequentially. This decouples handler
 // goroutines from write latency and provides natural backpressure via
 // the channel buffer.
+//
+// The writer exits when writerStop is closed. It uses a select so that
+// any messages already buffered when the stop signal arrives are still
+// drained (each iteration may pick a buffered message before the stop
+// case). responses is never closed, so late senders cannot panic; they
+// drop their response via the <-dead path in sendResponse.
 func (conn *Conn) writer() {
 	defer close(conn.writerDone)
-	for msg := range conn.responses {
-		err := conn.codec.WriteMessage(msg.hdr, msg.body)
-		conn.pendingWrites.Done()
-		if err != nil {
-			msg := err.Error()
-			if !strings.Contains(msg, "websocket: close sent") &&
-				!strings.Contains(msg, "write: broken pipe") {
-				logger.Errorf(conn.context, "error writing response: %T %+v", err, err)
+	for {
+		select {
+		case msg := <-conn.responses:
+			conn.writeResponse(msg)
+		case <-conn.writerStop:
+			// Best-effort drain of anything still buffered before
+			// exiting. Late writes that arrive after this point are
+			// dropped by sendResponse's <-dead branch.
+			for {
+				select {
+				case msg := <-conn.responses:
+					conn.writeResponse(msg)
+				default:
+					return
+				}
 			}
+		}
+	}
+}
+
+// writeResponse writes a single queued response to the codec and marks
+// the pending write as done. Errors that indicate the peer has gone
+// away are expected during shutdown and are not logged.
+func (conn *Conn) writeResponse(msg responseMsg) {
+	err := conn.codec.WriteMessage(msg.hdr, msg.body)
+	conn.pendingWrites.done()
+	if err != nil {
+		msg := err.Error()
+		if !strings.Contains(msg, "websocket: close sent") &&
+			!strings.Contains(msg, "write: broken pipe") {
+			logger.Errorf(conn.context, "error writing response: %T %+v", err, err)
 		}
 	}
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -41,8 +41,8 @@ type Codec interface {
 
 	// WriteMessage writes a message with the given header and body.
 	// The body will always be a struct. It may be called concurrently
-	// with ReadHeader and ReadBody, but will not be called
-	// concurrently with itself.
+	// with ReadHeader, ReadBody, and other calls to WriteMessage.
+	// Implementations must handle their own write serialization.
 	WriteMessage(hdr *Header, body any) error
 
 	// Close closes the codec. It may be called concurrently
@@ -162,10 +162,6 @@ type Conn struct {
 
 	// srvPending represents the current server requests.
 	srvPending sync.WaitGroup
-
-	// sending guards the write side of the codec - it ensures
-	// that codec.WriteMessage is not called concurrently.
-	sending sync.Mutex
 
 	// mutex guards the following values.
 	mutex sync.Mutex
@@ -636,9 +632,7 @@ func (conn *Conn) sendResponse(hdr *Header, body any) {
 func (conn *Conn) writer() {
 	defer close(conn.writerDone)
 	for msg := range conn.responses {
-		conn.sending.Lock()
 		err := conn.codec.WriteMessage(msg.hdr, msg.body)
-		conn.sending.Unlock()
 		conn.pendingWrites.Done()
 		if err != nil {
 			msg := err.Error()

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -146,6 +146,12 @@ func (noopTracingRoot) FlightRecorder() flightrecorder.FlightRecorder {
 // Note that we use "client request" and "server request" to name
 // requests initiated locally and remotely respectively.
 
+// responseMsg represents a response message queued for writing.
+type responseMsg struct {
+	hdr  *Header
+	body any
+}
+
 // Conn represents an RPC endpoint.  It can both initiate and receive
 // RPC requests.  There may be multiple outstanding Calls associated
 // with a single Client, and a Client may be used by multiple goroutines
@@ -159,7 +165,6 @@ type Conn struct {
 
 	// sending guards the write side of the codec - it ensures
 	// that codec.WriteMessage is not called concurrently.
-	// It also guards shutdown.
 	sending sync.Mutex
 
 	// mutex guards the following values.
@@ -204,6 +209,20 @@ type Conn struct {
 	inputLoopError error
 
 	recorderFactory RecorderFactory
+
+	// responses is a buffered channel used to queue server response
+	// messages for the writer goroutine. Handler goroutines push
+	// responses here instead of directly acquiring the sending mutex,
+	// eliminating head-of-line blocking between concurrent handlers.
+	responses chan responseMsg
+
+	// writerDone is closed when the writer goroutine exits.
+	writerDone chan struct{}
+
+	// pendingWrites tracks responses that have been queued but not yet
+	// written by the writer goroutine. Close() waits on this to ensure
+	// all responses are flushed before the codec is closed.
+	pendingWrites sync.WaitGroup
 }
 
 // NewConn creates a new connection that uses the given codec for
@@ -233,6 +252,9 @@ func (conn *Conn) Start(ctx context.Context) {
 	if conn.dead == nil {
 		conn.context, conn.cancelContext = context.WithCancel(ctx)
 		conn.dead = make(chan struct{})
+		conn.responses = make(chan responseMsg, 128)
+		conn.writerDone = make(chan struct{})
+		go conn.writer()
 		go conn.input()
 	}
 }
@@ -379,11 +401,22 @@ func (conn *Conn) Close() error {
 	}
 	conn.mutex.Unlock()
 
+	// Wait for any responses queued by handler goroutines to be written
+	// by the writer goroutine. This ensures all responses are flushed to
+	// the client before the codec is closed.
+	conn.pendingWrites.Wait()
+
 	// Closing the codec should cause the input loop to terminate.
 	if err := conn.codec.Close(); err != nil {
 		logger.Debugf(conn.context, "error closing codec: %v", err)
 	}
 	<-conn.dead
+
+	// Now that the input loop has exited and all handler goroutines are
+	// done, close the responses channel to signal the writer to drain
+	// any remaining messages and exit.
+	close(conn.responses)
+	<-conn.writerDone
 
 	return conn.inputLoopError
 }
@@ -427,8 +460,6 @@ type Killer interface {
 // appropriately.
 func (conn *Conn) input() {
 	err := conn.loop()
-	conn.sending.Lock()
-	defer conn.sending.Unlock()
 	conn.mutex.Lock()
 	defer conn.mutex.Unlock()
 
@@ -503,7 +534,8 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 		}
 		// We don't transform the error here. bindRequest will have
 		// already transformed it and returned a zero req.
-		return conn.writeErrorResponse(hdr, err, recorder)
+		conn.sendErrorResponse(hdr, err, recorder)
+		return nil
 	}
 	var argp any
 	var arg reflect.Value
@@ -530,7 +562,8 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 		// the error is actually a framing or syntax
 		// problem, then the next ReadHeader should pick
 		// up the problem and abort.
-		return conn.writeErrorResponse(hdr, req.transformErrors(err), recorder)
+		conn.sendErrorResponse(hdr, req.transformErrors(err), recorder)
+		return nil
 	}
 	var body any = struct{}{}
 	if req.ParamsType() != nil {
@@ -538,7 +571,8 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 	}
 	if err := recorder.HandleRequest(hdr, body); err != nil {
 		logger.Errorf(context.TODO(), "error recording request %+v with arg %+v: %T %+v", req, arg, err, err)
-		return conn.writeErrorResponse(hdr, req.transformErrors(err), recorder)
+		conn.sendErrorResponse(hdr, req.transformErrors(err), recorder)
+		return nil
 	}
 
 	// Hold the lock whilst checking the closing flag.
@@ -548,7 +582,8 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 
 	if closing {
 		// We're closing down - no new requests may be initiated.
-		return conn.writeErrorResponse(hdr, req.transformErrors(ErrShutdown), recorder)
+		conn.sendErrorResponse(hdr, req.transformErrors(ErrShutdown), recorder)
+		return nil
 	}
 
 	conn.srvPending.Add(1)
@@ -557,9 +592,10 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 	return nil
 }
 
-func (conn *Conn) writeErrorResponse(reqHdr *Header, err error, recorder Recorder) error {
-	conn.sending.Lock()
-	defer conn.sending.Unlock()
+// sendErrorResponse constructs an error response and queues it for writing.
+// It calls recorder.HandleReply before queuing, ensuring observer work is not
+// performed while holding any write lock.
+func (conn *Conn) sendErrorResponse(reqHdr *Header, err error, recorder Recorder) {
 	hdr := &Header{
 		RequestId:  reqHdr.RequestId,
 		Version:    reqHdr.Version,
@@ -579,8 +615,39 @@ func (conn *Conn) writeErrorResponse(reqHdr *Header, err error, recorder Recorde
 	if err := recorder.HandleReply(reqHdr.Request, hdr, struct{}{}); err != nil {
 		logger.Errorf(context.TODO(), "error recording reply %+v: %T %+v", hdr, err, err)
 	}
+	conn.sendResponse(hdr, struct{}{})
+}
 
-	return conn.codec.WriteMessage(hdr, struct{}{})
+// sendResponse queues a response message for the writer goroutine.
+// It blocks if the response buffer is full, providing natural backpressure.
+// If the connection is dead, the response is dropped.
+func (conn *Conn) sendResponse(hdr *Header, body any) {
+	conn.pendingWrites.Add(1)
+	select {
+	case conn.responses <- responseMsg{hdr: hdr, body: body}:
+	case <-conn.dead:
+		conn.pendingWrites.Done()
+	}
+}
+
+// writer is the dedicated goroutine that drains the responses channel
+// and writes messages to the codec. It serializes all response writes,
+// eliminating mutex contention between handler goroutines.
+func (conn *Conn) writer() {
+	defer close(conn.writerDone)
+	for msg := range conn.responses {
+		conn.sending.Lock()
+		err := conn.codec.WriteMessage(msg.hdr, msg.body)
+		conn.sending.Unlock()
+		conn.pendingWrites.Done()
+		if err != nil {
+			msg := err.Error()
+			if !strings.Contains(msg, "websocket: close sent") &&
+				!strings.Contains(msg, "write: broken pipe") {
+				logger.Errorf(conn.context, "error writing response: %T %+v", err, err)
+			}
+		}
+	}
 }
 
 // boundRequest represents an RPC request that is
@@ -640,7 +707,7 @@ func (conn *Conn) runRequest(
 		if panicResult := recover(); panicResult != nil {
 			logger.Criticalf(conn.context,
 				"panic running request %+v with arg %+v: %v\n%v", req, arg, panicResult, string(debug.Stack()))
-			_ = conn.writeErrorResponse(&req.hdr, errors.Errorf("%v", panicResult), recorder)
+			conn.sendErrorResponse(&req.hdr, errors.Errorf("%v", panicResult), recorder)
 		}
 	}()
 
@@ -698,7 +765,7 @@ func (conn *Conn) callRequest(
 		// Record the first error, this is the one that will be returned to
 		// the client.
 		trace.SpanFromContext(ctx).RecordError(err)
-		err = conn.writeErrorResponse(&req.hdr, req.transformErrors(err), recorder)
+		conn.sendErrorResponse(&req.hdr, req.transformErrors(err), recorder)
 	} else {
 		hdr := &Header{
 			RequestId:  req.hdr.RequestId,
@@ -721,27 +788,7 @@ func (conn *Conn) callRequest(
 			logger.Tracef(ctx, "error capturing flight recorder: %v", err)
 		}
 
-		// Guard against concurrent writes to the codec, but ensure that
-		// if there is a panic during WriteMessage we don't hold the lock.
-		conn.sending.Lock()
-		defer conn.sending.Unlock()
-
-		err = conn.codec.WriteMessage(hdr, rvi)
-	}
-	if err != nil {
-		// If the message failed due to the other end closing the socket, that
-		// is expected when an agent restarts so no need to log an  error.
-		// The error type here is errors.errorString so all we can do is a match
-		// on the error string content.
-		msg := err.Error()
-		if !strings.Contains(msg, "websocket: close sent") &&
-			!strings.Contains(msg, "write: broken pipe") {
-
-			// Record the second error, this is the one that will be recorded if
-			// we can't write the response to the client.
-			trace.SpanFromContext(ctx).RecordError(err)
-			logger.Errorf(ctx, "error writing response: %T %+v", err, err)
-		}
+		conn.sendResponse(hdr, rvi)
 	}
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -11,6 +11,7 @@ import (
 	"runtime/pprof"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/juju/core/flightrecorder"
@@ -152,6 +153,16 @@ type responseMsg struct {
 	body any
 }
 
+// serverConfig holds the server-side configuration that is set once
+// (or rarely changed) via Serve/ServeRoot. It is stored in an atomic
+// pointer so that the hot request path (bindRequest, getRecorder,
+// withTrace) can read it without acquiring a mutex.
+type serverConfig struct {
+	root            Root
+	transformErrors func(error) error
+	recorderFactory RecorderFactory
+}
+
 // Conn represents an RPC endpoint.  It can both initiate and receive
 // RPC requests.  There may be multiple outstanding Calls associated
 // with a single Client, and a Client may be used by multiple goroutines
@@ -163,15 +174,19 @@ type Conn struct {
 	// srvPending represents the current server requests.
 	srvPending sync.WaitGroup
 
+	// closing is set atomically when the connection is shutting down
+	// via Close. When set, no more client or server requests will be
+	// initiated. Using atomic.Bool allows the hot server request path
+	// to check this without acquiring the mutex.
+	closing atomic.Bool
+
+	// config holds the server-side configuration (root, transformErrors,
+	// recorderFactory). It is stored atomically and read lock-free on
+	// the hot path.
+	config atomic.Pointer[serverConfig]
+
 	// mutex guards the following values.
 	mutex sync.Mutex
-
-	// root represents  the current root object that serves the RPC requests.
-	// It may be nil if nothing is being served.
-	root Root
-
-	// transformErrors is used to transform returned errors.
-	transformErrors func(error) error
 
 	// reqId holds the latest client request id.
 	reqId uint64
@@ -182,11 +197,6 @@ type Conn struct {
 	// tombstones holds the client request ids that have been
 	// cancelled.
 	tombstones map[uint64]struct{}
-
-	// closing is set when the connection is shutting down via
-	// Close.  When this is set, no more client or server requests
-	// will be initiated.
-	closing bool
 
 	// shutdown is set when the input loop terminates. When this
 	// is set, no more client requests will be sent to the server.
@@ -203,8 +213,6 @@ type Conn struct {
 	// inputLoopError holds the error that caused the input loop to
 	// terminate prematurely.  It is set before dead is closed.
 	inputLoopError error
-
-	recorderFactory RecorderFactory
 
 	// responses is a buffered channel used to queue server response
 	// messages for the writer goroutine. Handler goroutines push
@@ -226,12 +234,15 @@ type Conn struct {
 // before any requests are sent or received. If recorderFactory is
 // non-nil, it will be called to get a new recorder for every request.
 func NewConn(codec Codec, factory RecorderFactory) *Conn {
-	return &Conn{
-		codec:           codec,
-		clientPending:   make(map[uint64]*Call),
-		tombstones:      make(map[uint64]struct{}),
-		recorderFactory: ensureFactory(factory),
+	conn := &Conn{
+		codec:         codec,
+		clientPending: make(map[uint64]*Call),
+		tombstones:    make(map[uint64]struct{}),
 	}
+	conn.config.Store(&serverConfig{
+		recorderFactory: ensureFactory(factory),
+	})
+	return conn
 }
 
 // Start starts the RPC connection running.  It must be called at
@@ -320,11 +331,11 @@ func (conn *Conn) serve(root Root, factory RecorderFactory, transformErrors func
 	if transformErrors == nil {
 		transformErrors = noopTransform
 	}
-	conn.mutex.Lock()
-	defer conn.mutex.Unlock()
-	conn.root = root
-	conn.recorderFactory = ensureFactory(factory)
-	conn.transformErrors = transformErrors
+	conn.config.Store(&serverConfig{
+		root:            root,
+		transformErrors: transformErrors,
+		recorderFactory: ensureFactory(factory),
+	})
 }
 
 // noopTransform is used when transformErrors is not supplied to Serve.
@@ -350,23 +361,19 @@ func (conn *Conn) Dead() <-chan struct{} {
 //
 // Calling Close multiple times is not an error.
 func (conn *Conn) Close() error {
-	conn.mutex.Lock()
-	if conn.closing {
-		conn.mutex.Unlock()
+	if !conn.closing.CompareAndSwap(false, true) {
 		// Golang's net/rpc returns rpc.ErrShutdown if you ask to close
 		// a closing or shutdown connection. Our choice is that Close
 		// is an idempotent way to ask for resources to be released and
 		// isn't a failure if called multiple times.
 		return nil
 	}
-	conn.closing = true
-	if conn.root != nil {
+	if cfg := conn.config.Load(); cfg.root != nil {
 		// Kill calls down into the resources to stop all the resources which
 		// includes watchers. The watches need to be killed in order for their
 		// API methods to return, otherwise they are just waiting.
-		conn.root.Kill()
+		cfg.root.Kill()
 	}
-	conn.mutex.Unlock()
 
 	// Wait for any outstanding server requests to complete
 	// and write their replies before closing the codec. We
@@ -388,14 +395,12 @@ func (conn *Conn) Close() error {
 		logger.Warningf(conn.context, "timed out waiting for outstanding requests, closing anyway")
 	}
 
-	conn.mutex.Lock()
-	if conn.root != nil {
+	if cfg := conn.config.Load(); cfg.root != nil {
 		// It is possible that since we last Killed the root, other resources
 		// may have been added during some of the pending call resolutions.
 		// So to release these resources, double tap the root.
-		conn.root.Kill()
+		cfg.root.Kill()
 	}
-	conn.mutex.Unlock()
 
 	// Wait for any responses queued by handler goroutines to be written
 	// by the writer goroutine. This ensures all responses are flushed to
@@ -459,7 +464,7 @@ func (conn *Conn) input() {
 	conn.mutex.Lock()
 	defer conn.mutex.Unlock()
 
-	if conn.closing || errors.Is(err, io.EOF) {
+	if conn.closing.Load() || errors.Is(err, io.EOF) {
 		err = errors.Errorf(
 			"connection is shut down: %w", err,
 		).Add(ErrShutdown)
@@ -513,9 +518,7 @@ func (conn *Conn) readBody(resp any, isRequest bool) error {
 }
 
 func (conn *Conn) getRecorder() Recorder {
-	conn.mutex.Lock()
-	defer conn.mutex.Unlock()
-	return conn.recorderFactory()
+	return conn.config.Load().recorderFactory()
 }
 
 func (conn *Conn) handleRequest(hdr *Header) error {
@@ -571,12 +574,7 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 		return nil
 	}
 
-	// Hold the lock whilst checking the closing flag.
-	conn.mutex.Lock()
-	closing := conn.closing
-	conn.mutex.Unlock()
-
-	if closing {
+	if conn.closing.Load() {
 		// We're closing down - no new requests may be initiated.
 		conn.sendErrorResponse(hdr, req.transformErrors(ErrShutdown), recorder)
 		return nil
@@ -656,15 +654,12 @@ type boundRequest struct {
 // request held in the given header and returns
 // a boundRequest that can call those methods.
 func (conn *Conn) bindRequest(hdr *Header) (boundRequest, error) {
-	conn.mutex.Lock()
-	root := conn.root
-	transformErrors := conn.transformErrors
-	conn.mutex.Unlock()
+	cfg := conn.config.Load()
 
-	if root == nil {
+	if cfg.root == nil {
 		return boundRequest{}, errors.New("no service")
 	}
-	caller, err := root.FindMethod(
+	caller, err := cfg.root.FindMethod(
 		hdr.Request.Type, hdr.Request.Version, hdr.Request.Action)
 	if err != nil {
 		if _, ok := err.(*rpcreflect.CallNotImplementedError); ok {
@@ -672,13 +667,13 @@ func (conn *Conn) bindRequest(hdr *Header) (boundRequest, error) {
 				error: err,
 			}
 		} else {
-			err = transformErrors(err)
+			err = cfg.transformErrors(err)
 		}
 		return boundRequest{}, err
 	}
 	return boundRequest{
 		MethodCaller:    caller,
-		transformErrors: transformErrors,
+		transformErrors: cfg.transformErrors,
 		hdr:             *hdr,
 	}, nil
 }
@@ -721,14 +716,13 @@ func (conn *Conn) runRequest(
 }
 
 func (conn *Conn) withTrace(ctx context.Context, request Request, fn func(ctx context.Context)) {
-	// For some asinine reason, the connection may not have a root. In that
-	// case we just call the function without tracing.
-	if conn.root == nil {
+	cfg := conn.config.Load()
+	if cfg.root == nil {
 		fn(ctx)
 		return
 	}
 
-	ctx, span := conn.root.StartTrace(ctx)
+	ctx, span := cfg.root.StartTrace(ctx)
 	defer span.End(
 		trace.StringAttr("request.type", request.Type),
 		trace.IntAttr("request.version", request.Version),
@@ -789,12 +783,10 @@ func (conn *Conn) callRequest(
 var noop = flightrecorder.NoopRecorder{}
 
 func (conn *Conn) getFlightRecorder() flightrecorder.FlightRecorder {
-	// For some asinine reason, the connection may not have a root. In that
-	// case we just return a noop flight recorder.
-	if conn.root == nil {
-		return noop
+	if cfg := conn.config.Load(); cfg.root != nil {
+		return cfg.root.FlightRecorder()
 	}
-	return conn.root.FlightRecorder()
+	return noop
 }
 
 type serverError struct {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -149,8 +149,12 @@ func (noopTracingRoot) FlightRecorder() flightrecorder.FlightRecorder {
 
 // responseMsg represents a response message queued for writing.
 type responseMsg struct {
-	hdr  *Header
-	body any
+	ctx      context.Context
+	request  Request
+	recorder Recorder
+	hdr      *Header
+	body     any
+	done     func(error)
 }
 
 // serverConfig holds the server-side configuration that is set once
@@ -163,10 +167,11 @@ type serverConfig struct {
 	recorderFactory RecorderFactory
 }
 
-// writeCounter tracks the number of responses that have been queued by
-// handler goroutines but not yet written by the writer goroutine. Close
-// waits on it (with a timeout) to flush responses before closing the
-// codec.
+// writeCounter tracks responses from the point at which a handler starts
+// trying to queue them until the writer goroutine has written or dropped
+// them. Close waits on it (with a timeout) to flush responses before closing
+// the codec. Counting blocked queue operations is intentional: otherwise
+// Close could observe zero while a response is about to be queued.
 //
 // The count is an atomic, so the hot path (add on every response, done
 // after every write) is lock-free. Wakeup is push-based: the done() that
@@ -289,8 +294,12 @@ type Conn struct {
 	// running (and therefore still sending) when Close tears the writer
 	// down, so closing it would risk a send-on-closed-channel panic.
 	// Instead the writer is signaled to stop via writerStop, and late
-	// senders drop their response via the <-dead path in sendResponse.
+	// senders drop their response after observing writerStopped.
 	responses chan responseMsg
+
+	// writerStopped prevents new responses from entering the queue once the
+	// writer begins shutting down.
+	writerStopped atomic.Bool
 
 	// writerStop is closed by Close to ask the writer goroutine to
 	// exit. The writer selects on it alongside responses, so it can
@@ -312,12 +321,6 @@ type Conn struct {
 	// writeFlushTimeout bounds the wait for queued responses to be
 	// written during Close. It is overridable for tests.
 	writeFlushTimeout time.Duration
-
-	// responseHook, when non-nil, is signalled (non-blocking) once a
-	// response has been queued or dropped in sendResponse. It is nil in
-	// production and used only by tests to observe sendResponse
-	// completion. It must be set before Start.
-	responseHook chan struct{}
 }
 
 // NewConn creates a new connection that uses the given codec for
@@ -356,6 +359,7 @@ func (conn *Conn) Start(ctx context.Context) {
 		conn.responses = make(chan responseMsg, 128)
 		conn.writerStop = make(chan struct{})
 		conn.writerDone = make(chan struct{})
+		// writerDone is the join point for this connection-scoped goroutine.
 		go conn.writer()
 		go conn.input()
 	}
@@ -520,10 +524,17 @@ func (conn *Conn) Close() error {
 	// to stop. responses is intentionally not closed: handler
 	// goroutines that survived the srvPending timeout may still call
 	// sendResponse, and closing responses would risk a
-	// send-on-closed-channel panic. Late senders drop their response
-	// via the <-dead path in sendResponse instead.
+	// send-on-closed-channel panic. writerStopped prevents late senders
+	// from adding work after the writer begins draining.
+	conn.writerStopped.Store(true)
 	close(conn.writerStop)
-	<-conn.writerDone
+	select {
+	case <-conn.writerDone:
+	case <-time.After(conn.writeFlushTimeout):
+		// Codec.Close is only required to unblock reads. Do not strand Close
+		// forever if a codec leaves an in-progress WriteMessage blocked.
+		logger.Warningf(conn.context, "timed out waiting for response writer to stop")
+	}
 
 	return conn.inputLoopError
 }
@@ -639,7 +650,7 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 		}
 		// We don't transform the error here. bindRequest will have
 		// already transformed it and returned a zero req.
-		conn.sendErrorResponse(hdr, err, recorder)
+		conn.sendErrorResponse(conn.context, hdr, err, recorder, nil)
 		return nil
 	}
 	var argp any
@@ -667,7 +678,7 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 		// the error is actually a framing or syntax
 		// problem, then the next ReadHeader should pick
 		// up the problem and abort.
-		conn.sendErrorResponse(hdr, req.transformErrors(err), recorder)
+		conn.sendErrorResponse(conn.context, hdr, req.transformErrors(err), recorder, nil)
 		return nil
 	}
 	var body any = struct{}{}
@@ -676,13 +687,13 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 	}
 	if err := recorder.HandleRequest(hdr, body); err != nil {
 		logger.Errorf(context.TODO(), "error recording request %+v with arg %+v: %T %+v", req, arg, err, err)
-		conn.sendErrorResponse(hdr, req.transformErrors(err), recorder)
+		conn.sendErrorResponse(conn.context, hdr, req.transformErrors(err), recorder, nil)
 		return nil
 	}
 
 	if conn.closing.Load() {
 		// We're closing down - no new requests may be initiated.
-		conn.sendErrorResponse(hdr, req.transformErrors(ErrShutdown), recorder)
+		conn.sendErrorResponse(conn.context, hdr, req.transformErrors(ErrShutdown), recorder, nil)
 		return nil
 	}
 
@@ -695,7 +706,20 @@ func (conn *Conn) handleRequest(hdr *Header) error {
 // sendErrorResponse constructs an error response and queues it for writing.
 // It calls recorder.HandleReply before queuing, ensuring observer work is not
 // performed while holding any write lock.
-func (conn *Conn) sendErrorResponse(reqHdr *Header, err error, recorder Recorder) {
+func (conn *Conn) sendErrorResponse(
+	ctx context.Context,
+	reqHdr *Header,
+	err error,
+	recorder Recorder,
+	done func(error),
+) {
+	hdr, body := conn.makeErrorResponse(reqHdr, err, recorder)
+	conn.sendResponse(ctx, reqHdr.Request, recorder, hdr, body, done)
+}
+
+func (conn *Conn) makeErrorResponse(
+	reqHdr *Header, err error, recorder Recorder,
+) (*Header, any) {
 	hdr := &Header{
 		RequestId:  reqHdr.RequestId,
 		Version:    reqHdr.Version,
@@ -715,24 +739,46 @@ func (conn *Conn) sendErrorResponse(reqHdr *Header, err error, recorder Recorder
 	if err := recorder.HandleReply(reqHdr.Request, hdr, struct{}{}); err != nil {
 		logger.Errorf(context.TODO(), "error recording reply %+v: %T %+v", hdr, err, err)
 	}
-	conn.sendResponse(hdr, struct{}{})
+	return hdr, struct{}{}
 }
 
 // sendResponse queues a response message for the writer goroutine.
 // It blocks if the response buffer is full, providing natural backpressure.
 // If the connection is dead, the response is dropped.
-func (conn *Conn) sendResponse(hdr *Header, body any) {
+func (conn *Conn) sendResponse(
+	ctx context.Context,
+	request Request,
+	recorder Recorder,
+	hdr *Header,
+	body any,
+	done func(error),
+) {
+	msg := responseMsg{
+		ctx:      context.WithoutCancel(ctx),
+		request:  request,
+		recorder: recorder,
+		hdr:      hdr,
+		body:     body,
+		done:     done,
+	}
+	if conn.writerStopped.Load() {
+		conn.finishResponse(msg, nil)
+		return
+	}
 	conn.pendingWrites.add()
+	// Pair the second check with writer's pendingWrites drain. If shutdown
+	// began between the first check and add, undo the accounting without
+	// attempting to queue to a writer that may already have exited.
+	if conn.writerStopped.Load() {
+		conn.pendingWrites.done()
+		conn.finishResponse(msg, nil)
+		return
+	}
 	select {
-	case conn.responses <- responseMsg{hdr: hdr, body: body}:
+	case conn.responses <- msg:
 	case <-conn.dead:
 		conn.pendingWrites.done()
-	}
-	if h := conn.responseHook; h != nil {
-		select {
-		case h <- struct{}{}:
-		default:
-		}
+		conn.finishResponse(msg, nil)
 	}
 }
 
@@ -745,7 +791,7 @@ func (conn *Conn) sendResponse(hdr *Header, body any) {
 // any messages already buffered when the stop signal arrives are still
 // drained (each iteration may pick a buffered message before the stop
 // case). responses is never closed, so late senders cannot panic; they
-// drop their response via the <-dead path in sendResponse.
+// drop their response after observing writerStopped in sendResponse.
 func (conn *Conn) writer() {
 	defer close(conn.writerDone)
 	for {
@@ -753,17 +799,17 @@ func (conn *Conn) writer() {
 		case msg := <-conn.responses:
 			conn.writeResponse(msg)
 		case <-conn.writerStop:
-			// Best-effort drain of anything still buffered before
-			// exiting. Late writes that arrive after this point are
-			// dropped by sendResponse's <-dead branch.
-			for {
+			// Drain queued responses and wait for any sender that passed the
+			// first writerStopped check. The sender's second check either
+			// drops the response or leaves it accounted for here to consume.
+			for conn.pendingWrites.n.Load() != 0 {
 				select {
 				case msg := <-conn.responses:
 					conn.writeResponse(msg)
-				default:
-					return
+				case <-conn.pendingWrites.notify:
 				}
 			}
+			return
 		}
 	}
 }
@@ -772,14 +818,72 @@ func (conn *Conn) writer() {
 // the pending write as done. Errors that indicate the peer has gone
 // away are expected during shutdown and are not logged.
 func (conn *Conn) writeResponse(msg responseMsg) {
-	err := conn.codec.WriteMessage(msg.hdr, msg.body)
-	conn.pendingWrites.done()
-	if err != nil {
-		msg := err.Error()
-		if !strings.Contains(msg, "websocket: close sent") &&
-			!strings.Contains(msg, "write: broken pipe") {
-			logger.Errorf(conn.context, "error writing response: %T %+v", err, err)
+	var responseErr error
+	defer conn.pendingWrites.done()
+	defer func() {
+		if panicResult := recover(); panicResult != nil {
+			responseErr = errors.Errorf("panic completing response write: %v", panicResult)
+			logger.Criticalf(msg.ctx, "%v\n%v", responseErr, string(debug.Stack()))
 		}
+		conn.finishResponse(msg, responseErr)
+	}()
+
+	err, panicResult, panicStack := conn.writeMessage(msg.hdr, msg.body)
+	responseErr = err
+	if panicResult != nil {
+		responseErr = errors.Errorf("panic writing response: %v", panicResult)
+		logger.Criticalf(msg.ctx, "%v\n%v", responseErr, string(panicStack))
+
+		// A response value may panic while being marshalled. Preserve the old
+		// request-goroutine behaviour by returning that panic as an RPC error.
+		reqHdr := *msg.hdr
+		reqHdr.Request = msg.request
+		errHdr, errBody := conn.makeErrorResponse(&reqHdr, responseErr, msg.recorder)
+		fallbackErr, fallbackPanic, fallbackStack := conn.writeMessage(errHdr, errBody)
+		if fallbackPanic != nil {
+			logger.Criticalf(msg.ctx,
+				"panic writing error response: %v\n%v", fallbackPanic, string(fallbackStack))
+		} else {
+			conn.logResponseWriteError(msg.ctx, fallbackErr)
+		}
+	} else {
+		conn.logResponseWriteError(msg.ctx, err)
+	}
+}
+
+func (conn *Conn) finishResponse(msg responseMsg, err error) {
+	if msg.done == nil {
+		return
+	}
+	defer func() {
+		if panicResult := recover(); panicResult != nil {
+			logger.Criticalf(msg.ctx,
+				"panic finishing response trace: %v\n%v", panicResult, string(debug.Stack()))
+		}
+	}()
+	msg.done(err)
+}
+
+func (conn *Conn) writeMessage(hdr *Header, body any) (
+	err error, panicResult any, panicStack []byte,
+) {
+	defer func() {
+		panicResult = recover()
+		if panicResult != nil {
+			panicStack = debug.Stack()
+		}
+	}()
+	return conn.codec.WriteMessage(hdr, body), nil, nil
+}
+
+func (conn *Conn) logResponseWriteError(ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "websocket: close sent") &&
+		!strings.Contains(errMsg, "write: broken pipe") {
+		logger.Errorf(ctx, "error writing response: %T %+v", err, err)
 	}
 }
 
@@ -837,7 +941,9 @@ func (conn *Conn) runRequest(
 		if panicResult := recover(); panicResult != nil {
 			logger.Criticalf(conn.context,
 				"panic running request %+v with arg %+v: %v\n%v", req, arg, panicResult, string(debug.Stack()))
-			conn.sendErrorResponse(&req.hdr, errors.Errorf("%v", panicResult), recorder)
+			conn.sendErrorResponse(
+				conn.context, &req.hdr, errors.Errorf("%v", panicResult), recorder, nil,
+			)
 		}
 	}()
 
@@ -851,30 +957,48 @@ func (conn *Conn) runRequest(
 	// don't care, a new one will be curated for us.
 	ctx = trace.WithTraceScope(ctx, req.hdr.TraceID, req.hdr.SpanID, req.hdr.TraceFlags)
 
-	conn.withTrace(ctx, req.hdr.Request, func(ctx context.Context) {
-		conn.callRequest(ctx, req, arg, version, recorder)
+	conn.withTrace(ctx, req.hdr.Request, func(ctx context.Context, done func(error)) bool {
+		return conn.callRequest(ctx, req, arg, version, recorder, done)
 	})
 }
 
-func (conn *Conn) withTrace(ctx context.Context, request Request, fn func(ctx context.Context)) {
+func (conn *Conn) withTrace(
+	ctx context.Context,
+	request Request,
+	fn func(context.Context, func(error)) bool,
+) {
 	cfg := conn.config.Load()
 	if cfg.root == nil {
-		fn(ctx)
+		fn(ctx, nil)
 		return
 	}
 
 	ctx, span := cfg.root.StartTrace(ctx)
-	defer span.End(
-		trace.StringAttr("request.type", request.Type),
-		trace.IntAttr("request.version", request.Version),
-		trace.StringAttr("request.action", request.Action),
-	)
+	var finishOnce sync.Once
+	finish := func(err error) {
+		finishOnce.Do(func() {
+			if err != nil {
+				span.RecordError(err)
+			}
+			span.End(
+				trace.StringAttr("request.type", request.Type),
+				trace.IntAttr("request.version", request.Version),
+				trace.StringAttr("request.action", request.Action),
+			)
+		})
+	}
+	transferred := false
+	defer func() {
+		if !transferred {
+			finish(nil)
+		}
+	}()
 
 	// Set the otel.traceid for the goroutine, so profiling tools can then link
 	// the trace to the profile.
 	traceID, _ := trace.TraceIDFromContext(ctx)
 	pprof.Do(ctx, pprof.Labels(trace.OTELTraceID, traceID), func(ctx context.Context) {
-		fn(ctx)
+		transferred = fn(ctx, finish)
 	})
 }
 
@@ -884,7 +1008,8 @@ func (conn *Conn) callRequest(
 	arg reflect.Value,
 	version int,
 	recorder Recorder,
-) {
+	done func(error),
+) bool {
 	rv, err := req.Call(ctx, req.hdr.Request.Id, arg)
 	if err != nil {
 		if err := conn.getFlightRecorder().Capture(flightrecorder.KindError); err != nil {
@@ -894,7 +1019,7 @@ func (conn *Conn) callRequest(
 		// Record the first error, this is the one that will be returned to
 		// the client.
 		trace.SpanFromContext(ctx).RecordError(err)
-		conn.sendErrorResponse(&req.hdr, req.transformErrors(err), recorder)
+		conn.sendErrorResponse(ctx, &req.hdr, req.transformErrors(err), recorder, done)
 	} else {
 		hdr := &Header{
 			RequestId:  req.hdr.RequestId,
@@ -917,8 +1042,9 @@ func (conn *Conn) callRequest(
 			logger.Tracef(ctx, "error capturing flight recorder: %v", err)
 		}
 
-		conn.sendResponse(hdr, rvi)
+		conn.sendResponse(ctx, req.hdr.Request, recorder, hdr, rvi, done)
 	}
+	return true
 }
 
 var noop = flightrecorder.NoopRecorder{}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -762,7 +762,7 @@ func (conn *Conn) sendResponse(
 		done:     done,
 	}
 	if conn.writerStopped.Load() {
-		conn.finishResponse(msg, nil)
+		conn.finishResponse(msg, ErrShutdown)
 		return
 	}
 	conn.pendingWrites.add()
@@ -771,14 +771,14 @@ func (conn *Conn) sendResponse(
 	// attempting to queue to a writer that may already have exited.
 	if conn.writerStopped.Load() {
 		conn.pendingWrites.done()
-		conn.finishResponse(msg, nil)
+		conn.finishResponse(msg, ErrShutdown)
 		return
 	}
 	select {
 	case conn.responses <- msg:
 	case <-conn.dead:
 		conn.pendingWrites.done()
-		conn.finishResponse(msg, nil)
+		conn.finishResponse(msg, ErrShutdown)
 	}
 }
 


### PR DESCRIPTION
The RPC layer had a head-of-line blocking problem: when multiple server-side handler goroutines completed concurrently, they all contended on conn.sending to call codec.WriteMessage. A slow write (e.g. websocket backpressure) would block all other handlers from returning their responses, even though they were independent.

This PR introduces a dedicated writer goroutine with a buffered channel (responses chan responseMsg, buffer size 128). Handler goroutines now push their response to the channel and return immediately, decoupling request handling from write latency. The writer drains the channel sequentially, which is required by the underlying transport anyway.

> [!NOTE]
>  Crash semantics: If the agent crashes after a handler has committed data to the database but before the response is written to the client (i.e. the response is still queued in the channel), no ack will be sent back. This should be acceptable because clients are expected to be good citizens - on reconnect they re-fetch the full state rather than relying on the ack of a previous request.

Additional changes:

 1. conn.sending mutex removed — Write serialization is now handled by the single writer goroutine (and the codec's own mutex for the netConn case).
 2. conn.closing → atomic.Bool — The hot path (handleRequest, bindRequest) no longer acquires conn.mutex just to check closing.
 3. conn.root / transformErrors / recorderFactory → atomic.Pointer[serverConfig] — These are set once via Serve/ServeRoot and read on every request. Storing them atomically eliminates mutex contention on the request path.
 4. conn.reqId → atomic.Uint64 — Client request IDs no longer require the mutex.
 5. Codec.WriteMessage contract updated — Implementations must now handle their own write serialization, since concurrent WriteMessage calls are possible. The netConn codec gains a sync.Mutex for this purpose.
 6. Close() drains pending writes — Uses pendingWrites sync.WaitGroup to ensure all queued responses are flushed before closing the codec.


-----

This was spotted in the following PR https://github.com/juju/juju/pull/22395. 

<img width="1919" height="1132" alt="annotely_image (2)" src="https://github.com/user-attachments/assets/8d3cd639-9de8-4b87-b4ca-14dff23120cd" />

The conn.sending mutex was held for the entire duration of codec.WriteMessage - which is a network write (websocket frame over TCP). Every handler goroutine that finished processing its request had to acquire this single lock before it could respond:

 Handler A finishes → acquires conn.sending → WriteMessage (slow, backpressure) → releases
 Handler B finishes → blocks on conn.sending ← waiting for A's network write
 Handler C finishes → blocks on conn.sending ← waiting behind B
 Handler D finishes → blocks on conn.sending ← ...

The lock turned concurrent, independent responses into a serial queue gated by network I/O latency. If one write stalls (TCP window full, client slow to read), all other completed handlers pile up behind it - even though their work is done and their responses are ready.

This is classic head-of-line blocking: the latency of one slow write propagates to every other in-flight request, because they share a single serialization point that includes the I/O wait.

> [!NOTE]
> This is experimental, hence 4.1 branch.

## QA steps

We can lean on tracing here to ensure that we're not seeing this again. Set up tempo and bootstrap with tempo params.

```sh
$ juju bootstrap lxd test --config="open-telemetry-enabled=true" --config="open-telemetry-insecure=true" --config="open-telemetry-endpoint=192.168.0.38:4317" --config="open-telemetry-sample-ratio=1.0" --config "open-telemetry-tail-sampling-threshold=0"
```

Create some artificial noise.

```sh
$ for i in {1..30}; do juju add-model "model-$i" && juju deploy juju-qa-test &; done
```

Explore tempo.

## Links

...
