### PR TITLE
build(docs): align 2.9 doc infrastructure with 3.6

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,8 +249,23 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinxext.rediraffe',
     'sphinx_sitemap',
+    'sphinx_new_tab_link',
+    'sphinxcontrib.lightbox2',
+    'sphinx_llm.txt',
     ]
 
+# Customize sphinx_llm.txt
+## Add project summary:
+llms_txt_description = (
+    "Juju is an open source orchestration engine for deploying, integrating, "
+    "and managing applications across Kubernetes, VMs, and bare metal using "
+    "software operators called charms."
+)
+## Get cleaner markdown URLs (e.g., `page.md` instead of `page/index.html.md`):
+llms_txt_suffix_mode = "url-suffix"
+markdown_http_base = "https://documentation.ubuntu.com/juju/2.9"
+
+new_tab_link_show_external_link_icon = True
 
 # Add redirects, so they can be updated here to land with docs being moved
 # rediraffe_branch = "3.6"
@@ -266,6 +281,7 @@ exclude_patterns = [
 
 html_css_files = [
     "css/pdf.css",
+    "css/cookie-banner.css",
     "https://assets.ubuntu.com/v1/d86746ef-cookie_banner.css",
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,6 +16,7 @@ sphinxext-rediraffe
 sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
+sphinx-llm
 sphinx-related-links>=0.1.2
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2
@@ -31,3 +32,7 @@ sphinx-sitemap
 # Vale dependencies
 rst2html
 vale
+
+# Custom dependencies
+sphinx-new-tab-link
+sphinxcontrib.lightbox2


### PR DESCRIPTION
This PR aligns our docs setup in 2.9 with our setup in 3.6+ even more to minimize forward merge issues.

<details>
## What was added to 2.9:

**docs/requirements.txt:**
- `sphinx-llm` - Generates llms.txt for AI agent discoverability
- `sphinx-new-tab-link` - Opens external links in new tabs
- `sphinxcontrib.lightbox2` - Image viewer functionality

**docs/conf.py:**
- Added the three new extensions
- Configured sphinx_llm with project description and URL base for 2.9
- Configured new_tab_link to show external link icons
- Added local cookie-banner.css (matching 3.6 structure)

**What was NOT included:**
- `ibnote` - Not used in 2.9 docs, would require backporting scripts/
- Makefile changes - Build automation is version-specific (autogenerate-docs won't work in 2.9)

## Test results:
✅ Build succeeded: `make html` completed with 181 warnings (expected)
✅ llms.txt generated successfully with project description
✅ Extensions loaded without errors

## Impact on forward merges:
This should eliminate conflicts in:
- requirements.txt (except for version bumps)
- Most of conf.py (extensions and CSS now aligned)

Remaining expected conflicts in future merges:
- docs/Makefile (build automation differences - acceptable)
- Actual doc content changes
- Version-specific files

</details>


