### PR TITLE
feat: support O7k Keystone trust auth

### DIFF
--- a/api/common/cloudcred/attr.go
+++ b/api/common/cloudcred/attr.go
@@ -62,6 +62,7 @@ var attr = map[string]bool{
 	"openstack,userpass,project-domain-name":                 true,
 	"openstack,userpass,tenant-id":                           true,
 	"openstack,userpass,tenant-name":                         true,
+	"openstack,userpass,trust-id":                            true,
 	"openstack,userpass,user-domain-name":                    true,
 	"openstack,userpass,username":                            true,
 	"openstack,userpass,version":                             true,

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -82,7 +82,7 @@ including the locations searched.
   - Credentials:
     - On Linux, ` + "`$HOME/.novarc`" + `.
     - Environment variables: ` + "`OS_USERNAME`" + `, ` + "`OS_PASSWORD`" + `, ` + "`OS_TENANT_NAME`" + `,
-	   ` + "`OS_DOMAIN_NAME`" + `.
+	   ` + "`OS_DOMAIN_NAME`" + `, ` + "`OS_TRUST_ID`" + `.
 
 - LXD
   - Credentials:

--- a/docs/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju.md
@@ -55,6 +55,12 @@ Attributes:
 - `domain-name`: The OpenStack domain name. (optional)
 - `project-domain-name`: The OpenStack project domain name. (optional)
 - `user-domain-name`: The OpenStack user domain name. (optional)
+- `trust-id`: The OpenStack Keystone trust ID. (optional; requires Keystone v3)
+
+For Keystone v3 trust authentication, use `userpass` with `username`,
+`password`, `user-domain-name`, `version: "3"`, and `trust-id`. The trust
+defines the delegated project scope, so project and tenant attributes are not
+required.
 
 ## Notes on `juju bootstrap`
 

--- a/docs/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju.md
+++ b/docs/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju.md
@@ -59,8 +59,8 @@ Attributes:
 
 For Keystone v3 trust authentication, use `userpass` with `username`,
 `password`, `user-domain-name`, `version: "3"`, and `trust-id`. The trust
-defines the delegated project scope, so project and tenant attributes are not
-required.
+defines the delegated project scope, so do not set `tenant-name`, `tenant-id`,
+or `domain-name` with `trust-id`.
 
 ## Notes on `juju bootstrap`
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/autoload-credentials.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/autoload-credentials.md
@@ -57,7 +57,7 @@ including the locations searched.
   - Credentials:
     - On Linux, `$HOME/.novarc`.
     - Environment variables: `OS_USERNAME`, `OS_PASSWORD`, `OS_TENANT_NAME`,
-	   `OS_DOMAIN_NAME`.
+	   `OS_DOMAIN_NAME`, `OS_TRUST_ID`.
 
 - LXD
   - Credentials:

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-delve/delve v1.26.1
-	github.com/go-goose/goose/v5 v5.1.4
+	github.com/go-goose/goose/v5 v5.1.6
 	github.com/go-logr/logr v1.4.3
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.2
 	github.com/google/gnostic-models v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/go-delve/delve v1.26.1 h1:V1F0hzAjXCpsBP+I/E6fVUTLC/ZBSs1YWUb8cTtIWFE
 github.com/go-delve/delve v1.26.1/go.mod h1:Ua/k2AAu4cLrUXGSRVH1b2Nzq2aCK188b9EYlAojlz4=
 github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62 h1:IGtvsNyIuRjl04XAOFGACozgUD7A82UffYxZt4DWbvA=
 github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62/go.mod h1:biJCRbqp51wS+I92HMqn5H8/A0PAhxn2vyOT+JqhiGI=
-github.com/go-goose/goose/v5 v5.1.4 h1:L2H+sTKp9BZehpHAs9EBz65L7hUZuxj8WqQn9lt/cNg=
-github.com/go-goose/goose/v5 v5.1.4/go.mod h1:wm2H9/ef6rvcIrvqv9WumylTUczf8m/f103RkZwYNdA=
+github.com/go-goose/goose/v5 v5.1.6 h1:ntjInQrjRsL6CXgYM3AiPOYkGMvptHvTnDzcgllydRQ=
+github.com/go-goose/goose/v5 v5.1.6/go.mod h1:wm2H9/ef6rvcIrvqv9WumylTUczf8m/f103RkZwYNdA=
 github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
 github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/internal/provider/openstack/credentials.go
+++ b/internal/provider/openstack/credentials.go
@@ -114,15 +114,14 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (c OpenstackCredentials) DetectCredentials(cloudName string) (*cloud.CloudCredential, error) {
+	ctx := context.TODO()
 	result := cloud.CloudCredential{
 		AuthCredentials: make(map[string]cloud.Credential),
 	}
 
 	// Try just using environment variables
-	creds, user, region, err := c.detectCredential(context.TODO())
-	if err == nil {
-		result.DefaultRegion = region
-		result.AuthCredentials[user] = *creds
+	if err := c.updateCredentialFromEnv(ctx, &result); err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	// Now look for .novarc file in home dir.
@@ -138,10 +137,8 @@ func (c OpenstackCredentials) DetectCredentials(cloudName string) (*cloud.CloudC
 			k = stripExport.ReplaceAllString(k, "")
 			os.Setenv(k, v)
 		}
-		creds, user, region, err := c.detectCredential(context.TODO())
-		if err == nil {
-			result.DefaultRegion = region
-			result.AuthCredentials[user] = *creds
+		if err := c.updateCredentialFromEnv(ctx, &result); err != nil {
+			return nil, errors.Trace(err)
 		}
 	}
 	if len(result.AuthCredentials) == 0 {
@@ -150,22 +147,38 @@ func (c OpenstackCredentials) DetectCredentials(cloudName string) (*cloud.CloudC
 	return &result, nil
 }
 
+func (c OpenstackCredentials) updateCredentialFromEnv(ctx context.Context, result *cloud.CloudCredential) error {
+	creds, user, region, err := c.detectCredential(ctx)
+	if err != nil {
+		if errors.Is(err, errors.NotFound) {
+			return nil
+		}
+		return errors.Trace(err)
+	}
+	result.DefaultRegion = region
+	result.AuthCredentials[user] = *creds
+	return nil
+}
+
 func (c OpenstackCredentials) detectCredential(ctx context.Context) (*cloud.Credential, string, string, error) {
 	creds, err := identity.CredentialsFromEnv()
 	if err != nil {
 		return nil, "", "", errors.Errorf("failed to retrieve credential from env : %v", err)
 	}
 	if creds.TenantName == "" {
-		logger.Debugf(ctx, "neither OS_TENANT_NAME nor OS_PROJECT_NAME environment variable not set")
+		logger.Debugf(ctx, "OS_TENANT_NAME and OS_PROJECT_NAME environment variables are not set")
 	}
 	if creds.TenantID == "" {
-		logger.Debugf(ctx, "neither OS_TENANT_ID nor OS_PROJECT_ID environment variable not set")
+		logger.Debugf(ctx, "OS_TENANT_ID and OS_PROJECT_ID environment variables are not set")
 	}
 	if creds.User == "" {
-		return nil, "", "", errors.NewNotFound(nil, "neither OS_USERNAME nor OS_ACCESS_KEY environment variable not set")
+		return nil, "", "", errors.NewNotFound(nil, "OS_USERNAME and OS_ACCESS_KEY environment variables are not set")
 	}
 	if creds.Secrets == "" {
-		return nil, "", "", errors.NewNotFound(nil, "neither OS_PASSWORD nor OS_SECRET_KEY environment variable not set")
+		return nil, "", "", errors.NewNotFound(nil, "OS_PASSWORD and OS_SECRET_KEY environment variables are not set")
+	}
+	if err := validateTrustCredentialScope(*creds); err != nil {
+		return nil, "", "", errors.Trace(err)
 	}
 
 	user, err := utils.LocalUsername()

--- a/internal/provider/openstack/credentials.go
+++ b/internal/provider/openstack/credentials.go
@@ -177,9 +177,6 @@ func (c OpenstackCredentials) detectCredential(ctx context.Context) (*cloud.Cred
 	if creds.Secrets == "" {
 		return nil, "", "", errors.NewNotFound(nil, "OS_PASSWORD and OS_SECRET_KEY environment variables are not set")
 	}
-	if err := validateTrustCredentialScope(*creds); err != nil {
-		return nil, "", "", errors.Trace(err)
-	}
 
 	user, err := utils.LocalUsername()
 	if err != nil {
@@ -195,6 +192,9 @@ func (c OpenstackCredentials) detectCredential(ctx context.Context) (*cloud.Cred
 	// If OS_USERNAME or NOVA_USERNAME is set, assume userpass.
 	var credential cloud.Credential
 	if os.Getenv("OS_USERNAME") != "" || os.Getenv("NOVA_USERNAME") != "" {
+		if err := validateTrustCredentialScope(*creds); err != nil {
+			return nil, "", "", errors.Trace(err)
+		}
 		user = creds.User
 		credential = cloud.NewCredential(
 			cloud.UserPassAuthType,

--- a/internal/provider/openstack/credentials.go
+++ b/internal/provider/openstack/credentials.go
@@ -28,6 +28,7 @@ const (
 	CredAttrDomainName        = "domain-name"
 	CredAttrProjectDomainName = "project-domain-name"
 	CredAttrUserDomainName    = "user-domain-name"
+	CredAttrTrustID           = "trust-id"
 	CredAttrAccessKey         = "access-key"
 	CredAttrSecretKey         = "secret-key"
 	CredAttrVersion           = "version"
@@ -74,6 +75,11 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 			}, {
 				CredAttrUserDomainName, cloud.CredentialAttr{
 					Description: "The OpenStack user domain name.",
+					Optional:    true,
+				},
+			}, {
+				CredAttrTrustID, cloud.CredentialAttr{
+					Description: "The OpenStack trust ID.",
 					Optional:    true,
 				},
 			},
@@ -188,6 +194,7 @@ func (c OpenstackCredentials) detectCredential(ctx context.Context) (*cloud.Cred
 				CredAttrProjectDomainName: creds.ProjectDomain,
 				CredAttrDomainName:        creds.Domain,
 				CredAttrVersion:           version,
+				CredAttrTrustID:           creds.TrustID,
 			},
 		)
 	} else {

--- a/internal/provider/openstack/credentials_test.go
+++ b/internal/provider/openstack/credentials_test.go
@@ -57,6 +57,7 @@ func (s *credentialsSuite) TestUserPassCredentialsValid(c *tc.C) {
 		"username":    "bob",
 		"password":    "dobbs",
 		"tenant-name": "gary",
+		"trust-id":    "trust",
 	})
 }
 
@@ -117,11 +118,40 @@ func (s *credentialsSuite) TestDetectCredentialsUserPassEnvironmentVariables(c *
 			"tenant-id":           "xyz",
 			"domain-name":         "",
 			"project-domain-name": "",
+			"trust-id":            "",
 			"user-domain-name":    "user-domain",
 		},
 	)
 	expected.Label = `openstack region "west" project "gary" user "bob"`
 	c.Assert(credentials.AuthCredentials["bob"], tc.DeepEquals, expected)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsUserPassTrustEnvironmentVariables(c *tc.C) {
+	s.PatchEnvironment("OS_IDENTITY_API_VERSION", "3")
+	s.PatchEnvironment("OS_USERNAME", "admin")
+	s.PatchEnvironment("OS_PASSWORD", "secret")
+	s.PatchEnvironment("OS_REGION_NAME", "region")
+	s.PatchEnvironment("OS_USER_DOMAIN_NAME", "admin_domain")
+	s.PatchEnvironment("OS_TRUST_ID", "trust-id")
+
+	credentials, err := s.provider.DetectCredentials("")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(credentials.DefaultRegion, tc.Equals, "region")
+	expected := cloud.NewCredential(
+		cloud.UserPassAuthType, map[string]string{
+			"version":             "3",
+			"username":            "admin",
+			"password":            "secret",
+			"tenant-name":         "",
+			"tenant-id":           "",
+			"domain-name":         "",
+			"project-domain-name": "",
+			"trust-id":            "trust-id",
+			"user-domain-name":    "admin_domain",
+		},
+	)
+	expected.Label = `openstack region "region" project "" user "admin"`
+	c.Assert(credentials.AuthCredentials["admin"], tc.DeepEquals, expected)
 }
 
 func (s *credentialsSuite) TestDetectCredentialsUserPassDefaultDomain(c *tc.C) {
@@ -145,6 +175,7 @@ func (s *credentialsSuite) TestDetectCredentialsUserPassDefaultDomain(c *tc.C) {
 			"tenant-id":           "",
 			"domain-name":         "",
 			"project-domain-name": "default-domain",
+			"trust-id":            "",
 			"user-domain-name":    "default-domain",
 		},
 	)
@@ -190,6 +221,7 @@ OS_PROJECT_DOMAIN_NAME=project-domain
 			"tenant-id":           "xyz",
 			"domain-name":         "",
 			"project-domain-name": "project-domain",
+			"trust-id":            "",
 			"user-domain-name":    "",
 		},
 	)

--- a/internal/provider/openstack/credentials_test.go
+++ b/internal/provider/openstack/credentials_test.go
@@ -86,6 +86,8 @@ func (s *credentialsSuite) TestDetectCredentialsAccessKeyEnvironmentVariables(c 
 	s.PatchEnvironment("OS_ACCESS_KEY", "key-id")
 	s.PatchEnvironment("OS_SECRET_KEY", "secret-access-key")
 	s.PatchEnvironment("OS_REGION_NAME", "east")
+	// Trust auth only applies to userpass; it must not reject access keys.
+	s.PatchEnvironment("OS_TRUST_ID", "trust-id")
 
 	credentials, err := s.provider.DetectCredentials("")
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/provider/openstack/credentials_test.go
+++ b/internal/provider/openstack/credentials_test.go
@@ -57,7 +57,14 @@ func (s *credentialsSuite) TestUserPassCredentialsValid(c *tc.C) {
 		"username":    "bob",
 		"password":    "dobbs",
 		"tenant-name": "gary",
-		"trust-id":    "trust",
+	})
+}
+
+func (s *credentialsSuite) TestUserPassTrustCredentialsValid(c *tc.C) {
+	envtesting.AssertProviderCredentialsValid(c, s.provider, "userpass", map[string]string{
+		"username": "bob",
+		"password": "dobbs",
+		"trust-id": "trust",
 	})
 }
 
@@ -154,6 +161,25 @@ func (s *credentialsSuite) TestDetectCredentialsUserPassTrustEnvironmentVariable
 	c.Assert(credentials.AuthCredentials["admin"], tc.DeepEquals, expected)
 }
 
+func (s *credentialsSuite) TestDetectCredentialsUserPassTrustWithProjectEnvironmentVariablesRejects(c *tc.C) {
+	s.PatchEnvironment("OS_IDENTITY_API_VERSION", "3")
+	s.PatchEnvironment("OS_PROJECT_NAME", "gary")
+	s.PatchEnvironment("OS_USERNAME", "admin")
+	s.PatchEnvironment("OS_PASSWORD", "secret")
+	s.PatchEnvironment("OS_USER_DOMAIN_NAME", "admin_domain")
+	s.PatchEnvironment("OS_TRUST_ID", "trust-id")
+
+	_, err := s.provider.DetectCredentials("")
+	c.Assert(err, tc.ErrorMatches, "trust-id cannot be used with project or domain scope attributes: tenant-name")
+}
+
+func (s *credentialsSuite) TestDetectCredentialsInvalidEnvironmentVariablesRejects(c *tc.C) {
+	s.PatchEnvironment("OS_AUTH_VERSION", "not-a-version")
+
+	_, err := s.provider.DetectCredentials("")
+	c.Assert(err, tc.ErrorMatches, "failed to retrieve credential from env : cred.Version is not a valid integer type.*")
+}
+
 func (s *credentialsSuite) TestDetectCredentialsUserPassDefaultDomain(c *tc.C) {
 	s.PatchEnvironment("OS_AUTH_VERSION", "3")
 	s.PatchEnvironment("USER", "fred")
@@ -181,6 +207,32 @@ func (s *credentialsSuite) TestDetectCredentialsUserPassDefaultDomain(c *tc.C) {
 	)
 	expected.Label = `openstack region "west" project "gary" user "bob"`
 	c.Assert(credentials.AuthCredentials["bob"], tc.DeepEquals, expected)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsInvalidNovarcRejects(c *tc.C) {
+	if runtime.GOOS != "linux" {
+		c.Skip("not running linux")
+	}
+	home := utils.Home()
+	dir := c.MkDir()
+	err := utils.SetHome(dir)
+	c.Assert(err, tc.ErrorIsNil)
+	s.AddCleanup(func(c *tc.C) {
+		err := utils.SetHome(home)
+		c.Assert(err, tc.ErrorIsNil)
+	})
+
+	content := `
+OS_AUTH_VERSION=not-a-version
+OS_USERNAME=bob
+OS_PASSWORD=dobbs
+`[1:]
+	novarc := filepath.Join(dir, ".novarc")
+	err = os.WriteFile(novarc, []byte(content), 0600)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.provider.DetectCredentials("")
+	c.Assert(err, tc.ErrorMatches, "failed to retrieve credential from env : cred.Version is not a valid integer type.*")
 }
 
 func (s *credentialsSuite) TestDetectCredentialsNovarc(c *tc.C) {

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -849,7 +849,34 @@ func newCredentials(spec environscloudspec.CloudSpec) (identity.Credentials, ide
 		cred.Secrets = credAttrs[CredAttrSecretKey]
 		authMode = identity.AuthKeyPair
 	}
+	if err := validateTrustCredentialScope(cred); err != nil {
+		return identity.Credentials{}, 0, errors.Trace(err)
+	}
 	return cred, authMode, nil
+}
+
+func validateTrustCredentialScope(cred identity.Credentials) error {
+	if cred.TrustID == "" {
+		return nil
+	}
+	var scopeAttrs []string
+	if cred.TenantName != "" {
+		scopeAttrs = append(scopeAttrs, CredAttrTenantName)
+	}
+	if cred.TenantID != "" {
+		scopeAttrs = append(scopeAttrs, CredAttrTenantID)
+	}
+	if cred.Domain != "" {
+		scopeAttrs = append(scopeAttrs, CredAttrDomainName)
+	}
+	if len(scopeAttrs) == 0 {
+		return nil
+	}
+	return errors.NewNotValid(nil, fmt.Sprintf(
+		"%s cannot be used with project or domain scope attributes: %s",
+		CredAttrTrustID,
+		strings.Join(scopeAttrs, ", "),
+	))
 }
 
 func tlsConfig(certStrs []string) *tls.Config {

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -844,13 +844,13 @@ func newCredentials(spec environscloudspec.CloudSpec) (identity.Credentials, ide
 		} else {
 			authMode = identity.AuthUserPass
 		}
+		if err := validateTrustCredentialScope(cred); err != nil {
+			return identity.Credentials{}, 0, errors.Trace(err)
+		}
 	case cloud.AccessKeyAuthType:
 		cred.User = credAttrs[CredAttrAccessKey]
 		cred.Secrets = credAttrs[CredAttrSecretKey]
 		authMode = identity.AuthKeyPair
-	}
-	if err := validateTrustCredentialScope(cred); err != nil {
-		return identity.Credentials{}, 0, errors.Trace(err)
 	}
 	return cred, authMode, nil
 }

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -822,11 +822,16 @@ func newCredentials(spec environscloudspec.CloudSpec) (identity.Credentials, ide
 		cred.ProjectDomain = credAttrs[CredAttrProjectDomainName]
 		cred.UserDomain = credAttrs[CredAttrUserDomainName]
 		cred.Domain = credAttrs[CredAttrDomainName]
+		cred.TrustID = credAttrs[CredAttrTrustID]
 		if credAttrs[CredAttrVersion] != "" {
 			version, err := strconv.Atoi(credAttrs[CredAttrVersion])
 			if err != nil {
 				return identity.Credentials{}, 0,
 					errors.Errorf("cred.Version is not a valid integer type : %v", err)
+			}
+			if version < 3 && cred.TrustID != "" {
+				return identity.Credentials{}, 0,
+					errors.Errorf("cred.TrustID requires Keystone identity version 3")
 			}
 			if version < 3 {
 				authMode = identity.AuthUserPass
@@ -834,7 +839,7 @@ func newCredentials(spec environscloudspec.CloudSpec) (identity.Credentials, ide
 				authMode = identity.AuthUserPassV3
 			}
 			cred.Version = version
-		} else if cred.Domain != "" || cred.UserDomain != "" || cred.ProjectDomain != "" {
+		} else if cred.Domain != "" || cred.UserDomain != "" || cred.ProjectDomain != "" || cred.TrustID != "" {
 			authMode = identity.AuthUserPassV3
 		} else {
 			authMode = identity.AuthUserPass

--- a/internal/provider/openstack/provider_test.go
+++ b/internal/provider/openstack/provider_test.go
@@ -868,6 +868,43 @@ func (s *providerUnitTests) TestNewCredentialsWithTrustID(c *tc.C) {
 	c.Check(authmode, tc.Equals, identity.AuthUserPassV3)
 }
 
+func (s *providerUnitTests) TestNewCredentialsWithTrustIDAndScopeRejects(c *tc.C) {
+	for _, test := range []struct {
+		attr  string
+		value string
+	}{{
+		attr:  CredAttrTenantName,
+		value: "someTenant",
+	}, {
+		attr:  CredAttrTenantID,
+		value: "someID",
+	}, {
+		attr:  CredAttrDomainName,
+		value: "openstack_domain",
+	}} {
+		attrs := map[string]string{
+			CredAttrUserName:       "user",
+			CredAttrPassword:       "secret",
+			CredAttrUserDomainName: "openstack_userdomain",
+			CredAttrTrustID:        "trust-id",
+		}
+		attrs[test.attr] = test.value
+		creds := cloud.NewCredential(cloud.UserPassAuthType, attrs)
+		clouldSpec := environscloudspec.CloudSpec{
+			Type:       "openstack",
+			Region:     "openstack_region",
+			Name:       "openstack",
+			Endpoint:   "http://endpoint",
+			Credential: &creds,
+		}
+
+		_, _, err := newCredentials(clouldSpec)
+		c.Check(err, tc.ErrorMatches,
+			fmt.Sprintf("%s cannot be used with project or domain scope attributes: %s", CredAttrTrustID, test.attr),
+			tc.Commentf(test.attr))
+	}
+}
+
 func (s *providerUnitTests) TestNewCredentialsWithTrustIDAndVersion2(c *tc.C) {
 	creds := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 		"version":  "2",

--- a/internal/provider/openstack/provider_test.go
+++ b/internal/provider/openstack/provider_test.go
@@ -840,6 +840,52 @@ func (s *providerUnitTests) TestNewCredentialsWithoutVersionWithUserDomain(c *tc
 	c.Check(authmode, tc.Equals, identity.AuthUserPassV3)
 }
 
+func (s *providerUnitTests) TestNewCredentialsWithTrustID(c *tc.C) {
+	creds := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"username":         "user",
+		"password":         "secret",
+		"user-domain-name": "openstack_userdomain",
+		"trust-id":         "trust-id",
+	})
+	clouldSpec := environscloudspec.CloudSpec{
+		Type:       "openstack",
+		Region:     "openstack_region",
+		Name:       "openstack",
+		Endpoint:   "http://endpoint",
+		Credential: &creds,
+	}
+	cred, authmode, err := newCredentials(clouldSpec)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cred, tc.Equals, identity.Credentials{
+		URL:           "http://endpoint",
+		User:          "user",
+		Secrets:       "secret",
+		Region:        "openstack_region",
+		UserDomain:    "openstack_userdomain",
+		ProjectDomain: "",
+		TrustID:       "trust-id",
+	})
+	c.Check(authmode, tc.Equals, identity.AuthUserPassV3)
+}
+
+func (s *providerUnitTests) TestNewCredentialsWithTrustIDAndVersion2(c *tc.C) {
+	creds := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"version":  "2",
+		"username": "user",
+		"password": "secret",
+		"trust-id": "trust-id",
+	})
+	clouldSpec := environscloudspec.CloudSpec{
+		Type:       "openstack",
+		Region:     "openstack_region",
+		Name:       "openstack",
+		Endpoint:   "http://endpoint",
+		Credential: &creds,
+	}
+	_, _, err := newCredentials(clouldSpec)
+	c.Assert(err, tc.ErrorMatches, "cred.TrustID requires Keystone identity version 3")
+}
+
 func (s *providerUnitTests) TestNewCredentialsWithVersion2(c *tc.C) {
 	creds := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
 		"version":     "2",


### PR DESCRIPTION
Supports OpenStack auth with V3 Keystone trusts.

The change is quite simple, bringing in [v5.1.6 of the goose dependency](https://github.com/go-goose/goose/releases/tag/v5.1.6), and populating the trust ID as required in order to use the feature.

Validation is included that prevents redundant fields being specified with trust ID.

## QA steps

These steps were agent assisted:
- Install Sunbeam in a VM using [the guide](https://canonical-openstack.readthedocs-hosted.com/en/latest/tutorial/get-started-with-openstack/).
- Add images/metadata.
- Add a trust credential.
- Add the sunbeam cloud and credential to Juju.
- Verify the credential:
```
client-credentials:
  sunbeam:
    juju-trust:
      content:
        auth-type: userpass
        trust-id: 4565196522ac424fb4c0c3dba799b8b5
        user-domain-name: Default
        username: juju-trustee
        version: "3"
```
- Bootstrap with it: 
```
juju bootstrap sunbeam/RegionOne sunbeam \
    --credential juju-trust \
    --metadata-source <your-location> \
    --bootstrap-base ubuntu@24.04 \
    --bootstrap-constraints "arch=amd64 allocate-public-ip=true" \
    --constraints "arch=amd64 allocate-public-ip=true" \
    --config network=juju-network \
    --config external-network=external-network \
    --model-default network=juju-network \
    --model-default external-network=external-network \
    --debug
```
- Verify success.

## Documentation changes

The trust ID key is mentioned in the OpenStack cloud documentation, plus the help content for `autoload-credentials`.

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9602](https://warthogs.atlassian.net/browse/JUJU-9602)

[JUJU-9602]: https://warthogs.atlassian.net/browse/JUJU-9602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ